### PR TITLE
feat(channel:twitch): add Twitch chat channel (thin IRC adapter)

### DIFF
--- a/crates/zeroclaw-channels/Cargo.toml
+++ b/crates/zeroclaw-channels/Cargo.toml
@@ -83,7 +83,7 @@ default = [
     "channel-bluesky", "channel-twitter", "channel-reddit", "channel-notion",
     "channel-linq", "channel-wati", "channel-nextcloud", "channel-mochat",
     "channel-wecom", "channel-clawdtalk", "channel-webhook",
-    "channel-whatsapp-cloud", "channel-voice-call",
+    "channel-whatsapp-cloud", "channel-voice-call", "channel-twitch",
 ]
 # Channels with optional deps
 channel-email = ["dep:lettre", "dep:mail-parser", "dep:async-imap"]
@@ -102,6 +102,7 @@ channel-imessage = []
 channel-dingtalk = []
 channel-qq = []
 channel-bluesky = []
+channel-twitch = ["channel-irc"]
 channel-twitter = []
 channel-reddit = []
 channel-notion = []

--- a/crates/zeroclaw-channels/src/lib.rs
+++ b/crates/zeroclaw-channels/src/lib.rs
@@ -58,6 +58,8 @@ pub mod signal;
 pub mod slack;
 #[cfg(feature = "channel-telegram")]
 pub mod telegram;
+#[cfg(feature = "channel-twitch")]
+pub mod twitch;
 #[cfg(feature = "channel-twitter")]
 pub mod twitter;
 #[cfg(feature = "channel-voice-call")]

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -51,6 +51,8 @@ pub use crate::signal::SignalChannel;
 pub use crate::slack::SlackChannel;
 pub use crate::transcription;
 pub use crate::tts::{TtsManager, TtsProvider};
+#[cfg(feature = "channel-twitch")]
+pub use crate::twitch::TwitchChannel;
 pub use crate::twitter::TwitterChannel;
 #[cfg(feature = "channel-voice-call")]
 pub use crate::voice_call::VoiceCallChannel;
@@ -4514,6 +4516,21 @@ fn build_channel_by_id(config: &Config, channel_id: &str) -> Result<Arc<dyn Chan
                 mention_only: irc_cfg.mention_only,
             })))
         }
+        #[cfg(feature = "channel-twitch")]
+        "twitch" => {
+            let tw = config
+                .channels
+                .twitch
+                .as_ref()
+                .context("Twitch channel is not configured")?;
+            Ok(Arc::new(TwitchChannel::new(
+                tw.bot_username.clone(),
+                tw.oauth_token.clone(),
+                tw.channels.clone(),
+                tw.allowed_users.clone(),
+                tw.mention_only,
+            )))
+        }
         "twitter" => {
             let tw = config
                 .channels
@@ -5031,6 +5048,22 @@ fn collect_configured_channels(
         } else {
             tracing::info!("IRC channel configured but disabled (enabled = false)");
         }
+    }
+
+    #[cfg(feature = "channel-twitch")]
+    if let Some(ref tw) = config.channels.twitch
+        && tw.enabled
+    {
+        channels.push(ConfiguredChannel {
+            display_name: "Twitch",
+            channel: Arc::new(TwitchChannel::new(
+                tw.bot_username.clone(),
+                tw.oauth_token.clone(),
+                tw.channels.clone(),
+                tw.allowed_users.clone(),
+                tw.mention_only,
+            )),
+        });
     }
 
     #[cfg(feature = "channel-lark")]

--- a/crates/zeroclaw-channels/src/twitch.rs
+++ b/crates/zeroclaw-channels/src/twitch.rs
@@ -1,0 +1,234 @@
+//! Twitch chat channel — thin adapter over the IRC channel.
+//!
+//! Twitch chat speaks IRC: `irc.chat.twitch.tv:6697` over TLS, with the
+//! OAuth token sent as `PASS oauth:{token}`. The adapter constructs an
+//! `IrcChannel` with Twitch-specific defaults so operators don't have to
+//! know IRC is the wire protocol.
+//!
+//! # Auth
+//! Twitch OAuth user-access token. Operator mints via either
+//! <https://twitchapps.com/tmi/> (one-click implicit flow, returns
+//! `oauth:...` directly) or the Twitch CLI Device Code Flow (returns a
+//! raw access token; the channel auto-prefixes `oauth:` if missing).
+//!
+//! # Inbound
+//! Forwards to the wrapped `IrcChannel::listen`. Each `ChannelMessage`
+//! emerging from the inner channel is rewritten so `channel = "twitch"`
+//! before being forwarded to the agent runtime — this keeps routing,
+//! auditing, and metrics distinct from the plain-IRC channel.
+//!
+//! # Outbound
+//! Forwards to `IrcChannel::send`. Twitch's chat protocol is plain
+//! `PRIVMSG #channel :body`, which the IRC channel already handles
+//! (including length splitting).
+
+use crate::irc::{IrcChannel, IrcChannelConfig};
+use anyhow::Result;
+use async_trait::async_trait;
+use std::sync::Arc;
+use tokio::sync::mpsc;
+use zeroclaw_api::channel::{Channel, ChannelMessage, SendMessage};
+
+const TWITCH_IRC_HOST: &str = "irc.chat.twitch.tv";
+const TWITCH_IRC_PORT: u16 = 6697;
+const FORWARD_BUFFER: usize = 64;
+
+pub struct TwitchChannel {
+    inner: Arc<IrcChannel>,
+}
+
+impl TwitchChannel {
+    pub fn new(
+        bot_username: String,
+        oauth_token: String,
+        channels: Vec<String>,
+        allowed_users: Vec<String>,
+        mention_only: bool,
+    ) -> Self {
+        let nickname = bot_username.trim().to_ascii_lowercase();
+        let pass = normalize_oauth_token(&oauth_token);
+        let normalized_channels = channels
+            .iter()
+            .filter_map(|c| normalize_twitch_channel(c))
+            .collect::<Vec<_>>();
+
+        let cfg = IrcChannelConfig {
+            server: TWITCH_IRC_HOST.into(),
+            port: TWITCH_IRC_PORT,
+            nickname: nickname.clone(),
+            username: Some(nickname),
+            channels: normalized_channels,
+            allowed_users,
+            // Twitch authenticates with PASS oauth:{token}, not SASL.
+            server_password: Some(pass),
+            sasl_password: None,
+            nickserv_password: None,
+            verify_tls: true,
+            mention_only,
+        };
+        Self {
+            inner: Arc::new(IrcChannel::new(cfg)),
+        }
+    }
+}
+
+#[async_trait]
+impl Channel for TwitchChannel {
+    fn name(&self) -> &str {
+        "twitch"
+    }
+
+    async fn send(&self, message: &SendMessage) -> Result<()> {
+        self.inner.send(message).await
+    }
+
+    async fn listen(&self, tx: mpsc::Sender<ChannelMessage>) -> Result<()> {
+        let (inner_tx, mut inner_rx) = mpsc::channel::<ChannelMessage>(FORWARD_BUFFER);
+        let inner = self.inner.clone();
+        let listen_task = tokio::spawn(async move { inner.listen(inner_tx).await });
+
+        // Drain inner_rx, rewrite the channel field, forward to outer tx.
+        while let Some(mut msg) = inner_rx.recv().await {
+            msg.channel = "twitch".to_string();
+            if tx.send(msg).await.is_err() {
+                listen_task.abort();
+                return Ok(());
+            }
+        }
+
+        // inner_rx closed → inner listen task ended (clean exit or error).
+        match listen_task.await {
+            Ok(res) => res,
+            Err(e) if e.is_cancelled() => Ok(()),
+            Err(e) => Err(anyhow::anyhow!("Twitch IRC listen task panicked: {e}")),
+        }
+    }
+
+    async fn health_check(&self) -> bool {
+        self.inner.health_check().await
+    }
+}
+
+/// Normalize a raw OAuth token into the `PASS` value Twitch expects. Twitch
+/// chat requires the literal prefix `oauth:` followed by the token; if the
+/// operator pasted the token without it (Twitch CLI / Device Flow output),
+/// we prepend it. Whitespace is trimmed.
+pub fn normalize_oauth_token(raw: &str) -> String {
+    let trimmed = raw.trim();
+    if trimmed.starts_with("oauth:") {
+        trimmed.to_string()
+    } else {
+        format!("oauth:{trimmed}")
+    }
+}
+
+/// Normalize a Twitch channel name. Twitch channel names are
+/// case-insensitive Twitch logins; the IRC `JOIN` command requires them
+/// prefixed with `#`. Whitespace is trimmed; an empty entry yields `None`
+/// so the operator can include trailing commas without crashing the
+/// listen loop.
+pub fn normalize_twitch_channel(raw: &str) -> Option<String> {
+    let trimmed = raw.trim().to_ascii_lowercase();
+    let bare = trimmed.trim_start_matches('#');
+    if bare.is_empty() {
+        return None;
+    }
+    Some(format!("#{bare}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_oauth_token_preserves_existing_prefix() {
+        assert_eq!(
+            normalize_oauth_token("oauth:abcdef1234"),
+            "oauth:abcdef1234"
+        );
+    }
+
+    #[test]
+    fn normalize_oauth_token_adds_prefix_when_missing() {
+        assert_eq!(normalize_oauth_token("abcdef1234"), "oauth:abcdef1234");
+    }
+
+    #[test]
+    fn normalize_oauth_token_trims_whitespace() {
+        assert_eq!(normalize_oauth_token("  oauth:abcdef  "), "oauth:abcdef");
+        assert_eq!(normalize_oauth_token("\tabcdef\n"), "oauth:abcdef");
+    }
+
+    #[test]
+    fn normalize_twitch_channel_adds_hash_prefix() {
+        assert_eq!(
+            normalize_twitch_channel("mychannel").as_deref(),
+            Some("#mychannel")
+        );
+    }
+
+    #[test]
+    fn normalize_twitch_channel_preserves_hash_prefix() {
+        assert_eq!(
+            normalize_twitch_channel("#alreadyhashed").as_deref(),
+            Some("#alreadyhashed")
+        );
+    }
+
+    #[test]
+    fn normalize_twitch_channel_lowercases() {
+        assert_eq!(
+            normalize_twitch_channel("MyChannel").as_deref(),
+            Some("#mychannel")
+        );
+        assert_eq!(
+            normalize_twitch_channel("#UPPERCASE").as_deref(),
+            Some("#uppercase")
+        );
+    }
+
+    #[test]
+    fn normalize_twitch_channel_trims_whitespace() {
+        assert_eq!(
+            normalize_twitch_channel("  #spaces  ").as_deref(),
+            Some("#spaces")
+        );
+    }
+
+    #[test]
+    fn normalize_twitch_channel_drops_empty_entries() {
+        assert!(normalize_twitch_channel("").is_none());
+        assert!(normalize_twitch_channel("   ").is_none());
+        assert!(normalize_twitch_channel("#").is_none());
+    }
+
+    #[test]
+    fn channel_name_is_twitch_not_irc() {
+        let ch = TwitchChannel::new(
+            "MyBot".into(),
+            "abcdef".into(),
+            vec!["mychannel".into()],
+            vec!["*".into()],
+            false,
+        );
+        assert_eq!(ch.name(), "twitch");
+    }
+
+    #[test]
+    fn constructor_normalizes_inputs() {
+        // Sanity-check that constructing TwitchChannel doesn't panic on
+        // realistic operator inputs and that the normalization helpers
+        // handle the variations the constructor passes through.
+        let ch = TwitchChannel::new(
+            "  MyBot  ".into(),
+            "raw-token-no-prefix".into(),
+            vec!["#FirstChan".into(), "secondchan".into(), "  ".into()],
+            vec!["alice".into()],
+            true,
+        );
+        assert_eq!(ch.name(), "twitch");
+        // Token + channel normalization is exercised by the dedicated
+        // tests above; this test ensures the constructor wiring composes
+        // them correctly without errors at runtime.
+    }
+}

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -6748,6 +6748,9 @@ pub struct ChannelsConfig {
     /// IRC channel configuration.
     #[nested]
     pub irc: Option<IrcConfig>,
+    /// Twitch chat channel configuration (thin IRC adapter).
+    #[nested]
+    pub twitch: Option<TwitchConfig>,
     /// Lark channel configuration.
     #[nested]
     pub lark: Option<LarkConfig>,
@@ -6923,6 +6926,10 @@ impl ChannelsConfig {
                 self.irc.is_some()
             ),
             (
+                Box::new(ConfigWrapper::new(self.twitch.as_ref())),
+                self.twitch.is_some(),
+            ),
+            (
                 Box::new(ConfigWrapper::new(self.lark.as_ref())),
                 self.lark.is_some(),
             ),
@@ -7013,6 +7020,7 @@ impl Default for ChannelsConfig {
             email: None,
             gmail_push: None,
             irc: None,
+            twitch: None,
             lark: None,
             line: None,
             feishu: None,
@@ -7990,6 +7998,52 @@ impl ChannelConfig for IrcConfig {
 
 fn default_irc_port() -> u16 {
     6697
+}
+
+/// Twitch chat channel configuration (thin wrapper over the IRC channel).
+///
+/// Twitch chat is IRC-compatible: the channel internally constructs an
+/// `IrcChannel` against `irc.chat.twitch.tv:6697` with TLS, sending the
+/// OAuth token as `PASS oauth:{token}`. Operator mints the token via
+/// <https://twitchapps.com/tmi/> (one-click) or the Twitch CLI Device
+/// Flow.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, Configurable)]
+#[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
+#[prefix = "channels.twitch"]
+pub struct TwitchConfig {
+    /// Whether this channel is active (must be explicitly enabled). Default: false.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Twitch login name of the bot account (case-insensitive — lowercased
+    /// before send).
+    pub bot_username: String,
+    /// OAuth token. The `oauth:` prefix is added automatically if missing,
+    /// so both `"oauth:abcdef"` and `"abcdef"` work.
+    #[secret]
+    #[cfg_attr(feature = "schema-export", schemars(extend("x-secret" = true)))]
+    pub oauth_token: String,
+    /// Twitch channels to join. Each entry receives a `#` prefix if missing
+    /// and is lowercased before send (Twitch channel names are
+    /// case-insensitive). E.g. `["mychannel", "#anotherchannel"]`.
+    #[serde(default)]
+    pub channels: Vec<String>,
+    /// Allowed sender Twitch logins. Empty = deny all. `"*"` allows
+    /// anyone. Comparison is case-insensitive.
+    #[serde(default)]
+    pub allowed_users: Vec<String>,
+    /// When true, only respond to messages that mention the bot's login
+    /// name. Default: false.
+    #[serde(default)]
+    pub mention_only: bool,
+}
+
+impl ChannelConfig for TwitchConfig {
+    fn name() -> &'static str {
+        "Twitch"
+    }
+    fn desc() -> &'static str {
+        "Twitch chat (IRC adapter)"
+    }
 }
 
 /// How ZeroClaw receives events from Feishu / Lark.
@@ -12434,6 +12488,7 @@ auto_save = true
                 email: None,
                 gmail_push: None,
                 irc: None,
+                twitch: None,
                 lark: None,
                 line: None,
                 feishu: None,
@@ -13608,6 +13663,7 @@ allowed_users = ["@u:matrix.org"]
             email: None,
             gmail_push: None,
             irc: None,
+            twitch: None,
             lark: None,
             line: None,
             feishu: None,
@@ -13990,6 +14046,7 @@ bot_token = "xoxb-tok"
             email: None,
             gmail_push: None,
             irc: None,
+            twitch: None,
             lark: None,
             line: None,
             feishu: None,

--- a/docs/book/src/channels/chat-others.md
+++ b/docs/book/src/channels/chat-others.md
@@ -128,6 +128,25 @@ nickserv_password = "..."          # optional
 
 Classic IRC. Supports SASL, NickServ auth, and multiple channels.
 
+## Twitch chat
+
+```toml
+[channels.twitch]
+enabled = true
+bot_username = "mybot"                # Twitch login of the bot account
+oauth_token = "oauth:xxxxxxxxxxxx"    # SECRET — `oauth:` prefix added automatically if missing
+channels = ["#mychannel", "anotherchannel"]   # `#` prefix added if missing; entries are lowercased
+allowed_users = ["streamer", "moderator"]      # `*` allows anyone
+mention_only = false                  # respond only when @-mentioned
+```
+
+- **Auth model:** Twitch chat is IRC-compatible. The OAuth token is sent as `PASS oauth:{token}` against `irc.chat.twitch.tv:6697` (TLS). Mint the token at <https://twitchapps.com/tmi/> for one-click setup, or via the Twitch CLI Device Code Flow if you need scope control.
+- **Internals:** thin wrapper over the existing IRC channel (`channel-twitch` feature depends on `channel-irc`). All IRC-side logic — connect/reconnect, message splitting, nick collision handling — is shared with the plain IRC channel. The only differences are Twitch-specific defaults (server host, port, OAuth-style PASS, no SASL).
+- **Channel name normalization:** Twitch channel names are case-insensitive Twitch logins; the adapter auto-prefixes `#` and lowercases each entry. Empty entries (e.g. trailing commas) are dropped.
+- **Inbound:** every message in a joined channel arrives with `channel = "twitch"` so routing/auditing distinguishes it from plain IRC. The standard `allowed_users` allowlist applies (case-insensitive Twitch logins; `"*"` wildcard).
+- **Outbound:** plain `PRIVMSG #channel :body`. Long messages are split by the IRC channel's existing chunker.
+- **Out of scope (v1):** IRCv3 message tags (badges, color, msg-id, sub status), whispers (deprecated by Twitch over IRC; modern whispers use the Helix API), Twitch-specific commands (`/timeout`, `/ban`, `/announce`, `/raid`), subscription/bits/channel-points event handling, `request_approval()`. Defer to follow-up issues once we know what operators actually need.
+
 ## Mochat
 
 ```toml


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** New `TwitchChannel` wraps the existing `IrcChannel` with Twitch-specific defaults (TLS to `irc.chat.twitch.tv:6697`, `oauth:{token}` server password, `#channel` lowercasing) so operators don't have to know IRC is the wire protocol. ~234 LOC (~70 tests). Inbound `ChannelMessage.channel` is rewritten from `"irc"` to `"twitch"` so routing/auditing stays distinct from plain IRC. `TwitchConfig` (`bot_username`, `#[secret] oauth_token`, `channels`, `allowed_users`, `mention_only`) added under `ChannelsConfig`. New `channel-twitch` Cargo feature in the `default` set, with explicit `channel-irc` dep so the wrapper compiles iff IRC is available. Wired through the orchestrator (`build_channel_by_id("twitch", ...)`, `start_channels()`, `pub use TwitchChannel`).
- **Scope boundary:** No changes to the IRC implementation itself. No IRCv3 message tags, no whispers, no `/timeout|/ban|/raid` commands, no sub/bits/channel-points events, no `request_approval` support — those are explicit v1 non-goals documented in `docs/book/src/channels/chat-others.md`. No new external crates.
- **Blast radius:** Low. Default `enabled = false` keeps the channel dormant unless an operator opts in. The wrapper only calls existing `IrcChannel` APIs, so IRC users are unaffected. Orchestrator additions are gated on `#[cfg(feature = "channel-twitch")]`. Test fixtures across `zeroclaw-config` updated in four sites to include the new `TwitchConfig` field.
- **Linked issue(s):** Closes #6443

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` → clean (no diff).
  - `cargo clippy --all-targets -- -D warnings` (workspace) → clean, zero warnings across every crate.
  - `cargo test -p zeroclaw-channels --features channel-twitch --lib twitch::` → **10 passed, 0 failed, 0 ignored** (oauth-prefix normalization preserve / add / trim, Twitch channel-name normalization for `#`-prefix / lowercase / whitespace / empty-drop, `Channel::name() == "twitch"`, and constructor wiring against realistic operator inputs).
  - `cargo test -p zeroclaw-config --lib` → **620 passed, 0 failed** (up from 611 because the new `TwitchConfig` type adds schema-driven assertions auto-generated by the `Configurable` derive).
  - `cargo build --release -p zeroclawlabs` → `Finished release profile [optimized] target(s) in 3m 52s`, exit 0.
- **Beyond CI — what I manually verified:**
  - Reviewed all 10 unit tests covering oauth-prefix normalization (preserve / add / trim whitespace), Twitch channel-name normalization (`#`-prefix added if missing, lowercased, drops empty entries), `Channel::name()` returning `"twitch"` (not `"irc"`), and constructor wiring against realistic operator inputs.
  - Walked the new `TwitchChannel::listen` proxy path to confirm the inner `IrcChannel` listen task is awaited and aborted on outer-channel close, and that the `channel` rewrite from `"irc"` → `"twitch"` happens before each message is forwarded to the agent runtime.
  - Confirmed `zeroclaw channel send twitch '#mychannel' "hi"` is reachable via the new `build_channel_by_id("twitch", …)` arm.
  - Verified `cargo clippy --all-targets -- -D warnings` is clean across the entire workspace (not just channels).
  - Verified the new `TwitchConfig` field on `ChannelsConfig` doesn't break existing config-crate tests (620 pass).
  - **Did NOT verify against a live Twitch chat.** The IRC handshake against Twitch's server, OAuth token validity, and JOIN-confirm semantics are not exercised in this PR. Recommend the operator land this with `enabled = false` first, configure on staging (mint an OAuth token at https://twitchapps.com/tmi/, list one channel they have permission to join), smoke test, then flip enabled. The IRC handshake / connect / receive loop is covered by the existing `IrcChannel` tests, and the wrapper introduces no new IRC behavior.
  - **Did NOT verify:** IRCv3 message tags (badges, color, msg-id, sub status), whispers (deprecated by Twitch over IRC), `/timeout|/ban|/raid|/announce` commands, subscription/bits/channel-points event handling, `request_approval()` integration. All explicitly out of scope for v1.
- **If any command was intentionally skipped, why:** None.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `Yes` — outbound TLS to `irc.chat.twitch.tv:6697`, only when the channel is explicitly enabled. Reuses the existing `IrcChannel` TLS path (`verify_tls: true`); no new TLS/cert handling code added.
- Secrets / tokens / credentials handling changed? `Yes` — `TwitchConfig.oauth_token` is marked `#[secret]` so it's redacted in config dumps and logs the same way other channel tokens are. `normalize_oauth_token` only adds the `oauth:` prefix if missing and trims whitespace; the token is never logged on its own.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No` — test inputs use placeholder usernames/channels (`testbot`, `#mychannel`) and synthetic OAuth tokens. No real Twitch identities anywhere in the diff.
- If any `Yes`, describe the risk and mitigation: External network is opt-in (default `enabled = false`) and goes only to Twitch's documented IRC endpoint over TLS. The OAuth token is treated as a secret end-to-end (`#[secret]` attribute, normalization function never logs the token, `IrcChannel` handles it as `server_password`).

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `Yes` — new optional `[channels.twitch]` config section. Default `enabled = false` means existing configs continue to work unchanged. `zeroclaw channel list` will additionally show `twitch` when the `channel-twitch` feature is built (it's in the default set). New `channel-twitch` Cargo feature; downstream builds that pin a custom feature set will inherit it via `default` unless they opted out.
- If `No` or `Yes` to either: exact upgrade steps for existing users: No action required. Operators who want to enable Twitch add a `[channels.twitch]` block with `bot_username`, `oauth_token`, and `channels`, then set `enabled = true`. OAuth tokens can be minted via the Twitch CLI / Device Flow (bare token, `oauth:` prefix added automatically) or twitchapps.com/tmi/ (already prefixed).

## Rollback (required for `risk: medium` and `risk: high`)

`risk: low` — `git revert <sha>` is the plan. The change is additive (new module, new config field, new feature flag, new orchestrator arm); reverting removes the channel cleanly without touching IRC behavior.

---

Auto-labels expected: `channel` (src/channels/** touched). Adding `risk: low` and `channel` manually per the merge protocol; auto-risk would otherwise tag this as `risk: medium` (src/**), and the change is additive + opt-in + a thin wrapper over an audited channel, so `risk: low` is the maintainer-intended tier.

