### PR TITLE
fix(cli): make `zeroclaw models set` actually write config

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1996,15 +1996,37 @@ async fn main() -> Result<()> {
 
         Commands::Cron { cron_command } => cron::handle_command(cron_command, &config),
 
-        Commands::Models { model_command } => {
-            let provider = match &model_command {
-                ModelCommands::Refresh { provider, .. } | ModelCommands::List { provider } => {
-                    provider.as_deref()
+        Commands::Models { model_command } => match model_command {
+            ModelCommands::Set { model } => {
+                let (provider, bare_model) = match model.split_once('/') {
+                    Some((p, m)) if !p.is_empty() && !m.is_empty() => {
+                        (Some(p.to_string()), m.to_string())
+                    }
+                    _ => (None, model),
+                };
+                if let Some(p) = provider {
+                    config.providers.fallback = Some(p);
+                } else if config.providers.fallback.is_none() {
+                    anyhow::bail!(
+                        "No default provider set. Pass `provider/model` (e.g. ollama/glm-5.1:cloud) or set providers.fallback first."
+                    );
                 }
-                _ => None,
-            };
-            doctor::run_models(&config, provider, false).await
-        }
+                config.ensure_fallback_provider().model = Some(bare_model.clone());
+                config.save().await?;
+                let provider_name = config.providers.fallback.as_deref().unwrap_or("?");
+                println!("Default model set: {provider_name}/{bare_model}");
+                Ok(())
+            }
+            other => {
+                let provider = match &other {
+                    ModelCommands::Refresh { provider, .. } | ModelCommands::List { provider } => {
+                        provider.as_deref()
+                    }
+                    _ => None,
+                };
+                doctor::run_models(&config, provider, false).await
+            }
+        },
 
         Commands::Providers => {
             let providers = providers::list_providers();


### PR DESCRIPTION
## Summary

`zeroclaw models set <model>` is documented as "Set the default model in config" (`src/main.rs:1080`) but is currently a silent no-op — the model argument is discarded and the config is never written. This PR makes the subcommand actually save.

## Root cause

`Commands::Models` only handled `Refresh` and `List`; everything else (including `Set`) fell through to `_ => None` and called `doctor::run_models`:

```rust
Commands::Models { model_command } => {
    let provider = match &model_command {
        ModelCommands::Refresh { provider, .. } | ModelCommands::List { provider } => {
            provider.as_deref()
        }
        _ => None,                          // ← Set lands here
    };
    doctor::run_models(&config, provider, false).await
}
```

## Fix

`Set` is now its own arm:

- Accepts `provider/model` (e.g. `ollama/glm-5.1:cloud`) or bare `model` (uses existing `providers.fallback`).
- Writes `providers.fallback` and the fallback provider's `model`.
- Calls `config.save()`.
- Bails with a clear message if there's no existing fallback and the caller didn't supply `provider/`.

## Repro on master

```
$ zeroclaw models set ollama/glm-5.1:cloud
# Runs the doctor probe, no config write.
$ zeroclaw status
🤖 Provider:      openrouter
   Model:         (default)
```

## After this PR

```
$ zeroclaw models set ollama/glm-5.1:cloud
Default model set: ollama/glm-5.1:cloud
$ zeroclaw status
🤖 Provider:      ollama
   Model:         glm-5.1:cloud
```

## Test plan

- [x] Manual: `zeroclaw models set <provider>/<model>` writes both fields and `zeroclaw status` reflects them.
- [x] Manual: `zeroclaw models set <model>` (bare) updates only `model` on existing fallback.
- [x] Manual: `zeroclaw models set <model>` with no fallback configured errors with a clear message.
- [x] `cargo build --release` clean.
- [ ] Unit test for the dispatch arm — happy to add if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)