### PR TITLE
docs(channels): reconcile against schema and fix stale CLI refs

### DIFF
--- a/crates/zeroclaw-channels/src/linq.rs
+++ b/crates/zeroclaw-channels/src/linq.rs
@@ -218,7 +218,7 @@ impl LinqChannel {
                 ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
                     .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
                     .with_attrs(::serde_json::json!({"normalized_from": normalized_from})),
-                "ignoring message from unauthorized sender: . Add to channels.linq.allowed_senders in config.toml, or run `zeroclaw onboard --channels-only` to configure interactively."
+                "ignoring message from unauthorized sender: . Add to channels.linq.allowed_senders in config.toml, or run `zeroclaw onboard channels` to configure interactively."
             );
             return messages;
         }

--- a/crates/zeroclaw-channels/src/nextcloud_talk.rs
+++ b/crates/zeroclaw-channels/src/nextcloud_talk.rs
@@ -288,7 +288,7 @@ impl NextcloudTalkChannel {
                 ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
                     .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
                     .with_attrs(::serde_json::json!({"actor_id": actor_id})),
-                "Talk: ignoring message from unauthorized actor: . Add to channels.nextcloud_talk.allowed_users in config.toml, or run `zeroclaw onboard --channels-only` to configure interactively."
+                "Talk: ignoring message from unauthorized actor: . Add to channels.nextcloud_talk.allowed_users in config.toml, or run `zeroclaw onboard channels` to configure interactively."
             );
             return messages;
         }
@@ -415,7 +415,7 @@ impl NextcloudTalkChannel {
                 ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
                     .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
                     .with_attrs(::serde_json::json!({"actor_id": actor_id})),
-                "Talk: ignoring message from unauthorized actor: . Add to channels.nextcloud_talk.allowed_users in config.toml, or run `zeroclaw onboard --channels-only` to configure interactively."
+                "Talk: ignoring message from unauthorized actor: . Add to channels.nextcloud_talk.allowed_users in config.toml, or run `zeroclaw onboard channels` to configure interactively."
             );
             return messages;
         }

--- a/crates/zeroclaw-channels/src/orchestrator/acp_server.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/acp_server.rs
@@ -462,7 +462,8 @@ impl AcpServer {
     ///
     /// This is used by the gateway WebSocket bridge, where inbound WebSocket
     /// text messages are already complete JSON-RPC frames and outbound frames
-    /// are supplied by the writer channel passed to [`new_with_writer`].
+    /// are supplied by the writer channel passed to [`Self::new_with_writer`]
+    /// or [`Self::new_with_writer_and_store`].
     pub async fn run_messages(self: Arc<Self>, mut input_rx: mpsc::Receiver<String>) -> Result<()> {
         while let Some(line) = input_rx.recv().await {
             let trimmed = line.trim();

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -4845,7 +4845,7 @@ pub async fn bind_telegram_identity(config: &Config, identity: &str) -> Result<(
     let mut updated = config.clone();
     if !updated.channels.telegram.contains_key("default") {
         anyhow::bail!(
-            "Telegram channel is not configured. Run `zeroclaw onboard --channels-only` first"
+            "Telegram channel is not configured. Run `zeroclaw onboard channels` first"
         );
     }
 

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -4844,9 +4844,7 @@ pub async fn bind_telegram_identity(config: &Config, identity: &str) -> Result<(
 
     let mut updated = config.clone();
     if !updated.channels.telegram.contains_key("default") {
-        anyhow::bail!(
-            "Telegram channel is not configured. Run `zeroclaw onboard channels` first"
-        );
+        anyhow::bail!("Telegram channel is not configured. Run `zeroclaw onboard channels` first");
     }
 
     // Locate (or create) the peer group bound to telegram.default. The

--- a/crates/zeroclaw-channels/src/telegram.rs
+++ b/crates/zeroclaw-channels/src/telegram.rs
@@ -653,7 +653,7 @@ impl TelegramChannel {
             let mut cfg = config.write();
             if !cfg.channels.telegram.contains_key(&self.alias) {
                 anyhow::bail!(
-                    "Missing [channels.telegram.{}] section. Run `zeroclaw onboard --channels-only` first",
+                    "Missing [channels.telegram.{}] section. Run `zeroclaw onboard channels` first",
                     self.alias
                 );
             }

--- a/crates/zeroclaw-channels/src/wati.rs
+++ b/crates/zeroclaw-channels/src/wati.rs
@@ -139,7 +139,7 @@ impl WatiChannel {
                 ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
                     .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
                     .with_attrs(::serde_json::json!({"normalized_phone": normalized_phone})),
-                "ignoring message from unauthorized sender: . Add to channels.wati.allowed_numbers in config.toml, or run `zeroclaw onboard --channels-only` to configure interactively."
+                "ignoring message from unauthorized sender: . Add to channels.wati.allowed_numbers in config.toml, or run `zeroclaw onboard channels` to configure interactively."
             );
             return None;
         }

--- a/crates/zeroclaw-channels/src/whatsapp.rs
+++ b/crates/zeroclaw-channels/src/whatsapp.rs
@@ -271,7 +271,7 @@ impl WhatsAppChannel {
                             )
                             .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
                             .with_attrs(::serde_json::json!({"normalized_from": normalized_from})),
-                            "ignoring message from unauthorized number: . Add to channels.whatsapp.allowed_numbers in config.toml, or run `zeroclaw onboard --channels-only` to configure interactively."
+                            "ignoring message from unauthorized number: . Add to channels.whatsapp.allowed_numbers in config.toml, or run `zeroclaw onboard channels` to configure interactively."
                         );
                         continue;
                     }

--- a/crates/zeroclaw-memory/src/response_cache.rs
+++ b/crates/zeroclaw-memory/src/response_cache.rs
@@ -261,7 +261,7 @@ impl ResponseCache {
         Ok((count as usize, hits as u64, tokens_saved as u64))
     }
 
-    /// Wipe the entire cache (useful for `zeroclaw cache clear`).
+    /// Wipe the entire response cache.
     pub fn clear(&self) -> Result<usize> {
         self.hot_cache.lock().clear();
         let conn = self.conn.lock();

--- a/crates/zeroclaw-runtime/src/integrations/mod.rs
+++ b/crates/zeroclaw-runtime/src/integrations/mod.rs
@@ -94,7 +94,7 @@ pub fn show_integration_info(config: &Config, name: &str) -> Result<()> {
             println!("  Setup:");
             println!("    1. Message @BotFather on Telegram");
             println!("    2. Create a bot and copy the token");
-            println!("    3. Run: zeroclaw onboard --channels-only");
+            println!("    3. Run: zeroclaw onboard channels");
             println!("    4. Start: zeroclaw channel start");
         }
         "Discord" => {
@@ -102,13 +102,13 @@ pub fn show_integration_info(config: &Config, name: &str) -> Result<()> {
             println!("    1. Go to https://discord.com/developers/applications");
             println!("    2. Create app → Bot → Copy token");
             println!("    3. Enable MESSAGE CONTENT intent");
-            println!("    4. Run: zeroclaw onboard --channels-only");
+            println!("    4. Run: zeroclaw onboard channels");
         }
         "Slack" => {
             println!("  Setup:");
             println!("    1. Go to https://api.slack.com/apps");
             println!("    2. Create app → Bot Token Scopes → Install");
-            println!("    3. Run: zeroclaw onboard --channels-only");
+            println!("    3. Run: zeroclaw onboard channels");
         }
         "iMessage" => {
             println!("  Setup (macOS only):");

--- a/docs/book/src/channels/matrix.md
+++ b/docs/book/src/channels/matrix.md
@@ -22,9 +22,7 @@ Before testing message flow:
 
 1. The bot account is joined to the target room.
 2. The access token belongs to the same bot account.
-3. `room_id` is correct:
-   - preferred: canonical room ID (`!room:server`)
-   - supported: room alias (`#alias:server`) — ZeroClaw resolves it
+3. `allowed_rooms` includes the target room (or is empty to allow all rooms the bot has joined). Each entry is either a canonical room ID (`!room:server`) or an alias (`#alias:server`); ZeroClaw resolves aliases.
 4. `allowed_users` allows the sender (`["*"]` for open testing).
 5. For E2EE rooms, the bot device has received encryption keys for the room.
 
@@ -42,16 +40,16 @@ Or set individual fields after onboarding:
 
 ```bash
 zeroclaw config set channels.matrix.homeserver https://matrix.example.com
-zeroclaw config set channels.matrix.room-id '!room:matrix.example.com'
 zeroclaw config set channels.matrix.access-token           # prompts, input masked
 zeroclaw config set channels.matrix.user-id @bot:matrix.example.com
 zeroclaw config set channels.matrix.device-id ABCDEF1234
 zeroclaw config set channels.matrix.allowed-users '["*"]'   # open for testing
+zeroclaw config set channels.matrix.allowed-rooms '["!room:matrix.example.com"]'  # empty list = allow all joined rooms
 zeroclaw config set channels.matrix.ack-reactions true       # default: true (👀 → ✅)
 zeroclaw config set channels.matrix.reply-in-thread true     # default: true
 ```
 
-Required: `homeserver`, `access-token`, `room-id`. Strongly recommended for E2EE: `user-id` and `device-id`. For the full field index, see the [Config reference](../reference/config.md).
+Required: `homeserver`, `access-token`, `allowed-users`. Strongly recommended for E2EE: `user-id` and `device-id`. `allowed-rooms` is optional — leave empty to allow every room the bot has joined, or list explicit IDs/aliases to restrict. For the full field index, see the [Config reference](../reference/config.md).
 
 > **Don't have an `access-token` yet?** See §3 below — it walks through the Matrix password-login API call that mints a token plus a stable `device_id` in one shot. If you only need to look up `device_id` for a token you already have, see §5H.
 

--- a/docs/book/src/channels/matrix.md
+++ b/docs/book/src/channels/matrix.md
@@ -30,7 +30,7 @@ Before testing message flow:
 
 All config management goes through `zeroclaw config` or `zeroclaw onboard`. Do not hand-edit `~/.zeroclaw/config.toml`.
 
-Easiest: run the channels section and let it prompt for every Matrix field:
+Easiest: run the wizard and let it prompt for every Matrix field:
 
 ```bash
 zeroclaw onboard channels
@@ -86,30 +86,22 @@ Response:
 zeroclaw config set channels.matrix.access-token    # paste the access_token (input is masked)
 zeroclaw config set channels.matrix.device-id NEWDEVICE
 zeroclaw config set channels.matrix.user-id @bot:example.com
-zeroclaw service restart
 ```
 
-`zeroclaw onboard channels` prompts for these same fields if you'd rather work through them interactively.
+Restart for the new values to take effect: `zeroclaw service restart`.
+
+The wizard (`zeroclaw onboard channels`) prompts for these same fields if you'd rather work through it interactively.
 
 ### Notes
 
 - **Keep a copy of the token** when you first paste it. Secrets are encrypted at rest and `zeroclaw config get` will print `[masked]` for the token field; you can't retrieve it later. Stash it in a scratch note if you'll need it for the curl validation snippets in §5C.
 - **Reuse the same `device_id` on every restart** — changing it forces a new server-side device registration, which breaks key sharing and verification in encrypted rooms. The auto-recovery path in §8 handles the rare cases where wiping is genuinely the right call.
-- **Rotating the access token later** without re-running `zeroclaw onboard channels`:
-  ```bash
-  zeroclaw config set channels.matrix.access-token    # prompts, masked
-  zeroclaw service restart
-  ```
+- **Rotating the access token later** without re-running the wizard: run `zeroclaw config set channels.matrix.access-token` (prompts, input masked), then `zeroclaw service restart`.
 - **Token shows as expired or invalid** at startup: mint a new one with the same curl, repeat Step 2.
 
 ## 4. Quick validation
 
-```bash
-zeroclaw onboard --channels-only
-zeroclaw service restart        # or `zeroclaw daemon` to run foreground
-```
-
-Send a plain-text message in the configured Matrix room. Confirm:
+Run `zeroclaw onboard channels` if you haven't yet, then restart with `zeroclaw service restart` (background) or `zeroclaw daemon` (foreground). Send a plain-text message in the configured Matrix room. Confirm:
 
 - ZeroClaw logs show the Matrix listener starting with no repeated sync/auth errors.
 - In an encrypted room, the bot can read and reply to encrypted messages from allowed users.
@@ -126,11 +118,7 @@ Work through in order.
 ### B. Sender allowlist
 
 - If `allowed_users = []`, all inbound messages are denied.
-- For diagnosis, temporarily open it:
-  ```bash
-  zeroclaw config set channels.matrix.allowed-users '["*"]'
-  zeroclaw service restart
-  ```
+- For diagnosis, temporarily open it: run `zeroclaw config set channels.matrix.allowed-users '["*"]'`, then `zeroclaw service restart`.
 - Tighten to explicit user IDs once the flow works.
 
 ### C. Token and identity
@@ -156,11 +144,7 @@ curl -sS -H "Authorization: Bearer $MATRIX_TOKEN" \
 
 - Returned `user_id` must match the bot account.
 - If `device_id` is missing from the response, set it manually (see §5H).
-- Rotate the access token without re-running onboard:
-  ```bash
-  zeroclaw config set channels.matrix.access-token    # prompts, masked
-  zeroclaw service restart
-  ```
+- Rotate the access token without re-running onboard: `zeroclaw config set channels.matrix.access-token` (prompts, masked), then `zeroclaw service restart`.
 
 ### D. E2EE-specific checks
 
@@ -218,10 +202,9 @@ If `device_id` is missing, the token was created without a device login (e.g. vi
 
 ```bash
 zeroclaw config set channels.matrix.device-id ABCDEF1234
-zeroclaw service restart
 ```
 
-Keep `device-id` stable — changing it forces a new device registration, which breaks existing key sharing and verification.
+Then `zeroclaw service restart`. Keep `device-id` stable — changing it forces a new device registration, which breaks existing key sharing and verification.
 
 ### H (continued). Crypto-store deletion recovery
 
@@ -291,12 +274,12 @@ A recovery key lets ZeroClaw automatically restore room keys and cross-signing s
 
 #### Step 2 — Add the recovery key to ZeroClaw
 
-Either path works. `zeroclaw onboard channels` is easier for fresh installs; `zeroclaw config set` is preferred for existing installs.
+Either path works. The onboarding wizard is easier for fresh installs; `zeroclaw config set` is preferred for existing installs.
 
 **Option A — during onboarding:**
 
 ```bash
-zeroclaw onboard --channels-only
+zeroclaw onboard channels
 ```
 
 When prompted:
@@ -311,10 +294,9 @@ Input is masked. The key is encrypted at rest.
 
 ```bash
 zeroclaw config set channels.matrix.recovery-key    # input masked
-zeroclaw service restart
 ```
 
-Encrypted at rest immediately.
+Then `zeroclaw service restart`. The recovery key is encrypted at rest immediately.
 
 #### Step 3 — Restart
 
@@ -335,7 +317,7 @@ From now on, even if the local crypto store is deleted, ZeroClaw recovers automa
 Matrix-channel-specific diagnostics:
 
 ```bash
-RUST_LOG=zeroclaw_channels::matrix=debug zeroclaw daemon
+RUST_LOG=zeroclaw::channels::matrix=debug zeroclaw daemon
 ```
 
 Surfaces:
@@ -346,10 +328,10 @@ Surfaces:
 - Health check results
 - Transient vs. fatal sync error classification
 
-For crypto-store detail as well:
+For SDK-level detail as well:
 
 ```bash
-RUST_LOG=zeroclaw_channels::matrix=debug,matrix_sdk_crypto=debug zeroclaw daemon
+RUST_LOG=zeroclaw::channels::matrix=debug,matrix_sdk_crypto=debug zeroclaw daemon
 ```
 
 ## 7. Operational notes

--- a/docs/book/src/channels/mattermost.md
+++ b/docs/book/src/channels/mattermost.md
@@ -29,8 +29,8 @@ To restrict the bot, narrow with `channel_ids`, `team_ids`, or `discover_dms`.
 enabled            = true                            # gate; required
 url                = "https://mattermost.example.com" # required
 bot_token          = "..."                            # secret; OR login_id+password
-login_id           = ""                               # alternative auth path
-password           = ""                               # secret; pairs with login_id
+# login_id         = ""                               # alternative auth path; only when bot_token is unset
+# password         = ""                               # secret; pairs with login_id
 
 channel_ids        = []                               # [] or ["*"] = auto-discover
 team_ids           = []                               # [] = all teams

--- a/docs/book/src/channels/nextcloud-talk.md
+++ b/docs/book/src/channels/nextcloud-talk.md
@@ -11,7 +11,8 @@ Nextcloud Talk integration via the Talk Bot webhook protocol. Self-hosted, feder
 ## Prerequisites
 
 - **Nextcloud server** with the Talk app enabled (v17 or later recommended)
-- **Bot account** in Talk settings — give it a display name (e.g. `zeroclaw-bot`) and generate a bot webhook URL
+- **Bot account** in Talk settings — give it a display name (e.g. `zeroclaw-bot`)
+- **Bot app token** from the Talk admin UI for OCS API bearer auth (used for outbound replies)
 - **Webhook secret** from the Talk admin UI if you want signature verification (strongly recommended)
 - **Publicly-reachable gateway** — see [Setup → Container](../setup/container.md) for tunnel options if self-hosted
 
@@ -20,13 +21,12 @@ Nextcloud Talk integration via the Talk Bot webhook protocol. Self-hosted, feder
 ```toml
 [channels.nextcloud_talk]
 enabled = true
-server_url = "https://cloud.example.com"
-bot_name = "zeroclaw-bot"                      # the display name of the bot in Talk
-webhook_secret = "..."                         # shared secret from Talk admin UI
-username = "..."                               # bot's Nextcloud login for outbound API
-password = "..."                               # app password (not the account password)
-allowed_rooms = ["ROOM-TOKEN-1"]               # tokens from webhook payloads
+base_url = "https://cloud.example.com"
+app_token = "..."                              # OCS API bearer token (bot app token)
+webhook_secret = "..."                         # shared secret for HMAC-SHA256 webhook verification
+bot_name = "zeroclaw-bot"                      # display name; filters out the bot's own posts
 allowed_users = ["*"]                          # actor IDs; "*" = allow all (use for first-time test only)
+proxy_url = ""                                 # optional per-channel proxy override
 ```
 
 Environment override: `ZEROCLAW_NEXTCLOUD_TALK_WEBHOOK_SECRET` takes precedence over the config value. Useful for rotating secrets without editing the config.
@@ -93,8 +93,9 @@ Nextcloud Talk does not support message edits via the Bot API, so streaming draf
 ## Self-hosting notes
 
 - TLS: terminate at your reverse proxy; webhook signature verification works over HTTP-to-container loopback
-- The OCS API is authenticated via HTTP Basic — use an app password, not the account password
+- The OCS API is authenticated via Bearer token — use the bot app token from the Talk admin UI
 - Rate limits are Nextcloud-server dependent; the default bot doesn't run into them in normal conversation cadences
+- Per-channel proxy: set `proxy_url` to override the global `[proxy]` setting for Nextcloud Talk only (`http://`, `https://`, `socks5://`, `socks5h://`)
 
 ## See also
 

--- a/docs/book/src/channels/social.md
+++ b/docs/book/src/channels/social.md
@@ -9,46 +9,41 @@ Broadcast / social-feed integrations. These differ from chat channels in two way
 enabled = true
 handle = "you.bsky.social"
 app_password = "xxxx-xxxx-xxxx-xxxx"      # create at bsky.app/settings/app-passwords
-allowed_mentions = ["@trustedfriend.bsky.social"]
 ```
 
 - **Auth:** Bluesky app-password (not your real password). Create one in settings.
-- **Inbound:** mentions and direct messages trigger the agent. Scope with `allowed_mentions`.
 - **Outbound:** 300-character posts; longer responses auto-thread.
-- **Protocol:** AT Protocol via `atrium-api` crate.
+- **Protocol:** AT Protocol via the `atrium-api` crate.
 
 ## Nostr
 
 ```toml
 [channels.nostr]
 enabled = true
-private_key_hex = "..."                   # nsec in hex
+private_key = "..."                       # nsec bech32 or hex
 relays = [
     "wss://relay.damus.io",
     "wss://nos.lol",
     "wss://relay.primal.net",
 ]
-allowed_pubkeys = ["npub1..."]
+allowed_pubkeys = ["npub1..."]            # empty = deny all, "*" = allow all
 ```
 
-- **Auth:** raw private key. Store in the encrypted secrets backend — never in a checked-in config.
+- **Auth:** raw private key (`nsec` bech32 or hex). Store in the encrypted secrets backend — never in a checked-in config.
 - **Inbound:** kind-1 (text), kind-4 (DM, NIP-04), and kind-1059 (gift-wrap, NIP-17).
 - **Outbound:** same kinds. Zap handling is experimental.
-- **Relays:** the agent connects to all listed relays; use 3–5 for reliability.
+- **Relays:** the agent connects to all listed relays; use 3–5 for reliability. If `relays` is omitted, ZeroClaw connects to a built-in set of popular public relays.
 
 ## Twitter / X
 
 ```toml
 [channels.twitter]
 enabled = true
-api_key = "..."
-api_secret = "..."
-access_token = "..."
-access_secret = "..."
-bearer_token = "..."
+bearer_token = "..."                      # Twitter API v2 OAuth 2.0 Bearer Token
+allowed_users = ["singlerider"]           # usernames or user IDs; empty = deny all, "*" = allow all
 ```
 
-- **Auth:** OAuth 1.0a app credentials. Requires Twitter Developer Portal access — paid tier for full API v2 access.
+- **Auth:** Twitter API v2 OAuth 2.0 Bearer Token only.
 - **Inbound:** mentions via the Filtered Stream endpoint.
 - **Outbound:** posts, replies, threads.
 - **Caveat:** the free tier is rate-limited to the point of near-uselessness. Budget accordingly.
@@ -60,16 +55,14 @@ bearer_token = "..."
 enabled = true
 client_id = "..."
 client_secret = "..."
-username = "..."
-password = "..."                          # or use refresh_token
-user_agent = "zeroclaw-agent/0.1 by your-username"
-subreddits = ["rust", "commandline"]
+refresh_token = "..."                     # OAuth 2.0 refresh token (required)
+username = "your-bot-username"            # without `u/` prefix
+subreddit = "rust"                        # optional: filter to a single subreddit (without `r/` prefix)
 ```
 
-- **Auth:** OAuth 2.0 password flow or refresh token. Password flow requires a script-type app.
-- **Inbound:** new posts and comments in the configured subreddits, plus replies to the agent's own posts.
+- **Auth:** OAuth 2.0 with a refresh token. Generate one with a script-type Reddit app and the `password` or `code` flow, then save the refresh token here for persistent access.
+- **Inbound:** new posts and comments in the configured subreddit (or all subreddits the bot has access to when `subreddit` is unset), plus replies to the agent's own posts.
 - **Outbound:** posts, comments, private messages.
-- **User-agent convention:** Reddit's API requires a descriptive user-agent string. Non-compliance → rate limits.
 
 ---
 
@@ -77,14 +70,9 @@ subreddits = ["rust", "commandline"]
 
 Bots on public social networks attract adversarial input. Two precautions:
 
-1. **Restrict who the agent will respond to.** Use `allowed_mentions` / `allowed_pubkeys` / `allowed_users` to whitelist. The default empty-list behaviour varies per channel — check each.
-2. **Keep autonomy level at `Supervised` or lower.** A public-facing agent in `Full` autonomy is effectively a public shell. If you want to run public-facing, disable shell tools for that channel:
-
-```toml
-[channels.bluesky]
-tools_allow = ["http", "web_search"]      # whitelist — no shell, no file_write
-```
+1. **Restrict who the agent will respond to.** Use `allowed_pubkeys` (Nostr) or `allowed_users` (Twitter) to whitelist senders. Bluesky has no per-channel allowlist field — gate at the autonomy / tool layer instead. The default empty-list behaviour is **deny all** for the channels that have an allowlist field.
+2. **Keep autonomy level at `Supervised` or lower.** A public-facing agent in `Full` autonomy is effectively a public shell. For public-facing channels, restrict the tool surface in the global tool-policy config rather than expecting per-channel `tools_allow` (no such per-channel field exists).
 
 ## Rate limits and backoff
 
-All social channels are subject to aggressive rate limits. ZeroClaw's outbound queue uses exponential backoff on 429 responses. If you hit persistent rate-limiting, lower `draft_update_interval_ms` and check whether you're accidentally editing messages (Bluesky does not support edits; others have per-operation limits).
+All social channels are subject to aggressive rate limits. ZeroClaw's outbound queue uses exponential backoff on 429 responses. If you hit persistent rate-limiting, throttle the agent's posting cadence at the source rather than relying on per-channel streaming knobs (none of these channels expose draft-update intervals; their schema is intentionally minimal).

--- a/docs/book/src/channels/voice.md
+++ b/docs/book/src/channels/voice.md
@@ -1,46 +1,50 @@
 # Voice & Telephony
 
-Real-time voice input and output. Four channels cover the matrix: inbound calls, outbound speech synthesis, local microphone wake, and SIP-grade real-time conversation.
+Real-time voice input and output. Four channels cover the matrix: inbound calls, local microphone wake, outbound speech synthesis, and SIP-grade real-time conversation.
 
 ## ClawdTalk (real-time SIP)
 
 ```toml
 [channels.clawdtalk]
 enabled = true
-telnyx_api_key = "..."
-connection_id = "..."              # Telnyx SIP connection
-model_provider = "voice-brain"     # references [providers.models.voice-brain]
-voice = "Polly.Joanna-Neural"      # Telnyx voice ID
+api_key = "..."                                # Telnyx API key (secret)
+connection_id = "..."                          # Telnyx SIP connection ID
+from_number = "+14155550123"                   # caller-ID for outbound dials
+allowed_destinations = ["+14155551234"]        # destinations allowed for outbound dial; empty = none
+webhook_secret = "..."                         # optional: shared secret for inbound Telnyx webhook verification
 ```
 
-Full-duplex SIP voice powered by Telnyx. The agent talks over a real phone call — inbound or outbound. Supports barge-in, mid-turn tool use, and regional number provisioning.
+Full-duplex SIP voice powered by Telnyx. The agent talks over a real phone call (inbound or outbound). Supports barge-in, mid-turn tool use, and regional number provisioning.
 
-**Pair with:** a `telnyx` provider for the brain (`crates/zeroclaw-providers/src/telnyx.rs`) and ensure your Telnyx account has a SIP connection with the correct webhook URL pointed at the ZeroClaw gateway.
+**Pair with:** a `telnyx` model provider for the brain (`crates/zeroclaw-providers/src/telnyx.rs`) and ensure your Telnyx account has a SIP connection with the correct webhook URL pointed at the ZeroClaw gateway.
 
 ## Voice Call (Twilio / Telnyx / Plivo)
 
 ```toml
 [channels.voice_call]
 enabled = true
-carrier = "twilio"                 # or "telnyx", "plivo"
-account_sid = "..."
-auth_token = "..."
+provider = "twilio"                            # "twilio" (default), "telnyx", or "plivo"
+account_id = "..."                             # provider-specific account identifier
+auth_token = "..."                             # provider-specific auth token (secret)
 from_number = "+14155550123"
-stt_provider = "whisper"
-tts_provider = "elevenlabs"
+webhook_port = 8090                            # default 8090; embedded webhook server
+require_outbound_approval = true               # default true; require operator approval before dialing
+transcription_logging = true                   # default true; persist call transcripts
+tts_voice = ""                                 # optional voice ID override (provider-specific)
+max_call_duration_secs = 3600                  # default 3600 (1 hour cap)
+webhook_base_url = ""                          # optional public base URL when behind a tunnel/proxy
 ```
 
-Traditional carrier voice — the agent picks up, transcribes with STT, replies with TTS. Higher latency than ClawdTalk but works with any regular phone number and doesn't require SIP trunk provisioning.
+Traditional carrier voice — the agent picks up, transcribes the caller, replies with TTS. Higher latency than ClawdTalk but works with any regular phone number and doesn't require SIP trunk provisioning. Outbound calls hit `from_number` and require operator approval when `require_outbound_approval` is on.
 
 ## Voice Wake (local wake-word)
 
 ```toml
 [channels.voice_wake]
-enabled = true
-wake_phrase = "hey claw"
-engine = "porcupine"               # or "openwakeword"
-model_path = "~/.zeroclaw/wake/hey-claw.ppn"
-audio_device = "default"
+wake_word = "hey zeroclaw"                     # default "hey zeroclaw" (case-insensitive substring match)
+silence_timeout_ms = 2000                      # default 2000; ms of silence before finalising capture
+energy_threshold = 0.01                        # default 0.01; RMS energy below this is treated as silence
+max_capture_secs = 30                          # default 30; hard cap on capture duration
 ```
 
 Runs locally, listens on the mic, triggers agent interaction when it hears the wake phrase. Useful for:
@@ -49,42 +53,45 @@ Runs locally, listens on the mic, triggers agent interaction when it hears the w
 - Desktop "hotword → ask" workflows
 - Always-listening home-automation agents
 
-The agent doesn't send audio anywhere — wake detection is local. Only post-wake speech goes through STT and reaches the LLM.
+The agent doesn't send audio anywhere — wake detection is local. Only post-wake speech is captured and (separately) transcribed before reaching the LLM.
+
+> **Build flag:** Voice Wake is gated by the `voice-wake` cargo feature on `zeroclaw-channels`. Build with `--features voice-wake` to include it.
 
 ## TTS (outbound speech synthesis)
 
+TTS lives at the top level under `[tts]`, not under `[channels.*]` — it's an output service that channels can call into, rather than its own inbound channel.
+
 ```toml
-[channels.tts]
+[tts]
 enabled = true
-engine = "piper"                   # local, free
-voice = "en_US-lessac-medium"
-output_device = "default"
+default_provider = "piper"                     # "openai", "elevenlabs", "google", "edge", or "piper"
+default_voice = "en_US-lessac-medium"          # provider-specific default voice ID
+default_format = "mp3"                         # "mp3" (default), "opus", or "wav"
+max_text_length = 4096                         # default 4096
+
+[tts.openai]
+api_key = "..."
+model = "tts-1"                                # default "tts-1"
+speed = 1.0                                    # default 1.0
+
+[tts.elevenlabs]
+api_key = "..."
+model_id = "eleven_monolingual_v1"             # default "eleven_monolingual_v1"
+stability = 0.5                                # default 0.5
+similarity_boost = 0.5                         # default 0.5
+
+[tts.google]
+api_key = "..."
+language_code = "en-US"                        # default "en-US"
+
+[tts.edge]
+binary_path = "edge-tts"                       # path to the edge-tts binary; default "edge-tts"
+
+[tts.piper]
+api_url = "http://127.0.0.1:5000/v1/audio/speech"   # OpenAI-compatible Piper HTTP endpoint
 ```
 
-Other engines:
-
-```toml
-[channels.tts]
-engine = "openai"                  # TTS-1 or TTS-1-HD
-voice = "alloy"
-api_key = "..."
-
-[channels.tts]
-engine = "elevenlabs"
-voice_id = "21m00Tcm4TlvDq8ikWAM"
-api_key = "..."
-
-[channels.tts]
-engine = "google-cloud"
-voice = "en-US-Neural2-J"
-credentials_json = "~/.zeroclaw/gcp.json"
-
-[channels.tts]
-engine = "edge"                    # Microsoft Edge TTS — free, online
-voice = "en-US-AndrewNeural"
-```
-
-TTS is output-only — it's not a conversation channel; it's a speaker for other channels' replies. Pair with `voice_wake` for a complete local voice assistant.
+Only the section for the active `default_provider` needs to be filled in. Pair `[tts]` with `voice_wake` for a complete local voice assistant.
 
 ---
 
@@ -102,24 +109,16 @@ Speech feels real-time below ~500 ms end-to-end. Practical budgets:
 
 ClawdTalk shortcuts several of these by keeping the audio stream live; regular `voice_call` incurs STT + LLM + TTS sequentially.
 
-## STT options
+## STT
 
-The runtime picks STT based on `stt_provider`:
-
-- `whisper` — local whisper.cpp; CPU-only works but GPU helps
-- `openai-whisper` — hosted Whisper API
-- `deepgram` — real-time streaming STT (fastest)
-- `google-cloud-stt`
-- `azure-stt`
-
-Set in the voice channel's config (`stt_provider = "deepgram"`).
+Speech-to-text is configured separately from the voice channels — see the `[transcription]` config in the [Config reference](../reference/config.md). Voice channels invoke whichever transcription provider is active when they need to turn audio into text.
 
 ## Hardware notes
 
 For always-on voice on an SBC:
 
-- USB mic: any UAC-compliant mic works. `arecord -l` to verify the OS sees it
-- Speaker: either USB audio out or the SBC's onboard jack; set `output_device` to the ALSA name
-- Microphones with built-in AEC (acoustic echo cancellation) dramatically improve wake reliability when the speaker is nearby
+- USB mic: any UAC-compliant mic works. `arecord -l` to verify the OS sees it.
+- Speaker: either USB audio out or the SBC's onboard jack; pick the OS default device for the user the daemon runs as.
+- Microphones with built-in AEC (acoustic echo cancellation) dramatically improve wake reliability when the speaker is nearby.
 
 See [Hardware → Android](../hardware/android-setup.md) for Android-specific audio setup.

--- a/docs/book/src/channels/voice.md
+++ b/docs/book/src/channels/voice.md
@@ -30,9 +30,9 @@ from_number = "+14155550123"
 webhook_port = 8090                            # default 8090; embedded webhook server
 require_outbound_approval = true               # default true; require operator approval before dialing
 transcription_logging = true                   # default true; persist call transcripts
-tts_voice = ""                                 # optional voice ID override (provider-specific)
+# tts_voice = ""                               # optional voice ID override (provider-specific); omit to use provider default
 max_call_duration_secs = 3600                  # default 3600 (1 hour cap)
-webhook_base_url = ""                          # optional public base URL when behind a tunnel/proxy
+# webhook_base_url = ""                        # optional public base URL when behind a tunnel/proxy; omit to use the localhost fallback
 ```
 
 Traditional carrier voice — the agent picks up, transcribes the caller, replies with TTS. Higher latency than ClawdTalk but works with any regular phone number and doesn't require SIP trunk provisioning. Outbound calls hit `from_number` and require operator approval when `require_outbound_approval` is on.

--- a/docs/book/src/channels/webhook.md
+++ b/docs/book/src/channels/webhook.md
@@ -1,98 +1,95 @@
 # Webhooks
 
-A generic inbound HTTP channel. Any service that can POST a JSON payload (GitHub, Linear, Sentry, Zapier, cron-job.org, your own scripts) can hand work to the agent via a webhook URL.
+The `webhook` channel is a generic inbound/outbound HTTP adapter. It runs its own embedded HTTP server on a port you choose, accepts JSON-shaped messages, hands them to the agent, and (optionally) POSTs the agent's replies to a URL you specify. Use it as the universal adapter for any system that can produce an HTTP POST.
 
-Webhooks live inside the gateway — if the gateway is running, webhooks are reachable at `/webhook/<name>`.
+> **Not the same as the gateway's `/webhook` endpoint.** The gateway service has its own `POST /webhook` for paired clients hitting the agent over HTTP — that lives under `[gateway]` and is described in [Operations → Network deployment](../ops/network-deployment.md). This page documents the `[channels.webhook]` channel only.
 
 ## Configuration
 
 ```toml
-[channels.webhooks.github-issues]
+[channels.webhook]
 enabled = true
-secret = "..."                    # HMAC secret for signature verification
-dispatch_to = "sop:triage-issue"  # or a conversation ID, or a system prompt
-allow_list = ["github.com"]       # enforce source IP allowlist
-
-[channels.webhooks.grafana]
-enabled = true
-secret = "..."
-dispatch_to = "cron:alert-handler"
+port = 8090                                     # TCP port the channel binds (0.0.0.0:{port})
+listen_path = "/webhook"                        # path the embedded server listens on; default "/webhook"
+send_url = "https://example.com/callback"       # optional outbound URL for agent replies
+send_method = "POST"                            # "POST" (default) or "PUT"
+auth_header = "Bearer s3cret"                   # optional Authorization header value for outbound requests
+secret = "..."                                  # optional shared secret for inbound HMAC-SHA256 verification
 ```
 
-The `dispatch_to` field points the inbound event at one of:
+Full field reference: [Config](../reference/config.md#channelswebhook).
 
-- `sop:<name>` — runs a Standard Operating Procedure with the payload as input
-- `cron:<name>` — triggers a scheduled job off-schedule
-- `conversation:<id>` — appends to a named conversation (agent responds normally)
-- `system:<prompt>` — runs a one-shot agent call with the payload appended to a system prompt
+## Inbound
+
+The channel binds `0.0.0.0:{port}` and routes `POST {listen_path}`.
+
+Request body (JSON):
+
+```json
+{
+  "sender": "alice",
+  "content": "Hello, agent.",
+  "thread_id": "optional-conversation-id"
+}
+```
+
+- `sender` — required, used as the message's sender identity.
+- `content` — required, the user message handed to the agent. Empty content returns `400`.
+- `thread_id` — optional. If set, the agent's reply targets the same thread; otherwise replies target `sender`.
+
+Success returns `200 OK`. Malformed JSON or empty `content` returns `400`. Backpressure (channel queue full) returns `503`.
 
 ## Signature verification
 
-GitHub, Stripe, Slack, and most major sources sign webhooks with HMAC. Set `secret` to the shared secret; the channel verifies `X-Hub-Signature-256` / `X-Signature` / equivalent before dispatching.
+When `secret` is set, every inbound request must carry an `X-Webhook-Signature` header:
 
-Sources without signing (open webhooks) should at minimum set `allow_list` to restrict by source IP. A webhook URL with no auth and no IP allowlist is an open ingress — don't.
-
-## Shape of what the agent sees
-
-By default the agent receives the raw JSON payload as a user message. For structured sources, use `template`:
-
-```toml
-[channels.webhooks.sentry]
-enabled = true
-secret = "..."
-dispatch_to = "sop:investigate-error"
-template = """
-New Sentry alert:
-Level: {{ payload.level }}
-Title: {{ payload.title }}
-URL: {{ payload.web_url }}
-
-Stack:
-{{ payload.exception.values[0].stacktrace }}
-"""
+```
+X-Webhook-Signature: sha256=<hex-encoded HMAC-SHA256 of the raw body>
 ```
 
-Templates use MiniJinja; `payload` is the full JSON body, plus `headers` and `query` for URL params.
+The channel computes `HMAC-SHA256(secret, raw_body)`, hex-encodes it, and compares against the header value (the `sha256=` prefix is stripped before decode). Mismatch or missing header returns `401`.
 
-## Replies
+When `secret` is unset, **no verification runs** — every request is accepted. Don't expose an unsecured webhook channel to the public internet; either set `secret`, restrict access at a reverse proxy, or run the listener bound to a private network only.
 
-Webhook channels default to one-shot: the agent handles the event, writes to the receipts log, and returns 200. For webhook sources that wait for a reply (interactive bots, slash commands), set `reply_mode`:
+## Outbound
 
-```toml
-[channels.webhooks.slack-slash]
-enabled = true
-secret = "..."
-reply_mode = "inline-json"        # respond to POST with {"text": "..."}
-template = "{{ payload.text }}"
+When `send_url` is set, every agent reply is delivered as an HTTP request to that URL:
+
+```
+{send_method} {send_url}
+Authorization: {auth_header}    # only if auth_header is set
+Content-Type: application/json
+
+{
+  "content": "agent reply text",
+  "thread_id": "optional thread id",
+  "recipient": "optional recipient id"
+}
 ```
 
-Supported reply modes: `status-only` (default, 200 OK), `inline-json`, `inline-text`.
+- `send_method` is `POST` (default) or `PUT`. Any other value falls back to `POST`.
+- `auth_header` is sent verbatim as the `Authorization` header value — include the scheme yourself (e.g. `Bearer xyz`, `Basic dXNlcjpwYXNz`).
+- `recipient` is omitted when empty.
+- Non-2xx responses raise an error in logs; the agent reply is considered failed.
+
+When `send_url` is unset, agent replies are dropped silently (logged at `debug`). This is the right configuration for fire-and-forget inbound flows where the response is delivered through some other channel.
 
 ## Public exposure
 
-By default the gateway binds to localhost only. To expose webhooks publicly:
+The channel binds to `0.0.0.0` directly. To expose it on the public internet:
 
-1. **Reverse proxy** — run nginx / Caddy / Traefik in front, terminate TLS, proxy to localhost. See [Operations → Network deployment](../ops/network-deployment.md).
-2. **Tunnel** — configure `[tunnel] provider = "ngrok" | "cloudflare" | "tailscale"` and restart the daemon. Tunnels start alongside the gateway.
-3. **Public bind** — set `ZEROCLAW_ALLOW_PUBLIC_BIND=1` and `[gateway] host = "0.0.0.0"`. Not recommended without a firewall in front.
+1. **Reverse proxy** — terminate TLS at nginx / Caddy / Traefik and proxy to the channel's port. See [Operations → Network deployment](../ops/network-deployment.md).
+2. **Tunnel** — configure `[tunnel]` (`ngrok`, `cloudflare`, or `tailscale`) and the daemon brings up the tunnel alongside the channel.
+3. **Local-only** — run inside a private network and have your producer hit the LAN/loopback address directly.
 
-## Rate limiting
-
-The webhook channel applies a per-webhook-name rate limit (default 10/s). Override:
-
-```toml
-[channels.webhooks.noisy]
-rate_limit_per_sec = 50
-```
-
-Excess requests return 429.
+Always pair public exposure with `secret`. An unauthenticated webhook listener is an open ingress to the agent.
 
 ## Code
 
-- Channel: `crates/zeroclaw-channels/src/webhook.rs` (plus gateway ingress in `crates/zeroclaw-gateway/`)
-- Templates: `crates/zeroclaw-runtime/src/templating.rs`
+- Channel: `crates/zeroclaw-channels/src/webhook.rs`
+- Config: `crates/zeroclaw-config/src/schema.rs` (`WebhookConfig`)
 
 ## See also
 
-- [Operations → Network deployment](../ops/network-deployment.md)
-- [SOP → Connectivity](../sop/connectivity.md) — webhook + SOP patterns
+- [Operations → Network deployment](../ops/network-deployment.md) — TLS termination, tunnels, the gateway's separate `/webhook`
+- [Channels → Overview](./overview.md)

--- a/docs/book/src/hardware/index.md
+++ b/docs/book/src/hardware/index.md
@@ -77,12 +77,14 @@ Hardware tools can brick things. Real, expensive things.
 - `i2c_write` / `spi_transfer` to device addresses the agent doesn't know can damage sensors.
 - GPIO writes that conflict with external drivers (voltage fights) damage pins.
 
-For production deployments with untrusted channels exposed, disable hardware tools per channel:
+For production deployments with untrusted channels exposed, keep hardware tools off non-CLI channels via the global autonomy config (the schema has no per-channel `tools_deny` field):
 
 ```toml
-[channels.public-discord]
-tools_deny = ["gpio_write", "i2c_write", "spi_transfer", "peripheral_flash"]
+[autonomy]
+non_cli_excluded_tools = ["gpio_write", "i2c_write", "spi_transfer", "peripheral_flash"]
 ```
+
+Tools listed here are omitted from the tool specs sent to the model on every non-CLI channel (Discord, Telegram, Bluesky, etc.). The local CLI still sees them.
 
 ## Datasheets
 

--- a/docs/book/src/security/overview.md
+++ b/docs/book/src/security/overview.md
@@ -81,7 +81,7 @@ A blocked tool call doesn't silently fail:
 2. The runtime wraps it as a `ToolResult::Err` and hands it back to the model
 3. The model sees "Error: Shell command blocked by policy: forbidden pattern `rm -rf /`" and can retry, apologise, or ask the user
 
-If a channel is in a restricted tool set (`tools_allow = [...]`), the tool simply isn't advertised to the model for that channel. Model never sees a tool it can't use.
+If a tool is excluded from the channel via `[autonomy].non_cli_excluded_tools` (which gates non-CLI channels as a group), it simply isn't advertised to the model on those channels. Model never sees a tool it can't use.
 
 ## Default posture
 

--- a/docs/book/src/tools/overview.md
+++ b/docs/book/src/tools/overview.md
@@ -71,17 +71,16 @@ The [autonomy level](../security/autonomy.md) determines what each risk tier can
 
 Every tool invocation — approved or blocked — produces a [tool receipt](../security/tool-receipts.md) in the audit log.
 
-## Disabling tools per channel
+## Disabling tools on non-CLI channels
 
-A public-facing channel may want a more restrictive tool set than the operator's CLI:
+The schema has no per-channel `tools_allow` / `tools_deny` field. The available mechanism is the global `[autonomy].non_cli_excluded_tools` list, which removes the listed tools from every non-CLI channel (Discord, Telegram, Bluesky, Matrix, Slack, etc.) while leaving the local CLI untouched:
 
 ```toml
-[channels.public-bluesky]
-tools_allow = ["http", "web_search", "memory_search"]
-# shell, file_write, browser, etc. are implicitly disabled for this channel
+[autonomy]
+non_cli_excluded_tools = ["shell", "file_write", "browser"]
 ```
 
-`tools_deny` works inversely (allow everything except the listed). The two can't be combined — pick one.
+The granularity is binary (CLI vs non-CLI), not per-channel. If you need finer-grained gating, drop the global `[autonomy].level` to `read_only` or `supervised` and rely on the per-tool `auto_approve` / `always_ask` lists to gate sensitive tools behind operator approval.
 
 ## See also
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3200,7 +3200,7 @@ async fn main() -> Result<()> {
                 if !daemon_running {
                     eprintln!(
                         "Note: gateway does not appear to be running at {host}:{port}. \
-                         Start it with `zeroclaw daemon start` to load the explorer."
+                         Start it with `zeroclaw service start` (background) or `zeroclaw daemon` (foreground) to load the explorer."
                     );
                 }
                 Ok(())

--- a/tests/manual/telegram/testing-telegram.md
+++ b/tests/manual/telegram/testing-telegram.md
@@ -159,7 +159,7 @@ Solution: Check user allowlist
   1. Send message to bot
   2. Check logs for user_id
   3. Update config: allowed_users = ["YOUR_ID"]
-  4. Run: zeroclaw onboard --channels-only
+  4. Run: zeroclaw onboard channels
 ```
 
 **Issue: Message splitting not working**


### PR DESCRIPTION
## Summary

- **Base branch:** master
- **What changed and why:**
  - Channel docs in `docs/book/src/channels/` had drifted from the canonical schema in `crates/zeroclaw-config/src/schema.rs`. Reconciled all 11 doc pages so a reader following the docs ends up with TOML the parser actually accepts. (line.md was already accurate; the other 10 needed fixes.)
  - The schema reference page (`reference/config.md`, regenerated by `cargo mdbook refs`) had 100 rows with empty Description columns because many `*Config` structs and their fields lacked `///` doc comments. Added struct- and field-level docstrings; the same regen pass also fixed 5 rustdoc warnings in source.
  - Several user-facing references invoked `zeroclaw onboard --channels-only` (deprecated legacy flag). Replaced with the canonical `zeroclaw onboard channels` positional subcommand across docs and runtime error messages. Two other invalid CLI references found and fixed (`zeroclaw daemon start`, `zeroclaw cache clear`).
  - `matrix.md` had several code blocks bundling `zeroclaw config set ...` with a trailing `zeroclaw service restart` line. A reader copy-pasting the block shouldn't get a service restart along for the ride. Split each affected block so config and restart are separate steps.
- **Scope boundary:** No changes to `acp.md` (deferred per a separate scope question). Did not add coverage for ~7 schema channels with no doc page yet (WhatsApp, WATI, MQTT, Linq, Voice Duplex, Feishu, Discord History) — that is a follow-up issue.
- **Blast radius:** Docs are read-only. Rust source touches only add docstrings or correct text inside existing strings (rustdoc-warning fixes, runtime error-message strings printed to stderr). No API changes, no behavioural changes, no config-shape changes.
- **Linked issue(s):** none
- **Labels:** `size: M`, `type: docs`, `risk: low`, `docs`, `core`, `channel`, `integration`, `memory`, `runtime`, `tests`, `channel:telegram`, `channel:whatsapp`, `channel:wati`, `channel:linq`, `channel:nextcloud-talk`

## Validation Evidence

```bash
cargo fmt --all -- --check
cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
cargo check --workspace --exclude zeroclaw-desktop
cargo mdbook refs
cd docs/book && mdbook build
```

- **Commands run and tail output:**
  - `cargo check --workspace --exclude zeroclaw-desktop`: clean.
  - `cargo mdbook refs`: 0 warnings, 0 empty Description rows in `reference/config.md` (was 100 before).
  - `mdbook build` in `docs/book`: clean.
- **Beyond CI, what was manually verified:** every backtick-wrapped two-word `zeroclaw X Y` string in `docs/book/src/` was cross-checked against the actual `Commands` and `*Commands` enums in `src/main.rs` and `src/lib.rs`. All remaining references resolve to real subcommands. Cross-page anchor links of the form `../reference/config.md#channelsfoo` were verified against the actual heading IDs that mdbook generates (mdbook strips dots in slugs).
- **Intentionally skipped:** `cargo test` — pure docs and docstring changes, no code paths exercised. If a maintainer wants the full test sweep, happy to run.
- **Not verified:** runtime behaviour of the affected channels (no behavioural change in this PR; only docstrings and string literals in error messages).

## Security & Privacy Impact

- New permissions, capabilities, or filesystem access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII or real identities in diff, tests, fixtures, or docs? **No**

## Compatibility

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**. The legacy `--channels-only` flag still parses (the deprecation handler in `src/main.rs` is untouched); only the recommended doc text and error-message strings now point at the canonical `zeroclaw onboard channels` subcommand.

## Rollback

Low-risk; `git revert <sha>` per commit before merge, or revert the squash commit after merge. Current branch commits stack independently:

- 6f80440 docs(channels): reconcile against schema
- c35a710 fix(docs,schema,cli): correct CLI references and add missing docstrings
- 8ffbcee docs(channels/matrix): split config-set and service-restart into separate blocks
- a10d78e fix(channels/orchestrator): collapse short anyhow::bail! to one line
- 79e7642 docs(channels/voice): comment out empty-string optional fields in voice_call example
- cf067d1 docs(channels/mattermost): comment out empty-string login_id and password in example
