### PR TITLE
feat(providers): add Inception Labs (Mercury) as a model provider

### DIFF
--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -981,6 +981,7 @@ fn resolve_provider_credential(name: &str, credential_override: Option<&str>) ->
         "featherless" => vec!["FEATHERLESS_API_KEY"],
         "arcee" => vec!["ARCEE_API_KEY"],
         "lambda-ai" | "lambda_ai" => vec!["LAMBDA_API_KEY"],
+        "inception" => vec!["INCEPTION_API_KEY"],
         "llamacpp" | "llama.cpp" => vec!["LLAMACPP_API_KEY"],
         "sglang" => vec!["SGLANG_API_KEY"],
         "vllm" => vec!["VLLM_API_KEY"],
@@ -1787,6 +1788,12 @@ fn create_provider_with_url_and_options(
         "lambda-ai" | "lambda_ai" => Ok(compat(OpenAiCompatibleProvider::new(
             "Lambda AI",
             "https://api.lambda.ai/v1",
+            key,
+            AuthStyle::Bearer,
+        ))),
+        "inception" => Ok(compat(OpenAiCompatibleProvider::new(
+            "Inception Labs",
+            "https://api.inceptionlabs.ai/v1",
             key,
             AuthStyle::Bearer,
         ))),
@@ -2691,6 +2698,14 @@ pub fn list_providers() -> Vec<ProviderInfo> {
             activation: ProviderActivation::FallbackKey,
             local: false,
         },
+        ProviderInfo {
+            name: "inception",
+            display_name: "Inception Labs (Mercury)",
+            description: "Mercury diffusion-LLM",
+            aliases: &[],
+            activation: ProviderActivation::FallbackKey,
+            local: false,
+        },
     ]
 }
 
@@ -3590,6 +3605,19 @@ mod tests {
         assert_eq!(resolved, Some("lambda-test".to_string()));
     }
 
+    #[test]
+    fn factory_inception() {
+        assert!(create_provider("inception", Some("inception-test")).is_ok());
+    }
+
+    #[test]
+    fn resolve_provider_credential_inception_env() {
+        let _env_lock = env_lock();
+        let _guard = EnvGuard::set("INCEPTION_API_KEY", Some("inception-test"));
+        let resolved = resolve_provider_credential("inception", None);
+        assert_eq!(resolved, Some("inception-test".to_string()));
+    }
+
     // ── Custom / BYOP provider ─────────────────────────────
 
     #[test]
@@ -3921,6 +3949,7 @@ mod tests {
             "featherless",
             "arcee",
             "lambda-ai",
+            "inception",
             "ovhcloud",
         ];
         for name in providers {


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Wire Inception Labs (https://inceptionlabs.ai) as an OpenAI-compatible model provider so the onboard wizard surfaces it alongside other Bearer-auth chat-completions endpoints.
  - Inception Labs builds the **Mercury** family of **diffusion-LLMs** (Mercury 2, Mercury Coder) — a genuinely novel architecture vs. every other autoregressive provider in ZeroClaw's registry, with sub-second latency on long completions and significant 2026 industry buzz.
  - Pure drop-in via the existing `compatible.rs` runtime — same shape as `cerebras` / `sambanova` / `morph` / `deepmyst`. Base URL `https://api.inceptionlabs.ai/v1`, Bearer auth, `INCEPTION_API_KEY`.
  - No new transport, retry, or auth code: only a factory arm, a credential-resolver row, a `list_providers()` entry, and matching unit tests.
- **Scope boundary:** Does NOT add a Mercury-specific provider crate, diffusion-aware request shaping, step-count tuning controls, or tool-call adapter changes. Does NOT touch `compatible.rs`, the agent loop, runtime cost accounting, or any other provider's wiring.
- **Blast radius:** Contained to `zeroclaw-providers`. Existing providers are untouched; the only behavioral change is that `kind = "inception"` now resolves instead of erroring. Onboard wizard picks up the new entry from `list_providers()` automatically.
- **Linked issue:** Closes #6458

## Validation Evidence

```bash
cargo test -p zeroclaw-providers --lib inception
cargo test -p zeroclaw-providers --lib -- factory_all_providers_create_successfully listed_providers
```

- `cargo test -p zeroclaw-providers --lib inception` — **2 passed, 0 failed, 0 ignored** (`factory_inception`, `resolve_provider_credential_inception_env`).
- `cargo test -p zeroclaw-providers --lib -- factory_all_providers_create_successfully listed_providers` — **3 passed, 0 failed, 0 ignored** (`factory_all_providers_create_successfully` with `inception` added, `listed_providers_have_unique_ids_and_aliases`, `listed_providers_and_aliases_are_constructible`).
- Verified Inception Labs' public docs list the OpenAI-compatible chat-completions API at `https://api.inceptionlabs.ai/v1` with `Authorization: Bearer`, matching the wiring.
- Did NOT run an end-to-end live call against `api.inceptionlabs.ai` — local-only test surface, since this is a thin compatible-provider wiring with no new transport code.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No** by default. The provider only resolves when an operator explicitly configures `kind = "inception"`, at which point the existing `compatible.rs` HTTP client talks to `api.inceptionlabs.ai/v1`.
- Secrets / tokens / credentials handling changed? **No** — `INCEPTION_API_KEY` is read through the same `resolve_provider_credential` path used by every other provider (env var lookup, no logging, no persistence beyond the in-memory provider).
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No** — test keys are placeholders (`inception-test`).

## Compatibility

- Backward compatible? **Yes** — additive only. No existing provider name, alias, env var, config field, or default behavior changes.
- Config / env / CLI surface changed? **Yes (additive)** — new optional config kind `inception` and new optional env var `INCEPTION_API_KEY`. Both are inert unless an operator opts in.
- Upgrade steps for existing users: none. To use Inception Labs, set `INCEPTION_API_KEY` and select `kind = "inception"` in the provider config (or pick "Inception Labs (Mercury)" in the onboard wizard).

## Rollback

`git revert <sha>` — single commit touching only `crates/zeroclaw-providers/src/lib.rs`. Reverting removes the factory arm, env-var row, `list_providers()` entry, and the two new tests without affecting any other provider.
