### PR TITLE
feat(web): open agent chat from memory row when session_id is present

### DIFF
--- a/web/src/pages/Memory.tsx
+++ b/web/src/pages/Memory.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import {
   Brain,
   Search,
@@ -6,9 +7,11 @@ import {
   Trash2,
   X,
   Filter,
+  MessageSquare,
 } from 'lucide-react';
 import type { MemoryEntry } from '@/types/api';
 import { getMemory, storeMemory, deleteMemory } from '@/lib/api';
+import { SESSION_ID_STORAGE_KEY } from '@/lib/ws';
 import { t } from '@/lib/i18n';
 
 function truncate(text: string, max: number): string {
@@ -22,6 +25,7 @@ function formatDate(iso: string): string {
 }
 
 export default function Memory() {
+  const navigate = useNavigate();
   const [entries, setEntries] = useState<MemoryEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -29,6 +33,21 @@ export default function Memory() {
   const [categoryFilter, setCategoryFilter] = useState('');
   const [showForm, setShowForm] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+
+  // Recover the agent chat session this memory was captured in. The chat
+  // page reads `getOrCreateSessionId()` (backed by SESSION_ID_STORAGE_KEY)
+  // on mount and hydrates messages via `getSessionMessages(sid)`, so
+  // overwriting the key + navigating to /agent is enough to load the
+  // saved transcript. (#6145)
+  const handleOpenChat = (sessionId: string) => {
+    try {
+      localStorage.setItem(SESSION_ID_STORAGE_KEY, sessionId);
+    } catch {
+      // localStorage unavailable (e.g. private mode); fall through to
+      // navigation, which will create a fresh session.
+    }
+    navigate('/agent');
+  };
 
   // Form state
   const [formKey, setFormKey] = useState('');
@@ -256,12 +275,23 @@ export default function Memory() {
                         </button>
                       </div>
                     ) : (
-                      <button
-                        onClick={() => setConfirmDelete(entry.key)}
-                        className="btn-icon"
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </button>
+                      <div className="flex items-center justify-end gap-1">
+                        {entry.session_id && (
+                          <button
+                            onClick={() => handleOpenChat(entry.session_id!)}
+                            className="btn-icon"
+                            title={`Open chat session ${entry.session_id.slice(0, 8)}…`}
+                          >
+                            <MessageSquare className="h-4 w-4" />
+                          </button>
+                        )}
+                        <button
+                          onClick={() => setConfirmDelete(entry.key)}
+                          className="btn-icon"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </button>
+                      </div>
                     )}
                   </td>
                 </tr>


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** `MemoryEntry` already carries `session_id` (zeroclaw-api `memory_traits.rs:36`, populated by the SQLite backend on auto-saves). The Web UI's Memory table ignored it. This PR renders a chat-bubble button on rows with a non-null `session_id`. Clicking writes the session_id into `SESSION_ID_STORAGE_KEY` and navigates to `/agent`; `AgentChat` hydrates via the existing `getSessionMessages(sid)` flow so the saved transcript loads automatically.
- **Scope boundary:** Rows without a `session_id` (manually-stored memories, or entries from before the column was added) render no button — clean degradation. No backend changes; no schema changes; no new endpoints. Did not surface session metadata (channel, model, last-active timestamp) on the row — that's a separate UX iteration.
- **Blast radius:** Memory page only. Chat page unchanged. The localStorage write path is identical to the existing chat-init flow, just triggered from a different surface.
- **Linked issue(s):** Closes #6145.

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- **Commands run and tail output:** Web-only TS change; no Rust battery applies. `cargo web check` (typecheck) deferred to CI per maintainer's pace.
- **Beyond CI — what did you manually verify?** Verified `MemoryEntry.session_id` is `Option<String>` end-to-end (Rust `memory_traits.rs:36` → TS `types/api.ts:86`); verified `getOrCreateSessionId()` reads `SESSION_ID_STORAGE_KEY` on chat mount (`AgentChat.tsx:34`, `lib/ws.ts:29`) and that `getSessionMessages(sid)` is awaited before render with localStorage as fallback (`AgentChat.tsx:66-101`).
- **If any command was intentionally skipped, why:** Local typecheck deferred at maintainer's request.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: N/A.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: exact upgrade steps for existing users: None required. Existing rows without a `session_id` render exactly as before.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <merge-sha>` is clean — single commit, single file.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Memory page rendering errors after enabling — symptom would surface as a JS exception in the browser console; the Memory route falls back to its existing layout once reverted.