### PR TITLE
feat(channels/discord): treat reply-to-bot as implicit mention

### DIFF
--- a/crates/zeroclaw-channels/src/discord.rs
+++ b/crates/zeroclaw-channels/src/discord.rs
@@ -1140,7 +1140,15 @@ impl Channel for DiscordChannel {
                     // inherently private and implicitly addressed to the bot, so bypass
                     // the mention gate — requiring a @mention in a DM is never correct.
                     let is_dm = d.get("guild_id").is_none();
-                    let effective_mention_only = self.mention_only && !is_dm;
+                    // Treat a reply to one of the bot's own messages as an implicit mention.
+                    let is_reply_to_bot = d
+                        .get("referenced_message")
+                        .and_then(|r| r.get("author"))
+                        .and_then(|a| a.get("id"))
+                        .and_then(|i| i.as_str())
+                        == Some(bot_user_id.as_str());
+                    let effective_mention_only =
+                        self.mention_only && !is_dm && !is_reply_to_bot;
                     let Some(clean_content) =
                         normalize_incoming_content(content, effective_mention_only, &bot_user_id)
                     else {


### PR DESCRIPTION
## Summary

When `mention_only = true`, the Discord channel only triggers on messages whose `content` contains a literal `<@bot_id>` tag. Discord's **reply** feature attaches the original message via `referenced_message` in the gateway payload but does **not** inject the mention tag into `content` unless the user explicitly toggles "mention this user" on the reply (off by default in most clients).

Result: clicking *Reply* on the bot's own messages does nothing, which is surprising for users — the natural conversational pattern.

## Behavior change

A message whose `referenced_message.author.id == bot_user_id` is now treated as an implicit mention — the `mention_only` gate is bypassed for replies-to-bot, identical to how DMs already bypass it (`is_dm` check on the same line).

## Preserved

- Plain `<@bot>` mentions still gate the same way.
- `mention_only = false` still accepts everything.
- DM bypass still works.
- Allow-list, guild filter, bot self-skip all unchanged.
- Replies to *other users* in `mention_only` channels are still ignored.

## Test plan

- [x] Manual: `mention_only = true`. Click Reply on bot's message in a guild channel → bot responds.
- [x] Manual: same setting. Reply to another user's message → no response (correct).
- [x] Manual: same setting. Plain @mention of bot → still works.
- [x] Manual: same setting. Random channel chatter → still ignored.
- [x] `cargo build --release` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)