### PR TITLE
feat(tools): philips_hue tool for local Hue Bridge

### DIFF
--- a/CHANGELOG-next.md
+++ b/CHANGELOG-next.md
@@ -116,6 +116,7 @@
 
 - `SessionResetTool` and `SessionDeleteTool` for in-agent session management (#5696).
 - `SessionsCurrentTool` exposes the active session identity (#6033).
+- `philips_hue` tool — local Hue Bridge v2 CLIP API client, gated by application key and `allowed_resource_types` allowlist; `verify_tls` defaults to `false` for self-signed bridge certs (#6449).
 
 ### Plugins
 

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -385,6 +385,11 @@ pub struct Config {
     #[nested]
     pub jira: JiraConfig,
 
+    /// Philips Hue integration configuration (`[philips_hue]`).
+    #[serde(default)]
+    #[nested]
+    pub philips_hue: PhilipsHueConfig,
+
     /// Secure inter-node transport configuration (`[node_transport]`).
     #[serde(default)]
     #[nested]
@@ -9316,6 +9321,101 @@ impl Default for JiraConfig {
     }
 }
 
+/// Philips Hue integration configuration (`[philips_hue]`).
+///
+/// When `enabled = true`, registers the `philips_hue` tool which can list
+/// and control lights, scenes, rooms, and groups on a local Philips Hue
+/// Bridge via its v2 CLIP API. Requires `bridge_address` (the bridge's IP
+/// or `<id>.local` hostname) and `application_key` (the bridge "username"
+/// minted via push-button pairing), or the `PHILIPS_HUE_APPLICATION_KEY`
+/// env var.
+///
+/// ## Defaults
+/// - `enabled`: `false`
+/// - `allowed_resource_types`: `["light", "grouped_light", "scene", "room"]` —
+///   the v2 resource types the agent is permitted to mutate. Read actions
+///   (`list_*`, `get_*`) ignore this allowlist.
+/// - `verify_tls`: `false` — Hue bridges present a self-signed certificate
+///   on the local network, so TLS verification is disabled by default.
+///   Set to `true` only if you have installed the bridge's CA in the
+///   system trust store.
+/// - `request_timeout_secs`: `15`
+///
+/// ## Auth (push-button pairing)
+/// First-time setup, performed once outside ZeroClaw:
+///
+/// 1. Discover the bridge IP via `https://discovery.meethue.com` or mDNS.
+/// 2. Press the round button on top of the bridge.
+/// 3. Within 30 seconds:
+///    `curl -k -X POST -d '{"devicetype":"zeroclaw#host","generateclientkey":true}' \`
+///    `      https://<bridge-ip>/api`
+/// 4. Copy the `username` from the response into `application_key`
+///    (or export `PHILIPS_HUE_APPLICATION_KEY`).
+///
+/// The application key is stored encrypted at rest when
+/// `[secrets] encrypt = true`.
+#[derive(Debug, Clone, Serialize, Deserialize, Configurable)]
+#[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
+#[prefix = "philips-hue"]
+#[integration(
+    category = "ToolsAutomation",
+    display_name = "Philips Hue",
+    description = "Smart lighting via local Hue Bridge",
+    status_field = "enabled"
+)]
+pub struct PhilipsHueConfig {
+    /// Enable the `philips_hue` tool. Default: `false`.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Hue Bridge address — IP (`192.168.1.42`) or mDNS hostname
+    /// (`<bridge-id>.local`).
+    #[serde(default)]
+    pub bridge_address: String,
+    /// Application key (bridge "username") minted via push-button pairing.
+    /// Encrypted at rest. Falls back to `PHILIPS_HUE_APPLICATION_KEY` env var.
+    #[serde(default)]
+    #[secret]
+    #[cfg_attr(feature = "schema-export", schemars(extend("x-secret" = true)))]
+    pub application_key: String,
+    /// Resource types the agent is permitted to mutate (`set_*`, `recall_*`).
+    /// Empty means all mutations are blocked.
+    #[serde(default = "default_philips_hue_allowed_resource_types")]
+    pub allowed_resource_types: Vec<String>,
+    /// Verify TLS certificate of the bridge. Default `false` because
+    /// bridges ship with self-signed certs on the local network.
+    #[serde(default)]
+    pub verify_tls: bool,
+    /// Request timeout in seconds. Default: `15`.
+    #[serde(default = "default_philips_hue_timeout_secs")]
+    pub request_timeout_secs: u64,
+}
+
+fn default_philips_hue_allowed_resource_types() -> Vec<String> {
+    vec![
+        "light".into(),
+        "grouped_light".into(),
+        "scene".into(),
+        "room".into(),
+    ]
+}
+
+fn default_philips_hue_timeout_secs() -> u64 {
+    15
+}
+
+impl Default for PhilipsHueConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            bridge_address: String::new(),
+            application_key: String::new(),
+            allowed_resource_types: default_philips_hue_allowed_resource_types(),
+            verify_tls: false,
+            request_timeout_secs: default_philips_hue_timeout_secs(),
+        }
+    }
+}
+
 ///
 /// Controls the read-only cloud transformation analysis tools:
 /// IaC review, migration assessment, cost analysis, and architecture review.
@@ -9634,6 +9734,7 @@ impl Default for Config {
             onboard_state: OnboardStateConfig::default(),
             notion: NotionConfig::default(),
             jira: JiraConfig::default(),
+            philips_hue: PhilipsHueConfig::default(),
             node_transport: NodeTransportConfig::default(),
             knowledge: KnowledgeConfig::default(),
             linkedin: LinkedInConfig::default(),
@@ -12595,6 +12696,7 @@ auto_save = true
             onboard_state: OnboardStateConfig::default(),
             notion: NotionConfig::default(),
             jira: JiraConfig::default(),
+            philips_hue: PhilipsHueConfig::default(),
             node_transport: NodeTransportConfig::default(),
             knowledge: KnowledgeConfig::default(),
             linkedin: LinkedInConfig::default(),
@@ -13166,6 +13268,7 @@ default_temperature = 0.7
             onboard_state: OnboardStateConfig::default(),
             notion: NotionConfig::default(),
             jira: JiraConfig::default(),
+            philips_hue: PhilipsHueConfig::default(),
             node_transport: NodeTransportConfig::default(),
             knowledge: KnowledgeConfig::default(),
             linkedin: LinkedInConfig::default(),

--- a/crates/zeroclaw-runtime/src/integrations/mod.rs
+++ b/crates/zeroclaw-runtime/src/integrations/mod.rs
@@ -148,6 +148,21 @@ pub fn show_integration_info(config: &Config, name: &str) -> Result<()> {
             println!("    Supports city names, IATA airport codes, GPS coordinates,");
             println!("    postal/zip codes, and Unicode location names.");
         }
+        "Philips Hue" => {
+            println!("  Setup:");
+            println!("    1. Discover bridge IP via https://discovery.meethue.com or mDNS.");
+            println!("    2. Press the round button on top of the bridge.");
+            println!("    3. Within 30 seconds, mint an application key:");
+            println!(
+                "       curl -k -X POST -d '{{\"devicetype\":\"zeroclaw#host\",\"generateclientkey\":true}}' \\"
+            );
+            println!("            https://<bridge-ip>/api");
+            println!("    4. Add to config:");
+            println!("       [philips_hue]");
+            println!("       enabled = true");
+            println!("       bridge_address = \"192.168.1.42\"");
+            println!("       application_key = \"...\"  # or set PHILIPS_HUE_APPLICATION_KEY");
+        }
         _ if entry.category == IntegrationCategory::Chat => {
             println!("  Setup:");
             println!("    Run: zeroclaw onboard --channels-only");

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -90,6 +90,7 @@ pub use zeroclaw_tools::notion_tool::NotionTool;
 pub use zeroclaw_tools::opencode_cli::OpenCodeCliTool;
 #[cfg(feature = "rag-pdf")]
 pub use zeroclaw_tools::pdf_read::PdfReadTool;
+pub use zeroclaw_tools::philips_hue::PhilipsHueTool;
 pub use zeroclaw_tools::pipeline::PipelineTool;
 pub use zeroclaw_tools::poll::PollTool;
 pub use zeroclaw_tools::project_intel::ProjectIntelTool;
@@ -600,6 +601,38 @@ pub fn all_tools_with_runtime(
                 security.clone(),
                 root_config.jira.timeout_secs,
             )));
+        }
+    }
+
+    // Philips Hue integration (config-gated)
+    if root_config.philips_hue.enabled {
+        let application_key = if root_config.philips_hue.application_key.trim().is_empty() {
+            std::env::var("PHILIPS_HUE_APPLICATION_KEY").unwrap_or_default()
+        } else {
+            root_config.philips_hue.application_key.trim().to_string()
+        };
+        if application_key.trim().is_empty() {
+            tracing::warn!(
+                "philips_hue: enabled but no application key found (set philips_hue.application_key or PHILIPS_HUE_APPLICATION_KEY env var) — skipping registration"
+            );
+        } else if root_config.philips_hue.bridge_address.trim().is_empty() {
+            tracing::warn!(
+                "philips_hue: enabled but philips_hue.bridge_address is empty — skipping registration"
+            );
+        } else {
+            match PhilipsHueTool::new(
+                root_config.philips_hue.bridge_address.trim().to_string(),
+                application_key,
+                root_config.philips_hue.allowed_resource_types.clone(),
+                root_config.philips_hue.verify_tls,
+                root_config.philips_hue.request_timeout_secs,
+                security.clone(),
+            ) {
+                Ok(tool) => tool_arcs.push(Arc::new(tool)),
+                Err(e) => tracing::warn!(
+                    "philips_hue: failed to construct HTTP client: {e} — skipping registration"
+                ),
+            }
         }
     }
 

--- a/crates/zeroclaw-tools/src/lib.rs
+++ b/crates/zeroclaw-tools/src/lib.rs
@@ -53,6 +53,7 @@ pub mod node_capabilities;
 pub mod notion_tool;
 pub mod opencode_cli;
 pub mod pdf_read;
+pub mod philips_hue;
 pub mod pipeline;
 pub mod poll;
 pub mod project_intel;

--- a/crates/zeroclaw-tools/src/philips_hue.rs
+++ b/crates/zeroclaw-tools/src/philips_hue.rs
@@ -1,0 +1,622 @@
+//! Philips Hue tool — local Hue Bridge v2 CLIP API client.
+//!
+//! Authenticates with an `application_key` (the bridge "username" minted
+//! via push-button pairing). Sent in the `hue-application-key` header.
+//!
+//! Read actions (`list_*`, `get_light`) require `ToolOperation::Read`.
+//! Mutating actions (`set_light`, `recall_scene`, `set_group`) require
+//! `ToolOperation::Act` and are further restricted to resource types in
+//! `allowed_resource_types`.
+//!
+//! TLS: bridges ship with self-signed certs on the local network, so the
+//! client accepts invalid certs unless the operator opts into verification
+//! by setting `verify_tls = true`.
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use std::sync::Arc;
+use std::time::Duration;
+use zeroclaw_api::tool::{Tool, ToolResult};
+use zeroclaw_config::policy::{SecurityPolicy, ToolOperation};
+
+const MAX_ERROR_BODY_CHARS: usize = 500;
+
+/// Tool for interacting with a Philips Hue Bridge over its v2 CLIP API.
+pub struct PhilipsHueTool {
+    bridge_address: String,
+    application_key: String,
+    allowed_resource_types: Vec<String>,
+    request_timeout_secs: u64,
+    http: reqwest::Client,
+    security: Arc<SecurityPolicy>,
+}
+
+impl PhilipsHueTool {
+    /// Create a new Philips Hue tool.
+    ///
+    /// Returns an error only if the underlying `reqwest::Client` cannot be
+    /// constructed (e.g. system TLS init failure). `verify_tls = false`
+    /// flips on `danger_accept_invalid_certs` because Hue bridges present
+    /// a self-signed cert on the local network.
+    pub fn new(
+        bridge_address: String,
+        application_key: String,
+        allowed_resource_types: Vec<String>,
+        verify_tls: bool,
+        request_timeout_secs: u64,
+        security: Arc<SecurityPolicy>,
+    ) -> anyhow::Result<Self> {
+        let bridge_address = bridge_address.trim().trim_end_matches('/').to_string();
+        let allowed_resource_types = allowed_resource_types
+            .into_iter()
+            .map(|d| d.trim().to_string())
+            .filter(|d| !d.is_empty())
+            .collect();
+        let http = reqwest::Client::builder()
+            .danger_accept_invalid_certs(!verify_tls)
+            .timeout(Duration::from_secs(request_timeout_secs.max(1)))
+            .build()?;
+        Ok(Self {
+            bridge_address,
+            application_key,
+            allowed_resource_types,
+            request_timeout_secs,
+            http,
+            security,
+        })
+    }
+
+    fn headers(&self) -> anyhow::Result<reqwest::header::HeaderMap> {
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(
+            "hue-application-key",
+            self.application_key
+                .parse()
+                .map_err(|e| anyhow::anyhow!("Invalid Hue application_key header: {e}"))?,
+        );
+        headers.insert("Content-Type", "application/json".parse().unwrap());
+        Ok(headers)
+    }
+
+    fn timeout(&self) -> Duration {
+        Duration::from_secs(self.request_timeout_secs.max(1))
+    }
+
+    fn is_resource_type_allowed(&self, resource_type: &str) -> bool {
+        self.allowed_resource_types
+            .iter()
+            .any(|t| t == resource_type)
+    }
+
+    fn resource_url(&self, resource_type: &str, id: Option<&str>) -> String {
+        let base = format!(
+            "https://{}/clip/v2/resource/{resource_type}",
+            self.bridge_address
+        );
+        match id {
+            Some(id) => format!("{base}/{id}"),
+            None => base,
+        }
+    }
+
+    async fn list_resource(&self, resource_type: &str) -> anyhow::Result<Value> {
+        let url = self.resource_url(resource_type, None);
+        let resp = self
+            .http
+            .get(&url)
+            .headers(self.headers()?)
+            .timeout(self.timeout())
+            .send()
+            .await?;
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            let truncated =
+                crate::util_helpers::truncate_with_ellipsis(&body, MAX_ERROR_BODY_CHARS);
+            anyhow::bail!("Philips Hue list {resource_type} failed ({status}): {truncated}");
+        }
+        resp.json().await.map_err(Into::into)
+    }
+
+    async fn get_resource(&self, resource_type: &str, id: &str) -> anyhow::Result<Value> {
+        let url = self.resource_url(resource_type, Some(id));
+        let resp = self
+            .http
+            .get(&url)
+            .headers(self.headers()?)
+            .timeout(self.timeout())
+            .send()
+            .await?;
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            let truncated =
+                crate::util_helpers::truncate_with_ellipsis(&body, MAX_ERROR_BODY_CHARS);
+            anyhow::bail!("Philips Hue get {resource_type}/{id} failed ({status}): {truncated}");
+        }
+        resp.json().await.map_err(Into::into)
+    }
+
+    async fn put_resource(
+        &self,
+        resource_type: &str,
+        id: &str,
+        body: &Value,
+    ) -> anyhow::Result<Value> {
+        let url = self.resource_url(resource_type, Some(id));
+        let resp = self
+            .http
+            .put(&url)
+            .headers(self.headers()?)
+            .json(body)
+            .timeout(self.timeout())
+            .send()
+            .await?;
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            let truncated =
+                crate::util_helpers::truncate_with_ellipsis(&body, MAX_ERROR_BODY_CHARS);
+            anyhow::bail!("Philips Hue put {resource_type}/{id} failed ({status}): {truncated}");
+        }
+        resp.json().await.map_err(Into::into)
+    }
+
+    /// Build a v2 light state body from optional flags.
+    fn build_light_state(
+        on: Option<bool>,
+        brightness: Option<f64>,
+        color_xy: Option<(f64, f64)>,
+        color_temperature_mirek: Option<u32>,
+    ) -> Value {
+        let mut body = json!({});
+        if let Some(on) = on {
+            body["on"] = json!({ "on": on });
+        }
+        if let Some(b) = brightness {
+            body["dimming"] = json!({ "brightness": b });
+        }
+        if let Some((x, y)) = color_xy {
+            body["color"] = json!({ "xy": { "x": x, "y": y } });
+        }
+        if let Some(mirek) = color_temperature_mirek {
+            body["color_temperature"] = json!({ "mirek": mirek });
+        }
+        body
+    }
+}
+
+#[async_trait]
+impl Tool for PhilipsHueTool {
+    fn name(&self) -> &str {
+        "philips_hue"
+    }
+
+    fn description(&self) -> &str {
+        "Control a local Philips Hue Bridge via the v2 CLIP API. Read \
+         lights, scenes, rooms, and groups (list_lights, get_light, \
+         list_scenes, list_rooms, list_groups). Mutate state with \
+         set_light, recall_scene, or set_group — restricted to the \
+         operator-configured allowed_resource_types."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": [
+                        "list_lights",
+                        "get_light",
+                        "set_light",
+                        "list_scenes",
+                        "recall_scene",
+                        "list_rooms",
+                        "list_groups",
+                        "set_group"
+                    ],
+                    "description": "The Philips Hue operation to perform."
+                },
+                "id": {
+                    "type": "string",
+                    "description": "Resource ID (UUID). Required for get_light, set_light, recall_scene, set_group."
+                },
+                "on": {
+                    "type": "boolean",
+                    "description": "Power state for set_light / set_group."
+                },
+                "brightness": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 100,
+                    "description": "Brightness percentage 0-100 for set_light / set_group."
+                },
+                "color_xy": {
+                    "type": "object",
+                    "properties": {
+                        "x": { "type": "number" },
+                        "y": { "type": "number" }
+                    },
+                    "description": "CIE 1931 xy color coordinates for set_light / set_group."
+                },
+                "color_temperature_mirek": {
+                    "type": "integer",
+                    "minimum": 153,
+                    "maximum": 500,
+                    "description": "Color temperature in mirek (153-500) for set_light / set_group."
+                }
+            },
+            "required": ["action"]
+        })
+    }
+
+    async fn execute(&self, args: Value) -> anyhow::Result<ToolResult> {
+        let action = match args.get("action").and_then(|v| v.as_str()) {
+            Some(a) => a,
+            None => {
+                return Ok(ToolResult {
+                    success: false,
+                    output: String::new(),
+                    error: Some("Missing required parameter: action".into()),
+                });
+            }
+        };
+
+        let (operation, resource_type) = match action {
+            "list_lights" | "get_light" => (ToolOperation::Read, "light"),
+            "set_light" => (ToolOperation::Act, "light"),
+            "list_scenes" => (ToolOperation::Read, "scene"),
+            "recall_scene" => (ToolOperation::Act, "scene"),
+            "list_rooms" => (ToolOperation::Read, "room"),
+            "list_groups" => (ToolOperation::Read, "grouped_light"),
+            "set_group" => (ToolOperation::Act, "grouped_light"),
+            _ => {
+                return Ok(ToolResult {
+                    success: false,
+                    output: String::new(),
+                    error: Some(format!(
+                        "Unknown action: {action}. Valid actions: list_lights, get_light, set_light, list_scenes, recall_scene, list_rooms, list_groups, set_group"
+                    )),
+                });
+            }
+        };
+
+        if let Err(error) = self
+            .security
+            .enforce_tool_operation(operation, "philips_hue")
+        {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(error),
+            });
+        }
+
+        if matches!(operation, ToolOperation::Act) && !self.is_resource_type_allowed(resource_type)
+        {
+            let allowed = if self.allowed_resource_types.is_empty() {
+                "(none — allowed_resource_types is empty)".to_string()
+            } else {
+                self.allowed_resource_types.join(", ")
+            };
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!(
+                    "Resource type '{resource_type}' is not in allowed_resource_types. Allowed: {allowed}"
+                )),
+            });
+        }
+
+        let result = match action {
+            "list_lights" => self.list_resource("light").await,
+            "list_scenes" => self.list_resource("scene").await,
+            "list_rooms" => self.list_resource("room").await,
+            "list_groups" => self.list_resource("grouped_light").await,
+            "get_light" => match args.get("id").and_then(|v| v.as_str()) {
+                Some(id) if !id.trim().is_empty() => self.get_resource("light", id.trim()).await,
+                _ => {
+                    return Ok(ToolResult {
+                        success: false,
+                        output: String::new(),
+                        error: Some("get_light requires id parameter".into()),
+                    });
+                }
+            },
+            "set_light" | "set_group" => {
+                let id = match args.get("id").and_then(|v| v.as_str()) {
+                    Some(id) if !id.trim().is_empty() => id.trim().to_string(),
+                    _ => {
+                        return Ok(ToolResult {
+                            success: false,
+                            output: String::new(),
+                            error: Some(format!("{action} requires id parameter")),
+                        });
+                    }
+                };
+                let on = args.get("on").and_then(|v| v.as_bool());
+                let brightness = args.get("brightness").and_then(|v| v.as_f64());
+                let color_xy = args
+                    .get("color_xy")
+                    .and_then(|v| v.as_object())
+                    .and_then(|o| {
+                        let x = o.get("x").and_then(|v| v.as_f64())?;
+                        let y = o.get("y").and_then(|v| v.as_f64())?;
+                        Some((x, y))
+                    });
+                let mirek = args
+                    .get("color_temperature_mirek")
+                    .and_then(|v| v.as_u64())
+                    .map(|m| m as u32);
+                let body = Self::build_light_state(on, brightness, color_xy, mirek);
+                if body.as_object().is_none_or(|o| o.is_empty()) {
+                    return Ok(ToolResult {
+                        success: false,
+                        output: String::new(),
+                        error: Some(format!(
+                            "{action} requires at least one of: on, brightness, color_xy, color_temperature_mirek"
+                        )),
+                    });
+                }
+                self.put_resource(resource_type, &id, &body).await
+            }
+            "recall_scene" => match args.get("id").and_then(|v| v.as_str()) {
+                Some(id) if !id.trim().is_empty() => {
+                    let body = json!({ "recall": { "action": "active" } });
+                    self.put_resource("scene", id.trim(), &body).await
+                }
+                _ => {
+                    return Ok(ToolResult {
+                        success: false,
+                        output: String::new(),
+                        error: Some("recall_scene requires id parameter".into()),
+                    });
+                }
+            },
+            _ => unreachable!(),
+        };
+
+        match result {
+            Ok(value) => Ok(ToolResult {
+                success: true,
+                output: serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string()),
+                error: None,
+            }),
+            Err(e) => Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(e.to_string()),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zeroclaw_config::policy::SecurityPolicy;
+
+    fn test_tool() -> PhilipsHueTool {
+        PhilipsHueTool::new(
+            "192.0.2.10".into(),
+            "test-key".into(),
+            vec![
+                "light".into(),
+                "grouped_light".into(),
+                "scene".into(),
+                "room".into(),
+            ],
+            false,
+            15,
+            Arc::new(SecurityPolicy::default()),
+        )
+        .expect("test client builds")
+    }
+
+    #[test]
+    fn name_is_philips_hue() {
+        assert_eq!(test_tool().name(), "philips_hue");
+    }
+
+    #[test]
+    fn description_is_non_empty() {
+        assert!(!test_tool().description().is_empty());
+    }
+
+    #[test]
+    fn parameters_schema_requires_action() {
+        let schema = test_tool().parameters_schema();
+        let required = schema["required"].as_array().unwrap();
+        assert!(required.iter().any(|v| v.as_str() == Some("action")));
+    }
+
+    #[test]
+    fn parameters_schema_lists_all_actions() {
+        let schema = test_tool().parameters_schema();
+        let actions = schema["properties"]["action"]["enum"].as_array().unwrap();
+        let names: Vec<&str> = actions.iter().filter_map(|v| v.as_str()).collect();
+        for expected in &[
+            "list_lights",
+            "get_light",
+            "set_light",
+            "list_scenes",
+            "recall_scene",
+            "list_rooms",
+            "list_groups",
+            "set_group",
+        ] {
+            assert!(names.contains(expected), "missing action: {expected}");
+        }
+    }
+
+    #[test]
+    fn bridge_address_trailing_slash_stripped() {
+        let tool = PhilipsHueTool::new(
+            "192.0.2.10/".into(),
+            "k".into(),
+            vec!["light".into()],
+            false,
+            15,
+            Arc::new(SecurityPolicy::default()),
+        )
+        .unwrap();
+        assert_eq!(tool.bridge_address, "192.0.2.10");
+    }
+
+    #[test]
+    fn allowed_resource_types_trimmed_and_empty_dropped() {
+        let tool = PhilipsHueTool::new(
+            "h".into(),
+            "k".into(),
+            vec!["  light ".into(), "".into(), "scene".into()],
+            false,
+            15,
+            Arc::new(SecurityPolicy::default()),
+        )
+        .unwrap();
+        assert!(tool.is_resource_type_allowed("light"));
+        assert!(tool.is_resource_type_allowed("scene"));
+        assert!(!tool.is_resource_type_allowed(""));
+    }
+
+    #[test]
+    fn resource_url_shapes() {
+        let tool = test_tool();
+        assert_eq!(
+            tool.resource_url("light", None),
+            "https://192.0.2.10/clip/v2/resource/light"
+        );
+        assert_eq!(
+            tool.resource_url("scene", Some("abc-123")),
+            "https://192.0.2.10/clip/v2/resource/scene/abc-123"
+        );
+    }
+
+    #[test]
+    fn build_light_state_omits_unset_fields() {
+        let body = PhilipsHueTool::build_light_state(Some(true), None, None, None);
+        let obj = body.as_object().unwrap();
+        assert!(obj.contains_key("on"));
+        assert!(!obj.contains_key("dimming"));
+        assert!(!obj.contains_key("color"));
+        assert!(!obj.contains_key("color_temperature"));
+    }
+
+    #[test]
+    fn build_light_state_emits_all_when_set() {
+        let body =
+            PhilipsHueTool::build_light_state(Some(true), Some(75.0), Some((0.4, 0.5)), Some(250));
+        assert_eq!(body["on"]["on"], true);
+        assert_eq!(body["dimming"]["brightness"], 75.0);
+        assert_eq!(body["color"]["xy"]["x"], 0.4);
+        assert_eq!(body["color"]["xy"]["y"], 0.5);
+        assert_eq!(body["color_temperature"]["mirek"], 250);
+    }
+
+    #[tokio::test]
+    async fn execute_missing_action_returns_error() {
+        let result = test_tool().execute(json!({})).await.unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("action"));
+    }
+
+    #[tokio::test]
+    async fn execute_unknown_action_returns_error() {
+        let result = test_tool()
+            .execute(json!({"action": "nope"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("Unknown action"));
+    }
+
+    #[tokio::test]
+    async fn execute_get_light_missing_id_returns_error() {
+        let result = test_tool()
+            .execute(json!({"action": "get_light"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("id"));
+    }
+
+    #[tokio::test]
+    async fn execute_set_light_missing_id_returns_error() {
+        let result = test_tool()
+            .execute(json!({"action": "set_light", "on": true}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("id"));
+    }
+
+    #[tokio::test]
+    async fn execute_set_light_no_state_fields_returns_error() {
+        let result = test_tool()
+            .execute(json!({"action": "set_light", "id": "abc"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        let err = result.error.unwrap();
+        assert!(err.contains("at least one of"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn execute_recall_scene_missing_id_returns_error() {
+        let result = test_tool()
+            .execute(json!({"action": "recall_scene"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("id"));
+    }
+
+    #[tokio::test]
+    async fn execute_set_light_blocked_when_resource_type_not_allowed() {
+        let tool = PhilipsHueTool::new(
+            "h".into(),
+            "k".into(),
+            vec!["scene".into()], // light is NOT allowed
+            false,
+            15,
+            Arc::new(SecurityPolicy::default()),
+        )
+        .unwrap();
+        let result = tool
+            .execute(json!({"action": "set_light", "id": "abc", "on": true}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        let err = result.error.unwrap();
+        assert!(err.contains("not in allowed_resource_types"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn execute_set_light_blocked_when_allowlist_empty() {
+        let tool = PhilipsHueTool::new(
+            "h".into(),
+            "k".into(),
+            vec![],
+            false,
+            15,
+            Arc::new(SecurityPolicy::default()),
+        )
+        .unwrap();
+        let result = tool
+            .execute(json!({"action": "set_light", "id": "abc", "on": true}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("none"));
+    }
+
+    #[test]
+    fn spec_reflects_metadata() {
+        let tool = test_tool();
+        let spec = tool.spec();
+        assert_eq!(spec.name, "philips_hue");
+        assert_eq!(spec.description, tool.description());
+        assert!(spec.parameters.is_object());
+    }
+}

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -58,6 +58,7 @@
 - [Overview](./tools/overview.md)
 - [MCP (Model Context Protocol)](./tools/mcp.md)
 - [Browser automation](./tools/browser.md)
+- [Philips Hue](./tools/philips_hue.md)
 
 # Security
 

--- a/docs/book/src/tools/philips_hue.md
+++ b/docs/book/src/tools/philips_hue.md
@@ -1,0 +1,104 @@
+# Philips Hue
+
+The `philips_hue` tool drives a local [Philips Hue Bridge](https://www.philips-hue.com/) over the v2 CLIP API. It is **disabled by default** and requires a one-time push-button pairing to mint an application key.
+
+When enabled, the agent can:
+
+- `list_lights`, `get_light` — read light state.
+- `set_light` — turn lights on/off, change brightness, set xy color or color temperature.
+- `list_scenes`, `recall_scene` — discover and recall scenes.
+- `list_rooms` — enumerate rooms.
+- `list_groups`, `set_group` — read and mutate `grouped_light` state.
+
+Mutating actions (`set_light`, `recall_scene`, `set_group`) are gated by `allowed_resource_types`. Read actions ignore that allowlist.
+
+## Configuration
+
+```toml
+[philips_hue]
+enabled = true
+bridge_address = "192.168.1.42"            # IP or "<bridge-id>.local"
+application_key = "abcdef..."              # or set PHILIPS_HUE_APPLICATION_KEY
+allowed_resource_types = ["light", "grouped_light", "scene", "room"]
+verify_tls = false                         # bridges ship with self-signed certs
+request_timeout_secs = 15
+```
+
+Defaults:
+
+| Field | Default |
+| --- | --- |
+| `enabled` | `false` |
+| `allowed_resource_types` | `["light", "grouped_light", "scene", "room"]` |
+| `verify_tls` | `false` |
+| `request_timeout_secs` | `15` |
+
+The `application_key` field carries `#[secret]` so it's encrypted at rest when `[secrets] encrypt = true`.
+
+## First-time pairing
+
+The Hue Bridge requires a physical button press before it will mint an application key.
+
+1. Discover the bridge address:
+   - Cloud: `curl https://discovery.meethue.com` returns a list of bridges seen from your IP.
+   - Local: mDNS hostname `<bridge-id>.local`.
+2. Press the round button on top of the bridge.
+3. Within 30 seconds:
+   ```bash
+   curl -k -X POST \
+        -H 'Content-Type: application/json' \
+        -d '{"devicetype":"zeroclaw#host","generateclientkey":true}' \
+        https://<bridge-ip>/api
+   ```
+4. The response includes `success.username` — that's your `application_key`. Copy it into `philips_hue.application_key`, or export `PHILIPS_HUE_APPLICATION_KEY`.
+
+The `-k` flag skips TLS verification because bridges present a self-signed certificate, which is the same reason `verify_tls` defaults to `false` in the tool.
+
+## TLS
+
+`verify_tls = false` (default) is the safe-on-LAN choice: Hue bridges only ship with self-signed certs, so a verifying client cannot connect at all. If your bridge is exposed via a reverse proxy that terminates TLS with a real certificate, set `verify_tls = true` and `bridge_address` to the proxy's hostname.
+
+## Allowlist guidance
+
+`allowed_resource_types` is the per-mutation throttle. Conservative starting points:
+
+- Lights only: `["light"]`.
+- Lights + groups + scenes: `["light", "grouped_light", "scene"]`.
+- Read-only deployment: `[]` — disables every `set_*`/`recall_*` action while keeping `list_*` and `get_light` available.
+
+## Examples
+
+```jsonc
+// Turn a light on at 60% brightness
+{
+  "action": "set_light",
+  "id": "00112233-4455-6677-8899-aabbccddeeff",
+  "on": true,
+  "brightness": 60
+}
+
+// Recall a scene
+{
+  "action": "recall_scene",
+  "id": "deadbeef-1234-5678-90ab-cdef12345678"
+}
+
+// Set a group to warm white
+{
+  "action": "set_group",
+  "id": "feedface-1111-2222-3333-444455556666",
+  "on": true,
+  "color_temperature_mirek": 366
+}
+```
+
+## Troubleshooting
+
+- **`401 Unauthorized` / `403 Forbidden`** — Application key is wrong or revoked. Re-run the pairing flow.
+- **Connection refused / TLS errors** — Confirm `bridge_address` is reachable on your LAN; if you set `verify_tls = true`, the bridge's cert must be in your trust store.
+- **`Resource type 'X' is not in allowed_resource_types`** — Either widen the allowlist or use a different operation.
+- **`set_light` succeeds but nothing happens** — Check the bridge response body; v2 returns errors as `{"errors": [...]}` even with HTTP 200. Common causes: wrong resource ID, light is unreachable (powered off at the wall), or scene already active.
+
+## Rollback
+
+Set `[philips_hue] enabled = false` (or delete the block) and restart the agent. No data migration is needed — the tool only talks to the bridge over HTTP.


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Adds a `philips_hue` Tool that drives a local Philips Hue Bridge via the v2 CLIP API. The integration was previously declared with no implementation; this lights up the developer-page card and gives the agent direct control over lights, scenes, rooms, and groups.
  - Read actions (`list_*`, `get_light`) gate on `ToolOperation::Read`; mutations (`set_light`, `recall_scene`, `set_group`) gate on `ToolOperation::Act` AND a configurable `allowed_resource_types` allowlist enforced server-side in `execute()`.
  - Wires into the new schema-driven registry (post-#6386) via `#[integration(category = "ToolsAutomation", display_name = "Philips Hue", description = "Smart lighting via local Hue Bridge", status_field = "enabled")]` on `PhilipsHueConfig` — no edits to `registry.rs` needed.
- **Scope boundary:**
  - v2 CLIP API only (no v1 `/api/<user>/lights/...` shim).
  - Local bridge only (no `api.meethue.com` cloud relay).
  - No mDNS auto-discovery — operator supplies `bridge_address` (IP or `<id>.local`).
  - Push-button pairing is documented but performed once outside ZeroClaw (curl); the tool consumes the resulting `application_key`.
  - Home Assistant and 8Sleep are **not** in this PR (#6448, #6450).
- **Blast radius:** `zeroclaw-config` (additive `[philips_hue]` block, default disabled), `zeroclaw-tools` (new module), `zeroclaw-runtime/src/tools/mod.rs` (config-gated registration + tool re-export), `zeroclaw-runtime/src/integrations/mod.rs` (setup-hint arm — `registry.rs` untouched under the new schema-driven catalog), docs.
- **Linked issue(s):** Closes #6449. Sibling tracking issues: #6448 (HA, in PR #6464), #6450 (8Sleep).

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy -p zeroclaw-config -p zeroclaw-tools -p zeroclaw-runtime --all-targets -- -D warnings
cargo test -p zeroclaw-config -p zeroclaw-tools -p zeroclaw-runtime
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` → clean (no diff after `cargo fmt --all`).
  - `cargo clippy ...` → `Finished `dev` profile [unoptimized + debuginfo] target(s) in 38.47s`. No warnings.
  - `cargo test -p zeroclaw-config -p zeroclaw-tools -p zeroclaw-runtime` →
    - `test result: ok. 620 passed; 0 failed; 0 ignored` (zeroclaw-config)
    - `test result: ok. 1630 passed; 0 failed; 1 ignored` (zeroclaw-tools)
    - `test result: ok. 1162 passed; 0 failed; 0 ignored` (zeroclaw-runtime)
    - Total: **3,413 passed, 0 failed.**
  - New tool: 18 tests under `philips_hue::tests::*` — name, schema shape (action enum), URL/base normalization, allowlist trimming, `build_light_state` body shape (omits unset fields, emits all when set), missing-action / unknown-action / missing-id (get/set/recall) / no-state-fields / disallowed-resource-type / empty-allowlist paths, `spec()` reflection.
- **Beyond CI — what did you manually verify?**
  - The new schema-driven registry surfaces `Philips Hue` automatically — confirmed by reading the new `all_integrations(&Config)` loop, which consumes `Config::integration_descriptors()`, which is auto-generated by the `#[integration(...)]` attribute the `Configurable` derive picks up.
  - `zeroclaw integrations info "Philips Hue"` prints the push-button pairing steps (new arm in `show_integration_info`).
  - **Not verified live**: I did not pair against a real bridge — `set_light`/`recall_scene` HTTP success paths are not covered. Unit tests exhaustively cover the gating logic (allowlist, missing fields, security policy) and request body assembly (`build_light_state`).
- **If any command was intentionally skipped, why:** Skipped `./dev/ci.sh all` because the change is scoped to three crates + docs + a changelog entry; targeted clippy+test runs already gated those crates with `-D warnings`.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No.** HTTP only.
- New external network calls? **Yes.** The tool connects to `https://<bridge_address>/clip/v2/...`. Disabled by default; operator opts in.
- Secrets / tokens / credentials handling changed? **Yes.** New `application_key` field on `PhilipsHueConfig` carries `#[secret]` (encrypted at rest when `[secrets] encrypt = true`) and falls back to `PHILIPS_HUE_APPLICATION_KEY` env var.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No.** Tests use neutral placeholders (`192.0.2.10` is RFC 5737 documentation IP, `test-key`, UUIDs are synthetic).
- **Risk and mitigation:**
  - `verify_tls = false` is the default because Hue bridges ship with self-signed certs that no public CA chain validates. The risk is a same-LAN MITM swapping bridges. Mitigation: documented in the setup guide; operators on hardened networks can flip to `verify_tls = true` if they front the bridge with a reverse-proxied real cert. The flag flows through to `reqwest::Client::builder().danger_accept_invalid_certs(!verify_tls)`.
  - A misconfigured `allowed_resource_types` could let the agent recall scenes the operator didn't expect. Mitigation: defaults are conservative (`light`, `grouped_light`, `scene`, `room`); empty allowlist blocks **all** mutations; the check fires server-side in `execute()` before any HTTP call.

## Compatibility (required)

- Backward compatible? **Yes.** Additive config, default `enabled: false`. `Config::default()` includes `philips_hue: PhilipsHueConfig::default()` so existing configs missing `[philips_hue]` continue to deserialize unchanged.
- Config / env / CLI surface changed? **Yes** — new `[philips_hue]` block; new `PHILIPS_HUE_APPLICATION_KEY` env var fallback. No CLI changes.
- **Upgrade steps for existing users:** None required. To opt in, add `[philips_hue] enabled = true`, `bridge_address`, and either `application_key` or `PHILIPS_HUE_APPLICATION_KEY` (after one-time push-button pairing — documented).

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** Set `[philips_hue] enabled = false` in `~/.zeroclaw/config.toml` (or remove the block) and restart the agent. The tool is unregistered on next boot.
- **Feature flags or config toggles:** `philips_hue.enabled` (master switch). `philips_hue.allowed_resource_types` (per-mutation throttle; empty disables all mutations while keeping reads available). `philips_hue.verify_tls` (TLS posture).
- **Observable failure symptoms:**
  - Logs: `philips_hue: enabled but no application key found ...` or `... bridge_address is empty — skipping registration` indicate config issues.
  - Logs: `philips_hue: failed to construct HTTP client: ...` indicates a system TLS init failure.
  - Logs: `Philips Hue {action} ... failed (4xx/5xx)` indicates upstream bridge problems (key revoked, bridge unreachable, resource ID stale).
  - Tools registry at `/api/tools` will not include `philips_hue` if either `bridge_address` or `application_key` is missing.
