### PR TITLE
feat(tools): home_assistant tool for HA REST API

### DIFF
--- a/CHANGELOG-next.md
+++ b/CHANGELOG-next.md
@@ -116,6 +116,7 @@
 
 - `SessionResetTool` and `SessionDeleteTool` for in-agent session management (#5696).
 - `SessionsCurrentTool` exposes the active session identity (#6033).
+- `home_assistant` tool — REST-API client for a self-hosted Home Assistant instance, gated by long-lived access token and `allowed_domains` allowlist (#6448).
 
 ### Plugins
 

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -385,6 +385,11 @@ pub struct Config {
     #[nested]
     pub jira: JiraConfig,
 
+    /// Home Assistant integration configuration (`[home_assistant]`).
+    #[serde(default)]
+    #[nested]
+    pub home_assistant: HomeAssistantConfig,
+
     /// Secure inter-node transport configuration (`[node_transport]`).
     #[serde(default)]
     #[nested]
@@ -9316,6 +9321,86 @@ impl Default for JiraConfig {
     }
 }
 
+/// Home Assistant integration configuration (`[home_assistant]`).
+///
+/// When `enabled = true`, registers the `home_assistant` tool which can read
+/// entity state and call services on a self-hosted Home Assistant instance via
+/// its REST API. Requires `base_url` (e.g. `http://homeassistant.local:8123`)
+/// and `access_token` (a long-lived access token), or the
+/// `HOME_ASSISTANT_TOKEN` env var.
+///
+/// ## Defaults
+/// - `enabled`: `false`
+/// - `allowed_domains`: `["light", "switch", "scene", "climate", "media_player",
+///   "input_boolean", "script", "automation"]` — the service domains the agent
+///   is permitted to call. Add or remove entries to widen or narrow the
+///   blast radius.
+/// - `request_timeout_secs`: `15`
+///
+/// ## Auth
+/// Generate a long-lived access token from the HA UI under
+/// *Profile → Security → Long-lived access tokens*. The token is stored
+/// encrypted at rest when `[secrets] encrypt = true`.
+#[derive(Debug, Clone, Serialize, Deserialize, Configurable)]
+#[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
+#[prefix = "home-assistant"]
+#[integration(
+    category = "ToolsAutomation",
+    display_name = "Home Assistant",
+    description = "Home automation hub",
+    status_field = "enabled"
+)]
+pub struct HomeAssistantConfig {
+    /// Enable the `home_assistant` tool. Default: `false`.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Home Assistant base URL, e.g. `http://homeassistant.local:8123`.
+    #[serde(default)]
+    pub base_url: String,
+    /// Long-lived access token. Encrypted at rest. Falls back to
+    /// `HOME_ASSISTANT_TOKEN` env var.
+    #[serde(default)]
+    #[secret]
+    #[cfg_attr(feature = "schema-export", schemars(extend("x-secret" = true)))]
+    pub access_token: String,
+    /// Service domains the agent is permitted to call. Empty means
+    /// no `call_service` actions are allowed.
+    #[serde(default = "default_home_assistant_allowed_domains")]
+    pub allowed_domains: Vec<String>,
+    /// Request timeout in seconds. Default: `15`.
+    #[serde(default = "default_home_assistant_timeout_secs")]
+    pub request_timeout_secs: u64,
+}
+
+fn default_home_assistant_allowed_domains() -> Vec<String> {
+    vec![
+        "light".into(),
+        "switch".into(),
+        "scene".into(),
+        "climate".into(),
+        "media_player".into(),
+        "input_boolean".into(),
+        "script".into(),
+        "automation".into(),
+    ]
+}
+
+fn default_home_assistant_timeout_secs() -> u64 {
+    15
+}
+
+impl Default for HomeAssistantConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            base_url: String::new(),
+            access_token: String::new(),
+            allowed_domains: default_home_assistant_allowed_domains(),
+            request_timeout_secs: default_home_assistant_timeout_secs(),
+        }
+    }
+}
+
 ///
 /// Controls the read-only cloud transformation analysis tools:
 /// IaC review, migration assessment, cost analysis, and architecture review.
@@ -9634,6 +9719,7 @@ impl Default for Config {
             onboard_state: OnboardStateConfig::default(),
             notion: NotionConfig::default(),
             jira: JiraConfig::default(),
+            home_assistant: HomeAssistantConfig::default(),
             node_transport: NodeTransportConfig::default(),
             knowledge: KnowledgeConfig::default(),
             linkedin: LinkedInConfig::default(),
@@ -12595,6 +12681,7 @@ auto_save = true
             onboard_state: OnboardStateConfig::default(),
             notion: NotionConfig::default(),
             jira: JiraConfig::default(),
+            home_assistant: HomeAssistantConfig::default(),
             node_transport: NodeTransportConfig::default(),
             knowledge: KnowledgeConfig::default(),
             linkedin: LinkedInConfig::default(),
@@ -13166,6 +13253,7 @@ default_temperature = 0.7
             onboard_state: OnboardStateConfig::default(),
             notion: NotionConfig::default(),
             jira: JiraConfig::default(),
+            home_assistant: HomeAssistantConfig::default(),
             node_transport: NodeTransportConfig::default(),
             knowledge: KnowledgeConfig::default(),
             linkedin: LinkedInConfig::default(),

--- a/crates/zeroclaw-runtime/src/integrations/mod.rs
+++ b/crates/zeroclaw-runtime/src/integrations/mod.rs
@@ -148,6 +148,17 @@ pub fn show_integration_info(config: &Config, name: &str) -> Result<()> {
             println!("    Supports city names, IATA airport codes, GPS coordinates,");
             println!("    postal/zip codes, and Unicode location names.");
         }
+        "Home Assistant" => {
+            println!("  Setup:");
+            println!("    1. Generate a long-lived access token in HA:");
+            println!("       Profile → Security → Long-lived access tokens");
+            println!("    2. Add to config:");
+            println!("       [home_assistant]");
+            println!("       enabled = true");
+            println!("       base_url = \"http://homeassistant.local:8123\"");
+            println!("       access_token = \"...\"  # or set HOME_ASSISTANT_TOKEN");
+            println!("    3. Narrow `allowed_domains` to only the service domains you trust.");
+        }
         _ if entry.category == IntegrationCategory::Chat => {
             println!("  Setup:");
             println!("    Run: zeroclaw onboard --channels-only");

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -67,6 +67,7 @@ pub use zeroclaw_tools::google_workspace::GoogleWorkspaceTool;
 pub use zeroclaw_tools::hardware_board_info::HardwareBoardInfoTool;
 pub use zeroclaw_tools::hardware_memory_map::HardwareMemoryMapTool;
 pub use zeroclaw_tools::hardware_memory_read::HardwareMemoryReadTool;
+pub use zeroclaw_tools::home_assistant::HomeAssistantTool;
 pub use zeroclaw_tools::http_request::HttpRequestTool;
 pub use zeroclaw_tools::image_gen::ImageGenTool;
 pub use zeroclaw_tools::image_info::ImageInfoTool;
@@ -599,6 +600,32 @@ pub fn all_tools_with_runtime(
                 root_config.jira.allowed_actions.clone(),
                 security.clone(),
                 root_config.jira.timeout_secs,
+            )));
+        }
+    }
+
+    // Home Assistant integration (config-gated)
+    if root_config.home_assistant.enabled {
+        let access_token = if root_config.home_assistant.access_token.trim().is_empty() {
+            std::env::var("HOME_ASSISTANT_TOKEN").unwrap_or_default()
+        } else {
+            root_config.home_assistant.access_token.trim().to_string()
+        };
+        if access_token.trim().is_empty() {
+            tracing::warn!(
+                "home_assistant: enabled but no access token found (set home_assistant.access_token or HOME_ASSISTANT_TOKEN env var) — skipping registration"
+            );
+        } else if root_config.home_assistant.base_url.trim().is_empty() {
+            tracing::warn!(
+                "home_assistant: enabled but home_assistant.base_url is empty — skipping registration"
+            );
+        } else {
+            tool_arcs.push(Arc::new(HomeAssistantTool::new(
+                root_config.home_assistant.base_url.trim().to_string(),
+                access_token,
+                root_config.home_assistant.allowed_domains.clone(),
+                root_config.home_assistant.request_timeout_secs,
+                security.clone(),
             )));
         }
     }

--- a/crates/zeroclaw-tools/src/home_assistant.rs
+++ b/crates/zeroclaw-tools/src/home_assistant.rs
@@ -1,0 +1,475 @@
+//! Home Assistant tool — REST API client for a self-hosted Home Assistant instance.
+//!
+//! Authenticates with a long-lived access token. Read actions (`get_state`,
+//! `list_states`, `list_services`) require `ToolOperation::Read`; mutating
+//! actions (`call_service`) require `ToolOperation::Act`. Service domains
+//! callable through `call_service` are restricted by `allowed_domains` —
+//! configure narrowly in production.
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use std::sync::Arc;
+use std::time::Duration;
+use zeroclaw_api::tool::{Tool, ToolResult};
+use zeroclaw_config::policy::{SecurityPolicy, ToolOperation};
+
+/// Maximum number of characters to include from an error response body.
+const MAX_ERROR_BODY_CHARS: usize = 500;
+
+/// Tool for interacting with a Home Assistant instance over its REST API.
+pub struct HomeAssistantTool {
+    base_url: String,
+    access_token: String,
+    allowed_domains: Vec<String>,
+    request_timeout_secs: u64,
+    http: reqwest::Client,
+    security: Arc<SecurityPolicy>,
+}
+
+impl HomeAssistantTool {
+    /// Create a new Home Assistant tool. `base_url` is normalized by stripping
+    /// any trailing `/`.
+    pub fn new(
+        base_url: String,
+        access_token: String,
+        allowed_domains: Vec<String>,
+        request_timeout_secs: u64,
+        security: Arc<SecurityPolicy>,
+    ) -> Self {
+        let base_url = base_url.trim_end_matches('/').to_string();
+        let allowed_domains = allowed_domains
+            .into_iter()
+            .map(|d| d.trim().to_string())
+            .filter(|d| !d.is_empty())
+            .collect();
+        Self {
+            base_url,
+            access_token,
+            allowed_domains,
+            request_timeout_secs,
+            http: reqwest::Client::new(),
+            security,
+        }
+    }
+
+    fn headers(&self) -> anyhow::Result<reqwest::header::HeaderMap> {
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(
+            "Authorization",
+            format!("Bearer {}", self.access_token)
+                .parse()
+                .map_err(|e| anyhow::anyhow!("Invalid Home Assistant token header: {e}"))?,
+        );
+        headers.insert("Content-Type", "application/json".parse().unwrap());
+        Ok(headers)
+    }
+
+    fn timeout(&self) -> Duration {
+        Duration::from_secs(self.request_timeout_secs.max(1))
+    }
+
+    fn is_domain_allowed(&self, domain: &str) -> bool {
+        self.allowed_domains.iter().any(|d| d == domain)
+    }
+
+    async fn list_states(&self) -> anyhow::Result<Value> {
+        let url = format!("{}/api/states", self.base_url);
+        let resp = self
+            .http
+            .get(&url)
+            .headers(self.headers()?)
+            .timeout(self.timeout())
+            .send()
+            .await?;
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            let truncated =
+                crate::util_helpers::truncate_with_ellipsis(&body, MAX_ERROR_BODY_CHARS);
+            anyhow::bail!("Home Assistant list_states failed ({status}): {truncated}");
+        }
+        resp.json().await.map_err(Into::into)
+    }
+
+    async fn get_state(&self, entity_id: &str) -> anyhow::Result<Value> {
+        let url = format!("{}/api/states/{entity_id}", self.base_url);
+        let resp = self
+            .http
+            .get(&url)
+            .headers(self.headers()?)
+            .timeout(self.timeout())
+            .send()
+            .await?;
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            let truncated =
+                crate::util_helpers::truncate_with_ellipsis(&body, MAX_ERROR_BODY_CHARS);
+            anyhow::bail!(
+                "Home Assistant get_state failed for '{entity_id}' ({status}): {truncated}"
+            );
+        }
+        resp.json().await.map_err(Into::into)
+    }
+
+    async fn list_services(&self) -> anyhow::Result<Value> {
+        let url = format!("{}/api/services", self.base_url);
+        let resp = self
+            .http
+            .get(&url)
+            .headers(self.headers()?)
+            .timeout(self.timeout())
+            .send()
+            .await?;
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            let truncated =
+                crate::util_helpers::truncate_with_ellipsis(&body, MAX_ERROR_BODY_CHARS);
+            anyhow::bail!("Home Assistant list_services failed ({status}): {truncated}");
+        }
+        resp.json().await.map_err(Into::into)
+    }
+
+    async fn call_service(
+        &self,
+        domain: &str,
+        service: &str,
+        service_data: Option<&Value>,
+    ) -> anyhow::Result<Value> {
+        let url = format!("{}/api/services/{domain}/{service}", self.base_url);
+        let body = service_data.cloned().unwrap_or_else(|| json!({}));
+        let resp = self
+            .http
+            .post(&url)
+            .headers(self.headers()?)
+            .json(&body)
+            .timeout(self.timeout())
+            .send()
+            .await?;
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            let truncated =
+                crate::util_helpers::truncate_with_ellipsis(&body, MAX_ERROR_BODY_CHARS);
+            anyhow::bail!(
+                "Home Assistant call_service {domain}.{service} failed ({status}): {truncated}"
+            );
+        }
+        resp.json().await.map_err(Into::into)
+    }
+}
+
+#[async_trait]
+impl Tool for HomeAssistantTool {
+    fn name(&self) -> &str {
+        "home_assistant"
+    }
+
+    fn description(&self) -> &str {
+        "Interact with a self-hosted Home Assistant instance via its REST API. \
+         Read entity state (get_state, list_states), discover available services \
+         (list_services), or trigger automations and devices (call_service). \
+         Service domains callable through call_service are restricted by the \
+         operator's allowed_domains config."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["get_state", "list_states", "list_services", "call_service"],
+                    "description": "The Home Assistant operation to perform."
+                },
+                "entity_id": {
+                    "type": "string",
+                    "description": "Entity ID, e.g. 'light.kitchen'. Required for get_state."
+                },
+                "domain": {
+                    "type": "string",
+                    "description": "Service domain, e.g. 'light'. Required for call_service."
+                },
+                "service": {
+                    "type": "string",
+                    "description": "Service name, e.g. 'turn_on'. Required for call_service."
+                },
+                "service_data": {
+                    "type": "object",
+                    "description": "Optional service payload. May include 'entity_id' to scope the call."
+                }
+            },
+            "required": ["action"]
+        })
+    }
+
+    async fn execute(&self, args: Value) -> anyhow::Result<ToolResult> {
+        let action = match args.get("action").and_then(|v| v.as_str()) {
+            Some(a) => a,
+            None => {
+                return Ok(ToolResult {
+                    success: false,
+                    output: String::new(),
+                    error: Some("Missing required parameter: action".into()),
+                });
+            }
+        };
+
+        let operation = match action {
+            "get_state" | "list_states" | "list_services" => ToolOperation::Read,
+            "call_service" => ToolOperation::Act,
+            _ => {
+                return Ok(ToolResult {
+                    success: false,
+                    output: String::new(),
+                    error: Some(format!(
+                        "Unknown action: {action}. Valid actions: get_state, list_states, list_services, call_service"
+                    )),
+                });
+            }
+        };
+
+        if let Err(error) = self
+            .security
+            .enforce_tool_operation(operation, "home_assistant")
+        {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(error),
+            });
+        }
+
+        let result = match action {
+            "list_states" => self.list_states().await,
+            "list_services" => self.list_services().await,
+            "get_state" => {
+                let entity_id = match args.get("entity_id").and_then(|v| v.as_str()) {
+                    Some(id) if !id.trim().is_empty() => id.trim(),
+                    _ => {
+                        return Ok(ToolResult {
+                            success: false,
+                            output: String::new(),
+                            error: Some("get_state requires entity_id parameter".into()),
+                        });
+                    }
+                };
+                self.get_state(entity_id).await
+            }
+            "call_service" => {
+                let domain = match args.get("domain").and_then(|v| v.as_str()) {
+                    Some(d) if !d.trim().is_empty() => d.trim(),
+                    _ => {
+                        return Ok(ToolResult {
+                            success: false,
+                            output: String::new(),
+                            error: Some("call_service requires domain parameter".into()),
+                        });
+                    }
+                };
+                let service = match args.get("service").and_then(|v| v.as_str()) {
+                    Some(s) if !s.trim().is_empty() => s.trim(),
+                    _ => {
+                        return Ok(ToolResult {
+                            success: false,
+                            output: String::new(),
+                            error: Some("call_service requires service parameter".into()),
+                        });
+                    }
+                };
+                if !self.is_domain_allowed(domain) {
+                    let allowed = if self.allowed_domains.is_empty() {
+                        "(none — allowed_domains is empty)".to_string()
+                    } else {
+                        self.allowed_domains.join(", ")
+                    };
+                    return Ok(ToolResult {
+                        success: false,
+                        output: String::new(),
+                        error: Some(format!(
+                            "Service domain '{domain}' is not in allowed_domains. Allowed: {allowed}"
+                        )),
+                    });
+                }
+                let service_data = args.get("service_data");
+                self.call_service(domain, service, service_data).await
+            }
+            _ => unreachable!(),
+        };
+
+        match result {
+            Ok(value) => Ok(ToolResult {
+                success: true,
+                output: serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string()),
+                error: None,
+            }),
+            Err(e) => Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(e.to_string()),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zeroclaw_config::policy::SecurityPolicy;
+
+    fn test_tool() -> HomeAssistantTool {
+        HomeAssistantTool::new(
+            "http://homeassistant.local:8123".into(),
+            "test-token".into(),
+            vec!["light".into(), "switch".into()],
+            15,
+            Arc::new(SecurityPolicy::default()),
+        )
+    }
+
+    #[test]
+    fn name_is_home_assistant() {
+        assert_eq!(test_tool().name(), "home_assistant");
+    }
+
+    #[test]
+    fn description_is_non_empty() {
+        assert!(!test_tool().description().is_empty());
+    }
+
+    #[test]
+    fn parameters_schema_requires_action() {
+        let schema = test_tool().parameters_schema();
+        let required = schema["required"].as_array().unwrap();
+        assert!(required.iter().any(|v| v.as_str() == Some("action")));
+    }
+
+    #[test]
+    fn parameters_schema_lists_all_actions() {
+        let schema = test_tool().parameters_schema();
+        let actions = schema["properties"]["action"]["enum"].as_array().unwrap();
+        let names: Vec<&str> = actions.iter().filter_map(|v| v.as_str()).collect();
+        for expected in &["get_state", "list_states", "list_services", "call_service"] {
+            assert!(names.contains(expected), "missing action: {expected}");
+        }
+    }
+
+    #[test]
+    fn base_url_trailing_slash_stripped() {
+        let tool = HomeAssistantTool::new(
+            "http://hass.local:8123/".into(),
+            "t".into(),
+            vec![],
+            15,
+            Arc::new(SecurityPolicy::default()),
+        );
+        assert_eq!(tool.base_url, "http://hass.local:8123");
+    }
+
+    #[test]
+    fn allowed_domains_trimmed_and_empty_dropped() {
+        let tool = HomeAssistantTool::new(
+            "http://h".into(),
+            "t".into(),
+            vec!["  light ".into(), "".into(), "switch".into()],
+            15,
+            Arc::new(SecurityPolicy::default()),
+        );
+        assert!(tool.is_domain_allowed("light"));
+        assert!(tool.is_domain_allowed("switch"));
+        assert!(!tool.is_domain_allowed(""));
+    }
+
+    #[tokio::test]
+    async fn execute_missing_action_returns_error() {
+        let result = test_tool().execute(json!({})).await.unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("action"));
+    }
+
+    #[tokio::test]
+    async fn execute_unknown_action_returns_error() {
+        let result = test_tool()
+            .execute(json!({"action": "nope"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("Unknown action"));
+    }
+
+    #[tokio::test]
+    async fn execute_get_state_missing_entity_id_returns_error() {
+        let result = test_tool()
+            .execute(json!({"action": "get_state"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("entity_id"));
+    }
+
+    #[tokio::test]
+    async fn execute_call_service_missing_domain_returns_error() {
+        let result = test_tool()
+            .execute(json!({"action": "call_service", "service": "turn_on"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("domain"));
+    }
+
+    #[tokio::test]
+    async fn execute_call_service_missing_service_returns_error() {
+        let result = test_tool()
+            .execute(json!({"action": "call_service", "domain": "light"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("service"));
+    }
+
+    #[tokio::test]
+    async fn execute_call_service_disallowed_domain_returns_error() {
+        let result = test_tool()
+            .execute(json!({
+                "action": "call_service",
+                "domain": "lock",
+                "service": "unlock"
+            }))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        let err = result.error.unwrap();
+        assert!(err.contains("not in allowed_domains"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn execute_call_service_empty_allowed_domains_blocks_all() {
+        let tool = HomeAssistantTool::new(
+            "http://h".into(),
+            "t".into(),
+            vec![],
+            15,
+            Arc::new(SecurityPolicy::default()),
+        );
+        let result = tool
+            .execute(json!({
+                "action": "call_service",
+                "domain": "light",
+                "service": "turn_on"
+            }))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("none"));
+    }
+
+    #[test]
+    fn spec_reflects_metadata() {
+        let tool = test_tool();
+        let spec = tool.spec();
+        assert_eq!(spec.name, "home_assistant");
+        assert_eq!(spec.description, tool.description());
+        assert!(spec.parameters.is_object());
+    }
+}

--- a/crates/zeroclaw-tools/src/lib.rs
+++ b/crates/zeroclaw-tools/src/lib.rs
@@ -30,6 +30,7 @@ pub mod google_workspace;
 pub mod hardware_board_info;
 pub mod hardware_memory_map;
 pub mod hardware_memory_read;
+pub mod home_assistant;
 pub mod http_request;
 pub mod image_gen;
 pub mod image_info;

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -58,6 +58,7 @@
 - [Overview](./tools/overview.md)
 - [MCP (Model Context Protocol)](./tools/mcp.md)
 - [Browser automation](./tools/browser.md)
+- [Home Assistant](./tools/home_assistant.md)
 
 # Security
 

--- a/docs/book/src/tools/home_assistant.md
+++ b/docs/book/src/tools/home_assistant.md
@@ -1,0 +1,78 @@
+# Home Assistant
+
+The `home_assistant` tool talks to a self-hosted [Home Assistant](https://www.home-assistant.io/) instance over its REST API. It is **disabled by default** and gated behind a config block plus a long-lived access token.
+
+When enabled, the agent can:
+
+- `get_state` — read a single entity's state.
+- `list_states` — enumerate every entity HA exposes.
+- `list_services` — discover service domains and the services each domain supports.
+- `call_service` — trigger a service (turn lights on/off, run an automation, etc.) restricted to operator-allowed domains.
+
+## Configuration
+
+```toml
+[home_assistant]
+enabled = true
+base_url = "http://homeassistant.local:8123"
+access_token = "eyJhbGciOi..."             # or set HOME_ASSISTANT_TOKEN
+allowed_domains = ["light", "switch", "scene", "script"]
+request_timeout_secs = 15
+```
+
+Defaults:
+
+| Field | Default |
+| --- | --- |
+| `enabled` | `false` |
+| `allowed_domains` | `["light", "switch", "scene", "climate", "media_player", "input_boolean", "script", "automation"]` |
+| `request_timeout_secs` | `15` |
+
+The `access_token` field carries the `#[secret]` attribute, so it is encrypted at rest when `[secrets] encrypt = true`.
+
+## Generating a long-lived access token
+
+1. Open Home Assistant in a browser.
+2. Click your profile (bottom-left) → **Security** tab.
+3. Scroll to **Long-lived access tokens** → **Create token**.
+4. Name it (e.g. `zeroclaw`) and copy the value — HA only shows it once.
+5. Either paste into `home_assistant.access_token` or export `HOME_ASSISTANT_TOKEN`.
+
+## Allowlist guidance
+
+`allowed_domains` is the blast radius for `call_service`. Start with the smallest set you need:
+
+- Lights only? `["light"]`.
+- Lights + scenes? `["light", "scene"]`.
+- Need to fire HA automations? Add `"automation"` or `"script"`.
+
+Read actions (`get_state`, `list_states`, `list_services`) ignore `allowed_domains` — they are read-only and surface anything HA exposes to the token's user.
+
+## Examples
+
+```jsonc
+// Turn on the kitchen lights
+{
+  "action": "call_service",
+  "domain": "light",
+  "service": "turn_on",
+  "service_data": { "entity_id": "light.kitchen", "brightness_pct": 60 }
+}
+
+// Read a single sensor
+{
+  "action": "get_state",
+  "entity_id": "sensor.living_room_temperature"
+}
+```
+
+## Troubleshooting
+
+- **`401 Unauthorized`** — Token is wrong, expired, or revoked. Mint a new one.
+- **Timeouts** — Bump `request_timeout_secs`; if HA is on a separate VLAN, check routing.
+- **Domain `'X'` not in allowed_domains** — Either widen `allowed_domains` or use a different service domain.
+- **Self-signed TLS** — If `base_url` is `https://` with an internal CA, the underlying `reqwest` client will reject it. Either install the CA in the system trust store or terminate TLS at a reverse proxy.
+
+## Rollback
+
+Set `[home_assistant] enabled = false` (or remove the block) and restart the agent. No data migration is needed; the integration only reads/writes through HA's own REST API.


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Adds a `home_assistant` Tool that drives a self-hosted Home Assistant instance via its REST API. Until now, `crates/zeroclaw-runtime/src/integrations/registry.rs:634-639` declared HA as `ComingSoon` with no implementation behind it.
  - Read actions (`get_state`, `list_states`, `list_services`) gate on `ToolOperation::Read`; `call_service` gates on `ToolOperation::Act` AND a configurable `allowed_domains` allowlist so operators control the blast radius.
  - Wires the integration registry's `status_fn` to flip `Available → Active` when `home_assistant.enabled = true`, and the developer page picks it up automatically.
- **Scope boundary:**
  - No inbound webhook routing (HA → ZeroClaw automations) — that is a follow-up.
  - No mDNS/auto-discovery — operator supplies `base_url`.
  - No WebSocket subscriptions — REST only in v1.
  - Hue and 8Sleep are **not** in this PR; they ship in #6449 and #6450.
- **Blast radius:** `zeroclaw-config` (additive `[home_assistant]` block, default disabled), `zeroclaw-tools` (new module), `zeroclaw-runtime/src/tools/mod.rs` (config-gated registration in `all_tools_with_runtime`), `zeroclaw-runtime/src/integrations/{mod,registry}.rs` (status flip + setup-hint arm), docs.
- **Linked issue(s):** Closes #6448. Sibling tracking issues: #6449 (Hue), #6450 (8Sleep).

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy -p zeroclaw-config -p zeroclaw-tools -p zeroclaw-runtime --all-targets -- -D warnings
cargo test -p zeroclaw-config -p zeroclaw-tools -p zeroclaw-runtime
cargo check -p zeroclaw-gateway
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` → clean (no diff after `cargo fmt --all` was run).
  - `cargo clippy ...` → `Finished `dev` profile [unoptimized + debuginfo] target(s) in 47.60s`. No warnings.
  - `cargo test -p zeroclaw-config -p zeroclaw-tools -p zeroclaw-runtime` →
    - `test result: ok. 620 passed; 0 failed; 0 ignored` (zeroclaw-config)
    - `test result: ok. 1641 passed; 0 failed; 1 ignored` (zeroclaw-tools)
    - `test result: ok. 1158 passed; 0 failed; 0 ignored` (zeroclaw-runtime)
    - Total: **3,420 passed, 0 failed.**
  - New tool: 14 tests under `home_assistant::tests::*` — name, schema shape (action enum, required fields), URL/base normalization, allowlist trimming, missing-action / unknown-action / missing-entity / missing-domain / missing-service / disallowed-domain / empty-allowlist paths, `spec()` reflection.
  - New registry tests: `home_assistant_available_when_not_configured` and `home_assistant_active_when_enabled` — confirm the developer-page card flips when config is set.
  - `cargo check -p zeroclaw-gateway` → builds; gateway surfaces tools via `state.tools_registry` from `all_tools_with_runtime`, so the new tool auto-appears at `GET /api/tools` when `[home_assistant] enabled = true`.
- **Beyond CI — what did you manually verify?**
  - Developer-page integration card moves from `🔜 Coming Soon` to `⚪ Available` (and `✅ Active` once configured) — the registry test exercises both states.
  - `zeroclaw integrations info "Home Assistant"` now prints the LLAT setup steps (the new arm in `show_integration_info`).
  - **Not verified live**: I did not stand up a real HA instance and execute end-to-end — `call_service` against an actual `light.turn_on` is left to follow-up smoke once the PR lands. The unit tests cover error paths (missing fields, disallowed domains) but not the HTTP success path.
- **If any command was intentionally skipped, why:** Skipped the full `./dev/ci.sh all` because the change is scoped to three crates + docs + a changelog entry; the targeted clippy+test runs already gated those crates with `-D warnings`.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No.** The tool uses HTTP only.
- New external network calls? **Yes.** The tool POSTs/GETs `home_assistant.base_url`. Disabled by default; the operator opts in.
- Secrets / tokens / credentials handling changed? **Yes.** A new `access_token` field on `HomeAssistantConfig` carries `#[secret]`, so it's encrypted at rest when `[secrets] encrypt = true`. Token also resolves from `HOME_ASSISTANT_TOKEN` env var as a fallback.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No.** Tests use neutral placeholders (`http://homeassistant.local:8123`, `test-token`, `light.kitchen`).
- **Risk and mitigation:** A misconfigured `allowed_domains` could let the agent trigger unexpected automations. Mitigation: `allowed_domains` is enforced server-side in the tool's `execute` (not just in the schema); empty allowlist blocks **all** `call_service` calls; defaults are conservative (no `lock`, no `cover`, no `notify`).

## Compatibility (required)

- Backward compatible? **Yes.** Additive config, default `enabled: false`. `Config::default()` includes `home_assistant: HomeAssistantConfig::default()`, so existing configs missing `[home_assistant]` continue to deserialize unchanged.
- Config / env / CLI surface changed? **Yes** — new `[home_assistant]` block; new `HOME_ASSISTANT_TOKEN` env var fallback. No CLI changes.
- **Upgrade steps for existing users:** None required. To opt in, add `[home_assistant] enabled = true`, `base_url`, and either `access_token` or `HOME_ASSISTANT_TOKEN`.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** Set `[home_assistant] enabled = false` in `~/.zeroclaw/config.toml` (or remove the block) and restart the agent. The tool is unregistered on next boot.
- **Feature flags or config toggles:** `home_assistant.enabled` (boolean) is the master switch. `home_assistant.allowed_domains` is the per-action throttle.
- **Observable failure symptoms:**
  - Logs: `home_assistant: enabled but no access token found ...` or `... base_url is empty — skipping registration` indicate config issues.
  - Logs: `Home Assistant {action} failed (4xx/5xx)` indicates upstream HA problems (token revoked, instance unreachable).
  - Metric: tools registry size at gateway boot will not include `home_assistant` if either token or base_url is missing.
