### PR TITLE
feat(channel:sinch): add Sinch SMS channel

### DIFF
--- a/crates/zeroclaw-channels/Cargo.toml
+++ b/crates/zeroclaw-channels/Cargo.toml
@@ -81,8 +81,8 @@ default = [
     "channel-discord", "channel-slack", "channel-signal", "channel-mattermost",
     "channel-irc", "channel-imessage", "channel-dingtalk", "channel-qq",
     "channel-bluesky", "channel-twitter", "channel-reddit", "channel-notion",
-    "channel-linq", "channel-wati", "channel-nextcloud", "channel-mochat",
-    "channel-wecom", "channel-clawdtalk", "channel-webhook",
+    "channel-linq", "channel-sinch", "channel-wati", "channel-nextcloud",
+    "channel-mochat", "channel-wecom", "channel-clawdtalk", "channel-webhook",
     "channel-whatsapp-cloud", "channel-voice-call",
 ]
 # Channels with optional deps
@@ -106,6 +106,7 @@ channel-twitter = []
 channel-reddit = []
 channel-notion = []
 channel-linq = []
+channel-sinch = []
 channel-wati = []
 channel-nextcloud = []
 channel-mochat = []

--- a/crates/zeroclaw-channels/src/lib.rs
+++ b/crates/zeroclaw-channels/src/lib.rs
@@ -54,6 +54,8 @@ pub mod qq;
 pub mod reddit;
 #[cfg(feature = "channel-signal")]
 pub mod signal;
+#[cfg(feature = "channel-sinch")]
+pub mod sinch;
 #[cfg(feature = "channel-slack")]
 pub mod slack;
 #[cfg(feature = "channel-telegram")]

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -48,6 +48,8 @@ pub use crate::notion::NotionChannel;
 pub use crate::qq::QQChannel;
 pub use crate::reddit::RedditChannel;
 pub use crate::signal::SignalChannel;
+#[cfg(feature = "channel-sinch")]
+pub use crate::sinch::SinchChannel;
 pub use crate::slack::SlackChannel;
 pub use crate::transcription;
 pub use crate::tts::{TtsManager, TtsProvider};
@@ -4476,6 +4478,22 @@ fn build_channel_by_id(config: &Config, channel_id: &str) -> Result<Arc<dyn Chan
                 lq.allowed_senders.clone(),
             )))
         }
+        #[cfg(feature = "channel-sinch")]
+        "sinch" => {
+            let sn = config
+                .channels
+                .sinch
+                .as_ref()
+                .context("Sinch channel is not configured")?;
+            Ok(Arc::new(SinchChannel::new(
+                sn.service_plan_id.clone(),
+                sn.api_token.clone(),
+                sn.region.clone(),
+                sn.from_number.clone(),
+                sn.allowed_numbers.clone(),
+                sn.callback_secret.clone(),
+            )))
+        }
         #[cfg(feature = "channel-email")]
         "email" => {
             let em = config
@@ -4598,7 +4616,8 @@ fn build_channel_by_id(config: &Config, channel_id: &str) -> Result<Arc<dyn Chan
         other => anyhow::bail!(
             "Unknown channel '{other}'. Supported: telegram, discord, slack, mattermost, signal, \
             matrix, whatsapp, qq, lark, feishu, dingtalk, wecom, nextcloud_talk, wati, linq, \
-            email, gmail_push, irc, twitter, mochat, discord_history, imessage, line, voice-call"
+            sinch, email, gmail_push, irc, twitter, mochat, discord_history, imessage, line, \
+            voice-call"
         ),
     }
 }
@@ -4948,6 +4967,25 @@ fn collect_configured_channels(
             });
         } else {
             tracing::info!("Linq channel configured but disabled (enabled = false)");
+        }
+    }
+
+    #[cfg(feature = "channel-sinch")]
+    if let Some(ref sn) = config.channels.sinch {
+        if sn.enabled {
+            channels.push(ConfiguredChannel {
+                display_name: "Sinch",
+                channel: Arc::new(SinchChannel::new(
+                    sn.service_plan_id.clone(),
+                    sn.api_token.clone(),
+                    sn.region.clone(),
+                    sn.from_number.clone(),
+                    sn.allowed_numbers.clone(),
+                    sn.callback_secret.clone(),
+                )),
+            });
+        } else {
+            tracing::info!("Sinch channel configured but disabled (enabled = false)");
         }
     }
 

--- a/crates/zeroclaw-channels/src/sinch.rs
+++ b/crates/zeroclaw-channels/src/sinch.rs
@@ -1,0 +1,646 @@
+//! Sinch SMS channel — sends via Sinch's REST `Batches` resource and receives
+//! via gateway-routed webhooks.
+//!
+//! Mirrors the gateway-registered pattern used by WhatsApp Cloud, Linq, WATI,
+//! and Twilio: this channel's `listen()` is a keep-alive no-op; the
+//! `zeroclaw-gateway` crate hosts a hardcoded `POST /sinch/sms` route whose
+//! handler reads `application/json` payloads, validates the
+//! `x-sinch-webhook-signature` header, and converts each request into a
+//! [`ChannelMessage`].
+//!
+//! # Auth
+//! Sinch separates outbound and inbound credentials:
+//!
+//! - **Outbound** uses a service plan ID (public, identifies the project) and
+//!   a Bearer API token. The URL is region-scoped:
+//!   `https://{region}.sms.api.sinch.com/xms/v1/{service_plan_id}/batches`.
+//! - **Inbound webhooks** are signed with a separate `callback_secret`. The
+//!   `x-sinch-webhook-signature` header has the format `v1,{nonce},{base64-sig}`
+//!   where the signature is HMAC-SHA256 over `nonce_bytes || raw_body` keyed by
+//!   `callback_secret`.
+//!
+//! # Outbound
+//! `POST https://{region}.sms.api.sinch.com/xms/v1/{service_plan_id}/batches`
+//! with JSON body `{"from": from_number, "to": [to_number], "body": body}`.
+//! Long bodies are split into ≤1600-char chunks at sentence/word boundaries
+//! with a `(i/N)` continuation marker so recipients can reassemble.
+//!
+//! # Inbound
+//! The gateway handler verifies the signature, drops senders not on the
+//! `allowed_numbers` allowlist, and forwards each `mo_text` payload to the
+//! agent loop.
+//!
+//! Reference: <https://developers.sinch.com/docs/sms/api-reference/sms/tag/Batches/>
+
+use anyhow::{Context, Result, bail};
+use async_trait::async_trait;
+use zeroclaw_api::channel::{Channel, ChannelMessage, SendMessage};
+
+/// Sinch segments outbound messages transparently. Mirroring Twilio's
+/// behaviour: bodies above 1600 characters are split client-side into
+/// numbered chunks so a single API call never carries a giant payload.
+const SINCH_MESSAGE_LIMIT: usize = 1600;
+/// Hardcoded inbound webhook path on the gateway. Operators point Sinch's
+/// "Callback URL" at `https://{gateway}/sinch/sms`.
+pub const SINCH_WEBHOOK_PATH: &str = "/sinch/sms";
+
+/// Sinch SMS channel — see module docs.
+pub struct SinchChannel {
+    service_plan_id: String,
+    api_token: String,
+    region: String,
+    from_number: String,
+    allowed_numbers: Vec<String>,
+    callback_secret: String,
+}
+
+impl SinchChannel {
+    pub fn new(
+        service_plan_id: String,
+        api_token: String,
+        region: String,
+        from_number: String,
+        allowed_numbers: Vec<String>,
+        callback_secret: String,
+    ) -> Self {
+        Self {
+            service_plan_id,
+            api_token,
+            region,
+            from_number,
+            allowed_numbers,
+            callback_secret,
+        }
+    }
+
+    fn http_client(&self) -> reqwest::Client {
+        zeroclaw_config::schema::build_runtime_proxy_client("channel.sinch")
+    }
+
+    fn outbound_base(&self) -> String {
+        format!("https://{}.sms.api.sinch.com", self.region)
+    }
+
+    fn outbound_url(&self) -> String {
+        format!(
+            "{}/xms/v1/{}/batches",
+            self.outbound_base(),
+            self.service_plan_id
+        )
+    }
+
+    /// Configurable base URL hook used by tests. Production uses the
+    /// region-scoped Sinch host; tests substitute a wiremock URI.
+    #[cfg(test)]
+    fn outbound_url_with_base(&self, base: &str) -> String {
+        format!("{base}/xms/v1/{}/batches", self.service_plan_id)
+    }
+
+    /// Whether the inbound `from` number is permitted. Empty allowlist denies
+    /// everyone; `"*"` matches anyone; otherwise an exact case-insensitive
+    /// E.164 match is required.
+    pub fn is_number_allowed(&self, phone: &str) -> bool {
+        is_number_allowed_for_list(&self.allowed_numbers, phone)
+    }
+
+    /// Verify a Sinch webhook signature. Sinch's algorithm:
+    ///
+    /// 1. The `x-sinch-webhook-signature` header has three comma-separated
+    ///    parts: `v1,{nonce},{base64-sig}`. Reject anything with a different
+    ///    version prefix or fewer parts.
+    /// 2. Compute HMAC-SHA256 over `nonce_bytes || raw_body` (concatenated
+    ///    bytes) using the `callback_secret` as the key.
+    /// 3. Base64-encode the digest and constant-time-compare against the
+    ///    third header part.
+    pub fn verify_signature(&self, raw_body: &[u8], header_value: &str) -> bool {
+        verify_sinch_signature(&self.callback_secret, raw_body, header_value)
+    }
+
+    /// Convert an inbound Sinch webhook payload into a [`ChannelMessage`].
+    /// Returns `None` when the payload isn't a `mo_text` message, the sender
+    /// isn't on the allowlist, or required fields are missing/empty.
+    pub fn parse_webhook_payload(&self, json: &serde_json::Value) -> Option<ChannelMessage> {
+        let msg_type = json.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        if msg_type != "mo_text" {
+            tracing::debug!("Sinch: dropping webhook payload of type {msg_type:?}");
+            return None;
+        }
+        let from = json
+            .get("from")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .trim();
+        if from.is_empty() {
+            return None;
+        }
+        if !self.is_number_allowed(from) {
+            tracing::debug!("Sinch: dropping SMS from {from} (not in allowed_numbers)");
+            return None;
+        }
+        let body = json
+            .get("body")
+            .and_then(|v| v.as_str())
+            .map(|s| s.trim().to_string())
+            .unwrap_or_default();
+        if body.is_empty() {
+            tracing::debug!("Sinch: dropping empty-body SMS from {from}");
+            return None;
+        }
+        let id = json
+            .get("id")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| format!("sinch-{}", chrono::Utc::now().timestamp_millis()));
+        Some(ChannelMessage {
+            id: format!("sinch_{id}"),
+            sender: from.to_string(),
+            reply_target: from.to_string(),
+            content: body,
+            channel: "sinch".to_string(),
+            timestamp: chrono::Utc::now().timestamp().cast_unsigned(),
+            thread_ts: None,
+            interruption_scope_id: None,
+            attachments: vec![],
+        })
+    }
+
+    async fn post_message_chunk(
+        &self,
+        to: &str,
+        body: &str,
+        base_override: Option<&str>,
+    ) -> Result<()> {
+        let url = match base_override {
+            #[cfg(test)]
+            Some(b) => self.outbound_url_with_base(b),
+            #[cfg(not(test))]
+            Some(_) => self.outbound_url(),
+            None => self.outbound_url(),
+        };
+        let payload = serde_json::json!({
+            "from": self.from_number,
+            "to": [to],
+            "body": body,
+        });
+        let resp = self
+            .http_client()
+            .post(&url)
+            .bearer_auth(&self.api_token)
+            .json(&payload)
+            .send()
+            .await
+            .context("Sinch Batches POST failed")?;
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            bail!("Sinch Batches POST returned {status}: {body}");
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Channel for SinchChannel {
+    fn name(&self) -> &str {
+        "sinch"
+    }
+
+    async fn send(&self, message: &SendMessage) -> Result<()> {
+        let to = message.recipient.trim();
+        if to.is_empty() {
+            bail!("Sinch send: empty recipient");
+        }
+        let chunks = chunk_sms(&message.content, SINCH_MESSAGE_LIMIT);
+        if chunks.is_empty() {
+            return Ok(());
+        }
+        for chunk in chunks {
+            self.post_message_chunk(to, &chunk, None).await?;
+        }
+        Ok(())
+    }
+
+    async fn listen(&self, _tx: tokio::sync::mpsc::Sender<ChannelMessage>) -> Result<()> {
+        // Sinch uses webhooks (push-based), not polling. The gateway hosts
+        // POST /sinch/sms and routes inbound payloads via parse_webhook_payload.
+        tracing::info!(
+            "Sinch channel active (webhook mode). Configure Sinch's Callback URL to POST \
+             to your gateway's {SINCH_WEBHOOK_PATH} endpoint."
+        );
+        loop {
+            tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
+        }
+    }
+
+    async fn health_check(&self) -> bool {
+        // Probe the Batches list — succeeds when service_plan_id + token
+        // are valid. `page_size=1` keeps the response trivial.
+        let url = format!(
+            "{}/xms/v1/{}/batches?page_size=1",
+            self.outbound_base(),
+            self.service_plan_id
+        );
+        self.http_client()
+            .get(&url)
+            .bearer_auth(&self.api_token)
+            .send()
+            .await
+            .map(|r| r.status().is_success())
+            .unwrap_or(false)
+    }
+}
+
+/// Allowlist matcher with `"*"` wildcard. Comparison is case-insensitive and
+/// strips internal whitespace so `"+1 555 555 0199"` round-trips against the
+/// canonical E.164 `"+15555550199"`.
+pub fn is_number_allowed_for_list(allowlist: &[String], phone: &str) -> bool {
+    if allowlist.is_empty() {
+        return false;
+    }
+    if allowlist.iter().any(|n| n == "*") {
+        return true;
+    }
+    let normalized = phone
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect::<String>()
+        .to_ascii_lowercase();
+    allowlist.iter().any(|entry| {
+        let canon = entry
+            .chars()
+            .filter(|c| !c.is_whitespace())
+            .collect::<String>()
+            .to_ascii_lowercase();
+        canon == normalized
+    })
+}
+
+fn verify_sinch_signature(callback_secret: &str, raw_body: &[u8], header_value: &str) -> bool {
+    use hmac::{Hmac, Mac};
+    use sha2::Sha256;
+    if header_value.is_empty() {
+        return false;
+    }
+    let parts: Vec<&str> = header_value.splitn(3, ',').collect();
+    if parts.len() != 3 {
+        return false;
+    }
+    let (version, nonce, expected_sig) = (parts[0], parts[1], parts[2]);
+    if version != "v1" {
+        return false;
+    }
+    if nonce.is_empty() {
+        return false;
+    }
+    let Ok(mut mac) = Hmac::<Sha256>::new_from_slice(callback_secret.as_bytes()) else {
+        return false;
+    };
+    mac.update(nonce.as_bytes());
+    mac.update(raw_body);
+    let computed = mac.finalize().into_bytes();
+    let expected_b64 = base64_encode(&computed);
+    constant_time_eq(expected_b64.as_bytes(), expected_sig.as_bytes())
+}
+
+fn base64_encode(bytes: &[u8]) -> String {
+    use base64::Engine;
+    base64::engine::general_purpose::STANDARD.encode(bytes)
+}
+
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff: u8 = 0;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+/// Split an outbound body into ≤`limit`-character chunks. Single-chunk bodies
+/// are returned as-is; multi-chunk bodies receive a `(i/N) ` prefix on each
+/// part so the recipient can reassemble. Splits prefer sentence enders, then
+/// whitespace, then a hard char cut.
+pub fn chunk_sms(body: &str, limit: usize) -> Vec<String> {
+    let body = body.trim();
+    if body.is_empty() {
+        return vec![];
+    }
+    if body.chars().count() <= limit {
+        return vec![body.to_string()];
+    }
+    const MARKER_RESERVE: usize = 8; // "(99/99) "
+    let body_budget = limit.saturating_sub(MARKER_RESERVE).max(1);
+    let mut chunks: Vec<String> = Vec::new();
+    let mut remaining: &str = body;
+    while !remaining.is_empty() {
+        if remaining.chars().count() <= body_budget {
+            chunks.push(remaining.to_string());
+            break;
+        }
+        let split_at = pick_split_point(remaining, body_budget);
+        let (head, tail) = remaining.split_at(split_at);
+        chunks.push(head.trim_end().to_string());
+        remaining = tail.trim_start();
+    }
+    if chunks.len() == 1 {
+        return chunks;
+    }
+    let total = chunks.len();
+    chunks
+        .into_iter()
+        .enumerate()
+        .map(|(i, c)| format!("({}/{total}) {c}", i + 1))
+        .collect()
+}
+
+fn pick_split_point(text: &str, char_budget: usize) -> usize {
+    let mut budget_idx = text.len();
+    for (i, (byte_idx, _)) in text.char_indices().enumerate() {
+        if i == char_budget {
+            budget_idx = byte_idx;
+            break;
+        }
+    }
+    let head = &text[..budget_idx];
+    if let Some(idx) = head.rfind(['.', '!', '?', '\n']) {
+        return (idx + 1).min(budget_idx);
+    }
+    if let Some(idx) = head.rfind(char::is_whitespace) {
+        return idx + 1;
+    }
+    budget_idx
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ch() -> SinchChannel {
+        SinchChannel::new(
+            "test-service-plan".into(),
+            "test-api-token".into(),
+            "us".into(),
+            "+15555550100".into(),
+            vec!["+15555550199".into()],
+            "test-callback-secret".into(),
+        )
+    }
+
+    /// Compute the signature header a real Sinch webhook would include for
+    /// the given (secret, nonce, body) — used to round-trip the verifier.
+    fn make_signature_header(secret: &str, nonce: &str, body: &[u8]) -> String {
+        use hmac::{Hmac, Mac};
+        use sha2::Sha256;
+        let mut mac =
+            Hmac::<Sha256>::new_from_slice(secret.as_bytes()).expect("any key length is valid");
+        mac.update(nonce.as_bytes());
+        mac.update(body);
+        let computed = mac.finalize().into_bytes();
+        let sig = base64_encode(&computed);
+        format!("v1,{nonce},{sig}")
+    }
+
+    #[test]
+    fn allowlist_empty_denies_everyone() {
+        assert!(!is_number_allowed_for_list(&[], "+15555550199"));
+    }
+
+    #[test]
+    fn allowlist_wildcard_allows_anyone() {
+        let allow = vec!["*".into()];
+        assert!(is_number_allowed_for_list(&allow, "+15555550199"));
+        assert!(is_number_allowed_for_list(&allow, "+447700900000"));
+    }
+
+    #[test]
+    fn allowlist_matches_e164_exact() {
+        let allow = vec!["+15555550199".into()];
+        assert!(is_number_allowed_for_list(&allow, "+15555550199"));
+        assert!(!is_number_allowed_for_list(&allow, "+15555550100"));
+    }
+
+    #[test]
+    fn allowlist_strips_whitespace() {
+        let allow = vec!["+1 555 555 0199".into()];
+        assert!(is_number_allowed_for_list(&allow, "+15555550199"));
+    }
+
+    #[test]
+    fn chunk_sms_short_passes_through() {
+        let chunks = chunk_sms("hi there", SINCH_MESSAGE_LIMIT);
+        assert_eq!(chunks, vec!["hi there"]);
+    }
+
+    #[test]
+    fn chunk_sms_long_is_split_with_marker_and_preserves_content() {
+        let body = "alpha beta gamma. ".repeat(120);
+        let chunks = chunk_sms(&body, 100);
+        assert!(chunks.len() >= 2, "expected ≥2 chunks, got {chunks:?}");
+        for (i, c) in chunks.iter().enumerate() {
+            assert!(
+                c.starts_with(&format!("({}/", i + 1)),
+                "missing marker on chunk {i}: {c:?}"
+            );
+            assert!(
+                c.chars().count() <= 100,
+                "chunk {i} exceeds limit: {c:?} ({} chars)",
+                c.chars().count()
+            );
+        }
+        // Total reassembled content (after stripping markers) covers every
+        // original word — markers reserve space, never drop characters.
+        let mut joined = String::new();
+        for c in &chunks {
+            // Strip "(i/N) " prefix.
+            let stripped = c.split_once(' ').map(|(_, rest)| rest).unwrap_or(c);
+            if !joined.is_empty() {
+                joined.push(' ');
+            }
+            joined.push_str(stripped);
+        }
+        let original_words: usize = body.split_whitespace().count();
+        let joined_words: usize = joined.split_whitespace().count();
+        assert_eq!(
+            joined_words, original_words,
+            "chunked body lost or duplicated words"
+        );
+    }
+
+    #[test]
+    fn chunk_sms_empty_returns_no_chunks() {
+        let chunks = chunk_sms("   ", SINCH_MESSAGE_LIMIT);
+        assert!(chunks.is_empty());
+    }
+
+    #[test]
+    fn parse_webhook_drops_outside_allowlist() {
+        let payload = serde_json::json!({
+            "type": "mo_text",
+            "from": "+15555550999",
+            "to": "+15555550100",
+            "body": "hello",
+            "id": "abc123",
+        });
+        assert!(ch().parse_webhook_payload(&payload).is_none());
+    }
+
+    #[test]
+    fn parse_webhook_drops_empty_body() {
+        let payload = serde_json::json!({
+            "type": "mo_text",
+            "from": "+15555550199",
+            "to": "+15555550100",
+            "body": "  ",
+            "id": "abc123",
+        });
+        assert!(ch().parse_webhook_payload(&payload).is_none());
+    }
+
+    #[test]
+    fn parse_webhook_drops_non_mo_text_type() {
+        let payload = serde_json::json!({
+            "type": "delivery_report_sms",
+            "from": "+15555550199",
+            "to": "+15555550100",
+            "body": "hello",
+            "id": "abc123",
+        });
+        assert!(ch().parse_webhook_payload(&payload).is_none());
+    }
+
+    #[test]
+    fn parse_webhook_returns_message_on_allowed_mo_text() {
+        let payload = serde_json::json!({
+            "type": "mo_text",
+            "from": "+15555550199",
+            "to": "+15555550100",
+            "body": "hello world",
+            "id": "01HXXXMSGID",
+        });
+        let msg = ch()
+            .parse_webhook_payload(&payload)
+            .expect("expected message");
+        assert_eq!(msg.sender, "+15555550199");
+        assert_eq!(msg.reply_target, "+15555550199");
+        assert_eq!(msg.content, "hello world");
+        assert_eq!(msg.channel, "sinch");
+        assert_eq!(msg.id, "sinch_01HXXXMSGID");
+    }
+
+    #[test]
+    fn verify_signature_round_trip() {
+        let secret = "test-callback-secret";
+        let body = b"{\"type\":\"mo_text\",\"from\":\"+15555550199\"}";
+        let header = make_signature_header(secret, "nonce-xyz-1", body);
+        assert!(verify_sinch_signature(secret, body, &header));
+    }
+
+    #[test]
+    fn verify_signature_rejects_tampered_body() {
+        let secret = "test-callback-secret";
+        let body = b"{\"type\":\"mo_text\",\"from\":\"+15555550199\"}";
+        let header = make_signature_header(secret, "nonce-xyz-1", body);
+        let tampered = b"{\"type\":\"mo_text\",\"from\":\"+15555559999\"}";
+        assert!(!verify_sinch_signature(secret, tampered, &header));
+    }
+
+    #[test]
+    fn verify_signature_rejects_wrong_secret() {
+        let body = b"hello";
+        let header = make_signature_header("real-secret", "nonce-1", body);
+        assert!(!verify_sinch_signature("wrong-secret", body, &header));
+    }
+
+    #[test]
+    fn verify_signature_rejects_wrong_version_prefix() {
+        let secret = "test-callback-secret";
+        let body = b"hello";
+        // Compute a v1 header but mutate the prefix to v0.
+        let valid = make_signature_header(secret, "nonce-1", body);
+        let mut parts = valid.splitn(3, ',');
+        let _ = parts.next();
+        let nonce = parts.next().unwrap_or("");
+        let sig = parts.next().unwrap_or("");
+        let mutated = format!("v0,{nonce},{sig}");
+        assert!(!verify_sinch_signature(secret, body, &mutated));
+    }
+
+    #[test]
+    fn verify_signature_rejects_missing_nonce() {
+        let secret = "test-callback-secret";
+        let body = b"hello";
+        // Header with empty nonce slot.
+        let header = "v1,,abcd1234";
+        assert!(!verify_sinch_signature(secret, body, header));
+    }
+
+    #[test]
+    fn verify_signature_rejects_empty_header() {
+        assert!(!verify_sinch_signature("secret", b"body", ""));
+    }
+
+    #[test]
+    fn verify_signature_rejects_too_few_parts() {
+        let secret = "test-callback-secret";
+        // Only two comma-separated parts.
+        assert!(!verify_sinch_signature(secret, b"body", "v1,nonce"));
+        // No commas at all.
+        assert!(!verify_sinch_signature(secret, b"body", "v1noncesig"));
+    }
+
+    mod http_tests {
+        use super::*;
+        use wiremock::matchers::{body_json_string, header, header_exists, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        #[tokio::test]
+        async fn send_posts_to_batches_endpoint_with_bearer_and_array_to() {
+            let server = MockServer::start().await;
+
+            let expected_body = serde_json::json!({
+                "from": "+15555550100",
+                "to": ["+15555550199"],
+                "body": "hello there",
+            });
+
+            Mock::given(method("POST"))
+                .and(path("/xms/v1/test-service-plan/batches"))
+                .and(header_exists("authorization"))
+                .and(header("content-type", "application/json"))
+                .and(body_json_string(expected_body.to_string()))
+                .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                    "id": "01HXX-batch-id",
+                })))
+                .expect(1)
+                .mount(&server)
+                .await;
+
+            let sinch = ch();
+            sinch
+                .post_message_chunk("+15555550199", "hello there", Some(&server.uri()))
+                .await
+                .expect("send succeeds");
+        }
+
+        #[tokio::test]
+        async fn send_surfaces_4xx_as_error() {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/xms/v1/test-service-plan/batches"))
+                .respond_with(
+                    ResponseTemplate::new(401).set_body_string("{\"code\": \"unauthorized\"}"),
+                )
+                .mount(&server)
+                .await;
+
+            let err = ch()
+                .post_message_chunk("+15555550199", "hi", Some(&server.uri()))
+                .await
+                .expect_err("expected error");
+            let msg = format!("{err:#}");
+            assert!(msg.contains("401"), "missing 401 in error: {msg}");
+        }
+    }
+}

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -6773,6 +6773,11 @@ pub struct ChannelsConfig {
     #[display_name = "Linq"]
     #[description = "Linq Partner API for iMessage/RCS/SMS"]
     pub linq: Option<LinqConfig>,
+    /// Sinch SMS channel configuration.
+    #[nested]
+    #[display_name = "Sinch"]
+    #[description = "Sinch programmable SMS"]
+    pub sinch: Option<SinchConfig>,
     /// WATI WhatsApp Business API channel configuration.
     #[nested]
     #[display_name = "WATI"]
@@ -6987,6 +6992,10 @@ impl ChannelsConfig {
                 self.linq.is_some(),
             ),
             (
+                Box::new(ConfigWrapper::new(self.sinch.as_ref())),
+                self.sinch.is_some(),
+            ),
+            (
                 Box::new(ConfigWrapper::new(self.wati.as_ref())),
                 self.wati.is_some(),
             ),
@@ -7092,6 +7101,7 @@ impl Default for ChannelsConfig {
             signal: None,
             whatsapp: None,
             linq: None,
+            sinch: None,
             wati: None,
             nextcloud_talk: None,
             email: None,
@@ -7790,6 +7800,67 @@ impl ChannelConfig for LinqConfig {
     }
     fn desc() -> &'static str {
         "iMessage/RCS/SMS via Linq API"
+    }
+}
+
+/// Sinch SMS channel configuration.
+///
+/// Inbound SMS arrives via the gateway at the hardcoded path `/sinch/sms`.
+/// The operator must point Sinch's "Callback URL" setting at
+/// `https://{public-gateway-url}/sinch/sms` — usually behind one of the
+/// configured `[tunnel]` providers (Cloudflare Tunnel, Tailscale Funnel,
+/// ngrok, Pinggy, or a custom command).
+///
+/// Outbound calls are region-scoped: `region = "us"` targets
+/// `us.sms.api.sinch.com`, `region = "eu"` targets `eu.sms.api.sinch.com`.
+/// Pick the region that matches the data residency of your Sinch project.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, Configurable)]
+#[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
+#[prefix = "channels.sinch"]
+pub struct SinchConfig {
+    /// Whether this channel is active (must be explicitly enabled). Default: false.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Sinch service plan ID (project identifier, public). Used as a path
+    /// component on the Batches API endpoint.
+    pub service_plan_id: String,
+    /// Sinch API token used as the HTTP `Bearer` credential for outbound
+    /// `POST /xms/v1/{service_plan_id}/batches` requests. Distinct from
+    /// `callback_secret`.
+    #[secret]
+    #[cfg_attr(feature = "schema-export", schemars(extend("x-secret" = true)))]
+    pub api_token: String,
+    /// Sinch SMS region. `"us"` (default) targets `us.sms.api.sinch.com`,
+    /// `"eu"` targets `eu.sms.api.sinch.com`. Other values are passed through
+    /// verbatim to the URL host but only `us`/`eu` are documented.
+    #[serde(default = "default_sinch_region")]
+    pub region: String,
+    /// Phone number to send from, in E.164 format (e.g. `"+15555550100"`).
+    /// Must be a number provisioned for your Sinch service plan.
+    pub from_number: String,
+    /// Allowed sender numbers in E.164 format (e.g. `"+15555550199"`). Empty
+    /// list = deny all. `"*"` allows everyone (use with care; this is a
+    /// public PSTN endpoint).
+    #[serde(default)]
+    pub allowed_numbers: Vec<String>,
+    /// HMAC-SHA256 secret used to verify the `x-sinch-webhook-signature`
+    /// header (`v1,nonce,base64(sig)` over `nonce_bytes || raw_body`).
+    /// Distinct from `api_token`.
+    #[secret]
+    #[cfg_attr(feature = "schema-export", schemars(extend("x-secret" = true)))]
+    pub callback_secret: String,
+}
+
+fn default_sinch_region() -> String {
+    "us".into()
+}
+
+impl ChannelConfig for SinchConfig {
+    fn name() -> &'static str {
+        "Sinch"
+    }
+    fn desc() -> &'static str {
+        "SMS via Sinch (US/EU regions)"
     }
 }
 
@@ -12526,6 +12597,7 @@ auto_save = true
                 signal: None,
                 whatsapp: None,
                 linq: None,
+                sinch: None,
                 wati: None,
                 nextcloud_talk: None,
                 email: None,
@@ -13700,6 +13772,7 @@ allowed_users = ["@u:matrix.org"]
             signal: None,
             whatsapp: None,
             linq: None,
+            sinch: None,
             wati: None,
             nextcloud_talk: None,
             email: None,
@@ -14082,6 +14155,7 @@ bot_token = "xoxb-tok"
                 approval_timeout_secs: 300,
             }),
             linq: None,
+            sinch: None,
             wati: None,
             nextcloud_talk: None,
             email: None,

--- a/crates/zeroclaw-gateway/src/api.rs
+++ b/crates/zeroclaw-gateway/src/api.rs
@@ -1277,6 +1277,7 @@ mod tests {
             whatsapp_app_secret: None,
             linq: None,
             linq_signing_secret: None,
+            sinch: None,
             nextcloud_talk: None,
             nextcloud_talk_webhook_secret: None,
             wati: None,

--- a/crates/zeroclaw-gateway/src/lib.rs
+++ b/crates/zeroclaw-gateway/src/lib.rs
@@ -53,7 +53,7 @@ use zeroclaw_api::channel::{Channel, SendMessage};
 use zeroclaw_api::tool::ToolSpec;
 use zeroclaw_channels::{
     gmail_push::GmailPushChannel, linq::LinqChannel, nextcloud_talk::NextcloudTalkChannel,
-    wati::WatiChannel, whatsapp::WhatsAppChannel,
+    sinch::SinchChannel, wati::WatiChannel, whatsapp::WhatsAppChannel,
 };
 use zeroclaw_config::policy::SecurityPolicy;
 use zeroclaw_config::schema::Config;
@@ -122,6 +122,10 @@ fn whatsapp_memory_key(msg: &zeroclaw_api::channel::ChannelMessage) -> String {
 
 fn linq_memory_key(msg: &zeroclaw_api::channel::ChannelMessage) -> String {
     format!("linq_{}_{}", msg.sender, msg.id)
+}
+
+fn sinch_memory_key(msg: &zeroclaw_api::channel::ChannelMessage) -> String {
+    format!("sinch_{}_{}", msg.sender, msg.id)
 }
 
 fn wati_memory_key(msg: &zeroclaw_api::channel::ChannelMessage) -> String {
@@ -382,6 +386,10 @@ pub struct AppState {
     pub linq: Option<Arc<LinqChannel>>,
     /// Linq webhook signing secret for signature verification
     pub linq_signing_secret: Option<Arc<str>>,
+    /// Sinch SMS channel (US/EU regions). Inbound webhooks land at
+    /// `POST /sinch/sms` and are HMAC-verified via
+    /// `SinchChannel::verify_signature`.
+    pub sinch: Option<Arc<SinchChannel>>,
     pub nextcloud_talk: Option<Arc<NextcloudTalkChannel>>,
     /// Nextcloud Talk webhook secret for signature verification
     pub nextcloud_talk_webhook_secret: Option<Arc<str>>,
@@ -696,6 +704,25 @@ pub async fn run_gateway(
         ))
     });
 
+    // Sinch channel (if configured AND enabled). Outbound goes to the
+    // region-scoped Batches API; inbound is HMAC-verified by the gateway
+    // handler at POST /sinch/sms.
+    let sinch_channel: Option<Arc<SinchChannel>> = config
+        .channels
+        .sinch
+        .as_ref()
+        .filter(|sn| sn.enabled)
+        .map(|sn| {
+            Arc::new(SinchChannel::new(
+                sn.service_plan_id.clone(),
+                sn.api_token.clone(),
+                sn.region.clone(),
+                sn.from_number.clone(),
+                sn.allowed_numbers.clone(),
+                sn.callback_secret.clone(),
+            ))
+        });
+
     // Linq signing secret for webhook signature verification
     // Priority: environment variable > config file
     let linq_signing_secret: Option<Arc<str>> = std::env::var("ZEROCLAW_LINQ_SIGNING_SECRET")
@@ -985,6 +1012,7 @@ pub async fn run_gateway(
         whatsapp_app_secret,
         linq: linq_channel,
         linq_signing_secret,
+        sinch: sinch_channel,
         nextcloud_talk: nextcloud_talk_channel,
         nextcloud_talk_webhook_secret,
         wati: wati_channel,
@@ -1047,6 +1075,7 @@ pub async fn run_gateway(
         .route("/whatsapp", get(handle_whatsapp_verify))
         .route("/whatsapp", post(handle_whatsapp_message))
         .route("/linq", post(handle_linq_webhook))
+        .route("/sinch/sms", post(handle_sinch_sms_webhook))
         .route("/wati", get(handle_wati_verify))
         .route("/wati", post(handle_wati_webhook))
         .route("/nextcloud-talk", post(handle_nextcloud_talk_webhook))
@@ -2091,6 +2120,131 @@ async fn handle_linq_webhook(
     (StatusCode::OK, Json(serde_json::json!({"status": "ok"})))
 }
 
+/// POST /sinch/sms — incoming SMS webhook from Sinch.
+///
+/// Sinch sends `application/json` POSTs with at least `from`, `to`, `body`,
+/// `id`, and `type` (we only act on `mo_text`). The handler:
+///
+/// 1. Reads the `x-sinch-webhook-signature` header (`v1,nonce,base64-sig`)
+///    and verifies it via `SinchChannel::verify_signature` over the raw body
+///    bytes. A failure returns 401 and the SMS is dropped — no message ever
+///    reaches the agent. (Unlike Twilio, Sinch's signature is over the body
+///    only, not the URL — no host reconstruction needed.)
+/// 2. Parses the body as JSON. Malformed JSON returns 400.
+/// 3. Calls `SinchChannel::parse_webhook_payload`, which checks
+///    `type == "mo_text"` and applies the `allowed_numbers` allowlist.
+///    Filtered/non-text payloads return 200 with an empty body so Sinch
+///    doesn't retry.
+/// 4. Forwards the resulting `ChannelMessage` to the agent loop and replies
+///    via `SinchChannel::send`.
+async fn handle_sinch_sms_webhook(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> impl IntoResponse {
+    let Some(ref sinch) = state.sinch else {
+        return (
+            StatusCode::NOT_FOUND,
+            [(header::CONTENT_TYPE, "application/json")],
+            Json(serde_json::json!({"error": "Sinch not configured"})).to_string(),
+        );
+    };
+
+    let signature = headers
+        .get("x-sinch-webhook-signature")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    if !sinch.verify_signature(&body, signature) {
+        tracing::warn!(
+            "Sinch webhook signature verification failed (signature: {})",
+            if signature.is_empty() {
+                "missing"
+            } else {
+                "invalid"
+            }
+        );
+        return (
+            StatusCode::UNAUTHORIZED,
+            [(header::CONTENT_TYPE, "application/json")],
+            Json(serde_json::json!({"error": "Invalid signature"})).to_string(),
+        );
+    }
+
+    let payload: serde_json::Value = match serde_json::from_slice(&body) {
+        Ok(v) => v,
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                [(header::CONTENT_TYPE, "application/json")],
+                Json(serde_json::json!({"error": "Invalid JSON body"})).to_string(),
+            );
+        }
+    };
+
+    let Some(msg) = sinch.parse_webhook_payload(&payload) else {
+        // Either the type wasn't `mo_text`, the sender wasn't on the
+        // allowlist, or the body was empty. ACK with 200 so Sinch doesn't
+        // retry.
+        return (
+            StatusCode::OK,
+            [(header::CONTENT_TYPE, "application/json")],
+            String::new(),
+        );
+    };
+
+    tracing::info!(
+        "Sinch SMS from {}: {}",
+        msg.sender,
+        truncate_with_ellipsis(&msg.content, 50)
+    );
+    let session_id = sender_session_id("sinch", &msg);
+
+    if state.auto_save && !zeroclaw_memory::should_skip_autosave_content(&msg.content) {
+        let key = sinch_memory_key(&msg);
+        let _ = state
+            .mem
+            .store(
+                &key,
+                &msg.content,
+                MemoryCategory::Conversation,
+                Some(&session_id),
+            )
+            .await;
+    }
+
+    match Box::pin(run_gateway_chat_with_tools(
+        &state,
+        &msg.content,
+        Some(&session_id),
+    ))
+    .await
+    {
+        Ok(GatewayChatOutcome { response, .. }) => {
+            if let Err(e) = sinch
+                .send(&SendMessage::new(response, &msg.reply_target))
+                .await
+            {
+                tracing::error!("Failed to send Sinch reply: {e}");
+            }
+        }
+        Err(e) => {
+            tracing::error!("LLM error for Sinch message: {e:#}");
+            let _ = sinch
+                .send(&SendMessage::new(
+                    "Sorry, I couldn't process your message right now.",
+                    &msg.reply_target,
+                ))
+                .await;
+        }
+    }
+
+    (
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, "application/json")],
+        String::new(),
+    )
+}
+
 /// GET /wati — WATI webhook verification (echoes hub.challenge)
 async fn handle_wati_verify(
     State(state): State<AppState>,
@@ -2678,6 +2832,7 @@ mod tests {
             whatsapp_app_secret: None,
             linq: None,
             linq_signing_secret: None,
+            sinch: None,
             nextcloud_talk: None,
             nextcloud_talk_webhook_secret: None,
             wati: None,
@@ -2752,6 +2907,7 @@ mod tests {
             whatsapp_app_secret: None,
             linq: None,
             linq_signing_secret: None,
+            sinch: None,
             nextcloud_talk: None,
             nextcloud_talk_webhook_secret: None,
             wati: None,
@@ -3211,6 +3367,7 @@ mod tests {
             whatsapp_app_secret: None,
             linq: None,
             linq_signing_secret: None,
+            sinch: None,
             nextcloud_talk: None,
             nextcloud_talk_webhook_secret: None,
             wati: None,
@@ -3293,6 +3450,7 @@ mod tests {
             whatsapp_app_secret: None,
             linq: None,
             linq_signing_secret: None,
+            sinch: None,
             nextcloud_talk: None,
             nextcloud_talk_webhook_secret: None,
             wati: None,
@@ -3387,6 +3545,7 @@ mod tests {
             whatsapp_app_secret: None,
             linq: None,
             linq_signing_secret: None,
+            sinch: None,
             nextcloud_talk: None,
             nextcloud_talk_webhook_secret: None,
             wati: None,
@@ -3453,6 +3612,7 @@ mod tests {
             whatsapp_app_secret: None,
             linq: None,
             linq_signing_secret: None,
+            sinch: None,
             nextcloud_talk: None,
             nextcloud_talk_webhook_secret: None,
             wati: None,
@@ -3524,6 +3684,7 @@ mod tests {
             whatsapp_app_secret: None,
             linq: None,
             linq_signing_secret: None,
+            sinch: None,
             nextcloud_talk: None,
             nextcloud_talk_webhook_secret: None,
             wati: None,
@@ -3600,6 +3761,7 @@ mod tests {
             whatsapp_app_secret: None,
             linq: None,
             linq_signing_secret: None,
+            sinch: None,
             nextcloud_talk: None,
             nextcloud_talk_webhook_secret: None,
             wati: None,
@@ -3673,6 +3835,7 @@ mod tests {
             whatsapp_app_secret: None,
             linq: None,
             linq_signing_secret: None,
+            sinch: None,
             nextcloud_talk: Some(channel),
             nextcloud_talk_webhook_secret: Some(Arc::from(secret)),
             wati: None,

--- a/docs/book/src/channels/chat-others.md
+++ b/docs/book/src/channels/chat-others.md
@@ -148,6 +148,39 @@ databases = ["..."]                # DB IDs the agent can write to
 
 Treats a Notion database as a message surface. Useful for asynchronous workflows where the "channel" is a task inbox.
 
+## Sinch (SMS)
+
+```toml
+[channels.sinch]
+enabled = false                    # disabled by default — opt in explicitly
+service_plan_id = "..."            # public Sinch project ID
+api_token = "..."                  # Bearer token for outbound (xms/v1/.../batches)
+region = "us"                      # "us" or "eu" (data residency)
+from_number = "+15555550100"       # E.164, provisioned in your Sinch console
+allowed_numbers = ["+15555550199"] # exact match; "*" allows all
+callback_secret = "..."            # HMAC-SHA256 secret for inbound webhooks
+```
+
+Sinch is a Twilio-sibling SMS gateway popular in the Nordics and APAC. Mirrors the [Twilio](#) gateway-registered pattern: this is a webhook-driven channel, not a polling one.
+
+**Auth model.** Outbound requests use Bearer auth on `https://{region}.sms.api.sinch.com/xms/v1/{service_plan_id}/batches`. The `service_plan_id` identifies your Sinch project (public) and the `api_token` is the secret credential. Inbound webhooks are signed separately with `callback_secret` — do not reuse the API token.
+
+**Inbound webhook.** Configure your Sinch service plan's "Callback URL" to point at:
+
+```
+https://{public-gateway-url}/sinch/sms
+```
+
+This must be reachable from the public internet, so you'll typically run one of the configured `[tunnel]` providers (Cloudflare Tunnel, Tailscale Funnel, ngrok, Pinggy, or a custom command). The gateway hosts `POST /sinch/sms` directly — there is no webhook subscription dance.
+
+**Signature scheme.** Sinch sends an `x-sinch-webhook-signature` header in the format `v1,{nonce},{base64-sig}`. The signature is HMAC-SHA256 over `nonce_bytes || raw_body` keyed by `callback_secret`. The gateway verifies this header on every inbound request and returns `401` on mismatch — there is no fail-open path. The signature covers the body only, not the URL, so reverse-proxy host rewrites are harmless.
+
+**Region selection.** `region = "us"` targets `us.sms.api.sinch.com`; `region = "eu"` targets `eu.sms.api.sinch.com`. Pick whichever matches the data residency configured for your Sinch project — the wrong region will return 401/404 even with valid credentials.
+
+**Trial accounts.** Sinch trial credentials can only send to numbers you've verified in the Sinch dashboard. Add your own test number to the allowed list and verify it before expecting messages to land.
+
+**Cost.** SMS pricing is per-segment and varies by destination country — long bodies are split into ≤1600-char chunks with a `(i/N)` continuation marker, and each chunk is billed separately. See Sinch's pricing page for current rates.
+
 ---
 
 ## When to prefer a dedicated guide


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - New `SinchChannel`: gateway-registered SMS channel for Sinch, sibling to the recently merged Twilio (#6429). Same architecture (`listen()` no-op, gateway hosts a hardcoded `POST /sinch/sms` route), different signature scheme — Sinch uses an `x-sinch-webhook-signature: v1,{nonce},{base64-sig}` header where `sig = HMAC-SHA256(nonce + raw_body, callback_secret)`.
  - Outbound: `POST https://{region}.sms.api.sinch.com/xms/v1/{service_plan_id}/batches` with `Authorization: Bearer {api_token}`, JSON body `{"from", "to":[…], "body"}`. `region` is `us` or `eu` (default `us`). Bodies over 1600 chars are split at sentence/word boundaries with `(i/N) ` continuation markers.
  - Inbound at `POST /sinch/sms`: reads `x-sinch-webhook-signature`, splits on `,` into `(version, nonce, expected_sig)`, validates the `v1` prefix, recomputes HMAC-SHA256 in constant time, parses the JSON payload, filters to `type == "mo_text"`, applies the allowlist, and forwards a `ChannelMessage`. Fails closed with 401 on signature mismatch.
- **Scope boundary:** Sinch only. No changes to Twilio, Plivo, or any other channel. No new external crates (`hmac`+`sha2`+`base64` already in the workspace). Out of scope: MMS, delivery receipts, Sinch Voice/Conversation/Verification APIs, `request_approval()` integration.
- **Blast radius:** New optional channel module + new gateway route + new optional config section. Default `enabled = false`; the gateway route returns 404 when Sinch is not configured. `channel-sinch` is now in the `default` cargo feature set; downstream packagers building with `--no-default-features` are unaffected.
- **Linked issue(s):** Closes #6452

## Validation Evidence (required)

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` → clean.
  - `cargo clippy --all-targets -- -D warnings` (workspace) → clean, zero warnings.
  - `cargo test -p zeroclaw-channels --features channel-sinch --lib sinch::` → **20 passed, 0 failed**.
  - `cargo test -p zeroclaw-config --lib` → **620 passed, 0 failed**.
  - `cargo test -p zeroclaw-gateway --lib` → **164 passed, 0 failed**.
  - `cargo build --release -p zeroclawlabs` → `Finished release profile [optimized] target(s) in 4m 38s`, exit 0.
- **Beyond CI — what was manually verified:**
  - Reviewed all 20 unit + wiremock tests covering allowlist matching (empty/wildcard/exact/whitespace-stripped), webhook payload parsing (drops outside-allowlist + empty + non-`mo_text` types; accepts allowed `mo_text`), `v1,nonce,sig` signature validator (round-trip against self-computed expected; tampered body / wrong secret / `v0,...` rejected / missing nonce / empty header all fail), 1600-char chunk splitter with `(i/N)` markers, wiremock outbound POST shape (Bearer auth + JSON `{"from","to":[..],"body"}` body + region URL substitution), and 4xx → `Err`.
  - Verified `cargo clippy --all-targets -- -D warnings` is clean across the entire workspace.
  - Verified the gateway handler validates the signature **before** parsing JSON or routing to the agent — fails closed (401) on signature mismatch and 400 on JSON parse error.
  - Confirmed `cargo build --release -p zeroclawlabs` succeeds with default features (which now include `channel-sinch`) — 4m 38s, exit 0.
  - **Did NOT verify against a live Sinch account.** The signature math, route plumbing, region URL substitution, and allowlist all pass under wiremock + unit tests, but the end-to-end "operator texts the number, gets a reply" round-trip has not been smoke-tested. Recommend the operator land this with `enabled = false` first, configure on staging behind their existing `[tunnel]` provider, smoke test, then flip enabled.
  - Did NOT verify: MMS / multimedia, delivery receipts / status callbacks, Sinch Voice / Conversation API / Verification API, `request_approval()` integration.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `Yes` — outbound HTTPS to `{region}.sms.api.sinch.com` only when `[channels.sinch]` is configured and `enabled = true`. Inbound is the new `POST /sinch/sms` gateway route, which 404s when Sinch is not configured.
- Secrets / tokens / credentials handling changed? `Yes` — two new secret fields in `[channels.sinch]`: `api_token` (Bearer for outbound) and `callback_secret` (HMAC key for inbound signature verification — distinct from `api_token`, copied separately from the Sinch dashboard). Both redacted via the existing config-secret pipeline; never logged.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No` — fixtures use synthetic numbers and Sinch's documented test patterns.
- **Risk and mitigation:**
  - `AGENTS.md` classifies `crates/zeroclaw-gateway/src/**` as **risk: high**, hence the explicit security walkthrough.
  - **Signature verification fails closed**: missing or invalid `x-sinch-webhook-signature` → 401, message dropped before reaching the agent loop.
  - **`v1` version prefix enforced**: anything else (including `v0`) rejected immediately.
  - **Allowlist enforced**: senders not in `allowed_numbers` are dropped at the channel boundary even if signature is valid.
  - **Constant-time compare** on the base64 signature to avoid timing leaks.
  - **Default `enabled = false`** means a misconfigured deployment cannot accidentally accept SMS.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `Yes` — additive only.
- **Upgrade steps for existing users:** None required. `[channels.sinch]` is optional; existing configs without it continue to work. To opt in: add the section with `service_plan_id`, `api_token` (secret), `region` (defaults to `us`), `from_number`, `allowed_numbers`, and `callback_secret` (secret), then set `enabled = true` and configure Sinch's callback webhook to `https://<your-tunnel>/sinch/sms` (POST).

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** Single squash-merge revert: `git revert <merge-sha>`. No migrations, no schema changes.
- **Feature flags or config toggles:**
  - Compile-time: feature flag `channel-sinch` on `zeroclaw-channels` (default-on; can be turned off to remove the module).
  - Runtime: `[channels.sinch] enabled = false` disables without removing config or code.
- **Observable failure symptoms:**
  - Inbound signature failures: grep gateway logs for `sinch_signature_invalid` / 401 responses on `POST /sinch/sms`.
  - Outbound send failures: errors from `SinchChannel::send` log the upstream Sinch error code; grep for `sinch_send_failed`.
  - Region misconfiguration: 404 / 401 on outbound POSTs (operator picked the wrong `us`/`eu` value).
  - Allowlist drops: grep for `sinch_sender_not_allowed`.
  - Misconfiguration at startup: the channel will not appear in `zeroclaw channel list`.

