### PR TITLE
fix(web/agent-chat): default tool_call/tool_result off, add toolbar toggle

### DIFF
--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -435,6 +435,8 @@ const translations: Record<Locale, Record<string, string>> = {
     'agent.clear_all': 'Clear all',
     'agent.delete_message': 'Delete message',
     'agent.compact_mode': 'Compact',
+    'agent.tool_activity_show': 'Show tool activity',
+    'agent.tool_activity_hide': 'Hide tool activity',
     'agent.running': 'Running…',
     'agent.stop': 'Stop',
 

--- a/web/src/pages/AgentChat.tsx
+++ b/web/src/pages/AgentChat.tsx
@@ -1,5 +1,5 @@
 import { memo, useState, useEffect, useRef, useCallback } from 'react';
-import { Send, Square, Bot, User, AlertCircle, Copy, Check, X, Trash2, Minimize2, Maximize2 } from 'lucide-react';
+import { Send, Square, Bot, User, AlertCircle, Copy, Check, X, Trash2, Minimize2, Maximize2, Wrench } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import type { WsMessage } from '@/types/api';
@@ -52,9 +52,9 @@ export default function AgentChat() {
   });
   // #6348: tool execution is plumbing, not chat. Default off so tool_call /
   // tool_result frames do not surface inline in the conversation transcript.
-  // Power users can flip 'zeroclaw_show_tool_activity' in localStorage; a
-  // proper toggle UI is a follow-up.
-  const [showToolActivity] = useState(() => {
+  // Toggleable from the chat toolbar (Wrench button); the same flag persists
+  // to `localStorage.zeroclaw_show_tool_activity` for cross-session memory.
+  const [showToolActivity, setShowToolActivity] = useState(() => {
     try { return localStorage.getItem('zeroclaw_show_tool_activity') === '1'; } catch { return false; }
   });
   const pendingContentRef = useRef('');
@@ -400,6 +400,14 @@ export default function AgentChat() {
     });
   }, []);
 
+  const toggleToolActivity = useCallback(() => {
+    setShowToolActivity((prev) => {
+      const next = !prev;
+      try { localStorage.setItem('zeroclaw_show_tool_activity', next ? '1' : '0'); } catch { /* noop */ }
+      return next;
+    });
+  }, []);
+
   /**
    * Fallback copy using a temporary textarea for HTTP contexts
    * where navigator.clipboard is unavailable.
@@ -446,6 +454,17 @@ export default function AgentChat() {
           >
             {compact ? <Maximize2 className="h-3 w-3" /> : <Minimize2 className="h-3 w-3" />}
             {t('agent.compact_mode')}
+          </button>
+          <button
+            type="button"
+            onClick={toggleToolActivity}
+            className="btn-secondary flex items-center gap-1.5 text-xs"
+            style={{ padding: '0.3rem 0.75rem', borderRadius: '0.5rem' }}
+            aria-label={showToolActivity ? t('agent.tool_activity_hide') : t('agent.tool_activity_show')}
+            aria-pressed={showToolActivity}
+          >
+            <Wrench className="h-3 w-3" />
+            {showToolActivity ? t('agent.tool_activity_hide') : t('agent.tool_activity_show')}
           </button>
           <button
             type="button"

--- a/web/src/pages/AgentChat.tsx
+++ b/web/src/pages/AgentChat.tsx
@@ -50,7 +50,7 @@ export default function AgentChat() {
   const [compact, setCompact] = useState(() => {
     try { return localStorage.getItem('zeroclaw_chat_compact') === '1'; } catch { return false; }
   });
-  // #6348: tool execution is plumbing, not chat. Default off so tool_call /
+  // Tool execution is plumbing, not chat. Default off so tool_call /
   // tool_result frames do not surface inline in the conversation transcript.
   // Toggleable from the chat toolbar (Wrench button); the same flag persists
   // to `localStorage.zeroclaw_show_tool_activity` for cross-session memory.
@@ -187,11 +187,6 @@ export default function AgentChat() {
         }
 
         case 'tool_call': {
-          // #6348: tool execution is plumbing, not chat content. Skip
-          // inline rendering unless the operator explicitly opts in via
-          // localStorage 'zeroclaw_show_tool_activity'. A future commit
-          // will route tool activity into the existing collapsed
-          // Thinking strip so it has a discoverable home.
           if (!showToolActivity) {
             break;
           }
@@ -224,8 +219,6 @@ export default function AgentChat() {
         }
 
         case 'tool_result': {
-          // #6348: tool errors and results should not surface as chat
-          // content. Same gate as tool_call above.
           if (!showToolActivity) {
             break;
           }

--- a/web/src/pages/AgentChat.tsx
+++ b/web/src/pages/AgentChat.tsx
@@ -57,6 +57,11 @@ export default function AgentChat() {
   const [showToolActivity, setShowToolActivity] = useState(() => {
     try { return localStorage.getItem('zeroclaw_show_tool_activity') === '1'; } catch { return false; }
   });
+  // The WebSocket onMessage handler is installed once with `[]` deps so it
+  // can read the latest toggle without a reconnect-per-toggle. Mirror the
+  // state into a ref the handler reads at message time.
+  const showToolActivityRef = useRef(showToolActivity);
+  useEffect(() => { showToolActivityRef.current = showToolActivity; }, [showToolActivity]);
   const pendingContentRef = useRef('');
   const pendingThinkingRef = useRef('');
   // Snapshot of thinking captured at chunk_reset, so it survives the reset.
@@ -187,7 +192,7 @@ export default function AgentChat() {
         }
 
         case 'tool_call': {
-          if (!showToolActivity) {
+          if (!showToolActivityRef.current) {
             break;
           }
           const toolName = msg.name ?? 'unknown';
@@ -219,7 +224,7 @@ export default function AgentChat() {
         }
 
         case 'tool_result': {
-          if (!showToolActivity) {
+          if (!showToolActivityRef.current) {
             break;
           }
           setMessages((prev) => {

--- a/web/src/pages/AgentChat.tsx
+++ b/web/src/pages/AgentChat.tsx
@@ -50,6 +50,13 @@ export default function AgentChat() {
   const [compact, setCompact] = useState(() => {
     try { return localStorage.getItem('zeroclaw_chat_compact') === '1'; } catch { return false; }
   });
+  // #6348: tool execution is plumbing, not chat. Default off so tool_call /
+  // tool_result frames do not surface inline in the conversation transcript.
+  // Power users can flip 'zeroclaw_show_tool_activity' in localStorage; a
+  // proper toggle UI is a follow-up.
+  const [showToolActivity] = useState(() => {
+    try { return localStorage.getItem('zeroclaw_show_tool_activity') === '1'; } catch { return false; }
+  });
   const pendingContentRef = useRef('');
   const pendingThinkingRef = useRef('');
   // Snapshot of thinking captured at chunk_reset, so it survives the reset.
@@ -180,6 +187,14 @@ export default function AgentChat() {
         }
 
         case 'tool_call': {
+          // #6348: tool execution is plumbing, not chat content. Skip
+          // inline rendering unless the operator explicitly opts in via
+          // localStorage 'zeroclaw_show_tool_activity'. A future commit
+          // will route tool activity into the existing collapsed
+          // Thinking strip so it has a discoverable home.
+          if (!showToolActivity) {
+            break;
+          }
           const toolName = msg.name ?? 'unknown';
           const toolArgs = msg.args;
           setMessages((prev) => {
@@ -209,6 +224,11 @@ export default function AgentChat() {
         }
 
         case 'tool_result': {
+          // #6348: tool errors and results should not surface as chat
+          // content. Same gate as tool_call above.
+          if (!showToolActivity) {
+            break;
+          }
           setMessages((prev) => {
             // Forward scan: find the FIRST unresolved toolCall (order-guaranteed by backend)
             const idx = prev.findIndex((m) => m.toolCall && m.toolCall.output === undefined);


### PR DESCRIPTION
## Summary

The dashboard's Agent chat was rendering every `tool_call` and `tool_result` WebSocket frame as a standalone card in the message stream, including errored tool calls (e.g. `memory_recall` returning "Provide at least 'query' ..."), alongside the user message and the assistant reply. That noise belongs in an activity surface, not the conversation transcript.

Two changes:

- Gate the inline render of `tool_call` and `tool_result` behind a `showToolActivity` flag (default false). The flag persists to `localStorage.zeroclaw_show_tool_activity` for cross-session memory.
- Add a discoverable Wrench toggle to the chat toolbar next to Compact, with `aria-pressed` semantics and `agent.tool_activity_show` / `agent.tool_activity_hide` i18n strings. Operators can flip the gate without dropping into devtools.

Audit of the full WsMessage union confirms `tool_call` and `tool_result` are the only frames that should be gated as plumbing. `cron_result` is asynchronous output from a job the operator explicitly scheduled, not internal-to-turn agent reasoning, so it stays in the transcript unconditionally.

Closes #6348

## Validation Evidence

```bash
cd web && npm run build
```

Builds cleanly (only the pre-existing chunk-size warnings).

## Security & Privacy Impact

- New permissions, capabilities, or filesystem access scope? No.
- New external network calls? No.
- Secrets / tokens / credentials handling changed? No.
- PII or real identities in diff, tests, fixtures, or docs? No.

## Compatibility

- Backward compatible? Yes. Default behaviour stops surfacing the noisy cards; users who want the prior behaviour click the Wrench toggle (or set `localStorage.zeroclaw_show_tool_activity = '1'`).
- Config / env / CLI surface changed? No.

## Rollback

`git revert <merge-sha>`. Two-file diff (`web/src/pages/AgentChat.tsx`, `web/src/lib/i18n.ts`). Operators who specifically want the noisy cards back set the localStorage flag.
