### PR TITLE
fix(config/secrets): surface .secret_key mismatch on enc2 decrypt failure

### DIFF
--- a/crates/zeroclaw-config/src/secrets.rs
+++ b/crates/zeroclaw-config/src/secrets.rs
@@ -142,7 +142,15 @@ impl SecretStore {
 
         let plaintext_bytes = cipher
             .decrypt(nonce, ciphertext)
-            .map_err(|_| anyhow::anyhow!("Decryption failed — wrong key or tampered data"))?;
+            .map_err(|_| {
+                tracing::error!(
+                    key_path = %self.key_path.display(),
+                    "enc2: decryption failed. `.secret_key` is missing or does not match the key used to encrypt this value. \
+                     Common cause: volume wipe, container migration, or backup-restore where `.secret_key` was not preserved alongside `config.toml`. \
+                     Restore the original `.secret_key` from backup, or re-encrypt the affected secrets via `zeroclaw onboard`."
+                );
+                anyhow::anyhow!("enc2: decryption failed (wrong `.secret_key` or tampered ciphertext)")
+            })?;
 
         String::from_utf8(plaintext_bytes)
             .context("Decrypted secret is not valid UTF-8 — corrupt data")
@@ -469,6 +477,27 @@ mod tests {
         let encrypted = store1.encrypt("secret-for-store1").unwrap();
         let result = store2.decrypt(&encrypted);
         assert!(result.is_err(), "Decrypting with a different key must fail");
+    }
+
+    #[test]
+    fn decrypt_error_message_mentions_secret_key() {
+        // Operators hitting a missing or mismatched `.secret_key` (volume wipe,
+        // container migration, backup-restore without the key file) need the
+        // error message to point at the root cause. Otherwise the failure
+        // cascades into a misleading "All providers/models failed" message
+        // with no diagnostic for the underlying decrypt failure (#6205).
+        let tmp1 = TempDir::new().unwrap();
+        let tmp2 = TempDir::new().unwrap();
+        let store1 = SecretStore::new(tmp1.path(), true);
+        let store2 = SecretStore::new(tmp2.path(), true);
+
+        let encrypted = store1.encrypt("secret-for-store1").unwrap();
+        let err = store2.decrypt(&encrypted).expect_err("wrong key must fail");
+        let msg = err.to_string();
+        assert!(
+            msg.contains(".secret_key"),
+            "decrypt error must mention `.secret_key` so operators can diagnose missing/mismatched keys: got {msg:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - When `enc2:` decryption fails (e.g. `.secret_key` not preserved across a volume wipe, container migration, or backup-restore), the generic `anyhow` error propagates through the provider chain and surfaces as a misleading "All providers/models failed" cascade with no hint about the underlying decrypt failure.
  - Emit a `tracing::error!` at the cipher-failure site naming the configured key path and typical operator scenarios, and include a `.secret_key` mention in the returned error string so the symptom is debuggable from logs alone.
- **Scope boundary:** does not change decryption behavior, error type, or any call site. Pure messaging upgrade at the source. Legacy `enc:` path and the post-decrypt UTF-8 path are unchanged.
- **Blast radius:** `crates/zeroclaw-config/src/secrets.rs` only. Every caller of `SecretStore::decrypt` (gateway, providers, channels, tools, webauthn) inherits the better message without their own changes.
- **Linked issue(s):** Closes #6205. The full startup-sweep that walks every encrypted config field is intentionally deferred to #6270 (Configurable macro V3 rework), where the schema-walk infrastructure for alias-keyed maps will already exist.

## Validation Evidence (required)

- **Commands run and tail output:**

```bash
$ cargo fmt --all -- --check
(no output)

$ cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 38s

$ cargo test -p zeroclaw-config secrets::
test secrets::tests::decrypt_error_message_mentions_secret_key ... ok
... (42 passed; 0 failed; 0 ignored)
```

- **Beyond CI — what did you manually verify?** Reviewed every existing call site of `SecretStore::decrypt` (`zeroclaw-runtime`, `zeroclaw-tools`, `zeroclaw-gateway`, legacy `src/`) to confirm the error-type signature is unchanged (still `anyhow::Error`), so no caller code adapts.
- **If any command was intentionally skipped, why:** none.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No (the decrypt path itself is unchanged; only the error message changes)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- If any `Yes`, describe the risk and mitigation: N/A

The new `tracing::error!` log includes the on-disk key path (e.g. `~/.zeroclaw/.secret_key`), the documented file location and not its contents. Existing log output already references this path during setup/onboarding, so this does not expand the disclosure surface.

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- If `No` or `Yes` to either: exact upgrade steps for existing users: N/A

## Rollback

- **Fast rollback command/path:** `git revert <merge-sha>`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** before this PR, operators with a missing or mismatched `.secret_key` saw "All providers/models failed" with no decrypt diagnostic. After: same code path, but logs carry an explicit ERROR with the key path and a recovery hint.
