### PR TITLE
fix(runtime/cost): WARN once per (provider, model) pair on missing pricing

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/cost.rs
+++ b/crates/zeroclaw-runtime/src/agent/cost.rs
@@ -79,6 +79,19 @@ pub fn record_tool_loop_cost_usage(
     Some((cost_usage.total_tokens, cost_usage.cost_usd))
 }
 
+/// Insert `(provider, model)` into `seen`. Returns `true` on first sighting,
+/// `false` thereafter. Split out from `warn_once_missing_pricing` so the
+/// dedup contract can be unit-tested with a caller-owned set instead of the
+/// process-static one.
+fn missing_pricing_first_sighting(
+    seen: &Mutex<HashSet<(String, String)>>,
+    provider: &str,
+    model: &str,
+) -> bool {
+    seen.lock()
+        .insert((provider.to_string(), model.to_string()))
+}
+
 /// First-time WARN, subsequent DEBUG, per `(provider, model)` pair.
 ///
 /// The default pricing catalog has no entries for most non-OpenAI/Anthropic/
@@ -91,9 +104,7 @@ pub fn record_tool_loop_cost_usage(
 fn warn_once_missing_pricing(provider: &str, model: &str) {
     static SEEN: OnceLock<Mutex<HashSet<(String, String)>>> = OnceLock::new();
     let seen = SEEN.get_or_init(|| Mutex::new(HashSet::new()));
-    let key = (provider.to_string(), model.to_string());
-    let first_sighting = seen.lock().insert(key);
-    if first_sighting {
+    if missing_pricing_first_sighting(seen, provider, model) {
         tracing::warn!(
             provider,
             model,
@@ -125,4 +136,76 @@ pub fn check_tool_loop_budget() -> Option<BudgetCheck> {
                 .check_budget(0.0)
                 .unwrap_or(BudgetCheck::Allowed)
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fresh_seen() -> Mutex<HashSet<(String, String)>> {
+        Mutex::new(HashSet::new())
+    }
+
+    #[test]
+    fn first_sighting_returns_true() {
+        let seen = fresh_seen();
+        assert!(
+            missing_pricing_first_sighting(&seen, "minimax", "MiniMax-M2.7"),
+            "first observation of a (provider, model) pair must report first-sighting"
+        );
+    }
+
+    #[test]
+    fn second_sighting_same_pair_returns_false() {
+        let seen = fresh_seen();
+        assert!(missing_pricing_first_sighting(
+            &seen, "minimax", "MiniMax-M2.7"
+        ));
+        assert!(
+            !missing_pricing_first_sighting(&seen, "minimax", "MiniMax-M2.7"),
+            "second sighting of the same pair must NOT re-fire WARN"
+        );
+    }
+
+    #[test]
+    fn different_models_under_same_provider_are_independent() {
+        let seen = fresh_seen();
+        assert!(missing_pricing_first_sighting(
+            &seen, "minimax", "MiniMax-M2.7"
+        ));
+        assert!(
+            missing_pricing_first_sighting(&seen, "minimax", "MiniMax-M3.0"),
+            "different model under same provider is a distinct pair"
+        );
+    }
+
+    #[test]
+    fn different_providers_for_same_model_are_independent() {
+        // Same model name served by two different providers — operator may
+        // configure them at different rates, so the warn must fire for each.
+        let seen = fresh_seen();
+        assert!(missing_pricing_first_sighting(
+            &seen,
+            "openrouter",
+            "anthropic/claude-sonnet-4-5"
+        ));
+        assert!(
+            missing_pricing_first_sighting(
+                &seen,
+                "anthropic",
+                "anthropic/claude-sonnet-4-5"
+            ),
+            "different provider for the same model is a distinct pair"
+        );
+    }
+
+    #[test]
+    fn empty_strings_dedup_independently() {
+        // Defensive: empty provider or model shouldn't collide with each other.
+        let seen = fresh_seen();
+        assert!(missing_pricing_first_sighting(&seen, "", "model"));
+        assert!(missing_pricing_first_sighting(&seen, "provider", ""));
+        assert!(missing_pricing_first_sighting(&seen, "", ""));
+        assert!(!missing_pricing_first_sighting(&seen, "", ""));
+    }
 }

--- a/crates/zeroclaw-runtime/src/agent/cost.rs
+++ b/crates/zeroclaw-runtime/src/agent/cost.rs
@@ -159,7 +159,9 @@ mod tests {
     fn second_sighting_same_pair_returns_false() {
         let seen = fresh_seen();
         assert!(missing_pricing_first_sighting(
-            &seen, "minimax", "MiniMax-M2.7"
+            &seen,
+            "minimax",
+            "MiniMax-M2.7"
         ));
         assert!(
             !missing_pricing_first_sighting(&seen, "minimax", "MiniMax-M2.7"),
@@ -171,7 +173,9 @@ mod tests {
     fn different_models_under_same_provider_are_independent() {
         let seen = fresh_seen();
         assert!(missing_pricing_first_sighting(
-            &seen, "minimax", "MiniMax-M2.7"
+            &seen,
+            "minimax",
+            "MiniMax-M2.7"
         ));
         assert!(
             missing_pricing_first_sighting(&seen, "minimax", "MiniMax-M3.0"),
@@ -190,11 +194,7 @@ mod tests {
             "anthropic/claude-sonnet-4-5"
         ));
         assert!(
-            missing_pricing_first_sighting(
-                &seen,
-                "anthropic",
-                "anthropic/claude-sonnet-4-5"
-            ),
+            missing_pricing_first_sighting(&seen, "anthropic", "anthropic/claude-sonnet-4-5"),
             "different provider for the same model is a distinct pair"
         );
     }

--- a/crates/zeroclaw-runtime/src/agent/cost.rs
+++ b/crates/zeroclaw-runtime/src/agent/cost.rs
@@ -1,6 +1,8 @@
 use crate::cost::CostTracker;
 use crate::cost::types::{BudgetCheck, TokenUsage as CostTokenUsage};
-use std::sync::Arc;
+use parking_lot::Mutex;
+use std::collections::HashSet;
+use std::sync::{Arc, OnceLock};
 use zeroclaw_config::schema::ModelPricing;
 
 // ── Cost tracking via task-local ──
@@ -63,11 +65,7 @@ pub fn record_tool_loop_cost_usage(
     );
 
     if pricing.is_none() {
-        tracing::debug!(
-            provider = provider_name,
-            model,
-            "Cost tracking recorded token usage with zero pricing (no pricing entry found)"
-        );
+        warn_once_missing_pricing(provider_name, model);
     }
 
     if let Err(error) = ctx.tracker.record_usage(cost_usage.clone()) {
@@ -79,6 +77,40 @@ pub fn record_tool_loop_cost_usage(
     }
 
     Some((cost_usage.total_tokens, cost_usage.cost_usd))
+}
+
+/// First-time WARN, subsequent DEBUG, per `(provider, model)` pair.
+///
+/// The default pricing catalog has no entries for most non-OpenAI/Anthropic/
+/// Google models. Operators only realize their cost-tracking surface is
+/// reporting zero when they happen to enable DEBUG logging — a pure-DEBUG
+/// signal is too quiet for "your cost enforcement is silently inert" to
+/// register. Promote the first sighting per-pair to WARN with a config-path
+/// pointer; all subsequent same-pair occurrences stay at DEBUG so the warn
+/// stream doesn't get spammy.
+fn warn_once_missing_pricing(provider: &str, model: &str) {
+    static SEEN: OnceLock<Mutex<HashSet<(String, String)>>> = OnceLock::new();
+    let seen = SEEN.get_or_init(|| Mutex::new(HashSet::new()));
+    let key = (provider.to_string(), model.to_string());
+    let first_sighting = seen.lock().insert(key);
+    if first_sighting {
+        tracing::warn!(
+            provider,
+            model,
+            "Cost tracking: no pricing entry found for {provider}/{model} — \
+             token usage will be recorded with zero cost and budget enforcement \
+             is inert for this model. Add a pricing entry to config.toml under \
+             `[cost.prices.\"{provider}/{model}\"]` with `input = <USD per 1M tokens>` \
+             and `output = <USD per 1M tokens>` to enable cost tracking. \
+             This warning fires once per (provider, model) pair per process.",
+        );
+    } else {
+        tracing::debug!(
+            provider,
+            model,
+            "Cost tracking recorded token usage with zero pricing (no pricing entry found)",
+        );
+    }
 }
 
 /// Check budget before an LLM call. Returns `None` when no cost tracking


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Default pricing catalog has entries for OpenAI/Anthropic/Google only. Operators using MiniMax, Kimi, GLM, Qwen, Doubao, Groq, etc. (most of the "50+ providers" surface) get zero-cost records and silently inert budget enforcement.
  - Today the only signal is a DEBUG line per LLM call — too quiet for "your cost surface is silently inert" to register.
  - Promote the first sighting per `(provider, model)` to WARN with a concrete config-path pointer: `[cost.prices."<provider>/<model>"]` with `input = ...` and `output = ...`. Subsequent occurrences stay at DEBUG.
  - Dedup uses a process-local `OnceLock<Mutex<HashSet<(String, String)>>>` (parking_lot::Mutex, already in workspace).
- **Scope boundary:** Logging only. Does not change cost calculations, does not ship a default pricing catalog (option 1 of the issue is intentionally out of scope — V3 places pricing inline on each `ModelProviderConfig` and operators are expected to set their own rates).
- **Blast radius:** First inference call per (provider, model) pair without configured pricing emits an extra WARN line. Operators with all pricing configured see zero behavior change.
- **Linked issue(s):** Closes #5807 — addresses option 3 (actionable log).

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
cargo test
```

- **Commands run and tail output:** Deferring to CI per maintainer instruction.
- **Beyond CI — what did you manually verify?** Lock is released before tracing call (temporary `seen.lock()` dropped at the semicolon, then if/else runs unlocked). HashSet bounded by distinct (provider, model) pairs seen — realistically <100 entries per process.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes` — log-level change only.
- Config / env / CLI surface changed? `No`

## Rollback (required for `risk: medium` and `risk: high`)

`git revert <sha>` is the plan.
