### PR TITLE
fix(security): allow safe device redirect targets in path policy

### DIFF
--- a/crates/zeroclaw-config/src/policy.rs
+++ b/crates/zeroclaw-config/src/policy.rs
@@ -642,7 +642,11 @@ fn contains_unsafe_output_redirect(command: &str) -> bool {
         // non-operator character after the device name prevents the match —
         // blocking bypasses like `2>/dev/stderr.log` or `>/dev/zero/path`.
         // The terminator is captured and preserved in the replacement.
-        Regex::new(r"\d*>[ ]?/dev/(null|zero|stdout|stderr)(\s|[;&|)]|$)").unwrap()
+        Regex::new(&format!(
+            r"\d*>[ ]?/dev/({})(\s|[;&|)]|$)",
+            safe_device_redirect_names_pattern()
+        ))
+        .unwrap()
     });
 
     let safe = re.replace_all(command, "$2").to_string();
@@ -776,18 +780,52 @@ fn attached_short_option_value(token: &str) -> Option<&str> {
     if value.is_empty() { None } else { Some(value) }
 }
 
-fn redirection_target(token: &str) -> Option<&str> {
-    let marker_idx = token.find(['<', '>'])?;
+enum RedirectionArgument<'a> {
+    Target { prefix: &'a str, target: &'a str },
+    NeedsNextToken { prefix: &'a str },
+    FdOnly { prefix: &'a str },
+    None,
+}
+
+fn parse_redirection_argument(token: &str) -> RedirectionArgument<'_> {
+    let Some(marker_idx) = token.find(['<', '>']) else {
+        return RedirectionArgument::None;
+    };
+    let prefix = token[..marker_idx].trim();
     let mut rest = &token[marker_idx + 1..];
     rest = rest.trim_start_matches(['<', '>']);
+    if let Some(after_amp) = rest.strip_prefix('&') {
+        let remaining = after_amp.trim_start_matches(|c: char| c.is_ascii_digit() || c == '-');
+        if remaining.is_empty() {
+            return RedirectionArgument::FdOnly { prefix };
+        }
+    }
     rest = rest.trim_start_matches('&');
     rest = rest.trim_start_matches(|c: char| c.is_ascii_digit());
     let trimmed = rest.trim();
     if trimmed.is_empty() {
-        None
+        RedirectionArgument::NeedsNextToken { prefix }
     } else {
-        Some(trimmed)
+        RedirectionArgument::Target {
+            prefix,
+            target: trimmed,
+        }
     }
+}
+
+const SAFE_DEVICE_REDIRECT_TARGETS: [&str; 4] =
+    ["/dev/null", "/dev/stdout", "/dev/stderr", "/dev/zero"];
+
+fn safe_device_redirect_names_pattern() -> String {
+    SAFE_DEVICE_REDIRECT_TARGETS
+        .iter()
+        .map(|target| target.trim_start_matches("/dev/"))
+        .collect::<Vec<_>>()
+        .join("|")
+}
+
+fn is_safe_device_redirect_target(target: &str) -> bool {
+    SAFE_DEVICE_REDIRECT_TARGETS.contains(&strip_wrapping_quotes(target).trim())
 }
 
 /// Extract the basename from a command path, handling both Unix (`/`) and
@@ -1293,6 +1331,26 @@ impl SecurityPolicy {
                 None
             }
         };
+        let forbidden_non_redirect_candidate = |raw: &str| {
+            let candidate = strip_wrapping_quotes(raw).trim();
+            if candidate.is_empty() || candidate.contains("://") {
+                return None;
+            }
+            if candidate.starts_with('-') {
+                if let Some((_, value)) = candidate.split_once('=')
+                    && let Some(blocked) = forbidden_candidate(value)
+                {
+                    return Some(blocked);
+                }
+                if let Some(value) = attached_short_option_value(candidate)
+                    && let Some(blocked) = forbidden_candidate(value)
+                {
+                    return Some(blocked);
+                }
+                return None;
+            }
+            forbidden_candidate(candidate)
+        };
 
         for segment in split_unquoted_segments(command) {
             let cmd_part = skip_env_assignments(&segment);
@@ -1301,42 +1359,78 @@ impl SecurityPolicy {
                 continue;
             };
 
+            let executable_redirect = parse_redirection_argument(strip_wrapping_quotes(executable));
+            let mut next_is_redirect_target = false;
             // Cover inline forms like `cat</etc/passwd`.
-            if let Some(target) = redirection_target(strip_wrapping_quotes(executable))
-                && let Some(blocked) = forbidden_candidate(target)
-            {
-                return Some(blocked);
+            match executable_redirect {
+                RedirectionArgument::Target { target, .. } => {
+                    if !is_safe_device_redirect_target(target)
+                        && let Some(blocked) = forbidden_candidate(target)
+                    {
+                        return Some(blocked);
+                    }
+                }
+                RedirectionArgument::NeedsNextToken { .. } => {
+                    next_is_redirect_target = true;
+                }
+                RedirectionArgument::FdOnly { .. } | RedirectionArgument::None => {}
             }
 
             for token in words {
                 let candidate = strip_wrapping_quotes(token).trim();
-                if candidate.is_empty() || candidate.contains("://") {
+                if candidate.is_empty() {
                     continue;
                 }
 
-                if let Some(target) = redirection_target(candidate)
-                    && let Some(blocked) = forbidden_candidate(target)
-                {
-                    return Some(blocked);
+                if next_is_redirect_target {
+                    next_is_redirect_target = false;
+                    if is_safe_device_redirect_target(candidate) {
+                        continue;
+                    }
+                    if let Some(blocked) = forbidden_candidate(candidate) {
+                        return Some(blocked);
+                    }
+                    continue;
+                }
+
+                if candidate.contains("://") {
+                    continue;
+                }
+
+                match parse_redirection_argument(candidate) {
+                    RedirectionArgument::Target { prefix, target } => {
+                        if let Some(blocked) = forbidden_non_redirect_candidate(prefix) {
+                            return Some(blocked);
+                        }
+                        if is_safe_device_redirect_target(target) {
+                            continue;
+                        }
+                        if let Some(blocked) = forbidden_candidate(target) {
+                            return Some(blocked);
+                        }
+                    }
+                    RedirectionArgument::NeedsNextToken { prefix } => {
+                        if let Some(blocked) = forbidden_non_redirect_candidate(prefix) {
+                            return Some(blocked);
+                        }
+                        next_is_redirect_target = true;
+                        continue;
+                    }
+                    RedirectionArgument::FdOnly { prefix } => {
+                        if let Some(blocked) = forbidden_non_redirect_candidate(prefix) {
+                            return Some(blocked);
+                        }
+                        continue;
+                    }
+                    RedirectionArgument::None => {}
                 }
 
                 // Handle option assignment forms like `--file=/etc/passwd`.
-                if candidate.starts_with('-') {
-                    if let Some((_, value)) = candidate.split_once('=')
-                        && let Some(blocked) = forbidden_candidate(value)
-                    {
-                        return Some(blocked);
-                    }
-                    if let Some(value) = attached_short_option_value(candidate)
-                        && let Some(blocked) = forbidden_candidate(value)
-                    {
-                        return Some(blocked);
-                    }
-                    continue;
-                }
-
-                if let Some(blocked) = forbidden_candidate(candidate) {
+                if let Some(blocked) = forbidden_non_redirect_candidate(candidate) {
                     return Some(blocked);
+                }
+                if candidate.starts_with('-') {
+                    continue;
                 }
             }
         }
@@ -1743,6 +1837,14 @@ mod tests {
 
     fn default_policy() -> SecurityPolicy {
         SecurityPolicy::default()
+    }
+
+    fn unix_forbidden_path_policy() -> SecurityPolicy {
+        SecurityPolicy {
+            workspace_dir: PathBuf::from("/workspace"),
+            forbidden_paths: vec!["/dev".into(), "/etc".into()],
+            ..SecurityPolicy::default()
+        }
     }
 
     fn readonly_policy() -> SecurityPolicy {
@@ -2745,7 +2847,7 @@ mod tests {
 
     #[test]
     fn forbidden_path_argument_detects_absolute_path() {
-        let p = default_policy();
+        let p = unix_forbidden_path_policy();
         assert_eq!(
             p.forbidden_path_argument("cat /etc/passwd"),
             Some("/etc/passwd".into())
@@ -2774,7 +2876,7 @@ mod tests {
 
     #[test]
     fn forbidden_path_argument_detects_option_assignment_paths() {
-        let p = default_policy();
+        let p = unix_forbidden_path_policy();
         assert_eq!(
             p.forbidden_path_argument("grep --file=/etc/passwd root ./src"),
             Some("/etc/passwd".into())
@@ -2796,7 +2898,7 @@ mod tests {
 
     #[test]
     fn forbidden_path_argument_detects_short_option_attached_paths() {
-        let p = default_policy();
+        let p = unix_forbidden_path_policy();
         assert_eq!(
             p.forbidden_path_argument("grep -f/etc/passwd root ./src"),
             Some("/etc/passwd".into())
@@ -2832,13 +2934,80 @@ mod tests {
 
     #[test]
     fn forbidden_path_argument_detects_input_redirection_paths() {
-        let p = default_policy();
+        let p = unix_forbidden_path_policy();
         assert_eq!(
             p.forbidden_path_argument("cat </etc/passwd"),
             Some("/etc/passwd".into())
         );
         assert_eq!(
             p.forbidden_path_argument("cat</etc/passwd"),
+            Some("/etc/passwd".into())
+        );
+    }
+
+    #[test]
+    fn forbidden_path_argument_allows_safe_device_redirect_targets() {
+        let p = unix_forbidden_path_policy();
+        assert_eq!(p.forbidden_path_argument("ls missing 2>/dev/null"), None);
+        assert_eq!(p.forbidden_path_argument("ls missing 2> /dev/null"), None);
+        assert_eq!(p.forbidden_path_argument("echo hi >/dev/stdout"), None);
+        assert_eq!(p.forbidden_path_argument("echo hi > /dev/stdout"), None);
+        assert_eq!(p.forbidden_path_argument("echo err 1>/dev/stderr"), None);
+        assert_eq!(p.forbidden_path_argument("echo err 1> /dev/stderr"), None);
+        assert_eq!(p.forbidden_path_argument("cat </dev/zero"), None);
+        assert_eq!(p.forbidden_path_argument("cat < /dev/zero"), None);
+        #[cfg(not(target_os = "windows"))]
+        assert_eq!(p.forbidden_path_argument("cat /dev/null"), None);
+        assert_eq!(p.forbidden_path_argument("cat ./safe.txt>/dev/null"), None);
+        assert_eq!(p.forbidden_path_argument("cat> /dev/null"), None);
+        assert_eq!(p.forbidden_path_argument("cat ./safe.txt>&2"), None);
+    }
+
+    #[test]
+    fn forbidden_path_argument_blocks_unsafe_redirect_targets() {
+        let p = unix_forbidden_path_policy();
+        assert_eq!(
+            p.forbidden_path_argument("echo hi >/etc/passwd"),
+            Some("/etc/passwd".into())
+        );
+        assert_eq!(
+            p.forbidden_path_argument("echo hi > /etc/passwd"),
+            Some("/etc/passwd".into())
+        );
+        assert_eq!(
+            p.forbidden_path_argument("echo hi >/dev/stderr.log"),
+            Some("/dev/stderr.log".into())
+        );
+        assert_eq!(
+            p.forbidden_path_argument("echo hi > /dev/stderr.log"),
+            Some("/dev/stderr.log".into())
+        );
+        assert_eq!(
+            p.forbidden_path_argument("cat </dev/zero/etc/passwd"),
+            Some("/dev/zero/etc/passwd".into())
+        );
+        assert_eq!(
+            p.forbidden_path_argument("echo hi >/dev/null/../../etc/passwd"),
+            Some("/dev/null/../../etc/passwd".into())
+        );
+        assert_eq!(
+            p.forbidden_path_argument("cat</dev/null /etc/passwd"),
+            Some("/etc/passwd".into())
+        );
+        assert_eq!(
+            p.forbidden_path_argument("cat /etc/passwd>/dev/null"),
+            Some("/etc/passwd".into())
+        );
+        assert_eq!(
+            p.forbidden_path_argument("cat /etc/passwd> /dev/null"),
+            Some("/etc/passwd".into())
+        );
+        assert_eq!(
+            p.forbidden_path_argument("cat /etc/passwd>&2"),
+            Some("/etc/passwd".into())
+        );
+        assert_eq!(
+            p.forbidden_path_argument("grep --file=/etc/passwd>/dev/null root"),
             Some("/etc/passwd".into())
         );
     }

--- a/crates/zeroclaw-config/src/policy.rs
+++ b/crates/zeroclaw-config/src/policy.rs
@@ -624,7 +624,11 @@ fn contains_unsafe_output_redirect(command: &str) -> bool {
         // non-operator character after the device name prevents the match —
         // blocking bypasses like `2>/dev/stderr.log` or `>/dev/zero/path`.
         // The terminator is captured and preserved in the replacement.
-        Regex::new(r"\d*>[ ]?/dev/(null|zero|stdout|stderr)(\s|[;&|)]|$)").unwrap()
+        Regex::new(&format!(
+            r"\d*>[ ]?/dev/({})(\s|[;&|)]|$)",
+            safe_device_redirect_names_pattern()
+        ))
+        .unwrap()
     });
 
     let safe = re.replace_all(command, "$2").to_string();
@@ -758,18 +762,52 @@ fn attached_short_option_value(token: &str) -> Option<&str> {
     if value.is_empty() { None } else { Some(value) }
 }
 
-fn redirection_target(token: &str) -> Option<&str> {
-    let marker_idx = token.find(['<', '>'])?;
+enum RedirectionArgument<'a> {
+    Target { prefix: &'a str, target: &'a str },
+    NeedsNextToken { prefix: &'a str },
+    FdOnly { prefix: &'a str },
+    None,
+}
+
+fn parse_redirection_argument(token: &str) -> RedirectionArgument<'_> {
+    let Some(marker_idx) = token.find(['<', '>']) else {
+        return RedirectionArgument::None;
+    };
+    let prefix = token[..marker_idx].trim();
     let mut rest = &token[marker_idx + 1..];
     rest = rest.trim_start_matches(['<', '>']);
+    if let Some(after_amp) = rest.strip_prefix('&') {
+        let remaining = after_amp.trim_start_matches(|c: char| c.is_ascii_digit() || c == '-');
+        if remaining.is_empty() {
+            return RedirectionArgument::FdOnly { prefix };
+        }
+    }
     rest = rest.trim_start_matches('&');
     rest = rest.trim_start_matches(|c: char| c.is_ascii_digit());
     let trimmed = rest.trim();
     if trimmed.is_empty() {
-        None
+        RedirectionArgument::NeedsNextToken { prefix }
     } else {
-        Some(trimmed)
+        RedirectionArgument::Target {
+            prefix,
+            target: trimmed,
+        }
     }
+}
+
+const SAFE_DEVICE_REDIRECT_TARGETS: [&str; 4] =
+    ["/dev/null", "/dev/stdout", "/dev/stderr", "/dev/zero"];
+
+fn safe_device_redirect_names_pattern() -> String {
+    SAFE_DEVICE_REDIRECT_TARGETS
+        .iter()
+        .map(|target| target.trim_start_matches("/dev/"))
+        .collect::<Vec<_>>()
+        .join("|")
+}
+
+fn is_safe_device_redirect_target(target: &str) -> bool {
+    SAFE_DEVICE_REDIRECT_TARGETS.contains(&strip_wrapping_quotes(target).trim())
 }
 
 /// Extract the basename from a command path, handling both Unix (`/`) and
@@ -1267,6 +1305,26 @@ impl SecurityPolicy {
                 None
             }
         };
+        let forbidden_non_redirect_candidate = |raw: &str| {
+            let candidate = strip_wrapping_quotes(raw).trim();
+            if candidate.is_empty() || candidate.contains("://") {
+                return None;
+            }
+            if candidate.starts_with('-') {
+                if let Some((_, value)) = candidate.split_once('=')
+                    && let Some(blocked) = forbidden_candidate(value)
+                {
+                    return Some(blocked);
+                }
+                if let Some(value) = attached_short_option_value(candidate)
+                    && let Some(blocked) = forbidden_candidate(value)
+                {
+                    return Some(blocked);
+                }
+                return None;
+            }
+            forbidden_candidate(candidate)
+        };
 
         for segment in split_unquoted_segments(command) {
             let cmd_part = skip_env_assignments(&segment);
@@ -1275,42 +1333,78 @@ impl SecurityPolicy {
                 continue;
             };
 
+            let executable_redirect = parse_redirection_argument(strip_wrapping_quotes(executable));
+            let mut next_is_redirect_target = false;
             // Cover inline forms like `cat</etc/passwd`.
-            if let Some(target) = redirection_target(strip_wrapping_quotes(executable))
-                && let Some(blocked) = forbidden_candidate(target)
-            {
-                return Some(blocked);
+            match executable_redirect {
+                RedirectionArgument::Target { target, .. } => {
+                    if !is_safe_device_redirect_target(target)
+                        && let Some(blocked) = forbidden_candidate(target)
+                    {
+                        return Some(blocked);
+                    }
+                }
+                RedirectionArgument::NeedsNextToken { .. } => {
+                    next_is_redirect_target = true;
+                }
+                RedirectionArgument::FdOnly { .. } | RedirectionArgument::None => {}
             }
 
             for token in words {
                 let candidate = strip_wrapping_quotes(token).trim();
-                if candidate.is_empty() || candidate.contains("://") {
+                if candidate.is_empty() {
                     continue;
                 }
 
-                if let Some(target) = redirection_target(candidate)
-                    && let Some(blocked) = forbidden_candidate(target)
-                {
-                    return Some(blocked);
+                if next_is_redirect_target {
+                    next_is_redirect_target = false;
+                    if is_safe_device_redirect_target(candidate) {
+                        continue;
+                    }
+                    if let Some(blocked) = forbidden_candidate(candidate) {
+                        return Some(blocked);
+                    }
+                    continue;
+                }
+
+                if candidate.contains("://") {
+                    continue;
+                }
+
+                match parse_redirection_argument(candidate) {
+                    RedirectionArgument::Target { prefix, target } => {
+                        if let Some(blocked) = forbidden_non_redirect_candidate(prefix) {
+                            return Some(blocked);
+                        }
+                        if is_safe_device_redirect_target(target) {
+                            continue;
+                        }
+                        if let Some(blocked) = forbidden_candidate(target) {
+                            return Some(blocked);
+                        }
+                    }
+                    RedirectionArgument::NeedsNextToken { prefix } => {
+                        if let Some(blocked) = forbidden_non_redirect_candidate(prefix) {
+                            return Some(blocked);
+                        }
+                        next_is_redirect_target = true;
+                        continue;
+                    }
+                    RedirectionArgument::FdOnly { prefix } => {
+                        if let Some(blocked) = forbidden_non_redirect_candidate(prefix) {
+                            return Some(blocked);
+                        }
+                        continue;
+                    }
+                    RedirectionArgument::None => {}
                 }
 
                 // Handle option assignment forms like `--file=/etc/passwd`.
-                if candidate.starts_with('-') {
-                    if let Some((_, value)) = candidate.split_once('=')
-                        && let Some(blocked) = forbidden_candidate(value)
-                    {
-                        return Some(blocked);
-                    }
-                    if let Some(value) = attached_short_option_value(candidate)
-                        && let Some(blocked) = forbidden_candidate(value)
-                    {
-                        return Some(blocked);
-                    }
-                    continue;
-                }
-
-                if let Some(blocked) = forbidden_candidate(candidate) {
+                if let Some(blocked) = forbidden_non_redirect_candidate(candidate) {
                     return Some(blocked);
+                }
+                if candidate.starts_with('-') {
+                    continue;
                 }
             }
         }
@@ -1707,6 +1801,14 @@ mod tests {
 
     fn default_policy() -> SecurityPolicy {
         SecurityPolicy::default()
+    }
+
+    fn unix_forbidden_path_policy() -> SecurityPolicy {
+        SecurityPolicy {
+            workspace_dir: PathBuf::from("/workspace"),
+            forbidden_paths: vec!["/dev".into(), "/etc".into()],
+            ..SecurityPolicy::default()
+        }
     }
 
     fn readonly_policy() -> SecurityPolicy {
@@ -2689,7 +2791,7 @@ mod tests {
 
     #[test]
     fn forbidden_path_argument_detects_absolute_path() {
-        let p = default_policy();
+        let p = unix_forbidden_path_policy();
         assert_eq!(
             p.forbidden_path_argument("cat /etc/passwd"),
             Some("/etc/passwd".into())
@@ -2718,7 +2820,7 @@ mod tests {
 
     #[test]
     fn forbidden_path_argument_detects_option_assignment_paths() {
-        let p = default_policy();
+        let p = unix_forbidden_path_policy();
         assert_eq!(
             p.forbidden_path_argument("grep --file=/etc/passwd root ./src"),
             Some("/etc/passwd".into())
@@ -2740,7 +2842,7 @@ mod tests {
 
     #[test]
     fn forbidden_path_argument_detects_short_option_attached_paths() {
-        let p = default_policy();
+        let p = unix_forbidden_path_policy();
         assert_eq!(
             p.forbidden_path_argument("grep -f/etc/passwd root ./src"),
             Some("/etc/passwd".into())
@@ -2776,13 +2878,82 @@ mod tests {
 
     #[test]
     fn forbidden_path_argument_detects_input_redirection_paths() {
-        let p = default_policy();
+        let p = unix_forbidden_path_policy();
         assert_eq!(
             p.forbidden_path_argument("cat </etc/passwd"),
             Some("/etc/passwd".into())
         );
         assert_eq!(
             p.forbidden_path_argument("cat</etc/passwd"),
+            Some("/etc/passwd".into())
+        );
+    }
+
+    #[test]
+    fn forbidden_path_argument_allows_safe_device_redirect_targets() {
+        let p = unix_forbidden_path_policy();
+        assert_eq!(p.forbidden_path_argument("ls missing 2>/dev/null"), None);
+        assert_eq!(p.forbidden_path_argument("ls missing 2> /dev/null"), None);
+        assert_eq!(p.forbidden_path_argument("echo hi >/dev/stdout"), None);
+        assert_eq!(p.forbidden_path_argument("echo hi > /dev/stdout"), None);
+        assert_eq!(p.forbidden_path_argument("echo err 1>/dev/stderr"), None);
+        assert_eq!(p.forbidden_path_argument("echo err 1> /dev/stderr"), None);
+        assert_eq!(p.forbidden_path_argument("cat </dev/zero"), None);
+        assert_eq!(p.forbidden_path_argument("cat < /dev/zero"), None);
+        assert_eq!(p.forbidden_path_argument("cat ./safe.txt>/dev/null"), None);
+        assert_eq!(p.forbidden_path_argument("cat> /dev/null"), None);
+        assert_eq!(p.forbidden_path_argument("cat ./safe.txt>&2"), None);
+    }
+
+    #[test]
+    fn forbidden_path_argument_blocks_unsafe_redirect_targets() {
+        let p = unix_forbidden_path_policy();
+        assert_eq!(
+            p.forbidden_path_argument("echo hi >/etc/passwd"),
+            Some("/etc/passwd".into())
+        );
+        assert_eq!(
+            p.forbidden_path_argument("echo hi > /etc/passwd"),
+            Some("/etc/passwd".into())
+        );
+        assert_eq!(
+            p.forbidden_path_argument("echo hi >/dev/stderr.log"),
+            Some("/dev/stderr.log".into())
+        );
+        assert_eq!(
+            p.forbidden_path_argument("echo hi > /dev/stderr.log"),
+            Some("/dev/stderr.log".into())
+        );
+        assert_eq!(
+            p.forbidden_path_argument("cat </dev/zero/etc/passwd"),
+            Some("/dev/zero/etc/passwd".into())
+        );
+        assert_eq!(
+            p.forbidden_path_argument("echo hi >/dev/null/../../etc/passwd"),
+            Some("/dev/null/../../etc/passwd".into())
+        );
+        assert_eq!(
+            p.forbidden_path_argument("cat /dev/null"),
+            Some("/dev/null".into())
+        );
+        assert_eq!(
+            p.forbidden_path_argument("cat</dev/null /etc/passwd"),
+            Some("/etc/passwd".into())
+        );
+        assert_eq!(
+            p.forbidden_path_argument("cat /etc/passwd>/dev/null"),
+            Some("/etc/passwd".into())
+        );
+        assert_eq!(
+            p.forbidden_path_argument("cat /etc/passwd> /dev/null"),
+            Some("/etc/passwd".into())
+        );
+        assert_eq!(
+            p.forbidden_path_argument("cat /etc/passwd>&2"),
+            Some("/etc/passwd".into())
+        );
+        assert_eq!(
+            p.forbidden_path_argument("grep --file=/etc/passwd>/dev/null root"),
             Some("/etc/passwd".into())
         );
     }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Rebased this PR onto current `master` after #6532 changed the exact null-device path policy.
  - Fixed `forbidden_path_argument` so exact safe device redirect targets are not treated as regular forbidden path arguments.
  - Extracted the safe device redirect target list into `SAFE_DEVICE_REDIRECT_TARGETS` so the redirect allowlist has one source of truth.
  - Reworked redirect argument parsing into explicit `Target`, `NeedsNextToken`, and `FdOnly` states to cover both attached and spaced redirect forms.
  - Added regression coverage for safe redirect targets and unsafe redirect/path combinations such as `cat /etc/passwd>/dev/null`.
- **Scope boundary:** This PR does not change the command allowlist, shell execution behavior, config/env/CLI surface, or the broader path policy outside redirect target parsing. It preserves #6532's exact null-device allowance instead of narrowing `/dev/null` to redirect-only usage.
- **Blast radius:** `crates/zeroclaw-config` path policy checks and any shell/tool execution path that calls `SecurityPolicy::forbidden_path_argument`.
- **Linked issue(s):** Closes #5518. Related #5524. Related #5160. Related #6532.
- **Labels:** bug, risk: high, size: S, config, security.

## Validation Evidence (required)

Local validation is the signal CI cannot replace. Run the full battery and paste literal output (tails, failures, warnings — not "all passed").

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

Docs-only changes: replace with markdown lint + link-integrity (`scripts/ci/docs_quality_gate.sh`). Bootstrap scripts: add `bash -n install.sh`.

- **Commands run and tail output:**

```text
$ cargo fmt --all -- --check
<no output; exit 0>
```

```text
$ cargo clippy --all-targets -- -D warnings
    Checking zeroclaw-config v0.7.5 (...\crates\zeroclaw-config)
    Checking zeroclaw-memory v0.7.5 (...\crates\zeroclaw-memory)
    Checking zeroclaw-providers v0.7.5 (...\crates\zeroclaw-providers)
    Checking zeroclaw-tui v0.7.5 (...\crates\zeroclaw-tui)
    Checking zeroclaw-tools v0.7.5 (...\crates\zeroclaw-tools)
    Checking zeroclaw-runtime v0.7.5 (...\crates\zeroclaw-runtime)
    Checking zeroclaw-hardware v0.7.5 (...\crates\zeroclaw-hardware)
    Checking zeroclaw-channels v0.7.5 (...\crates\zeroclaw-channels)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 11m 16s
```

```text
$ cargo test
running 243 tests
...
test commands::update::tests::find_asset_url_picks_correct_gnu_over_android ... FAILED
...
failures:

---- commands::update::tests::find_asset_url_picks_correct_gnu_over_android stdout ----

thread 'commands::update::tests::find_asset_url_picks_correct_gnu_over_android' (7996) panicked at src\commands\update.rs:475:9:
should find an asset

failures:
    commands::update::tests::find_asset_url_picks_correct_gnu_over_android

test result: FAILED. 242 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.49s

Finished `test` profile [unoptimized + debuginfo] target(s) in 9m 29s
error: test failed, to rerun pass `--lib`
```

```text
$ git diff --check
<no output; exit 0>
```

- **Beyond CI — what did you manually verify?**
  - Ran focused regression tests for the changed policy surface on the rebased head:

```text
$ cargo test -p zeroclaw-config forbidden_path_argument -- --nocapture
running 11 tests
...
test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 612 filtered out; finished in 0.01s
```

```text
$ cargo test -p zeroclaw-config safe_redirect -- --nocapture
running 5 tests
...
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 618 filtered out; finished in 0.03s
```

  - Verified the full-suite `cargo test` failure is not introduced by this PR by reproducing the same focused failure on `origin/master` at `c1ec59de` in a detached worktree:

```text
$ cargo test commands::update::tests::find_asset_url_picks_correct_gnu_over_android -- --nocapture
running 1 test
test commands::update::tests::find_asset_url_picks_correct_gnu_over_android ... FAILED

thread 'commands::update::tests::find_asset_url_picks_correct_gnu_over_android' (20784) panicked at src\commands\update.rs:475:9:
should find an asset

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 242 filtered out; finished in 0.00s
```

  - Verified safe redirect forms such as `2>/dev/null`, `2> /dev/null`, `>/dev/stdout`, `< /dev/zero`, and `>&2`.
  - Verified unsafe targets such as `/dev/stderr.log`, `/dev/null/../../etc/passwd`, and `>/etc/passwd` remain blocked.
  - Verified forbidden path prefixes before a redirect, such as `cat /etc/passwd>/dev/null`, remain blocked.
  - Verified that Unix `/dev/null` as a normal path argument remains aligned with #6532's exact null-device allowance instead of being re-blocked by this PR.
- **If any command was intentionally skipped, why:** None. Full `cargo test` was run; it failed on a Windows-local test that also fails on current `origin/master` and is outside this PR's changed policy surface.

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? (`Yes`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation:
  - This intentionally allows only exact safe device redirect targets (`/dev/null`, `/dev/stdout`, `/dev/stderr`, `/dev/zero`) when they are used as shell redirect targets, and preserves #6532's exact null-device path allowance. Derived paths such as `/dev/stderr.log`, traversal-like paths such as `/dev/null/../../etc/passwd`, and dangerous non-redirect inputs such as `/etc/passwd` remain blocked by regression tests.

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: exact upgrade steps for existing users: No user action required.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PRs: `git revert <sha>` is the plan unless otherwise noted.

Medium/high-risk PRs must fill:

- **Fast rollback command/path:** `git revert <merge-commit-or-squash-sha>`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:**
  - Safe redirect commands such as `ls missing 2>/dev/null` fail with `Path blocked by security policy: /dev/null`.
  - Or, conversely, an unsafe redirect target under `/dev` or `/etc` is unexpectedly accepted by `forbidden_path_argument`.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): Not applicable.
- Scope materially carried forward: Not applicable.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`Yes/No`): Not applicable.
- If `No`, why (inspiration-only, no direct code/design carry-over): Not applicable.

---

**Labels** live in the GitHub label UI, not in the body. Set `risk:*`, `size:*`, and scope labels via the sidebar. Auto-label corrections: add `risk: manual` and the intended label.

**Privacy contract** (`docs/book/src/contributing/privacy.md`) is a merge gate. Never commit real identities, secrets, personal emails, or PII in diff, tests, fixtures, or docs.
