### PR TITLE
fix(channels): recall autosaved conversation memories

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -1898,51 +1898,119 @@ async fn build_memory_context(
     min_relevance_score: f64,
     session_id: Option<&str>,
 ) -> String {
-    let mut context = String::new();
+    build_memory_context_for_sessions(mem, user_msg, min_relevance_score, &[session_id]).await
+}
 
-    if let Ok(entries) = mem.recall(user_msg, 5, session_id, None, None).await {
-        let mut included = 0usize;
-        let mut used_chars = 0usize;
+async fn build_memory_context_for_sessions(
+    mem: &dyn Memory,
+    user_msg: &str,
+    min_relevance_score: f64,
+    session_ids: &[Option<&str>],
+) -> String {
+    let mut entries = Vec::new();
+    let mut seen_keys = HashSet::new();
 
-        for entry in entries.iter().filter(|e| match e.score {
-            Some(score) => score >= min_relevance_score,
-            None => true, // keep entries without a score (e.g. non-vector backends)
-        }) {
-            if included >= MEMORY_CONTEXT_MAX_ENTRIES {
-                break;
-            }
-
-            if should_skip_memory_context_entry(&entry.key, &entry.content) {
-                continue;
-            }
-
-            let content = if entry.content.chars().count() > MEMORY_CONTEXT_ENTRY_MAX_CHARS {
-                truncate_with_ellipsis(&entry.content, MEMORY_CONTEXT_ENTRY_MAX_CHARS)
-            } else {
-                entry.content.clone()
-            };
-
-            let line = format!("- {}: {}\n", entry.key, content);
-            let line_chars = line.chars().count();
-            if used_chars + line_chars > MEMORY_CONTEXT_MAX_CHARS {
-                break;
-            }
-
-            if included == 0 {
-                context.push_str("[Memory context]\n");
-            }
-
-            context.push_str(&line);
-            used_chars += line_chars;
-            included += 1;
+    match session_ids {
+        [] => {}
+        [session_id] => {
+            let recalled = mem.recall(user_msg, 5, *session_id, None, None).await;
+            append_recalled_memory_entries(&mut entries, &mut seen_keys, recalled);
         }
-
-        if included > 0 {
-            context.push_str("[/Memory context]\n\n");
+        [first_session_id, second_session_id] => {
+            let (first_entries, second_entries) = tokio::join!(
+                mem.recall(user_msg, 5, *first_session_id, None, None),
+                mem.recall(user_msg, 5, *second_session_id, None, None)
+            );
+            append_recalled_memory_entries(&mut entries, &mut seen_keys, first_entries);
+            append_recalled_memory_entries(&mut entries, &mut seen_keys, second_entries);
+        }
+        _ => {
+            for session_id in session_ids {
+                let recalled = mem.recall(user_msg, 5, *session_id, None, None).await;
+                append_recalled_memory_entries(&mut entries, &mut seen_keys, recalled);
+            }
         }
     }
 
+    format_memory_context(&entries, min_relevance_score)
+}
+
+fn append_recalled_memory_entries(
+    entries: &mut Vec<zeroclaw_memory::MemoryEntry>,
+    seen_keys: &mut HashSet<String>,
+    recalled: Result<Vec<zeroclaw_memory::MemoryEntry>>,
+) {
+    if let Ok(recalled) = recalled {
+        for entry in recalled {
+            if seen_keys.insert(entry.key.clone()) {
+                entries.push(entry);
+            }
+        }
+    }
+}
+
+fn format_memory_context(
+    entries: &[zeroclaw_memory::MemoryEntry],
+    min_relevance_score: f64,
+) -> String {
+    let mut context = String::new();
+
+    let mut included = 0usize;
+    let mut used_chars = 0usize;
+
+    for entry in entries.iter().filter(|e| match e.score {
+        Some(score) => score >= min_relevance_score,
+        None => true, // keep entries without a score (e.g. non-vector backends)
+    }) {
+        if included >= MEMORY_CONTEXT_MAX_ENTRIES {
+            break;
+        }
+
+        if should_skip_memory_context_entry(&entry.key, &entry.content) {
+            continue;
+        }
+
+        let content = if entry.content.chars().count() > MEMORY_CONTEXT_ENTRY_MAX_CHARS {
+            truncate_with_ellipsis(&entry.content, MEMORY_CONTEXT_ENTRY_MAX_CHARS)
+        } else {
+            entry.content.clone()
+        };
+
+        let line = format!("- {}: {}\n", entry.key, content);
+        let line_chars = line.chars().count();
+        if used_chars + line_chars > MEMORY_CONTEXT_MAX_CHARS {
+            break;
+        }
+
+        if included == 0 {
+            context.push_str("[Memory context]\n");
+        }
+
+        context.push_str(&line);
+        used_chars += line_chars;
+        included += 1;
+    }
+
+    if included > 0 {
+        context.push_str("[/Memory context]\n\n");
+    }
+
     context
+}
+
+fn is_group_reply_target(reply_target: &str) -> bool {
+    reply_target.contains("@g.us") || reply_target.starts_with("group:")
+}
+
+fn sender_memory_session_ids<'a>(
+    msg: &'a zeroclaw_api::channel::ChannelMessage,
+    history_key: &'a str,
+) -> Vec<Option<&'a str>> {
+    if is_group_reply_target(&msg.reply_target) {
+        vec![Some(&msg.sender)]
+    } else {
+        vec![Some(history_key), Some(&msg.sender)]
+    }
 }
 
 /// Extract a compact summary of tool interactions from history messages added
@@ -2812,16 +2880,16 @@ async fn process_channel_message(
     // ── Dual-scope memory recall ──────────────────────────────────
     // Always recall before each LLM call (not just first turn).
     // For group chats: merge sender-scope + group-scope memories.
-    // For DMs: sender-scope only.
-    let is_group_chat =
-        msg.reply_target.contains("@g.us") || msg.reply_target.starts_with("group:");
+    // For DMs: recall from the current conversation scope plus sender scope.
+    let is_group_chat = is_group_reply_target(&msg.reply_target);
 
     let mem_recall_start = Instant::now();
-    let sender_memory_fut = build_memory_context(
+    let sender_session_ids = sender_memory_session_ids(&msg, &history_key);
+    let sender_memory_fut = build_memory_context_for_sessions(
         ctx.memory.as_ref(),
         &msg.content,
         ctx.min_relevance_score,
-        Some(&msg.sender),
+        sender_session_ids.as_slice(),
     );
 
     let (sender_memory, group_memory) = if is_group_chat {
@@ -2844,7 +2912,7 @@ async fn process_channel_message(
         "⏱ Memory recall completed"
     );
 
-    // Merge sender + group memories, avoiding duplicates
+    // Merge sender and group memory context blocks.
     let memory_context = if group_memory.is_empty() {
         sender_memory
     } else if sender_memory.is_empty() {
@@ -9770,6 +9838,105 @@ BTC is currently around $65,000 based on latest tool output."#
         let context = build_memory_context(&mem, "age", 0.0, None).await;
         assert!(context.contains("[Memory context]"));
         assert!(context.contains("Age is 45"));
+    }
+
+    #[tokio::test]
+    async fn autosaved_conversation_memory_is_recalled_by_sender_scope() {
+        let tmp = TempDir::new().unwrap();
+        let mem = SqliteMemory::new(tmp.path()).unwrap();
+        let msg = zeroclaw_api::channel::ChannelMessage {
+            id: "msg_1".into(),
+            sender: "U123".into(),
+            reply_target: "C456".into(),
+            content: "Project codename is quartz".into(),
+            channel: "slack".into(),
+            timestamp: 1,
+            thread_ts: None,
+            interruption_scope_id: None,
+            attachments: vec![],
+        };
+        let history_key = conversation_history_key(&msg);
+
+        mem.store(
+            &conversation_memory_key(&msg),
+            &msg.content,
+            MemoryCategory::Conversation,
+            Some(&history_key),
+        )
+        .await
+        .unwrap();
+
+        let session_ids = sender_memory_session_ids(&msg, &history_key);
+        let context = build_memory_context_for_sessions(&mem, "quartz", 0.0, &session_ids).await;
+
+        assert!(
+            context.contains("Project codename is quartz"),
+            "sender recall should include autosaved memories stored under the current session key, got: {context}"
+        );
+    }
+
+    #[tokio::test]
+    async fn autosaved_group_conversation_memory_stays_session_scoped() {
+        let tmp = TempDir::new().unwrap();
+        let mem = SqliteMemory::new(tmp.path()).unwrap();
+        let group_a_msg = zeroclaw_api::channel::ChannelMessage {
+            id: "msg_1".into(),
+            sender: "U123".into(),
+            reply_target: "group:alpha".into(),
+            content: "Group alpha codename is quartz".into(),
+            channel: "slack".into(),
+            timestamp: 1,
+            thread_ts: None,
+            interruption_scope_id: None,
+            attachments: vec![],
+        };
+        let group_b_msg = zeroclaw_api::channel::ChannelMessage {
+            id: "msg_2".into(),
+            sender: "U123".into(),
+            reply_target: "group:beta".into(),
+            content: "What was the codename?".into(),
+            channel: "slack".into(),
+            timestamp: 2,
+            thread_ts: None,
+            interruption_scope_id: None,
+            attachments: vec![],
+        };
+        let group_a_history_key = conversation_history_key(&group_a_msg);
+        let group_b_history_key = conversation_history_key(&group_b_msg);
+
+        mem.store(
+            &conversation_memory_key(&group_a_msg),
+            &group_a_msg.content,
+            MemoryCategory::Conversation,
+            Some(&group_a_history_key),
+        )
+        .await
+        .unwrap();
+
+        let group_b_sender_session_ids =
+            sender_memory_session_ids(&group_b_msg, &group_b_history_key);
+        assert_eq!(group_b_sender_session_ids, vec![Some("U123")]);
+
+        let sender_context =
+            build_memory_context_for_sessions(&mem, "quartz", 0.0, &group_b_sender_session_ids)
+                .await;
+        let group_context =
+            build_memory_context(&mem, "quartz", 0.0, Some(&group_b_history_key)).await;
+        let source_group_context =
+            build_memory_context(&mem, "quartz", 0.0, Some(&group_a_history_key)).await;
+
+        assert!(
+            sender_context.is_empty(),
+            "sender scope must not leak autosaved group memory from another group, got: {sender_context}"
+        );
+        assert!(
+            group_context.is_empty(),
+            "target group scope must not include another group's autosaved memory, got: {group_context}"
+        );
+        assert!(
+            source_group_context.contains("Group alpha codename is quartz"),
+            "source group scope should still recall its own autosaved memory, got: {source_group_context}"
+        );
     }
 
     /// Auto-saved photo messages must not surface through memory context,


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Updated channel memory-context recall so non-group messages query both the current conversation history key and the sender scope. Autosaved `Conversation` memories are stored under the current history key, so sender-only recall could miss them.
  - Kept group-chat recall session-scoped. Group messages still use sender scope plus the current group/history scope; the new fallback does not broaden one group conversation into another.
  - Split the memory-context formatting from recall collection so multi-session recall can dedupe entries before formatting.
  - Added focused regressions for autosaved sender recall and cross-group isolation.
- **Scope boundary:** Does not change memory storage keys, memory backend behavior, session persistence, provider behavior, group-target detection rules, or user-facing command/tool syntax.
- **Blast radius:** Channel orchestrator memory-context assembly for autosaved conversation memories. Non-group messages may now recover recent autosaved entries that were previously invisible because store and recall scopes differed.
- **Linked issue(s):** Closes #5550

## Validation Evidence (required)

- **Commands run and tail output:**

```bash
time cargo fmt --all -- --check 2>&1 | tail -30
```

```text
cargo fmt --all -- --check 2>&1  2.75s user 0.21s system 80% cpu 3.685 total
tail -30  0.00s user 0.00s system 0% cpu 3.684 total
```

```bash
time cargo test -p zeroclaw-channels autosaved_ --lib 2>&1 | tail -30
```

```text
   Compiling zeroclaw-channels v0.7.4 (/Users/natalie/Development/claws/.zeroclaw/issue-5550-autosaved-recall-current/crates/zeroclaw-channels)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 8.54s
     Running unittests src/lib.rs (target/debug/deps/zeroclaw_channels-cfd3b4e3d9880d03)

running 2 tests
test orchestrator::tests::autosaved_conversation_memory_is_recalled_by_sender_scope ... ok
test orchestrator::tests::autosaved_group_conversation_memory_stays_session_scoped ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 939 filtered out; finished in 0.02s

cargo test -p zeroclaw-channels autosaved_ --lib 2>&1  8.86s user 1.61s system 102% cpu 10.167 total
tail -30  0.00s user 0.00s system 0% cpu 10.167 total
```

```bash
time cargo test -p zeroclaw-channels build_memory_context --lib 2>&1 | tail -30
```

```text
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.63s
     Running unittests src/lib.rs (target/debug/deps/zeroclaw_channels-cfd3b4e3d9880d03)

running 2 tests
test orchestrator::tests::build_memory_context_includes_recalled_entries ... ok
test orchestrator::tests::build_memory_context_excludes_image_marker_entries ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 939 filtered out; finished in 0.01s

cargo test -p zeroclaw-channels build_memory_context --lib 2>&1  0.22s user 0.11s system 47% cpu 0.697 total
tail -30  0.00s user 0.00s system 0% cpu 0.696 total
```

```bash
time cargo clippy -p zeroclaw-channels --all-targets -- -D warnings 2>&1 | tail -30
```

```text
    Checking zeroclaw-channels v0.7.4 (/Users/natalie/Development/claws/.zeroclaw/issue-5550-autosaved-recall-current/crates/zeroclaw-channels)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 4.64s
cargo clippy -p zeroclaw-channels --all-targets -- -D warnings 2>&1  5.25s user 0.62s system 124% cpu 4.713 total
tail -30  0.00s user 0.00s system 0% cpu 4.713 total
```

```bash
git diff --check origin/master...HEAD
git diff --check
```

```text
# both commands completed with no output
```

- **Beyond CI — what did you manually verify?**
  - Rebasing onto current `origin/master` completed cleanly before push.
  - Ran the Simplify review passes. Architecture found no issue; correctness found no blockers; simplicity suggested avoiding serial recall in the hot path. The implementation now runs the two non-group recall queries concurrently while preserving deterministic merge/dedupe order.
  - Reviewed the final diff and confirmed the touched source is limited to `crates/zeroclaw-channels/src/orchestrator/mod.rs`.
  - Reviewed the comment-only cleanup after draft creation so the source comments now match the non-group recall behavior.
  - `git diff --check origin/master...HEAD` and `git diff --check` both passed with no whitespace errors.
- **If any command was intentionally skipped, why:**
  - Full workspace `cargo test`, workspace clippy, and `./dev/ci.sh all` were skipped because this is a targeted channel orchestrator fix and the focused tests/clippy above cover the changed crate and behavior.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: `N/A`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No upgrade steps required. This is a bug fix for channel memory recall scope selection.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** Revert this PR commit from `master`.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Channel replies stop receiving expected memory context, autosaved conversation facts remain invisible in direct/non-group recall, or group chat memory leaks across distinct group sessions. The focused regressions in `zeroclaw-channels` should fail if the fixed contract regresses.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): `N/A`
- Scope materially carried forward: `N/A`
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `N/A`
- If `No`, why (inspiration-only, no direct code/design carry-over): `N/A`
