### PR TITLE
fix(docker): unbreak workspace-member resolution in Dockerfile and Dockerfile.debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,13 +32,20 @@ COPY --parents crates/*/Cargo.toml ./
 COPY --parents crates/aardvark-sys/build.rs ./
 # apps/tauri: .dockerignore whitelists only Cargo.toml; src and build.rs are stubbed below.
 COPY apps/tauri/Cargo.toml apps/tauri/Cargo.toml
+# tools/fill-translations and xtask are dev/build tools; copy manifests only so
+# Cargo can resolve the workspace, then stub their entry points so the
+# dependency pre-fetch step succeeds without building them into the image.
+COPY tools/fill-translations/Cargo.toml tools/fill-translations/Cargo.toml
+COPY xtask/Cargo.toml xtask/Cargo.toml
 # Create dummy targets for all workspace members so manifest parsing succeeds.
-RUN mkdir -p src benches apps/tauri/src \
+RUN mkdir -p src benches apps/tauri/src tools/fill-translations/src xtask/src \
     && echo "fn main() {}" > src/main.rs \
     && echo "" > src/lib.rs \
     && echo "fn main() {}" > benches/agent_benchmarks.rs \
     && echo "fn main() {}" > apps/tauri/src/main.rs \
     && echo "fn main() {}" > apps/tauri/build.rs \
+    && echo "fn main() {}" > tools/fill-translations/src/main.rs \
+    && echo "fn main() {}" > xtask/src/main.rs \
     && for d in crates/*/; do mkdir -p "${d}src" && printf '' > "${d}src/lib.rs"; done
 RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,id=zeroclaw-cargo-git,target=/usr/local/cargo/git,sharing=locked \

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,9 +38,13 @@ COPY apps/tauri/Cargo.toml apps/tauri/Cargo.toml
 COPY tools/fill-translations/Cargo.toml tools/fill-translations/Cargo.toml
 COPY xtask/Cargo.toml xtask/Cargo.toml
 # Create dummy targets for all workspace members so manifest parsing succeeds.
-RUN mkdir -p src benches apps/tauri/src tools/fill-translations/src xtask/src \
+# `src/bin/zeroclaw-acp-bridge.rs` is required because the `acp-bridge` feature
+# is in the root crate's default set; cargo selects the bin target during the
+# pre-fetch build even with only the workspace lib stubbed.
+RUN mkdir -p src src/bin benches apps/tauri/src tools/fill-translations/src xtask/src \
     && echo "fn main() {}" > src/main.rs \
     && echo "" > src/lib.rs \
+    && echo "fn main() {}" > src/bin/zeroclaw-acp-bridge.rs \
     && echo "fn main() {}" > benches/agent_benchmarks.rs \
     && echo "fn main() {}" > apps/tauri/src/main.rs \
     && echo "fn main() {}" > apps/tauri/build.rs \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.7
+# syntax=docker/dockerfile:1.7-labs
 
 # ── Stage 0: Frontend build ─────────────────────────────────────
 FROM node:22-alpine AS web-builder
@@ -41,7 +41,7 @@ COPY xtask/Cargo.toml xtask/Cargo.toml
 # `src/bin/zeroclaw-acp-bridge.rs` is required because the `acp-bridge` feature
 # is in the root crate's default set; cargo selects the bin target during the
 # pre-fetch build even with only the workspace lib stubbed.
-RUN mkdir -p src src/bin benches apps/tauri/src tools/fill-translations/src xtask/src \
+RUN mkdir -p src src/bin benches apps/tauri/src tools/fill-translations/src xtask/src/bin \
     && echo "fn main() {}" > src/main.rs \
     && echo "" > src/lib.rs \
     && echo "fn main() {}" > src/bin/zeroclaw-acp-bridge.rs \
@@ -49,7 +49,10 @@ RUN mkdir -p src src/bin benches apps/tauri/src tools/fill-translations/src xtas
     && echo "fn main() {}" > apps/tauri/src/main.rs \
     && echo "fn main() {}" > apps/tauri/build.rs \
     && echo "fn main() {}" > tools/fill-translations/src/main.rs \
-    && echo "fn main() {}" > xtask/src/main.rs \
+    && echo "" > xtask/src/lib.rs \
+    && echo "fn main() {}" > xtask/src/bin/mdbook.rs \
+    && echo "fn main() {}" > xtask/src/bin/fluent.rs \
+    && echo "fn main() {}" > xtask/src/bin/web.rs \
     && for d in crates/*/; do mkdir -p "${d}src" && printf '' > "${d}src/lib.rs"; done
 RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,id=zeroclaw-cargo-git,target=/usr/local/cargo/git,sharing=locked \
@@ -59,11 +62,14 @@ RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/regist
     else \
       cargo build --release --locked; \
     fi
-RUN rm -rf src benches
+RUN rm -rf src benches crates xtask tools/fill-translations
 
 # 2. Copy only build-relevant source paths (avoid cache-busting on docs/tests/scripts)
 COPY src/ src/
 COPY benches/ benches/
+COPY crates/ crates/
+COPY xtask/ xtask/
+COPY tools/fill-translations/ tools/fill-translations/
 COPY *.rs .
 RUN touch src/main.rs
 RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
@@ -71,7 +77,14 @@ RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/regist
     --mount=type=cache,id=zeroclaw-target,target=/app/target,sharing=locked \
     rm -rf target/release/.fingerprint/zeroclawlabs-* \
            target/release/deps/zeroclawlabs-* \
-           target/release/incremental/zeroclawlabs-* && \
+           target/release/incremental/zeroclawlabs-* \
+           target/release/.fingerprint/zeroclaw-* \
+           target/release/deps/zeroclaw_* \
+           target/release/incremental/zeroclaw_* \
+           target/release/.fingerprint/xtask-* \
+           target/release/deps/xtask-* \
+           target/release/.fingerprint/fill-translations-* \
+           target/release/deps/fill_translations-* && \
     if [ -n "$ZEROCLAW_CARGO_FEATURES" ]; then \
       cargo build --release --locked --features "$ZEROCLAW_CARGO_FEATURES"; \
     else \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -47,12 +47,23 @@ COPY --parents crates/*/Cargo.toml ./
 COPY --parents crates/aardvark-sys/build.rs ./
 # apps/tauri: .dockerignore whitelists only Cargo.toml; src is stubbed below.
 COPY apps/tauri/Cargo.toml apps/tauri/Cargo.toml
+# tools/fill-translations and xtask are dev/build tools; copy manifests only so
+# Cargo can resolve the workspace, then stub their entry points so the
+# dependency pre-fetch step succeeds without building them into the image.
+COPY tools/fill-translations/Cargo.toml tools/fill-translations/Cargo.toml
+COPY xtask/Cargo.toml xtask/Cargo.toml
 # Create dummy targets for all workspace members so manifest parsing succeeds.
-RUN mkdir -p src benches apps/tauri/src \
+# `src/bin/zeroclaw-acp-bridge.rs` is required because the `acp-bridge` feature
+# is in the root crate's default set; cargo selects the bin target during the
+# pre-fetch build even with only the workspace lib stubbed.
+RUN mkdir -p src src/bin benches apps/tauri/src tools/fill-translations/src xtask/src \
     && echo "fn main() {}" > src/main.rs \
     && echo "" > src/lib.rs \
+    && echo "fn main() {}" > src/bin/zeroclaw-acp-bridge.rs \
     && echo "fn main() {}" > benches/agent_benchmarks.rs \
     && echo "fn main() {}" > apps/tauri/src/main.rs \
+    && echo "fn main() {}" > tools/fill-translations/src/main.rs \
+    && echo "fn main() {}" > xtask/src/main.rs \
     && for d in crates/*/; do mkdir -p "${d}src" && printf '' > "${d}src/lib.rs"; done
 RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,id=zeroclaw-cargo-git,target=/usr/local/cargo/git,sharing=locked \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.7
+# syntax=docker/dockerfile:1.7-labs
 
 # ── Stage 0: Frontend build ─────────────────────────────────────
 FROM node:22-alpine AS web-builder
@@ -56,14 +56,17 @@ COPY xtask/Cargo.toml xtask/Cargo.toml
 # `src/bin/zeroclaw-acp-bridge.rs` is required because the `acp-bridge` feature
 # is in the root crate's default set; cargo selects the bin target during the
 # pre-fetch build even with only the workspace lib stubbed.
-RUN mkdir -p src src/bin benches apps/tauri/src tools/fill-translations/src xtask/src \
+RUN mkdir -p src src/bin benches apps/tauri/src tools/fill-translations/src xtask/src/bin \
     && echo "fn main() {}" > src/main.rs \
     && echo "" > src/lib.rs \
     && echo "fn main() {}" > src/bin/zeroclaw-acp-bridge.rs \
     && echo "fn main() {}" > benches/agent_benchmarks.rs \
     && echo "fn main() {}" > apps/tauri/src/main.rs \
     && echo "fn main() {}" > tools/fill-translations/src/main.rs \
-    && echo "fn main() {}" > xtask/src/main.rs \
+    && echo "" > xtask/src/lib.rs \
+    && echo "fn main() {}" > xtask/src/bin/mdbook.rs \
+    && echo "fn main() {}" > xtask/src/bin/fluent.rs \
+    && echo "fn main() {}" > xtask/src/bin/web.rs \
     && for d in crates/*/; do mkdir -p "${d}src" && printf '' > "${d}src/lib.rs"; done
 RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,id=zeroclaw-cargo-git,target=/usr/local/cargo/git,sharing=locked \
@@ -73,16 +76,29 @@ RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/regist
     else \
       cargo build --release --locked; \
     fi
-RUN rm -rf src benches
+RUN rm -rf src benches crates xtask tools/fill-translations
 
 # 2. Copy only build-relevant source paths (avoid cache-busting on docs/tests/scripts)
 COPY src/ src/
 COPY benches/ benches/
+COPY crates/ crates/
+COPY xtask/ xtask/
+COPY tools/fill-translations/ tools/fill-translations/
 COPY --from=web-builder /web/dist web/dist
 RUN touch src/main.rs src/lib.rs
 RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,id=zeroclaw-cargo-git,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,id=zeroclaw-target,target=/app/target,sharing=locked \
+    rm -rf target/release/.fingerprint/zeroclawlabs-* \
+           target/release/deps/zeroclawlabs-* \
+           target/release/incremental/zeroclawlabs-* \
+           target/release/.fingerprint/zeroclaw-* \
+           target/release/deps/zeroclaw_* \
+           target/release/incremental/zeroclaw_* \
+           target/release/.fingerprint/xtask-* \
+           target/release/deps/xtask-* \
+           target/release/.fingerprint/fill-translations-* \
+           target/release/deps/fill_translations-* && \
     if [ -n "$ZEROCLAW_CARGO_FEATURES" ]; then \
       cargo build --release --locked --features "$ZEROCLAW_CARGO_FEATURES"; \
     else \


### PR DESCRIPTION
> **Update 2026-05-04 (II):** scope expanded again to incorporate @arucil's parallel fix from #6186 (superseded by this PR). Their PR landed first in time but covers only `Dockerfile`; this PR covers both `Dockerfile` and `Dockerfile.debian`, which is why the supersede direction is this way around. @arucil's deeper changes are folded in with co-author attribution: stub all three xtask `[[bin]]` targets (mdbook, fluent, web) backed by an empty `xtask/src/lib.rs` rather than a single `xtask/src/main.rs` (which was structurally wrong because `xtask/Cargo.toml` declares explicit bin paths and no `[lib]`); expand the post-prefetch cleanup to drop `crates/`, `xtask/`, and `tools/fill-translations/` before re-COPYing the real source so cached stub artifacts can't shadow the second-stage build; broaden the fingerprint/deps purge to include `zeroclaw-*`, `xtask-*`, and `fill-translations-*`; bump syntax to `dockerfile:1.7-labs` since `--parents` is a labs feature.

> **Update 2026-05-04:** scope expanded after @Audacity88's review (4216605164) — adds `src/bin/zeroclaw-acp-bridge.rs` stub to the pre-fetch step (cargo selects the bin target during dependency caching because `acp-bridge` is in the default feature set), and applies the same pre-fetch shape to `Dockerfile.debian` (which was missing both this PR's original `tools/fill-translations` / `xtask` manifest copies + stubs AND the acp-bridge stub). Title updated to reflect the two-file scope. Now closes both halves of #6304.

## Summary

- **Base branch:** `master`
- **Supersedes:** #6186 (@arucil) — same root cause, narrower scope. Co-author trailer added to the merge commit.
- **What changed and why:**
  - Added `COPY tools/fill-translations/Cargo.toml` and `COPY xtask/Cargo.toml` to the dependency pre-fetch stage of both Dockerfiles. Both crates are listed as workspace members in `Cargo.toml` but were never copied into the build context, causing Cargo to abort manifest resolution before any compilation begins (the originally-reported #6304 failure mode).
  - Stubbed `src/bin/zeroclaw-acp-bridge.rs` in the pre-fetch step. The root crate declares `[[bin]] name = "zeroclaw-acp-bridge"` with `required-features = ["acp-bridge"]`, and `acp-bridge` is in the default feature set; cargo selects the bin target during dependency caching, so without the stub the build fails with the same `can't find bin` error #6304 reported.
  - Stubbed all three xtask `[[bin]]` targets (mdbook, fluent, web) plus an empty `xtask/src/lib.rs`. The previous single `xtask/src/main.rs` stub did not match `xtask/Cargo.toml`, which declares three explicit bin paths and no `[lib]`. (From @arucil's #6186.)
  - Expanded the post-prefetch cleanup to remove `crates/`, `xtask/`, and `tools/fill-translations/` before re-COPYing the real source, and broadened the fingerprint/deps purge to include `zeroclaw-*`, `xtask-*`, and `fill-translations-*` artifacts so the second build picks up real source instead of stub artifacts cached from the prefetch. (From @arucil's #6186.)
  - Bumped syntax to `dockerfile:1.7-labs`. The `--parents` flag is a labs feature; the prior `1.7` declaration was wrong even on the original Dockerfile. (From @arucil's #6186.)
  - Brought `Dockerfile.debian` up to the same shape as `Dockerfile`.
  - Neither `tools/fill-translations` nor `xtask` is built into the release image; the stubs exist only to satisfy workspace manifest parsing and the prefetch `cargo build`.
- **Scope boundary:** `Dockerfile` and `Dockerfile.debian` only. No changes to `Cargo.toml`, workspace membership, or any Rust source.
- **Blast radius:** Docker dependency pre-fetch layer in both base images. The dep pre-fetch layer cache will be invalidated once on first build after this change for each image.
- **Linked issue(s):** `Closes #6304`, supersedes #6186.

## Validation Evidence (required)

Author-local full Docker validation was not run because the author did not have a Docker daemon available. Each fix is structurally identical to a stub pattern already used in the same Dockerfile (workspace-member stub mirrors the `apps/tauri` pattern; the acp-bridge bin stub mirrors the workspace-lib stub; the xtask bin stubs mirror the explicit bin paths in `xtask/Cargo.toml`).

Maintainer follow-up validation against `origin/master` simulated the Docker dependency pre-fetch layer with `cargo metadata --locked --no-deps --format-version 1` and reproduced the #6304 root cause:

```text
error: failed to load manifest for workspace member `/private/tmp/zc-6304-prefetch.X8Zmr7/tools/fill-translations`
referenced by workspace at `/private/tmp/zc-6304-prefetch.X8Zmr7/Cargo.toml`

Caused by:
  failed to read `/private/tmp/zc-6304-prefetch.X8Zmr7/tools/fill-translations/Cargo.toml`

Caused by:
  No such file or directory (os error 2)
```

The same simulation against the original PR head (5e2b2b2b7ab625d80bd9fc4d8f346c91afcdb17e) showed Cargo workspace metadata resolution succeeded (rc=0).

@Audacity88's review caught a second failure mode that `cargo metadata` does not exercise: the actual `cargo build` step in the Dockerfile selects the `zeroclaw-acp-bridge` bin target (because `acp-bridge` is in the default feature set), so a build that gets past manifest resolution still fails with `can't find bin`. The follow-up commit (c1ee250c7) addresses that across both Dockerfiles.

@arucil's #6186 caught the third failure mode: even with the workspace manifests stubbed correctly, the prefetch leaves cached stub artifacts in the target directory, and the second-stage build reuses them instead of rebuilding the real source. The expanded `rm -rf` and fingerprint purge in the latest commit addresses that.

- **Beyond CI — what did you manually verify?** Confirmed `tools/fill-translations` and `xtask` are both listed in `Cargo.toml` workspace members and both were absent from the pre-PR Dockerfile copy/stub layer. Confirmed `[[bin]] zeroclaw-acp-bridge` is declared in `Cargo.toml` with `required-features = ["acp-bridge"]` and that `acp-bridge` is in the default feature set. Confirmed `xtask/Cargo.toml` declares three explicit `[[bin]]` paths (mdbook, fluent, web) and no `[lib]`. Confirmed `Dockerfile.debian` had neither the workspace-member nor the acp-bridge stubs before this PR.
- **If any command was intentionally skipped, why:** Full `docker build .` validation remains unavailable from this maintainer environment because the local Dockerfile frontend fails before the Cargo step. The targeted pre-fetch simulation covers the reported #6304 manifest-resolution failure mode; the bin-target and stub-artifact failure modes are structural fixes mirroring existing patterns.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert 1e79523a7 c1ee250c7 5e2b2b2b7`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Docker dependency pre-fetch or build steps fail before compiling ZeroClaw; look for Cargo workspace manifest resolution errors involving `tools/fill-translations` or `xtask`, the `can't find bin zeroclaw-acp-bridge` error during the pre-fetch `cargo build`, or `can't find bin mdbook|fluent|web` for xtask.
