### PR TITLE
fix(agent): exclude Conversation memories from build_context recall (#5415 follow-up)

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -370,9 +370,7 @@ async fn build_context(
                 // own autosaves but miss Conversation entries written by
                 // channel handlers (Discord, gateway, WhatsApp, …) under
                 // their own keys. See #5415 / #5456.
-                if exclude_conversation
-                    && matches!(entry.category, MemoryCategory::Conversation)
-                {
+                if exclude_conversation && matches!(entry.category, MemoryCategory::Conversation) {
                     continue;
                 }
                 if zeroclaw_memory::is_assistant_autosave_key(&entry.key) {

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -335,11 +335,17 @@ fn autosave_memory_key(prefix: &str) -> String {
 /// Entries with a hybrid score below `min_relevance_score` are dropped to
 /// prevent unrelated memories from bleeding into the conversation.
 /// Core memories are exempt from time decay (evergreen).
+///
+/// `exclude_conversation` skips `MemoryCategory::Conversation` entries
+/// regardless of their key shape. Set to `true` for autonomous/scheduled
+/// runs (cron, daemon heartbeat) so chat memory cannot leak into prompts
+/// the user did not initiate. See #5415 / #5456.
 async fn build_context(
     mem: &dyn Memory,
     user_msg: &str,
     min_relevance_score: f64,
     session_id: Option<&str>,
+    exclude_conversation: bool,
 ) -> String {
     let mut context = String::new();
 
@@ -359,6 +365,16 @@ async fn build_context(
         if !relevant.is_empty() {
             context.push_str("[Memory context]\n");
             for entry in &relevant {
+                // Scheduled (cron / heartbeat) runs must not see chat-origin
+                // memories. The autosave-key checks below catch the agent's
+                // own autosaves but miss Conversation entries written by
+                // channel handlers (Discord, gateway, WhatsApp, …) under
+                // their own keys. See #5415 / #5456.
+                if exclude_conversation
+                    && matches!(entry.category, MemoryCategory::Conversation)
+                {
+                    continue;
+                }
                 if zeroclaw_memory::is_assistant_autosave_key(&entry.key) {
                     continue;
                 }
@@ -2534,12 +2550,16 @@ pub async fn run(
                 .await;
         }
 
-        // Inject memory + hardware RAG context into user message
+        // Inject memory + hardware RAG context into user message.
+        // For non-interactive runs (cron, daemon heartbeat), exclude
+        // Conversation-category memories so chat history does not leak
+        // into autonomous executions. See #5415 / #5456.
         let mem_context = build_context(
             mem.as_ref(),
             &effective_msg,
             config.memory.min_relevance_score,
             memory_session_id.as_deref(),
+            !interactive,
         )
         .await;
         let rag_limit = if config.agent.compact_context { 2 } else { 5 };
@@ -2821,12 +2841,15 @@ pub async fn run(
                     .await;
             }
 
-            // Inject memory + hardware RAG context into user message
+            // Inject memory + hardware RAG context into user message.
+            // Interactive REPL: keep Conversation memories (user is actively
+            // chatting in this session and may want their own history recalled).
             let mem_context = build_context(
                 mem.as_ref(),
                 &effective_input,
                 config.memory.min_relevance_score,
                 memory_session_id.as_deref(),
+                false,
             )
             .await;
             let rag_limit = if config.agent.compact_context { 2 } else { 5 };
@@ -3406,11 +3429,15 @@ pub async fn process_message(
     }
 
     let effective_msg_ref = effective_message.as_str();
+    // process_message is the channel entrypoint (Discord, Telegram, gateway,
+    // etc.) — recall is scoped to the channel's session_id, so retrieving the
+    // user's own Conversation history within their session is intended.
     let mem_context = build_context(
         mem.as_ref(),
         effective_msg_ref,
         config.memory.min_relevance_score,
         session_id,
+        false,
     )
     .await;
     let rag_limit = if config.agent.compact_context { 2 } else { 5 };
@@ -6366,7 +6393,7 @@ mod tests {
         .await
         .unwrap();
 
-        let context = build_context(&mem, "status updates", 0.0, None).await;
+        let context = build_context(&mem, "status updates", 0.0, None, false).await;
         assert!(context.contains("user_preference"));
         assert!(!context.contains("assistant_resp_poisoned"));
         assert!(!context.contains("fabricated event"));
@@ -6401,10 +6428,54 @@ mod tests {
         .await
         .unwrap();
 
-        let context = build_context(&mem, "answers", 0.0, None).await;
+        let context = build_context(&mem, "answers", 0.0, None, false).await;
         assert!(context.contains("user_preference"));
         assert!(!context.contains("user_msg"));
         assert!(!context.contains("embedding prior context"));
+    }
+
+    /// Regression: cron / heartbeat runs must not surface chat-origin
+    /// `Conversation` memories — the leak path the #5456 prefix filter
+    /// missed because `agent::run` performs a second, unfiltered recall
+    /// inside `build_context`. See #5415.
+    #[tokio::test]
+    async fn build_context_excludes_conversation_when_flag_set() {
+        let tmp = TempDir::new().unwrap();
+        let mem = SqliteMemory::new(tmp.path()).unwrap();
+        // A Conversation entry written by a chat channel with a non-autosave
+        // key (autosave keys are already skipped by the existing filters).
+        mem.store(
+            "discord:guild:chan:msg-42",
+            "Reminder for Alice: the API key is in 1Password vault Foo.",
+            MemoryCategory::Conversation,
+            Some("discord:guild:chan"),
+        )
+        .await
+        .unwrap();
+        // A non-Conversation memory that should still surface so we know the
+        // function still does its job — only Conversation should be dropped.
+        mem.store(
+            "team_oncall",
+            "Primary on-call rotates every Monday at 09:00 UTC.",
+            MemoryCategory::Core,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let context = build_context(&mem, "Alice on-call", 0.0, None, true).await;
+        assert!(
+            !context.contains("Alice"),
+            "Conversation memory leaked into scheduled context: {context}"
+        );
+        assert!(
+            !context.contains("API key"),
+            "Conversation memory leaked into scheduled context: {context}"
+        );
+        assert!(
+            context.contains("team_oncall"),
+            "Non-Conversation memory should still surface: {context}"
+        );
     }
 
     // ═══════════════════════════════════════════════════════════════════════

--- a/crates/zeroclaw-runtime/tests/scheduled_no_conversation_leak_5415.rs
+++ b/crates/zeroclaw-runtime/tests/scheduled_no_conversation_leak_5415.rs
@@ -1,0 +1,174 @@
+//! Integration test for #5415 (follow-up to #5456).
+//!
+//! Reproduces the chat → scheduled-task leak at the agent-loop level. The
+//! daemon heartbeat path (`crates/zeroclaw-runtime/src/daemon/mod.rs`) calls
+//! `agent::run(..., interactive=false, session_state_file=None, ...)`. With
+//! no session_state_file, the agent's `memory_session_id` is `None`, so the
+//! SQLite recall inside `build_context` is unscoped and returns Conversation
+//! memories from any channel session. Before the fix, those entries were
+//! embedded into the prompt sent to the provider.
+//!
+//! (The cron path generates a fresh `cron-{uuid}` session per run, so SQLite
+//! session scoping happens to mask the leak there under the SQLite backend.
+//! The build_context filter is still required for defense in depth — the
+//! markdown backend ignores session_id entirely (memory/markdown.rs:163), and
+//! the heartbeat path has no session scoping at all.)
+//!
+//! Setup
+//! 1. Spin up a minimal axum-based OpenAI-compatible server that records every
+//!    `/chat/completions` request body.
+//! 2. Plant a Conversation entry in `SqliteMemory` under a non-autosave key.
+//! 3. Build a `Config` whose fallback provider is `custom:<mock-url>`.
+//! 4. Call `agent::run` with daemon-heartbeat parameters (`interactive=false`,
+//!    `session_state_file=None`).
+//! 5. Assert no captured request body contains the planted unique sentinel.
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use axum::{Router, extract::State, routing::post};
+use tempfile::TempDir;
+use tokio::sync::Mutex as AsyncMutex;
+use zeroclaw_config::providers::ProvidersConfig;
+use zeroclaw_config::schema::{Config, ModelProviderConfig};
+use zeroclaw_memory::{Memory, MemoryCategory, SqliteMemory};
+
+// Unique sentinel that exists ONLY in the planted Conversation entry — must
+// not appear in the cron prompt or any system prompt. If it surfaces in the
+// captured request body, the only path it could have taken is build_context's
+// recall + injection.
+const SECRET_SENTINEL: &str = "blue-walrus-7421-conversation-leak-canary";
+const FAKE_OPENAI_RESPONSE: &str = r#"{"id":"chatcmpl-test","object":"chat.completion","created":0,"model":"test-model","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}"#;
+
+type CapturedBodies = Arc<AsyncMutex<Vec<String>>>;
+
+async fn handle_chat(State(captured): State<CapturedBodies>, body: String) -> &'static str {
+    captured.lock().await.push(body);
+    FAKE_OPENAI_RESPONSE
+}
+
+async fn spawn_mock_provider() -> (SocketAddr, CapturedBodies) {
+    let captured: CapturedBodies = Arc::new(AsyncMutex::new(Vec::new()));
+    let app = Router::new()
+        .route("/chat/completions", post(handle_chat))
+        .with_state(captured.clone());
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app.into_make_service()).await;
+    });
+    (addr, captured)
+}
+
+#[tokio::test]
+async fn scheduled_run_does_not_leak_conversation_memory_into_provider_request() {
+    let tmp = TempDir::new().unwrap();
+    let workspace_dir = tmp.path().join("workspace");
+    tokio::fs::create_dir_all(&workspace_dir).await.unwrap();
+
+    // ── Mock provider ───────────────────────────────────────────────
+    let (addr, captured) = spawn_mock_provider().await;
+    let provider_name = format!("custom:http://{addr}");
+
+    // ── Plant a chat-origin Conversation memory ────────────────────
+    // Keys like "discord:guild:chan:msg-N" come from real channel handlers
+    // (gateway/lib.rs auto-save); they bypass the existing autosave-key
+    // skip-list because they don't match user_msg_*/assistant_resp_*.
+    //
+    // session_id is `None` to model the user-reported repro: Conversation
+    // entries that lack session scoping (older data, channels that don't
+    // populate session_id, or backends without strict session filtering).
+    // With a session_id set, SQLite's recall filter scopes it out before
+    // build_context runs — the bug manifests precisely when scoping fails.
+    {
+        let mem = SqliteMemory::new(&workspace_dir).unwrap();
+        mem.store(
+            "discord:guild:chan:msg-42",
+            // Includes overlap words ("reminder", "today") so the keyword
+            // search returns this entry for the cron prompt below, plus the
+            // unique SECRET_SENTINEL the assertion looks for.
+            &format!(
+                "Reminder from today's chat: {SECRET_SENTINEL} — do not surface this in scheduled tasks."
+            ),
+            MemoryCategory::Conversation,
+            None,
+        )
+        .await
+        .unwrap();
+    }
+
+    // ── Config pointing the agent at the mock provider ─────────────
+    let mut models = HashMap::new();
+    models.insert(
+        provider_name.clone(),
+        ModelProviderConfig {
+            api_key: Some("test-key".to_string()),
+            model: Some("test-model".to_string()),
+            ..Default::default()
+        },
+    );
+    let mut config = Config {
+        workspace_dir: workspace_dir.clone(),
+        config_path: tmp.path().join("config.toml"),
+        providers: ProvidersConfig {
+            fallback: Some(provider_name.clone()),
+            models,
+            ..Default::default()
+        },
+        ..Config::default()
+    };
+    // No retries / no waits — fail fast if the mock has issues, and don't
+    // multiply the captured bodies during this test.
+    config.reliability.scheduler_retries = 0;
+    config.reliability.provider_retries = 0;
+    // Drop the relevance threshold so the recall surfaces the planted entry
+    // deterministically; production threshold is 0.4 and would filter out
+    // weakly-matching entries before build_context's category filter runs.
+    config.memory.min_relevance_score = 0.0;
+
+    // ── Drive the daemon-heartbeat invocation pattern ──────────────
+    // Matches `crates/zeroclaw-runtime/src/daemon/mod.rs:476` / `:599`:
+    //   crate::agent::run(
+    //       config, Some(prompt), None, None, temp,
+    //       vec![], false, None, None,
+    //   )
+    // `interactive=false` + `session_state_file=None` is exactly the heartbeat
+    // shape that bypasses session scoping inside `build_context`.
+    let prompt =
+        "Any reminders to surface today? Pull anything relevant from memory.".to_string();
+    let run_result = zeroclaw_runtime::agent::run(
+        config,
+        Some(prompt),
+        None,
+        None,
+        0.7,
+        vec![],
+        false,
+        None,
+        None,
+    )
+    .await;
+    let (success, output) = match run_result {
+        Ok(out) => (true, out),
+        Err(err) => (false, format!("agent run errored: {err:#}")),
+    };
+
+    // We don't strictly require success — even if the agent loop bails after
+    // the first chat round, the captured request body is what we audit.
+    let bodies = captured.lock().await;
+    assert!(
+        !bodies.is_empty(),
+        "mock provider received zero requests — agent run never reached the LLM. \
+         job success={success}, output={output}"
+    );
+
+    for (i, body) in bodies.iter().enumerate() {
+        assert!(
+            !body.contains(SECRET_SENTINEL),
+            "Conversation memory leaked into scheduled-run LLM request #{i}: \
+             sentinel {SECRET_SENTINEL:?} found in body. Full body:\n{body}"
+        );
+    }
+}

--- a/crates/zeroclaw-runtime/tests/scheduled_no_conversation_leak_5415.rs
+++ b/crates/zeroclaw-runtime/tests/scheduled_no_conversation_leak_5415.rs
@@ -136,8 +136,7 @@ async fn scheduled_run_does_not_leak_conversation_memory_into_provider_request()
     //   )
     // `interactive=false` + `session_state_file=None` is exactly the heartbeat
     // shape that bypasses session scoping inside `build_context`.
-    let prompt =
-        "Any reminders to surface today? Pull anything relevant from memory.".to_string();
+    let prompt = "Any reminders to surface today? Pull anything relevant from memory.".to_string();
     let run_result = zeroclaw_runtime::agent::run(
         config,
         Some(prompt),


### PR DESCRIPTION
## Summary

PR #5456 filtered `MemoryCategory::Conversation` from the prefix the cron scheduler and daemon heartbeat *prepend* to scheduled prompts. But both paths then call `agent::run`, which performs a **second, independent** memory recall inside [`build_context()`](crates/zeroclaw-runtime/src/agent/loop_.rs#L338-L391) — and that second pass had no category filter. Conversation entries written by channel handlers (Discord, gateway, WhatsApp, …) under their own non-autosave keys slipped through, allowing chat context to surface in scheduled executions.

This PR adds an `exclude_conversation: bool` parameter to `build_context`. The single-shot arm of `agent::run` passes `!interactive`, so cron and heartbeat (both `interactive=false`) get the filter while the interactive REPL and the channel `process_message` entrypoint keep their existing behavior — users chatting in a session may still legitimately recall their own Conversation memories within that session's scope.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: medium`
- Size label (auto-managed): `size: S`
- Scope labels: `runtime`, `memory`, `cron`, `daemon`, `security`

## Change Metadata

- Change type: `security`, `bug`
- Primary scope: `runtime`

## Linked Issue

- Closes #5415 (follow-up to #5456)

## Validation Evidence (required)

```bash
cargo test -p zeroclaw-runtime --lib build_context
# 3 passed (incl. new build_context_excludes_conversation_when_flag_set regression)

cargo test -p zeroclaw-runtime --lib
# 1616 passed; 0 failed

cargo test -p zeroclaw-runtime --lib cron
# 141 passed; 0 failed

cargo clippy -p zeroclaw-runtime --lib --tests -- -D warnings
# clean

cargo check --workspace
# clean
```

### TDD red→green proof

The new test `build_context_excludes_conversation_when_flag_set` was written first and verified to fail before the filter was added. The red-phase panic message captured live:

```
test agent::loop_::tests::build_context_excludes_conversation_when_flag_set ... FAILED
panicked at crates/zeroclaw-runtime/src/agent/loop_.rs:6457:9:
Conversation memory leaked into scheduled context: [Memory context]
- team_oncall: Primary on-call rotates every Monday at 09:00 UTC.
- discord:guild:chan:msg-42: Reminder for Alice: the API key is in 1Password vault Foo.
[/Memory context]
```

After adding the filter, same test passes. The leaked sentinel ("Reminder for Alice…") in the assertion message makes future regressions instantly recognizable.

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`
- This PR **further reduces** data exposure by closing the second-recall leak that #5456 missed.

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Closes a confirmed cross-session leak path: chat content stored under non-autosave Conversation keys (e.g. `discord:guild:chan:msg-42`) was reaching scheduled task prompts via the agent loop's internal `build_context` recall.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Human Verification (required)

- Verified scenarios:
  - Cron job (`interactive=false`) → Conversation entries with channel-style keys no longer surface in the recalled `[Memory context]` block.
  - Daemon heartbeat (`interactive=false`) → same coverage via shared `agent::run` single-shot path.
  - Interactive REPL (`interactive=true`) → Conversation memories still surface (existing tests `build_context_ignores_legacy_assistant_autosave_entries` and `build_context_ignores_user_autosave_entries` continue to assert this).
  - Channel `process_message` (Discord/Telegram/gateway) → unchanged; Conversation recall within session scope intact.

## Side Effects / Blast Radius (required)

- Affected subsystems: scheduled-task prompt assembly inside `agent::run`'s single-shot path.
- Potential unintended effects: cron/heartbeat jobs that previously (incorrectly) benefited from cross-session Conversation memories will lose that context. **This is the intended fix.**

## Rollback Plan (required)

- Fast rollback: `git revert <merge-commit>` on `master`.

## Risks and Mitigations

- Risk: a cron job intentionally configured to read Conversation history (uncommon — cron `uses_memory` is generally for Core/Daily) loses it.
  - Mitigation: explicit Conversation reads via the `memory_search` tool are unaffected — only the implicit prompt-prefix recall is filtered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)