### PR TITLE
fix(workspace): set default-run = "zeroclaw" to unblock docs deploy CI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ name = "zeroclawlabs"
 # on crates.io. Flip or remove this once the multi-crate publish topology is
 # designed per RFC #5579.
 publish = false
+default-run = "zeroclaw"
 version.workspace = true
 edition.workspace = true
 authors = ["theonlyhennygod"]


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:** Add `default-run = "zeroclaw"` under `[package]` in root `Cargo.toml`. PR #6167 (ACP v1) introduced a second binary target (`zeroclaw-acp-bridge`) without setting `default-run`. Cargo therefore refuses bare `cargo run` with `error: 'cargo run' could not determine which binary to run`. The `Deploy mdBook docs to Pages` workflow shells out to `cargo run --no-default-features --features schema-export -- markdown-help` (and `markdown-schema`) from `xtask/src/cmd/mdbook/refs.rs::build_refs` to regenerate `reference/cli.md` and `reference/config.md`. Both invocations have failed on every push to `master` since #6167 landed.
- **Scope boundary:** Single-line addition to root `Cargo.toml`. No source, workflow, or xtask logic is modified. `zeroclaw-acp-bridge` continues to build via `cargo build --bin zeroclaw-acp-bridge` and is feature-gated behind `acp-bridge` regardless.
- **Blast radius:** Restores prior behavior of bare `cargo run` (and the xtask `mdbook` target) on the workspace root. Anything that was already passing an explicit `--bin` is unaffected. No effect on release artifacts, packaging, or downstream crates.
- **Linked issue(s):** Related to #6167 (introduced the regression). No tracking issue filed; failing runs: 25249300645, 25257843096, 25259291221.

## Validation Evidence (required)

Local validation is the signal CI cannot replace. Run the full battery and paste literal output (tails, failures, warnings — not "all passed").

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

Docs-only changes: replace with markdown lint + link-integrity (`scripts/ci/docs_quality_gate.sh`). Bootstrap scripts: add `bash -n install.sh`.

- **Commands run and tail output:**
  - `cargo run --no-default-features --features schema-export -- markdown-help` -> exit 0 (previously failed at argument parsing with `error: 'cargo run' could not determine which binary to run`).
  - `cargo run --no-default-features --features schema-export -- markdown-schema` -> exit 0 (same prior failure mode).
  - `cargo build --bin zeroclaw-acp-bridge --features acp-bridge` -> exit 0; second binary remains buildable.
  - `rustc --version` -> `rustc 1.93.1 (01f6ddf75 2026-02-11)`.
- **Beyond CI — what did you manually verify?** Reproduced the exact failing path (`xtask::cmd::mdbook::refs::build_refs`) by invoking the two `cargo run` commands it shells out to from the repo root; both now succeed and emit the expected markdown. Did NOT manually verify the GitHub Actions `Deploy mdBook docs to Pages` job end-to-end — it will run on this PR.
- **If any command was intentionally skipped, why:** Full `cargo test` / `clippy` / `fmt` battery skipped — the change is a single Cargo manifest field that does not affect any compiled code path, only `cargo run`'s default binary selection. Manifest correctness is validated by Cargo at the next `cargo` invocation.

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: N/A.

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: exact upgrade steps for existing users: None — `cargo run` now resolves to `zeroclaw` as it did before #6167. Anyone who needs the bridge binary can keep using `cargo run --bin zeroclaw-acp-bridge`.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PR: `git revert <sha>` is the plan.