### PR TITLE
fix(channel): persist WeChat context_tokens and expand tilde in config paths

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -220,6 +220,16 @@ const CHANNEL_HOOK_MAX_OUTBOUND_CHARS: usize = 20_000;
 type ProviderCacheMap = Arc<Mutex<HashMap<String, Arc<dyn Provider>>>>;
 type RouteSelectionMap = Arc<Mutex<HashMap<String, ChannelRouteSelection>>>;
 
+#[cfg(feature = "channel-wechat")]
+fn expand_tilde_in_path(path: &str) -> PathBuf {
+    if let Some(stripped) = path.strip_prefix("~/")
+        && let Some(home) = directories::UserDirs::new().map(|u| u.home_dir().to_path_buf())
+    {
+        return home.join(stripped);
+    }
+    PathBuf::from(path)
+}
+
 fn effective_channel_message_timeout_secs(configured: u64) -> u64 {
     configured.max(MIN_CHANNEL_MESSAGE_TIMEOUT_SECS)
 }
@@ -4260,7 +4270,7 @@ fn build_channel_by_id(config: &Config, channel_id: &str) -> Result<Arc<dyn Chan
                     wc.allowed_users.clone(),
                     wc.api_base_url.clone(),
                     wc.cdn_base_url.clone(),
-                    wc.state_dir.as_ref().map(std::path::PathBuf::from),
+                    wc.state_dir.as_ref().map(|s| expand_tilde_in_path(s)),
                 )?
                 .with_workspace_dir(config.workspace_dir.clone()),
             ))
@@ -5025,7 +5035,7 @@ fn collect_configured_channels(
                 wechat.allowed_users.clone(),
                 wechat.api_base_url.clone(),
                 wechat.cdn_base_url.clone(),
-                wechat.state_dir.as_ref().map(std::path::PathBuf::from),
+                wechat.state_dir.as_ref().map(|s| expand_tilde_in_path(s)),
             ) {
                 Ok(channel) => {
                     channels.push(ConfiguredChannel {
@@ -5943,7 +5953,7 @@ pub async fn deliver_announcement(
                 wc.allowed_users.clone(),
                 wc.api_base_url.clone(),
                 wc.cdn_base_url.clone(),
-                wc.state_dir.as_ref().map(std::path::PathBuf::from),
+                wc.state_dir.as_ref().map(|s| expand_tilde_in_path(s)),
             )?
             .with_workspace_dir(config.workspace_dir.clone());
             zeroclaw_api::channel::Channel::send(&ch, &SendMessage::new(&safe_output, target))

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -5181,7 +5181,7 @@ fn build_channel_by_id(
                     peer_resolver,
                     wc.api_base_url.clone(),
                     wc.cdn_base_url.clone(),
-                    wc.state_dir.as_ref().map(std::path::PathBuf::from),
+                    wc.state_dir.as_ref().map(|s| expand_tilde_in_path(s)),
                 )?
                 .with_persistence(config_arc.clone())
                 .with_workspace_dir(config.data_dir.clone()),
@@ -6278,7 +6278,7 @@ fn collect_configured_channels(
             peer_resolver,
             wechat.api_base_url.clone(),
             wechat.cdn_base_url.clone(),
-            wechat.state_dir.as_ref().map(std::path::PathBuf::from),
+            wechat.state_dir.as_ref().map(|s| expand_tilde_in_path(s)),
         ) {
             Ok(channel) => {
                 channels.push(ConfiguredChannel {
@@ -7622,6 +7622,11 @@ pub async fn deliver_announcement(
     Ok(())
 }
 
+#[cfg(feature = "channel-wechat")]
+fn expand_tilde_in_path(path: &str) -> PathBuf {
+    PathBuf::from(shellexpand::tilde(path).as_ref())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -8051,6 +8056,20 @@ mod tests {
         assert_eq!(channel_message_timeout_budget_secs(300, 1), 300);
         assert_eq!(channel_message_timeout_budget_secs(300, 2), 600);
         assert_eq!(channel_message_timeout_budget_secs(300, 3), 900);
+    }
+
+    #[cfg(feature = "channel-wechat")]
+    #[test]
+    fn expand_tilde_in_path_expands_home_prefix() {
+        let expanded = expand_tilde_in_path("~/wechat-state");
+        assert!(!expanded.starts_with("~"));
+        assert!(expanded.ends_with("wechat-state"));
+
+        let absolute = expand_tilde_in_path("/absolute/path");
+        assert_eq!(absolute, PathBuf::from("/absolute/path"));
+
+        let relative = expand_tilde_in_path("relative/path");
+        assert_eq!(relative, PathBuf::from("relative/path"));
     }
 
     #[test]

--- a/crates/zeroclaw-channels/src/wechat.rs
+++ b/crates/zeroclaw-channels/src/wechat.rs
@@ -396,11 +396,13 @@ struct AccountData {
     saved_at: Option<String>,
 }
 
-/// Persistent sync cursor.
+/// Persistent sync cursor and context tokens.
 #[derive(serde::Serialize, serde::Deserialize, Default)]
 struct SyncData {
     #[serde(default)]
     get_updates_buf: String,
+    #[serde(default)]
+    context_tokens: HashMap<String, String>,
 }
 
 /// Write bytes to a file with owner-only permissions (0o600) on Unix.
@@ -626,10 +628,18 @@ impl WeChatChannel {
         let sync_path = self.state_dir.join("sync.json");
         if let Ok(data) = std::fs::read_to_string(&sync_path)
             && let Ok(sync) = serde_json::from_str::<SyncData>(&data)
-            && !sync.get_updates_buf.is_empty()
         {
-            *self.cursor.lock() = sync.get_updates_buf;
-            tracing::info!("WeChat: loaded persisted sync cursor");
+            if !sync.get_updates_buf.is_empty() {
+                *self.cursor.lock() = sync.get_updates_buf;
+                tracing::info!("WeChat: loaded persisted sync cursor");
+            }
+            if !sync.context_tokens.is_empty() {
+                *self.context_tokens.lock() = sync.context_tokens;
+                tracing::info!(
+                    "WeChat: loaded {} persisted context tokens",
+                    self.context_tokens.lock().len()
+                );
+            }
         }
     }
 
@@ -663,8 +673,32 @@ impl WeChatChannel {
             tracing::warn!("WeChat: failed to create state dir: {e}");
             return;
         }
+        let context_tokens = self.context_tokens.lock().clone();
         let data = SyncData {
             get_updates_buf: cursor.to_string(),
+            context_tokens,
+        };
+        let path = self.state_dir.join("sync.json");
+        match serde_json::to_string(&data) {
+            Ok(json) => {
+                if let Err(e) = write_private(&path, json.as_bytes()) {
+                    tracing::warn!("WeChat: failed to write sync data: {e}");
+                }
+            }
+            Err(e) => tracing::warn!("WeChat: failed to serialize sync data: {e}"),
+        }
+    }
+
+    fn save_sync_data(&self) {
+        if let Err(e) = std::fs::create_dir_all(&self.state_dir) {
+            tracing::warn!("WeChat: failed to create state dir: {e}");
+            return;
+        }
+        let cursor = self.cursor.lock().clone();
+        let context_tokens = self.context_tokens.lock().clone();
+        let data = SyncData {
+            get_updates_buf: cursor,
+            context_tokens,
         };
         let path = self.state_dir.join("sync.json");
         match serde_json::to_string(&data) {
@@ -689,6 +723,7 @@ impl WeChatChannel {
         self.context_tokens
             .lock()
             .insert(user_id.to_string(), token.to_string());
+        self.save_sync_data();
     }
 
     fn get_context_token(&self, user_id: &str) -> Option<String> {
@@ -1729,10 +1764,12 @@ impl Channel for WeChatChannel {
                         "WeChat: session expired (errcode {SESSION_EXPIRED_ERRCODE}), pausing for {} min",
                         SESSION_PAUSE_DURATION.as_secs() / 60
                     );
-                    // Clear token so we re-login after pause
+                    // Clear token and context_tokens so we re-login after pause
                     if let Ok(mut t) = self.bot_token.write() {
                         *t = None;
                     }
+                    self.context_tokens.lock().clear();
+                    self.save_sync_data();
                     tokio::time::sleep(SESSION_PAUSE_DURATION).await;
                     // Try to re-login
                     if let Err(e) = self.ensure_logged_in().await {

--- a/crates/zeroclaw-channels/src/wechat.rs
+++ b/crates/zeroclaw-channels/src/wechat.rs
@@ -491,11 +491,13 @@ struct AccountData {
     saved_at: Option<String>,
 }
 
-/// Persistent sync cursor.
+/// Persistent sync cursor and context tokens.
 #[derive(serde::Serialize, serde::Deserialize, Default)]
 struct SyncData {
     #[serde(default)]
     get_updates_buf: String,
+    #[serde(default)]
+    context_tokens: HashMap<String, String>,
 }
 
 /// Write bytes to a file with owner-only permissions (0o600) on Unix.
@@ -755,14 +757,23 @@ impl WeChatChannel {
         let sync_path = self.state_dir.join("sync.json");
         if let Ok(data) = std::fs::read_to_string(&sync_path)
             && let Ok(sync) = serde_json::from_str::<SyncData>(&data)
-            && !sync.get_updates_buf.is_empty()
         {
-            *self.cursor.lock() = sync.get_updates_buf;
-            ::zeroclaw_log::record!(
-                INFO,
-                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note),
-                "loaded persisted sync cursor"
-            );
+            if !sync.get_updates_buf.is_empty() {
+                *self.cursor.lock() = sync.get_updates_buf;
+                ::zeroclaw_log::record!(
+                    INFO,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note),
+                    "loaded persisted sync cursor"
+                );
+            }
+            if !sync.context_tokens.is_empty() {
+                *self.context_tokens.lock() = sync.context_tokens;
+                ::zeroclaw_log::record!(
+                    INFO,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note),
+                    "loaded persisted context tokens"
+                );
+            }
         }
     }
 
@@ -809,7 +820,7 @@ impl WeChatChannel {
     }
 
     /// Save sync cursor to disk.
-    fn save_cursor(&self, cursor: &str) {
+    fn save_sync_data(&self) {
         if let Err(e) = std::fs::create_dir_all(&self.state_dir) {
             ::zeroclaw_log::record!(
                 WARN,
@@ -821,7 +832,8 @@ impl WeChatChannel {
             return;
         }
         let data = SyncData {
-            get_updates_buf: cursor.to_string(),
+            get_updates_buf: self.cursor.lock().clone(),
+            context_tokens: self.context_tokens.lock().clone(),
         };
         let path = self.state_dir.join("sync.json");
         match serde_json::to_string(&data) {
@@ -858,6 +870,7 @@ impl WeChatChannel {
         self.context_tokens
             .lock()
             .insert(user_id.to_string(), token.to_string());
+        self.save_sync_data();
     }
 
     fn get_context_token(&self, user_id: &str) -> Option<String> {
@@ -2137,6 +2150,8 @@ impl Channel for WeChatChannel {
                     if let Ok(mut t) = self.bot_token.write() {
                         *t = None;
                     }
+                    self.context_tokens.lock().clear();
+                    self.save_sync_data();
                     tokio::time::sleep(SESSION_PAUSE_DURATION).await;
                     // Try to re-login
                     if let Err(e) = self.ensure_logged_in().await {
@@ -2177,7 +2192,7 @@ impl Channel for WeChatChannel {
             {
                 cursor = new_cursor.to_string();
                 *self.cursor.lock() = cursor.clone();
-                self.save_cursor(&cursor);
+                self.save_sync_data();
             }
 
             if let Some(next_timeout) = data
@@ -2621,5 +2636,197 @@ mod tests {
             .and_then(|value| value.as_str())
             .unwrap_or("");
         assert!(!version.is_empty());
+    }
+
+    #[test]
+    fn sync_data_round_trip_preserves_context_tokens() {
+        let temp = tempdir().unwrap();
+        let state_dir = temp.path().to_path_buf();
+
+        let mut context_tokens = HashMap::new();
+        context_tokens.insert("user123".to_string(), "token_abc".to_string());
+        context_tokens.insert("user456".to_string(), "token_xyz".to_string());
+
+        let original_data = SyncData {
+            get_updates_buf: "cursor_value".to_string(),
+            context_tokens: context_tokens.clone(),
+        };
+
+        let sync_path = state_dir.join("sync.json");
+        let json = serde_json::to_string(&original_data).unwrap();
+        write_private(&sync_path, json.as_bytes()).unwrap();
+
+        let loaded_json = std::fs::read_to_string(&sync_path).unwrap();
+        let loaded_data: SyncData = serde_json::from_str(&loaded_json).unwrap();
+
+        assert_eq!(loaded_data.get_updates_buf, "cursor_value");
+        assert_eq!(loaded_data.context_tokens.len(), 2);
+        assert_eq!(
+            loaded_data.context_tokens.get("user123"),
+            Some(&"token_abc".to_string())
+        );
+        assert_eq!(
+            loaded_data.context_tokens.get("user456"),
+            Some(&"token_xyz".to_string())
+        );
+    }
+
+    #[test]
+    fn sync_data_backward_compatible_with_missing_context_tokens() {
+        let old_json = r#"{"get_updates_buf":"old_cursor"}"#;
+        let data: SyncData = serde_json::from_str(old_json).unwrap();
+
+        assert_eq!(data.get_updates_buf, "old_cursor");
+        assert!(data.context_tokens.is_empty());
+    }
+
+    #[test]
+    fn context_tokens_survive_channel_restart() {
+        let temp = tempdir().unwrap();
+        let state_dir = temp.path().to_path_buf();
+
+        {
+            let ch = WeChatChannel::new(
+                "test",
+                Arc::new(|| vec!["*".to_string()]),
+                None,
+                None,
+                Some(state_dir.clone()),
+            )
+            .unwrap();
+            ch.set_context_token("acct1:userA", "tok_A");
+            ch.set_context_token("acct1:userB", "tok_B");
+            *ch.cursor.lock() = "cursor_123".to_string();
+            ch.save_sync_data();
+        }
+
+        let ch2 = WeChatChannel::new(
+            "test",
+            Arc::new(|| vec!["*".to_string()]),
+            None,
+            None,
+            Some(state_dir),
+        )
+        .unwrap();
+
+        assert_eq!(
+            ch2.get_context_token("acct1:userA"),
+            Some("tok_A".to_string())
+        );
+        assert_eq!(
+            ch2.get_context_token("acct1:userB"),
+            Some("tok_B".to_string())
+        );
+        assert_eq!(ch2.get_context_token("nonexistent"), None);
+        assert_eq!(*ch2.cursor.lock(), "cursor_123");
+    }
+
+    #[test]
+    fn set_context_token_persists_immediately() {
+        let temp = tempdir().unwrap();
+        let state_dir = temp.path().to_path_buf();
+
+        let ch = WeChatChannel::new(
+            "test",
+            Arc::new(|| vec!["*".to_string()]),
+            None,
+            None,
+            Some(state_dir.clone()),
+        )
+        .unwrap();
+        ch.set_context_token("acct:user1", "immediate_tok");
+
+        let ch2 = WeChatChannel::new(
+            "test",
+            Arc::new(|| vec!["*".to_string()]),
+            None,
+            None,
+            Some(state_dir),
+        )
+        .unwrap();
+        assert_eq!(
+            ch2.get_context_token("acct:user1"),
+            Some("immediate_tok".to_string())
+        );
+    }
+
+    #[test]
+    fn save_sync_data_preserves_context_tokens() {
+        let temp = tempdir().unwrap();
+        let state_dir = temp.path().to_path_buf();
+
+        let ch = WeChatChannel::new(
+            "test",
+            Arc::new(|| vec!["*".to_string()]),
+            None,
+            None,
+            Some(state_dir.clone()),
+        )
+        .unwrap();
+        ch.set_context_token("acct:user1", "my_token");
+        *ch.cursor.lock() = "new_cursor_value".to_string();
+        ch.save_sync_data();
+
+        let ch2 = WeChatChannel::new(
+            "test",
+            Arc::new(|| vec!["*".to_string()]),
+            None,
+            None,
+            Some(state_dir),
+        )
+        .unwrap();
+        assert_eq!(*ch2.cursor.lock(), "new_cursor_value");
+        assert_eq!(
+            ch2.get_context_token("acct:user1"),
+            Some("my_token".to_string())
+        );
+    }
+
+    #[test]
+    fn load_from_empty_state_dir_produces_defaults() {
+        let temp = tempdir().unwrap();
+        let state_dir = temp.path().to_path_buf();
+
+        let ch = WeChatChannel::new(
+            "test",
+            Arc::new(|| vec!["*".to_string()]),
+            None,
+            None,
+            Some(state_dir),
+        )
+        .unwrap();
+
+        assert_eq!(ch.get_context_token("anything"), None);
+        assert_eq!(*ch.cursor.lock(), "");
+    }
+
+    #[test]
+    fn context_token_overwrite_persists_latest() {
+        let temp = tempdir().unwrap();
+        let state_dir = temp.path().to_path_buf();
+
+        let ch = WeChatChannel::new(
+            "test",
+            Arc::new(|| vec!["*".to_string()]),
+            None,
+            None,
+            Some(state_dir.clone()),
+        )
+        .unwrap();
+        ch.set_context_token("acct:user1", "old_token");
+        ch.set_context_token("acct:user1", "new_token");
+
+        let ch2 = WeChatChannel::new(
+            "test",
+            Arc::new(|| vec!["*".to_string()]),
+            None,
+            None,
+            Some(state_dir),
+        )
+        .unwrap();
+        assert_eq!(
+            ch2.get_context_token("acct:user1"),
+            Some("new_token".to_string())
+        );
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Fixed WeChat channel losing `context_tokens` on restart, causing repeated QR code scans
  - Added `context_tokens` field to `SyncData` struct for persistence across restarts
  - Implemented `expand_tilde_in_path()` helper to properly expand `~` in config file paths
  - Fixed bug where `state_dir = "~/.zeroclaw/wechat"` was treated as literal directory name
  - Added regression tests for `SyncData` round-trip and backward compatibility
- **Scope boundary:** Only affects WeChat channel state persistence and config path resolution in orchestrator
- **Blast radius:** Medium — isolated to WeChat channel internal state management and path parsing logic, but touches runtime persistence behavior
- **Linked issue(s):** Fixes user-reported issue where WeChat requires QR re-scan after every ZeroClaw restart

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
# Output: (no output - all files formatted correctly)

cargo clippy --all-targets -- -D warnings
# Output: Finished `dev` profile [unoptimized + debuginfo] target(s) in 6.57s

cargo test -p zeroclaw-channels --features channel-wechat --lib wechat
# Output: test result: ok. 25 passed; 0 failed; 0 ignored; 0 measured; 950 filtered out
```

- **Commands run and tail output:** All validation commands passed successfully. The WeChat-specific tests now include 2 new regression tests for `SyncData` round-trip persistence and backward compatibility.
- **Beyond CI — what did you manually verify?**
  - Verified `expand_tilde_in_path()` correctly expands `~/` prefix to user home directory
  - Confirmed `SyncData` serialization includes `context_tokens` field with proper `#[serde(default)]`
  - Tested `save_sync_data()` is called whenever `set_context_token()` updates tokens
  - Verified session expiry (errcode -14) clears `context_tokens` and persists empty state
  - Manually tested config with `state_dir = "~/.zeroclaw/wechat"` now creates correct path
  - Added regression tests: `sync_data_round_trip_preserves_context_tokens` and `sync_data_backward_compatible_with_missing_context_tokens`
- **If any command was intentionally skipped, why:** None skipped

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (No)
- New external network calls? (No)
- Secrets / tokens / credentials handling changed? (Yes)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (No)
- If any Yes, describe the risk and mitigation: `context_tokens` are now persisted to `~/.zeroclaw/wechat/sync.json` with 0o600 permissions (owner-only read/write), matching the existing security level of `bot_token` in `account.json`. The `expand_tilde_in_path()` function ensures paths are resolved to actual home directory, preventing accidental creation of literal `~` directories. No new security risks introduced.

## Compatibility (required)

- Backward compatible? (Yes)
- Config / env / CLI surface changed? (No)
- If No or Yes to either: Fully backward compatible. Existing `sync.json` files without `context_tokens` field will load successfully (field defaults to empty HashMap via `#[serde(default)]`). Config files with `state_dir = "~/.zeroclaw/wechat"` will now work correctly (previously created wrong path like `/path/to/cwd/~/.zeroclaw/wechat`).

## Rollback (required for risk: medium and risk: high)

Medium-risk PR rollback plan:

- **Fast rollback command/path:** `git revert <sha>` is sufficient. If reverted, WeChat will revert to previous behavior: `context_tokens` lost on restart (requiring QR re-scan), and `~` in config paths treated as literal directory name.
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Users report repeated QR code scans after restart, or WeChat state directory created in unexpected location (literal `~` directory instead of home directory expansion).