### PR TITLE
fix(runtime): strip image markers from non-vision context compression

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/context_compressor.rs
+++ b/crates/zeroclaw-runtime/src/agent/context_compressor.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use zeroclaw_api::provider::{ChatMessage, Provider};
 use zeroclaw_memory::traits::Memory;
+use zeroclaw_providers::multimodal;
 
 pub use zeroclaw_config::scattered_types::ContextCompressionConfig;
 
@@ -305,7 +306,11 @@ impl ContextCompressor {
 
         // Build transcript from the middle section
         let middle = &history[start..end];
-        let transcript = build_transcript(middle, self.config.source_max_chars);
+        let transcript = build_summarizer_transcript(
+            middle,
+            self.config.source_max_chars,
+            provider.supports_vision(),
+        );
 
         if transcript.is_empty() {
             return Ok(false);
@@ -491,6 +496,20 @@ fn build_transcript(messages: &[ChatMessage], max_chars: usize) -> String {
     }
 }
 
+fn build_summarizer_transcript(
+    messages: &[ChatMessage],
+    max_chars: usize,
+    supports_vision: bool,
+) -> String {
+    let transcript = build_transcript(messages, max_chars);
+    if supports_vision {
+        return transcript;
+    }
+
+    let (cleaned, refs) = multimodal::parse_image_markers(&transcript);
+    if refs.is_empty() { transcript } else { cleaned }
+}
+
 fn truncate_chars(s: &str, max: usize) -> String {
     if s.len() <= max {
         return s.to_string();
@@ -512,11 +531,45 @@ fn truncate_chars(s: &str, max: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use async_trait::async_trait;
+    use parking_lot::Mutex;
 
     fn msg(role: &str, content: &str) -> ChatMessage {
         ChatMessage {
             role: role.to_string(),
             content: content.to_string(),
+        }
+    }
+
+    struct CaptureSummarizerProvider {
+        supports_vision: bool,
+        seen_messages: Mutex<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl Provider for CaptureSummarizerProvider {
+        async fn chat_with_system(
+            &self,
+            _system_prompt: Option<&str>,
+            message: &str,
+            _model: &str,
+            _temperature: Option<f64>,
+        ) -> Result<String> {
+            self.seen_messages.lock().push(message.to_string());
+            Ok("summary".to_string())
+        }
+
+        async fn chat(
+            &self,
+            _request: zeroclaw_api::provider::ChatRequest<'_>,
+            _model: &str,
+            _temperature: Option<f64>,
+        ) -> Result<zeroclaw_api::provider::ChatResponse> {
+            unreachable!("context compressor uses chat_with_system")
+        }
+
+        fn supports_vision(&self) -> bool {
+            self.supports_vision
         }
     }
 
@@ -681,6 +734,25 @@ mod tests {
     }
 
     #[test]
+    fn test_build_summarizer_transcript_strips_image_markers_for_non_vision_provider() {
+        let messages = vec![msg(
+            "user",
+            "Describe this photo [IMAGE:/tmp/test.png]\nKeep the caption",
+        )];
+        let transcript = build_summarizer_transcript(&messages, 10_000, false);
+        assert!(!transcript.contains("[IMAGE:"));
+        assert!(transcript.contains("Describe this photo"));
+        assert!(transcript.contains("Keep the caption"));
+    }
+
+    #[test]
+    fn test_build_summarizer_transcript_keeps_image_markers_for_vision_provider() {
+        let messages = vec![msg("user", "Describe this photo [IMAGE:/tmp/test.png]")];
+        let transcript = build_summarizer_transcript(&messages, 10_000, true);
+        assert!(transcript.contains("[IMAGE:/tmp/test.png]"));
+    }
+
+    #[test]
     fn test_truncate_chars() {
         assert_eq!(truncate_chars("hello world", 5), "hello...");
         assert_eq!(truncate_chars("hi", 10), "hi");
@@ -717,6 +789,38 @@ mod tests {
         assert!(!config.enabled);
         assert_eq!(config.protect_first_n, 5);
         assert_eq!(config.max_passes, 1);
+    }
+
+    #[tokio::test]
+    async fn compress_if_needed_strips_image_markers_before_non_vision_summarization() {
+        let config = ContextCompressionConfig {
+            protect_first_n: 1,
+            protect_last_n: 1,
+            threshold_ratio: 0.01,
+            ..Default::default()
+        };
+        let compressor = ContextCompressor::new(config, 64);
+        let provider = CaptureSummarizerProvider {
+            supports_vision: false,
+            seen_messages: Mutex::new(Vec::new()),
+        };
+        let mut history = vec![
+            msg("system", "sys"),
+            msg("user", "Earlier question [IMAGE:/tmp/example.png]"),
+            msg("assistant", "Earlier answer"),
+            msg("user", "Newest question"),
+        ];
+
+        let result = compressor
+            .compress_if_needed(&mut history, &provider, "model")
+            .await
+            .expect("compression should succeed");
+
+        assert!(result.compressed);
+        let seen = provider.seen_messages.lock();
+        let prompt = seen.last().expect("summarizer should be invoked");
+        assert!(!prompt.contains("[IMAGE:"));
+        assert!(!prompt.contains("/tmp/example.png"));
     }
 
     // ── fast_trim_tool_results tests ────────────────────────────────


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - This closes the remaining auxiliary-path gap after the image-marker fixes in `#6183` and `#6184`.
  - Strip `[IMAGE:...]` markers from the context-compression summarizer transcript when the active provider does not support vision.
  - Keep the existing behavior for vision-capable providers so image-bearing context is preserved where it is actually safe to send.
  - Add focused regression coverage for both the transcript builder and the compression path so auxiliary summarization no longer races ahead of the main multimodal capability guard.
- **Scope boundary:**
  - Does not change Telegram channel ingestion.
  - Does not alter the main agent-loop vision guard in `loop_.rs`.
  - Does not modify the provider multimodal pipeline beyond preventing non-vision summarization requests from carrying raw markers in the first place.
- **Blast radius:**
  - Runtime context compression / summarization only.
  - Affects auxiliary `chat_with_system(...)` summarizer calls for long histories.
- **Linked issue(s):** Closes #5897, Related #6097, Related #5453, Related #6039

## Validation Evidence (required)

Local validation is the signal CI cannot replace. Run the full battery and paste literal output (tails, failures, warnings — not "all passed").

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

Docs-only changes: replace with markdown lint + link-integrity (`scripts/ci/docs_quality_gate.sh`). Bootstrap scripts: add `bash -n install.sh`.

- **Commands run and tail output:**

```bash
$ cargo fmt --package zeroclaw-runtime
# exited 0

$ cargo test -p zeroclaw-runtime compress_if_needed_strips_image_markers_before_non_vision_summarization -- --nocapture
running 1 test
test agent::context_compressor::tests::compress_if_needed_strips_image_markers_before_non_vision_summarization ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1578 filtered out; finished in 0.01s

$ cargo test -p zeroclaw-runtime context_compressor -- --nocapture
running 30 tests
...
test agent::context_compressor::tests::compress_if_needed_strips_image_markers_before_non_vision_summarization ... ok
...
test result: ok. 30 passed; 0 failed; 0 ignored; 0 measured; 1549 filtered out; finished in 0.01s

$ cargo clippy -p zeroclaw-runtime --all-targets -- -D warnings
# blocked by pre-existing unrelated warning in crates/zeroclaw-config/src/policy.rs:552

$ cargo clippy -p zeroclaw-runtime --all-targets --no-deps -- -D warnings
# blocked by pre-existing unrelated warnings in:
# - crates/zeroclaw-runtime/src/agent/classifier.rs:32
# - crates/zeroclaw-runtime/src/agent/loop_.rs:1771
# - crates/zeroclaw-runtime/src/heartbeat/engine.rs:252
```

- **Beyond CI — what did you manually verify?**
  - Verified that non-vision summarization no longer receives raw `[IMAGE:...]` markers in the auxiliary compression path.
  - Verified that the same transcript path still preserves image markers when the provider supports vision.
- **If any command was intentionally skipped, why:**
  - Skipped full `cargo test` because this PR is scoped to the runtime context-compression path and the touched module has focused regression coverage.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation:

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: exact upgrade steps for existing users:

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** Revert the merge commit for #6189.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Context-compression summarizer calls for non-vision providers again receive raw `[IMAGE:...]` markers, or vision-capable summarization unexpectedly loses image markers in compressed history.
