### PR TITLE
fix(matrix): avoid duplicate inbound replies — drop event handlers when sync loop returns

### DIFF
--- a/crates/zeroclaw-channels/src/matrix.rs
+++ b/crates/zeroclaw-channels/src/matrix.rs
@@ -1036,8 +1036,19 @@ mod inbound {
     }
 
     pub(super) async fn run_sync_loop(client: Client, ctx: HandlerCtx) -> anyhow::Result<()> {
+        // Bind handler lifetime to this function's scope. matrix-sdk 0.16's
+        // `add_event_handler` registers handlers on the cached `Client` and
+        // never deduplicates — so without explicit removal, every supervisor
+        // restart of `run_sync_loop` (after sleep/wake, WLAN drop, transient
+        // sync errors) would stack a fresh handler on top of the existing
+        // one, multiplying every inbound event by the restart count.
+        //
+        // Wrapping the returned `EventHandlerHandle` in
+        // `EventHandlerDropGuard` makes the SDK call `remove_event_handler`
+        // when this function returns, keeping exactly one active handler
+        // per event type at all times.
         let handler_ctx = ctx.clone();
-        client.add_event_handler(
+        let message_handler = client.add_event_handler(
             move |ev: OriginalSyncRoomMessageEvent, room: Room, raw: RawEvent| {
                 let ctx = handler_ctx.clone();
                 async move {
@@ -1047,18 +1058,21 @@ mod inbound {
                 }
             },
         );
+        let _message_handler_guard = client.event_handler_drop_guard(message_handler);
 
         // Surface inbound events the SDK couldn't decrypt by reacting ❓ on
         // the encrypted event so the operator notices a key gap in chat
         // instead of silent dropping. Best-effort: prophylactic in normally-
         // healthy rooms where decryption succeeds.
         let encrypted_ctx = ctx.clone();
-        client.add_event_handler(move |ev: OriginalSyncRoomEncryptedEvent, room: Room| {
-            let ctx = encrypted_ctx.clone();
-            async move {
-                handle_undecryptable(ctx, ev, room).await;
-            }
-        });
+        let encrypted_handler =
+            client.add_event_handler(move |ev: OriginalSyncRoomEncryptedEvent, room: Room| {
+                let ctx = encrypted_ctx.clone();
+                async move {
+                    handle_undecryptable(ctx, ev, room).await;
+                }
+            });
+        let _encrypted_handler_guard = client.event_handler_drop_guard(encrypted_handler);
 
         info!("matrix: starting sync loop");
         // Run an initial sync once so the sync token + state are populated,


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - `run_sync_loop` registered a fresh event handler on every entry via `client.add_event_handler(...)` but never removed it on return. Each supervised restart accumulated another handler on the reused `Client`, causing every inbound event to be dispatched to all registered copies (2x, 3x, ... Nx replies).
  - Fixed by binding handler lifetime to the sync-loop scope using `Client::event_handler_drop_guard()` (matrix-sdk 0.16). Handlers register on entry and drop automatically on return, so exactly one handler per event type is active at all times regardless of restart count.
- **Scope boundary:** Only changes Matrix inbound event handler registration. Does not touch outbound dispatch, other channel adapters, or the supervisor/orchestrator restart logic.
- **Blast radius:** Matrix channel only. No other channels or subsystems register event handlers via this code path.
- **Linked issue(s):** Closes #6376

## Validation Evidence (required)

Local validation is the signal CI cannot replace. Run the full battery and paste literal output (tails, failures, warnings — not "all passed").

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

Docs-only changes: replace with markdown lint + link-integrity (`scripts/ci/docs_quality_gate.sh`). Bootstrap scripts: add `bash -n install.sh`.

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` — passed
  - `cargo clippy --release -p zeroclaw-channels --features channel-matrix --all-targets -- -D warnings` — passed
  - `cargo build --release --features channel-matrix` — passed
- **Beyond CI — what did you manually verify?** Manual WLAN toggle reproduction: confirmed 2x/3x duplicate replies before fix, consistently single reply after. Verified across multiple restart cycles.
- **If any command was intentionally skipped, why:** `cargo test` — pre-existing failing test `outbound_sandbox::rejects_absolute_outside_workspace` on macOS is unrelated to this PR. Full test suite otherwise clean.

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No

## Rollback (required for `risk: medium` and `risk: high`)

`git revert <sha>` is the plan.

---

**Labels** live in the GitHub label UI, not in the body. Set `risk:*`, `size:*`, and scope labels via the sidebar. Auto-label corrections: add `risk: manual` and the intended label.

**Commit trailers** capture AI-assisted collaboration (`Co-Authored-By: Claude ...`) — no separate section needed.

**Privacy contract** (`docs/book/src/contributing/privacy.md`) is a merge gate. Never commit real identities, secrets, personal emails, or PII in diff, tests, fixtures, or docs.
