### PR TITLE
fix: recover 4 small fixes lost in bulk revert c3ff635

### DIFF
--- a/crates/zeroclaw-channels/src/mattermost.rs
+++ b/crates/zeroclaw-channels/src/mattermost.rs
@@ -79,9 +79,11 @@ impl MattermostChannel {
     }
 
     fn http_client(&self) -> reqwest::Client {
-        zeroclaw_config::schema::build_channel_proxy_client(
+        zeroclaw_config::schema::build_channel_proxy_client_with_timeouts(
             "channel.mattermost",
             self.proxy_url.as_deref(),
+            30,
+            10,
         )
     }
 

--- a/crates/zeroclaw-runtime/src/heartbeat/engine.rs
+++ b/crates/zeroclaw-runtime/src/heartbeat/engine.rs
@@ -325,14 +325,18 @@ impl HeartbeatEngine {
 
     /// Build the Phase 1 LLM decision prompt for two-phase heartbeat.
     pub fn build_decision_prompt(tasks: &[HeartbeatTask]) -> String {
-        let mut prompt = String::from(
+        let now = chrono::Utc::now();
+        let mut prompt = format!(
             "You are a heartbeat scheduler. Review the following periodic tasks and decide \
              whether any should be executed right now.\n\n\
+             Current time: {} UTC ({})\n\n\
              Consider:\n\
              - Task priority (high tasks are more urgent)\n\
              - Whether the task is time-sensitive or can wait\n\
              - Whether running the task now would provide value\n\n\
              Tasks:\n",
+            now.format("%Y-%m-%d %H:%M:%S"),
+            now.format("%A"),
         );
 
         for (i, task) in tasks.iter().enumerate() {
@@ -585,6 +589,10 @@ mod tests {
         assert!(prompt.contains("2. [medium] Review calendar"));
         assert!(prompt.contains("skip"));
         assert!(prompt.contains("run:"));
+        assert!(
+            prompt.contains("Current time:"),
+            "prompt must include current datetime for time-sensitive decisions"
+        );
     }
 
     #[test]

--- a/crates/zeroclaw-runtime/src/security/bubblewrap.rs
+++ b/crates/zeroclaw-runtime/src/security/bubblewrap.rs
@@ -45,6 +45,15 @@ impl Sandbox for BubblewrapSandbox {
             "--ro-bind",
             "/usr",
             "/usr",
+            "--ro-bind",
+            "/usr/local",
+            "/usr/local",
+            "--ro-bind",
+            "/bin",
+            "/bin",
+            "--ro-bind",
+            "/sbin",
+            "/sbin",
             "--dev",
             "/dev",
             "--proc",
@@ -170,6 +179,19 @@ mod tests {
         assert!(
             args.contains(&"--ro-bind".to_string()),
             "must include read-only bind for /usr"
+        );
+        assert!(args.contains(&"/usr".to_string()), "must include /usr bind");
+        assert!(
+            args.contains(&"/usr/local".to_string()),
+            "must include /usr/local bind for tools like python3"
+        );
+        assert!(
+            args.contains(&"/bin".to_string()),
+            "must include /bin bind for core system tools"
+        );
+        assert!(
+            args.contains(&"/sbin".to_string()),
+            "must include /sbin bind for system administration tools"
         );
         assert!(
             args.contains(&"--dev".to_string()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1478,7 +1478,8 @@ async fn main() -> Result<()> {
                     info!("🔄 Restarting ZeroClaw Gateway on {addr}");
 
                     // Try to gracefully shutdown existing gateway via admin endpoint
-                    match shutdown_gateway(&host, port).await {
+                    match shutdown_gateway(&host, port, config.gateway.path_prefix.as_deref()).await
+                    {
                         Ok(()) => {
                             info!("   ✓ Existing gateway on {addr} shut down gracefully");
                             // Poll until the port is free (connection refused) or timeout
@@ -2649,8 +2650,9 @@ fn log_gateway_start(host: &str, port: u16) {
 
 /// Gracefully shutdown a running gateway via the admin endpoint.
 #[cfg(feature = "agent-runtime")]
-async fn shutdown_gateway(host: &str, port: u16) -> Result<()> {
-    let url = format!("http://{host}:{port}/admin/shutdown");
+async fn shutdown_gateway(host: &str, port: u16, path_prefix: Option<&str>) -> Result<()> {
+    let prefix = path_prefix.unwrap_or("");
+    let url = format!("http://{host}:{port}{prefix}/admin/shutdown");
     let client = reqwest::Client::new();
 
     match client

--- a/src/main.rs
+++ b/src/main.rs
@@ -1515,7 +1515,9 @@ async fn main() -> Result<()> {
 
                     // Fetch live pairing code from running gateway
                     // If --new is specified, generate a fresh pairing code
-                    match fetch_paircode(host, port, new).await {
+                    match fetch_paircode(host, port, config.gateway.path_prefix.as_deref(), new)
+                        .await
+                    {
                         Ok(Some(code)) => {
                             println!("🔐 Gateway pairing is enabled.");
                             println!();
@@ -2651,8 +2653,7 @@ fn log_gateway_start(host: &str, port: u16) {
 /// Gracefully shutdown a running gateway via the admin endpoint.
 #[cfg(feature = "agent-runtime")]
 async fn shutdown_gateway(host: &str, port: u16, path_prefix: Option<&str>) -> Result<()> {
-    let prefix = path_prefix.unwrap_or("");
-    let url = format!("http://{host}:{port}{prefix}/admin/shutdown");
+    let url = gateway_admin_url(host, port, path_prefix, "/admin/shutdown");
     let client = reqwest::Client::new();
 
     match client
@@ -2673,12 +2674,17 @@ async fn shutdown_gateway(host: &str, port: u16, path_prefix: Option<&str>) -> R
 /// Fetch the current pairing code from a running gateway.
 /// If `new` is true, generates a fresh pairing code via POST request.
 #[cfg(feature = "agent-runtime")]
-async fn fetch_paircode(host: &str, port: u16, new: bool) -> Result<Option<String>> {
+async fn fetch_paircode(
+    host: &str,
+    port: u16,
+    path_prefix: Option<&str>,
+    new: bool,
+) -> Result<Option<String>> {
     let client = reqwest::Client::new();
 
     let response = if new {
         // Generate a new pairing code via POST
-        let url = format!("http://{host}:{port}/admin/paircode/new");
+        let url = gateway_admin_url(host, port, path_prefix, "/admin/paircode/new");
         client
             .post(&url)
             .timeout(std::time::Duration::from_secs(5))
@@ -2686,7 +2692,7 @@ async fn fetch_paircode(host: &str, port: u16, new: bool) -> Result<Option<Strin
             .await
     } else {
         // Get existing pairing code via GET
-        let url = format!("http://{host}:{port}/admin/paircode");
+        let url = gateway_admin_url(host, port, path_prefix, "/admin/paircode");
         client
             .get(&url)
             .timeout(std::time::Duration::from_secs(5))
@@ -2716,6 +2722,12 @@ async fn fetch_paircode(host: &str, port: u16, new: bool) -> Result<Option<Strin
         .get("pairing_code")
         .and_then(|v| v.as_str())
         .map(String::from))
+}
+
+#[cfg(feature = "agent-runtime")]
+fn gateway_admin_url(host: &str, port: u16, path_prefix: Option<&str>, admin_path: &str) -> String {
+    let prefix = path_prefix.unwrap_or("");
+    format!("http://{host}:{port}{prefix}{admin_path}")
 }
 
 // ─── Generic Pending OAuth Login ────────────────────────────────────────────
@@ -3457,6 +3469,24 @@ mod tests {
         assert!(
             has_model_flag,
             "onboard help should include --model for quick setup overrides"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "agent-runtime")]
+    fn gateway_admin_url_uses_unprefixed_admin_path_by_default() {
+        assert_eq!(
+            gateway_admin_url("127.0.0.1", 42617, None, "/admin/paircode"),
+            "http://127.0.0.1:42617/admin/paircode"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "agent-runtime")]
+    fn gateway_admin_url_prepends_configured_path_prefix() {
+        assert_eq!(
+            gateway_admin_url("localhost", 42617, Some("/zeroclaw"), "/admin/paircode/new"),
+            "http://localhost:42617/zeroclaw/admin/paircode/new"
         );
     }
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Recovers 4 small fixes lost in bulk revert c3ff635. All are mechanical ports from the old `src/` layout to the current `crates/` structure, with the gateway admin CLI recovery extended to cover the sibling `get-paircode` path-prefix case from the same original fix area. Each fix is kept as a narrow subsystem change with `Co-authored-by` trailers for the original author where carried forward.
- **Scope boundary:** Four independent small fixes. No new features, no architectural changes, no credential handling changes, and no public API surface changes beyond making existing gateway admin CLI commands respect an existing `path_prefix` config.
- **Blast radius:** Narrow behavior fixes across separate subsystems: sandbox bind paths, Mattermost HTTP timeout behavior, heartbeat scheduler prompt context, and gateway admin CLI URL construction. The fixes do not share runtime state.
- **Risk:** `risk: high` because this restores read-only sandbox bind paths under `crates/zeroclaw-runtime/src/security/bubblewrap.rs`. Labels are applied: `risk: high`, `risk: manual`, `size: S`, and the matching scope/module labels.
- **Linked issue(s):** Tracked in #6074.

### Recovered fixes

| Commit | Original PR | Fix | Original author |
|--------|-------------|-----|-----------------|
| `3e0a08c1` | #4341 | Add `/usr/local`, `/bin`, `/sbin` read-only bind paths to bubblewrap sandbox | @linyibin |
| `8c3c890c` | #4635 | Add 30s/10s timeout to Mattermost HTTP client to avoid unbounded upstream waits | @linyibin |
| `babe7f1e` | #4554 | Inject current UTC datetime into scheduler decision prompt | @rareba |
| `df43e516` + follow-up | #4555 | Respect `path_prefix` in gateway shutdown, extended in this PR to the sibling `get-paircode` admin paths | @rareba |

## Validation Evidence (required)

- **Commands run and tail output:**

**Note:** CI is green on head commit `2548f9435` after the trailer-only privacy scrub. The final local `cargo clippy -p zeroclawlabs --all-targets` and `gateway_admin_url` test below cover the final intended branch state.

```bash
$ cargo fmt --all -- --check
(clean)

$ cargo clippy -p zeroclaw-runtime -p zeroclaw-channels -- -D warnings
Finished dev profile in 8m43s (no warnings)

$ cargo check -p zeroclawlabs
Finished dev profile in 13m04s (main.rs path_prefix change compiles)

$ cargo test -p zeroclaw-runtime -- decision_prompt_includes_all_tasks
test result: ok. 1 passed; 0 failed (new "Current time:" assertion passes)

$ cargo test -p zeroclawlabs gateway_admin_url
test result: ok. 2 passed; 0 failed (gateway admin URL helper covers unprefixed and prefixed paths)

$ cargo clippy -p zeroclawlabs --all-targets -- -D warnings
Finished dev profile in 14m24s (no warnings)

$ cargo test -p zeroclaw-runtime --features sandbox-bubblewrap bubblewrap_wrap_command_binds_required_paths
test security::bubblewrap::tests::bubblewrap_wrap_command_binds_required_paths ... ok
test result: ok. 1 passed; 0 failed; 1583 filtered out
```

- **Beyond CI — what did you manually verify?** I traced each restored fix against the current module layout and checked that the gateway admin helper is shared by shutdown, existing paircode fetch, and new paircode generation. The feature-gated bubblewrap unit test now covers the restored read-only bind paths locally. Mattermost timeout is a one-line swap to an existing timeout-enabled helper already used by Slack. The earlier runtime/channel clippy and root `cargo check` runs predate the follow-up paircode commit, but final `cargo clippy -p zeroclawlabs --all-targets`, `cargo test -p zeroclawlabs gateway_admin_url`, and the feature-gated bubblewrap test passed against the final intended branch state.
- **If any command was intentionally skipped, why:** Full `cargo test` was not run locally because the focused root test harness already took 31m22s on this machine and this PR is still covered by CI. The local checks above cover formatting, the changed runtime/channel crates, root CLI compilation, the heartbeat prompt assertion, and the new gateway admin URL helper.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **Yes (bubblewrap fix)** — restores `/usr/local`, `/bin`, and `/sbin` as read-only bind mounts inside the sandbox so commands can resolve common system-tool paths. The mounts are read-only, so sandboxed processes cannot modify those paths.
- New external network calls? **No.** The Mattermost change adds client timeouts to existing outbound calls; it does not add a new destination or call path.
- Secrets / tokens / credentials handling changed? **No.**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No.**
- If any `Yes`, describe the risk and mitigation: The sandbox bind-path change broadens read-only visibility for standard system binary locations, restoring the behavior from the superseded fix. The mitigation is that the paths are read-only and remain within the existing bubblewrap sandbox policy.

## Compatibility (required)

- Backward compatible? **Yes.** Existing configs and commands continue to work; `gateway path_prefix` now applies consistently to gateway admin CLI calls that already target gateway admin endpoints.
- Config / env / CLI surface changed? **No.** No new flags, config keys, or environment variables are introduced.
- If `No` or `Yes` to either: No user action required.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** For this high-risk recovery batch, `git revert <merge-commit>` reverts the whole PR, or revert the individual recovery commit that causes trouble.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Sandbox regression would appear as command/tool failures resolving system binaries. Mattermost regression would appear as delayed or failed webhook/channel HTTP responses. Heartbeat regression would appear in scheduler decision prompt content. Gateway regression would appear as `zeroclaw gateway shutdown` or `zeroclaw gateway get-paircode` failing behind a configured `gateway.path_prefix`.

## Supersede Attribution

- **Superseded PRs + authors:** #4341 by @linyibin; #4635 by @linyibin; #4554 by @rareba; #4555 by @rareba.
- **Scope materially carried forward:** Yes. Each recovered fix is ported to the current layout with only the changes needed for the modern module structure. The paircode path-prefix coverage is a small follow-up extension to the same gateway admin CLI fix area from #4555.
- **`Co-authored-by` trailers added in commit messages for incorporated contributors?** Yes, on every carried-forward commit.
