### PR TITLE
fix(xtask): resolve real mdbook binary, avoid xtask self-spawn

### DIFF
--- a/xtask/src/cmd/mdbook/build.rs
+++ b/xtask/src/cmd/mdbook/build.rs
@@ -34,9 +34,10 @@ pub fn build_locales(root: &std::path::Path) -> anyhow::Result<()> {
             .join(" ")
     );
     inject_lang_switcher_locales(&book, &entries)?;
+    let mdbook = mdbook_program()?;
     for entry in &entries {
         run_cmd(
-            Command::new("mdbook")
+            Command::new(&mdbook)
                 .args(["build", "-d", &format!("book/{}", entry.code)])
                 .env("MDBOOK_BOOK__LANGUAGE", &entry.code)
                 .current_dir(&book),

--- a/xtask/src/cmd/mdbook/serve.rs
+++ b/xtask/src/cmd/mdbook/serve.rs
@@ -66,7 +66,7 @@ pub fn run(locale: Option<&str>) -> anyhow::Result<()> {
     crate::cmd::mdbook::build::assemble(&root)?;
 
     // Watch the active locale for live-reload (rebuilds book/{locale}/ on change)
-    let mut watch = Command::new("mdbook")
+    let mut watch = Command::new(mdbook_program()?)
         .args(["watch", "-d", &format!("book/{watch_locale}")])
         .env("MDBOOK_BOOK__LANGUAGE", &watch_locale)
         .current_dir(&book)
@@ -133,7 +133,7 @@ pub fn run(locale: Option<&str>) -> anyhow::Result<()> {
 
 fn build_one_locale(book: &Path, locale: &str) -> anyhow::Result<()> {
     run_cmd(
-        Command::new("mdbook")
+        Command::new(mdbook_program()?)
             .args(["build", "-d", &format!("book/{locale}")])
             .env("MDBOOK_BOOK__LANGUAGE", locale)
             .current_dir(book),

--- a/xtask/src/cmd/mdbook/sync.rs
+++ b/xtask/src/cmd/mdbook/sync.rs
@@ -27,7 +27,7 @@ pub fn run(
     // Step 1: extract English msgids
     println!("==> Extracting English msgids → {}", pot.display());
     run_cmd(
-        Command::new("mdbook")
+        Command::new(mdbook_program()?)
             .args(["build", "-d", "po-extract"])
             .env("MDBOOK_OUTPUT__XGETTEXT__POT_FILE", "messages.pot")
             .current_dir(&book),

--- a/xtask/src/util.rs
+++ b/xtask/src/util.rs
@@ -77,6 +77,36 @@ fn tool_on_path(cmd: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Resolve the real `mdbook` binary on PATH, skipping the xtask's own build dir.
+/// The xtask itself is named `mdbook`; Cargo prepends `target/debug` and
+/// `target/debug/deps` to PATH for `cargo run`, and on Windows `Command::new`
+/// also searches the parent process's directory first — so without this guard
+/// the xtask would recursively spawn itself.
+pub fn mdbook_program() -> anyhow::Result<PathBuf> {
+    let exclude = std::env::current_exe()
+        .ok()
+        .and_then(|p| p.parent().map(Path::to_owned))
+        .and_then(|p| std::fs::canonicalize(&p).ok());
+    let paths = std::env::var_os("PATH")
+        .ok_or_else(|| anyhow::anyhow!("PATH environment variable is unset"))?;
+    for dir in std::env::split_paths(&paths) {
+        if let (Some(ex), Ok(canon)) = (exclude.as_deref(), std::fs::canonicalize(&dir))
+            && canon.starts_with(ex)
+        {
+            continue;
+        }
+        for name in ["mdbook", "mdbook.exe"] {
+            let candidate = dir.join(name);
+            if candidate.is_file() {
+                return Ok(candidate);
+            }
+        }
+    }
+    anyhow::bail!(
+        "'mdbook' not found on PATH\n  install: cargo install mdbook --version 0.5.0 --locked"
+    )
+}
+
 pub fn run_cmd(cmd: &mut Command) -> anyhow::Result<()> {
     let status = cmd.status()?;
     if !status.success() {


### PR DESCRIPTION
## Summary
The xtask binary is itself named `mdbook`, so `Command::new("mdbook")` from inside the xtask could resolve back to the xtask exe and recursively spawn itself.

Two contributors:
- Cargo prepends `target/debug` and `target/debug/deps` to `PATH` for `cargo run`, so the xtask's own build dir is on `PATH`.
- On Windows, `CreateProcess` *also* searches the parent process's directory before consulting `PATH`, so the xtask exe is found regardless of `PATH` ordering — Windows users hit this every time.

Introduces `util::mdbook_program()` which walks `PATH` manually, canonicalizes each entry, skips the xtask's own directory, and tries both `mdbook` and `mdbook.exe`. `build`, `serve`, and `sync` now resolve the real binary through this helper.

## Test plan
- [ ] `cargo xtask mdbook build` succeeds and invokes the upstream `mdbook`
- [ ] `cargo xtask mdbook serve` rebuilds on file change without recursion
- [ ] `cargo xtask mdbook sync --batch 1 --provider ollama` runs end-to-end
- [ ] Verified on Windows (where the bug reproduced); spot-check on Linux/macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)