### PR TITLE
feat(providers): add Upstage Solar as a model provider

### DIFF
--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -975,6 +975,7 @@ fn resolve_provider_credential(name: &str, credential_override: Option<&str>) ->
         "astrai" => vec!["ASTRAI_API_KEY"],
         "avian" => vec!["AVIAN_API_KEY"],
         "deepmyst" | "deep-myst" => vec!["DEEPMYST_API_KEY"],
+        "morph" => vec!["MORPH_API_KEY"],
         "llamacpp" | "llama.cpp" => vec!["LLAMACPP_API_KEY"],
         "sglang" => vec!["SGLANG_API_KEY"],
         "vllm" => vec!["VLLM_API_KEY"],
@@ -1745,6 +1746,12 @@ fn create_provider_with_url_and_options(
         "deepmyst" | "deep-myst" => Ok(compat(OpenAiCompatibleProvider::new(
             "DeepMyst",
             "https://api.deepmyst.com/v1",
+            key,
+            AuthStyle::Bearer,
+        ))),
+        "morph" => Ok(compat(OpenAiCompatibleProvider::new(
+            "Morph",
+            "https://api.morphllm.com/v1",
             key,
             AuthStyle::Bearer,
         ))),
@@ -2601,6 +2608,14 @@ pub fn list_providers() -> Vec<ProviderInfo> {
             activation: ProviderActivation::FallbackKey,
             local: false,
         },
+        ProviderInfo {
+            name: "morph",
+            display_name: "Morph (Fast Apply)",
+            description: "Fast apply-edits LLM",
+            aliases: &[],
+            activation: ProviderActivation::FallbackKey,
+            local: false,
+        },
     ]
 }
 
@@ -3411,6 +3426,19 @@ mod tests {
         assert_eq!(resolved, Some("dm-test-key".to_string()));
     }
 
+    #[test]
+    fn factory_morph() {
+        assert!(create_provider("morph", Some("sk-morph-test")).is_ok());
+    }
+
+    #[test]
+    fn resolve_provider_credential_morph_env() {
+        let _env_lock = env_lock();
+        let _guard = EnvGuard::set("MORPH_API_KEY", Some("morph-test-key"));
+        let resolved = resolve_provider_credential("morph", None);
+        assert_eq!(resolved, Some("morph-test-key".to_string()));
+    }
+
     // ── Custom / BYOP provider ─────────────────────────────
 
     #[test]
@@ -3736,6 +3764,7 @@ mod tests {
             "nvidia",
             "astrai",
             "avian",
+            "morph",
             "ovhcloud",
         ];
         for name in providers {

--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -977,6 +977,7 @@ fn resolve_provider_credential(name: &str, credential_override: Option<&str>) ->
         "deepmyst" | "deep-myst" => vec!["DEEPMYST_API_KEY"],
         "morph" => vec!["MORPH_API_KEY"],
         "github-models" | "github_models" => vec!["GITHUB_MODELS_TOKEN"],
+        "upstage" => vec!["UPSTAGE_API_KEY"],
         "llamacpp" | "llama.cpp" => vec!["LLAMACPP_API_KEY"],
         "sglang" => vec!["SGLANG_API_KEY"],
         "vllm" => vec!["VLLM_API_KEY"],
@@ -1759,6 +1760,12 @@ fn create_provider_with_url_and_options(
         "github-models" | "github_models" => Ok(compat(OpenAiCompatibleProvider::new(
             "GitHub Models",
             "https://models.github.ai/inference",
+            key,
+            AuthStyle::Bearer,
+        ))),
+        "upstage" => Ok(compat(OpenAiCompatibleProvider::new(
+            "Upstage Solar",
+            "https://api.upstage.ai/v1/solar",
             key,
             AuthStyle::Bearer,
         ))),
@@ -2631,6 +2638,14 @@ pub fn list_providers() -> Vec<ProviderInfo> {
             activation: ProviderActivation::FallbackKey,
             local: false,
         },
+        ProviderInfo {
+            name: "upstage",
+            display_name: "Upstage Solar",
+            description: "Solar Pro 3 / Solar Mini",
+            aliases: &[],
+            activation: ProviderActivation::FallbackKey,
+            local: false,
+        },
     ]
 }
 
@@ -3477,6 +3492,19 @@ mod tests {
         assert_ne!(resolved, Some("gho_copilot_only".to_string()));
     }
 
+    #[test]
+    fn factory_upstage() {
+        assert!(create_provider("upstage", Some("up-test-key")).is_ok());
+    }
+
+    #[test]
+    fn resolve_provider_credential_upstage_env() {
+        let _env_lock = env_lock();
+        let _guard = EnvGuard::set("UPSTAGE_API_KEY", Some("upstage-test"));
+        let resolved = resolve_provider_credential("upstage", None);
+        assert_eq!(resolved, Some("upstage-test".to_string()));
+    }
+
     // ── Custom / BYOP provider ─────────────────────────────
 
     #[test]
@@ -3804,6 +3832,7 @@ mod tests {
             "avian",
             "morph",
             "github-models",
+            "upstage",
             "ovhcloud",
         ];
         for name in providers {

--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -976,6 +976,7 @@ fn resolve_provider_credential(name: &str, credential_override: Option<&str>) ->
         "avian" => vec!["AVIAN_API_KEY"],
         "deepmyst" | "deep-myst" => vec!["DEEPMYST_API_KEY"],
         "morph" => vec!["MORPH_API_KEY"],
+        "github-models" | "github_models" => vec!["GITHUB_MODELS_TOKEN"],
         "llamacpp" | "llama.cpp" => vec!["LLAMACPP_API_KEY"],
         "sglang" => vec!["SGLANG_API_KEY"],
         "vllm" => vec!["VLLM_API_KEY"],
@@ -1752,6 +1753,12 @@ fn create_provider_with_url_and_options(
         "morph" => Ok(compat(OpenAiCompatibleProvider::new(
             "Morph",
             "https://api.morphllm.com/v1",
+            key,
+            AuthStyle::Bearer,
+        ))),
+        "github-models" | "github_models" => Ok(compat(OpenAiCompatibleProvider::new(
+            "GitHub Models",
+            "https://models.github.ai/inference",
             key,
             AuthStyle::Bearer,
         ))),
@@ -2616,6 +2623,14 @@ pub fn list_providers() -> Vec<ProviderInfo> {
             activation: ProviderActivation::FallbackKey,
             local: false,
         },
+        ProviderInfo {
+            name: "github-models",
+            display_name: "GitHub Models",
+            description: "OpenAI/Meta/Microsoft via one GitHub PAT",
+            aliases: &["github_models"],
+            activation: ProviderActivation::FallbackKey,
+            local: false,
+        },
     ]
 }
 
@@ -3439,6 +3454,29 @@ mod tests {
         assert_eq!(resolved, Some("morph-test-key".to_string()));
     }
 
+    #[test]
+    fn factory_github_models() {
+        assert!(create_provider("github-models", Some("ghp_test_token")).is_ok());
+        assert!(create_provider("github_models", Some("ghp_test_token")).is_ok());
+    }
+
+    #[test]
+    fn resolve_provider_credential_github_models_env() {
+        let _env_lock = env_lock();
+        let _guard = EnvGuard::set("GITHUB_MODELS_TOKEN", Some("ghp_models_test"));
+        let resolved = resolve_provider_credential("github-models", None);
+        assert_eq!(resolved, Some("ghp_models_test".to_string()));
+    }
+
+    #[test]
+    fn github_models_does_not_consume_github_token() {
+        let _env_lock = env_lock();
+        let _models_guard = EnvGuard::set("GITHUB_MODELS_TOKEN", None);
+        let _token_guard = EnvGuard::set("GITHUB_TOKEN", Some("gho_copilot_only"));
+        let resolved = resolve_provider_credential("github-models", None);
+        assert_ne!(resolved, Some("gho_copilot_only".to_string()));
+    }
+
     // ── Custom / BYOP provider ─────────────────────────────
 
     #[test]
@@ -3765,6 +3803,7 @@ mod tests {
             "astrai",
             "avian",
             "morph",
+            "github-models",
             "ovhcloud",
         ];
         for name in providers {


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Wire Upstage Solar (https://api.upstage.ai/v1/solar) as an OpenAI-compatible provider so the onboard wizard surfaces it alongside other Bearer-auth chat-completions endpoints.
  - Upstage's Solar Pro 3 is a Korea-built foundation model with strong multilingual (KO/EN/JA) reasoning; it fills the "frontier-but-not-US-trained" gap for operators who want a reputable non-US provider without us having to write a custom client.
  - Pure drop-in via the existing `compatible.rs` runtime — same shape as `cerebras` / `sambanova` / `hyperbolic` / `deepmyst`. Final URL after `/chat/completions` append: `https://api.upstage.ai/v1/solar/chat/completions`.
- **Env-var design choice:** Standard pattern — `UPSTAGE_API_KEY`, no collision with any existing provider.
- **Scope boundary:** Does NOT add an Upstage-specific provider crate, custom request shaping, Document-AI / Embeddings / Translation endpoints, or rate-limit tracking. Does NOT touch `compatible.rs`, the agent loop, or any other provider's wiring.
- **Blast radius:** Contained to `zeroclaw-providers`. No existing provider changes behavior. The only behavioral change is that `kind = "upstage"` now resolves instead of erroring.
- **Linked issue:** Closes #6454

## Validation Evidence

```bash
cargo test -p zeroclaw-providers --lib upstage
cargo test -p zeroclaw-providers --lib factory_all_providers_create_successfully
cargo test -p zeroclaw-providers --lib listed_providers
```

- `cargo test -p zeroclaw-providers --lib upstage` — **2 passed, 0 failed**.
- `cargo test -p zeroclaw-providers --lib factory_all_providers_create_successfully` — **1 passed, 0 failed** (with `upstage` added to its provider list).
- `cargo test -p zeroclaw-providers --lib listed_providers` — **2 passed, 0 failed** (`listed_providers_have_unique_ids_and_aliases` and `listed_providers_and_aliases_are_constructible`).
- Two new unit tests pass: `factory_upstage`, `resolve_provider_credential_upstage_env`.
- Verified Upstage's public docs list `https://api.upstage.ai/v1/solar/chat/completions` with `Authorization: Bearer` and OpenAI-shaped chat completions, matching the wiring.
- Did NOT run an end-to-end live call against `api.upstage.ai` — local-only test surface, since this is a thin compatible-provider wiring with no new transport code.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No** by default. The provider only resolves when an operator explicitly configures `kind = "upstage"`.
- Secrets / tokens / credentials handling changed? **Yes (additive only)** — new env var `UPSTAGE_API_KEY`. No collision with existing env vars.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No** — test tokens are placeholders (`up-test-key`, `upstage-test`).

## Compatibility

- Backward compatible? **Yes** — additive only. No existing provider name, alias, env var, or default behavior changes.
- Config / env / CLI surface changed? **Yes (additive)** — new optional config kind `upstage` and new optional env var `UPSTAGE_API_KEY`. Both are inert unless an operator opts in.
- Upgrade steps for existing users: none. To use Upstage Solar, set `UPSTAGE_API_KEY` (an Upstage console API key) and select `kind = "upstage"`. Existing operators are unaffected.

## Rollback

`git revert d059333b7` — single commit touching only `crates/zeroclaw-providers/src/lib.rs`. Reverting removes the factory arm, env-var row, `list_providers()` entry, and the two new tests without affecting any other provider.