### PR TITLE
fix(installer): install prebuilt dashboard assets

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -145,6 +145,46 @@ detect_target_triple() {
   esac
 }
 
+# ── Dashboard asset install ───────────────────────────────────────
+
+web_dashboard_dist_dir() {
+  printf '%s\n' "$CARGO_HOME/bin/web/dist"
+}
+
+install_web_dashboard() {
+  local src_dir dest_dir staging_dir
+  src_dir="$1/web/dist"
+  dest_dir=$(web_dashboard_dist_dir)
+  staging_dir="${dest_dir}.tmp.$$"
+
+  if [ ! -f "$src_dir/index.html" ]; then
+    warn "Release archive did not include web/dist — falling back to source build"
+    return 1
+  fi
+
+  mkdir -p "$(dirname "$dest_dir")"
+  rm -rf "$staging_dir"
+  cp -R "$src_dir" "$staging_dir" || {
+    rm -rf "$staging_dir"
+    warn "Could not stage dashboard assets — falling back to source build"
+    return 1
+  }
+
+  if [ ! -f "$staging_dir/index.html" ]; then
+    rm -rf "$staging_dir"
+    warn "Staged dashboard assets are missing index.html — falling back to source build"
+    return 1
+  fi
+
+  rm -rf "$dest_dir"
+  mv "$staging_dir" "$dest_dir" || {
+    rm -rf "$staging_dir"
+    warn "Could not install dashboard assets — falling back to source build"
+    return 1
+  }
+  info "Dashboard: $dest_dir"
+}
+
 # ── Pre-built binary install ──────────────────────────────────────
 
 install_prebuilt() {
@@ -178,6 +218,7 @@ install_prebuilt() {
   if [ "$DRY_RUN" = true ]; then
     info "[dry-run] Would download $asset_url"
     info "[dry-run] Would install to $CARGO_HOME/bin/zeroclaw"
+    info "[dry-run] Would install dashboard to $(web_dashboard_dist_dir)"
     return 0
   fi
 
@@ -215,6 +256,7 @@ install_prebuilt() {
 
   tar -xzf "$tmp_dir/$asset_name" -C "$tmp_dir"
   mkdir -p "$CARGO_HOME/bin"
+  install_web_dashboard "$tmp_dir" || { rm -rf "$tmp_dir"; return 1; }
   install -m 755 "$tmp_dir/zeroclaw" "$CARGO_HOME/bin/zeroclaw"
 
   rm -rf "$tmp_dir"
@@ -269,6 +311,8 @@ do_uninstall() {
   echo
 
   local bin="$CARGO_HOME/bin/zeroclaw"
+  local dashboard_dir
+  dashboard_dir=$(web_dashboard_dist_dir)
 
   if [ -f "$bin" ]; then
     "$bin" service stop 2>/dev/null || true
@@ -279,13 +323,21 @@ do_uninstall() {
     warn "Binary not found at $bin"
   fi
 
+  if [ -d "$dashboard_dir" ]; then
+    rm -rf "$dashboard_dir"
+    info "Removed dashboard assets at $dashboard_dir"
+  fi
+
   local config_dir="$PREFIX/.zeroclaw"
   if [ -d "$config_dir" ]; then
     if [ -t 0 ]; then
       printf "  Remove config and data (%s)? [y/N] " "$config_dir"
       read confirm
       case "$confirm" in
-        [Yy]*) rm -rf "$config_dir"; info "Removed $config_dir" ;;
+        [Yy]*)
+          rm -rf "$config_dir"
+          info "Removed $config_dir"
+          ;;
         *)     info "Config preserved at $config_dir" ;;
       esac
     else


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Install packaged `web/dist` assets during prebuilt binary installs so the gateway and desktop dashboard work after a binary install.
  - Place dashboard assets under `$CARGO_HOME/bin/web/dist`, matching the gateway's existing binary-relative auto-detect path for the installed `zeroclaw` binary.
  - Stage dashboard assets before replacing an existing install, so failed copies do not leave stale or partial dashboard files.
  - Remove installed dashboard assets during uninstall independently from config/data cleanup.
- **Scope boundary:** This PR only updates the shell installer for prebuilt release archives. It does not change release packaging, the DMG bundle, gateway static-file lookup, source builds, or the web app itself.
- **Blast radius:** Prebuilt installer and uninstaller behavior. Runtime gateway behavior is unchanged; it already auto-detects `web/dist` next to the binary.
- **Linked issue(s):** Closes #6096. Supersedes #6154.

## Validation Evidence (required)

- **Commands run and tail output:**

```bash
git diff --check
```

Result: passed with no output.

```bash
sh -n install.sh
```

Result: passed with no output.

```bash
bash -n install.sh
```

Result: passed with no output.

```bash
./install.sh --dry-run --prebuilt --skip-onboard
```

Tail output:

```text
Installing ZeroClaw v0.7.4 (pre-built)
  ✓ Platform: aarch64-apple-darwin
  ✓ Source:   https://github.com/zeroclaw-labs/zeroclaw/releases/download/v0.7.4/zeroclaw-aarch64-apple-darwin.tar.gz

  ✓ [dry-run] Would download https://github.com/zeroclaw-labs/zeroclaw/releases/download/v0.7.4/zeroclaw-aarch64-apple-darwin.tar.gz
  ✓ [dry-run] Would install to /Users/dan/.cargo/bin/zeroclaw
  ✓ [dry-run] Would install dashboard to /Users/dan/.cargo/bin/web/dist
```

- **Beyond CI — what did you manually verify?**
  - Verified the target path matches the gateway's existing binary-relative `web/dist` auto-detect candidate.
  - Confirmed the branch is rebased on current `origin/master` and CI is green for the PR head.
  - Checked #6096 and #6154 history. #6154 restored dashboard extraction through platform data directories; this PR supersedes that approach by installing the dashboard next to the installed binary, matching the gateway's binary-adjacent `web/dist` auto-detect candidate and keeping install/uninstall artifacts in the installer-controlled prefix/bin tree.
- **If any command was intentionally skipped, why:**
  - Live prebuilt install/uninstall was not run locally because it would mutate the local user install target.
  - Full Docker/release packaging validation was not run because this PR does not change release archive generation; it consumes the existing `web/dist` payload when present in the prebuilt archive.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `Yes`. The prebuilt installer now writes bundled dashboard assets under `$CARGO_HOME/bin/web/dist` and removes that directory during uninstall. This stays within the installer-controlled prefix/bin tree.
- New external network calls? `No`. Existing release metadata and asset download calls are unchanged.
- Secrets / tokens / credentials handling changed? `No`.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`.
- If any `Yes`, describe the risk and mitigation: The filesystem write scope is limited to the same prefix-controlled install tree as the binary. Dashboard assets are copied from the checksum-verified release archive, staged before replacement, and removed as install artifacts during uninstall.

## Compatibility (required)

- Backward compatible? `Yes`.
- Config / env / CLI surface changed? `No`.
- If `No` or `Yes` to either: No user-facing config or CLI option changes. Existing users can rerun `install.sh --prebuilt` to install dashboard assets next to the binary.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <merge-commit>` or remove `$CARGO_HOME/bin/web/dist` manually to return to binary-only install behavior.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Installer output warning about missing or failed dashboard asset staging, or gateway fallback text: `Web dashboard not available. Set gateway.web_dist_dir...`.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): #6154 by @singlerider
- Scope materially carried forward: Restores dashboard asset installation for prebuilt installs so #6096 is resolved. This PR uses a different install target (`$CARGO_HOME/bin/web/dist`) than #6154's platform data directory approach, but carries forward the same user-facing fix and #6096 closure. The binary-adjacent install target is preferred here because it matches an existing gateway auto-detect candidate while keeping install and uninstall artifacts under the installer-controlled `$CARGO_HOME/bin` tree.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why (inspiration-only, no direct code/design carry-over): The implementation does not directly carry over #6154 code. It uses the gateway's binary-relative auto-detect path and a staging/replace install flow.
