### PR TITLE
fix(config): preserve dotted provider map keys

### DIFF
--- a/crates/zeroclaw-config/src/helpers.rs
+++ b/crates/zeroclaw-config/src/helpers.rs
@@ -7,6 +7,11 @@ use crate::traits::{PropFieldInfo, PropKind};
 /// return the HashMap key + the fully-qualified inner name that the value
 /// type's own `get_prop` / `set_prop` expects.
 ///
+/// HashMap keys are user-controlled and may contain dots, URLs, or hostnames
+/// (for example `providers.models.custom:https://example.invalid/v1.api-key`).
+/// Current map-keyed config sections expose leaf fields, so split from the
+/// right and preserve any dots inside the runtime key.
+///
 /// Returns `None` when the path doesn't match, letting the derive's
 /// generated code fall through to the next nested field.
 pub fn route_hashmap_path<'a>(
@@ -21,7 +26,7 @@ pub fn route_hashmap_path<'a>(
         format!("{my_prefix}.{field_name}")
     };
     let rest = name.strip_prefix(&key_prefix)?.strip_prefix('.')?;
-    let (hm_key, inner_suffix) = rest.split_once('.')?;
+    let (hm_key, inner_suffix) = rest.rsplit_once('.')?;
     let inner_name = if inner_prefix.is_empty() {
         inner_suffix.to_string()
     } else {

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -18046,6 +18046,95 @@ auto_approve = ["file_read", "file_write", "file_edit", "memory_recall", "memory
     }
 
     #[test]
+    async fn hashmap_property_paths_preserve_url_like_keys() {
+        let dir = TempDir::new().unwrap();
+        let mut config = Config {
+            config_path: dir.path().join("config.toml"),
+            workspace_dir: dir.path().join("workspace"),
+            ..Default::default()
+        };
+        let provider_key = "custom:https://api.example.invalid/v1";
+        config
+            .providers
+            .models
+            .insert(provider_key.to_string(), ModelProviderConfig::default());
+
+        let api_key_path = format!("providers.models.{provider_key}.api-key");
+        let base_url_path = format!("providers.models.{provider_key}.base-url");
+        let model_path = format!("providers.models.{provider_key}.model");
+        let temperature_path = format!("providers.models.{provider_key}.temperature");
+
+        assert!(
+            Config::prop_is_secret(&api_key_path),
+            "url-like provider keys must still route secret metadata"
+        );
+
+        config.set_prop(&api_key_path, "sk-test-custom").unwrap();
+        config
+            .set_prop(&base_url_path, "https://api.example.invalid/v1")
+            .unwrap();
+        config.set_prop(&model_path, "local-large").unwrap();
+        config.set_prop(&temperature_path, "0.2").unwrap();
+
+        let provider = config
+            .providers
+            .models
+            .get(provider_key)
+            .expect("custom provider key should be preserved exactly");
+        assert_eq!(provider.api_key.as_deref(), Some("sk-test-custom"));
+        assert_eq!(
+            provider.base_url.as_deref(),
+            Some("https://api.example.invalid/v1")
+        );
+        assert_eq!(provider.model.as_deref(), Some("local-large"));
+        assert_eq!(provider.temperature, Some(0.2));
+
+        assert_eq!(config.get_prop(&api_key_path).unwrap(), "**** (encrypted)");
+        assert_eq!(
+            config.get_prop(&base_url_path).unwrap(),
+            "https://api.example.invalid/v1"
+        );
+
+        config.save().await.unwrap();
+        let raw_toml = tokio::fs::read_to_string(&config.config_path)
+            .await
+            .unwrap();
+        assert!(
+            raw_toml.contains(provider_key),
+            "saved TOML should preserve the exact URL-like provider key"
+        );
+        assert!(
+            !raw_toml.contains("sk-test-custom"),
+            "saved TOML must not contain the plaintext custom provider API key"
+        );
+
+        let mut loaded: Config = toml::from_str::<crate::migration::V1Compat>(&raw_toml)
+            .unwrap()
+            .into_config();
+        loaded.config_path = config.config_path.clone();
+        loaded.workspace_dir = config.workspace_dir.clone();
+        let store = crate::secrets::SecretStore::new(dir.path(), loaded.secrets.encrypt);
+        loaded.decrypt_secrets(&store).unwrap();
+        let loaded_provider = loaded
+            .providers
+            .models
+            .get(provider_key)
+            .expect("saved custom provider key should reload exactly");
+        assert_eq!(
+            loaded.providers.fallback.as_deref(),
+            None,
+            "property round-trip should not invent a fallback provider"
+        );
+        assert_eq!(loaded_provider.api_key.as_deref(), Some("sk-test-custom"));
+        assert_eq!(
+            loaded_provider.base_url.as_deref(),
+            Some("https://api.example.invalid/v1")
+        );
+        assert_eq!(loaded_provider.model.as_deref(), Some("local-large"));
+        assert_eq!(loaded_provider.temperature, Some(0.2));
+    }
+
+    #[test]
     async fn enum_variants_callback_returns_values() {
         let mx = test_matrix_config();
         let fields = mx.prop_fields();

--- a/crates/zeroclaw-macros/src/lib.rs
+++ b/crates/zeroclaw-macros/src/lib.rs
@@ -301,9 +301,11 @@ pub fn derive_configurable(input: TokenStream) -> TokenStream {
                 // Path routing through HashMap<String, T>: the one parser
                 // lives in `crate::config::route_hashmap_path` so get/set
                 // don't duplicate it. Paths look like
-                // `<my_prefix>.<field>.<key>.<inner_suffix>`; on a hit the
-                // dispatch is forwarded to the value type's own get_prop /
-                // set_prop via its `configurable_prefix()`.
+                // `<my_prefix>.<field>.<key>.<inner_suffix>`; keys may contain
+                // dots/URLs, so the shared parser preserves the runtime key and
+                // splits on the final field separator. On a hit the dispatch is
+                // forwarded to the value type's own get_prop / set_prop via its
+                // `configurable_prefix()`.
                 let field_name_lit = snake_to_kebab(&field_ident.to_string());
                 nested_prop_is_secret.push(quote! {
                     if let Some((_hm_key, inner_name)) = crate::config::route_hashmap_path(

--- a/crates/zeroclaw-runtime/src/onboard/mod.rs
+++ b/crates/zeroclaw-runtime/src/onboard/mod.rs
@@ -1395,7 +1395,7 @@ mod tests {
         tokio::spawn(async move {
             axum::serve(listener, app).await.unwrap();
         });
-        format!("http://localhost:{port}")
+        format!("http://127.0.0.1:{port}")
     }
 
     #[tokio::test]
@@ -1675,6 +1675,40 @@ mod tests {
             .expect("custom provider entry should be seeded");
         assert_eq!(model_cfg.api_key.as_deref(), Some("sk-custom-test"));
         assert_eq!(model_cfg.model.as_deref(), Some("qwen-local"));
+    }
+
+    #[tokio::test]
+    async fn providers_custom_openai_menu_flow_persists_url_keyed_entry() {
+        let temp = TempDir::new().unwrap();
+        let mut cfg = test_cfg(&temp);
+        let base_url = spawn_models_endpoint(
+            StatusCode::OK,
+            r#"{"data":[{"id":"local-small"},{"id":"local-large"}]}"#,
+            None,
+        )
+        .await;
+        let provider = format!("custom:{base_url}");
+
+        let flags = Flags::default();
+        let mut ui = QuickUi::new()
+            .with("Provider", CUSTOM_OPENAI_COMPAT_LABEL)
+            .with("OpenAI-compatible base URL", base_url.clone())
+            .with("api-key", "sk-custom-test")
+            .with("Model", "local-large");
+
+        run(&mut cfg, &mut ui, Section::Providers, &flags)
+            .await
+            .unwrap();
+
+        assert_eq!(cfg.providers.fallback.as_deref(), Some(provider.as_str()));
+        let model_cfg = cfg
+            .providers
+            .models
+            .get(&provider)
+            .expect("custom provider entry should be persisted under its URL key");
+        assert_eq!(model_cfg.api_key.as_deref(), Some("sk-custom-test"));
+        assert_eq!(model_cfg.base_url.as_deref(), Some(base_url.as_str()));
+        assert_eq!(model_cfg.model.as_deref(), Some("local-large"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Preserve user-controlled `HashMap<String, T>` config keys that contain dots, URLs, or hostnames by routing map-key property paths from the final field separator instead of the first dot after the map section.
  - Keep the `Configurable` derive on the shared parser path and update the generated-code comment so future macro work understands why dotted map keys are supported.
  - Add regression coverage for `providers.models.custom:<url>.*` set/get/secret routing, save/reload preservation, and encrypted API-key persistence.
  - Add a menu-driven `zeroclaw onboard` regression for the custom OpenAI-compatible provider flow with distinct `OpenAI-compatible base URL`, `api-key`, and `Model` prompts.
- **Scope boundary:** This PR only fixes property routing for existing map-keyed config paths and onboarding regression coverage. It does not change provider resolution, model discovery semantics, config schema fields, or advanced-settings behavior.
- **Issue coverage:** The unknown-property failure is fixed by the parser change. The prompt-label report was not independently reproduced in this validation; the added onboarding regression uses QuickUi's prompt-text lookup to exercise distinct `OpenAI-compatible base URL`, `api-key`, and `Model` prompts, so conflating the API-key prompt label with the base URL prompt would fail the scripted flow.
- **Blast radius:** `zeroclaw-config` property routing for nested `HashMap<String, T>` sections, generated `Configurable` map-key accessors, and runtime onboarding tests. Current map-backed config sections expose leaf fields; no provider runtime request path is changed.
- **Labels:** `bug`, `risk: medium`, `size: S`, `config`, `onboard`, `provider:compatible`
- **Linked issue(s):** Closes #6206

## Validation Evidence (required)

Local validation is the signal CI cannot replace. Run the full battery and paste literal output (tails, failures, warnings — not "all passed").

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

Docs-only changes: replace with markdown lint + link-integrity (`scripts/ci/docs_quality_gate.sh`). Bootstrap scripts: add `bash -n install.sh`.

- **Commands run and tail output:**

```bash
git diff --check
```

```text
passed with no output
```

```bash
time cargo fmt --all -- --check 2>&1 | tail -30
```

```text
cargo fmt --all -- --check 2>&1  2.13s user 0.11s system 81% cpu 2.740 total
tail -30  0.00s user 0.00s system 0% cpu 2.740 total
```

```bash
time cargo clippy -p zeroclaw-config -p zeroclaw-macros -p zeroclaw-runtime --all-targets -- -D warnings 2>&1 | tail -30
```

```text
   Compiling zeroclaw-macros v0.7.4 (<worktree>/crates/zeroclaw-macros)
    Checking zeroclaw-config v0.7.4 (<worktree>/crates/zeroclaw-config)
    Checking zeroclaw-providers v0.7.4 (<worktree>/crates/zeroclaw-providers)
    Checking zeroclaw-memory v0.7.4 (<worktree>/crates/zeroclaw-memory)
    Checking zeroclaw-tools v0.7.4 (<worktree>/crates/zeroclaw-tools)
    Checking zeroclaw-runtime v0.7.4 (<worktree>/crates/zeroclaw-runtime)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 23.72s
cargo clippy -p zeroclaw-config -p zeroclaw-macros -p zeroclaw-runtime  -- -D  31.91s user 2.47s system 144% cpu 23.817 total
tail -30  0.00s user 0.00s system 0% cpu 23.817 total
```

Note: zsh's `time` summary truncates the displayed command, but the command executed is the full command shown above with `--all-targets`.

```bash
time cargo test -p zeroclaw-config hashmap_property_paths_preserve_url_like_keys --lib 2>&1 | tail -30
```

```text
   Compiling zeroclaw-macros v0.7.4 (<worktree>/crates/zeroclaw-macros)
   Compiling zeroclaw-config v0.7.4 (<worktree>/crates/zeroclaw-config)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 18.95s
     Running unittests src/lib.rs (target/debug/deps/zeroclaw_config-d67f42cc17a1531d)

running 1 test
test schema::tests::hashmap_property_paths_preserve_url_like_keys ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 608 filtered out; finished in 0.02s

cargo test -p zeroclaw-config hashmap_property_paths_preserve_url_like_keys    27.85s user 1.98s system 152% cpu 19.558 total
tail -30  0.00s user 0.00s system 0% cpu 19.558 total
```

```bash
time cargo test -p zeroclaw-runtime providers_custom_openai_menu_flow_persists_url_keyed_entry --lib 2>&1 | tail -30
```

```text
   Compiling zeroclaw-config v0.7.4 (<worktree>/crates/zeroclaw-config)
   Compiling zeroclaw-memory v0.7.4 (<worktree>/crates/zeroclaw-memory)
   Compiling zeroclaw-providers v0.7.4 (<worktree>/crates/zeroclaw-providers)
   Compiling zeroclaw-tools v0.7.4 (<worktree>/crates/zeroclaw-tools)
   Compiling zeroclaw-runtime v0.7.4 (<worktree>/crates/zeroclaw-runtime)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 38.63s
     Running unittests src/lib.rs (target/debug/deps/zeroclaw_runtime-1044190b969cf612)

running 1 test
test onboard::tests::providers_custom_openai_menu_flow_persists_url_keyed_entry ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1624 filtered out; finished in 0.13s

cargo test -p zeroclaw-runtime  --lib 2>&1  68.07s user 6.73s system 188% cpu 39.754 total
tail -30  0.00s user 0.00s system 0% cpu 39.754 total
```

- **Beyond CI — what did you manually verify?** Reviewed the final diff after rebasing onto `origin/master` `1c206c9aa`; the rebase was clean and the dotted-key regression remained isolated. Ran `zeroclaw-simplify-review` and scanned the diff for secret/PII terms. The config regression verifies the URL-like provider key survives set/get/secret routing, save/reload, and API-key encryption. The runtime regression verifies menu-driven custom OpenAI-compatible onboarding writes the dotted `custom:http://127.0.0.1:<port>` provider entry with distinct base URL, API-key, and model answers.
- **If any command was intentionally skipped, why:** Full workspace `cargo clippy --all-targets -- -D warnings` and full workspace `cargo test` were not run locally because this is a narrow parser/onboarding fix and the focused commands cover the changed behavior. Focused all-targets clippy was run for the changed config, macro, and runtime crates. Local absolute paths in pasted validation output were redacted as `<worktree>`. The runtime test was run outside the Codex sandbox because it binds a local `127.0.0.1` test server; a sandboxed earlier run failed before assertions with `PermissionDenied` on `TcpListener::bind("127.0.0.1:0")`.

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `Yes`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: This fixes the property-routing path used to set and inspect provider API keys when the provider map key contains a URL-like custom OpenAI-compatible endpoint. The regression test verifies the fake API key is encrypted on save and is not present in plaintext TOML; no real credential is included.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: exact upgrade steps for existing users: No upgrade step. Existing config remains valid; users who previously had to hand-write `custom:<url>` provider entries can use onboarding once this fix lands.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PRs: `git revert <sha>` is the plan unless otherwise noted.

Medium/high-risk PRs must fill:

- **Fast rollback command/path:** `git revert <merge-commit-sha>` for this PR.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** `zeroclaw onboard` or config property writes report `Unknown property 'providers.models.custom:<url>.<field>'`, custom OpenAI-compatible provider entries fail to persist, or API-key secret metadata stops routing for `providers.models.<key>.api-key`.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Scope materially carried forward: N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why (inspiration-only, no direct code/design carry-over): No superseded PR scope was incorporated.
