### PR TITLE
fix: sanitize session keys at the channel orchestrator layer

### DIFF
--- a/crates/zeroclaw-api/src/lib.rs
+++ b/crates/zeroclaw-api/src/lib.rs
@@ -23,6 +23,7 @@ pub mod peripherals_traits;
 pub mod provider;
 pub mod runtime_traits;
 pub mod schema;
+pub mod session_keys;
 pub mod tool;
 pub mod vad;
 

--- a/crates/zeroclaw-api/src/session_keys.rs
+++ b/crates/zeroclaw-api/src/session_keys.rs
@@ -1,0 +1,63 @@
+//! Session key normalization shared across infra and memory backends.
+//!
+//! Channel orchestration uses two identifiers derived from a `ChannelMessage`:
+//! one ends up as a JSONL filename (via `SessionStore::session_path`) and as
+//! an in-memory HashMap key for the conversation history cache, while the
+//! same identifier is also passed to `Memory::store`/`Memory::recall` as the
+//! `session_id` filter. Because filesystem-safe sanitization is applied when
+//! writing the JSONL file, every other layer must use the same sanitized form
+//! to keep lookups consistent across daemon restarts and persisted backends.
+
+/// Replace every character outside `[A-Za-z0-9_-]` with `_`. Idempotent.
+///
+/// Callers building session keys must pre-apply this so the runtime HashMap
+/// key, the on-disk JSONL filename, and the `session_id` column in memory
+/// backends all agree.
+pub fn sanitize_session_key(key: &str) -> String {
+    key.chars()
+        .map(|c| {
+            if c.is_alphanumeric() || c == '_' || c == '-' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn replaces_special_characters_with_underscore() {
+        assert_eq!(
+            sanitize_session_key("slack_C123_1.2_user one"),
+            "slack_C123_1_2_user_one"
+        );
+    }
+
+    #[test]
+    fn preserves_alphanumeric_underscore_and_hyphen() {
+        let key = "abc-DEF_123";
+        assert_eq!(sanitize_session_key(key), key);
+    }
+
+    #[test]
+    fn is_idempotent() {
+        let once = sanitize_session_key("whatsapp_123@g.us_alice");
+        let twice = sanitize_session_key(&once);
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn handles_empty_string() {
+        assert_eq!(sanitize_session_key(""), "");
+    }
+
+    #[test]
+    fn preserves_unicode_alphanumeric() {
+        // is_alphanumeric() treats unicode letters/digits as alphanumeric.
+        assert_eq!(sanitize_session_key("user_Алиса"), "user_Алиса");
+    }
+}

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -412,22 +412,25 @@ impl InFlightTaskCompletion {
 
 fn conversation_memory_key(msg: &zeroclaw_api::channel::ChannelMessage) -> String {
     // Include thread_ts for per-topic memory isolation in forum groups
-    match &msg.thread_ts {
+    let raw = match &msg.thread_ts {
         Some(tid) => format!("{}_{}_{}_{}", msg.channel, tid, msg.sender, msg.id),
         None => format!("{}_{}_{}", msg.channel, msg.sender, msg.id),
-    }
+    };
+    zeroclaw_infra::session_store::sanitize_session_key(&raw)
 }
 
 pub fn conversation_history_key(msg: &zeroclaw_api::channel::ChannelMessage) -> String {
-    // Include reply_target for per-channel isolation (e.g. distinct Discord/Slack
-    // channels) and thread_ts for per-topic isolation in forum groups.
-    match &msg.thread_ts {
+    // Sanitize so the runtime HashMap key matches `SessionStore::list_sessions`
+    // after a restart; otherwise hydration loads sessions under the on-disk
+    // (sanitized) name while lookup keeps producing the un-sanitized form.
+    let raw = match &msg.thread_ts {
         Some(tid) => format!(
             "{}_{}_{}_{}",
             msg.channel, msg.reply_target, tid, msg.sender
         ),
         None => format!("{}_{}_{}", msg.channel, msg.reply_target, msg.sender),
-    }
+    };
+    zeroclaw_infra::session_store::sanitize_session_key(&raw)
 }
 
 fn followup_thread_id(msg: &zeroclaw_api::channel::ChannelMessage) -> Option<String> {

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -10709,8 +10709,8 @@ BTC is currently around $65,000 based on latest tool output."#
         };
 
         let key = conversation_history_key(&msg);
-        assert!(key.contains("$root:server"));
-        assert!(!key.contains("$reply:server"));
+        assert!(key.contains("_root_server"));
+        assert!(!key.contains("_reply_server"));
     }
 
     #[test]

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -437,22 +437,25 @@ impl InFlightTaskCompletion {
 
 fn conversation_memory_key(msg: &zeroclaw_api::channel::ChannelMessage) -> String {
     // Include thread_ts for per-topic memory isolation in forum groups
-    match &msg.thread_ts {
+    let raw = match &msg.thread_ts {
         Some(tid) => format!("{}_{}_{}_{}", msg.channel, tid, msg.sender, msg.id),
         None => format!("{}_{}_{}", msg.channel, msg.sender, msg.id),
-    }
+    };
+    zeroclaw_infra::session_store::sanitize_session_key(&raw)
 }
 
 pub fn conversation_history_key(msg: &zeroclaw_api::channel::ChannelMessage) -> String {
-    // Include reply_target for per-channel isolation (e.g. distinct Discord/Slack
-    // channels) and thread_ts for per-topic isolation in forum groups.
-    match &msg.thread_ts {
+    // Sanitize so the runtime HashMap key matches `SessionStore::list_sessions`
+    // after a restart; otherwise hydration loads sessions under the on-disk
+    // (sanitized) name while lookup keeps producing the un-sanitized form.
+    let raw = match &msg.thread_ts {
         Some(tid) => format!(
             "{}_{}_{}_{}",
             msg.channel, msg.reply_target, tid, msg.sender
         ),
         None => format!("{}_{}_{}", msg.channel, msg.reply_target, msg.sender),
-    }
+    };
+    zeroclaw_infra::session_store::sanitize_session_key(&raw)
 }
 
 fn followup_thread_id(msg: &zeroclaw_api::channel::ChannelMessage) -> Option<String> {

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -88,6 +88,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant, SystemTime};
 use tokio_util::sync::CancellationToken;
+use zeroclaw_api::session_keys::sanitize_session_key;
 use zeroclaw_config::schema::Config;
 use zeroclaw_memory::{self, MEMORY_CONTEXT_CLOSE, MEMORY_CONTEXT_OPEN, Memory};
 use zeroclaw_providers::reliable::{scope_provider_fallback, take_last_provider_fallback};
@@ -441,7 +442,7 @@ fn conversation_memory_key(msg: &zeroclaw_api::channel::ChannelMessage) -> Strin
         Some(tid) => format!("{}_{}_{}_{}", msg.channel, tid, msg.sender, msg.id),
         None => format!("{}_{}_{}", msg.channel, msg.sender, msg.id),
     };
-    zeroclaw_infra::session_store::sanitize_session_key(&raw)
+    sanitize_session_key(&raw)
 }
 
 pub fn conversation_history_key(msg: &zeroclaw_api::channel::ChannelMessage) -> String {
@@ -455,7 +456,7 @@ pub fn conversation_history_key(msg: &zeroclaw_api::channel::ChannelMessage) -> 
         ),
         None => format!("{}_{}_{}", msg.channel, msg.reply_target, msg.sender),
     };
-    zeroclaw_infra::session_store::sanitize_session_key(&raw)
+    sanitize_session_key(&raw)
 }
 
 fn followup_thread_id(msg: &zeroclaw_api::channel::ChannelMessage) -> Option<String> {
@@ -2053,14 +2054,16 @@ fn is_group_reply_target(reply_target: &str) -> bool {
     reply_target.contains("@g.us") || reply_target.starts_with("group:")
 }
 
-fn sender_memory_session_ids<'a>(
-    msg: &'a zeroclaw_api::channel::ChannelMessage,
-    history_key: &'a str,
-) -> Vec<Option<&'a str>> {
+fn sender_memory_session_ids(
+    msg: &zeroclaw_api::channel::ChannelMessage,
+    history_key: &str,
+) -> Vec<String> {
+    // Match the sanitized form persisted by memory backend migrations.
+    let sanitized_sender = sanitize_session_key(&msg.sender);
     if is_group_reply_target(&msg.reply_target) {
-        vec![Some(&msg.sender)]
+        vec![sanitized_sender]
     } else {
-        vec![Some(history_key), Some(&msg.sender)]
+        vec![history_key.to_string(), sanitized_sender]
     }
 }
 
@@ -2980,11 +2983,15 @@ async fn process_channel_message(
 
     let mem_recall_start = Instant::now();
     let sender_session_ids = sender_memory_session_ids(&msg, &history_key);
+    let sender_session_id_refs: Vec<Option<&str>> = sender_session_ids
+        .iter()
+        .map(|s| Some(s.as_str()))
+        .collect();
     let sender_memory_fut = build_memory_context_for_sessions(
         ctx.memory.as_ref(),
         &msg.content,
         ctx.min_relevance_score,
-        sender_session_ids.as_slice(),
+        sender_session_id_refs.as_slice(),
     );
 
     let (sender_memory, group_memory) = if is_group_chat {
@@ -10835,7 +10842,10 @@ BTC is currently around $65,000 based on latest tool output."#
         .unwrap();
 
         let session_ids = sender_memory_session_ids(&msg, &history_key);
-        let context = build_memory_context_for_sessions(&mem, "quartz", 0.0, &session_ids).await;
+        let session_id_refs: Vec<Option<&str>> =
+            session_ids.iter().map(|s| Some(s.as_str())).collect();
+        let context =
+            build_memory_context_for_sessions(&mem, "quartz", 0.0, &session_id_refs).await;
 
         assert!(
             context.contains("Project codename is quartz"),
@@ -10883,10 +10893,14 @@ BTC is currently around $65,000 based on latest tool output."#
 
         let group_b_sender_session_ids =
             sender_memory_session_ids(&group_b_msg, &group_b_history_key);
-        assert_eq!(group_b_sender_session_ids, vec![Some("U123")]);
+        assert_eq!(group_b_sender_session_ids, vec!["U123".to_string()]);
 
+        let group_b_sender_session_id_refs: Vec<Option<&str>> = group_b_sender_session_ids
+            .iter()
+            .map(|s| Some(s.as_str()))
+            .collect();
         let sender_context =
-            build_memory_context_for_sessions(&mem, "quartz", 0.0, &group_b_sender_session_ids)
+            build_memory_context_for_sessions(&mem, "quartz", 0.0, &group_b_sender_session_id_refs)
                 .await;
         let group_context =
             build_memory_context(&mem, "quartz", 0.0, Some(&group_b_history_key)).await;
@@ -10904,6 +10918,50 @@ BTC is currently around $65,000 based on latest tool output."#
         assert!(
             source_group_context.contains("Group alpha codename is quartz"),
             "source group scope should still recall its own autosaved memory, got: {source_group_context}"
+        );
+    }
+
+    #[tokio::test]
+    async fn sender_session_ids_match_migrated_matrix_sender_rows() {
+        let tmp = TempDir::new().unwrap();
+        let mem = SqliteMemory::new(tmp.path()).unwrap();
+        let raw_sender = "@alice:server";
+        let sanitized_sender = sanitize_session_key(raw_sender);
+        assert_eq!(sanitized_sender, "_alice_server");
+
+        mem.store(
+            "alice_fact",
+            "Alice favors filtered coffee",
+            MemoryCategory::Conversation,
+            Some(sanitized_sender.as_str()),
+        )
+        .await
+        .unwrap();
+
+        let msg = zeroclaw_api::channel::ChannelMessage {
+            id: "evt_1".into(),
+            sender: raw_sender.into(),
+            reply_target: "!room:server".into(),
+            content: "what coffee does alice prefer?".into(),
+            channel: "matrix".into(),
+            timestamp: 1,
+            thread_ts: None,
+            interruption_scope_id: None,
+            attachments: vec![],
+        };
+        let history_key = conversation_history_key(&msg);
+        let session_ids = sender_memory_session_ids(&msg, &history_key);
+        assert!(
+            session_ids.contains(&sanitized_sender),
+            "sender session ids must include sanitized sender, got: {session_ids:?}"
+        );
+        let session_id_refs: Vec<Option<&str>> =
+            session_ids.iter().map(|s| Some(s.as_str())).collect();
+        let context =
+            build_memory_context_for_sessions(&mem, "coffee", 0.0, &session_id_refs).await;
+        assert!(
+            context.contains("Alice favors filtered coffee"),
+            "sender recall must find migrated row stored under sanitized sender, got: {context}"
         );
     }
 

--- a/crates/zeroclaw-gateway/src/ws.rs
+++ b/crates/zeroclaw-gateway/src/ws.rs
@@ -218,7 +218,8 @@ async fn handle_socket(
     // Resolve session ID: use provided or generate a new UUID
     let session_id = session_id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
     let session_key = format!("{GW_SESSION_PREFIX}{session_id}");
-    let mut memory_session_id = session_id.clone();
+    // Match the sanitized form persisted by memory backend migrations.
+    let mut memory_session_id = zeroclaw_api::session_keys::sanitize_session_key(&session_id);
 
     // Hydrate session metadata from persistence (if available). Agent
     // construction is deferred until after the optional `connect` frame so the
@@ -284,7 +285,8 @@ async fn handle_socket(
                             "WebSocket connect params received"
                         );
                         if let Some(sid) = &cp.session_id {
-                            memory_session_id = sid.clone();
+                            memory_session_id =
+                                zeroclaw_api::session_keys::sanitize_session_key(sid);
                             debug!(
                                 session_id = sid,
                                 "WebSocket connect session override received"

--- a/crates/zeroclaw-infra/src/session_store.rs
+++ b/crates/zeroclaw-infra/src/session_store.rs
@@ -25,17 +25,8 @@ impl SessionStore {
 
     /// Compute the file path for a session key, sanitizing for filesystem safety.
     fn session_path(&self, session_key: &str) -> PathBuf {
-        let safe_key: String = session_key
-            .chars()
-            .map(|c| {
-                if c.is_alphanumeric() || c == '_' || c == '-' {
-                    c
-                } else {
-                    '_'
-                }
-            })
-            .collect();
-        self.sessions_dir.join(format!("{safe_key}.jsonl"))
+        self.sessions_dir
+            .join(format!("{}.jsonl", sanitize_session_key(session_key)))
     }
 
     /// Load all messages for a session from its JSONL file.
@@ -144,6 +135,21 @@ impl SessionStore {
     }
 }
 
+/// Replace every character outside `[A-Za-z0-9_-]` with `_`. Idempotent.
+/// Callers building session keys must pre-apply this so the runtime HashMap
+/// key and the filename returned by `list_sessions` agree across restarts.
+pub fn sanitize_session_key(key: &str) -> String {
+    key.chars()
+        .map(|c| {
+            if c.is_alphanumeric() || c == '_' || c == '-' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
 impl SessionBackend for SessionStore {
     fn load(&self, session_key: &str) -> Vec<ChatMessage> {
         self.load(session_key)
@@ -209,13 +215,42 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let store = SessionStore::new(tmp.path()).unwrap();
 
-        // Keys with special chars should be sanitized
         store
             .append("slack/thread:123/user", &ChatMessage::user("test"))
             .unwrap();
 
         let messages = store.load("slack/thread:123/user");
         assert_eq!(messages.len(), 1);
+    }
+
+    #[test]
+    fn sanitize_session_key_is_idempotent() {
+        let raw = "slack_C123_1.2_user one";
+        let once = sanitize_session_key(raw);
+        let twice = sanitize_session_key(&once);
+        assert_eq!(once, "slack_C123_1_2_user_one");
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn restart_simulation_matches_when_caller_pre_sanitizes() {
+        let tmp = TempDir::new().unwrap();
+        let runtime_key = sanitize_session_key("slack_C123_1.2_user one");
+
+        {
+            let store = SessionStore::new(tmp.path()).unwrap();
+            store.append(&runtime_key, &ChatMessage::user("first")).unwrap();
+            store.append(&runtime_key, &ChatMessage::assistant("ack")).unwrap();
+        }
+
+        let store = SessionStore::new(tmp.path()).unwrap();
+        let listed = store.list_sessions();
+        assert_eq!(listed, vec![runtime_key.clone()]);
+
+        let msgs = store.load(&listed[0]);
+        assert_eq!(msgs.len(), 2);
+        assert_eq!(msgs[0].content, "first");
+        assert_eq!(msgs[1].content, "ack");
     }
 
     #[test]

--- a/crates/zeroclaw-infra/src/session_store.rs
+++ b/crates/zeroclaw-infra/src/session_store.rs
@@ -239,8 +239,12 @@ mod tests {
 
         {
             let store = SessionStore::new(tmp.path()).unwrap();
-            store.append(&runtime_key, &ChatMessage::user("first")).unwrap();
-            store.append(&runtime_key, &ChatMessage::assistant("ack")).unwrap();
+            store
+                .append(&runtime_key, &ChatMessage::user("first"))
+                .unwrap();
+            store
+                .append(&runtime_key, &ChatMessage::assistant("ack"))
+                .unwrap();
         }
 
         let store = SessionStore::new(tmp.path()).unwrap();

--- a/crates/zeroclaw-infra/src/session_store.rs
+++ b/crates/zeroclaw-infra/src/session_store.rs
@@ -25,17 +25,8 @@ impl SessionStore {
 
     /// Compute the file path for a session key, sanitizing for filesystem safety.
     fn session_path(&self, session_key: &str) -> PathBuf {
-        let safe_key: String = session_key
-            .chars()
-            .map(|c| {
-                if c.is_alphanumeric() || c == '_' || c == '-' {
-                    c
-                } else {
-                    '_'
-                }
-            })
-            .collect();
-        self.sessions_dir.join(format!("{safe_key}.jsonl"))
+        self.sessions_dir
+            .join(format!("{}.jsonl", sanitize_session_key(session_key)))
     }
 
     /// Load all messages for a session from its JSONL file.
@@ -154,6 +145,21 @@ impl SessionStore {
     }
 }
 
+/// Replace every character outside `[A-Za-z0-9_-]` with `_`. Idempotent.
+/// Callers building session keys must pre-apply this so the runtime HashMap
+/// key and the filename returned by `list_sessions` agree across restarts.
+pub fn sanitize_session_key(key: &str) -> String {
+    key.chars()
+        .map(|c| {
+            if c.is_alphanumeric() || c == '_' || c == '-' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
 impl SessionBackend for SessionStore {
     fn load(&self, session_key: &str) -> Vec<ChatMessage> {
         self.load(session_key)
@@ -248,13 +254,42 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let store = SessionStore::new(tmp.path()).unwrap();
 
-        // Keys with special chars should be sanitized
         store
             .append("slack/thread:123/user", &ChatMessage::user("test"))
             .unwrap();
 
         let messages = store.load("slack/thread:123/user");
         assert_eq!(messages.len(), 1);
+    }
+
+    #[test]
+    fn sanitize_session_key_is_idempotent() {
+        let raw = "slack_C123_1.2_user one";
+        let once = sanitize_session_key(raw);
+        let twice = sanitize_session_key(&once);
+        assert_eq!(once, "slack_C123_1_2_user_one");
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn restart_simulation_matches_when_caller_pre_sanitizes() {
+        let tmp = TempDir::new().unwrap();
+        let runtime_key = sanitize_session_key("slack_C123_1.2_user one");
+
+        {
+            let store = SessionStore::new(tmp.path()).unwrap();
+            store.append(&runtime_key, &ChatMessage::user("first")).unwrap();
+            store.append(&runtime_key, &ChatMessage::assistant("ack")).unwrap();
+        }
+
+        let store = SessionStore::new(tmp.path()).unwrap();
+        let listed = store.list_sessions();
+        assert_eq!(listed, vec![runtime_key.clone()]);
+
+        let msgs = store.load(&listed[0]);
+        assert_eq!(msgs.len(), 2);
+        assert_eq!(msgs[0].content, "first");
+        assert_eq!(msgs[1].content, "ack");
     }
 
     #[test]

--- a/crates/zeroclaw-infra/src/session_store.rs
+++ b/crates/zeroclaw-infra/src/session_store.rs
@@ -278,8 +278,12 @@ mod tests {
 
         {
             let store = SessionStore::new(tmp.path()).unwrap();
-            store.append(&runtime_key, &ChatMessage::user("first")).unwrap();
-            store.append(&runtime_key, &ChatMessage::assistant("ack")).unwrap();
+            store
+                .append(&runtime_key, &ChatMessage::user("first"))
+                .unwrap();
+            store
+                .append(&runtime_key, &ChatMessage::assistant("ack"))
+                .unwrap();
         }
 
         let store = SessionStore::new(tmp.path()).unwrap();

--- a/crates/zeroclaw-infra/src/session_store.rs
+++ b/crates/zeroclaw-infra/src/session_store.rs
@@ -9,6 +9,7 @@ use crate::session_backend::SessionBackend;
 use std::io::{BufRead, Write};
 use std::path::{Path, PathBuf};
 use zeroclaw_api::provider::ChatMessage;
+pub use zeroclaw_api::session_keys::sanitize_session_key;
 
 /// Append-only JSONL session store for channel conversations.
 pub struct SessionStore {
@@ -143,21 +144,6 @@ impl SessionStore {
             })
             .collect()
     }
-}
-
-/// Replace every character outside `[A-Za-z0-9_-]` with `_`. Idempotent.
-/// Callers building session keys must pre-apply this so the runtime HashMap
-/// key and the filename returned by `list_sessions` agree across restarts.
-pub fn sanitize_session_key(key: &str) -> String {
-    key.chars()
-        .map(|c| {
-            if c.is_alphanumeric() || c == '_' || c == '-' {
-                c
-            } else {
-                '_'
-            }
-        })
-        .collect()
 }
 
 impl SessionBackend for SessionStore {

--- a/crates/zeroclaw-memory/src/postgres.rs
+++ b/crates/zeroclaw-memory/src/postgres.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::oneshot;
 use uuid::Uuid;
+use zeroclaw_api::session_keys::sanitize_session_key;
 
 /// Maximum allowed connect timeout (seconds) to avoid unreasonable waits.
 const POSTGRES_CONNECT_TIMEOUT_CAP_SECS: u64 = 300;
@@ -138,7 +139,62 @@ impl PostgresMemory {
             "
         ))?;
 
+        Self::migrate_session_ids_to_sanitized(client, qualified_table)?;
+
         Ok(())
+    }
+
+    /// One-shot, idempotent normalization of `memories.session_id`.
+    ///
+    /// Mirrors the SQLite path: the orchestrator sanitizes session keys at
+    /// the source so the runtime HashMap, on-disk JSONL filename, and the
+    /// `session_id` filter for recall all agree. Rows written before that
+    /// fix retained the raw, un-sanitized form (e.g. `slack_C123_1.2_user one`)
+    /// and would be invisible to the new sanitized recall filter. Rewrite
+    /// them once at startup; later runs find nothing to update because
+    /// `sanitize_session_key` is idempotent.
+    fn migrate_session_ids_to_sanitized(client: &mut Client, qualified_table: &str) -> Result<()> {
+        let select = format!(
+            "SELECT DISTINCT session_id FROM {qualified_table} WHERE session_id IS NOT NULL"
+        );
+        let rows = client.query(&select, &[])?;
+        let distinct: Vec<String> = rows.iter().map(|r| r.get(0)).collect();
+
+        let rewrites = Self::compute_session_id_rewrites(&distinct);
+        if rewrites.is_empty() {
+            return Ok(());
+        }
+
+        let update = format!("UPDATE {qualified_table} SET session_id = $1 WHERE session_id = $2");
+        let stmt = client.prepare(&update)?;
+        for (old, new) in &rewrites {
+            client.execute(&stmt, &[new, old])?;
+        }
+
+        tracing::info!(
+            rewritten = rewrites.len(),
+            "Normalized session_id values in memories table to sanitized form"
+        );
+
+        Ok(())
+    }
+
+    /// Pure plan of `(old, new)` `session_id` rewrites for the rows whose
+    /// stored value differs from its sanitized form. Extracted from
+    /// `migrate_session_ids_to_sanitized` so the rewrite logic is
+    /// unit-testable without a live PostgreSQL instance.
+    fn compute_session_id_rewrites(distinct: &[String]) -> Vec<(String, String)> {
+        distinct
+            .iter()
+            .filter_map(|old| {
+                let new = sanitize_session_key(old);
+                if new == *old {
+                    None
+                } else {
+                    Some((old.clone(), new))
+                }
+            })
+            .collect()
     }
 
     fn category_to_str(category: &MemoryCategory) -> String {
@@ -504,6 +560,68 @@ mod tests {
         assert!(
             outcome.unwrap().is_err(),
             "PostgresMemory::new should return a connect error for an unreachable endpoint"
+        );
+    }
+
+    // ── session_id migration ──────────────────────────────────────
+    //
+    // End-to-end migration coverage requires a live PostgreSQL instance, and
+    // the crate's existing Postgres test suite does not run one in CI. The
+    // unit tests below exercise the rewrite plan against the same
+    // `sanitize_session_key` helper used by the migration SQL, which is
+    // sufficient to verify the contract that `migrate_session_ids_to_sanitized`
+    // relies on: which values change, which stay, and idempotence on re-run.
+
+    #[test]
+    fn rewrites_only_values_that_change_under_sanitization() {
+        let distinct = vec![
+            "slack_C123_1.2_user one".to_string(),
+            "already_sanitized".to_string(),
+            "whatsapp_123@g.us_alice".to_string(),
+            "abc-DEF_123".to_string(),
+        ];
+
+        let rewrites = PostgresMemory::compute_session_id_rewrites(&distinct);
+        assert_eq!(rewrites.len(), 2, "only the two raw forms need rewriting");
+
+        let by_old: std::collections::HashMap<_, _> = rewrites.into_iter().collect();
+        assert_eq!(
+            by_old.get("slack_C123_1.2_user one").map(String::as_str),
+            Some("slack_C123_1_2_user_one")
+        );
+        assert_eq!(
+            by_old.get("whatsapp_123@g.us_alice").map(String::as_str),
+            Some("whatsapp_123_g_us_alice")
+        );
+    }
+
+    #[test]
+    fn no_rewrites_when_all_values_already_sanitized() {
+        let distinct = vec![
+            "slack_C123_1_2_user_one".to_string(),
+            "abc-DEF_123".to_string(),
+            "".to_string(),
+        ];
+        let rewrites = PostgresMemory::compute_session_id_rewrites(&distinct);
+        assert!(
+            rewrites.is_empty(),
+            "no UPDATE should be issued when every value is already sanitized"
+        );
+    }
+
+    #[test]
+    fn rewrite_plan_is_idempotent_when_reapplied() {
+        let raw = "slack_C123_1.2_user one";
+        let sanitized = sanitize_session_key(raw);
+
+        let first = PostgresMemory::compute_session_id_rewrites(&[raw.to_string()]);
+        assert_eq!(first.len(), 1);
+        assert_eq!(first[0].1, sanitized);
+
+        let second = PostgresMemory::compute_session_id_rewrites(&[sanitized]);
+        assert!(
+            second.is_empty(),
+            "re-running the plan over the rewritten value yields no further rewrite"
         );
     }
 }

--- a/crates/zeroclaw-memory/src/qdrant.rs
+++ b/crates/zeroclaw-memory/src/qdrant.rs
@@ -4,9 +4,11 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::sync::Arc;
 use tokio::sync::OnceCell;
 use uuid::Uuid;
+use zeroclaw_api::session_keys::sanitize_session_key;
 
 /// Qdrant vector database memory backend.
 ///
@@ -40,6 +42,9 @@ impl QdrantMemory {
 
         // Ensure collection exists with correct schema
         mem.ensure_collection().await?;
+        if mem.embedder.dimensions() > 0 {
+            mem.migrate_session_ids_to_sanitized().await?;
+        }
         mem.initialized.set(()).ok();
 
         Ok(mem)
@@ -73,6 +78,9 @@ impl QdrantMemory {
         self.initialized
             .get_or_try_init(|| async {
                 self.ensure_collection().await?;
+                if self.embedder.dimensions() > 0 {
+                    self.migrate_session_ids_to_sanitized().await?;
+                }
                 Ok::<(), anyhow::Error>(())
             })
             .await?;
@@ -160,6 +168,107 @@ impl QdrantMemory {
         Ok(())
     }
 
+    /// One-shot, idempotent normalization of `payload.session_id`.
+    ///
+    /// Mirrors the SQLite-backed migration: rewrite rows that were persisted
+    /// before the orchestrator sanitized session keys at the source so the
+    /// new sanitized recall filter still matches them. Iterates the
+    /// collection with a paginated scroll, gathers distinct `session_id`
+    /// values, and issues one `set payload` per (old → new) pair where the
+    /// sanitized form differs from the stored one.
+    async fn migrate_session_ids_to_sanitized(&self) -> Result<()> {
+        let mut seen: HashSet<String> = HashSet::new();
+        let mut next_offset: Option<serde_json::Value> = None;
+
+        loop {
+            let mut scroll_body = serde_json::json!({
+                "limit": 1000,
+                "with_payload": true,
+                "with_vector": false,
+            });
+            if let Some(ref offset) = next_offset {
+                scroll_body["offset"] = offset.clone();
+            }
+
+            let resp = self
+                .request(
+                    reqwest::Method::POST,
+                    &format!("/collections/{}/points/scroll", self.collection),
+                )
+                .json(&scroll_body)
+                .send()
+                .await
+                .context("failed to scroll Qdrant for session_id migration")?;
+
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let text = resp.text().await.unwrap_or_default();
+                anyhow::bail!("Qdrant scroll failed during migration ({status}): {text}");
+            }
+
+            let page: QdrantScrollResult = resp.json().await?;
+            for point in &page.result.points {
+                if let Some(ref payload) = point.payload
+                    && let Some(ref sid) = payload.session_id
+                {
+                    seen.insert(sid.clone());
+                }
+            }
+
+            match page.result.next_page_offset {
+                Some(offset) if !offset.is_null() => next_offset = Some(offset),
+                _ => break,
+            }
+        }
+
+        let mut rewritten = 0usize;
+        for old in &seen {
+            let new = sanitize_session_key(old);
+            if new == *old {
+                continue;
+            }
+
+            let body = serde_json::json!({
+                "payload": { "session_id": new },
+                "filter": {
+                    "must": [{
+                        "key": "session_id",
+                        "match": { "value": old }
+                    }]
+                }
+            });
+
+            let resp = self
+                .request(
+                    reqwest::Method::POST,
+                    &format!("/collections/{}/points/payload", self.collection),
+                )
+                .query(&[("wait", "true")])
+                .json(&body)
+                .send()
+                .await
+                .context("failed to set payload during Qdrant session_id migration")?;
+
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let text = resp.text().await.unwrap_or_default();
+                anyhow::bail!("Qdrant set payload failed during migration ({status}): {text}");
+            }
+
+            rewritten += 1;
+        }
+
+        if rewritten > 0 {
+            tracing::info!(
+                rewritten,
+                collection = %self.collection,
+                "Normalized session_id payload values in Qdrant collection to sanitized form"
+            );
+        }
+
+        Ok(())
+    }
+
     fn category_to_str(category: &MemoryCategory) -> String {
         match category {
             MemoryCategory::Core => "core".to_string(),
@@ -212,6 +321,8 @@ struct QdrantScrollResult {
 #[derive(Debug, Deserialize)]
 struct QdrantScrollPoints {
     points: Vec<QdrantPoint>,
+    #[serde(default)]
+    next_page_offset: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/zeroclaw-memory/src/sqlite.rs
+++ b/crates/zeroclaw-memory/src/sqlite.rs
@@ -13,6 +13,7 @@ use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
 use uuid::Uuid;
+use zeroclaw_api::session_keys::sanitize_session_key;
 use zeroclaw_config::schema::SearchMode;
 
 /// Maximum allowed open timeout (seconds) to avoid unreasonable waits.
@@ -231,6 +232,45 @@ impl SqliteMemory {
         // Migration: add superseded_by column
         if !schema_sql.contains("superseded_by") {
             conn.execute_batch("ALTER TABLE memories ADD COLUMN superseded_by TEXT;")?;
+        }
+
+        Self::migrate_session_ids_to_sanitized(conn)?;
+
+        Ok(())
+    }
+
+    /// One-shot, idempotent normalization of `memories.session_id`.
+    ///
+    /// The orchestrator sanitizes session keys at the source so the runtime
+    /// HashMap, on-disk JSONL filename, and `session_id` filter for recall
+    /// all agree. Rows written before that fix retained the raw, un-sanitized
+    /// form (e.g. `slack_C123_1.2_user one`) and would be invisible to the
+    /// new sanitized recall filter. Rewrite them once at startup; later runs
+    /// find nothing to update because `sanitize_session_key` is idempotent.
+    fn migrate_session_ids_to_sanitized(conn: &Connection) -> anyhow::Result<()> {
+        let distinct: Vec<String> = {
+            let mut stmt = conn
+                .prepare("SELECT DISTINCT session_id FROM memories WHERE session_id IS NOT NULL")?;
+            let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
+            rows.collect::<Result<Vec<_>, _>>()?
+        };
+
+        let mut update =
+            conn.prepare("UPDATE memories SET session_id = ?1 WHERE session_id = ?2")?;
+        let mut rewritten = 0usize;
+        for old in &distinct {
+            let new = sanitize_session_key(old);
+            if new != *old {
+                update.execute(params![new, old])?;
+                rewritten += 1;
+            }
+        }
+
+        if rewritten > 0 {
+            tracing::info!(
+                rewritten,
+                "Normalized session_id values in memories table to sanitized form"
+            );
         }
 
         Ok(())
@@ -2944,5 +2984,83 @@ mod tests {
 
         let results = mem.recall("Rust", 10, None, None, None).await.unwrap();
         assert!(!results.is_empty(), "Hybrid mode should find results");
+    }
+
+    // ── session_id migration ──────────────────────────────────────
+
+    #[tokio::test]
+    async fn migrates_legacy_session_ids_to_sanitized_form() {
+        let tmp = TempDir::new().unwrap();
+        let raw_sid = "slack_C123_1.2_user one";
+        let sanitized = sanitize_session_key(raw_sid);
+        assert_ne!(
+            raw_sid, sanitized,
+            "test only meaningful when sanitization changes the value"
+        );
+
+        {
+            let mem = SqliteMemory::new(tmp.path()).unwrap();
+            mem.store(
+                "legacy_key",
+                "stored before sanitize fix",
+                MemoryCategory::Conversation,
+                Some(raw_sid),
+            )
+            .await
+            .unwrap();
+            let pre = mem.list(None, Some(raw_sid)).await.unwrap();
+            assert_eq!(pre.len(), 1, "raw session_id should match before migration");
+        }
+
+        let mem = SqliteMemory::new(tmp.path()).unwrap();
+
+        let by_sanitized = mem.list(None, Some(&sanitized)).await.unwrap();
+        assert_eq!(
+            by_sanitized.len(),
+            1,
+            "row must be discoverable via sanitized session_id"
+        );
+        assert_eq!(by_sanitized[0].key, "legacy_key");
+
+        let by_raw = mem.list(None, Some(raw_sid)).await.unwrap();
+        assert!(
+            by_raw.is_empty(),
+            "raw form must no longer match after migration"
+        );
+    }
+
+    #[tokio::test]
+    async fn session_id_migration_is_idempotent() {
+        let tmp = TempDir::new().unwrap();
+        let sanitized = sanitize_session_key("slack_C123_1.2_user");
+
+        {
+            let mem = SqliteMemory::new(tmp.path()).unwrap();
+            mem.store("k", "v", MemoryCategory::Core, Some(&sanitized))
+                .await
+                .unwrap();
+        }
+
+        for _ in 0..3 {
+            let mem = SqliteMemory::new(tmp.path()).unwrap();
+            let entries = mem.list(None, Some(&sanitized)).await.unwrap();
+            assert_eq!(entries.len(), 1);
+        }
+    }
+
+    #[tokio::test]
+    async fn session_id_migration_leaves_null_rows_untouched() {
+        let tmp = TempDir::new().unwrap();
+
+        {
+            let mem = SqliteMemory::new(tmp.path()).unwrap();
+            mem.store("global", "no session", MemoryCategory::Core, None)
+                .await
+                .unwrap();
+        }
+
+        let mem = SqliteMemory::new(tmp.path()).unwrap();
+        let entry = mem.get("global").await.unwrap().expect("row should exist");
+        assert!(entry.session_id.is_none());
     }
 }

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -2558,7 +2558,10 @@ pub async fn run(
         if raw.is_empty() {
             None
         } else {
-            Some(format!("cli:{raw}"))
+            // Match the sanitized form persisted by memory backend migrations.
+            Some(zeroclaw_api::session_keys::sanitize_session_key(&format!(
+                "cli:{raw}"
+            )))
         }
     });
 

--- a/crates/zeroclaw-runtime/src/cron/scheduler.rs
+++ b/crates/zeroclaw-runtime/src/cron/scheduler.rs
@@ -357,7 +357,10 @@ async fn run_agent_job(
         Err(e) => {
             // Purge memories written during this failed run so they don't
             // pollute future recall and cause context snowball.
-            let mem_session_key = format!("cli:{}", session_path.display());
+            let mem_session_key = zeroclaw_api::session_keys::sanitize_session_key(&format!(
+                "cli:{}",
+                session_path.display()
+            ));
             if let Ok(mem) = zeroclaw_memory::create_memory(
                 &config.memory,
                 &config.workspace_dir,


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Slack channels lose the conversation buffer for every thread on every daemon restart. The on-disk JSONL still contains all the turns. The assistant just cannot see them.
  - To reproduce on master: send a few messages in a Slack thread, run `docker compose restart zeroclaw`, then ask the assistant about prior turns. It has no context.
  - Root cause: `SessionStore::session_path` derives the JSONL filename by replacing every char outside `[A-Za-z0-9_-]` with `_`. `list_sessions` reads the directory and returns those sanitized names, so on restart the orchestrator hydrates `conversation_histories` with sanitized keys. But `conversation_history_key` builds the runtime lookup key from `msg.thread_ts` (which contains a `.`) and `msg.sender` (which contains spaces) without sanitizing. The two forms never match, the lookup misses, and `History` is empty. Within a single process the same non-sanitized key is used for both insert and lookup, which is why this never surfaced before production.
  - Fix: apply the same sanitization at the source. `conversation_history_key` and `conversation_memory_key` now wrap their output with `sanitize_session_key`. The function moves out of inline code in `session_path` into a shared `pub fn sanitize_session_key` in a new `zeroclaw-api::session_keys` module (re-exported from `zeroclaw-infra::session_store` for source compatibility), so the orchestrator and every memory backend share one definition.
  - Persistence compatibility: `history_key` is also passed to `Memory::store`/`Memory::recall` as the `session_id` filter. Rows persisted before this patch carry the raw, un-sanitized form (e.g. `whatsapp_123@g.us_alice`) and would not match the new sanitized recall filter. To keep them discoverable, all three persistent backends with `session_id` filtering run a one-shot, idempotent migration during initialization:
    - `SqliteMemory::init_schema` — `SELECT DISTINCT session_id` and `UPDATE` every value whose sanitized form differs.
    - `QdrantMemory::ensure_initialized` — paginated scroll of the collection, one `set payload` per `(old → sanitized)` pair, gated by the existing `OnceCell` so it runs at most once per process. The `OnceCell` is process-local, so each daemon start still scrolls the collection once; the per-row idempotence (`sanitize_session_key` returns its input on already-sanitized values) means a later start performs a full scan with no payload writes, not a literal no-op.
    - `PostgresMemory::init_schema` — `SELECT DISTINCT session_id ... WHERE session_id IS NOT NULL`, then `UPDATE memories SET session_id = $1 WHERE session_id = $2` for each value whose sanitized form differs. Issued on the same OS-thread inside `PostgresMemory::new`, so the existing client/connection is reused — no extra connect.
  - The migrations are safe to re-run because `sanitize_session_key` is idempotent. JSONL files on disk were already sanitized by the prior `session_path` logic; no file migration needed.
- **Scope boundary:** Filesystem layout, JSONL format, the `SessionBackend` trait, `SqliteSessionBackend`, and the public API of `zeroclaw-channels` are untouched. The `Memory` trait is unchanged. `memories.key` (PRIMARY KEY, user-controllable from manual `memory.store` calls), `memory_audit.session_id` (timestamp-only queries), the markdown/none backends (no `session_id` filtering), and `knowledge_graph_pg.rs` (node-id based persistence — no `session_id` column or filter — confirmed via grep) are deliberately not touched. No new dependencies. No config or feature flag added.
- **Blast radius:** `conversation_history_key` (drives the in-memory `conversation_histories` HashMap), `conversation_memory_key` (drives the memory-recall key), and the initialization paths of `SqliteMemory`, `QdrantMemory`, and `PostgresMemory`. `auto_save` memory keys for messages are now sanitized too, which is consistent with what `SessionStore` already did for filenames. Migrations run once per backend instance startup; subsequent starts find already-sanitized values and issue no writes (SQLite/Postgres) or no payload updates (Qdrant).
- **Linked issue(s):** None filed; the bug surfaced on a production Slack deployment.

## Validation Evidence (required)

```bash
$ cargo fmt --all -- --check
# (no output, exit 0)

$ cargo clippy -p zeroclaw-memory --features memory-postgres --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 35.36s
# (no warnings)

$ cargo test -p zeroclaw-api
test result: ok. 34 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
# + doctests: 1 passed

$ cargo test -p zeroclaw-infra --lib
test result: ok. 64 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.05s

$ cargo test -p zeroclaw-memory --lib --features memory-postgres
test result: ok. 301 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.33s

$ cargo test -p zeroclaw-channels --lib
test result: ok. 989 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 6.91s
```

- **Commands run and tail output:** see the block above.
- **Beyond CI — what did you manually verify?**
  - Bug reproduction in a unit test: `restart_simulation_matches_when_caller_pre_sanitizes` in `session_store.rs` fails on master and passes here. It drops and recreates the `SessionStore` handle to mimic a cold-boot, then asserts that the rehydrated key matches what runtime lookup would produce when the caller pre-sanitizes.
  - SQLite persistence migration covered by three end-to-end tests in `sqlite.rs`: `migrates_legacy_session_ids_to_sanitized_form` (legacy raw `session_id` becomes discoverable via the sanitized form after reopen), `session_id_migration_is_idempotent` (three back-to-back reopens leave the row count unchanged), `session_id_migration_leaves_null_rows_untouched` (rows without `session_id` are not touched).
  - Postgres persistence migration covered by three unit tests in `postgres.rs` against the rewrite-plan helper (`compute_session_id_rewrites`): `rewrites_only_values_that_change_under_sanitization`, `no_rewrites_when_all_values_already_sanitized`, `rewrite_plan_is_idempotent_when_reapplied`. End-to-end Postgres coverage is out of scope here because the crate's existing Postgres test suite does not run a live PostgreSQL instance in CI; the migration SQL is a near-identical mirror of the SQLite path, gated by the same `sanitize_session_key` helper that the unit tests exercise.
  - End-to-end: built a Docker image from this branch (`Dockerfile.debian`), deployed to a Slack channel. Wrote a multi-turn thread, ran `docker compose restart`, asked the assistant about prior turns. It cited them. Existing Slack threads (sanitized filenames pre-dating the patch) also recover under the new runtime lookup, since the sanitized form matches. Memory entries autosaved in earlier daemon runs (with raw `session_id` values) remained visible to recall after the upgrade thanks to the SQLite migration.
- **Rebase aftermath:** Rebasing onto the current `master` pulled in `f97e1fe5 fix(matrix): avoid threading root timeline messages`, which added an orchestrator test (`orchestrator::tests::matrix_thread_conversation_history_key_uses_thread_root`) asserting on the raw Matrix event id (`$root:server`). The sanitization introduced here rewrites `$` and `:` to `_`, so the literals in that test were updated to their sanitized form (`_root_server` / `_reply_server`). Test intent — "thread root is used, not reply id" — is preserved; only the string compared against changes. The two pre-existing `telegram` orchestrator failures that the earlier PR body flagged as macOS-only fallout no longer reproduce on the current base (`989 passed; 0 failed`), so that caveat is dropped.
- **If any command was intentionally skipped, why:**
  - Full-workspace `cargo clippy --all-targets` runs only on the touched crates locally. The `rppal` Raspberry Pi GPIO crate (a transitive dep) does not compile on macOS. The CI Lint stage runs full-workspace clippy on Linux and is green for this PR.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No` — the Qdrant migration uses the same REST endpoints (`/points/scroll`, `/points/payload`) that existing operations already issue. The Postgres migration reuses the existing client/connection opened by `PostgresMemory::new` (no extra connect, no new credentials path).
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No` — test fixtures use synthetic identifiers (`Display Name`, `user one`).

## Compatibility (required)

- Backward compatible? `Yes` — existing on-disk JSONL files were already sanitized by the prior `session_path` logic; the new runtime lookup produces the same sanitized form, so they match. Persisted memory rows with raw `session_id` values are normalized to the sanitized form on first startup after upgrade by an idempotent migration in all three persistent scoped backends (SQLite, Qdrant, Postgres), so the new recall filter discovers them. `sanitize_session_key` is re-exported from `zeroclaw-infra::session_store`, so existing callers compile and run unchanged.
- Config / env / CLI surface changed? `No`
- Upgrade steps: None required. Migrations run automatically on first startup after upgrade; subsequent starts find sanitized values and issue no writes.

## Rollback (required for `risk: medium` and `risk: high`)

**Medium-risk** — aligns with the `risk: medium` label. The change touches the persistence-init path: SQLite runs an `UPDATE memories SET session_id = ?` pass during `init_schema`, Qdrant issues `set payload` calls against the collection during `ensure_initialized`, and Postgres runs an `UPDATE memories SET session_id = $1 WHERE session_id = $2` pass per changed value during `init_schema`.

`git revert <sha>` is the plan. After revert:

- The migration code is removed, but rows already rewritten on previous startups stay in their sanitized form — the rewrite is destructive of the old `session_id` value, so a revert does not restore the original strings. Functionally those rows remain discoverable as long as the orchestrator continues to produce sanitized keys at the source.
- If only the orchestrator change is reverted but the migration stays, recall keeps working because both the persisted `session_id` and the runtime lookup key revert to the same un-sanitized form, except for rows already normalized — those would become orphaned to the un-sanitized filter.
- For a complete back-out, revert the orchestrator commit and the migration commits together. The pre-fix behavior returns: Slack channels lose buffer on restart, but persisted data is intact.

No feature flag, no schema column added or removed; only behavior changes during init.
