### PR TITLE
fix(runtime): preserve plain-text assistant    before tool messages in context compressor boundary

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/context_compressor.rs
+++ b/crates/zeroclaw-runtime/src/agent/context_compressor.rs
@@ -416,23 +416,50 @@ fn align_boundary_forward(messages: &[ChatMessage], idx: usize) -> usize {
 /// already-protected `tool_result` blocks remain in the tail, creating
 /// the 400 "unexpected tool_use_id in tool_result blocks" failure mode
 /// at the root of #5813.
+///
+/// A tool-call-owning assistant is detected by *either* of:
+/// 1. Embedded JSON: `content` parses as JSON and contains a non-empty
+///    `tool_calls` array. This is how the OpenAI-compat reader (see
+///    `crates/zeroclaw-providers/src/openai.rs::convert_messages`) expects
+///    the history writer to serialize assistant-with-tool-calls messages.
+/// 2. Trailing tool messages: we just stepped over one or more `tool`
+///    messages while walking backward. By protocol a `tool` message can
+///    only follow an `assistant(tool_calls)`, so the preceding assistant
+///    owns those results regardless of how its content was serialized.
+///    This second path exists because, in practice, some provider code
+///    paths persist tool-call-owning assistants as plain-text content
+///    (without the JSON `tool_calls` field). Without this fallback those
+///    pairs get split — the assistant is summarized while the tool result
+///    remains in the protected tail — producing an outbound payload that
+///    strict servers reject (e.g. MiniMax returns HTTP 400 code 2013
+///    `invalid message role: system` after the resulting tool loop).
 fn align_boundary_backward(messages: &[ChatMessage], idx: usize) -> usize {
     let mut i = idx;
     loop {
+        let before_tools = i;
         while i > 0 && messages[i].role == "tool" {
             i -= 1;
         }
-        if messages[i].role == "assistant"
-            && let Ok(v) = serde_json::from_str::<serde_json::Value>(&messages[i].content)
-            && v.get("tool_calls")
-                .and_then(|a| a.as_array())
-                .is_some_and(|a| !a.is_empty())
-        {
-            if i == 0 {
-                break;
+        let saw_tool = i != before_tools;
+
+        if messages[i].role == "assistant" {
+            let has_json_tool_calls =
+                serde_json::from_str::<serde_json::Value>(&messages[i].content)
+                    .ok()
+                    .and_then(|v| {
+                        v.get("tool_calls")
+                            .and_then(|a| a.as_array())
+                            .map(|a| !a.is_empty())
+                    })
+                    .unwrap_or(false);
+
+            if saw_tool || has_json_tool_calls {
+                if i == 0 {
+                    break;
+                }
+                i -= 1;
+                continue;
             }
-            i -= 1;
-            continue;
         }
         break;
     }
@@ -716,6 +743,38 @@ mod tests {
         ];
         // No tool_calls on the assistant — boundary should not retreat.
         assert_eq!(align_boundary_backward(&messages, 2), 2);
+    }
+
+    /// Regression: the OpenAI-compat / MiniMax path can persist a
+    /// tool-call-owning assistant with plain-text content (no embedded
+    /// JSON `tool_calls` field). When such an assistant sits just
+    /// before the compression boundary and is followed by `tool`
+    /// messages in the protected tail, the boundary must retreat past
+    /// the assistant — otherwise the assistant gets summarized while
+    /// its tool result remains in the protected tail, producing the
+    /// orphaned-pair state that downstream strict servers reject
+    /// (MiniMax returns HTTP 400 code 2013 `invalid message role:
+    /// system` after the resulting tool loop).
+    #[test]
+    fn test_align_boundary_backward_plaintext_assistant_before_tool() {
+        let messages = vec![
+            msg("system", "sys"),
+            msg("user", "question"),
+            msg("assistant", "Let me check"),
+            msg("tool", "result payload"),
+            msg("assistant", "final"),
+        ];
+        // Initial boundary (protect_last_n = 2) lands on the tool at
+        // idx 3. Walking backward: idx 3 is tool → skip; idx 2 is a
+        // plain-text assistant. With JSON-only detection this returned
+        // 2 (the assistant was summarized while the tool stayed in the
+        // tail, creating the orphan). The fix recognizes the trailing
+        // tool as proof of ownership and retreats past the assistant.
+        let aligned = align_boundary_backward(&messages, 3);
+        assert!(
+            aligned < 2,
+            "boundary should retreat past plain-text assistant+tool pair, got {aligned}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Fix `align_boundary_backward` in `context_compressor.rs` so it recognizes a tool-call-owning assistant via *either* embedded JSON `tool_calls` (existing path) *or* the presence of trailing `tool` messages (new path). Previously only the JSON-content path was recognized, so when upstream code persisted an assistant with plain-text content the boundary did not retreat, the `assistant + tool` pair was split across the summarization boundary, and the assistant was replaced by `[CONTEXT SUMMARY]` while its matching tool result remained in the protected tail.
  - The resulting tool loop (model keeps re-issuing the same call because it never sees its own prior tool result in history) eventually produces a payload that MiniMax rejects with HTTP 400 code 2013 `invalid message role: system`. This is a different failure mode from #5743, which is about stale `tool_call_id` replay; here the entire pair is dropped rather than referenced incorrectly.
  - Adds a regression test `test_align_boundary_backward_plaintext_assistant_before_tool`.
- **Scope boundary:** does not modify `ChatMessage` struct, any provider adapter, session persistence schema, or the summary format. Does not address the separate `max_system_prompt_chars = 0` → empty-system-message 2013 failure (mentioned below for context only).
- **Blast radius:** `crates/zeroclaw-runtime/src/agent/context_compressor.rs` only. Affects compression boundary selection. Worst-case drift: slightly more messages retained in the protected tail when a plain-text assistant happens to sit just before the boundary and is followed by tool messages — i.e. more tokens, no correctness regression.
- **Linked issue(s):** (none — reporting as PR per CONTRIBUTING.md guidance, full context in this body)

## Validation Evidence (required)

```bash
cargo fmt -p zeroclaw-runtime -- --check   # exit 0, no diff
cargo clippy -p zeroclaw-runtime --lib --tests -- -D warnings
cargo test  -p zeroclaw-runtime --lib context_compressor
```

### `cargo fmt --check` — clean

No diff. Re-ran `cargo fmt -p zeroclaw-runtime` before commit to match rustfmt.toml.

### `cargo clippy -p zeroclaw-runtime --lib --tests -- -D warnings` — tail output

```
    Checking zeroclaw-providers v0.7.4 (/.../crates/zeroclaw-providers)
    Checking zeroclaw-memory v0.7.4 (/.../crates/zeroclaw-memory)
    Checking zeroclaw-tools v0.7.4 (/.../crates/zeroclaw-tools)
    Checking zeroclaw-runtime v0.7.4 (/.../crates/zeroclaw-runtime)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 57s
```

### `cargo test -p zeroclaw-runtime --lib context_compressor` — tail output

```
test agent::context_compressor::tests::test_align_boundary_backward_backs_up_past_tool_call_assistant ... ok
test agent::context_compressor::tests::test_align_boundary_backward_noop_on_plain_assistant ... ok
test agent::context_compressor::tests::test_align_boundary_backward_plaintext_assistant_before_tool ... ok
test agent::context_compressor::tests::test_align_boundary_forward_noop ... ok
test agent::context_compressor::tests::test_align_boundary_forward_skips_tool ... ok
... (full suite, 31 total)

test result: ok. 31 passed; 0 failed; 0 ignored; 0 measured; 1597 filtered out; finished in 0.01s
```

All three `align_boundary_backward_*` tests pass:
- Existing `backs_up_past_tool_call_assistant` (JSON-content detection path) — unchanged behavior.
- Existing `noop_on_plain_assistant` (no trailing tool, should not retreat) — unchanged behavior.
- New `plaintext_assistant_before_tool` (trailing-tool detection path) — the bug this PR fixes.

### Beyond CI — manually verified

- **End-to-end reproduction (v0.7.4 on Ubuntu 22.04, MiniMax-M2 via `custom:https://api.minimaxi.com/v1`)**: captured outbound `/chat/completions` payloads via a local Python reverse proxy during a failing multi-turn tool-using Feishu conversation. All four POSTs sent the same `[system, user]` only — no `assistant` and no `tool` messages — despite multiple tool iterations having occurred in the session. The user message's body began with `[Memory context]\n- compressed_context_<uuid>: ## Conversation Summary ...`, confirming the entire tool history had been folded into a single compressed-context memory fact and replaced in the outbound payload, consistent with the boundary-split hypothesis fixed here.
- **After-fix workaround verification**: with `agent.context_compression.enabled = false` the same multi-turn Feishu query ("OpenAI 2025 年预计营收有多少？") succeeded in 32 s (`llm_call_ms=32582`) with the correct answer ("OpenAPI is not publicly listed, no official 2025 revenue forecast …"), no 2013 error, no tool-loop warning. This PR's fix targets the compression path directly so users don't need this workaround.

### What I did NOT verify

- Full-repo `cargo test` across all crates: not run (mac dev environment, repo is large, many integration tests have external deps). Scope is local to `zeroclaw-runtime`; this crate's test suite is green.
- `./scripts/ci/rust_quality_gate.sh`: not run on this workstation — CI will cover.
- Anthropic / native-MiniMax / Ollama provider paths: I did not construct synthetic histories for each adapter. The change only broadens recognition (pair of `assistant + tool` adjacent in role order is already the canonical invariant all adapters rely on), so any adapter that was already working will continue to work.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- If any `Yes`, describe the risk and mitigation: n/a

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- Upgrade steps: none. Behavior change only affects cases that previously mis-compressed (plain-text assistant followed by tool message at the compression boundary). Such cases now correctly keep the pair in the protected tail.

## Rollback

`git revert <sha>` — low-risk, single-file, single-function change.

## Related but out of scope

For anyone searching for MiniMax + 2013 `invalid message role: system`: there is a second, independent trigger for the same error message that is **not** addressed by this PR — `agent.max_system_prompt_chars = 0` causes the daemon to emit an empty-string system message that MiniMax also rejects with 2013. That one fires on the very first request (no tool iterations needed). Workaround: set `max_system_prompt_chars` to any positive value (I used 4096). Happy to spin out a separate issue or PR for that if wanted; it's a smaller config-semantics question.

---


---

## Maintainer note

Closes #6361.

This PR fixes the primary failure path described in #6361: the compressor splitting `assistant + tool` pairs across the summarization boundary, leading to the tool loop and the MiniMax HTTP 400 code 2013 (`invalid message role: system`). The secondary `max_system_prompt_chars = 0` → empty-system-message 2013 failure mentioned in #6361 is explicitly out of scope for this PR per the scope-boundary note above; it should be tracked separately if it persists after this lands.

— @singlerider, 2026-05-28
