### PR TITLE
feat(web): mark OpenRouter free models in default-model dropdown

### DIFF
--- a/web/src/pages/config/sections/GeneralSection.tsx
+++ b/web/src/pages/config/sections/GeneralSection.tsx
@@ -47,7 +47,11 @@ const PROVIDER_OPTIONS = [
   { value: 'litellm', label: 'LiteLLM' },
 ];
 
-// Models grouped by provider. Newest models listed first.
+// Models grouped by provider. Newest models listed first. OpenRouter
+// `:free` variants are tagged "(Free)" so the dropdown surfaces the
+// no-cost options that are otherwise indistinguishable from paid model
+// IDs (#6070). The `:free` suffix is OpenRouter's canonical free-tier
+// marker — labelling here matches whatever the provider exposes.
 const MODELS_BY_PROVIDER: Record<string, { value: string; label: string }[]> = {
   openrouter: [
     { value: 'anthropic/claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
@@ -67,6 +71,17 @@ const MODELS_BY_PROVIDER: Record<string, { value: string; label: string }[]> = {
     { value: 'meta-llama/llama-4-70b', label: 'Llama 4 70B' },
     { value: 'mistralai/devstral-2', label: 'Devstral 2' },
     { value: 'qwen/qwen-3.6-plus-preview', label: 'Qwen 3.6 Plus Preview' },
+    // ── Free tier (`:free` suffix on OpenRouter) ───────────────────
+    { value: 'meta-llama/llama-3.3-70b-instruct:free', label: 'Llama 3.3 70B (Free)' },
+    { value: 'qwen/qwen3-coder:free', label: 'Qwen 3 Coder (Free)' },
+    { value: 'qwen/qwen3-next-80b-a3b-instruct:free', label: 'Qwen 3 Next 80B (Free)' },
+    { value: 'google/gemma-3-27b-it:free', label: 'Gemma 3 27B IT (Free)' },
+    { value: 'deepseek/deepseek-r1:free', label: 'DeepSeek R1 (Free)' },
+    { value: 'openai/gpt-oss-120b:free', label: 'GPT-OSS 120B (Free)' },
+    { value: 'openai/gpt-oss-20b:free', label: 'GPT-OSS 20B (Free)' },
+    { value: 'z-ai/glm-4.5-air:free', label: 'GLM 4.5 Air (Free)' },
+    { value: 'minimax/minimax-m2.5:free', label: 'MiniMax M2.5 (Free)' },
+    { value: 'nousresearch/hermes-3-llama-3.1-405b:free', label: 'Hermes 3 Llama 3.1 405B (Free)' },
   ],
   anthropic: [
     { value: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** GeneralSection's OpenRouter dropdown listed only paid model IDs. Users couldn't tell which were free, and the popular `:free` variants (Llama 3.3 70B Free, Qwen 3 Coder Free, GPT-OSS 120B Free, etc.) were entirely absent — exactly the "missing openrouter/free model" experience the issue reported. This PR adds a curated set of OpenRouter `:free` variants with "(Free)" in the label so the no-cost options are visually distinct from paid IDs.
- **Scope boundary:** Static curation only. The issue's secondary acceptance criterion ("List need regular (or instant) updates") is best served by a live fetch of `https://openrouter.ai/api/v1/models` (the public-models endpoint, no auth required) at dropdown mount with caching — that's an additive future change with its own failure modes (CORS, offline, OpenRouter outage). Shipping the static indicator first closes the visible UX gap and lets the live-polling layer land independently if/when the team prioritizes it.
- **Blast radius:** Single dropdown in the Config "General" section. No data-model, API, or runtime changes. Selecting a `:free` model writes the same `providers.models.openrouter.model` field as any other selection — runtime treats `:free` IDs identically.
- **Linked issue(s):** Closes #6070.

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- **Commands run and tail output:** Web-only TS change; no Rust battery applies. `cargo web check` (typecheck) deferred to CI per maintainer's pace.
- **Beyond CI — what did you manually verify?** Verified the `:free` suffix is the canonical OpenRouter free-tier marker per the example output in the issue body. Verified the dropdown options object shape (`{value, label}`) is unchanged so existing rendering, validation, and `onChange` handlers (`handleModelChange` writing to `providers.models.openrouter.model`) need no updates.
- **If any command was intentionally skipped, why:** Local typecheck deferred at maintainer's request.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: N/A.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: exact upgrade steps for existing users: None required. Existing model selections render unchanged.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** N/A — `risk: low`. `git revert <merge-sha>` is clean if needed.