### PR TITLE
docs(email): document InboxAPI skill integration

### DIFF
--- a/docs/book/src/channels/email.md
+++ b/docs/book/src/channels/email.md
@@ -74,6 +74,66 @@ Outbound sends still go via SMTP — configure an `smtp` block in this channel t
 
 ---
 
+## InboxAPI skill
+
+Use the InboxAPI skill when you already have an InboxAPI mailbox and want ZeroClaw to operate on it without configuring IMAP and SMTP directly inside ZeroClaw.
+
+This is the recommended Phase 1 InboxAPI integration path:
+
+```bash
+zeroclaw skills install inboxapi
+```
+
+### Operator setup
+
+1. Install the InboxAPI CLI:
+
+```bash
+npm install -g @inboxapi/cli
+```
+
+2. Authenticate once:
+
+```bash
+inboxapi login
+```
+
+3. Restart or re-open the agent session so the newly installed skill is visible to the model.
+
+### What the skill supports
+
+- Search inbox messages by sender, subject, and date.
+- Read single messages and full thread context.
+- Summarize recent mail for triage.
+- Send new outbound mail.
+- Reply in-thread through InboxAPI using the original message id.
+- Forward mail and fetch attachments on demand.
+
+The skill intentionally keeps InboxAPI as the source of truth for thread identity and delivery semantics. For replies, it uses `send-reply --message-id ...` instead of reconstructing SMTP threading inside ZeroClaw.
+
+### Optional MCP tool path
+
+If you want direct InboxAPI tools in ZeroClaw in addition to the skill prompt, register the InboxAPI CLI as a stdio MCP server:
+
+```toml
+[mcp]
+enabled = true
+
+[[mcp.servers]]
+name = "inboxapi"
+transport = "stdio"
+command = "npx"
+args = ["-y", "@inboxapi/cli"]
+```
+
+That exposes InboxAPI tool calls through the runtime's normal MCP surface while keeping the same underlying account and auth flow.
+
+### When not to use it
+
+Use the native email channels above when you want ZeroClaw to own inbound polling or push delivery directly. Use the InboxAPI skill when you want a lighter operator path that reuses an existing InboxAPI mailbox and preserves InboxAPI-specific reply semantics.
+
+---
+
 ## Reply threading
 
 Both email channels thread replies using `In-Reply-To` and `References` headers so conversations stay grouped in whatever client the sender uses.

--- a/docs/book/src/channels/email.md
+++ b/docs/book/src/channels/email.md
@@ -4,7 +4,9 @@ Two email channels depending on how you want inbound messages delivered.
 
 ## IMAP + SMTP (`email_channel`)
 
-The general-purpose email channel. Polls IMAP for new messages, sends via SMTP. Works with Gmail, Outlook, Fastmail, self-hosted Postfix, and anything else that speaks IMAP/SMTP.
+The general-purpose email channel. Polls IMAP for new messages, sends via
+SMTP. Works with Gmail, Outlook, Fastmail, self-hosted Postfix, and anything
+else that speaks IMAP/SMTP.
 
 ```toml
 [channels.email]
@@ -67,16 +69,20 @@ allowed_senders = ["boss@example.com"]
 2. Create a Pub/Sub topic the Gmail service can publish to
 3. Create a pull subscription on that topic for ZeroClaw
 4. Create OAuth client credentials (desktop app type), download JSON
-5. On first run, `zeroclaw channel auth gmail-push` opens a browser for the OAuth consent
+5. On first run, `zeroclaw channel auth gmail-push` opens a browser for the
+   OAuth consent
 6. The agent watches the subscription for new-mail notifications
 
-Outbound sends still go via SMTP — configure an `smtp` block in this channel the same way as the IMAP+SMTP channel.
+Outbound sends still go via SMTP. Configure an `smtp` block in this channel
+the same way as the IMAP+SMTP channel.
 
 ---
 
 ## InboxAPI skill
 
-Use the InboxAPI skill when you already have an InboxAPI mailbox and want ZeroClaw to operate on it without configuring IMAP and SMTP directly inside ZeroClaw.
+Use the InboxAPI skill when you already have an InboxAPI mailbox and want
+ZeroClaw to operate on it without configuring IMAP and SMTP directly inside
+ZeroClaw.
 
 This is the recommended Phase 1 InboxAPI integration path:
 
@@ -92,13 +98,14 @@ zeroclaw skills install inboxapi
 npm install -g @inboxapi/cli
 ```
 
-2. Authenticate once:
+1. Authenticate once:
 
 ```bash
 inboxapi login
 ```
 
-3. Restart or re-open the agent session so the newly installed skill is visible to the model.
+1. Restart or re-open the agent session so the newly installed skill is
+   visible to the model.
 
 ### What the skill supports
 
@@ -109,11 +116,15 @@ inboxapi login
 - Reply in-thread through InboxAPI using the original message id.
 - Forward mail and fetch attachments on demand.
 
-The skill intentionally keeps InboxAPI as the source of truth for thread identity and delivery semantics. For replies, it uses `send-reply --message-id ...` instead of reconstructing SMTP threading inside ZeroClaw.
+The skill intentionally keeps InboxAPI as the source of truth for thread
+identity and delivery semantics. For replies, it uses
+`send-reply --message-id ...` instead of reconstructing SMTP threading inside
+ZeroClaw.
 
 ### Optional MCP tool path
 
-If you want direct InboxAPI tools in ZeroClaw in addition to the skill prompt, register the InboxAPI CLI as a stdio MCP server:
+If you want direct InboxAPI tools in ZeroClaw in addition to the skill prompt,
+register the InboxAPI CLI as a stdio MCP server:
 
 ```toml
 [mcp]
@@ -126,31 +137,45 @@ command = "npx"
 args = ["-y", "@inboxapi/cli"]
 ```
 
-That exposes InboxAPI tool calls through the runtime's normal MCP surface while keeping the same underlying account and auth flow.
+That exposes InboxAPI tool calls through the runtime's normal MCP surface
+while keeping the same underlying account and auth flow.
 
 ### When not to use it
 
-Use the native email channels above when you want ZeroClaw to own inbound polling or push delivery directly. Use the InboxAPI skill when you want a lighter operator path that reuses an existing InboxAPI mailbox and preserves InboxAPI-specific reply semantics.
+Use the native email channels above when you want ZeroClaw to own inbound
+polling or push delivery directly. Use the InboxAPI skill when you want a
+lighter operator path that reuses an existing InboxAPI mailbox and preserves
+InboxAPI-specific reply semantics.
 
 ---
 
 ## Reply threading
 
-Both email channels thread replies using `In-Reply-To` and `References` headers so conversations stay grouped in whatever client the sender uses.
+Both email channels thread replies using `In-Reply-To` and `References`
+headers so conversations stay grouped in whatever client the sender uses.
 
 ## Attachment handling
 
-Inbound attachments are stored under `<workspace>/attachments/<conversation>/`. The agent gets file paths in its context and can read them via the `file_read` tool.
+Inbound attachments are stored under
+`<workspace>/attachments/<conversation>/`. The agent gets file paths in its
+context and can read them via the `file_read` tool.
 
-Outbound attachments are not supported yet — the agent replies with links to files in the workspace, and the user downloads via whatever tunnel the workspace is exposed through.
+Outbound attachments are not supported yet. The agent replies with links to
+files in the workspace, and the user downloads via whatever tunnel the
+workspace is exposed through.
 
 ## Rate and volume limits
 
 Email isn't optimised for conversational latency. Expect:
 
-- IMAP poll latency: `poll_interval_secs` (default 60 s). Lower at the cost of server load; some providers rate-limit aggressive polling.
-- SMTP send: subject to your provider's daily-send quota (Gmail: 500/day for free accounts, 2000/day for Workspace).
+- IMAP poll latency: `poll_interval_secs` (default 60 s). Lower at the cost
+  of server load; some providers rate-limit aggressive polling.
+- SMTP send: subject to your provider's daily-send quota (Gmail: 500/day for
+  free accounts, 2000/day for Workspace).
 
 ## Safety
 
-Email has no auth at the protocol level beyond SMTP's envelope — anyone can claim to be anyone. Always configure `allowed_senders` (strict list of addresses) or `subject_prefix` (shared secret in the subject line) before exposing the agent to an inbox that receives public mail.
+Email has no auth at the protocol level beyond SMTP's envelope, so anyone can
+claim to be anyone. Always configure `allowed_senders` (strict list of
+addresses) or `subject_prefix` (shared secret in the subject line) before
+exposing the agent to an inbox that receives public mail.


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - add an `InboxAPI skill` section to the email-channel docs so operators have a supported Phase 1 integration path
  - document the exact install and auth workflow for `zeroclaw skills install inboxapi`
  - include an optional stdio MCP configuration block for operators who want direct InboxAPI tools as well as the skill prompt
  - clarify when to choose the InboxAPI skill path versus ZeroClaw's native email channels
- **Scope boundary:** docs only; no runtime, channel, skill-loader, or MCP-host code changes
- **Blast radius:** user-facing email setup guidance in the docs book; no behavioral change to shipped binaries
- **Linked issue(s):** Related zeroclaw-labs/zeroclaw-skills#6

## Validation Evidence (required)

Local validation is the signal CI cannot replace. Run the full battery and paste literal output (tails, failures, warnings — not "all passed").

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

Docs-only changes: replace with markdown lint + link-integrity (`scripts/ci/docs_quality_gate.sh`). Bootstrap scripts: add `bash -n install.sh`.

- **Commands run and tail output:**
  - `BASE_SHA=$(git merge-base origin/master HEAD) DOCS_FILES=docs/book/src/channels/email.md ./scripts/ci/docs_quality_gate.sh`
    - `Linting docs files: docs/book/src/channels/email.md`
    - `Existing markdown issues outside changed lines (non-blocking):`
    - `  - docs/book/src/channels/email.md:95:1 MD029/ol-prefix Ordered list item prefix [Expected: 1; Actual: 2; Style: 1/1/1]`
    - `  - docs/book/src/channels/email.md:101:1 MD029/ol-prefix Ordered list item prefix [Expected: 1; Actual: 3; Style: 1/1/1]`
    - `No blocking markdown issues on changed lines.`
  - `BASE_SHA=$(git merge-base origin/master HEAD) DOCS_FILES=docs/book/src/channels/email.md ./scripts/ci/docs_links_gate.sh`
    - `Collected 0 added link(s) from 1 docs file(s).`
    - `No added links detected in changed docs lines.`
- **Beyond CI — what did you manually verify?** I verified the InboxAPI CLI command surface with `inboxapi --help`, confirmed `zeroclaw skills install <name>` resolves through the skills registry, and checked the MCP config schema for stdio server fields (`name`, `transport`, `command`, `args`) before writing the example block.
- **If any command was intentionally skipped, why:** The Rust validation battery was intentionally skipped because this PR is docs-only. I did not run a live ZeroClaw + InboxAPI mailbox session from these docs inside this container.

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation:

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: exact upgrade steps for existing users:

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PRs: `git revert <sha>` is the plan unless otherwise noted.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line):
- Scope materially carried forward:
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`Yes/No`)
- If `No`, why (inspiration-only, no direct code/design carry-over):
