### PR TITLE
feat(tools/web_search): implement Tavily search backend

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -3027,7 +3027,7 @@ pub struct WebSearchConfig {
     /// Enable `web_search_tool` for web searches
     #[serde(default)]
     pub enabled: bool,
-    /// Search provider: "duckduckgo" (free), "brave" (requires API key), or "searxng" (self-hosted)
+    /// Search provider: "duckduckgo" (free), "brave" (requires API key), "tavily" (requires API key), or "searxng" (self-hosted)
     #[serde(default = "default_web_search_provider")]
     pub provider: String,
     /// Brave Search API key (required if provider is "brave")
@@ -3035,6 +3035,11 @@ pub struct WebSearchConfig {
     #[secret]
     #[cfg_attr(feature = "schema-export", schemars(extend("x-secret" = true)))]
     pub brave_api_key: Option<String>,
+    /// Tavily Search API key (required if provider is "tavily")
+    #[serde(default)]
+    #[secret]
+    #[cfg_attr(feature = "schema-export", schemars(extend("x-secret" = true)))]
+    pub tavily_api_key: Option<String>,
     /// SearXNG instance URL (required if provider is `"searxng"`), e.g. `"https://searx.example.com"`.
     #[serde(default)]
     pub searxng_instance_url: Option<String>,
@@ -3064,6 +3069,7 @@ impl Default for WebSearchConfig {
             enabled: true,
             provider: default_web_search_provider(),
             brave_api_key: None,
+            tavily_api_key: None,
             searxng_instance_url: None,
             max_results: default_web_search_max_results(),
             timeout_secs: default_web_search_timeout_secs(),
@@ -11024,6 +11030,16 @@ impl Config {
             }
         }
 
+        // Tavily API key: ZEROCLAW_TAVILY_API_KEY or TAVILY_API_KEY
+        if let Ok(api_key) =
+            std::env::var("ZEROCLAW_TAVILY_API_KEY").or_else(|_| std::env::var("TAVILY_API_KEY"))
+        {
+            let api_key = api_key.trim();
+            if !api_key.is_empty() {
+                self.web_search.tavily_api_key = Some(api_key.to_string());
+            }
+        }
+
         // SearXNG instance URL: ZEROCLAW_SEARXNG_INSTANCE_URL or SEARXNG_INSTANCE_URL
         if let Ok(instance_url) = std::env::var("ZEROCLAW_SEARXNG_INSTANCE_URL")
             .or_else(|_| std::env::var("SEARXNG_INSTANCE_URL"))
@@ -12695,6 +12711,7 @@ default_temperature = 0.7
         config.composio.api_key = Some("composio-credential".into());
         config.browser.computer_use.api_key = Some("browser-credential".into());
         config.web_search.brave_api_key = Some("brave-credential".into());
+        config.web_search.tavily_api_key = Some("tavily-credential".into());
         config.storage.provider.config.db_url = Some("postgres://user:pw@host/db".into());
         config.channels.feishu = Some(FeishuConfig {
             enabled: true,
@@ -12770,6 +12787,13 @@ default_temperature = 0.7
         assert_eq!(
             store.decrypt(web_search_encrypted).unwrap(),
             "brave-credential"
+        );
+
+        let tavily_encrypted = stored.web_search.tavily_api_key.as_deref().unwrap();
+        assert!(crate::secrets::SecretStore::is_encrypted(tavily_encrypted));
+        assert_eq!(
+            store.decrypt(tavily_encrypted).unwrap(),
+            "tavily-credential"
         );
 
         let worker = stored.agents.get("worker").unwrap();

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -511,6 +511,7 @@ pub fn all_tools_with_runtime(
         tool_arcs.push(Arc::new(WebSearchTool::new_with_config(
             root_config.web_search.provider.clone(),
             root_config.web_search.brave_api_key.clone(),
+            root_config.web_search.tavily_api_key.clone(),
             root_config.web_search.searxng_instance_url.clone(),
             root_config.web_search.max_results,
             root_config.web_search.timeout_secs,

--- a/crates/zeroclaw-tools/src/web_search_tool.rs
+++ b/crates/zeroclaw-tools/src/web_search_tool.rs
@@ -281,10 +281,21 @@ impl WebSearchTool {
     }
 
     async fn search_tavily(&self, query: &str) -> anyhow::Result<String> {
+        self.search_tavily_at("https://api.tavily.com/search", query)
+            .await
+    }
+
+    /// Inner Tavily request implementation, parameterized on the endpoint URL
+    /// so request-shape tests can target a local mock server. Production calls
+    /// always go through [`Self::search_tavily`].
+    async fn search_tavily_at(&self, url: &str, query: &str) -> anyhow::Result<String> {
         let api_key = self.resolve_tavily_api_key()?;
 
+        // Tavily authenticates via `Authorization: Bearer <key>` per
+        // https://docs.tavily.com/documentation/api-reference/endpoint/search
+        // (the API also tolerates `api_key` in the body for legacy clients,
+        // but bearer-header is the documented contract).
         let body = serde_json::json!({
-            "api_key": api_key,
             "query": query,
             "max_results": self.max_results,
             "search_depth": "basic",
@@ -298,8 +309,8 @@ impl WebSearchTool {
         let client = builder.build()?;
 
         let response = client
-            .post("https://api.tavily.com/search")
-            .header("Content-Type", "application/json")
+            .post(url)
+            .bearer_auth(&api_key)
             .json(&body)
             .send()
             .await?;
@@ -890,6 +901,74 @@ mod tests {
         );
         let key = tool.resolve_tavily_api_key().unwrap();
         assert_eq!(key, "tvly-secret-key");
+    }
+
+    /// Regression: Tavily auth must travel as `Authorization: Bearer <key>`
+    /// (the documented contract per
+    /// https://docs.tavily.com/documentation/api-reference/endpoint/search),
+    /// NOT as an `api_key` field in the JSON body. The previous shape worked
+    /// against the live service for legacy reasons, but the docs identify
+    /// bearer-header as the canonical method.
+    #[tokio::test]
+    async fn test_tavily_request_uses_bearer_auth_header_not_body_field() {
+        use wiremock::matchers::{header, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/search"))
+            .and(header("authorization", "Bearer tvly-test-key"))
+            .and(header("content-type", "application/json"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "query": "what is rust",
+                "results": []
+            })))
+            .mount(&server)
+            .await;
+
+        let tool = WebSearchTool::new_with_config(
+            "tavily".to_string(),
+            None,
+            Some("tvly-test-key".to_string()),
+            None,
+            5,
+            15,
+            PathBuf::new(),
+            false,
+        );
+
+        let result = tool
+            .search_tavily_at(&format!("{}/search", server.uri()), "what is rust")
+            .await
+            .expect("request should succeed against the mock");
+        assert!(
+            result.contains("No results found"),
+            "parser should report empty results: {result}"
+        );
+
+        let recorded = server
+            .received_requests()
+            .await
+            .expect("wiremock should have captured the request");
+        assert_eq!(recorded.len(), 1, "expected exactly one POST /search");
+
+        let body: serde_json::Value =
+            serde_json::from_slice(&recorded[0].body).expect("body should be JSON");
+
+        // Auth must NOT leak into the body — bearer header is the only auth channel.
+        assert!(
+            body.get("api_key").is_none(),
+            "api_key must not appear in the request body; got: {body}"
+        );
+
+        // The documented body fields must still be present so the search
+        // contract continues to match the upstream API spec.
+        assert_eq!(body["query"], "what is rust");
+        assert_eq!(body["search_depth"], "basic");
+        assert_eq!(body["max_results"], 5);
+        assert_eq!(body["include_answer"], false);
+        assert_eq!(body["include_raw_content"], false);
     }
 
     #[test]

--- a/crates/zeroclaw-tools/src/web_search_tool.rs
+++ b/crates/zeroclaw-tools/src/web_search_tool.rs
@@ -8,17 +8,19 @@ use zeroclaw_api::tool::{Tool, ToolResult};
 
 /// Web search tool for searching the internet.
 /// Supports multiple providers: DuckDuckGo (free), Brave (requires API key),
-/// SearXNG (self-hosted, requires instance URL).
+/// Tavily (requires API key), SearXNG (self-hosted, requires instance URL).
 ///
-/// The Brave API key is resolved lazily at execution time: if the boot-time key
+/// API keys are resolved lazily at execution time: if the boot-time key
 /// is missing or still encrypted, the tool re-reads `config.toml`, decrypts the
-/// `[web_search] brave_api_key` field, and uses the result. This ensures that
+/// corresponding `[web_search]` field, and uses the result. This ensures that
 /// keys set or rotated after boot, and encrypted keys, are correctly picked up.
 pub struct WebSearchTool {
     /// Provider selector as configured by user. Routed via provider aliases at runtime.
     provider: String,
     /// Boot-time key snapshot (may be `None` if not yet configured at startup).
     boot_brave_api_key: Option<String>,
+    /// Boot-time Tavily key snapshot.
+    boot_tavily_api_key: Option<String>,
     /// SearXNG instance base URL (e.g. `"https://searx.example.com"`).
     searxng_instance_url: Option<String>,
     max_results: usize,
@@ -39,6 +41,7 @@ impl WebSearchTool {
         Self {
             provider: provider.trim().to_lowercase(),
             boot_brave_api_key: brave_api_key,
+            boot_tavily_api_key: None,
             searxng_instance_url: None,
             max_results: max_results.clamp(1, 10),
             timeout_secs: timeout_secs.max(1),
@@ -49,12 +52,14 @@ impl WebSearchTool {
 
     /// Create a `WebSearchTool` with config-reload and decryption support.
     ///
-    /// `config_path` is the path to `config.toml` so the tool can re-read the
-    /// Brave API key at execution time. `secrets_encrypt` controls whether the
-    /// key is decrypted via `SecretStore`.
+    /// `config_path` is the path to `config.toml` so the tool can re-read API
+    /// keys at execution time. `secrets_encrypt` controls whether the keys are
+    /// decrypted via `SecretStore`.
+    #[allow(clippy::too_many_arguments)]
     pub fn new_with_config(
         provider: String,
         brave_api_key: Option<String>,
+        tavily_api_key: Option<String>,
         searxng_instance_url: Option<String>,
         max_results: usize,
         timeout_secs: u64,
@@ -64,6 +69,7 @@ impl WebSearchTool {
         Self {
             provider: provider.trim().to_lowercase(),
             boot_brave_api_key: brave_api_key,
+            boot_tavily_api_key: tavily_api_key,
             searxng_instance_url,
             max_results: max_results.clamp(1, 10),
             timeout_secs: timeout_secs.max(1),
@@ -224,6 +230,122 @@ impl WebSearchTool {
 
         let json: serde_json::Value = response.json().await?;
         self.parse_brave_results(&json, query)
+    }
+
+    /// Resolve the Tavily API key from the boot-time snapshot, falling back
+    /// to a fresh config read + decryption when the boot-time value is absent.
+    fn resolve_tavily_api_key(&self) -> anyhow::Result<String> {
+        if let Some(ref key) = self.boot_tavily_api_key
+            && !key.is_empty()
+            && !zeroclaw_config::secrets::SecretStore::is_encrypted(key)
+        {
+            return Ok(key.clone());
+        }
+        self.reload_tavily_api_key()
+    }
+
+    /// Re-read `config.toml` and decrypt `[web_search] tavily_api_key`.
+    fn reload_tavily_api_key(&self) -> anyhow::Result<String> {
+        let contents = std::fs::read_to_string(&self.config_path).map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to read config file {} for Tavily API key: {e}",
+                self.config_path.display()
+            )
+        })?;
+
+        let config: zeroclaw_config::schema::Config = toml::from_str(&contents).map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to parse config file {} for Tavily API key: {e}",
+                self.config_path.display()
+            )
+        })?;
+
+        let raw_key = config
+            .web_search
+            .tavily_api_key
+            .filter(|k| !k.is_empty())
+            .ok_or_else(|| anyhow::anyhow!("Tavily API key not configured"))?;
+
+        if zeroclaw_config::secrets::SecretStore::is_encrypted(&raw_key) {
+            let zeroclaw_dir = self.config_path.parent().unwrap_or_else(|| Path::new("."));
+            let store =
+                zeroclaw_config::secrets::SecretStore::new(zeroclaw_dir, self.secrets_encrypt);
+            let plaintext = store.decrypt(&raw_key)?;
+            if plaintext.is_empty() {
+                anyhow::bail!("Tavily API key not configured (decrypted value is empty)");
+            }
+            Ok(plaintext)
+        } else {
+            Ok(raw_key)
+        }
+    }
+
+    async fn search_tavily(&self, query: &str) -> anyhow::Result<String> {
+        let api_key = self.resolve_tavily_api_key()?;
+
+        let body = serde_json::json!({
+            "api_key": api_key,
+            "query": query,
+            "max_results": self.max_results,
+            "search_depth": "basic",
+            "include_answer": false,
+            "include_raw_content": false,
+        });
+
+        let builder = reqwest::Client::builder().timeout(Duration::from_secs(self.timeout_secs));
+        let builder =
+            zeroclaw_config::schema::apply_runtime_proxy_to_builder(builder, "tool.web_search");
+        let client = builder.build()?;
+
+        let response = client
+            .post("https://api.tavily.com/search")
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            anyhow::bail!("Tavily search failed with status: {}", response.status());
+        }
+
+        let json: serde_json::Value = response.json().await?;
+        self.parse_tavily_results(&json, query)
+    }
+
+    fn parse_tavily_results(
+        &self,
+        json: &serde_json::Value,
+        query: &str,
+    ) -> anyhow::Result<String> {
+        let results = json
+            .get("results")
+            .and_then(|r| r.as_array())
+            .ok_or_else(|| anyhow::anyhow!("Invalid Tavily API response"))?;
+
+        if results.is_empty() {
+            return Ok(format!("No results found for: {}", query));
+        }
+
+        let mut lines = vec![format!("Search results for: {} (via Tavily)", query)];
+
+        for (i, result) in results.iter().take(self.max_results).enumerate() {
+            let title = result
+                .get("title")
+                .and_then(|t| t.as_str())
+                .unwrap_or("No title");
+            let url = result.get("url").and_then(|u| u.as_str()).unwrap_or("");
+            // Tavily returns a pre-cleaned `content` field (not just a snippet),
+            // so it doubles as the description for the LLM caller.
+            let content = result.get("content").and_then(|c| c.as_str()).unwrap_or("");
+
+            lines.push(format!("{}. {}", i + 1, title));
+            lines.push(format!("   {}", url));
+            if !content.is_empty() {
+                lines.push(format!("   {}", content));
+            }
+        }
+
+        Ok(lines.join("\n"))
     }
 
     fn parse_brave_results(&self, json: &serde_json::Value, query: &str) -> anyhow::Result<String> {
@@ -424,10 +546,9 @@ impl Tool for WebSearchTool {
         }
 
         let result = match resolution.route {
-            WebSearchProviderRoute::DuckDuckGo | WebSearchProviderRoute::Tavily => {
-                self.search_duckduckgo(query).await?
-            } // TODO: implement Tavily search
+            WebSearchProviderRoute::DuckDuckGo => self.search_duckduckgo(query).await?,
             WebSearchProviderRoute::Brave => self.search_brave(query).await?,
+            WebSearchProviderRoute::Tavily => self.search_tavily(query).await?,
             WebSearchProviderRoute::SearXNG => self.search_searxng(query).await?,
         };
 
@@ -562,6 +683,7 @@ mod tests {
             "brave".to_string(),
             None,
             None,
+            None,
             5,
             15,
             config_path,
@@ -589,6 +711,7 @@ mod tests {
             "brave".to_string(),
             Some(encrypted),
             None,
+            None,
             5,
             15,
             config_path,
@@ -608,6 +731,7 @@ mod tests {
             "searxng".to_string(),
             None,
             None,
+            None,
             5,
             15,
             config_path,
@@ -621,6 +745,123 @@ mod tests {
                 .to_string()
                 .contains("SearXNG instance URL not configured")
         );
+    }
+
+    #[test]
+    fn test_parse_tavily_results_empty() {
+        let tool = WebSearchTool::new("tavily".to_string(), None, 5, 15);
+        let json = serde_json::json!({"results": []});
+        let result = tool.parse_tavily_results(&json, "test").unwrap();
+        assert!(result.contains("No results found"));
+    }
+
+    #[test]
+    fn test_parse_tavily_results_with_data() {
+        let tool = WebSearchTool::new("tavily".to_string(), None, 5, 15);
+        let json = serde_json::json!({
+            "query": "test",
+            "results": [
+                {
+                    "title": "Tavily Example",
+                    "url": "https://example.com",
+                    "content": "Pre-cleaned summary content from Tavily",
+                    "score": 0.91
+                },
+                {
+                    "title": "Another Result",
+                    "url": "https://example.org",
+                    "content": "Second result body"
+                }
+            ]
+        });
+        let result = tool.parse_tavily_results(&json, "test").unwrap();
+        assert!(result.contains("Tavily Example"));
+        assert!(result.contains("https://example.com"));
+        assert!(result.contains("Pre-cleaned summary content from Tavily"));
+        assert!(result.contains("via Tavily"));
+    }
+
+    #[test]
+    fn test_parse_tavily_results_invalid_response() {
+        let tool = WebSearchTool::new("tavily".to_string(), None, 5, 15);
+        let json = serde_json::json!({"error": "bad api key"});
+        let result = tool.parse_tavily_results(&json, "test");
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Invalid Tavily API response")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_execute_tavily_without_api_key() {
+        // No boot key + no config field → resolve_tavily_api_key must error
+        // before any network call is attempted.
+        let tmp = tempfile::tempdir().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(&config_path, "[web_search]\n").unwrap();
+
+        let tool = WebSearchTool::new_with_config(
+            "tavily".to_string(),
+            None,
+            None,
+            None,
+            5,
+            15,
+            config_path,
+            false,
+        );
+        let result = tool.execute(json!({"query": "test"})).await;
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Tavily API key not configured")
+        );
+    }
+
+    #[test]
+    fn test_resolve_tavily_api_key_uses_boot_key() {
+        let tool = WebSearchTool::new_with_config(
+            "tavily".to_string(),
+            None,
+            Some("tvly-boot-key".to_string()),
+            None,
+            5,
+            15,
+            PathBuf::new(),
+            false,
+        );
+        let key = tool.resolve_tavily_api_key().unwrap();
+        assert_eq!(key, "tvly-boot-key");
+    }
+
+    #[test]
+    fn test_resolve_tavily_api_key_reloads_from_config() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            "[web_search]\ntavily_api_key = \"tvly-fresh-from-disk\"\n",
+        )
+        .unwrap();
+
+        // No boot key — forces reload from config
+        let tool = WebSearchTool::new_with_config(
+            "tavily".to_string(),
+            None,
+            None,
+            None,
+            5,
+            15,
+            config_path,
+            false,
+        );
+        let key = tool.resolve_tavily_api_key().unwrap();
+        assert_eq!(key, "tvly-fresh-from-disk");
     }
 
     #[test]
@@ -674,6 +915,7 @@ mod tests {
         let tool = WebSearchTool {
             provider: "searxng".to_string(),
             boot_brave_api_key: None,
+            boot_tavily_api_key: None,
             searxng_instance_url: Some("https://searx.example.com".to_string()),
             max_results: 5,
             timeout_secs: 15,
@@ -698,6 +940,7 @@ mod tests {
             "searxng".to_string(),
             None,
             None,
+            None,
             5,
             15,
             config_path,
@@ -717,6 +960,7 @@ mod tests {
 
         let tool = WebSearchTool::new_with_config(
             "brave".to_string(),
+            None,
             None,
             None,
             5,

--- a/crates/zeroclaw-tools/src/web_search_tool.rs
+++ b/crates/zeroclaw-tools/src/web_search_tool.rs
@@ -865,6 +865,34 @@ mod tests {
     }
 
     #[test]
+    fn test_resolve_tavily_api_key_decrypts_encrypted_key() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = zeroclaw_config::secrets::SecretStore::new(tmp.path(), true);
+        let encrypted = store.encrypt("tvly-secret-key").unwrap();
+
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            format!("[web_search]\ntavily_api_key = \"{}\"\n", encrypted),
+        )
+        .unwrap();
+
+        // Boot key is the encrypted blob -- should trigger reload + decrypt
+        let tool = WebSearchTool::new_with_config(
+            "tavily".to_string(),
+            None,
+            Some(encrypted),
+            None,
+            5,
+            15,
+            config_path,
+            true,
+        );
+        let key = tool.resolve_tavily_api_key().unwrap();
+        assert_eq!(key, "tvly-secret-key");
+    }
+
+    #[test]
     fn test_parse_searxng_results_empty() {
         let tool = WebSearchTool::new("searxng".to_string(), None, 5, 15);
         let json = serde_json::json!({"results": []});


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `WebSearchProviderRoute::Tavily` was already in `web_search_provider_routing.rs`, but `web_search_tool.rs:427` had a `// TODO: implement Tavily search` and silently fell through to DuckDuckGo. Setting `[web_search] provider = "tavily"` therefore looked configured but produced DDG-quality results, with no error to signal the gap.
  - Implements `search_tavily()` (POST `https://api.tavily.com/search` with JSON body, parses `results[].title|url|content`) following the same shape as `search_brave` / `search_searxng`.
  - Adds `[web_search] tavily_api_key` schema field with `#[secret]` so it gets the same boot-snapshot / lazy-reload-from-config.toml / SecretStore decryption pattern Brave already has.
  - Honors `ZEROCLAW_TAVILY_API_KEY` / `TAVILY_API_KEY` env-var overrides via the same loader path used for Brave.
  - Wires `tavily_api_key` through `WebSearchTool::new_with_config()` and the tool registration in `crates/zeroclaw-runtime/src/tools/mod.rs`.
- **Scope boundary:** Does NOT touch the routing enum (`WebSearchProviderRoute`), the DDG / Brave / SearXNG paths, or the agent loop. Tavily-specific options (`search_depth`, `include_answer`, `include_raw_content`) are hard-coded to "basic" / `false` / `false` in this PR — those can become config knobs in a follow-up if there is demand.
- **Blast radius:** Provider-side network call only; Tavily users get real results, every other provider unchanged. The `WebSearchTool::new_with_config` signature gained one parameter (`tavily_api_key`); the only production caller is `runtime/tools/mod.rs:511` which is updated in this PR. Tests using the constructor were updated too. `WebSearchTool::new` (the simpler 4-arg variant) is unchanged.
- **Linked issue(s):** None — this completes scaffolding that was already in tree.

## Validation Evidence (required)

```
$ cargo fmt --all -- --check
# (no output — exit 0)

$ ./scripts/ci/rust_quality_gate.sh
==> rust quality: cargo fmt --all -- --check
==> rust quality: cargo clippy --locked --all-targets -- -D clippy::correctness
warning: `zeroclaw-channels` (lib) generated 1 warning (run `cargo clippy --fix --lib -p zeroclaw-channels -- -D clippy::correctness` to apply 1 suggestion)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 46.45s
# exit 0 — that style warning exists on plain upstream/master, unrelated to this PR

$ cargo test --locked -p zeroclaw-tools --lib tavily
running 8 tests
test web_search_tool::tests::test_parse_tavily_results_empty ... ok
test web_search_tool::tests::test_resolve_tavily_api_key_uses_boot_key ... ok
test web_search_tool::tests::test_parse_tavily_results_with_data ... ok
test web_search_tool::tests::test_parse_tavily_results_invalid_response ... ok
test web_search_tool::tests::test_resolve_tavily_api_key_reloads_from_config ... ok
test web_search_tool::tests::test_execute_tavily_without_api_key ... ok
test web_search_tool::tests::test_resolve_tavily_api_key_decrypts_encrypted_key ... ok
test web_search_tool::tests::test_tavily_request_uses_bearer_auth_header_not_body_field ... ok
test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured

$ cargo test --locked -p zeroclaw-tools --lib web_search_tool
test result: ok. 27 passed; 0 failed; 0 ignored; 0 measured

$ cargo test --locked -p zeroclaw-config --lib config_save_encrypts
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
```

- **Commands run and tail output:** see above.
- **Beyond CI — what did you manually verify?** Confirmed against the documented Tavily API contract (`POST /search` with `Authorization: Bearer <api_key>` header and a JSON body containing `query`, `max_results`, `search_depth`, `include_answer`, and `include_raw_content`, returning `{results: [{title, url, content, score}]}`); the parser handles missing fields gracefully via `unwrap_or` defaults matching the existing Brave/SearXNG parsers.
- **If any command was intentionally skipped, why:** None. `cargo test --locked --workspace --lib` shows two pre-existing failures (`agent::tests::turn_preserves_text_alongside_tool_calls`, `onboard::tests::providers_forced_via_flags_persists_and_marks_completed`) that reproduce on plain `upstream/master` independently of this PR; verified via `git stash && git checkout upstream/master && cargo test`. The new Tavily tests added in this PR pass deterministically.

New tests added:

- `web_search_tool::tests::test_parse_tavily_results_empty`
- `web_search_tool::tests::test_parse_tavily_results_with_data`
- `web_search_tool::tests::test_parse_tavily_results_invalid_response`
- `web_search_tool::tests::test_execute_tavily_without_api_key`
- `web_search_tool::tests::test_resolve_tavily_api_key_uses_boot_key`
- `web_search_tool::tests::test_resolve_tavily_api_key_reloads_from_config`
- `web_search_tool::tests::test_resolve_tavily_api_key_decrypts_encrypted_key`
- `web_search_tool::tests::test_tavily_request_uses_bearer_auth_header_not_body_field`
- Schema `config_save_encrypts_nested_credentials` extended to assert `tavily_api_key` is also encrypted alongside `brave_api_key`.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **Yes** — `POST https://api.tavily.com/search`. Only triggered when the user explicitly sets `[web_search] provider = "tavily"`, and gated by the same `web_search.enabled` flag and runtime proxy plumbing as the existing Brave/SearXNG calls.
- Secrets / tokens / credentials handling changed? **Yes** — adds `[web_search] tavily_api_key` as a `#[secret]` field (encrypted at rest, decrypted on read via `SecretStore`, same pattern as `brave_api_key`).
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **Yes (additive only)**
  - New optional config field: `[web_search] tavily_api_key` (defaults to `None`)
  - New env vars: `ZEROCLAW_TAVILY_API_KEY` / `TAVILY_API_KEY`
  - No schema version bump needed (additive `#[serde(default)]` field)
  - Existing configs continue to work; users who had `provider = "tavily"` previously got DDG fallback and now get real Tavily results once they add a key.

## Rollback

Rollback risk: **low**. Default rollback: `git revert <sha>`. The change is additive: schema gains one optional `Option<String>` field, the tool struct gains one boot-snapshot field, and one match arm dispatches to the new method. Reverting the single commit fully restores prior behavior — users with `provider = "tavily"` would simply fall back to the previous DDG behavior again.
