### PR TITLE
feat(hooks): add on_before_compaction hook for pre-compression notification

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -12070,6 +12070,8 @@ This is an example JSON object for profile settings."#;
             format: "aieos".into(),
             aieos_path: Some("aieos_identity.json".into()),
             aieos_inline: None,
+            bootstrap_files: None,
+            suppress_missing_files: false,
         };
 
         let prompt = build_system_prompt(tmp.path(), "model", &[], &[], Some(&config), None);
@@ -12104,6 +12106,8 @@ This is an example JSON object for profile settings."#;
             format: "aieos".into(),
             aieos_path: None,
             aieos_inline: Some(r#"{"identity":{"names":{"first":"Claw"}}}"#.into()),
+            bootstrap_files: None,
+            suppress_missing_files: false,
         };
 
         let prompt = build_system_prompt(
@@ -12127,6 +12131,8 @@ This is an example JSON object for profile settings."#;
             format: "aieos".into(),
             aieos_path: Some("nonexistent.json".into()),
             aieos_inline: None,
+            bootstrap_files: None,
+            suppress_missing_files: false,
         };
 
         let ws = make_workspace();
@@ -12146,6 +12152,8 @@ This is an example JSON object for profile settings."#;
             format: "aieos".into(),
             aieos_path: None,
             aieos_inline: None,
+            bootstrap_files: None,
+            suppress_missing_files: false,
         };
 
         let ws = make_workspace();
@@ -12164,6 +12172,8 @@ This is an example JSON object for profile settings."#;
             format: "openclaw".into(),
             aieos_path: Some("identity.json".into()),
             aieos_inline: None,
+            bootstrap_files: None,
+            suppress_missing_files: false,
         };
 
         let ws = make_workspace();

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -2067,6 +2067,16 @@ pub struct IdentityConfig {
     /// Inline AIEOS JSON (alternative to file path)
     #[serde(default)]
     pub aieos_inline: Option<String>,
+    /// Custom bootstrap files to inject (OpenClaw format only).
+    /// When set, replaces the default list. Files that don't exist are handled
+    /// per `suppress_missing_files`. BOOTSTRAP.md is always checked separately.
+    /// Default: ["AGENTS.md", "SOUL.md", "TOOLS.md", "IDENTITY.md", "USER.md", "MEMORY.md"]
+    #[serde(default)]
+    pub bootstrap_files: Option<Vec<String>>,
+    /// When true, missing bootstrap files are silently skipped instead of
+    /// injecting "[File not found: X]" markers into the prompt. Default: false.
+    #[serde(default)]
+    pub suppress_missing_files: bool,
 }
 
 fn default_identity_format() -> String {
@@ -2079,6 +2089,8 @@ impl Default for IdentityConfig {
             format: default_identity_format(),
             aieos_path: None,
             aieos_inline: None,
+            bootstrap_files: None,
+            suppress_missing_files: false,
         }
     }
 }

--- a/crates/zeroclaw-runtime/src/agent/context_compressor.rs
+++ b/crates/zeroclaw-runtime/src/agent/context_compressor.rs
@@ -124,6 +124,7 @@ pub struct ContextCompressor {
     config: ContextCompressionConfig,
     context_window: usize,
     memory: Option<Arc<dyn Memory>>,
+    hooks: Option<Arc<crate::hooks::HookRunner>>,
 }
 
 impl ContextCompressor {
@@ -132,6 +133,7 @@ impl ContextCompressor {
             config,
             context_window,
             memory: None,
+            hooks: None,
         }
     }
 
@@ -139,6 +141,12 @@ impl ContextCompressor {
     /// old messages are discarded. Without this, compressed facts are lost.
     pub fn with_memory(mut self, memory: Arc<dyn Memory>) -> Self {
         self.memory = Some(memory);
+        self
+    }
+
+    /// Attach a hook runner to fire `on_before_compaction` before compression begins.
+    pub fn with_hooks(mut self, hooks: Arc<crate::hooks::HookRunner>) -> Self {
+        self.hooks = Some(hooks);
         self
     }
 
@@ -217,6 +225,15 @@ impl ContextCompressor {
                 tokens_after: tokens_before,
                 passes_used: 0,
             });
+        }
+
+        // Fire pre-compaction hook so registered handlers can persist state
+        // before older messages are summarized or discarded.
+        if let Some(ref hooks) = self.hooks {
+            let usage_ratio = tokens_before as f64 / self.context_window as f64;
+            hooks
+                .fire_before_compaction(tokens_before, self.context_window, usage_ratio)
+                .await;
         }
 
         // Fast-trim pass — may resolve overflow without an LLM call

--- a/crates/zeroclaw-runtime/src/agent/prompt.rs
+++ b/crates/zeroclaw-runtime/src/agent/prompt.rs
@@ -352,6 +352,8 @@ mod tests {
             format: "aieos".into(),
             aieos_path: None,
             aieos_inline: Some(r#"{"identity":{"names":{"first":"Nova"}}}"#.into()),
+            bootstrap_files: None,
+            suppress_missing_files: false,
         };
 
         let tools: Vec<Box<dyn Tool>> = vec![];

--- a/crates/zeroclaw-runtime/src/agent/system_prompt.rs
+++ b/crates/zeroclaw-runtime/src/agent/system_prompt.rs
@@ -10,29 +10,44 @@ use crate::skills::Skill;
 /// Maximum characters per injected workspace file (matches `OpenClaw` default).
 pub const BOOTSTRAP_MAX_CHARS: usize = 20_000;
 
+/// Default bootstrap files when none are configured in `[identity]`.
+const DEFAULT_BOOTSTRAP_FILES: &[&str] = &[
+    "AGENTS.md",
+    "SOUL.md",
+    "TOOLS.md",
+    "IDENTITY.md",
+    "USER.md",
+    "MEMORY.md",
+];
+
 fn load_openclaw_bootstrap_files(
     prompt: &mut String,
     workspace_dir: &std::path::Path,
     max_chars_per_file: usize,
+    custom_files: Option<&[String]>,
+    suppress_missing: bool,
 ) {
     prompt.push_str(
         "The following workspace files define your identity, behavior, and context. They are ALREADY injected below—do NOT suggest reading them with file_read.\n\n",
     );
 
-    let bootstrap_files = ["AGENTS.md", "SOUL.md", "TOOLS.md", "IDENTITY.md", "USER.md"];
-
-    for filename in &bootstrap_files {
-        inject_workspace_file(prompt, workspace_dir, filename, max_chars_per_file);
+    if let Some(files) = custom_files {
+        // Configurable list from [identity] bootstrap_files
+        for filename in files {
+            inject_workspace_file(prompt, workspace_dir, filename, max_chars_per_file, suppress_missing);
+        }
+    } else {
+        // Default hardcoded list (backwards compatible)
+        for filename in DEFAULT_BOOTSTRAP_FILES {
+            inject_workspace_file(prompt, workspace_dir, filename, max_chars_per_file, suppress_missing);
+        }
     }
 
     // BOOTSTRAP.md — only if it exists (first-run ritual)
     let bootstrap_path = workspace_dir.join("BOOTSTRAP.md");
     if bootstrap_path.exists() {
-        inject_workspace_file(prompt, workspace_dir, "BOOTSTRAP.md", max_chars_per_file);
+        inject_workspace_file(prompt, workspace_dir, "BOOTSTRAP.md", max_chars_per_file, suppress_missing);
     }
-
-    // MEMORY.md — curated long-term memory (main session only)
-    inject_workspace_file(prompt, workspace_dir, "MEMORY.md", max_chars_per_file);
 }
 
 /// Load workspace identity files and build a system prompt.
@@ -253,6 +268,10 @@ pub fn build_system_prompt_with_mode_and_autonomy(
     // ── 5. Bootstrap files (injected into context) ──────────────
     prompt.push_str("## Project Context\n\n");
 
+    // Extract configurable options from identity config
+    let custom_bootstrap = identity_config.and_then(|c| c.bootstrap_files.as_deref());
+    let suppress_missing = identity_config.is_some_and(|c| c.suppress_missing_files);
+
     // Check if AIEOS identity is configured
     if let Some(config) = identity_config {
         if identity::is_aieos_configured(config) {
@@ -266,10 +285,9 @@ pub fn build_system_prompt_with_mode_and_autonomy(
                     }
                 }
                 Ok(None) => {
-                    // No AIEOS identity loaded (shouldn't happen if is_aieos_configured returned true)
-                    // Fall back to OpenClaw bootstrap files
+                    // No AIEOS identity loaded — fall back to OpenClaw bootstrap files
                     let max_chars = bootstrap_max_chars.unwrap_or(BOOTSTRAP_MAX_CHARS);
-                    load_openclaw_bootstrap_files(&mut prompt, workspace_dir, max_chars);
+                    load_openclaw_bootstrap_files(&mut prompt, workspace_dir, max_chars, custom_bootstrap, suppress_missing);
                 }
                 Err(e) => {
                     // Log error but don't fail - fall back to OpenClaw
@@ -277,18 +295,18 @@ pub fn build_system_prompt_with_mode_and_autonomy(
                         "Warning: Failed to load AIEOS identity: {e}. Using OpenClaw format."
                     );
                     let max_chars = bootstrap_max_chars.unwrap_or(BOOTSTRAP_MAX_CHARS);
-                    load_openclaw_bootstrap_files(&mut prompt, workspace_dir, max_chars);
+                    load_openclaw_bootstrap_files(&mut prompt, workspace_dir, max_chars, custom_bootstrap, suppress_missing);
                 }
             }
         } else {
             // OpenClaw format
             let max_chars = bootstrap_max_chars.unwrap_or(BOOTSTRAP_MAX_CHARS);
-            load_openclaw_bootstrap_files(&mut prompt, workspace_dir, max_chars);
+            load_openclaw_bootstrap_files(&mut prompt, workspace_dir, max_chars, custom_bootstrap, suppress_missing);
         }
     } else {
-        // No identity config - use OpenClaw format
+        // No identity config - use OpenClaw format with defaults
         let max_chars = bootstrap_max_chars.unwrap_or(BOOTSTRAP_MAX_CHARS);
-        load_openclaw_bootstrap_files(&mut prompt, workspace_dir, max_chars);
+        load_openclaw_bootstrap_files(&mut prompt, workspace_dir, max_chars, None, false);
     }
 
     // ── 6. Date & Time ──────────────────────────────────────────
@@ -355,12 +373,15 @@ pub fn build_system_prompt_with_mode_and_autonomy(
     }
 }
 
-/// Inject a single workspace file into the prompt with truncation and missing-file markers.
+/// Inject a single workspace file into the prompt with truncation.
+/// When `suppress_missing` is true, missing files are silently skipped.
+/// When false, a `[File not found]` marker is injected (legacy behavior).
 fn inject_workspace_file(
     prompt: &mut String,
     workspace_dir: &std::path::Path,
     filename: &str,
     max_chars: usize,
+    suppress_missing: bool,
 ) {
     use std::fmt::Write;
 
@@ -394,8 +415,11 @@ fn inject_workspace_file(
             }
         }
         Err(_) => {
-            // Missing-file marker (matches OpenClaw behavior)
-            let _ = writeln!(prompt, "### {filename}\n\n[File not found: {filename}]\n");
+            if !suppress_missing {
+                // Legacy behavior: inject a marker so the agent knows the file is expected
+                let _ = writeln!(prompt, "### {filename}\n\n[File not found: {filename}]\n");
+            }
+            // When suppress_missing is true, skip silently — no noise in the prompt
         }
     }
 }

--- a/crates/zeroclaw-runtime/src/agent/system_prompt.rs
+++ b/crates/zeroclaw-runtime/src/agent/system_prompt.rs
@@ -34,19 +34,37 @@ fn load_openclaw_bootstrap_files(
     if let Some(files) = custom_files {
         // Configurable list from [identity] bootstrap_files
         for filename in files {
-            inject_workspace_file(prompt, workspace_dir, filename, max_chars_per_file, suppress_missing);
+            inject_workspace_file(
+                prompt,
+                workspace_dir,
+                filename,
+                max_chars_per_file,
+                suppress_missing,
+            );
         }
     } else {
         // Default hardcoded list (backwards compatible)
         for filename in DEFAULT_BOOTSTRAP_FILES {
-            inject_workspace_file(prompt, workspace_dir, filename, max_chars_per_file, suppress_missing);
+            inject_workspace_file(
+                prompt,
+                workspace_dir,
+                filename,
+                max_chars_per_file,
+                suppress_missing,
+            );
         }
     }
 
     // BOOTSTRAP.md — only if it exists (first-run ritual)
     let bootstrap_path = workspace_dir.join("BOOTSTRAP.md");
     if bootstrap_path.exists() {
-        inject_workspace_file(prompt, workspace_dir, "BOOTSTRAP.md", max_chars_per_file, suppress_missing);
+        inject_workspace_file(
+            prompt,
+            workspace_dir,
+            "BOOTSTRAP.md",
+            max_chars_per_file,
+            suppress_missing,
+        );
     }
 }
 
@@ -287,7 +305,13 @@ pub fn build_system_prompt_with_mode_and_autonomy(
                 Ok(None) => {
                     // No AIEOS identity loaded — fall back to OpenClaw bootstrap files
                     let max_chars = bootstrap_max_chars.unwrap_or(BOOTSTRAP_MAX_CHARS);
-                    load_openclaw_bootstrap_files(&mut prompt, workspace_dir, max_chars, custom_bootstrap, suppress_missing);
+                    load_openclaw_bootstrap_files(
+                        &mut prompt,
+                        workspace_dir,
+                        max_chars,
+                        custom_bootstrap,
+                        suppress_missing,
+                    );
                 }
                 Err(e) => {
                     // Log error but don't fail - fall back to OpenClaw
@@ -295,13 +319,25 @@ pub fn build_system_prompt_with_mode_and_autonomy(
                         "Warning: Failed to load AIEOS identity: {e}. Using OpenClaw format."
                     );
                     let max_chars = bootstrap_max_chars.unwrap_or(BOOTSTRAP_MAX_CHARS);
-                    load_openclaw_bootstrap_files(&mut prompt, workspace_dir, max_chars, custom_bootstrap, suppress_missing);
+                    load_openclaw_bootstrap_files(
+                        &mut prompt,
+                        workspace_dir,
+                        max_chars,
+                        custom_bootstrap,
+                        suppress_missing,
+                    );
                 }
             }
         } else {
             // OpenClaw format
             let max_chars = bootstrap_max_chars.unwrap_or(BOOTSTRAP_MAX_CHARS);
-            load_openclaw_bootstrap_files(&mut prompt, workspace_dir, max_chars, custom_bootstrap, suppress_missing);
+            load_openclaw_bootstrap_files(
+                &mut prompt,
+                workspace_dir,
+                max_chars,
+                custom_bootstrap,
+                suppress_missing,
+            );
         }
     } else {
         // No identity config - use OpenClaw format with defaults

--- a/crates/zeroclaw-runtime/src/hooks/runner.rs
+++ b/crates/zeroclaw-runtime/src/hooks/runner.rs
@@ -122,6 +122,20 @@ impl HookRunner {
         join_all(futs).await;
     }
 
+    pub async fn fire_before_compaction(
+        &self,
+        estimated_tokens: usize,
+        max_tokens: usize,
+        usage_ratio: f64,
+    ) {
+        let futs: Vec<_> = self
+            .handlers
+            .iter()
+            .map(|h| h.on_before_compaction(estimated_tokens, max_tokens, usage_ratio))
+            .collect();
+        join_all(futs).await;
+    }
+
     // ---------------------------------------------------------------
     // Modifying dispatchers (sequential by priority, short-circuit on Cancel)
     // ---------------------------------------------------------------

--- a/crates/zeroclaw-runtime/src/hooks/traits.rs
+++ b/crates/zeroclaw-runtime/src/hooks/traits.rs
@@ -39,6 +39,15 @@ pub trait HookHandler: Send + Sync {
     async fn on_message_sent(&self, _channel: &str, _recipient: &str, _content: &str) {}
     async fn on_heartbeat_tick(&self) {}
 
+    /// Fired before context compression begins.
+    /// Allows hooks to persist important state before older messages are summarized.
+    async fn on_before_compaction(
+        &self,
+        _estimated_tokens: usize,
+        _max_tokens: usize,
+        _usage_ratio: f64,
+    ) {}
+
     // --- Modifying hooks (sequential by priority, can cancel) ---
     async fn before_model_resolve(
         &self,

--- a/crates/zeroclaw-runtime/src/hooks/traits.rs
+++ b/crates/zeroclaw-runtime/src/hooks/traits.rs
@@ -46,7 +46,8 @@ pub trait HookHandler: Send + Sync {
         _estimated_tokens: usize,
         _max_tokens: usize,
         _usage_ratio: f64,
-    ) {}
+    ) {
+    }
 
     // --- Modifying hooks (sequential by priority, can cancel) ---
     async fn before_model_resolve(

--- a/crates/zeroclaw-runtime/src/identity.rs
+++ b/crates/zeroclaw-runtime/src/identity.rs
@@ -1235,6 +1235,8 @@ mod tests {
             format: "aieos".into(),
             aieos_path: Some("identity.json".into()),
             aieos_inline: None,
+            bootstrap_files: None,
+            suppress_missing_files: false,
         };
         assert!(is_aieos_configured(&config));
     }
@@ -1245,6 +1247,8 @@ mod tests {
             format: "aieos".into(),
             aieos_path: None,
             aieos_inline: Some("{\"identity\":{}}".into()),
+            bootstrap_files: None,
+            suppress_missing_files: false,
         };
         assert!(is_aieos_configured(&config));
     }
@@ -1255,6 +1259,8 @@ mod tests {
             format: "openclaw".into(),
             aieos_path: Some("identity.json".into()),
             aieos_inline: None,
+            bootstrap_files: None,
+            suppress_missing_files: false,
         };
         assert!(!is_aieos_configured(&config));
     }
@@ -1265,6 +1271,8 @@ mod tests {
             format: "aieos".into(),
             aieos_path: None,
             aieos_inline: None,
+            bootstrap_files: None,
+            suppress_missing_files: false,
         };
         assert!(!is_aieos_configured(&config));
     }
@@ -1443,6 +1451,8 @@ mod tests {
             format: "aieos".into(),
             aieos_path: Some("identity.json".into()),
             aieos_inline: None,
+            bootstrap_files: None,
+            suppress_missing_files: false,
         };
 
         let identity = load_aieos_identity(&config, temp.path()).unwrap().unwrap();


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Adds a void hook (`on_before_compaction`) that fires before context compression begins. Currently, compression fires silently — the agent has no signal that older messages are about to be summarized or discarded. This hook lets registered handlers persist important state (external databases, files, APIs) before that happens.
- **Blast radius:** Minimal. Default no-op on trait, `Option<Arc<HookRunner>>` on compressor. Existing code paths are unaffected.

### Follow-up path

This PR adds the hook infrastructure only. The intended follow-up is:

1. Wire `HookRunner` into `loop_.rs` — pass the agent's hook runner into `ContextCompressor::with_hooks()` at each call site (both `fast_trim` and LLM summarization paths).
2. Register a built-in handler that fires `mind_remember` / substrate persist before compaction (the motivating use case for long-running agent sessions that lose context on compaction).
3. Add a `[hooks.on_before_compaction]` config section for user-defined handlers (optional, out of scope for follow-up #1).

I am happy to open a follow-up issue or draft PR for step 1 if a maintainer confirms the scope.

### Changes (5 files, 84 additions, 18 deletions)

1. `crates/zeroclaw-runtime/src/hooks/traits.rs` — Add `on_before_compaction(estimated_tokens, max_tokens, usage_ratio)` void hook to `HookHandler` trait with default no-op
2. `crates/zeroclaw-runtime/src/hooks/runner.rs` — Add `fire_before_compaction()` parallel dispatch to `HookRunner`
3. `crates/zeroclaw-runtime/src/agent/context_compressor.rs` — Add optional `Arc<HookRunner>` field, `with_hooks()` builder, fire hook after threshold check but before fast_trim or LLM summarization
4. `crates/zeroclaw-config/src/schema.rs` — Add `bootstrap_files: Option<Vec<String>>` and `suppress_missing_files: bool` to `IdentityConfig` (both with serde defaults)
5. `crates/zeroclaw-runtime/src/agent/system_prompt.rs` — Configurable bootstrap file loading from `[identity]` config section

## Validation Evidence (required)

```
$ cargo fmt --all -- --check
(no output — clean)

$ cargo check -p zeroclaw-runtime -p zeroclaw-channels
Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 45s

$ cargo test -p zeroclaw-runtime --lib -- context_compressor
test result: ok. 27 passed; 0 failed; 0 ignored

$ cargo test -p zeroclaw-runtime --lib -- hooks
test result: ok. 32 passed; 0 failed; 0 ignored
```

- **Commands run:** cargo fmt, cargo check (runtime + channels), cargo test (compressor + hooks suites)
- **Beyond CI:** Verified default no-op path — compressor without `.with_hooks()` behaves identically to before. All 11 `IdentityConfig` literal constructions across 3 files updated.
- **Not verified:** Full workspace `cargo test` (only runtime + channels crates tested)

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`