### PR TITLE
fix(skills): deny unknown fields on SkillMeta to surface typos

### DIFF
--- a/crates/zeroclaw-runtime/src/skills/mod.rs
+++ b/crates/zeroclaw-runtime/src/skills/mod.rs
@@ -77,6 +77,7 @@ struct SkillManifest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct SkillMeta {
     name: String,
     description: String,
@@ -1732,5 +1733,83 @@ mod registry_tests {
     fn test_is_registry_source_rejects_special_chars() {
         assert!(!is_registry_source(".hidden"));
         assert!(!is_registry_source("~tilde"));
+    }
+}
+
+#[cfg(test)]
+mod skill_manifest_tests {
+    use super::*;
+
+    fn parse_manifest(toml: &str) -> Result<SkillManifest, toml::de::Error> {
+        toml::from_str::<SkillManifest>(toml)
+    }
+
+    #[test]
+    fn skill_manifest_known_fields_parse_ok() {
+        let toml = r#"
+[skill]
+name = "demo"
+description = "demo skill"
+version = "1.2.3"
+author = "Sai"
+tags = ["a", "b"]
+"#;
+        let manifest = parse_manifest(toml).expect("known fields must parse");
+        assert_eq!(manifest.skill.name, "demo");
+        assert_eq!(manifest.skill.description, "demo skill");
+        assert_eq!(manifest.skill.version, "1.2.3");
+        assert_eq!(manifest.skill.author.as_deref(), Some("Sai"));
+        assert_eq!(manifest.skill.tags, vec!["a".to_string(), "b".to_string()]);
+    }
+
+    #[test]
+    fn skill_manifest_uses_default_version_when_omitted() {
+        let toml = r#"
+[skill]
+name = "demo"
+description = "demo skill"
+"#;
+        let manifest = parse_manifest(toml).expect("optional fields must default");
+        assert_eq!(manifest.skill.version, default_version());
+        assert!(manifest.skill.author.is_none());
+        assert!(manifest.skill.tags.is_empty());
+    }
+
+    #[test]
+    fn skill_manifest_unknown_field_under_skill_is_an_error() {
+        // Regression test for issue #6128: a typo in the [skill] section used
+        // to be silently dropped because SkillMeta lacked
+        // `#[serde(deny_unknown_fields)]`. Skill authors hit this with names
+        // like `descriptin` or `autor`, got zero behavioural effect, and gave
+        // up. Now those typos surface as a parse error that names the field.
+        let toml = r#"
+[skill]
+name = "demo"
+description = "demo skill"
+descriptin = "typo - should be 'description'"
+"#;
+        let err = parse_manifest(toml).expect_err("unknown field must error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("descriptin") || msg.contains("unknown field"),
+            "expected the parse error to name the unknown field; got: {msg}",
+        );
+    }
+
+    #[test]
+    fn skill_manifest_unknown_field_at_top_level_still_allowed() {
+        // We only deny unknown fields under the `[skill]` table; the top-level
+        // SkillManifest deliberately stays permissive so future top-level
+        // tables (e.g. registry-specific extensions) don't break older
+        // SKILL.toml consumers.
+        let toml = r#"
+[skill]
+name = "demo"
+description = "demo skill"
+
+[future_table]
+some_key = "value"
+"#;
+        let _ = parse_manifest(toml).expect("unknown top-level table must still parse");
     }
 }


### PR DESCRIPTION
## Summary

Closes #6128.

\`SkillMeta\` accepted any extra field under \`[skill]\` and silently
dropped it. A skill author writing \`descriptin = \"...\"\` instead of
\`description\`, or \`autor\` instead of \`author\`, got zero behavioural
effect with no warning — the same silent-drop class that #5972 fixed
for the specific \`prompts\` case.

## Fix

\`#[serde(deny_unknown_fields)]\` on \`SkillMeta\` so \`toml::from_str\`
returns an error naming the unknown field instead of swallowing it.

The top-level \`SkillManifest\` deliberately **stays permissive** so a
future top-level table (registry-specific extensions, future-version
annotations, etc.) doesn't break older \`SKILL.toml\` consumers — the
strict check is scoped to the \`[skill]\` table, which is where the
typos described in the issue actually bite.

## Test plan

Added \`skill_manifest_tests\` module with four cases:

- [x] \`skill_manifest_known_fields_parse_ok\` — happy path with all
      optional fields populated.
- [x] \`skill_manifest_uses_default_version_when_omitted\` — pins the
      pre-existing \`default_version\` + optional-field behaviour so
      the deny attribute can't accidentally regress them.
- [x] \`skill_manifest_unknown_field_under_skill_is_an_error\` — the
      direct regression against the silent-drop. The assertion looks
      for the field name \`descriptin\` in the error message, matching
      what \`toml\`'s \`deny_unknown_fields\` produces.
- [x] \`skill_manifest_unknown_field_at_top_level_still_allowed\` —
      pins the deliberate top-level permissiveness so future tables
      don't fail to load.

\`cargo test -p zeroclaw-runtime --lib skills::skill_manifest_tests\`:
4 passed, 0 failed.

\`./scripts/ci/rust_quality_gate.sh\` is green (fmt, clippy, build).

## Backward-compat note

The issue body called out an edge case: in-the-wild \`SKILL.toml\`
files might contain extra fields under \`[skill]\` that current
zeroclaw silently ignores. Those would now fail to load with a clear
parse error naming the offending field. I checked the open-skills
fixtures and the in-repo skills under \`crates/zeroclaw-runtime/src/skills/\`
and didn't see any unknown fields in the wild. A release-note
callout would still be sensible for the next minor.