### PR TITLE
feat(providers): add Arcee AI as a model provider

### DIFF
--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -979,6 +979,7 @@ fn resolve_provider_credential(name: &str, credential_override: Option<&str>) ->
         "github-models" | "github_models" => vec!["GITHUB_MODELS_TOKEN"],
         "upstage" => vec!["UPSTAGE_API_KEY"],
         "featherless" => vec!["FEATHERLESS_API_KEY"],
+        "arcee" => vec!["ARCEE_API_KEY"],
         "llamacpp" | "llama.cpp" => vec!["LLAMACPP_API_KEY"],
         "sglang" => vec!["SGLANG_API_KEY"],
         "vllm" => vec!["VLLM_API_KEY"],
@@ -1773,6 +1774,12 @@ fn create_provider_with_url_and_options(
         "featherless" => Ok(compat(OpenAiCompatibleProvider::new(
             "Featherless AI",
             "https://api.featherless.ai/v1",
+            key,
+            AuthStyle::Bearer,
+        ))),
+        "arcee" => Ok(compat(OpenAiCompatibleProvider::new(
+            "Arcee AI",
+            "https://api.arcee.ai/api/v1",
             key,
             AuthStyle::Bearer,
         ))),
@@ -2661,6 +2668,14 @@ pub fn list_providers() -> Vec<ProviderInfo> {
             activation: ProviderActivation::FallbackKey,
             local: false,
         },
+        ProviderInfo {
+            name: "arcee",
+            display_name: "Arcee AI",
+            description: "Trinity / Conductor / Maestro",
+            aliases: &[],
+            activation: ProviderActivation::FallbackKey,
+            local: false,
+        },
     ]
 }
 
@@ -3533,6 +3548,19 @@ mod tests {
         assert_eq!(resolved, Some("featherless-test".to_string()));
     }
 
+    #[test]
+    fn factory_arcee() {
+        assert!(create_provider("arcee", Some("arcee-test")).is_ok());
+    }
+
+    #[test]
+    fn resolve_provider_credential_arcee_env() {
+        let _env_lock = env_lock();
+        let _guard = EnvGuard::set("ARCEE_API_KEY", Some("arcee-test"));
+        let resolved = resolve_provider_credential("arcee", None);
+        assert_eq!(resolved, Some("arcee-test".to_string()));
+    }
+
     // ── Custom / BYOP provider ─────────────────────────────
 
     #[test]
@@ -3862,6 +3890,7 @@ mod tests {
             "github-models",
             "upstage",
             "featherless",
+            "arcee",
             "ovhcloud",
         ];
         for name in providers {


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Wire Arcee AI (https://api.arcee.ai/api/v1) as an OpenAI-compatible provider so the onboard wizard surfaces it alongside other Bearer-auth chat-completions endpoints.
  - Arcee AI specializes in **small, fast, fine-tuned specialist models** (Trinity, Conductor, Maestro, Caller, Spotlight, Virtuoso-Small) — a frequently-requested addition for operators who want low-latency specialists alongside their primary frontier model.
  - Pure drop-in via the existing `compatible.rs` runtime — same shape as `cerebras` / `sambanova` / `hyperbolic` / `deepmyst`. Final URL after `/chat/completions` append: `https://api.arcee.ai/api/v1/chat/completions`.
- **Base URL note:** The canonical base URL `https://api.arcee.ai/api/v1` includes the `/api/v1` path segment — this is Arcee's actual published path (verified from arcee.ai docs), not a typo. The compatible runtime appends `/chat/completions` to reach the full endpoint.
- **Env-var design:** Uses dedicated `ARCEE_API_KEY`. No collision with any existing provider env var.
- **Scope boundary:** Does NOT add an Arcee-specific provider crate, custom request shaping, Conductor/Maestro routing logic, or rate-limit tracking. Does NOT touch `compatible.rs`, the agent loop, or any other provider's wiring.
- **Blast radius:** Contained to `zeroclaw-providers`. No existing provider changes behavior. The only behavioral change is that `kind = "arcee"` now resolves instead of erroring.
- **Linked issue:** Closes #6456

## Validation Evidence

```bash
cargo test -p zeroclaw-providers --lib arcee
cargo test -p zeroclaw-providers --lib -- factory_all_providers_create_successfully listed_providers
```

- `cargo test -p zeroclaw-providers --lib arcee` — **2 passed, 0 failed, 0 ignored** (`factory_arcee`, `resolve_provider_credential_arcee_env`).
- `cargo test -p zeroclaw-providers --lib -- factory_all_providers_create_successfully listed_providers` — **3 passed, 0 failed, 0 ignored** (`factory_all_providers_create_successfully`, `listed_providers_have_unique_ids_and_aliases`, `listed_providers_and_aliases_are_constructible`).
- Verified Arcee's public API base `https://api.arcee.ai/api/v1` accepts `Authorization: Bearer` with OpenAI-shaped chat completions, matching the wiring.
- Did NOT run an end-to-end live call against `api.arcee.ai` — local-only test surface, since this is a thin compatible-provider wiring with no new transport code.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No** by default. The provider only resolves when an operator explicitly configures `kind = "arcee"`.
- Secrets / tokens / credentials handling changed? **Yes (additive only)** — new env var `ARCEE_API_KEY`. No collision with any existing provider env var.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No** — test tokens are placeholders (`arcee-test`).

## Compatibility

- Backward compatible? **Yes** — additive only. No existing provider name, alias, env var, or default behavior changes.
- Config / env / CLI surface changed? **Yes (additive)** — new optional config kind `arcee` and new optional env var `ARCEE_API_KEY`. Both are inert unless an operator opts in.
- Upgrade steps for existing users: none. To use Arcee AI, set `ARCEE_API_KEY` and select `kind = "arcee"` with a valid Arcee model identifier (e.g. `trinity-mini`).

## Rollback

`git revert e795170c2` — single commit touching only `crates/zeroclaw-providers/src/lib.rs`. Reverting removes the factory arm, env-var row, `list_providers()` entry, and the two new tests without affecting any other provider.
