### PR TITLE
feat(web): chat input lock + stop button + running indicator

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -339,6 +339,17 @@ export function getSessionMessages(id: string): Promise<SessionMessagesResponse>
   );
 }
 
+/**
+ * Cancel an in-flight agent turn for a session. Idempotent — returns
+ * `{ status: "no_active_response" }` when the session is idle.
+ */
+export function abortSession(id: string): Promise<{ status: string }> {
+  return apiFetch<{ status: string }>(
+    `/api/sessions/${encodeURIComponent(id)}/abort`,
+    { method: 'POST' },
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Channels (detailed)
 // ---------------------------------------------------------------------------

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -505,6 +505,8 @@ const translations: Record<Locale, Record<string, string>> = {
     'agent.clear_all': 'Clear all',
     'agent.delete_message': 'Delete message',
     'agent.compact_mode': 'Compact',
+    'agent.running': 'Running…',
+    'agent.stop': 'Stop',
 
     // Tools
     'tools.title': 'Available Tools',

--- a/web/src/pages/AgentChat.tsx
+++ b/web/src/pages/AgentChat.tsx
@@ -1,5 +1,5 @@
 import { memo, useState, useEffect, useRef, useCallback } from 'react';
-import { Send, Bot, User, AlertCircle, Copy, Check, X, Trash2, Minimize2, Maximize2 } from 'lucide-react';
+import { Send, Square, Bot, User, AlertCircle, Copy, Check, X, Trash2, Minimize2, Maximize2 } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import type { WsMessage } from '@/types/api';
@@ -7,7 +7,7 @@ import { WebSocketClient, getOrCreateSessionId } from '@/lib/ws';
 import { generateUUID } from '@/lib/uuid';
 import { useDraft } from '@/hooks/useDraft';
 import { t } from '@/lib/i18n';
-import { getSessionMessages } from '@/lib/api';
+import { abortSession, getSessionMessages } from '@/lib/api';
 import ToolCallCard from '@/components/ToolCallCard';
 import type { ToolCallInfo } from '@/components/ToolCallCard';
 import {
@@ -357,6 +357,19 @@ export default function AgentChat() {
     setMessages([]);
   }, []);
 
+  // Stop button: POST /api/sessions/{id}/abort. The gateway cancels the
+  // in-flight turn, the WS handler sends an `error` frame which our
+  // onMessage handler already maps to typing=false.
+  const handleAbort = useCallback(async () => {
+    try {
+      await abortSession(sessionIdRef.current);
+    } catch {
+      // Best-effort: surface nothing if the abort itself fails. The
+      // user can retry, and any leaked typing state clears on the next
+      // server frame.
+    }
+  }, []);
+
   const toggleCompact = useCallback(() => {
     setCompact((prev) => {
       const next = !prev;
@@ -486,31 +499,54 @@ export default function AgentChat() {
             value={input}
             onChange={handleTextareaChange}
             onKeyDown={handleKeyDown}
-            placeholder={connected ? t('agent.type_message') : t('agent.connecting')}
-            disabled={!connected}
+            placeholder={!connected
+              ? t('agent.connecting')
+              : typing
+                ? t('agent.running')
+                : t('agent.type_message')}
+            disabled={!connected || typing}
             className="input-electric flex-1 px-4 text-sm resize-none disabled:opacity-40"
             style={{ minHeight: '44px', maxHeight: '200px', paddingTop: '10px', paddingBottom: '10px' }}
           />
-          <button
-            type='button'
-            onClick={handleSend}
-            disabled={!connected || !input.trim()}
-            className="btn-electric flex-shrink-0 rounded-2xl flex items-center justify-center"
-            style={{ color: 'white', width: '40px', height: '40px' }}
-          >
-            <Send className="h-5 w-5" />
-          </button>
+          {typing ? (
+            <button
+              type="button"
+              onClick={handleAbort}
+              className="btn-danger flex-shrink-0 rounded-2xl flex items-center justify-center"
+              style={{ color: 'white', width: '40px', height: '40px' }}
+              aria-label={t('agent.stop')}
+              title={t('agent.stop')}
+            >
+              <Square className="h-4 w-4" fill="currentColor" />
+            </button>
+          ) : (
+            <button
+              type='button'
+              onClick={handleSend}
+              disabled={!connected || !input.trim()}
+              className="btn-electric flex-shrink-0 rounded-2xl flex items-center justify-center"
+              style={{ color: 'white', width: '40px', height: '40px' }}
+            >
+              <Send className="h-5 w-5" />
+            </button>
+          )}
         </div>
         <div className="flex items-center justify-center mt-2 gap-2">
           <span
             className="status-dot"
-            style={connected
-              ? { background: 'var(--color-status-success)', boxShadow: '0 0 6px var(--color-status-success)' }
-              : { background: 'var(--color-status-error)', boxShadow: '0 0 6px var(--color-status-error)' }
+            style={typing
+              ? { background: 'var(--pc-accent)', boxShadow: '0 0 6px var(--pc-accent)' }
+              : connected
+                ? { background: 'var(--color-status-success)', boxShadow: '0 0 6px var(--color-status-success)' }
+                : { background: 'var(--color-status-error)', boxShadow: '0 0 6px var(--color-status-error)' }
             }
           />
           <span className="text-[10px]" style={{ color: 'var(--pc-text-faint)' }}>
-            {connected ? t('agent.connected_status') : t('agent.disconnected_status')}
+            {typing
+              ? t('agent.running')
+              : connected
+                ? t('agent.connected_status')
+                : t('agent.disconnected_status')}
           </span>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Three of #5999's four reported UX gaps shared a tight shape and land here together: (1) the textarea no longer stays live while a turn runs (placeholder flips to "Running…", input + Send disabled), (2) the Send button swaps to a Stop button while typing — click hits `POST /api/sessions/{id}/abort` (the gateway endpoint already cancels the in-flight CancellationToken; `abortSession` helper added to `lib/api.ts`), (3) the status footer shows a "Running…" label with an accent-coloured dot during typing so the at-a-glance state covers idle / running / disconnected.
- **Scope boundary:** The fourth gap — multi-session sidebar with new / switch / rename / delete — is intentionally not in this PR. It's a sizable change that intersects the existing `/sessions` UI rather than the chat view, and bundling it would balloon scope and review surface. Tracking that separately if the team wants it.
- **Blast radius:** AgentChat input area + status footer; one new API helper. No backend changes — `POST /api/sessions/{id}/abort` already existed (`#5705` substrate). The `typing` state machine was already in place; this PR just consumes it from the input and footer.
- **Linked issue(s):** Closes #5999. Refs #5705 (the abort endpoint this consumes).

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- **Commands run and tail output:** Web-only TS change; no Rust battery applies. `cargo web check` (typecheck) deferred to CI per maintainer's pace.
- **Beyond CI — what did you manually verify?** Walked the typing state machine — set on `chunk` / `thinking` / `tool_call` (line 135, 141 in `AgentChat.tsx`); cleared on `done`, `message`, `error` (lines 178, 271). The Stop click is best-effort: any abort RPC failure is swallowed so the next server frame still clears typing. New i18n keys (`agent.running`, `agent.stop`) added to the `en` block; the runtime fallback at `i18n.ts:11694` is `currentLocale → en → key`, so other locales surface English text instead of the literal key.
- **If any command was intentionally skipped, why:** Local typecheck deferred at maintainer's request.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No` — `abortSession` calls the same `apiFetch` machinery that all dashboard calls use, against an existing endpoint.
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: N/A.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: exact upgrade steps for existing users: None required.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** N/A — `risk: low`. `git revert <merge-sha>` is clean if needed.