### PR TITLE
fix(docker): repair builder stage so docker build runs end-to-end

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.7
+# syntax=docker/dockerfile:1.7-labs
 
 # ── Stage 0: Frontend build ─────────────────────────────────────
 FROM node:22-alpine AS web-builder
@@ -32,13 +32,22 @@ COPY --parents crates/*/Cargo.toml ./
 COPY --parents crates/aardvark-sys/build.rs ./
 # apps/tauri: .dockerignore whitelists only Cargo.toml; src and build.rs are stubbed below.
 COPY apps/tauri/Cargo.toml apps/tauri/Cargo.toml
+# Top-level workspace members beyond crates/ and apps/ — manifests only;
+# their source is stubbed below alongside src/, benches/, apps/tauri/.
+COPY tools/fill-translations/Cargo.toml tools/fill-translations/Cargo.toml
+COPY xtask/Cargo.toml xtask/Cargo.toml
 # Create dummy targets for all workspace members so manifest parsing succeeds.
 RUN mkdir -p src benches apps/tauri/src \
+        tools/fill-translations/src xtask/src/bin \
     && echo "fn main() {}" > src/main.rs \
     && echo "" > src/lib.rs \
     && echo "fn main() {}" > benches/agent_benchmarks.rs \
     && echo "fn main() {}" > apps/tauri/src/main.rs \
     && echo "fn main() {}" > apps/tauri/build.rs \
+    && echo "fn main() {}" > tools/fill-translations/src/main.rs \
+    && echo "" > xtask/src/lib.rs \
+    && echo "fn main() {}" > xtask/src/bin/mdbook.rs \
+    && echo "fn main() {}" > xtask/src/bin/fluent.rs \
     && for d in crates/*/; do mkdir -p "${d}src" && printf '' > "${d}src/lib.rs"; done
 RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,id=zeroclaw-cargo-git,target=/usr/local/cargo/git,sharing=locked \
@@ -48,11 +57,14 @@ RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/regist
     else \
       cargo build --release --locked; \
     fi
-RUN rm -rf src benches
+RUN rm -rf src benches crates xtask tools/fill-translations
 
 # 2. Copy only build-relevant source paths (avoid cache-busting on docs/tests/scripts)
 COPY src/ src/
 COPY benches/ benches/
+COPY crates/ crates/
+COPY xtask/ xtask/
+COPY tools/fill-translations/ tools/fill-translations/
 COPY *.rs .
 RUN touch src/main.rs
 RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
@@ -60,7 +72,14 @@ RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/regist
     --mount=type=cache,id=zeroclaw-target,target=/app/target,sharing=locked \
     rm -rf target/release/.fingerprint/zeroclawlabs-* \
            target/release/deps/zeroclawlabs-* \
-           target/release/incremental/zeroclawlabs-* && \
+           target/release/incremental/zeroclawlabs-* \
+           target/release/.fingerprint/zeroclaw-* \
+           target/release/deps/zeroclaw_* \
+           target/release/incremental/zeroclaw_* \
+           target/release/.fingerprint/xtask-* \
+           target/release/deps/xtask-* \
+           target/release/.fingerprint/fill-translations-* \
+           target/release/deps/fill_translations-* && \
     if [ -n "$ZEROCLAW_CARGO_FEATURES" ]; then \
       cargo build --release --locked --features "$ZEROCLAW_CARGO_FEATURES"; \
     else \


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** A clean (no-cache) `docker build .` on `master` currently fails for four independent reasons. This PR fixes all four so the documented build flow actually produces a working image.

  1. `COPY --parents` (line 31) requires the labs syntax, but the directive on line 1 declares `# syntax=docker/dockerfile:1.7`. Builds fail with `dockerfile parse error: unknown flag: parents`.

  2. The two non-`crates/` workspace members added by #5788 (`tools/fill-translations` and `xtask`) are not copied or stubbed for the dependency-prefetch dummy build, so cargo's manifest-parse step dies with `failed to load manifest for workspace member '/app/tools/fill-translations'`.

  3. The dummy build leaves stub `crates/*/src/lib.rs`, `xtask/src/...`, and `tools/fill-translations/src/main.rs` files in place. The second `COPY` pass only ships `src/` and `benches/`, so the second `cargo build` recompiles the workspace root against the empty stubs and dies with hundreds of `no <Type> in <module>` errors (216 errors in `zeroclaw-runtime`, 57 in `zeroclawlabs (lib)`).

  4. The fingerprint-invalidation `rm -rf` only targets the workspace root crate (`zeroclawlabs-*`), so even after the source is correct the cached stub artifacts of every internal `zeroclaw-*` crate, plus `xtask` and `fill-translations`, are reused — masking #3 with a stale cache when the build is run on a warm cache.

- **Scope boundary:** Only the `builder` stage in `Dockerfile` is touched. Runtime stages (`dev`, `release`), `.dockerignore`, web build, and any non-Docker code are unchanged. The output binary path (`/app/zeroclaw`) and image layout (`/usr/local/bin/zeroclaw`) are unchanged.

- **Blast radius:** Anyone running `docker build` from this repo or building the published image from source. Image consumers are unaffected (image content is identical to what the maintainers' own CI presumably produces, just buildable end-to-end).

- **Linked issue(s):** None — surfaced while doing local Docker builds for a downstream fork; figured the fix belongs upstream rather than diverging.

## Validation Evidence (required)

```
$ cargo fmt --all -- --check
# (no output — exit 0, no Rust source touched anyway)

$ ./scripts/ci/rust_quality_gate.sh
==> rust quality: cargo fmt --all -- --check
==> rust quality: cargo clippy --locked --all-targets -- -D clippy::correctness
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 23.06s
# exit 0

$ DOCKER_BUILDKIT=1 docker build -t zeroclaw-test .
# (full no-cache run with this patch)
#42 exporting to image
#42 exporting layers 0.7s done
#42 writing image sha256:fae1b1d324e40e14efebfb0f5b4f4fb0dc11be117541d2490c2755c3df06d812 done
#42 naming to docker.io/library/zeroclaw-test done
#42 DONE 0.7s
# exit 0 — produces a working 54.2MB image

$ docker run --rm zeroclaw-test status --format=human | head -3
🦀 ZeroClaw Status
Version:     0.7.3
```

- **Commands run and tail output:** see above.
- **Beyond CI — what did you manually verify?** Reproduced each of the four failure modes against plain `upstream/master`:
  - `1.7` syntax → `unknown flag: parents` at line 31
  - After fixing #1: manifest-parse error for `tools/fill-translations`
  - After fixing #2: 57 errors in `zeroclawlabs (lib)`, 216 in `zeroclaw-runtime` from empty crate stubs
  - After fixing #3 with warm cache: same 216 errors due to stale fingerprints
- **If any command was intentionally skipped, why:** None.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

This is a build-tooling fix; the resulting binary is identical in behavior. Net direction: less divergence between local builds and CI builds, fewer surprises for downstream packagers.

## Compatibility (required)

- Backward compatible? **Yes** for image consumers; for image builders the previously-broken `docker build` now succeeds.
- Config / env / CLI surface changed? **No**

`# syntax=docker/dockerfile:1.7-labs` is required for `--parents` and is a stable BuildKit frontend; no behavior change relative to a working `1.7-labs` build.

## Rollback

Risk: **low** (build-only change, no runtime behavior). Default rollback: `git revert <sha>`. After revert, the broken-but-published-image state is restored; users running pre-built images are unaffected at any point.