### PR TITLE
fix(providers/ollama): preserve `:cloud` suffix for non-ollama.com endpoints

### DIFF
--- a/crates/zeroclaw-providers/src/ollama.rs
+++ b/crates/zeroclaw-providers/src/ollama.rs
@@ -164,6 +164,13 @@ impl OllamaProvider {
             .is_some_and(|host| matches!(host.as_str(), "localhost" | "127.0.0.1" | "::1"))
     }
 
+    fn is_official_cloud_endpoint(&self) -> bool {
+        reqwest::Url::parse(&self.base_url)
+            .ok()
+            .and_then(|url| url.host_str().map(|h| h.to_ascii_lowercase()))
+            .is_some_and(|host| host == "ollama.com" || host == "api.ollama.com")
+    }
+
     fn http_client(&self) -> Client {
         zeroclaw_config::schema::build_runtime_proxy_client_with_timeouts(
             "provider.ollama",
@@ -174,7 +181,11 @@ impl OllamaProvider {
 
     fn resolve_request_details(&self, model: &str) -> anyhow::Result<(String, bool)> {
         let requests_cloud = model.ends_with(":cloud");
-        let normalized_model = model.strip_suffix(":cloud").unwrap_or(model).to_string();
+        let normalized_model = if requests_cloud && self.is_official_cloud_endpoint() {
+            model.strip_suffix(":cloud").unwrap_or(model).to_string()
+        } else {
+            model.to_string()
+        };
 
         if requests_cloud && self.is_local_endpoint() {
             anyhow::bail!(
@@ -183,7 +194,7 @@ impl OllamaProvider {
             );
         }
 
-        if requests_cloud && self.api_key.is_none() {
+        if requests_cloud && self.is_official_cloud_endpoint() && self.api_key.is_none() {
             anyhow::bail!(
                 "Model '{}' requested cloud routing, but no API key is configured. Set OLLAMA_API_KEY or config api_key.",
                 model

--- a/crates/zeroclaw-providers/src/ollama.rs
+++ b/crates/zeroclaw-providers/src/ollama.rs
@@ -1012,6 +1012,22 @@ mod tests {
     }
 
     #[test]
+    fn cloud_suffix_preserved_for_private_remote_without_api_key() {
+        let p = OllamaProvider::new(Some("http://100.126.1.2:11434"), None);
+        let (model, should_auth) = p.resolve_request_details("qwen3:cloud").unwrap();
+        assert_eq!(model, "qwen3:cloud");
+        assert!(!should_auth);
+    }
+
+    #[test]
+    fn cloud_suffix_preserved_for_private_remote_with_api_key() {
+        let p = OllamaProvider::new(Some("http://100.126.1.2:11434"), Some("ollama-key"));
+        let (model, should_auth) = p.resolve_request_details("qwen3:cloud").unwrap();
+        assert_eq!(model, "qwen3:cloud");
+        assert!(should_auth);
+    }
+
+    #[test]
     fn remote_endpoint_auth_enabled_when_key_present() {
         let p = OllamaProvider::new(Some("https://ollama.com"), Some("ollama-key"));
         let (_model, should_auth) = p.resolve_request_details("qwen3").unwrap();


### PR DESCRIPTION
## Summary

`OllamaProvider::resolve_request_details` unconditionally strips the `:cloud` suffix from the model name before sending the request. This breaks any self-hosted Ollama instance that proxies cloud models (Tailscale, LAN, on-prem) — the upstream `/api/tags` exposes them as literal `name: "<model>:cloud"` identifiers, and stripping the suffix produces a 404.

## Repro

Tailscale-hosted Ollama whose `/api/tags` includes `glm-5.1:cloud`:

```
$ curl -s http://100.x.x.x:11434/api/tags | jq -r '.models[].name'
glm-5.1:cloud
kimi-k2.6:cloud
qwen3.6:latest
…

$ zeroclaw agent -p ollama --model glm-5.1:cloud -m "hi"
ERROR Ollama error response: status=404 Not Found body_excerpt={"error":"model 'glm-5.1' not found"}
```

The bare `glm-5.1` doesn't exist on the server — only `glm-5.1:cloud` does.

## Fix

The `:cloud` shorthand is correct for `ollama.com` / `api.ollama.com` (their `/api/chat` accepts the bare name and routes to cloud) but incorrect for self-hosted Ollama instances that proxy cloud models with literal `:cloud` names.

- Add `is_official_cloud_endpoint()` matching host `ollama.com` or `api.ollama.com`.
- Strip `:cloud` only when the endpoint is official cloud; otherwise pass through verbatim.
- Skip the "no API key" guard when not official — self-hosted operators authenticate however they want (or not at all on a private network).
- Local-endpoint validation unchanged (`:cloud` against `localhost` still rejected with the same message).

## Test plan

- [x] Manual: `zeroclaw agent -p ollama --model glm-5.1:cloud` against `https://ollama.com` → succeeds (bare name sent).
- [x] Manual: same model against `http://100.126.x.x:11434` → succeeds (literal `:cloud` sent).
- [x] Manual: same model against `http://localhost:11434` → still fails with the existing local-endpoint error message.
- [x] `cargo build --release` clean.
- [ ] Worth adding a unit test asserting `resolve_request_details` preserves `:cloud` for non-official URLs — happy to add.

🤖 Generated with [Claude Code](https://claude.com/claude-code)