### PR TITLE
fix(daemon,gateway,channels): share canvas store across daemon subsystems

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -5221,7 +5221,10 @@ pub async fn doctor_channels(config: Config) -> Result<()> {
 
 /// Start all configured channels and route messages to the agent
 #[allow(clippy::too_many_lines)]
-pub async fn start_channels(config: Config) -> Result<()> {
+pub async fn start_channels(
+    config: Config,
+    canvas_store: Option<zeroclaw_runtime::tools::CanvasStore>,
+) -> Result<()> {
     let provider_name = resolved_default_provider(&config);
     let provider_runtime_options =
         zeroclaw_providers::provider_runtime_options_from_config(&config);
@@ -5320,7 +5323,12 @@ pub async fn start_channels(config: Config) -> Result<()> {
             .fallback_provider()
             .and_then(|e| e.api_key.as_deref()),
         &config,
-        None,
+        // Share the gateway's canvas store so frames pushed from
+        // channel-side agents reach the same WebSocket subscribers and
+        // REST snapshots the gateway serves (#5356). When `None`, the
+        // tool registry creates an orphaned store that nothing can
+        // observe — the original silent-failure shape.
+        canvas_store,
     );
 
     // Wire MCP tools into the registry before freezing — non-fatal.

--- a/crates/zeroclaw-gateway/src/lib.rs
+++ b/crates/zeroclaw-gateway/src/lib.rs
@@ -409,6 +409,7 @@ pub async fn run_gateway(
     port: u16,
     config: Config,
     external_event_tx: Option<tokio::sync::broadcast::Sender<serde_json::Value>>,
+    canvas_store: Option<CanvasStore>,
 ) -> Result<()> {
     // ── Security: warn on public bind without tunnel or explicit opt-in ──
     if is_public_bind(host) && config.tunnel.provider == "none" && !config.gateway.allow_public_bind
@@ -473,7 +474,12 @@ pub async fn run_gateway(
         (None, None)
     };
 
-    let canvas_store = tools::CanvasStore::new();
+    // Reuse the daemon-supplied canvas store when present so channel-
+    // server agents (Telegram/Discord/Slack) push frames into the same
+    // store the gateway's WebSocket and REST endpoints serve (#5356).
+    // Standalone gateway invocations (no daemon supervisor) fall back
+    // to a fresh store.
+    let canvas_store = canvas_store.unwrap_or_else(tools::CanvasStore::new);
 
     let (
         mut tools_registry_raw,

--- a/crates/zeroclaw-gateway/src/lib.rs
+++ b/crates/zeroclaw-gateway/src/lib.rs
@@ -479,7 +479,7 @@ pub async fn run_gateway(
     // store the gateway's WebSocket and REST endpoints serve (#5356).
     // Standalone gateway invocations (no daemon supervisor) fall back
     // to a fresh store.
-    let canvas_store = canvas_store.unwrap_or_else(tools::CanvasStore::new);
+    let canvas_store = canvas_store.unwrap_or_default();
 
     let (
         mut tools_registry_raw,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1658,18 +1658,40 @@ async fn main() -> Result<()> {
                 },
             ));
 
+            // Single canvas store shared between the gateway HTTP / WebSocket
+            // surface and the channel-server agents so canvas frames pushed
+            // from Telegram / Discord / Slack reach the same subscribers the
+            // web UI serves. Without this, channels build an orphaned
+            // CanvasStore::default() and frames are silently dropped (#5356).
+            let canvas_store = zeroclaw_runtime::tools::CanvasStore::new();
+            let canvas_store_for_gateway = canvas_store.clone();
+            let canvas_store_for_channels = canvas_store.clone();
+
             let subsystems = daemon::DaemonSubsystems {
                 #[cfg(feature = "gateway")]
-                gateway_start: Some(Box::new(|host, port, config, tx| {
+                gateway_start: Some(Box::new(move |host, port, config, tx| {
+                    let canvas_store = canvas_store_for_gateway.clone();
                     Box::pin(async move {
-                        Box::pin(zeroclaw_gateway::run_gateway(&host, port, config, tx)).await
+                        Box::pin(zeroclaw_gateway::run_gateway(
+                            &host,
+                            port,
+                            config,
+                            tx,
+                            Some(canvas_store),
+                        ))
+                        .await
                     })
                 })),
                 #[cfg(not(feature = "gateway"))]
                 gateway_start: None,
-                channels_start: Some(Box::new(|config| {
+                channels_start: Some(Box::new(move |config| {
+                    let canvas_store = canvas_store_for_channels.clone();
                     Box::pin(async move {
-                        Box::pin(zeroclaw_channels::orchestrator::start_channels(config)).await
+                        Box::pin(zeroclaw_channels::orchestrator::start_channels(
+                            config,
+                            Some(canvas_store),
+                        ))
+                        .await
                     })
                 })),
                 mqtt_start: Some(Box::new(|mqtt_config| {
@@ -1929,7 +1951,7 @@ async fn main() -> Result<()> {
         },
 
         Commands::Channel { channel_command } => match channel_command {
-            ChannelCommands::Start => Box::pin(channels::start_channels(config)).await,
+            ChannelCommands::Start => Box::pin(channels::start_channels(config, None)).await,
             ChannelCommands::Doctor => Box::pin(channels::doctor_channels(config)).await,
             other => Box::pin(channels::handle_command(other, &config)).await,
         },
@@ -3428,7 +3450,7 @@ async fn run_gateway_if_enabled(
     config: zeroclaw::config::Config,
     tx: Option<tokio::sync::broadcast::Sender<serde_json::Value>>,
 ) -> anyhow::Result<()> {
-    Box::pin(gateway::run_gateway(host, port, config, tx)).await
+    Box::pin(gateway::run_gateway(host, port, config, tx, None)).await
 }
 
 #[cfg(not(feature = "gateway"))]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** The `canvas` tool worked from the web UI (`/ws/chat`) but silently failed from channel agents (Telegram / Discord / Slack). Root cause matches the issue's source trace: the gateway constructs one `CanvasStore` and wires it into both `AppState` and its tool registry, while the channels orchestrator passed `None` to `all_tools_with_runtime` — which then built `CanvasStore::default()`, an orphaned instance with no subscribers. Frames pushed from channel-side agents landed in the orphan and never reached `/ws/canvas/:id` clients. Fix: thread a single `CanvasStore` from the daemon supervisor through both subsystems.
- **Scope boundary:** Standalone CLI invocations (`zeroclaw channels start`, the bare gateway helper) keep the original behaviour — they pass `None`, get a fresh inert store. There's no peer subsystem to share with in those modes, so the orphaned-but-isolated path is correct. No changes to `CanvasStore` itself; this is plumbing only.
- **Blast radius:** Two API signatures gain an `Option<CanvasStore>` parameter (`start_channels`, `run_gateway`). All four call sites are in this repo and updated in this PR. Daemon mode now shares one store; everything else is unchanged.
- **Linked issue(s):** Closes #5356.

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
cargo test
```

- **Commands run and tail output:** Local pre-push battery deferred to CI per maintainer's pace.
- **Beyond CI — what did you manually verify?** Verified all four `start_channels` / `run_gateway` call sites are updated (grep confirms): the daemon-mode pair (`main.rs:1675` / `main.rs:1690`) shares one store via cloned closures; the CLI standalone modes (`main.rs:1954` and the helper at `main.rs:3453`) pass `None`. `CanvasStore` is `Clone` (already used at `lib.rs:502` to share with `AppState`), so the share-by-clone pattern matches existing usage.
- **If any command was intentionally skipped, why:** Local fmt/clippy/test deferred at maintainer's request.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: N/A.

## Compatibility (required)

- Backward compatible? `Yes` for runtime behaviour; the new `canvas_store` parameter has an `Option` shape so any external caller can pass `None`. Source-compatible breakage: external code calling `start_channels(config)` or `run_gateway(host, port, config, tx)` directly needs a trailing `, None`. No SemVer-stable contract is violated since both functions live in `zeroclaw-channels` / `zeroclaw-gateway` which are internal crates.
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: exact upgrade steps for existing users: None required.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <merge-sha>` is clean — three files, additive parameter.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** If channel-side canvas pushes still don't reach subscribers after this lands, verify daemon mode (not standalone `channels start`) and confirm `/ws/canvas/:id` is connecting to the gateway port the daemon supervises. The fix only applies to daemon mode by design — standalone `zeroclaw channels start` was never intended to share canvas state with a separate gateway process.