### PR TITLE
ci(release): restore MUSL static binaries for Linux

### DIFF
--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -198,12 +198,22 @@ jobs:
             artifact: zeroclaw
             ext: tar.gz
           - os: ubuntu-22.04
+            target: x86_64-unknown-linux-musl
+            artifact: zeroclaw
+            ext: tar.gz
+            use_cross: true
+          - os: ubuntu-22.04
             target: aarch64-unknown-linux-gnu
             artifact: zeroclaw
             ext: tar.gz
             cross_compiler: gcc-aarch64-linux-gnu
             linker_env: CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER
             linker: aarch64-linux-gnu-gcc
+          - os: ubuntu-22.04
+            target: aarch64-unknown-linux-musl
+            artifact: zeroclaw
+            ext: tar.gz
+            use_cross: true
           - os: ubuntu-22.04
             target: armv7-unknown-linux-gnueabihf
             artifact: zeroclaw
@@ -259,6 +269,10 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y ${{ matrix.cross_compiler }}
 
+      - name: Install cross (MUSL targets)
+        if: matrix.use_cross
+        run: cargo install cross --git https://github.com/cross-rs/cross --locked
+
       - name: Setup Android NDK
         if: matrix.ndk
         run: echo "$ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64/bin" >> "$GITHUB_PATH"
@@ -278,10 +292,17 @@ jobs:
           fi
           # Use matrix-level feature override if set, otherwise use global RELEASE_CARGO_FEATURES
           FEATURES="${{ matrix.cargo_features || env.RELEASE_CARGO_FEATURES }}"
-          if [ "${{ matrix.skip_prometheus || 'false' }}" = "true" ]; then
-            cargo build --release --locked --no-default-features --features "agent-runtime,schema-export,${FEATURES}" --target ${{ matrix.target }}
+          # MUSL targets build via cross-rs (cross-compiled in a container);
+          # all other targets use the host cargo toolchain directly.
+          if [ "${{ matrix.use_cross || 'false' }}" = "true" ]; then
+            BUILD_CMD="cross build"
           else
-            cargo build --release --locked --features "${FEATURES}" --target ${{ matrix.target }}
+            BUILD_CMD="cargo build"
+          fi
+          if [ "${{ matrix.skip_prometheus || 'false' }}" = "true" ]; then
+            $BUILD_CMD --release --locked --no-default-features --features "agent-runtime,schema-export,${FEATURES}" --target ${{ matrix.target }}
+          else
+            $BUILD_CMD --release --locked --features "${FEATURES}" --target ${{ matrix.target }}
           fi
 
       - name: Check binary size
@@ -397,7 +418,9 @@ jobs:
         run: |
           required_assets=(
             "zeroclaw-x86_64-unknown-linux-gnu.tar.gz"
+            "zeroclaw-x86_64-unknown-linux-musl.tar.gz"
             "zeroclaw-aarch64-unknown-linux-gnu.tar.gz"
+            "zeroclaw-aarch64-unknown-linux-musl.tar.gz"
             "zeroclaw-armv7-unknown-linux-gnueabihf.tar.gz"
             "zeroclaw-arm-unknown-linux-gnueabihf.tar.gz"
             "zeroclaw-aarch64-apple-darwin.tar.gz"

--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -258,7 +258,7 @@ jobs:
         with:
           prefix-key: ${{ matrix.os }}-${{ matrix.target }}
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: web-dist
           path: web/dist/
@@ -271,7 +271,7 @@ jobs:
 
       - name: Install cross (MUSL targets)
         if: matrix.use_cross
-        run: cargo install cross --git https://github.com/cross-rs/cross --locked
+        run: cargo install cross --version 0.2.5 --locked
 
       - name: Setup Android NDK
         if: matrix.ndk


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - PR #1748 (merged 2026-02-25) added `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl` targets to `.github/workflows/pub-release.yml` using `cross-rs`. That workflow was deleted in 9923544 when CI was simplified, and the MUSL entries were not carried over to its replacement `release-stable-manual.yml` — so Alpine/musl users currently receive no static binaries from stable releases (regression).
  - Restore MUSL coverage in `release-stable-manual.yml` with three small edits: two new matrix entries (`use_cross: true`), an `Install cross (MUSL targets)` step gated on `matrix.use_cross`, and a build-step branch that runs `cross build` instead of `cargo build` when `use_cross` is true.
  - Add the two new tarballs (`zeroclaw-x86_64-unknown-linux-musl.tar.gz`, `zeroclaw-aarch64-unknown-linux-musl.tar.gz`) to the `publish` job's `required_assets` array so a missing MUSL artifact fails the release rather than silently shipping incomplete coverage.
- **Scope boundary:** CI workflow only. No Rust source, no Cargo.toml, no docs, no Docker images. The Docker job continues to consume only the `*-linux-gnu` artifacts; MUSL is for direct binary downloads.
- **Blast radius:** `release-stable-manual.yml` (stable release pipeline, triggered by `v*.*.*` tag push or `workflow_dispatch`). Adds two parallel matrix jobs and a longer total wall-clock for the build matrix on stable releases. Beta/CI workflows are unaffected. Existing release artifacts retain identical filenames.
- **Linked issue(s):** Related #1748 (original MUSL feature, now regressed).

## Validation Evidence (required)

This is a workflow-only change — no Rust source touched. Validation is YAML lint and a structural read-through of the diff against the previously-merged MUSL pattern from #1748.

```bash
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-stable-manual.yml')); print('YAML OK')"
# YAML OK
```

- **Commands run and tail output:**
  - `python3 -c "import yaml; yaml.safe_load(...)"` → `YAML OK`
  - `git diff` reviewed: 25 insertions, 2 deletions, all confined to the matrix, install step, build step, and `required_assets` list.
- **Beyond CI — what did you manually verify?**
  - Compared the diff against the merged #1748 patch to confirm the `cross-rs` install command and matrix shape match the previously-working approach.
  - Confirmed the build-step rewrite preserves the existing `skip_prometheus` / `FEATURES` branching for both `cross build` and `cargo build` paths.
  - Confirmed neither MUSL target sets `cross_compiler`, `linker_env`, `linker`, `skip_prometheus`, `cargo_features`, or `ndk` — `cross-rs` provides its own toolchain image, so the host `Install cross compiler` step (apt) and per-target linker overrides correctly do not run.
  - Confirmed the `Check binary size` and `Package (Unix)` steps already key off `matrix.target` / `matrix.artifact` and need no changes.
  - I did NOT run an actual cross build locally (requires Docker + multi-arch QEMU + a release tag); first real validation will be the next manual `workflow_dispatch` of `Release Stable`.
- **If any command was intentionally skipped, why:** `cargo fmt`, `cargo clippy`, `cargo test` skipped — no Rust source changes in this PR, only `.github/workflows/release-stable-manual.yml`.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `Yes` — the `Install cross (MUSL targets)` step runs `cargo install cross --git https://github.com/cross-rs/cross --locked`, which clones from `github.com/cross-rs/cross`. This matches the previously-merged approach in #1748 and only runs on the two MUSL matrix jobs during stable releases.
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: `cross-rs` is a well-established Rust cross-compilation tool (rust-lang ecosystem). Pinning by `--locked` constrains the dependency graph at install time; the source repo (`cross-rs/cross`) is the upstream canonical project. No untrusted user input flows into the workflow — `matrix.use_cross` is a static matrix value defined inside this file.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: exact upgrade steps for existing users: N/A — this is purely additive. Existing artifact filenames are unchanged. Two new artifacts (`zeroclaw-x86_64-unknown-linux-musl.tar.gz`, `zeroclaw-aarch64-unknown-linux-musl.tar.gz`) appear in releases starting with the next stable tag and are usable by Alpine / musl-based distros without any user-side changes.

## Rollback (required for `risk: medium` and `risk: high`)

This is `risk: high` (touches the release pipeline).

- **Fast rollback command/path:** `git revert <sha-of-this-merge>` on `master`. Single-commit, single-file revert; subsequent stable release runs revert to the pre-MUSL matrix.
- **Feature flags or config toggles:** None. To temporarily disable just MUSL without a full revert, comment out the two `use_cross: true` matrix entries and the two corresponding lines in `required_assets` — the rest of the matrix continues to build.
- **Observable failure symptoms:**
  - The `build (x86_64-unknown-linux-musl)` or `build (aarch64-unknown-linux-musl)` jobs fail in the Actions UI for the `Release Stable` workflow.
  - The `publish` job fails at the `Verify required release assets` step with `::error::Missing required release asset: zeroclaw-*-unknown-linux-musl.tar.gz` and the release is not published.
  - `cargo install cross ...` failure surfaces in the `Install cross (MUSL targets)` step log on the affected matrix job.