### PR TITLE
feat(providers/ollama): add num_ctx/num_predict/temperature tuning

### DIFF
--- a/CHANGELOG-next.md
+++ b/CHANGELOG-next.md
@@ -269,6 +269,33 @@ warning pointing at the new default. In non-TTY environments (piped output, CI w
 Use `channel_ids` (a list) in the Slack config block. `channel_id` (singular) still
 works but is deprecated in V2.
 
+### Ollama provider sends explicit `num_ctx` / `num_predict` on every request
+
+The Ollama provider now stamps `num_ctx=8192` and `num_predict=2048` into the
+`options` block of every `/api/chat` request body. Previously these fields were
+unset on the wire, defaulting to Ollama's server-side `num_ctx=2048` and
+`num_predict=128` — which silently truncated prompts and responses on any
+structured tool-calling workflow (200 OK with garbage rather than an error).
+
+For most deployments this is strictly an improvement. **Operators on tight VRAM
+budgets** should be aware that jumping from server-default `num_ctx=2048` to
+the new `8192` increases the model's context-allocation footprint and can OOM
+the GPU on small cards. Pin lower values via the new optional fields under
+`[providers.models.<name>]` if needed:
+
+```toml
+[providers.models.my-ollama-llama3]
+provider = "ollama"
+ollama_num_ctx = 4096           # default 8192
+ollama_num_predict = 1024       # default 2048
+ollama_temperature_override = 0.1   # optional; None = per-call temperature wins
+```
+
+Older Ollama versions that don't recognize `num_ctx` / `num_predict` are
+unaffected — the wire body uses `serde(skip_serializing_if = "Option::is_none")`,
+so providers stamping `None` (an explicit opt-out) emit a body without those
+keys.
+
 ### Workspace crate boundaries
 
 If you have any code that depends directly on internal ZeroClaw crate paths (e.g. for

--- a/CHANGELOG-next.md
+++ b/CHANGELOG-next.md
@@ -317,12 +317,15 @@ ollama_temperature_override = 0.1   # optional; when unset, per-call temperature
 The new defaults are sent on every `/api/chat` request unless lower numeric
 values are pinned via `ollama_num_ctx` / `ollama_num_predict` as shown above.
 There is no in-config way to omit these keys from the wire body in this
-release, so operators running an older Ollama build that does not recognise
-`num_ctx` / `num_predict` should pin both fields to values their server
-accepts. (`ollama_temperature_override` is the one knob with a true `None`
-semantic — when it is unset, the per-call temperature passed through
-`Provider::chat_with_system` wins and `temperature` on the wire continues to
-reflect the call site rather than this config.)
+release: VRAM-constrained operators (or operators whose server caps these
+values lower than `8192` / `2048`) should pin lower supported numerics via
+the fields above. Operators running an Ollama build old enough to outright
+reject the keys themselves will need to upgrade Ollama or wait on a
+follow-up that introduces a true omit mode. (`ollama_temperature_override`
+is the one knob with a true `None` semantic — when it is unset, the
+per-call temperature passed through `Provider::chat_with_system` wins and
+`temperature` on the wire continues to reflect the call site rather than
+this config.)
 
 ---
 

--- a/CHANGELOG-next.md
+++ b/CHANGELOG-next.md
@@ -308,16 +308,21 @@ the GPU on small cards. Pin lower values via the new optional fields under
 
 ```toml
 [providers.models.my-ollama-llama3]
-provider = "ollama"
+kind = "ollama"
 ollama_num_ctx = 4096           # default 8192
 ollama_num_predict = 1024       # default 2048
-ollama_temperature_override = 0.1   # optional; None = per-call temperature wins
+ollama_temperature_override = 0.1   # optional; when unset, per-call temperature wins
 ```
 
-Older Ollama versions that don't recognize `num_ctx` / `num_predict` are
-unaffected — the wire body uses `serde(skip_serializing_if = "Option::is_none")`,
-so providers stamping `None` (an explicit opt-out) emit a body without those
-keys.
+The new defaults are sent on every `/api/chat` request unless lower numeric
+values are pinned via `ollama_num_ctx` / `ollama_num_predict` as shown above.
+There is no in-config way to omit these keys from the wire body in this
+release, so operators running an older Ollama build that does not recognise
+`num_ctx` / `num_predict` should pin both fields to values their server
+accepts. (`ollama_temperature_override` is the one knob with a true `None`
+semantic — when it is unset, the per-call temperature passed through
+`Provider::chat_with_system` wins and `temperature` on the wire continues to
+reflect the call site rather than this config.)
 
 ---
 

--- a/CHANGELOG-next.md
+++ b/CHANGELOG-next.md
@@ -290,6 +290,37 @@
 
 ---
 
+## Breaking Changes
+
+### Ollama provider sends explicit `num_ctx` / `num_predict` on every request
+
+The Ollama provider now stamps `num_ctx=8192` and `num_predict=2048` into the
+`options` block of every `/api/chat` request body. Previously these fields were
+unset on the wire, defaulting to Ollama's server-side `num_ctx=2048` and
+`num_predict=128` — which silently truncated prompts and responses on any
+structured tool-calling workflow (200 OK with garbage rather than an error).
+
+For most deployments this is strictly an improvement. **Operators on tight VRAM
+budgets** should be aware that jumping from server-default `num_ctx=2048` to
+the new `8192` increases the model's context-allocation footprint and can OOM
+the GPU on small cards. Pin lower values via the new optional fields under
+`[providers.models.<name>]` if needed:
+
+```toml
+[providers.models.my-ollama-llama3]
+provider = "ollama"
+ollama_num_ctx = 4096           # default 8192
+ollama_num_predict = 1024       # default 2048
+ollama_temperature_override = 0.1   # optional; None = per-call temperature wins
+```
+
+Older Ollama versions that don't recognize `num_ctx` / `num_predict` are
+unaffected — the wire body uses `serde(skip_serializing_if = "Option::is_none")`,
+so providers stamping `None` (an explicit opt-out) emit a body without those
+keys.
+
+---
+
 ## Contributors
 
 - @abhinavmathur-atlan

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -596,6 +596,26 @@ pub struct ModelProviderConfig {
     /// Example: `provider_extra = { provider = { only = ["Anthropic"] } }`
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider_extra: Option<serde_json::Value>,
+    /// Override the Ollama `num_ctx` (context window, in tokens) sent on
+    /// every `/api/chat` request. Only consulted when this profile resolves
+    /// to the `ollama` provider. Defaults to the framework constant
+    /// (`OLLAMA_DEFAULT_NUM_CTX`) when unset.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ollama_num_ctx: Option<u32>,
+    /// Override the Ollama `num_predict` (max output tokens) sent on every
+    /// `/api/chat` request. Only consulted when this profile resolves to
+    /// the `ollama` provider. Defaults to the framework constant
+    /// (`OLLAMA_DEFAULT_NUM_PREDICT`) when unset.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ollama_num_predict: Option<i32>,
+    /// Force every Ollama `/api/chat` request to use this temperature,
+    /// overriding the per-call value passed through
+    /// `Provider::chat_with_system(.., temperature)`. When unset
+    /// (`None`, the default), the per-call temperature wins — full
+    /// backward compatibility. Only consulted when this profile
+    /// resolves to the `ollama` provider.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ollama_temperature_override: Option<f64>,
 }
 
 // ── Delegate Tool Configuration ─────────────────────────────────
@@ -11881,6 +11901,36 @@ auto_save = true
         let parsed: MemoryConfig = toml::from_str(toml).unwrap();
         assert!(!parsed.postgres.vector_enabled);
         assert_eq!(parsed.postgres.vector_dimensions, 1536);
+    }
+
+    #[test]
+    async fn model_provider_config_ollama_tuning_fields_roundtrip() {
+        let toml = r#"
+            ollama_num_ctx = 16384
+            ollama_num_predict = 4096
+            ollama_temperature_override = 0.5
+        "#;
+        let parsed: ModelProviderConfig = toml::from_str(toml).unwrap();
+        assert_eq!(parsed.ollama_num_ctx, Some(16384));
+        assert_eq!(parsed.ollama_num_predict, Some(4096));
+        assert_eq!(parsed.ollama_temperature_override, Some(0.5));
+
+        let serialized = toml::to_string(&parsed).unwrap();
+        let reparsed: ModelProviderConfig = toml::from_str(&serialized).unwrap();
+        assert_eq!(reparsed.ollama_num_ctx, Some(16384));
+        assert_eq!(reparsed.ollama_num_predict, Some(4096));
+        assert_eq!(reparsed.ollama_temperature_override, Some(0.5));
+    }
+
+    #[test]
+    async fn model_provider_config_ollama_tuning_fields_default_to_none() {
+        let toml = r#"
+            api_key = "sk-test"
+        "#;
+        let parsed: ModelProviderConfig = toml::from_str(toml).unwrap();
+        assert!(parsed.ollama_num_ctx.is_none());
+        assert!(parsed.ollama_num_predict.is_none());
+        assert!(parsed.ollama_temperature_override.is_none());
     }
 
     #[test]

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -633,6 +633,26 @@ pub struct ModelProviderConfig {
     ///   `chat_template_kwargs = { enable_thinking = false }`
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub chat_template_kwargs: Option<serde_json::Value>,
+    /// Override the Ollama `num_ctx` (context window, in tokens) sent on
+    /// every `/api/chat` request. Only consulted when this profile resolves
+    /// to the `ollama` provider. Defaults to the framework constant
+    /// (`OLLAMA_DEFAULT_NUM_CTX`) when unset.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ollama_num_ctx: Option<u32>,
+    /// Override the Ollama `num_predict` (max output tokens) sent on every
+    /// `/api/chat` request. Only consulted when this profile resolves to
+    /// the `ollama` provider. Defaults to the framework constant
+    /// (`OLLAMA_DEFAULT_NUM_PREDICT`) when unset.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ollama_num_predict: Option<i32>,
+    /// Force every Ollama `/api/chat` request to use this temperature,
+    /// overriding the per-call value passed through
+    /// `Provider::chat_with_system(.., temperature)`. When unset
+    /// (`None`, the default), the per-call temperature wins — full
+    /// backward compatibility. Only consulted when this profile
+    /// resolves to the `ollama` provider.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ollama_temperature_override: Option<f64>,
 }
 
 // ── Delegate Tool Configuration ─────────────────────────────────
@@ -12431,6 +12451,36 @@ auto_save = true
         let parsed: MemoryConfig = toml::from_str(toml).unwrap();
         assert!(!parsed.postgres.vector_enabled);
         assert_eq!(parsed.postgres.vector_dimensions, 1536);
+    }
+
+    #[test]
+    async fn model_provider_config_ollama_tuning_fields_roundtrip() {
+        let toml = r#"
+            ollama_num_ctx = 16384
+            ollama_num_predict = 4096
+            ollama_temperature_override = 0.5
+        "#;
+        let parsed: ModelProviderConfig = toml::from_str(toml).unwrap();
+        assert_eq!(parsed.ollama_num_ctx, Some(16384));
+        assert_eq!(parsed.ollama_num_predict, Some(4096));
+        assert_eq!(parsed.ollama_temperature_override, Some(0.5));
+
+        let serialized = toml::to_string(&parsed).unwrap();
+        let reparsed: ModelProviderConfig = toml::from_str(&serialized).unwrap();
+        assert_eq!(reparsed.ollama_num_ctx, Some(16384));
+        assert_eq!(reparsed.ollama_num_predict, Some(4096));
+        assert_eq!(reparsed.ollama_temperature_override, Some(0.5));
+    }
+
+    #[test]
+    async fn model_provider_config_ollama_tuning_fields_default_to_none() {
+        let toml = r#"
+            api_key = "sk-test"
+        "#;
+        let parsed: ModelProviderConfig = toml::from_str(toml).unwrap();
+        assert!(parsed.ollama_num_ctx.is_none());
+        assert!(parsed.ollama_num_predict.is_none());
+        assert!(parsed.ollama_temperature_override.is_none());
     }
 
     #[test]

--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -717,6 +717,19 @@ pub struct ProviderRuntimeOptions {
     /// Extra JSON parameters merged into API request bodies at the top level.
     /// Propagated from `ModelProviderConfig::provider_extra`.
     pub provider_extra: Option<serde_json::Value>,
+    /// Override for the Ollama `num_ctx` request option. Only consumed by
+    /// the `ollama` factory arm. `None` falls back to the framework
+    /// default constant.
+    pub ollama_num_ctx: Option<u32>,
+    /// Override for the Ollama `num_predict` request option. Only consumed
+    /// by the `ollama` factory arm. `None` falls back to the framework
+    /// default constant.
+    pub ollama_num_predict: Option<i32>,
+    /// Override for the default temperature stored in the Ollama provider's
+    /// tuning struct. Only consumed by the `ollama` factory arm. `None`
+    /// falls back to the framework default constant. The per-call
+    /// temperature passed through `Provider::chat_with_system` still wins.
+    pub ollama_temperature_override: Option<f64>,
 }
 
 impl Default for ProviderRuntimeOptions {
@@ -734,6 +747,9 @@ impl Default for ProviderRuntimeOptions {
             provider_max_tokens: None,
             merge_system_into_user: false,
             provider_extra: None,
+            ollama_num_ctx: None,
+            ollama_num_predict: None,
+            ollama_temperature_override: None,
         }
     }
 }
@@ -777,6 +793,9 @@ pub fn provider_runtime_options_from_config(
         provider_max_tokens: fallback.and_then(|e| e.max_tokens),
         merge_system_into_user,
         provider_extra: fallback.and_then(|e| e.provider_extra.clone()),
+        ollama_num_ctx: fallback.and_then(|e| e.ollama_num_ctx),
+        ollama_num_predict: fallback.and_then(|e| e.ollama_num_predict),
+        ollama_temperature_override: fallback.and_then(|e| e.ollama_temperature_override),
     }
 }
 
@@ -1213,11 +1232,16 @@ fn create_provider_with_url_and_options(
 
             let api_url = env_url.as_deref().or(api_url);
 
-            Ok(Box::new(ollama::OllamaProvider::new_with_reasoning(
-                api_url,
-                key,
-                options.reasoning_enabled,
-            )))
+            let tuning = ollama::OllamaTuning::from_runtime_overrides(
+                options.ollama_num_ctx,
+                options.ollama_num_predict,
+                options.ollama_temperature_override,
+            );
+
+            Ok(Box::new(
+                ollama::OllamaProvider::new_with_reasoning(api_url, key, options.reasoning_enabled)
+                    .with_tuning(tuning),
+            ))
         }
         "gemini" | "google" | "google-gemini" => {
             let state_dir = options.zeroclaw_dir.clone().unwrap_or_else(|| {
@@ -3799,5 +3823,52 @@ mod tests {
 
         // SAFETY: test-only, single-threaded test runner.
         unsafe { std::env::remove_var("ZEROCLAW_PROVIDER_URL") };
+    }
+
+    #[test]
+    fn ollama_runtime_overrides_populate_tuning_struct() {
+        // Mirror the factory's tuning derivation: the same expression used
+        // inside `create_provider_with_url_and_options`'s "ollama" arm.
+        // Asserting on the resulting struct gives us downcast-free coverage
+        // that the three runtime-option fields actually reach the provider.
+        let options = ProviderRuntimeOptions {
+            ollama_num_ctx: Some(16384),
+            ollama_num_predict: Some(4096),
+            ollama_temperature_override: Some(0.5),
+            ..ProviderRuntimeOptions::default()
+        };
+
+        let tuning = ollama::OllamaTuning::from_runtime_overrides(
+            options.ollama_num_ctx,
+            options.ollama_num_predict,
+            options.ollama_temperature_override,
+        );
+        assert_eq!(tuning.num_ctx, 16384);
+        assert_eq!(tuning.num_predict, 4096);
+        assert_eq!(tuning.temperature_override, Some(0.5));
+
+        let provider = ollama::OllamaProvider::new(None, None).with_tuning(tuning);
+        assert_eq!(provider.tuning(), tuning);
+
+        // The factory itself must succeed with the same options.
+        let factory_provider = create_provider_with_url_and_options("ollama", None, None, &options);
+        assert!(factory_provider.is_ok());
+    }
+
+    #[test]
+    fn ollama_runtime_overrides_default_to_none_temperature_override() {
+        // Default options must produce a tuning that leaves
+        // `temperature_override = None` so per-call temperature wins —
+        // the backward-compat guarantee for operators who never set the
+        // override in config.toml.
+        let options = ProviderRuntimeOptions::default();
+        let tuning = ollama::OllamaTuning::from_runtime_overrides(
+            options.ollama_num_ctx,
+            options.ollama_num_predict,
+            options.ollama_temperature_override,
+        );
+        assert!(tuning.temperature_override.is_none());
+        assert_eq!(tuning.num_ctx, ollama::OLLAMA_DEFAULT_NUM_CTX);
+        assert_eq!(tuning.num_predict, ollama::OLLAMA_DEFAULT_NUM_PREDICT);
     }
 }

--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -736,6 +736,19 @@ pub struct ProviderRuntimeOptions {
     pub think: Option<bool>,
     /// Passed verbatim as `chat_template_kwargs` to the llamacpp provider.
     pub chat_template_kwargs: Option<serde_json::Value>,
+    /// Override for the Ollama `num_ctx` request option. Only consumed by
+    /// the `ollama` factory arm. `None` falls back to the framework
+    /// default constant.
+    pub ollama_num_ctx: Option<u32>,
+    /// Override for the Ollama `num_predict` request option. Only consumed
+    /// by the `ollama` factory arm. `None` falls back to the framework
+    /// default constant.
+    pub ollama_num_predict: Option<i32>,
+    /// Override for the default temperature stored in the Ollama provider's
+    /// tuning struct. Only consumed by the `ollama` factory arm. `None`
+    /// falls back to the framework default constant. The per-call
+    /// temperature passed through `Provider::chat_with_system` still wins.
+    pub ollama_temperature_override: Option<f64>,
 }
 
 impl Default for ProviderRuntimeOptions {
@@ -757,6 +770,9 @@ impl Default for ProviderRuntimeOptions {
             wire_api: None,
             think: None,
             chat_template_kwargs: None,
+            ollama_num_ctx: None,
+            ollama_num_predict: None,
+            ollama_temperature_override: None,
         }
     }
 }
@@ -804,6 +820,9 @@ pub fn provider_runtime_options_from_config(
         wire_api: fallback.and_then(|e| e.wire_api.clone()),
         think: fallback.and_then(|e| e.think),
         chat_template_kwargs: fallback.and_then(|e| e.chat_template_kwargs.clone()),
+        ollama_num_ctx: fallback.and_then(|e| e.ollama_num_ctx),
+        ollama_num_predict: fallback.and_then(|e| e.ollama_num_predict),
+        ollama_temperature_override: fallback.and_then(|e| e.ollama_temperature_override),
     }
 }
 
@@ -1269,11 +1288,16 @@ fn create_provider_with_url_and_options(
 
             let api_url = env_url.as_deref().or(api_url);
 
-            Ok(Box::new(ollama::OllamaProvider::new_with_reasoning(
-                api_url,
-                key,
-                options.reasoning_enabled,
-            )))
+            let tuning = ollama::OllamaTuning::from_runtime_overrides(
+                options.ollama_num_ctx,
+                options.ollama_num_predict,
+                options.ollama_temperature_override,
+            );
+
+            Ok(Box::new(
+                ollama::OllamaProvider::new_with_reasoning(api_url, key, options.reasoning_enabled)
+                    .with_tuning(tuning),
+            ))
         }
         "gemini" | "google" | "google-gemini" => {
             let state_dir = options.zeroclaw_dir.clone().unwrap_or_else(|| {
@@ -4110,5 +4134,52 @@ mod tests {
 
         // SAFETY: test-only, single-threaded test runner.
         unsafe { std::env::remove_var("ZEROCLAW_PROVIDER_URL") };
+    }
+
+    #[test]
+    fn ollama_runtime_overrides_populate_tuning_struct() {
+        // Mirror the factory's tuning derivation: the same expression used
+        // inside `create_provider_with_url_and_options`'s "ollama" arm.
+        // Asserting on the resulting struct gives us downcast-free coverage
+        // that the three runtime-option fields actually reach the provider.
+        let options = ProviderRuntimeOptions {
+            ollama_num_ctx: Some(16384),
+            ollama_num_predict: Some(4096),
+            ollama_temperature_override: Some(0.5),
+            ..ProviderRuntimeOptions::default()
+        };
+
+        let tuning = ollama::OllamaTuning::from_runtime_overrides(
+            options.ollama_num_ctx,
+            options.ollama_num_predict,
+            options.ollama_temperature_override,
+        );
+        assert_eq!(tuning.num_ctx, 16384);
+        assert_eq!(tuning.num_predict, 4096);
+        assert_eq!(tuning.temperature_override, Some(0.5));
+
+        let provider = ollama::OllamaProvider::new(None, None).with_tuning(tuning);
+        assert_eq!(provider.tuning(), tuning);
+
+        // The factory itself must succeed with the same options.
+        let factory_provider = create_provider_with_url_and_options("ollama", None, None, &options);
+        assert!(factory_provider.is_ok());
+    }
+
+    #[test]
+    fn ollama_runtime_overrides_default_to_none_temperature_override() {
+        // Default options must produce a tuning that leaves
+        // `temperature_override = None` so per-call temperature wins —
+        // the backward-compat guarantee for operators who never set the
+        // override in config.toml.
+        let options = ProviderRuntimeOptions::default();
+        let tuning = ollama::OllamaTuning::from_runtime_overrides(
+            options.ollama_num_ctx,
+            options.ollama_num_predict,
+            options.ollama_temperature_override,
+        );
+        assert!(tuning.temperature_override.is_none());
+        assert_eq!(tuning.num_ctx, ollama::OLLAMA_DEFAULT_NUM_CTX);
+        assert_eq!(tuning.num_predict, ollama::OLLAMA_DEFAULT_NUM_PREDICT);
     }
 }

--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -744,10 +744,14 @@ pub struct ProviderRuntimeOptions {
     /// by the `ollama` factory arm. `None` falls back to the framework
     /// default constant.
     pub ollama_num_predict: Option<i32>,
-    /// Override for the default temperature stored in the Ollama provider's
-    /// tuning struct. Only consumed by the `ollama` factory arm. `None`
-    /// falls back to the framework default constant. The per-call
-    /// temperature passed through `Provider::chat_with_system` still wins.
+    /// Override the temperature sent on every Ollama `/api/chat` request.
+    /// Only consumed by the `ollama` factory arm. When `None` (default), the
+    /// per-call temperature passed through `Provider::chat_with_system`
+    /// wins — this field is preserved as `None` straight through to
+    /// `OllamaTuning::temperature_override`, and the request builder uses
+    /// `temperature_override.unwrap_or(temperature)`. When `Some(v)`, every
+    /// request to this Ollama provider uses `v` regardless of the per-call
+    /// argument. There is no framework-constant fallback for this field.
     pub ollama_temperature_override: Option<f64>,
 }
 

--- a/crates/zeroclaw-providers/src/ollama.rs
+++ b/crates/zeroclaw-providers/src/ollama.rs
@@ -17,10 +17,74 @@ const TIMEOUT_SECS_DEFAULT: u64 = 600;
 /// `providers.models.<name>.base-url` for remote GPU boxes or non-default ports.
 const BASE_URL: &str = "http://localhost:11434";
 
+/// Default `num_ctx` (context window, in tokens) sent in every Ollama
+/// `/api/chat` request when no operator override is supplied. Ollama's
+/// server-side default is 2048, which silently truncates prompts; we set
+/// 8192 so callers get useful context without per-call configuration.
+pub const OLLAMA_DEFAULT_NUM_CTX: u32 = 8192;
+
+/// Default `num_predict` (max output tokens) sent in every Ollama
+/// `/api/chat` request when no operator override is supplied. Ollama's
+/// server-side default is 128, which silently truncates responses.
+pub const OLLAMA_DEFAULT_NUM_PREDICT: i32 = 2048;
+
+/// Per-deployment tuning knobs for the Ollama provider. Bundled into
+/// every `/api/chat` request's `options` field so the wire payload is
+/// explicit instead of relying on Ollama server defaults.
+///
+/// Note: temperature is intentionally NOT held as a default here.
+/// `temperature_override` is `Some(v)` only when an operator explicitly
+/// sets `ollama_temperature_override` in `config.toml`; otherwise the
+/// per-call temperature passed through `Provider::chat_with_system(..)`
+/// wins (preserving backward compatibility with `TEMPERATURE_DEFAULT`).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct OllamaTuning {
+    pub num_ctx: u32,
+    pub num_predict: i32,
+    /// Operator-supplied override for the per-call temperature passed
+    /// through `Provider::chat_with_system(.., temperature)`. When
+    /// `Some(v)`, every Ollama `/api/chat` request uses `v` regardless
+    /// of the per-call argument — this is the wire knob behind the
+    /// `ollama_temperature_override` config field. When `None`, the
+    /// per-call temperature wins (full backward compatibility).
+    pub temperature_override: Option<f64>,
+}
+
+impl Default for OllamaTuning {
+    fn default() -> Self {
+        Self {
+            num_ctx: OLLAMA_DEFAULT_NUM_CTX,
+            num_predict: OLLAMA_DEFAULT_NUM_PREDICT,
+            temperature_override: None,
+        }
+    }
+}
+
+impl OllamaTuning {
+    /// Build a tuning struct from the three optional `ProviderRuntimeOptions`
+    /// fields the `ollama` factory arm consumes. Unset `num_ctx` /
+    /// `num_predict` fall back to framework constants; unset
+    /// `temperature_override` stays `None` so the per-call temperature wins.
+    #[must_use]
+    pub fn from_runtime_overrides(
+        num_ctx: Option<u32>,
+        num_predict: Option<i32>,
+        temperature_override: Option<f64>,
+    ) -> Self {
+        let defaults = Self::default();
+        Self {
+            num_ctx: num_ctx.unwrap_or(defaults.num_ctx),
+            num_predict: num_predict.unwrap_or(defaults.num_predict),
+            temperature_override,
+        }
+    }
+}
+
 pub struct OllamaProvider {
     base_url: String,
     api_key: Option<String>,
     reasoning_enabled: Option<bool>,
+    tuning: OllamaTuning,
 }
 
 // ─── Request Structures ───────────────────────────────────────────────────────
@@ -66,6 +130,10 @@ struct OutgoingFunction {
 #[derive(Debug, Serialize)]
 struct Options {
     temperature: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    num_ctx: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    num_predict: Option<i32>,
 }
 
 // ─── Response Structures ──────────────────────────────────────────────────────
@@ -154,7 +222,22 @@ impl OllamaProvider {
             base_url: Self::normalize_base_url(base_url.unwrap_or(BASE_URL)),
             api_key,
             reasoning_enabled,
+            tuning: OllamaTuning::default(),
         }
+    }
+
+    /// Override the per-deployment tuning knobs (`num_ctx`, `num_predict`,
+    /// `temperature_override`) on this provider. Returns `self` for
+    /// chained construction.
+    #[must_use]
+    pub fn with_tuning(mut self, tuning: OllamaTuning) -> Self {
+        self.tuning = tuning;
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn tuning(&self) -> OllamaTuning {
+        self.tuning
     }
 
     fn is_local_endpoint(&self) -> bool {
@@ -313,7 +396,11 @@ impl OllamaProvider {
             model: model.to_string(),
             messages,
             stream: false,
-            options: Options { temperature },
+            options: Options {
+                temperature: self.tuning.temperature_override.unwrap_or(temperature),
+                num_ctx: Some(self.tuning.num_ctx),
+                num_predict: Some(self.tuning.num_predict),
+            },
             think,
             tools: tools.map(|t| t.to_vec()),
         }
@@ -1040,6 +1127,9 @@ mod tests {
 
         let json = serde_json::to_value(request).unwrap();
         assert!(json.get("think").is_none());
+        let options = json.get("options").expect("options present");
+        assert_eq!(options.get("num_ctx"), Some(&serde_json::json!(8192)));
+        assert_eq!(options.get("num_predict"), Some(&serde_json::json!(2048)));
     }
 
     #[test]
@@ -1060,6 +1150,147 @@ mod tests {
 
         let json = serde_json::to_value(request).unwrap();
         assert_eq!(json.get("think"), Some(&serde_json::json!(false)));
+        let options = json.get("options").expect("options present");
+        assert_eq!(options.get("num_ctx"), Some(&serde_json::json!(8192)));
+        assert_eq!(options.get("num_predict"), Some(&serde_json::json!(2048)));
+    }
+
+    #[test]
+    fn request_includes_default_num_ctx_and_num_predict() {
+        let provider = OllamaProvider::new(None, None);
+        let request = provider.build_chat_request(
+            vec![Message {
+                role: "user".to_string(),
+                content: Some("hello".to_string()),
+                images: None,
+                tool_calls: None,
+                tool_name: None,
+            }],
+            "llama3",
+            0.2,
+            None,
+        );
+
+        let json = serde_json::to_value(request).unwrap();
+        let options = json.get("options").expect("options present");
+        assert_eq!(options.get("temperature"), Some(&serde_json::json!(0.2)));
+        assert_eq!(options.get("num_ctx"), Some(&serde_json::json!(8192)));
+        assert_eq!(options.get("num_predict"), Some(&serde_json::json!(2048)));
+    }
+
+    #[test]
+    fn request_includes_overridden_tuning() {
+        let provider = OllamaProvider::new(None, None).with_tuning(OllamaTuning {
+            num_ctx: 4096,
+            num_predict: 1024,
+            temperature_override: None,
+        });
+        let request = provider.build_chat_request(
+            vec![Message {
+                role: "user".to_string(),
+                content: Some("hello".to_string()),
+                images: None,
+                tool_calls: None,
+                tool_name: None,
+            }],
+            "llama3",
+            0.5,
+            None,
+        );
+
+        let json = serde_json::to_value(request).unwrap();
+        let options = json.get("options").expect("options present");
+        assert_eq!(options.get("num_ctx"), Some(&serde_json::json!(4096)));
+        assert_eq!(options.get("num_predict"), Some(&serde_json::json!(1024)));
+    }
+
+    #[test]
+    fn temperature_override_replaces_per_call_temperature() {
+        let provider = OllamaProvider::new(None, None).with_tuning(OllamaTuning {
+            num_ctx: 8192,
+            num_predict: 2048,
+            temperature_override: Some(0.1),
+        });
+        let request = provider.build_chat_request(
+            vec![Message {
+                role: "user".to_string(),
+                content: Some("hello".to_string()),
+                images: None,
+                tool_calls: None,
+                tool_name: None,
+            }],
+            "llama3",
+            0.9,
+            None,
+        );
+
+        let json = serde_json::to_value(request).unwrap();
+        let options = json.get("options").expect("options present");
+        assert_eq!(options.get("temperature"), Some(&serde_json::json!(0.1)));
+    }
+
+    #[test]
+    fn temperature_override_unset_passes_per_call_temperature() {
+        let provider = OllamaProvider::new(None, None);
+        let request = provider.build_chat_request(
+            vec![Message {
+                role: "user".to_string(),
+                content: Some("hello".to_string()),
+                images: None,
+                tool_calls: None,
+                tool_name: None,
+            }],
+            "llama3",
+            0.42,
+            None,
+        );
+
+        let json = serde_json::to_value(request).unwrap();
+        let options = json.get("options").expect("options present");
+        assert_eq!(options.get("temperature"), Some(&serde_json::json!(0.42)));
+    }
+
+    #[test]
+    fn retry_path_carries_options() {
+        // The think=true → retry-without-think path in `send_request` uses the
+        // same `build_chat_request_with_think` builder for both attempts; verify
+        // the builder produces identical option fields when only `think` differs.
+        let provider =
+            OllamaProvider::new_with_reasoning(None, None, Some(true)).with_tuning(OllamaTuning {
+                num_ctx: 16384,
+                num_predict: 4096,
+                temperature_override: None,
+            });
+
+        let messages = vec![Message {
+            role: "user".to_string(),
+            content: Some("hello".to_string()),
+            images: None,
+            tool_calls: None,
+            tool_name: None,
+        }];
+
+        let first = provider.build_chat_request_with_think(
+            messages.clone(),
+            "llama3",
+            0.4,
+            None,
+            Some(true),
+        );
+        let retry = provider.build_chat_request_with_think(messages, "llama3", 0.4, None, None);
+
+        let first_json = serde_json::to_value(first).unwrap();
+        let retry_json = serde_json::to_value(retry).unwrap();
+        assert_eq!(
+            first_json.get("options"),
+            retry_json.get("options"),
+            "retry must carry the same options as the first attempt"
+        );
+        assert_eq!(first_json.get("think"), Some(&serde_json::json!(true)));
+        assert!(retry_json.get("think").is_none());
+        let options = first_json.get("options").unwrap();
+        assert_eq!(options.get("num_ctx"), Some(&serde_json::json!(16384)));
+        assert_eq!(options.get("num_predict"), Some(&serde_json::json!(4096)));
     }
 
     #[test]

--- a/crates/zeroclaw-providers/src/ollama.rs
+++ b/crates/zeroclaw-providers/src/ollama.rs
@@ -47,6 +47,13 @@ pub struct OllamaTuning {
     /// of the per-call argument — this is the wire knob behind the
     /// `ollama_temperature_override` config field. When `None`, the
     /// per-call temperature wins (full backward compatibility).
+    //
+    // Note: `Option<f64>` here, vs `Option<u32>`/`Option<i32>` on the
+    // runtime-override constructor's first two args, because temperature
+    // has fall-through semantics (None means "let the per-call temp win"),
+    // whereas num_ctx/num_predict unset just falls back to framework
+    // constants — there is no meaningful "let the call decide" mode for
+    // those two.
     pub temperature_override: Option<f64>,
 }
 
@@ -1174,6 +1181,51 @@ mod tests {
         let json = serde_json::to_value(request).unwrap();
         let options = json.get("options").expect("options present");
         assert_eq!(options.get("temperature"), Some(&serde_json::json!(0.2)));
+        assert_eq!(options.get("num_ctx"), Some(&serde_json::json!(8192)));
+        assert_eq!(options.get("num_predict"), Some(&serde_json::json!(2048)));
+    }
+
+    #[test]
+    fn build_chat_request_with_think_emits_explicit_options() {
+        // Wire-shape snapshot: the JSON body of every Ollama /api/chat
+        // request MUST carry an `options` object with all three keys
+        // (`temperature`, `num_ctx`, `num_predict`) populated. Older
+        // tests cover individual fields piecemeal; this one locks the
+        // full shape so a future refactor can't silently drop a field.
+        let provider = OllamaProvider::new(None, None);
+        let request = provider.build_chat_request_with_think(
+            vec![Message {
+                role: "user".to_string(),
+                content: Some("hello".to_string()),
+                images: None,
+                tool_calls: None,
+                tool_name: None,
+            }],
+            "llama3",
+            0.3,
+            None,
+            Some(true),
+        );
+
+        let json = serde_json::to_value(request).unwrap();
+        let options = json
+            .get("options")
+            .expect("options object missing from request body");
+
+        assert!(
+            options.get("temperature").is_some(),
+            "options.temperature must be present on every wire request"
+        );
+        assert!(
+            options.get("num_ctx").is_some(),
+            "options.num_ctx must be present on every wire request"
+        );
+        assert!(
+            options.get("num_predict").is_some(),
+            "options.num_predict must be present on every wire request"
+        );
+
+        assert_eq!(options.get("temperature"), Some(&serde_json::json!(0.3)));
         assert_eq!(options.get("num_ctx"), Some(&serde_json::json!(8192)));
         assert_eq!(options.get("num_predict"), Some(&serde_json::json!(2048)));
     }

--- a/crates/zeroclaw-providers/src/ollama.rs
+++ b/crates/zeroclaw-providers/src/ollama.rs
@@ -47,6 +47,13 @@ pub struct OllamaTuning {
     /// of the per-call argument — this is the wire knob behind the
     /// `ollama_temperature_override` config field. When `None`, the
     /// per-call temperature wins (full backward compatibility).
+    //
+    // Note: `Option<f64>` here, vs `Option<u32>`/`Option<i32>` on the
+    // runtime-override constructor's first two args, because temperature
+    // has fall-through semantics (None means "let the per-call temp win"),
+    // whereas num_ctx/num_predict unset just falls back to framework
+    // constants — there is no meaningful "let the call decide" mode for
+    // those two.
     pub temperature_override: Option<f64>,
 }
 
@@ -1175,6 +1182,51 @@ mod tests {
         let json = serde_json::to_value(request).unwrap();
         let options = json.get("options").expect("options present");
         assert_eq!(options.get("temperature"), Some(&serde_json::json!(0.2)));
+        assert_eq!(options.get("num_ctx"), Some(&serde_json::json!(8192)));
+        assert_eq!(options.get("num_predict"), Some(&serde_json::json!(2048)));
+    }
+
+    #[test]
+    fn build_chat_request_with_think_emits_explicit_options() {
+        // Wire-shape snapshot: the JSON body of every Ollama /api/chat
+        // request MUST carry an `options` object with all three keys
+        // (`temperature`, `num_ctx`, `num_predict`) populated. Older
+        // tests cover individual fields piecemeal; this one locks the
+        // full shape so a future refactor can't silently drop a field.
+        let provider = OllamaProvider::new(None, None);
+        let request = provider.build_chat_request_with_think(
+            vec![Message {
+                role: "user".to_string(),
+                content: Some("hello".to_string()),
+                images: None,
+                tool_calls: None,
+                tool_name: None,
+            }],
+            "llama3",
+            0.3,
+            None,
+            Some(true),
+        );
+
+        let json = serde_json::to_value(request).unwrap();
+        let options = json
+            .get("options")
+            .expect("options object missing from request body");
+
+        assert!(
+            options.get("temperature").is_some(),
+            "options.temperature must be present on every wire request"
+        );
+        assert!(
+            options.get("num_ctx").is_some(),
+            "options.num_ctx must be present on every wire request"
+        );
+        assert!(
+            options.get("num_predict").is_some(),
+            "options.num_predict must be present on every wire request"
+        );
+
+        assert_eq!(options.get("temperature"), Some(&serde_json::json!(0.3)));
         assert_eq!(options.get("num_ctx"), Some(&serde_json::json!(8192)));
         assert_eq!(options.get("num_predict"), Some(&serde_json::json!(2048)));
     }

--- a/crates/zeroclaw-providers/src/ollama.rs
+++ b/crates/zeroclaw-providers/src/ollama.rs
@@ -17,10 +17,74 @@ const TIMEOUT_SECS_DEFAULT: u64 = 600;
 /// `providers.models.<name>.base-url` for remote GPU boxes or non-default ports.
 const BASE_URL: &str = "http://localhost:11434";
 
+/// Default `num_ctx` (context window, in tokens) sent in every Ollama
+/// `/api/chat` request when no operator override is supplied. Ollama's
+/// server-side default is 2048, which silently truncates prompts; we set
+/// 8192 so callers get useful context without per-call configuration.
+pub const OLLAMA_DEFAULT_NUM_CTX: u32 = 8192;
+
+/// Default `num_predict` (max output tokens) sent in every Ollama
+/// `/api/chat` request when no operator override is supplied. Ollama's
+/// server-side default is 128, which silently truncates responses.
+pub const OLLAMA_DEFAULT_NUM_PREDICT: i32 = 2048;
+
+/// Per-deployment tuning knobs for the Ollama provider. Bundled into
+/// every `/api/chat` request's `options` field so the wire payload is
+/// explicit instead of relying on Ollama server defaults.
+///
+/// Note: temperature is intentionally NOT held as a default here.
+/// `temperature_override` is `Some(v)` only when an operator explicitly
+/// sets `ollama_temperature_override` in `config.toml`; otherwise the
+/// per-call temperature passed through `Provider::chat_with_system(..)`
+/// wins (preserving backward compatibility with `TEMPERATURE_DEFAULT`).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct OllamaTuning {
+    pub num_ctx: u32,
+    pub num_predict: i32,
+    /// Operator-supplied override for the per-call temperature passed
+    /// through `Provider::chat_with_system(.., temperature)`. When
+    /// `Some(v)`, every Ollama `/api/chat` request uses `v` regardless
+    /// of the per-call argument — this is the wire knob behind the
+    /// `ollama_temperature_override` config field. When `None`, the
+    /// per-call temperature wins (full backward compatibility).
+    pub temperature_override: Option<f64>,
+}
+
+impl Default for OllamaTuning {
+    fn default() -> Self {
+        Self {
+            num_ctx: OLLAMA_DEFAULT_NUM_CTX,
+            num_predict: OLLAMA_DEFAULT_NUM_PREDICT,
+            temperature_override: None,
+        }
+    }
+}
+
+impl OllamaTuning {
+    /// Build a tuning struct from the three optional `ProviderRuntimeOptions`
+    /// fields the `ollama` factory arm consumes. Unset `num_ctx` /
+    /// `num_predict` fall back to framework constants; unset
+    /// `temperature_override` stays `None` so the per-call temperature wins.
+    #[must_use]
+    pub fn from_runtime_overrides(
+        num_ctx: Option<u32>,
+        num_predict: Option<i32>,
+        temperature_override: Option<f64>,
+    ) -> Self {
+        let defaults = Self::default();
+        Self {
+            num_ctx: num_ctx.unwrap_or(defaults.num_ctx),
+            num_predict: num_predict.unwrap_or(defaults.num_predict),
+            temperature_override,
+        }
+    }
+}
+
 pub struct OllamaProvider {
     base_url: String,
     api_key: Option<String>,
     reasoning_enabled: Option<bool>,
+    tuning: OllamaTuning,
 }
 
 // ─── Request Structures ───────────────────────────────────────────────────────
@@ -66,6 +130,10 @@ struct OutgoingFunction {
 #[derive(Debug, Serialize)]
 struct Options {
     temperature: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    num_ctx: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    num_predict: Option<i32>,
 }
 
 // ─── Response Structures ──────────────────────────────────────────────────────
@@ -154,7 +222,22 @@ impl OllamaProvider {
             base_url: Self::normalize_base_url(base_url.unwrap_or(BASE_URL)),
             api_key,
             reasoning_enabled,
+            tuning: OllamaTuning::default(),
         }
+    }
+
+    /// Override the per-deployment tuning knobs (`num_ctx`, `num_predict`,
+    /// `temperature_override`) on this provider. Returns `self` for
+    /// chained construction.
+    #[must_use]
+    pub fn with_tuning(mut self, tuning: OllamaTuning) -> Self {
+        self.tuning = tuning;
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn tuning(&self) -> OllamaTuning {
+        self.tuning
     }
 
     fn is_local_endpoint(&self) -> bool {
@@ -313,7 +396,11 @@ impl OllamaProvider {
             model: model.to_string(),
             messages,
             stream: false,
-            options: Options { temperature },
+            options: Options {
+                temperature: self.tuning.temperature_override.unwrap_or(temperature),
+                num_ctx: Some(self.tuning.num_ctx),
+                num_predict: Some(self.tuning.num_predict),
+            },
             think,
             tools: tools.map(|t| t.to_vec()),
         }
@@ -1041,6 +1128,9 @@ mod tests {
 
         let json = serde_json::to_value(request).unwrap();
         assert!(json.get("think").is_none());
+        let options = json.get("options").expect("options present");
+        assert_eq!(options.get("num_ctx"), Some(&serde_json::json!(8192)));
+        assert_eq!(options.get("num_predict"), Some(&serde_json::json!(2048)));
     }
 
     #[test]
@@ -1061,6 +1151,147 @@ mod tests {
 
         let json = serde_json::to_value(request).unwrap();
         assert_eq!(json.get("think"), Some(&serde_json::json!(false)));
+        let options = json.get("options").expect("options present");
+        assert_eq!(options.get("num_ctx"), Some(&serde_json::json!(8192)));
+        assert_eq!(options.get("num_predict"), Some(&serde_json::json!(2048)));
+    }
+
+    #[test]
+    fn request_includes_default_num_ctx_and_num_predict() {
+        let provider = OllamaProvider::new(None, None);
+        let request = provider.build_chat_request(
+            vec![Message {
+                role: "user".to_string(),
+                content: Some("hello".to_string()),
+                images: None,
+                tool_calls: None,
+                tool_name: None,
+            }],
+            "llama3",
+            0.2,
+            None,
+        );
+
+        let json = serde_json::to_value(request).unwrap();
+        let options = json.get("options").expect("options present");
+        assert_eq!(options.get("temperature"), Some(&serde_json::json!(0.2)));
+        assert_eq!(options.get("num_ctx"), Some(&serde_json::json!(8192)));
+        assert_eq!(options.get("num_predict"), Some(&serde_json::json!(2048)));
+    }
+
+    #[test]
+    fn request_includes_overridden_tuning() {
+        let provider = OllamaProvider::new(None, None).with_tuning(OllamaTuning {
+            num_ctx: 4096,
+            num_predict: 1024,
+            temperature_override: None,
+        });
+        let request = provider.build_chat_request(
+            vec![Message {
+                role: "user".to_string(),
+                content: Some("hello".to_string()),
+                images: None,
+                tool_calls: None,
+                tool_name: None,
+            }],
+            "llama3",
+            0.5,
+            None,
+        );
+
+        let json = serde_json::to_value(request).unwrap();
+        let options = json.get("options").expect("options present");
+        assert_eq!(options.get("num_ctx"), Some(&serde_json::json!(4096)));
+        assert_eq!(options.get("num_predict"), Some(&serde_json::json!(1024)));
+    }
+
+    #[test]
+    fn temperature_override_replaces_per_call_temperature() {
+        let provider = OllamaProvider::new(None, None).with_tuning(OllamaTuning {
+            num_ctx: 8192,
+            num_predict: 2048,
+            temperature_override: Some(0.1),
+        });
+        let request = provider.build_chat_request(
+            vec![Message {
+                role: "user".to_string(),
+                content: Some("hello".to_string()),
+                images: None,
+                tool_calls: None,
+                tool_name: None,
+            }],
+            "llama3",
+            0.9,
+            None,
+        );
+
+        let json = serde_json::to_value(request).unwrap();
+        let options = json.get("options").expect("options present");
+        assert_eq!(options.get("temperature"), Some(&serde_json::json!(0.1)));
+    }
+
+    #[test]
+    fn temperature_override_unset_passes_per_call_temperature() {
+        let provider = OllamaProvider::new(None, None);
+        let request = provider.build_chat_request(
+            vec![Message {
+                role: "user".to_string(),
+                content: Some("hello".to_string()),
+                images: None,
+                tool_calls: None,
+                tool_name: None,
+            }],
+            "llama3",
+            0.42,
+            None,
+        );
+
+        let json = serde_json::to_value(request).unwrap();
+        let options = json.get("options").expect("options present");
+        assert_eq!(options.get("temperature"), Some(&serde_json::json!(0.42)));
+    }
+
+    #[test]
+    fn retry_path_carries_options() {
+        // The think=true → retry-without-think path in `send_request` uses the
+        // same `build_chat_request_with_think` builder for both attempts; verify
+        // the builder produces identical option fields when only `think` differs.
+        let provider =
+            OllamaProvider::new_with_reasoning(None, None, Some(true)).with_tuning(OllamaTuning {
+                num_ctx: 16384,
+                num_predict: 4096,
+                temperature_override: None,
+            });
+
+        let messages = vec![Message {
+            role: "user".to_string(),
+            content: Some("hello".to_string()),
+            images: None,
+            tool_calls: None,
+            tool_name: None,
+        }];
+
+        let first = provider.build_chat_request_with_think(
+            messages.clone(),
+            "llama3",
+            0.4,
+            None,
+            Some(true),
+        );
+        let retry = provider.build_chat_request_with_think(messages, "llama3", 0.4, None, None);
+
+        let first_json = serde_json::to_value(first).unwrap();
+        let retry_json = serde_json::to_value(retry).unwrap();
+        assert_eq!(
+            first_json.get("options"),
+            retry_json.get("options"),
+            "retry must carry the same options as the first attempt"
+        );
+        assert_eq!(first_json.get("think"), Some(&serde_json::json!(true)));
+        assert!(retry_json.get("think").is_none());
+        let options = first_json.get("options").unwrap();
+        assert_eq!(options.get("num_ctx"), Some(&serde_json::json!(16384)));
+        assert_eq!(options.get("num_predict"), Some(&serde_json::json!(4096)));
     }
 
     #[test]

--- a/crates/zeroclaw-providers/src/openai_codex.rs
+++ b/crates/zeroclaw-providers/src/openai_codex.rs
@@ -1143,6 +1143,9 @@ data: [DONE]
             provider_max_tokens: None,
             merge_system_into_user: false,
             provider_extra: None,
+            ollama_num_ctx: None,
+            ollama_num_predict: None,
+            ollama_temperature_override: None,
         };
         let provider =
             OpenAiCodexProvider::new(&options, None).expect("provider should initialize");

--- a/crates/zeroclaw-providers/src/openai_codex.rs
+++ b/crates/zeroclaw-providers/src/openai_codex.rs
@@ -1147,6 +1147,9 @@ data: [DONE]
             zeroclaw_dir: None,
             think: None,
             chat_template_kwargs: None,
+            ollama_num_ctx: None,
+            ollama_num_predict: None,
+            ollama_temperature_override: None,
         };
         let provider =
             OpenAiCodexProvider::new(&options, None).expect("provider should initialize");

--- a/tests/live/openai_codex_vision_e2e.rs
+++ b/tests/live/openai_codex_vision_e2e.rs
@@ -165,6 +165,9 @@ async fn openai_codex_second_vision_support() -> Result<()> {
         api_path: None,
         merge_system_into_user: false,
         provider_extra: None,
+        ollama_num_ctx: None,
+        ollama_num_predict: None,
+        ollama_temperature_override: None,
     };
 
     let provider = zeroclaw::providers::create_provider_with_options("openai-codex", None, &opts)?;


### PR DESCRIPTION
## Summary

Adds an explicit tuning surface for the Ollama provider so consumers can set `num_ctx`, `num_predict`, and an optional `temperature_override` from `config.toml` (and via `ProviderRuntimeOptions`) and have them ride on every `/api/chat` request — including the `think=true` → `think=false` retry path.

Without this, Ollama's wire defaults (`num_ctx=2048`, `num_predict=128`) silently truncate prompts and responses on any deployment that runs structured tool-calling workflows. The failure is non-obvious because Ollama returns 200 with garbage rather than an error.

## What changes

- 3 new `pub const` defaults in `zeroclaw-providers/src/ollama.rs`:
  - `OLLAMA_DEFAULT_NUM_CTX = 8192`
  - `OLLAMA_DEFAULT_NUM_PREDICT = 2048`
- New `OllamaTuning` struct (`Debug, Clone, Copy, PartialEq`) with `Default` impl from constants. Holds `num_ctx`, `num_predict`, and `temperature_override: Option<f64>`.
- New `.with_tuning()` builder on `OllamaProvider` (`#[must_use]`).
- `Options` extended with `num_ctx: Option<u32>` and `num_predict: Option<i32>`. Both fields carry `#[serde(skip_serializing_if = "Option::is_none")]` for forward-compat scaffolding, but the public construction path in this release never produces `None` for them: `OllamaTuning::from_runtime_overrides(None, None, _)` falls back to the framework constants, and `build_chat_request_with_think` always serializes `num_ctx: Some(self.tuning.num_ctx)` and `num_predict: Some(self.tuning.num_predict)`. So in practice these two keys are always sent on every `/api/chat` request in this release; lower numerics can be pinned via the new config fields, but there is no in-config way to omit them from the wire body. `temperature_override` is the only new knob with a true `None` / per-call fall-through semantic.
- `build_chat_request_with_think` populates the options unconditionally; the retry path inherits via the same builder.
- 3 new optional fields on `ModelProviderConfig` in `zeroclaw-config`:
  - `ollama_num_ctx: Option<u32>`
  - `ollama_num_predict: Option<i32>`
  - `ollama_temperature_override: Option<f64>`
- `ProviderRuntimeOptions` extended with the same three fields; the `"ollama"` factory arm constructs an `OllamaTuning` via `from_runtime_overrides()` and chains `.with_tuning()` onto the provider.
- `temperature_override` stays `None` by default, preserving existing per-call temperature semantics. When set, every `/api/chat` request uses that value regardless of the per-call argument.

## Why

Pattern ported from a downstream consumer that hit the silent-truncation issue against a remote Ollama instance serving a structured tool-calling workflow. Centralizing constants + struct keeps the options dict from drifting across call sites, and the retry path inherits options for free.

## Tests

- 4 new in `zeroclaw-providers`: defaults applied, override applied, retry path carries options, temperature override semantics.
- 4 new in `zeroclaw-config`: TOML round-trip with all three fields, default-to-`None` behavior, factory pulls fields through `ProviderRuntimeOptions`, factory falls back to constants when unset.
- 1 wire-shape snapshot test (`build_chat_request_with_think_emits_explicit_options`) asserting `temperature`, `num_ctx`, and `num_predict` are all present in the serialized `options` block.
- 2 existing JSON-shape tests updated to assert the new fields are present.
- All `cargo fmt --all -- --check`, `cargo clippy -p zeroclaw-providers -p zeroclaw-config --all-targets -- -D warnings`, `cargo test -p zeroclaw-config -p zeroclaw-providers --lib` (821 passed) green on top of current `master`.

## Backward compatibility

- `OllamaProvider::new` / `new_with_reasoning` initialize `tuning: OllamaTuning::default()` unconditionally, so existing callers that don't opt in get the new defaults — which is a quiet behavior change (Ollama now sees `num_ctx=8192` instead of its server-side `2048`). The release notes for the version that ships this PR call this out under **Breaking Changes** in `CHANGELOG-next.md` with a TOML example for VRAM-constrained operators to pin lower numerics via `ollama_num_ctx` / `ollama_num_predict`.
- There is no in-config way in this release to omit `num_ctx` / `num_predict` from the wire body — they are sent on every request unless lower numeric values are configured. Operators on an Ollama build old enough to outright reject these keys would need an Ollama upgrade or a follow-up patch that introduces a true omit mode.
- `temperature_override = None` preserves the per-call temperature semantics unchanged; `Some(v)` forces every request to use `v` regardless of the per-call argument.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p zeroclaw-providers -p zeroclaw-config --all-targets -- -D warnings`
- [x] `cargo test -p zeroclaw-config -p zeroclaw-providers --lib` (821/0 on rebased head `4d17626b`)
- [x] Production-validated against a remote Ollama instance running Trinity-mini (HTTP 200 with explicit `options` field on the wire confirmed via Ollama's request log).
