### PR TITLE
feat(providers/groq): per-profile native_tools override on ModelProviderConfig

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -603,6 +603,15 @@ pub struct ModelProviderConfig {
     /// Example: `provider_extra = { provider = { only = ["Anthropic"] } }`
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider_extra: Option<serde_json::Value>,
+    /// Override the provider's default for native tool calling.
+    /// `None` (default) honors the provider's built-in choice. `Some(true)`
+    /// forces native tool calls on, `Some(false)` forces text-fallback.
+    /// Currently consulted only by the Groq factory, which defaults to
+    /// text-fallback because llama-family Groq models reject native tool
+    /// calls with HTTP 400 (#5848). Setting `native_tools = true` re-enables
+    /// native tool calling for Groq models that support it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub native_tools: Option<bool>,
 }
 
 // ── Delegate Tool Configuration ─────────────────────────────────

--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -717,6 +717,12 @@ pub struct ProviderRuntimeOptions {
     /// Extra JSON parameters merged into API request bodies at the top level.
     /// Propagated from `ModelProviderConfig::provider_extra`.
     pub provider_extra: Option<serde_json::Value>,
+    /// Override the provider's default for native tool calling. `None` honors
+    /// the per-provider built-in choice. `Some(true)` forces native tool
+    /// calls on; `Some(false)` forces text-fallback. Propagated from
+    /// `ModelProviderConfig::native_tools`. Currently consulted only by the
+    /// Groq factory branch (#5932).
+    pub native_tools: Option<bool>,
 }
 
 impl Default for ProviderRuntimeOptions {
@@ -734,6 +740,7 @@ impl Default for ProviderRuntimeOptions {
             provider_max_tokens: None,
             merge_system_into_user: false,
             provider_extra: None,
+            native_tools: None,
         }
     }
 }
@@ -777,6 +784,7 @@ pub fn provider_runtime_options_from_config(
         provider_max_tokens: fallback.and_then(|e| e.max_tokens),
         merge_system_into_user,
         provider_extra: fallback.and_then(|e| e.provider_extra.clone()),
+        native_tools: fallback.and_then(|e| e.native_tools),
     }
 }
 
@@ -1425,15 +1433,22 @@ fn create_provider_with_url_and_options(
         }
 
         // ── Extended ecosystem (community favorites) ─────────
-        "groq" => Ok(compat(
-            OpenAiCompatibleProvider::new(
+        "groq" => {
+            let mut p = OpenAiCompatibleProvider::new(
                 "Groq",
                 "https://api.groq.com/openai/v1",
                 key,
                 AuthStyle::Bearer,
-            )
-            .without_native_tools(),
-        )),
+            );
+            // Default to text-fallback because Groq's llama-family models
+            // reject native tool calls with HTTP 400 (#5848). Operators can
+            // override per-profile via `[providers.models.<alias>] native_tools = true`
+            // to enable native tool calling for Groq models that support it.
+            if options.native_tools != Some(true) {
+                p = p.without_native_tools();
+            }
+            Ok(compat(p))
+        }
         "mistral" => Ok(compat(OpenAiCompatibleProvider::new(
             "Mistral",
             "https://api.mistral.ai/v1",
@@ -3041,6 +3056,75 @@ mod tests {
     #[test]
     fn factory_groq() {
         assert!(create_provider("groq", Some("key")).is_ok());
+    }
+
+    #[test]
+    fn factory_groq_disables_native_tools_by_default() {
+        // Default behavior preserves the #5848 blanket disable: llama-family
+        // Groq models reject native tool calls with HTTP 400.
+        let provider =
+            create_provider_with_options("groq", Some("key"), &ProviderRuntimeOptions::default())
+                .expect("groq factory must succeed");
+        assert!(
+            !provider.supports_native_tools(),
+            "Groq must default to text-fallback for llama-family compatibility (#5848)"
+        );
+    }
+
+    #[test]
+    fn factory_groq_honors_native_tools_override_true() {
+        // Operator opt-in via `[providers.models.<alias>] native_tools = true`
+        // skips the default disable so non-llama Groq models can use native
+        // tool calling (#5932).
+        let options = ProviderRuntimeOptions {
+            native_tools: Some(true),
+            ..Default::default()
+        };
+        let provider = create_provider_with_options("groq", Some("key"), &options)
+            .expect("groq factory must succeed");
+        assert!(
+            provider.supports_native_tools(),
+            "Groq with `native_tools = true` must enable native tool calling (#5932)"
+        );
+    }
+
+    #[test]
+    fn factory_groq_native_tools_override_false_keeps_disable() {
+        // Explicit `native_tools = false` matches the default behavior; this
+        // documents that the option is tri-state and `Some(false)` is not a
+        // no-op surprise.
+        let options = ProviderRuntimeOptions {
+            native_tools: Some(false),
+            ..Default::default()
+        };
+        let provider = create_provider_with_options("groq", Some("key"), &options)
+            .expect("groq factory must succeed");
+        assert!(
+            !provider.supports_native_tools(),
+            "Groq with explicit `native_tools = false` must remain text-fallback"
+        );
+    }
+
+    #[test]
+    fn provider_runtime_options_from_config_propagates_native_tools() {
+        // The end-to-end path the operator uses: setting `native_tools` on
+        // the active provider profile must reach `ProviderRuntimeOptions`
+        // so the Groq factory branch sees it (#5932).
+        let mut config = zeroclaw_config::schema::Config::default();
+        let mut groq = zeroclaw_config::schema::ModelProviderConfig {
+            native_tools: Some(true),
+            ..Default::default()
+        };
+        groq.base_url = Some("https://api.groq.com/openai/v1".to_string());
+        config.providers.models.insert("groq".to_string(), groq);
+        config.providers.fallback = Some("groq".to_string());
+
+        let options = provider_runtime_options_from_config(&config);
+        assert_eq!(
+            options.native_tools,
+            Some(true),
+            "native_tools must propagate from the active provider profile to runtime options"
+        );
     }
 
     #[test]

--- a/crates/zeroclaw-providers/src/openai_codex.rs
+++ b/crates/zeroclaw-providers/src/openai_codex.rs
@@ -1131,18 +1131,8 @@ data: [DONE]
     #[test]
     fn capabilities_includes_vision() {
         let options = ProviderRuntimeOptions {
-            provider_api_url: None,
-            zeroclaw_dir: None,
             secrets_encrypt: false,
-            auth_profile_override: None,
-            reasoning_enabled: None,
-            reasoning_effort: None,
-            provider_timeout_secs: None,
-            extra_headers: std::collections::HashMap::new(),
-            api_path: None,
-            provider_max_tokens: None,
-            merge_system_into_user: false,
-            provider_extra: None,
+            ..Default::default()
         };
         let provider =
             OpenAiCodexProvider::new(&options, None).expect("provider should initialize");

--- a/tests/live/openai_codex_vision_e2e.rs
+++ b/tests/live/openai_codex_vision_e2e.rs
@@ -154,17 +154,8 @@ async fn openai_codex_second_vision_support() -> Result<()> {
     // Create provider with profile override
     let opts = ProviderRuntimeOptions {
         auth_profile_override: Some("second".to_string()),
-        provider_api_url: None,
-        zeroclaw_dir: None,
         secrets_encrypt: false,
-        reasoning_enabled: None,
-        reasoning_effort: None,
-        provider_timeout_secs: None,
-        provider_max_tokens: None,
-        extra_headers: std::collections::HashMap::new(),
-        api_path: None,
-        merge_system_into_user: false,
-        provider_extra: None,
+        ..Default::default()
     };
 
     let provider = zeroclaw::providers::create_provider_with_options("openai-codex", None, &opts)?;


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Groq's blanket `.without_native_tools()` (#5848) was added because llama-family Groq models reject native tool calls with HTTP 400. The disable applies to every Groq model, including ones that do support native tool calling, forcing them through the slower text-fallback path.
  - Add a `native_tools: Option<bool>` field to `ModelProviderConfig` so operators can override the default per-profile. Plumb the value through `ProviderRuntimeOptions` and consult it in the Groq factory branch: when `native_tools = true`, skip the unconditional disable.
  - Tri-state semantics: `None` honors the provider default, `Some(true)` forces native on, `Some(false)` is explicit text-fallback. Default behavior preserved exactly.
- **Scope boundary:** only the Groq factory branch consults the new field. Other providers default to native-tools-enabled and don't need an override yet. The new field is generic on `ModelProviderConfig`, so future providers can opt in to consulting it without schema changes.
- **Blast radius:** schema field on `ModelProviderConfig`, one field on `ProviderRuntimeOptions`, the propagation in `provider_runtime_options_from_config`, and the Groq factory branch. No other call sites change.
- **Linked issue(s):** Closes #5932.

## Validation Evidence (required)

- **Commands run and tail output:**

```bash
$ cargo fmt --all -- --check
(no output)

$ cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.07s

$ cargo test -p zeroclaw-providers -- factory_groq provider_runtime_options_from_config
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured (4 new + 1 existing)
```

- **Beyond CI — what did you manually verify?** Confirmed all manual `ProviderRuntimeOptions` literal constructions (test fixtures in `openai_codex.rs:1133`, `tests/live/openai_codex_vision_e2e.rs:155`) compile against the new shape; converted them to `..Default::default()` for forward compatibility. Verified the existing `is_native_tool_schema_unsupported` fallback in `compatible.rs:172` still catches HTTP 400s from llama-family models when an operator opts in to `native_tools = true` and runs a llama model, so the override is not a footgun.
- **If any command was intentionally skipped, why:** none.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? Yes (additive `#[serde(default)]` field; existing configs deserialize unchanged)
- Config / env / CLI surface changed? No (schema gains an optional field; existing operators unaffected unless they opt in)
- If `No` or `Yes` to either: exact upgrade steps for existing users: N/A

## Rollback

- **Fast rollback command/path:** `git revert <merge-sha>`
- **Feature flags or config toggles:** None (the new `native_tools` field is the toggle; operators who don't set it get today's behavior exactly)
- **Observable failure symptoms:** if an operator opts in but their model can't handle native tool calls, the existing `is_native_tool_schema_unsupported` fallback at `compatible.rs:172` catches the HTTP 400 and routes through text-fallback automatically; the visible symptom is a brief retry, not a hard failure.

## V3 collision note

Adds a field to V2 `ModelProviderConfig`. PR #6266 (V3 schema migration) will need the same field on V3's `ModelProviderConfig` too; per the "Schema V3 is for breaking changes, not additions" rule this is additive and free, so it's a one-line merge fixup when V3 lands.
