### PR TITLE
fix(xai): correct base URL and restore native /models endpoint

### DIFF
--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -48,6 +48,9 @@ pub struct OpenAiCompatibleProvider {
     api_path: Option<String>,
     /// Maximum output tokens to include in API requests.
     max_tokens: Option<u32>,
+    /// models.dev catalog key for this provider (e.g. "xai").
+    /// When set, `list_models` fetches from the models.dev catalog.
+    models_dev_key: Option<String>,
 }
 
 /// How the provider expects the API key to be sent.
@@ -246,6 +249,7 @@ impl OpenAiCompatibleProvider {
             reasoning_effort: None,
             api_path: None,
             max_tokens: None,
+            models_dev_key: None,
         }
     }
 
@@ -293,6 +297,13 @@ impl OpenAiCompatibleProvider {
     /// Set the maximum output tokens for API requests.
     pub fn with_max_tokens(mut self, max_tokens: Option<u32>) -> Self {
         self.max_tokens = max_tokens;
+        self
+    }
+
+    /// Set the models.dev catalog key for this provider.
+    /// When set, `list_models` returns the catalog's model list for that key.
+    pub fn with_models_dev_key(mut self, key: &str) -> Self {
+        self.models_dev_key = Some(key.to_string());
         self
     }
 
@@ -1749,6 +1760,49 @@ impl Provider for OpenAiCompatibleProvider {
             native_tool_calling: self.native_tool_calling,
             vision: self.supports_vision,
             prompt_caching: false,
+        }
+    }
+
+    async fn list_models(&self) -> anyhow::Result<Vec<String>> {
+        // When a credential is present, hit the provider's native /models endpoint
+        // (OpenAI-compatible: GET {base_url}/models).
+        if let Some(credential) = self.credential.as_deref() {
+            let url = format!("{}/models", self.base_url);
+            let response = self
+                .apply_auth_header(self.http_client().get(&url), Some(credential))
+                .send()
+                .await
+                .map_err(|e| {
+                    anyhow::anyhow!("{} model list request failed: {url}: {e}", self.name)
+                })?;
+            if !response.status().is_success() {
+                let status = response.status();
+                anyhow::bail!("{} model list failed at {url}: HTTP {status}", self.name);
+            }
+            #[derive(serde::Deserialize)]
+            struct ModelsResponse {
+                data: Vec<ModelEntry>,
+            }
+            #[derive(serde::Deserialize)]
+            struct ModelEntry {
+                id: String,
+            }
+            let body: ModelsResponse = response.json().await.map_err(|e| {
+                anyhow::anyhow!("{} model list returned invalid JSON: {e}", self.name)
+            })?;
+            let mut ids: Vec<String> = body
+                .data
+                .into_iter()
+                .map(|e| e.id.trim().to_string())
+                .filter(|id| !id.is_empty())
+                .collect();
+            ids.sort();
+            return Ok(ids);
+        }
+        // No credential — fall back to the models.dev catalog when available.
+        match &self.models_dev_key {
+            Some(key) => crate::models_dev::list_models_for(key).await,
+            None => anyhow::bail!("live model listing is not supported for this provider"),
         }
     }
 

--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -124,6 +124,27 @@ fn apply_auth_to_request(
     }
 }
 
+#[derive(Deserialize)]
+struct ModelsResponse {
+    data: Vec<ModelEntry>,
+}
+
+#[derive(Deserialize)]
+struct ModelEntry {
+    id: String,
+}
+
+fn normalize_model_ids(body: ModelsResponse) -> Vec<String> {
+    let mut ids: Vec<String> = body
+        .data
+        .into_iter()
+        .map(|e| e.id.trim().to_string())
+        .filter(|id| !id.is_empty())
+        .collect();
+    ids.sort();
+    ids
+}
+
 impl OpenAiCompatibleProvider {
     pub fn new(
         name: &str,
@@ -1779,25 +1800,10 @@ impl Provider for OpenAiCompatibleProvider {
                 let status = response.status();
                 anyhow::bail!("{} model list failed at {url}: HTTP {status}", self.name);
             }
-            #[derive(serde::Deserialize)]
-            struct ModelsResponse {
-                data: Vec<ModelEntry>,
-            }
-            #[derive(serde::Deserialize)]
-            struct ModelEntry {
-                id: String,
-            }
             let body: ModelsResponse = response.json().await.map_err(|e| {
                 anyhow::anyhow!("{} model list returned invalid JSON: {e}", self.name)
             })?;
-            let mut ids: Vec<String> = body
-                .data
-                .into_iter()
-                .map(|e| e.id.trim().to_string())
-                .filter(|id| !id.is_empty())
-                .collect();
-            ids.sort();
-            return Ok(ids);
+            return Ok(normalize_model_ids(body));
         }
         // No credential — fall back to the models.dev catalog when available.
         match &self.models_dev_key {
@@ -2622,6 +2628,20 @@ mod tests {
             !err_msg.contains("API key not set"),
             "should not get credential error, got: {err_msg}"
         );
+    }
+
+    #[test]
+    fn normalize_model_ids_trims_filters_and_sorts() {
+        let body = serde_json::from_value(serde_json::json!({
+            "data": [
+                {"id": " zeta-model "},
+                {"id": ""},
+                {"id": "alpha-model"}
+            ]
+        }))
+        .unwrap();
+
+        assert_eq!(normalize_model_ids(body), vec!["alpha-model", "zeta-model"]);
     }
 
     #[test]

--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -1440,12 +1440,10 @@ fn create_provider_with_url_and_options(
             key,
             AuthStyle::Bearer,
         ))),
-        "xai" | "grok" => Ok(compat(OpenAiCompatibleProvider::new(
-            "xAI",
-            "https://api.x.ai",
-            key,
-            AuthStyle::Bearer,
-        ))),
+        "xai" | "grok" => Ok(compat(
+            OpenAiCompatibleProvider::new("xAI", "https://api.x.ai/v1", key, AuthStyle::Bearer)
+                .with_models_dev_key("xai"),
+        )),
         "deepseek" => Ok(compat(OpenAiCompatibleProvider::new(
             "DeepSeek",
             "https://api.deepseek.com",


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Correct xAI provider base URL from `https://api.x.ai` to `https://api.x.ai/v1` so chat completions hit the right path (xAI's API is versioned under `/v1`, like OpenAI's).
  - Add `with_models_dev_key("xai")` to the xAI factory so the provider can fall back to the [models.dev](https://models.dev) catalog when no credential is configured.
  - Implement `Provider::list_models()` on `OpenAiCompatibleProvider`: when a credential is present, GET `{base_url}/models` and return the sorted, de-empty'd `data[].id` list; otherwise consult the configured `models_dev_key`; otherwise bail with the trait's default error message. This restores native model discovery for every OpenAI-compatible provider.
- **Scope boundary:** No changes to other provider configurations, no changes to chat/streaming code paths, no changes to the `Provider` trait surface. Only xAI gets `with_models_dev_key` set; other providers continue to use whatever catalog wiring they already had (or none).
- **Blast radius:**
  - xAI users: chat completions previously broken by the `/v1`-less URL now work; `list_models` now returns a real list.
  - Every other OpenAI-compatible provider (OpenAI, DeepSeek, Mistral, Together, Groq, Moonshot, Venice, GLM, Ollama, OpenRouter, Kimi, Qwen, MiniMax, ZAI, Bedrock, etc.): `list_models()` now hits their native `/models` endpoint when a credential is present instead of bailing with "live model listing is not supported". Providers that don't expose `/models` will surface an HTTP error from the call instead of the previous static bail.
- **Linked issue(s):** —

## Validation Evidence (required)

- **Commands run and tail output:**

```
$ cargo fmt --all -- --check
exit=0   (no output)

$ cargo test -p zeroclaw-providers normalize_model_ids_trims_filters_and_sorts
running 1 test
test compatible::tests::normalize_model_ids_trims_filters_and_sorts ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 783 filtered out; finished in 0.00s

$ cargo clippy --all-targets -- -D warnings
    Checking zeroclaw-providers v0.7.4 (.../crates/zeroclaw-providers)
    Checking zeroclaw-runtime v0.7.4 (.../crates/zeroclaw-runtime)
    Checking zeroclaw-hardware v0.7.4 (.../crates/zeroclaw-hardware)
    Checking zeroclaw-channels v0.7.4 (.../crates/zeroclaw-channels)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 16s

$ cargo build
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 35s

$ cargo test
test result: ok. 229 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 228 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 205 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 159 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok.  18 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok.   5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out  (system)
test result: ok.   0 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out  (live — gated on external credentials)
Doc-tests zeroclaw: 0 passed; 0 failed
```

- **Beyond CI — what did you manually verify?** Live-tested against xAI with a real `XAI_API_KEY` end-to-end:
  1. **Model listing** — `zeroclaw onboard → Providers → xAI (Grok) → Model` returned the full provider catalog from `https://api.x.ai/v1/models` and the onboarding wizard rendered it correctly:

<img width="2710" height="1536" alt="Screenshot_20260502_145027" src="https://github.com/user-attachments/assets/462544f3-a8a5-4913-a9e5-bfdee307f3b0" />


  2. **Chat completions** — verified the corrected `/v1` base URL against `/v1/chat/completions` end-to-end inside a ZeroClaw ACP session (model "Grok 4.3" selected from the listing above; full request/response round-trip):

<img width="1587" height="1489" alt="Screenshot_20260502_150442" src="https://github.com/user-attachments/assets/991c9e26-27d1-4a60-9533-8ad99d54620a" />

<img width="1595" height="1477" alt="Screenshot_20260502_150507" src="https://github.com/user-attachments/assets/c718f28c-8bd3-4a26-ab2d-ac6bc415db3a" />


- **If any command was intentionally skipped, why:** None skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `Yes` — `OpenAiCompatibleProvider::list_models()` can now issue an on-demand `GET {base_url}/models` request when a provider credential is configured. The request uses the existing provider credential path, targets only the configured provider endpoint, and is limited to explicit model-discovery calls.
- Secrets / tokens / credentials handling changed? `No` — credential is read via the existing `apply_auth_header` path.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes` for callers — `list_models()` previously errored; it now returns data when possible. The base URL change is a behavior fix, not a config change.
- Config / env / CLI surface changed? `No` — no new config keys; the xAI provider key (`xai` / `grok`) and credential lookup are unchanged.
- If `No` or `Yes` to either: existing users with the `xai` provider configured do not need to do anything; broken chat completions will start working on first request.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <merge-sha>` on the merge commit. Both files are isolated to `crates/zeroclaw-providers` with no migrations or persistent state.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Failures from xAI chat completions returning 404/4xx (URL regression); errors from `Provider::list_models()` calls on OpenAI-compatible providers that don't actually expose a `/models` endpoint — grep logs for `"model list failed at"` or `"model list request failed"`.
