### PR TITLE
fix(providers/anthropic): respect base_url config for default provider

### DIFF
--- a/crates/zeroclaw-providers/src/anthropic.rs
+++ b/crates/zeroclaw-providers/src/anthropic.rs
@@ -12,7 +12,7 @@ use zeroclaw_api::tool::ToolSpec;
 
 /// Anthropic's API documentation lists 1.0 as the default sampling temperature.
 const TEMPERATURE_DEFAULT: f64 = 1.0;
-/// Anthropic's public API endpoint. Overrideable via `providers.models.<name>.base-url`.
+/// Anthropic's public API endpoint. Overrideable via `providers.models.<name>.base_url`.
 const BASE_URL: &str = "https://api.anthropic.com";
 
 pub struct AnthropicProvider {

--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -1223,7 +1223,7 @@ fn create_provider_with_url_and_options(
             Ok(Box::new(p))
         }
         "anthropic" => {
-            let mut p = anthropic::AnthropicProvider::new(key);
+            let mut p = anthropic::AnthropicProvider::with_base_url(key, api_url);
             if let Some(mt) = options.provider_max_tokens {
                 p = p.with_max_tokens(mt);
             }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - The `"anthropic"` branch in `create_provider_with_url_and_options` (`crates/zeroclaw-providers/src/lib.rs`) constructed `AnthropicProvider::new(key)`, dropping the `api_url` argument.
  - Every other branch in the same `match` (openai, ollama, openrouter, anthropic-custom, …) forwards `api_url` via `with_base_url`. Anthropic was the lone outlier.
  - As a result, setting `[providers.models.anthropic] base_url = "..."` in `config.toml` had no effect — Anthropic requests always went to `https://api.anthropic.com` regardless. The doc-comment on `BASE_URL` already advertises this knob as supported.
  - One-line wiring fix: forward `api_url` into `with_base_url(key, api_url)`. Plus a doc-comment typo (`base-url` → `base_url`) so it matches the actual serde field name.
- **Scope boundary:** No changes to provider semantics, request bodies, auth handling, or the `anthropic-custom:` provider (which already worked correctly). No new config keys.
- **Blast radius:** Only users who had set `base_url` under `[providers.models.anthropic]` and got silently ignored — they will now actually be routed to their configured endpoint. Users who never set `base_url` continue to hit `https://api.anthropic.com` (unchanged default via `BASE_URL` constant in `with_base_url`).
- **Linked issue(s):** none

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test -p zeroclaw-providers
```

- **Commands run and tail output:**

  `cargo fmt --all -- --check` → exit 0 (no output).

  `cargo clippy --all-targets -- -D warnings` tail:
  ```
      Checking zeroclaw-providers v0.7.4 (.../crates/zeroclaw-providers)
      Checking zeroclaw-runtime v0.7.4 (.../crates/zeroclaw-runtime)
      Checking zeroclaw-channels v0.7.4 (.../crates/zeroclaw-channels)
      Finished `dev` profile [unoptimized + debuginfo] target(s) in 53.61s
  ```

  `cargo test -p zeroclaw-providers` tail:
  ```
  test result: ok. 783 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 4.02s

     Doc-tests zeroclaw_providers
  test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.00s
  ```

  Existing `creates_with_custom_base_url` and `default_base_url_when_none_provided` tests in `anthropic.rs` already cover both branches of the changed code path.

- **Beyond CI — what did you manually verify?**
  Patched daemon (`cargo build --release --features channel-matrix`), set `[providers.models.anthropic] base_url = "http://127.0.0.1:8000"`, ran a local reverse-proxy (`mitmweb --mode reverse:https://api.anthropic.com -p 8000`) and confirmed Anthropic requests now flow through the configured proxy instead of the hardcoded default. Also verified the unchanged path (no `base_url` in config) still hits `https://api.anthropic.com`.

- **If any command was intentionally skipped, why:** Workspace-wide `cargo test` not run because the change is confined to `zeroclaw-providers` and the workspace test suite is large; downstream crates rebuild and link cleanly (verified in the release build).

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No** (this PR enables an existing config knob to redirect existing calls; it does not add any new outbound destination)
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility (required)

- Backward compatible? **Yes** — the default behavior (no `base_url` set) is unchanged because `with_base_url(key, None)` falls back to the `BASE_URL` constant, identical to the previous `new(key)` path.
- Config / env / CLI surface changed? **No** — the `base_url` field on `ProviderModelConfig` already exists in the schema; this change just makes the documented field actually take effect for the default `anthropic` provider.
- **Upgrade steps for existing users:** none. Users who never set `base_url` see no behavior change. Users who *had* set it on `[providers.models.anthropic]` and were relying on the (broken) silent ignore should remove the field before upgrading; users who set it intending it to work get the documented behavior.

## Rollback

Low-risk: `git revert <sha>` is the plan.