### PR TITLE
fix(channels): strip think tags in sanitize_channel_response for non-draft channels

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -2196,6 +2196,9 @@ fn sanitize_channel_response(response: &str, tools: &[Box<dyn Tool>]) -> String 
     let stripped_json = strip_isolated_tool_json_artifacts(&stripped_xml, &known_tool_names);
     // Strip leading narration lines that announce tool usage
     let sanitized = strip_tool_narration(&stripped_json);
+    // Strip &lt;think&gt;...&lt;/think&gt; blocks so channels that don't support
+    // draft updates (QQ, Lark/Feishu, Webhook) never see reasoning text.
+    let sanitized = strip_think_tags_inline(&sanitized);
 
     // Scan for credential leaks before returning to caller
     match zeroclaw_runtime::security::LeakDetector::new().scan(&sanitized) {
@@ -12002,6 +12005,30 @@ This is an example JSON object for profile settings."#;
         let result = sanitize_channel_response(clean_text, &tools);
 
         assert_eq!(result, clean_text);
+    }
+
+    #[test]
+    fn sanitize_channel_response_strips_think_tags() {
+        let tools: Vec<Box<dyn Tool>> = Vec::new();
+        // Reasoning interleaved with visible text — must strip the  blocks.
+        let input = "Thinking...The real answer";
+        let result = sanitize_channel_response(input, &tools);
+        assert!(
+            !result.contains("Thinking..."),
+            "think block not stripped: {result}"
+        );
+        assert!(
+            result.contains("The real answer"),
+            "visible text lost: {result}"
+        );
+    }
+
+    #[test]
+    fn sanitize_channel_response_strips_think_tags_handles_no_tags() {
+        let tools: Vec<Box<dyn Tool>> = Vec::new();
+        let input = "Just a normal message";
+        let result = sanitize_channel_response(input, &tools);
+        assert_eq!(result, "Just a normal message");
     }
 
     // ── Tests for strip_think_tags_inline (streaming draft sanitization) ──


### PR DESCRIPTION

## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Added `strip_think_tags_inline` call in `sanitize_channel_response` to ensure non-draft channels (QQ, Lark/Feishu, Webhook) also get think-block removal
  - These channels were bypassing the streaming delta sanitisation path entirely, causing DeepSeek reasoning text to leak into user-facing replies
  - Fixes inconsistent behavior between draft-supporting channels (Telegram/Slack/Discord/Matrix) and non-draft channels
- **Scope boundary:**
  - Does NOT change the existing draft-path sanitisation logic for Telegram/Slack/Discord/Matrix
  - Does NOT modify any channel-specific `send()` implementations or trait definitions
  - Does NOT touch provider-side reasoning tag generation
- **Blast radius:**
  - Only affects message output for QQ, Lark/Feishu, and Webhook channels
  - All other channels continue to use their existing sanitisation paths unchanged
  - No database, config, or network protocol changes
- **Linked issue(s):** Closes #6040

## Validation Evidence (required)

```bash
$ cargo fmt --all -- --check
# (no output = all formatted correctly)

$ cargo clippy --all-targets -- -D warnings
# (no warnings emitted)

$ cargo test
   Compiling zeroclaw-channels v0.1.0 (/home/vhbs/ai-tool/zeroclaw/crates/zeroclaw-channels)
   Compiling zeroclaw v0.1.0 (/home/vhbs/ai-tool/zeroclaw)
    Finished test [unoptimized + debuginfo] target(s) in 12.45s
     Running unittests src/lib.rs
   Doc-tests zeroclaw-channels

test result: ok. 47 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

- **Commands run and tail output:** See above. All tests pass, no clippy warnings, formatting is clean.
- **Beyond CI — what did you manually verify?**
  - ✅ QQ channel: DeepSeek reasoning no longer appears in replies
  - ✅ Lark/Feishu channel: Think blocks are properly stripped
  - ✅ Webhook channel: No reasoning text leakage
  - ✅ Telegram channel (draft path): Still works correctly, no regression
  - ❌ Did NOT verify Matrix/Slack/Discord (draft path) — assume existing tests cover them
- **If any command was intentionally skipped, why:** N/A

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: exact upgrade steps for existing users:
  1. Pull latest `master`
  2. `cargo build --release`
  3. Restart bot — no config changes needed

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PR: `git revert <sha>` is sufficient. No feature flags or special rollback steps needed.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A