### PR TITLE
Document email channel settings

### DIFF
--- a/docs/book/src/channels/email.md
+++ b/docs/book/src/channels/email.md
@@ -9,25 +9,30 @@ The general-purpose email channel. Polls IMAP for new messages, sends via SMTP. 
 ```toml
 [channels.email]
 enabled = true
-
-[channels.email.imap]
-host = "imap.example.com"
-port = 993
-username = "you@example.com"
-password = "..."                 # or app-password for Gmail/iCloud
-mailbox = "INBOX"
-poll_interval_secs = 60
-
-[channels.email.smtp]
-host = "smtp.example.com"
-port = 587
-username = "you@example.com"
-password = "..."
-
-[channels.email.filter]
-allowed_senders = ["boss@example.com", "alerts@example.com"]
+allowed_senders = []
+default_subject = "ZeroClaw Message"
+from_address = "demo@gmail.com"
+idle_timeout_secs = 1740
+imap_folder = "INBOX" # optional foldier to use
+imap_host = "imap.gmail.com"
+imap_port = 993
+imap_tls = true
+max_attachment_bytes = 26214400
+password = "enc2:cdf60071892ba88c753338db62c592fa7b54426ad8ed0e0bfceb403c5ddb506f"
+smtp_host = "smtp.gmail.com"
+smtp_port = 465
+smtp_tls = true
+username = "demo"
 subject_prefix = "[agent]"       # only respond to subjects starting with this
+poll_interval_secs = 60 # if the server doesn't support IDLE mode, how frequently poll the server for updates
+reply_format = "text"            # or "html"
+include_thread = true            # include conversation thread
 ```
+
+### General tips
+
+- If your server doesn't support SSL/TLS, make sure to set both `imap_tls = false` and `smtp_tls = false`.
+- Concequentially, if your server uses SSL/TLS, make sure to set both `imap_tls = true` and `smtp_tls = true`
 
 ### Gmail gotchas
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:** Updated email configuration docs to match new logic, including IMAP and SMTP settings. Added general tips for SSL/TLS configurations.
- **Scope boundary:** docs only change
- **Blast radius:** docs only change
- **Linked issue(s):** `Closes #`, `Related #`, `Depends on #` (stacked), `Supersedes #` (replacing older PR)