### PR TITLE
fix(gateway): target paircode retrieval to running instance

### DIFF
--- a/crates/zeroclaw-gateway/src/lib.rs
+++ b/crates/zeroclaw-gateway/src/lib.rs
@@ -812,7 +812,14 @@ pub async fn run_gateway(
         println!("     Send: POST {pfx}/pair with header X-Pairing-Code: {code}");
     } else if pairing.require_pairing() {
         println!("  🔒 Pairing: ACTIVE (bearer token required)");
-        println!("     To pair a new device: zeroclaw gateway get-paircode --new");
+        println!(
+            "     To pair a new device: {}",
+            format_paircode_recovery_command(host, actual_port)
+        );
+        println!(
+            "     Fallback: {}",
+            format_paircode_recovery_curl(host, actual_port, pfx)
+        );
         println!();
     } else {
         println!("  ⚠️  Pairing: DISABLED (all requests accepted)");
@@ -1176,6 +1183,26 @@ pub async fn run_gateway(
     }
 
     Ok(())
+}
+
+fn format_paircode_recovery_command(host: &str, port: u16) -> String {
+    let mut cmd = format!("zeroclaw gateway get-paircode --new --port {port}");
+    if let Some(host_arg) = paircode_recovery_host_arg(host) {
+        cmd.push_str(" --host ");
+        cmd.push_str(host_arg);
+    }
+    cmd
+}
+
+fn paircode_recovery_host_arg(host: &str) -> Option<&str> {
+    match host {
+        "127.0.0.1" | "localhost" | "::1" | "0.0.0.0" | "::" => None,
+        _ => Some(host),
+    }
+}
+
+fn format_paircode_recovery_curl(host: &str, port: u16, path_prefix: &str) -> String {
+    format!("curl -s -X POST http://{host}:{port}{path_prefix}/admin/paircode/new")
 }
 
 // ══════════════════════════════════════════════════════════════════════════════
@@ -2368,6 +2395,38 @@ mod tests {
     #[test]
     fn security_timeout_default_is_30_seconds() {
         assert_eq!(REQUEST_TIMEOUT_SECS, 30);
+    }
+
+    #[test]
+    fn paircode_recovery_command_includes_alternate_port() {
+        assert_eq!(
+            format_paircode_recovery_command("127.0.0.1", 42617),
+            "zeroclaw gateway get-paircode --new --port 42617"
+        );
+    }
+
+    #[test]
+    fn paircode_recovery_command_includes_specific_host_when_needed() {
+        assert_eq!(
+            format_paircode_recovery_command("192.168.1.20", 42617),
+            "zeroclaw gateway get-paircode --new --port 42617 --host 192.168.1.20"
+        );
+    }
+
+    #[test]
+    fn paircode_recovery_curl_targets_running_instance() {
+        assert_eq!(
+            format_paircode_recovery_curl("127.0.0.1", 42617, ""),
+            "curl -s -X POST http://127.0.0.1:42617/admin/paircode/new"
+        );
+    }
+
+    #[test]
+    fn paircode_recovery_curl_preserves_path_prefix() {
+        assert_eq!(
+            format_paircode_recovery_curl("127.0.0.1", 42617, "/gw"),
+            "curl -s -X POST http://127.0.0.1:42617/gw/admin/paircode/new"
+        );
     }
 
     #[test]

--- a/crates/zeroclaw-gateway/src/lib.rs
+++ b/crates/zeroclaw-gateway/src/lib.rs
@@ -908,7 +908,14 @@ pub async fn run_gateway(
         println!("     Send: POST {pfx}/pair with header X-Pairing-Code: {code}");
     } else if pairing.require_pairing() {
         println!("  🔒 Pairing: ACTIVE (bearer token required)");
-        println!("     To pair a new device: zeroclaw gateway get-paircode --new");
+        println!(
+            "     To pair a new device: {}",
+            format_paircode_recovery_command(host, actual_port)
+        );
+        println!(
+            "     Fallback: {}",
+            format_paircode_recovery_curl(host, actual_port, pfx)
+        );
         println!();
     } else {
         println!("  ⚠️  Pairing: DISABLED (all requests accepted)");
@@ -1334,6 +1341,26 @@ pub async fn run_gateway(
     }
 
     Ok(())
+}
+
+fn format_paircode_recovery_command(host: &str, port: u16) -> String {
+    let mut cmd = format!("zeroclaw gateway get-paircode --new --port {port}");
+    if let Some(host_arg) = paircode_recovery_host_arg(host) {
+        cmd.push_str(" --host ");
+        cmd.push_str(host_arg);
+    }
+    cmd
+}
+
+fn paircode_recovery_host_arg(host: &str) -> Option<&str> {
+    match host {
+        "127.0.0.1" | "localhost" | "::1" | "0.0.0.0" | "::" => None,
+        _ => Some(host),
+    }
+}
+
+fn format_paircode_recovery_curl(host: &str, port: u16, path_prefix: &str) -> String {
+    format!("curl -s -X POST http://{host}:{port}{path_prefix}/admin/paircode/new")
 }
 
 // ══════════════════════════════════════════════════════════════════════════════
@@ -2689,6 +2716,38 @@ mod tests {
     #[test]
     fn security_timeout_default_is_30_seconds() {
         assert_eq!(REQUEST_TIMEOUT_SECS, 30);
+    }
+
+    #[test]
+    fn paircode_recovery_command_includes_alternate_port() {
+        assert_eq!(
+            format_paircode_recovery_command("127.0.0.1", 42617),
+            "zeroclaw gateway get-paircode --new --port 42617"
+        );
+    }
+
+    #[test]
+    fn paircode_recovery_command_includes_specific_host_when_needed() {
+        assert_eq!(
+            format_paircode_recovery_command("192.168.1.20", 42617),
+            "zeroclaw gateway get-paircode --new --port 42617 --host 192.168.1.20"
+        );
+    }
+
+    #[test]
+    fn paircode_recovery_curl_targets_running_instance() {
+        assert_eq!(
+            format_paircode_recovery_curl("127.0.0.1", 42617, ""),
+            "curl -s -X POST http://127.0.0.1:42617/admin/paircode/new"
+        );
+    }
+
+    #[test]
+    fn paircode_recovery_curl_preserves_path_prefix() {
+        assert_eq!(
+            format_paircode_recovery_curl("127.0.0.1", 42617, "/gw"),
+            "curl -s -X POST http://127.0.0.1:42617/gw/admin/paircode/new"
+        );
     }
 
     #[test]

--- a/crates/zeroclaw-runtime/src/agent/context_compressor.rs
+++ b/crates/zeroclaw-runtime/src/agent/context_compressor.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use zeroclaw_api::provider::{ChatMessage, Provider};
 use zeroclaw_memory::traits::Memory;
+use zeroclaw_providers::multimodal;
 
 pub use zeroclaw_config::scattered_types::ContextCompressionConfig;
 
@@ -305,7 +306,11 @@ impl ContextCompressor {
 
         // Build transcript from the middle section
         let middle = &history[start..end];
-        let transcript = build_transcript(middle, self.config.source_max_chars);
+        let transcript = build_summarizer_transcript(
+            middle,
+            self.config.source_max_chars,
+            provider.supports_vision(),
+        );
 
         if transcript.is_empty() {
             return Ok(false);
@@ -491,6 +496,20 @@ fn build_transcript(messages: &[ChatMessage], max_chars: usize) -> String {
     }
 }
 
+fn build_summarizer_transcript(
+    messages: &[ChatMessage],
+    max_chars: usize,
+    supports_vision: bool,
+) -> String {
+    let transcript = build_transcript(messages, max_chars);
+    if supports_vision {
+        return transcript;
+    }
+
+    let (cleaned, refs) = multimodal::parse_image_markers(&transcript);
+    if refs.is_empty() { transcript } else { cleaned }
+}
+
 fn truncate_chars(s: &str, max: usize) -> String {
     if s.len() <= max {
         return s.to_string();
@@ -512,11 +531,45 @@ fn truncate_chars(s: &str, max: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use async_trait::async_trait;
+    use parking_lot::Mutex;
 
     fn msg(role: &str, content: &str) -> ChatMessage {
         ChatMessage {
             role: role.to_string(),
             content: content.to_string(),
+        }
+    }
+
+    struct CaptureSummarizerProvider {
+        supports_vision: bool,
+        seen_messages: Mutex<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl Provider for CaptureSummarizerProvider {
+        async fn chat_with_system(
+            &self,
+            _system_prompt: Option<&str>,
+            message: &str,
+            _model: &str,
+            _temperature: Option<f64>,
+        ) -> Result<String> {
+            self.seen_messages.lock().push(message.to_string());
+            Ok("summary".to_string())
+        }
+
+        async fn chat(
+            &self,
+            _request: zeroclaw_api::provider::ChatRequest<'_>,
+            _model: &str,
+            _temperature: Option<f64>,
+        ) -> Result<zeroclaw_api::provider::ChatResponse> {
+            unreachable!("context compressor uses chat_with_system")
+        }
+
+        fn supports_vision(&self) -> bool {
+            self.supports_vision
         }
     }
 
@@ -681,6 +734,25 @@ mod tests {
     }
 
     #[test]
+    fn test_build_summarizer_transcript_strips_image_markers_for_non_vision_provider() {
+        let messages = vec![msg(
+            "user",
+            "Describe this photo [IMAGE:/tmp/test.png]\nKeep the caption",
+        )];
+        let transcript = build_summarizer_transcript(&messages, 10_000, false);
+        assert!(!transcript.contains("[IMAGE:"));
+        assert!(transcript.contains("Describe this photo"));
+        assert!(transcript.contains("Keep the caption"));
+    }
+
+    #[test]
+    fn test_build_summarizer_transcript_keeps_image_markers_for_vision_provider() {
+        let messages = vec![msg("user", "Describe this photo [IMAGE:/tmp/test.png]")];
+        let transcript = build_summarizer_transcript(&messages, 10_000, true);
+        assert!(transcript.contains("[IMAGE:/tmp/test.png]"));
+    }
+
+    #[test]
     fn test_truncate_chars() {
         assert_eq!(truncate_chars("hello world", 5), "hello...");
         assert_eq!(truncate_chars("hi", 10), "hi");
@@ -717,6 +789,38 @@ mod tests {
         assert!(!config.enabled);
         assert_eq!(config.protect_first_n, 5);
         assert_eq!(config.max_passes, 1);
+    }
+
+    #[tokio::test]
+    async fn compress_if_needed_strips_image_markers_before_non_vision_summarization() {
+        let config = ContextCompressionConfig {
+            protect_first_n: 1,
+            protect_last_n: 1,
+            threshold_ratio: 0.01,
+            ..Default::default()
+        };
+        let compressor = ContextCompressor::new(config, 64);
+        let provider = CaptureSummarizerProvider {
+            supports_vision: false,
+            seen_messages: Mutex::new(Vec::new()),
+        };
+        let mut history = vec![
+            msg("system", "sys"),
+            msg("user", "Earlier question [IMAGE:/tmp/example.png]"),
+            msg("assistant", "Earlier answer"),
+            msg("user", "Newest question"),
+        ];
+
+        let result = compressor
+            .compress_if_needed(&mut history, &provider, "model")
+            .await
+            .expect("compression should succeed");
+
+        assert!(result.compressed);
+        let seen = provider.seen_messages.lock();
+        let prompt = seen.last().expect("summarizer should be invoked");
+        assert!(!prompt.contains("[IMAGE:"));
+        assert!(!prompt.contains("/tmp/example.png"));
     }
 
     // ── fast_trim_tool_results tests ────────────────────────────────

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,11 +165,20 @@ was previously paired (useful for adding additional clients).
 
 Examples:
   zeroclaw gateway get-paircode       # show current pairing code
-  zeroclaw gateway get-paircode --new # generate a new pairing code")]
+  zeroclaw gateway get-paircode --new # generate a new pairing code
+  zeroclaw gateway get-paircode --new --port 3001 # target alternate-port gateway")]
     GetPaircode {
         /// Generate a new pairing code (even if already paired)
         #[arg(long)]
         new: bool,
+
+        /// Port of the running gateway to query; defaults to config gateway.port
+        #[arg(short, long)]
+        port: Option<u16>,
+
+        /// Host of the running gateway to query; defaults to config gateway.host
+        #[arg(long)]
+        host: Option<String>,
     },
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1508,13 +1508,12 @@ async fn main() -> Result<()> {
                     log_gateway_start(&host, port);
                     Box::pin(run_gateway_if_enabled(&host, port, config, None)).await
                 }
-                Some(zeroclaw::GatewayCommands::GetPaircode { new }) => {
-                    let port = config.gateway.port;
-                    let host = &config.gateway.host;
+                Some(zeroclaw::GatewayCommands::GetPaircode { new, port, host }) => {
+                    let (port, host) = resolve_gateway_addr(&config, port, host);
 
                     // Fetch live pairing code from running gateway
                     // If --new is specified, generate a fresh pairing code
-                    match fetch_paircode(host, port, new).await {
+                    match fetch_paircode(&host, port, new).await {
                         Ok(Some(code)) => {
                             println!("🔐 Gateway pairing is enabled.");
                             println!();
@@ -2638,10 +2637,10 @@ async fn shutdown_gateway(host: &str, port: u16) -> Result<()> {
 #[cfg(feature = "agent-runtime")]
 async fn fetch_paircode(host: &str, port: u16, new: bool) -> Result<Option<String>> {
     let client = reqwest::Client::new();
+    let url = paircode_admin_url(host, port, new);
 
     let response = if new {
         // Generate a new pairing code via POST
-        let url = format!("http://{host}:{port}/admin/paircode/new");
         client
             .post(&url)
             .timeout(std::time::Duration::from_secs(5))
@@ -2649,7 +2648,6 @@ async fn fetch_paircode(host: &str, port: u16, new: bool) -> Result<Option<Strin
             .await
     } else {
         // Get existing pairing code via GET
-        let url = format!("http://{host}:{port}/admin/paircode");
         client
             .get(&url)
             .timeout(std::time::Duration::from_secs(5))
@@ -2679,6 +2677,16 @@ async fn fetch_paircode(host: &str, port: u16, new: bool) -> Result<Option<Strin
         .get("pairing_code")
         .and_then(|v| v.as_str())
         .map(String::from))
+}
+
+#[cfg(feature = "agent-runtime")]
+fn paircode_admin_url(host: &str, port: u16, new: bool) -> String {
+    let path = if new {
+        "/admin/paircode/new"
+    } else {
+        "/admin/paircode"
+    };
+    format!("http://{host}:{port}{path}")
 }
 
 // ─── Generic Pending OAuth Login ────────────────────────────────────────────
@@ -3512,6 +3520,46 @@ mod tests {
             Commands::Onboard { quick, .. } => assert!(quick),
             other => panic!("expected onboard command, got {other:?}"),
         }
+    }
+
+    #[test]
+    #[cfg(feature = "agent-runtime")]
+    fn gateway_get_paircode_cli_accepts_port_and_host_overrides() {
+        let cli = Cli::try_parse_from([
+            "zeroclaw",
+            "gateway",
+            "get-paircode",
+            "--new",
+            "--port",
+            "3001",
+            "--host",
+            "192.168.1.20",
+        ])
+        .expect("gateway get-paircode overrides should parse");
+
+        match cli.command {
+            Commands::Gateway {
+                gateway_command: Some(zeroclaw::GatewayCommands::GetPaircode { new, port, host }),
+            } => {
+                assert!(new);
+                assert_eq!(port, Some(3001));
+                assert_eq!(host.as_deref(), Some("192.168.1.20"));
+            }
+            other => panic!("expected gateway get-paircode command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "agent-runtime")]
+    fn paircode_admin_url_targets_requested_instance() {
+        assert_eq!(
+            paircode_admin_url("127.0.0.1", 3001, false),
+            "http://127.0.0.1:3001/admin/paircode"
+        );
+        assert_eq!(
+            paircode_admin_url("127.0.0.1", 3001, true),
+            "http://127.0.0.1:3001/admin/paircode/new"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1614,13 +1614,12 @@ async fn main() -> Result<()> {
                     log_gateway_start(&host, port);
                     Box::pin(run_gateway_if_enabled(&host, port, config, None)).await
                 }
-                Some(zeroclaw::GatewayCommands::GetPaircode { new }) => {
-                    let port = config.gateway.port;
-                    let host = &config.gateway.host;
+                Some(zeroclaw::GatewayCommands::GetPaircode { new, port, host }) => {
+                    let (port, host) = resolve_gateway_addr(&config, port, host);
 
                     // Fetch live pairing code from running gateway
                     // If --new is specified, generate a fresh pairing code
-                    match fetch_paircode(host, port, config.gateway.path_prefix.as_deref(), new)
+                    match fetch_paircode(&host, port, config.gateway.path_prefix.as_deref(), new)
                         .await
                     {
                         Ok(Some(code)) => {
@@ -4005,6 +4004,56 @@ mod tests {
             Commands::Onboard { quick, .. } => assert!(quick),
             other => panic!("expected onboard command, got {other:?}"),
         }
+    }
+
+    #[test]
+    #[cfg(feature = "agent-runtime")]
+    fn gateway_get_paircode_cli_accepts_port_and_host_overrides() {
+        let cli = Cli::try_parse_from([
+            "zeroclaw",
+            "gateway",
+            "get-paircode",
+            "--new",
+            "--port",
+            "3001",
+            "--host",
+            "192.168.1.20",
+        ])
+        .expect("gateway get-paircode overrides should parse");
+
+        match cli.command {
+            Commands::Gateway {
+                gateway_command: Some(zeroclaw::GatewayCommands::GetPaircode { new, port, host }),
+            } => {
+                assert!(new);
+                assert_eq!(port, Some(3001));
+                assert_eq!(host.as_deref(), Some("192.168.1.20"));
+            }
+            other => panic!("expected gateway get-paircode command, got {other:?}"),
+        }
+    }
+
+    /// Regression for PR #6192: when the user passes `--port`/`--host` to
+    /// `gateway get-paircode`, the override must compose with the configured
+    /// `path_prefix` rather than bypass it. `fetch_paircode` threads
+    /// `path_prefix` through `gateway_admin_url`; this test pins that the URL
+    /// we'd actually send still hits `<prefix>/admin/paircode/new`.
+    #[test]
+    #[cfg(feature = "agent-runtime")]
+    fn paircode_url_combines_host_port_override_with_configured_path_prefix() {
+        assert_eq!(
+            gateway_admin_url(
+                "127.0.0.1",
+                9001,
+                Some("/agents/myagent"),
+                "/admin/paircode/new"
+            ),
+            "http://127.0.0.1:9001/agents/myagent/admin/paircode/new",
+        );
+        assert_eq!(
+            gateway_admin_url("192.168.1.20", 42617, Some("/gw"), "/admin/paircode"),
+            "http://192.168.1.20:42617/gw/admin/paircode",
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Add `--port` and `--host` to `zeroclaw gateway get-paircode` so it can target the actual running gateway instance instead of always using the configured default port.
  - Thread `path_prefix` through `fetch_paircode` so host/port overrides compose with the configured `[gateway].path_prefix` from #6169 instead of bypassing it.
  - Update the gateway startup banner to print an instance-specific recovery command when pairing is active but no code is currently shown.
  - Add the exact localhost `curl` fallback for the running instance so alternate-port and random-port launches are immediately recoverable without guessing the admin endpoint.
  - Add focused regressions for CLI parsing, admin endpoint URL targeting (host/port + `path_prefix`), and startup-banner recovery formatting.
- **Scope boundary:**
  - Does not auto-generate or rotate pairing codes on startup.
  - Does not change `PairingGuard` semantics, token persistence, or onboarding flow.
- **Blast radius:**
  - Gateway startup banner copy.
  - `zeroclaw gateway get-paircode` CLI surface.
  - No change to pairing/auth core behavior.
- **Linked issue(s):** Closes #5266, Related #6169

## Validation Evidence (required)

Local validation is the signal CI cannot replace. Run the full battery and paste literal output (tails, failures, warnings — not "all passed").

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- **Commands run and tail output:**

```bash
cargo test -p zeroclaw-gateway paircode_recovery_ -- --nocapture
```

```text
running 4 tests
test tests::paircode_recovery_curl_targets_running_instance ... ok
test tests::paircode_recovery_command_includes_alternate_port ... ok
test tests::paircode_recovery_curl_preserves_path_prefix ... ok
test tests::paircode_recovery_command_includes_specific_host_when_needed ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 173 filtered out; finished in 0.00s
```

```bash
cargo test --bin zeroclaw paircode -- --nocapture
```

```text
running 2 tests
test tests::paircode_url_combines_host_port_override_with_configured_path_prefix ... ok
test tests::gateway_get_paircode_cli_accepts_port_and_host_overrides ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 236 filtered out; finished in 0.00s
```

```bash
cargo test --bin zeroclaw gateway_admin_url_ -- --nocapture
```

```text
running 2 tests
test tests::gateway_admin_url_prepends_configured_path_prefix ... ok
test tests::gateway_admin_url_uses_unprefixed_admin_path_by_default ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 235 filtered out; finished in 0.00s
```

```bash
cargo fmt --all -- --check
```

```text
(no output, exit 0)
```

```bash
cargo check --bin zeroclaw
```

```text
Finished `dev` profile [unoptimized + debuginfo] target(s) in 35.59s
```

```bash
cargo clippy --bin zeroclaw --all-targets -- -D warnings
```

```text
error: this `if` can be collapsed into the outer `match`
   --> crates/zeroclaw-config/src/policy.rs:552:25
(pre-existing on master, unrelated to this diff; reproduces with our changes stashed)
```

- **Beyond CI — what did you manually verify?**
  - Ran the repo-built gateway locally with `cargo run -- gateway start -p 0`.
  - Verified the startup banner printed:
    - `zeroclaw gateway get-paircode --new --port <actual_port>`
    - `curl -s -X POST http://127.0.0.1:<actual_port>/admin/paircode/new`
  - Verified both recovery paths against the live instance:
    - `cargo run -- gateway get-paircode --new --port <actual_port>` returned a fresh code.
    - `curl -s -X POST http://127.0.0.1:<actual_port>/admin/paircode/new` returned a fresh code JSON payload.
  - Verified the `path_prefix` integration via the new `paircode_url_combines_host_port_override_with_configured_path_prefix` regression test (composes `--host`/`--port` with the configured `[gateway].path_prefix`).
- **If any command was intentionally skipped, why:**
  - Full-workspace `cargo clippy --all-targets -- -D warnings` is currently blocked by a pre-existing `collapsible_match` warning in `crates/zeroclaw-config/src/policy.rs:552`, unrelated to this diff. Reproduces on master and with these changes stashed.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation:

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`Yes`)
- If `No` or `Yes` to either: exact upgrade steps for existing users:
  - Existing `zeroclaw gateway get-paircode` usage continues to work.
  - New optional flags are available when targeting a non-default gateway instance:
    - `zeroclaw gateway get-paircode --new --port <port>`
    - `zeroclaw gateway get-paircode --new --host <host> --port <port>`
  - When `[gateway].path_prefix` is configured, host/port overrides compose with it (no need to repeat the prefix on the CLI).

## Rollback (required for `risk: medium` and `risk: high`)

`git revert <squash-merge-sha>` (or `git revert c7c3ee20b28d166df365edaedf78d9aefcecba5e` against the pre-squash branch tip) cleanly reverts all three changed files. Operator-visible effects of a revert:

- `zeroclaw gateway get-paircode` loses the `--host` and `--port` overrides and falls back to the configured `[gateway].host` / `[gateway].port` defaults.
- The startup banner drops the instance-specific `... --port <actual> ...` recovery line and the `curl` fallback line; pairing-code recovery on alternate-port or random-port gateways returns to the pre-#5266 ambiguous state.
- `path_prefix` plumbing in `fetch_paircode` is reverted to its pre-PR shape, which still composes correctly with master's `gateway_admin_url` from #6169 — no follow-up revert needed.

`PairingGuard`, token persistence, onboarding flow, and the `/admin/paircode*` route handlers themselves are untouched by this PR, so revert is safe at any time and does not require coordinated config, token, or session changes.

---

**Labels** live in the GitHub label UI, not in the body. Set `risk:*`, `size:*`, and scope labels via the sidebar. Auto-label corrections: add `risk: manual` and the intended label.


**Privacy contract** (`docs/book/src/contributing/privacy.md`) is a merge gate. Never commit real identities, secrets, personal emails, or PII in diff, tests, fixtures, or docs.


