### PR TITLE
fix(cron): allow whatsapp as cron delivery channel

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -5953,6 +5953,92 @@ pub async fn deliver_announcement(
         "wechat" => {
             anyhow::bail!("WeChat channel requires the `channel-wechat` feature");
         }
+        "mattermost" => {
+            let mm = config
+                .channels
+                .mattermost
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("mattermost channel not configured"))?;
+            let ch = MattermostChannel::new(
+                mm.url.clone(),
+                mm.bot_token.clone(),
+                mm.channel_id.clone(),
+                mm.allowed_users.clone(),
+                mm.thread_replies.unwrap_or(true),
+                mm.mention_only.unwrap_or(false),
+            );
+            zeroclaw_api::channel::Channel::send(&ch, &SendMessage::new(&safe_output, target))
+                .await?;
+        }
+        "matrix" => {
+            #[cfg(feature = "channel-matrix")]
+            {
+                let mx = config
+                    .channels
+                    .matrix
+                    .as_ref()
+                    .ok_or_else(|| anyhow::anyhow!("matrix channel not configured"))?;
+                let state_dir = config
+                    .config_path
+                    .parent()
+                    .map(|p| p.join("state").join("matrix"))
+                    .unwrap_or_else(|| std::path::PathBuf::from(".zeroclaw/state/matrix"));
+                let ch = MatrixChannel::new(mx.clone(), state_dir)?
+                    .with_workspace_dir(config.workspace_dir.clone());
+                zeroclaw_api::channel::Channel::send(&ch, &SendMessage::new(&safe_output, target))
+                    .await?;
+            }
+            #[cfg(not(feature = "channel-matrix"))]
+            {
+                anyhow::bail!("Matrix channel requires the `channel-matrix` feature");
+            }
+        }
+        "qq" => {
+            let qq = config
+                .channels
+                .qq
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("qq channel not configured"))?;
+            let ch = QQChannel::new(
+                qq.app_id.clone(),
+                qq.app_secret.clone(),
+                qq.allowed_users.clone(),
+            );
+            zeroclaw_api::channel::Channel::send(&ch, &SendMessage::new(&safe_output, target))
+                .await?;
+        }
+        "whatsapp" | "whatsapp-web" | "whatsapp_web" => {
+            #[cfg(feature = "whatsapp-web")]
+            {
+                let wa = config
+                    .channels
+                    .whatsapp
+                    .as_ref()
+                    .ok_or_else(|| anyhow::anyhow!("whatsapp channel not configured"))?;
+                if !wa.is_web_config() {
+                    anyhow::bail!(
+                        "WhatsApp channel send requires Web mode (session_path must be set)"
+                    );
+                }
+                let ch = WhatsAppWebChannel::new(
+                    wa.session_path.clone().unwrap_or_default(),
+                    wa.pair_phone.clone(),
+                    wa.pair_code.clone(),
+                    wa.allowed_numbers.clone(),
+                    wa.mention_only,
+                    wa.mode.clone(),
+                    wa.dm_policy.clone(),
+                    wa.group_policy.clone(),
+                    wa.self_chat_mode,
+                );
+                zeroclaw_api::channel::Channel::send(&ch, &SendMessage::new(&safe_output, target))
+                    .await?;
+            }
+            #[cfg(not(feature = "whatsapp-web"))]
+            {
+                anyhow::bail!("WhatsApp channel requires the `whatsapp-web` feature");
+            }
+        }
         other => anyhow::bail!("unsupported delivery channel: {other}"),
     }
     Ok(())

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -707,7 +707,7 @@ fn maybe_inject_channel_delivery_defaults(
 
     if !matches!(
         channel_name,
-        "telegram" | "discord" | "slack" | "mattermost" | "matrix"
+        "telegram" | "discord" | "slack" | "mattermost" | "matrix" | "qq" | "whatsapp"
     ) {
         return;
     }
@@ -5287,6 +5287,78 @@ mod tests {
                 "mode": "announce",
                 "channel": "telegram",
                 "to": "chat-42",
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn run_tool_call_loop_injects_whatsapp_delivery_defaults_for_cron_add() {
+        let provider = ScriptedProvider::from_text_responses(vec![
+            r#"<tool_call>
+{"name":"cron_add","arguments":{"job_type":"agent","prompt":"daily news brief","schedule":{"kind":"every","every_ms":60000}}}
+</tool_call>"#,
+            "done",
+        ]);
+
+        let recorded_args = Arc::new(Mutex::new(Vec::new()));
+        let tools_registry: Vec<Box<dyn Tool>> = vec![Box::new(RecordingArgsTool::new(
+            "cron_add",
+            Arc::clone(&recorded_args),
+        ))];
+
+        let mut history = vec![
+            ChatMessage::system("test-system"),
+            ChatMessage::user("send me news every minute on whatsapp"),
+        ];
+        let observer = NoopObserver;
+
+        let result = run_tool_call_loop(
+            &provider,
+            &mut history,
+            &tools_registry,
+            &observer,
+            "mock-provider",
+            "mock-model",
+            0.0,
+            true,
+            None,
+            "whatsapp",
+            Some("+15551234567"),
+            &zeroclaw_config::schema::MultimodalConfig::default(),
+            4,
+            None,
+            None,
+            None,
+            &[],
+            &[],
+            None,
+            None,
+            &zeroclaw_config::schema::PacingConfig::default(),
+            0,
+            0,
+            None,
+            None, // channel
+            None, // receipt_generator
+            None, // collected_receipts
+        )
+        .await
+        .expect("cron_add delivery defaults should be injected for whatsapp");
+
+        assert!(
+            result.ends_with("done"),
+            "result should end with 'done', got: {result}"
+        );
+
+        let recorded = recorded_args
+            .lock()
+            .expect("recorded args lock should be valid");
+        let delivery = recorded[0]["delivery"].clone();
+        assert_eq!(
+            delivery,
+            serde_json::json!({
+                "mode": "announce",
+                "channel": "whatsapp",
+                "to": "+15551234567",
             })
         );
     }

--- a/crates/zeroclaw-runtime/src/cron/mod.rs
+++ b/crates/zeroclaw-runtime/src/cron/mod.rs
@@ -62,7 +62,8 @@ pub fn validate_delivery_config(delivery: Option<&DeliveryConfig>) -> Result<()>
         bail!("delivery.channel is required for announce mode");
     };
     match channel.to_ascii_lowercase().as_str() {
-        "telegram" | "discord" | "slack" | "mattermost" | "signal" | "matrix" | "qq" => {}
+        "telegram" | "discord" | "slack" | "mattermost" | "signal" | "matrix" | "qq"
+        | "whatsapp" => {}
         other => bail!("unsupported delivery channel: {other}"),
     }
 
@@ -742,5 +743,59 @@ mod tests {
         assert_eq!(jobs.len(), 1);
         assert_eq!(jobs[0].job_type, JobType::Shell);
         assert_eq!(jobs[0].command, "echo ok");
+    }
+}
+
+#[cfg(test)]
+mod delivery_validation_tests {
+    use super::*;
+
+    #[test]
+    fn validate_delivery_config_accepts_all_supported_channels() {
+        for channel in [
+            "telegram",
+            "discord",
+            "slack",
+            "mattermost",
+            "signal",
+            "matrix",
+            "qq",
+            "whatsapp",
+        ] {
+            let delivery = DeliveryConfig {
+                mode: "announce".into(),
+                channel: Some(channel.into()),
+                to: Some("dest-1".into()),
+                best_effort: true,
+            };
+            validate_delivery_config(Some(&delivery))
+                .unwrap_or_else(|err| panic!("channel {channel} should be accepted: {err}"));
+        }
+    }
+
+    #[test]
+    fn validate_delivery_config_accepts_whatsapp_case_insensitive() {
+        for variant in ["whatsapp", "WhatsApp", "WHATSAPP"] {
+            let delivery = DeliveryConfig {
+                mode: "announce".into(),
+                channel: Some(variant.into()),
+                to: Some("+15551234567".into()),
+                best_effort: true,
+            };
+            validate_delivery_config(Some(&delivery))
+                .unwrap_or_else(|err| panic!("variant {variant} should be accepted: {err}"));
+        }
+    }
+
+    #[test]
+    fn validate_delivery_config_rejects_unsupported_channel() {
+        let delivery = DeliveryConfig {
+            mode: "announce".into(),
+            channel: Some("notarealchannel".into()),
+            to: Some("dest".into()),
+            best_effort: true,
+        };
+        let err = validate_delivery_config(Some(&delivery)).unwrap_err();
+        assert!(err.to_string().contains("unsupported delivery channel"));
     }
 }

--- a/crates/zeroclaw-runtime/src/tools/cron_add.rs
+++ b/crates/zeroclaw-runtime/src/tools/cron_add.rs
@@ -146,7 +146,7 @@ impl Tool for CronAddTool {
                         },
                         "channel": {
                             "type": "string",
-                            "enum": ["telegram", "discord", "slack", "mattermost", "matrix", "qq"],
+                            "enum": ["telegram", "discord", "slack", "mattermost", "matrix", "qq", "whatsapp"],
                             "description": "Channel type to deliver output to"
                         },
                         "to": {
@@ -475,6 +475,60 @@ mod tests {
 
         assert!(!result.success);
         assert!(result.error.unwrap_or_default().contains("not allowed"));
+    }
+
+    #[tokio::test]
+    async fn shell_job_persists_whatsapp_delivery() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = test_config(&tmp).await;
+        let tool = CronAddTool::new(cfg.clone(), test_security(&cfg));
+        let result = tool
+            .execute(json!({
+                "schedule": { "kind": "cron", "expr": "*/5 * * * *" },
+                "job_type": "shell",
+                "command": "echo ok",
+                "delivery": {
+                    "mode": "announce",
+                    "channel": "whatsapp",
+                    "to": "+15551234567",
+                    "best_effort": true
+                }
+            }))
+            .await
+            .unwrap();
+
+        assert!(result.success, "{:?}", result.error);
+
+        let jobs = cron::list_jobs(&cfg).unwrap();
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(jobs[0].delivery.mode, "announce");
+        assert_eq!(jobs[0].delivery.channel.as_deref(), Some("whatsapp"));
+        assert_eq!(jobs[0].delivery.to.as_deref(), Some("+15551234567"));
+        assert!(jobs[0].delivery.best_effort);
+    }
+
+    #[tokio::test]
+    async fn schema_delivery_channel_enum_includes_whatsapp() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = test_config(&tmp).await;
+        let tool = CronAddTool::new(cfg.clone(), test_security(&cfg));
+        let schema = tool.parameters_schema();
+
+        let channel_enum = schema["properties"]["delivery"]["properties"]["channel"]["enum"]
+            .as_array()
+            .expect("delivery.channel must have an enum");
+        let channel_strs: Vec<&str> = channel_enum.iter().filter_map(|v| v.as_str()).collect();
+        for ch in &[
+            "telegram",
+            "discord",
+            "slack",
+            "mattermost",
+            "matrix",
+            "qq",
+            "whatsapp",
+        ] {
+            assert!(channel_strs.contains(ch), "delivery.channel missing: {ch}");
+        }
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-runtime/src/tools/cron_update.rs
+++ b/crates/zeroclaw-runtime/src/tools/cron_update.rs
@@ -151,7 +151,7 @@ impl Tool for CronUpdateTool {
                                 },
                                 "channel": {
                                     "type": "string",
-                                    "enum": ["telegram", "discord", "slack", "mattermost", "matrix"],
+                                    "enum": ["telegram", "discord", "slack", "mattermost", "matrix", "qq", "whatsapp"],
                                     "description": "Channel type to deliver output to"
                                 },
                                 "to": {
@@ -475,7 +475,15 @@ mod tests {
             .as_array()
             .expect("patch.delivery.channel must have an enum");
         let channel_strs: Vec<&str> = channel_enum.iter().filter_map(|v| v.as_str()).collect();
-        for ch in &["telegram", "discord", "slack", "mattermost", "matrix"] {
+        for ch in &[
+            "telegram",
+            "discord",
+            "slack",
+            "mattermost",
+            "matrix",
+            "qq",
+            "whatsapp",
+        ] {
             assert!(channel_strs.contains(ch), "delivery.channel missing: {ch}");
         }
     }


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Cron jobs scheduled via `cron_add`/`cron_update` can now deliver their output to a configured WhatsApp channel (`delivery = { mode: "announce", channel: "whatsapp", to: "<msisdn>" }`). WhatsApp Web/Cloud was already wired into the channel runtime, the allowlist, `build_channel_by_id`, and the `send_channel_message` CLI path, but the cron pipeline rejected `"whatsapp"` at four separate layers (validation, two JSON-schema enums, the agent-loop auto-injector, and the registry-miss fallback in `deliver_announcement`). This patch lines those four spots up with the rest of the codebase and adds `qq` everywhere it had been forgotten too.
  - Reconstruct-on-miss `deliver_announcement` in `zeroclaw-channels/src/orchestrator/mod.rs` now also covers `mattermost`, `matrix`, `qq`, and `whatsapp` so deliveries still succeed when the live `CRON_CHANNEL_REGISTRY` isn't populated (headless cron-only deployments, the daemon-startup window).
- **Scope boundary:** This PR does NOT introduce new channels, alter delivery semantics (`announce`/`none` mode behavior is unchanged), touch security/leak-detection (still runs through `LeakDetector::scan` before send), modify the daemon scheduler, or change any non-cron call site (interactive channel sends already routed through `send_channel_message`, which already supported WhatsApp).
- **Blast radius:** `cron_add` / `cron_update` tool schemas (LLM-visible enum widens by `whatsapp`/`qq`); `validate_delivery_config` accepts two more channel strings; `maybe_inject_channel_delivery_defaults` auto-fills delivery for two more channels when the agent is chatting via that channel; `deliver_announcement` no longer hard-fails for `mattermost|matrix|qq|whatsapp` when the live registry is missing. No persisted-state shape changes — `DeliveryConfig` is unchanged.
- **Linked issue(s):** `Closes #6224`

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test --workspace --lib
cargo test -p zeroclaw-runtime --lib cron
cargo test -p zeroclaw-runtime --lib injects
cargo test -p zeroclaw-channels --lib --features channel-telegram
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` -> clean (no output).
  - `cargo clippy --all-targets -- -D warnings` -> `Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 11s`, no warnings.
  - `cargo test -p zeroclaw-runtime --lib cron` -> `test result: ok. 146 passed; 0 failed; 0 ignored; 0 measured; 1446 filtered out` — includes new `tools::cron_add::tests::shell_job_persists_whatsapp_delivery`, `tools::cron_add::tests::schema_delivery_channel_enum_includes_whatsapp`, the updated `tools::cron_update::tests::patch_schema_covers_all_cronjobpatch_fields_and_schedule_is_oneof`, and the new `cron::delivery_validation_tests::*` trio.
  - `cargo test -p zeroclaw-runtime --lib injects` -> `test result: ok. 2 passed` — pre-existing `injects_channel_delivery_defaults_for_cron_add` plus new `injects_whatsapp_delivery_defaults_for_cron_add`.
  - `cargo test -p zeroclaw-runtime` -> `test result: ok. 1592 passed; 0 failed; 1 ignored`.
  - `cargo test -p zeroclaw-channels --lib --features channel-telegram` -> `test result: ok. 1118 passed; 0 failed; 1 ignored`.
- **Beyond CI — what did you manually verify?**
  - Walked the validated set vs `deliver_announcement` fallback set vs `build_channel_by_id` set: validated set is `telegram|discord|slack|mattermost|signal|matrix|qq|whatsapp` and every member is now reachable through both the registry path and the reconstruct-on-miss path (telegram/wechat behind their `cfg(feature)` gates as before).
  - Confirmed `validate_delivery_config` lower-cases the channel string before matching, so the new `whatsapp` arm accepts `WhatsApp`/`WHATSAPP` as well — covered by `validate_delivery_config_accepts_whatsapp_case_insensitive`.
  - Confirmed the auto-injector still skips when `delivery.mode = "none"` (regression coverage by existing `preserves_explicit_cron_delivery_none`).
  - Did NOT verify a live end-to-end WhatsApp Web delivery on a real account — no test credentials. Logic match-up to the existing `send_channel_message` whatsapp arm is the proxy.
- **If any command was intentionally skipped, why:** `./dev/ci.sh all` requires Docker and was skipped in favor of running the workspace test/lint commands directly; `cargo test -p zeroclaw-channels --lib` (no features) shows two pre-existing failures (`build_channel_by_id_configured_telegram_succeeds`, `build_channel_by_id_unconfigured_telegram_returns_error`) that reproduce on `master` without the `channel-telegram` feature — unrelated to this PR.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No` — WhatsApp/Mattermost/Matrix/QQ already make outbound calls; this only widens which channels cron can pick.
- Secrets / tokens / credentials handling changed? `No` — `LeakDetector::scan` still runs on the output before any of the new arms are reached, identical to the existing `discord`/`telegram` arms.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No` — test data uses `+15551234567` (placeholder MSISDN) and synthetic IDs.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No` — the `[channels.whatsapp]` config block already exists; no new keys, env vars, or CLI flags. The user-visible change is that `cron_add` / `cron_update` no longer reject `channel = "whatsapp"`.
- If `No` or `Yes` to either: exact upgrade steps for existing users: none — existing cron jobs continue to function unchanged.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <merge-sha>` — no schema/state migrations to unwind.
- **Feature flags or config toggles:** None. The `whatsapp-web` cargo feature already gates the actual channel implementation; deliveries to whatsapp on a build without that feature now produce the same `WhatsApp channel requires the `whatsapp-web` feature` error that the live-registry path produced before.
- **Observable failure symptoms:**
  - `tracing::warn!` from `deliver_announcement` (`channel = "whatsapp", target = ...`) followed by an `unsupported delivery channel: whatsapp` error in cron run history would indicate the validation list and the routing list have drifted again.
  - `cron_add` / `cron_update` rejecting `channel: "whatsapp"` with `delivery.channel must be one of ...` from the JSON-schema validator means the schema enum no longer matches `validate_delivery_config`.