### PR TITLE
feat(agent,config): activate HMAC tool receipts — wiring stripped from #5168

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -3190,7 +3190,12 @@ async fn process_channel_message(
                         None, // shared_budget
                         target_channel.as_deref(),
                         ctx.receipt_generator.as_ref(),
-                        Some(&tool_receipts_collector),
+                        // Collector is meaningful only when the generator is
+                        // active. Pass None when receipts are disabled so the
+                        // call site reflects that coupling explicitly.
+                        ctx.receipt_generator
+                            .as_ref()
+                            .map(|_| &tool_receipts_collector),
                     ),
                     ),
                     ),
@@ -3517,13 +3522,22 @@ async fn process_channel_message(
                     eprintln!("  ❌ Failed to reply on {}: {e}", channel.name());
                 }
                 // Send tool receipts as a separate message in the same thread.
-                if let Some(ref block) = receipts_block {
-                    let _ = channel
+                // The block is the operator-facing audit surface for the feature,
+                // so a dropped send must leave a log signal rather than silently
+                // disappear.
+                if let Some(ref block) = receipts_block
+                    && let Err(e) = channel
                         .send(
                             &SendMessage::new(block, &msg.reply_target)
                                 .in_thread(msg.thread_ts.clone()),
                         )
-                        .await;
+                        .await
+                {
+                    tracing::warn!(
+                        channel = channel.name(),
+                        error = %e,
+                        "failed to send tool receipts block"
+                    );
                 }
             }
         }
@@ -7342,6 +7356,252 @@ BTC is currently around $65,000 based on latest tool output."#
         assert!(reply.contains("BTC is currently around"));
         assert!(!reply.contains("\"tool_calls\""));
         assert!(!reply.contains("mock_price"));
+    }
+
+    #[tokio::test]
+    async fn process_channel_message_renders_trailing_tool_receipts_block_when_enabled() {
+        // Activated path: a real ReceiptGenerator + show_receipts_in_response=true
+        // must produce a second send carrying the "Tool receipts:" block with a
+        // valid zc-receipt-* token. Pre-#6214 this was dead code from the test
+        // suite because every ChannelRuntimeContext literal pinned the feature
+        // off; this test guards the integration so a regression in the block
+        // render or send call surfaces in CI rather than in production.
+        let channel_impl = Arc::new(RecordingChannel::default());
+        let channel: Arc<dyn Channel> = channel_impl.clone();
+
+        let mut channels_by_name = HashMap::new();
+        channels_by_name.insert(channel.name().to_string(), channel);
+
+        let runtime_ctx = Arc::new(ChannelRuntimeContext {
+            channels_by_name: Arc::new(channels_by_name),
+            provider: Arc::new(ToolCallingProvider),
+            default_provider: Arc::new("test-provider".to_string()),
+            memory: Arc::new(NoopMemory),
+            tools_registry: Arc::new(vec![Box::new(MockPriceTool)]),
+            observer: Arc::new(NoopObserver),
+            system_prompt: Arc::new("test-system-prompt".to_string()),
+            model: Arc::new("test-model".to_string()),
+            temperature: 0.0,
+            auto_save_memory: false,
+            max_tool_iterations: 10,
+            min_relevance_score: 0.0,
+            conversation_histories: Arc::new(Mutex::new(lru::LruCache::new(
+                std::num::NonZeroUsize::new(MAX_CONVERSATION_SENDERS).unwrap(),
+            ))),
+            pending_new_sessions: Arc::new(Mutex::new(HashSet::new())),
+            provider_cache: Arc::new(Mutex::new(HashMap::new())),
+            route_overrides: Arc::new(Mutex::new(HashMap::new())),
+            api_key: None,
+            api_url: None,
+            reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
+            provider_runtime_options: zeroclaw_providers::ProviderRuntimeOptions::default(),
+            workspace_dir: Arc::new(std::env::temp_dir()),
+            prompt_config: Arc::new(zeroclaw_config::schema::Config::default()),
+            message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
+            interrupt_on_new_message: InterruptOnNewMessageConfig {
+                telegram: false,
+                slack: false,
+                discord: false,
+                mattermost: false,
+                matrix: false,
+            },
+            non_cli_excluded_tools: Arc::new(Vec::new()),
+            // Full autonomy + auto-approve mock_price so the loop actually
+            // reaches execute_one_tool. The other tests in this file pass
+            // under Supervised because ToolCallingProvider returns the BTC
+            // reply regardless of whether the tool ran (the LLM only needs
+            // to see a `[Tool results]` user message — even a "denied"
+            // payload triggers the deterministic response). Receipts only
+            // generate on the actual execute path, so we need the gate
+            // open here.
+            autonomy_level: AutonomyLevel::Full,
+            tool_call_dedup_exempt: Arc::new(Vec::new()),
+            multimodal: zeroclaw_config::schema::MultimodalConfig::default(),
+            media_pipeline: zeroclaw_config::schema::MediaPipelineConfig::default(),
+            transcription_config: zeroclaw_config::schema::TranscriptionConfig::default(),
+            hooks: None,
+            model_routes: Arc::new(Vec::new()),
+            query_classification: zeroclaw_config::schema::QueryClassificationConfig::default(),
+            ack_reactions: true,
+            show_tool_calls: true,
+            session_store: None,
+            approval_manager: Arc::new(ApprovalManager::for_non_interactive(&{
+                let mut autonomy = zeroclaw_config::schema::AutonomyConfig::default();
+                autonomy.level = zeroclaw_config::autonomy::AutonomyLevel::Full;
+                autonomy.auto_approve.push("mock_price".to_string());
+                autonomy
+            })),
+            activated_tools: None,
+            cost_tracking: None,
+            pacing: zeroclaw_config::schema::PacingConfig::default(),
+            max_tool_result_chars: 0,
+            context_token_budget: 0,
+            debouncer: Arc::new(zeroclaw_infra::debounce::MessageDebouncer::new(
+                Duration::ZERO,
+            )),
+            receipt_generator: Some(
+                zeroclaw_runtime::agent::tool_receipts::ReceiptGenerator::new(),
+            ),
+            show_receipts_in_response: true,
+        });
+
+        process_channel_message(
+            runtime_ctx,
+            zeroclaw_api::channel::ChannelMessage {
+                id: "msg-1".to_string(),
+                sender: "alice".to_string(),
+                reply_target: "chat-42".to_string(),
+                content: "What is the BTC price now?".to_string(),
+                channel: "test-channel".to_string(),
+                timestamp: 1,
+                thread_ts: None,
+                interruption_scope_id: None,
+                attachments: vec![],
+            },
+            CancellationToken::new(),
+        )
+        .await;
+
+        let sent_messages = channel_impl.sent_messages.lock().await;
+        // Two sends: the model's reply and the trailing receipts block.
+        assert!(
+            sent_messages.len() >= 2,
+            "expected at least 2 sends (reply + receipts block), got {}: {:?}",
+            sent_messages.len(),
+            sent_messages
+        );
+
+        let receipts_message = sent_messages
+            .iter()
+            .find(|m| m.contains("Tool receipts:"))
+            .unwrap_or_else(|| {
+                panic!(
+                    "no `Tool receipts:` send found; got {:?}",
+                    sent_messages.as_slice()
+                )
+            });
+        assert!(
+            receipts_message.starts_with("chat-42:"),
+            "receipts block must be sent to the same reply target as the agent reply, got {receipts_message}"
+        );
+        assert!(
+            receipts_message.contains("---\nTool receipts:"),
+            "receipts block must be prefixed with the documented `---\\nTool receipts:` separator, got {receipts_message}"
+        );
+        assert!(
+            receipts_message.contains("zc-receipt-"),
+            "receipts block must carry at least one zc-receipt-* HMAC token (proves the generator actually ran), got {receipts_message}"
+        );
+        assert!(
+            receipts_message.contains("mock_price"),
+            "receipts block should name the tool that produced the receipt, got {receipts_message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn process_channel_message_omits_receipts_block_when_disabled() {
+        // Backward-compat: with show_receipts_in_response=false (default), no
+        // trailing receipts message is sent — even when a generator is active
+        // and the loop ran tools. This is the path every other test relies on
+        // implicitly; assert it once explicitly.
+        let channel_impl = Arc::new(RecordingChannel::default());
+        let channel: Arc<dyn Channel> = channel_impl.clone();
+
+        let mut channels_by_name = HashMap::new();
+        channels_by_name.insert(channel.name().to_string(), channel);
+
+        let runtime_ctx = Arc::new(ChannelRuntimeContext {
+            channels_by_name: Arc::new(channels_by_name),
+            provider: Arc::new(ToolCallingProvider),
+            default_provider: Arc::new("test-provider".to_string()),
+            memory: Arc::new(NoopMemory),
+            tools_registry: Arc::new(vec![Box::new(MockPriceTool)]),
+            observer: Arc::new(NoopObserver),
+            system_prompt: Arc::new("test-system-prompt".to_string()),
+            model: Arc::new("test-model".to_string()),
+            temperature: 0.0,
+            auto_save_memory: false,
+            max_tool_iterations: 10,
+            min_relevance_score: 0.0,
+            conversation_histories: Arc::new(Mutex::new(lru::LruCache::new(
+                std::num::NonZeroUsize::new(MAX_CONVERSATION_SENDERS).unwrap(),
+            ))),
+            pending_new_sessions: Arc::new(Mutex::new(HashSet::new())),
+            provider_cache: Arc::new(Mutex::new(HashMap::new())),
+            route_overrides: Arc::new(Mutex::new(HashMap::new())),
+            api_key: None,
+            api_url: None,
+            reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
+            provider_runtime_options: zeroclaw_providers::ProviderRuntimeOptions::default(),
+            workspace_dir: Arc::new(std::env::temp_dir()),
+            prompt_config: Arc::new(zeroclaw_config::schema::Config::default()),
+            message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
+            interrupt_on_new_message: InterruptOnNewMessageConfig {
+                telegram: false,
+                slack: false,
+                discord: false,
+                mattermost: false,
+                matrix: false,
+            },
+            non_cli_excluded_tools: Arc::new(Vec::new()),
+            // Match the enabled-test setup so the tool actually runs; the
+            // assertion below proves the receipt-block send is gated on
+            // `show_receipts_in_response` and not on whether the loop saw
+            // any receipts.
+            autonomy_level: AutonomyLevel::Full,
+            tool_call_dedup_exempt: Arc::new(Vec::new()),
+            multimodal: zeroclaw_config::schema::MultimodalConfig::default(),
+            media_pipeline: zeroclaw_config::schema::MediaPipelineConfig::default(),
+            transcription_config: zeroclaw_config::schema::TranscriptionConfig::default(),
+            hooks: None,
+            model_routes: Arc::new(Vec::new()),
+            query_classification: zeroclaw_config::schema::QueryClassificationConfig::default(),
+            ack_reactions: true,
+            show_tool_calls: true,
+            session_store: None,
+            approval_manager: Arc::new(ApprovalManager::for_non_interactive(&{
+                let mut autonomy = zeroclaw_config::schema::AutonomyConfig::default();
+                autonomy.level = zeroclaw_config::autonomy::AutonomyLevel::Full;
+                autonomy.auto_approve.push("mock_price".to_string());
+                autonomy
+            })),
+            activated_tools: None,
+            cost_tracking: None,
+            pacing: zeroclaw_config::schema::PacingConfig::default(),
+            max_tool_result_chars: 0,
+            context_token_budget: 0,
+            debouncer: Arc::new(zeroclaw_infra::debounce::MessageDebouncer::new(
+                Duration::ZERO,
+            )),
+            receipt_generator: Some(
+                zeroclaw_runtime::agent::tool_receipts::ReceiptGenerator::new(),
+            ),
+            show_receipts_in_response: false,
+        });
+
+        process_channel_message(
+            runtime_ctx,
+            zeroclaw_api::channel::ChannelMessage {
+                id: "msg-1".to_string(),
+                sender: "alice".to_string(),
+                reply_target: "chat-42".to_string(),
+                content: "What is the BTC price now?".to_string(),
+                channel: "test-channel".to_string(),
+                timestamp: 1,
+                thread_ts: None,
+                interruption_scope_id: None,
+                attachments: vec![],
+            },
+            CancellationToken::new(),
+        )
+        .await;
+
+        let sent_messages = channel_impl.sent_messages.lock().await;
+        assert!(
+            !sent_messages.iter().any(|m| m.contains("Tool receipts:")),
+            "no receipts block must be sent when show_receipts_in_response=false; got {:?}",
+            sent_messages.as_slice()
+        );
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -388,6 +388,14 @@ struct ChannelRuntimeContext {
     max_tool_result_chars: usize,
     context_token_budget: usize,
     debouncer: Arc<zeroclaw_infra::debounce::MessageDebouncer>,
+    /// HMAC receipt generator. `Some` when `[agent.tool_receipts] enabled = true`.
+    /// Threaded into `run_tool_call_loop` so `tool_execution::execute_one_tool`
+    /// can sign each result.
+    receipt_generator: Option<zeroclaw_runtime::agent::tool_receipts::ReceiptGenerator>,
+    /// Mirror of `[agent.tool_receipts] show_in_response`. When true,
+    /// `process_channel_message` renders the per-turn collector as a trailing
+    /// `Tool receipts:` block sent after the main reply.
+    show_receipts_in_response: bool,
 }
 
 #[derive(Clone)]
@@ -3132,6 +3140,11 @@ async fn process_channel_message(
     #[allow(clippy::cast_possible_truncation)]
     let elapsed_before_llm_ms = started_at.elapsed().as_millis() as u64;
     tracing::info!(elapsed_before_llm_ms, "⏱ Starting LLM call");
+    // Per-turn collector. `tool_execution::execute_one_tool` pushes
+    // `<tool_name>: <receipt>` here whenever a receipt is generated, so the
+    // orchestrator can render the trailing `Tool receipts:` block after the
+    // loop returns. Inert when `receipt_generator` is `None`.
+    let tool_receipts_collector: std::sync::Mutex<Vec<String>> = std::sync::Mutex::new(Vec::new());
     let (llm_result, fallback_info) = scope_provider_fallback(async {
         let llm_result = loop {
             let loop_result = tokio::select! {
@@ -3176,8 +3189,8 @@ async fn process_channel_message(
                         ctx.context_token_budget,
                         None, // shared_budget
                         target_channel.as_deref(),
-                        None, // receipt_generator
-                        None, // collected_receipts
+                        ctx.receipt_generator.as_ref(),
+                        Some(&tool_receipts_collector),
                     ),
                     ),
                     ),
@@ -3459,6 +3472,26 @@ async fn process_channel_message(
                 started_at.elapsed().as_millis(),
                 truncate_with_ellipsis(&delivered_response, 80)
             );
+            // Build the trailing `Tool receipts:` block from the per-turn
+            // collector. Empty when receipts are disabled or no tool ran.
+            let receipts_block = if ctx.show_receipts_in_response {
+                let receipts = tool_receipts_collector
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner());
+                if receipts.is_empty() {
+                    None
+                } else {
+                    use std::fmt::Write as _;
+                    let mut block = String::from("---\nTool receipts:");
+                    for r in receipts.iter() {
+                        write!(block, "\n  {r}").ok();
+                    }
+                    Some(block)
+                }
+            } else {
+                None
+            };
+
             if let Some(channel) = target_channel.as_ref() {
                 if let Some(ref draft_id) = draft_message_id {
                     if let Err(e) = channel
@@ -3482,6 +3515,15 @@ async fn process_channel_message(
                     .await
                 {
                     eprintln!("  ❌ Failed to reply on {}: {e}", channel.name());
+                }
+                // Send tool receipts as a separate message in the same thread.
+                if let Some(ref block) = receipts_block {
+                    let _ = channel
+                        .send(
+                            &SendMessage::new(block, &msg.reply_target)
+                                .in_thread(msg.thread_ts.clone()),
+                        )
+                        .await;
                 }
             }
         }
@@ -5518,6 +5560,18 @@ pub async fn start_channels(config: Config) -> Result<()> {
         system_prompt.push_str(&deferred_section);
     }
 
+    // Append the receipt-echo instruction so the model carries
+    // `[receipt: zc-receipt-...]` markers verbatim into its response.
+    if config.agent.tool_receipts.enabled && config.agent.tool_receipts.inject_system_prompt {
+        system_prompt.push_str(
+            "\n## Tool Execution Receipts\n\n\
+             Every tool result includes a `[receipt: ...]` field. This is a cryptographic \
+             signature proving the tool actually executed. You must include the receipt \
+             verbatim when referencing tool results. Do not modify, omit, or fabricate receipts. \
+             A missing or invalid receipt indicates a fabricated tool call.\n\n",
+        );
+    }
+
     if !skills.is_empty() {
         println!(
             "  🧩 Skills:   {}",
@@ -5760,6 +5814,12 @@ pub async fn start_channels(config: Config) -> Result<()> {
         debouncer: Arc::new(zeroclaw_infra::debounce::MessageDebouncer::new(
             Duration::from_millis(config.channels.debounce_ms),
         )),
+        receipt_generator: if config.agent.tool_receipts.enabled {
+            Some(zeroclaw_runtime::agent::tool_receipts::ReceiptGenerator::new())
+        } else {
+            None
+        },
+        show_receipts_in_response: config.agent.tool_receipts.show_in_response,
     });
 
     // Hydrate in-memory conversation histories from persisted JSONL session files.
@@ -6336,6 +6396,8 @@ mod tests {
             debouncer: Arc::new(zeroclaw_infra::debounce::MessageDebouncer::new(
                 Duration::ZERO,
             )),
+            receipt_generator: None,
+            show_receipts_in_response: false,
         };
 
         assert!(compact_sender_history(&ctx, &sender));
@@ -6462,6 +6524,8 @@ mod tests {
             debouncer: Arc::new(zeroclaw_infra::debounce::MessageDebouncer::new(
                 Duration::ZERO,
             )),
+            receipt_generator: None,
+            show_receipts_in_response: false,
         };
 
         append_sender_turn(&ctx, &sender, ChatMessage::user("hello"));
@@ -6545,6 +6609,8 @@ mod tests {
             debouncer: Arc::new(zeroclaw_infra::debounce::MessageDebouncer::new(
                 Duration::ZERO,
             )),
+            receipt_generator: None,
+            show_receipts_in_response: false,
         };
 
         assert!(rollback_orphan_user_turn(&ctx, &sender, "pending"));
@@ -6645,6 +6711,8 @@ mod tests {
             debouncer: Arc::new(zeroclaw_infra::debounce::MessageDebouncer::new(
                 Duration::ZERO,
             )),
+            receipt_generator: None,
+            show_receipts_in_response: false,
         };
 
         assert!(rollback_orphan_user_turn(
@@ -7246,6 +7314,8 @@ BTC is currently around $65,000 based on latest tool output."#
             debouncer: Arc::new(zeroclaw_infra::debounce::MessageDebouncer::new(
                 Duration::ZERO,
             )),
+            receipt_generator: None,
+            show_receipts_in_response: false,
         });
 
         process_channel_message(
@@ -7338,6 +7408,8 @@ BTC is currently around $65,000 based on latest tool output."#
             debouncer: Arc::new(zeroclaw_infra::debounce::MessageDebouncer::new(
                 Duration::ZERO,
             )),
+            receipt_generator: None,
+            show_receipts_in_response: false,
         });
 
         process_channel_message(
@@ -7444,6 +7516,8 @@ BTC is currently around $65,000 based on latest tool output."#
             debouncer: Arc::new(zeroclaw_infra::debounce::MessageDebouncer::new(
                 Duration::ZERO,
             )),
+            receipt_generator: None,
+            show_receipts_in_response: false,
         });
 
         process_channel_message(
@@ -7535,6 +7609,8 @@ BTC is currently around $65,000 based on latest tool output."#
             debouncer: Arc::new(zeroclaw_infra::debounce::MessageDebouncer::new(
                 Duration::ZERO,
             )),
+            receipt_generator: None,
+            show_receipts_in_response: false,
         });
 
         process_channel_message(
@@ -7636,6 +7712,8 @@ BTC is currently around $65,000 based on latest tool output."#
             debouncer: Arc::new(zeroclaw_infra::debounce::MessageDebouncer::new(
                 Duration::ZERO,
             )),
+            receipt_generator: None,
+            show_receipts_in_response: false,
         });
 
         process_channel_message(
@@ -7758,6 +7836,8 @@ BTC is currently around $65,000 based on latest tool output."#
             debouncer: Arc::new(zeroclaw_infra::debounce::MessageDebouncer::new(
                 Duration::ZERO,
             )),
+            receipt_generator: None,
+            show_receipts_in_response: false,
         });
 
         process_channel_message(
@@ -7861,6 +7941,8 @@ BTC is currently around $65,000 based on latest tool output."#
             debouncer: Arc::new(zeroclaw_infra::debounce::MessageDebouncer::new(
                 Duration::ZERO,
             )),
+            receipt_generator: None,
+            show_receipts_in_response: false,
         });
 
         process_channel_message(
@@ -7979,6 +8061,8 @@ BTC is currently around $65,000 based on latest tool output."#
             debouncer: Arc::new(zeroclaw_infra::debounce::MessageDebouncer::new(
                 Duration::ZERO,
             )),
+            receipt_generator: None,
+            show_receipts_in_response: false,
         });
 
         process_channel_message(
@@ -8085,6 +8169,8 @@ BTC is currently around $65,000 based on latest tool output."#
             debouncer: Arc::new(zeroclaw_infra::debounce::MessageDebouncer::new(
                 Duration::ZERO,
             )),
+            receipt_generator: None,
+            show_receipts_in_response: false,
         });
 
         process_channel_message(
@@ -8181,6 +8267,8 @@ BTC is currently around $65,000 based on latest tool output."#
             debouncer: Arc::new(zeroclaw_infra::debounce::MessageDebouncer::new(
                 Duration::ZERO,
             )),
+            receipt_generator: None,
+            show_receipts_in_response: false,
         });
 
         process_channel_message(
@@ -8400,6 +8488,8 @@ BTC is currently around $65,000 based on latest tool output."#
             debouncer: Arc::new(zeroclaw_infra::debounce::MessageDebouncer::new(
                 Duration::ZERO,
             )),
+            receipt_generator: None,
+            show_receipts_in_response: false,
         });
 
         let (tx, rx) = tokio::sync::mpsc::channel::<zeroclaw_api::channel::ChannelMessage>(4);
@@ -8514,6 +8604,8 @@ BTC is currently around $65,000 based on latest tool output."#
             debouncer: Arc::new(zeroclaw_infra::debounce::MessageDebouncer::new(
                 Duration::ZERO,
             )),
+            receipt_generator: None,
+            show_receipts_in_response: false,
         });
 
         let (tx, rx) = tokio::sync::mpsc::channel::<zeroclaw_api::channel::ChannelMessage>(8);
@@ -8647,6 +8739,8 @@ BTC is currently around $65,000 based on latest tool output."#
             debouncer: Arc::new(zeroclaw_infra::debounce::MessageDebouncer::new(
                 Duration::ZERO,
             )),
+            receipt_generator: None,
+            show_receipts_in_response: false,
         });
 
         let (tx, rx) = tokio::sync::mpsc::channel::<zeroclaw_api::channel::ChannelMessage>(8);
@@ -8777,6 +8871,8 @@ BTC is currently around $65,000 based on latest tool output."#
             debouncer: Arc::new(zeroclaw_infra::debounce::MessageDebouncer::new(
                 Duration::ZERO,
             )),
+            receipt_generator: None,
+            show_receipts_in_response: false,
         });
 
         let (tx, rx) = tokio::sync::mpsc::channel::<zeroclaw_api::channel::ChannelMessage>(8);
@@ -8885,6 +8981,8 @@ BTC is currently around $65,000 based on latest tool output."#
             debouncer: Arc::new(zeroclaw_infra::debounce::MessageDebouncer::new(
                 Duration::ZERO,
             )),
+            receipt_generator: None,
+            show_receipts_in_response: false,
         });
 
         process_channel_message(
@@ -8974,6 +9072,8 @@ BTC is currently around $65,000 based on latest tool output."#
             debouncer: Arc::new(zeroclaw_infra::debounce::MessageDebouncer::new(
                 Duration::ZERO,
             )),
+            receipt_generator: None,
+            show_receipts_in_response: false,
         });
 
         process_channel_message(
@@ -9063,6 +9163,8 @@ BTC is currently around $65,000 based on latest tool output."#
             debouncer: Arc::new(zeroclaw_infra::debounce::MessageDebouncer::new(
                 Duration::ZERO,
             )),
+            receipt_generator: None,
+            show_receipts_in_response: false,
         });
 
         process_channel_message(
@@ -9858,6 +9960,8 @@ BTC is currently around $65,000 based on latest tool output."#
             debouncer: Arc::new(zeroclaw_infra::debounce::MessageDebouncer::new(
                 Duration::ZERO,
             )),
+            receipt_generator: None,
+            show_receipts_in_response: false,
         });
 
         process_channel_message(
@@ -10004,6 +10108,8 @@ BTC is currently around $65,000 based on latest tool output."#
             debouncer: Arc::new(zeroclaw_infra::debounce::MessageDebouncer::new(
                 Duration::ZERO,
             )),
+            receipt_generator: None,
+            show_receipts_in_response: false,
         });
 
         process_channel_message(
@@ -10191,6 +10297,8 @@ BTC is currently around $65,000 based on latest tool output."#
             debouncer: Arc::new(zeroclaw_infra::debounce::MessageDebouncer::new(
                 Duration::ZERO,
             )),
+            receipt_generator: None,
+            show_receipts_in_response: false,
         });
 
         process_channel_message(
@@ -10309,6 +10417,8 @@ BTC is currently around $65,000 based on latest tool output."#
             debouncer: Arc::new(zeroclaw_infra::debounce::MessageDebouncer::new(
                 Duration::ZERO,
             )),
+            receipt_generator: None,
+            show_receipts_in_response: false,
         });
 
         process_channel_message(
@@ -10933,6 +11043,8 @@ This is an example JSON object for profile settings."#;
             debouncer: Arc::new(zeroclaw_infra::debounce::MessageDebouncer::new(
                 Duration::ZERO,
             )),
+            receipt_generator: None,
+            show_receipts_in_response: false,
         });
 
         // Simulate a photo attachment message with [IMAGE:] marker.
@@ -11031,6 +11143,8 @@ This is an example JSON object for profile settings."#;
             debouncer: Arc::new(zeroclaw_infra::debounce::MessageDebouncer::new(
                 Duration::ZERO,
             )),
+            receipt_generator: None,
+            show_receipts_in_response: false,
         });
 
         process_channel_message(
@@ -11161,6 +11275,8 @@ This is an example JSON object for profile settings."#;
             debouncer: Arc::new(zeroclaw_infra::debounce::MessageDebouncer::new(
                 std::time::Duration::ZERO,
             )),
+            receipt_generator: None,
+            show_receipts_in_response: false,
             media_pipeline: zeroclaw_config::schema::MediaPipelineConfig::default(),
             transcription_config: zeroclaw_config::schema::TranscriptionConfig::default(),
         });
@@ -11339,6 +11455,8 @@ This is an example JSON object for profile settings."#;
             debouncer: Arc::new(zeroclaw_infra::debounce::MessageDebouncer::new(
                 Duration::ZERO,
             )),
+            receipt_generator: None,
+            show_receipts_in_response: false,
         });
 
         process_channel_message(
@@ -11461,6 +11579,8 @@ This is an example JSON object for profile settings."#;
             debouncer: Arc::new(zeroclaw_infra::debounce::MessageDebouncer::new(
                 Duration::ZERO,
             )),
+            receipt_generator: None,
+            show_receipts_in_response: false,
         });
 
         process_channel_message(
@@ -11575,6 +11695,8 @@ This is an example JSON object for profile settings."#;
             debouncer: Arc::new(zeroclaw_infra::debounce::MessageDebouncer::new(
                 Duration::ZERO,
             )),
+            receipt_generator: None,
+            show_receipts_in_response: false,
         });
 
         process_channel_message(
@@ -11709,6 +11831,8 @@ This is an example JSON object for profile settings."#;
             debouncer: Arc::new(zeroclaw_infra::debounce::MessageDebouncer::new(
                 Duration::ZERO,
             )),
+            receipt_generator: None,
+            show_receipts_in_response: false,
         });
 
         process_channel_message(
@@ -12025,6 +12149,8 @@ This is an example JSON object for profile settings."#;
             debouncer: Arc::new(zeroclaw_infra::debounce::MessageDebouncer::new(
                 Duration::ZERO,
             )),
+            receipt_generator: None,
+            show_receipts_in_response: false,
         });
 
         let (tx, rx) = tokio::sync::mpsc::channel::<zeroclaw_api::channel::ChannelMessage>(8);

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -3143,8 +3143,17 @@ async fn process_channel_message(
     // Per-turn collector. `tool_execution::execute_one_tool` pushes
     // `<tool_name>: <receipt>` here whenever a receipt is generated, so the
     // orchestrator can render the trailing `Tool receipts:` block after the
-    // loop returns. Inert when `receipt_generator` is `None`.
-    let tool_receipts_collector: std::sync::Mutex<Vec<String>> = std::sync::Mutex::new(Vec::new());
+    // loop returns. Wrapped in `Arc` so the same handle can be shared into
+    // `TOOL_LOOP_RECEIPT_CONTEXT` for subagent forwarding (#6182). Inert when
+    // `receipt_generator` is `None`.
+    let tool_receipts_collector: std::sync::Arc<std::sync::Mutex<Vec<String>>> =
+        std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let receipt_scope = ctx.receipt_generator.as_ref().map(|generator| {
+        zeroclaw_runtime::agent::tool_receipts::ReceiptScope {
+            generator: generator.clone(),
+            collector: std::sync::Arc::clone(&tool_receipts_collector),
+        }
+    });
     let (llm_result, fallback_info) = scope_provider_fallback(async {
         let llm_result = loop {
             let loop_result = tokio::select! {
@@ -3157,6 +3166,8 @@ async fn process_channel_message(
                             .or_else(|| Some(msg.id.clone())),
                         zeroclaw_runtime::agent::loop_::TOOL_LOOP_COST_TRACKING_CONTEXT.scope(
                             cost_tracking_context.clone(),
+                        zeroclaw_runtime::agent::tool_receipts::TOOL_LOOP_RECEIPT_CONTEXT.scope(
+                            receipt_scope.clone(),
                         run_tool_call_loop(
                         active_provider.as_ref(),
                         &mut history,
@@ -3195,7 +3206,8 @@ async fn process_channel_message(
                         // call site reflects that coupling explicitly.
                         ctx.receipt_generator
                             .as_ref()
-                            .map(|_| &tool_receipts_collector),
+                            .map(|_| tool_receipts_collector.as_ref()),
+                    ),
                     ),
                     ),
                     ),
@@ -3479,6 +3491,9 @@ async fn process_channel_message(
             );
             // Build the trailing `Tool receipts:` block from the per-turn
             // collector. Empty when receipts are disabled or no tool ran.
+            // Includes receipts from delegate sub-agents because the same
+            // `Arc<Mutex<Vec<String>>>` is forwarded via
+            // `TOOL_LOOP_RECEIPT_CONTEXT` into sub-loops (see #6182).
             let receipts_block = if ctx.show_receipts_in_response {
                 let receipts = tool_receipts_collector
                     .lock()
@@ -7602,6 +7617,136 @@ BTC is currently around $65,000 based on latest tool output."#
             "no receipts block must be sent when show_receipts_in_response=false; got {:?}",
             sent_messages.as_slice()
         );
+    }
+
+    #[tokio::test]
+    async fn process_channel_message_disabled_receipt_generator_emits_no_receipts_anywhere() {
+        // Strict #6182 acceptance criterion: enabled=false must emit no
+        // receipt anywhere — not in any sent message, not in the model's
+        // view of conversation history. `receipt_generator: None` is the
+        // wire-level reflection of `[agent.tool_receipts] enabled = false`.
+        // Distinct from the show_in_response=false test above (which keeps
+        // the generator on but suppresses the trailing block); this one
+        // proves nothing is signed in the first place.
+        let channel_impl = Arc::new(RecordingChannel::default());
+        let channel: Arc<dyn Channel> = channel_impl.clone();
+
+        let mut channels_by_name = HashMap::new();
+        channels_by_name.insert(channel.name().to_string(), channel);
+
+        let runtime_ctx = Arc::new(ChannelRuntimeContext {
+            channels_by_name: Arc::new(channels_by_name),
+            provider: Arc::new(ToolCallingProvider),
+            default_provider: Arc::new("test-provider".to_string()),
+            memory: Arc::new(NoopMemory),
+            tools_registry: Arc::new(vec![Box::new(MockPriceTool)]),
+            observer: Arc::new(NoopObserver),
+            system_prompt: Arc::new("test-system-prompt".to_string()),
+            model: Arc::new("test-model".to_string()),
+            temperature: 0.0,
+            auto_save_memory: false,
+            max_tool_iterations: 10,
+            min_relevance_score: 0.0,
+            conversation_histories: Arc::new(Mutex::new(lru::LruCache::new(
+                std::num::NonZeroUsize::new(MAX_CONVERSATION_SENDERS).unwrap(),
+            ))),
+            pending_new_sessions: Arc::new(Mutex::new(HashSet::new())),
+            provider_cache: Arc::new(Mutex::new(HashMap::new())),
+            route_overrides: Arc::new(Mutex::new(HashMap::new())),
+            api_key: None,
+            api_url: None,
+            reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
+            provider_runtime_options: zeroclaw_providers::ProviderRuntimeOptions::default(),
+            workspace_dir: Arc::new(std::env::temp_dir()),
+            prompt_config: Arc::new(zeroclaw_config::schema::Config::default()),
+            message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
+            interrupt_on_new_message: InterruptOnNewMessageConfig {
+                telegram: false,
+                slack: false,
+                discord: false,
+                mattermost: false,
+                matrix: false,
+            },
+            non_cli_excluded_tools: Arc::new(Vec::new()),
+            autonomy_level: AutonomyLevel::Full,
+            tool_call_dedup_exempt: Arc::new(Vec::new()),
+            multimodal: zeroclaw_config::schema::MultimodalConfig::default(),
+            media_pipeline: zeroclaw_config::schema::MediaPipelineConfig::default(),
+            transcription_config: zeroclaw_config::schema::TranscriptionConfig::default(),
+            hooks: None,
+            model_routes: Arc::new(Vec::new()),
+            query_classification: zeroclaw_config::schema::QueryClassificationConfig::default(),
+            ack_reactions: true,
+            show_tool_calls: true,
+            session_store: None,
+            approval_manager: Arc::new(ApprovalManager::for_non_interactive(&{
+                let mut autonomy = zeroclaw_config::schema::AutonomyConfig::default();
+                autonomy.level = zeroclaw_config::autonomy::AutonomyLevel::Full;
+                autonomy.auto_approve.push("mock_price".to_string());
+                autonomy
+            })),
+            activated_tools: None,
+            cost_tracking: None,
+            pacing: zeroclaw_config::schema::PacingConfig::default(),
+            max_tool_result_chars: 0,
+            context_token_budget: 0,
+            debouncer: Arc::new(zeroclaw_infra::debounce::MessageDebouncer::new(
+                Duration::ZERO,
+            )),
+            receipt_generator: None,
+            show_receipts_in_response: false,
+        });
+
+        process_channel_message(
+            runtime_ctx.clone(),
+            zeroclaw_api::channel::ChannelMessage {
+                id: "msg-1".to_string(),
+                sender: "alice".to_string(),
+                reply_target: "chat-42".to_string(),
+                content: "What is the BTC price now?".to_string(),
+                channel: "test-channel".to_string(),
+                timestamp: 1,
+                thread_ts: None,
+                interruption_scope_id: None,
+                attachments: vec![],
+            },
+            CancellationToken::new(),
+        )
+        .await;
+
+        let sent_messages = channel_impl.sent_messages.lock().await;
+        assert!(
+            !sent_messages.is_empty(),
+            "agent must still respond when receipts are disabled"
+        );
+        assert!(
+            !sent_messages.iter().any(|m| m.contains("zc-receipt-")),
+            "no zc-receipt- token must appear in any sent message when receipts are disabled, got {:?}",
+            sent_messages.as_slice()
+        );
+        assert!(
+            !sent_messages.iter().any(|m| m.contains("Tool receipts:")),
+            "no `Tool receipts:` block must be sent when receipts are disabled, got {:?}",
+            sent_messages.as_slice()
+        );
+
+        // Strict surface check: the model's view of conversation history must
+        // not carry a `[receipt: ` trailer either, otherwise an LLM trained
+        // on echoing receipts could leak signed-looking output even though
+        // nothing was actually signed.
+        let histories = runtime_ctx
+            .conversation_histories
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        for (_key, turns) in histories.iter() {
+            for msg in turns.iter() {
+                assert!(
+                    !msg.content.contains("[receipt: "),
+                    "no `[receipt: ` trailer must appear in conversation history when receipts are disabled, got: {}",
+                    msg.content
+                );
+            }
+        }
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -1457,6 +1457,46 @@ fn default_local_whisper_timeout_secs() -> u64 {
     300
 }
 
+/// HMAC tool execution receipt configuration (`[agent.tool_receipts]`).
+///
+/// Receipts are short HMAC-SHA256 tags appended to tool results so the model
+/// cannot claim it ran a tool that never actually executed. See
+/// `docs/book/src/security/tool-receipts.md`.
+#[derive(Debug, Clone, Serialize, Deserialize, Configurable)]
+#[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
+#[prefix = "agent.tool_receipts"]
+pub struct ToolReceiptsConfig {
+    /// Generate HMAC receipts on every tool execution. Default: `false`.
+    /// When false, the entire receipt subsystem is inert (no key, no
+    /// generation, no append, no system-prompt addendum).
+    #[serde(default)]
+    pub enabled: bool,
+    /// Append a trailing `Tool receipts:` block to user-visible replies so
+    /// receipts are auditable from the channel surface, not just the
+    /// internal history. Default: `false`.
+    #[serde(default)]
+    pub show_in_response: bool,
+    /// Inject the receipt-echo instruction into the system prompt so the
+    /// model carries receipts verbatim into its response. Default: `true`.
+    /// No effect when `enabled = false`.
+    #[serde(default = "default_inject_system_prompt")]
+    pub inject_system_prompt: bool,
+}
+
+fn default_inject_system_prompt() -> bool {
+    true
+}
+
+impl Default for ToolReceiptsConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            show_in_response: false,
+            inject_system_prompt: default_inject_system_prompt(),
+        }
+    }
+}
+
 /// Agent orchestration configuration (`[agent]` section).
 #[derive(Debug, Clone, Serialize, Deserialize, Configurable)]
 #[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
@@ -1541,6 +1581,11 @@ pub struct AgentConfig {
     /// behavior). Default: `2`.
     #[serde(default = "default_keep_tool_context_turns")]
     pub keep_tool_context_turns: usize,
+
+    /// HMAC tool execution receipt configuration.
+    #[nested]
+    #[serde(default)]
+    pub tool_receipts: ToolReceiptsConfig,
 }
 
 fn default_max_tool_result_chars() -> usize {
@@ -1591,6 +1636,7 @@ impl Default for AgentConfig {
             context_compression: crate::scattered_types::ContextCompressionConfig::default(),
             max_tool_result_chars: default_max_tool_result_chars(),
             keep_tool_context_turns: default_keep_tool_context_turns(),
+            tool_receipts: ToolReceiptsConfig::default(),
         }
     }
 }

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -802,31 +802,6 @@ fn maybe_inject_channel_delivery_defaults(
 //   • the cancellation token fires (external abort).
 
 /// Append a receipt footer to the response text if any receipts were collected.
-///
-/// Format:
-/// ```text
-/// \n\n---\nTool receipts:\n  shell: zc-receipt-...\n  web_search: zc-receipt-...
-/// ```
-pub fn append_receipt_footer(
-    response: String,
-    collected_receipts: Option<&std::sync::Mutex<Vec<String>>>,
-) -> String {
-    let Some(store) = collected_receipts else {
-        return response;
-    };
-    let Ok(receipts) = store.lock() else {
-        return response;
-    };
-    if receipts.is_empty() {
-        return response;
-    }
-    let mut footer = format!("{response}\n\n---\nTool receipts:");
-    for entry in receipts.iter() {
-        footer.push_str(&format!("\n  {entry}"));
-    }
-    footer
-}
-
 /// Execute a single turn of the agent loop: send messages, parse tool calls,
 /// execute tools, and loop until the LLM produces a final text response.
 #[allow(clippy::too_many_arguments)]
@@ -1466,10 +1441,7 @@ pub async fn run_tool_call_loop(
             }
 
             history.push(ChatMessage::assistant(response_text.clone()));
-            return Ok(append_receipt_footer(
-                accumulated_display_text,
-                collected_receipts,
-            ));
+            return Ok(accumulated_display_text);
         }
 
         // Accumulate text from this iteration (tool calls present, loop continues).
@@ -2023,10 +1995,7 @@ pub async fn run_tool_call_loop(
                 anyhow::bail!("Agent exceeded maximum tool iterations ({max_iterations})")
             }
             accumulated_display_text.push_str(&text);
-            Ok(append_receipt_footer(
-                accumulated_display_text,
-                collected_receipts,
-            ))
+            Ok(accumulated_display_text)
         }
         Err(e) => {
             tracing::warn!(error = %e, "Final summary LLM call failed, bailing");
@@ -7521,45 +7490,5 @@ Let me check the result."#;
         .expect("should succeed without cost scope");
 
         assert_eq!(result, "ok");
-    }
-
-    // ── append_receipt_footer tests ──────────────────────────────
-
-    #[test]
-    fn receipt_footer_empty_receipts_unchanged() {
-        let store = std::sync::Mutex::new(Vec::<String>::new());
-        let result = super::append_receipt_footer("Hello world".to_string(), Some(&store));
-        assert_eq!(result, "Hello world");
-    }
-
-    #[test]
-    fn receipt_footer_none_store_unchanged() {
-        let result = super::append_receipt_footer("Hello world".to_string(), None);
-        assert_eq!(result, "Hello world");
-    }
-
-    #[test]
-    fn receipt_footer_single_receipt() {
-        let store = std::sync::Mutex::new(vec!["shell: zc-receipt-1234567890-abcdef".to_string()]);
-        let result = super::append_receipt_footer("The date is Monday.".to_string(), Some(&store));
-        assert_eq!(
-            result,
-            "The date is Monday.\n\n---\nTool receipts:\n  shell: zc-receipt-1234567890-abcdef"
-        );
-    }
-
-    #[test]
-    fn receipt_footer_multiple_receipts() {
-        let store = std::sync::Mutex::new(vec![
-            "shell: zc-receipt-100-aaa".to_string(),
-            "web_search: zc-receipt-200-bbb".to_string(),
-            "file_read: zc-receipt-300-ccc".to_string(),
-        ]);
-        let result = super::append_receipt_footer("Done.".to_string(), Some(&store));
-        let expected = "Done.\n\n---\nTool receipts:\
-            \n  shell: zc-receipt-100-aaa\
-            \n  web_search: zc-receipt-200-bbb\
-            \n  file_read: zc-receipt-300-ccc";
-        assert_eq!(result, expected);
     }
 }

--- a/crates/zeroclaw-runtime/src/agent/tool_receipts.rs
+++ b/crates/zeroclaw-runtime/src/agent/tool_receipts.rs
@@ -120,6 +120,23 @@ impl ReceiptGenerator {
     }
 }
 
+/// Per-turn receipt forwarding scope, used to thread the generator and
+/// the per-turn collector through delegate sub-loops without changing the
+/// `Tool` trait signature. Mirrors the pattern used by
+/// `TOOL_LOOP_COST_TRACKING_CONTEXT`.
+#[derive(Clone)]
+pub struct ReceiptScope {
+    pub generator: ReceiptGenerator,
+    pub collector: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+}
+
+tokio::task_local! {
+    /// Set by the orchestrator when `[agent.tool_receipts] enabled = true`.
+    /// `DelegateTool` reads this to forward receipts into sub-agent tool loops
+    /// so subagent tool calls land in the same per-turn collector.
+    pub static TOOL_LOOP_RECEIPT_CONTEXT: Option<ReceiptScope>;
+}
+
 /// Parse a receipt string into (timestamp, hash).
 /// Expected format: `zc-receipt-{timestamp}-{base64url_hash}`
 fn parse_receipt(receipt: &str) -> Option<(u64, &str)> {

--- a/crates/zeroclaw-runtime/src/tools/delegate.rs
+++ b/crates/zeroclaw-runtime/src/tools/delegate.rs
@@ -788,6 +788,18 @@ impl DelegateTool {
             }
         }
 
+        // Capture the current receipt scope so each spawned sub-agent task
+        // re-enters it. `tokio::spawn` does not propagate task-locals, so
+        // without this `execute_sync`'s `try_with` would resolve to `None`
+        // inside the spawn and the parallel agents would run unsigned even
+        // when the parent turn has receipts enabled. The collector is `Arc`'d
+        // inside `ReceiptScope`, so all parallel agents push into the same
+        // per-turn collector the orchestrator renders after the loop returns.
+        let parent_receipt_scope = crate::agent::tool_receipts::TOOL_LOOP_RECEIPT_CONTEXT
+            .try_with(Clone::clone)
+            .ok()
+            .flatten();
+
         // Spawn all agents concurrently
         let mut handles = Vec::with_capacity(agent_names.len());
         for agent_name in &agent_names {
@@ -804,6 +816,7 @@ impl DelegateTool {
             let agent_name = agent_name.clone();
             let prompt = prompt.to_string();
             let args_clone = args.clone();
+            let receipt_scope = parent_receipt_scope.clone();
 
             handles.push(tokio::spawn(async move {
                 let inner = DelegateTool {
@@ -819,8 +832,13 @@ impl DelegateTool {
                     cancellation_token,
                     memory: None,
                 };
-                let result = Box::pin(inner.execute_sync(&agent_name, &prompt, &args_clone)).await;
-                (agent_name, result)
+                let agent_name_for_return = agent_name.clone();
+                let result = crate::agent::tool_receipts::TOOL_LOOP_RECEIPT_CONTEXT
+                    .scope(receipt_scope, async move {
+                        Box::pin(inner.execute_sync(&agent_name, &prompt, &args_clone)).await
+                    })
+                    .await;
+                (agent_name_for_return, result)
             }));
         }
 
@@ -1153,6 +1171,17 @@ impl DelegateTool {
         let agentic_timeout_secs = agent_config
             .agentic_timeout_secs
             .unwrap_or(self.delegate_config.agentic_timeout_secs);
+        // Forward the per-turn receipt scope from the parent loop so subagent
+        // tool calls land in the same collector as the top-level turn. When
+        // receipts are disabled (or no scope is set, e.g. CLI / background
+        // delegate spawn) this resolves to `None` and the sub-loop runs
+        // unsigned, matching the parent.
+        let receipt_scope = crate::agent::tool_receipts::TOOL_LOOP_RECEIPT_CONTEXT
+            .try_with(Clone::clone)
+            .ok()
+            .flatten();
+        let receipt_generator = receipt_scope.as_ref().map(|s| &s.generator);
+        let collected_receipts = receipt_scope.as_ref().map(|s| s.collector.as_ref());
         let result = tokio::time::timeout(
             Duration::from_secs(agentic_timeout_secs),
             run_tool_call_loop(
@@ -1181,8 +1210,8 @@ impl DelegateTool {
                 0,    // context_token_budget: 0 = disabled for subagents
                 None, // shared_budget: TODO thread from parent in future
                 None, // channel: delegate subagents don't support approval
-                None, // receipt_generator
-                None, // collected_receipts
+                receipt_generator,
+                collected_receipts,
             ),
         )
         .await;
@@ -1896,6 +1925,81 @@ mod tests {
                 .as_deref()
                 .unwrap_or("")
                 .contains("maximum tool iterations (2)")
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_agentic_forwards_receipt_scope_into_subagent_loop() {
+        // Receipt forwarding through the delegate sub-loop is the activation
+        // pass for #6182's delegate.rs:1184 acceptance criterion. With
+        // `TOOL_LOOP_RECEIPT_CONTEXT` scoped, every sub-tool call inside the
+        // delegate must produce a receipt that lands in the same per-turn
+        // collector the parent passed in. Without the task-local read in
+        // `execute_sync` this test fails: the collector stays empty because
+        // the sub-loop runs unsigned with `None, None` for the receipt args.
+        use crate::agent::tool_receipts::{
+            ReceiptGenerator, ReceiptScope, TOOL_LOOP_RECEIPT_CONTEXT,
+        };
+
+        let config = agentic_config(vec!["echo_tool".to_string()], 10);
+        let tool = DelegateTool::new(HashMap::new(), None, test_security())
+            .with_parent_tools(Arc::new(RwLock::new(vec![Arc::new(EchoTool)])));
+
+        let collector: Arc<std::sync::Mutex<Vec<String>>> =
+            Arc::new(std::sync::Mutex::new(Vec::new()));
+        let scope = ReceiptScope {
+            generator: ReceiptGenerator::new(),
+            collector: Arc::clone(&collector),
+        };
+
+        let provider = OneToolThenFinalProvider;
+        let result = TOOL_LOOP_RECEIPT_CONTEXT
+            .scope(Some(scope), async {
+                tool.execute_agentic("agentic", &config, &provider, "run", 0.2)
+                    .await
+            })
+            .await
+            .unwrap();
+
+        assert!(
+            result.success,
+            "delegate sub-loop must complete: {result:?}"
+        );
+        let receipts = collector.lock().unwrap();
+        assert_eq!(
+            receipts.len(),
+            1,
+            "expected exactly one receipt for the single echo_tool sub-call, got: {:?}",
+            receipts.as_slice()
+        );
+        assert!(
+            receipts[0].starts_with("echo_tool: zc-receipt-"),
+            "sub-tool receipt must be tagged with the tool name and a zc-receipt- HMAC token, got: {}",
+            receipts[0]
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_agentic_emits_no_receipts_when_scope_absent() {
+        // Backward-compat for callers without a scoped receipt context (CLI,
+        // background spawn that does not forward scope, tests). The sub-loop
+        // must run unsigned and the agent output must not carry a
+        // `[receipt: ` trailer.
+        let config = agentic_config(vec!["echo_tool".to_string()], 10);
+        let tool = DelegateTool::new(HashMap::new(), None, test_security())
+            .with_parent_tools(Arc::new(RwLock::new(vec![Arc::new(EchoTool)])));
+
+        let provider = OneToolThenFinalProvider;
+        let result = tool
+            .execute_agentic("agentic", &config, &provider, "run", 0.2)
+            .await
+            .unwrap();
+
+        assert!(result.success);
+        assert!(
+            !result.output.contains("[receipt: "),
+            "no receipt trailer must appear in agent output when receipts are disabled, got: {}",
+            result.output
         );
     }
 

--- a/docs/book/src/security/tool-receipts.md
+++ b/docs/book/src/security/tool-receipts.md
@@ -111,7 +111,7 @@ inject_system_prompt = true # instruct the model to echo receipts verbatim
 | Receipt appended to tool result | Shipped |
 | Debug log of receipts | Shipped |
 | `show_in_response` | Shipped |
-| System-prompt instruction to echo receipts | In flight |
+| System-prompt instruction to echo receipts | Shipped |
 | Persistent audit database of receipts | Planned |
 | Cross-session receipt verification | Not planned (see ephemeral-key design) |
 

--- a/docs/book/src/security/tool-receipts.md
+++ b/docs/book/src/security/tool-receipts.md
@@ -8,13 +8,15 @@ The practical outcome: the model cannot claim to have run a tool it didn't run, 
 
 An LLM is a string generator. By default, nothing prevents it from narrating a tool call it never made ("I ran `git log` and the latest commit is…"), or inventing a result for a tool call ("The weather API says 72°F" — when the call timed out). For an agent with autonomy, this is more than a correctness issue — it's a deniability issue.
 
-Tool receipts close that gap with the cheapest possible construct: a symmetric MAC with an ephemeral per-session key.
+Tool receipts close that gap with the cheapest possible construct: a symmetric MAC with an ephemeral process-lifetime key.
+
+> **What "session" means here.** The HMAC key is generated once when `start_channels` initialises the channel server and lives for the lifetime of that daemon process. Every channel, every conversation, and every delegate sub-agent inside that process verifies against the same key. Restarting the daemon rotates it; there is no per-conversation or per-channel scoping. "Session" is used elsewhere in this document as shorthand for "this daemon process."
 
 Based on: Basu, A. (2026). "Tool Receipts, Not Zero-Knowledge Proofs: Practical Hallucination Detection for AI Agents." [arXiv:2603.10060](https://doi.org/10.48550/arXiv.2603.10060).
 
 ## How it works
 
-1. At agent-loop startup, a 256-bit key is generated. It's ephemeral — never written to disk, never sent to the model, never logged.
+1. At channel-server startup, a 256-bit key is generated and held in `ChannelRuntimeContext` for the lifetime of the daemon process. It's ephemeral — never written to disk, never sent to the model, never logged. A daemon restart rotates the key.
 2. After each tool invocation, the runtime computes:
    ```
    receipt = HMAC-SHA256(key, tool_name || args || result || timestamp)
@@ -49,7 +51,9 @@ The `zc-receipt-` prefix exists so the leak detector doesn't redact them (receip
 
 - **Don't constrain text output.** The model can still say things unrelated to any tool call.
 - **Don't force tool use.** Receipts are only generated when a tool is called; they don't help with "the model answered from prior knowledge when it should have looked something up".
-- **Don't travel across sessions.** Ephemeral keys mean a receipt from session A can't be verified in session B.
+- **Don't travel across daemon restarts.** The ephemeral key is rotated on every daemon process start, so a receipt generated under one process cannot be verified by the next.
+- **Don't isolate channels or conversations from each other within a single daemon.** All channels and all conversations in one daemon process share the key. The threat model targets LLM fabrication inside the process, not cross-channel forgery.
+- **Don't extend to background or detached delegate spawns.** Background and parallel delegate spawns that detach from the user's turn (`background: true`) do not surface receipts in the user-visible block, since the per-turn collector is rendered before those spawns finish. Receipts inside synchronous delegate sub-agents are captured.
 
 ## Viewing receipts
 
@@ -92,7 +96,7 @@ inject_system_prompt = true # instruct the model to echo receipts verbatim
 
 ## Security properties
 
-- **Ephemeral key per session.** Never persisted, never logged, never in the model's context. Compromising long-term storage gains nothing.
+- **Ephemeral key per daemon process.** Generated at `start_channels` time, held only in memory, rotated on every restart. Never persisted, never logged, never in the model's context. Compromising long-term storage gains nothing.
 - **Standard MAC primitives.** `hmac` + `sha2` from the Rust ecosystem.
 - **Negligible overhead.** <1 ms per tool call.
 - **No new external dependencies.**


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** #5168 shipped the HMAC receipt crypto core + threaded `Option<&ReceiptGenerator>` through `run_tool_call_loop` / `tool_execution`, but the activation pieces (config struct, channel-context plumbing, system-prompt addendum, response-block render) were stripped before the squash. Every caller passed `None`; no receipt ever fired despite docs describing the activated shape. This PR re-lands the stripped wiring exactly as the original branch commit ba16cacbf had it, adapted to the post-workspace-split crate layout, plus full activation through delegate sub-agent loops so #6182 closes against every acceptance criterion (no remaining "delegate continues to pass `None`" carve-out).
- **What changed and why (cont.):** New `[agent.tool_receipts]` config section (`enabled`, `show_in_response`, `inject_system_prompt`); `ChannelRuntimeContext` carries `Option<ReceiptGenerator>` + `show_receipts_in_response`; `start_channels` instantiates the generator from config and appends the receipt-echo addendum to the system prompt; `process_channel_message` declares a per-turn `Arc<Mutex<Vec<String>>>` collector and threads both into `run_tool_call_loop`; after the main reply lands, when `show_in_response = true`, the collector is rendered as a trailing `Tool receipts:` block sent as a follow-up message in the same thread.
- **Delegate forwarding:** `agent::tool_receipts` introduces a `TOOL_LOOP_RECEIPT_CONTEXT` task-local mirroring `TOOL_LOOP_COST_TRACKING_CONTEXT`. The orchestrator scopes the per-turn `ReceiptScope` (generator clone + Arc'd collector) before entering the tool loop. `DelegateTool::execute_sync` reads it and forwards generator + collector into the sub-agent's `run_tool_call_loop`, so subagent tool calls produce receipts that land in the same per-turn collector the user-visible block renders from. Multi-agent: `execute_parallel` captures the parent scope and re-enters it inside each `tokio::spawn` (task-locals don't auto-propagate), so parallel sub-agents share the collector via `Arc`. Multi-channel: each `process_channel_message` invocation builds its own `Arc<Mutex<Vec<String>>>` and its own task-local scope; concurrent channel turns never cross-pollute. Background spawns intentionally stay unsigned because the per-turn collector is rendered before they finish; documented as a known limitation in the security doc.
- **Scope boundary:** CLI and legacy `agent_turn` callers also stay at `None, None` — receipts are a channel-mode feature.
- **Blast radius:** Default-off (`enabled = false`), so existing deployments deserialize unchanged and observe identical behavior. When enabled: every tool result gains a `[receipt: zc-receipt-...]` trailer in the model's view of history (including delegate sub-agent results); the system prompt grows by ~400 chars; one extra channel message is sent per turn that ran any tool when `show_in_response = true`; daemon-process-lifetime HMAC key (rotated on restart, never persisted, never logged).
- **Linked issue(s):** Closes #6182. References #5168 (the squash that lost this wiring).

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
cargo test --workspace --exclude zeroclaw-desktop --features ci-all
```

- **Commands run and tail output (against current head `a12c8d59b`):**
  - `cargo fmt --all -- --check`: clean (no output).
  - `cargo clippy ... --features ci-all -- -D warnings`: `Finished dev profile [unoptimized + debuginfo] target(s) in 1m 39s` (zero warnings, zero errors).
  - `cargo test --workspace --exclude zeroclaw-desktop --features ci-all`: all green; relevant counts include `zeroclaw-runtime` (1573 + 4 doctests, all pass), `zeroclaw-channels` orchestrator (24 process_channel_message tests including the new strict-disabled coverage, all pass), `zeroclaw-runtime` delegate suite (6 execute_agentic tests including the two new receipt-forwarding tests, all pass).
- **Beyond CI — what was manually verified?** Walked the original stripped commit (ba16cacbf) field-by-field against the post-workspace-split crate layout and confirmed every piece (config struct, `ChannelRuntimeContext` fields, `start_channels` instantiation, `process_channel_message` collector + call-site flip, response-block render, system-prompt addendum) re-lands at the equivalent location. Verified the receipt-generator + collector parameters in `run_tool_call_loop` already exist in master (no signature changes needed). 34 of 34 `ChannelRuntimeContext` constructors updated with the two new fields (the test sites all set them to `None` / `false`, plus three new test sites for receipt coverage). Verified delegate forwarding end-to-end: `execute_agentic_forwards_receipt_scope_into_subagent_loop` exercises the real `EchoTool` path through a scoped `TOOL_LOOP_RECEIPT_CONTEXT` and asserts the receipt lands in the parent collector with a valid `zc-receipt-` HMAC token. Strict disabled coverage: `process_channel_message_disabled_receipt_generator_emits_no_receipts_anywhere` proves no `zc-receipt-` token in any sent message and no `[receipt: ` trailer in any conversation history when `receipt_generator: None`.
- **Test surface added by this PR:**
  - `process_channel_message_renders_trailing_tool_receipts_block_when_enabled` (full activated path).
  - `process_channel_message_omits_receipts_block_when_disabled` (`show_in_response = false` with generator on).
  - `process_channel_message_disabled_receipt_generator_emits_no_receipts_anywhere` (strict #6182 enabled-false: no receipt anywhere — sent messages, history, anywhere).
  - `execute_agentic_forwards_receipt_scope_into_subagent_loop` (delegate forwards receipts into sub-loop when scope is set).
  - `execute_agentic_emits_no_receipts_when_scope_absent` (delegate runs unsigned when scope is unset).

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No` — the HMAC key is ephemeral per daemon process, generated via `ring::SystemRandom`, never persisted or logged, rotated on every restart. Same key handling as #5168. The security doc clarifies that "session" in this design means daemon-process lifetime (one shared key across every channel and conversation in the process); cross-channel and cross-conversation isolation is not part of the threat model and is documented as such.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: N/A.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `Yes` (additive)
- If `No` or `Yes` to either: exact upgrade steps for existing users: None required. The new `[agent.tool_receipts]` section is fully optional — `#[serde(default)]` on the field plus per-field defaults mean existing `config.toml` files load unchanged with `enabled = false`. Operators who want receipts add:
  ```toml
  [agent.tool_receipts]
  enabled = true
  show_in_response = false   # opt in for user-visible auditable block
  inject_system_prompt = true
  ```
- The generated config reference (`docs/book/src/reference/config.md`) is gitignored and regenerated on every `cargo mdbook build` (which the docs-deploy workflow runs). Local regeneration produces a new `### agent.tool_receipts` section with `enabled`, `inject_system_prompt`, and `show_in_response` rows; CI's docs deploy will pick this up automatically — no manual edit is possible (or appropriate) since the reference is a derived artifact.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <merge-sha>` against master. The PR squash-merges to a single commit on master regardless of how many commits land in the branch, so the revert is always single-commit. For deployed instances: set `[agent.tool_receipts] enabled = false` and reload; no code revert needed for users.
- **Feature flags or config toggles:** `[agent.tool_receipts] enabled` is the master switch. `show_in_response` controls the user-visible block. `inject_system_prompt` controls the system-prompt addendum. All three default to safe values.
- **Observable failure symptoms:**
  - System prompt blow-out: model context overflows after enabling — grep daemon logs for `system_prompt` truncation warnings; cap via `agent.max_system_prompt_chars`.
  - Channel double-message: `Tool receipts:` block sent on a channel where threading is broken would produce a stray top-level message — symptom is two messages per turn on the affected channel.
  - Model failing to echo receipts: provider-specific behavior; not a regression but the auditable signal is degraded. Mitigation: `show_in_response = true` to surface receipts independent of the model.
