### PR TITLE
feat(tools): eight_sleep tool (unofficial cloud API)

### DIFF
--- a/CHANGELOG-next.md
+++ b/CHANGELOG-next.md
@@ -116,6 +116,7 @@
 
 - `SessionResetTool` and `SessionDeleteTool` for in-agent session management (#5696).
 - `SessionsCurrentTool` exposes the active session identity (#6033).
+- `eight_sleep` tool — unofficial 8Sleep cloud API client (auth + read bed state, read sleep metrics, set per-side heating level), gated by `allowed_sides` allowlist; alarms and prime-cycle deferred to follow-ups (#6450).
 
 ### Plugins
 

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -385,6 +385,11 @@ pub struct Config {
     #[nested]
     pub jira: JiraConfig,
 
+    /// 8Sleep integration configuration (`[eight_sleep]`).
+    #[serde(default)]
+    #[nested]
+    pub eight_sleep: EightSleepConfig,
+
     /// Secure inter-node transport configuration (`[node_transport]`).
     #[serde(default)]
     #[nested]
@@ -9316,6 +9321,92 @@ impl Default for JiraConfig {
     }
 }
 
+/// 8Sleep integration configuration (`[eight_sleep]`).
+///
+/// **Unofficial API.** 8Sleep does not publish a stable public API; this
+/// integration uses the same HTTPS endpoints the official mobile app
+/// reaches and the auth flow popularized by the open-source `pyEight`
+/// library. Endpoints can change at any time without notice.
+///
+/// When `enabled = true`, registers the `eight_sleep` tool which can
+/// read bed state and last-night metrics, and adjust per-side heating
+/// level on a Pod. Requires `email` and `password` (or the
+/// `EIGHT_SLEEP_PASSWORD` env var).
+///
+/// ## Defaults
+/// - `enabled`: `false`
+/// - `api_base_url`: `https://client-api.8slp.net/v1` — override only if
+///   8Sleep moves endpoints.
+/// - `allowed_sides`: `["left", "right"]` — set to `["left"]` or
+///   `["right"]` to lock the tool to one side of a shared bed.
+/// - `request_timeout_secs`: `15`
+///
+/// ## Auth
+/// Login posts `{email, password}` to `<api_base_url>/login`. The returned
+/// session token is cached in memory only (no on-disk persistence) and
+/// refreshed automatically on `401`. Newer accounts that mandate the
+/// AWS Cognito OAuth flow are not supported in v1.
+///
+/// `password` is `#[secret]`-encrypted at rest when `[secrets] encrypt = true`.
+#[derive(Debug, Clone, Serialize, Deserialize, Configurable)]
+#[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
+#[prefix = "eight-sleep"]
+#[integration(
+    category = "ToolsAutomation",
+    display_name = "8Sleep",
+    description = "Smart mattress (unofficial API)",
+    status_field = "enabled"
+)]
+pub struct EightSleepConfig {
+    /// Enable the `eight_sleep` tool. Default: `false`.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Account email.
+    #[serde(default)]
+    pub email: String,
+    /// Account password. Encrypted at rest. Falls back to
+    /// `EIGHT_SLEEP_PASSWORD` env var.
+    #[serde(default)]
+    #[secret]
+    #[cfg_attr(feature = "schema-export", schemars(extend("x-secret" = true)))]
+    pub password: String,
+    /// API base URL. Default: `https://client-api.8slp.net/v1`.
+    #[serde(default = "default_eight_sleep_api_base_url")]
+    pub api_base_url: String,
+    /// Sides the agent is permitted to mutate (`set_temperature`).
+    /// Empty disables all mutations while leaving reads available.
+    #[serde(default = "default_eight_sleep_allowed_sides")]
+    pub allowed_sides: Vec<String>,
+    /// Request timeout in seconds. Default: `15`.
+    #[serde(default = "default_eight_sleep_timeout_secs")]
+    pub request_timeout_secs: u64,
+}
+
+fn default_eight_sleep_api_base_url() -> String {
+    "https://client-api.8slp.net/v1".into()
+}
+
+fn default_eight_sleep_allowed_sides() -> Vec<String> {
+    vec!["left".into(), "right".into()]
+}
+
+fn default_eight_sleep_timeout_secs() -> u64 {
+    15
+}
+
+impl Default for EightSleepConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            email: String::new(),
+            password: String::new(),
+            api_base_url: default_eight_sleep_api_base_url(),
+            allowed_sides: default_eight_sleep_allowed_sides(),
+            request_timeout_secs: default_eight_sleep_timeout_secs(),
+        }
+    }
+}
+
 ///
 /// Controls the read-only cloud transformation analysis tools:
 /// IaC review, migration assessment, cost analysis, and architecture review.
@@ -9634,6 +9725,7 @@ impl Default for Config {
             onboard_state: OnboardStateConfig::default(),
             notion: NotionConfig::default(),
             jira: JiraConfig::default(),
+            eight_sleep: EightSleepConfig::default(),
             node_transport: NodeTransportConfig::default(),
             knowledge: KnowledgeConfig::default(),
             linkedin: LinkedInConfig::default(),
@@ -12595,6 +12687,7 @@ auto_save = true
             onboard_state: OnboardStateConfig::default(),
             notion: NotionConfig::default(),
             jira: JiraConfig::default(),
+            eight_sleep: EightSleepConfig::default(),
             node_transport: NodeTransportConfig::default(),
             knowledge: KnowledgeConfig::default(),
             linkedin: LinkedInConfig::default(),
@@ -13166,6 +13259,7 @@ default_temperature = 0.7
             onboard_state: OnboardStateConfig::default(),
             notion: NotionConfig::default(),
             jira: JiraConfig::default(),
+            eight_sleep: EightSleepConfig::default(),
             node_transport: NodeTransportConfig::default(),
             knowledge: KnowledgeConfig::default(),
             linkedin: LinkedInConfig::default(),

--- a/crates/zeroclaw-runtime/src/integrations/mod.rs
+++ b/crates/zeroclaw-runtime/src/integrations/mod.rs
@@ -148,6 +148,16 @@ pub fn show_integration_info(config: &Config, name: &str) -> Result<()> {
             println!("    Supports city names, IATA airport codes, GPS coordinates,");
             println!("    postal/zip codes, and Unicode location names.");
         }
+        "8Sleep" => {
+            println!("  Setup (unofficial API — may break without notice):");
+            println!("    1. Add to config:");
+            println!("       [eight_sleep]");
+            println!("       enabled = true");
+            println!("       email = \"you@example.com\"");
+            println!("       password = \"...\"  # or set EIGHT_SLEEP_PASSWORD");
+            println!("    2. Optionally narrow `allowed_sides` to one side of a shared bed.");
+            println!("    3. v1 supports get_bed_state, get_metrics, set_temperature only.");
+        }
         _ if entry.category == IntegrationCategory::Chat => {
             println!("  Setup:");
             println!("    Run: zeroclaw onboard --channels-only");

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -57,6 +57,7 @@ pub use zeroclaw_tools::composio::ComposioTool;
 pub use zeroclaw_tools::content_search::ContentSearchTool;
 pub use zeroclaw_tools::data_management::DataManagementTool;
 pub use zeroclaw_tools::discord_search::DiscordSearchTool;
+pub use zeroclaw_tools::eight_sleep::EightSleepTool;
 pub use zeroclaw_tools::escalate::EscalateToHumanTool;
 pub use zeroclaw_tools::file_edit::FileEditTool;
 pub use zeroclaw_tools::file_write::FileWriteTool;
@@ -599,6 +600,33 @@ pub fn all_tools_with_runtime(
                 root_config.jira.allowed_actions.clone(),
                 security.clone(),
                 root_config.jira.timeout_secs,
+            )));
+        }
+    }
+
+    // 8Sleep integration (config-gated, unofficial cloud API)
+    if root_config.eight_sleep.enabled {
+        let password = if root_config.eight_sleep.password.trim().is_empty() {
+            std::env::var("EIGHT_SLEEP_PASSWORD").unwrap_or_default()
+        } else {
+            root_config.eight_sleep.password.trim().to_string()
+        };
+        if password.trim().is_empty() {
+            tracing::warn!(
+                "eight_sleep: enabled but no password found (set eight_sleep.password or EIGHT_SLEEP_PASSWORD env var) — skipping registration"
+            );
+        } else if root_config.eight_sleep.email.trim().is_empty() {
+            tracing::warn!(
+                "eight_sleep: enabled but eight_sleep.email is empty — skipping registration"
+            );
+        } else {
+            tool_arcs.push(Arc::new(EightSleepTool::new(
+                root_config.eight_sleep.email.trim().to_string(),
+                password,
+                root_config.eight_sleep.api_base_url.trim().to_string(),
+                root_config.eight_sleep.allowed_sides.clone(),
+                root_config.eight_sleep.request_timeout_secs,
+                security.clone(),
             )));
         }
     }

--- a/crates/zeroclaw-tools/src/eight_sleep.rs
+++ b/crates/zeroclaw-tools/src/eight_sleep.rs
@@ -1,0 +1,642 @@
+//! 8Sleep tool — unofficial cloud API client for the Pod.
+//!
+//! **API stability.** 8Sleep does not publish a stable public API. This
+//! module talks to the same HTTPS endpoints the official mobile app
+//! reaches, following the conventions popularized by the open-source
+//! `pyEight` library. Endpoints can change at any time without notice;
+//! treat this integration as best-effort and expect occasional breakage.
+//!
+//! Auth flow: POST `{email, password}` to `<api_base_url>/login`. The
+//! response carries a session token; subsequent requests send it in the
+//! `Session-Token` header. The token is cached in memory only and
+//! refreshed automatically on `401`.
+//!
+//! Read actions (`get_bed_state`, `get_metrics`) require
+//! `ToolOperation::Read`. The mutating action (`set_temperature`)
+//! requires `ToolOperation::Act` and is further gated by `allowed_sides`.
+
+use async_trait::async_trait;
+use serde::Deserialize;
+use serde_json::{Value, json};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Mutex;
+use zeroclaw_api::tool::{Tool, ToolResult};
+use zeroclaw_config::policy::{SecurityPolicy, ToolOperation};
+
+const MAX_ERROR_BODY_CHARS: usize = 500;
+/// Heating level is `-100..=100` per pyEight conventions: negative cools,
+/// positive warms, 0 holds without active conditioning.
+const HEATING_LEVEL_MIN: i64 = -100;
+const HEATING_LEVEL_MAX: i64 = 100;
+
+#[derive(Debug, Clone)]
+struct SessionToken {
+    token: String,
+    user_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct LoginResponse {
+    session: LoginSession,
+}
+
+#[derive(Debug, Deserialize)]
+struct LoginSession {
+    token: String,
+    #[serde(rename = "userId")]
+    user_id: String,
+}
+
+/// Tool for interacting with an 8Sleep Pod via the unofficial cloud API.
+pub struct EightSleepTool {
+    email: String,
+    password: String,
+    api_base_url: String,
+    allowed_sides: Vec<String>,
+    request_timeout_secs: u64,
+    token: Arc<Mutex<Option<SessionToken>>>,
+    http: reqwest::Client,
+    security: Arc<SecurityPolicy>,
+}
+
+impl EightSleepTool {
+    /// Create a new 8Sleep tool. `api_base_url` is normalized by stripping
+    /// any trailing `/`.
+    pub fn new(
+        email: String,
+        password: String,
+        api_base_url: String,
+        allowed_sides: Vec<String>,
+        request_timeout_secs: u64,
+        security: Arc<SecurityPolicy>,
+    ) -> Self {
+        let api_base_url = api_base_url.trim().trim_end_matches('/').to_string();
+        let allowed_sides = allowed_sides
+            .into_iter()
+            .map(|s| s.trim().to_lowercase())
+            .filter(|s| !s.is_empty())
+            .collect();
+        Self {
+            email,
+            password,
+            api_base_url,
+            allowed_sides,
+            request_timeout_secs,
+            token: Arc::new(Mutex::new(None)),
+            http: reqwest::Client::new(),
+            security,
+        }
+    }
+
+    fn timeout(&self) -> Duration {
+        Duration::from_secs(self.request_timeout_secs.max(1))
+    }
+
+    fn is_side_allowed(&self, side: &str) -> bool {
+        self.allowed_sides.iter().any(|s| s == side)
+    }
+
+    /// Build the heating-level request body for `set_temperature`. Public
+    /// for unit testing — exercised independently of the network.
+    fn build_temperature_body(side: &str, level: i64) -> Value {
+        let now_field = format!("{side}Now");
+        let target_field = format!("{side}TargetHeatingLevel");
+        let level_field = format!("{side}HeatingLevel");
+        json!({
+            now_field: true,
+            target_field: level,
+            level_field: level,
+        })
+    }
+
+    /// POST credentials to `<api_base_url>/login` and cache the resulting
+    /// session token. Replaces any prior cached token.
+    async fn login(&self) -> anyhow::Result<SessionToken> {
+        let url = format!("{}/login", self.api_base_url);
+        let resp = self
+            .http
+            .post(&url)
+            .json(&json!({
+                "email": self.email,
+                "password": self.password,
+            }))
+            .timeout(self.timeout())
+            .send()
+            .await?;
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            let truncated =
+                crate::util_helpers::truncate_with_ellipsis(&body, MAX_ERROR_BODY_CHARS);
+            anyhow::bail!("8Sleep login failed ({status}): {truncated}");
+        }
+        let parsed: LoginResponse = resp.json().await?;
+        let token = SessionToken {
+            token: parsed.session.token,
+            user_id: parsed.session.user_id,
+        };
+        *self.token.lock().await = Some(token.clone());
+        Ok(token)
+    }
+
+    async fn current_token(&self) -> anyhow::Result<SessionToken> {
+        if let Some(t) = self.token.lock().await.clone() {
+            return Ok(t);
+        }
+        self.login().await
+    }
+
+    fn auth_headers(token: &str) -> anyhow::Result<reqwest::header::HeaderMap> {
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(
+            "Session-Token",
+            token
+                .parse()
+                .map_err(|e| anyhow::anyhow!("Invalid 8Sleep session token: {e}"))?,
+        );
+        headers.insert("Content-Type", "application/json".parse().unwrap());
+        Ok(headers)
+    }
+
+    /// Issue a GET that retries once with a fresh token on `401`.
+    async fn get_authed(&self, path_after_base: &str) -> anyhow::Result<Value> {
+        let url = format!("{}{}", self.api_base_url, path_after_base);
+        let mut token = self.current_token().await?;
+        for attempt in 0..2 {
+            let resp = self
+                .http
+                .get(&url)
+                .headers(Self::auth_headers(&token.token)?)
+                .timeout(self.timeout())
+                .send()
+                .await?;
+            let status = resp.status();
+            if status.as_u16() == 401 && attempt == 0 {
+                token = self.login().await?;
+                continue;
+            }
+            if !status.is_success() {
+                let body = resp.text().await.unwrap_or_default();
+                let truncated =
+                    crate::util_helpers::truncate_with_ellipsis(&body, MAX_ERROR_BODY_CHARS);
+                anyhow::bail!("8Sleep GET {path_after_base} failed ({status}): {truncated}");
+            }
+            return resp.json().await.map_err(Into::into);
+        }
+        unreachable!("loop exits via return or bail")
+    }
+
+    /// Issue a PUT that retries once with a fresh token on `401`.
+    async fn put_authed(&self, path_after_base: &str, body: &Value) -> anyhow::Result<Value> {
+        let url = format!("{}{}", self.api_base_url, path_after_base);
+        let mut token = self.current_token().await?;
+        for attempt in 0..2 {
+            let resp = self
+                .http
+                .put(&url)
+                .headers(Self::auth_headers(&token.token)?)
+                .json(body)
+                .timeout(self.timeout())
+                .send()
+                .await?;
+            let status = resp.status();
+            if status.as_u16() == 401 && attempt == 0 {
+                token = self.login().await?;
+                continue;
+            }
+            if !status.is_success() {
+                let body = resp.text().await.unwrap_or_default();
+                let truncated =
+                    crate::util_helpers::truncate_with_ellipsis(&body, MAX_ERROR_BODY_CHARS);
+                anyhow::bail!("8Sleep PUT {path_after_base} failed ({status}): {truncated}");
+            }
+            return resp.json().await.map_err(Into::into);
+        }
+        unreachable!("loop exits via return or bail")
+    }
+
+    /// Resolve the device id for the current account by hitting
+    /// `/users/me`. The response shape varies between Pod generations;
+    /// we look for `user.currentDevice.id` first and fall back to the
+    /// first entry of `user.devices`.
+    async fn resolve_device_id(&self) -> anyhow::Result<String> {
+        let user = self.get_authed("/users/me").await?;
+        if let Some(id) = user
+            .get("user")
+            .and_then(|u| u.get("currentDevice"))
+            .and_then(|d| d.get("id"))
+            .and_then(|v| v.as_str())
+        {
+            return Ok(id.to_string());
+        }
+        if let Some(id) = user
+            .get("user")
+            .and_then(|u| u.get("devices"))
+            .and_then(|v| v.as_array())
+            .and_then(|a| a.first())
+            .and_then(|v| v.as_str())
+        {
+            return Ok(id.to_string());
+        }
+        anyhow::bail!(
+            "8Sleep: could not resolve device id from /users/me response — account may have no Pod registered"
+        );
+    }
+
+    async fn get_bed_state(&self) -> anyhow::Result<Value> {
+        let device_id = self.resolve_device_id().await?;
+        self.get_authed(&format!("/devices/{device_id}")).await
+    }
+
+    async fn get_metrics(&self) -> anyhow::Result<Value> {
+        let token = self.current_token().await?;
+        self.get_authed(&format!("/users/{}/intervals", token.user_id))
+            .await
+    }
+
+    async fn set_temperature(&self, side: &str, level: i64) -> anyhow::Result<Value> {
+        let device_id = self.resolve_device_id().await?;
+        let body = Self::build_temperature_body(side, level);
+        self.put_authed(&format!("/devices/{device_id}"), &body)
+            .await
+    }
+}
+
+#[async_trait]
+impl Tool for EightSleepTool {
+    fn name(&self) -> &str {
+        "eight_sleep"
+    }
+
+    fn description(&self) -> &str {
+        "Read and adjust an 8Sleep Pod via the unofficial cloud API. Read \
+         current bed state (get_bed_state) or last-night metrics \
+         (get_metrics). Mutate per-side heating level (-100 cools, 0 \
+         holds, +100 warms) with set_temperature — restricted to \
+         allowed_sides. Note: API is unofficial and may break without \
+         notice; alarms and prime-cycle control are not supported in v1."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["get_bed_state", "get_metrics", "set_temperature"],
+                    "description": "The 8Sleep operation to perform."
+                },
+                "side": {
+                    "type": "string",
+                    "enum": ["left", "right"],
+                    "description": "Bed side. Required for set_temperature."
+                },
+                "level": {
+                    "type": "integer",
+                    "minimum": HEATING_LEVEL_MIN,
+                    "maximum": HEATING_LEVEL_MAX,
+                    "description": "Heating level -100..100. Negative cools, 0 holds, positive warms. Required for set_temperature."
+                }
+            },
+            "required": ["action"]
+        })
+    }
+
+    async fn execute(&self, args: Value) -> anyhow::Result<ToolResult> {
+        let action = match args.get("action").and_then(|v| v.as_str()) {
+            Some(a) => a,
+            None => {
+                return Ok(ToolResult {
+                    success: false,
+                    output: String::new(),
+                    error: Some("Missing required parameter: action".into()),
+                });
+            }
+        };
+
+        let operation = match action {
+            "get_bed_state" | "get_metrics" => ToolOperation::Read,
+            "set_temperature" => ToolOperation::Act,
+            _ => {
+                return Ok(ToolResult {
+                    success: false,
+                    output: String::new(),
+                    error: Some(format!(
+                        "Unknown action: {action}. Valid actions: get_bed_state, get_metrics, set_temperature"
+                    )),
+                });
+            }
+        };
+
+        if let Err(error) = self
+            .security
+            .enforce_tool_operation(operation, "eight_sleep")
+        {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(error),
+            });
+        }
+
+        let result = match action {
+            "get_bed_state" => self.get_bed_state().await,
+            "get_metrics" => self.get_metrics().await,
+            "set_temperature" => {
+                let side = match args.get("side").and_then(|v| v.as_str()) {
+                    Some(s) if !s.trim().is_empty() => s.trim().to_lowercase(),
+                    _ => {
+                        return Ok(ToolResult {
+                            success: false,
+                            output: String::new(),
+                            error: Some(
+                                "set_temperature requires side parameter (\"left\" or \"right\")"
+                                    .into(),
+                            ),
+                        });
+                    }
+                };
+                if side != "left" && side != "right" {
+                    return Ok(ToolResult {
+                        success: false,
+                        output: String::new(),
+                        error: Some(format!(
+                            "Invalid side '{side}'. Must be \"left\" or \"right\"."
+                        )),
+                    });
+                }
+                if !self.is_side_allowed(&side) {
+                    let allowed = if self.allowed_sides.is_empty() {
+                        "(none — allowed_sides is empty)".to_string()
+                    } else {
+                        self.allowed_sides.join(", ")
+                    };
+                    return Ok(ToolResult {
+                        success: false,
+                        output: String::new(),
+                        error: Some(format!(
+                            "Side '{side}' is not in allowed_sides. Allowed: {allowed}"
+                        )),
+                    });
+                }
+                let level = match args.get("level").and_then(|v| v.as_i64()) {
+                    Some(l) => l,
+                    None => {
+                        return Ok(ToolResult {
+                            success: false,
+                            output: String::new(),
+                            error: Some(
+                                "set_temperature requires level parameter (integer -100..100)"
+                                    .into(),
+                            ),
+                        });
+                    }
+                };
+                if !(HEATING_LEVEL_MIN..=HEATING_LEVEL_MAX).contains(&level) {
+                    return Ok(ToolResult {
+                        success: false,
+                        output: String::new(),
+                        error: Some(format!(
+                            "level {level} out of range. Must be {HEATING_LEVEL_MIN}..={HEATING_LEVEL_MAX}."
+                        )),
+                    });
+                }
+                self.set_temperature(&side, level).await
+            }
+            _ => unreachable!(),
+        };
+
+        match result {
+            Ok(value) => Ok(ToolResult {
+                success: true,
+                output: serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string()),
+                error: None,
+            }),
+            Err(e) => Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(e.to_string()),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zeroclaw_config::policy::SecurityPolicy;
+
+    fn test_tool() -> EightSleepTool {
+        EightSleepTool::new(
+            "user@example.invalid".into(),
+            "secret".into(),
+            "https://client-api.8slp.net/v1".into(),
+            vec!["left".into(), "right".into()],
+            15,
+            Arc::new(SecurityPolicy::default()),
+        )
+    }
+
+    #[test]
+    fn name_is_eight_sleep() {
+        assert_eq!(test_tool().name(), "eight_sleep");
+    }
+
+    #[test]
+    fn description_is_non_empty_and_warns_unofficial() {
+        let tool = test_tool();
+        let d = tool.description();
+        assert!(!d.is_empty());
+        assert!(d.to_lowercase().contains("unofficial"));
+    }
+
+    #[test]
+    fn parameters_schema_requires_action() {
+        let schema = test_tool().parameters_schema();
+        let required = schema["required"].as_array().unwrap();
+        assert!(required.iter().any(|v| v.as_str() == Some("action")));
+    }
+
+    #[test]
+    fn parameters_schema_lists_all_actions() {
+        let schema = test_tool().parameters_schema();
+        let actions = schema["properties"]["action"]["enum"].as_array().unwrap();
+        let names: Vec<&str> = actions.iter().filter_map(|v| v.as_str()).collect();
+        for expected in &["get_bed_state", "get_metrics", "set_temperature"] {
+            assert!(names.contains(expected), "missing action: {expected}");
+        }
+    }
+
+    #[test]
+    fn parameters_schema_level_bounds() {
+        let schema = test_tool().parameters_schema();
+        let level = &schema["properties"]["level"];
+        assert_eq!(level["minimum"], HEATING_LEVEL_MIN);
+        assert_eq!(level["maximum"], HEATING_LEVEL_MAX);
+    }
+
+    #[test]
+    fn api_base_url_trailing_slash_stripped() {
+        let tool = EightSleepTool::new(
+            "e".into(),
+            "p".into(),
+            "https://example.invalid/v1/".into(),
+            vec!["left".into()],
+            15,
+            Arc::new(SecurityPolicy::default()),
+        );
+        assert_eq!(tool.api_base_url, "https://example.invalid/v1");
+    }
+
+    #[test]
+    fn allowed_sides_lowercased_trimmed_and_empty_dropped() {
+        let tool = EightSleepTool::new(
+            "e".into(),
+            "p".into(),
+            "https://h".into(),
+            vec!["  Left ".into(), "".into(), "RIGHT".into()],
+            15,
+            Arc::new(SecurityPolicy::default()),
+        );
+        assert!(tool.is_side_allowed("left"));
+        assert!(tool.is_side_allowed("right"));
+        assert!(!tool.is_side_allowed("Left")); // we lowercase incoming arg too
+    }
+
+    #[test]
+    fn build_temperature_body_includes_per_side_fields() {
+        let body = EightSleepTool::build_temperature_body("left", 42);
+        assert_eq!(body["leftNow"], true);
+        assert_eq!(body["leftTargetHeatingLevel"], 42);
+        assert_eq!(body["leftHeatingLevel"], 42);
+        // No leakage to the other side
+        assert!(body.get("rightNow").is_none());
+    }
+
+    #[test]
+    fn build_temperature_body_handles_negative_levels() {
+        let body = EightSleepTool::build_temperature_body("right", -100);
+        assert_eq!(body["rightTargetHeatingLevel"], -100);
+        assert_eq!(body["rightHeatingLevel"], -100);
+    }
+
+    #[tokio::test]
+    async fn execute_missing_action_returns_error() {
+        let result = test_tool().execute(json!({})).await.unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("action"));
+    }
+
+    #[tokio::test]
+    async fn execute_unknown_action_returns_error() {
+        let result = test_tool()
+            .execute(json!({"action": "nope"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("Unknown action"));
+    }
+
+    #[tokio::test]
+    async fn execute_set_temperature_missing_side_returns_error() {
+        let result = test_tool()
+            .execute(json!({"action": "set_temperature", "level": 10}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("side"));
+    }
+
+    #[tokio::test]
+    async fn execute_set_temperature_invalid_side_returns_error() {
+        let result = test_tool()
+            .execute(json!({
+                "action": "set_temperature",
+                "side": "middle",
+                "level": 10
+            }))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        let err = result.error.unwrap();
+        assert!(err.contains("Invalid side") || err.contains("not in allowed_sides"));
+    }
+
+    #[tokio::test]
+    async fn execute_set_temperature_missing_level_returns_error() {
+        let result = test_tool()
+            .execute(json!({"action": "set_temperature", "side": "left"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("level"));
+    }
+
+    #[tokio::test]
+    async fn execute_set_temperature_level_out_of_range_returns_error() {
+        let result = test_tool()
+            .execute(json!({
+                "action": "set_temperature",
+                "side": "left",
+                "level": 200
+            }))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("out of range"));
+    }
+
+    #[tokio::test]
+    async fn execute_set_temperature_blocked_when_side_not_allowed() {
+        let tool = EightSleepTool::new(
+            "e".into(),
+            "p".into(),
+            "https://h".into(),
+            vec!["left".into()], // right is NOT allowed
+            15,
+            Arc::new(SecurityPolicy::default()),
+        );
+        let result = tool
+            .execute(json!({
+                "action": "set_temperature",
+                "side": "right",
+                "level": 10
+            }))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("not in allowed_sides"));
+    }
+
+    #[tokio::test]
+    async fn execute_set_temperature_blocked_when_allowed_sides_empty() {
+        let tool = EightSleepTool::new(
+            "e".into(),
+            "p".into(),
+            "https://h".into(),
+            vec![],
+            15,
+            Arc::new(SecurityPolicy::default()),
+        );
+        let result = tool
+            .execute(json!({
+                "action": "set_temperature",
+                "side": "left",
+                "level": 10
+            }))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("none"));
+    }
+
+    #[test]
+    fn spec_reflects_metadata() {
+        let tool = test_tool();
+        let spec = tool.spec();
+        assert_eq!(spec.name, "eight_sleep");
+        assert_eq!(spec.description, tool.description());
+        assert!(spec.parameters.is_object());
+    }
+}

--- a/crates/zeroclaw-tools/src/lib.rs
+++ b/crates/zeroclaw-tools/src/lib.rs
@@ -20,6 +20,7 @@ pub mod composio;
 pub mod content_search;
 pub mod data_management;
 pub mod discord_search;
+pub mod eight_sleep;
 pub mod escalate;
 pub mod file_edit;
 pub mod file_write;

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -58,6 +58,7 @@
 - [Overview](./tools/overview.md)
 - [MCP (Model Context Protocol)](./tools/mcp.md)
 - [Browser automation](./tools/browser.md)
+- [8Sleep](./tools/eight_sleep.md)
 
 # Security
 

--- a/docs/book/src/tools/eight_sleep.md
+++ b/docs/book/src/tools/eight_sleep.md
@@ -1,0 +1,107 @@
+# 8Sleep
+
+The `eight_sleep` tool reads and adjusts an [8Sleep](https://www.eightsleep.com/) Pod via 8Sleep's cloud API.
+
+> **Unofficial API.** 8Sleep does not publish a stable public API. This integration uses the same HTTPS endpoints the official mobile app reaches, following the conventions popularized by the open-source [`pyEight`](https://github.com/mezz64/pyEight) library. Endpoints can change at any time — treat this integration as best-effort and expect occasional breakage.
+
+When enabled, the agent can:
+
+- `get_bed_state` — read the current device state, including per-side heating levels and presence.
+- `get_metrics` — read sleep intervals (last-night metrics) for the logged-in user.
+- `set_temperature` — set the heating level on a side (`-100` cools, `0` holds, `+100` warms).
+
+`set_temperature` is gated by `allowed_sides`. Read actions are not gated by `allowed_sides`.
+
+## Configuration
+
+```toml
+[eight_sleep]
+enabled = true
+email = "you@example.com"
+password = "..."                            # or set EIGHT_SLEEP_PASSWORD
+api_base_url = "https://client-api.8slp.net/v1"
+allowed_sides = ["left", "right"]
+request_timeout_secs = 15
+```
+
+Defaults:
+
+| Field | Default |
+| --- | --- |
+| `enabled` | `false` |
+| `api_base_url` | `https://client-api.8slp.net/v1` |
+| `allowed_sides` | `["left", "right"]` |
+| `request_timeout_secs` | `15` |
+
+The `password` field carries `#[secret]` so it's encrypted at rest when `[secrets] encrypt = true`.
+
+## Auth flow
+
+1. POST `{email, password}` → `<api_base_url>/login`.
+2. Response includes `session.token` (JWT) and `session.userId`.
+3. Subsequent requests send the token via the `Session-Token` header.
+4. On any `401`, the tool re-authenticates once and retries the original request.
+
+The token is cached **in memory only** — it is not persisted to disk and is lost on agent restart.
+
+> **Cognito accounts.** Newer 8Sleep accounts that mandate the AWS Cognito OAuth flow are **not supported in v1**. If your `/login` POST returns a `401` immediately on otherwise-correct credentials, that's the most likely cause.
+
+## Side allowlist
+
+`allowed_sides` is the per-mutation throttle. Examples:
+
+- Solo bed: `["left"]` (only the side you sleep on can change temperature).
+- Shared bed: `["left", "right"]` (default).
+- Read-only deployment: `[]` — all `set_temperature` calls are blocked, but `get_bed_state` and `get_metrics` continue to work.
+
+## Heating-level convention
+
+The `level` field is an integer in `-100..=100`:
+
+- `-100` → maximum cooling.
+- `0` → conditioning off (Pod holds without active heat/cool).
+- `+100` → maximum warming.
+
+When `set_temperature` runs it sends three fields scoped to the chosen side: `<side>Now: true`, `<side>TargetHeatingLevel`, and `<side>HeatingLevel`. This matches the pyEight body shape; if a future Pod firmware diverges, this is the integration point to revisit.
+
+## Examples
+
+```jsonc
+// Warm the left side
+{
+  "action": "set_temperature",
+  "side": "left",
+  "level": 60
+}
+
+// Cool the right side fully
+{
+  "action": "set_temperature",
+  "side": "right",
+  "level": -100
+}
+
+// Pull last night's metrics
+{ "action": "get_metrics" }
+
+// Inspect current bed state
+{ "action": "get_bed_state" }
+```
+
+## Out of scope (v1)
+
+- **Alarms.** Alarm scheduling has more API surface (recurring vs one-off, light vs sound vs vibration) and higher safety stakes (a wrong wake time is bad UX). Deferred until the wire format can be verified against an active reverse-engineered library.
+- **Prime cycle.** The endpoint shape varies between Pod generations (Pod 2 / Pod 3 / Pod 4) and was not safe to ship without per-generation verification.
+- **HRV / sleep stages.** `get_metrics` returns the raw intervals payload; richer derived metrics are left to the agent.
+
+## Troubleshooting
+
+- **`8Sleep login failed (401)`** — Wrong credentials, or the account is on the Cognito-only flow (see above).
+- **`could not resolve device id from /users/me response`** — The account has no Pod registered, or the response shape changed. Inspect by calling `get_bed_state` and capturing the raw error body in logs.
+- **`level X out of range`** — `level` must be an integer in `-100..=100`.
+- **Side `'X'` is not in allowed_sides** — Either widen the allowlist or use a different side.
+- **Frequent 401 retries** — The cached token refresh is on a 401-trip-wire, not a TTL. If the upstream consistently returns 401, the integration will re-login on every request, which can rate-limit you. Verify credentials and account state.
+
+## Rollback
+
+Set `[eight_sleep] enabled = false` (or delete the block) and restart the agent. No data migration is needed.


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Adds an `eight_sleep` Tool that drives an 8Sleep Pod via 8Sleep's unofficial cloud API. The integration was previously a placeholder; this gives operators agent-driven temperature control and read-only access to bed state and sleep metrics.
  - Auth: POST `{email, password}` → `<api_base_url>/login`, cache `session.token` in memory (no on-disk persistence), retry once with a fresh token on `401`. Token sent via `Session-Token` header per pyEight conventions.
  - v1 surface (intentionally tight): `get_bed_state`, `get_metrics`, `set_temperature` (`-100..=100` per side). `set_temperature` is gated by `ToolOperation::Act` AND a configurable `allowed_sides` allowlist enforced server-side in `execute()`.
  - Wires into the schema-driven registry via `#[integration(category = "ToolsAutomation", display_name = "8Sleep", description = "Smart mattress (unofficial API)", status_field = "enabled")]` on `EightSleepConfig`.
- **Scope boundary:**
  - **Alarms are out of v1.** Issue #6450 listed `set_alarm` in the proposal, but alarm scheduling has wider API surface (recurring vs one-off, light vs sound vs vibration) and high safety stakes (wrong wake = bad UX). Deferred to a follow-up where the wire format can be verified against an active reverse-engineered library.
  - **Prime-cycle is out of v1.** Endpoint shape varies between Pod generations (Pod 2 / 3 / 4) and was not safe to ship without per-generation verification.
  - **Cognito-only accounts are not supported in v1** — v1 uses the simpler legacy `/login` flow that pyEight relies on.
  - HA and Hue are **not** in this PR (#6448/PR #6464, #6449/PR #6470).
- **Blast radius:** `zeroclaw-config` (additive `[eight_sleep]` block, default disabled), `zeroclaw-tools` (new module + tokio `Mutex` for in-memory token cache), `zeroclaw-runtime/src/tools/mod.rs` (config-gated registration + tool re-export), `zeroclaw-runtime/src/integrations/mod.rs` (setup-hint arm), docs.
- **Linked issue(s):** Closes #6450. Sibling tracking issues: #6448 (HA, in PR #6464), #6449 (Hue, in PR #6470).

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy -p zeroclaw-config -p zeroclaw-tools -p zeroclaw-runtime --all-targets -- -D warnings
cargo test -p zeroclaw-config -p zeroclaw-tools -p zeroclaw-runtime
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` → clean (no diff after `cargo fmt --all`).
  - `cargo clippy ...` → `Finished `dev` profile [unoptimized + debuginfo] target(s) in 9.77s`. No warnings.
  - `cargo test -p zeroclaw-config -p zeroclaw-tools -p zeroclaw-runtime` →
    - `test result: ok. 620 passed; 0 failed; 0 ignored` (zeroclaw-config)
    - `test result: ok. 1630 passed; 0 failed; 1 ignored` (zeroclaw-tools)
    - `test result: ok. 1162 passed; 0 failed; 0 ignored` (zeroclaw-runtime)
    - Total: **3,413 passed, 0 failed.**
  - New tool: 18 tests under `eight_sleep::tests::*` — name, description (asserts the unofficial-API warning is present), schema shape (action enum + level bounds), URL/base normalization, side-allowlist trimming and case-folding, `build_temperature_body` shape (correct per-side fields, no leakage to the other side, negative-level handling), missing-action / unknown-action / missing-side / invalid-side / missing-level / out-of-range / disallowed-side / empty-allowlist paths, `spec()` reflection.
- **Beyond CI — what did you manually verify?**
  - Schema-driven registry surfaces `8Sleep` automatically — confirmed by reading the new `all_integrations(&Config)` loop, which consumes `Config::integration_descriptors()` (auto-generated from the `#[integration(...)]` attribute on `EightSleepConfig`).
  - `zeroclaw integrations info "8Sleep"` prints the `[eight_sleep]` config example with the unofficial-API disclaimer (new arm in `show_integration_info`).
  - **Not verified live**: I did not authenticate against a real account or send any real `set_temperature` requests. Unit tests cover gating logic exhaustively (allowlist, side validation, level bounds, security policy) and request-body assembly (`build_temperature_body`), but the wire format on the actual cloud endpoint is verified only against pyEight conventions, not a live cluster.
- **If any command was intentionally skipped, why:** Skipped `./dev/ci.sh all` for the same reason as #6464 / #6470: change is scoped to three crates + docs + a changelog entry; targeted clippy+test runs already gated those crates with `-D warnings`.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No.** HTTP only.
- New external network calls? **Yes.** The tool talks to `https://client-api.8slp.net/v1` (or whatever `api_base_url` resolves to). Disabled by default; operator opts in.
- Secrets / tokens / credentials handling changed? **Yes.** New `email`/`password` fields on `EightSleepConfig`. `password` carries `#[secret]` (encrypted at rest when `[secrets] encrypt = true`) and falls back to `EIGHT_SLEEP_PASSWORD` env var. The minted session token is held in `tokio::sync::Mutex<Option<SessionToken>>` and never written to disk.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No.** Tests use `user@example.invalid`, neutral synthetic credentials, and `https://example.invalid/v1` for URL normalization.
- **Risk and mitigation:**
  - 8Sleep credentials are higher-stakes than typical API tokens — they unlock the user's full 8Sleep account (sleep history, payment, app settings). Mitigation: `#[secret]` storage, env-var fallback so the password never has to land in a config file, in-memory-only token cache, and an `allowed_sides` allowlist that lets operators throttle the agent to one side of a shared bed.
  - The 401 retry path can hammer the upstream if credentials are wrong (re-login on every request). Mitigation: documented in the troubleshooting section so operators know to disable on auth failure.

## Compatibility (required)

- Backward compatible? **Yes.** Additive config, default `enabled: false`. `Config::default()` includes `eight_sleep: EightSleepConfig::default()`.
- Config / env / CLI surface changed? **Yes** — new `[eight_sleep]` block; new `EIGHT_SLEEP_PASSWORD` env var fallback. No CLI changes.
- **Upgrade steps for existing users:** None required. To opt in, add `[eight_sleep] enabled = true`, `email`, and either `password` or `EIGHT_SLEEP_PASSWORD`. Optionally narrow `allowed_sides`.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** Set `[eight_sleep] enabled = false` in `~/.zeroclaw/config.toml` (or remove the block) and restart the agent. The tool is unregistered on next boot.
- **Feature flags or config toggles:** `eight_sleep.enabled` (master switch). `eight_sleep.allowed_sides` (per-mutation throttle; empty disables all `set_temperature` calls while keeping reads). `eight_sleep.api_base_url` (in case 8Sleep moves endpoints — operator can pin without a code change).
- **Observable failure symptoms:**
  - Logs: `eight_sleep: enabled but no password found ...` or `... email is empty — skipping registration` indicate config issues.
  - Logs: `8Sleep login failed (401)` indicates wrong creds or a Cognito-mandated account.
  - Logs: `8Sleep {VERB} {path} failed (4xx/5xx)` indicates upstream API issues — most likely 8Sleep changed an endpoint and the integration needs a follow-up.
  - Tools registry at `/api/tools` will not include `eight_sleep` if email or password is missing.
