### PR TITLE
feat(providers): add stepfun-intl endpoint

### DIFF
--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -67,6 +67,8 @@ const GLM_GLOBAL_BASE_URL: &str = "https://api.z.ai/api/paas/v4";
 const GLM_CN_BASE_URL: &str = "https://open.bigmodel.cn/api/paas/v4";
 const MOONSHOT_INTL_BASE_URL: &str = "https://api.moonshot.ai/v1";
 const MOONSHOT_CN_BASE_URL: &str = "https://api.moonshot.cn/v1";
+const STEPFUN_CN_BASE_URL: &str = "https://api.stepfun.com/v1";
+const STEPFUN_INTL_BASE_URL: &str = "https://api.stepfun.ai/v1";
 const QWEN_CN_BASE_URL: &str = "https://dashscope.aliyuncs.com/compatible-mode/v1";
 const QWEN_INTL_BASE_URL: &str = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1";
 const QWEN_US_BASE_URL: &str = "https://dashscope-us.aliyuncs.com/compatible-mode/v1";
@@ -1693,7 +1695,13 @@ fn create_provider_with_url_and_options(
         // ── Chinese AI providers ─────────────────────────────
         "stepfun" | "step" => Ok(compat(OpenAiCompatibleProvider::new(
             "Stepfun",
-            "https://api.stepfun.com/v1",
+            STEPFUN_CN_BASE_URL,
+            key,
+            AuthStyle::Bearer,
+        ))),
+        "stepfun-intl" | "step-intl" => Ok(compat(OpenAiCompatibleProvider::new(
+            "Stepfun (International)",
+            STEPFUN_INTL_BASE_URL,
             key,
             AuthStyle::Bearer,
         ))),
@@ -2376,6 +2384,12 @@ pub fn list_providers() -> Vec<ProviderInfo> {
             name: "stepfun",
             display_name: "Stepfun",
             aliases: &["step"],
+            local: false,
+        },
+        ProviderInfo {
+            name: "stepfun-intl",
+            display_name: "Stepfun (International)",
+            aliases: &["step-intl"],
             local: false,
         },
         ProviderInfo {


### PR DESCRIPTION
> **Maintainer edit (@singlerider, 2026-05-04):** updated title to conventional-commit format, expanded "What changed and why" bullets per @WareWolf-MoonWall's review, swapped scope-boundary and blast-radius to match the template definitions, corrected the security-section answer (adding a base URL constant is not a credentials-handling change), and pasted the test-output tail inline. Code change unchanged from @aredridel's submission at 70f2445d3970a2686597efe1ab31aaac0e2b9c6b.

## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Stepfun operates separate endpoints for Chinese users (`api.stepfun.com/v1`) and international users (`api.stepfun.ai/v1`); the existing `stepfun` provider only covered the CN endpoint.
  - Users outside China calling `https://api.stepfun.com/v1` hit connectivity issues; a new `stepfun-intl` (alias `step-intl`) provider routes to `https://api.stepfun.ai/v1` instead.
  - Refactored the existing hardcoded `stepfun.com` URL into a new `STEPFUN_CN_BASE_URL` constant alongside the new `STEPFUN_INTL_BASE_URL`, matching the Moonshot CN/INTL and GLM CN/Global naming pattern already in the file.
- **Scope boundary:** does not touch model routing, the config schema, or any existing provider behavior. No changes to auth flow, token lifecycle, or secret storage.
- **Blast radius:** users who configure `provider: stepfun` (or alias `step`) by name are unaffected — the existing match arm is unchanged. The new `stepfun-intl` alias is purely additive.
- **Linked issue(s):** Closes #6307

## Validation Evidence (required)

```bash
:; ./scripts/ci/rust_quality_gate.sh
==> rust quality: cargo fmt --all -- --check
==> rust quality: cargo clippy --locked --all-targets -- -D clippy::correctness
    Checking zeroclaw-api v0.7.4 (...)
   Compiling zeroclaw-macros v0.7.4 (...)
   ...
    Checking zeroclaw-channels v0.7.4 (...)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 55s
```

Test run tail (full log: <https://github.com/user-attachments/files/27318463/log.txt>):

```
     Running tests/test_live.rs (target/debug/deps/live-77ad49ad00a35a36)

running 7 tests
test live::gemini_fallback_oauth_refresh::gemini_warmup_refreshes_expired_oauth_token ... ignored, requires live Gemini OAuth credentials with refresh_token
test live::gemini_fallback_oauth_refresh::gemini_warmup_with_valid_credentials ... ignored, requires live Gemini OAuth credentials
test live::openai_codex_vision_e2e::openai_codex_second_vision_support ... ignored, requires live OpenAI Codex OAuth credentials (second profile)
test live::openai_codex_vision_e2e::provider_vision_support ... ignored, requires live provider OAuth credentials
test live::providers::e2e_live_openai_codex_multi_turn ... ignored, requires live OpenAI Codex OAuth credentials
test live::zai_jwt_auth::live_zai_jwt_auth_chat ... ignored, requires live ZAI_API_KEY
test live::zai_jwt_auth::live_zai_jwt_auth_multi_turn ... ignored, requires live ZAI_API_KEY

test result: ok. 0 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/test_system.rs (target/debug/deps/system-1c799781dff586f1)

running 5 tests
test system::full_stack::system_tool_arguments_passed_correctly ... ok
test system::full_stack::system_simple_text_response ... ok
test system::full_stack::system_parallel_tool_execution ... ok
test system::full_stack::system_multi_turn_conversation ... ok
test system::full_stack::system_tool_execution_flow ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s
```

Earlier suites in the same run: `229 passed`, `228 passed`, `18 passed`, `205 passed`, `159 passed` (all 0 failed).

- **Commands run and tail output:** `./scripts/ci/rust_quality_gate.sh` (clean) and full `cargo test` (824 passed total across all suites, 7 ignored requiring live credentials, 0 failed).
- **Beyond CI — what did you manually verify?** Original author confirmed the new endpoint works with their international API token.
- **If any command was intentionally skipped, why:** N/A.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No** — the provider is only reached when an operator explicitly configures `provider: stepfun-intl`. No new outbound traffic by default.
- Secrets / tokens / credentials handling changed? **No** — adding a base URL constant is not a change to credentials handling. The `Bearer` auth style and token lifecycle are unchanged.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility (required)

- Backward compatible? **Yes** — additive provider entry; no existing provider path changes.
- Config / env / CLI surface changed? **Yes (additive only)** — operators can now set `provider: stepfun-intl` (or alias `step-intl`); existing `stepfun` / `step` configurations continue to work unchanged.
- Exact upgrade steps for existing users: none needed. To opt into the new endpoint, change `provider` in `config.toml` to `stepfun-intl`.

## Rollback

`git revert 56be5946e` — provider entry is fully isolated from the rest of the codebase.
