### PR TITLE
docs(config): update YOLO config examples

### DIFF
--- a/docs/book/src/getting-started/yolo.md
+++ b/docs/book/src/getting-started/yolo.md
@@ -38,10 +38,10 @@ enabled = false
 enabled = false
 
 [security.sandbox]
-backend = "noop"
+backend = "none"
 
 [gateway]
-pairing_required = false
+require_pairing = false
 ```
 
 Or — coming soon — a single preset:

--- a/docs/book/src/security/sandboxing.md
+++ b/docs/book/src/security/sandboxing.md
@@ -19,10 +19,10 @@ You can force a backend:
 
 ```toml
 [security.sandbox]
-backend = "bubblewrap"        # or "landlock", "firejail", "docker", "seatbelt", "noop"
+backend = "bubblewrap"        # or "landlock", "firejail", "docker", "sandbox-exec", "none"
 ```
 
-Set `backend = "noop"` to disable sandboxing entirely (part of [YOLO mode](../getting-started/yolo.md)).
+Set `backend = "none"` to disable sandboxing entirely (part of [YOLO mode](../getting-started/yolo.md)).
 
 ## What the sandbox confines
 
@@ -107,7 +107,7 @@ Native macOS sandbox (`sandbox-exec`). Profiles are SBPL — we bundle one for t
 
 Limitation: some CLI tools (older versions of `git`, some Homebrew-linked binaries) don't cooperate with Seatbelt's file-access rules. If you see "Operation not permitted" errors from the agent's shell calls on macOS, check if the tool needs broader filesystem access and consider switching to Docker.
 
-### `noop`
+### `none`
 
 No sandboxing. Tools run with the full privileges of the ZeroClaw service user. This is what YOLO mode enables. Loud, obvious, intentional.
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Updated the YOLO-mode config snippet to use the current `[security.sandbox] backend = "none"` value.
  - Updated the YOLO-mode gateway snippet to use the current `[gateway] require_pairing = false` key.
  - Updated the sandboxing reference to list the current accepted explicit backends, including `sandbox-exec` and `none`.
- **Scope boundary:** docs-only; no runtime config parsing, defaults, or behavior changed.
- **Blast radius:** limited to two mdBook pages under `docs/book/src`; users following local/YOLO testing docs get config values that match the current schema.
- **Linked issue(s):** Closes #6149

## Validation Evidence (required)

Local validation is the signal CI cannot replace. Run the full battery and paste literal output (tails, failures, warnings — not "all passed").

Docs-only change, so I ran the docs gates requested by the PR template.

- **Commands run and tail output:**

```text
$ git diff --check
# no output
```

```text
$ DOCS_FILES="docs/book/src/getting-started/yolo.md
docs/book/src/security/sandboxing.md" BASE_SHA="$(git merge-base origin/master HEAD)" ./scripts/ci/docs_quality_gate.sh
Linting docs files: docs/book/src/getting-started/yolo.md docs/book/src/security/sandboxing.md
markdownlint-cli2 v0.20.0 (markdownlint v0.40.0)
Finding: docs/book/src/getting-started/yolo.md docs/book/src/security/sandboxing.md !target/**
Linting: 2 file(s)
Summary: 0 error(s)
```

```text
$ DOCS_FILES="docs/book/src/getting-started/yolo.md
docs/book/src/security/sandboxing.md" BASE_SHA="$(git merge-base origin/master HEAD)" ./scripts/ci/docs_links_gate.sh
Collected 0 added link(s) from 2 docs file(s).
No added links detected in changed docs lines.
```

- **Beyond CI — what did you manually verify?**
  - Cross-checked `crates/zeroclaw-config/src/schema.rs`: `GatewayConfig` exposes `require_pairing`, and `SandboxBackend` accepts lowercase `none`; `SandboxExec` has the `sandbox-exec` alias.
  - Confirmed the touched docs no longer contain the stale `pairing_required`, `backend = "noop"`, or `seatbelt` config values.
- **If any command was intentionally skipped, why:**
  - Full Rust tests were skipped because this is a docs-only correction and the repo template points docs-only changes to the docs quality/link gates.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No` — docs only; it documents the current surface)
- If `No` or `Yes` to either: Existing users who copied the stale docs for local/YOLO testing should use `backend = "none"` and `require_pairing = false`; no code migration is introduced by this PR.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk docs-only PR. Rollback plan: `git revert <sha>`.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A
