### PR TITLE
fix(cli): capture original bash completion function body to prevent infinite recursion

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3001,7 +3001,9 @@ fn write_shell_completion<W: Write>(shell: CompletionShell, writer: &mut W) -> R
                 r#"
 # Dynamic completion for zeroclaw config get/set paths
 if type _zeroclaw &>/dev/null; then
-    _zeroclaw_clap_orig() {{ _zeroclaw "$@"; }}
+    # Capture the original clap-generated function body so the wrapper
+    # can fall back to it without entering an infinite recursion loop.
+    eval "$(declare -f _zeroclaw | sed '1s/_zeroclaw/_zeroclaw_clap_orig/')"
     _zeroclaw() {{
         local cur="${{COMP_WORDS[COMP_CWORD]}}"
         if [[ "${{COMP_WORDS[*]}}" =~ "config "(get|set)" " ]]; then
@@ -3973,6 +3975,26 @@ mod tests {
         assert!(
             script.contains("zeroclaw"),
             "completion script should reference binary name"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "agent-runtime")]
+    fn bash_completion_avoids_infinite_recursion() {
+        let mut output = Vec::new();
+        write_shell_completion(CompletionShell::Bash, &mut output)
+            .expect("completion generation should succeed");
+        let script = String::from_utf8(output).expect("completion output should be valid utf-8");
+        // The wrapper must capture the original clap-generated function body
+        // (via declare -f) rather than calling _zeroclaw by name, which would
+        // create an infinite recursion loop after _zeroclaw is redefined.
+        assert!(
+            script.contains("declare -f _zeroclaw"),
+            "bash completion should use declare -f to capture the original _zeroclaw function body"
+        );
+        assert!(
+            !script.contains("_zeroclaw_clap_orig() { _zeroclaw \"$@\"; }"),
+            "bash completion must not define _zeroclaw_clap_orig as a simple forwarder to _zeroclaw"
         );
     }
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Fixes bash completion recursion reported in #6402.
  - The bash completion wrapper previously saved the original clap-generated `_zeroclaw` function as a forwarder, not as a body copy.
  - After `_zeroclaw` was redefined later in the same script, the forwarder called the new wrapper and created an infinite recursion loop on Tab completion.
  - This change uses `declare -f` to copy the original function body before redefining `_zeroclaw`, matching the existing Zsh body-copy approach.
- **Scope boundary:** Bash completion wrapper only. No change to Zsh completion, config semantics, or the public CLI command surface.
- **Blast radius:** Bash users relying on generated completions for `zeroclaw config get/set`.
- **Linked issue(s):** Closes #6402.
- **Labels:** `size: XS`, `risk: medium`, `core`

## Validation Evidence

- **Commands run and tail output:**
  - CI is green on head `beca678c`, including Lint, Test, Security, build matrix, feature checks, benchmarks compile, and CI Required Gate.
  - Regression test added: `bash_completion_avoids_infinite_recursion`.
- **Beyond CI — what did you manually verify?**
  - Review verified that the generated script contains the `declare -f _zeroclaw` body-capture path and no longer contains the old `_zeroclaw_clap_orig() { _zeroclaw "$@"; }` forwarder pattern.
- **If any command was intentionally skipped, why:**
  - No additional local maintainer command was run during body cleanup; this edit records existing PR/CI/review evidence only.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? No.
- New external network calls? No.
- Secrets / tokens / credentials handling changed? No.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No.
- If any `Yes`, describe the risk and mitigation: Not applicable.

## Compatibility

- Backward compatible? Yes.
- Config / env / CLI surface changed? No.
- If `No` or `Yes` to either: No upgrade steps required. Existing bash completion users get the same completion surface without the recursion failure.

## Rollback

- **Fast rollback command/path:** Revert this PR's squash commit after merge, or before merge revert head commit `beca678c`.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Bash completion for `zeroclaw` regresses to recursion or hangs on Tab completion, especially around `config get/set`.
