### PR TITLE
refactor(memory): share memory context marker constants

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -89,7 +89,7 @@ use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant, SystemTime};
 use tokio_util::sync::CancellationToken;
 use zeroclaw_config::schema::Config;
-use zeroclaw_memory::{self, Memory};
+use zeroclaw_memory::{self, MEMORY_CONTEXT_CLOSE, MEMORY_CONTEXT_OPEN, Memory};
 use zeroclaw_providers::reliable::{scope_provider_fallback, take_last_provider_fallback};
 use zeroclaw_providers::{self, ChatMessage, Provider};
 use zeroclaw_runtime::agent::loop_::{
@@ -2009,7 +2009,8 @@ fn format_memory_context(
         }
 
         if included == 0 {
-            context.push_str("[Memory context]\n");
+            context.push_str(MEMORY_CONTEXT_OPEN);
+            context.push('\n');
         }
 
         context.push_str(&line);
@@ -2018,7 +2019,8 @@ fn format_memory_context(
     }
 
     if included > 0 {
-        context.push_str("[/Memory context]\n\n");
+        context.push_str(MEMORY_CONTEXT_CLOSE);
+        context.push_str("\n\n");
     }
 
     context
@@ -10377,7 +10379,7 @@ BTC is currently around $65,000 based on latest tool output."#
             .unwrap();
 
         let context = build_memory_context(&mem, "age", 0.0, None).await;
-        assert!(context.contains("[Memory context]"));
+        assert!(context.contains(MEMORY_CONTEXT_OPEN));
         assert!(context.contains("Age is 45"));
     }
 
@@ -10953,7 +10955,7 @@ BTC is currently around $65,000 based on latest tool output."#
         assert_eq!(calls[0].len(), 2);
         // Memory context is injected into the system prompt, not the user message.
         assert_eq!(calls[0][0].0, "system");
-        assert!(calls[0][0].1.contains("[Memory context]"));
+        assert!(calls[0][0].1.contains(MEMORY_CONTEXT_OPEN));
         assert!(calls[0][0].1.contains("Age is 45"));
         assert_eq!(calls[0][1].0, "user");
         assert_eq!(calls[0][1].1, "hello");
@@ -10967,7 +10969,7 @@ BTC is currently around $65,000 based on latest tool output."#
             .expect("history should be stored for sender");
         assert_eq!(turns[0].role, "user");
         assert_eq!(turns[0].content, "hello");
-        assert!(!turns[0].content.contains("[Memory context]"));
+        assert!(!turns[0].content.contains(MEMORY_CONTEXT_OPEN));
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-memory/src/lib.rs
+++ b/crates/zeroclaw-memory/src/lib.rs
@@ -16,6 +16,11 @@
 //! Channel-scoped variants (e.g. `telegram_user_msg_*`, `discord_*`) are
 //! **not** filtered — they use different prefixes and are handled separately.
 
+/// Opening delimiter for recalled memory injected into provider context.
+pub const MEMORY_CONTEXT_OPEN: &str = "[Memory context]";
+/// Closing delimiter for recalled memory injected into provider context.
+pub const MEMORY_CONTEXT_CLOSE: &str = "[/Memory context]";
+
 pub mod audit;
 pub mod backend;
 pub mod chunker;
@@ -189,8 +194,14 @@ pub fn should_skip_autosave_content(content: &str) -> bool {
     lowered.starts_with("[cron:")
         || lowered.starts_with("[heartbeat task")
         || lowered.starts_with("[distilled_")
-        || lowered.starts_with("[memory context]")
+        || starts_with_ignore_ascii_case(normalized, MEMORY_CONTEXT_OPEN)
         || lowered.contains("distilled_index_sig:")
+}
+
+fn starts_with_ignore_ascii_case(value: &str, prefix: &str) -> bool {
+    value
+        .get(..prefix.len())
+        .is_some_and(|candidate| candidate.eq_ignore_ascii_case(prefix))
 }
 
 #[derive(Clone, PartialEq, Eq)]
@@ -536,9 +547,9 @@ mod tests {
         assert!(should_skip_autosave_content(
             "[Heartbeat Task | high] Execute scheduled patrol"
         ));
-        assert!(should_skip_autosave_content(
-            "[Memory context]\n- user_msg_abc: some recalled memory\n[/Memory context]\n\n[cron:uuid job] prompt"
-        ));
+        assert!(should_skip_autosave_content(&format!(
+            "{MEMORY_CONTEXT_OPEN}\n- user_msg_abc: some recalled memory\n{MEMORY_CONTEXT_CLOSE}\n\n[cron:uuid job] prompt"
+        )));
         assert!(!should_skip_autosave_content(
             "User prefers concise answers."
         ));

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -49,7 +49,9 @@ use uuid::Uuid;
 use zeroclaw_api::channel::Channel;
 use zeroclaw_api::provider::StreamEvent;
 use zeroclaw_config::schema::Config;
-use zeroclaw_memory::{self, Memory, MemoryCategory, decay};
+use zeroclaw_memory::{
+    self, MEMORY_CONTEXT_CLOSE, MEMORY_CONTEXT_OPEN, Memory, MemoryCategory, decay,
+};
 use zeroclaw_providers::multimodal;
 use zeroclaw_providers::{
     self, ChatMessage, ChatRequest, Provider, ProviderCapabilityError, ToolCall,
@@ -363,7 +365,7 @@ async fn build_context(
             .collect();
 
         if !relevant.is_empty() {
-            context.push_str("[Memory context]\n");
+            let mut included = false;
             for entry in &relevant {
                 // Scheduled (cron / heartbeat) runs must not see chat-origin
                 // memories. The autosave-key checks below catch the agent's
@@ -391,12 +393,16 @@ async fn build_context(
                 if entry.content.contains("<tool_result") {
                     continue;
                 }
+                if !included {
+                    context.push_str(MEMORY_CONTEXT_OPEN);
+                    context.push('\n');
+                    included = true;
+                }
                 let _ = writeln!(context, "- {}: {}", entry.key, entry.content);
             }
-            if context == "[Memory context]\n" {
-                context.clear();
-            } else {
-                context.push_str("[/Memory context]\n\n");
+            if included {
+                context.push_str(MEMORY_CONTEXT_CLOSE);
+                context.push_str("\n\n");
             }
         }
     }

--- a/crates/zeroclaw-runtime/src/agent/memory_loader.rs
+++ b/crates/zeroclaw-runtime/src/agent/memory_loader.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use std::fmt::Write;
-use zeroclaw_memory::{self, Memory, decay};
+use zeroclaw_memory::{self, MEMORY_CONTEXT_CLOSE, MEMORY_CONTEXT_OPEN, Memory, decay};
 
 #[async_trait]
 pub trait MemoryLoader: Send + Sync {
@@ -53,7 +53,8 @@ impl MemoryLoader for DefaultMemoryLoader {
         // Apply time decay: older non-Core memories score lower
         decay::apply_time_decay(&mut entries, decay::DEFAULT_HALF_LIFE_DAYS);
 
-        let mut context = String::from("[Memory context]\n");
+        let mut context = String::new();
+        let mut included = false;
         for entry in entries {
             if zeroclaw_memory::is_assistant_autosave_key(&entry.key) {
                 continue;
@@ -69,15 +70,21 @@ impl MemoryLoader for DefaultMemoryLoader {
             {
                 continue;
             }
+            if !included {
+                context.push_str(MEMORY_CONTEXT_OPEN);
+                context.push('\n');
+                included = true;
+            }
             let _ = writeln!(context, "- {}: {}", entry.key, entry.content);
         }
 
         // If all entries were below threshold, return empty
-        if context == "[Memory context]\n" {
+        if !included {
             return Ok(String::new());
         }
 
-        context.push_str("[/Memory context]\n\n");
+        context.push_str(MEMORY_CONTEXT_CLOSE);
+        context.push_str("\n\n");
         Ok(context)
     }
 }
@@ -86,7 +93,9 @@ impl MemoryLoader for DefaultMemoryLoader {
 mod tests {
     use super::*;
     use std::sync::Arc;
-    use zeroclaw_memory::{Memory, MemoryCategory, MemoryEntry};
+    use zeroclaw_memory::{
+        MEMORY_CONTEXT_CLOSE, MEMORY_CONTEXT_OPEN, Memory, MemoryCategory, MemoryEntry,
+    };
 
     struct MockMemory;
     struct MockMemoryWithEntries {
@@ -218,8 +227,10 @@ mod tests {
             .load_context(&MockMemory, "hello", None)
             .await
             .unwrap();
-        assert!(context.contains("[Memory context]"));
-        assert!(context.contains("- k: v"));
+        assert_eq!(
+            context,
+            format!("{MEMORY_CONTEXT_OPEN}\n- k: v\n{MEMORY_CONTEXT_CLOSE}\n\n")
+        );
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-runtime/src/cron/scheduler.rs
+++ b/crates/zeroclaw-runtime/src/cron/scheduler.rs
@@ -13,6 +13,7 @@ use tokio::process::Command;
 use tokio::time::{self, Duration};
 use zeroclaw_config::schema::Config;
 use zeroclaw_config::schema::{CronJobDecl, CronScheduleDecl};
+use zeroclaw_memory::{MEMORY_CONTEXT_CLOSE, MEMORY_CONTEXT_OPEN};
 
 const MIN_POLL_SECONDS: u64 = 5;
 const SHELL_JOB_TIMEOUT_SECS: u64 = 120;
@@ -303,7 +304,7 @@ async fn run_agent_job(
                     if ctx.is_empty() {
                         String::new()
                     } else {
-                        format!("[Memory context]\n{ctx}\n[/Memory context]\n\n")
+                        format!("{MEMORY_CONTEXT_OPEN}\n{ctx}\n{MEMORY_CONTEXT_CLOSE}\n\n")
                     }
                 }
                 _ => String::new(),

--- a/crates/zeroclaw-runtime/src/daemon/mod.rs
+++ b/crates/zeroclaw-runtime/src/daemon/mod.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use tokio::task::JoinHandle;
 use tokio::time::Duration;
 use zeroclaw_config::schema::Config;
+use zeroclaw_memory::{MEMORY_CONTEXT_CLOSE, MEMORY_CONTEXT_OPEN};
 
 const STATUS_FLUSH_SECONDS: u64 = 5;
 
@@ -576,7 +577,9 @@ async fn run_heartbeat_worker(config: Config) -> Result<()> {
                         if ctx.is_empty() {
                             None
                         } else {
-                            Some(format!("[Memory context]\n{ctx}\n[/Memory context]\n\n"))
+                            Some(format!(
+                                "{MEMORY_CONTEXT_OPEN}\n{ctx}\n{MEMORY_CONTEXT_CLOSE}\n\n"
+                            ))
                         }
                     }
                     _ => None,


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Added shared `MEMORY_CONTEXT_OPEN` and `MEMORY_CONTEXT_CLOSE` constants in `zeroclaw-memory`.
  - Updated runtime, cron, daemon, and channel/orchestrator memory-context injection sites to use the shared constants instead of repeated string literals.
  - Tied autosave synthetic-content filtering to `MEMORY_CONTEXT_OPEN` so filtering and generation cannot drift if the marker contract changes later.
  - Tightened the runtime loader test to assert the full memory-context wrapper shape.
- **Scope boundary:** This PR does not change memory recall behavior, marker text, filtering policy, prompt assembly order, or the number of recalled entries.
- **Blast radius:** Memory context prompt assembly in `zeroclaw-runtime` and `zeroclaw-channels`; this adds two public `zeroclaw-memory` constants for shared workspace use, with no breaking API, config, CLI, storage schema, or provider behavior changes.
- **Linked issue(s):** Closes #6081

## Validation Evidence (required)

Local validation was focused on the touched memory, runtime, and channel paths.

```bash
time cargo test -p zeroclaw-memory autosave_content_filter_drops_cron_and_distilled_noise --lib 2>&1 | tail -30
```

```text
running 1 test
test tests::autosave_content_filter_drops_cron_and_distilled_noise ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 282 filtered out; finished in 0.00s

cargo test -p zeroclaw-memory  --lib 2>&1  86.88s user 7.57s system 277% cpu 34.020 total
tail -30  0.00s user 0.00s system 0% cpu 34.019 total
```

```bash
time cargo test -p zeroclaw-runtime default_loader_formats_context --lib 2>&1 | tail -30
```

```text
running 1 test
test agent::memory_loader::tests::default_loader_formats_context ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1620 filtered out; finished in 0.00s

cargo test -p zeroclaw-runtime default_loader_formats_context --lib 2>&1  39.60s user 4.37s system 146% cpu 30.068 total
tail -30  0.00s user 0.00s system 0% cpu 30.065 total
```

```bash
time cargo test -p zeroclaw-channels build_memory_context_includes_recalled_entries --lib 2>&1 | tail -30
```

```text
running 1 test
test orchestrator::tests::build_memory_context_includes_recalled_entries ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 937 filtered out; finished in 0.01s

cargo test -p zeroclaw-channels build_memory_context_includes_recalled_entrie  58.07s user 6.45s system 127% cpu 50.464 total
tail -30  0.00s user 0.00s system 0% cpu 50.461 total
```

```bash
time cargo fmt --all -- --check 2>&1 | tail -30
```

```text
cargo fmt --all -- --check 2>&1  2.16s user 0.07s system 91% cpu 2.447 total
tail -30  0.00s user 0.00s system 0% cpu 2.447 total
```

```bash
git diff --check
```

```text
No output; command passed.
```

- **Commands run and tail output:** See command blocks above.
- **Beyond CI — what did you manually verify?** Manually reviewed the full diff after formatting and after Simplify fixes. Ran a literal audit confirming raw `[Memory context]` / `[/Memory context]` strings now only exist in `MEMORY_CONTEXT_OPEN` and `MEMORY_CONTEXT_CLOSE`.
- **If any command was intentionally skipped, why:** Full workspace `cargo test` and `cargo clippy --all-targets -- -D warnings` were skipped because this is a narrow constants/refactor patch and the approved focused tests cover the touched memory, runtime, and channel paths. The next broader check, if requested, would be scoped clippy for the touched crates.

After the final rebase onto `origin/master` `0cf558bd`, I reran cheap sanity checks: `git diff --check origin/master...HEAD`, the marker literal audit, and `cargo fmt --all -- --check`; the pushed head is `3682d6e8`.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: `N/A`

This PR only centralizes existing in-process prompt delimiter strings. It does not add data collection, storage, network access, credentials handling, authorization checks, or autonomous execution paths.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: exact upgrade steps for existing users: `N/A`

The marker text remains unchanged, so existing behavior and stored content are not migrated or reinterpreted differently.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <merge-sha>`
- **Feature flags or config toggles:** `None`
- **Observable failure symptoms:** Memory context unexpectedly missing from model prompts, duplicated memory context in saved autosave content, or focused tests `default_loader_formats_context` / `build_memory_context_includes_recalled_entries` failing.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A

