### PR TITLE
(docs): clarify syntax for custom openai-compatible provider

### DIFF
--- a/docs/book/src/providers/custom.md
+++ b/docs/book/src/providers/custom.md
@@ -11,7 +11,7 @@ Three ways to add a provider ZeroClaw doesn't ship with:
 If the service speaks OpenAI chat-completions, this is a config-only change:
 
 ```toml
-[providers.models.my-endpoint]
+[providers.models."custom:https://my-gateway.example.com"]
 kind = "openai-compatible"
 base_url = "https://my-gateway.example.com"
 model = "my-model-id"

--- a/docs/book/src/providers/custom.md
+++ b/docs/book/src/providers/custom.md
@@ -21,7 +21,7 @@ api_key = "..."                    # omit if the endpoint needs no auth
 Then reference it:
 
 ```toml
-default_model = "my-endpoint"
+default_model = "custom:https://my-gateway.example.com"
 ```
 
 This is the same implementation used for Groq, Mistral, xAI, and every other OpenAI-compat provider in the [catalog](./catalog.md).


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
- I fixed the documentation for adding a custom OpenAI-compatible provider.
- I wanted to use Ollama's OpenAI compatible interface with ZeroClaw
- I noticed `ollama launch opencode --model qwen3-coder-next` was working (`ollama launch` provides an OpenAI compatible wrapper)
- ZeroClaw's direct support for Ollama providers was not working with tool calls with Gemma and Qwen models, and I was seeing 500s in my Ollama server logs.
- Switching to a custom OpenAI provider got tools working again
- **Scope boundary:** only one .md file changed
- **Blast radius:** one .md file
- **Linked issue(s):** workaround for https://github.com/zeroclaw-labs/zeroclaw/issues/5962

## Validation Evidence (required)

```
$ ./scripts/ci/docs_quality_gate.sh 
Linting docs files: docs/book/src/providers/custom.md
markdownlint-cli2 v0.20.0 (markdownlint v0.40.0)
Finding: docs/book/src/providers/custom.md !target/**
Linting: 1 file(s)
Summary: 0 error(s)
```

- **Beyond CI — what did you manually verify?**
I tested the change I describe here and it worked.

```
$ grep -A5 <hostname> ~/.zeroclaw/config.toml
[providers.models."custom:http://<hostname>:<port>/v1"]
base_url = "http://<hotname>:<port>/v1"
max_tokens = 4096
model = "qwen3-coder-next:q4_K_M"
temperature = 0.8
timeout_secs = 600

$ zeroclaw service start

$ zeroclaw agent
2026-05-03T06:21:54.454588Z  INFO zeroclaw_config::schema: Config loaded path=/home/tidux/.zeroclaw/config.toml workspace=/home/tidux/.zeroclaw/workspace source="default" initialized=true
2026-05-03T06:21:54.456093Z  INFO zeroclaw_runtime::agent::loop_: Memory initialized backend="sqlite"
2026-05-03T06:21:54.456630Z  INFO zeroclaw_runtime::security::detect: No sandbox backend available, using application-layer security
🦀 ZeroClaw Interactive Mode
Type /help for commands.

> What's the weather like in Osaka today?
🤔 Thinking...
💬 Got 1 tool call(s) (28s)
⏳ weather
✅ weather (0s)
🤔 Thinking (round 2)...
In Osaka today (as of 5:12 AM), it's partly cloudy with a temperature of 22°C (feels like 25°C). Humidity is at 57%, wind is 22 km/h from the south, and there's minimal precipitation (0.9 mm). Visibility is good at 10 km.
> 
```

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**, it aligns docs with the existing config surface

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert 68a875b5bec65a77d98d773fc36db932c966ce74`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Docs don't build

---

**Labels** live in the GitHub label UI, not in the body. Set `risk:*`, `size:*`, and scope labels via the sidebar. Auto-label corrections: add `risk: manual` and the intended label.

**Commit trailers** capture AI-assisted collaboration (`Co-Authored-By: Claude ...`) — no separate section needed.

**Privacy contract** (`docs/book/src/contributing/privacy.md`) is a merge gate. Never commit real identities, secrets, personal emails, or PII in diff, tests, fixtures, or docs.
