### PR TITLE
fix(multimodal): normalize image markers across agent and tool history

### DIFF
--- a/CHANGELOG-next.md
+++ b/CHANGELOG-next.md
@@ -329,6 +329,36 @@ this config.)
 
 ---
 
+## Behavior Changes
+
+### Tool outputs that mention local image paths are now uploaded to the provider
+
+Tool results — including `shell` and skill output — that print real local
+image paths (e.g. `ls /pictures`, `find . -name '*.png'`, an image-generation
+tool that prints the saved file path) are now canonicalized into
+`[IMAGE:...]` markers before history replay and base64-inlined into the next
+provider request. This is the fix for #6097 (local image reading failed) and
+#5453 (WebSocket `/ws/chat` did not process `[IMAGE:]` markers), and brings
+the agent and provider sides of the multimodal pipeline back into parity.
+
+The behavior shift is real and worth flagging: image bytes that previously
+stayed on the local filesystem when surfaced by a shell-style tool are now
+uploaded to whichever provider the next turn dispatches to. Only paths where
+`Path::is_file()` returns `true` and the extension is one of `png`, `jpg`,
+`jpeg`, `webp`, `gif`, `bmp` are wrapped, and existing `[IMAGE:...]` markers
+are not double-wrapped, but operators running shell tools over directories
+of personal or sensitive images should be aware.
+
+The per-request image budget (`max_images`, default `4`) and the LRU
+`trim_old_images` policy bound the cumulative upload cost — older images are
+dropped before the cap is exceeded — but the privacy posture has shifted.
+See `docs/book/src/contributing/privacy.md` and the new doc note on
+`MultimodalConfig.max_images` for the current upload semantics. Operators
+who do not want this behavior can keep tool outputs free of literal image
+paths, or scope shell tools away from image-bearing directories. (#6183)
+
+---
+
 ## Contributors
 
 - @abhinavmathur-atlan

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -1931,11 +1931,30 @@ impl Default for PipelineConfig {
 }
 
 /// Multimodal (image) handling configuration (`[multimodal]` section).
+///
+/// # Privacy and cost note
+///
+/// Tool results that print real local image paths (e.g. shell tools doing
+/// `ls /pictures` or `find . -name '*.png'`) are canonicalized into
+/// `[IMAGE:...]` markers and base64-inlined into the next provider request.
+/// This means image bytes that previously stayed local will be uploaded to
+/// the configured provider when surfaced by a tool.
+///
+/// `max_images` (and the `trim_old_images` LRU policy) bounds the per-request
+/// image budget, but operators running shell-style tools over directories of
+/// personal or sensitive images should be aware of the upload semantics. See
+/// `docs/book/src/contributing/privacy.md` for the project's privacy stance.
 #[derive(Debug, Clone, Serialize, Deserialize, Configurable)]
 #[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
 #[prefix = "multimodal"]
 pub struct MultimodalConfig {
     /// Maximum number of image attachments accepted per request.
+    ///
+    /// Caps the total number of `[IMAGE:...]` markers that survive into the
+    /// provider request after multimodal preprocessing. Older images are
+    /// dropped first when the cumulative count exceeds this limit. Acts as
+    /// the upper bound on per-turn upload cost when tool outputs surface
+    /// local image paths.
     #[serde(default = "default_multimodal_max_images")]
     pub max_images: usize,
     /// Maximum image payload size in MiB before base64 encoding.

--- a/crates/zeroclaw-providers/src/multimodal.rs
+++ b/crates/zeroclaw-providers/src/multimodal.rs
@@ -133,7 +133,7 @@ pub fn parse_image_markers(content: &str) -> (String, Vec<String>) {
 pub fn count_image_markers(messages: &[ChatMessage]) -> usize {
     messages
         .iter()
-        .filter(|m| m.role == "user")
+        .filter(|m| should_normalize_message_images(&m.role))
         .map(|m| parse_image_markers(&m.content).1.len())
         .sum()
 }
@@ -157,6 +157,10 @@ pub fn extract_ollama_image_payload(image_ref: &str) -> Option<String> {
     }
 }
 
+fn should_normalize_message_images(role: &str) -> bool {
+    matches!(role, "user" | "tool")
+}
+
 pub async fn prepare_messages_for_provider(
     messages: &[ChatMessage],
     config: &MultimodalConfig,
@@ -175,7 +179,7 @@ pub async fn prepare_messages_for_provider(
 
     // When image count exceeds the limit, strip markers from oldest messages
     // first so that the most recent (most relevant) images survive. This
-    // prevents conversations from becoming permanently stuck once the
+    // prevents conversations from becoming permanently  stuck once the
     // cumulative image count crosses the threshold.
     let trimmed = if total_images > max_images {
         trim_old_images(messages, max_images)
@@ -187,7 +191,7 @@ pub async fn prepare_messages_for_provider(
 
     let mut normalized_messages = Vec::with_capacity(trimmed.len());
     for message in &trimmed {
-        if message.role != "user" {
+        if !should_normalize_message_images(&message.role) {
             normalized_messages.push(message.clone());
             continue;
         }
@@ -225,7 +229,7 @@ fn trim_old_images(messages: &[ChatMessage], max_images: usize) -> Vec<ChatMessa
     let image_positions: Vec<(usize, usize)> = messages
         .iter()
         .enumerate()
-        .filter(|(_, m)| m.role == "user")
+        .filter(|(_, m)| should_normalize_message_images(&m.role))
         .filter_map(|(i, m)| {
             let count = parse_image_markers(&m.content).1.len();
             if count > 0 { Some((i, count)) } else { None }
@@ -631,6 +635,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn prepare_messages_normalizes_tool_message_local_image_to_data_uri() {
+        let temp = tempfile::tempdir().unwrap();
+        let image_path = temp.path().join("tool-sample.png");
+
+        std::fs::write(
+            &image_path,
+            [0x89, b'P', b'N', b'G', b'\r', b'\n', 0x1a, b'\n'],
+        )
+        .unwrap();
+
+        let messages = vec![ChatMessage::tool(format!(
+            "<tool_result name=\"image_gen\">\nGenerated image [IMAGE:{}]\n</tool_result>",
+            image_path.display()
+        ))];
+
+        let prepared = prepare_messages_for_provider(&messages, &MultimodalConfig::default())
+            .await
+            .unwrap();
+
+        assert!(prepared.contains_images);
+        assert_eq!(prepared.messages.len(), 1);
+        assert_eq!(prepared.messages[0].role, "tool");
+
+        let (cleaned, refs) = parse_image_markers(&prepared.messages[0].content);
+        assert!(cleaned.contains("<tool_result name=\"image_gen\">"));
+        assert!(cleaned.contains("Generated image"));
+        assert_eq!(refs.len(), 1);
+        assert!(refs[0].starts_with("data:image/png;base64,"));
+    }
+
+    #[tokio::test]
     async fn prepare_messages_trims_excess_images_from_older_messages() {
         // 3 messages, each with 1 image — max is 2.
         // The oldest message's image should be stripped.
@@ -718,6 +753,22 @@ mod tests {
         // Newest user image kept
         let (_, refs2) = parse_image_markers(&trimmed[2].content);
         assert_eq!(refs2.len(), 1);
+    }
+
+    #[test]
+    fn trim_old_images_counts_tool_messages() {
+        let messages = vec![
+            ChatMessage::tool("[IMAGE:/tmp/tool-old.png]\nGenerated".to_string()),
+            ChatMessage::user("[IMAGE:/tmp/user-new.png]\nNewest".to_string()),
+        ];
+
+        let trimmed = trim_old_images(&messages, 1);
+        let (_, refs0) = parse_image_markers(&trimmed[0].content);
+        assert!(refs0.is_empty(), "oldest tool image should be stripped");
+        assert!(trimmed[0].content.contains("Generated"));
+
+        let (_, refs1) = parse_image_markers(&trimmed[1].content);
+        assert_eq!(refs1.len(), 1);
     }
 
     #[test]

--- a/crates/zeroclaw-providers/src/multimodal.rs
+++ b/crates/zeroclaw-providers/src/multimodal.rs
@@ -161,6 +161,50 @@ fn should_normalize_message_images(role: &str) -> bool {
     matches!(role, "user" | "tool")
 }
 
+/// Attempt to normalize image markers inside a native tool-result JSON
+/// payload produced by `NativeToolDispatcher::to_provider_messages`. On
+/// success, returns the reserialized JSON string with the inner `content`
+/// field rewritten to inline `[IMAGE:data:…]` markers (data URIs). Returns
+/// `Ok(None)` when the payload is not a JSON object with a string `content`
+/// field, when the inner content has no normalizable markers, or when no
+/// rewriting is needed — letting the caller fall through to the existing
+/// plain-text path. The returned JSON preserves `tool_call_id` and any
+/// other top-level fields so downstream native adapters
+/// (e.g. `OpenAiCompatibleProvider::convert_messages_for_native`) can keep
+/// recovering the tool-call linkage via `serde_json::from_str`.
+async fn normalize_native_tool_result_json(
+    content: &str,
+    config: &MultimodalConfig,
+    max_bytes: usize,
+    remote_client: &Client,
+) -> anyhow::Result<Option<String>> {
+    let Ok(serde_json::Value::Object(mut obj)) = serde_json::from_str::<serde_json::Value>(content)
+    else {
+        return Ok(None);
+    };
+
+    let Some(serde_json::Value::String(inner)) = obj.get("content").cloned() else {
+        return Ok(None);
+    };
+
+    let (cleaned_text, refs) = parse_image_markers(&inner);
+    if refs.is_empty() {
+        return Ok(None);
+    }
+
+    let mut normalized_refs = Vec::with_capacity(refs.len());
+    for reference in refs {
+        let data_uri =
+            normalize_image_reference(&reference, config, max_bytes, remote_client).await?;
+        normalized_refs.push(data_uri);
+    }
+
+    let new_inner = compose_multimodal_message(&cleaned_text, &normalized_refs);
+    obj.insert("content".to_string(), serde_json::Value::String(new_inner));
+
+    Ok(Some(serde_json::Value::Object(obj).to_string()))
+}
+
 pub async fn prepare_messages_for_provider(
     messages: &[ChatMessage],
     config: &MultimodalConfig,
@@ -193,6 +237,32 @@ pub async fn prepare_messages_for_provider(
     for message in &trimmed {
         if !should_normalize_message_images(&message.role) {
             normalized_messages.push(message.clone());
+            continue;
+        }
+
+        // Native tool dispatchers wrap tool results as a JSON object
+        // (`{"tool_call_id":"…","content":"…"}`) so that provider adapters
+        // can recover `tool_call_id` via `serde_json::from_str` on
+        // `message.content`. Treating that JSON blob as plain text would
+        // strip markers out of the `content` field and append the data URI
+        // outside the JSON object, breaking the native tool-result contract
+        // and dropping `tool_call_id`. When we recognise that shape,
+        // normalize only the inner `content` string and reserialize the
+        // JSON so adapters keep seeing the structure they expect. Falls
+        // through to the plain-text path for non-JSON tool messages.
+        if message.role == "tool"
+            && let Some(prepared) = normalize_native_tool_result_json(
+                &message.content,
+                config,
+                max_bytes,
+                &remote_client,
+            )
+            .await?
+        {
+            normalized_messages.push(ChatMessage {
+                role: message.role.clone(),
+                content: prepared,
+            });
             continue;
         }
 
@@ -635,6 +705,11 @@ mod tests {
     }
 
     #[tokio::test]
+    // Covers the plain-text fallback path for `role == "tool"` messages
+    // whose `content` is not a native-dispatcher JSON payload (e.g.
+    // synthetic XML-shaped input or future non-JSON tool transports). The
+    // JSON-shaped native contract is exercised by
+    // `prepare_messages_preserves_native_tool_result_json_shape` below.
     async fn prepare_messages_normalizes_tool_message_local_image_to_data_uri() {
         let temp = tempfile::tempdir().unwrap();
         let image_path = temp.path().join("tool-sample.png");
@@ -663,6 +738,70 @@ mod tests {
         assert!(cleaned.contains("Generated image"));
         assert_eq!(refs.len(), 1);
         assert!(refs[0].starts_with("data:image/png;base64,"));
+    }
+
+    // Regression for the JSON-clobber bug surfaced on PR #6183: native tool
+    // dispatchers serialize tool results as `{"tool_call_id":"…","content":"…"}`
+    // and downstream adapters (e.g. `OpenAiCompatibleProvider::convert_messages_for_native`)
+    // recover `tool_call_id` via `serde_json::from_str` on the message
+    // content. The multimodal preprocessor must keep that JSON intact while
+    // still inlining any `[IMAGE:/path]` markers inside the inner `content`
+    // field. Asserts:
+    //   1. Prepared content is still valid JSON.
+    //   2. `tool_call_id` survives unchanged.
+    //   3. The inner `content` field carries `data:image/png;base64,…`
+    //      (marker rewritten) and keeps surrounding text.
+    #[tokio::test]
+    async fn prepare_messages_preserves_native_tool_result_json_shape() {
+        let temp = tempfile::tempdir().unwrap();
+        let image_path = temp.path().join("native-tool-result.png");
+        std::fs::write(
+            &image_path,
+            [0x89, b'P', b'N', b'G', b'\r', b'\n', 0x1a, b'\n'],
+        )
+        .unwrap();
+
+        let native_tool_content = serde_json::json!({
+            "tool_call_id": "tc1",
+            "content": format!("see attached [IMAGE:{}]", image_path.display()),
+        })
+        .to_string();
+
+        let messages = vec![ChatMessage::tool(native_tool_content)];
+
+        let prepared = prepare_messages_for_provider(&messages, &MultimodalConfig::default())
+            .await
+            .expect("preparation should succeed for native tool-result JSON");
+
+        assert!(prepared.contains_images);
+        assert_eq!(prepared.messages.len(), 1);
+        assert_eq!(prepared.messages[0].role, "tool");
+
+        let value: serde_json::Value = serde_json::from_str(&prepared.messages[0].content)
+            .expect("prepared tool message must remain valid JSON");
+
+        assert_eq!(
+            value.get("tool_call_id").and_then(|v| v.as_str()),
+            Some("tc1"),
+            "tool_call_id must survive multimodal preprocessing unchanged"
+        );
+
+        let inner = value
+            .get("content")
+            .and_then(|v| v.as_str())
+            .expect("content must remain a JSON string");
+        assert!(
+            inner.contains("see attached"),
+            "surrounding text in tool content should survive normalization"
+        );
+        assert!(
+            inner.contains("data:image/png;base64,"),
+            "local image path inside tool content should be rewritten to a data URI"
+        );
+        assert!(
+            !inner.contains("native-tool-result.png"),
+            "raw local path must not leak after normalization"
+        );
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-providers/src/multimodal.rs
+++ b/crates/zeroclaw-providers/src/multimodal.rs
@@ -179,7 +179,7 @@ pub async fn prepare_messages_for_provider(
 
     // When image count exceeds the limit, strip markers from oldest messages
     // first so that the most recent (most relevant) images survive. This
-    // prevents conversations from becoming permanently  stuck once the
+    // prevents conversations from becoming permanently stuck once the
     // cumulative image count crosses the threshold.
     let trimmed = if total_images > max_images {
         trim_old_images(messages, max_images)

--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -31,6 +31,7 @@ pub struct Agent {
     tool_dispatcher: Box<dyn ToolDispatcher>,
     memory_loader: Box<dyn MemoryLoader>,
     config: zeroclaw_config::schema::AgentConfig,
+    multimodal_config: zeroclaw_config::schema::MultimodalConfig,
     model_name: String,
     temperature: f64,
     workspace_dir: std::path::PathBuf,
@@ -69,6 +70,7 @@ pub struct AgentBuilder {
     tool_dispatcher: Option<Box<dyn ToolDispatcher>>,
     memory_loader: Option<Box<dyn MemoryLoader>>,
     config: Option<zeroclaw_config::schema::AgentConfig>,
+    multimodal_config: Option<zeroclaw_config::schema::MultimodalConfig>,
     model_name: Option<String>,
     temperature: Option<f64>,
     workspace_dir: Option<std::path::PathBuf>,
@@ -105,6 +107,7 @@ impl AgentBuilder {
             tool_dispatcher: None,
             memory_loader: None,
             config: None,
+            multimodal_config: None,
             model_name: None,
             temperature: None,
             workspace_dir: None,
@@ -162,6 +165,14 @@ impl AgentBuilder {
 
     pub fn config(mut self, config: zeroclaw_config::schema::AgentConfig) -> Self {
         self.config = Some(config);
+        self
+    }
+
+    pub fn multimodal_config(
+        mut self,
+        multimodal_config: zeroclaw_config::schema::MultimodalConfig,
+    ) -> Self {
+        self.multimodal_config = Some(multimodal_config);
         self
     }
 
@@ -297,6 +308,7 @@ impl AgentBuilder {
                 .memory_loader
                 .unwrap_or_else(|| Box::new(DefaultMemoryLoader::default())),
             config: self.config.unwrap_or_default(),
+            multimodal_config: self.multimodal_config.unwrap_or_default(),
             model_name: self
                 .model_name
                 .unwrap_or_else(|| "anthropic/claude-sonnet-4-20250514".into()),
@@ -552,6 +564,7 @@ impl Agent {
             )))
             .prompt_builder(SystemPromptBuilder::with_defaults())
             .config(config.agent.clone())
+            .multimodal_config(config.multimodal.clone())
             .model_name(model_name)
             .temperature(
                 fallback_provider_ag
@@ -644,6 +657,18 @@ impl Agent {
             autonomy_level: self.autonomy_level,
         };
         self.prompt_builder.build(&ctx)
+    }
+
+    async fn prepare_provider_messages(
+        &self,
+        messages: &[ChatMessage],
+    ) -> Result<Vec<ChatMessage>> {
+        let prepared = zeroclaw_providers::multimodal::prepare_messages_for_provider(
+            messages,
+            &self.multimodal_config,
+        )
+        .await?;
+        Ok(prepared.messages)
     }
 
     async fn execute_tool_call(&self, call: &ParsedToolCall) -> ToolExecutionResult {
@@ -906,11 +931,13 @@ impl Agent {
                 });
             }
 
+            let prepared_messages = self.prepare_provider_messages(&messages).await?;
+
             let response = match self
                 .provider
                 .chat(
                     ChatRequest {
-                        messages: &messages,
+                        messages: &prepared_messages,
                         tools: if self.tool_dispatcher.should_send_tool_specs() {
                             Some(&self.tool_specs)
                         } else {
@@ -1090,6 +1117,8 @@ impl Agent {
                 });
             }
 
+            let prepared_messages = self.prepare_provider_messages(&messages).await?;
+
             // ── Streaming LLM call ────────────────────────────────────
             // Try streaming first; if the provider returns content we
             // forward deltas.  Otherwise fall back to non-streaming chat.
@@ -1098,7 +1127,7 @@ impl Agent {
             let stream_opts = zeroclaw_providers::traits::StreamOptions::new(true);
             let mut stream = self.provider.stream_chat(
                 zeroclaw_providers::ChatRequest {
-                    messages: &messages,
+                    messages: &prepared_messages,
                     tools: if self.tool_dispatcher.should_send_tool_specs() {
                         Some(&self.tool_specs)
                     } else {
@@ -1215,7 +1244,7 @@ impl Agent {
                 // Fall back to non-streaming chat, with cancellation guard
                 let chat_fut = self.provider.chat(
                     ChatRequest {
-                        messages: &messages,
+                        messages: &prepared_messages,
                         tools: if self.tool_dispatcher.should_send_tool_specs() {
                             Some(&self.tool_specs)
                         } else {
@@ -1492,6 +1521,80 @@ mod tests {
                 });
             }
             Ok(guard.remove(0))
+        }
+    }
+
+    struct MultimodalCaptureProvider {
+        seen_user_messages: Arc<Mutex<Vec<String>>>,
+        streamed: bool,
+    }
+
+    #[async_trait]
+    impl Provider for MultimodalCaptureProvider {
+        async fn chat_with_system(
+            &self,
+            _system_prompt: Option<&str>,
+            _message: &str,
+            _model: &str,
+            _temperature: Option<f64>,
+        ) -> Result<String> {
+            Ok("ok".into())
+        }
+
+        async fn chat(
+            &self,
+            request: ChatRequest<'_>,
+            _model: &str,
+            _temperature: Option<f64>,
+        ) -> Result<zeroclaw_providers::ChatResponse> {
+            if let Some(message) = request.messages.iter().rfind(|msg| msg.role == "user") {
+                self.seen_user_messages.lock().push(message.content.clone());
+            }
+            Ok(zeroclaw_providers::ChatResponse {
+                text: Some("done".into()),
+                tool_calls: vec![],
+                usage: None,
+                reasoning_content: None,
+            })
+        }
+
+        fn stream_chat(
+            &self,
+            request: ChatRequest<'_>,
+            _model: &str,
+            _temperature: Option<f64>,
+            _options: zeroclaw_providers::traits::StreamOptions,
+        ) -> futures_util::stream::BoxStream<
+            'static,
+            zeroclaw_providers::traits::StreamResult<zeroclaw_providers::traits::StreamEvent>,
+        > {
+            use futures_util::stream::{self, StreamExt};
+
+            if let Some(message) = request.messages.iter().rfind(|msg| msg.role == "user") {
+                self.seen_user_messages.lock().push(message.content.clone());
+            }
+
+            if self.streamed {
+                let chunk = zeroclaw_providers::traits::StreamEvent::TextDelta(
+                    zeroclaw_providers::traits::StreamChunk {
+                        delta: "stream-done".into(),
+                        is_final: false,
+                        reasoning: None,
+                        token_count: 0,
+                    },
+                );
+                stream::iter(vec![
+                    Ok(chunk),
+                    Ok(zeroclaw_providers::traits::StreamEvent::Final),
+                ])
+                .boxed()
+            } else {
+                stream::iter(vec![Ok(zeroclaw_providers::traits::StreamEvent::Final)]).boxed()
+            }
+        }
+
+        fn supports_vision(&self) -> bool {
+            true
         }
     }
 
@@ -2032,6 +2135,111 @@ mod tests {
         assert!(
             has_tool_result,
             "Should have emitted a ToolResult event for 'echo'"
+        );
+    }
+
+    #[tokio::test]
+    async fn turn_normalizes_user_image_markers_before_provider_call() {
+        let seen_user_messages = Arc::new(Mutex::new(Vec::new()));
+        let provider = Box::new(MultimodalCaptureProvider {
+            seen_user_messages: seen_user_messages.clone(),
+            streamed: false,
+        });
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let image_path = temp.path().join("agent-turn.png");
+        std::fs::write(
+            &image_path,
+            [0x89, b'P', b'N', b'G', b'\r', b'\n', 0x1a, b'\n'],
+        )
+        .expect("write fixture");
+
+        let memory_cfg = zeroclaw_config::schema::MemoryConfig {
+            backend: "none".into(),
+            ..zeroclaw_config::schema::MemoryConfig::default()
+        };
+        let mem: Arc<dyn Memory> = Arc::from(
+            zeroclaw_memory::create_memory(&memory_cfg, std::path::Path::new("/tmp"), None)
+                .expect("memory creation should succeed with valid config"),
+        );
+
+        let observer: Arc<dyn Observer> = Arc::from(crate::observability::NoopObserver {});
+        let mut agent = Agent::builder()
+            .provider(provider)
+            .tools(vec![Box::new(MockTool)])
+            .memory(mem)
+            .observer(observer)
+            .tool_dispatcher(Box::new(NativeToolDispatcher))
+            .workspace_dir(std::path::PathBuf::from("/tmp"))
+            .multimodal_config(zeroclaw_config::schema::MultimodalConfig::default())
+            .build()
+            .expect("agent builder should succeed with valid config");
+
+        agent
+            .turn(&format!("inspect [IMAGE:{}]", image_path.display()))
+            .await
+            .expect("turn should succeed");
+
+        let seen = seen_user_messages.lock();
+        let last = seen.last().expect("provider should receive a user message");
+        assert!(
+            last.contains("data:image/png;base64,"),
+            "expected normalized data URI in provider request, got: {last}"
+        );
+    }
+
+    #[tokio::test]
+    async fn turn_streamed_normalizes_user_image_markers_before_provider_call() {
+        let seen_user_messages = Arc::new(Mutex::new(Vec::new()));
+        let provider = Box::new(MultimodalCaptureProvider {
+            seen_user_messages: seen_user_messages.clone(),
+            streamed: true,
+        });
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let image_path = temp.path().join("agent-stream.png");
+        std::fs::write(
+            &image_path,
+            [0x89, b'P', b'N', b'G', b'\r', b'\n', 0x1a, b'\n'],
+        )
+        .expect("write fixture");
+
+        let memory_cfg = zeroclaw_config::schema::MemoryConfig {
+            backend: "none".into(),
+            ..zeroclaw_config::schema::MemoryConfig::default()
+        };
+        let mem: Arc<dyn Memory> = Arc::from(
+            zeroclaw_memory::create_memory(&memory_cfg, std::path::Path::new("/tmp"), None)
+                .expect("memory creation should succeed with valid config"),
+        );
+
+        let observer: Arc<dyn Observer> = Arc::from(crate::observability::NoopObserver {});
+        let mut agent = Agent::builder()
+            .provider(provider)
+            .tools(vec![Box::new(MockTool)])
+            .memory(mem)
+            .observer(observer)
+            .tool_dispatcher(Box::new(NativeToolDispatcher))
+            .workspace_dir(std::path::PathBuf::from("/tmp"))
+            .multimodal_config(zeroclaw_config::schema::MultimodalConfig::default())
+            .build()
+            .expect("agent builder should succeed with valid config");
+
+        let (event_tx, _event_rx) = tokio::sync::mpsc::channel::<TurnEvent>(8);
+        agent
+            .turn_streamed(
+                &format!("inspect [IMAGE:{}]", image_path.display()),
+                event_tx,
+                None,
+            )
+            .await
+            .expect("turn_streamed should succeed");
+
+        let seen = seen_user_messages.lock();
+        let last = seen.last().expect("provider should receive a user message");
+        assert!(
+            last.contains("data:image/png;base64,"),
+            "expected normalized data URI in provider request, got: {last}"
         );
     }
 

--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -34,6 +34,7 @@ pub struct Agent {
     tool_dispatcher: Box<dyn ToolDispatcher>,
     memory_loader: Box<dyn MemoryLoader>,
     config: zeroclaw_config::schema::AgentConfig,
+    multimodal_config: zeroclaw_config::schema::MultimodalConfig,
     model_name: String,
     temperature: f64,
     workspace_dir: std::path::PathBuf,
@@ -132,6 +133,7 @@ pub struct AgentBuilder {
     tool_dispatcher: Option<Box<dyn ToolDispatcher>>,
     memory_loader: Option<Box<dyn MemoryLoader>>,
     config: Option<zeroclaw_config::schema::AgentConfig>,
+    multimodal_config: Option<zeroclaw_config::schema::MultimodalConfig>,
     model_name: Option<String>,
     temperature: Option<f64>,
     workspace_dir: Option<std::path::PathBuf>,
@@ -169,6 +171,7 @@ impl AgentBuilder {
             tool_dispatcher: None,
             memory_loader: None,
             config: None,
+            multimodal_config: None,
             model_name: None,
             temperature: None,
             workspace_dir: None,
@@ -227,6 +230,14 @@ impl AgentBuilder {
 
     pub fn config(mut self, config: zeroclaw_config::schema::AgentConfig) -> Self {
         self.config = Some(config);
+        self
+    }
+
+    pub fn multimodal_config(
+        mut self,
+        multimodal_config: zeroclaw_config::schema::MultimodalConfig,
+    ) -> Self {
+        self.multimodal_config = Some(multimodal_config);
         self
     }
 
@@ -367,6 +378,7 @@ impl AgentBuilder {
                 .memory_loader
                 .unwrap_or_else(|| Box::new(DefaultMemoryLoader::default())),
             config: self.config.unwrap_or_default(),
+            multimodal_config: self.multimodal_config.unwrap_or_default(),
             // No silent vendor-default model. Callers that construct `Agent` via the
             // builder must set `model_name` explicitly (via `.model_name(...)` or via
             // `Agent::from_config`, which resolves from `[providers]`). The sentinel
@@ -755,6 +767,7 @@ impl Agent {
             )))
             .prompt_builder(SystemPromptBuilder::with_defaults())
             .config(config.agent.clone())
+            .multimodal_config(config.multimodal.clone())
             .model_name(model_name)
             .temperature(
                 fallback_provider_ag
@@ -858,6 +871,18 @@ impl Agent {
             autonomy_level: self.autonomy_level,
         };
         self.prompt_builder.build(&ctx)
+    }
+
+    async fn prepare_provider_messages(
+        &self,
+        messages: &[ChatMessage],
+    ) -> Result<Vec<ChatMessage>> {
+        let prepared = zeroclaw_providers::multimodal::prepare_messages_for_provider(
+            messages,
+            &self.multimodal_config,
+        )
+        .await?;
+        Ok(prepared.messages)
     }
 
     async fn execute_tool_call(&self, call: &ParsedToolCall) -> ToolExecutionResult {
@@ -1233,11 +1258,13 @@ impl Agent {
                 });
             }
 
+            let prepared_messages = self.prepare_provider_messages(&messages).await?;
+
             let response = match self
                 .provider
                 .chat(
                     ChatRequest {
-                        messages: &messages,
+                        messages: &prepared_messages,
                         tools: if self.should_send_tool_specs() {
                             Some(&self.tool_specs)
                         } else {
@@ -1413,6 +1440,8 @@ impl Agent {
                 });
             }
 
+            let prepared_messages = self.prepare_provider_messages(&messages).await?;
+
             // ── Streaming LLM call ────────────────────────────────────
             // Try streaming first; if the provider returns content we
             // forward deltas.  Otherwise fall back to non-streaming chat.
@@ -1422,7 +1451,7 @@ impl Agent {
                 zeroclaw_providers::traits::StreamOptions::new(self.provider.supports_streaming());
             let mut stream = self.provider.stream_chat(
                 zeroclaw_providers::ChatRequest {
-                    messages: &messages,
+                    messages: &prepared_messages,
                     tools: if self.should_send_tool_specs() {
                         Some(&self.tool_specs)
                     } else {
@@ -1560,7 +1589,7 @@ impl Agent {
                 // Fall back to non-streaming chat, with cancellation guard
                 let chat_fut = self.provider.chat(
                     ChatRequest {
-                        messages: &messages,
+                        messages: &prepared_messages,
                         tools: if self.should_send_tool_specs() {
                             Some(&self.tool_specs)
                         } else {
@@ -1863,6 +1892,80 @@ mod tests {
                 });
             }
             Ok(guard.remove(0))
+        }
+    }
+
+    struct MultimodalCaptureProvider {
+        seen_user_messages: Arc<Mutex<Vec<String>>>,
+        streamed: bool,
+    }
+
+    #[async_trait]
+    impl Provider for MultimodalCaptureProvider {
+        async fn chat_with_system(
+            &self,
+            _system_prompt: Option<&str>,
+            _message: &str,
+            _model: &str,
+            _temperature: Option<f64>,
+        ) -> Result<String> {
+            Ok("ok".into())
+        }
+
+        async fn chat(
+            &self,
+            request: ChatRequest<'_>,
+            _model: &str,
+            _temperature: Option<f64>,
+        ) -> Result<zeroclaw_providers::ChatResponse> {
+            if let Some(message) = request.messages.iter().rfind(|msg| msg.role == "user") {
+                self.seen_user_messages.lock().push(message.content.clone());
+            }
+            Ok(zeroclaw_providers::ChatResponse {
+                text: Some("done".into()),
+                tool_calls: vec![],
+                usage: None,
+                reasoning_content: None,
+            })
+        }
+
+        fn stream_chat(
+            &self,
+            request: ChatRequest<'_>,
+            _model: &str,
+            _temperature: Option<f64>,
+            _options: zeroclaw_providers::traits::StreamOptions,
+        ) -> futures_util::stream::BoxStream<
+            'static,
+            zeroclaw_providers::traits::StreamResult<zeroclaw_providers::traits::StreamEvent>,
+        > {
+            use futures_util::stream::{self, StreamExt};
+
+            if let Some(message) = request.messages.iter().rfind(|msg| msg.role == "user") {
+                self.seen_user_messages.lock().push(message.content.clone());
+            }
+
+            if self.streamed {
+                let chunk = zeroclaw_providers::traits::StreamEvent::TextDelta(
+                    zeroclaw_providers::traits::StreamChunk {
+                        delta: "stream-done".into(),
+                        is_final: false,
+                        reasoning: None,
+                        token_count: 0,
+                    },
+                );
+                stream::iter(vec![
+                    Ok(chunk),
+                    Ok(zeroclaw_providers::traits::StreamEvent::Final),
+                ])
+                .boxed()
+            } else {
+                stream::iter(vec![Ok(zeroclaw_providers::traits::StreamEvent::Final)]).boxed()
+            }
+        }
+
+        fn supports_vision(&self) -> bool {
+            true
         }
     }
 
@@ -3111,6 +3214,111 @@ mod tests {
         );
         assert_eq!(call_ids.get("file_read"), result_ids.get("file_read"));
         assert_eq!(call_ids.get("shell"), result_ids.get("shell"));
+    }
+
+    #[tokio::test]
+    async fn turn_normalizes_user_image_markers_before_provider_call() {
+        let seen_user_messages = Arc::new(Mutex::new(Vec::new()));
+        let provider = Box::new(MultimodalCaptureProvider {
+            seen_user_messages: seen_user_messages.clone(),
+            streamed: false,
+        });
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let image_path = temp.path().join("agent-turn.png");
+        std::fs::write(
+            &image_path,
+            [0x89, b'P', b'N', b'G', b'\r', b'\n', 0x1a, b'\n'],
+        )
+        .expect("write fixture");
+
+        let memory_cfg = zeroclaw_config::schema::MemoryConfig {
+            backend: "none".into(),
+            ..zeroclaw_config::schema::MemoryConfig::default()
+        };
+        let mem: Arc<dyn Memory> = Arc::from(
+            zeroclaw_memory::create_memory(&memory_cfg, std::path::Path::new("/tmp"), None)
+                .expect("memory creation should succeed with valid config"),
+        );
+
+        let observer: Arc<dyn Observer> = Arc::from(crate::observability::NoopObserver {});
+        let mut agent = Agent::builder()
+            .provider(provider)
+            .tools(vec![Box::new(MockTool)])
+            .memory(mem)
+            .observer(observer)
+            .tool_dispatcher(Box::new(NativeToolDispatcher))
+            .workspace_dir(std::path::PathBuf::from("/tmp"))
+            .multimodal_config(zeroclaw_config::schema::MultimodalConfig::default())
+            .build()
+            .expect("agent builder should succeed with valid config");
+
+        agent
+            .turn(&format!("inspect [IMAGE:{}]", image_path.display()))
+            .await
+            .expect("turn should succeed");
+
+        let seen = seen_user_messages.lock();
+        let last = seen.last().expect("provider should receive a user message");
+        assert!(
+            last.contains("data:image/png;base64,"),
+            "expected normalized data URI in provider request, got: {last}"
+        );
+    }
+
+    #[tokio::test]
+    async fn turn_streamed_normalizes_user_image_markers_before_provider_call() {
+        let seen_user_messages = Arc::new(Mutex::new(Vec::new()));
+        let provider = Box::new(MultimodalCaptureProvider {
+            seen_user_messages: seen_user_messages.clone(),
+            streamed: true,
+        });
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let image_path = temp.path().join("agent-stream.png");
+        std::fs::write(
+            &image_path,
+            [0x89, b'P', b'N', b'G', b'\r', b'\n', 0x1a, b'\n'],
+        )
+        .expect("write fixture");
+
+        let memory_cfg = zeroclaw_config::schema::MemoryConfig {
+            backend: "none".into(),
+            ..zeroclaw_config::schema::MemoryConfig::default()
+        };
+        let mem: Arc<dyn Memory> = Arc::from(
+            zeroclaw_memory::create_memory(&memory_cfg, std::path::Path::new("/tmp"), None)
+                .expect("memory creation should succeed with valid config"),
+        );
+
+        let observer: Arc<dyn Observer> = Arc::from(crate::observability::NoopObserver {});
+        let mut agent = Agent::builder()
+            .provider(provider)
+            .tools(vec![Box::new(MockTool)])
+            .memory(mem)
+            .observer(observer)
+            .tool_dispatcher(Box::new(NativeToolDispatcher))
+            .workspace_dir(std::path::PathBuf::from("/tmp"))
+            .multimodal_config(zeroclaw_config::schema::MultimodalConfig::default())
+            .build()
+            .expect("agent builder should succeed with valid config");
+
+        let (event_tx, _event_rx) = tokio::sync::mpsc::channel::<TurnEvent>(8);
+        agent
+            .turn_streamed(
+                &format!("inspect [IMAGE:{}]", image_path.display()),
+                event_tx,
+                None,
+            )
+            .await
+            .expect("turn_streamed should succeed");
+
+        let seen = seen_user_messages.lock();
+        let last = seen.last().expect("provider should receive a user message");
+        assert!(
+            last.contains("data:image/png;base64,"),
+            "expected normalized data URI in provider request, got: {last}"
+        );
     }
 
     /// Reproduction test for the orphan-tool_results trim bug.

--- a/crates/zeroclaw-runtime/src/agent/dispatcher.rs
+++ b/crates/zeroclaw-runtime/src/agent/dispatcher.rs
@@ -1,3 +1,4 @@
+use super::history::canonicalize_tool_result_media_markers;
 use crate::tools::{Tool, ToolSpec};
 use serde_json::Value;
 use std::fmt::Write;
@@ -119,10 +120,11 @@ impl ToolDispatcher for XmlToolDispatcher {
         let mut content = String::new();
         for result in results {
             let status = if result.success { "ok" } else { "error" };
+            let output = canonicalize_tool_result_media_markers(&result.output);
             let _ = writeln!(
                 content,
                 "<tool_result name=\"{}\" status=\"{}\">\n{}\n</tool_result>",
-                result.name, status, result.output
+                result.name, status, output
             );
         }
         ConversationMessage::Chat(ChatMessage::user(format!("[Tool results]\n{content}")))
@@ -151,10 +153,11 @@ impl ToolDispatcher for XmlToolDispatcher {
                 ConversationMessage::ToolResults(results) => {
                     let mut content = String::new();
                     for result in results {
+                        let output = canonicalize_tool_result_media_markers(&result.content);
                         let _ = writeln!(
                             content,
                             "<tool_result id=\"{}\">\n{}\n</tool_result>",
-                            result.tool_call_id, result.content
+                            result.tool_call_id, output
                         );
                     }
                     vec![ChatMessage::user(format!("[Tool results]\n{content}"))]
@@ -200,7 +203,7 @@ impl ToolDispatcher for NativeToolDispatcher {
                     .tool_call_id
                     .clone()
                     .unwrap_or_else(|| "unknown".to_string()),
-                content: result.output.clone(),
+                content: canonicalize_tool_result_media_markers(&result.output),
             })
             .collect();
         ConversationMessage::ToolResults(messages)
@@ -235,7 +238,7 @@ impl ToolDispatcher for NativeToolDispatcher {
                         ChatMessage::tool(
                             serde_json::json!({
                                 "tool_call_id": result.tool_call_id,
-                                "content": result.content,
+                                "content": canonicalize_tool_result_media_markers(&result.content),
                             })
                             .to_string(),
                         )

--- a/crates/zeroclaw-runtime/src/agent/dispatcher.rs
+++ b/crates/zeroclaw-runtime/src/agent/dispatcher.rs
@@ -1,3 +1,4 @@
+use super::history::canonicalize_tool_result_media_markers;
 use crate::tools::{Tool, ToolSpec};
 use serde_json::Value;
 use std::fmt::Write;
@@ -119,10 +120,11 @@ impl ToolDispatcher for XmlToolDispatcher {
         let mut content = String::new();
         for result in results {
             let status = if result.success { "ok" } else { "error" };
+            let output = canonicalize_tool_result_media_markers(&result.output);
             let _ = writeln!(
                 content,
                 "<tool_result name=\"{}\" status=\"{}\">\n{}\n</tool_result>",
-                result.name, status, result.output
+                result.name, status, output
             );
         }
         ConversationMessage::Chat(ChatMessage::user(format!("[Tool results]\n{content}")))
@@ -155,10 +157,11 @@ impl ToolDispatcher for XmlToolDispatcher {
                 ConversationMessage::ToolResults(results) => {
                     let mut content = String::new();
                     for result in results {
+                        let output = canonicalize_tool_result_media_markers(&result.content);
                         let _ = writeln!(
                             content,
                             "<tool_result id=\"{}\">\n{}\n</tool_result>",
-                            result.tool_call_id, result.content
+                            result.tool_call_id, output
                         );
                     }
                     vec![ChatMessage::user(format!("[Tool results]\n{content}"))]
@@ -204,7 +207,7 @@ impl ToolDispatcher for NativeToolDispatcher {
                     .tool_call_id
                     .clone()
                     .unwrap_or_else(|| "unknown".to_string()),
-                content: result.output.clone(),
+                content: canonicalize_tool_result_media_markers(&result.output),
             })
             .collect();
         ConversationMessage::ToolResults(messages)
@@ -239,7 +242,7 @@ impl ToolDispatcher for NativeToolDispatcher {
                         ChatMessage::tool(
                             serde_json::json!({
                                 "tool_call_id": result.tool_call_id,
-                                "content": result.content,
+                                "content": canonicalize_tool_result_media_markers(&result.content),
                             })
                             .to_string(),
                         )

--- a/crates/zeroclaw-runtime/src/agent/history.rs
+++ b/crates/zeroclaw-runtime/src/agent/history.rs
@@ -1,13 +1,19 @@
 use crate::agent::history_pruner::remove_orphaned_tool_messages;
 use anyhow::Result;
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
+use std::sync::LazyLock;
 use zeroclaw_providers::ChatMessage;
 
 /// Default trigger for auto-compaction when non-system message count exceeds this threshold.
 /// Prefer passing the config-driven value via `run_tool_call_loop`; this constant is only
 /// used when callers omit the parameter.
 pub const DEFAULT_MAX_HISTORY_MESSAGES: usize = 50;
+
+static LOCAL_IMAGE_PATH_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"/[^\s<>'"`\]\)]+?\.(?i:png|jpe?g|webp|gif|bmp)"#).expect("valid image path regex")
+});
 
 /// Find the largest byte index `<= i` that is a valid char boundary.
 /// MSRV-compatible replacement for `str::floor_char_boundary` (stable in 1.91).
@@ -54,6 +60,60 @@ pub fn truncate_tool_result(output: &str, max_chars: usize) -> String {
         truncated_chars,
         &output[tail_start..]
     )
+}
+
+fn is_existing_local_image_path(path: &str) -> bool {
+    let candidate = Path::new(path);
+    candidate.is_absolute()
+        && candidate.is_file()
+        && candidate
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .is_some_and(|ext| {
+                matches!(
+                    ext.to_ascii_lowercase().as_str(),
+                    "png" | "jpg" | "jpeg" | "webp" | "gif" | "bmp"
+                )
+            })
+}
+
+/// Rewrite real local image file paths in tool output into `[IMAGE:...]`
+/// markers so the multimodal pipeline can normalize them before the next
+/// provider call. This targets shell/skill outputs that print filesystem
+/// paths directly rather than returning explicit media markers.
+pub fn canonicalize_tool_result_media_markers(output: &str) -> String {
+    let mut rewritten = String::with_capacity(output.len());
+    let mut cursor = 0usize;
+    let mut changed = false;
+
+    for mat in LOCAL_IMAGE_PATH_RE.find_iter(output) {
+        let start = mat.start();
+        let end = mat.end();
+        let path = &output[start..end];
+
+        // Skip paths that are already part of an explicit media marker.
+        if output[..start].ends_with("[IMAGE:") {
+            continue;
+        }
+
+        if !is_existing_local_image_path(path) {
+            continue;
+        }
+
+        rewritten.push_str(&output[cursor..start]);
+        rewritten.push_str("[IMAGE:");
+        rewritten.push_str(path);
+        rewritten.push(']');
+        cursor = end;
+        changed = true;
+    }
+
+    if !changed {
+        return output.to_string();
+    }
+
+    rewritten.push_str(&output[cursor..]);
+    rewritten
 }
 
 /// Truncate a tool message's content, preserving JSON structure when the
@@ -214,4 +274,36 @@ pub fn save_interactive_session_history(path: &Path, history: &[ChatMessage]) ->
     let payload = serde_json::to_string_pretty(&InteractiveSessionState::from_history(history))?;
     std::fs::write(path, payload)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonicalize_tool_result_media_markers_wraps_existing_local_image_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let image = dir.path().join("generated.png");
+        std::fs::write(&image, [0x89, b'P', b'N', b'G', b'\r', b'\n', 0x1a, b'\n']).unwrap();
+
+        let input = format!("Image generated successfully.\nFile: {}", image.display());
+        let output = canonicalize_tool_result_media_markers(&input);
+
+        assert!(output.contains("[IMAGE:"));
+        assert!(output.contains(&format!("[IMAGE:{}]", image.display())));
+    }
+
+    #[test]
+    fn canonicalize_tool_result_media_markers_ignores_missing_paths() {
+        let input = "File: /tmp/definitely-missing-zeroclaw-image.png";
+        let output = canonicalize_tool_result_media_markers(input);
+        assert_eq!(output, input);
+    }
+
+    #[test]
+    fn canonicalize_tool_result_media_markers_preserves_existing_markers() {
+        let input = "Already tagged [IMAGE:/tmp/already-tagged.png]";
+        let output = canonicalize_tool_result_media_markers(input);
+        assert_eq!(output, input);
+    }
 }

--- a/crates/zeroclaw-runtime/src/agent/history.rs
+++ b/crates/zeroclaw-runtime/src/agent/history.rs
@@ -28,9 +28,70 @@ pub fn floor_char_boundary(s: &str, i: usize) -> usize {
     pos
 }
 
+/// Indicates which side of a truncated string a boundary belongs to when
+/// nudging it away from a half-cut `[IMAGE:...]` marker.
+#[derive(Clone, Copy)]
+enum TruncationSide {
+    /// Boundary is the end of the kept head; nudge backward (out of the marker).
+    Head,
+    /// Boundary is the start of the kept tail; nudge forward (out of the marker).
+    Tail,
+}
+
+/// If `boundary` falls inside an `[IMAGE:...]` marker (i.e. between an
+/// unclosed `[IMAGE:` and its closing `]`), nudge it onto the nearest
+/// complete-marker boundary. The malformed half-marker is dropped into the
+/// truncated middle rather than emitted to the regex, which would otherwise
+/// silently fail to match and quietly lose the image.
+fn nudge_around_image_marker(s: &str, boundary: usize, side: TruncationSide) -> usize {
+    const OPEN: &str = "[IMAGE:";
+    if boundary == 0 || boundary >= s.len() {
+        return boundary;
+    }
+
+    // Walk forward to find the most recent `[IMAGE:` whose `[` is strictly
+    // before `boundary`. Searching forward (rather than `rfind` on a prefix)
+    // correctly handles the case where `boundary` itself splits the literal
+    // `[IMAGE:` token.
+    let mut search_from = 0usize;
+    let mut last_open: Option<usize> = None;
+    while let Some(rel) = s[search_from..].find(OPEN) {
+        let open_idx = search_from + rel;
+        if open_idx >= boundary {
+            break;
+        }
+        last_open = Some(open_idx);
+        search_from = open_idx + OPEN.len();
+    }
+    let Some(open_idx) = last_open else {
+        return boundary;
+    };
+
+    // First `]` after the opener closes the marker (canonicalize regex
+    // forbids `]` inside paths, so this is unambiguous in practice).
+    let close_idx = match s[open_idx..].find(']') {
+        Some(rel) => open_idx + rel,
+        None => return boundary, // malformed input — leave the boundary alone
+    };
+
+    if close_idx < boundary {
+        return boundary; // marker fully closed before boundary — safe
+    }
+
+    match side {
+        TruncationSide::Head => open_idx,
+        TruncationSide::Tail => (close_idx + 1).min(s.len()),
+    }
+}
+
 /// Truncate a tool result to `max_chars`, keeping head (2/3) + tail (1/3)
 /// with a marker in the middle. Returns input unchanged if within limit or
 /// `max_chars == 0` (disabled).
+///
+/// Boundaries are nudged inward when they would split an `[IMAGE:...]`
+/// marker, so the multimodal regex never sees a half-marker in the
+/// surviving head/tail. This matches the canonicalization step that runs
+/// immediately before truncation in `run_tool_call_loop`.
 pub fn truncate_tool_result(output: &str, max_chars: usize) -> String {
     if max_chars == 0 || output.len() <= max_chars {
         return output.to_string();
@@ -49,6 +110,13 @@ pub fn truncate_tool_result(output: &str, max_chars: usize) -> String {
         }
         pos
     };
+
+    // Step boundaries away from any `[IMAGE:...]` marker they would bisect.
+    // `[IMAGE:` and `]` are pure ASCII, so the adjusted indices land on
+    // valid UTF-8 char boundaries.
+    let head_end = nudge_around_image_marker(output, head_end, TruncationSide::Head);
+    let tail_start = nudge_around_image_marker(output, tail_start, TruncationSide::Tail);
+
     // Guard against overlap when max_chars is very small
     if head_end >= tail_start {
         return output[..floor_char_boundary(output, max_chars)].to_string();
@@ -305,5 +373,67 @@ mod tests {
         let input = "Already tagged [IMAGE:/tmp/already-tagged.png]";
         let output = canonicalize_tool_result_media_markers(input);
         assert_eq!(output, input);
+    }
+
+    /// Regression: when `truncate_tool_result`'s head boundary fell inside an
+    /// `[IMAGE:...]` marker, the head ended up containing a half-marker like
+    /// `[IMAGE:/very/long/pa` that the multimodal regex would silently fail
+    /// to match. The boundary now rewinds to the marker opener so the broken
+    /// half is dropped into the truncated middle. See PR #6183 review.
+    #[test]
+    fn truncate_tool_result_does_not_split_image_marker_at_head_boundary() {
+        // 200-byte path → marker length 207 bytes. With max_chars=80 the
+        // naive head_end (= 80 * 2 / 3 = 53) falls inside the marker.
+        let path = format!("/tmp/{}.png", "a".repeat(200));
+        let marker = format!("[IMAGE:{path}]");
+        let output = format!("prefix-text {marker} trailing-text padding-padding");
+
+        let truncated = truncate_tool_result(&output, 80);
+
+        assert!(
+            truncated.contains("[... ") && truncated.contains("characters truncated ...]"),
+            "expected truncation marker in output, got: {truncated}"
+        );
+        // No half-`[IMAGE:` marker should leak into the surviving content.
+        let stripped = truncated.replace(&marker, "");
+        assert!(
+            !stripped.contains("[IMAGE:"),
+            "half-`[IMAGE:` marker leaked into truncated output: {truncated}"
+        );
+    }
+
+    /// Regression: tail boundary previously could land inside an
+    /// `[IMAGE:...]` marker, leaving a stray closing `...png]` fragment in
+    /// the surviving tail. The boundary now advances past the closing `]`.
+    #[test]
+    fn truncate_tool_result_does_not_split_image_marker_at_tail_boundary() {
+        // Marker placed near the end so tail_start (~max_chars / 3 from the
+        // end) lands inside it.
+        let path = format!("/tmp/{}.png", "b".repeat(200));
+        let marker = format!("[IMAGE:{path}]");
+        let output = format!("{} preamble-content-line {marker} ending", "x".repeat(400));
+
+        let truncated = truncate_tool_result(&output, 90);
+
+        let stripped = truncated.replace(&marker, "");
+        assert!(
+            !stripped.contains("[IMAGE:") && !stripped.contains(".png]"),
+            "half-`[IMAGE:` marker leaked into truncated output: {truncated}"
+        );
+    }
+
+    /// When a complete `[IMAGE:...]` marker fits naturally inside the
+    /// retained head, truncation must not damage it.
+    #[test]
+    fn truncate_tool_result_keeps_complete_marker_in_head() {
+        let marker = "[IMAGE:/tmp/short.png]";
+        let output = format!("{marker} {}", "y".repeat(500));
+
+        let truncated = truncate_tool_result(&output, 200);
+
+        assert!(
+            truncated.starts_with(marker),
+            "expected head to retain full marker, got: {truncated}"
+        );
     }
 }

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -72,9 +72,9 @@ const DEFAULT_MAX_TOOL_ITERATIONS: usize = 10;
 
 // History management moved to `super::history`.
 pub use super::history::{
-    emergency_history_trim, estimate_history_tokens, fast_trim_tool_results,
-    load_interactive_session_history, save_interactive_session_history, trim_history,
-    truncate_tool_result,
+    canonicalize_tool_result_media_markers, emergency_history_trim, estimate_history_tokens,
+    fast_trim_tool_results, load_interactive_session_history, save_interactive_session_history,
+    trim_history, truncate_tool_result,
 };
 
 /// Minimum user-message length (in chars) for auto-save to memory.
@@ -1871,7 +1871,8 @@ pub async fn run_tool_call_loop(
                     }
                 }
             }
-            let mut result_output = truncate_tool_result(&outcome.output, max_tool_result_chars);
+            let canonical_output = canonicalize_tool_result_media_markers(&outcome.output);
+            let mut result_output = truncate_tool_result(&canonical_output, max_tool_result_chars);
             // Append HMAC receipt to tool result when receipts are enabled (#4830)
             if let Some(ref receipt) = outcome.receipt {
                 tracing::debug!(tool = %tool_name, receipt = %receipt, "Tool receipt generated");

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -74,9 +74,9 @@ const DEFAULT_MAX_TOOL_ITERATIONS: usize = 10;
 
 // History management moved to `super::history`.
 pub use super::history::{
-    emergency_history_trim, estimate_history_tokens, fast_trim_tool_results,
-    load_interactive_session_history, save_interactive_session_history, trim_history,
-    truncate_tool_result,
+    canonicalize_tool_result_media_markers, emergency_history_trim, estimate_history_tokens,
+    fast_trim_tool_results, load_interactive_session_history, save_interactive_session_history,
+    trim_history, truncate_tool_result,
 };
 
 /// Minimum user-message length (in chars) for auto-save to memory.
@@ -1935,7 +1935,8 @@ pub async fn run_tool_call_loop(
                     }
                 }
             }
-            let mut result_output = truncate_tool_result(&outcome.output, max_tool_result_chars);
+            let canonical_output = canonicalize_tool_result_media_markers(&outcome.output);
+            let mut result_output = truncate_tool_result(&canonical_output, max_tool_result_chars);
             // Append HMAC receipt to tool result when receipts are enabled (#4830)
             if let Some(ref receipt) = outcome.receipt {
                 tracing::debug!(tool = %tool_name, receipt = %receipt, "Tool receipt generated");

--- a/crates/zeroclaw-runtime/src/agent/tests.rs
+++ b/crates/zeroclaw-runtime/src/agent/tests.rs
@@ -1188,11 +1188,19 @@ fn xml_format_results_includes_status_and_output() {
 
 #[test]
 fn native_format_results_maps_tool_call_ids() {
+    let temp = tempfile::tempdir().unwrap();
+    let image_path = temp.path().join("generated.png");
+    std::fs::write(
+        &image_path,
+        [0x89, b'P', b'N', b'G', b'\r', b'\n', 0x1a, b'\n'],
+    )
+    .unwrap();
+
     let dispatcher = NativeToolDispatcher;
     let results = vec![
         ToolExecutionResult {
             name: "a".into(),
-            output: "out1".into(),
+            output: format!("File: {}", image_path.display()),
             success: true,
             tool_call_id: Some("tc-001".into()),
         },
@@ -1209,12 +1217,41 @@ fn native_format_results_maps_tool_call_ids() {
         ConversationMessage::ToolResults(r) => {
             assert_eq!(r.len(), 2);
             assert_eq!(r[0].tool_call_id, "tc-001");
-            assert_eq!(r[0].content, "out1");
+            assert!(r[0].content.contains("[IMAGE:"));
+            assert!(r[0].content.contains(&image_path.display().to_string()));
             assert_eq!(r[1].tool_call_id, "tc-002");
             assert_eq!(r[1].content, "out2");
         }
         _ => panic!("Expected ToolResults"),
     }
+}
+
+#[test]
+fn xml_format_results_wraps_local_image_paths() {
+    let temp = tempfile::tempdir().unwrap();
+    let image_path = temp.path().join("xml-generated.png");
+    std::fs::write(
+        &image_path,
+        [0x89, b'P', b'N', b'G', b'\r', b'\n', 0x1a, b'\n'],
+    )
+    .unwrap();
+
+    let dispatcher = XmlToolDispatcher;
+    let results = vec![ToolExecutionResult {
+        name: "shell".into(),
+        output: format!("Saved image to {}", image_path.display()),
+        success: true,
+        tool_call_id: None,
+    }];
+
+    let msg = dispatcher.format_results(&results);
+    let content = match msg {
+        ConversationMessage::Chat(c) => c.content,
+        _ => panic!("Expected Chat variant"),
+    };
+
+    assert!(content.contains("[IMAGE:"));
+    assert!(content.contains(&image_path.display().to_string()));
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -1253,11 +1290,19 @@ fn xml_dispatcher_converts_history_to_provider_messages() {
 
 #[test]
 fn native_dispatcher_converts_tool_results_to_tool_messages() {
+    let temp = tempfile::tempdir().unwrap();
+    let image_path = temp.path().join("history.png");
+    std::fs::write(
+        &image_path,
+        [0x89, b'P', b'N', b'G', b'\r', b'\n', 0x1a, b'\n'],
+    )
+    .unwrap();
+
     let dispatcher = NativeToolDispatcher;
     let history = vec![ConversationMessage::ToolResults(vec![
         ToolResultMessage {
             tool_call_id: "tc1".into(),
-            content: "output1".into(),
+            content: format!("Saved image to {}", image_path.display()),
         },
         ToolResultMessage {
             tool_call_id: "tc2".into(),
@@ -1269,6 +1314,12 @@ fn native_dispatcher_converts_tool_results_to_tool_messages() {
     assert_eq!(messages.len(), 2);
     assert_eq!(messages[0].role, "tool");
     assert_eq!(messages[1].role, "tool");
+    assert!(messages[0].content.contains("[IMAGE:"));
+    assert!(
+        messages[0]
+            .content
+            .contains(&image_path.display().to_string())
+    );
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/crates/zeroclaw-runtime/src/agent/tests.rs
+++ b/crates/zeroclaw-runtime/src/agent/tests.rs
@@ -1306,11 +1306,19 @@ fn xml_format_results_includes_status_and_output() {
 
 #[test]
 fn native_format_results_maps_tool_call_ids() {
+    let temp = tempfile::tempdir().unwrap();
+    let image_path = temp.path().join("generated.png");
+    std::fs::write(
+        &image_path,
+        [0x89, b'P', b'N', b'G', b'\r', b'\n', 0x1a, b'\n'],
+    )
+    .unwrap();
+
     let dispatcher = NativeToolDispatcher;
     let results = vec![
         ToolExecutionResult {
             name: "a".into(),
-            output: "out1".into(),
+            output: format!("File: {}", image_path.display()),
             success: true,
             tool_call_id: Some("tc-001".into()),
         },
@@ -1327,12 +1335,41 @@ fn native_format_results_maps_tool_call_ids() {
         ConversationMessage::ToolResults(r) => {
             assert_eq!(r.len(), 2);
             assert_eq!(r[0].tool_call_id, "tc-001");
-            assert_eq!(r[0].content, "out1");
+            assert!(r[0].content.contains("[IMAGE:"));
+            assert!(r[0].content.contains(&image_path.display().to_string()));
             assert_eq!(r[1].tool_call_id, "tc-002");
             assert_eq!(r[1].content, "out2");
         }
         _ => panic!("Expected ToolResults"),
     }
+}
+
+#[test]
+fn xml_format_results_wraps_local_image_paths() {
+    let temp = tempfile::tempdir().unwrap();
+    let image_path = temp.path().join("xml-generated.png");
+    std::fs::write(
+        &image_path,
+        [0x89, b'P', b'N', b'G', b'\r', b'\n', 0x1a, b'\n'],
+    )
+    .unwrap();
+
+    let dispatcher = XmlToolDispatcher;
+    let results = vec![ToolExecutionResult {
+        name: "shell".into(),
+        output: format!("Saved image to {}", image_path.display()),
+        success: true,
+        tool_call_id: None,
+    }];
+
+    let msg = dispatcher.format_results(&results);
+    let content = match msg {
+        ConversationMessage::Chat(c) => c.content,
+        _ => panic!("Expected Chat variant"),
+    };
+
+    assert!(content.contains("[IMAGE:"));
+    assert!(content.contains(&image_path.display().to_string()));
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -1372,11 +1409,19 @@ fn xml_dispatcher_converts_history_to_provider_messages() {
 
 #[test]
 fn native_dispatcher_converts_tool_results_to_tool_messages() {
+    let temp = tempfile::tempdir().unwrap();
+    let image_path = temp.path().join("history.png");
+    std::fs::write(
+        &image_path,
+        [0x89, b'P', b'N', b'G', b'\r', b'\n', 0x1a, b'\n'],
+    )
+    .unwrap();
+
     let dispatcher = NativeToolDispatcher;
     let history = vec![ConversationMessage::ToolResults(vec![
         ToolResultMessage {
             tool_call_id: "tc1".into(),
-            content: "output1".into(),
+            content: format!("Saved image to {}", image_path.display()),
         },
         ToolResultMessage {
             tool_call_id: "tc2".into(),
@@ -1388,6 +1433,12 @@ fn native_dispatcher_converts_tool_results_to_tool_messages() {
     assert_eq!(messages.len(), 2);
     assert_eq!(messages[0].role, "tool");
     assert_eq!(messages[1].role, "tool");
+    assert!(messages[0].content.contains("[IMAGE:"));
+    assert!(
+        messages[0]
+            .content
+            .contains(&image_path.display().to_string())
+    );
 }
 
 // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Normalize image-bearing tool results at the runtime boundary so shell/skill output that returns a real local image path is rewritten into `[IMAGE:...]` before history replay.
  - Extend provider-side multimodal preprocessing from `user`-only to `user` and `tool` messages so replayed tool history is converted into provider-safe `data:` URIs.
  - Run multimodal preprocessing inside `Agent::turn` and `Agent::turn_streamed` so WebSocket / agent callers stop sending raw `[IMAGE:...]` markers as plain text.
  - **Preserve native tool-result JSON shape** during multimodal preprocessing. `NativeToolDispatcher::to_provider_messages` wraps tool results as `{"tool_call_id": "...", "content": "..."}` so downstream native adapters (`compatible.rs`, `openrouter.rs`, `openai.rs`, `copilot.rs`, `ollama.rs`, `azure_openai.rs`) can recover the tool-call linkage via `serde_json::from_str`. The provider preprocessor now parses that JSON, rewrites `[IMAGE:/...]` markers only inside the inner `content` string, and reserializes the JSON so `tool_call_id` and any sibling fields round-trip untouched.
  - Truncation in `truncate_tool_result` now nudges head/tail boundaries away from `[IMAGE:...]` markers it would otherwise bisect, dropping the broken half into the truncated middle.
  - `MultimodalConfig` gains a privacy/cost doc note covering the new tool-output upload semantics, and `max_images` is documented as the per-turn upload-budget ceiling.
  - `CHANGELOG-next.md` gains a `## Behavior Changes` section flagging that tool outputs which mention real local image paths are now base64-uploaded to the configured provider.
  - Add focused regression coverage for tool-history replay, agent-provider multimodal preparation, truncation marker preservation, and native tool-result JSON preservation.
- **Scope boundary:**
  - Does not change Discord/channel attachment ingestion.
  - Does not solve the auxiliary capability-guard ordering bug from `#5897`.
  - Does not broaden assistant/system image replay behavior.
- **Blast radius:**
  - Runtime agent message preparation.
  - Tool-result history serialization.
  - Provider multimodal normalization for replayed tool messages.
  - Native tool-result JSON contract consumed by six provider adapters.
  - WebSocket / other `Agent::turn*` consumers.
- **Linked issue(s):** Closes #6097, Closes #5453, Related #5897

## Validation Evidence (required)

Local validation against branch HEAD `4569b2fa`:

```bash
$ cargo fmt --all -- --check
# exited 0 — clean

$ cargo clippy --all-targets -- -D warnings
# exited 0 — 0 warnings workspace-wide

$ cargo test -p zeroclaw-providers multimodal
test result: ok. 24 passed; 0 failed; 0 ignored; 0 measured; 800 filtered out; finished in 0.03s

$ cargo test -p zeroclaw-providers compatible
test result: ok. 120 passed; 0 failed; 0 ignored; 0 measured; 704 filtered out; finished in 0.01s

$ cargo test -p zeroclaw-runtime truncate_tool_result
# 10 passed; 0 failed (summed across binaries)

$ cargo test -p zeroclaw-runtime canonicalize_tool_result_media_markers
# 3 passed; 0 failed (summed across binaries)

$ cargo test -p zeroclaw-runtime normalizes_user_image_markers_before_provider_call
# 2 passed; 0 failed

$ cargo test -p zeroclaw-runtime --lib agent::dispatcher
test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 1650 filtered out; finished in 0.01s

$ cargo test --workspace --lib
# workspace lib: 6668 passed, 0 failed, 3 ignored
```

- **Beyond CI — what did you manually verify?**
  - The agent path sends a normalized `data:image/...;base64,...` payload to the provider instead of a raw `[IMAGE:...]` marker for both `turn` and `turn_streamed`.
  - Tool-result history carrying image markers survives replay through the multimodal pipeline.
  - Native tool-result JSON wrappers (`{"tool_call_id":"...","content":"..."}`) remain valid JSON after multimodal preprocessing: parsed `tool_call_id` round-trips unchanged, and the data URI is inlined into the inner `content` string. Confirmed end-to-end by `prepare_messages_preserves_native_tool_result_json_shape`.
  - Reviewed the six native adapters that consume that JSON (`compatible.rs:1515`, `openrouter.rs:272`, `openai.rs:290`, `copilot.rs:337`, `ollama.rs:484`, `azure_openai.rs:248`) to confirm they all rely on `serde_json::from_str` over `message.content` to recover `tool_call_id`.
- **If any command was intentionally skipped, why:**
  - None. Full workspace clippy and lib test surface were executed.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- New behavior: tool outputs that mention real local image paths are now base64-uploaded to the configured provider, capped per turn by `multimodal.max_images`. This is documented in `CHANGELOG-next.md` under "Behavior Changes" and in the `MultimodalConfig` doc comments.

## Rollback (required for `risk: medium` and `risk: high`)

This PR is labeled `risk: high` because it touches the runtime agent loop, tool-result history serialization, and the provider multimodal contract consumed by six native adapters. Revert path:

```bash
git revert 4569b2fa 2d887db5 f4d4b08b
```

Revert in commit-order (newest first). After revert, native tool-result JSON returns to the pre-change behavior where `[IMAGE:/...]` markers reach the provider unmodified for the `tool` role, and the older marker-canonicalization plus user-only multimodal preprocessing remain. No config or schema rollback required — `MultimodalConfig` keys were doc-only additions.
