### PR TITLE
fix: derive HTTP client timeout from tool_timeout_secs (fixes #6383)

### DIFF
--- a/crates/zeroclaw-tools/src/mcp_transport.rs
+++ b/crates/zeroclaw-tools/src/mcp_transport.rs
@@ -150,15 +150,20 @@ impl McpTransportConn for StdioTransport {
 pub struct HttpTransport {
     url: String,
     /// Per-server tool-call SSE read timeout, from `McpServerConfig.tool_timeout_secs`.
-    /// `None` falls back to `RECV_TIMEOUT_SECS` (used for init/list, where a slow
-    /// server should be cut short). Tool calls — which the client layer already
-    /// wraps in `tool_timeout_secs` — need the same budget at the transport
-    /// layer; otherwise the inner 30s fires first on slow SSE responses (e.g.
-    /// Canva's `generate-design`, 45–90s) and the outer timeout is unreachable.
+    /// `None` falls back to `RECV_TIMEOUT_SECS` for init/list operations.
+    /// Also drives the reqwest client-wide timeout via `http_client_timeout_secs`
+    /// so the client never fires before the configured per-call budget.
     tool_timeout_secs: Option<u64>,
     client: reqwest::Client,
     headers: std::collections::HashMap<String, String>,
     session_id: Option<String>,
+}
+
+/// Compute the reqwest client-wide timeout so it never undercuts the configured
+/// tool budget. The client timeout must be at least as large as `tool_timeout_secs`
+/// so it does not fire before the per-call SSE read wrapper.
+fn http_client_timeout_secs(tool_timeout_secs: Option<u64>) -> u64 {
+    tool_timeout_secs.unwrap_or(120).max(120)
 }
 
 impl HttpTransport {
@@ -170,7 +175,9 @@ impl HttpTransport {
             .clone();
 
         let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(120))
+            .timeout(Duration::from_secs(http_client_timeout_secs(
+                config.tool_timeout_secs,
+            )))
             .build()
             .context("failed to build HTTP client")?;
 
@@ -1065,6 +1072,37 @@ mod tests {
                 .and_then(|v| v.to_str().ok()),
             Some("session-xyz")
         );
+    }
+
+    // ── http_client_timeout_secs tests ───────────────────────────────────────
+
+    #[test]
+    fn http_client_timeout_defaults_to_120_when_tool_timeout_unset() {
+        assert_eq!(http_client_timeout_secs(None), 120);
+    }
+
+    #[test]
+    fn http_client_timeout_uses_tool_timeout_when_above_120() {
+        assert_eq!(http_client_timeout_secs(Some(300)), 300);
+        assert_eq!(http_client_timeout_secs(Some(600)), 600);
+    }
+
+    #[test]
+    fn http_client_timeout_keeps_120_floor_when_tool_timeout_below_120() {
+        assert_eq!(http_client_timeout_secs(Some(30)), 120);
+        assert_eq!(http_client_timeout_secs(Some(1)), 120);
+    }
+
+    #[test]
+    fn http_transport_builds_successfully_with_high_tool_timeout() {
+        let config = McpServerConfig {
+            name: "test-http-slow".into(),
+            transport: McpTransport::Http,
+            url: Some("http://localhost/mcp".into()),
+            tool_timeout_secs: Some(300),
+            ..Default::default()
+        };
+        assert!(HttpTransport::new(&config).is_ok());
     }
 
     // ── derive_message_url tests ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Fixes #6383.
  - `HttpTransport::new()` no longer builds the reqwest client with a hardcoded 120s timeout when `tool_timeout_secs` is configured above 120s.
  - Adds `http_client_timeout_secs(tool_timeout_secs: Option<u64>) -> u64`, returning `max(tool_timeout_secs, 120)` so the reqwest client timeout cannot undercut the configured tool-call budget.
  - Updates focused transport tests for unset, below-floor, above-floor, and high-timeout construction cases.
- **Scope boundary:** This PR only adjusts the streamable HTTP `HttpTransport` client timeout. It does not retune all MCP request timeout policy and does not change the older `SseTransport` POST timeout path.
- **Blast radius:** HTTP/SSE MCP tool calls using `HttpTransport`, especially servers configured with `tool_timeout_secs > 120`.
- **Linked issue(s):** Closes #6383.

## Validation Evidence (required)

- **Commands run and tail output:**

Author-reported local validation:

```bash
cargo test -p zeroclaw-tools --lib mcp_transport
```

Literal local tail output was not pasted into the PR body. Reviewer-side validation did not rerun local cargo; review relied on source inspection plus GitHub CI.

GitHub CI on head `c63378cd84c0ed4dbfc65d801e618846cdd1d6da` is green:

```text
Lint: pass
Check (all features): pass
Check (no default features): pass
Check (32-bit): pass
Test: pass
Security: pass
Build x86_64-unknown-linux-gnu: pass
Build aarch64-apple-darwin: pass
Build x86_64-pc-windows-msvc: pass
Benchmarks Compile: pass
CI Required Gate: pass
```

- **Beyond CI — what did you manually verify?** Source inspection verifies the previous hardcoded `Duration::from_secs(120)` in `HttpTransport::new()` is now derived from `tool_timeout_secs` with a 120s floor. No live slow HTTP/SSE MCP server repro output is included in this PR.
- **If any command was intentionally skipped, why:** Reviewer did not rerun local cargo because the PR is a one-file, focused change with green workspace CI. No live long-running MCP server was exercised because the regression is covered by source inspection and focused unit tests.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: Not applicable.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No upgrade steps required. Existing `tool_timeout_secs` configuration keeps working; this PR makes the HTTP client timeout honor that existing budget when it is above 120s.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** Revert the squash commit for this PR, or revert PR #6397 from GitHub after merge.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** HTTP/SSE MCP tools may time out too early or wait longer than expected. Relevant symptoms include MCP tool-call timeout errors, `HTTP request to MCP server failed`, or streamable HTTP SSE timeout messages around slow MCP tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
