### PR TITLE
fix(gateway): evict cancel_tokens entry when session is deleted mid-turn

### DIFF
--- a/crates/zeroclaw-gateway/src/api.rs
+++ b/crates/zeroclaw-gateway/src/api.rs
@@ -1414,6 +1414,23 @@ pub async fn handle_api_session_delete(
     };
 
     let session_key = format!("gw_{id}");
+
+    // If a turn is in flight for this session, cancel it and evict the entry
+    // from `cancel_tokens` here rather than leaving the WebSocket handler's
+    // post-`tokio::join!` cleanup (`ws.rs:535`) as the only path. Without
+    // this, deleting a session mid-turn leaks the map entry until the
+    // streaming task happens to wake up — and on a process crash the
+    // entry is lost entirely (#5835).
+    let token = state
+        .cancel_tokens
+        .lock()
+        .expect("cancel_tokens lock poisoned")
+        .remove(&session_key);
+    if let Some(token) = token {
+        token.cancel();
+        tracing::info!(session_key, "cancelled in-flight turn for deleted session");
+    }
+
     match backend.delete_session(&session_key) {
         Ok(true) => Json(serde_json::json!({"deleted": true, "session_id": id})).into_response(),
         Ok(false) => (


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** `DELETE /api/sessions/{id}` left the `AppState.cancel_tokens` entry alive when a turn was in flight at delete time. The WebSocket handler is the only path that removes the entry today (post-`tokio::join!` at `ws.rs:535`), so a deleted session whose turn future hadn't unblocked yet held its slot. On a process crash the entry leaked entirely. Map is bounded by concurrently active sessions so the impact is benign in practice but accumulates across long-running daemons. Fix: mirror the abort handler's lock pattern in `handle_api_session_delete` and remove + cancel the token before calling `backend.delete_session`.
- **Scope boundary:** Did not move the cancel token into per-session state (issue's option 3, called out in #5705 review) — that's a structural refactor and the issue lists it as a future direction. Did not add a periodic sweep (option 2) — option 1 (this PR) addresses the documented concrete leak path; sweep is a defense-in-depth follow-up if the team wants it.
- **Blast radius:** Confined to the gateway session-delete path. Concurrent abort + delete is harmless: both call `.cancel()`; cancellation tokens are idempotent. The WebSocket handler's existing `.remove()` at `ws.rs:535` becomes a no-op when the entry is already gone.
- **Linked issue(s):** Closes #5835. Refs #5705 (cancel-token lifecycle review).

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
cargo test
```

- **Commands run and tail output:** Local pre-push battery deferred to CI per maintainer's pace; opened as draft so CI can exercise the full sweep before review.
- **Beyond CI — what did you manually verify?** Walked the abort handler at `api.rs:1564-1620` to confirm the lock-then-cancel pattern, verified `tokio_util::sync::CancellationToken` is idempotent (multiple `.cancel()` calls are safe), and verified the WebSocket handler's post-turn `.remove()` at `ws.rs:535` is safe to be a no-op when the entry was already evicted.
- **If any command was intentionally skipped, why:** Local fmt/clippy/test deferred at maintainer's request.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: N/A.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: exact upgrade steps for existing users: None required.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <merge-sha>` is clean — single commit, single file.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Pre-existing leak symptom (slow growth of `cancel_tokens` HashMap when sessions are deleted mid-turn) reverses; nothing else should change.