### PR TITLE
feat(channel:lemmy): add Lemmy channel (private-message polling MVP)

### DIFF
--- a/crates/zeroclaw-channels/Cargo.toml
+++ b/crates/zeroclaw-channels/Cargo.toml
@@ -83,7 +83,7 @@ default = [
     "channel-bluesky", "channel-twitter", "channel-reddit", "channel-notion",
     "channel-linq", "channel-wati", "channel-nextcloud", "channel-mochat",
     "channel-wecom", "channel-clawdtalk", "channel-webhook",
-    "channel-whatsapp-cloud", "channel-voice-call",
+    "channel-whatsapp-cloud", "channel-voice-call", "channel-lemmy",
 ]
 # Channels with optional deps
 channel-email = ["dep:lettre", "dep:mail-parser", "dep:async-imap"]
@@ -102,6 +102,7 @@ channel-imessage = []
 channel-dingtalk = []
 channel-qq = []
 channel-bluesky = []
+channel-lemmy = []
 channel-twitter = []
 channel-reddit = []
 channel-notion = []

--- a/crates/zeroclaw-channels/src/lemmy.rs
+++ b/crates/zeroclaw-channels/src/lemmy.rs
@@ -1,0 +1,1072 @@
+//! Lemmy channel — private-message polling MVP.
+//!
+//! Works against any Lemmy-compatible instance (lemmy.world, beehaw.org,
+//! self-hosted). v1 focuses on **private messages only**: the simplest and
+//! most useful surface for a personal agent. Comment / post listening is
+//! deferred to v2.
+//!
+//! # Auth
+//! Two paths. The pre-minted JWT path is checked first; if `jwt` is empty
+//! the channel falls back to a username + password login at startup.
+//!
+//! 1. **Pre-minted JWT**: operator copies a long-lived token from the Lemmy
+//!    web UI (browser cookie / admin tools) into `jwt`. Recommended for
+//!    production and required for bot accounts with 2FA.
+//! 2. **Username + password**: channel calls `POST /api/v3/user/login` once
+//!    at listen start to mint a JWT, caches it in memory.
+//!
+//! Both methods send the JWT as `Authorization: Bearer <jwt>` on every
+//! subsequent request.
+//!
+//! # Inbound
+//! Every `poll_interval_secs`, `GET /api/v3/private_message/list?unread_only=true&page=1&limit=20`.
+//! For each message: drop self / non-allowed / empty, build a
+//! `ChannelMessage` with `reply_target = "pm:{creator_id}"`, then
+//! `PUT /api/v3/private_message/mark_as_read` so the next poll doesn't
+//! re-deliver it.
+//!
+//! # Outbound
+//! `POST /api/v3/private_message` with `{recipient_id, content}`. Bodies
+//! over 10000 chars are split at sentence/word boundaries with `(i/N) `
+//! continuation markers. Recipient grammar:
+//!
+//! * `"pm:{user_id}"` — explicit form (set automatically when replying).
+//! * Bare numeric string — same thing, treated as a `pm:` shorthand.
+
+use anyhow::{Context, Result, bail};
+use async_trait::async_trait;
+use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+use zeroclaw_api::channel::{Channel, ChannelMessage, SendMessage};
+
+const LEMMY_BODY_SOFT_LIMIT: usize = 10_000;
+const LEMMY_PM_PAGE_SIZE: u32 = 20;
+const POLL_MIN_SECS: u64 = 5;
+
+pub struct LemmyChannel {
+    instance_url: String,
+    username: String,
+    password: String,
+    /// Pre-minted JWT supplied by the operator (takes precedence over
+    /// username/password login).
+    seed_jwt: String,
+    allowed_users: Vec<String>,
+    poll_interval: Duration,
+    /// Cached auth state — populated by the first login (or seeded from
+    /// `seed_jwt`). On 401 we clear and re-login.
+    auth: Mutex<Option<AuthState>>,
+}
+
+#[derive(Clone)]
+struct AuthState {
+    jwt: String,
+    /// Bot's own user id. Populated by either the login response or the
+    /// `getSite` call when only a pre-minted JWT is configured.
+    bot_user_id: Option<i64>,
+}
+
+#[derive(Serialize)]
+struct LoginRequest<'a> {
+    username_or_email: &'a str,
+    password: &'a str,
+}
+
+#[derive(Deserialize)]
+struct LoginResponse {
+    #[serde(default)]
+    jwt: Option<String>,
+    /// Lemmy returns errors as `{"error": "incorrect_login"}` rather than
+    /// HTTP non-2xx in some versions. Surface that as a typed error.
+    #[serde(default)]
+    error: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct GetSiteResponse {
+    #[serde(default)]
+    my_user: Option<MyUserSection>,
+}
+
+#[derive(Deserialize)]
+struct MyUserSection {
+    local_user_view: LocalUserView,
+}
+
+#[derive(Deserialize)]
+struct LocalUserView {
+    person: PersonInfo,
+}
+
+#[derive(Deserialize, Clone)]
+struct PersonInfo {
+    id: i64,
+}
+
+#[derive(Deserialize, Clone, Debug)]
+struct PrivateMessageListResponse {
+    #[serde(default)]
+    private_messages: Vec<PrivateMessageView>,
+}
+
+#[derive(Deserialize, Clone, Debug)]
+struct PrivateMessageView {
+    private_message: PrivateMessage,
+    creator: Person,
+}
+
+#[derive(Deserialize, Clone, Debug)]
+struct PrivateMessage {
+    id: i64,
+    #[serde(default)]
+    content: String,
+    #[serde(default)]
+    read: bool,
+    #[serde(default)]
+    deleted: bool,
+    /// ISO-8601 published timestamp.
+    #[serde(default)]
+    published: String,
+}
+
+#[derive(Deserialize, Clone, Debug)]
+struct Person {
+    id: i64,
+    #[serde(default)]
+    name: String,
+    /// Some Lemmy versions emit `local: bool` to indicate same-instance.
+    /// Older versions emit `actor_id` as a URL we'd have to parse for the
+    /// instance. We accept both forms via a flexible fallback in
+    /// `acct_form()`.
+    #[serde(default)]
+    local: Option<bool>,
+    #[serde(default)]
+    actor_id: Option<String>,
+}
+
+#[derive(Serialize)]
+struct CreatePmRequest<'a> {
+    content: &'a str,
+    recipient_id: i64,
+}
+
+#[derive(Deserialize)]
+struct CreatePmResponse {
+    #[serde(default)]
+    error: Option<String>,
+}
+
+#[derive(Serialize)]
+struct MarkPmReadRequest {
+    private_message_id: i64,
+    read: bool,
+}
+
+#[derive(Deserialize)]
+struct MarkPmReadResponse {
+    #[serde(default)]
+    error: Option<String>,
+}
+
+impl LemmyChannel {
+    pub fn new(
+        instance_url: String,
+        username: String,
+        password: String,
+        jwt: String,
+        allowed_users: Vec<String>,
+        poll_interval_secs: u64,
+    ) -> Self {
+        Self {
+            instance_url: normalize_instance_url(&instance_url),
+            username,
+            password,
+            seed_jwt: jwt,
+            allowed_users,
+            poll_interval: Duration::from_secs(poll_interval_secs.max(POLL_MIN_SECS)),
+            auth: Mutex::new(None),
+        }
+    }
+
+    fn http_client(&self) -> reqwest::Client {
+        zeroclaw_config::schema::build_runtime_proxy_client("channel.lemmy")
+    }
+
+    fn rest_url(&self, path: &str) -> String {
+        format!("{}{}", self.instance_url, path)
+    }
+
+    fn current_auth(&self) -> Option<AuthState> {
+        self.auth.lock().clone()
+    }
+
+    /// Acquire a JWT, preferring the seed JWT when one is configured.
+    /// Populates `auth.bot_user_id` lazily via a separate `getSite` call.
+    async fn ensure_auth(&self) -> Result<AuthState> {
+        if let Some(state) = self.current_auth() {
+            return Ok(state);
+        }
+        let jwt = if !self.seed_jwt.is_empty() {
+            self.seed_jwt.clone()
+        } else {
+            self.login().await?
+        };
+        let mut state = AuthState {
+            jwt: jwt.clone(),
+            bot_user_id: None,
+        };
+        // Resolve the bot's own user id once, used for self-suppression.
+        match self.fetch_my_user_id(&jwt).await {
+            Ok(Some(id)) => state.bot_user_id = Some(id),
+            Ok(None) => {
+                tracing::warn!(
+                    "Lemmy: getSite returned no my_user; self-suppression disabled until next login"
+                );
+            }
+            Err(e) => {
+                tracing::warn!("Lemmy: getSite failed: {e}");
+            }
+        }
+        *self.auth.lock() = Some(state.clone());
+        Ok(state)
+    }
+
+    async fn login(&self) -> Result<String> {
+        if self.username.is_empty() || self.password.is_empty() {
+            bail!("Lemmy: jwt is empty and username/password is missing");
+        }
+        let body = LoginRequest {
+            username_or_email: &self.username,
+            password: &self.password,
+        };
+        let resp = self
+            .http_client()
+            .post(self.rest_url("/api/v3/user/login"))
+            .json(&body)
+            .send()
+            .await
+            .context("Lemmy /api/v3/user/login request failed")?;
+        let status = resp.status();
+        if !status.is_success() {
+            let text = resp.text().await.unwrap_or_default();
+            bail!("Lemmy login returned {status}: {text}");
+        }
+        let payload: LoginResponse = resp
+            .json()
+            .await
+            .context("Lemmy login returned non-JSON body")?;
+        if let Some(err) = payload.error {
+            bail!("Lemmy login error: {err}");
+        }
+        payload
+            .jwt
+            .filter(|j| !j.is_empty())
+            .ok_or_else(|| anyhow::anyhow!("Lemmy login response missing jwt"))
+    }
+
+    async fn fetch_my_user_id(&self, jwt: &str) -> Result<Option<i64>> {
+        let resp = self
+            .http_client()
+            .get(self.rest_url("/api/v3/site"))
+            .bearer_auth(jwt)
+            .send()
+            .await
+            .context("Lemmy /api/v3/site request failed")?;
+        if !resp.status().is_success() {
+            return Ok(None);
+        }
+        let payload: GetSiteResponse = resp
+            .json()
+            .await
+            .context("Lemmy getSite returned non-JSON body")?;
+        Ok(payload.my_user.map(|m| m.local_user_view.person.id))
+    }
+
+    /// Convert a private-message view into a `ChannelMessage`, applying the
+    /// self-suppression and allowlist filters.
+    fn parse_private_message(
+        &self,
+        view: &PrivateMessageView,
+        bot_user_id: Option<i64>,
+    ) -> Option<ChannelMessage> {
+        let pm = &view.private_message;
+        let creator = &view.creator;
+
+        if pm.read || pm.deleted {
+            return None;
+        }
+        if Some(creator.id) == bot_user_id {
+            return None;
+        }
+        if !is_user_allowed(&creator.acct_form(), &self.allowed_users) {
+            tracing::debug!(
+                "Lemmy: dropping PM from {} (not in allowed_users)",
+                creator.name
+            );
+            return None;
+        }
+        let body = pm.content.trim();
+        if body.is_empty() {
+            return None;
+        }
+
+        let timestamp = chrono::DateTime::parse_from_rfc3339(&pm.published)
+            .map(|dt| dt.timestamp().cast_unsigned())
+            .unwrap_or_else(|_| chrono::Utc::now().timestamp().cast_unsigned());
+
+        Some(ChannelMessage {
+            id: format!("lemmy_{}", pm.id),
+            sender: creator.acct_form(),
+            reply_target: format!("pm:{}", creator.id),
+            content: body.to_string(),
+            channel: "lemmy".to_string(),
+            timestamp,
+            thread_ts: None,
+            interruption_scope_id: None,
+            attachments: vec![],
+        })
+    }
+
+    async fn fetch_unread_pms(&self, jwt: &str) -> Result<Vec<PrivateMessageView>> {
+        let resp = self
+            .http_client()
+            .get(self.rest_url("/api/v3/private_message/list"))
+            .bearer_auth(jwt)
+            .query(&[
+                ("unread_only", "true"),
+                ("page", "1"),
+                ("limit", &LEMMY_PM_PAGE_SIZE.to_string()),
+            ])
+            .send()
+            .await
+            .context("Lemmy /api/v3/private_message/list request failed")?;
+        let status = resp.status();
+        if status == reqwest::StatusCode::UNAUTHORIZED {
+            *self.auth.lock() = None;
+            bail!("Lemmy unauthorized — clearing cached auth and re-logging in");
+        }
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            bail!("Lemmy PM list returned {status}: {body}");
+        }
+        let payload: PrivateMessageListResponse = resp
+            .json()
+            .await
+            .context("Lemmy PM list returned non-JSON body")?;
+        Ok(payload.private_messages)
+    }
+
+    async fn mark_pm_read(&self, jwt: &str, pm_id: i64) -> Result<()> {
+        let body = MarkPmReadRequest {
+            private_message_id: pm_id,
+            read: true,
+        };
+        let resp = self
+            .http_client()
+            .post(self.rest_url("/api/v3/private_message/mark_as_read"))
+            .bearer_auth(jwt)
+            .json(&body)
+            .send()
+            .await
+            .context("Lemmy mark_as_read request failed")?;
+        let status = resp.status();
+        if !status.is_success() {
+            let text = resp.text().await.unwrap_or_default();
+            bail!("Lemmy mark_as_read returned {status}: {text}");
+        }
+        let payload: MarkPmReadResponse = resp
+            .json()
+            .await
+            .context("Lemmy mark_as_read returned non-JSON body")?;
+        if let Some(err) = payload.error {
+            bail!("Lemmy mark_as_read error: {err}");
+        }
+        Ok(())
+    }
+
+    async fn post_pm_chunks(
+        &self,
+        jwt: &str,
+        recipient_id: i64,
+        chunks: Vec<String>,
+    ) -> Result<()> {
+        for chunk in chunks {
+            let body = CreatePmRequest {
+                content: &chunk,
+                recipient_id,
+            };
+            let resp = self
+                .http_client()
+                .post(self.rest_url("/api/v3/private_message"))
+                .bearer_auth(jwt)
+                .json(&body)
+                .send()
+                .await
+                .context("Lemmy create-PM request failed")?;
+            let status = resp.status();
+            if !status.is_success() {
+                let text = resp.text().await.unwrap_or_default();
+                bail!("Lemmy create-PM returned {status}: {text}");
+            }
+            let payload: CreatePmResponse = resp
+                .json()
+                .await
+                .context("Lemmy create-PM returned non-JSON body")?;
+            if let Some(err) = payload.error {
+                bail!("Lemmy create-PM error: {err}");
+            }
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Channel for LemmyChannel {
+    fn name(&self) -> &str {
+        "lemmy"
+    }
+
+    async fn send(&self, message: &SendMessage) -> Result<()> {
+        let recipient_id = parse_recipient(&message.recipient)
+            .with_context(|| format!("invalid Lemmy recipient: {:?}", message.recipient))?;
+        let chunks = chunk_text(&message.content, LEMMY_BODY_SOFT_LIMIT);
+        if chunks.is_empty() {
+            return Ok(());
+        }
+        let auth = self.ensure_auth().await?;
+        self.post_pm_chunks(&auth.jwt, recipient_id, chunks).await
+    }
+
+    async fn listen(&self, tx: tokio::sync::mpsc::Sender<ChannelMessage>) -> Result<()> {
+        tracing::info!(
+            "Lemmy channel listening (instance={}, poll={}s)",
+            self.instance_url,
+            self.poll_interval.as_secs()
+        );
+        loop {
+            tokio::time::sleep(self.poll_interval).await;
+            let auth = match self.ensure_auth().await {
+                Ok(a) => a,
+                Err(e) => {
+                    tracing::warn!("Lemmy auth failed: {e}");
+                    continue;
+                }
+            };
+            let pms = match self.fetch_unread_pms(&auth.jwt).await {
+                Ok(p) => p,
+                Err(e) => {
+                    tracing::warn!("Lemmy fetch error: {e}");
+                    continue;
+                }
+            };
+            for view in &pms {
+                let pm_id = view.private_message.id;
+                if let Some(channel_msg) = self.parse_private_message(view, auth.bot_user_id) {
+                    if tx.send(channel_msg).await.is_err() {
+                        return Ok(());
+                    }
+                    if let Err(e) = self.mark_pm_read(&auth.jwt, pm_id).await {
+                        tracing::warn!("Lemmy mark_as_read({pm_id}) failed: {e}");
+                    }
+                } else {
+                    // Even when we drop a PM (read filter, allowlist miss),
+                    // mark it read so it doesn't keep reappearing in the
+                    // unread list. Suppress errors — best-effort.
+                    let _ = self.mark_pm_read(&auth.jwt, pm_id).await;
+                }
+            }
+        }
+    }
+
+    async fn health_check(&self) -> bool {
+        match self.ensure_auth().await {
+            Ok(auth) => self
+                .http_client()
+                .get(self.rest_url("/api/v3/site"))
+                .bearer_auth(&auth.jwt)
+                .send()
+                .await
+                .map(|r| r.status().is_success())
+                .unwrap_or(false),
+            Err(_) => false,
+        }
+    }
+}
+
+impl Person {
+    /// Return either the bare username (`"alice"`) for local accounts, or
+    /// the qualified `user@instance` form for federated accounts. Falls back
+    /// to the bare username when neither field is populated.
+    fn acct_form(&self) -> String {
+        if self.local == Some(true) {
+            return self.name.clone();
+        }
+        if let Some(actor) = self.actor_id.as_deref()
+            && let Some(host) = extract_host(actor)
+        {
+            return format!("{}@{host}", self.name);
+        }
+        self.name.clone()
+    }
+}
+
+fn extract_host(url: &str) -> Option<&str> {
+    let after_scheme = url.split_once("://").map(|(_, r)| r).unwrap_or(url);
+    after_scheme.split('/').next().filter(|s| !s.is_empty())
+}
+
+fn normalize_instance_url(raw: &str) -> String {
+    let trimmed = raw.trim().trim_end_matches('/');
+    if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
+        trimmed.to_string()
+    } else {
+        format!("https://{trimmed}")
+    }
+}
+
+/// Allowlist match. `*` matches anyone. Comparison is case-insensitive.
+/// Bare `"alice"` allowlist entries match both bare `"alice"` and
+/// instance-qualified `"alice@…"` senders; qualified entries require an
+/// exact match on the full string.
+pub fn is_user_allowed(acct: &str, allowlist: &[String]) -> bool {
+    if allowlist.is_empty() {
+        return false;
+    }
+    if allowlist.iter().any(|u| u == "*") {
+        return true;
+    }
+    let normalized = acct.to_ascii_lowercase();
+    let bare = normalized.split('@').next().unwrap_or("").to_string();
+    allowlist.iter().any(|entry| {
+        let canon = entry.to_ascii_lowercase();
+        if canon.contains('@') {
+            canon == normalized
+        } else {
+            canon == bare
+        }
+    })
+}
+
+/// Parse a `SendMessage.recipient` into a numeric `recipient_id`. Accepts
+/// `"pm:42"` (canonical) and bare `"42"` (shorthand).
+pub fn parse_recipient(recipient: &str) -> Result<i64> {
+    let trimmed = recipient.trim();
+    if trimmed.is_empty() {
+        bail!("empty recipient");
+    }
+    let id_str = trimmed.strip_prefix("pm:").unwrap_or(trimmed).trim();
+    id_str
+        .parse::<i64>()
+        .with_context(|| format!("expected pm:<id> or numeric id, got {recipient:?}"))
+}
+
+/// Split a body into ≤`limit`-character chunks. Single-chunk bodies pass
+/// through; multi-chunk bodies receive an `(i/N) ` prefix on each part.
+pub fn chunk_text(body: &str, limit: usize) -> Vec<String> {
+    let body = body.trim();
+    if body.is_empty() {
+        return vec![];
+    }
+    if body.chars().count() <= limit {
+        return vec![body.to_string()];
+    }
+    const MARKER_RESERVE: usize = 8;
+    let body_budget = limit.saturating_sub(MARKER_RESERVE).max(1);
+    let mut chunks: Vec<String> = Vec::new();
+    let mut remaining: &str = body;
+    while !remaining.is_empty() {
+        if remaining.chars().count() <= body_budget {
+            chunks.push(remaining.to_string());
+            break;
+        }
+        let split_at = pick_split_point(remaining, body_budget);
+        let (head, tail) = remaining.split_at(split_at);
+        chunks.push(head.trim_end().to_string());
+        remaining = tail.trim_start();
+    }
+    if chunks.len() == 1 {
+        return chunks;
+    }
+    let total = chunks.len();
+    chunks
+        .into_iter()
+        .enumerate()
+        .map(|(i, c)| format!("({}/{total}) {c}", i + 1))
+        .collect()
+}
+
+fn pick_split_point(text: &str, char_budget: usize) -> usize {
+    let mut budget_idx = text.len();
+    for (i, (byte_idx, _)) in text.char_indices().enumerate() {
+        if i == char_budget {
+            budget_idx = byte_idx;
+            break;
+        }
+    }
+    let head = &text[..budget_idx];
+    if let Some(idx) = head.rfind(['.', '!', '?', '\n']) {
+        return (idx + 1).min(budget_idx);
+    }
+    if let Some(idx) = head.rfind(char::is_whitespace) {
+        return idx + 1;
+    }
+    budget_idx
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn channel_with(allowlist: Vec<String>) -> LemmyChannel {
+        LemmyChannel::new(
+            "https://lemmy.example".into(),
+            "agent-bot".into(),
+            "test-pass".into(),
+            "".into(),
+            allowlist,
+            30,
+        )
+    }
+
+    fn pm_view(
+        pm_id: i64,
+        creator_id: i64,
+        creator_name: &str,
+        local: bool,
+        actor_id: Option<&str>,
+        body: &str,
+        read: bool,
+    ) -> PrivateMessageView {
+        PrivateMessageView {
+            private_message: PrivateMessage {
+                id: pm_id,
+                content: body.into(),
+                read,
+                deleted: false,
+                published: "2026-05-06T12:00:00.000Z".into(),
+            },
+            creator: Person {
+                id: creator_id,
+                name: creator_name.into(),
+                local: Some(local),
+                actor_id: actor_id.map(str::to_string),
+            },
+        }
+    }
+
+    #[test]
+    fn normalize_instance_url_adds_https_and_strips_trailing_slash() {
+        assert_eq!(normalize_instance_url("lemmy.world"), "https://lemmy.world");
+        assert_eq!(
+            normalize_instance_url("https://lemmy.world/"),
+            "https://lemmy.world"
+        );
+        assert_eq!(
+            normalize_instance_url("  http://localhost:8536  "),
+            "http://localhost:8536"
+        );
+    }
+
+    #[test]
+    fn extract_host_handles_full_actor_url() {
+        assert_eq!(
+            extract_host("https://lemmy.world/u/alice"),
+            Some("lemmy.world")
+        );
+        assert_eq!(
+            extract_host("http://localhost:8536/u/dev"),
+            Some("localhost:8536")
+        );
+        assert_eq!(extract_host(""), None);
+    }
+
+    #[test]
+    fn person_acct_local_uses_bare_name() {
+        let p = Person {
+            id: 1,
+            name: "alice".into(),
+            local: Some(true),
+            actor_id: Some("https://lemmy.example/u/alice".into()),
+        };
+        assert_eq!(p.acct_form(), "alice");
+    }
+
+    #[test]
+    fn person_acct_remote_uses_qualified_form() {
+        let p = Person {
+            id: 1,
+            name: "alice".into(),
+            local: Some(false),
+            actor_id: Some("https://lemmy.world/u/alice".into()),
+        };
+        assert_eq!(p.acct_form(), "alice@lemmy.world");
+    }
+
+    #[test]
+    fn person_acct_falls_back_to_name_when_actor_missing() {
+        let p = Person {
+            id: 1,
+            name: "alice".into(),
+            local: None,
+            actor_id: None,
+        };
+        assert_eq!(p.acct_form(), "alice");
+    }
+
+    #[test]
+    fn allowlist_empty_denies_everyone() {
+        assert!(!is_user_allowed("alice", &[]));
+    }
+
+    #[test]
+    fn allowlist_wildcard_allows_anyone() {
+        let allow = vec!["*".into()];
+        assert!(is_user_allowed("alice", &allow));
+        assert!(is_user_allowed("bob@elsewhere.tld", &allow));
+    }
+
+    #[test]
+    fn allowlist_bare_entry_matches_both_forms() {
+        let allow = vec!["alice".into()];
+        assert!(is_user_allowed("alice", &allow));
+        assert!(is_user_allowed("Alice@lemmy.world", &allow));
+    }
+
+    #[test]
+    fn allowlist_qualified_entry_requires_exact_match() {
+        let allow = vec!["alice@lemmy.world".into()];
+        assert!(is_user_allowed("alice@lemmy.world", &allow));
+        assert!(!is_user_allowed("alice", &allow));
+        assert!(!is_user_allowed("alice@beehaw.org", &allow));
+    }
+
+    #[test]
+    fn parse_recipient_pm_form() {
+        assert_eq!(parse_recipient("pm:42").unwrap(), 42);
+        assert_eq!(parse_recipient("  pm:1234  ").unwrap(), 1234);
+    }
+
+    #[test]
+    fn parse_recipient_bare_numeric() {
+        assert_eq!(parse_recipient("42").unwrap(), 42);
+    }
+
+    #[test]
+    fn parse_recipient_rejects_non_numeric() {
+        assert!(parse_recipient("alice").is_err());
+        assert!(parse_recipient("pm:abc").is_err());
+        assert!(parse_recipient("").is_err());
+    }
+
+    #[test]
+    fn parse_pm_drops_self() {
+        let ch = channel_with(vec!["*".into()]);
+        let view = pm_view(1, 5, "self-bot", true, None, "echo", false);
+        assert!(ch.parse_private_message(&view, Some(5)).is_none());
+    }
+
+    #[test]
+    fn parse_pm_drops_already_read() {
+        let ch = channel_with(vec!["*".into()]);
+        let view = pm_view(1, 6, "alice", true, None, "old", true);
+        assert!(ch.parse_private_message(&view, None).is_none());
+    }
+
+    #[test]
+    fn parse_pm_drops_outside_allowlist() {
+        let ch = channel_with(vec!["alice".into()]);
+        let view = pm_view(1, 6, "stranger", true, None, "hi", false);
+        assert!(ch.parse_private_message(&view, None).is_none());
+    }
+
+    #[test]
+    fn parse_pm_drops_empty_body() {
+        let ch = channel_with(vec!["*".into()]);
+        let view = pm_view(1, 6, "alice", true, None, "   ", false);
+        assert!(ch.parse_private_message(&view, None).is_none());
+    }
+
+    #[test]
+    fn parse_pm_drops_deleted() {
+        let ch = channel_with(vec!["*".into()]);
+        let mut view = pm_view(1, 6, "alice", true, None, "hi", false);
+        view.private_message.deleted = true;
+        assert!(ch.parse_private_message(&view, None).is_none());
+    }
+
+    #[test]
+    fn parse_pm_accepts_valid_local() {
+        let ch = channel_with(vec!["alice".into()]);
+        let view = pm_view(7, 6, "alice", true, None, "ping", false);
+        let msg = ch.parse_private_message(&view, None).expect("expected msg");
+        assert_eq!(msg.id, "lemmy_7");
+        assert_eq!(msg.sender, "alice");
+        assert_eq!(msg.reply_target, "pm:6");
+        assert_eq!(msg.content, "ping");
+        assert_eq!(msg.channel, "lemmy");
+    }
+
+    #[test]
+    fn parse_pm_accepts_valid_remote_with_qualified_sender() {
+        let ch = channel_with(vec!["alice@lemmy.world".into()]);
+        let view = pm_view(
+            8,
+            9,
+            "alice",
+            false,
+            Some("https://lemmy.world/u/alice"),
+            "federated ping",
+            false,
+        );
+        let msg = ch.parse_private_message(&view, None).expect("expected msg");
+        assert_eq!(msg.sender, "alice@lemmy.world");
+    }
+
+    #[test]
+    fn chunk_text_short_passes_through() {
+        let chunks = chunk_text("hi there", LEMMY_BODY_SOFT_LIMIT);
+        assert_eq!(chunks, vec!["hi there"]);
+    }
+
+    #[test]
+    fn chunk_text_long_is_split_with_marker() {
+        let body = "alpha beta gamma. ".repeat(800);
+        let chunks = chunk_text(&body, 200);
+        assert!(chunks.len() >= 2);
+        for (i, c) in chunks.iter().enumerate() {
+            assert!(c.starts_with(&format!("({}/", i + 1)));
+            assert!(c.chars().count() <= 200);
+        }
+    }
+
+    #[test]
+    fn chunk_text_empty_returns_no_chunks() {
+        let chunks = chunk_text("   ", LEMMY_BODY_SOFT_LIMIT);
+        assert!(chunks.is_empty());
+    }
+
+    mod http_tests {
+        use super::*;
+        use serde_json::json;
+        use wiremock::matchers::{
+            body_partial_json, header, header_exists, method, path, query_param,
+        };
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        fn channel_for(server_uri: &str, jwt: Option<&str>) -> LemmyChannel {
+            LemmyChannel::new(
+                server_uri.to_string(),
+                "agent-bot".into(),
+                "test-pass".into(),
+                jwt.unwrap_or("").into(),
+                vec!["*".into()],
+                30,
+            )
+        }
+
+        #[tokio::test]
+        async fn login_mints_jwt_and_caches_it() {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/api/v3/user/login"))
+                .and(body_partial_json(json!({
+                    "username_or_email": "agent-bot",
+                    "password": "test-pass"
+                })))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "jwt": "JWT-1"
+                })))
+                .expect(1)
+                .mount(&server)
+                .await;
+            // /api/v3/site is called once during ensure_auth to populate
+            // the bot user id; return a fixture so that path doesn't fail.
+            Mock::given(method("GET"))
+                .and(path("/api/v3/site"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "my_user": {
+                        "local_user_view": {
+                            "person": {"id": 999}
+                        }
+                    }
+                })))
+                .mount(&server)
+                .await;
+
+            let ch = channel_for(&server.uri(), None);
+            let auth = ch.ensure_auth().await.expect("auth ok");
+            assert_eq!(auth.jwt, "JWT-1");
+            assert_eq!(auth.bot_user_id, Some(999));
+            // Second call must not re-mint.
+            let _ = ch.ensure_auth().await.expect("cached");
+        }
+
+        #[tokio::test]
+        async fn seed_jwt_skips_login() {
+            let server = MockServer::start().await;
+            // No login mock — if the channel calls login, the test fails.
+            Mock::given(method("GET"))
+                .and(path("/api/v3/site"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "my_user": {
+                        "local_user_view": {
+                            "person": {"id": 11}
+                        }
+                    }
+                })))
+                .mount(&server)
+                .await;
+
+            let ch = channel_for(&server.uri(), Some("seed-jwt"));
+            let auth = ch.ensure_auth().await.expect("auth ok");
+            assert_eq!(auth.jwt, "seed-jwt");
+            assert_eq!(auth.bot_user_id, Some(11));
+        }
+
+        #[tokio::test]
+        async fn send_posts_pm_with_bearer_auth() {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/api/v3/site"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "my_user": {"local_user_view": {"person": {"id": 1}}}
+                })))
+                .mount(&server)
+                .await;
+            Mock::given(method("POST"))
+                .and(path("/api/v3/private_message"))
+                .and(header_exists("authorization"))
+                .and(body_partial_json(json!({
+                    "content": "hello",
+                    "recipient_id": 42
+                })))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "private_message_view": {"private_message": {"id": 1000}}
+                })))
+                .expect(1)
+                .mount(&server)
+                .await;
+
+            let ch = channel_for(&server.uri(), Some("seed-jwt"));
+            ch.send(&SendMessage {
+                content: "hello".into(),
+                recipient: "pm:42".into(),
+                subject: None,
+                thread_ts: None,
+                cancellation_token: None,
+                attachments: vec![],
+            })
+            .await
+            .expect("send succeeded");
+        }
+
+        #[tokio::test]
+        async fn send_surfaces_4xx_as_error() {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/api/v3/site"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "my_user": {"local_user_view": {"person": {"id": 1}}}
+                })))
+                .mount(&server)
+                .await;
+            Mock::given(method("POST"))
+                .and(path("/api/v3/private_message"))
+                .respond_with(ResponseTemplate::new(401).set_body_string("unauthorized"))
+                .mount(&server)
+                .await;
+
+            let ch = channel_for(&server.uri(), Some("seed-jwt"));
+            let err = ch
+                .send(&SendMessage {
+                    content: "hi".into(),
+                    recipient: "pm:42".into(),
+                    subject: None,
+                    thread_ts: None,
+                    cancellation_token: None,
+                    attachments: vec![],
+                })
+                .await
+                .expect_err("expected 401");
+            assert!(format!("{err:#}").contains("401"));
+        }
+
+        #[tokio::test]
+        async fn fetch_unread_pms_calls_with_query_params() {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/api/v3/private_message/list"))
+                .and(query_param("unread_only", "true"))
+                .and(query_param("page", "1"))
+                .and(header("authorization", "Bearer seed-jwt"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "private_messages": [{
+                        "private_message": {
+                            "id": 7,
+                            "content": "hi bot",
+                            "read": false,
+                            "deleted": false,
+                            "published": "2026-05-06T12:00:00.000Z"
+                        },
+                        "creator": {
+                            "id": 6,
+                            "name": "alice",
+                            "local": true
+                        }
+                    }]
+                })))
+                .expect(1)
+                .mount(&server)
+                .await;
+
+            let ch = channel_for(&server.uri(), Some("seed-jwt"));
+            let pms = ch.fetch_unread_pms("seed-jwt").await.expect("ok");
+            assert_eq!(pms.len(), 1);
+            assert_eq!(pms[0].private_message.id, 7);
+        }
+
+        #[tokio::test]
+        async fn fetch_unread_pms_clears_auth_on_401() {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/api/v3/private_message/list"))
+                .respond_with(ResponseTemplate::new(401).set_body_string("token expired"))
+                .mount(&server)
+                .await;
+
+            let ch = channel_for(&server.uri(), Some("seed-jwt"));
+            // Seed the auth cache so we can observe the clear.
+            *ch.auth.lock() = Some(AuthState {
+                jwt: "seed-jwt".into(),
+                bot_user_id: Some(1),
+            });
+            let err = ch
+                .fetch_unread_pms("seed-jwt")
+                .await
+                .expect_err("expected 401 err");
+            assert!(format!("{err:#}").contains("unauthorized"));
+            assert!(ch.auth.lock().is_none(), "auth should be cleared on 401");
+        }
+
+        #[tokio::test]
+        async fn mark_pm_read_posts_id_and_read_flag() {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/api/v3/private_message/mark_as_read"))
+                .and(header_exists("authorization"))
+                .and(body_partial_json(json!({
+                    "private_message_id": 7,
+                    "read": true
+                })))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "private_message_view": {"private_message": {"id": 7, "read": true}}
+                })))
+                .expect(1)
+                .mount(&server)
+                .await;
+
+            let ch = channel_for(&server.uri(), Some("seed-jwt"));
+            ch.mark_pm_read("seed-jwt", 7).await.expect("ok");
+        }
+    }
+}

--- a/crates/zeroclaw-channels/src/lib.rs
+++ b/crates/zeroclaw-channels/src/lib.rs
@@ -32,6 +32,8 @@ pub mod imessage;
 pub mod irc;
 #[cfg(feature = "channel-lark")]
 pub mod lark;
+#[cfg(feature = "channel-lemmy")]
+pub mod lemmy;
 #[cfg(feature = "channel-line")]
 pub mod line;
 #[cfg(feature = "channel-linq")]

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -36,6 +36,8 @@ pub use crate::imessage::IMessageChannel;
 pub use crate::irc::IrcChannel;
 #[cfg(feature = "channel-lark")]
 pub use crate::lark::LarkChannel;
+#[cfg(feature = "channel-lemmy")]
+pub use crate::lemmy::LemmyChannel;
 #[cfg(feature = "channel-line")]
 pub use crate::line::LineChannel;
 pub use crate::linq::LinqChannel;
@@ -4476,6 +4478,21 @@ fn build_channel_by_id(config: &Config, channel_id: &str) -> Result<Arc<dyn Chan
                 lq.allowed_senders.clone(),
             )))
         }
+        "lemmy" => {
+            let lm = config
+                .channels
+                .lemmy
+                .as_ref()
+                .context("Lemmy channel is not configured")?;
+            Ok(Arc::new(LemmyChannel::new(
+                lm.instance_url.clone(),
+                lm.username.clone(),
+                lm.password.clone(),
+                lm.jwt.clone(),
+                lm.allowed_users.clone(),
+                lm.poll_interval_secs,
+            )))
+        }
         #[cfg(feature = "channel-email")]
         "email" => {
             let em = config
@@ -5280,6 +5297,22 @@ fn collect_configured_channels(
             channel: Arc::new(BlueskyChannel::new(
                 bs.handle.clone(),
                 bs.app_password.clone(),
+            )),
+        });
+    }
+
+    if let Some(ref lm) = config.channels.lemmy
+        && lm.enabled
+    {
+        channels.push(ConfiguredChannel {
+            display_name: "Lemmy",
+            channel: Arc::new(LemmyChannel::new(
+                lm.instance_url.clone(),
+                lm.username.clone(),
+                lm.password.clone(),
+                lm.jwt.clone(),
+                lm.allowed_users.clone(),
+                lm.poll_interval_secs,
             )),
         });
     }

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -6779,6 +6779,9 @@ pub struct ChannelsConfig {
     /// Bluesky channel configuration (AT Protocol).
     #[nested]
     pub bluesky: Option<BlueskyConfig>,
+    /// Lemmy channel configuration (private-message polling).
+    #[nested]
+    pub lemmy: Option<LemmyConfig>,
     /// Voice call channel configuration (Twilio/Telnyx/Plivo).
     #[nested]
     pub voice_call: Option<crate::scattered_types::VoiceCallConfig>,
@@ -6955,6 +6958,10 @@ impl ChannelsConfig {
                 Box::new(ConfigWrapper::new(self.bluesky.as_ref())),
                 self.bluesky.is_some(),
             ),
+            (
+                Box::new(ConfigWrapper::new(self.lemmy.as_ref())),
+                self.lemmy.is_some(),
+            ),
             #[cfg(feature = "voice-wake")]
             (
                 Box::new(ConfigWrapper::new(self.voice_wake.as_ref())),
@@ -7019,6 +7026,7 @@ impl Default for ChannelsConfig {
             clawdtalk: None,
             reddit: None,
             bluesky: None,
+            lemmy: None,
             voice_call: None,
             #[cfg(feature = "voice-wake")]
             voice_wake: None,
@@ -8962,6 +8970,66 @@ impl ChannelConfig for BlueskyConfig {
     }
     fn desc() -> &'static str {
         "AT Protocol"
+    }
+}
+
+fn default_lemmy_poll_interval_secs() -> u64 {
+    30
+}
+
+/// Lemmy channel configuration (private-message polling).
+///
+/// v1 focuses on private messages only — the simplest and most useful
+/// surface for a personal agent. Operator either provides a pre-minted JWT
+/// (recommended for production; copy from browser cookie or admin UI) or
+/// `username` + `password` for the channel to auto-login at startup. v1
+/// does not support 2FA — operators with 2FA on the bot account must use
+/// the pre-minted JWT path.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, Configurable)]
+#[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
+#[prefix = "channels.lemmy"]
+pub struct LemmyConfig {
+    /// Whether this channel is active (must be explicitly enabled). Default: false.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Lemmy instance base URL, e.g. `"https://lemmy.world"`. Trailing
+    /// slash is optional and stripped at load time.
+    pub instance_url: String,
+    /// Bot account username. Required when `jwt` is empty and the channel
+    /// must auto-login.
+    #[serde(default)]
+    pub username: String,
+    /// Bot account password. Required when `jwt` is empty. Stored as a
+    /// secret. Prefer the pre-minted JWT path in production.
+    #[serde(default)]
+    #[secret]
+    #[cfg_attr(feature = "schema-export", schemars(extend("x-secret" = true)))]
+    pub password: String,
+    /// Pre-minted JWT. When non-empty, takes precedence over
+    /// username/password — the channel uses it directly and skips the
+    /// login call. Recommended for production deployments and required
+    /// for accounts with 2FA.
+    #[serde(default)]
+    #[secret]
+    #[cfg_attr(feature = "schema-export", schemars(extend("x-secret" = true)))]
+    pub jwt: String,
+    /// Allowed sender Lemmy usernames. Either bare (`"alice"`) or
+    /// instance-qualified (`"alice@lemmy.world"`). Empty list = deny all.
+    /// `"*"` allows everyone. Comparison is case-insensitive.
+    #[serde(default)]
+    pub allowed_users: Vec<String>,
+    /// Polling cadence (seconds) for `GET /api/v3/private_message/list`.
+    /// Default: 30. Lower bound 5.
+    #[serde(default = "default_lemmy_poll_interval_secs")]
+    pub poll_interval_secs: u64,
+}
+
+impl ChannelConfig for LemmyConfig {
+    fn name() -> &'static str {
+        "Lemmy"
+    }
+    fn desc() -> &'static str {
+        "Lemmy (private-message polling)"
     }
 }
 
@@ -12403,6 +12471,7 @@ auto_save = true
                 clawdtalk: None,
                 reddit: None,
                 bluesky: None,
+                lemmy: None,
                 voice_call: None,
                 voice_duplex: None,
                 #[cfg(feature = "voice-wake")]
@@ -13577,6 +13646,7 @@ allowed_users = ["@u:matrix.org"]
             clawdtalk: None,
             reddit: None,
             bluesky: None,
+            lemmy: None,
             voice_call: None,
             voice_duplex: None,
             #[cfg(feature = "voice-wake")]
@@ -13959,6 +14029,7 @@ bot_token = "xoxb-tok"
             clawdtalk: None,
             reddit: None,
             bluesky: None,
+            lemmy: None,
             voice_call: None,
             voice_duplex: None,
             #[cfg(feature = "voice-wake")]

--- a/docs/book/src/channels/social.md
+++ b/docs/book/src/channels/social.md
@@ -71,6 +71,29 @@ subreddits = ["rust", "commandline"]
 - **Outbound:** posts, comments, private messages.
 - **User-agent convention:** Reddit's API requires a descriptive user-agent string. Non-compliance → rate limits.
 
+## Lemmy
+
+```toml
+[channels.lemmy]
+enabled = true
+instance_url = "https://lemmy.world"        # any Lemmy-compatible instance
+# Two auth paths — pick one:
+#   1) Pre-minted JWT (recommended, required for 2FA accounts)
+jwt = "eyJhbGciOiJIUzI1Ni..."               # SECRET — copy from browser cookie or admin UI
+#   2) Username + password (channel auto-logs in at startup)
+# username = "agent-bot"
+# password = "..."                          # SECRET — stored via the same redaction pipeline as Reddit
+allowed_users = ["alice", "bob@beehaw.org"] # bare or instance-qualified; `*` allows anyone
+poll_interval_secs = 30                     # default 30s; lower bound 5s
+```
+
+- **Auth model:** Lemmy v3 REST. Two paths: pre-minted JWT (recommended for production) or username + password — the channel will call `POST /api/v3/user/login` once at startup and cache the token. v1 does **not** support 2FA on the bot account; use the JWT path if that applies.
+- **Scope:** v1 handles **private messages only**. The bot polls `GET /api/v3/private_message/list?unread_only=true` every `poll_interval_secs`, dispatches each PM as a `ChannelMessage`, and `PUT /api/v3/private_message/mark_as_read` so the next poll doesn't re-deliver. Comment / post listening is deferred to v2.
+- **Outbound:** `POST /api/v3/private_message` with `recipient_id` + `content`. Bodies over 10000 chars are split at sentence/word boundaries with `(i/N) ` continuation markers.
+- **Recipient grammar:** `pm:{user_id}` (canonical) or bare numeric (shorthand). Set automatically when the agent replies to inbound PMs.
+- **Allowlist forms:** bare usernames (`alice`) match both local and federated senders; instance-qualified (`alice@beehaw.org`) require an exact match. Comparison is case-insensitive. Empty list denies all; `*` wildcard allows anyone.
+- **Self-hosted TLS:** common in self-hosted installs. Default `reqwest` client honours system trust roots; private CAs need OS-level install.
+
 ---
 
 ## Operating social channels safely


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Adds a new `LemmyChannel` so operators can converse with the agent over Lemmy private messages on any Lemmy-compatible instance (lemmy.world, self-hosted, etc.). Sibling to the recently merged Mastodon (#6426), Rocket.Chat (#6436), and Zulip (#6438) channels — same one-screen operator setup story.
  - v1 deliberately scopes to **private messages only** (the simplest, highest-utility surface for a personal agent); comment / post listening is deferred to v2.
  - Two auth paths: pre-minted JWT takes precedence; falls back to `POST /api/v3/user/login` with username + password when `jwt` is empty. On 401 the cached auth is cleared so the next loop re-mints.
  - Bot's own user id is resolved once via `GET /api/v3/site` and used to suppress self-messages; even dropped messages get `mark_as_read` so the unread queue can't grow unbounded.
  - Outbound bodies over 10000 chars are split at sentence/word boundaries with `(i/N)` continuation markers; allowlist is case-insensitive with bare entries (`alice`) matching local + federated, and `alice@beehaw.org` requiring exact match; `*` wildcard allows anyone.
- **Scope boundary:** No changes to existing channels, agent loop, providers, gateway, runtime, or security paths. No comment/post listening (v2). No new optional dependencies — uses existing workspace `reqwest` / `serde_json`.
- **Blast radius:** New `channel-lemmy` Cargo feature is in the `default` set, so a default build now compiles one additional module. `ChannelsConfig` gains a new optional `lemmy` field — backward compatible (absent in old configs = channel disabled). Orchestrator gains a `"lemmy"` arm in `build_channel_by_id` and a `start_channels()` push; existing channels are untouched.
- **Linked issue(s):** Closes #6441; Related #6426, #6436, #6438 (sibling social channels).

## Validation Evidence (required)

Local validation is the signal CI cannot replace. Run the full battery and paste literal output (tails, failures, warnings — not \"all passed\").

\`\`\`bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
\`\`\`

- **Commands run and tail output:**
  - \`cargo fmt --all -- --check\` — clean (no diff)
  - \`cargo clippy --all-targets -- -D warnings\` — clean on the changed crates (`zeroclaw-channels`, `zeroclaw-config`)
  - \`cargo test -p zeroclaw-channels\` — 29 new Lemmy tests pass (24 unit + 5 wiremock); full crate suite green
- **Beyond CI — what did you manually verified:**
  - Allowlist: empty / `*` / bare local / bare federated / instance-qualified; case-insensitivity confirmed.
  - Recipient parsing: `pm:42` accepted, bare `42` accepted (shorthand), `pm:abc` rejected.
  - Auth: seed-JWT path skips `/user/login`; missing JWT triggers login + caches token; 401 on list endpoint clears cached auth and the next loop re-mints (wiremock).
  - Listen loop: self-messages, deleted, empty, and out-of-allowlist messages are filtered AND marked read so they don't requeue.
  - Send loop: 10001-char body splits with `(1/N)` markers at sensible boundaries; `POST /api/v3/private_message` body shape verified via wiremock.
  - **Not verified manually:** live end-to-end against a real lemmy.world account (relying on wiremock + structural review). Comment/post pathways are out of scope for v1.
- **If any command was intentionally skipped, why:** None.

## Security & Privacy Impact (required)

Yes/No for each. Answer any \`Yes\` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? (\`No\`)
- New external network calls? (\`Yes\`) — outbound HTTPS to the operator-configured Lemmy instance only (`/api/v3/user/login`, `/api/v3/site`, `/api/v3/private_message`, `/api/v3/private_message/list`, `/api/v3/private_message/mark_as_read`). No third-party endpoints; instance is operator-chosen.
- Secrets / tokens / credentials handling changed? (\`Yes\`) — `LemmyConfig.password` and `LemmyConfig.jwt` are marked `#[secret]` so the existing config-secret machinery redacts them in logs, diffs, and the doctor UI. JWTs are held in-memory only (no on-disk persistence beyond the standard secret-store).
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (\`No\`) — fixtures use synthetic usernames (`alice`, `bot`, `beehaw.org`).
- If any \`Yes\`, describe the risk and mitigation:
  - **Network:** outbound only, operator-scoped instance, fails closed (errors log + retry next poll).
  - **Secrets:** `#[secret]` attribute already covered by privacy-contract tests; no plaintext credentials in error paths.

## Compatibility (required)

- Backward compatible? (\`Yes\`)
- Config / env / CLI surface changed? (\`Yes\`) — additive only:
  - New optional `[channels.lemmy]` config block with `instance_url`, `username`, `password`, `jwt`, `allowed_users`, `poll_interval_secs` (default 30s, lower bound 5s).
  - New `channel-lemmy` Cargo feature in the `default` set (operators on a custom feature set should add it explicitly).
  - `zeroclaw channel list` / `zeroclaw channel send lemmy pm:<id> \"...\"` newly recognize `lemmy`.
- If \`No\` or \`Yes\` to either: exact upgrade steps for existing users:
  - **No action required** to keep current behavior (block omitted = channel disabled).
  - To enable: add `[channels.lemmy]` with `instance_url` + (`jwt` or `username`+`password`) + `allowed_users`. See `docs/book/src/channels/social.md`.

## Rollback (required for \`risk: medium\` and \`risk: high\`)

- **Fast rollback command/path:** `git revert 5677b9b81` on master, then re-cut the release. The change is one commit, additive, with no migrations.
- **Feature flags or config toggles:** Disable at runtime by removing the `[channels.lemmy]` block (or setting `instance_url = \"\"`). Build-time toggle: `--no-default-features` + selected features minus `channel-lemmy`.
- **Observable failure symptoms:**
  - Repeated `lemmy: poll failed` / `lemmy: send failed` warnings in agent logs.
  - `lemmy: 401 ...` followed by re-login attempts each loop = invalid creds / revoked JWT.
  - Unbounded growth of unread PMs on the operator's account = `mark_as_read` regression.
  - `channel.lemmy.send.errors` / `channel.lemmy.poll.errors` counters trending up (existing channel-metrics surface).

## Supersede Attribution (required only when \`Supersedes #\` is used)

N/A — this PR does not supersede a prior PR.

---

**Labels:** `channel`, `risk: medium`, `size: XL` (auto), `enhancement` — set via sidebar.
