### PR TITLE
fix(ci): re-introduce post-release CHANGELOG-next.md cleanup as a PR

### DIFF
--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -18,6 +18,7 @@ concurrency:
 permissions:
   contents: write
   packages: write
+  pull-requests: write
 
 env:
   CARGO_TERM_COLOR: always
@@ -463,6 +464,31 @@ jobs:
               --notes-file release-notes.md \
               --latest
           fi
+
+      - name: Open cleanup PR for CHANGELOG-next.md
+        if: hashFiles('CHANGELOG-next.md') != ''
+        continue-on-error: true   # never block announcements
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.validate.outputs.tag }}
+        run: |
+          set -euo pipefail
+          BRANCH="chore/post-release-cleanup-${TAG}"
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Start from master so the PR diff is just the deletion
+          git fetch origin master --depth=1
+          git checkout -B "$BRANCH" origin/master
+          git rm CHANGELOG-next.md
+          git commit -m "chore: remove CHANGELOG-next.md after ${TAG} release"
+          git push -u origin "$BRANCH" --force-with-lease
+          gh pr create \
+            --base master \
+            --head "$BRANCH" \
+            --title "chore: post-release cleanup for ${TAG}" \
+            --body "Removes \`CHANGELOG-next.md\` consumed by the **${TAG}** release notes. Auto-opened by \`release-stable-manual.yml\`. Safe to merge once required checks pass." \
+            --label "ci" \
+            --label "type: chore"
 
   redeploy-website:
     name: Trigger Website Redeploy


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Re-introduces the post-release `CHANGELOG-next.md` cleanup that PR #6265 had to delete entirely after branch protection started rejecting its direct push to `master` (GH006). The deletion stopped the failure but left a real footgun (see below).
  - The original step did `git push origin HEAD:master`. With "CI Required Gate" required and "Changes must be made through a pull request" enforced on `master`, that push fails — and because the step exit-1s, the whole `publish` job fails. Every downstream job gated on `needs.publish.result == 'success'` (Tweet, Discord, AUR, Scoop, Homebrew) then skips, so the release exists on GitHub but is never announced and package managers go stale. v0.7.3 (Apr 19) and the May 1 master dispatch both hit this.
  - PR #6265 (merged 2026-05-04, commit 66e7ef670) removed the step. That stops the failure but the `release-notes` job still uses `CHANGELOG-next.md` as the release body when present (`release-stable-manual.yml` lines 132-134), so a leftover file from a previous release would silently become the notes for the next one. No release has actually run since #6265 landed, so this hasn't bitten yet.
  - New step opens a PR from a fresh `chore/post-release-cleanup-<tag>` branch instead of pushing to `master`, gated on `hashFiles('CHANGELOG-next.md') != ''` and marked `continue-on-error: true` so it can never again block announcements. `--force-with-lease` keeps re-runs of the same release idempotent.
  - Adds `pull-requests: write` to the workflow-level `permissions:` block so `GITHUB_TOKEN` can open the PR via `gh pr create`.
- **Scope boundary:** Only `.github/workflows/release-stable-manual.yml`. Does not change the cleanup *content* (still a single `git rm CHANGELOG-next.md` + commit), the release-notes generation, branch protection, or any other workflow.
- **Blast radius:** Release path only. The new step runs after the GitHub Release is already created, is `continue-on-error: true`, and is a no-op when `CHANGELOG-next.md` doesn't exist — so failure cannot regress the publish job or downstream announcement/package-manager jobs. Worst case is identical to today (no auto-cleanup, manual delete needed).
- **Linked issue(s):** Related #6265 (regression introduced by the deletion this PR rebuilds on a safer footing).

## Validation Evidence (required)

CI-only change to a single workflow file — no Rust touched, so the standard `cargo` battery doesn't apply. Validation is YAML correctness + manual reasoning about the workflow semantics.

```bash
$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-stable-manual.yml')); print('yaml OK')"
yaml OK

$ git diff --stat origin/master...HEAD
 .github/workflows/release-stable-manual.yml | 26 ++++++++++++++++++++++++++
 1 file changed, 26 insertions(+)
```

- **Commands run and tail output:** `python3 yaml.safe_load` on the modified workflow → `yaml OK`. `actionlint` is not installed locally; the in-repo `actionlint` CI workflow will run on this PR and is the authoritative gate.
- **Beyond CI — what did you manually verify?**
  - `if: hashFiles('CHANGELOG-next.md') != ''` correctly no-ops when the file is absent (which it is on `master` today after #6265 landed), so no behaviour change on releases that don't ship a hand-written changelog.
  - `continue-on-error: true` on the new step means even a hard failure (e.g., the `chore/post-release-cleanup-<tag>` branch already existing in a weird state, label not present, transient API error) keeps the `publish` job green and lets the announce/package-manager jobs proceed — the exact regression PR #6265 was working around.
  - `git checkout -B "$BRANCH" origin/master` plus `--force-with-lease` makes the step idempotent under workflow re-runs of the same tag.
  - Workflow-level `permissions:` already had `contents: write` and `packages: write`; adding `pull-requests: write` is the minimum delta needed for `gh pr create` with `GITHUB_TOKEN`. No new secret, no new external network surface, no new third-party action.
  - Did NOT verify in a live release dispatch — would require an actual tag.
- **If any command was intentionally skipped, why:** No `cargo` commands — pure YAML/CI change, doesn't touch any Rust crate, fixtures, docs build, or install script.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `Yes` — adds `pull-requests: write` to the workflow's `GITHUB_TOKEN` so the new step can call `gh pr create`. Scoped to this workflow; no new repo-wide grant. Minimum permission needed for the operation.
- New external network calls? `No` — uses GitHub's own API via `gh` (already used elsewhere in this workflow for `gh release create`).
- Secrets / tokens / credentials handling changed? `No` — same `secrets.GITHUB_TOKEN` already in use by adjacent steps. No new secret introduced.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No` — commit/PR is authored by `github-actions[bot]` (`41898282+github-actions[bot]@users.noreply.github.com`), the standard noreply identity.
- If any `Yes`, describe the risk and mitigation: `pull-requests: write` lets this workflow open/edit PRs in the repo. Mitigated by scope (only the new step uses it, and only to open one cleanup PR per release tag); the PR still requires a human to merge through the same branch-protection gates as any other PR.

## Compatibility (required)

- Backward compatible? `Yes` — no surface change for users, contributors, or downstream consumers. Affects only the release pipeline.
- Config / env / CLI surface changed? `No` — no new inputs, env vars, secrets, or release artifacts. Tag-handling, release-notes generation, asset matrix, and Docker push are untouched.
- If `No` or `Yes` to either: exact upgrade steps for existing users: N/A.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <merge-commit-sha> && git push origin master` (or revert via the GitHub UI). Single-file change, trivial revert. Reverts the workflow to its current `master` state — i.e., the post-#6265 behaviour where no auto-cleanup happens.
- **Feature flags or config toggles:** None. The step itself is implicitly self-disabling via `if: hashFiles('CHANGELOG-next.md') != ''` — if the file isn't shipped with a release, the step is a no-op and there's nothing to roll back.
- **Observable failure symptoms:** Watch the next stable-release run in `release-stable-manual.yml`:
  - `publish` job: the new "Open cleanup PR for CHANGELOG-next.md" step. `continue-on-error: true` means it'll show as a green check with a yellow warning annotation if it fails, not a red X. Look in that step's log for `gh pr create` errors (most likely cause of failure: label name mismatch or branch-name collision).
  - Downstream announce jobs (`tweet`, `discord`) and package-manager jobs (`scoop`, `aur`, `homebrew`): these must run, not skip. If they skip, that means the `publish` job failed despite `continue-on-error` — this PR didn't deliver on its core promise and should be reverted.
  - New PR appears titled `chore: post-release cleanup for v<tag>` from `github-actions[bot]` against `master`, labelled `ci` and `type: chore`.