### PR TITLE
fix(channel:whatsapp): scope fromMe replies to self-chat or triggers

### DIFF
--- a/crates/zeroclaw-channels/src/whatsapp_web.rs
+++ b/crates/zeroclaw-channels/src/whatsapp_web.rs
@@ -787,6 +787,37 @@ impl WaAttachmentKind {
     }
 }
 
+/// Decide whether a `fromMe` message outside the operator's self-chat is an
+/// intentional operator-typed bot trigger.
+///
+/// The default response to a `fromMe` mirror is to drop, because WhatsApp Web
+/// echoes every message the operator types from any linked device and replying
+/// would impersonate them. The exception is when the operator has configured
+/// `dm_mention_patterns` / `group_mention_patterns` and the text matches —
+/// that is the explicit opt-in that distinguishes a deliberate trigger
+/// (e.g. typing `TinyBot foo` in a friend's DM) from a normal mirrored
+/// message.
+///
+/// Returns `true` when the message should fall through to the regular policy
+/// branches; `false` when it should be dropped as a mirror.
+#[cfg(feature = "whatsapp-web")]
+fn fromme_outside_self_chat_is_operator_trigger(
+    is_group: bool,
+    dm_mention_patterns: &[regex::Regex],
+    group_mention_patterns: &[regex::Regex],
+    text: &str,
+) -> bool {
+    let applicable = if is_group {
+        group_mention_patterns
+    } else {
+        dm_mention_patterns
+    };
+    if applicable.is_empty() {
+        return false;
+    }
+    super::whatsapp::WhatsAppChannel::text_matches_patterns(applicable, text)
+}
+
 /// Find the closing `]` that matches an already-consumed opening `[`.
 #[cfg(feature = "whatsapp-web")]
 #[allow(dead_code)] // WIP: used by parse_attachment_markers
@@ -1197,12 +1228,22 @@ impl Channel for WhatsAppWebChannel {
                                                 );
                                             }
                                         }
-                                    } else if info.source.is_from_me {
+                                    } else if info.source.is_from_me
+                                        && !fromme_outside_self_chat_is_operator_trigger(
+                                            is_group,
+                                            &wa_dm_mention_patterns,
+                                            &wa_group_mention_patterns,
+                                            msg.text_content().unwrap_or(""),
+                                        )
+                                    {
                                         // fromMe outside the self-chat thread is a mirror of the
                                         // operator's own outbound message to a third party (DM or
-                                        // group). Replying would impersonate the operator to the
-                                        // recipient. Drop unconditionally — `self_chat_mode` only
-                                        // gates the dedicated self-chat thread above.
+                                        // group). Replying would impersonate the operator. Drop —
+                                        // unless the operator has configured a mention pattern
+                                        // and the text matches it (the workflow @ilteoood uses
+                                        // with `TinyBot ...` triggers), in which case the helper
+                                        // returns true and we fall through to the policy branches
+                                        // below to treat the message like an inbound trigger.
                                         tracing::debug!(
                                             "WhatsApp Web: ignoring fromMe message outside self-chat thread (chat={chat}, sender={sender})"
                                         );
@@ -2223,5 +2264,136 @@ mod tests {
             mime_from_path(std::path::Path::new("/tmp/e.xyz")),
             "application/octet-stream"
         );
+    }
+
+    // ── fromme_outside_self_chat_is_operator_trigger (#6351) ───────────
+
+    #[test]
+    #[cfg(feature = "whatsapp-web")]
+    fn fromme_trigger_drops_when_no_mention_patterns_configured() {
+        let dm: Vec<regex::Regex> = vec![];
+        let group: Vec<regex::Regex> = vec![];
+        // Without configured patterns, a fromMe message in a third-party
+        // DM or group must drop — there is no opt-in signal that says the
+        // operator wants outbound mirrors to be treated as triggers.
+        assert!(!fromme_outside_self_chat_is_operator_trigger(
+            false,
+            &dm,
+            &group,
+            "TinyBot foo"
+        ));
+        assert!(!fromme_outside_self_chat_is_operator_trigger(
+            true,
+            &dm,
+            &group,
+            "TinyBot foo"
+        ));
+    }
+
+    #[test]
+    #[cfg(feature = "whatsapp-web")]
+    fn fromme_trigger_falls_through_when_dm_pattern_matches() {
+        // @ilteoood's configured workflow: dm_mention_patterns = ["TinyBot"].
+        // Operator types "TinyBot translate this" in a friend's DM →
+        // intentional invocation, must fall through.
+        let dm = vec![
+            regex::RegexBuilder::new("TinyBot")
+                .case_insensitive(true)
+                .build()
+                .unwrap(),
+        ];
+        let group: Vec<regex::Regex> = vec![];
+        assert!(fromme_outside_self_chat_is_operator_trigger(
+            false,
+            &dm,
+            &group,
+            "TinyBot translate this"
+        ));
+    }
+
+    #[test]
+    #[cfg(feature = "whatsapp-web")]
+    fn fromme_trigger_drops_when_dm_pattern_does_not_match() {
+        // Operator types a normal message in a friend's DM — even with
+        // patterns configured, no match means it stays an outbound mirror
+        // and must be dropped to prevent impersonation.
+        let dm = vec![
+            regex::RegexBuilder::new("TinyBot")
+                .case_insensitive(true)
+                .build()
+                .unwrap(),
+        ];
+        let group: Vec<regex::Regex> = vec![];
+        assert!(!fromme_outside_self_chat_is_operator_trigger(
+            false,
+            &dm,
+            &group,
+            "see you at 7"
+        ));
+    }
+
+    #[test]
+    #[cfg(feature = "whatsapp-web")]
+    fn fromme_trigger_uses_group_patterns_for_group_threads() {
+        // group_mention_patterns gates the group case; dm patterns must
+        // not be consulted for group messages and vice versa. This pins
+        // the predicate's branch selection.
+        let dm: Vec<regex::Regex> = vec![
+            regex::RegexBuilder::new("DmTrigger")
+                .case_insensitive(true)
+                .build()
+                .unwrap(),
+        ];
+        let group = vec![
+            regex::RegexBuilder::new("GroupTrigger")
+                .case_insensitive(true)
+                .build()
+                .unwrap(),
+        ];
+        // In a group, only group_patterns matter.
+        assert!(fromme_outside_self_chat_is_operator_trigger(
+            true,
+            &dm,
+            &group,
+            "GroupTrigger hi"
+        ));
+        assert!(!fromme_outside_self_chat_is_operator_trigger(
+            true,
+            &dm,
+            &group,
+            "DmTrigger hi"
+        ));
+        // In a DM, only dm_patterns matter.
+        assert!(fromme_outside_self_chat_is_operator_trigger(
+            false,
+            &dm,
+            &group,
+            "DmTrigger hi"
+        ));
+        assert!(!fromme_outside_self_chat_is_operator_trigger(
+            false,
+            &dm,
+            &group,
+            "GroupTrigger hi"
+        ));
+    }
+
+    #[test]
+    #[cfg(feature = "whatsapp-web")]
+    fn fromme_trigger_drops_when_text_is_empty() {
+        // Voice notes and media-only messages return empty text. With no
+        // text to match against, the operator-trigger path must drop —
+        // never transcribe a fromMe voice note just to check whether it
+        // is a bot trigger (cost + impersonation risk).
+        let dm = vec![
+            regex::RegexBuilder::new("TinyBot")
+                .case_insensitive(true)
+                .build()
+                .unwrap(),
+        ];
+        let group: Vec<regex::Regex> = vec![];
+        assert!(!fromme_outside_self_chat_is_operator_trigger(
+            false, &dm, &group, ""
+        ));
     }
 }

--- a/crates/zeroclaw-channels/src/whatsapp_web.rs
+++ b/crates/zeroclaw-channels/src/whatsapp_web.rs
@@ -1197,6 +1197,16 @@ impl Channel for WhatsAppWebChannel {
                                                 );
                                             }
                                         }
+                                    } else if info.source.is_from_me {
+                                        // fromMe outside the self-chat thread is a mirror of the
+                                        // operator's own outbound message to a third party (DM or
+                                        // group). Replying would impersonate the operator to the
+                                        // recipient. Drop unconditionally — `self_chat_mode` only
+                                        // gates the dedicated self-chat thread above.
+                                        tracing::debug!(
+                                            "WhatsApp Web: ignoring fromMe message outside self-chat thread (chat={chat}, sender={sender})"
+                                        );
+                                        return;
                                     } else if is_group {
                                         match wa_group_policy {
                                             zeroclaw_config::schema::WhatsAppChatPolicy::Ignore => {


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Personal-mode handler treated every `fromMe = true` event as eligible for an agent reply when `self_chat_mode = true`, regardless of which chat thread it belonged to. WhatsApp Web mirrors the operator's outbound messages to all linked devices as `fromMe`; with the operator's number in `allowed_numbers`, the bot piggybacked replies onto whichever contact the operator was messaging, impersonating them.
  - Added a guard for `info.source.is_from_me` between the self-chat branch and the group/DM policy branches. The self-chat branch (`sender_user == chat_user`, not group, fromMe) keeps existing behaviour; any other thread with `fromMe = true` drops before policies run, except when the message is an operator-typed mention trigger (see next bullet).
  - The guard predicate distinguishes mirrors from operator-typed triggers via `fromme_outside_self_chat_is_operator_trigger(is_group, dm_patterns, group_patterns, text)`. When the applicable mention pattern (`dm_mention_patterns` for DMs, `group_mention_patterns` for groups) is configured and the text matches, the message falls through to the regular DM/group policy branches and is processed like an inbound trigger (this is @ilteoood's verified workflow with `dm_mention_patterns = ["TinyBot"]`). Otherwise it drops.
  - Voice notes and media-only fromMe messages drop unconditionally. There is no text to match against, and transcribing a fromMe voice note just to test trigger status is both expensive and an impersonation vector.
- **Scope boundary:** Personal mode only on the WhatsApp Web channel. Business mode skips the whole gated block. No other channels touched. The mention-pattern fall-through reuses existing `text_matches_patterns`; no new pattern-matching primitives.
- **Blast radius:** WhatsApp Web channel only. Inbound (not fromMe) DM and group behaviour is unchanged: `dm_mention_patterns` and `group_mention_patterns` still apply exactly as before. Self-chat behaviour is unchanged when `chat_jid` matches the bot's own jid. The narrowed-then-relaxed posture matches what operators had before #6351 minus the impersonation vector.
- **Linked issue(s):** Closes #6351

## Validation Evidence (required)

```bash
cargo +nightly fmt --all -- --check
cargo clippy -p zeroclaw-channels --all-targets    # without whatsapp-web (heavy native deps)
cargo test
```

- **Commands run and tail output:**
  - `cargo +nightly fmt --all -- --check`: clean (no output).
  - `cargo clippy -p zeroclaw-channels --all-targets`: zero warnings without the `whatsapp-web` feature. The feature has a `prost` transitive-dep build issue locally that is unrelated to this change (the branch is 31 commits behind master); CI builds the feature cleanly.
  - GitHub CI (12 checks at head 51d25d39f8): all green, including `Test`, `Check (all features)` (which exercises `whatsapp-web` via `--features ci-all`), `Lint`, and `Security`.
- **Beyond CI, what was manually verified:**
  - Read the surrounding handler in `whatsapp_web.rs` to confirm branch ordering: `is_self_chat` → fromMe-mirror drop (with mention-pattern fall-through) → group policy → DM policy. The helper sits in the right place and does not shadow the self-chat branch.
  - Five unit tests on the helper pin the predicate matrix:
    - `fromme_trigger_drops_when_no_mention_patterns_configured`: neither DM nor group patterns configured, drop in both DM and group threads.
    - `fromme_trigger_falls_through_when_dm_pattern_matches`: @ilteoood's `TinyBot` config plus matching text, fall through.
    - `fromme_trigger_drops_when_dm_pattern_does_not_match`: patterns configured but text does not match, drop.
    - `fromme_trigger_uses_group_patterns_for_group_threads`: pins the DM-vs-group pattern selection (DM patterns are not consulted in groups and vice versa).
    - `fromme_trigger_drops_when_text_is_empty`: voice notes and media-only messages drop.
- **If any command was intentionally skipped, why:** local `cargo test --features whatsapp-web` is blocked by a `prost` build issue on the merge-base of this branch that is unrelated to the diff; CI runs the gated tests with the feature enabled and they pass.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes` for operators with no mention patterns configured: behaviour matches the prior "drop all fromMe mirrors outside self-chat" posture (the impersonation vector is closed). For operators who had `dm_mention_patterns` or `group_mention_patterns` set, the @ilteoood workflow (operator types a trigger phrase in a third-party DM or group) is preserved.
- Config / env / CLI surface changed? `No`
- Upgrade steps for existing users: none required.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <merge-sha>` against master. Squash-merge is single-commit, so revert is single-commit.
- **Feature flags or config toggles:** None. The fix is wired inline in the WhatsApp Web handler.
- **Observable failure symptoms:** the bot replying to messages the operator typed in third-party DMs or groups, addressing the contact instead of the operator. Symptom would surface in user reports as "bot impersonates me again". Operators can mitigate by removing their own number from `allowed_numbers` until a forward-fix lands.
