### PR TITLE
docs: clarify review and PR workflow guidance

### DIFF
--- a/.claude/skills/github-pr-review-session/SKILL.md
+++ b/.claude/skills/github-pr-review-session/SKILL.md
@@ -30,6 +30,8 @@ Read these files at the start of every session. They are authoritative.
   issue format conventions, definition of done (§9–10)
 - `docs/book/src/foundations/fnd-005-contribution-culture.md` — review voice,
   feedback taxonomy, and the norms every review must follow
+- `docs/book/src/contributing/pr-review-protocol.md` — review body Markdown
+  format, including H3 taxonomy headings and draft-delivery preference
 - `tmp/handoff.md` — session state; tells you which PRs are already reviewed,
   what's still open, and what's next in the queue
 
@@ -94,7 +96,9 @@ The protocol specifies:
 - **How to cross-check** the diff against local source files
 - **The take-stock checkpoint** before writing anything
 - **The verdict decision tree** — which flag to use based on review state
-- **The feedback taxonomy** (🔴 / 🟡 / ✅ / 🔵 / 🟢) and how to apply it
+- **The feedback taxonomy** (🔴 / 🟡 / ✅ / 🔵 / 🟢), including the required
+  H3 review-body heading format that starts each formal finding with the
+  taxonomy emoji
 - **The posting convention** (write to `tmp/review-<number>.md`, post with
   `--body-file`)
 
@@ -104,13 +108,15 @@ fetches sequentially wastes time and the results are independent.
 ### Phase 3 — Write and post
 
 1. Write the review body to `tmp/review-<number>.md`.
-2. Post using the verdict flag from the decision tree:
+2. Apply the required Markdown style guidance from `docs/book/src/contributing/pr-review-protocol.md` before showing or posting the draft. Confirm the context intro is present, each formal finding heading is an H3 that starts with the required taxonomy emoji, prose is not accidentally hard-wrapped, and the review has had a plain-language pass.
+3. Show the draft to the active reviewer before posting. Prefer a link to `tmp/review-<number>.md` plus a short summary; if the full draft needs to be inline, paste it as regular text rather than wrapping the whole review in a fenced Markdown block.
+4. Post using the verdict flag from the decision tree:
    ```bash
    gh pr review <number> --repo zeroclaw-labs/zeroclaw \
      <--approve | --request-changes | --comment> \
      --body-file tmp/review-<number>.md
    ```
-3. Confirm the post succeeded.
+5. Confirm the post succeeded.
 
 ### Phase 3.5 — Milestone alignment
 
@@ -233,13 +239,22 @@ These norms are documented in
 4. **Always write to `tmp/review-<number>.md` before posting.** The tmp file
    is the source of truth for what was posted. It also lets you inspect before
    posting if the user asks.
-5. **Always run milestone alignment after posting**, unless the PR is a
+5. **Always apply the Markdown style guide before showing or posting public text.**
+   Use `docs/book/src/contributing/pr-review-protocol.md` for reviews, comments,
+   PR bodies, checklist notes, and handoff notes. This is a required drafting
+   step, not optional cleanup. Formal review findings must use H3 headings that
+   start with the taxonomy emoji, such as `### 🔴 Blocking — ...`; headings such
+   as `### Blocking — ...` or numbered findings do not satisfy the protocol.
+6. **Always show drafts to the active reviewer as a file link or regular text by default.**
+   Do not wrap an entire public review/comment/PR draft in a fenced Markdown
+   block unless the active reviewer explicitly asks for that format.
+7. **Always run milestone alignment after posting**, unless the PR is a
    documented no-milestone type (`chore:`/`deps:` prefix or deps-only diff).
    Note the skip reason in the handoff when bypassing.
-6. **Always update `tmp/handoff.md` after posting.** The handoff is useless if
+8. **Always update `tmp/handoff.md` after posting.** The handoff is useless if
    it's not current. Include the milestone alignment outcome.
-7. **Never merge.** Never push to contributor branches.
-8. **Never approve over another reviewer's active CHANGES_REQUESTED.**
+9. **Never merge.** Never push to contributor branches.
+10. **Never approve over another reviewer's active CHANGES_REQUESTED.**
    Check the reviews API output before choosing a verdict flag.
-9. **Never post a review that re-raises a settled point** without explicitly
+11. **Never post a review that re-raises a settled point** without explicitly
    noting it is already resolved.

--- a/.claude/skills/github-pr-review-session/SKILL.md
+++ b/.claude/skills/github-pr-review-session/SKILL.md
@@ -23,15 +23,13 @@ Read these files at the start of every session. They are authoritative.
 
 - `AGENTS.md` — risk tiers, high-risk paths, anti-patterns, commands
 - `docs/book/src/contributing/pr-review-protocol.md` — **the full review protocol**;
-  follow it exactly for every PR
+  follow it exactly for every PR, including the review-body Markdown format
 - `.github/pull_request_template.md` — required PR body sections; used to
   check template completeness
 - `docs/book/src/foundations/fnd-003-governance.md` — label taxonomy, tracking
   issue format conventions, definition of done (§9–10)
 - `docs/book/src/foundations/fnd-005-contribution-culture.md` — review voice,
   feedback taxonomy, and the norms every review must follow
-- `docs/book/src/contributing/pr-review-protocol.md` — review body Markdown
-  format, including H3 taxonomy headings and draft-delivery preference
 - `tmp/handoff.md` — session state; tells you which PRs are already reviewed,
   what's still open, and what's next in the queue
 
@@ -108,8 +106,12 @@ fetches sequentially wastes time and the results are independent.
 ### Phase 3 — Write and post
 
 1. Write the review body to `tmp/review-<number>.md`.
-2. Apply the required Markdown style guidance from `docs/book/src/contributing/pr-review-protocol.md` before showing or posting the draft. Confirm the context intro is present, each formal finding heading is an H3 that starts with the required taxonomy emoji, prose is not accidentally hard-wrapped, and the review has had a plain-language pass.
-3. Show the draft to the active reviewer before posting. Prefer a link to `tmp/review-<number>.md` plus a short summary; if the full draft needs to be inline, paste it as regular text rather than wrapping the whole review in a fenced Markdown block.
+2. Before showing or posting, confirm the context intro is present, formal
+   finding headings are H3 headings that start with taxonomy emoji, prose is not
+   accidentally hard-wrapped, and the review has had a plain-language pass.
+3. Show the draft to the active reviewer before posting. Prefer a link to
+   `tmp/review-<number>.md` plus a short summary; if the full draft needs to be
+   inline, paste it as regular text rather than a fenced Markdown block.
 4. Post using the verdict flag from the decision tree:
    ```bash
    gh pr review <number> --repo zeroclaw-labs/zeroclaw \
@@ -239,12 +241,10 @@ These norms are documented in
 4. **Always write to `tmp/review-<number>.md` before posting.** The tmp file
    is the source of truth for what was posted. It also lets you inspect before
    posting if the user asks.
-5. **Always apply the Markdown style guide before showing or posting public text.**
-   Use `docs/book/src/contributing/pr-review-protocol.md` for reviews, comments,
-   PR bodies, checklist notes, and handoff notes. This is a required drafting
-   step, not optional cleanup. Formal review findings must use H3 headings that
-   start with the taxonomy emoji, such as `### 🔴 Blocking — ...`; headings such
-   as `### Blocking — ...` or numbered findings do not satisfy the protocol.
+5. **Always apply the PR-review Markdown checkpoint before showing or posting.**
+   Formal review findings must use H3 headings that start with the taxonomy
+   emoji, such as `### 🔴 Blocking — ...`; headings such as
+   `### Blocking — ...` or numbered findings do not satisfy the protocol.
 6. **Always show drafts to the active reviewer as a file link or regular text by default.**
    Do not wrap an entire public review/comment/PR draft in a fenced Markdown
    block unless the active reviewer explicitly asks for that format.

--- a/.claude/skills/github-pr-review-session/SKILL.md
+++ b/.claude/skills/github-pr-review-session/SKILL.md
@@ -93,6 +93,9 @@ The protocol specifies:
   `docs/book/src/foundations/fnd-005-contribution-culture.md`
 - **How to cross-check** the diff against local source files
 - **The take-stock checkpoint** before writing anything
+- **Label hygiene** — fix obvious label mismatches yourself when the active
+  reviewer has label permissions, after approval for the public-state mutation;
+  do not ask authors to update labels they may not be allowed to edit
 - **The verdict decision tree** — which flag to use based on review state
 - **The feedback taxonomy** (🔴 / 🟡 / ✅ / 🔵 / 🟢), including the required
   H3 review-body heading format that starts each formal finding with the

--- a/.claude/skills/github-pr/SKILL.md
+++ b/.claude/skills/github-pr/SKILL.md
@@ -21,6 +21,24 @@ Before opening or updating a PR body, read `.github/pull_request_template.md` an
 
 This parsed structure drives how you fill, present, and edit the PR body.
 
+## Shared: Authorship Hygiene
+
+ZeroClaw PR bodies and commits should not end with bot or AI attribution such as
+`Co-authored-by: Claude <...>`, `Co-authored-by: Codex <...>`, or generated
+footers like `Created with Claude Code` / `Generated with Claude Code`.
+
+Before opening a PR, scan local commit messages and the drafted PR body:
+
+```bash
+git log origin/master..HEAD --format=%B | rg -i '(^[[:space:]]*(Co-authored-by|Co-Authored-By):.*(Claude|Codex|ChatGPT|Copilot|GitHub Copilot|Gemini|\[bot\]|dependabot|github-actions|web-flow|blacksmith|noreply@(anthropic|openai)\.com)|^[[:space:]]*(Created with Claude Code|Generated with Claude Code)[[:space:]]*$)'
+```
+
+Before updating a PR body, scan the proposed body for the same patterns. Remove
+bot/AI co-author trailers and generated tool footers from PR text before showing
+or submitting it. If local unpublished commits contain those footers, tell the
+user and ask before rewriting commit history. Do not rewrite a pushed branch or
+any contributor branch solely for attribution cleanup without explicit approval.
+
 ---
 
 ## Mode: Open a New PR
@@ -43,6 +61,10 @@ rustc --version 2>/dev/null
 ```
 
 Also review the changed files and commit messages to understand the nature of the change (bug fix, feature, refactor, docs, chore, etc.) and which subsystems are affected.
+
+Run the authorship-hygiene scan from the shared section before pushing or
+opening the PR. Remove bot/AI attribution from the PR body. If commit messages
+need cleanup, ask the user before amending or rebasing.
 
 ### Step 1a: Run the Validation Battery (required before drafting)
 
@@ -74,6 +96,8 @@ Using the parsed template structure and gathered context, draft a complete PR bo
 - For Yes/No fields, infer from the diff (e.g., if no files in `src/security/` changed, security impact is likely all No).
 - For required sections, always provide a substantive answer. For optional sections, fill if there's enough context, otherwise leave the template prompts in place.
 - Draft a conventional commit-style PR title based on the changes (e.g., `feat(provider): add retry budget override`, `fix(channel): handle disconnect gracefully`, `chore(ci): update workflow targets`).
+- Do not include bot/AI `Co-authored-by` trailers or generated tool footers in
+  the PR body.
 
 ### Step 3: Present Draft for Review
 
@@ -188,7 +212,10 @@ When the user wants to sync the PR description after pushing new changes:
 
 3. **If any of the new commits touch code (not pure docs)**, re-run the validation battery from Step 1a before updating the Validation Evidence section. Stale validation evidence is worse than no evidence — it misleads the reviewer.
 
-4. Present proposed updates section-by-section and confirm before applying.
+4. Scan the proposed body for bot/AI co-author trailers or generated tool
+   footers and remove them before showing or submitting the update.
+
+5. Present proposed updates section-by-section and confirm before applying.
 
 ### Step 6: Apply Updates
 
@@ -227,6 +254,10 @@ Return the PR URL.
 - **For updates, only modify requested sections.** Preserve everything else exactly as-is.
 - **Always show diffs before applying body edits.** Present current vs proposed for each changed section.
 - **Never include personal/sensitive data** in PR content per ZeroClaw's privacy contract.
+- **Never include bot/AI attribution footers** in PR body text. Strip
+  `Co-authored-by` trailers for AI tools/bots and generated footers such as
+  `Created with Claude Code`; preserve human attribution where the template asks
+  for incorporated contributors.
 - **For label changes**, only use labels that exist in the repository. Check with `gh label list` if unsure.
 - **Fetch the latest body before editing** to avoid clobbering concurrent changes.
 - **For new PRs**, push the branch before creating (with `-u` to set upstream tracking).

--- a/.claude/skills/github-pr/SKILL.md
+++ b/.claude/skills/github-pr/SKILL.md
@@ -23,9 +23,10 @@ This parsed structure drives how you fill, present, and edit the PR body.
 
 ## Shared: Authorship Hygiene
 
-ZeroClaw PR bodies and commits should not end with bot or AI attribution such as
-`Co-authored-by: Claude <...>`, `Co-authored-by: Codex <...>`, or generated
-footers like `Created with Claude Code` / `Generated with Claude Code`.
+ZeroClaw PR bodies and landed commit-message tails should not include bot or AI
+attribution such as `Co-authored-by: Claude <...>`, `Co-authored-by: Codex
+<...>`, or generated footers like `Created with Claude Code` / `Generated with
+Claude Code`.
 
 Before opening a PR, scan local commit messages and the drafted PR body:
 
@@ -33,11 +34,10 @@ Before opening a PR, scan local commit messages and the drafted PR body:
 git log origin/master..HEAD --format=%B | rg -i '(^[[:space:]]*(Co-authored-by|Co-Authored-By):.*(Claude|Codex|ChatGPT|Copilot|GitHub Copilot|Gemini|\[bot\]|dependabot|github-actions|web-flow|blacksmith|noreply@(anthropic|openai)\.com)|^[[:space:]]*(Created with Claude Code|Generated with Claude Code)[[:space:]]*$)'
 ```
 
-Before updating a PR body, scan the proposed body for the same patterns. Remove
-bot/AI co-author trailers and generated tool footers from PR text before showing
-or submitting it. If local unpublished commits contain those footers, tell the
-user and ask before rewriting commit history. Do not rewrite a pushed branch or
-any contributor branch solely for attribution cleanup without explicit approval.
+Before showing or submitting PR text, remove bot/AI co-author trailers and
+generated tool footers. If local unpublished commits contain those footers, tell
+the user and ask before rewriting commit history. Do not rewrite a pushed branch
+or contributor branch solely for attribution cleanup without explicit approval.
 
 ---
 
@@ -62,10 +62,6 @@ rustc --version 2>/dev/null
 
 Also review the changed files and commit messages to understand the nature of the change (bug fix, feature, refactor, docs, chore, etc.) and which subsystems are affected.
 
-Run the authorship-hygiene scan from the shared section before pushing or
-opening the PR. Remove bot/AI attribution from the PR body. If commit messages
-need cleanup, ask the user before amending or rebasing.
-
 ### Step 1a: Run the Validation Battery (required before drafting)
 
 Before drafting the PR body, actually run the commands the PR template's "Validation Evidence" section asks for. Do not paraphrase results, do not write "tests pass" from memory, do not skip on the assumption that CI will catch it. The evidence section needs literal output from a real local run:
@@ -73,7 +69,6 @@ Before drafting the PR body, actually run the commands the PR template's "Valida
 ```bash
 cargo fmt --all -- --check
 cargo clippy --all-targets -- -D warnings
-cargo build
 cargo test
 ```
 
@@ -96,8 +91,8 @@ Using the parsed template structure and gathered context, draft a complete PR bo
 - For Yes/No fields, infer from the diff (e.g., if no files in `src/security/` changed, security impact is likely all No).
 - For required sections, always provide a substantive answer. For optional sections, fill if there's enough context, otherwise leave the template prompts in place.
 - Draft a conventional commit-style PR title based on the changes (e.g., `feat(provider): add retry budget override`, `fix(channel): handle disconnect gracefully`, `chore(ci): update workflow targets`).
-- Do not include bot/AI `Co-authored-by` trailers or generated tool footers in
-  the PR body.
+- Apply the shared authorship-hygiene check before showing or submitting the PR
+  body.
 
 ### Step 3: Present Draft for Review
 
@@ -212,8 +207,8 @@ When the user wants to sync the PR description after pushing new changes:
 
 3. **If any of the new commits touch code (not pure docs)**, re-run the validation battery from Step 1a before updating the Validation Evidence section. Stale validation evidence is worse than no evidence — it misleads the reviewer.
 
-4. Scan the proposed body for bot/AI co-author trailers or generated tool
-   footers and remove them before showing or submitting the update.
+4. Apply the shared authorship-hygiene check before showing or submitting the
+   update.
 
 5. Present proposed updates section-by-section and confirm before applying.
 
@@ -254,10 +249,8 @@ Return the PR URL.
 - **For updates, only modify requested sections.** Preserve everything else exactly as-is.
 - **Always show diffs before applying body edits.** Present current vs proposed for each changed section.
 - **Never include personal/sensitive data** in PR content per ZeroClaw's privacy contract.
-- **Never include bot/AI attribution footers** in PR body text. Strip
-  `Co-authored-by` trailers for AI tools/bots and generated footers such as
-  `Created with Claude Code`; preserve human attribution where the template asks
-  for incorporated contributors.
+- **Never include bot/AI attribution footers** in PR body text. Follow
+  **Shared: Authorship Hygiene** before showing or submitting PR text.
 - **For label changes**, only use labels that exist in the repository. Check with `gh label list` if unsure.
 - **Fetch the latest body before editing** to avoid clobbering concurrent changes.
 - **For new PRs**, push the branch before creating (with `-u` to set upstream tracking).

--- a/.claude/skills/squash-merge/SKILL.md
+++ b/.claude/skills/squash-merge/SKILL.md
@@ -89,6 +89,33 @@ Note: commits from the API are in API order, which is typically chronological bu
 
 ### Step 3: Derive the Squash Commit Subject
 
+Before deriving the final merge command, sanitize the squash commit body. Source
+commits and PR bodies may contain AI or bot `Co-authored-by` trailers, or
+generated footers such as `Created with Claude Code`, but the landed squash
+commit on `master` should not attribute authorship to tools or bots. Strip those
+bot/AI trailers and generated footers from `$COMMITS`; preserve intentional
+human co-author trailers when they credit incorporated code or design work.
+
+Strip any `Co-authored-by` / `Co-Authored-By` line where the name or email
+identifies an AI tool, model, automation account, or bot, including:
+
+- `Claude`, `Codex`, `ChatGPT`, `Copilot`, `GitHub Copilot`, `Gemini`
+- names matching `gpt-*`, `claude-*`, `gemini-*`, or `copilot-*`
+- names or emails containing `[bot]`, `dependabot`, `github-actions`,
+  `web-flow`, or `blacksmith`
+- `noreply@anthropic.com` or `noreply@openai.com`
+- generated footers such as `Created with Claude Code` or
+  `Generated with Claude Code`
+
+After sanitizing, run a quick body check before asking for merge confirmation:
+
+```bash
+printf '%s\n' "$COMMITS" | rg -i '(^[[:space:]]*(Co-authored-by|Co-Authored-By):.*(Claude|Codex|ChatGPT|Copilot|GitHub Copilot|Gemini|\[bot\]|dependabot|github-actions|web-flow|blacksmith|noreply@(anthropic|openai)\.com)|^[[:space:]]*(Created with Claude Code|Generated with Claude Code)[[:space:]]*$)'
+```
+
+If this prints anything, stop and strip the remaining bot attribution or
+generated footer before continuing.
+
 ```bash
 PR_TITLE=$(gh pr view "$NUMBER" --repo zeroclaw-labs/zeroclaw --json title --jq '.title')
 SUBJECT="${PR_TITLE} (#${NUMBER})"
@@ -119,6 +146,8 @@ gh pr merge $NUMBER --repo zeroclaw-labs/zeroclaw --squash \
   ```
   $COMMITS
   ```
+- Bot/AI co-author trailers and generated tool footers have been stripped from
+  the squash commit body.
 
 Run this command? (yes/no)
 
@@ -158,6 +187,7 @@ Report to the user: merge commit SHA and PR URL.
 - **Never push squash commits directly to `upstream/master`** — always use `gh pr merge`. Direct push produces "Closed" not "Merged", breaks issue auto-close, and loses PR association.
 - **Never use `gh pr merge --squash` without `--subject` and `--body`** — the auto-generated message omits the PR number and uses inconsistent formatting.
 - **Never let GitHub auto-generate the squash message** — no web UI merge, no merge button clicks.
+- **Always strip bot/AI attribution from the squash body** — remove `Co-authored-by` trailers for Claude, Codex, Copilot, ChatGPT, Gemini, automation accounts, and bots before confirmation. Also remove generated tool footers such as `Created with Claude Code` / `Generated with Claude Code`. Preserve intentional human co-author trailers.
 - **Always assign PR title and commit body to shell variables** — never interpolate untrusted content directly into quoted command arguments.
 - **Always run pre-flight checks** (merge conflicts, review decision) before confirming — do not skip them even if the user says "just merge it."
 - **Always confirm before merging, no exceptions** — show the user the exact expanded command with real values and require an explicit yes. Never infer consent.

--- a/.claude/skills/squash-merge/SKILL.md
+++ b/.claude/skills/squash-merge/SKILL.md
@@ -89,25 +89,11 @@ Note: commits from the API are in API order, which is typically chronological bu
 
 ### Step 3: Derive the Squash Commit Subject
 
-Before deriving the final merge command, sanitize the squash commit body. Source
-commits and PR bodies may contain AI or bot `Co-authored-by` trailers, or
-generated footers such as `Created with Claude Code`, but the landed squash
-commit on `master` should not attribute authorship to tools or bots. Strip those
-bot/AI trailers and generated footers from `$COMMITS`; preserve intentional
-human co-author trailers when they credit incorporated code or design work.
-
-Strip any `Co-authored-by` / `Co-Authored-By` line where the name or email
-identifies an AI tool, model, automation account, or bot, including:
-
-- `Claude`, `Codex`, `ChatGPT`, `Copilot`, `GitHub Copilot`, `Gemini`
-- names matching `gpt-*`, `claude-*`, `gemini-*`, or `copilot-*`
-- names or emails containing `[bot]`, `dependabot`, `github-actions`,
-  `web-flow`, or `blacksmith`
-- `noreply@anthropic.com` or `noreply@openai.com`
-- generated footers such as `Created with Claude Code` or
-  `Generated with Claude Code`
-
-After sanitizing, run a quick body check before asking for merge confirmation:
+Before deriving the final merge command, sanitize `$COMMITS`: strip bot/AI
+`Co-authored-by` trailers and generated tool footers, while preserving human
+co-author trailers only when they credit incorporated contributor work under the
+superseding and privacy rules. Then verify the body before asking for merge
+confirmation:
 
 ```bash
 printf '%s\n' "$COMMITS" | rg -i '(^[[:space:]]*(Co-authored-by|Co-Authored-By):.*(Claude|Codex|ChatGPT|Copilot|GitHub Copilot|Gemini|\[bot\]|dependabot|github-actions|web-flow|blacksmith|noreply@(anthropic|openai)\.com)|^[[:space:]]*(Created with Claude Code|Generated with Claude Code)[[:space:]]*$)'
@@ -140,14 +126,13 @@ gh pr merge $NUMBER --repo zeroclaw-labs/zeroclaw --squash \
 
 **Effect:**
 - PR #$NUMBER will be permanently merged (state → Merged, purple badge)
-- Linked issues will auto-close
+- Issues referenced with closing keywords will auto-close
 - Squash commit subject: `$SUBJECT`
 - Squash commit body:
   ```
   $COMMITS
   ```
-- Bot/AI co-author trailers and generated tool footers have been stripped from
-  the squash commit body.
+- Bot/AI attribution has been stripped from the squash commit body.
 
 Run this command? (yes/no)
 
@@ -187,7 +172,9 @@ Report to the user: merge commit SHA and PR URL.
 - **Never push squash commits directly to `upstream/master`** — always use `gh pr merge`. Direct push produces "Closed" not "Merged", breaks issue auto-close, and loses PR association.
 - **Never use `gh pr merge --squash` without `--subject` and `--body`** — the auto-generated message omits the PR number and uses inconsistent formatting.
 - **Never let GitHub auto-generate the squash message** — no web UI merge, no merge button clicks.
-- **Always strip bot/AI attribution from the squash body** — remove `Co-authored-by` trailers for Claude, Codex, Copilot, ChatGPT, Gemini, automation accounts, and bots before confirmation. Also remove generated tool footers such as `Created with Claude Code` / `Generated with Claude Code`. Preserve intentional human co-author trailers.
+- **Always strip bot/AI attribution from the squash body** before confirmation.
+  Preserve intentional human co-author trailers only under the superseding and
+  privacy rules.
 - **Always assign PR title and commit body to shell variables** — never interpolate untrusted content directly into quoted command arguments.
 - **Always run pre-flight checks** (merge conflicts, review decision) before confirming — do not skip them even if the user says "just merge it."
 - **Always confirm before merging, no exceptions** — show the user the exact expanded command with real values and require an explicit yes. Never infer consent.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
 - **What changed and why:** (2–5 bullets — the diff shows *what*, you explain *why*)
 - **Scope boundary:** (what this PR explicitly does NOT change)
 - **Blast radius:** (what other subsystems or consumers could be affected)
-- **Linked issue(s):** `Closes #`, `Related #`, `Depends on #` (stacked), `Supersedes #` (replacing older PR)
+- **Linked issue(s):** Use plain text outside backticks. Write `Closes`, `Related`, `Depends on`, or `Supersedes` followed by the real issue or PR number.
 
 ## Validation Evidence (required)
 
@@ -59,6 +59,9 @@ Medium/high-risk PRs must fill:
 
 **Labels** live in the GitHub label UI, not in the body. Set `risk:*`, `size:*`, and scope labels via the sidebar. Auto-label corrections: add `risk: manual` and the intended label.
 
-**Commit trailers** capture AI-assisted collaboration (`Co-Authored-By: Claude ...`) — no separate section needed.
+**Do not add bot/AI attribution footers** such as `Co-authored-by: Claude ...`
+or `Created with Claude Code` to the PR body or commit-message tail. Human
+co-author trailers for incorporated contributors are still appropriate when the
+supersede-attribution section applies.
 
 **Privacy contract** (`docs/book/src/contributing/privacy.md`) is a merge gate. Never commit real identities, secrets, personal emails, or PII in diff, tests, fixtures, or docs.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,9 @@
 - **What changed and why:** (2–5 bullets — the diff shows *what*, you explain *why*)
 - **Scope boundary:** (what this PR explicitly does NOT change)
 - **Blast radius:** (what other subsystems or consumers could be affected)
-- **Linked issue(s):** Use plain text outside backticks. Write `Closes`, `Related`, `Depends on`, or `Supersedes` followed by the real issue or PR number.
+- **Linked issue(s):** Use plain text outside backticks. Use `Closes #`,
+  `Fixes #`, or `Resolves #` only for issues this PR fully resolves. Use
+  `Related #`, `Depends on #`, or `Supersedes #` for non-closing relationships.
 
 ## Validation Evidence (required)
 
@@ -61,7 +63,7 @@ Medium/high-risk PRs must fill:
 
 **Do not add bot/AI attribution footers** such as `Co-authored-by: Claude ...`
 or `Created with Claude Code` to the PR body or commit-message tail. Human
-co-author trailers for incorporated contributors are still appropriate when the
-supersede-attribution section applies.
+co-author trailers are appropriate only for incorporated contributor work under
+the supersede-attribution section and privacy contract.
 
 **Privacy contract** (`docs/book/src/contributing/privacy.md`) is a merge gate. Never commit real identities, secrets, personal emails, or PII in diff, tests, fixtures, or docs.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -61,7 +61,7 @@ Medium/high-risk PRs must fill:
 
 ---
 
-**Labels** live in the GitHub label UI, not in the body. Set `risk:*`, `size:*`, and scope labels via the sidebar. Auto-label corrections: add `risk: manual` and the intended label.
+**Labels** live in the GitHub label UI, not in the body. Maintainers and reviewers with label permissions set `risk:*`, `size:*`, and scope labels via the sidebar. If auto-labels need correction, add `risk: manual` and the intended label. Contributors without label permission can note the mismatch in a comment.
 
 **Do not add bot/AI attribution footers** such as `Co-authored-by: Claude ...`
 or `Created with Claude Code` to the PR body or commit-message tail. Human

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,8 @@
 - **Linked issue(s):** Use plain text outside backticks. Use `Closes #`,
   `Fixes #`, or `Resolves #` only for issues this PR fully resolves. Use
   `Related #`, `Depends on #`, or `Supersedes #` for non-closing relationships.
+- **Labels:** Snapshot the current GitHub labels after labels are applied, for
+  example `type: docs`, `risk: low`, `size: S`, `docs`.
 
 ## Validation Evidence (required)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,7 +121,7 @@ Branch/commit/PR rules:
 
 AI coding assistant skills live in `.claude/skills/`. Use the right one for the job:
 
-- `.claude/skills/github-pr-review-session/SKILL.md` — PR review co-pilot; assists **you** as the human reviewer. Posts reviews as WareWolf-MoonWall using the RFC feedback taxonomy (🔴/🟡/✅/🔵/🟢). Trigger: `review 1234`, `re-review 1234`, `go through the queue`.
+- `.claude/skills/github-pr-review-session/SKILL.md` — PR review co-pilot; assists **you** as the human reviewer. Posts reviews as WareWolf-MoonWall using the RFC feedback taxonomy (🔴/🟡/✅/🔵/🟢). Formal review findings use H3 headings that start with the taxonomy emoji. Trigger: `review 1234`, `re-review 1234`, `go through the queue`.
 - `.claude/skills/changelog-generation/SKILL.md` — generates `CHANGELOG-next.md` between stable tags, resolves contributors via GraphQL, feeds the release workflow. Trigger: `generate changelog`, `release notes for v0.7.x`.
 - `.claude/skills/github-issue-triage/SKILL.md` — Issue triage and lifecycle management; manages the backlog, labels, and stale policies. Trigger: `triage issues`, `sweep issues`, `handle issue #N`.
 - `.claude/skills/github-issue/SKILL.md` — Interactively files structured GitHub issues (bug reports or feature requests) using repo templates. Trigger: `file issue`, `report bug`, `feature request`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,7 +121,7 @@ Branch/commit/PR rules:
 
 AI coding assistant skills live in `.claude/skills/`. Use the right one for the job:
 
-- `.claude/skills/github-pr-review-session/SKILL.md` — PR review co-pilot; assists **you** as the human reviewer. Posts reviews as WareWolf-MoonWall using the RFC feedback taxonomy (🔴/🟡/✅/🔵/🟢). Formal review findings use H3 headings that start with the taxonomy emoji. Trigger: `review 1234`, `re-review 1234`, `go through the queue`.
+- `.claude/skills/github-pr-review-session/SKILL.md` — PR review co-pilot; assists **you** as the human reviewer. Resolves the active reviewer from session state or `gh`, uses the RFC feedback taxonomy (🔴/🟡/✅/🔵/🟢), and formats formal review findings as H3 headings that start with the taxonomy emoji. Trigger: `review 1234`, `re-review 1234`, `go through the queue`.
 - `.claude/skills/changelog-generation/SKILL.md` — generates `CHANGELOG-next.md` between stable tags, resolves contributors via GraphQL, feeds the release workflow. Trigger: `generate changelog`, `release notes for v0.7.x`.
 - `.claude/skills/github-issue-triage/SKILL.md` — Issue triage and lifecycle management; manages the backlog, labels, and stale policies. Trigger: `triage issues`, `sweep issues`, `handle issue #N`.
 - `.claude/skills/github-issue/SKILL.md` — Interactively files structured GitHub issues (bug reports or feature requests) using repo templates. Trigger: `file issue`, `report bug`, `feature request`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,7 +124,7 @@ For maintainer-facing content (PR workflow, reviewer playbook, release runbook, 
 - **Template is mandatory.** Complete every section in `.github/pull_request_template.md`.
 - **Validation evidence is required** — actual command output, not "CI will check."
 - **Privacy and identity discipline is a merge gate.** Never commit real names, emails, tokens, or PII.
-- **Co-authoring with AI is welcome.** Use the `Co-Authored-By` trailer where AI tools materially contributed.
+- **AI-assisted collaboration is welcome.** Do not add bot/AI attribution trailers or generated tool footers to PR bodies or commit-message tails. Human `Co-authored-by` trailers remain appropriate when they credit incorporated contributor work.
 - **Squash-merge with conventional commits** is the merge style.
 
 ## Reporting

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,7 +124,7 @@ For maintainer-facing content (PR workflow, reviewer playbook, release runbook, 
 - **Template is mandatory.** Complete every section in `.github/pull_request_template.md`.
 - **Validation evidence is required** — actual command output, not "CI will check."
 - **Privacy and identity discipline is a merge gate.** Never commit real names, emails, tokens, or PII.
-- **AI-assisted collaboration is welcome.** Do not add bot/AI attribution trailers or generated tool footers to PR bodies or commit-message tails. Human `Co-authored-by` trailers remain appropriate when they credit incorporated contributor work.
+- **AI-assisted collaboration is welcome.** Do not add bot/AI attribution trailers or generated tool footers to PR bodies or commit-message tails. Human `Co-authored-by` trailers remain appropriate for incorporated contributor work when they follow the superseding and privacy rules.
 - **Squash-merge with conventional commits** is the merge style.
 
 ## Reporting

--- a/docs/book/src/channels/acp.md
+++ b/docs/book/src/channels/acp.md
@@ -148,9 +148,9 @@ If the client never replies (crash, network drop, user closes IDE), the request 
 
 `ask_user` uses the same `session/request_permission` mechanism, mapping the question's `choices` to permission options. Free-form (no-choices) `ask_user` is not supported until the [ACP elicitation RFD](https://github.com/zed-industries/agent-client-protocol/blob/main/docs/rfds/elicitation.mdx) lands. Calling `ask_user` without `choices` on an ACP session fast-fails with a clear error.
 
-### `session/cancel`
+### `session/cancel` _(ZeroClaw extension)_
 
-Abort an in-flight `session/prompt` turn.
+Abort an in-flight `session/prompt` turn. `session/cancel` is a ZeroClaw-specific extension, not part of the base ACP spec. If a future ACP spec revision adds `session/cancel` with different semantics, ZeroClaw will move this extension to `_meta/session/cancel` rather than changing the method's meaning in place.
 
 **Cancel vs. stop:** `session/cancel` aborts an in-flight prompt turn and returns `stopReason: "cancelled"` with any streamed text accumulated up to the interrupt point. `session/stop` gracefully ends the session after the current turn completes — it waits for the turn to finish rather than interrupting it.
 

--- a/docs/book/src/channels/acp.md
+++ b/docs/book/src/channels/acp.md
@@ -150,7 +150,9 @@ If the client never replies (crash, network drop, user closes IDE), the request 
 
 ### `session/cancel` _(ZeroClaw extension)_
 
-Abort an in-flight `session/prompt` turn. `session/cancel` is a ZeroClaw-specific extension, not part of the base ACP spec. If a future ACP spec revision adds `session/cancel` with different semantics, ZeroClaw will move this extension to `_meta/session/cancel` rather than changing the method's meaning in place.
+Abort an in-flight `session/prompt` turn. This method is a ZeroClaw extension,
+not part of the base ACP spec. If ACP later standardizes a conflicting
+`session/cancel`, ZeroClaw will move its extension to `_meta/session/cancel`.
 
 **Cancel vs. stop:** `session/cancel` aborts an in-flight prompt turn and returns `stopReason: "cancelled"` with any streamed text accumulated up to the interrupt point. `session/stop` gracefully ends the session after the current turn completes — it waits for the turn to finish rather than interrupting it.
 

--- a/docs/book/src/contributing/how-to.md
+++ b/docs/book/src/contributing/how-to.md
@@ -67,7 +67,7 @@ refactor(runtime): split agent loop into steps
 chore: bump tokio to 1.43
 ```
 
-Co-authoring with AI is encouraged; add `Co-Authored-By:` trailers in commit messages where AI tools materially contributed. See FND-005 (Contribution Culture) for the full norm.
+AI-assisted collaboration is welcome, but do not add bot/AI attribution trailers or generated tool footers to PR bodies or commit-message tails. Preserve human `Co-authored-by:` trailers when they credit incorporated contributor work. See FND-005 (Contribution Culture) for the full norm.
 
 ## Pull requests
 

--- a/docs/book/src/contributing/how-to.md
+++ b/docs/book/src/contributing/how-to.md
@@ -25,7 +25,7 @@ The key checkpoints:
 - **PR template** — `.github/pull_request_template.md`. Fill it out. The summary, validation evidence, and compatibility sections are non-negotiable.
 - **CI** — runs on every PR. `ci.yml` is the composite gate; all legs must pass.
 - **Labels** — scope (`scope:providers`, `scope:channels`, etc.) and risk (`risk:low` / `risk:medium` / `risk:high`) are auto-applied by path-labeler. Double-check they match your change; if not, flag in a comment.
-- **Review** — maintainers review. Findings follow `[blocking]` / `[suggestion]` / `[question]` tiers. Address blockers; suggestions are optional; questions need an answer.
+- **Review** — maintainers review. Findings use the PR review taxonomy: 🔴 blocking, 🟡 warning, 🔵 suggestion, 🟢 praise, and ✅ resolved. Address blockers; warnings should get a response; suggestions are optional.
 
 ## Code style
 
@@ -67,7 +67,7 @@ refactor(runtime): split agent loop into steps
 chore: bump tokio to 1.43
 ```
 
-AI-assisted collaboration is welcome, but do not add bot/AI attribution trailers or generated tool footers to PR bodies or commit-message tails. Preserve human `Co-authored-by:` trailers when they credit incorporated contributor work. See FND-005 (Contribution Culture) for the full norm.
+AI-assisted collaboration is welcome, but do not add bot/AI attribution trailers or generated tool footers to PR bodies or commit-message tails. Human `Co-authored-by:` trailers remain appropriate for incorporated contributor work when they follow the superseding and privacy rules. See FND-005 (Contribution Culture) for the full norm.
 
 ## Pull requests
 

--- a/docs/book/src/contributing/how-to.md
+++ b/docs/book/src/contributing/how-to.md
@@ -24,7 +24,7 @@ The key checkpoints:
 
 - **PR template** — `.github/pull_request_template.md`. Fill it out. The summary, validation evidence, and compatibility sections are non-negotiable.
 - **CI** — runs on every PR. `ci.yml` is the composite gate; all legs must pass.
-- **Labels** — scope (`scope:providers`, `scope:channels`, etc.) and risk (`risk:low` / `risk:medium` / `risk:high`) are auto-applied by path-labeler. Double-check they match your change; if not, flag in a comment.
+- **Labels** — scope (`scope:providers`, `scope:channels`, etc.) and risk (`risk:low` / `risk:medium` / `risk:high`) are auto-applied by path-labeler. Double-check they match your change. If they look wrong and you cannot edit labels, flag the mismatch in a comment; maintainers or reviewers with label permissions can correct obvious mismatches directly.
 - **Review** — maintainers review. Findings use the PR review taxonomy: 🔴 blocking, 🟡 warning, 🔵 suggestion, 🟢 praise, and ✅ resolved. Address blockers; warnings should get a response; suggestions are optional.
 
 ## Code style

--- a/docs/book/src/contributing/pr-review-protocol.md
+++ b/docs/book/src/contributing/pr-review-protocol.md
@@ -79,18 +79,32 @@ The take-stock pass is what stops you from re-raising settled points and what su
 | Your review is approving and no other reviewer holds an active block | `--approve` |
 | Your review is rejecting on substantive grounds you'd block on personally | `--request-changes` |
 | You have nothing new to block on but other reviewers hold active blocks | `--comment` |
-| You have specific findings but they're all `[suggestion]` / `[question]` | `--comment` |
+| You have specific findings but they're all `[suggestion]` / non-blocking clarification questions | `--comment` |
 | You're a maintainer override-approving over another reviewer's `CHANGES_REQUESTED` | **Don't.** Get the other reviewer to dismiss or convert their review first. |
 
 ## Feedback taxonomy
 
-Findings in review bodies and inline comments use this scale (from FND-005):
+Findings in review bodies and inline comments use this PR-review scale, adapted from FND-005. The `✅ [resolved]` entry is for re-reviews that acknowledge addressed findings.
 
 - **🔴 [blocking]** — must be addressed before merge. Use sparingly; every blocker is real or the scale loses meaning.
 - **🟡 [warning]** — should be addressed; not blocking but the reviewer wants the author to look.
 - **🔵 [suggestion]** — optional. Author can accept or pass.
 - **🟢 [praise]** — what's working. Specific praise teaches what to repeat. Generic "great work" teaches nothing.
 - **✅ [resolved]** — explicitly acknowledging that a prior finding has been addressed in a later commit. Use this when you're re-reviewing — it shows the author their work registered.
+
+## Review body Markdown format
+
+Formal review body findings should use H3 headings that start with the taxonomy emoji. This keeps severity and required action easy to scan.
+
+Use these canonical forms:
+
+- `### 🔴 Blocking — short issue title`
+- `### 🟡 Warning — short issue title`
+- `### 🔵 Suggestion — short issue title`
+- `### 🟢 What looks good — short positive title`
+- `### ✅ Resolved — short resolved item`
+
+Do not write headings like `### Blocking — ...`, `### Finding 1 — ...`, or numbered findings for formal review bodies. Those miss the required taxonomy marker and make the review harder to scan.
 
 ## Voice
 
@@ -104,7 +118,7 @@ Write as a thoughtful senior contributor who has read everything and cares about
 
 ## Inline vs body
 
-- **Inline diff comments** for every `[blocking]` / `[suggestion]` / `[question]` finding tied to a specific line. Anchor the feedback to the code so the author can resolve it inline.
+- **Inline diff comments** for every `[blocking]` / `[suggestion]` finding tied to a specific line. Anchor the feedback to the code so the author can resolve it inline.
 - **Review body** for overall verdict, comprehension summary, cross-references to other PRs, and template-level issues that aren't tied to a specific line.
 - **Bare commit hashes** (never wrap in backticks — GitHub auto-links bare hashes; backticks block the auto-link).
 - **`@`-prefixed usernames** in all review content (chat, body, inline). `@WareWolf-MoonWall`, not `WareWolf-MoonWall`.

--- a/docs/book/src/contributing/pr-review-protocol.md
+++ b/docs/book/src/contributing/pr-review-protocol.md
@@ -79,7 +79,7 @@ The take-stock pass is what stops you from re-raising settled points and what su
 | Your review is approving and no other reviewer holds an active block | `--approve` |
 | Your review is rejecting on substantive grounds you'd block on personally | `--request-changes` |
 | You have nothing new to block on but other reviewers hold active blocks | `--comment` |
-| You have specific findings but they're all `[suggestion]` / non-blocking clarification questions | `--comment` |
+| You have specific findings but they're all 🔵 suggestions or non-blocking clarification questions | `--comment` |
 | You're a maintainer override-approving over another reviewer's `CHANGES_REQUESTED` | **Don't.** Get the other reviewer to dismiss or convert their review first. |
 
 ## Feedback taxonomy
@@ -113,12 +113,15 @@ Write as a thoughtful senior contributor who has read everything and cares about
 - **Be specific.** Vague feedback creates anxiety without direction. Explain the principle behind every finding, not just the verdict.
 - **Name what is good.** Specific praise (`✅ The merge order is correct because…`) builds shared judgment over time.
 - **Separate work from person.** "This approach has a problem" not "you made a mistake."
-- **Don't re-raise settled points.** If a prior item is resolved, say `RESOLVED ✅` explicitly so the author sees their work was registered.
+- **Don't re-raise settled points.** If a prior item is resolved, use
+  `### ✅ Resolved — ...` so the author sees their work was registered.
 - **Reference RFCs by section** when they're the basis for a finding. "Per FND-006 §4.3" is more useful than "per our standards."
 
 ## Inline vs body
 
-- **Inline diff comments** for every `[blocking]` / `[suggestion]` finding tied to a specific line. Anchor the feedback to the code so the author can resolve it inline.
+- **Inline diff comments** for every 🔴 blocking, 🟡 warning, or 🔵 suggestion
+  finding tied to a specific line. Anchor the feedback to the code so the
+  author can resolve it inline.
 - **Review body** for overall verdict, comprehension summary, cross-references to other PRs, and template-level issues that aren't tied to a specific line.
 - **Bare commit hashes** (never wrap in backticks — GitHub auto-links bare hashes; backticks block the auto-link).
 - **`@`-prefixed usernames** in all review content (chat, body, inline). `@WareWolf-MoonWall`, not `WareWolf-MoonWall`.

--- a/docs/book/src/contributing/pr-review-protocol.md
+++ b/docs/book/src/contributing/pr-review-protocol.md
@@ -72,6 +72,12 @@ Before you write a single line of review, name out loud:
 
 The take-stock pass is what stops you from re-raising settled points and what surfaces who's actually waiting on what.
 
+## Label hygiene
+
+Labels are maintainer metadata, not a contributor blocker. If the right label is obvious and you have permission, fix it yourself before finalizing the review. If you are acting through an assistant, draft the exact label change and get the human reviewer's approval before mutating GitHub.
+
+Ask the author about labels only when the right label choice is ambiguous or nobody with label permissions is available. Do not request changes or hold merge solely because an author cannot edit labels.
+
 ## Verdict decision tree
 
 | Situation | Verdict flag |

--- a/docs/book/src/foundations/fnd-005-contribution-culture.md
+++ b/docs/book/src/foundations/fnd-005-contribution-culture.md
@@ -174,10 +174,10 @@ patterns to repeat. Generic praise ("great work!") teaches nothing. Specific pra
 this logic in isolation without standing up the whole agent loop") teaches the principle
 and reinforces the decision.
 
-**Use the feedback taxonomy.** The four-bucket model in Section 5 gives every comment a
-clear weight. Reviewers who mix blocking issues with minor suggestions without
-distinguishing between them force the author to guess which things actually need to
-change. Do not make people guess.
+**Use the feedback taxonomy.** The taxonomy in Section 5 gives every comment a clear
+weight. Reviewers who mix blocking issues with minor suggestions without distinguishing
+between them force the author to guess which things actually need to change. Do not make
+people guess.
 
 ---
 
@@ -522,8 +522,15 @@ work and explain why. That combination is rare. It is worth taking seriously.
 
 ## 5. The feedback taxonomy
 
-Every review comment on this project carries one of four weights. Using them consistently
-means reviewers communicate clearly and authors know exactly what requires action.
+Every review comment on this project carries an explicit weight. Using those weights
+consistently means reviewers communicate clearly and authors know exactly what requires
+action.
+
+The categories below describe the project's review intent. The operational PR review
+protocol maps that intent into the canonical GitHub review categories and heading format:
+🔴 blocking, 🟡 warning, 🔵 suggestion, 🟢 praise, and ✅ resolved. When writing PR
+reviews, use `docs/book/src/contributing/pr-review-protocol.md` for the exact category
+names, emoji, and Markdown heading format.
 
 ---
 

--- a/docs/book/src/foundations/fnd-005-contribution-culture.md
+++ b/docs/book/src/foundations/fnd-005-contribution-culture.md
@@ -526,11 +526,11 @@ Every review comment on this project carries an explicit weight. Using those wei
 consistently means reviewers communicate clearly and authors know exactly what requires
 action.
 
-The categories below describe the project's review intent. The operational PR review
-protocol maps that intent into the canonical GitHub review categories and heading format:
-🔴 blocking, 🟡 warning, 🔵 suggestion, 🟢 praise, and ✅ resolved. When writing PR
-reviews, use `docs/book/src/contributing/pr-review-protocol.md` for the exact category
-names, emoji, and Markdown heading format.
+The categories below describe the project's review intent. PR reviews render
+that intent through the review protocol's emoji headings: 🔴 blocking,
+🟡 warning, 🔵 suggestion, 🟢 praise, and ✅ resolved. Use
+`docs/book/src/contributing/pr-review-protocol.md` for the exact PR-review
+format.
 
 ---
 

--- a/docs/book/src/maintainers/reviewer-playbook.md
+++ b/docs/book/src/maintainers/reviewer-playbook.md
@@ -27,6 +27,8 @@ When uncertain, treat as higher risk.
 
 If the path-labeler's risk inference is contextually wrong, apply `risk: manual` and set the final `risk:*` label explicitly — manual freezes any future automated recalculation.
 
+Labels are maintainer metadata. If the correct label is obvious and you have permission, fix it yourself before finalizing the review. Ask the author only when the right label choice is ambiguous or nobody with label permissions is available.
+
 ## Standard workflow
 
 ### Five-minute intake


### PR DESCRIPTION
## Summary

- **Base branch:** master
- **What changed and why:**
  - Clarified that bot/AI attribution footers do not belong in PR bodies or landed squash commit-message tails, while human co-author trailers remain available for incorporated contributor work under superseding and privacy rules.
  - Tightened the PR review draft flow: formal reviews still use `tmp/review-<number>.md` and `--body-file`, and the review skill now explicitly requires showing the draft before posting while keeping PR-review Markdown rules scoped to reviews/review comments.
  - Clarified linked-issue wording so closing keywords are reserved for fully resolved issues, while Related, Depends on, and Supersedes remain non-closing relationship metadata.
  - Added a PR-template label snapshot field so PR-body gates can compare the body's declared labels against live GitHub labels.
  - Clarified label hygiene: reviewers with label permissions should fix obvious label mismatches themselves, not block contributors who may not be allowed to edit labels.
  - Made PR-review taxonomy guidance consistent across the review protocol, contribution guide, FND-005, and review skill: formal findings use H3 headings that start with taxonomy emoji.
  - Clarified that ACP `session/cancel` is a ZeroClaw extension and that a future conflicting ACP standard method would move ZeroClaw's extension to `_meta/session/cancel`.
- **Scope boundary:** This PR only updates contributor/maintainer workflow docs, assistant skills, the PR template, and one ACP docs-contract note. It does not add a CI enforcement hook, rewrite existing history, change runtime code, regenerate locale catalogs, or remove human contributor attribution.
- **Blast radius:** Contributor and maintainer workflow text plus one ACP docs sentence. The highest-risk surface is wording clarity in the PR/review/squash-merge skills, reviewer playbook, and PR template.
- **Linked issue(s):** Related #6408.
- **Labels:** `size: S`, `type: docs`, `ci`, `risk: low`, `docs`. The `ci` label is present because workflow/template/skill files changed; this PR does not change GitHub Actions or add a CI enforcement hook.

## Validation Evidence (required)

- **Commands run and tail output:**

```text
git diff --check
Result: passed; no output.

scripts/ci/docs_quality_gate.sh
Result: sandbox run failed before linting because npm registry DNS lookup failed for markdownlint-cli2. Rerun outside the Codex sandbox passed: existing markdown issues were outside changed lines, with no blocking markdown issues on changed lines.

PR body / proposed squash-body attribution check
Result: no bot/AI attribution footers are present in this PR body. The local branch commit created by Codex carries the environment-required `Co-authored-by: Codex <noreply@openai.com>` trailer; the updated squash-merge guidance strips bot/AI trailers from the landed squash body.
```

- **Beyond CI — what did you manually verify?** Checked the final diff for duplicate guidance, over-broad review-format scope, linked-issue wording, reviewer-identity wording, label-permission wording, taxonomy consistency, and attribution/privacy wording.
- **If any command was intentionally skipped, why:** Rust fmt, clippy, build, and test were skipped because this is a docs/template/skill-only change with no Rust source changes. Locale catalog regeneration was not run in this cleanup because the current docs sync path is already known to fail before extraction when `book.toml` references the generated, gitignored `theme/lang-switcher.js`; this PR intentionally does not hand-edit generated locale catalogs.

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: None.

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: Existing users do not need to change config, env vars, CLI usage, or runtime behavior. This only changes contributor workflow guidance and docs wording.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PRs: revert this PR's commits unless otherwise noted.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Scope materially carried forward: N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`No`)
- If `No`, why (inspiration-only, no direct code/design carry-over): No superseded PR or incorporated contributor patch.
