### PR TITLE
fix(xtask:web): re-run npm install when node_modules is stale vs lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13076,6 +13076,7 @@ dependencies = [
  "clap",
  "reqwest 0.12.28",
  "serde_json",
+ "tempfile",
  "tokio",
  "toml 0.8.2",
  "tower-http",

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -27,3 +27,6 @@ toml = "0.8"
 tokio = { version = "1.50", default-features = false, features = ["rt-multi-thread", "macros", "net"] }
 tower-http = { version = "0.6", default-features = false, features = ["fs"] }
 zeroclaw-gateway = { workspace = true, features = ["schema-export"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/xtask/src/bin/web.rs
+++ b/xtask/src/bin/web.rs
@@ -154,3 +154,79 @@ fn bin(tool: &str) -> String {
         tool.to_string()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::node_modules_needs_install;
+    use std::fs;
+    use std::thread::sleep;
+    use std::time::Duration;
+    use tempfile::TempDir;
+
+    fn fresh_web_dir() -> TempDir {
+        let dir = TempDir::new().expect("tempdir");
+        fs::write(dir.path().join("package-lock.json"), "{}").unwrap();
+        dir
+    }
+
+    #[test]
+    fn needs_install_when_node_modules_missing() {
+        let dir = fresh_web_dir();
+        // No node_modules at all → must trigger install.
+        assert!(node_modules_needs_install(dir.path()));
+    }
+
+    #[test]
+    fn needs_install_when_sentinel_missing() {
+        // node_modules exists but `.package-lock.json` sentinel was never written
+        // (e.g. partial / failed previous install). Must trigger install.
+        let dir = fresh_web_dir();
+        fs::create_dir(dir.path().join("node_modules")).unwrap();
+        assert!(node_modules_needs_install(dir.path()));
+    }
+
+    #[test]
+    fn needs_install_when_lock_is_newer_than_sentinel() {
+        // The actual staleness fix: a pull or merge updated package-lock.json
+        // after the last install. Sentinel is OLDER than lock → reinstall.
+        let dir = fresh_web_dir();
+        let nm = dir.path().join("node_modules");
+        fs::create_dir(&nm).unwrap();
+        fs::write(nm.join(".package-lock.json"), "{}").unwrap();
+        // Wait a measurable tick, then bump lock mtime.
+        sleep(Duration::from_millis(20));
+        fs::write(dir.path().join("package-lock.json"), "{ \"updated\": true }").unwrap();
+        assert!(
+            node_modules_needs_install(dir.path()),
+            "stale node_modules (sentinel older than lock) must reinstall"
+        );
+    }
+
+    #[test]
+    fn skips_when_sentinel_is_at_least_as_new_as_lock() {
+        // Clean install just finished. Sentinel mtime ≥ lock mtime → no
+        // spurious reinstall on every build invocation.
+        let dir = fresh_web_dir();
+        let nm = dir.path().join("node_modules");
+        fs::create_dir(&nm).unwrap();
+        // Write sentinel AFTER lock so its mtime is newer.
+        sleep(Duration::from_millis(20));
+        fs::write(nm.join(".package-lock.json"), "{}").unwrap();
+        assert!(
+            !node_modules_needs_install(dir.path()),
+            "fresh node_modules must not trigger spurious reinstall"
+        );
+    }
+
+    #[test]
+    fn skips_when_lock_missing() {
+        // Defensive case: no package-lock.json (unusual — repo always has one).
+        // Without a signal we cannot tell if node_modules is stale; treat as
+        // valid to avoid a reinstall loop.
+        let dir = TempDir::new().expect("tempdir");
+        let nm = dir.path().join("node_modules");
+        fs::create_dir(&nm).unwrap();
+        fs::write(nm.join(".package-lock.json"), "{}").unwrap();
+        assert!(!node_modules_needs_install(dir.path()));
+    }
+}

--- a/xtask/src/bin/web.rs
+++ b/xtask/src/bin/web.rs
@@ -195,7 +195,11 @@ mod tests {
         fs::write(nm.join(".package-lock.json"), "{}").unwrap();
         // Wait a measurable tick, then bump lock mtime.
         sleep(Duration::from_millis(20));
-        fs::write(dir.path().join("package-lock.json"), "{ \"updated\": true }").unwrap();
+        fs::write(
+            dir.path().join("package-lock.json"),
+            "{ \"updated\": true }",
+        )
+        .unwrap();
         assert!(
             node_modules_needs_install(dir.path()),
             "stale node_modules (sentinel older than lock) must reinstall"

--- a/xtask/src/bin/web.rs
+++ b/xtask/src/bin/web.rs
@@ -70,6 +70,29 @@ fn npm_install(web_dir: &Path) -> Result<()> {
     run_cmd(Command::new(bin("npm")).current_dir(web_dir).arg("install"))
 }
 
+/// Whether `web/node_modules` is missing or stale relative to `package-lock.json`.
+///
+/// npm writes a `node_modules/.package-lock.json` sentinel after every successful
+/// install. If it's absent, or if the checked-in `package-lock.json` is newer
+/// (a pull or merge updated dependencies), the install needs to re-run.
+fn node_modules_needs_install(web_dir: &Path) -> bool {
+    let node_modules = web_dir.join("node_modules");
+    if !node_modules.exists() {
+        return true;
+    }
+    let sentinel = node_modules.join(".package-lock.json");
+    let lock = web_dir.join("package-lock.json");
+    let (Ok(sentinel_meta), Ok(lock_meta)) = (sentinel.metadata(), lock.metadata()) else {
+        // Sentinel missing → install never completed cleanly. Lock missing → treat
+        // node_modules as authoritative (no signal to re-install).
+        return !sentinel.exists() && lock.exists();
+    };
+    match (sentinel_meta.modified(), lock_meta.modified()) {
+        (Ok(sentinel_t), Ok(lock_t)) => lock_t > sentinel_t,
+        _ => false,
+    }
+}
+
 fn npm_run(web_dir: &Path, script: &str) -> Result<()> {
     println!("==> npm run {script}");
     run_cmd(
@@ -88,7 +111,7 @@ fn npx(web_dir: &Path, args: &[&str]) -> Result<()> {
 
 fn gen_api(web_dir: &Path, spec_path: &Path) -> Result<()> {
     require_tool("npm", "https://nodejs.org/ or `nvm install --lts`")?;
-    if !web_dir.join("node_modules").exists() {
+    if node_modules_needs_install(web_dir) {
         npm_install(web_dir)?;
     }
     let out_rel = PathBuf::from("src/lib/api-generated.ts");


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `gen_api()` already auto-runs npm install when `node_modules` is missing (#6175 follow-up), but didn't re-run after a pull or merge updated `package-lock.json`. `npx --no-install openapi-typescript` failed cryptically against a stale `node_modules`.
  - Added `node_modules_needs_install(web_dir)` that checks both presence and freshness vs `node_modules/.package-lock.json` (npm's post-install sentinel).
  - All build-like commands (`build`, `dev`, `check`) inherit the check via `gen_api()`. `cargo web install` is unchanged and remains idempotent.
- **Scope boundary:** xtask/web only. Doesn't change which packages are installed, doesn't add staleness signals beyond the lock file, doesn't second-guess npm.
- **Blast radius:** Anyone running `cargo web build` / `dev` / `check` after a `package-lock.json` update will trigger an extra `npm install` — that is the desired behavior. Clean checkouts and unchanged-deps invocations are unchanged.
- **Linked issue(s):** Closes #6291

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
cargo test
```

- **Commands run and tail output:** Deferring to CI per maintainer instruction.
- **Beyond CI — what did you manually verify?** Walked through the four mtime/existence cases mentally:
  - `node_modules` missing → install. (Existing behavior preserved.)
  - sentinel + lock both readable, `lock_t > sentinel_t` → install.
  - sentinel + lock both readable, otherwise → skip.
  - sentinel missing but lock present → install (treat as never-completed).
  - lock missing → skip (no signal; defensive).

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No` (npm install was already running on missing `node_modules`)
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes` — strictly an additive trigger.
- Config / env / CLI surface changed? `No`

## Rollback (required for `risk: medium` and `risk: high`)

`git revert <sha>` is the plan.
