### PR TITLE
feat(providers): add Featherless AI as a model provider

### DIFF
--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -978,6 +978,7 @@ fn resolve_provider_credential(name: &str, credential_override: Option<&str>) ->
         "morph" => vec!["MORPH_API_KEY"],
         "github-models" | "github_models" => vec!["GITHUB_MODELS_TOKEN"],
         "upstage" => vec!["UPSTAGE_API_KEY"],
+        "featherless" => vec!["FEATHERLESS_API_KEY"],
         "llamacpp" | "llama.cpp" => vec!["LLAMACPP_API_KEY"],
         "sglang" => vec!["SGLANG_API_KEY"],
         "vllm" => vec!["VLLM_API_KEY"],
@@ -1766,6 +1767,12 @@ fn create_provider_with_url_and_options(
         "upstage" => Ok(compat(OpenAiCompatibleProvider::new(
             "Upstage Solar",
             "https://api.upstage.ai/v1/solar",
+            key,
+            AuthStyle::Bearer,
+        ))),
+        "featherless" => Ok(compat(OpenAiCompatibleProvider::new(
+            "Featherless AI",
+            "https://api.featherless.ai/v1",
             key,
             AuthStyle::Bearer,
         ))),
@@ -2646,6 +2653,14 @@ pub fn list_providers() -> Vec<ProviderInfo> {
             activation: ProviderActivation::FallbackKey,
             local: false,
         },
+        ProviderInfo {
+            name: "featherless",
+            display_name: "Featherless AI",
+            description: "Serverless OSS models",
+            aliases: &[],
+            activation: ProviderActivation::FallbackKey,
+            local: false,
+        },
     ]
 }
 
@@ -3505,6 +3520,19 @@ mod tests {
         assert_eq!(resolved, Some("upstage-test".to_string()));
     }
 
+    #[test]
+    fn factory_featherless() {
+        assert!(create_provider("featherless", Some("ftherless-test")).is_ok());
+    }
+
+    #[test]
+    fn resolve_provider_credential_featherless_env() {
+        let _env_lock = env_lock();
+        let _guard = EnvGuard::set("FEATHERLESS_API_KEY", Some("featherless-test"));
+        let resolved = resolve_provider_credential("featherless", None);
+        assert_eq!(resolved, Some("featherless-test".to_string()));
+    }
+
     // ── Custom / BYOP provider ─────────────────────────────
 
     #[test]
@@ -3833,6 +3861,7 @@ mod tests {
             "morph",
             "github-models",
             "upstage",
+            "featherless",
             "ovhcloud",
         ];
         for name in providers {


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Wire Featherless AI (https://api.featherless.ai/v1) as an OpenAI-compatible provider so the onboard wizard surfaces it alongside other Bearer-auth chat-completions endpoints.
  - Featherless AI is a popular serverless inference host that exposes thousands of open-weight HuggingFace models (Llama, Qwen, Mistral, DeepSeek, Gemma, plus many community fine-tunes) behind a single OpenAI-compatible endpoint — frequently requested by operators who want broad community-model access without standing up local GPU infra.
  - Pure drop-in via the existing `compatible.rs` runtime — same shape as `cerebras` / `sambanova` / `deepmyst` / `avian`. Final URL after `/chat/completions` append: `https://api.featherless.ai/v1/chat/completions`.
- **Env-var design choice:** Standard dedicated env var `FEATHERLESS_API_KEY` (no shared-token collision risk — Featherless is unique to this provider).
- **Scope boundary:** Does NOT add a Featherless-specific provider crate, model-discovery flow, custom request shaping, or rate-limit tracking. Does NOT touch `compatible.rs`, the agent loop, or any other provider's wiring.
- **Blast radius:** Contained to `zeroclaw-providers`. No existing provider changes behavior. The only behavioral change is that `kind = "featherless"` now resolves instead of erroring.
- **Linked issue:** Closes #6455

## Validation Evidence

```bash
cargo test -p zeroclaw-providers --lib featherless
cargo test -p zeroclaw-providers --lib factory_all_providers_create_successfully
cargo test -p zeroclaw-providers --lib listed_providers
```

- `cargo test -p zeroclaw-providers --lib featherless` — **2 passed, 0 failed, 0 ignored** (`factory_featherless`, `resolve_provider_credential_featherless_env`).
- `cargo test -p zeroclaw-providers --lib factory_all_providers_create_successfully` — **1 passed, 0 failed** (with `"featherless"` added to its provider list).
- `cargo test -p zeroclaw-providers --lib listed_providers` — **2 passed, 0 failed** (`listed_providers_have_unique_ids_and_aliases`, `listed_providers_and_aliases_are_constructible`).
- Verified Featherless AI's public docs list `https://api.featherless.ai/v1` with `Authorization: Bearer` and OpenAI-shaped chat completions, matching the wiring.
- Did NOT run an end-to-end live call against `api.featherless.ai` — local-only test surface, since this is a thin compatible-provider wiring with no new transport code.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No** by default. The provider only resolves when an operator explicitly configures `kind = "featherless"`.
- Secrets / tokens / credentials handling changed? **Yes (additive only)** — new env var `FEATHERLESS_API_KEY`. No existing env var is shadowed or consumed.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No** — test tokens are placeholders (`ftherless-test`, `featherless-test`).

## Compatibility

- Backward compatible? **Yes** — additive only. No existing provider name, alias, env var, or default behavior changes.
- Config / env / CLI surface changed? **Yes (additive)** — new optional config kind `featherless` and new optional env var `FEATHERLESS_API_KEY`. Both are inert unless an operator opts in.
- Upgrade steps for existing users: none. To use Featherless AI, set `FEATHERLESS_API_KEY` and select `kind = "featherless"`.

## Rollback

`git revert 4f38f2878` — single commit touching only `crates/zeroclaw-providers/src/lib.rs`. Reverting removes the factory arm, env-var row, `list_providers()` entry, and the two new tests without affecting any other provider.