### PR TITLE
feat(providers): add Lambda AI Inference as a model provider

### DIFF
--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -980,6 +980,7 @@ fn resolve_provider_credential(name: &str, credential_override: Option<&str>) ->
         "upstage" => vec!["UPSTAGE_API_KEY"],
         "featherless" => vec!["FEATHERLESS_API_KEY"],
         "arcee" => vec!["ARCEE_API_KEY"],
+        "lambda-ai" | "lambda_ai" => vec!["LAMBDA_API_KEY"],
         "llamacpp" | "llama.cpp" => vec!["LLAMACPP_API_KEY"],
         "sglang" => vec!["SGLANG_API_KEY"],
         "vllm" => vec!["VLLM_API_KEY"],
@@ -1780,6 +1781,12 @@ fn create_provider_with_url_and_options(
         "arcee" => Ok(compat(OpenAiCompatibleProvider::new(
             "Arcee AI",
             "https://api.arcee.ai/api/v1",
+            key,
+            AuthStyle::Bearer,
+        ))),
+        "lambda-ai" | "lambda_ai" => Ok(compat(OpenAiCompatibleProvider::new(
+            "Lambda AI",
+            "https://api.lambda.ai/v1",
             key,
             AuthStyle::Bearer,
         ))),
@@ -2676,6 +2683,14 @@ pub fn list_providers() -> Vec<ProviderInfo> {
             activation: ProviderActivation::FallbackKey,
             local: false,
         },
+        ProviderInfo {
+            name: "lambda-ai",
+            display_name: "Lambda AI",
+            description: "Lambda Labs hosted inference",
+            aliases: &["lambda_ai"],
+            activation: ProviderActivation::FallbackKey,
+            local: false,
+        },
     ]
 }
 
@@ -3561,6 +3576,20 @@ mod tests {
         assert_eq!(resolved, Some("arcee-test".to_string()));
     }
 
+    #[test]
+    fn factory_lambda_ai() {
+        assert!(create_provider("lambda-ai", Some("lambda-test")).is_ok());
+        assert!(create_provider("lambda_ai", Some("lambda-test")).is_ok());
+    }
+
+    #[test]
+    fn resolve_provider_credential_lambda_ai_env() {
+        let _env_lock = env_lock();
+        let _guard = EnvGuard::set("LAMBDA_API_KEY", Some("lambda-test"));
+        let resolved = resolve_provider_credential("lambda-ai", None);
+        assert_eq!(resolved, Some("lambda-test".to_string()));
+    }
+
     // ── Custom / BYOP provider ─────────────────────────────
 
     #[test]
@@ -3891,6 +3920,7 @@ mod tests {
             "upstage",
             "featherless",
             "arcee",
+            "lambda-ai",
             "ovhcloud",
         ];
         for name in providers {


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Wire Lambda AI Inference (https://api.lambda.ai/v1) as an OpenAI-compatible provider so the onboard wizard surfaces it alongside other Bearer-auth chat-completions endpoints.
  - Lambda Labs is a well-known GPU-cloud brand among ML practitioners; their hosted inference API offers a curated catalog of open-weight models (Llama 3.1/3.3, DeepSeek R1/V3, Hermes, Qwen) at competitive prices, frequently requested by users who already rent Lambda GPU instances.
  - Pure drop-in via the existing `compatible.rs` runtime — same shape as `cerebras` / `sambanova` / `hyperbolic` / `avian` / `deepmyst`. Final URL after `/chat/completions` append: `https://api.lambda.ai/v1/chat/completions`.
- **Naming choice:** Canonical `lambda-ai` (alias `lambda_ai`). Plain `lambda` is intentionally avoided — it would collide with AWS Lambda terminology in operator mental models. The `-ai` suffix mirrors how `vercel-ai` and `cloudflare-ai` are already disambiguated from their parent brands in the registry.
- **Env-var design:** Standard `LAMBDA_API_KEY` (Bearer auth). No collision with any existing provider's env var.
- **Scope boundary:** Does NOT add a Lambda-specific provider crate, custom request shaping, or any Lambda GPU-instance management API surface. Does NOT touch `compatible.rs`, the agent loop, or any other provider's wiring.
- **Blast radius:** Contained to `zeroclaw-providers`. No existing provider changes behavior. The only behavioral change is that `kind = "lambda-ai"` (or alias `"lambda_ai"`) now resolves instead of erroring.
- **Linked issue:** Closes #6457

## Validation Evidence

```bash
cargo test -p zeroclaw-providers --lib lambda_ai
cargo test -p zeroclaw-providers --lib -- factory_all_providers_create_successfully listed_providers
```

- `cargo test -p zeroclaw-providers --lib lambda_ai` — **2 passed, 0 failed, 0 ignored**.
- `cargo test -p zeroclaw-providers --lib -- factory_all_providers_create_successfully listed_providers` — **3 passed, 0 failed, 0 ignored** (`factory_all_providers_create_successfully`, `listed_providers_have_unique_ids_and_aliases`, `listed_providers_and_aliases_are_constructible`).
- Two new unit tests pass: `factory_lambda_ai`, `resolve_provider_credential_lambda_ai_env`.
- `lambda-ai` added to the registry-wide constructibility list and to `list_providers()` so the registry self-consistency tests cover it.
- Verified Lambda AI's public docs list `https://api.lambda.ai/v1` with `Authorization: Bearer` and OpenAI-shaped chat completions, matching the wiring.
- Did NOT run an end-to-end live call against `api.lambda.ai` — local-only test surface, since this is a thin compatible-provider wiring with no new transport code.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No** by default. The provider only resolves when an operator explicitly configures `kind = "lambda-ai"`.
- Secrets / tokens / credentials handling changed? **Yes (additive only)** — new env var `LAMBDA_API_KEY`. No collision with any existing provider's env var.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No** — test tokens are placeholders (`lambda-test`).

## Compatibility

- Backward compatible? **Yes** — additive only. No existing provider name, alias, env var, or default behavior changes.
- Config / env / CLI surface changed? **Yes (additive)** — new optional config kind `lambda-ai` (alias `lambda_ai`) and new optional env var `LAMBDA_API_KEY`. Both are inert unless an operator opts in.
- Upgrade steps for existing users: none. To use Lambda AI, set `LAMBDA_API_KEY` (a Lambda Cloud API key) and select `kind = "lambda-ai"`.

## Rollback

`git revert 9afeaf45d` — single commit touching only `crates/zeroclaw-providers/src/lib.rs`. Reverting removes the factory arm, env-var row, `list_providers()` entry, and the two new tests without affecting any other provider.