### PR TITLE
feat(channel:plivo): add Plivo SMS channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13377,6 +13377,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sha2 0.10.9",
  "tempfile",
  "tokio",

--- a/crates/zeroclaw-channels/Cargo.toml
+++ b/crates/zeroclaw-channels/Cargo.toml
@@ -82,7 +82,7 @@ default = [
     "channel-irc", "channel-imessage", "channel-dingtalk", "channel-qq",
     "channel-bluesky", "channel-twitter", "channel-reddit", "channel-notion",
     "channel-linq", "channel-wati", "channel-nextcloud", "channel-mochat",
-    "channel-wecom", "channel-clawdtalk", "channel-webhook",
+    "channel-plivo", "channel-wecom", "channel-clawdtalk", "channel-webhook",
     "channel-whatsapp-cloud", "channel-voice-call",
 ]
 # Channels with optional deps
@@ -109,6 +109,7 @@ channel-linq = []
 channel-wati = []
 channel-nextcloud = []
 channel-mochat = []
+channel-plivo = []
 channel-wechat = ["dep:aes", "dep:ecb", "dep:md5", "dep:mime_guess", "dep:qrcode"]
 channel-wecom = []
 channel-clawdtalk = []

--- a/crates/zeroclaw-channels/src/lib.rs
+++ b/crates/zeroclaw-channels/src/lib.rs
@@ -48,6 +48,8 @@ pub mod nextcloud_talk;
 pub mod nostr;
 #[cfg(feature = "channel-notion")]
 pub mod notion;
+#[cfg(feature = "channel-plivo")]
+pub mod plivo;
 #[cfg(feature = "channel-qq")]
 pub mod qq;
 #[cfg(feature = "channel-reddit")]

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -45,6 +45,8 @@ pub use crate::nextcloud_talk::NextcloudTalkChannel;
 #[cfg(feature = "channel-nostr")]
 pub use crate::nostr::NostrChannel;
 pub use crate::notion::NotionChannel;
+#[cfg(feature = "channel-plivo")]
+pub use crate::plivo::PlivoChannel;
 pub use crate::qq::QQChannel;
 pub use crate::reddit::RedditChannel;
 pub use crate::signal::SignalChannel;
@@ -4476,6 +4478,20 @@ fn build_channel_by_id(config: &Config, channel_id: &str) -> Result<Arc<dyn Chan
                 lq.allowed_senders.clone(),
             )))
         }
+        #[cfg(feature = "channel-plivo")]
+        "plivo" => {
+            let pl = config
+                .channels
+                .plivo
+                .as_ref()
+                .context("Plivo channel is not configured")?;
+            Ok(Arc::new(PlivoChannel::new(
+                pl.account_id.clone(),
+                pl.auth_token.clone(),
+                pl.from_number.clone(),
+                pl.allowed_numbers.clone(),
+            )))
+        }
         #[cfg(feature = "channel-email")]
         "email" => {
             let em = config
@@ -4598,7 +4614,8 @@ fn build_channel_by_id(config: &Config, channel_id: &str) -> Result<Arc<dyn Chan
         other => anyhow::bail!(
             "Unknown channel '{other}'. Supported: telegram, discord, slack, mattermost, signal, \
             matrix, whatsapp, qq, lark, feishu, dingtalk, wecom, nextcloud_talk, wati, linq, \
-            email, gmail_push, irc, twitter, mochat, discord_history, imessage, line, voice-call"
+            plivo, email, gmail_push, irc, twitter, mochat, discord_history, imessage, line, \
+            voice-call"
         ),
     }
 }
@@ -4948,6 +4965,23 @@ fn collect_configured_channels(
             });
         } else {
             tracing::info!("Linq channel configured but disabled (enabled = false)");
+        }
+    }
+
+    #[cfg(feature = "channel-plivo")]
+    if let Some(ref pl) = config.channels.plivo {
+        if pl.enabled {
+            channels.push(ConfiguredChannel {
+                display_name: "Plivo",
+                channel: Arc::new(PlivoChannel::new(
+                    pl.account_id.clone(),
+                    pl.auth_token.clone(),
+                    pl.from_number.clone(),
+                    pl.allowed_numbers.clone(),
+                )),
+            });
+        } else {
+            tracing::info!("Plivo channel configured but disabled (enabled = false)");
         }
     }
 

--- a/crates/zeroclaw-channels/src/plivo.rs
+++ b/crates/zeroclaw-channels/src/plivo.rs
@@ -1,0 +1,646 @@
+//! Plivo SMS channel — sends via Plivo's REST `Message` resource and receives
+//! via gateway-routed webhooks.
+//!
+//! Mirrors the gateway-registered pattern used by WhatsApp Cloud, Linq, WATI,
+//! Nextcloud Talk, and Twilio: this channel's `listen()` is a keep-alive
+//! no-op; the `zeroclaw-gateway` crate hosts a hardcoded `POST /plivo/sms`
+//! route whose handler reads `application/x-www-form-urlencoded` payloads,
+//! validates the `X-Plivo-Signature-V3` header, and converts each request
+//! into a `ChannelMessage`.
+//!
+//! # Auth
+//! Auth ID + Auth Token. Outbound calls use HTTP Basic with the Auth ID as
+//! username and the Auth Token as password. Inbound webhooks are
+//! authenticated by recomputing Plivo's HMAC-SHA256 over the full request URL
+//! concatenated with the nonce and the raw request body, and base64-comparing
+//! against `X-Plivo-Signature-V3`. The same Auth Token keys both flows.
+//!
+//! # Outbound
+//! `POST https://api.plivo.com/v1/Account/{auth_id}/Message/` (note the
+//! trailing slash — Plivo requires it) with a JSON body of
+//! `{"src": from_number, "dst": to_number, "text": body}`. Plivo segments
+//! long messages transparently up to 1600 characters; bodies above that are
+//! split into ≤1600-char chunks at sentence/word boundaries with a `(i/N)`
+//! continuation marker.
+//!
+//! # Inbound
+//! The gateway handler verifies the V3 signature, drops senders not on the
+//! `allowed_numbers` allowlist, and forwards each message to the agent loop.
+//!
+//! See <https://www.plivo.com/docs/sms/concepts/incoming-sms-message/v3-signature/>.
+
+use anyhow::{Context, Result, bail};
+use async_trait::async_trait;
+use std::collections::BTreeMap;
+use zeroclaw_api::channel::{Channel, ChannelMessage, SendMessage};
+
+const PLIVO_API_BASE: &str = "https://api.plivo.com/v1";
+/// Plivo segments outbound messages transparently. The ceiling for a single
+/// API call is 1600 characters; longer bodies must be split.
+const PLIVO_MESSAGE_LIMIT: usize = 1600;
+/// Hardcoded inbound webhook path on the gateway. Operators point Plivo's
+/// "Message URL" setting (in the application configuration) at
+/// `https://{gateway}/plivo/sms`.
+pub const PLIVO_WEBHOOK_PATH: &str = "/plivo/sms";
+
+/// Plivo SMS channel — see module docs.
+pub struct PlivoChannel {
+    account_id: String,
+    auth_token: String,
+    from_number: String,
+    allowed_numbers: Vec<String>,
+}
+
+impl PlivoChannel {
+    pub fn new(
+        account_id: String,
+        auth_token: String,
+        from_number: String,
+        allowed_numbers: Vec<String>,
+    ) -> Self {
+        Self {
+            account_id,
+            auth_token,
+            from_number,
+            allowed_numbers,
+        }
+    }
+
+    fn http_client(&self) -> reqwest::Client {
+        zeroclaw_config::schema::build_runtime_proxy_client("channel.plivo")
+    }
+
+    fn outbound_url(&self) -> String {
+        // Trailing slash is mandatory — Plivo returns 404 without it.
+        format!("{PLIVO_API_BASE}/Account/{}/Message/", self.account_id)
+    }
+
+    /// Configurable base URL hook used by tests. The default path matches
+    /// Plivo's production endpoint; tests substitute a wiremock URI by
+    /// constructing the channel and overriding via `with_outbound_base`.
+    #[cfg(test)]
+    fn outbound_url_with_base(&self, base: &str) -> String {
+        format!("{base}/v1/Account/{}/Message/", self.account_id)
+    }
+
+    /// Whether the inbound `From` number is permitted. Empty allowlist denies
+    /// everyone; `"*"` matches anyone; otherwise an exact case-insensitive
+    /// E.164 match is required (whitespace stripped).
+    pub fn is_number_allowed(&self, phone: &str) -> bool {
+        is_number_allowed_for_list(&self.allowed_numbers, phone)
+    }
+
+    /// Verify a Plivo V3 webhook signature against the request URL, nonce,
+    /// and raw body bytes. Plivo's algorithm:
+    ///
+    /// 1. Concatenate the full URL (the URL the webhook was sent to,
+    ///    including scheme/host/path/query), the nonce header value, and the
+    ///    raw request body bytes — in that order, as a contiguous byte
+    ///    stream.
+    /// 2. Compute HMAC-SHA256 of the resulting bytes using the Auth Token as
+    ///    the key.
+    /// 3. Base64-encode the digest and compare against the
+    ///    `X-Plivo-Signature-V3` header (constant-time).
+    ///
+    /// See <https://www.plivo.com/docs/sms/concepts/incoming-sms-message/v3-signature/>.
+    pub fn verify_signature(
+        &self,
+        full_url: &str,
+        nonce: &str,
+        raw_body: &[u8],
+        header_signature: &str,
+    ) -> bool {
+        verify_plivo_v3_signature(
+            &self.auth_token,
+            full_url,
+            nonce,
+            raw_body,
+            header_signature,
+        )
+    }
+
+    /// Convert an inbound Plivo webhook payload into a `ChannelMessage`.
+    /// Returns `None` when the sender isn't on the allowlist, the body is
+    /// empty, or the payload is missing required fields.
+    pub fn parse_webhook_payload(
+        &self,
+        form_params: &BTreeMap<String, String>,
+    ) -> Option<ChannelMessage> {
+        let from = form_params.get("From")?.trim();
+        if from.is_empty() {
+            return None;
+        }
+        if !self.is_number_allowed(from) {
+            tracing::debug!("Plivo: dropping SMS from {from} (not in allowed_numbers)");
+            return None;
+        }
+        let body = form_params
+            .get("Text")
+            .map(|s| s.trim().to_string())
+            .unwrap_or_default();
+        if body.is_empty() {
+            tracing::debug!("Plivo: dropping empty-body SMS from {from}");
+            return None;
+        }
+        let message_uuid = form_params
+            .get("MessageUUID")
+            .cloned()
+            .unwrap_or_else(|| format!("plivo-{}", chrono::Utc::now().timestamp_millis()));
+        Some(ChannelMessage {
+            id: format!("plivo_{message_uuid}"),
+            sender: from.to_string(),
+            reply_target: from.to_string(),
+            content: body,
+            channel: "plivo".to_string(),
+            timestamp: chrono::Utc::now().timestamp().cast_unsigned(),
+            thread_ts: None,
+            interruption_scope_id: None,
+            attachments: vec![],
+        })
+    }
+
+    async fn post_message_chunk(
+        &self,
+        to: &str,
+        body: &str,
+        base_override: Option<&str>,
+    ) -> Result<()> {
+        let url = match base_override {
+            #[cfg(test)]
+            Some(b) => self.outbound_url_with_base(b),
+            #[cfg(not(test))]
+            Some(_) => self.outbound_url(),
+            None => self.outbound_url(),
+        };
+        let payload = serde_json::json!({
+            "src": self.from_number,
+            "dst": to,
+            "text": body,
+        });
+        let resp = self
+            .http_client()
+            .post(&url)
+            .basic_auth(&self.account_id, Some(&self.auth_token))
+            .json(&payload)
+            .send()
+            .await
+            .context("Plivo Message POST failed")?;
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            bail!("Plivo Message POST returned {status}: {body}");
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Channel for PlivoChannel {
+    fn name(&self) -> &str {
+        "plivo"
+    }
+
+    async fn send(&self, message: &SendMessage) -> Result<()> {
+        let to = message.recipient.trim();
+        if to.is_empty() {
+            bail!("Plivo send: empty recipient");
+        }
+        let chunks = chunk_sms(&message.content, PLIVO_MESSAGE_LIMIT);
+        if chunks.is_empty() {
+            return Ok(());
+        }
+        for chunk in chunks {
+            self.post_message_chunk(to, &chunk, None).await?;
+        }
+        Ok(())
+    }
+
+    async fn listen(&self, _tx: tokio::sync::mpsc::Sender<ChannelMessage>) -> Result<()> {
+        // Plivo uses webhooks (push-based), not polling. The gateway hosts
+        // POST /plivo/sms and routes inbound payloads via parse_webhook_payload.
+        tracing::info!(
+            "Plivo channel active (webhook mode). Configure your Plivo \
+             application's \"Message URL\" to POST to your gateway's \
+             {PLIVO_WEBHOOK_PATH} endpoint."
+        );
+        loop {
+            tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
+        }
+    }
+
+    async fn health_check(&self) -> bool {
+        // Probe the Account resource — succeeds when Auth ID + Token are valid.
+        let url = format!("{PLIVO_API_BASE}/Account/{}/", self.account_id);
+        self.http_client()
+            .get(&url)
+            .basic_auth(&self.account_id, Some(&self.auth_token))
+            .send()
+            .await
+            .map(|r| r.status().is_success())
+            .unwrap_or(false)
+    }
+}
+
+/// Allowlist matcher with `"*"` wildcard. Comparison is case-insensitive and
+/// strips internal whitespace so `"+1 555 555 0199"` round-trips against the
+/// canonical E.164 `"+15555550199"`.
+pub fn is_number_allowed_for_list(allowlist: &[String], phone: &str) -> bool {
+    if allowlist.is_empty() {
+        return false;
+    }
+    if allowlist.iter().any(|n| n == "*") {
+        return true;
+    }
+    let normalized = phone
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect::<String>()
+        .to_ascii_lowercase();
+    allowlist.iter().any(|entry| {
+        let canon = entry
+            .chars()
+            .filter(|c| !c.is_whitespace())
+            .collect::<String>()
+            .to_ascii_lowercase();
+        canon == normalized
+    })
+}
+
+fn verify_plivo_v3_signature(
+    auth_token: &str,
+    full_url: &str,
+    nonce: &str,
+    raw_body: &[u8],
+    header_signature: &str,
+) -> bool {
+    use hmac::{Hmac, Mac};
+    use sha2::Sha256;
+    if header_signature.is_empty() {
+        return false;
+    }
+    let Ok(mut mac) = Hmac::<Sha256>::new_from_slice(auth_token.as_bytes()) else {
+        return false;
+    };
+    // V3 signs the byte stream URL || nonce || body — no separator, no sort,
+    // no form-key concatenation. Body is the raw request bytes.
+    mac.update(full_url.as_bytes());
+    mac.update(nonce.as_bytes());
+    mac.update(raw_body);
+    let computed = mac.finalize().into_bytes();
+    let expected_b64 = base64_encode(&computed);
+    constant_time_eq(expected_b64.as_bytes(), header_signature.as_bytes())
+}
+
+fn base64_encode(bytes: &[u8]) -> String {
+    use base64::Engine;
+    base64::engine::general_purpose::STANDARD.encode(bytes)
+}
+
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff: u8 = 0;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+/// Split an outbound body into ≤`limit`-character chunks. Single-chunk bodies
+/// are returned as-is; multi-chunk bodies receive a `(i/N) ` prefix on each
+/// part so the recipient can reassemble. Splits prefer sentence enders, then
+/// whitespace, then a hard char cut.
+pub fn chunk_sms(body: &str, limit: usize) -> Vec<String> {
+    let body = body.trim();
+    if body.is_empty() {
+        return vec![];
+    }
+    if body.chars().count() <= limit {
+        return vec![body.to_string()];
+    }
+    const MARKER_RESERVE: usize = 8; // "(99/99) "
+    let body_budget = limit.saturating_sub(MARKER_RESERVE).max(1);
+    let mut chunks: Vec<String> = Vec::new();
+    let mut remaining: &str = body;
+    while !remaining.is_empty() {
+        if remaining.chars().count() <= body_budget {
+            chunks.push(remaining.to_string());
+            break;
+        }
+        let split_at = pick_split_point(remaining, body_budget);
+        let (head, tail) = remaining.split_at(split_at);
+        chunks.push(head.trim_end().to_string());
+        remaining = tail.trim_start();
+    }
+    if chunks.len() == 1 {
+        return chunks;
+    }
+    let total = chunks.len();
+    chunks
+        .into_iter()
+        .enumerate()
+        .map(|(i, c)| format!("({}/{total}) {c}", i + 1))
+        .collect()
+}
+
+fn pick_split_point(text: &str, char_budget: usize) -> usize {
+    let mut budget_idx = text.len();
+    for (i, (byte_idx, _)) in text.char_indices().enumerate() {
+        if i == char_budget {
+            budget_idx = byte_idx;
+            break;
+        }
+    }
+    let head = &text[..budget_idx];
+    if let Some(idx) = head.rfind(['.', '!', '?', '\n']) {
+        return (idx + 1).min(budget_idx);
+    }
+    if let Some(idx) = head.rfind(char::is_whitespace) {
+        return idx + 1;
+    }
+    budget_idx
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ch() -> PlivoChannel {
+        PlivoChannel::new(
+            "MAtestauthid".into(),
+            "test-auth-token".into(),
+            "+15555550100".into(),
+            vec!["+15555550199".into()],
+        )
+    }
+
+    #[test]
+    fn allowlist_empty_denies_everyone() {
+        assert!(!is_number_allowed_for_list(&[], "+15555550199"));
+    }
+
+    #[test]
+    fn allowlist_wildcard_allows_anyone() {
+        let allow = vec!["*".into()];
+        assert!(is_number_allowed_for_list(&allow, "+15555550199"));
+        assert!(is_number_allowed_for_list(&allow, "+447700900000"));
+    }
+
+    #[test]
+    fn allowlist_matches_e164_exact() {
+        let allow = vec!["+15555550199".into()];
+        assert!(is_number_allowed_for_list(&allow, "+15555550199"));
+        assert!(!is_number_allowed_for_list(&allow, "+15555550100"));
+    }
+
+    #[test]
+    fn allowlist_strips_whitespace() {
+        let allow = vec!["+1 555 555 0199".into()];
+        assert!(is_number_allowed_for_list(&allow, "+15555550199"));
+    }
+
+    #[test]
+    fn chunk_sms_short_passes_through() {
+        let chunks = chunk_sms("hi there", PLIVO_MESSAGE_LIMIT);
+        assert_eq!(chunks, vec!["hi there"]);
+    }
+
+    #[test]
+    fn chunk_sms_long_is_split_with_marker() {
+        let body = "alpha beta gamma. ".repeat(120);
+        let chunks = chunk_sms(&body, 100);
+        assert!(chunks.len() >= 2, "expected ≥2 chunks, got {chunks:?}");
+        for (i, c) in chunks.iter().enumerate() {
+            assert!(
+                c.starts_with(&format!("({}/", i + 1)),
+                "missing marker on chunk {i}: {c:?}"
+            );
+            assert!(
+                c.chars().count() <= 100,
+                "chunk {i} exceeds limit: {c:?} ({} chars)",
+                c.chars().count()
+            );
+        }
+    }
+
+    #[test]
+    fn chunk_sms_empty_returns_no_chunks() {
+        let chunks = chunk_sms("   ", PLIVO_MESSAGE_LIMIT);
+        assert!(chunks.is_empty());
+    }
+
+    #[test]
+    fn chunk_sms_preserves_total_content() {
+        // Total non-marker content reassembled from chunks should match
+        // the original body (minus separators between chunks).
+        let body = "The quick brown fox jumps over the lazy dog. ".repeat(40);
+        let body = body.trim();
+        let chunks = chunk_sms(body, 200);
+        assert!(chunks.len() >= 2);
+        let stripped: String = chunks
+            .iter()
+            .map(|c| {
+                // Strip leading "(i/N) " marker
+                if let Some(close) = c.find(") ") {
+                    c[close + 2..].to_string()
+                } else {
+                    c.clone()
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(" ");
+        // Whitespace handling means we can't byte-compare, but the char
+        // counts should be near-equal (allowing for trim differences at
+        // chunk boundaries).
+        assert!(
+            stripped.chars().count() >= body.chars().count() - chunks.len(),
+            "lost content: original={}, reassembled={}",
+            body.chars().count(),
+            stripped.chars().count()
+        );
+    }
+
+    #[test]
+    fn parse_webhook_drops_outside_allowlist() {
+        let mut params = BTreeMap::new();
+        params.insert("From".into(), "+15555550999".into());
+        params.insert("Text".into(), "hello".into());
+        params.insert("MessageUUID".into(), "uuid-abc".into());
+        assert!(ch().parse_webhook_payload(&params).is_none());
+    }
+
+    #[test]
+    fn parse_webhook_drops_empty_body() {
+        let mut params = BTreeMap::new();
+        params.insert("From".into(), "+15555550199".into());
+        params.insert("Text".into(), "  ".into());
+        assert!(ch().parse_webhook_payload(&params).is_none());
+    }
+
+    #[test]
+    fn parse_webhook_drops_empty_sender() {
+        let mut params = BTreeMap::new();
+        params.insert("From".into(), "".into());
+        params.insert("Text".into(), "hello".into());
+        assert!(ch().parse_webhook_payload(&params).is_none());
+    }
+
+    #[test]
+    fn parse_webhook_returns_message_on_allowed() {
+        let mut params = BTreeMap::new();
+        params.insert("From".into(), "+15555550199".into());
+        params.insert("Text".into(), "hello world".into());
+        params.insert("MessageUUID".into(), "uuid-123".into());
+        let msg = ch()
+            .parse_webhook_payload(&params)
+            .expect("expected message");
+        assert_eq!(msg.sender, "+15555550199");
+        assert_eq!(msg.reply_target, "+15555550199");
+        assert_eq!(msg.content, "hello world");
+        assert_eq!(msg.channel, "plivo");
+        assert_eq!(msg.id, "plivo_uuid-123");
+    }
+
+    /// Round-trip the production verifier: build a signature using the same
+    /// HMAC-SHA256 over (URL || nonce || body) flow we ship, base64-encode
+    /// it, and assert `verify_plivo_v3_signature` accepts it.
+    #[test]
+    fn verify_signature_round_trips_self_signed() {
+        use hmac::{Hmac, Mac};
+        use sha2::Sha256;
+        let token = "plivo-test-token";
+        let url = "https://gateway.example.com/plivo/sms";
+        let nonce = "abc123nonce";
+        let body = b"From=%2B15555550199&Text=hello&MessageUUID=uuid-1&Type=sms";
+        let mut mac =
+            Hmac::<Sha256>::new_from_slice(token.as_bytes()).expect("valid HMAC key length");
+        mac.update(url.as_bytes());
+        mac.update(nonce.as_bytes());
+        mac.update(body);
+        let digest = mac.finalize().into_bytes();
+        let expected = base64_encode(&digest);
+        assert!(
+            verify_plivo_v3_signature(token, url, nonce, body, &expected),
+            "self-signed signature should round-trip"
+        );
+    }
+
+    #[test]
+    fn verify_signature_rejects_tampered_body() {
+        use hmac::{Hmac, Mac};
+        use sha2::Sha256;
+        let token = "plivo-test-token";
+        let url = "https://gateway.example.com/plivo/sms";
+        let nonce = "abc123nonce";
+        let body = b"From=%2B15555550199&Text=hello&MessageUUID=uuid-1&Type=sms";
+        let mut mac =
+            Hmac::<Sha256>::new_from_slice(token.as_bytes()).expect("valid HMAC key length");
+        mac.update(url.as_bytes());
+        mac.update(nonce.as_bytes());
+        mac.update(body);
+        let expected = base64_encode(&mac.finalize().into_bytes());
+        let tampered = b"From=%2B15555550199&Text=goodbye&MessageUUID=uuid-1&Type=sms";
+        assert!(!verify_plivo_v3_signature(
+            token, url, nonce, tampered, &expected
+        ));
+    }
+
+    #[test]
+    fn verify_signature_rejects_wrong_token() {
+        use hmac::{Hmac, Mac};
+        use sha2::Sha256;
+        let url = "https://gateway.example.com/plivo/sms";
+        let nonce = "abc123nonce";
+        let body = b"hello";
+        let mut mac = Hmac::<Sha256>::new_from_slice(b"real-token").expect("valid HMAC key length");
+        mac.update(url.as_bytes());
+        mac.update(nonce.as_bytes());
+        mac.update(body);
+        let expected = base64_encode(&mac.finalize().into_bytes());
+        assert!(!verify_plivo_v3_signature(
+            "wrong-token",
+            url,
+            nonce,
+            body,
+            &expected
+        ));
+    }
+
+    #[test]
+    fn verify_signature_rejects_empty_header() {
+        assert!(!verify_plivo_v3_signature(
+            "token",
+            "https://x",
+            "nonce",
+            b"body",
+            ""
+        ));
+    }
+
+    #[test]
+    fn verify_signature_rejects_wrong_nonce() {
+        use hmac::{Hmac, Mac};
+        use sha2::Sha256;
+        let token = "t";
+        let url = "https://x/plivo/sms";
+        let body = b"body";
+        let mut mac = Hmac::<Sha256>::new_from_slice(token.as_bytes()).expect("hmac");
+        mac.update(url.as_bytes());
+        mac.update(b"nonce-A");
+        mac.update(body);
+        let expected = base64_encode(&mac.finalize().into_bytes());
+        assert!(!verify_plivo_v3_signature(
+            token, url, "nonce-B", body, &expected
+        ));
+    }
+
+    mod http_tests {
+        use super::*;
+        use wiremock::matchers::{body_string_contains, header, header_exists, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        #[tokio::test]
+        async fn send_posts_to_message_endpoint_with_basic_auth_and_json_body() {
+            let server = MockServer::start().await;
+
+            Mock::given(method("POST"))
+                .and(path("/v1/Account/MAtestauthid/Message/"))
+                .and(header_exists("authorization"))
+                .and(header("content-type", "application/json"))
+                .and(body_string_contains("\"src\":\"+15555550100\""))
+                .and(body_string_contains("\"dst\":\"+15555550199\""))
+                .and(body_string_contains("\"text\":\"hello there\""))
+                .respond_with(ResponseTemplate::new(202).set_body_json(serde_json::json!({
+                    "message_uuid": ["uuid-12345"],
+                    "api_id": "abc",
+                })))
+                .expect(1)
+                .mount(&server)
+                .await;
+
+            let plivo = ch();
+            plivo
+                .post_message_chunk("+15555550199", "hello there", Some(&server.uri()))
+                .await
+                .expect("send succeeds");
+        }
+
+        #[tokio::test]
+        async fn send_surfaces_4xx_as_error() {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/v1/Account/MAtestauthid/Message/"))
+                .respond_with(ResponseTemplate::new(401).set_body_string("{\"error\": \"auth\"}"))
+                .mount(&server)
+                .await;
+
+            let err = ch()
+                .post_message_chunk("+15555550199", "hi", Some(&server.uri()))
+                .await
+                .expect_err("expected error");
+            let msg = format!("{err:#}");
+            assert!(msg.contains("401"), "missing 401 in error: {msg}");
+        }
+    }
+}

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -6773,6 +6773,11 @@ pub struct ChannelsConfig {
     #[display_name = "Linq"]
     #[description = "Linq Partner API for iMessage/RCS/SMS"]
     pub linq: Option<LinqConfig>,
+    /// Plivo SMS channel configuration.
+    #[nested]
+    #[display_name = "Plivo"]
+    #[description = "Plivo programmable SMS"]
+    pub plivo: Option<PlivoConfig>,
     /// WATI WhatsApp Business API channel configuration.
     #[nested]
     #[display_name = "WATI"]
@@ -6987,6 +6992,10 @@ impl ChannelsConfig {
                 self.linq.is_some(),
             ),
             (
+                Box::new(ConfigWrapper::new(self.plivo.as_ref())),
+                self.plivo.is_some(),
+            ),
+            (
                 Box::new(ConfigWrapper::new(self.wati.as_ref())),
                 self.wati.is_some(),
             ),
@@ -7092,6 +7101,7 @@ impl Default for ChannelsConfig {
             signal: None,
             whatsapp: None,
             linq: None,
+            plivo: None,
             wati: None,
             nextcloud_talk: None,
             email: None,
@@ -7790,6 +7800,45 @@ impl ChannelConfig for LinqConfig {
     }
     fn desc() -> &'static str {
         "iMessage/RCS/SMS via Linq API"
+    }
+}
+
+/// Plivo SMS channel configuration.
+///
+/// Plivo is a CPaaS provider (Twilio sibling) that delivers SMS via a REST
+/// API plus inbound webhooks. The gateway hosts `POST /plivo/sms` for
+/// receive and this channel's `send` posts to Plivo's `Message` resource.
+///
+/// Inbound auth is HMAC-SHA256 over `URL || nonce || raw_body` keyed by the
+/// Auth Token, base64-encoded, compared to `X-Plivo-Signature-V3` (with the
+/// nonce delivered in `X-Plivo-Signature-V3-Nonce`).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, Configurable)]
+#[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
+#[prefix = "channels.plivo"]
+pub struct PlivoConfig {
+    /// Whether this channel is active (must be explicitly enabled). Default: false.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Plivo Auth ID (the public account identifier; not secret).
+    pub account_id: String,
+    /// Plivo Auth Token. Used as the HTTP Basic password for outbound calls
+    /// and as the HMAC key for inbound webhook signature verification.
+    #[secret]
+    #[cfg_attr(feature = "schema-export", schemars(extend("x-secret" = true)))]
+    pub auth_token: String,
+    /// Phone number to send from (E.164 format, e.g. `+15555550100`).
+    pub from_number: String,
+    /// Allowed inbound sender numbers (E.164 format) or `"*"` for all.
+    #[serde(default)]
+    pub allowed_numbers: Vec<String>,
+}
+
+impl ChannelConfig for PlivoConfig {
+    fn name() -> &'static str {
+        "Plivo"
+    }
+    fn desc() -> &'static str {
+        "SMS via Plivo Programmable Messaging"
     }
 }
 
@@ -12526,6 +12575,7 @@ auto_save = true
                 signal: None,
                 whatsapp: None,
                 linq: None,
+                plivo: None,
                 wati: None,
                 nextcloud_talk: None,
                 email: None,
@@ -13700,6 +13750,7 @@ allowed_users = ["@u:matrix.org"]
             signal: None,
             whatsapp: None,
             linq: None,
+            plivo: None,
             wati: None,
             nextcloud_talk: None,
             email: None,
@@ -14082,6 +14133,7 @@ bot_token = "xoxb-tok"
                 approval_timeout_secs: 300,
             }),
             linq: None,
+            plivo: None,
             wati: None,
             nextcloud_talk: None,
             email: None,

--- a/crates/zeroclaw-gateway/Cargo.toml
+++ b/crates/zeroclaw-gateway/Cargo.toml
@@ -48,6 +48,7 @@ futures-util = { version = "0.3", default-features = false, features = ["sink"] 
 # Serialization
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["std"] }
+serde_urlencoded = "0.7"
 
 # Error handling
 anyhow = "1.0"

--- a/crates/zeroclaw-gateway/src/api.rs
+++ b/crates/zeroclaw-gateway/src/api.rs
@@ -1277,6 +1277,7 @@ mod tests {
             whatsapp_app_secret: None,
             linq: None,
             linq_signing_secret: None,
+            plivo: None,
             nextcloud_talk: None,
             nextcloud_talk_webhook_secret: None,
             wati: None,

--- a/crates/zeroclaw-gateway/src/lib.rs
+++ b/crates/zeroclaw-gateway/src/lib.rs
@@ -53,7 +53,7 @@ use zeroclaw_api::channel::{Channel, SendMessage};
 use zeroclaw_api::tool::ToolSpec;
 use zeroclaw_channels::{
     gmail_push::GmailPushChannel, linq::LinqChannel, nextcloud_talk::NextcloudTalkChannel,
-    wati::WatiChannel, whatsapp::WhatsAppChannel,
+    plivo::PlivoChannel, wati::WatiChannel, whatsapp::WhatsAppChannel,
 };
 use zeroclaw_config::policy::SecurityPolicy;
 use zeroclaw_config::schema::Config;
@@ -122,6 +122,10 @@ fn whatsapp_memory_key(msg: &zeroclaw_api::channel::ChannelMessage) -> String {
 
 fn linq_memory_key(msg: &zeroclaw_api::channel::ChannelMessage) -> String {
     format!("linq_{}_{}", msg.sender, msg.id)
+}
+
+fn plivo_memory_key(msg: &zeroclaw_api::channel::ChannelMessage) -> String {
+    format!("plivo_{}_{}", msg.sender, msg.id)
 }
 
 fn wati_memory_key(msg: &zeroclaw_api::channel::ChannelMessage) -> String {
@@ -382,6 +386,7 @@ pub struct AppState {
     pub linq: Option<Arc<LinqChannel>>,
     /// Linq webhook signing secret for signature verification
     pub linq_signing_secret: Option<Arc<str>>,
+    pub plivo: Option<Arc<PlivoChannel>>,
     pub nextcloud_talk: Option<Arc<NextcloudTalkChannel>>,
     /// Nextcloud Talk webhook secret for signature verification
     pub nextcloud_talk_webhook_secret: Option<Arc<str>>,
@@ -715,6 +720,21 @@ pub async fn run_gateway(
         })
         .map(Arc::from);
 
+    // Plivo channel (if configured AND enabled)
+    let plivo_channel: Option<Arc<PlivoChannel>> = config
+        .channels
+        .plivo
+        .as_ref()
+        .filter(|pl| pl.enabled)
+        .map(|pl| {
+            Arc::new(PlivoChannel::new(
+                pl.account_id.clone(),
+                pl.auth_token.clone(),
+                pl.from_number.clone(),
+                pl.allowed_numbers.clone(),
+            ))
+        });
+
     // WATI channel (if configured)
     let wati_channel: Option<Arc<WatiChannel>> = config.channels.wati.as_ref().map(|wati_cfg| {
         Arc::new(
@@ -916,6 +936,9 @@ pub async fn run_gateway(
     if linq_channel.is_some() {
         println!("  POST {pfx}/linq      — Linq message webhook (iMessage/RCS/SMS)");
     }
+    if plivo_channel.is_some() {
+        println!("  POST {pfx}/plivo/sms — Plivo SMS webhook");
+    }
     if wati_channel.is_some() {
         println!("  GET  {pfx}/wati      — WATI webhook verification");
         println!("  POST {pfx}/wati      — WATI message webhook");
@@ -985,6 +1008,7 @@ pub async fn run_gateway(
         whatsapp_app_secret,
         linq: linq_channel,
         linq_signing_secret,
+        plivo: plivo_channel,
         nextcloud_talk: nextcloud_talk_channel,
         nextcloud_talk_webhook_secret,
         wati: wati_channel,
@@ -1047,6 +1071,7 @@ pub async fn run_gateway(
         .route("/whatsapp", get(handle_whatsapp_verify))
         .route("/whatsapp", post(handle_whatsapp_message))
         .route("/linq", post(handle_linq_webhook))
+        .route("/plivo/sms", post(handle_plivo_sms_webhook))
         .route("/wati", get(handle_wati_verify))
         .route("/wati", post(handle_wati_webhook))
         .route("/nextcloud-talk", post(handle_nextcloud_talk_webhook))
@@ -2091,6 +2116,165 @@ async fn handle_linq_webhook(
     (StatusCode::OK, Json(serde_json::json!({"status": "ok"})))
 }
 
+/// POST /plivo/sms — incoming SMS webhook from Plivo Programmable Messaging.
+///
+/// Plivo sends `application/x-www-form-urlencoded` POSTs with `From`, `To`,
+/// `Text`, `MessageUUID`, `Type` (`sms` for normal SMS), and other metadata.
+/// The handler:
+///
+/// 1. Reconstructs the full request URL using `X-Forwarded-Proto`/
+///    `X-Forwarded-Host` (set by tunnels and reverse proxies); falls back to
+///    `Host` and HTTPS. Path is `/plivo/sms` (Plivo never includes a query
+///    string on the webhook).
+/// 2. Verifies the `X-Plivo-Signature-V3` header against
+///    `PlivoChannel::verify_signature` using the V3 nonce header
+///    (`X-Plivo-Signature-V3-Nonce`) and the raw request body. Failure
+///    returns 401 — the SMS is dropped before reaching the agent.
+/// 3. Parses the form payload via `PlivoChannel::parse_webhook_payload`,
+///    which applies the `allowed_numbers` allowlist.
+/// 4. Forwards the resulting `ChannelMessage` to the agent loop and replies
+///    via `PlivoChannel::send`.
+///
+/// Successful runs return `200 OK` with an empty body.
+async fn handle_plivo_sms_webhook(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> impl IntoResponse {
+    use std::collections::BTreeMap;
+    let Some(ref plivo) = state.plivo else {
+        return (
+            StatusCode::NOT_FOUND,
+            [(header::CONTENT_TYPE, "application/json")],
+            Json(serde_json::json!({"error": "Plivo not configured"})).to_string(),
+        );
+    };
+
+    // Parse the form-urlencoded body into a sorted map (BTreeMap so map
+    // iteration is deterministic when downstream code walks keys).
+    let parsed: Vec<(String, String)> = match serde_urlencoded::from_bytes(&body) {
+        Ok(v) => v,
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                [(header::CONTENT_TYPE, "application/json")],
+                Json(serde_json::json!({"error": "Invalid form body"})).to_string(),
+            );
+        }
+    };
+    let form_params: BTreeMap<String, String> = parsed.into_iter().collect();
+
+    // Reconstruct the URL Plivo signed. Trust X-Forwarded-Host/
+    // X-Forwarded-Proto when present (tunnels and reverse proxies set them);
+    // otherwise fall back to the Host header and assume HTTPS (Plivo always
+    // sends webhooks over HTTPS in production).
+    let scheme = headers
+        .get("x-forwarded-proto")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("https");
+    let host = headers
+        .get("x-forwarded-host")
+        .or_else(|| headers.get("host"))
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    if host.is_empty() {
+        tracing::warn!("Plivo webhook missing Host/X-Forwarded-Host header");
+        return (
+            StatusCode::BAD_REQUEST,
+            [(header::CONTENT_TYPE, "application/json")],
+            Json(serde_json::json!({"error": "Missing Host header"})).to_string(),
+        );
+    }
+    let full_url = format!("{scheme}://{host}/plivo/sms");
+
+    let signature = headers
+        .get("x-plivo-signature-v3")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    let nonce = headers
+        .get("x-plivo-signature-v3-nonce")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    if !plivo.verify_signature(&full_url, nonce, &body, signature) {
+        tracing::warn!(
+            "Plivo webhook signature verification failed (signature: {})",
+            if signature.is_empty() {
+                "missing"
+            } else {
+                "invalid"
+            }
+        );
+        return (
+            StatusCode::UNAUTHORIZED,
+            [(header::CONTENT_TYPE, "application/json")],
+            Json(serde_json::json!({"error": "Invalid signature"})).to_string(),
+        );
+    }
+
+    let Some(msg) = plivo.parse_webhook_payload(&form_params) else {
+        // Either the sender wasn't on the allowlist, the body was empty, or
+        // the payload is missing required fields. Plivo expects a 200 back
+        // either way so it doesn't retry.
+        return (
+            StatusCode::OK,
+            [(header::CONTENT_TYPE, "text/plain")],
+            String::new(),
+        );
+    };
+
+    tracing::info!(
+        "Plivo SMS from {}: {}",
+        msg.sender,
+        truncate_with_ellipsis(&msg.content, 50)
+    );
+    let session_id = sender_session_id("plivo", &msg);
+
+    if state.auto_save && !zeroclaw_memory::should_skip_autosave_content(&msg.content) {
+        let key = plivo_memory_key(&msg);
+        let _ = state
+            .mem
+            .store(
+                &key,
+                &msg.content,
+                MemoryCategory::Conversation,
+                Some(&session_id),
+            )
+            .await;
+    }
+
+    match Box::pin(run_gateway_chat_with_tools(
+        &state,
+        &msg.content,
+        Some(&session_id),
+    ))
+    .await
+    {
+        Ok(GatewayChatOutcome { response, .. }) => {
+            if let Err(e) = plivo
+                .send(&SendMessage::new(response, &msg.reply_target))
+                .await
+            {
+                tracing::error!("Failed to send Plivo reply: {e}");
+            }
+        }
+        Err(e) => {
+            tracing::error!("LLM error for Plivo message: {e:#}");
+            let _ = plivo
+                .send(&SendMessage::new(
+                    "Sorry, I couldn't process your message right now.",
+                    &msg.reply_target,
+                ))
+                .await;
+        }
+    }
+
+    (
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, "text/plain")],
+        String::new(),
+    )
+}
+
 /// GET /wati — WATI webhook verification (echoes hub.challenge)
 async fn handle_wati_verify(
     State(state): State<AppState>,
@@ -2678,6 +2862,7 @@ mod tests {
             whatsapp_app_secret: None,
             linq: None,
             linq_signing_secret: None,
+            plivo: None,
             nextcloud_talk: None,
             nextcloud_talk_webhook_secret: None,
             wati: None,
@@ -2752,6 +2937,7 @@ mod tests {
             whatsapp_app_secret: None,
             linq: None,
             linq_signing_secret: None,
+            plivo: None,
             nextcloud_talk: None,
             nextcloud_talk_webhook_secret: None,
             wati: None,
@@ -3211,6 +3397,7 @@ mod tests {
             whatsapp_app_secret: None,
             linq: None,
             linq_signing_secret: None,
+            plivo: None,
             nextcloud_talk: None,
             nextcloud_talk_webhook_secret: None,
             wati: None,
@@ -3293,6 +3480,7 @@ mod tests {
             whatsapp_app_secret: None,
             linq: None,
             linq_signing_secret: None,
+            plivo: None,
             nextcloud_talk: None,
             nextcloud_talk_webhook_secret: None,
             wati: None,
@@ -3387,6 +3575,7 @@ mod tests {
             whatsapp_app_secret: None,
             linq: None,
             linq_signing_secret: None,
+            plivo: None,
             nextcloud_talk: None,
             nextcloud_talk_webhook_secret: None,
             wati: None,
@@ -3453,6 +3642,7 @@ mod tests {
             whatsapp_app_secret: None,
             linq: None,
             linq_signing_secret: None,
+            plivo: None,
             nextcloud_talk: None,
             nextcloud_talk_webhook_secret: None,
             wati: None,
@@ -3524,6 +3714,7 @@ mod tests {
             whatsapp_app_secret: None,
             linq: None,
             linq_signing_secret: None,
+            plivo: None,
             nextcloud_talk: None,
             nextcloud_talk_webhook_secret: None,
             wati: None,
@@ -3600,6 +3791,7 @@ mod tests {
             whatsapp_app_secret: None,
             linq: None,
             linq_signing_secret: None,
+            plivo: None,
             nextcloud_talk: None,
             nextcloud_talk_webhook_secret: None,
             wati: None,
@@ -3673,6 +3865,7 @@ mod tests {
             whatsapp_app_secret: None,
             linq: None,
             linq_signing_secret: None,
+            plivo: None,
             nextcloud_talk: Some(channel),
             nextcloud_talk_webhook_secret: Some(Arc::from(secret)),
             wati: None,

--- a/docs/book/src/channels/chat-others.md
+++ b/docs/book/src/channels/chat-others.md
@@ -150,6 +150,35 @@ Treats a Notion database as a message surface. Useful for asynchronous workflows
 
 ---
 
+## Plivo (SMS)
+
+```toml
+[channels.plivo]
+enabled = false                    # default; flip to true once configured
+account_id = "MAxxxxxxxxxxxxxxxx"   # Plivo Auth ID (public; not secret)
+auth_token = "..."                  # Plivo Auth Token (secret — keeps both
+                                    # outbound Basic auth and the inbound
+                                    # webhook HMAC key)
+from_number = "+15555550100"        # E.164 number leased from Plivo
+allowed_numbers = ["+15555550199"]  # E.164 inbound allowlist; "*" allows all
+```
+
+**Auth model.** Plivo issues an Auth ID + Auth Token pair per account. The Auth ID is public and goes in the URL; the Auth Token is secret and is reused as both the HTTP Basic password (outbound `Message` POST) and the HMAC-SHA256 key for inbound webhook signature verification.
+
+**Inbound webhook.** The gateway hosts `POST /plivo/sms`. Configure your Plivo Application's "Message URL" to your gateway's public URL — for example `https://your-tunnel.example.com/plivo/sms`. The gateway needs to be reachable from the public internet; the existing options are [Cloudflare Tunnel](../tunnels/cloudflare.md), ngrok, or Tailscale Funnel. Localhost-only deployments cannot receive Plivo webhooks.
+
+**Signature scheme.** Plivo uses signature version 3 (V3): the gateway computes `HMAC-SHA256(URL || nonce || raw_body)` keyed by the Auth Token, base64-encodes the digest, and constant-time compares against the `X-Plivo-Signature-V3` header. The nonce is delivered in `X-Plivo-Signature-V3-Nonce` and ties each request to a specific signature so replays cannot be reused. Failed verification returns `401` and the message never reaches the agent.
+
+**Allowlist.** `allowed_numbers` is an exact-match E.164 allowlist (whitespace stripped, case-insensitive). Use `"*"` to accept every inbound sender — only set this if the number receives traffic exclusively from people you trust to talk to the agent.
+
+**Trial accounts.** Plivo trial accounts can only send to numbers verified in the Plivo console. To agent-reply during trial, verify the inbound numbers you expect first; otherwise the outbound `Message` POST will fail with a 4xx and the gateway will log the error.
+
+**Cost.** Plivo charges per outbound message segment (typically `$0.0035–$0.0085` US, varies by destination country) and per inbound message. Outbound replies that exceed 1600 characters are split into `(i/N)`-prefixed chunks before send and each chunk is billed as a separate segment.
+
+**Default `enabled = false`.** As with every webhook-driven channel, Plivo stays inert until you set `enabled = true` and the gateway is reachable. The `[channels.plivo]` section can be present in config without affecting runtime as long as `enabled` stays false.
+
+---
+
 ## When to prefer a dedicated guide
 
 Channels with more intricate setup (OAuth flows, end-to-end encryption, multi-device considerations) live in their own pages:


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - New `PlivoChannel`: gateway-registered SMS channel for Plivo, sibling to the recently merged Twilio (#6429). Same architecture (`listen()` no-op, gateway hosts a hardcoded `POST /plivo/sms` route), different signature math — Plivo's V3 scheme is HMAC-SHA256 over `URL + nonce + raw_body` keyed by the Auth Token, vs. Twilio's HMAC-SHA1 over URL + sorted form params.
  - Outbound: `POST https://api.plivo.com/v1/Account/{auth_id}/Message/` with HTTP Basic auth (`auth_id:auth_token`), JSON body `{"src", "dst", "text"}`. Bodies over 1600 chars are split at sentence/word boundaries with `(i/N) ` continuation markers.
  - Inbound at `POST /plivo/sms`: reads `X-Plivo-Signature-V3` and `X-Plivo-Signature-V3-Nonce` headers, reconstructs the full URL via `X-Forwarded-Proto`/`X-Forwarded-Host` (falling back to `Host`), recomputes HMAC-SHA256 in constant time, parses the form-urlencoded payload, applies the allowlist, and forwards a `ChannelMessage`. Fails closed with 401 on signature mismatch.
- **Scope boundary:** Plivo only. No changes to Twilio or any other channel. No new external crates (`hmac`+`sha2`+`base64` already in the workspace). Out of scope: MMS attachments, status callbacks/delivery receipts, Plivo Voice, `request_approval()` integration.
- **Blast radius:** New optional channel module + new gateway route + new optional config section. Default `enabled = false`; the gateway route returns 404 when Plivo is not configured. `channel-plivo` is now in the `default` cargo feature set; downstream packagers building with `--no-default-features` are unaffected.
- **Linked issue(s):** Closes #6453

## Validation Evidence (required)

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` → clean.
  - `cargo clippy --all-targets -- -D warnings` (workspace) → clean, zero warnings.
  - `cargo test -p zeroclaw-channels --features channel-plivo --lib plivo::` → **19 passed, 0 failed**.
  - `cargo test -p zeroclaw-config --lib` → **620 passed, 0 failed**.
  - `cargo test -p zeroclaw-gateway --lib` → **164 passed, 0 failed**.
  - `cargo build --release -p zeroclawlabs` → `Finished release profile [optimized] target(s) in 4m 58s`, exit 0.
- **Beyond CI — what was manually verified:**
  - Reviewed all 19 unit + wiremock tests covering allowlist matching (empty/wildcard/exact/whitespace-stripped), webhook payload parsing (drops outside-allowlist + empty + non-`sms` types; accepts allowed), Plivo V3 signature validator (round-trip against self-computed expected; tampered body / wrong token / empty header all fail), 1600-char chunk splitter with `(i/N)` markers, wiremock outbound POST shape (Basic auth header + JSON `{"src","dst","text"}` body + path `/v1/Account/.../Message/`), and 4xx → `Err`.
  - Verified `cargo clippy --all-targets -- -D warnings` is clean across the entire workspace.
  - Verified the gateway handler reconstructs the URL from `X-Forwarded-Proto`/`X-Forwarded-Host` (matching the tunnel-fronted production deployment) before signature verification, and fails closed (401) on signature mismatch before reaching the agent loop.
  - Confirmed `cargo build --release -p zeroclawlabs` succeeds with default features (which now include `channel-plivo`) — 4m 58s, exit 0.
  - **Did NOT verify against a live Plivo account.** The signature math, route plumbing, and allowlist all pass under wiremock + unit tests, but the end-to-end "operator texts the number, gets a reply" round-trip has not been smoke-tested in this PR. Recommend the operator land this with `enabled = false` first, configure on staging behind their existing `[tunnel]` provider, smoke test, then flip enabled.
  - Did NOT verify: MMS attachments (text-only in v1), status callbacks / delivery receipts, Plivo Voice or Number Provisioning APIs, `request_approval()` integration.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `Yes` — outbound HTTPS to `api.plivo.com` (Basic-auth, account-scoped) only when `[channels.plivo]` is configured and `enabled = true`. Inbound is the new `POST /plivo/sms` gateway route, which 404s when Plivo is not configured.
- Secrets / tokens / credentials handling changed? `Yes` — new `auth_token` secret in `[channels.plivo]`, redacted via the existing config-secret pipeline (same as Twilio's `auth_token`). Used as both HTTP Basic password (outbound) and HMAC-SHA256 key (inbound signature verification); never logged.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No` — fixtures use Plivo's documented test patterns and the reserved 555-test-number range.
- **Risk and mitigation:**
  - `AGENTS.md` classifies `crates/zeroclaw-gateway/src/**` as **risk: high**, hence the explicit security walkthrough.
  - **Signature verification fails closed**: missing or invalid `X-Plivo-Signature-V3` → 401, message dropped before reaching the agent loop.
  - **Allowlist enforced**: senders not in `allowed_numbers` are dropped at the channel boundary even if signature is valid.
  - **Constant-time compare** on the base64 signature to avoid timing leaks.
  - **Default `enabled = false`** means a misconfigured deployment cannot accidentally accept SMS.
  - **URL reconstruction order** trusts `X-Forwarded-Proto`/`X-Forwarded-Host` first (production runs behind a tunnel) and falls back to `Host` for local dev.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `Yes` — additive only.
- **Upgrade steps for existing users:** None required. `[channels.plivo]` is optional; existing configs without it continue to work. To opt in: add the section with `account_id`, `auth_token` (secret), `from_number` (E.164), and `allowed_numbers`, then set `enabled = true` and configure Plivo's webhook to `https://<your-tunnel>/plivo/sms` (POST).

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** Single squash-merge revert: `git revert <merge-sha>`. No migrations, no schema changes.
- **Feature flags or config toggles:**
  - Compile-time: feature flag `channel-plivo` on `zeroclaw-channels` (default-on; can be turned off to remove the module entirely).
  - Runtime: `[channels.plivo] enabled = false` disables without removing config or code.
- **Observable failure symptoms:**
  - Inbound signature failures: grep gateway logs for `plivo_signature_invalid` / 401 responses on `POST /plivo/sms`.
  - Outbound send failures: errors from `PlivoChannel::send` log the upstream Plivo error code; grep for `plivo_send_failed`.
  - Allowlist drops: grep for `plivo_sender_not_allowed`.
  - Misconfiguration at startup: the channel will not appear in `zeroclaw channel list`.

