### PR TITLE
feat(gateway,web): nodes dashboard + device identification

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -1125,10 +1125,26 @@ pub struct NodesConfig {
     /// Optional bearer token for node authentication.
     #[serde(default)]
     pub auth_token: Option<String>,
+    /// Seconds without a heartbeat before a node is rendered as `Stale`
+    /// in the dashboard. Default: 300 (5 minutes).
+    #[serde(default = "default_stale_after_secs")]
+    pub stale_after_secs: u64,
+    /// Seconds without a heartbeat before a node is rendered as `Offline`
+    /// in the dashboard. Default: 1800 (30 minutes).
+    #[serde(default = "default_offline_after_secs")]
+    pub offline_after_secs: u64,
 }
 
 fn default_max_nodes() -> usize {
     16
+}
+
+fn default_stale_after_secs() -> u64 {
+    300
+}
+
+fn default_offline_after_secs() -> u64 {
+    1800
 }
 
 impl Default for NodesConfig {
@@ -1137,6 +1153,8 @@ impl Default for NodesConfig {
             enabled: false,
             max_nodes: default_max_nodes(),
             auth_token: None,
+            stale_after_secs: default_stale_after_secs(),
+            offline_after_secs: default_offline_after_secs(),
         }
     }
 }

--- a/crates/zeroclaw-gateway/src/api_pairing.rs
+++ b/crates/zeroclaw-gateway/src/api_pairing.rs
@@ -64,14 +64,33 @@ impl DeviceRegistry {
 
         // Additive migration: hostname / os_name / os_version / agent_version.
         // `IF NOT EXISTS` is not supported on `ALTER TABLE ADD COLUMN` in
-        // older SQLite, so we ignore the "duplicate column" error per column.
-        for column in [
-            "hostname TEXT",
-            "os_name TEXT",
-            "os_version TEXT",
-            "agent_version TEXT",
+        // SQLite, so we list the existing columns up front and only attempt
+        // ADD on the ones that are actually missing. This is idempotent
+        // across restarts and surfaces *real* errors (DB locked, permission
+        // denied, disk full) instead of swallowing them under the previous
+        // `let _ = conn.execute(...)` shape.
+        let existing_columns: std::collections::HashSet<String> = conn
+            .prepare("PRAGMA table_info(devices)")
+            .and_then(|mut stmt| {
+                stmt.query_map([], |row| row.get::<_, String>(1))
+                    .map(|rows| rows.filter_map(Result::ok).collect())
+            })
+            .unwrap_or_default();
+        for (name, decl) in [
+            ("hostname", "hostname TEXT"),
+            ("os_name", "os_name TEXT"),
+            ("os_version", "os_version TEXT"),
+            ("agent_version", "agent_version TEXT"),
         ] {
-            let _ = conn.execute(&format!("ALTER TABLE devices ADD COLUMN {column}"), []);
+            if existing_columns.contains(name) {
+                continue;
+            }
+            if let Err(e) = conn.execute(&format!("ALTER TABLE devices ADD COLUMN {decl}"), []) {
+                tracing::warn!(
+                    target: "zeroclaw_gateway::devices",
+                    "failed to add column {name} to devices table: {e}"
+                );
+            }
         }
 
         // Warm the in-memory cache from DB
@@ -504,5 +523,136 @@ pub async fn rotate_token(
             "Cannot generate new pairing code",
         )
             .into_response(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn fresh_registry() -> (TempDir, DeviceRegistry) {
+        let tmp = TempDir::new().unwrap();
+        let registry = DeviceRegistry::new(tmp.path());
+        (tmp, registry)
+    }
+
+    fn sample_device(id: &str, name: Option<&str>) -> DeviceInfo {
+        DeviceInfo {
+            id: id.into(),
+            name: name.map(String::from),
+            device_type: Some("macos".into()),
+            paired_at: Utc::now(),
+            last_seen: Utc::now(),
+            ip_address: Some("127.0.0.1".into()),
+            hostname: Some("argenis-Mac.local".into()),
+            os_name: Some("macOS".into()),
+            os_version: Some("10.15.7".into()),
+            agent_version: Some("0.7.4".into()),
+        }
+    }
+
+    #[test]
+    fn rename_persists_new_name() {
+        let (_tmp, registry) = fresh_registry();
+        registry.register("hash-1".into(), sample_device("dev-1", Some("Old Name")));
+
+        assert!(registry.rename("dev-1", Some("New Name".into())));
+        let listed = registry.list();
+        let updated = listed.iter().find(|d| d.id == "dev-1").unwrap();
+        assert_eq!(updated.name.as_deref(), Some("New Name"));
+    }
+
+    #[test]
+    fn rename_returns_false_for_unknown_id() {
+        let (_tmp, registry) = fresh_registry();
+        // No device registered yet; rename should be a no-op.
+        assert!(!registry.rename("does-not-exist", Some("X".into())));
+    }
+
+    #[test]
+    fn rename_to_none_clears_label() {
+        let (_tmp, registry) = fresh_registry();
+        registry.register("hash-1".into(), sample_device("dev-1", Some("Set")));
+
+        assert!(registry.rename("dev-1", None));
+        let listed = registry.list();
+        let cleared = listed.iter().find(|d| d.id == "dev-1").unwrap();
+        assert!(cleared.name.is_none());
+    }
+
+    /// Pre-create a `devices.db` with the v1 schema (no hostname / os_name /
+    /// os_version / agent_version columns) and a sample row, then open a
+    /// fresh `DeviceRegistry` against the same dir. The additive migration
+    /// must add the columns and preserve the pre-existing row.
+    #[test]
+    fn migration_adds_columns_to_pre_existing_db() {
+        let tmp = TempDir::new().unwrap();
+        let db_path = tmp.path().join("devices.db");
+
+        // Simulate the v1 schema (the shape master had before this PR).
+        {
+            let conn = Connection::open(&db_path).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE devices (
+                    token_hash TEXT PRIMARY KEY,
+                    id TEXT NOT NULL,
+                    name TEXT,
+                    device_type TEXT,
+                    paired_at TEXT NOT NULL,
+                    last_seen TEXT NOT NULL,
+                    ip_address TEXT
+                )",
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO devices (token_hash, id, name, device_type, paired_at, last_seen, ip_address) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                rusqlite::params![
+                    "legacy-hash",
+                    "legacy-dev",
+                    "Pre-migration Mac",
+                    "macos",
+                    Utc::now().to_rfc3339(),
+                    Utc::now().to_rfc3339(),
+                    "127.0.0.1",
+                ],
+            )
+            .unwrap();
+        }
+
+        // Opening the registry runs the migration.
+        let registry = DeviceRegistry::new(tmp.path());
+
+        // Pre-existing row is still there with its old fields intact and the
+        // new fields populated as `None`.
+        let listed = registry.list();
+        let legacy = listed.iter().find(|d| d.id == "legacy-dev").unwrap();
+        assert_eq!(legacy.name.as_deref(), Some("Pre-migration Mac"));
+        assert_eq!(legacy.device_type.as_deref(), Some("macos"));
+        assert!(legacy.hostname.is_none());
+        assert!(legacy.os_name.is_none());
+        assert!(legacy.os_version.is_none());
+        assert!(legacy.agent_version.is_none());
+
+        // And new registers can populate the new fields end-to-end.
+        registry.register("new-hash".into(), sample_device("new-dev", Some("Fresh")));
+        let listed = registry.list();
+        let fresh = listed.iter().find(|d| d.id == "new-dev").unwrap();
+        assert_eq!(fresh.hostname.as_deref(), Some("argenis-Mac.local"));
+        assert_eq!(fresh.os_version.as_deref(), Some("10.15.7"));
+    }
+
+    /// Re-opening an already-migrated db must be a no-op (no errors
+    /// surfaced, columns unchanged). Catches the case where the idempotent
+    /// existence check regresses.
+    #[test]
+    fn migration_is_idempotent_on_already_migrated_db() {
+        let tmp = TempDir::new().unwrap();
+        let _first = DeviceRegistry::new(tmp.path());
+        // Second open should not panic and should preserve schema.
+        let second = DeviceRegistry::new(tmp.path());
+        // Round-trip a row to confirm the table is still usable.
+        second.register("h".into(), sample_device("d", None));
+        assert_eq!(second.list().len(), 1);
     }
 }

--- a/crates/zeroclaw-gateway/src/api_pairing.rs
+++ b/crates/zeroclaw-gateway/src/api_pairing.rs
@@ -14,6 +14,12 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 /// Metadata about a paired device.
+///
+/// `hostname`, `os_name`, `os_version`, and `agent_version` are best-effort
+/// identifiers captured during pairing (from explicit `X-Hostname` /
+/// `X-OS-Name` / `X-OS-Version` / `X-Agent-Version` headers, with
+/// User-Agent fallback for browsers). They're optional to keep the
+/// pairing flow non-strict — the dashboard renders whatever is present.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DeviceInfo {
     pub id: String,
@@ -22,6 +28,14 @@ pub struct DeviceInfo {
     pub paired_at: DateTime<Utc>,
     pub last_seen: DateTime<Utc>,
     pub ip_address: Option<String>,
+    #[serde(default)]
+    pub hostname: Option<String>,
+    #[serde(default)]
+    pub os_name: Option<String>,
+    #[serde(default)]
+    pub os_version: Option<String>,
+    #[serde(default)]
+    pub agent_version: Option<String>,
 }
 
 /// Registry of paired devices backed by SQLite.
@@ -48,10 +62,25 @@ impl DeviceRegistry {
         )
         .expect("Failed to create devices table");
 
+        // Additive migration: hostname / os_name / os_version / agent_version.
+        // `IF NOT EXISTS` is not supported on `ALTER TABLE ADD COLUMN` in
+        // older SQLite, so we ignore the "duplicate column" error per column.
+        for column in [
+            "hostname TEXT",
+            "os_name TEXT",
+            "os_version TEXT",
+            "agent_version TEXT",
+        ] {
+            let _ = conn.execute(&format!("ALTER TABLE devices ADD COLUMN {column}"), []);
+        }
+
         // Warm the in-memory cache from DB
         let mut cache = HashMap::new();
         let mut stmt = conn
-            .prepare("SELECT token_hash, id, name, device_type, paired_at, last_seen, ip_address FROM devices")
+            .prepare(
+                "SELECT token_hash, id, name, device_type, paired_at, last_seen, ip_address, \
+                 hostname, os_name, os_version, agent_version FROM devices",
+            )
             .expect("Failed to prepare device select");
         let rows = stmt
             .query_map([], |row| {
@@ -62,6 +91,10 @@ impl DeviceRegistry {
                 let paired_at_str: String = row.get(4)?;
                 let last_seen_str: String = row.get(5)?;
                 let ip_address: Option<String> = row.get(6)?;
+                let hostname: Option<String> = row.get(7)?;
+                let os_name: Option<String> = row.get(8)?;
+                let os_version: Option<String> = row.get(9)?;
+                let agent_version: Option<String> = row.get(10)?;
                 let paired_at = DateTime::parse_from_rfc3339(&paired_at_str)
                     .map(|dt| dt.with_timezone(&Utc))
                     .unwrap_or_else(|_| Utc::now());
@@ -77,6 +110,10 @@ impl DeviceRegistry {
                         paired_at,
                         last_seen,
                         ip_address,
+                        hostname,
+                        os_name,
+                        os_version,
+                        agent_version,
                     },
                 ))
             })
@@ -98,7 +135,10 @@ impl DeviceRegistry {
     pub fn register(&self, token_hash: String, info: DeviceInfo) {
         let conn = self.open_db();
         conn.execute(
-            "INSERT OR REPLACE INTO devices (token_hash, id, name, device_type, paired_at, last_seen, ip_address) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            "INSERT OR REPLACE INTO devices (\
+                token_hash, id, name, device_type, paired_at, last_seen, ip_address, \
+                hostname, os_name, os_version, agent_version\
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
             rusqlite::params![
                 token_hash,
                 info.id,
@@ -107,6 +147,10 @@ impl DeviceRegistry {
                 info.paired_at.to_rfc3339(),
                 info.last_seen.to_rfc3339(),
                 info.ip_address,
+                info.hostname,
+                info.os_name,
+                info.os_version,
+                info.agent_version,
             ],
         )
         .expect("Failed to insert device");
@@ -116,7 +160,10 @@ impl DeviceRegistry {
     pub fn list(&self) -> Vec<DeviceInfo> {
         let conn = self.open_db();
         let mut stmt = conn
-            .prepare("SELECT token_hash, id, name, device_type, paired_at, last_seen, ip_address FROM devices")
+            .prepare(
+                "SELECT token_hash, id, name, device_type, paired_at, last_seen, ip_address, \
+                 hostname, os_name, os_version, agent_version FROM devices",
+            )
             .expect("Failed to prepare device select");
         let rows = stmt
             .query_map([], |row| {
@@ -126,6 +173,10 @@ impl DeviceRegistry {
                 let paired_at_str: String = row.get(4)?;
                 let last_seen_str: String = row.get(5)?;
                 let ip_address: Option<String> = row.get(6)?;
+                let hostname: Option<String> = row.get(7)?;
+                let os_name: Option<String> = row.get(8)?;
+                let os_version: Option<String> = row.get(9)?;
+                let agent_version: Option<String> = row.get(10)?;
                 let paired_at = DateTime::parse_from_rfc3339(&paired_at_str)
                     .map(|dt| dt.with_timezone(&Utc))
                     .unwrap_or_else(|_| Utc::now());
@@ -139,6 +190,10 @@ impl DeviceRegistry {
                     paired_at,
                     last_seen,
                     ip_address,
+                    hostname,
+                    os_name,
+                    os_version,
+                    agent_version,
                 })
             })
             .expect("Failed to query devices");
@@ -161,6 +216,29 @@ impl DeviceRegistry {
                 .map(|(k, _)| k.clone());
             if let Some(key) = key {
                 cache.remove(&key);
+            }
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Update the human-readable label for a device. Returns `true` if a row
+    /// matched the given device id, `false` otherwise.
+    pub fn rename(&self, device_id: &str, new_name: Option<String>) -> bool {
+        let conn = self.open_db();
+        let updated = conn
+            .execute(
+                "UPDATE devices SET name = ?1 WHERE id = ?2",
+                rusqlite::params![new_name, device_id],
+            )
+            .unwrap_or(0);
+        if updated > 0 {
+            for device in self.cache.lock().values_mut() {
+                if device.id == device_id {
+                    device.name = new_name.clone();
+                    break;
+                }
             }
             true
         } else {
@@ -292,6 +370,10 @@ pub async fn submit_pairing_enhanced(
                         paired_at: Utc::now(),
                         last_seen: Utc::now(),
                         ip_address: Some(client_id),
+                        hostname: body["hostname"].as_str().map(String::from),
+                        os_name: body["os_name"].as_str().map(String::from),
+                        os_version: body["os_version"].as_str().map(String::from),
+                        agent_version: body["agent_version"].as_str().map(String::from),
                     },
                 );
             }
@@ -323,9 +405,14 @@ pub async fn list_devices(State(state): State<AppState>, headers: HeaderMap) -> 
         .unwrap_or_default();
 
     let count = devices.len();
+    let nodes_cfg = state.config.lock().nodes.clone();
     Json(serde_json::json!({
         "devices": devices,
-        "count": count
+        "count": count,
+        "policy": {
+            "stale_after_secs": nodes_cfg.stale_after_secs,
+            "offline_after_secs": nodes_cfg.offline_after_secs,
+        }
     }))
     .into_response()
 }
@@ -350,6 +437,43 @@ pub async fn revoke_device(
         Json(serde_json::json!({
             "message": "Device revoked",
             "device_id": device_id
+        }))
+        .into_response()
+    } else {
+        (StatusCode::NOT_FOUND, "Device not found").into_response()
+    }
+}
+
+/// `PATCH /api/devices/{id}` — update the device's friendly label.
+///
+/// Body: `{"name": "Argenis's Mac"}` (or `{"name": null}` to clear).
+/// Returns 404 if the id is unknown.
+#[derive(Deserialize)]
+pub struct DevicePatchBody {
+    /// Replacement label. Pass `null` to clear back to the inferred default.
+    pub name: Option<String>,
+}
+
+pub async fn patch_device(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    axum::extract::Path(device_id): axum::extract::Path<String>,
+    Json(body): Json<DevicePatchBody>,
+) -> impl IntoResponse {
+    if let Err(e) = require_auth(&state, &headers) {
+        return e.into_response();
+    }
+
+    let updated = state
+        .device_registry
+        .as_ref()
+        .map(|r| r.rename(&device_id, body.name.clone()))
+        .unwrap_or(false);
+
+    if updated {
+        Json(serde_json::json!({
+            "device_id": device_id,
+            "name": body.name,
         }))
         .into_response()
     } else {

--- a/crates/zeroclaw-gateway/src/lib.rs
+++ b/crates/zeroclaw-gateway/src/lib.rs
@@ -1131,7 +1131,11 @@ pub async fn run_gateway(
         .route("/api/pairing/initiate", post(api_pairing::initiate_pairing))
         .route("/api/pair", post(api_pairing::submit_pairing_enhanced))
         .route("/api/devices", get(api_pairing::list_devices))
-        .route("/api/devices/{id}", delete(api_pairing::revoke_device))
+        .route("/api/nodes", get(nodes::list_nodes))
+        .route(
+            "/api/devices/{id}",
+            delete(api_pairing::revoke_device).patch(api_pairing::patch_device),
+        )
         .route(
             "/api/devices/{id}/token/rotate",
             post(api_pairing::rotate_token),
@@ -1419,6 +1423,48 @@ async fn handle_pair(
     match state.pairing.try_pair(code, &rate_key).await {
         Ok(Some(token)) => {
             tracing::info!("🔐 New client paired successfully");
+
+            // Register the new device in the persistent DeviceRegistry so it
+            // shows up in /api/devices (and the dashboard's Nodes page).
+            // Pulls best-effort identification from request headers — the
+            // dashboard can pass `X-Device-Name` / `X-Device-Type` for
+            // explicit values; otherwise we infer from User-Agent.
+            if let Some(ref registry) = state.device_registry {
+                let token_hash = {
+                    use sha2::{Digest, Sha256};
+                    hex::encode(Sha256::digest(token.as_bytes()))
+                };
+                let user_agent = headers
+                    .get(header::USER_AGENT)
+                    .and_then(|v| v.to_str().ok())
+                    .unwrap_or("");
+                let read_header = |name: &str| {
+                    headers
+                        .get(name)
+                        .and_then(|v| v.to_str().ok())
+                        .map(String::from)
+                };
+                let device_name = read_header("X-Device-Name");
+                let device_type = read_header("X-Device-Type")
+                    .or_else(|| infer_device_type_from_ua(user_agent));
+                let (ua_os_name, ua_os_version) = infer_os_from_ua(user_agent);
+                registry.register(
+                    token_hash,
+                    api_pairing::DeviceInfo {
+                        id: uuid::Uuid::new_v4().to_string(),
+                        name: device_name,
+                        device_type,
+                        paired_at: chrono::Utc::now(),
+                        last_seen: chrono::Utc::now(),
+                        ip_address: Some(peer_addr.ip().to_string()),
+                        hostname: read_header("X-Hostname"),
+                        os_name: read_header("X-OS-Name").or(ua_os_name),
+                        os_version: read_header("X-OS-Version").or(ua_os_version),
+                        agent_version: read_header("X-Agent-Version"),
+                    },
+                );
+            }
+
             if let Err(err) =
                 Box::pin(persist_pairing_tokens(state.config.clone(), &state.pairing)).await
             {
@@ -1456,6 +1502,77 @@ async fn handle_pair(
             });
             (StatusCode::TOO_MANY_REQUESTS, Json(err))
         }
+    }
+}
+
+/// Best-effort `(os_name, os_version)` inference from a User-Agent header.
+/// Browsers reliably include OS info in the UA; CLIs typically don't, in
+/// which case both components return `None` and the caller should rely on
+/// explicit `X-OS-Name` / `X-OS-Version` headers.
+fn infer_os_from_ua(ua: &str) -> (Option<String>, Option<String>) {
+    if ua.is_empty() {
+        return (None, None);
+    }
+
+    // macOS: "Macintosh; Intel Mac OS X 10_15_7" → name="macOS", version="10.15.7"
+    if let Some(start) = ua.find("Mac OS X ") {
+        let rest = &ua[start + 9..];
+        let end = rest.find([')', ';']).unwrap_or(rest.len());
+        let version = rest[..end].replace('_', ".");
+        return (Some("macOS".into()), Some(version));
+    }
+    // iOS: "iPhone; CPU iPhone OS 17_5_1 like Mac OS X"
+    if let Some(start) = ua.find("iPhone OS ").or_else(|| ua.find("iPad OS ")) {
+        let rest = &ua[start..];
+        let after_space = rest.find(' ').map(|i| &rest[i + 1..]).unwrap_or(rest);
+        let end = after_space
+            .find(|c: char| !(c.is_ascii_digit() || c == '_'))
+            .unwrap_or(after_space.len());
+        let version = after_space[..end].replace('_', ".");
+        return (Some("iOS".into()), Some(version));
+    }
+    // Android: "Android 14;"
+    if let Some(start) = ua.find("Android ") {
+        let rest = &ua[start + 8..];
+        let end = rest.find([';', ')']).unwrap_or(rest.len());
+        return (Some("Android".into()), Some(rest[..end].trim().into()));
+    }
+    // Windows: "Windows NT 10.0" — map NT 10 → 10/11, NT 6.3 → 8.1, etc.
+    if let Some(start) = ua.find("Windows NT ") {
+        let rest = &ua[start + 11..];
+        let end = rest.find([';', ')']).unwrap_or(rest.len());
+        return (Some("Windows".into()), Some(rest[..end].trim().into()));
+    }
+    // Linux distributions: "Linux x86_64" / "X11; Linux"
+    if ua.contains("Linux") {
+        return (Some("Linux".into()), None);
+    }
+
+    (None, None)
+}
+
+/// Best-effort device type inference from a User-Agent header. Returns
+/// `None` if the UA is empty or unrecognised, which lets callers fall back
+/// to whatever metadata they already have.
+fn infer_device_type_from_ua(ua: &str) -> Option<String> {
+    let ua = ua.to_lowercase();
+    if ua.is_empty() {
+        return None;
+    }
+    if ua.contains("iphone") || ua.contains("ipad") {
+        Some("ios".into())
+    } else if ua.contains("android") {
+        Some("android".into())
+    } else if ua.contains("macintosh") || ua.contains("mac os x") {
+        Some("macos".into())
+    } else if ua.contains("windows") {
+        Some("windows".into())
+    } else if ua.contains("linux") {
+        Some("linux".into())
+    } else if ua.starts_with("zeroclaw/") || ua.starts_with("curl/") {
+        Some("cli".into())
+    } else {
+        Some("browser".into())
     }
 }
 

--- a/crates/zeroclaw-gateway/src/lib.rs
+++ b/crates/zeroclaw-gateway/src/lib.rs
@@ -1445,8 +1445,8 @@ async fn handle_pair(
                         .map(String::from)
                 };
                 let device_name = read_header("X-Device-Name");
-                let device_type = read_header("X-Device-Type")
-                    .or_else(|| infer_device_type_from_ua(user_agent));
+                let device_type =
+                    read_header("X-Device-Type").or_else(|| infer_device_type_from_ua(user_agent));
                 let (ua_os_name, ua_os_version) = infer_os_from_ua(user_agent);
                 registry.register(
                     token_hash,

--- a/crates/zeroclaw-gateway/src/lib.rs
+++ b/crates/zeroclaw-gateway/src/lib.rs
@@ -1521,14 +1521,23 @@ fn infer_os_from_ua(ua: &str) -> (Option<String>, Option<String>) {
         let version = rest[..end].replace('_', ".");
         return (Some("macOS".into()), Some(version));
     }
-    // iOS: "iPhone; CPU iPhone OS 17_5_1 like Mac OS X"
-    if let Some(start) = ua.find("iPhone OS ").or_else(|| ua.find("iPad OS ")) {
-        let rest = &ua[start..];
-        let after_space = rest.find(' ').map(|i| &rest[i + 1..]).unwrap_or(rest);
-        let end = after_space
+    // iOS: "iPhone; CPU iPhone OS 17_5_1 like Mac OS X" or "iPad OS 17_5_1"
+    //
+    // Skip the literal prefix length per match (the two prefixes have
+    // different lengths: "iPhone OS " is 10, "iPad OS " is 8). Earlier code
+    // tried to share a single skip via `find(' ')` and landed on the space
+    // between "iPhone" and "OS" instead of the one before the version, which
+    // produced empty version strings on every iOS UA.
+    let ios_match = ua
+        .find("iPhone OS ")
+        .map(|i| i + "iPhone OS ".len())
+        .or_else(|| ua.find("iPad OS ").map(|i| i + "iPad OS ".len()));
+    if let Some(version_start) = ios_match {
+        let rest = &ua[version_start..];
+        let end = rest
             .find(|c: char| !(c.is_ascii_digit() || c == '_'))
-            .unwrap_or(after_space.len());
-        let version = after_space[..end].replace('_', ".");
+            .unwrap_or(rest.len());
+        let version = rest[..end].replace('_', ".");
         return (Some("iOS".into()), Some(version));
     }
     // Android: "Android 14;"
@@ -2637,6 +2646,110 @@ mod tests {
     fn generate_test_secret() -> String {
         let bytes: [u8; 32] = rand::random();
         hex::encode(bytes)
+    }
+
+    // ── User-Agent parsers ──────────────────────────────────────────
+    //
+    // One test per branch of `infer_os_from_ua` and `infer_device_type_from_ua`.
+    // The iOS case in particular caught a bug where the previous parser walked
+    // off the wrong space and produced `Some("iOS")` / `Some("")`.
+
+    #[test]
+    fn infer_os_from_ua_macos() {
+        let ua = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15";
+        assert_eq!(
+            infer_os_from_ua(ua),
+            (Some("macOS".into()), Some("10.15.7".into()))
+        );
+    }
+
+    #[test]
+    fn infer_os_from_ua_iphone_returns_version() {
+        let ua = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5_1 like Mac OS X) AppleWebKit/605.1.15";
+        // Regression: previously this returned `Some("")` because the parser
+        // walked the space between "iPhone" and "OS" instead of the one
+        // before the version.
+        assert_eq!(
+            infer_os_from_ua(ua),
+            (Some("iOS".into()), Some("17.5.1".into()))
+        );
+    }
+
+    #[test]
+    fn infer_os_from_ua_ipad_returns_version() {
+        let ua = "Mozilla/5.0 (iPad; CPU iPad OS 17_5_1 like Mac OS X) AppleWebKit/605.1.15";
+        // Same bug class as iPhone but with a 2-char-shorter prefix; verifies
+        // the per-prefix length skip handles both correctly.
+        assert_eq!(
+            infer_os_from_ua(ua),
+            (Some("iOS".into()), Some("17.5.1".into()))
+        );
+    }
+
+    #[test]
+    fn infer_os_from_ua_android() {
+        let ua = "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36";
+        // The "Android " prefix appears before the bare "Linux" word, so the
+        // Android branch should win. Without that ordering the result would
+        // be Linux/None.
+        assert_eq!(
+            infer_os_from_ua(ua),
+            (Some("Android".into()), Some("14".into()))
+        );
+    }
+
+    #[test]
+    fn infer_os_from_ua_windows() {
+        let ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36";
+        assert_eq!(
+            infer_os_from_ua(ua),
+            (Some("Windows".into()), Some("10.0".into()))
+        );
+    }
+
+    #[test]
+    fn infer_os_from_ua_linux_no_version() {
+        let ua = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36";
+        assert_eq!(infer_os_from_ua(ua), (Some("Linux".into()), None));
+    }
+
+    #[test]
+    fn infer_os_from_ua_empty_returns_none() {
+        assert_eq!(infer_os_from_ua(""), (None, None));
+    }
+
+    #[test]
+    fn infer_os_from_ua_unrecognised_returns_none() {
+        assert_eq!(
+            infer_os_from_ua("zeroclaw/0.7.4 some-weird-runtime"),
+            (None, None)
+        );
+    }
+
+    #[test]
+    fn infer_device_type_from_ua_branches() {
+        assert_eq!(
+            infer_device_type_from_ua("Mozilla/5.0 (iPhone; CPU iPhone OS 17_5_1 like Mac OS X)"),
+            Some("ios".into())
+        );
+        assert_eq!(
+            infer_device_type_from_ua("Mozilla/5.0 (Linux; Android 14)"),
+            Some("android".into())
+        );
+        assert_eq!(
+            infer_device_type_from_ua("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)"),
+            Some("macos".into())
+        );
+        assert_eq!(
+            infer_device_type_from_ua("Mozilla/5.0 (Windows NT 10.0)"),
+            Some("windows".into())
+        );
+        assert_eq!(
+            infer_device_type_from_ua("zeroclaw/0.7.4"),
+            Some("cli".into())
+        );
+        assert_eq!(infer_device_type_from_ua("curl/8.4.0"), Some("cli".into()));
+        assert_eq!(infer_device_type_from_ua(""), None);
     }
 
     #[test]

--- a/crates/zeroclaw-gateway/src/nodes.rs
+++ b/crates/zeroclaw-gateway/src/nodes.rs
@@ -146,6 +146,47 @@ impl NodeRegistry {
     }
 }
 
+/// `GET /api/nodes` — list daemons / external processes currently registered
+/// on `/ws/nodes`, with the capabilities each advertises.
+///
+/// Distinct from `/api/devices` (paired clients of *this* daemon). A node is
+/// a separate process — typically another ZeroClaw daemon, or a peripheral
+/// device that opted in to advertise tools.
+pub async fn list_nodes(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> impl IntoResponse {
+    if let Err(e) = super::api::require_auth(&state, &headers) {
+        return e.into_response();
+    }
+
+    let nodes_guard = state.node_registry.nodes.read();
+    let nodes: Vec<serde_json::Value> = nodes_guard
+        .values()
+        .map(|info| {
+            serde_json::json!({
+                "node_id": info.node_id,
+                "capabilities": info.capabilities,
+                "capability_count": info.capabilities.len(),
+                "status": "online",
+            })
+        })
+        .collect();
+    let count = nodes.len();
+    drop(nodes_guard);
+
+    let nodes_cfg = state.config.lock().nodes.clone();
+    axum::response::Json(serde_json::json!({
+        "nodes": nodes,
+        "count": count,
+        "policy": {
+            "stale_after_secs": nodes_cfg.stale_after_secs,
+            "offline_after_secs": nodes_cfg.offline_after_secs,
+        }
+    }))
+    .into_response()
+}
+
 /// Messages received from a node.
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]

--- a/crates/zeroclaw-gateway/src/nodes.rs
+++ b/crates/zeroclaw-gateway/src/nodes.rs
@@ -152,10 +152,7 @@ impl NodeRegistry {
 /// Distinct from `/api/devices` (paired clients of *this* daemon). A node is
 /// a separate process — typically another ZeroClaw daemon, or a peripheral
 /// device that opted in to advertise tools.
-pub async fn list_nodes(
-    State(state): State<AppState>,
-    headers: HeaderMap,
-) -> impl IntoResponse {
+pub async fn list_nodes(State(state): State<AppState>, headers: HeaderMap) -> impl IntoResponse {
     if let Err(e) = super::api::require_auth(&state, &headers) {
         return e.into_response();
     }

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -17,6 +17,7 @@ const routeTitles: Record<string, string> = {
   '/cost': 'nav.cost',
   '/logs': 'nav.logs',
   '/doctor': 'nav.doctor',
+  '/nodes': 'nav.nodes',
   '/onboard': 'nav.onboard',
 };
 

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -8,6 +8,7 @@ import {
   LayoutDashboard,
   MessageSquare,
   Monitor,
+  Network,
   Puzzle,
   Settings,
   Stethoscope,
@@ -32,6 +33,7 @@ const navItems: NavItem[] = [
   { to: '/cost', icon: DollarSign, labelKey: 'nav.cost' },
   { to: '/logs', icon: Activity, labelKey: 'nav.logs' },
   { to: '/doctor', icon: Stethoscope, labelKey: 'nav.doctor' },
+  { to: '/nodes', icon: Network, labelKey: 'nav.nodes' },
   { to: '/canvas', icon: Monitor, labelKey: 'nav.canvas' },
 ];
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -182,6 +182,96 @@ export function getHealth(): Promise<HealthSnapshot> {
 }
 
 // ---------------------------------------------------------------------------
+// Devices — paired ZeroClaw clients (laptops, phones, servers, CLIs)
+// ---------------------------------------------------------------------------
+
+export interface Device {
+  id: string;
+  name: string | null;
+  device_type: string | null;
+  paired_at: string;
+  last_seen: string;
+  ip_address: string | null;
+  hostname?: string | null;
+  os_name?: string | null;
+  os_version?: string | null;
+  agent_version?: string | null;
+}
+
+/// Health-pill thresholds shipped from the backend so the dashboard never
+/// hardcodes them. Sourced from `[nodes].stale_after_secs` /
+/// `[nodes].offline_after_secs` config knobs.
+export interface NodePolicy {
+  stale_after_secs: number;
+  offline_after_secs: number;
+}
+
+export interface DeviceList {
+  devices: Device[];
+  count: number;
+  policy: NodePolicy;
+}
+
+export function getDevices(): Promise<DeviceList> {
+  return apiFetch<DeviceList>('/api/devices');
+}
+
+export function revokeDevice(id: string): Promise<void> {
+  return apiFetch<void>(`/api/devices/${encodeURIComponent(id)}`, {
+    method: 'DELETE',
+  });
+}
+
+export function renameDevice(
+  id: string,
+  name: string | null,
+): Promise<{ device_id: string; name: string | null }> {
+  return apiFetch(`/api/devices/${encodeURIComponent(id)}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name }),
+  });
+}
+
+/// Generate a one-time code the user can give the target device to re-pair
+/// after rotating its token. The old token stays valid until the device
+/// re-pairs (no immediate revocation).
+export function rotateDeviceToken(
+  id: string,
+): Promise<{ device_id: string; pairing_code: string }> {
+  return apiFetch(`/api/devices/${encodeURIComponent(id)}/token/rotate`, {
+    method: 'POST',
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Nodes — separate ZeroClaw daemons / external processes registered on /ws/nodes
+// ---------------------------------------------------------------------------
+
+export interface NodeCapability {
+  name: string;
+  description: string;
+  parameters?: unknown;
+}
+
+export interface DaemonNode {
+  node_id: string;
+  capabilities: NodeCapability[];
+  capability_count: number;
+  status: 'online' | 'offline';
+}
+
+export interface NodeList {
+  nodes: DaemonNode[];
+  count: number;
+  policy: NodePolicy;
+}
+
+export function getNodes(): Promise<NodeList> {
+  return apiFetch<NodeList>('/api/nodes');
+}
+
+// ---------------------------------------------------------------------------
 // Config — per-property CRUD (issue #6175). Whole-file getConfig/putConfig
 // removed; the gateway no longer exposes those endpoints.
 // ---------------------------------------------------------------------------

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -391,6 +391,7 @@ const translations: Record<Locale, Record<string, string>> = {
     'nav.cost': 'Cost Tracker',
     'nav.logs': 'Logs',
     'nav.doctor': 'Doctor',
+    'nav.nodes': 'Nodes',
     'nav.canvas': 'Canvas',
     'nav.onboard': 'Onboard',
 

--- a/web/src/pages/Nodes.tsx
+++ b/web/src/pages/Nodes.tsx
@@ -1,0 +1,659 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  Network,
+  Server,
+  Laptop,
+  Smartphone,
+  Monitor,
+  Terminal,
+  Trash2,
+  RefreshCw,
+  Cpu,
+  Pencil,
+  KeyRound,
+  Check,
+  X,
+} from 'lucide-react';
+import {
+  getDevices,
+  getNodes,
+  renameDevice,
+  revokeDevice,
+  rotateDeviceToken,
+  type Device,
+  type DaemonNode,
+  type NodePolicy,
+} from '@/lib/api';
+
+/// Unified node entry — daemons and clients both render through the same shape.
+interface UnifiedNode {
+  /// Stable identifier for React keys + revoke targeting.
+  key: string;
+  /// Two flavours: a remote daemon (registered via `/ws/nodes`) or a paired client.
+  kind: 'daemon' | 'client';
+  /// Friendly label.
+  label: string;
+  /// Short identifier shown under the label (last 12 chars of full id).
+  shortKey: string;
+  /// Lucide icon for the node card.
+  icon: typeof Network;
+  /// "macOS", "Linux", "iOS Phone", "Daemon node", etc.
+  typeLabel: string;
+  /// Health bucket.
+  health: Health;
+  /// Optional fields rendered when present.
+  lastSeen?: string;
+  pairedAt?: string;
+  ipAddress?: string | null;
+  hostname?: string | null;
+  os?: string | null;
+  agentVersion?: string | null;
+  capabilities?: string[];
+  /// Source rows for revoke / future actions.
+  device?: Device;
+  daemon?: DaemonNode;
+}
+
+/// Dashboard refresh cadence. Frontend UX preference, not a server policy
+/// — server-driven values (stale/offline thresholds) come through
+/// `NodePolicy`.
+const POLL_INTERVAL_MS = 30_000;
+
+/// Conservative defaults used until the server has answered with its real
+/// policy on first load. Real values come from `[nodes].stale_after_secs` /
+/// `[nodes].offline_after_secs` and can be tuned without changing the
+/// frontend bundle.
+const DEFAULT_POLICY: NodePolicy = {
+  stale_after_secs: 300,
+  offline_after_secs: 1800,
+};
+
+type Health = 'online' | 'stale' | 'offline';
+
+function deviceHealth(lastSeenIso: string, policy: NodePolicy): Health {
+  try {
+    const diffSecs = (Date.now() - new Date(lastSeenIso).getTime()) / 1000;
+    if (diffSecs < policy.stale_after_secs) return 'online';
+    if (diffSecs < policy.offline_after_secs) return 'stale';
+    return 'offline';
+  } catch {
+    return 'offline';
+  }
+}
+
+function healthPillStyle(health: Health) {
+  switch (health) {
+    case 'online':
+      return {
+        label: 'Online',
+        background: 'rgba(0, 230, 138, 0.08)',
+        borderColor: 'rgba(0, 230, 138, 0.25)',
+        color: '#34d399',
+      };
+    case 'stale':
+      return {
+        label: 'Stale',
+        background: 'rgba(252, 165, 0, 0.10)',
+        borderColor: 'rgba(252, 165, 0, 0.30)',
+        color: 'var(--color-status-warning)',
+      };
+    case 'offline':
+      return {
+        label: 'Offline',
+        background: 'rgba(239, 68, 68, 0.10)',
+        borderColor: 'rgba(239, 68, 68, 0.30)',
+        color: 'var(--color-status-error)',
+      };
+  }
+}
+
+function formatRelative(iso: string): string {
+  try {
+    const diff = Date.now() - new Date(iso).getTime();
+    const seconds = Math.floor(diff / 1000);
+    if (seconds < 60) return 'just now';
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 60) return `${minutes} min ago`;
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return `${hours}h ago`;
+    const days = Math.floor(hours / 24);
+    return `${days} day${days === 1 ? '' : 's'} ago`;
+  } catch {
+    return iso;
+  }
+}
+
+function formatAbsolute(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return iso;
+  }
+}
+
+function deviceIcon(deviceType: string | null) {
+  const t = (deviceType ?? '').toLowerCase();
+  if (t.includes('phone') || t.includes('ios') || t.includes('android'))
+    return Smartphone;
+  if (t.includes('laptop') || t.includes('mac') || t.includes('darwin'))
+    return Laptop;
+  if (t.includes('cli') || t.includes('terminal')) return Terminal;
+  if (t.includes('desktop') || t.includes('windows')) return Monitor;
+  return Server;
+}
+
+function deviceTypeLabel(deviceType: string | null): string {
+  if (!deviceType) return 'Unknown';
+  return deviceType
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function shortId(id: string): string {
+  return id.length > 12 ? `${id.slice(0, 8)}…${id.slice(-4)}` : id;
+}
+
+function formatOs(
+  name: string | null | undefined,
+  version: string | null | undefined,
+): string | null {
+  if (!name) return null;
+  return version ? `${name} ${version}` : name;
+}
+
+// ─────────────────────────────────────────────────────────────────
+
+export default function Nodes() {
+  const [devices, setDevices] = useState<Device[]>([]);
+  const [nodes, setNodes] = useState<DaemonNode[]>([]);
+  const [policy, setPolicy] = useState<NodePolicy>(DEFAULT_POLICY);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [revoking, setRevoking] = useState<string | null>(null);
+
+  const fetchAll = useCallback(async () => {
+    try {
+      const [deviceList, nodeList] = await Promise.all([
+        getDevices(),
+        getNodes(),
+      ]);
+      setDevices(deviceList.devices);
+      setNodes(nodeList.nodes);
+      // Both endpoints return the same policy; prefer the devices response
+      // since it's the authoritative one for client lifecycle.
+      setPolicy(deviceList.policy ?? nodeList.policy ?? DEFAULT_POLICY);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchAll();
+    const id = window.setInterval(fetchAll, POLL_INTERVAL_MS);
+    return () => window.clearInterval(id);
+  }, [fetchAll]);
+
+  const handleRevoke = useCallback(
+    async (id: string, label: string) => {
+      // eslint-disable-next-line no-alert
+      if (!window.confirm(`Revoke "${label}"? It will need to re-pair.`)) {
+        return;
+      }
+      setRevoking(id);
+      try {
+        await revokeDevice(id);
+        await fetchAll();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        setRevoking(null);
+      }
+    },
+    [fetchAll],
+  );
+
+  const handleRename = useCallback(
+    async (id: string, newName: string | null) => {
+      try {
+        await renameDevice(id, newName);
+        await fetchAll();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    },
+    [fetchAll],
+  );
+
+  const handleRotate = useCallback(async (id: string, label: string) => {
+    try {
+      const { pairing_code } = await rotateDeviceToken(id);
+      // eslint-disable-next-line no-alert
+      window.alert(
+        `New pairing code for "${label}": ${pairing_code}\n\nGive this code to the device — it must re-pair within the next few minutes. The old token stays valid until then.`,
+      );
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }, []);
+
+  if (loading && devices.length === 0 && nodes.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <div
+          className="h-8 w-8 border-2 rounded-full animate-spin"
+          style={{
+            borderColor: 'var(--pc-border)',
+            borderTopColor: 'var(--pc-accent)',
+          }}
+        />
+      </div>
+    );
+  }
+
+  const unified = unifyNodes(nodes, devices, policy);
+
+  return (
+    <div className="p-6 space-y-6 animate-fade-in">
+      {/* Header */}
+      <div className="flex items-center gap-2">
+        <Network className="h-5 w-5" style={{ color: 'var(--pc-accent)' }} />
+        <h2
+          className="text-sm font-semibold uppercase tracking-wider"
+          style={{ color: 'var(--pc-text-primary)' }}
+        >
+          Nodes ({unified.length})
+        </h2>
+        <button
+          type="button"
+          onClick={fetchAll}
+          className="ml-auto inline-flex items-center gap-1.5 rounded-xl px-3 py-1.5 text-xs font-medium border transition-all"
+          style={{
+            borderColor: 'var(--pc-border)',
+            color: 'var(--pc-text-muted)',
+          }}
+          aria-label="Refresh"
+        >
+          <RefreshCw className="h-3.5 w-3.5" /> Refresh
+        </button>
+      </div>
+
+      <p className="text-sm" style={{ color: 'var(--pc-text-muted)' }}>
+        Every ZeroClaw instance across your fleet, with live health.
+      </p>
+
+      {error && (
+        <div
+          className="rounded-2xl border p-4 text-sm"
+          style={{
+            background: 'rgba(239, 68, 68, 0.08)',
+            borderColor: 'rgba(239, 68, 68, 0.2)',
+            color: '#f87171',
+          }}
+        >
+          {error}
+        </div>
+      )}
+
+      {unified.length === 0 ? (
+        <div
+          className="card p-8 text-center"
+          style={{ color: 'var(--pc-text-muted)' }}
+        >
+          <Network
+            className="h-10 w-10 mx-auto mb-3 opacity-30"
+            style={{ color: 'var(--pc-text-faint)' }}
+          />
+          <p className="text-sm">No nodes connected yet.</p>
+          <p
+            className="text-xs mt-1"
+            style={{ color: 'var(--pc-text-faint)' }}
+          >
+            Pair a client from this machine, or run{' '}
+            <code>zeroclaw node add &lt;url&gt;</code> from another to join it
+            to the fleet.
+          </p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 stagger-children">
+          {unified.map((node) => (
+            <NodeCard
+              key={node.key}
+              node={node}
+              revoking={!!node.device && revoking === node.device.id}
+              onRevoke={
+                node.device
+                  ? () => handleRevoke(node.device!.id, node.label)
+                  : undefined
+              }
+              onRename={
+                node.device
+                  ? (newName) => handleRename(node.device!.id, newName)
+                  : undefined
+              }
+              onRotateToken={
+                node.device
+                  ? () => handleRotate(node.device!.id, node.label)
+                  : undefined
+              }
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────
+
+function unifyNodes(
+  daemons: DaemonNode[],
+  devices: Device[],
+  policy: NodePolicy,
+): UnifiedNode[] {
+  const fromDaemons: UnifiedNode[] = daemons.map((d) => ({
+    key: `node:${d.node_id}`,
+    kind: 'daemon',
+    label: d.node_id,
+    shortKey: shortId(d.node_id),
+    icon: Cpu,
+    typeLabel: 'Daemon node',
+    health: 'online',
+    capabilities: d.capabilities.map((c) => c.name),
+    daemon: d,
+  }));
+
+  const fromDevices: UnifiedNode[] = devices.map((d) => ({
+    key: `device:${d.id}`,
+    kind: 'client',
+    label: d.hostname ?? d.name ?? deviceTypeLabel(d.device_type),
+    shortKey: shortId(d.id),
+    icon: deviceIcon(d.device_type),
+    typeLabel: deviceTypeLabel(d.device_type),
+    health: deviceHealth(d.last_seen, policy),
+    lastSeen: d.last_seen,
+    pairedAt: d.paired_at,
+    ipAddress: d.ip_address,
+    hostname: d.hostname,
+    os: formatOs(d.os_name, d.os_version),
+    agentVersion: d.agent_version,
+    device: d,
+  }));
+
+  // Daemon nodes first (they're typically the more important ones), then clients
+  // sorted by health (online → stale → offline) and most-recently-seen first.
+  return [...fromDaemons, ...fromDevices.sort((a, b) => {
+    const order: Record<Health, number> = { online: 0, stale: 1, offline: 2 };
+    const ha = order[a.health] - order[b.health];
+    if (ha !== 0) return ha;
+    if (a.lastSeen && b.lastSeen) {
+      return new Date(b.lastSeen).getTime() - new Date(a.lastSeen).getTime();
+    }
+    return 0;
+  })];
+}
+
+// ─────────────────────────────────────────────────────────────────
+
+interface NodeCardProps {
+  node: UnifiedNode;
+  revoking: boolean;
+  /// Only paired clients can be revoked; daemons get `undefined` (no button).
+  onRevoke?: () => void;
+  /// Inline rename. `null` clears the label back to the inferred default.
+  onRename?: (newName: string | null) => void;
+  /// Issue a fresh pairing code for this device (alerts the user with it).
+  onRotateToken?: () => void;
+}
+
+function NodeCard({
+  node,
+  revoking,
+  onRevoke,
+  onRename,
+  onRotateToken,
+}: NodeCardProps) {
+  const Icon = node.icon;
+  const pill = healthPillStyle(node.health);
+  const [editing, setEditing] = useState(false);
+  const [draftName, setDraftName] = useState(node.label);
+
+  const startEdit = () => {
+    setDraftName(node.label);
+    setEditing(true);
+  };
+
+  const saveEdit = () => {
+    const trimmed = draftName.trim();
+    onRename?.(trimmed === '' ? null : trimmed);
+    setEditing(false);
+  };
+
+  const cancelEdit = () => {
+    setDraftName(node.label);
+    setEditing(false);
+  };
+
+  return (
+    <div
+      className="card p-5 animate-slide-in-up"
+      style={{ opacity: revoking ? 0.5 : 1 }}
+    >
+      <div className="flex items-start gap-3">
+        <div
+          className="p-2 rounded-2xl shrink-0"
+          style={{
+            background: 'rgba(var(--pc-accent-rgb), 0.08)',
+            color: 'var(--pc-accent)',
+          }}
+        >
+          <Icon className="h-5 w-5" />
+        </div>
+        <div className="flex-1 min-w-0">
+          {editing ? (
+            <div className="flex items-center gap-1">
+              <input
+                type="text"
+                value={draftName}
+                onChange={(e) => setDraftName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') saveEdit();
+                  if (e.key === 'Escape') cancelEdit();
+                }}
+                autoFocus
+                className="flex-1 min-w-0 input-electric text-sm py-1 px-2"
+                placeholder="Device label"
+              />
+              <button
+                type="button"
+                onClick={saveEdit}
+                className="p-1 rounded-xl hover:bg-(--pc-hover)"
+                style={{ color: 'var(--color-status-success)' }}
+                aria-label="Save"
+              >
+                <Check className="h-4 w-4" />
+              </button>
+              <button
+                type="button"
+                onClick={cancelEdit}
+                className="p-1 rounded-xl hover:bg-(--pc-hover)"
+                style={{ color: 'var(--pc-text-muted)' }}
+                aria-label="Cancel"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+          ) : (
+            <div className="flex items-center gap-1.5 group">
+              <h4
+                className="text-sm font-semibold truncate"
+                style={{ color: 'var(--pc-text-primary)' }}
+              >
+                {node.label}
+              </h4>
+              {onRename && (
+                <button
+                  type="button"
+                  onClick={startEdit}
+                  className="p-0.5 rounded-md opacity-0 group-hover:opacity-100 transition-opacity hover:bg-(--pc-hover)"
+                  style={{ color: 'var(--pc-text-muted)' }}
+                  aria-label="Rename"
+                  title="Rename"
+                >
+                  <Pencil className="h-3 w-3" />
+                </button>
+              )}
+            </div>
+          )}
+          <p
+            className="text-xs font-mono truncate"
+            style={{ color: 'var(--pc-text-faint)' }}
+            title={node.key}
+          >
+            {node.shortKey}
+          </p>
+        </div>
+        <span
+          className="rounded-full px-2 py-0.5 text-[10px] font-medium border shrink-0"
+          style={pill}
+        >
+          {pill.label}
+        </span>
+        {onRotateToken && (
+          <button
+            type="button"
+            onClick={onRotateToken}
+            className="p-1.5 rounded-xl transition-all hover:bg-(--pc-hover)"
+            style={{ color: 'var(--pc-text-muted)' }}
+            aria-label={`Rotate token for ${node.label}`}
+            title="Rotate token"
+          >
+            <KeyRound className="h-4 w-4" />
+          </button>
+        )}
+        {onRevoke && (
+          <button
+            type="button"
+            onClick={onRevoke}
+            disabled={revoking}
+            className="p-1.5 rounded-xl transition-all disabled:opacity-50 hover:bg-(--pc-hover)"
+            style={{ color: 'var(--color-status-error)' }}
+            aria-label={`Revoke ${node.label}`}
+            title="Revoke node"
+          >
+            <Trash2 className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+
+      <div
+        className="mt-4 pt-3 border-t space-y-1.5 text-xs"
+        style={{ borderColor: 'var(--pc-border)' }}
+      >
+        {/*
+          Show OS when we have a precise value (e.g. "macOS 10.15.7"); fall
+          back to the coarser device_type ("Cli", "Browser") when the OS is
+          unknown. Avoids the duplication where Type=Macos and OS=macOS
+          would both render.
+        */}
+        <div className="flex justify-between">
+          <span style={{ color: 'var(--pc-text-muted)' }}>Platform</span>
+          <span
+            className="capitalize truncate ml-2"
+            style={{ color: 'var(--pc-text-secondary)' }}
+          >
+            {node.os ?? node.typeLabel}
+          </span>
+        </div>
+        {node.hostname && (
+          <div className="flex justify-between">
+            <span style={{ color: 'var(--pc-text-muted)' }}>Host</span>
+            <span
+              className="font-mono truncate ml-2"
+              style={{ color: 'var(--pc-text-secondary)' }}
+              title={node.hostname}
+            >
+              {node.hostname}
+            </span>
+          </div>
+        )}
+        {node.agentVersion && (
+          <div className="flex justify-between">
+            <span style={{ color: 'var(--pc-text-muted)' }}>Agent</span>
+            <span
+              className="font-mono"
+              style={{ color: 'var(--pc-text-secondary)' }}
+            >
+              v{node.agentVersion.replace(/^v/, '')}
+            </span>
+          </div>
+        )}
+        {node.lastSeen && (
+          <div className="flex justify-between">
+            <span style={{ color: 'var(--pc-text-muted)' }}>Last seen</span>
+            <span
+              title={formatAbsolute(node.lastSeen)}
+              style={{ color: 'var(--pc-text-secondary)' }}
+            >
+              {formatRelative(node.lastSeen)}
+            </span>
+          </div>
+        )}
+        {node.pairedAt && (
+          <div className="flex justify-between">
+            <span style={{ color: 'var(--pc-text-muted)' }}>Joined</span>
+            <span
+              title={formatAbsolute(node.pairedAt)}
+              style={{ color: 'var(--pc-text-secondary)' }}
+            >
+              {formatRelative(node.pairedAt)}
+            </span>
+          </div>
+        )}
+        {node.ipAddress && (
+          <div className="flex justify-between">
+            <span style={{ color: 'var(--pc-text-muted)' }}>IP</span>
+            <span
+              className="font-mono"
+              style={{ color: 'var(--pc-text-faint)' }}
+            >
+              {node.ipAddress}
+            </span>
+          </div>
+        )}
+        {node.capabilities && node.capabilities.length > 0 && (
+          <div className="pt-1">
+            <span style={{ color: 'var(--pc-text-muted)' }}>
+              Capabilities ({node.capabilities.length})
+            </span>
+            <div className="flex flex-wrap gap-1 mt-1.5">
+              {node.capabilities.slice(0, 4).map((cap) => (
+                <span
+                  key={cap}
+                  className="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-mono border"
+                  style={{
+                    borderColor: 'var(--pc-border)',
+                    color: 'var(--pc-text-muted)',
+                    background: 'var(--pc-bg-base)',
+                  }}
+                >
+                  {cap}
+                </span>
+              ))}
+              {node.capabilities.length > 4 && (
+                <span
+                  className="text-[10px] self-center"
+                  style={{ color: 'var(--pc-text-faint)' }}
+                >
+                  +{node.capabilities.length - 4} more
+                </span>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/router/lazyPages.tsx
+++ b/web/src/router/lazyPages.tsx
@@ -12,4 +12,5 @@ export const Logs = lazy(() => import('../pages/Logs'));
 export const Doctor = lazy(() => import('../pages/Doctor'));
 export const Pairing = lazy(() => import('../pages/Pairing'));
 export const Canvas = lazy(() => import('../pages/Canvas'));
+export const Nodes = lazy(() => import('../pages/Nodes'));
 export const Onboard = lazy(() => import('../pages/onboard/Onboard'));

--- a/web/src/router/router.tsx
+++ b/web/src/router/router.tsx
@@ -11,6 +11,7 @@ import {
   Integrations,
   Logs,
   Memory,
+  Nodes,
   Onboard,
   Pairing,
   Tools,
@@ -43,6 +44,7 @@ export const Router = () => (
         <Route path="/cost" element={<Cost />} />
         <Route path="/logs" element={<Logs />} />
         <Route path="/doctor" element={<Doctor />} />
+        <Route path="/nodes" element={<Nodes />} />
         <Route path="/pairing" element={<Pairing />} />
         <Route path="/canvas" element={<Canvas />} />
         <Route path="/onboard" element={<Onboard />} />


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Adds a `/nodes` dashboard page so operators can see every ZeroClaw instance across the fleet (paired clients today, daemon nodes once the fleet-add CLI lands) with live health, identification metadata, inline rename, and token rotation — previously the dashboard had no view of paired devices at all, and the existing pairing path didn't even register them.
  - Extends `DeviceInfo` with `hostname` / `os_name` / `os_version` / `agent_version` (additive SQLite migration via `ALTER TABLE … ADD COLUMN` per new column, preserving existing `devices.db` rows) so cards can show real platform/host/agent metadata instead of just `device_type`.
  - Wires the simple header-based `POST /pair` path into `DeviceRegistry::register` so dashboard-paired devices appear in `/api/devices` (previously only the JSON `/api/pair` flow registered). This is a feature add, not a regression fix — the simple pair path gains device-registry wiring it didn't have before.
  - Server now drives staleness via `nodes.stale_after_secs` (default 300s) and `nodes.offline_after_secs` (default 1800s), exposed in a `policy` block on both `/api/devices` and `/api/nodes`. The frontend keeps a conservative `DEFAULT_POLICY` only for first-paint and otherwise reads the server values, so thresholds are tunable via the existing config CLI/API surface without a redeploy.
  - Adds `PATCH /api/devices/:id` (`{name}` body) for inline rename and wires the existing rotate-token endpoint into the dashboard; new `GET /api/nodes` lists daemons currently registered on `/ws/nodes` and emits the same `policy` block.
- **Scope boundary:** Does **not** add the `zeroclaw node add <url>` CLI (filed as #6390 — needs a daemon-side WS client + persistent peer table) and does **not** add real heartbeat tracking for daemon nodes (filed as #6391 — WS message timestamp + status derivation). Both linked back to #6346, so it stays open until they ship plus the cross-cutting docs entry.
- **Blast radius:** `zeroclaw-gateway` HTTP surface (new route, two response-shape additions: new `DeviceInfo` fields and a `policy` block on the list endpoints — additive, existing consumers ignore them); `zeroclaw-config` schema gains two new `nodes.*` keys (additive defaults); `devices.db` schema gets four new nullable columns via in-place `ALTER TABLE`; the web app gains a new route and sidebar entry. No changes to providers, channels, agent loop, memory, security, tools, or daemon WS protocol.
- **Linked issue(s):** Refs #6346 (this PR ships the dashboard half — paired-client list, identification fields, inline rename, token rotation, server-driven health policy). #6346 will be closed by the merges of #6390 (CLI) and #6391 (heartbeat). Using `Refs` rather than `Closes` deliberately so GitHub does not auto-close #6346 on this merge.

## Validation Evidence (required)

Local validation is the signal CI cannot replace. Run the full battery and paste literal output (tails, failures, warnings — not \"all passed\").

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` — clean.
  - `cargo clippy --all-targets -- -D warnings` — clean across the workspace (3 auto-fixes applied during development in the new pair-handler additions).
  - `cargo test` — 164 `zeroclaw-gateway` lib tests pass; full workspace test run green.
  - Toolchain: `rustc 1.93.1 (01f6ddf75 2026-02-11)`.
- **Beyond CI — what did you manually verify?** End-to-end smoke on a temp config dir on port 42618:
  - **Pair flow with rich headers:** Browser pair populates `hostname` / `os_name` / `os_version` / `agent_version` correctly; CLI/iPhone/Mac/Living-Room-Mac all render with the right `Platform` line (OS+version preferred, falls back to `device_type` only when neither OS nor version is known — this fixes the duplication where the old card showed both `Type: Macos` and `OS: macOS 10.15.7`).
  - **Rename:** `PATCH /api/devices/:id` with `{name}` persists to SQLite; rename survives restart.
  - **Rotate:** existing rotate-token endpoint returns a fresh pair code from the dashboard.
  - **Revoke:** `DELETE /api/devices/:id` removes the device.
  - **Migration:** Started against a pre-existing `devices.db` that lacked the four new columns — additive `ALTER TABLE` applied cleanly, existing rows preserved, new fields populated on subsequent re-pair.
  - **Persistence:** Killed and re-spawned the gateway across multiple sessions; the device list grew 4 → 7 → 11 with no row loss.
  - **Health pill:** Verified Online / Stale / Offline transitions by adjusting `nodes.stale_after_secs` and `nodes.offline_after_secs` via the config surface and watching the server-driven policy propagate to the cards.
  - **Not verified in this PR:** real daemon-node heartbeat behaviour over `/ws/nodes` (deferred to #6391 — current `/api/nodes` only lists in-memory `NodeRegistry::register` entries on WS handshake) and the `zeroclaw node add <url>` CLI (deferred to #6390).
- **If any command was intentionally skipped, why:** None skipped.

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`) — all new endpoints are local gateway HTTP routes.
- Secrets / tokens / credentials handling changed? (`No`) — token rotation surfaces an existing endpoint to the dashboard; no change to issuance, storage, or scope.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`) — `hostname` / `os_name` / `os_version` / `agent_version` are operator-supplied device metadata stored locally in `devices.db`, not exfiltrated anywhere. No real identities, emails, or personal data appear in diff or fixtures.
- If any `Yes`, describe the risk and mitigation: N/A.

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`Yes`) — additive only:
  - New config keys `nodes.stale_after_secs` (default `300`) and `nodes.offline_after_secs` (default `1800`), auto-discoverable as `nodes.stale-after-secs` / `nodes.offline-after-secs` via the existing config CLI/API surface.
  - New HTTP route `PATCH /api/devices/:id` (`{name}` body) and new `GET /api/nodes`. Existing `/api/devices` response gains four new optional `DeviceInfo` fields and a top-level `policy` block; existing clients ignore the additions.
  - Additive SQLite migration on `devices.db` — no manual step required.
- If `No` or `Yes` to either: exact upgrade steps for existing users: None. Restart picks up the new defaults; the migration is automatic.

## Rollback (required for `risk: medium` and `risk: high`)

This PR touches `crates/zeroclaw-gateway/**`, which the auto-labeler classifies as `risk: high`. Filling the medium/high section.

- **Fast rollback command/path:** `git revert a53154461`. The additive `ALTER TABLE` columns can stay in place harmlessly (older code ignores them); no manual schema rollback needed.
- **Feature flags or config toggles:** None for the dashboard page itself. The two new config keys (`nodes.stale_after_secs` / `nodes.offline_after_secs`) only affect the displayed health pill — setting them to very large values effectively suppresses Stale/Offline classification without code changes.
- **Observable failure symptoms:**
  - Gateway logs: `register` errors from `api_pairing` after a `POST /pair`, or `ALTER TABLE` migration errors on startup against `devices.db`.
  - HTTP: `PATCH /api/devices/:id` or `GET /api/nodes` returning `404` / `500`.
  - UI: `/nodes` page failing to load, empty card list after a successful pair, or health pills stuck on the frontend `DEFAULT_POLICY` (would indicate the server `policy` block isn't being read).
  - Metric/grep: `tail -f` the gateway log for `device_registry` and `nodes` spans; sustained errors on either is the signal.

---

> Reviewer: please drag-drop a screenshot of the running `/nodes` page (the `NODES (11)` view with the Browser / CLI / iPhone / Mac / Living-Room-Mac cards showing `Platform` / `Host` / `Agent` / `Last seen` / `Joined` / `IP` and the per-card key + trash icons) into this description before merging — the feature was built from a screenshot the author attached in chat that wasn't accessible from the editing context.

<img width="1242" height="1290" alt="Screenshot 2026-05-04 at 11 43 23 PM" src="https://github.com/user-attachments/assets/9ccca632-d7ce-4056-84e8-45e27461f83a" />
