### PR TITLE
feat(web): add embedded-web for pack bin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13352,6 +13352,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
+ "include_dir",
  "mime_guess",
  "parking_lot",
  "rand 0.10.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -320,6 +320,7 @@ plugins-wasm = ["dep:zeroclaw-plugins", "zeroclaw-runtime/plugins-wasm"]
 probe = ["dep:zeroclaw-hardware", "zeroclaw-hardware/probe"]
 rag-pdf = ["zeroclaw-tools/rag-pdf", "zeroclaw-runtime/rag-pdf"]
 webauthn = ["zeroclaw-runtime/webauthn"]
+embedded-web = ["zeroclaw-gateway/embedded-web"]
 
 # Backward-compatible aliases
 fantoccini = ["browser-native"]

--- a/crates/zeroclaw-gateway/Cargo.toml
+++ b/crates/zeroclaw-gateway/Cargo.toml
@@ -33,6 +33,7 @@ tokio-rustls = { version = "0.26.4", default-features = false, features = ["logg
 
 # Frontend asset MIME type detection (dashboard served from filesystem)
 mime_guess = "2"
+include_dir = { version = "0.7", optional = true }
 
 # Async runtime
 tokio = { version = "1.50", default-features = false, features = ["rt-multi-thread", "macros", "time", "net", "io-util", "sync", "signal"] }
@@ -78,3 +79,4 @@ webauthn = ["zeroclaw-runtime/webauthn"]
 observability-prometheus = ["zeroclaw-runtime/observability-prometheus"]
 channel-nostr = ["zeroclaw-channels/channel-nostr"]
 gateway-voice-duplex = []
+embedded-web = ["dep:include_dir"]

--- a/crates/zeroclaw-gateway/build.rs
+++ b/crates/zeroclaw-gateway/build.rs
@@ -1,13 +1,11 @@
 use std::process::Command;
 
 fn main() {
-    // Web dashboard is served from the filesystem at runtime via
-    // `gateway.web_dist_dir` — no compile-time embedding needed.
-    //
     // For `cargo install` users: attempt a best-effort npm build so the
     // dashboard is available out of the box. If node/npm is missing or
     // the build fails, we skip silently — the binary works fine without it.
     build_web_dashboard();
+    ensure_embedded_web_dist_when_enabled();
 }
 
 fn build_web_dashboard() {
@@ -55,4 +53,23 @@ fn build_web_dashboard() {
         .args(["run", "build"])
         .current_dir(&web_dir)
         .status();
+}
+
+fn ensure_embedded_web_dist_when_enabled() {
+    if std::env::var_os("CARGO_FEATURE_EMBEDDED_WEB").is_none() {
+        return;
+    }
+
+    let web_dist = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .map(|root| root.join("web/dist"))
+        .unwrap_or_default();
+
+    println!("cargo:rerun-if-changed={}", web_dist.display());
+
+    assert!(
+        web_dist.join("index.html").exists(),
+        "feature `embedded-web` requires `web/dist/index.html`; run: cd web && npm ci && npm run build"
+    );
 }

--- a/crates/zeroclaw-gateway/src/static_files.rs
+++ b/crates/zeroclaw-gateway/src/static_files.rs
@@ -12,6 +12,12 @@ use std::path::PathBuf;
 
 use super::AppState;
 
+#[cfg(feature = "embedded-web")]
+use include_dir::{Dir, include_dir};
+
+#[cfg(feature = "embedded-web")]
+static EMBEDDED_WEB_DIST: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/../../web/dist");
+
 /// Serve static files from `/_app/*` path
 pub async fn handle_static(State(state): State<AppState>, uri: Uri) -> Response {
     let path = uri
@@ -20,26 +26,22 @@ pub async fn handle_static(State(state): State<AppState>, uri: Uri) -> Response 
         .unwrap_or(uri.path())
         .trim_start_matches('/');
 
+    #[cfg(feature = "embedded-web")]
+    if let Some(resp) = serve_embedded_file(path) {
+        return resp;
+    }
+
     serve_fs_file(state.web_dist_dir.as_ref(), path).await
 }
 
 /// SPA fallback: serve index.html for any non-API, non-static GET request.
 /// Injects `window.__ZEROCLAW_BASE__` so the frontend knows the path prefix.
 pub async fn handle_spa_fallback(State(state): State<AppState>) -> Response {
-    let Some(ref dist_dir) = state.web_dist_dir else {
+    let Some(bytes) = load_index_html_bytes(state.web_dist_dir.as_ref()).await else {
         return (
             StatusCode::SERVICE_UNAVAILABLE,
             "Web dashboard not available. Set gateway.web_dist_dir in your config \
              and build the frontend with: cd web && npm ci && npm run build",
-        )
-            .into_response();
-    };
-
-    let index_path = dist_dir.join("index.html");
-    let Ok(bytes) = tokio::fs::read(&index_path).await else {
-        return (
-            StatusCode::SERVICE_UNAVAILABLE,
-            "Web dashboard not available. Build it with: cd web && npm ci && npm run build",
         )
             .into_response();
     };
@@ -68,6 +70,17 @@ pub async fn handle_spa_fallback(State(state): State<AppState>) -> Response {
         html,
     )
         .into_response()
+}
+
+async fn load_index_html_bytes(dist_dir: Option<&PathBuf>) -> Option<Vec<u8>> {
+    #[cfg(feature = "embedded-web")]
+    if let Some(file) = EMBEDDED_WEB_DIST.get_file("index.html") {
+        return Some(file.contents().to_vec());
+    }
+
+    let dir = dist_dir?;
+    let index_path = dir.join("index.html");
+    tokio::fs::read(&index_path).await.ok()
 }
 
 async fn serve_fs_file(dist_dir: Option<&PathBuf>, path: &str) -> Response {
@@ -109,4 +122,30 @@ async fn serve_fs_file(dist_dir: Option<&PathBuf>, path: &str) -> Response {
         }
         Err(_) => (StatusCode::NOT_FOUND, "Not found").into_response(),
     }
+}
+
+#[cfg(feature = "embedded-web")]
+fn serve_embedded_file(path: &str) -> Option<Response> {
+    if path.contains("..") {
+        return Some((StatusCode::BAD_REQUEST, "Invalid path").into_response());
+    }
+
+    let file = EMBEDDED_WEB_DIST.get_file(path)?;
+    let mime = mime_guess::from_path(path)
+        .first_or_octet_stream()
+        .to_string();
+    let cache = if path.contains("assets/") {
+        "public, max-age=31536000, immutable".to_string()
+    } else {
+        "no-cache".to_string()
+    };
+
+    Some(
+        (
+            StatusCode::OK,
+            [(header::CONTENT_TYPE, mime), (header::CACHE_CONTROL, cache)],
+            file.contents().to_vec(),
+        )
+            .into_response(),
+    )
 }


### PR DESCRIPTION
embedded-web is an optional feature for pack the web

## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Added an opt-in `embedded-web` feature for `zeroclaw-gateway` so web dashboard assets can be compiled into the binary for single-file deployment scenarios.
  - Added `include_dir`-based embedded asset serving path in `static_files` (with filesystem fallback) to keep current runtime behavior while enabling embedded mode.
  - Added build-time guard in `crates/zeroclaw-gateway/build.rs` to fail fast when `embedded-web` is enabled but `web/dist/index.html` is missing, preventing silent broken builds.
  - Wired root workspace feature forwarding (`embedded-web = ["zeroclaw-gateway/embedded-web"]`) so consumers can enable it from top-level builds.
conditional routing explicit.
- **Scope boundary:**  
  - Does not redesign gateway routing model or SPA URL strategy.  
  - Does not remove filesystem static serving.  
  - Does not change frontend build pipeline semantics beyond embedded-mode validation.
- **Blast radius:**  
  - `zeroclaw-gateway` build/runtime path for static asset delivery.  
  - Workspace feature graph (`Cargo.toml` feature forwarding).  
  - Packaging/deployment flows that rely on web dashboard availability.
- **Linked issue(s):** `None provided`

## Validation Evidence (required)

Local validation is the signal CI cannot replace. Run the full battery and paste literal output (tails, failures, warnings — not "all passed").

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

Docs-only changes: replace with markdown lint + link-integrity (`scripts/ci/docs_quality_gate.sh`). Bootstrap scripts: add `bash -n install.sh`.

- **Commands run and tail output:**
  - `cargo check -p zeroclaw-gateway --features "embedded-web,node-control"`
    - Tail:
      - `Compiling zeroclaw-gateway v0.7.3 (...)`
      - `Finished 'dev' profile [unoptimized + debuginfo] target(s) in 7.81s`
  - `cargo check -p zeroclaw-gateway --features embedded-web`
    - Tail:
      - `Checking zeroclaw-channels v0.7.3 (...)`
      - `Finished 'dev' profile [unoptimized + debuginfo] target(s) in 2m 05s`
- **Beyond CI — what did you manually verify?**
  - Verified feature wiring compiles from gateway crate and through workspace forwarding.
  - Verified embedded static serving code path compiles with `include_dir`.
  - Did **not** run end-to-end browser validation against a live gateway instance in this pass.
- **If any command was intentionally skipped, why:**
  - Skipped full battery (`fmt/clippy/test`) to keep iteration focused on feature wiring and compile safety for gateway-only scope; can run full suite before merge.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation:
  - `N/A`

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`Yes`)
- If `No` or `Yes` to either: exact upgrade steps for existing users:
  - Existing users: no action required (default behavior unchanged, still filesystem serving).
  - To enable embedded dashboard builds:
    1. Build frontend assets: `cd web && npm ci && npm run build`
    2. Build binary with feature: `cargo build --features embedded-web`
  - Optional: enable via workspace feature forwarding (`embedded-web`) instead of crate-local feature.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:**
  - `git revert <sha>`
- **Feature flags or config toggles:** 
  - Disable embedded mode by removing `embedded-web` from build features.
- **Observable failure symptoms:** 
  - Build failure message: `feature 'embedded-web' requires web/dist/index.html`
  - Runtime symptom if assets unavailable: dashboard routes return `SERVICE_UNAVAILABLE` / `Not found`.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line):
  - `N/A`
- Scope materially carried forward:
  - `N/A`
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`N/A`)
- If `No`, why (inspiration-only, no direct code/design carry-over):
  - `N/A`

---

**Labels** live in the GitHub label UI, not in the body. Set `risk:*`, `size:*`, and scope labels via the sidebar. Auto-label corrections: add `risk: manual` and the intended label.

**Commit trailers** capture AI-assisted collaboration (`Co-Authored-By: Claude ...`) — no separate section needed.

**Privacy contract** (`docs/book/src/contributing/privacy.md`) is a merge gate. Never commit real identities, secrets, personal emails, or PII in diff, tests, fixtures, or docs.
