### PR TITLE
fix(channels): reject concurrent ACP prompts

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/acp_server.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/acp_server.rs
@@ -101,6 +101,7 @@ const INTERNAL_ERROR: i32 = -32603;
 // Custom error codes
 const SESSION_NOT_FOUND: i32 = -32000;
 const SESSION_LIMIT_REACHED: i32 = -32001;
+const SESSION_BUSY: i32 = -32002;
 const ACP_PROTOCOL_VERSION: u64 = 1;
 
 // ── Outbound JSON-RPC plumbing ───────────────────────────────────
@@ -282,12 +283,9 @@ pub struct AcpServer {
     /// **Single-turn-per-session invariant:** this map holds at most one token
     /// per `session_id` because the ACP protocol does not pipeline multiple
     /// `session/prompt` calls on the same session — each prompt must complete
-    /// (or be cancelled) before the next one is sent. A second `session/prompt`
-    /// arriving while the first is in flight would overwrite turn 1's token in
-    /// this map, so a `session/cancel` fired between the overwrite and turn 1's
-    /// completion would silently target turn 2 instead. The worst-case outcome
-    /// is "cancel doesn't take" rather than data corruption. If pipelining is
-    /// needed in the future, the key should become `(session_id, turn_id)`.
+    /// (or be cancelled) before the next one is sent. A second prompt is
+    /// rejected before it can overwrite the active turn's token. If pipelining
+    /// is needed in the future, the key should become `(session_id, turn_id)`.
     cancel_tokens: Arc<std::sync::Mutex<HashMap<String, tokio_util::sync::CancellationToken>>>,
 }
 
@@ -642,8 +640,6 @@ impl AcpServer {
             })?
         };
 
-        let (event_tx, mut event_rx) = tokio::sync::mpsc::channel::<TurnEvent>(100);
-
         // Create a cancellation token for this turn and register it so that a
         // concurrent `session/cancel` notification can fire it without waiting
         // for the inner session lock (which is held for the full turn duration).
@@ -651,12 +647,8 @@ impl AcpServer {
         // mutex are short, infallible HashMap operations (insert/remove/get)
         // that never call user code, panic, or block on I/O.
         let cancel_token = tokio_util::sync::CancellationToken::new();
-        {
-            self.cancel_tokens
-                .lock()
-                .expect("cancel_tokens lock poisoned — invariant: all guarded critical sections are short, infallible HashMap ops")
-                .insert(session_id.clone(), cancel_token.clone());
-        }
+        self.register_cancel_token(&session_id, cancel_token.clone())?;
+        let (event_tx, mut event_rx) = tokio::sync::mpsc::channel::<TurnEvent>(100);
 
         // Move the Arc into the spawned task and lock inside it.  The inner
         // Mutex stays locked for the duration of the turn, preventing
@@ -689,12 +681,7 @@ impl AcpServer {
 
         // Remove the cancel token regardless of outcome — the turn is over.
         // Lock poisoned invariant: same as the insert site above.
-        {
-            self.cancel_tokens
-                .lock()
-                .expect("cancel_tokens lock poisoned — invariant: all guarded critical sections are short, infallible HashMap ops")
-                .remove(&session_id);
-        }
+        self.remove_cancel_token(&session_id);
 
         let turn_result = turn_handle.await.map_err(|e| RpcError {
             code: INTERNAL_ERROR,
@@ -710,16 +697,7 @@ impl AcpServer {
         };
 
         if was_cancelled {
-            let content = if accumulated_text.is_empty() {
-                "[interrupted by user]".to_string()
-            } else {
-                format!("{accumulated_text}\n\n[interrupted by user]")
-            };
-            return Ok(serde_json::json!({
-                "sessionId": session_id,
-                "stopReason": "cancelled",
-                "content": content,
-            }));
+            return Ok(Self::cancelled_prompt_result(session_id, &accumulated_text));
         }
 
         let result = turn_result.map_err(|e| RpcError {
@@ -728,11 +706,51 @@ impl AcpServer {
             data: None,
         })?;
 
-        Ok(serde_json::json!({
+        Ok(Self::prompt_result(session_id, "end_turn", result))
+    }
+
+    fn register_cancel_token(
+        &self,
+        session_id: &str,
+        cancel_token: tokio_util::sync::CancellationToken,
+    ) -> std::result::Result<(), RpcError> {
+        let mut tokens = self
+            .cancel_tokens
+            .lock()
+            .expect("cancel_tokens lock poisoned — invariant: all guarded critical sections are short, infallible HashMap ops");
+        if tokens.contains_key(session_id) {
+            return Err(RpcError {
+                code: SESSION_BUSY,
+                message: format!("Session already has an active prompt turn: {session_id}"),
+                data: None,
+            });
+        }
+        tokens.insert(session_id.to_string(), cancel_token);
+        Ok(())
+    }
+
+    fn remove_cancel_token(&self, session_id: &str) {
+        self.cancel_tokens
+            .lock()
+            .expect("cancel_tokens lock poisoned — invariant: all guarded critical sections are short, infallible HashMap ops")
+            .remove(session_id);
+    }
+
+    fn prompt_result(session_id: String, stop_reason: &'static str, text: String) -> Value {
+        serde_json::json!({
             "sessionId": session_id,
-            "stopReason": "end_turn",
-            "content": result,  // full assembled response for clients that expect it
-        }))
+            "stopReason": stop_reason,
+            "content": text,
+        })
+    }
+
+    fn cancelled_prompt_result(session_id: String, accumulated_text: &str) -> Value {
+        let content = if accumulated_text.is_empty() {
+            "[interrupted by user]".to_string()
+        } else {
+            format!("{accumulated_text}\n\n[interrupted by user]")
+        };
+        Self::prompt_result(session_id, "cancelled", content)
     }
 
     fn parse_prompt(params: &Value) -> std::result::Result<String, RpcError> {
@@ -815,6 +833,7 @@ impl AcpServer {
     async fn handle_session_cancel(&self, params: &Value) -> RpcResult {
         let session_id = params
             .get("sessionId")
+            .or_else(|| params.get("session_id"))
             .and_then(|v| v.as_str())
             .ok_or_else(|| RpcError {
                 code: INVALID_PARAMS,
@@ -1372,6 +1391,29 @@ mod tests {
     }
 
     #[test]
+    fn prompt_result_preserves_content_string_shape() {
+        let result = AcpServer::prompt_result("test-sid".to_string(), "end_turn", "hello".into());
+        assert_eq!(result["sessionId"], "test-sid");
+        assert_eq!(result["stopReason"], "end_turn");
+        assert_eq!(result["content"], "hello");
+    }
+
+    #[test]
+    fn cancelled_prompt_result_preserves_content_string_shape() {
+        let with_partial =
+            AcpServer::cancelled_prompt_result("test-sid".to_string(), "partial text");
+        assert_eq!(with_partial["sessionId"], "test-sid");
+        assert_eq!(with_partial["stopReason"], "cancelled");
+        assert_eq!(
+            with_partial["content"],
+            "partial text\n\n[interrupted by user]"
+        );
+
+        let marker_only = AcpServer::cancelled_prompt_result("test-sid".to_string(), "");
+        assert_eq!(marker_only["content"], "[interrupted by user]");
+    }
+
+    #[test]
     fn test_tool_call_and_update_serialization() {
         // Test tool_call (initial pending event)
         let tool_call_notif = JsonRpcNotification {
@@ -1630,6 +1672,107 @@ mod tests {
             result.is_ok(),
             "unknown-session cancel must succeed: {result:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn session_cancel_accepts_snake_case_session_id() {
+        let cwd = tempfile::tempdir().unwrap();
+        let server = Arc::new(AcpServer::new(
+            make_test_config(cwd.path()),
+            AcpServerConfig::default(),
+        ));
+
+        let session_id = "sess_snake_case_cancel";
+        let active_token = tokio_util::sync::CancellationToken::new();
+        server
+            .register_cancel_token(session_id, active_token.clone())
+            .expect("active turn should register token");
+
+        server
+            .handle_session_cancel(&serde_json::json!({ "session_id": session_id }))
+            .await
+            .expect("snake_case session_id should cancel the active turn");
+
+        assert!(active_token.is_cancelled());
+    }
+
+    /// A second prompt for the same session must fail before it can overwrite
+    /// the active turn's cancellation token.
+    #[tokio::test]
+    async fn register_cancel_token_rejects_concurrent_prompt_for_session() {
+        let cwd = tempfile::tempdir().unwrap();
+        let server = Arc::new(AcpServer::new(
+            make_test_config(cwd.path()),
+            AcpServerConfig::default(),
+        ));
+
+        let session_id = "sess_active_turn";
+        let active_token = tokio_util::sync::CancellationToken::new();
+        let queued_token = tokio_util::sync::CancellationToken::new();
+
+        server
+            .register_cancel_token(session_id, active_token.clone())
+            .expect("first prompt should register its token");
+        let err = server
+            .register_cancel_token(session_id, queued_token.clone())
+            .expect_err("second prompt must not overwrite active token");
+
+        assert_eq!(err.code, SESSION_BUSY);
+        assert!(
+            err.message.contains("active prompt turn"),
+            "error should explain why prompt was rejected: {}",
+            err.message
+        );
+
+        server
+            .handle_session_cancel(&serde_json::json!({ "sessionId": session_id }))
+            .await
+            .expect("cancel should still target active token");
+
+        assert!(active_token.is_cancelled());
+        assert!(
+            !queued_token.is_cancelled(),
+            "rejected prompt's token must not become the active cancel target"
+        );
+    }
+
+    #[tokio::test]
+    async fn session_prompt_rejects_concurrent_turn_before_agent_starts() {
+        let cwd = tempfile::tempdir().unwrap();
+        let server = Arc::new(AcpServer::new(
+            make_test_config(cwd.path()),
+            AcpServerConfig::default(),
+        ));
+
+        let new_result = server
+            .handle_session_new(&serde_json::json!({
+                "cwd": cwd.path().to_string_lossy()
+            }))
+            .await
+            .expect("session/new must succeed");
+        let session_id = new_result["sessionId"].as_str().unwrap().to_string();
+        let active_token = tokio_util::sync::CancellationToken::new();
+        server
+            .register_cancel_token(&session_id, active_token.clone())
+            .expect("simulated active turn should register token");
+
+        let err = server
+            .handle_session_prompt(
+                &serde_json::json!({
+                    "sessionId": session_id.clone(),
+                    "prompt": "queued prompt"
+                }),
+                &serde_json::json!(2),
+            )
+            .await
+            .expect_err("concurrent prompt must be rejected before provider work starts");
+
+        assert_eq!(err.code, SESSION_BUSY);
+        server
+            .handle_session_cancel(&serde_json::json!({ "sessionId": session_id }))
+            .await
+            .expect("cancel should still target the original active token");
+        assert!(active_token.is_cancelled());
     }
 
     /// Verify that inserting and removing a cancel token from the map works

--- a/docs/book/src/channels/acp.md
+++ b/docs/book/src/channels/acp.md
@@ -91,11 +91,11 @@ Send a prompt. The response is a sequence of `session/update` notifications stre
 ← {"jsonrpc":"2.0","id":3,"result":{
     "sessionId": "s-ab12cd",
     "stopReason": "end_turn",
-    "content": [{"type": "text", "text": "The last commit introduces..."}]
+    "content": "The last commit introduces..."
   }}
 ```
 
-`stopReason` is `"end_turn"` on normal completion. The `content` array mirrors the final assistant message.
+`stopReason` is `"end_turn"` on normal completion. The ACP completion signal is `stopReason`; ZeroClaw also includes the current final `content` string for existing clients.
 
 ### `session/update` notifications (agent → client)
 
@@ -150,13 +150,14 @@ If the client never replies (crash, network drop, user closes IDE), the request 
 
 ### `session/cancel`
 
-Abort an in-flight `session/prompt` turn. Not in the base ACP spec — ZeroClaw-specific. If a future ACP spec revision adds `session/cancel` with different semantics, this will be renamed `_meta/session/cancel`.
+Abort an in-flight `session/prompt` turn.
 
 **Cancel vs. stop:** `session/cancel` aborts an in-flight prompt turn and returns `stopReason: "cancelled"` with any streamed text accumulated up to the interrupt point. `session/stop` gracefully ends the session after the current turn completes — it waits for the turn to finish rather than interrupting it.
 
+The canonical parameter is `sessionId`; `session_id` is accepted as a compatibility alias.
+
 ```json
 → {"jsonrpc":"2.0","method":"session/cancel","params":{"sessionId":"s-ab12cd"}}
-← {"jsonrpc":"2.0","id":null,"result":{}}
 ← {"jsonrpc":"2.0","method":"session/update","params":{
     "sessionId": "s-ab12cd",
     "update": {"sessionUpdate": "agent_message_chunk", "content": {"type":"text","text":"partial..."}}
@@ -167,6 +168,8 @@ Abort an in-flight `session/prompt` turn. Not in the base ACP spec — ZeroClaw-
     "content": "partial...\n\n[interrupted by user]"
   }}
 ```
+
+Only one `session/prompt` may be active for a session at a time. A second prompt for the same session is rejected until the active turn completes or is cancelled.
 
 If no turn is active for the session, the cancel is a noop — it succeeds silently without error. This follows ACP notification semantics: notifications must not produce errors.
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Reject a second `session/prompt` for the same ACP session while a turn is active, so the queued prompt cannot replace the active turn's cancel token.
  - Keep cancelled turns as successful ACP prompt results with `stopReason: "cancelled"` instead of surfacing cancellation as a JSON-RPC error.
  - Preserve ZeroClaw's current `session/prompt.result.content` string shape for live ACP-client compatibility.
  - Accept `session_id` as a `session/cancel` alias, matching the other ACP session handlers.
  - Fix the `session/cancel` docs example so a notification does not show an impossible JSON-RPC response.
- **Scope boundary:** This PR does not add ACP prompt pipelining, per-turn cancel IDs, provider changes, runtime tool-loop changes, or non-ACP channel behavior.
- **Blast radius:** ACP clients that call the `channel-acp-server` feature. The intentional behavior change is that duplicate prompts for the same active session now fail fast with JSON-RPC error code `-32002` instead of replacing the active turn's cancel token. The prompt result `content` shape remains the current string form for compatibility.
- **Linked issue(s):** Closes #6406

## Validation Evidence (required)

- **Commands run and tail output:**

```bash
time cargo fmt --all -- --check 2>&1 | tail -30
time cargo test -p zeroclaw-channels --features channel-acp-server --lib acp_server 2>&1 | tail -30
time cargo clippy -p zeroclaw-channels --features channel-acp-server --all-targets -- -D warnings 2>&1 | tail -30
git diff --check
```

```text
cargo fmt: PASS in 2.572s
cargo test: PASS, 28 passed, 0 failed, 956 filtered out in 1:14.03
cargo clippy: PASS in 37.127s
git diff --check: PASS with no output
```

- **Beyond CI — what did you manually verify?** I rebased the branch onto `origin/master` at `67311047b`, verified the patch is limited to the ACP server and ACP docs, and checked the current ACP schema/docs before preserving ZeroClaw's existing prompt-result `content` string shape. I also checked the diff for privacy-sensitive content; the new test data uses neutral session IDs and placeholder text only.
- **If any command was intentionally skipped, why:** Full workspace `cargo test` and full workspace `cargo clippy --all-targets -- -D warnings` were not run because the changed code is isolated to the feature-gated ACP server path. I ran the focused crate all-targets clippy and ACP server unit tests with `--features channel-acp-server`, which is the feature required to compile this module. CodeRabbit was skipped because the installed CLI is not authenticated on this machine.

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: None.

## Compatibility (required)

- Backward compatible? (`Mostly`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: Existing ACP clients that read `session/prompt.result.content` as a raw string keep that shape. Clients that pipeline a second `session/prompt` before the active turn finishes will now receive JSON-RPC error code `-32002` and should retry after the active turn completes or is cancelled.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PRs: `git revert <sha>` is the plan unless otherwise noted.

Medium/high-risk PRs must fill:

- **Fast rollback command/path:** `git revert <landed commit SHA>`
- **Feature flags or config toggles:** None. This only compiles when `channel-acp-server` is enabled.
- **Observable failure symptoms:** Duplicate prompts may receive JSON-RPC error code `-32002` while an active turn is still running, or cancellation may fail to interrupt the active ACP turn if this patch regresses.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Scope materially carried forward: N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`Yes/No`): N/A
- If `No`, why (inspiration-only, no direct code/design carry-over): N/A
