### PR TITLE
feat(channel:telnyx): add Telnyx SMS channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13236,6 +13236,7 @@ dependencies = [
  "cpal",
  "directories",
  "ecb",
+ "ed25519-dalek",
  "futures-util",
  "hex",
  "hmac 0.12.1",

--- a/crates/zeroclaw-channels/Cargo.toml
+++ b/crates/zeroclaw-channels/Cargo.toml
@@ -23,6 +23,7 @@ async-trait = "0.1"
 base64 = "0.22"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std", "serde"] }
 directories = "6.0"
+ed25519-dalek = { version = "2", default-features = false, optional = true }
 futures-util = { version = "0.3", default-features = false, features = ["sink"] }
 hmac = "0.12"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png"], optional = true }
@@ -81,8 +82,8 @@ default = [
     "channel-discord", "channel-slack", "channel-signal", "channel-mattermost",
     "channel-irc", "channel-imessage", "channel-dingtalk", "channel-qq",
     "channel-bluesky", "channel-twitter", "channel-reddit", "channel-notion",
-    "channel-linq", "channel-wati", "channel-nextcloud", "channel-mochat",
-    "channel-wecom", "channel-clawdtalk", "channel-webhook",
+    "channel-linq", "channel-telnyx", "channel-wati", "channel-nextcloud",
+    "channel-mochat", "channel-wecom", "channel-clawdtalk", "channel-webhook",
     "channel-whatsapp-cloud", "channel-voice-call",
 ]
 # Channels with optional deps
@@ -106,6 +107,7 @@ channel-twitter = []
 channel-reddit = []
 channel-notion = []
 channel-linq = []
+channel-telnyx = ["dep:ed25519-dalek"]
 channel-wati = []
 channel-nextcloud = []
 channel-mochat = []

--- a/crates/zeroclaw-channels/src/lib.rs
+++ b/crates/zeroclaw-channels/src/lib.rs
@@ -58,6 +58,8 @@ pub mod signal;
 pub mod slack;
 #[cfg(feature = "channel-telegram")]
 pub mod telegram;
+#[cfg(feature = "channel-telnyx")]
+pub mod telnyx;
 #[cfg(feature = "channel-twitter")]
 pub mod twitter;
 #[cfg(feature = "channel-voice-call")]

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -70,6 +70,8 @@ pub use crate::link_enricher;
 pub use crate::matrix::MatrixChannel;
 #[cfg(feature = "channel-telegram")]
 pub use crate::telegram::TelegramChannel;
+#[cfg(feature = "channel-telnyx")]
+pub use crate::telnyx::TelnyxChannel;
 #[cfg(feature = "whatsapp-web")]
 pub use crate::whatsapp_web::WhatsAppWebChannel;
 pub use zeroclaw_infra::debounce::MessageDebouncer;
@@ -4476,6 +4478,24 @@ fn build_channel_by_id(config: &Config, channel_id: &str) -> Result<Arc<dyn Chan
                 lq.allowed_senders.clone(),
             )))
         }
+        #[cfg(feature = "channel-telnyx")]
+        "telnyx" => {
+            let tx = config
+                .channels
+                .telnyx
+                .as_ref()
+                .context("Telnyx channel is not configured")?;
+            Ok(Arc::new(
+                TelnyxChannel::new(
+                    tx.api_key.clone(),
+                    tx.from_number.clone(),
+                    tx.messaging_profile_id.clone(),
+                    tx.allowed_numbers.clone(),
+                    &tx.public_key,
+                )
+                .context("Failed to construct Telnyx channel (check public_key)")?,
+            ))
+        }
         #[cfg(feature = "channel-email")]
         "email" => {
             let em = config
@@ -4598,7 +4618,8 @@ fn build_channel_by_id(config: &Config, channel_id: &str) -> Result<Arc<dyn Chan
         other => anyhow::bail!(
             "Unknown channel '{other}'. Supported: telegram, discord, slack, mattermost, signal, \
             matrix, whatsapp, qq, lark, feishu, dingtalk, wecom, nextcloud_talk, wati, linq, \
-            email, gmail_push, irc, twitter, mochat, discord_history, imessage, line, voice-call"
+            telnyx, email, gmail_push, irc, twitter, mochat, discord_history, imessage, line, \
+            voice-call"
         ),
     }
 }
@@ -4948,6 +4969,34 @@ fn collect_configured_channels(
             });
         } else {
             tracing::info!("Linq channel configured but disabled (enabled = false)");
+        }
+    }
+
+    #[cfg(feature = "channel-telnyx")]
+    if let Some(ref tx) = config.channels.telnyx {
+        if tx.enabled {
+            match TelnyxChannel::new(
+                tx.api_key.clone(),
+                tx.from_number.clone(),
+                tx.messaging_profile_id.clone(),
+                tx.allowed_numbers.clone(),
+                &tx.public_key,
+            ) {
+                Ok(telnyx) => {
+                    channels.push(ConfiguredChannel {
+                        display_name: "Telnyx",
+                        channel: Arc::new(telnyx),
+                    });
+                }
+                Err(e) => {
+                    tracing::error!(
+                        "Telnyx channel construction failed (check public_key): {e:#}. \
+                         Skipping Telnyx — fix the config and reload."
+                    );
+                }
+            }
+        } else {
+            tracing::info!("Telnyx channel configured but disabled (enabled = false)");
         }
     }
 

--- a/crates/zeroclaw-channels/src/telnyx.rs
+++ b/crates/zeroclaw-channels/src/telnyx.rs
@@ -1,0 +1,811 @@
+//! Telnyx SMS channel — sends via Telnyx's V2 `Messages` resource and
+//! receives via gateway-routed webhooks.
+//!
+//! Mirrors the gateway-registered pattern used by Twilio, WhatsApp Cloud,
+//! Linq, WATI, and Nextcloud Talk: this channel's `listen()` is a keep-alive
+//! no-op; the `zeroclaw-gateway` crate hosts a hardcoded `POST /telnyx/sms`
+//! route whose handler reads JSON payloads, validates the
+//! `telnyx-signature-ed25519` header against an Ed25519 public key, and
+//! converts each request into a `ChannelMessage`.
+//!
+//! # Auth
+//! Two distinct values, copied separately from the Telnyx portal:
+//! * **V2 API key** — sent as `Authorization: Bearer {api_key}` for all
+//!   outbound REST calls.
+//! * **Ed25519 public key** — base64-encoded, used to verify inbound webhook
+//!   signatures. Telnyx publishes the public key in the portal; operators
+//!   must update `public_key` in config when Telnyx rotates it.
+//!
+//! # Outbound
+//! `POST https://api.telnyx.com/v2/messages` with a JSON body containing
+//! `from`, `to`, and `text`. When a `messaging_profile_id` is configured,
+//! it is included as well. Telnyx accepts up to 1600 characters per request;
+//! longer bodies are split into ≤1600-char chunks at sentence/word
+//! boundaries with a `(i/N) ` continuation marker.
+//!
+//! # Inbound
+//! The gateway handler verifies the Ed25519 signature over the message bytes
+//! `{timestamp}|{raw_body}` (literal pipe separator), enforces a 5-minute
+//! timestamp anti-replay window, drops senders not on the `allowed_numbers`
+//! allowlist, and forwards each `message.received` event to the agent loop.
+//! See <https://developers.telnyx.com/docs/messaging/webhooks>.
+
+use anyhow::{Context, Result, bail};
+use async_trait::async_trait;
+use zeroclaw_api::channel::{Channel, ChannelMessage, SendMessage};
+
+const TELNYX_API_BASE: &str = "https://api.telnyx.com";
+/// Telnyx accepts up to 1600 characters per outbound API call. Longer bodies
+/// must be split.
+const TELNYX_MESSAGE_LIMIT: usize = 1600;
+/// Anti-replay window for inbound webhooks. Telnyx-signed payloads older or
+/// further in the future than this many seconds are rejected outright.
+const TELNYX_SIGNATURE_WINDOW_SECS: i64 = 300;
+/// Hardcoded inbound webhook path on the gateway. Operators point Telnyx's
+/// "Webhook URL" setting at `https://{gateway}/telnyx/sms`.
+pub const TELNYX_WEBHOOK_PATH: &str = "/telnyx/sms";
+
+/// Telnyx SMS channel — see module docs.
+pub struct TelnyxChannel {
+    api_key: String,
+    from_number: String,
+    messaging_profile_id: Option<String>,
+    allowed_numbers: Vec<String>,
+    verifying_key: ed25519_dalek::VerifyingKey,
+}
+
+impl TelnyxChannel {
+    /// Build a Telnyx channel. The base64-encoded `public_key_b64` must
+    /// decode to a 32-byte Ed25519 verifying key; `Err` is returned otherwise
+    /// so the daemon can log + skip rather than panic on a config typo.
+    pub fn new(
+        api_key: String,
+        from_number: String,
+        messaging_profile_id: Option<String>,
+        allowed_numbers: Vec<String>,
+        public_key_b64: &str,
+    ) -> Result<Self> {
+        use base64::Engine;
+        let trimmed = public_key_b64.trim();
+        if trimmed.is_empty() {
+            bail!(
+                "Telnyx public_key is empty — copy the Ed25519 public key from the Telnyx portal"
+            );
+        }
+        let raw = base64::engine::general_purpose::STANDARD
+            .decode(trimmed)
+            .with_context(|| "Telnyx public_key is not valid base64")?;
+        let bytes: [u8; 32] = raw.as_slice().try_into().map_err(|_| {
+            anyhow::anyhow!(
+                "Telnyx public_key must decode to 32 bytes (got {})",
+                raw.len()
+            )
+        })?;
+        let verifying_key = ed25519_dalek::VerifyingKey::from_bytes(&bytes).map_err(|e| {
+            anyhow::anyhow!("Telnyx public_key is not a valid Ed25519 verifying key: {e}")
+        })?;
+        Ok(Self {
+            api_key,
+            from_number,
+            messaging_profile_id,
+            allowed_numbers,
+            verifying_key,
+        })
+    }
+
+    fn http_client(&self) -> reqwest::Client {
+        zeroclaw_config::schema::build_runtime_proxy_client("channel.telnyx")
+    }
+
+    fn outbound_url(&self) -> String {
+        format!("{TELNYX_API_BASE}/v2/messages")
+    }
+
+    /// Configurable base URL hook used by tests. The default path matches
+    /// Telnyx's production endpoint; tests substitute a wiremock URI.
+    #[cfg(test)]
+    fn outbound_url_with_base(&self, base: &str) -> String {
+        format!("{base}/v2/messages")
+    }
+
+    fn whoami_url(&self) -> String {
+        format!("{TELNYX_API_BASE}/v2/whoami")
+    }
+
+    /// Whether the inbound `from` number is permitted. Empty allowlist
+    /// denies everyone; `"*"` matches anyone; otherwise an exact
+    /// case-insensitive E.164 match (with whitespace stripped) is required.
+    pub fn is_number_allowed(&self, phone: &str) -> bool {
+        is_number_allowed_for_list(&self.allowed_numbers, phone)
+    }
+
+    /// Verify a Telnyx webhook signature.
+    ///
+    /// Telnyx's algorithm:
+    /// 1. Read `telnyx-timestamp` (unix epoch seconds, as a string) and
+    ///    `telnyx-signature-ed25519` (base64-encoded 64-byte signature).
+    /// 2. Reject if `|now - timestamp| > 300s` (5-minute anti-replay window).
+    /// 3. Construct the signed message bytes: `{timestamp}|{raw_body}`
+    ///    (literal pipe separator).
+    /// 4. Verify the Ed25519 signature against the operator-configured
+    ///    public key using strict verification (`verify_strict`).
+    ///
+    /// `now_unix` is taken as a parameter so the gateway can pass
+    /// `chrono::Utc::now().timestamp()` while tests can use deterministic
+    /// values.
+    ///
+    /// See <https://developers.telnyx.com/docs/messaging/webhooks>.
+    pub fn verify_signature(
+        &self,
+        timestamp_str: &str,
+        raw_body: &[u8],
+        signature_b64: &str,
+        now_unix: i64,
+    ) -> bool {
+        verify_telnyx_signature(
+            &self.verifying_key,
+            timestamp_str,
+            raw_body,
+            signature_b64,
+            now_unix,
+        )
+    }
+
+    /// Convert an inbound Telnyx webhook payload into a `ChannelMessage`.
+    /// Returns `None` when the event is not a `message.received`, the sender
+    /// isn't on the allowlist, or the body is empty.
+    pub fn parse_webhook_payload(&self, json: &serde_json::Value) -> Option<ChannelMessage> {
+        let data = json.get("data")?;
+        let event_type = data
+            .get("event_type")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        if event_type != "message.received" {
+            tracing::debug!("Telnyx: dropping non-message event type '{event_type}'");
+            return None;
+        }
+        let payload = data.get("payload")?;
+        let from = payload
+            .get("from")
+            .and_then(|v| v.get("phone_number"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .trim();
+        if from.is_empty() {
+            return None;
+        }
+        if !self.is_number_allowed(from) {
+            tracing::debug!("Telnyx: dropping SMS from {from} (not in allowed_numbers)");
+            return None;
+        }
+        let body = payload
+            .get("text")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .trim()
+            .to_string();
+        if body.is_empty() {
+            tracing::debug!("Telnyx: dropping empty-body SMS from {from}");
+            return None;
+        }
+        let id = data
+            .get("id")
+            .and_then(|v| v.as_str())
+            .map(str::to_owned)
+            .unwrap_or_else(|| format!("telnyx-{}", chrono::Utc::now().timestamp_millis()));
+        Some(ChannelMessage {
+            id: format!("telnyx_{id}"),
+            sender: from.to_string(),
+            reply_target: from.to_string(),
+            content: body,
+            channel: "telnyx".to_string(),
+            timestamp: chrono::Utc::now().timestamp().cast_unsigned(),
+            thread_ts: None,
+            interruption_scope_id: None,
+            attachments: vec![],
+        })
+    }
+
+    async fn post_message_chunk(
+        &self,
+        to: &str,
+        body: &str,
+        base_override: Option<&str>,
+    ) -> Result<()> {
+        let url = match base_override {
+            #[cfg(test)]
+            Some(b) => self.outbound_url_with_base(b),
+            #[cfg(not(test))]
+            Some(_) => self.outbound_url(),
+            None => self.outbound_url(),
+        };
+        let mut payload = serde_json::json!({
+            "from": self.from_number,
+            "to": to,
+            "text": body,
+        });
+        if let Some(profile_id) = self.messaging_profile_id.as_deref()
+            && !profile_id.is_empty()
+            && let Some(obj) = payload.as_object_mut()
+        {
+            obj.insert(
+                "messaging_profile_id".to_string(),
+                serde_json::Value::String(profile_id.to_string()),
+            );
+        }
+        let resp = self
+            .http_client()
+            .post(&url)
+            .bearer_auth(&self.api_key)
+            .json(&payload)
+            .send()
+            .await
+            .context("Telnyx Messages POST failed")?;
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            bail!("Telnyx Messages POST returned {status}: {body}");
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Channel for TelnyxChannel {
+    fn name(&self) -> &str {
+        "telnyx"
+    }
+
+    async fn send(&self, message: &SendMessage) -> Result<()> {
+        let to = message.recipient.trim();
+        if to.is_empty() {
+            bail!("Telnyx send: empty recipient");
+        }
+        let chunks = chunk_sms(&message.content, TELNYX_MESSAGE_LIMIT);
+        if chunks.is_empty() {
+            return Ok(());
+        }
+        for chunk in chunks {
+            self.post_message_chunk(to, &chunk, None).await?;
+        }
+        Ok(())
+    }
+
+    async fn listen(&self, _tx: tokio::sync::mpsc::Sender<ChannelMessage>) -> Result<()> {
+        // Telnyx uses webhooks (push-based), not polling. The gateway hosts
+        // POST /telnyx/sms and routes inbound payloads via parse_webhook_payload.
+        tracing::info!(
+            "Telnyx channel active (webhook mode). Configure Telnyx's webhook URL \
+             to POST to your gateway's {TELNYX_WEBHOOK_PATH} endpoint."
+        );
+        loop {
+            tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
+        }
+    }
+
+    async fn health_check(&self) -> bool {
+        // Probe an authenticated endpoint — succeeds when the V2 API key is
+        // valid. `/v2/whoami` returns the authenticated user info and is the
+        // cheapest authenticated GET available.
+        self.http_client()
+            .get(self.whoami_url())
+            .bearer_auth(&self.api_key)
+            .send()
+            .await
+            .map(|r| r.status().is_success())
+            .unwrap_or(false)
+    }
+}
+
+/// Allowlist matcher with `"*"` wildcard. Comparison is case-insensitive and
+/// strips internal whitespace so `"+1 555 555 0199"` round-trips against the
+/// canonical E.164 `"+15555550199"`.
+pub fn is_number_allowed_for_list(allowlist: &[String], phone: &str) -> bool {
+    if allowlist.is_empty() {
+        return false;
+    }
+    if allowlist.iter().any(|n| n == "*") {
+        return true;
+    }
+    let normalized = phone
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect::<String>()
+        .to_ascii_lowercase();
+    allowlist.iter().any(|entry| {
+        let canon = entry
+            .chars()
+            .filter(|c| !c.is_whitespace())
+            .collect::<String>()
+            .to_ascii_lowercase();
+        canon == normalized
+    })
+}
+
+fn verify_telnyx_signature(
+    verifying_key: &ed25519_dalek::VerifyingKey,
+    timestamp_str: &str,
+    raw_body: &[u8],
+    signature_b64: &str,
+    now_unix: i64,
+) -> bool {
+    use base64::Engine;
+    if signature_b64.is_empty() || timestamp_str.is_empty() {
+        return false;
+    }
+    let timestamp: i64 = match timestamp_str.parse() {
+        Ok(t) => t,
+        Err(_) => return false,
+    };
+    if (now_unix - timestamp).abs() > TELNYX_SIGNATURE_WINDOW_SECS {
+        return false;
+    }
+    let sig_bytes = match base64::engine::general_purpose::STANDARD.decode(signature_b64) {
+        Ok(b) => b,
+        Err(_) => return false,
+    };
+    let sig_arr: [u8; 64] = match sig_bytes.as_slice().try_into() {
+        Ok(a) => a,
+        Err(_) => return false,
+    };
+    let signature = ed25519_dalek::Signature::from_bytes(&sig_arr);
+    let mut message = format!("{timestamp_str}|").into_bytes();
+    message.extend_from_slice(raw_body);
+    verifying_key.verify_strict(&message, &signature).is_ok()
+}
+
+/// Split an outbound body into ≤`limit`-character chunks. Single-chunk bodies
+/// are returned as-is; multi-chunk bodies receive a `(i/N) ` prefix on each
+/// part so the recipient can reassemble. Splits prefer sentence enders, then
+/// whitespace, then a hard char cut.
+pub fn chunk_sms(body: &str, limit: usize) -> Vec<String> {
+    let body = body.trim();
+    if body.is_empty() {
+        return vec![];
+    }
+    if body.chars().count() <= limit {
+        return vec![body.to_string()];
+    }
+    const MARKER_RESERVE: usize = 8; // "(99/99) "
+    let body_budget = limit.saturating_sub(MARKER_RESERVE).max(1);
+    let mut chunks: Vec<String> = Vec::new();
+    let mut remaining: &str = body;
+    while !remaining.is_empty() {
+        if remaining.chars().count() <= body_budget {
+            chunks.push(remaining.to_string());
+            break;
+        }
+        let split_at = pick_split_point(remaining, body_budget);
+        let (head, tail) = remaining.split_at(split_at);
+        chunks.push(head.trim_end().to_string());
+        remaining = tail.trim_start();
+    }
+    if chunks.len() == 1 {
+        return chunks;
+    }
+    let total = chunks.len();
+    chunks
+        .into_iter()
+        .enumerate()
+        .map(|(i, c)| format!("({}/{total}) {c}", i + 1))
+        .collect()
+}
+
+fn pick_split_point(text: &str, char_budget: usize) -> usize {
+    let mut budget_idx = text.len();
+    for (i, (byte_idx, _)) in text.char_indices().enumerate() {
+        if i == char_budget {
+            budget_idx = byte_idx;
+            break;
+        }
+    }
+    let head = &text[..budget_idx];
+    if let Some(idx) = head.rfind(['.', '!', '?', '\n']) {
+        return (idx + 1).min(budget_idx);
+    }
+    if let Some(idx) = head.rfind(char::is_whitespace) {
+        return idx + 1;
+    }
+    budget_idx
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Deterministic Ed25519 keypair seed used across signature tests. The
+    /// `[1u8; 32]` seed is arbitrary — what matters is that the verifying
+    /// key derived from it matches the signing key used to sign the test
+    /// payloads, so no real Telnyx credentials are involved.
+    const TEST_SEED: [u8; 32] = [1u8; 32];
+
+    fn test_signing_key() -> ed25519_dalek::SigningKey {
+        ed25519_dalek::SigningKey::from_bytes(&TEST_SEED)
+    }
+
+    fn test_public_key_b64() -> String {
+        use base64::Engine;
+        base64::engine::general_purpose::STANDARD
+            .encode(test_signing_key().verifying_key().as_bytes())
+    }
+
+    fn ch() -> TelnyxChannel {
+        TelnyxChannel::new(
+            "test-api-key".into(),
+            "+15555550100".into(),
+            None,
+            vec!["+15555550199".into()],
+            &test_public_key_b64(),
+        )
+        .expect("test channel construction succeeds")
+    }
+
+    fn ch_with_profile() -> TelnyxChannel {
+        TelnyxChannel::new(
+            "test-api-key".into(),
+            "+15555550100".into(),
+            Some("mp_test_profile".into()),
+            vec!["+15555550199".into()],
+            &test_public_key_b64(),
+        )
+        .expect("test channel with profile construction succeeds")
+    }
+
+    #[test]
+    fn allowlist_empty_denies_everyone() {
+        assert!(!is_number_allowed_for_list(&[], "+15555550199"));
+    }
+
+    #[test]
+    fn allowlist_wildcard_allows_anyone() {
+        let allow = vec!["*".into()];
+        assert!(is_number_allowed_for_list(&allow, "+15555550199"));
+        assert!(is_number_allowed_for_list(&allow, "+447700900000"));
+    }
+
+    #[test]
+    fn allowlist_matches_e164_exact() {
+        let allow = vec!["+15555550199".into()];
+        assert!(is_number_allowed_for_list(&allow, "+15555550199"));
+        assert!(!is_number_allowed_for_list(&allow, "+15555550100"));
+    }
+
+    #[test]
+    fn allowlist_strips_whitespace() {
+        let allow = vec!["+1 555 555 0199".into()];
+        assert!(is_number_allowed_for_list(&allow, "+15555550199"));
+    }
+
+    #[test]
+    fn new_rejects_empty_public_key() {
+        let result = TelnyxChannel::new("k".into(), "+15555550100".into(), None, vec![], "");
+        let Err(err) = result else {
+            panic!("empty public_key should error");
+        };
+        let msg = format!("{err:#}");
+        assert!(msg.contains("empty"), "error should mention empty: {msg}");
+    }
+
+    #[test]
+    fn new_rejects_invalid_base64() {
+        let result = TelnyxChannel::new(
+            "k".into(),
+            "+15555550100".into(),
+            None,
+            vec![],
+            "!!!not-base64!!!",
+        );
+        let Err(err) = result else {
+            panic!("malformed base64 should error");
+        };
+        let msg = format!("{err:#}");
+        assert!(msg.contains("base64"), "error should mention base64: {msg}");
+    }
+
+    #[test]
+    fn new_rejects_wrong_length() {
+        use base64::Engine;
+        let too_short = base64::engine::general_purpose::STANDARD.encode([0u8; 16]);
+        let result =
+            TelnyxChannel::new("k".into(), "+15555550100".into(), None, vec![], &too_short);
+        let Err(err) = result else {
+            panic!("16-byte key should error");
+        };
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("32 bytes"),
+            "error should mention 32 bytes: {msg}"
+        );
+    }
+
+    #[test]
+    fn chunk_sms_short_passes_through() {
+        let chunks = chunk_sms("hi there", TELNYX_MESSAGE_LIMIT);
+        assert_eq!(chunks, vec!["hi there"]);
+    }
+
+    #[test]
+    fn chunk_sms_long_is_split_with_marker() {
+        let body = "alpha beta gamma. ".repeat(120);
+        let chunks = chunk_sms(&body, 100);
+        assert!(chunks.len() >= 2, "expected ≥2 chunks, got {chunks:?}");
+        for (i, c) in chunks.iter().enumerate() {
+            assert!(
+                c.starts_with(&format!("({}/", i + 1)),
+                "missing marker on chunk {i}: {c:?}"
+            );
+            assert!(
+                c.chars().count() <= 100,
+                "chunk {i} exceeds limit: {c:?} ({} chars)",
+                c.chars().count()
+            );
+        }
+    }
+
+    #[test]
+    fn chunk_sms_empty_returns_no_chunks() {
+        let chunks = chunk_sms("   ", TELNYX_MESSAGE_LIMIT);
+        assert!(chunks.is_empty());
+    }
+
+    #[test]
+    fn chunk_sms_preserves_total_content() {
+        let body = "alpha beta gamma. ".repeat(120);
+        let chunks = chunk_sms(&body, 100);
+        // Strip "(i/N) " markers, concat, and ensure no characters got lost.
+        let recombined: String = chunks
+            .iter()
+            .map(|c| {
+                if let Some(rest) = c.split_once(") ") {
+                    rest.1.to_string()
+                } else {
+                    c.clone()
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(" ");
+        let stripped_orig: String = body.split_whitespace().collect::<Vec<_>>().join(" ");
+        let stripped_recomb: String = recombined.split_whitespace().collect::<Vec<_>>().join(" ");
+        assert_eq!(stripped_orig, stripped_recomb);
+    }
+
+    #[test]
+    fn parse_webhook_drops_outside_allowlist() {
+        let payload = serde_json::json!({
+            "data": {
+                "event_type": "message.received",
+                "id": "abc",
+                "payload": {
+                    "from": { "phone_number": "+15555550999" },
+                    "to": [{ "phone_number": "+15555550100" }],
+                    "text": "hello",
+                }
+            }
+        });
+        assert!(ch().parse_webhook_payload(&payload).is_none());
+    }
+
+    #[test]
+    fn parse_webhook_drops_empty_body() {
+        let payload = serde_json::json!({
+            "data": {
+                "event_type": "message.received",
+                "id": "abc",
+                "payload": {
+                    "from": { "phone_number": "+15555550199" },
+                    "to": [{ "phone_number": "+15555550100" }],
+                    "text": "   ",
+                }
+            }
+        });
+        assert!(ch().parse_webhook_payload(&payload).is_none());
+    }
+
+    #[test]
+    fn parse_webhook_drops_non_message_received_event() {
+        let payload = serde_json::json!({
+            "data": {
+                "event_type": "message.sent",
+                "id": "abc",
+                "payload": {
+                    "from": { "phone_number": "+15555550199" },
+                    "text": "hello",
+                }
+            }
+        });
+        assert!(ch().parse_webhook_payload(&payload).is_none());
+    }
+
+    #[test]
+    fn parse_webhook_returns_message_on_allowed() {
+        let payload = serde_json::json!({
+            "data": {
+                "event_type": "message.received",
+                "id": "msg_abc123",
+                "payload": {
+                    "from": { "phone_number": "+15555550199" },
+                    "to": [{ "phone_number": "+15555550100" }],
+                    "text": "hello world",
+                }
+            }
+        });
+        let msg = ch()
+            .parse_webhook_payload(&payload)
+            .expect("expected message");
+        assert_eq!(msg.sender, "+15555550199");
+        assert_eq!(msg.reply_target, "+15555550199");
+        assert_eq!(msg.content, "hello world");
+        assert_eq!(msg.channel, "telnyx");
+        assert_eq!(msg.id, "telnyx_msg_abc123");
+    }
+
+    /// Build a valid Telnyx-style signature header for the given timestamp +
+    /// raw body using the deterministic test signing key.
+    fn sign_b64(timestamp: &str, raw_body: &[u8]) -> String {
+        use base64::Engine;
+        use ed25519_dalek::Signer;
+        let mut msg = format!("{timestamp}|").into_bytes();
+        msg.extend_from_slice(raw_body);
+        let sig = test_signing_key().sign(&msg);
+        base64::engine::general_purpose::STANDARD.encode(sig.to_bytes())
+    }
+
+    #[test]
+    fn verify_signature_accepts_valid_payload() {
+        let now: i64 = 1_700_000_000;
+        let ts = now.to_string();
+        let body = b"{\"data\":{\"event_type\":\"message.received\"}}";
+        let sig = sign_b64(&ts, body);
+        assert!(ch().verify_signature(&ts, body, &sig, now));
+    }
+
+    #[test]
+    fn verify_signature_rejects_tampered_body() {
+        let now: i64 = 1_700_000_000;
+        let ts = now.to_string();
+        let body = b"original body";
+        let sig = sign_b64(&ts, body);
+        let tampered = b"different body";
+        assert!(!ch().verify_signature(&ts, tampered, &sig, now));
+    }
+
+    #[test]
+    fn verify_signature_rejects_tampered_timestamp() {
+        let now: i64 = 1_700_000_000;
+        let ts = now.to_string();
+        let body = b"hello";
+        let sig = sign_b64(&ts, body);
+        // Move ts by 1 second — signature was for `1_700_000_000|hello`, now
+        // we present `1_700_000_001|hello`.
+        let bumped = (now + 1).to_string();
+        assert!(!ch().verify_signature(&bumped, body, &sig, now + 1));
+    }
+
+    #[test]
+    fn verify_signature_rejects_far_future_timestamp() {
+        let now: i64 = 1_700_000_000;
+        let future = now + 600; // 10 min ahead — outside 5-min window
+        let ts = future.to_string();
+        let body = b"hello";
+        let sig = sign_b64(&ts, body);
+        assert!(!ch().verify_signature(&ts, body, &sig, now));
+    }
+
+    #[test]
+    fn verify_signature_rejects_far_past_timestamp() {
+        let now: i64 = 1_700_000_000;
+        let past = now - 600; // 10 min ago — outside 5-min window
+        let ts = past.to_string();
+        let body = b"hello";
+        let sig = sign_b64(&ts, body);
+        assert!(!ch().verify_signature(&ts, body, &sig, now));
+    }
+
+    #[test]
+    fn verify_signature_rejects_wrong_signature_length() {
+        use base64::Engine;
+        let now: i64 = 1_700_000_000;
+        let ts = now.to_string();
+        let body = b"hello";
+        // 32 bytes encoded — wrong length, real signatures are 64 bytes.
+        let too_short = base64::engine::general_purpose::STANDARD.encode([0u8; 32]);
+        assert!(!ch().verify_signature(&ts, body, &too_short, now));
+    }
+
+    #[test]
+    fn verify_signature_rejects_malformed_base64() {
+        let now: i64 = 1_700_000_000;
+        let ts = now.to_string();
+        let body = b"hello";
+        assert!(!ch().verify_signature(&ts, body, "!!!not-base64!!!", now));
+    }
+
+    #[test]
+    fn verify_signature_rejects_empty_signature() {
+        let now: i64 = 1_700_000_000;
+        let ts = now.to_string();
+        assert!(!ch().verify_signature(&ts, b"hello", "", now));
+    }
+
+    #[test]
+    fn verify_signature_rejects_unparseable_timestamp() {
+        let now: i64 = 1_700_000_000;
+        let body = b"hello";
+        let sig = sign_b64("1700000000", body);
+        assert!(!ch().verify_signature("not-a-number", body, &sig, now));
+    }
+
+    mod http_tests {
+        use super::*;
+        use wiremock::matchers::{body_string_contains, header, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        #[tokio::test]
+        async fn send_posts_json_with_bearer_auth() {
+            let server = MockServer::start().await;
+
+            Mock::given(method("POST"))
+                .and(path("/v2/messages"))
+                .and(header("authorization", "Bearer test-api-key"))
+                .and(header("content-type", "application/json"))
+                .and(body_string_contains("\"from\":\"+15555550100\""))
+                .and(body_string_contains("\"to\":\"+15555550199\""))
+                .and(body_string_contains("\"text\":\"hello there\""))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "data": { "id": "msg_abc" },
+                })))
+                .expect(1)
+                .mount(&server)
+                .await;
+
+            let telnyx = ch();
+            telnyx
+                .post_message_chunk("+15555550199", "hello there", Some(&server.uri()))
+                .await
+                .expect("send succeeds");
+        }
+
+        #[tokio::test]
+        async fn send_includes_messaging_profile_id_when_set() {
+            let server = MockServer::start().await;
+
+            Mock::given(method("POST"))
+                .and(path("/v2/messages"))
+                .and(body_string_contains(
+                    "\"messaging_profile_id\":\"mp_test_profile\"",
+                ))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "data": { "id": "msg_abc" },
+                })))
+                .expect(1)
+                .mount(&server)
+                .await;
+
+            let telnyx = ch_with_profile();
+            telnyx
+                .post_message_chunk("+15555550199", "with profile", Some(&server.uri()))
+                .await
+                .expect("send succeeds");
+        }
+
+        #[tokio::test]
+        async fn send_surfaces_4xx_as_error() {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/v2/messages"))
+                .respond_with(
+                    ResponseTemplate::new(401)
+                        .set_body_string("{\"errors\":[{\"code\":\"10003\"}]}"),
+                )
+                .mount(&server)
+                .await;
+
+            let err = ch()
+                .post_message_chunk("+15555550199", "hi", Some(&server.uri()))
+                .await
+                .expect_err("expected error");
+            let msg = format!("{err:#}");
+            assert!(msg.contains("401"), "missing 401 in error: {msg}");
+        }
+    }
+}

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -6773,6 +6773,11 @@ pub struct ChannelsConfig {
     #[display_name = "Linq"]
     #[description = "Linq Partner API for iMessage/RCS/SMS"]
     pub linq: Option<LinqConfig>,
+    /// Telnyx SMS channel configuration.
+    #[nested]
+    #[display_name = "Telnyx SMS"]
+    #[description = "Telnyx programmable SMS (Ed25519 signed)"]
+    pub telnyx: Option<TelnyxConfig>,
     /// WATI WhatsApp Business API channel configuration.
     #[nested]
     #[display_name = "WATI"]
@@ -6987,6 +6992,10 @@ impl ChannelsConfig {
                 self.linq.is_some(),
             ),
             (
+                Box::new(ConfigWrapper::new(self.telnyx.as_ref())),
+                self.telnyx.is_some(),
+            ),
+            (
                 Box::new(ConfigWrapper::new(self.wati.as_ref())),
                 self.wati.is_some(),
             ),
@@ -7092,6 +7101,7 @@ impl Default for ChannelsConfig {
             signal: None,
             whatsapp: None,
             linq: None,
+            telnyx: None,
             wati: None,
             nextcloud_talk: None,
             email: None,
@@ -7790,6 +7800,66 @@ impl ChannelConfig for LinqConfig {
     }
     fn desc() -> &'static str {
         "iMessage/RCS/SMS via Linq API"
+    }
+}
+
+/// Telnyx SMS channel configuration.
+///
+/// Inbound SMS arrives via the gateway at the hardcoded path `/telnyx/sms`.
+/// The operator must point Telnyx's webhook URL at
+/// `https://{public-gateway-url}/telnyx/sms` — usually behind one of the
+/// configured `[tunnel]` providers (Cloudflare Tunnel, Tailscale Funnel,
+/// ngrok, Pinggy, or a custom command).
+///
+/// Telnyx uses **two distinct credentials**, copied separately from the
+/// portal:
+/// * `api_key` — V2 API key sent as `Authorization: Bearer ...` for outbound
+///   calls. Treated as a secret.
+/// * `public_key` — base64-encoded Ed25519 public key, used to verify the
+///   `telnyx-signature-ed25519` header on inbound webhooks. Public; rotated
+///   in the Telnyx portal — operators must update this value here whenever
+///   Telnyx rotates the key.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, Configurable)]
+#[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
+#[prefix = "channels.telnyx"]
+pub struct TelnyxConfig {
+    /// Whether this channel is active (must be explicitly enabled). Default: false.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Telnyx V2 API key. Sent as the HTTP `Authorization: Bearer ...`
+    /// credential on every outbound REST call.
+    #[secret]
+    #[cfg_attr(feature = "schema-export", schemars(extend("x-secret" = true)))]
+    pub api_key: String,
+    /// Phone number to send from, in E.164 format (e.g. `"+15555550100"`).
+    /// Must be a number provisioned in your Telnyx account.
+    pub from_number: String,
+    /// Optional Telnyx Messaging Profile ID. When set, outbound messages
+    /// are sent through the named profile instead of the bare `from_number`.
+    /// Useful for organisations that use Messaging Profiles for routing,
+    /// rate-limit, or compliance settings.
+    #[serde(default)]
+    pub messaging_profile_id: Option<String>,
+    /// Allowed sender numbers in E.164 format (e.g. `"+15555550199"`). Empty
+    /// list = deny all. `"*"` allows everyone (use with care; this is a
+    /// public PSTN endpoint).
+    #[serde(default)]
+    pub allowed_numbers: Vec<String>,
+    /// Base64-encoded Ed25519 public key used to verify inbound webhook
+    /// signatures. Distinct from `api_key` — copied from a different page
+    /// in the Telnyx portal. **Update this whenever Telnyx rotates the
+    /// signing key**, otherwise inbound webhooks will start failing
+    /// signature verification.
+    #[serde(default)]
+    pub public_key: String,
+}
+
+impl ChannelConfig for TelnyxConfig {
+    fn name() -> &'static str {
+        "Telnyx"
+    }
+    fn desc() -> &'static str {
+        "SMS via Telnyx Programmable Messaging"
     }
 }
 
@@ -12526,6 +12596,7 @@ auto_save = true
                 signal: None,
                 whatsapp: None,
                 linq: None,
+                telnyx: None,
                 wati: None,
                 nextcloud_talk: None,
                 email: None,
@@ -13700,6 +13771,7 @@ allowed_users = ["@u:matrix.org"]
             signal: None,
             whatsapp: None,
             linq: None,
+            telnyx: None,
             wati: None,
             nextcloud_talk: None,
             email: None,
@@ -14082,6 +14154,7 @@ bot_token = "xoxb-tok"
                 approval_timeout_secs: 300,
             }),
             linq: None,
+            telnyx: None,
             wati: None,
             nextcloud_talk: None,
             email: None,

--- a/crates/zeroclaw-gateway/src/api.rs
+++ b/crates/zeroclaw-gateway/src/api.rs
@@ -1277,6 +1277,7 @@ mod tests {
             whatsapp_app_secret: None,
             linq: None,
             linq_signing_secret: None,
+            telnyx: None,
             nextcloud_talk: None,
             nextcloud_talk_webhook_secret: None,
             wati: None,

--- a/crates/zeroclaw-gateway/src/lib.rs
+++ b/crates/zeroclaw-gateway/src/lib.rs
@@ -53,7 +53,7 @@ use zeroclaw_api::channel::{Channel, SendMessage};
 use zeroclaw_api::tool::ToolSpec;
 use zeroclaw_channels::{
     gmail_push::GmailPushChannel, linq::LinqChannel, nextcloud_talk::NextcloudTalkChannel,
-    wati::WatiChannel, whatsapp::WhatsAppChannel,
+    telnyx::TelnyxChannel, wati::WatiChannel, whatsapp::WhatsAppChannel,
 };
 use zeroclaw_config::policy::SecurityPolicy;
 use zeroclaw_config::schema::Config;
@@ -122,6 +122,10 @@ fn whatsapp_memory_key(msg: &zeroclaw_api::channel::ChannelMessage) -> String {
 
 fn linq_memory_key(msg: &zeroclaw_api::channel::ChannelMessage) -> String {
     format!("linq_{}_{}", msg.sender, msg.id)
+}
+
+fn telnyx_memory_key(msg: &zeroclaw_api::channel::ChannelMessage) -> String {
+    format!("telnyx_{}_{}", msg.sender, msg.id)
 }
 
 fn wati_memory_key(msg: &zeroclaw_api::channel::ChannelMessage) -> String {
@@ -382,6 +386,8 @@ pub struct AppState {
     pub linq: Option<Arc<LinqChannel>>,
     /// Linq webhook signing secret for signature verification
     pub linq_signing_secret: Option<Arc<str>>,
+    /// Telnyx SMS channel (Ed25519-signed inbound webhooks).
+    pub telnyx: Option<Arc<TelnyxChannel>>,
     pub nextcloud_talk: Option<Arc<NextcloudTalkChannel>>,
     /// Nextcloud Talk webhook secret for signature verification
     pub nextcloud_talk_webhook_secret: Option<Arc<str>>,
@@ -715,6 +721,33 @@ pub async fn run_gateway(
         })
         .map(Arc::from);
 
+    // Telnyx channel (if configured AND enabled). Constructor returns Err
+    // when `public_key` fails to decode — log + skip rather than panic the
+    // daemon over a config typo.
+    let telnyx_channel: Option<Arc<TelnyxChannel>> = config
+        .channels
+        .telnyx
+        .as_ref()
+        .filter(|tx| tx.enabled)
+        .and_then(|tx| {
+            match TelnyxChannel::new(
+                tx.api_key.clone(),
+                tx.from_number.clone(),
+                tx.messaging_profile_id.clone(),
+                tx.allowed_numbers.clone(),
+                &tx.public_key,
+            ) {
+                Ok(c) => Some(Arc::new(c)),
+                Err(e) => {
+                    tracing::error!(
+                        "Telnyx channel construction failed (check public_key): {e:#}. \
+                             Skipping Telnyx — fix the config and reload."
+                    );
+                    None
+                }
+            }
+        });
+
     // WATI channel (if configured)
     let wati_channel: Option<Arc<WatiChannel>> = config.channels.wati.as_ref().map(|wati_cfg| {
         Arc::new(
@@ -916,6 +949,9 @@ pub async fn run_gateway(
     if linq_channel.is_some() {
         println!("  POST {pfx}/linq      — Linq message webhook (iMessage/RCS/SMS)");
     }
+    if telnyx_channel.is_some() {
+        println!("  POST {pfx}/telnyx/sms — Telnyx SMS webhook");
+    }
     if wati_channel.is_some() {
         println!("  GET  {pfx}/wati      — WATI webhook verification");
         println!("  POST {pfx}/wati      — WATI message webhook");
@@ -985,6 +1021,7 @@ pub async fn run_gateway(
         whatsapp_app_secret,
         linq: linq_channel,
         linq_signing_secret,
+        telnyx: telnyx_channel,
         nextcloud_talk: nextcloud_talk_channel,
         nextcloud_talk_webhook_secret,
         wati: wati_channel,
@@ -1047,6 +1084,7 @@ pub async fn run_gateway(
         .route("/whatsapp", get(handle_whatsapp_verify))
         .route("/whatsapp", post(handle_whatsapp_message))
         .route("/linq", post(handle_linq_webhook))
+        .route("/telnyx/sms", post(handle_telnyx_sms_webhook))
         .route("/wati", get(handle_wati_verify))
         .route("/wati", post(handle_wati_webhook))
         .route("/nextcloud-talk", post(handle_nextcloud_talk_webhook))
@@ -2091,6 +2129,131 @@ async fn handle_linq_webhook(
     (StatusCode::OK, Json(serde_json::json!({"status": "ok"})))
 }
 
+/// POST /telnyx/sms — incoming SMS webhook from Telnyx Programmable Messaging.
+///
+/// Telnyx sends `application/json` POSTs containing an `event_type` and a
+/// nested `payload` with `from.phone_number`, `to[].phone_number`, and
+/// `text`. The handler:
+///
+/// 1. Reads the `telnyx-signature-ed25519` (base64-encoded 64-byte Ed25519
+///    signature) and `telnyx-timestamp` (unix epoch seconds, as a string)
+///    headers.
+/// 2. Verifies the signature against the operator-configured public key
+///    over the message bytes `{timestamp}|{raw_body}`. The verifier also
+///    enforces a 5-minute timestamp anti-replay window. A failure returns
+///    401 and the SMS is dropped — no message ever reaches the agent.
+/// 3. Parses the JSON body and calls `TelnyxChannel::parse_webhook_payload`,
+///    which filters out non-`message.received` events and applies the
+///    `allowed_numbers` allowlist.
+/// 4. Forwards the resulting `ChannelMessage` to the agent loop and replies
+///    via `TelnyxChannel::send`.
+///
+/// Successful runs return `200 OK` with an empty body.
+async fn handle_telnyx_sms_webhook(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> impl IntoResponse {
+    let Some(ref telnyx) = state.telnyx else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": "Telnyx not configured"})),
+        );
+    };
+
+    let signature = headers
+        .get("telnyx-signature-ed25519")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    let timestamp = headers
+        .get("telnyx-timestamp")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    let now_unix = chrono::Utc::now().timestamp();
+
+    if !telnyx.verify_signature(timestamp, &body, signature, now_unix) {
+        tracing::warn!(
+            "Telnyx webhook signature verification failed (signature: {}, timestamp: {})",
+            if signature.is_empty() {
+                "missing"
+            } else {
+                "invalid-or-out-of-window"
+            },
+            if timestamp.is_empty() {
+                "missing"
+            } else {
+                "present"
+            }
+        );
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(serde_json::json!({"error": "Invalid signature"})),
+        );
+    }
+
+    let Ok(payload) = serde_json::from_slice::<serde_json::Value>(&body) else {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "Invalid JSON payload"})),
+        );
+    };
+
+    let Some(msg) = telnyx.parse_webhook_payload(&payload) else {
+        // Either the sender wasn't on the allowlist, the body was empty,
+        // or the event type is not `message.received` (e.g. delivery
+        // status events). Acknowledge with 200 so Telnyx doesn't retry.
+        return (StatusCode::OK, Json(serde_json::json!({"status": "ok"})));
+    };
+
+    tracing::info!(
+        "Telnyx SMS from {}: {}",
+        msg.sender,
+        truncate_with_ellipsis(&msg.content, 50)
+    );
+    let session_id = sender_session_id("telnyx", &msg);
+
+    if state.auto_save && !zeroclaw_memory::should_skip_autosave_content(&msg.content) {
+        let key = telnyx_memory_key(&msg);
+        let _ = state
+            .mem
+            .store(
+                &key,
+                &msg.content,
+                MemoryCategory::Conversation,
+                Some(&session_id),
+            )
+            .await;
+    }
+
+    match Box::pin(run_gateway_chat_with_tools(
+        &state,
+        &msg.content,
+        Some(&session_id),
+    ))
+    .await
+    {
+        Ok(GatewayChatOutcome { response, .. }) => {
+            if let Err(e) = telnyx
+                .send(&SendMessage::new(response, &msg.reply_target))
+                .await
+            {
+                tracing::error!("Failed to send Telnyx reply: {e}");
+            }
+        }
+        Err(e) => {
+            tracing::error!("LLM error for Telnyx message: {e:#}");
+            let _ = telnyx
+                .send(&SendMessage::new(
+                    "Sorry, I couldn't process your message right now.",
+                    &msg.reply_target,
+                ))
+                .await;
+        }
+    }
+
+    (StatusCode::OK, Json(serde_json::json!({"status": "ok"})))
+}
+
 /// GET /wati — WATI webhook verification (echoes hub.challenge)
 async fn handle_wati_verify(
     State(state): State<AppState>,
@@ -2678,6 +2841,7 @@ mod tests {
             whatsapp_app_secret: None,
             linq: None,
             linq_signing_secret: None,
+            telnyx: None,
             nextcloud_talk: None,
             nextcloud_talk_webhook_secret: None,
             wati: None,
@@ -2752,6 +2916,7 @@ mod tests {
             whatsapp_app_secret: None,
             linq: None,
             linq_signing_secret: None,
+            telnyx: None,
             nextcloud_talk: None,
             nextcloud_talk_webhook_secret: None,
             wati: None,
@@ -3211,6 +3376,7 @@ mod tests {
             whatsapp_app_secret: None,
             linq: None,
             linq_signing_secret: None,
+            telnyx: None,
             nextcloud_talk: None,
             nextcloud_talk_webhook_secret: None,
             wati: None,
@@ -3293,6 +3459,7 @@ mod tests {
             whatsapp_app_secret: None,
             linq: None,
             linq_signing_secret: None,
+            telnyx: None,
             nextcloud_talk: None,
             nextcloud_talk_webhook_secret: None,
             wati: None,
@@ -3387,6 +3554,7 @@ mod tests {
             whatsapp_app_secret: None,
             linq: None,
             linq_signing_secret: None,
+            telnyx: None,
             nextcloud_talk: None,
             nextcloud_talk_webhook_secret: None,
             wati: None,
@@ -3453,6 +3621,7 @@ mod tests {
             whatsapp_app_secret: None,
             linq: None,
             linq_signing_secret: None,
+            telnyx: None,
             nextcloud_talk: None,
             nextcloud_talk_webhook_secret: None,
             wati: None,
@@ -3524,6 +3693,7 @@ mod tests {
             whatsapp_app_secret: None,
             linq: None,
             linq_signing_secret: None,
+            telnyx: None,
             nextcloud_talk: None,
             nextcloud_talk_webhook_secret: None,
             wati: None,
@@ -3600,6 +3770,7 @@ mod tests {
             whatsapp_app_secret: None,
             linq: None,
             linq_signing_secret: None,
+            telnyx: None,
             nextcloud_talk: None,
             nextcloud_talk_webhook_secret: None,
             wati: None,
@@ -3673,6 +3844,7 @@ mod tests {
             whatsapp_app_secret: None,
             linq: None,
             linq_signing_secret: None,
+            telnyx: None,
             nextcloud_talk: Some(channel),
             nextcloud_talk_webhook_secret: Some(Arc::from(secret)),
             wati: None,

--- a/docs/book/src/channels/chat-others.md
+++ b/docs/book/src/channels/chat-others.md
@@ -148,6 +148,29 @@ databases = ["..."]                # DB IDs the agent can write to
 
 Treats a Notion database as a message surface. Useful for asynchronous workflows where the "channel" is a task inbox.
 
+## Telnyx (SMS)
+
+```toml
+[channels.telnyx]
+enabled = false                          # default: off — opt in explicitly
+api_key = "KEY01234..."                  # V2 API key — Bearer auth for outbound
+from_number = "+15555550100"             # E.164 — must be provisioned in Telnyx
+messaging_profile_id = "mp_..."          # optional — send via a Messaging Profile
+allowed_numbers = ["+15555550199"]       # E.164 allowlist; "*" = anyone (careful!)
+public_key = "MCowBQYDK2VwAyEA..."       # base64 Ed25519 public key — see below
+```
+
+Telnyx's Programmable Messaging is a Twilio sibling. Inbound traffic arrives via webhooks at the gateway-hosted path `POST /telnyx/sms` — point Telnyx's webhook URL at `https://{tunnel}/telnyx/sms`, behind one of the configured `[tunnel]` providers (Cloudflare Tunnel, Tailscale Funnel, ngrok, Pinggy, or a custom command). A public tunnel is required because Telnyx will not deliver to non-routable addresses.
+
+**Two distinct credentials**, copied separately from the Telnyx portal — operators routinely conflate them, so the names matter:
+
+* `api_key` is the **V2 API key**. Sent as `Authorization: Bearer ...` on every outbound REST call (`POST https://api.telnyx.com/v2/messages`). Treat as a secret.
+* `public_key` is the **Ed25519 webhook public key**, base64-encoded. Used to verify the `telnyx-signature-ed25519` header on inbound webhooks. Public, but copied from a different page in the portal than the API key. **When Telnyx rotates the signing key (or you provision a new portal user), you must update `public_key` here** — otherwise inbound webhooks will start failing signature verification.
+
+Webhooks are signed with Ed25519 over the bytes `{telnyx-timestamp}|{raw_body}` (literal pipe separator). The gateway also enforces a **5-minute timestamp anti-replay window**: inbound requests with a `telnyx-timestamp` more than 300 seconds away from the gateway's clock are rejected with 401, even if the signature itself is valid. Keep your gateway host's clock in sync (NTP).
+
+If your Telnyx account is on a trial plan, outbound numbers must be verified in the portal first — otherwise `POST /v2/messages` returns 4xx and the gateway logs the failure. SMS is metered per segment; long agent replies are split into ≤1600-char chunks with a `(i/N)` continuation marker, so a single agent turn can produce multiple billable segments.
+
 ---
 
 ## When to prefer a dedicated guide


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - New `TelnyxChannel`: gateway-registered SMS channel for Telnyx, sibling to the recently merged Twilio (#6429). Same architecture (`listen()` no-op, gateway hosts a hardcoded `POST /telnyx/sms` route), different signature scheme — Telnyx uses **Ed25519 public-key signatures** (not HMAC) with a 5-minute timestamp anti-replay window.
  - Outbound: `POST https://api.telnyx.com/v2/messages` with `Authorization: Bearer {api_key}`, JSON body `{"from", "to", "text", "messaging_profile_id"?}`. Bodies over 1600 chars are split at sentence/word boundaries with `(i/N) ` continuation markers.
  - Inbound at `POST /telnyx/sms`: reads `telnyx-signature-ed25519` (base64) and `telnyx-timestamp` (unix epoch string) headers, rejects requests where `|now - timestamp| > 300s`, decodes the signature to 64 bytes, and Ed25519-verifies the message `{timestamp}|{raw_body}` (literal pipe separator) against the operator-configured `public_key`. Fails closed with 401 on signature mismatch or out-of-window timestamp.
  - **Two distinct credentials** (operator footgun called out in docs): `api_key` is the V2 Bearer token used for outbound; `public_key` is a separate base64-encoded Ed25519 verifying key used only for inbound signature verification. Both are copied from different places in the Telnyx portal.
- **Scope boundary:** Telnyx only. No changes to Twilio, Plivo, Sinch, or any other channel. New optional dep on `ed25519-dalek` (already in workspace lockfile transitively via `wa-rs-libsignal`; declared as a direct optional dep so the channel can use it). Out of scope: MMS / RCS, delivery-receipt webhooks, Telnyx Voice / Verify / Number Search APIs, automated public-key rotation, `request_approval()` integration.
- **Blast radius:** New optional channel module + new gateway route + new optional config section + new optional `ed25519-dalek` direct dep on `zeroclaw-channels`. Default `enabled = false`; the gateway route returns 404 when Telnyx is not configured. `channel-telnyx` is now in the `default` cargo feature set; downstream packagers building with `--no-default-features` are unaffected.
- **Linked issue(s):** Closes #6451

## Validation Evidence (required)

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` → clean.
  - `cargo clippy --all-targets -- -D warnings` (workspace) → clean, zero warnings.
  - `cargo test -p zeroclaw-channels --features channel-telnyx --lib telnyx::` → **27 passed, 0 failed**.
  - `cargo test -p zeroclaw-config --lib` → **620 passed, 0 failed**.
  - `cargo test -p zeroclaw-gateway --lib` → **164 passed, 0 failed**.
  - `cargo build --release -p zeroclawlabs` → `Finished release profile [optimized] target(s) in 4m 19s`, exit 0.
- **Beyond CI — what was manually verified:**
  - Reviewed all 27 unit + wiremock tests covering allowlist matching (empty/wildcard/exact/whitespace-stripped), webhook payload parsing (drops outside-allowlist + empty + non-`message.received` event types; accepts allowed), Ed25519 signature validator hermetic round-trip (deterministic `SigningKey` → `VerifyingKey`, sign `{ts}|{body}`, base64-encode, pass to `verify_signature` — must return `true`; tampered body / tampered timestamp / future-timestamp out of window / past-timestamp out of window / wrong-length signature / malformed-base64 all fail), 1600-char chunk splitter with `(i/N)` markers, wiremock outbound POST shape (Bearer auth + JSON `{"from","to","text"}` body + optional `messaging_profile_id` inclusion when set), and 4xx → `Err`.
  - Verified `cargo clippy --all-targets -- -D warnings` is clean across the entire workspace.
  - Verified the gateway handler validates the signature **before** parsing JSON or routing to the agent — fails closed (401) on signature mismatch or out-of-window timestamp, and 400 on JSON parse error.
  - Confirmed the timestamp anti-replay window is enforced as `|now - timestamp| > 300s` (both directions — future-skewed and past-skewed timestamps both rejected outside the window).
  - Confirmed `cargo build --release -p zeroclawlabs` succeeds with default features (which now include `channel-telnyx`) — 4m 19s, exit 0.
  - **Did NOT verify against a live Telnyx account.** The signature math, route plumbing, timestamp window, and allowlist all pass under wiremock + unit tests, but the end-to-end "operator texts the number, gets a reply" round-trip has not been smoke-tested. Recommend the operator land this with `enabled = false` first, configure on staging (set up an API key + messaging profile + webhook with the matching public key), smoke test, then flip enabled.
  - Did NOT verify: MMS / RCS, delivery-receipt webhooks (Telnyx sends them as separate event types — out of scope), Telnyx Voice / Verify / Number Search, automated public-key rotation, `request_approval()` integration.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `Yes` — outbound HTTPS to `api.telnyx.com` only when `[channels.telnyx]` is configured and `enabled = true`. Inbound is the new `POST /telnyx/sms` gateway route, which 404s when Telnyx is not configured.
- Secrets / tokens / credentials handling changed? `Yes` — new `api_key` secret in `[channels.telnyx]`, plus a non-secret but operator-supplied `public_key` (Ed25519 verifying key, base64). The secret is redacted via the existing config-secret pipeline; never logged. The public key is treated as configuration data (not secret) — it's a *verifying* key, not a signing key.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No` — fixtures generate deterministic Ed25519 keypairs in-test and use synthetic phone numbers.
- **Risk and mitigation:**
  - `AGENTS.md` classifies `crates/zeroclaw-gateway/src/**` + new crypto code as **risk: high**, hence the explicit security walkthrough.
  - **Ed25519 verification fails closed**: missing or invalid `telnyx-signature-ed25519`, malformed base64, wrong-length signature, or out-of-window timestamp all → 401, message dropped before reaching the agent loop.
  - **5-minute timestamp anti-replay window** prevents replay attacks even on signed payloads. Window enforced symmetrically (both future and past skew rejected).
  - **`api_key` ≠ `public_key`** explicitly documented; mixing them up is a common operator footgun on Telnyx and the docs call it out.
  - **Allowlist enforced**: senders not in `allowed_numbers` are dropped at the channel boundary even if signature and timestamp are valid.
  - **`verify_strict` from `ed25519-dalek`** is used (not the relaxed `verify`) — rejects malleable signatures.
  - **Default `enabled = false`** means a misconfigured deployment cannot accidentally accept SMS.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `Yes` — additive only.
- **Upgrade steps for existing users:** None required. `[channels.telnyx]` is optional; existing configs without it continue to work. To opt in: add the section with `api_key` (secret, V2 Bearer), `from_number` (E.164), `allowed_numbers`, `public_key` (base64 Ed25519, copied from the Telnyx portal), and optional `messaging_profile_id`. Then set `enabled = true` and configure Telnyx's webhook to `https://<your-tunnel>/telnyx/sms` (POST). Operators with key rotation must update `public_key` in config when Telnyx rotates.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** Single squash-merge revert: `git revert <merge-sha>`. No migrations, no schema changes.
- **Feature flags or config toggles:**
  - Compile-time: feature flag `channel-telnyx` on `zeroclaw-channels` (default-on; can be turned off to remove the module — and the optional `ed25519-dalek` direct dep with it).
  - Runtime: `[channels.telnyx] enabled = false` disables without removing config or code.
- **Observable failure symptoms:**
  - Inbound signature failures: grep gateway logs for `telnyx_signature_invalid` / 401 responses on `POST /telnyx/sms`.
  - Timestamp out of window: grep for `telnyx_timestamp_skew` (clock-drift between operator's host and Telnyx).
  - Public-key parse failures at startup: grep for `telnyx_public_key_invalid` (operator pasted the API key by mistake, or the base64 is corrupted).
  - Outbound send failures: errors from `TelnyxChannel::send` log the upstream Telnyx error code; grep for `telnyx_send_failed`.
  - Allowlist drops: grep for `telnyx_sender_not_allowed`.
  - Misconfiguration at startup: the channel will not appear in `zeroclaw channel list`.

