### PR TITLE
feat(gateway): DELETE /api/personality/{filename} endpoint

### DIFF
--- a/crates/zeroclaw-gateway/src/api_personality.rs
+++ b/crates/zeroclaw-gateway/src/api_personality.rs
@@ -400,9 +400,7 @@ pub async fn handle_delete(
     let path = personality_path(&workspace_dir, q.agent.as_deref(), allowed);
 
     let existed = path.exists();
-    if existed
-        && let Err(err) = std::fs::remove_file(&path)
-    {
+    if existed && let Err(err) = std::fs::remove_file(&path) {
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(serde_json::json!({

--- a/crates/zeroclaw-gateway/src/api_personality.rs
+++ b/crates/zeroclaw-gateway/src/api_personality.rs
@@ -115,6 +115,15 @@ pub struct PersonalityPutResponse {
 }
 
 #[derive(Debug, Serialize)]
+pub struct PersonalityDeleteResponse {
+    pub filename: String,
+    /// `true` when a file was actually removed; `false` when the file did not
+    /// exist (DELETE is idempotent — the BOOTSTRAP.md "delete after first
+    /// conversation" use case may fire after the file was already removed).
+    pub existed: bool,
+}
+
+#[derive(Debug, Serialize)]
 pub struct PersonalityConflict {
     pub error: &'static str,
     pub filename: String,
@@ -354,6 +363,60 @@ pub async fn handle_put(
     Json(PersonalityPutResponse {
         bytes_written,
         mtime_ms,
+    })
+    .into_response()
+}
+
+/// DELETE /api/personality/{filename} — remove an allowlisted personality file.
+///
+/// Idempotent: deleting a file that does not exist returns 200 with
+/// `existed: false` rather than 404. The primary motivating use case is the
+/// dashboard's "first-run completion" flow for `BOOTSTRAP.md` (the file is
+/// supposed to delete itself once the operator has finished onboarding;
+/// today it persists silently because there's no UI surface to remove it),
+/// but the route accepts any allowlisted filename so operators can reset
+/// other personality files to runtime defaults when needed. The runtime
+/// reload behaviour matches PUT — changes are picked up at the next
+/// session boundary.
+pub async fn handle_delete(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    axum::extract::Path(filename): axum::extract::Path<String>,
+    Query(q): Query<AgentQuery>,
+) -> impl IntoResponse {
+    if let Err(e) = require_auth(&state, &headers) {
+        return e.into_response();
+    }
+
+    let allowed = match validate_filename(&filename) {
+        Ok(f) => f,
+        Err(e) => return e.into_response(),
+    };
+
+    let workspace_dir = {
+        let cfg = state.config.lock();
+        cfg.workspace_dir.clone()
+    };
+    let path = personality_path(&workspace_dir, q.agent.as_deref(), allowed);
+
+    let existed = path.exists();
+    if existed
+        && let Err(err) = std::fs::remove_file(&path)
+    {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({
+                "error": "failed to delete personality file",
+                "filename": allowed,
+                "detail": err.to_string(),
+            })),
+        )
+            .into_response();
+    }
+
+    Json(PersonalityDeleteResponse {
+        filename: allowed.to_string(),
+        existed,
     })
     .into_response()
 }

--- a/crates/zeroclaw-gateway/src/lib.rs
+++ b/crates/zeroclaw-gateway/src/lib.rs
@@ -1051,7 +1051,9 @@ pub async fn run_gateway(
         )
         .route(
             "/api/personality/{filename}",
-            get(api_personality::handle_get).put(api_personality::handle_put),
+            get(api_personality::handle_get)
+                .put(api_personality::handle_put)
+                .delete(api_personality::handle_delete),
         )
         .route("/api/config/init", post(api_config::handle_init))
         .route("/api/config/migrate", post(api_config::handle_migrate))


### PR DESCRIPTION
## Summary

- **Base branch:** \`master\`
- **What changed and why:**
  - The persona editor backend was largely already in place: \`handle_index\`, \`handle_get\`, \`handle_put\`, \`handle_templates\` ship the EDITABLE_PERSONALITY_FILES allowlist, MAX_FILE_CHARS truncation, optimistic locking via \`expected_mtime_ms\`. The missing piece for #6344 was removing files — BOOTSTRAP.md is supposed to self-delete once onboarding completes but persists silently forever absent a UI surface.
  - Add \`handle_delete\`, wire it at \`DELETE /api/personality/{filename}\` alongside the existing GET/PUT on the same path.
  - Idempotent: deleting a file that does not exist returns 200 with \`existed: false\` rather than 404, so the eventual dashboard "first-run completion" flow can fire the call without race-condition fragility.
- **Scope boundary:** Backend only. Frontend persona editor surface (the dashboard \`/persona\` page from the issue's proposed solution) is intentionally out of scope for this PR — this lands the route the dashboard will need without bundling unrelated frontend work.
- **Blast radius:** New endpoint behind the same require_auth + allowlist gates as the existing personality handlers. No effect on operators who don't use it.
- **Linked issue(s):** \`Refs #6344\` — addresses the backend-deletion piece. Frontend persona editor surface is the remaining work.

## Validation Evidence (required)

\`\`\`bash
cargo fmt --all -- --check
cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
cargo test
\`\`\`

- **Commands run and tail output:** \`cargo check -p zeroclaw-gateway\` passes locally. fmt/clippy/test deferred to CI per maintainer instruction.
- **Beyond CI — what did you manually verify?**
  - \`validate_filename\` already gate-tests every code path; DELETE inherits the same allowlist coverage without needing a new test.
  - The \`existed\` flag in the response distinguishes "I removed it" from "it was already gone" so the dashboard can render meaningful UX for both first-run and re-run cases.
  - No path-traversal exposure: \`personality_path\` joins \`workspace_dir\` with a \`&'static str\` from the allowlist; user-supplied path components cannot escape.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? \`Yes\` — file deletion within the workspace, gated by the EDITABLE_PERSONALITY_FILES allowlist (same gate that already protects PUT).
- New external network calls? \`No\`
- Secrets / tokens / credentials handling changed? \`No\`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? \`No\`
- If any \`Yes\`, describe the risk and mitigation: deletion is restricted to the same allowlist as PUT (\`SOUL.md\`, \`IDENTITY.md\`, \`USER.md\`, \`AGENTS.md\`, \`TOOLS.md\`, \`HEARTBEAT.md\`, \`BOOTSTRAP.md\`, \`MEMORY.md\`); auth is required; path is built from a \`&'static str\` so traversal is structurally impossible.

## Compatibility (required)

- Backward compatible? \`Yes\` — additive endpoint.
- Config / env / CLI surface changed? \`No\`

## Rollback (required for \`risk: medium\` and \`risk: high\`)

\`git revert <sha>\` is the plan.