### PR TITLE
feat(providers): add credential_process support for Bedrock auth

### DIFF
--- a/crates/zeroclaw-providers/src/bedrock.rs
+++ b/crates/zeroclaw-providers/src/bedrock.rs
@@ -1,10 +1,11 @@
 //! AWS Bedrock provider using the Converse API.
 //!
-//! Authentication: supports two methods:
+//! Authentication: supports three methods:
 //! - **Bearer token**: set `BEDROCK_API_KEY` env var (takes precedence).
 //! - **SigV4 signing**: AWS AKSK (Access Key ID + Secret Access Key)
-//!   via environment variables or EC2 IMDSv2. SigV4 signing is implemented
-//!   manually using hmac/sha2 crates — no AWS SDK dependency.
+//!   via environment variables, `credential_process` in `~/.aws/config`,
+//!   or EC2 IMDSv2. SigV4 signing is implemented manually using hmac/sha2
+//!   crates — no AWS SDK dependency.
 
 use crate::traits::{
     ChatMessage, ChatRequest as ProviderChatRequest, ChatResponse as ProviderChatResponse,
@@ -15,6 +16,7 @@ use hmac::{Hmac, Mac};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use std::sync::Mutex;
 use zeroclaw_api::tool::ToolSpec;
 
 /// Hostname prefix for the Bedrock Runtime endpoint.
@@ -34,11 +36,15 @@ enum BedrockAuth {
 // ── AWS Credentials ─────────────────────────────────────────────
 
 /// Resolved AWS credentials for SigV4 signing.
+#[derive(Clone)]
 struct AwsCredentials {
     access_key_id: String,
     secret_access_key: String,
     session_token: Option<String>,
     region: String,
+    /// Credential expiry (from `credential_process` `Expiration` field).
+    /// `None` means no known expiry — treat as long-lived.
+    expires_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 impl AwsCredentials {
@@ -58,6 +64,97 @@ impl AwsCredentials {
             secret_access_key,
             session_token,
             region,
+            expires_at: None,
+        })
+    }
+
+    /// Parse `~/.aws/config` (or `$AWS_CONFIG_FILE`) and return the
+    /// `credential_process` command and optional `region` for the active profile.
+    fn parse_aws_config(content: &str, profile: &str) -> Option<(String, Option<String>)> {
+        let target = if profile == "default" {
+            "[default]".to_string()
+        } else {
+            format!("[profile {profile}]")
+        };
+
+        let mut in_section = false;
+        let mut cred_process = None;
+        let mut region = None;
+
+        for line in content.lines() {
+            let trimmed = line.trim();
+            if trimmed.starts_with('[') {
+                in_section = trimmed == target;
+                continue;
+            }
+            if !in_section || trimmed.starts_with('#') || trimmed.starts_with(';') {
+                continue;
+            }
+            if let Some((key, value)) = trimmed.split_once('=') {
+                match key.trim() {
+                    "credential_process" => cred_process = Some(value.trim().to_string()),
+                    "region" => region = Some(value.trim().to_string()),
+                    _ => {}
+                }
+            }
+        }
+        cred_process.map(|cmd| (cmd, region))
+    }
+
+    /// Resolve credentials via `credential_process` in `~/.aws/config`.
+    fn from_credential_process() -> anyhow::Result<Self> {
+        let config_path = std::env::var("AWS_CONFIG_FILE").unwrap_or_else(|_| {
+            let home = std::env::var("HOME").unwrap_or_else(|_| "~".to_string());
+            format!("{home}/.aws/config")
+        });
+        let content = std::fs::read_to_string(&config_path)
+            .map_err(|e| anyhow::anyhow!("Cannot read {config_path}: {e}"))?;
+        let profile = std::env::var("AWS_PROFILE").unwrap_or_else(|_| "default".to_string());
+        let (cmd, config_region) = Self::parse_aws_config(&content, &profile)
+            .ok_or_else(|| anyhow::anyhow!("No credential_process in [{profile}]"))?;
+
+        let output = std::process::Command::new("sh")
+            .args(["-c", &cmd])
+            .output()
+            .map_err(|e| anyhow::anyhow!("Failed to run credential_process: {e}"))?;
+        anyhow::ensure!(
+            output.status.success(),
+            "credential_process exited with {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+
+        let json: serde_json::Value = serde_json::from_slice(&output.stdout)
+            .map_err(|e| anyhow::anyhow!("credential_process output is not valid JSON: {e}"))?;
+
+        let access_key_id = json["AccessKeyId"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("Missing AccessKeyId in credential_process output"))?
+            .to_string();
+        let secret_access_key = json["SecretAccessKey"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("Missing SecretAccessKey in credential_process output"))?
+            .to_string();
+        let session_token = json["SessionToken"].as_str().map(|s| s.to_string());
+
+        let expires_at = json["Expiration"]
+            .as_str()
+            .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+            .map(|dt| dt.with_timezone(&chrono::Utc));
+
+        let region = env_optional("AWS_REGION")
+            .or_else(|| env_optional("AWS_DEFAULT_REGION"))
+            .or(config_region)
+            .unwrap_or_else(|| DEFAULT_REGION.to_string());
+
+        tracing::debug!("Loaded AWS credentials via credential_process");
+
+        Ok(Self {
+            access_key_id,
+            secret_access_key,
+            session_token,
+            region,
+            expires_at,
         })
     }
 
@@ -138,12 +235,16 @@ impl AwsCredentials {
             secret_access_key,
             session_token,
             region,
+            expires_at: None,
         })
     }
 
-    /// Resolve credentials: env vars first, then EC2 IMDS.
+    /// Resolve credentials: env vars first, then credential_process, then EC2 IMDS.
     async fn resolve() -> anyhow::Result<Self> {
         if let Ok(creds) = Self::from_env() {
+            return Ok(creds);
+        }
+        if let Ok(creds) = Self::from_credential_process() {
             return Ok(creds);
         }
         Self::from_imds().await
@@ -151,6 +252,15 @@ impl AwsCredentials {
 
     fn host(&self) -> String {
         format!("{ENDPOINT_PREFIX}.{}.amazonaws.com", self.region)
+    }
+
+    /// Returns `true` if credentials have a known expiry that has passed
+    /// (with 60s skew to allow for clock drift and network latency).
+    fn is_expired(&self) -> bool {
+        match self.expires_at {
+            Some(exp) => chrono::Utc::now() >= exp - chrono::Duration::seconds(60),
+            None => false,
+        }
     }
 }
 
@@ -472,6 +582,8 @@ struct ResponseToolUseWrapper {
 pub struct BedrockProvider {
     auth: Option<BedrockAuth>,
     max_tokens: u32,
+    /// Cached SigV4 credentials from `credential_process` (with expiry).
+    cred_cache: Mutex<Option<AwsCredentials>>,
 }
 
 impl Default for BedrockProvider {
@@ -487,11 +599,16 @@ impl BedrockProvider {
             return Self {
                 auth: Some(BedrockAuth::BearerToken(token)),
                 max_tokens: zeroclaw_api::provider::BASELINE_MAX_TOKENS,
+                cred_cache: Mutex::new(None),
             };
         }
         Self {
-            auth: AwsCredentials::from_env().ok().map(BedrockAuth::SigV4),
+            auth: AwsCredentials::from_env()
+                .or_else(|_| AwsCredentials::from_credential_process())
+                .ok()
+                .map(BedrockAuth::SigV4),
             max_tokens: zeroclaw_api::provider::BASELINE_MAX_TOKENS,
+            cred_cache: Mutex::new(None),
         }
     }
 
@@ -501,12 +618,14 @@ impl BedrockProvider {
             return Self {
                 auth: Some(BedrockAuth::BearerToken(token)),
                 max_tokens: zeroclaw_api::provider::BASELINE_MAX_TOKENS,
+                cred_cache: Mutex::new(None),
             };
         }
         let auth = AwsCredentials::resolve().await.ok().map(BedrockAuth::SigV4);
         Self {
             auth,
             max_tokens: zeroclaw_api::provider::BASELINE_MAX_TOKENS,
+            cred_cache: Mutex::new(None),
         }
     }
 
@@ -515,6 +634,7 @@ impl BedrockProvider {
         Self {
             auth: Some(BedrockAuth::BearerToken(token.to_string())),
             max_tokens: zeroclaw_api::provider::BASELINE_MAX_TOKENS,
+            cred_cache: Mutex::new(None),
         }
     }
 
@@ -568,7 +688,13 @@ impl BedrockProvider {
                     return Ok(BedrockAuth::BearerToken(token.clone()));
                 }
                 BedrockAuth::SigV4(_) => {
-                    // Re-resolve SigV4 credentials (they may have rotated).
+                    // Check credential cache before re-resolving.
+                    if let Ok(cache) = self.cred_cache.lock()
+                        && let Some(ref creds) = *cache
+                        && !creds.is_expired()
+                    {
+                        return Ok(BedrockAuth::SigV4(creds.clone()));
+                    }
                 }
             }
         }
@@ -578,6 +704,13 @@ impl BedrockProvider {
         }
         // Fall back to SigV4.
         if let Ok(creds) = AwsCredentials::from_env() {
+            return Ok(BedrockAuth::SigV4(creds));
+        }
+        if let Ok(creds) = AwsCredentials::from_credential_process() {
+            // Cache the credentials for reuse.
+            if let Ok(mut cache) = self.cred_cache.lock() {
+                *cache = Some(creds.clone());
+            }
             return Ok(BedrockAuth::SigV4(creds));
         }
         Ok(BedrockAuth::SigV4(AwsCredentials::from_imds().await?))
@@ -1296,6 +1429,7 @@ mod tests {
             secret_access_key: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".to_string(),
             session_token: None,
             region: "us-east-1".to_string(),
+            expires_at: None,
         };
 
         let timestamp = chrono::DateTime::parse_from_rfc3339("2024-01-15T12:00:00Z")
@@ -1335,6 +1469,7 @@ mod tests {
             secret_access_key: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".to_string(),
             session_token: Some("session-token-value".to_string()),
             region: "us-east-1".to_string(),
+            expires_at: None,
         };
 
         let timestamp = chrono::DateTime::parse_from_rfc3339("2024-01-15T12:00:00Z")
@@ -1376,6 +1511,7 @@ mod tests {
             secret_access_key: "secret".to_string(),
             session_token: None,
             region: "us-west-2".to_string(),
+            expires_at: None,
         };
         assert_eq!(creds.host(), "bedrock-runtime.us-west-2.amazonaws.com");
     }
@@ -1390,12 +1526,15 @@ mod tests {
 
     #[tokio::test]
     async fn chat_fails_without_credentials() {
-        let provider = {
-            let _env_lock = env_lock();
-            BedrockProvider {
-                auth: None,
-                max_tokens: zeroclaw_api::provider::BASELINE_MAX_TOKENS,
-            }
+        let _env_lock = env_lock();
+        let _ak = EnvGuard::set("AWS_ACCESS_KEY_ID", None);
+        let _sk = EnvGuard::set("AWS_SECRET_ACCESS_KEY", None);
+        let _bearer = EnvGuard::set("BEDROCK_API_KEY", None);
+        let _config = EnvGuard::set("AWS_CONFIG_FILE", Some("/dev/null"));
+        let provider = BedrockProvider {
+            auth: None,
+            max_tokens: zeroclaw_api::provider::BASELINE_MAX_TOKENS,
+            cred_cache: Mutex::new(None),
         };
         let result = provider
             .chat_with_system(None, "hello", "anthropic.claude-sonnet-4-6", Some(0.7))
@@ -1788,6 +1927,7 @@ mod tests {
         let provider = BedrockProvider {
             auth: None,
             max_tokens: zeroclaw_api::provider::BASELINE_MAX_TOKENS,
+            cred_cache: Mutex::new(None),
         };
         let result = provider.warmup().await;
         assert!(result.is_ok());
@@ -1798,6 +1938,7 @@ mod tests {
         let provider = BedrockProvider {
             auth: None,
             max_tokens: zeroclaw_api::provider::BASELINE_MAX_TOKENS,
+            cred_cache: Mutex::new(None),
         };
         let caps = provider.capabilities();
         assert!(caps.native_tool_calling);
@@ -1975,5 +2116,107 @@ mod tests {
         } else {
             panic!("Expected Text block for assistant message");
         }
+    }
+
+    // ── credential_process tests ────────────────────────────────
+
+    #[test]
+    fn parse_aws_config_default_profile() {
+        let config = "\
+[default]
+region=us-west-2
+credential_process=ada credentials print --account=123 --provider=conduit --role=MyRole
+";
+        let result = AwsCredentials::parse_aws_config(config, "default");
+        assert!(result.is_some());
+        let (cmd, region) = result.unwrap();
+        assert_eq!(
+            cmd,
+            "ada credentials print --account=123 --provider=conduit --role=MyRole"
+        );
+        assert_eq!(region.as_deref(), Some("us-west-2"));
+    }
+
+    #[test]
+    fn parse_aws_config_named_profile() {
+        let config = "\
+[default]
+region=us-east-1
+
+[profile myprofile]
+region=eu-west-1
+credential_process=aws sso get-role-credentials --profile myprofile
+";
+        let result = AwsCredentials::parse_aws_config(config, "myprofile");
+        assert!(result.is_some());
+        let (cmd, region) = result.unwrap();
+        assert!(cmd.contains("myprofile"));
+        assert_eq!(region.as_deref(), Some("eu-west-1"));
+    }
+
+    #[test]
+    fn parse_aws_config_missing_credential_process() {
+        let config = "\
+[default]
+region=us-west-2
+";
+        let result = AwsCredentials::parse_aws_config(config, "default");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn parse_aws_config_ignores_comments() {
+        let config = "\
+[default]
+# credential_process=should-be-ignored
+; credential_process=also-ignored
+credential_process=real-command
+";
+        let result = AwsCredentials::parse_aws_config(config, "default");
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().0, "real-command");
+    }
+
+    #[test]
+    fn parse_aws_config_nonexistent_profile() {
+        let config = "\
+[default]
+credential_process=some-command
+";
+        let result = AwsCredentials::parse_aws_config(config, "nonexistent");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn from_credential_process_parses_json_output() {
+        // Verify config parsing + JSON shape by using `echo` as the command.
+        let config = "\
+[default]
+credential_process=echo '{\"Version\":1,\"AccessKeyId\":\"AKIA\",\"SecretAccessKey\":\"secret\",\"SessionToken\":\"tok\"}'
+region=ap-southeast-1
+";
+        let (cmd, region) = AwsCredentials::parse_aws_config(config, "default").unwrap();
+        assert!(cmd.starts_with("echo"));
+        assert_eq!(region.as_deref(), Some("ap-southeast-1"));
+
+        let output = std::process::Command::new("sh")
+            .args(["-c", &cmd])
+            .output()
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+        assert_eq!(json["AccessKeyId"].as_str(), Some("AKIA"));
+        assert_eq!(json["SecretAccessKey"].as_str(), Some("secret"));
+        assert_eq!(json["SessionToken"].as_str(), Some("tok"));
+    }
+
+    #[test]
+    fn env_vars_take_precedence_over_credential_process() {
+        let _env_lock = env_lock();
+        let _ak = EnvGuard::set("AWS_ACCESS_KEY_ID", Some("FROM_ENV"));
+        let _sk = EnvGuard::set("AWS_SECRET_ACCESS_KEY", Some("secret_from_env"));
+
+        let creds = AwsCredentials::from_env();
+        assert!(creds.is_ok());
+        assert_eq!(creds.unwrap().access_key_id, "FROM_ENV");
     }
 }

--- a/crates/zeroclaw-providers/src/bedrock.rs
+++ b/crates/zeroclaw-providers/src/bedrock.rs
@@ -1535,6 +1535,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
     async fn chat_fails_without_credentials() {
         let _env_lock = env_lock();
         let _ak = EnvGuard::set("AWS_ACCESS_KEY_ID", None);

--- a/crates/zeroclaw-providers/src/bedrock.rs
+++ b/crates/zeroclaw-providers/src/bedrock.rs
@@ -2230,4 +2230,91 @@ region=ap-southeast-1
         assert!(creds.is_ok());
         assert_eq!(creds.unwrap().access_key_id, "FROM_ENV");
     }
+
+    // ── credential cache tests ──────────────────────────────────
+
+    fn make_creds(expires_at: Option<chrono::DateTime<chrono::Utc>>) -> AwsCredentials {
+        AwsCredentials {
+            access_key_id: "AKIA".to_string(),
+            secret_access_key: "secret".to_string(),
+            session_token: Some("tok".to_string()),
+            region: "us-west-2".to_string(),
+            expires_at,
+        }
+    }
+
+    #[test]
+    fn is_expired_returns_false_when_no_expiry() {
+        let creds = make_creds(None);
+        assert!(!creds.is_expired());
+    }
+
+    #[test]
+    fn is_expired_returns_false_when_future() {
+        let future = chrono::Utc::now() + chrono::Duration::hours(1);
+        let creds = make_creds(Some(future));
+        assert!(!creds.is_expired());
+    }
+
+    #[test]
+    fn is_expired_returns_true_when_past() {
+        let past = chrono::Utc::now() - chrono::Duration::hours(1);
+        let creds = make_creds(Some(past));
+        assert!(creds.is_expired());
+    }
+
+    #[test]
+    fn is_expired_returns_true_within_skew_window() {
+        // 30 seconds from now is within the 60s skew — should be treated as expired.
+        let soon = chrono::Utc::now() + chrono::Duration::seconds(30);
+        let creds = make_creds(Some(soon));
+        assert!(creds.is_expired());
+    }
+
+    #[test]
+    fn cached_credentials_returns_none_when_empty() {
+        let provider = BedrockProvider {
+            auth: None,
+            max_tokens: zeroclaw_api::provider::BASELINE_MAX_TOKENS,
+            cred_cache: Mutex::new(None),
+        };
+        assert!(provider.cached_credentials().is_none());
+    }
+
+    #[test]
+    fn cached_credentials_returns_some_when_valid() {
+        let future = chrono::Utc::now() + chrono::Duration::hours(1);
+        let provider = BedrockProvider {
+            auth: None,
+            max_tokens: zeroclaw_api::provider::BASELINE_MAX_TOKENS,
+            cred_cache: Mutex::new(Some(make_creds(Some(future)))),
+        };
+        let cached = provider.cached_credentials();
+        assert!(cached.is_some());
+        assert_eq!(cached.unwrap().access_key_id, "AKIA");
+    }
+
+    #[test]
+    fn cached_credentials_returns_none_when_expired() {
+        let past = chrono::Utc::now() - chrono::Duration::hours(1);
+        let provider = BedrockProvider {
+            auth: None,
+            max_tokens: zeroclaw_api::provider::BASELINE_MAX_TOKENS,
+            cred_cache: Mutex::new(Some(make_creds(Some(past)))),
+        };
+        assert!(provider.cached_credentials().is_none());
+    }
+
+    #[test]
+    fn cache_credentials_stores_and_retrieves() {
+        let future = chrono::Utc::now() + chrono::Duration::hours(1);
+        let provider = BedrockProvider {
+            auth: None,
+            max_tokens: zeroclaw_api::provider::BASELINE_MAX_TOKENS,
+            cred_cache: Mutex::new(None),
+        };
+        assert!(provider.cached_credentials().is_none());
+        provider.cache_credentials(&make_creds(Some(future)));
+        assert!(provider.cached_credentials().is_some());
+    }
 }

--- a/crates/zeroclaw-providers/src/bedrock.rs
+++ b/crates/zeroclaw-providers/src/bedrock.rs
@@ -679,6 +679,23 @@ impl BedrockProvider {
         format!("/model/{encoded}/converse")
     }
 
+    /// Check the credential cache for unexpired credentials.
+    fn cached_credentials(&self) -> Option<AwsCredentials> {
+        let cache = self.cred_cache.lock().ok()?;
+        let creds = cache.as_ref()?;
+        if creds.is_expired() {
+            return None;
+        }
+        Some(creds.clone())
+    }
+
+    /// Store credentials in the cache.
+    fn cache_credentials(&self, creds: &AwsCredentials) {
+        if let Ok(mut cache) = self.cred_cache.lock() {
+            *cache = Some(creds.clone());
+        }
+    }
+
     /// Resolve auth: use cached if available, otherwise try env vars then IMDS.
     async fn resolve_auth(&self) -> anyhow::Result<BedrockAuth> {
         // If we already have auth cached, re-resolve from the same source.
@@ -688,12 +705,8 @@ impl BedrockProvider {
                     return Ok(BedrockAuth::BearerToken(token.clone()));
                 }
                 BedrockAuth::SigV4(_) => {
-                    // Check credential cache before re-resolving.
-                    if let Ok(cache) = self.cred_cache.lock()
-                        && let Some(ref creds) = *cache
-                        && !creds.is_expired()
-                    {
-                        return Ok(BedrockAuth::SigV4(creds.clone()));
+                    if let Some(creds) = self.cached_credentials() {
+                        return Ok(BedrockAuth::SigV4(creds));
                     }
                 }
             }
@@ -707,10 +720,7 @@ impl BedrockProvider {
             return Ok(BedrockAuth::SigV4(creds));
         }
         if let Ok(creds) = AwsCredentials::from_credential_process() {
-            // Cache the credentials for reuse.
-            if let Ok(mut cache) = self.cred_cache.lock() {
-                *cache = Some(creds.clone());
-            }
+            self.cache_credentials(&creds);
             return Ok(BedrockAuth::SigV4(creds));
         }
         Ok(BedrockAuth::SigV4(AwsCredentials::from_imds().await?))


### PR DESCRIPTION
The Bedrock provider previously resolved AWS credentials only from environment variables or EC2 IMDSv2, which fails on developer machines where credentials are managed via `credential_process` in `~/.aws/config`.

Add `credential_process` support to the SigV4 credential resolution chain, slotting between env vars and IMDS. The implementation reads `~/.aws/config`, executes the configured command, and parses the JSON output per the [AWS credential_process spec](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html). Credentials are cached in memory and refreshed based on the `Expiration` field.

Resolution chain (in order):
1. `BEDROCK_API_KEY` env var (bearer token)
2. `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` env vars
3. `~/.aws/config` `credential_process` (new)
4. EC2 IMDSv2

Implemented without the AWS SDK for Rust — no new dependencies added. Uses a minimal hand-rolled INI parser and `std::process::Command`.

Includes 7 new tests and fixes the existing `chat_fails_without_credentials` test to account for the new path.

## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Added `parse_aws_config()` INI parser and `from_credential_process()` to `AwsCredentials` — enables developer machines using `credential_process` for auth
  - Added `Mutex<Option<AwsCredentials>>` credential cache with `Expiration`-based refresh — avoids subprocess overhead on every API request
  - Updated `resolve()`, `new()`, and `resolve_auth()` to include `credential_process` in the resolution chain
  - Fixed `chat_fails_without_credentials` test — env guards now cover the full test lifetime and block `credential_process` path
- **Scope boundary:** Does not add AWS SDK dependency. Does not implement `~/.aws/credentials` file parsing or SSO token flow. Windows `cmd /C` support deferred to follow-up.
- **Blast radius:** `crates/zeroclaw-providers/src/bedrock.rs` only. No other providers or subsystems affected.
- **Linked issue(s):** None

## Validation Evidence (required)

- **Commands run and tail output:**

```
$ cargo fmt --all -- --check
(no output — clean)

$ cargo clippy --all-targets -- -D warnings
(clean after collapsible_if fix)

$ cargo test -p zeroclaw-providers bedrock
test result: ok. 64 passed; 0 failed; 0 ignored; 0 measured; 726 filtered out

$ cargo run -- agent
(verified credential_process loads credentials, cache hit on subsequent requests — no repeated "Loaded AWS credentials" log lines)
```

- **Beyond CI — what did you manually verify?** Ran interactive `zeroclaw agent` session with no AWS env vars set, confirmed credentials resolved via `credential_process`, confirmed cache prevents repeated subprocess calls on subsequent requests.
- **If any command was intentionally skipped, why:** `./dev/ci.sh all` not run — full workspace build takes significant time; targeted provider tests cover the change.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **Yes** — reads `~/.aws/config` (or `$AWS_CONFIG_FILE`). Same trust model as AWS CLI/SDK; file is user-owned.
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **Yes** — credentials from `credential_process` are cached in memory (`Mutex<Option<AwsCredentials>>`). Same lifetime as the process. No disk persistence.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility (required)

- Backward compatible? **Yes** — additive change; existing env var and IMDS paths are untouched.
- Config / env / CLI surface changed? **No** — respects existing `AWS_CONFIG_FILE`, `AWS_PROFILE`, `AWS_REGION` env vars per AWS spec.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk: `git revert <sha>` is the plan.
