### PR TITLE
fix(runtime): align tool-call text preservation test

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/tests.rs
+++ b/crates/zeroclaw-runtime/src/agent/tests.rs
@@ -801,9 +801,12 @@ async fn turn_preserves_text_alongside_tool_calls() {
         "Expected non-empty final response after mixed text+tool"
     );
 
-    // The intermediate text should be in history
+    // The intermediate text should be preserved with its tool calls, not as a
+    // separate assistant chat entry that would create consecutive assistants.
     let has_intermediate = agent.history().iter().any(|msg| match msg {
-        ConversationMessage::Chat(c) => c.role == "assistant" && c.content.contains("Let me check"),
+        ConversationMessage::AssistantToolCalls { text, .. } => text
+            .as_deref()
+            .is_some_and(|content| content.contains("Let me check")),
         _ => false,
     });
     assert!(has_intermediate, "Intermediate text should be in history");


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Aligns `turn_preserves_text_alongside_tool_calls` with the current runtime history model for native tool-call turns.
  - Verifies narration text returned alongside tool calls is preserved on `ConversationMessage::AssistantToolCalls { text, .. }`.
  - Avoids reintroducing the stale expectation that mixed narration/tool-call responses should create a separate assistant chat entry.
- **Scope boundary:** This PR changes only a test assertion and comment. It does not change runtime behavior, provider dispatch, tool execution, history serialization, or message conversion.
- **Blast radius:** Test-only. The affected area is `zeroclaw-runtime` agent history coverage for native tool-call turns.
- **Linked issue(s):** Closes #6199. Related #6197.
- **Labels:** `bug`, `size: XS`, `risk: low`, `agent`, `runtime`, `tests`

## Validation Evidence (required)

- **Commands run and tail output:**

```bash
time cargo test -p zeroclaw-runtime turn_preserves_text_alongside_tool_calls 2>&1 | tail -30
```

```text
   Compiling zeroclaw-runtime v0.7.3 ($WORKTREE/crates/zeroclaw-runtime)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 1m 29s
     Running unittests src/lib.rs (target/debug/deps/zeroclaw_runtime-8cc9c7aaf619e2fc)

running 1 test
test agent::tests::turn_preserves_text_alongside_tool_calls ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1578 filtered out; finished in 0.02s

cargo test -p zeroclaw-runtime turn_preserves_text_alongside_tool_calls 2>&1  251.22s user 28.02s system 306% cpu 1:31.03 total
tail -30  0.00s user 0.00s system 0% cpu 1:31.03 total
```

```bash
time cargo fmt --all -- --check 2>&1 | tail -30
```

```text
cargo fmt --all -- --check 2>&1  2.06s user 0.10s system 86% cpu 2.500 total
tail -30  0.00s user 0.00s system 0% cpu 2.500 total
```

```bash
git diff --check
```

```text
(no output)
```

- **Beyond CI — what did you manually verify?** Reviewed the failing assertion against the current `ConversationMessage::AssistantToolCalls` enum shape, the blocking `Agent::turn` write path, and the existing duplicate-narration guards that prevent a plain assistant chat entry immediately before tool calls. Ran the three-pass Simplify review with reuse/architecture, correctness/quality, and efficiency/simplicity passes; all returned no findings.
- **If any command was intentionally skipped, why:** Skipped full local `cargo clippy --all-targets -- -D warnings` and full `cargo test` because this is a one-assertion test-only correction. The focused failing test, formatting, whitespace check, manual diff review, and Simplify review cover the changed behavior; CI also ran the broader workspace battery successfully.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: None.

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: No upgrade steps required. This is a test-only assertion update.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PRs: `git revert 89dbdd97` is the plan unless otherwise noted.

Medium/high-risk PRs must fill:

- **Fast rollback command/path:** `git revert 89dbdd97`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** The focused `zeroclaw-runtime` test `turn_preserves_text_alongside_tool_calls` fails again or workspace CI reports a regression in agent history tests.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): None.
- Scope materially carried forward: None.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`No`)
- If `No`, why (inspiration-only, no direct code/design carry-over): No superseded PR or incorporated external contribution.
