### PR TITLE
docs(maintainers): document merge process

### DIFF
--- a/docs/book/src/maintainers/pr-workflow.md
+++ b/docs/book/src/maintainers/pr-workflow.md
@@ -56,19 +56,139 @@ Before merge:
 - Migration / compatibility impact is documented.
 - Rollback path is concrete and fast.
 
-## Maintainer merge checklist
+## Maintainer merge process
 
-Every merge:
+Merging is a separate maintainer action from reviewing. A PR can be approved but still not ready to merge if the branch moved, CI restarted, labels are stale, rollback is unclear, or the final squash message would misrepresent the work.
 
-- Scope is focused and understandable.
-- CI gate is green.
+Use this process immediately before landing any PR.
+
+### 1. Refresh live state
+
+Before deciding anything, refresh the PR from GitHub. Do not rely on an old review tab, local queue snapshot, or earlier CI status.
+
+Verify:
+
+- PR is open, non-draft, and targets `master`.
+- Head SHA is the one you intend to merge.
+- Merge state is clean / mergeable.
+- `CI Required Gate` is green.
+- Required reviewers approved, including CODEOWNERS paths.
+- No active `CHANGES_REQUESTED` review remains.
+- No unresolved inline thread contains a merge-blocking question.
+- Risk, size, and scope labels match the final touched paths.
+- PR body still matches the final diff, validation evidence, security/privacy impact, compatibility notes, and rollback plan.
 - Docs-quality checks are green when docs changed.
-- Security and privacy fields are complete; evidence is redacted / anonymized.
-- Agent-workflow notes are sufficient for reproducibility (if AI-assisted).
-- Rollback plan is explicit.
-- Commit title follows Conventional Commits.
+- Linked issues / stacked PRs / superseded PRs are understood and named correctly.
 
-Squash-merge with full commit history preserved in the body. The `squash-merge` skill produces both the purple **Merged** badge and the conventional-commits formatted body — see [Skills](./skills.md) for invocation.
+If a maintainer pushed a fixup after approval, re-check review staleness and CI after that commit. Do not assume the previous ready state survived the new head.
+
+### 2. Decide whether a fixup is needed
+
+If the PR is conceptually ready but has a tiny mechanical defect, prefer the lightest correction that preserves contributor attribution:
+
+1. Push a trivial maintainer fixup to the contributor branch when `maintainerCanModify` is true and the fix is clearly within the PR's scope.
+2. Ask the author for changes when the fix is non-trivial, design-sensitive, or likely to conflict with their local work.
+3. Merge as-is and open a follow-up only when the current PR is correct and the follow-up is hardening or polish.
+4. Supersede only when the [superseding rules](./superseding.md) apply.
+
+After any fixup, return to step 1.
+
+### 3. Choose the merge strategy
+
+ZeroClaw's default and expected merge strategy is **squash merge for all PRs**.
+
+Use squash merge for:
+
+- Contributor PRs.
+- Docs-only changes.
+- Bug fixes and feature slices.
+- PRs with maintainer fixup commits.
+- PRs with iterative, messy, or review-response commits.
+- Any PR where "one PR = one revertable commit" is the right history model.
+
+Use a regular merge only with an explicit maintainer exception, and document why before merging. Valid exceptions are rare:
+
+- A long-lived integration branch where the branch topology is itself meaningful.
+- A release, backport, or stabilization branch where preserving merge ancestry matters.
+- A deliberately structured multi-commit series where each commit must remain separately bisectable on `master`.
+
+If a normal PR seems to need regular merge because it contains several independently meaningful changes, pause and consider splitting or stacking it instead. Do not use regular merge just to preserve messy review history.
+
+Never direct-push a squash commit to `master`. Direct pushes bypass the PR merge mechanism, so the PR shows as closed instead of merged and linked issues may not close correctly. Do not use GitHub's web UI auto-generated squash message either; it does not consistently preserve the project commit-message format.
+
+### 4. Prepare the squash message
+
+The squash subject must be a conventional commit and include the PR number:
+
+```text
+<PR title> (#<number>)
+```
+
+If the PR title is not a good conventional commit subject, fix the title or prepare a corrected subject before merging.
+
+The squash body preserves the PR's commit history:
+
+- For a multi-commit PR, include one bullet per PR commit: `- <short sha> <commit subject>`.
+- For a single-commit PR, use the original commit body, or leave the squash body blank if there is no useful body.
+- If maintainer fixups were pushed, include them in the preserved commit list rather than hiding them.
+- If superseded work was materially incorporated, include the required `Co-authored-by` trailers and supersede notes from [Superseding PRs](./superseding.md).
+
+For a PR with contributor commits plus maintainer fixups, the final `master` history should read as one coherent project change while the body still makes the branch history auditable.
+
+### 5. Confirm before merging
+
+Before running the merge command, show the maintainer the exact expanded command, final subject, final body, target PR, and effect. Explicit approval for the review, the fixup, or the checklist is not enough; merging needs its own confirmation.
+
+The confirmation should state:
+
+- PR number and title.
+- Head SHA being merged.
+- Merge strategy: squash.
+- Final squash subject.
+- Final squash body.
+- Expected effect: PR becomes merged, linked issues may close, and a new commit lands on `master`.
+
+Stop if the maintainer changes the subject/body, asks a question, or redirects the task. Resume only after the final command has been shown again and approved.
+
+### 6. Execute through the PR merge mechanism
+
+Use `gh pr merge` with an explicit subject and body:
+
+```bash
+gh pr merge <number> --repo zeroclaw-labs/zeroclaw --squash \
+  --subject "<subject>" \
+  --body "<body>"
+```
+
+If the command fails, report the error and stop. Do not retry, force-push, close/reopen, dismiss reviews, bypass checks, or use a different merge strategy unless a maintainer explicitly chooses that recovery path.
+
+### 7. Verify and clean up
+
+After the command succeeds, verify:
+
+- PR state is `MERGED`.
+- Merge commit SHA is present.
+- The final commit subject/body match what was approved.
+- Linked issues closed only when that was intended.
+- Any local handoff or queue document that was tracking the PR is updated or cleared.
+
+Never delete contributor branches. Branch cleanup is the contributor's choice.
+
+### Stop conditions
+
+Stop before merge if any of these are true:
+
+- CI Required Gate is missing, pending, or failing.
+- Merge state is dirty, blocked, or unknown.
+- Required review is missing.
+- Any active `CHANGES_REQUESTED` review remains.
+- CODEOWNERS or workflow-owner approval is missing for protected paths.
+- The PR body materially contradicts the diff or validation evidence.
+- Risk labels are clearly wrong for the touched paths.
+- Privacy/security fields are incomplete or the diff contains unredacted sensitive data.
+- The rollback path is missing or wrong for a medium/high-risk PR.
+- You cannot produce a conventional squash subject.
+- You think regular merge might be appropriate but no maintainer exception has been recorded.
 
 ## AI / Agent contribution policy
 

--- a/docs/book/src/maintainers/skills.md
+++ b/docs/book/src/maintainers/skills.md
@@ -63,7 +63,7 @@ PRs with merge conflicts receive `needs-author-action` only — no review, no di
 
 ## Squash-merge strategy
 
-ZeroClaw uses squash-merge for all PRs. The `squash-merge` skill produces both the purple **Merged** badge *and* a conventional-commits formatted squash message with full commit history in the body.
+ZeroClaw uses squash-merge for all PRs; see [PR Workflow](./pr-workflow.md#maintainer-merge-process) for the human merge-readiness process and rare regular-merge exceptions. The `squash-merge` skill handles the final execution step by producing both the purple **Merged** badge *and* a conventional-commits formatted squash message with full commit history in the body.
 
 ### Why the skill exists
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Expands the maintainer PR workflow with a final merge-readiness process separate from review approval.
  - Documents live-state checks for head SHA, CI, approvals, review state, labels, PR body accuracy, linked issues, and rollback readiness.
  - Codifies squash merge as the default for ZeroClaw PRs, with narrow regular-merge exceptions that require explicit maintainer rationale.
  - Documents exact pre-merge confirmation, explicit `gh pr merge --squash` usage, post-merge verification, and the rule not to delete contributor branches.
  - Updates the maintainer skills page to point squash-merge strategy readers back to the new merge process.
- **Scope boundary:** Docs only. This does not change GitHub settings, CI workflows, branch protection, merge automation, runtime behavior, or contributor-facing code.
- **Blast radius:** Maintainer documentation for PR merge decisions and squash execution. No runtime, build, config, or CLI impact.
- **Linked issue(s):** None.

## Validation Evidence (required)

- **Commands run and tail output:**

```bash
git diff --check origin/master...HEAD
```

```text
# completed with no output
```

```bash
./scripts/ci/docs_quality_gate.sh
```

```text
Linting docs files: docs/book/src/maintainers/pr-workflow.md docs/book/src/maintainers/skills.md
markdownlint-cli2 v0.20.0 (markdownlint v0.40.0)
Finding: docs/book/src/maintainers/pr-workflow.md docs/book/src/maintainers/skills.md !target/**
Linting: 2 file(s)
Summary: 0 error(s)
```

- **Beyond CI — what did you manually verify?** Verified the branch diff touches only maintainer documentation, confirmed the merge-process commit is not already on `origin/master`, and checked that there is no existing PR from this branch.
- **If any command was intentionally skipped, why:** `cargo fmt`, `cargo clippy`, and `cargo test` were skipped because this is docs-only. The docs quality gate is the relevant local validation.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: `N/A`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: exact upgrade steps for existing users: `N/A`

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk docs-only PR. Rollback plan: `git revert <merge_commit_sha>`.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A; this PR does not supersede another PR.
