### PR TITLE
fix(runtime/agent): preserve reasoning_content through context compression

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/context_compressor.rs
+++ b/crates/zeroclaw-runtime/src/agent/context_compressor.rs
@@ -376,9 +376,7 @@ impl ContextCompressor {
         }
 
         // Splice: head + [SUMMARY] + tail
-        let summary_msg = ChatMessage::assistant(format!(
-            "[CONTEXT SUMMARY \u{2014} {message_count} earlier messages compressed]\n\n{summary}"
-        ));
+        let summary_msg = build_summary_message(&history[start..end], &summary, message_count);
         history.splice(start..end, std::iter::once(summary_msg));
 
         // Repair orphaned tool pairs
@@ -503,6 +501,46 @@ fn truncate_chars(s: &str, max: usize) -> String {
     let mut result = s[..end].to_string();
     result.push_str("...");
     result
+}
+
+/// Construct the synthesized assistant message that replaces a compressed
+/// range. When the compressed range contains an assistant turn with
+/// `reasoning_content` (a thinking-mode response from providers like
+/// DeepSeek V4), embed the most recent such payload in the summary as a
+/// JSON-encoded `{content, reasoning_content}` body — matching the shape
+/// `build_native_assistant_history` already produces — so the next request
+/// to the provider passes its reasoning round-trip check. See #6269.
+fn build_summary_message(
+    compressed: &[ChatMessage],
+    summary: &str,
+    message_count: usize,
+) -> ChatMessage {
+    let summary_text = format!(
+        "[CONTEXT SUMMARY \u{2014} {message_count} earlier messages compressed]\n\n{summary}"
+    );
+
+    let last_reasoning = compressed
+        .iter()
+        .rev()
+        .filter(|m| m.role == "assistant")
+        .find_map(|m| {
+            serde_json::from_str::<serde_json::Value>(&m.content)
+                .ok()
+                .and_then(|v| {
+                    v.get("reasoning_content")
+                        .and_then(|rc| rc.as_str().map(ToString::to_string))
+                })
+        });
+
+    if let Some(rc) = last_reasoning {
+        let payload = serde_json::json!({
+            "content": summary_text,
+            "reasoning_content": rc,
+        });
+        ChatMessage::assistant(payload.to_string())
+    } else {
+        ChatMessage::assistant(summary_text)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -829,5 +867,90 @@ mod tests {
         let mut history = vec![msg("tool", &big)];
         let saved = compressor.fast_trim_tool_results(&mut history);
         assert_eq!(saved, 0);
+    }
+
+    /// When the compressed range has no thinking-mode reasoning_content,
+    /// the synthesized summary is plain text — same as before #6269.
+    #[test]
+    fn build_summary_message_uses_plain_text_when_no_reasoning() {
+        let compressed = vec![
+            msg("user", "what's the weather"),
+            msg("assistant", "it's sunny"),
+        ];
+        let out = build_summary_message(&compressed, "weather chat", 2);
+        assert_eq!(out.role, "assistant");
+        assert!(out.content.starts_with("[CONTEXT SUMMARY"));
+        assert!(out.content.contains("weather chat"));
+        assert!(
+            serde_json::from_str::<serde_json::Value>(&out.content).is_err(),
+            "plain-text summary must not parse as JSON"
+        );
+    }
+
+    /// Regression test for #6269 — when an assistant message in the
+    /// compressed range carries `reasoning_content` (thinking-mode replay
+    /// payload), the synthesized summary preserves it via JSON-encoded
+    /// content matching `build_native_assistant_history`'s shape.
+    /// Without this, providers that require reasoning round-trip
+    /// (DeepSeek V4 thinking) reject every post-compression request.
+    #[test]
+    fn build_summary_message_preserves_reasoning_content_when_present() {
+        let assistant_with_reasoning = serde_json::json!({
+            "content": "let me look",
+            "reasoning_content": "user wants weather; need to check",
+        })
+        .to_string();
+        let compressed = vec![
+            msg("user", "what's the weather"),
+            msg("assistant", &assistant_with_reasoning),
+        ];
+
+        let out = build_summary_message(&compressed, "weather chat", 2);
+        assert_eq!(out.role, "assistant");
+        let parsed: serde_json::Value = serde_json::from_str(&out.content)
+            .expect("summary must be JSON when reasoning_content is preserved");
+        assert!(
+            parsed["content"]
+                .as_str()
+                .is_some_and(|s| s.starts_with("[CONTEXT SUMMARY")),
+            "summary text belongs in `content`",
+        );
+        assert_eq!(
+            parsed["reasoning_content"].as_str(),
+            Some("user wants weather; need to check"),
+            "must carry reasoning_content from the most recent compressed assistant turn",
+        );
+    }
+
+    /// When multiple compressed assistant turns have reasoning_content,
+    /// the most recent one survives — this matches DeepSeek's protocol
+    /// expectation that the *immediately prior* assistant turn's
+    /// reasoning is what gets replayed.
+    #[test]
+    fn build_summary_message_picks_last_reasoning_content() {
+        let earlier = serde_json::json!({
+            "content": "first answer",
+            "reasoning_content": "EARLIER reasoning",
+        })
+        .to_string();
+        let later = serde_json::json!({
+            "content": "second answer",
+            "reasoning_content": "LATER reasoning",
+        })
+        .to_string();
+        let compressed = vec![
+            msg("user", "q1"),
+            msg("assistant", &earlier),
+            msg("user", "q2"),
+            msg("assistant", &later),
+        ];
+
+        let out = build_summary_message(&compressed, "two-turn chat", 4);
+        let parsed: serde_json::Value = serde_json::from_str(&out.content).unwrap();
+        assert_eq!(
+            parsed["reasoning_content"].as_str(),
+            Some("LATER reasoning"),
+            "must pick the most recent reasoning_content, not the earliest",
+        );
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `compress_once` previously replaced compressed messages with a plain-text assistant summary built via `ChatMessage::assistant(String)`, which discarded any `reasoning_content` from the compressed range. Thinking-mode providers (DeepSeek V4) then rejected every post-compression request with `reasoning_content in the thinking mode must be passed back to the API`.
  - Extracts a pure `build_summary_message` helper that scans the compressed range for the most recent assistant turn carrying `reasoning_content` and, when present, encodes the summary as a `{content, reasoning_content}` JSON payload — the same shape `build_native_assistant_history` already produces — so the next provider request passes its reasoning round-trip check.
  - When the compressed range has no `reasoning_content`, the summary stays plain text, preserving existing behavior for non-thinking-mode sessions.
  - Adds three unit tests on the helper to lock in plain-text fallback, reasoning preservation, and last-wins selection across multiple compressed turns.
- **Scope boundary:** Only changes how the synthesized summary message is constructed inside `ContextCompressor::compress_once`. Does not change compression triggering, summary text generation, tool-pair repair, fast-trim, or any provider/wire layer.
- **Blast radius:** `crates/zeroclaw-runtime/src/agent/context_compressor.rs` only. Affects every agent session that hits compression — for non-thinking sessions output is byte-identical to before. For thinking-mode sessions the compressed-range surrogate now carries a JSON payload that downstream native conversion reads back through the parser landed in #6284.
- **Linked issue(s):** Closes #6269. Depends on merged #6284.

> **End-to-end note:** This fix now pairs with the merged #6284 parser path. #6284 is what reads back the JSON-encoded `reasoning_content` this fix writes; together, the two PRs cover the compressed-summary replay path.

> **Credit:** Spike PoC by @Svtter at Svtter/zeroclaw@53aa93a9 — that exploration shaped the JSON-payload approach used here.

## Validation Evidence (required)

```bash
cargo fmt --all -- --check                                    # clean
cargo clippy -p zeroclaw-runtime --all-targets -- -D warnings # clean
cargo test -p zeroclaw-runtime                                # 1621/1621 passed
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` — no diff.
  - `cargo clippy -p zeroclaw-runtime --all-targets -- -D warnings` — no warnings.
  - `cargo test -p zeroclaw-runtime` — `test result: ok. 1621 passed; 0 failed; 0 ignored` (includes the three new regression tests below).
- **New regression tests added in `crates/zeroclaw-runtime/src/agent/context_compressor.rs`:**
  - `build_summary_message_uses_plain_text_when_no_reasoning` — when no `reasoning_content` is present in the compressed range, the summary stays plain text and does not parse as JSON (no regression for non-thinking sessions).
  - `build_summary_message_preserves_reasoning_content_when_present` — when an assistant turn in the compressed range carries `reasoning_content`, the summary is JSON with `{content, reasoning_content}` matching `build_native_assistant_history`'s shape.
  - `build_summary_message_picks_last_reasoning_content` — when multiple compressed assistant turns carry reasoning, the most recent one wins, matching DeepSeek's "immediately prior turn" replay protocol.
- **Beyond CI — what did you manually verify?**
  - Read the diff against `build_native_assistant_history` to confirm the JSON shape (`content` + `reasoning_content`) matches what the native converter writes for un-compressed assistant turns, so the #6284 parser treats the surrogate like a real assistant turn.
  - Walked through `compress_once` to confirm the helper is only called on the post-trim, post-budget compression path; tool-pair repair runs after the splice and is unaffected.
  - Did NOT exercise a live DeepSeek V4 thinking-mode session against the compressed surrogate end-to-end on the wire — that confirmation requires this PR to land with #6284. The unit tests cover the contract this PR owns (the summary message shape).
- **If any command was intentionally skipped, why:** None.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: N/A.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: exact upgrade steps for existing users: None — drop-in. For sessions that never carried `reasoning_content`, the synthesized summary is byte-identical to before. For thinking-mode sessions, the surrogate now carries the round-trip payload the provider already required.

## Rollback (required for `risk: medium` and `risk: high`)

Risk-high rollback path is still a normal `git revert <sha>`: the change is isolated to one helper function inside `context_compressor.rs`, behind a runtime branch that only activates when compressed assistant turns carry `reasoning_content`. Reverting restores the previous plain-text summary behavior with no migration cost; thinking-mode sessions would simply regress to the pre-fix failure mode (#6269).

---

## Maintainer note

Refs #6059.

#6059 is being addressed across three PRs covering the layers `reasoning_content` round-trips through:

- **#6980 (merged 2026-05-28)** — native tool requests routed through `NativeChatRequest` so assistant tool-call history preserves `reasoning_content`.
- **#6284 (merged 2026-05-30)** — plain-text assistant turns from thinking-mode providers preserved on replay.
- **#6285 (this PR)** — `reasoning_content` preserved through context compression.

This PR is the compressor piece. The issue stays open until this PR ships and the final current-master DeepSeek/Kimi thinking-mode smoke passes.

— @singlerider, 2026-05-28
