### PR TITLE
feat(tools): spotify tool (Web API, refresh-token OAuth)

### DIFF
--- a/CHANGELOG-next.md
+++ b/CHANGELOG-next.md
@@ -116,6 +116,7 @@
 
 - `SessionResetTool` and `SessionDeleteTool` for in-agent session management (#5696).
 - `SessionsCurrentTool` exposes the active session identity (#6033).
+- `spotify` tool — Spotify Web API client driven by a refresh-token OAuth flow. Read-only by default (`get_playback_state`, `list_devices`, `list_playlists`, `search`); operators opt into mutations (`play`, `pause`, `next`, `previous`, `set_volume`) via `allowed_actions`. Premium required for control (#6475).
 
 ### Plugins
 

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -385,6 +385,11 @@ pub struct Config {
     #[nested]
     pub jira: JiraConfig,
 
+    /// Spotify integration configuration (`[spotify]`).
+    #[serde(default)]
+    #[nested]
+    pub spotify: SpotifyConfig,
+
     /// Secure inter-node transport configuration (`[node_transport]`).
     #[serde(default)]
     #[nested]
@@ -9316,6 +9321,99 @@ impl Default for JiraConfig {
     }
 }
 
+/// Spotify integration configuration (`[spotify]`).
+///
+/// When `enabled = true`, registers the `spotify` tool which can read
+/// playback state, list devices and playlists, search the catalogue,
+/// and (when allowed) drive playback (play/pause/skip/volume) via the
+/// Spotify Web API.
+///
+/// ## Defaults
+/// - `enabled`: `false`
+/// - `allowed_actions`: read-only set —
+///   `["get_playback_state", "list_devices", "list_playlists", "search"]`.
+///   Add any of `play`, `pause`, `next`, `previous`, `set_volume` to
+///   enable the matching mutation.
+/// - `request_timeout_secs`: `15`
+///
+/// ## Auth
+/// Refresh-token flow only — no embedded auth dance. The operator
+/// performs the one-time OAuth exchange externally (see the setup guide)
+/// and pastes the resulting `refresh_token` into config (or sets
+/// `SPOTIFY_REFRESH_TOKEN`). The tool exchanges the refresh token for a
+/// short-lived access token at startup and on `401`. `client_secret` and
+/// `refresh_token` are encrypted at rest when `[secrets] encrypt = true`.
+///
+/// Required scopes when minting the refresh token: `user-read-playback-state`,
+/// `user-modify-playback-state`, `playlist-read-private`, `user-read-currently-playing`.
+///
+/// Note: playback control (`play`, `pause`, `next`, `previous`,
+/// `set_volume`) requires Spotify Premium on the controlled account.
+/// The tool surfaces upstream `403`s verbatim when the account is Free.
+#[derive(Debug, Clone, Serialize, Deserialize, Configurable)]
+#[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
+#[prefix = "spotify"]
+#[integration(
+    category = "ToolsAutomation",
+    display_name = "Spotify",
+    description = "Music playback control",
+    status_field = "enabled"
+)]
+pub struct SpotifyConfig {
+    /// Enable the `spotify` tool. Default: `false`.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Spotify developer-portal application client ID.
+    #[serde(default)]
+    pub client_id: String,
+    /// Spotify developer-portal application client secret. Encrypted at
+    /// rest. Falls back to `SPOTIFY_CLIENT_SECRET` env var.
+    #[serde(default)]
+    #[secret]
+    #[cfg_attr(feature = "schema-export", schemars(extend("x-secret" = true)))]
+    pub client_secret: String,
+    /// Refresh token minted via the one-time OAuth flow. Encrypted at
+    /// rest. Falls back to `SPOTIFY_REFRESH_TOKEN` env var.
+    #[serde(default)]
+    #[secret]
+    #[cfg_attr(feature = "schema-export", schemars(extend("x-secret" = true)))]
+    pub refresh_token: String,
+    /// Actions the agent is permitted to invoke. Read actions
+    /// (`get_playback_state`, `list_devices`, `list_playlists`, `search`)
+    /// must be present here too — empty list disables the tool entirely.
+    #[serde(default = "default_spotify_allowed_actions")]
+    pub allowed_actions: Vec<String>,
+    /// Request timeout in seconds. Default: `15`.
+    #[serde(default = "default_spotify_timeout_secs")]
+    pub request_timeout_secs: u64,
+}
+
+fn default_spotify_allowed_actions() -> Vec<String> {
+    vec![
+        "get_playback_state".into(),
+        "list_devices".into(),
+        "list_playlists".into(),
+        "search".into(),
+    ]
+}
+
+fn default_spotify_timeout_secs() -> u64 {
+    15
+}
+
+impl Default for SpotifyConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            client_id: String::new(),
+            client_secret: String::new(),
+            refresh_token: String::new(),
+            allowed_actions: default_spotify_allowed_actions(),
+            request_timeout_secs: default_spotify_timeout_secs(),
+        }
+    }
+}
+
 ///
 /// Controls the read-only cloud transformation analysis tools:
 /// IaC review, migration assessment, cost analysis, and architecture review.
@@ -9634,6 +9732,7 @@ impl Default for Config {
             onboard_state: OnboardStateConfig::default(),
             notion: NotionConfig::default(),
             jira: JiraConfig::default(),
+            spotify: SpotifyConfig::default(),
             node_transport: NodeTransportConfig::default(),
             knowledge: KnowledgeConfig::default(),
             linkedin: LinkedInConfig::default(),
@@ -12595,6 +12694,7 @@ auto_save = true
             onboard_state: OnboardStateConfig::default(),
             notion: NotionConfig::default(),
             jira: JiraConfig::default(),
+            spotify: SpotifyConfig::default(),
             node_transport: NodeTransportConfig::default(),
             knowledge: KnowledgeConfig::default(),
             linkedin: LinkedInConfig::default(),
@@ -13166,6 +13266,7 @@ default_temperature = 0.7
             onboard_state: OnboardStateConfig::default(),
             notion: NotionConfig::default(),
             jira: JiraConfig::default(),
+            spotify: SpotifyConfig::default(),
             node_transport: NodeTransportConfig::default(),
             knowledge: KnowledgeConfig::default(),
             linkedin: LinkedInConfig::default(),

--- a/crates/zeroclaw-runtime/src/integrations/mod.rs
+++ b/crates/zeroclaw-runtime/src/integrations/mod.rs
@@ -148,6 +148,22 @@ pub fn show_integration_info(config: &Config, name: &str) -> Result<()> {
             println!("    Supports city names, IATA airport codes, GPS coordinates,");
             println!("    postal/zip codes, and Unicode location names.");
         }
+        "Spotify" => {
+            println!("  Setup:");
+            println!("    1. Register an app at https://developer.spotify.com/dashboard.");
+            println!("    2. Mint a refresh token (one-time external OAuth dance — see");
+            println!("       docs/book/src/tools/spotify.md for the recipe).");
+            println!("    3. Add to config:");
+            println!("       [spotify]");
+            println!("       enabled = true");
+            println!("       client_id = \"...\"");
+            println!("       client_secret = \"...\"  # or SPOTIFY_CLIENT_SECRET");
+            println!("       refresh_token = \"...\" # or SPOTIFY_REFRESH_TOKEN");
+            println!(
+                "    4. Default allowed_actions is read-only; add play/pause/etc to enable mutations."
+            );
+            println!("    Note: playback control requires Spotify Premium.");
+        }
         _ if entry.category == IntegrationCategory::Chat => {
             println!("  Setup:");
             println!("    Run: zeroclaw onboard --channels-only");

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -102,6 +102,7 @@ pub use zeroclaw_tools::sessions::{
     SessionDeleteTool, SessionResetTool, SessionsCurrentTool, SessionsHistoryTool,
     SessionsListTool, SessionsSendTool,
 };
+pub use zeroclaw_tools::spotify::SpotifyTool;
 pub use zeroclaw_tools::swarm::SwarmTool;
 pub use zeroclaw_tools::text_browser::TextBrowserTool;
 pub use zeroclaw_tools::tool_search::ToolSearchTool;
@@ -599,6 +600,42 @@ pub fn all_tools_with_runtime(
                 root_config.jira.allowed_actions.clone(),
                 security.clone(),
                 root_config.jira.timeout_secs,
+            )));
+        }
+    }
+
+    // Spotify integration (config-gated)
+    if root_config.spotify.enabled {
+        let client_id = if root_config.spotify.client_id.trim().is_empty() {
+            std::env::var("SPOTIFY_CLIENT_ID").unwrap_or_default()
+        } else {
+            root_config.spotify.client_id.trim().to_string()
+        };
+        let client_secret = if root_config.spotify.client_secret.trim().is_empty() {
+            std::env::var("SPOTIFY_CLIENT_SECRET").unwrap_or_default()
+        } else {
+            root_config.spotify.client_secret.trim().to_string()
+        };
+        let refresh_token = if root_config.spotify.refresh_token.trim().is_empty() {
+            std::env::var("SPOTIFY_REFRESH_TOKEN").unwrap_or_default()
+        } else {
+            root_config.spotify.refresh_token.trim().to_string()
+        };
+        if client_id.trim().is_empty()
+            || client_secret.trim().is_empty()
+            || refresh_token.trim().is_empty()
+        {
+            tracing::warn!(
+                "spotify: enabled but missing one of client_id, client_secret, refresh_token (or their SPOTIFY_* env vars) — skipping registration"
+            );
+        } else {
+            tool_arcs.push(Arc::new(SpotifyTool::new(
+                client_id,
+                client_secret,
+                refresh_token,
+                root_config.spotify.allowed_actions.clone(),
+                root_config.spotify.request_timeout_secs,
+                security.clone(),
             )));
         }
     }

--- a/crates/zeroclaw-tools/src/lib.rs
+++ b/crates/zeroclaw-tools/src/lib.rs
@@ -63,6 +63,7 @@ pub mod report_template_tool;
 pub mod report_templates;
 pub mod screenshot;
 pub mod sessions;
+pub mod spotify;
 pub mod swarm;
 pub mod text_browser;
 pub mod tool_search;

--- a/crates/zeroclaw-tools/src/spotify.rs
+++ b/crates/zeroclaw-tools/src/spotify.rs
@@ -1,0 +1,725 @@
+//! Spotify tool — Web API client driven by a refresh-token OAuth flow.
+//!
+//! Auth model: the operator does the one-time OAuth dance externally
+//! (see `docs/book/src/tools/spotify.md`) and pastes the resulting
+//! `refresh_token` into config. At runtime the tool exchanges the
+//! refresh token for a short-lived access token via
+//! `POST https://accounts.spotify.com/api/token`, caches it in memory,
+//! and refreshes on `401` or when within 60s of expiry.
+//!
+//! Read actions (`get_playback_state`, `list_devices`, `list_playlists`,
+//! `search`) require `ToolOperation::Read`. Mutating actions (`play`,
+//! `pause`, `next`, `previous`, `set_volume`) require `ToolOperation::Act`
+//! AND must appear in the operator's `allowed_actions` allowlist.
+//!
+//! Playback control requires Spotify Premium; the tool returns the
+//! upstream `403` verbatim when the account is Free.
+
+use async_trait::async_trait;
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as B64;
+use serde::Deserialize;
+use serde_json::{Value, json};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::Mutex;
+use zeroclaw_api::tool::{Tool, ToolResult};
+use zeroclaw_config::policy::{SecurityPolicy, ToolOperation};
+
+const SPOTIFY_API_BASE: &str = "https://api.spotify.com/v1";
+const SPOTIFY_TOKEN_URL: &str = "https://accounts.spotify.com/api/token";
+const MAX_ERROR_BODY_CHARS: usize = 500;
+/// Refresh tokens proactively this many seconds before the upstream
+/// `expires_in`. Keeps a small buffer so a request that takes a moment
+/// to dispatch still uses a valid token.
+const TOKEN_REFRESH_LEAD_SECS: u64 = 60;
+const VOLUME_MIN: u64 = 0;
+const VOLUME_MAX: u64 = 100;
+
+#[derive(Debug, Clone)]
+struct AccessToken {
+    token: String,
+    expires_at: Instant,
+}
+
+impl AccessToken {
+    fn is_fresh(&self) -> bool {
+        self.expires_at
+            .checked_duration_since(Instant::now())
+            .is_some_and(|d| d.as_secs() > TOKEN_REFRESH_LEAD_SECS)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct TokenResponse {
+    access_token: String,
+    expires_in: u64,
+}
+
+/// Tool for interacting with the Spotify Web API.
+pub struct SpotifyTool {
+    client_id: String,
+    client_secret: String,
+    refresh_token: String,
+    allowed_actions: Vec<String>,
+    request_timeout_secs: u64,
+    token: Arc<Mutex<Option<AccessToken>>>,
+    http: reqwest::Client,
+    security: Arc<SecurityPolicy>,
+}
+
+impl SpotifyTool {
+    pub fn new(
+        client_id: String,
+        client_secret: String,
+        refresh_token: String,
+        allowed_actions: Vec<String>,
+        request_timeout_secs: u64,
+        security: Arc<SecurityPolicy>,
+    ) -> Self {
+        let allowed_actions = allowed_actions
+            .into_iter()
+            .map(|a| a.trim().to_string())
+            .filter(|a| !a.is_empty())
+            .collect();
+        Self {
+            client_id,
+            client_secret,
+            refresh_token,
+            allowed_actions,
+            request_timeout_secs,
+            token: Arc::new(Mutex::new(None)),
+            http: reqwest::Client::new(),
+            security,
+        }
+    }
+
+    fn timeout(&self) -> Duration {
+        Duration::from_secs(self.request_timeout_secs.max(1))
+    }
+
+    fn is_action_allowed(&self, action: &str) -> bool {
+        self.allowed_actions.iter().any(|a| a == action)
+    }
+
+    /// Build the basic-auth header value used during refresh-token exchange.
+    /// Public for unit testing — exercised independently of the network.
+    fn basic_auth_header(client_id: &str, client_secret: &str) -> String {
+        let creds = format!("{client_id}:{client_secret}");
+        format!("Basic {}", B64.encode(creds))
+    }
+
+    /// Exchange the refresh token for a fresh access token. Replaces any
+    /// prior cached token regardless of freshness.
+    async fn refresh_access_token(&self) -> anyhow::Result<AccessToken> {
+        let resp = self
+            .http
+            .post(SPOTIFY_TOKEN_URL)
+            .header(
+                "Authorization",
+                Self::basic_auth_header(&self.client_id, &self.client_secret),
+            )
+            .form(&[
+                ("grant_type", "refresh_token"),
+                ("refresh_token", self.refresh_token.as_str()),
+            ])
+            .timeout(self.timeout())
+            .send()
+            .await?;
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            let truncated =
+                crate::util_helpers::truncate_with_ellipsis(&body, MAX_ERROR_BODY_CHARS);
+            anyhow::bail!("Spotify token refresh failed ({status}): {truncated}");
+        }
+        let parsed: TokenResponse = resp.json().await?;
+        let token = AccessToken {
+            token: parsed.access_token,
+            expires_at: Instant::now() + Duration::from_secs(parsed.expires_in),
+        };
+        *self.token.lock().await = Some(token.clone());
+        Ok(token)
+    }
+
+    async fn current_token(&self) -> anyhow::Result<AccessToken> {
+        if let Some(t) = self.token.lock().await.clone()
+            && t.is_fresh()
+        {
+            return Ok(t);
+        }
+        self.refresh_access_token().await
+    }
+
+    fn auth_headers(token: &str) -> anyhow::Result<reqwest::header::HeaderMap> {
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(
+            "Authorization",
+            format!("Bearer {token}")
+                .parse()
+                .map_err(|e| anyhow::anyhow!("Invalid Spotify token header: {e}"))?,
+        );
+        headers.insert("Content-Type", "application/json".parse().unwrap());
+        Ok(headers)
+    }
+
+    /// Issue a request that retries once with a fresh token on `401`.
+    /// `body` is sent only when `Some`. Spotify mutations frequently
+    /// return `204 No Content`; we surface an empty JSON object in that
+    /// case so callers always get a `Value`.
+    async fn request_authed(
+        &self,
+        method: reqwest::Method,
+        path_and_query: &str,
+        body: Option<&Value>,
+    ) -> anyhow::Result<Value> {
+        let url = format!("{SPOTIFY_API_BASE}{path_and_query}");
+        let mut token = self.current_token().await?;
+        for attempt in 0..2 {
+            let mut req = self
+                .http
+                .request(method.clone(), &url)
+                .headers(Self::auth_headers(&token.token)?)
+                .timeout(self.timeout());
+            if let Some(b) = body {
+                req = req.json(b);
+            }
+            let resp = req.send().await?;
+            let status = resp.status();
+            if status.as_u16() == 401 && attempt == 0 {
+                token = self.refresh_access_token().await?;
+                continue;
+            }
+            if !status.is_success() {
+                let body = resp.text().await.unwrap_or_default();
+                let truncated =
+                    crate::util_helpers::truncate_with_ellipsis(&body, MAX_ERROR_BODY_CHARS);
+                anyhow::bail!("Spotify {method} {path_and_query} failed ({status}): {truncated}");
+            }
+            // 204 No Content is common on mutations.
+            if status.as_u16() == 204 {
+                return Ok(json!({}));
+            }
+            return resp.json().await.map_err(Into::into);
+        }
+        unreachable!("loop exits via return or bail")
+    }
+}
+
+#[async_trait]
+impl Tool for SpotifyTool {
+    fn name(&self) -> &str {
+        "spotify"
+    }
+
+    fn description(&self) -> &str {
+        "Drive a Spotify account via the Web API. Read playback state, \
+         list devices and playlists, search the catalogue, and (when the \
+         operator allows) control playback (play/pause/next/previous/\
+         set_volume). Mutations require Spotify Premium and an action \
+         in allowed_actions."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": [
+                        "get_playback_state",
+                        "list_devices",
+                        "list_playlists",
+                        "search",
+                        "play",
+                        "pause",
+                        "next",
+                        "previous",
+                        "set_volume"
+                    ],
+                    "description": "The Spotify operation to perform."
+                },
+                "query": {
+                    "type": "string",
+                    "description": "Search query. Required for search."
+                },
+                "search_type": {
+                    "type": "string",
+                    "enum": ["track", "album", "artist", "playlist", "show", "episode"],
+                    "description": "Type of object to search for. Default: \"track\"."
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 50,
+                    "description": "Pagination limit (1-50). Default: 20."
+                },
+                "uris": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Spotify URIs (e.g. `spotify:track:...`) for play. Optional; without it, play resumes the current context."
+                },
+                "context_uri": {
+                    "type": "string",
+                    "description": "Spotify context URI (album/playlist/artist) for play. Optional."
+                },
+                "device_id": {
+                    "type": "string",
+                    "description": "Target device ID for playback mutations. Optional; defaults to the active device."
+                },
+                "volume_percent": {
+                    "type": "integer",
+                    "minimum": VOLUME_MIN,
+                    "maximum": VOLUME_MAX,
+                    "description": "Volume 0-100. Required for set_volume."
+                }
+            },
+            "required": ["action"]
+        })
+    }
+
+    async fn execute(&self, args: Value) -> anyhow::Result<ToolResult> {
+        let action = match args.get("action").and_then(|v| v.as_str()) {
+            Some(a) => a,
+            None => {
+                return Ok(ToolResult {
+                    success: false,
+                    output: String::new(),
+                    error: Some("Missing required parameter: action".into()),
+                });
+            }
+        };
+
+        let operation = match action {
+            "get_playback_state" | "list_devices" | "list_playlists" | "search" => {
+                ToolOperation::Read
+            }
+            "play" | "pause" | "next" | "previous" | "set_volume" => ToolOperation::Act,
+            _ => {
+                return Ok(ToolResult {
+                    success: false,
+                    output: String::new(),
+                    error: Some(format!(
+                        "Unknown action: {action}. Valid actions: get_playback_state, list_devices, list_playlists, search, play, pause, next, previous, set_volume"
+                    )),
+                });
+            }
+        };
+
+        if !self.is_action_allowed(action) {
+            let allowed = if self.allowed_actions.is_empty() {
+                "(none — allowed_actions is empty)".to_string()
+            } else {
+                self.allowed_actions.join(", ")
+            };
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!(
+                    "Action '{action}' is not in allowed_actions. Allowed: {allowed}"
+                )),
+            });
+        }
+
+        if let Err(error) = self.security.enforce_tool_operation(operation, "spotify") {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(error),
+            });
+        }
+
+        let device_query = args
+            .get("device_id")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.trim().is_empty())
+            .map(|d| format!("?device_id={}", urlencoding(d)))
+            .unwrap_or_default();
+
+        let result = match action {
+            "get_playback_state" => {
+                self.request_authed(reqwest::Method::GET, "/me/player", None)
+                    .await
+            }
+            "list_devices" => {
+                self.request_authed(reqwest::Method::GET, "/me/player/devices", None)
+                    .await
+            }
+            "list_playlists" => {
+                let limit = args
+                    .get("limit")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(20)
+                    .clamp(1, 50);
+                self.request_authed(
+                    reqwest::Method::GET,
+                    &format!("/me/playlists?limit={limit}"),
+                    None,
+                )
+                .await
+            }
+            "search" => {
+                let query = match args.get("query").and_then(|v| v.as_str()) {
+                    Some(q) if !q.trim().is_empty() => q.trim().to_string(),
+                    _ => {
+                        return Ok(ToolResult {
+                            success: false,
+                            output: String::new(),
+                            error: Some("search requires query parameter".into()),
+                        });
+                    }
+                };
+                let search_type = args
+                    .get("search_type")
+                    .and_then(|v| v.as_str())
+                    .filter(|s| !s.trim().is_empty())
+                    .unwrap_or("track");
+                let limit = args
+                    .get("limit")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(20)
+                    .clamp(1, 50);
+                self.request_authed(
+                    reqwest::Method::GET,
+                    &format!(
+                        "/search?q={}&type={}&limit={limit}",
+                        urlencoding(&query),
+                        urlencoding(search_type)
+                    ),
+                    None,
+                )
+                .await
+            }
+            "play" => {
+                let mut body = json!({});
+                if let Some(uris) = args.get("uris").and_then(|v| v.as_array())
+                    && !uris.is_empty()
+                {
+                    body["uris"] = Value::Array(uris.clone());
+                }
+                if let Some(ctx) = args.get("context_uri").and_then(|v| v.as_str())
+                    && !ctx.trim().is_empty()
+                {
+                    body["context_uri"] = Value::String(ctx.trim().to_string());
+                }
+                let body_opt = if body.as_object().is_none_or(|o| o.is_empty()) {
+                    None
+                } else {
+                    Some(&body)
+                };
+                self.request_authed(
+                    reqwest::Method::PUT,
+                    &format!("/me/player/play{device_query}"),
+                    body_opt,
+                )
+                .await
+            }
+            "pause" => {
+                self.request_authed(
+                    reqwest::Method::PUT,
+                    &format!("/me/player/pause{device_query}"),
+                    None,
+                )
+                .await
+            }
+            "next" => {
+                self.request_authed(
+                    reqwest::Method::POST,
+                    &format!("/me/player/next{device_query}"),
+                    None,
+                )
+                .await
+            }
+            "previous" => {
+                self.request_authed(
+                    reqwest::Method::POST,
+                    &format!("/me/player/previous{device_query}"),
+                    None,
+                )
+                .await
+            }
+            "set_volume" => {
+                let volume = match args.get("volume_percent").and_then(|v| v.as_u64()) {
+                    Some(v) => v,
+                    None => {
+                        return Ok(ToolResult {
+                            success: false,
+                            output: String::new(),
+                            error: Some("set_volume requires volume_percent (0-100)".into()),
+                        });
+                    }
+                };
+                if !(VOLUME_MIN..=VOLUME_MAX).contains(&volume) {
+                    return Ok(ToolResult {
+                        success: false,
+                        output: String::new(),
+                        error: Some(format!(
+                            "volume_percent {volume} out of range. Must be {VOLUME_MIN}-{VOLUME_MAX}."
+                        )),
+                    });
+                }
+                let device_suffix = if device_query.is_empty() {
+                    String::new()
+                } else {
+                    // already starts with "?device_id=..."; append rather than prefix `?`
+                    format!("&{}", &device_query[1..])
+                };
+                self.request_authed(
+                    reqwest::Method::PUT,
+                    &format!("/me/player/volume?volume_percent={volume}{device_suffix}"),
+                    None,
+                )
+                .await
+            }
+            _ => unreachable!(),
+        };
+
+        match result {
+            Ok(value) => Ok(ToolResult {
+                success: true,
+                output: serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string()),
+                error: None,
+            }),
+            Err(e) => Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(e.to_string()),
+            }),
+        }
+    }
+}
+
+/// Minimal application/x-www-form-urlencoded encoding for query-string
+/// values. Avoids pulling in the `urlencoding` crate for one helper.
+fn urlencoding(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.bytes() {
+        match ch {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(ch as char);
+            }
+            _ => {
+                out.push_str(&format!("%{ch:02X}"));
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zeroclaw_config::policy::SecurityPolicy;
+
+    fn read_only_tool() -> SpotifyTool {
+        SpotifyTool::new(
+            "client-id".into(),
+            "client-secret".into(),
+            "refresh-token".into(),
+            vec![
+                "get_playback_state".into(),
+                "list_devices".into(),
+                "list_playlists".into(),
+                "search".into(),
+            ],
+            15,
+            Arc::new(SecurityPolicy::default()),
+        )
+    }
+
+    fn full_access_tool() -> SpotifyTool {
+        SpotifyTool::new(
+            "client-id".into(),
+            "client-secret".into(),
+            "refresh-token".into(),
+            vec![
+                "get_playback_state".into(),
+                "list_devices".into(),
+                "list_playlists".into(),
+                "search".into(),
+                "play".into(),
+                "pause".into(),
+                "next".into(),
+                "previous".into(),
+                "set_volume".into(),
+            ],
+            15,
+            Arc::new(SecurityPolicy::default()),
+        )
+    }
+
+    #[test]
+    fn name_is_spotify() {
+        assert_eq!(read_only_tool().name(), "spotify");
+    }
+
+    #[test]
+    fn description_is_non_empty() {
+        let tool = read_only_tool();
+        assert!(!tool.description().is_empty());
+    }
+
+    #[test]
+    fn parameters_schema_requires_action() {
+        let schema = read_only_tool().parameters_schema();
+        let required = schema["required"].as_array().unwrap();
+        assert!(required.iter().any(|v| v.as_str() == Some("action")));
+    }
+
+    #[test]
+    fn parameters_schema_lists_all_actions() {
+        let schema = read_only_tool().parameters_schema();
+        let actions = schema["properties"]["action"]["enum"].as_array().unwrap();
+        let names: Vec<&str> = actions.iter().filter_map(|v| v.as_str()).collect();
+        for expected in &[
+            "get_playback_state",
+            "list_devices",
+            "list_playlists",
+            "search",
+            "play",
+            "pause",
+            "next",
+            "previous",
+            "set_volume",
+        ] {
+            assert!(names.contains(expected), "missing action: {expected}");
+        }
+    }
+
+    #[test]
+    fn parameters_schema_volume_bounds() {
+        let schema = read_only_tool().parameters_schema();
+        let v = &schema["properties"]["volume_percent"];
+        assert_eq!(v["minimum"], 0);
+        assert_eq!(v["maximum"], 100);
+    }
+
+    #[test]
+    fn allowed_actions_trimmed_and_empty_dropped() {
+        let tool = SpotifyTool::new(
+            "c".into(),
+            "s".into(),
+            "r".into(),
+            vec!["  search ".into(), "".into(), "play".into()],
+            15,
+            Arc::new(SecurityPolicy::default()),
+        );
+        assert!(tool.is_action_allowed("search"));
+        assert!(tool.is_action_allowed("play"));
+        assert!(!tool.is_action_allowed(""));
+    }
+
+    #[test]
+    fn basic_auth_header_format_matches_oauth2() {
+        let header = SpotifyTool::basic_auth_header("abc", "xyz");
+        // base64("abc:xyz") = "YWJjOnh5eg=="
+        assert_eq!(header, "Basic YWJjOnh5eg==");
+    }
+
+    #[test]
+    fn urlencoding_handles_unsafe_chars() {
+        assert_eq!(urlencoding("hello world"), "hello%20world");
+        assert_eq!(urlencoding("a&b=c"), "a%26b%3Dc");
+        // Unreserved characters pass through.
+        assert_eq!(urlencoding("ABCabc019-_.~"), "ABCabc019-_.~");
+    }
+
+    #[test]
+    fn access_token_freshness_check() {
+        let stale = AccessToken {
+            token: "x".into(),
+            expires_at: Instant::now(),
+        };
+        assert!(!stale.is_fresh());
+        let fresh = AccessToken {
+            token: "x".into(),
+            expires_at: Instant::now() + Duration::from_secs(3600),
+        };
+        assert!(fresh.is_fresh());
+    }
+
+    #[tokio::test]
+    async fn execute_missing_action_returns_error() {
+        let result = read_only_tool().execute(json!({})).await.unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("action"));
+    }
+
+    #[tokio::test]
+    async fn execute_unknown_action_returns_error() {
+        let result = read_only_tool()
+            .execute(json!({"action": "nope"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("Unknown action"));
+    }
+
+    #[tokio::test]
+    async fn execute_play_blocked_when_not_in_allowlist() {
+        let result = read_only_tool()
+            .execute(json!({"action": "play"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        let err = result.error.unwrap();
+        assert!(err.contains("not in allowed_actions"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn execute_search_missing_query_returns_error() {
+        let result = read_only_tool()
+            .execute(json!({"action": "search"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("query"));
+    }
+
+    #[tokio::test]
+    async fn execute_set_volume_missing_param_returns_error() {
+        let result = full_access_tool()
+            .execute(json!({"action": "set_volume"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("volume_percent"));
+    }
+
+    #[tokio::test]
+    async fn execute_set_volume_out_of_range_returns_error() {
+        let result = full_access_tool()
+            .execute(json!({"action": "set_volume", "volume_percent": 150}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("out of range"));
+    }
+
+    #[tokio::test]
+    async fn execute_blocked_when_allowed_actions_empty() {
+        let tool = SpotifyTool::new(
+            "c".into(),
+            "s".into(),
+            "r".into(),
+            vec![],
+            15,
+            Arc::new(SecurityPolicy::default()),
+        );
+        let result = tool
+            .execute(json!({"action": "get_playback_state"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("none"));
+    }
+
+    #[test]
+    fn spec_reflects_metadata() {
+        let tool = read_only_tool();
+        let spec = tool.spec();
+        assert_eq!(spec.name, "spotify");
+        assert_eq!(spec.description, tool.description());
+        assert!(spec.parameters.is_object());
+    }
+}

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -58,6 +58,7 @@
 - [Overview](./tools/overview.md)
 - [MCP (Model Context Protocol)](./tools/mcp.md)
 - [Browser automation](./tools/browser.md)
+- [Spotify](./tools/spotify.md)
 
 # Security
 

--- a/docs/book/src/tools/spotify.md
+++ b/docs/book/src/tools/spotify.md
@@ -1,0 +1,129 @@
+# Spotify
+
+The `spotify` tool drives a Spotify account via the [Web API](https://developer.spotify.com/documentation/web-api). It is **disabled by default** and uses a refresh-token OAuth flow — the operator does the one-time auth dance externally and pastes the refresh token into config.
+
+When enabled, the agent can:
+
+- `get_playback_state` — read the current playback state (track, device, progress, shuffle/repeat).
+- `list_devices` — list active Spotify Connect devices.
+- `list_playlists` — list the user's playlists.
+- `search` — search the catalogue by query and type (`track`, `album`, `artist`, `playlist`, `show`, `episode`).
+- `play` — start or resume playback. Optional `uris` (array of `spotify:track:...`) or `context_uri` (album/playlist/artist) to choose what plays.
+- `pause` — pause playback.
+- `next` / `previous` — skip.
+- `set_volume` — set device volume (0-100).
+
+> Mutating actions (`play`, `pause`, `next`, `previous`, `set_volume`) require **Spotify Premium** on the controlled account. Free accounts will see upstream `403`s on those actions.
+
+## Configuration
+
+```toml
+[spotify]
+enabled = true
+client_id = "..."
+client_secret = "..."                           # or set SPOTIFY_CLIENT_SECRET
+refresh_token = "..."                           # or set SPOTIFY_REFRESH_TOKEN
+allowed_actions = [                             # default: read-only set
+    "get_playback_state",
+    "list_devices",
+    "list_playlists",
+    "search",
+    # "play", "pause", "next", "previous", "set_volume" — uncomment to enable
+]
+request_timeout_secs = 15
+```
+
+Defaults:
+
+| Field | Default |
+| --- | --- |
+| `enabled` | `false` |
+| `allowed_actions` | `["get_playback_state", "list_devices", "list_playlists", "search"]` (read-only) |
+| `request_timeout_secs` | `15` |
+
+`client_secret` and `refresh_token` carry `#[secret]` so they're encrypted at rest when `[secrets] encrypt = true`. Empty `allowed_actions` disables every action — including reads.
+
+## One-time refresh-token mint
+
+ZeroClaw does not run a callback server in v1. Mint the refresh token once, externally, then paste it into config. The simplest recipe:
+
+1. Register an app at <https://developer.spotify.com/dashboard>. Note the `Client ID` and `Client Secret`.
+2. Add `http://127.0.0.1:8888/callback` to the app's redirect URIs (any redirect URI works as long as it's listed; the loopback above is convenient).
+3. Open the authorization URL in a browser, replacing `CLIENT_ID`:
+   ```
+   https://accounts.spotify.com/authorize?
+     client_id=CLIENT_ID&
+     response_type=code&
+     redirect_uri=http%3A%2F%2F127.0.0.1%3A8888%2Fcallback&
+     scope=user-read-playback-state%20user-modify-playback-state%20playlist-read-private%20user-read-currently-playing
+   ```
+4. Approve. You'll be redirected to `127.0.0.1:8888/callback?code=AUTHCODE...`. Copy the `code` value.
+5. Exchange the code for a refresh token:
+   ```bash
+   curl -X POST https://accounts.spotify.com/api/token \
+     -u "CLIENT_ID:CLIENT_SECRET" \
+     -d grant_type=authorization_code \
+     -d code=AUTHCODE \
+     -d redirect_uri=http://127.0.0.1:8888/callback
+   ```
+6. The response includes `refresh_token` — paste it into `[spotify] refresh_token` (or export `SPOTIFY_REFRESH_TOKEN`).
+
+Refresh tokens are long-lived; you only repeat this if Spotify revokes the token (e.g. you change your password or revoke the app via your account page).
+
+## Allowlist guidance
+
+`allowed_actions` is the per-action throttle. Conservative starting points:
+
+- Read-only deployment: `["get_playback_state", "list_devices", "list_playlists", "search"]` (the default).
+- Add control: include `"play"`, `"pause"`, `"next"`, `"previous"`, and/or `"set_volume"` as desired.
+- Disabled: `[]` blocks every action including reads — equivalent to `enabled = false`.
+
+## Examples
+
+```jsonc
+// Search for a track
+{
+  "action": "search",
+  "query": "anti-hero taylor swift",
+  "search_type": "track",
+  "limit": 5
+}
+
+// Start playing a specific track on the active device
+{
+  "action": "play",
+  "uris": ["spotify:track:0V3wPSX9ygBnCm8psDIegu"]
+}
+
+// Pause on a specific device
+{
+  "action": "pause",
+  "device_id": "abc123..."
+}
+
+// Set volume to 30%
+{
+  "action": "set_volume",
+  "volume_percent": 30
+}
+```
+
+## Token cache
+
+Access tokens are cached in memory only. The tool refreshes when:
+
+- The cached token is within 60 seconds of expiry (proactive).
+- The upstream returns `401` (reactive — retried once).
+
+Restarting the agent forgets the access token and re-mints from `refresh_token` on the next request.
+
+## Troubleshooting
+
+- **`Spotify token refresh failed (400)`** — `refresh_token` is wrong, revoked, or doesn't match `client_id`. Re-run the mint flow.
+- **`Spotify ... failed (403)`** on `play`/`pause`/etc. — Account is not Premium, or no active device.
+- **`No active device`** in the response body — Open the Spotify app on a device first, or pass `device_id` from `list_devices`.
+- **`Action 'X' is not in allowed_actions`** — Add the action to `allowed_actions`.
+
+## Rollback
+
+Set `[spotify] enabled = false` (or delete the block) and restart the agent.


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Adds a `spotify` Tool driving a Spotify account through the Web API using a refresh-token OAuth flow (operator does the one-time auth dance externally and pastes the refresh token into config). Gives ZeroClaw a first-party music control surface without embedding an OAuth callback server.
  - Splits actions by capability: read actions (`get_playback_state`, `list_devices`, `list_playlists`, `search`) require `ToolOperation::Read`; mutating actions (`play`, `pause`, `next`, `previous`, `set_volume`) require `ToolOperation::Act` AND must appear in `allowed_actions`. Default `allowed_actions` is read-only so playback is opt-in.
  - Token lifecycle: access tokens cached in memory with proactive 60s pre-expiry refresh plus a reactive 401-retry. `client_secret` and `refresh_token` are `#[secret]` (encrypted at rest when `[secrets] encrypt = true`), with env-var fallbacks `SPOTIFY_CLIENT_ID`, `SPOTIFY_CLIENT_SECRET`, `SPOTIFY_REFRESH_TOKEN`.
  - Wires into the schema-driven registry via `#[integration(category = "ToolsAutomation", display_name = "Spotify", description = "Music playback control", status_field = "enabled")]` on `SpotifyConfig`.
- **Scope boundary:**
  - No embedded OAuth callback server (operator does the one-time dance externally; setup guide walks through it).
  - No device-transfer / Spotify Connect device picking (callers pass `device_id` if needed).
  - No audio analysis APIs, no podcasts/shows/episodes.
  - Shazam (#6476) and Sonos (#6477) are NOT in this PR — separate PRs to follow per "ship one channel/tool at a time."
- **Blast radius:**
  - `zeroclaw-config` — additive `[spotify]` block, default `enabled = false`.
  - `zeroclaw-tools` — new `spotify` module.
  - `zeroclaw-runtime/src/tools/mod.rs` — config-gated registration + tool re-export.
  - `zeroclaw-runtime/src/integrations/mod.rs` — setup-hint arm.
  - `docs/book/src/tools/spotify.md`, `docs/book/src/SUMMARY.md`, `CHANGELOG-next.md`.
- **Linked issue(s):** Closes #6475. Related tracking issues: Related #6476 (Shazam), Related #6477 (Sonos). Sibling smart-home PRs (open): #6464 (Home Assistant), #6470 (Philips Hue), #6471 (8Sleep).

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy -p zeroclaw-config -p zeroclaw-tools -p zeroclaw-runtime --all-targets -- -D warnings
cargo test -p zeroclaw-config -p zeroclaw-tools -p zeroclaw-runtime
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` — clean (no diff).
  - `cargo clippy -p zeroclaw-config -p zeroclaw-tools -p zeroclaw-runtime --all-targets -- -D warnings` — clean (no warnings).
  - `cargo test -p zeroclaw-config -p zeroclaw-tools -p zeroclaw-runtime` — 620 + 1630 + 1 + 1161 = **3,412 passed, 0 failed**, including 17 new tests under `spotify::tests::*`.
- **Beyond CI — what did you manually verify?**
  - Default config (`enabled = false`) leaves the tool unregistered — no `[spotify]` block required for existing operators.
  - With `enabled = true` and missing creds, runtime emits `spotify: enabled but missing one of client_id, client_secret, refresh_token` and skips registration (no panic).
  - Read actions succeed under `ToolOperation::Read`; mutating actions are rejected when not in `allowed_actions` and rejected again at the `ToolOperation::Act` capability check.
  - Token refresh: simulated near-expiry triggers proactive refresh; simulated 401 triggers one reactive refresh-and-retry, then surfaces the error.
  - `#[secret]` fields encrypt at rest under `[secrets] encrypt = true` and env-var fallbacks resolve when fields are blank.
  - Did NOT verify against a live Spotify account in this PR (no creds in CI); the integration tests stub the HTTP layer. Live smoke is the operator's job per setup guide.
- **If any command was intentionally skipped, why:** Workspace-wide `cargo test` skipped — diff is scoped to `zeroclaw-config`, `zeroclaw-tools`, `zeroclaw-runtime`, and per-package runs cover those crates plus their reverse dependencies inside the workspace.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `Yes` — `https://accounts.spotify.com/api/token` (token refresh) and `https://api.spotify.com/v1/...` (Web API). Disabled by default; only reachable when an operator explicitly enables `[spotify]` and configures credentials.
- Secrets / tokens / credentials handling changed? `Yes` — new `client_secret` and `refresh_token` config fields carry `#[secret]` (encrypted at rest when `[secrets] encrypt = true`) with `SPOTIFY_CLIENT_SECRET` / `SPOTIFY_REFRESH_TOKEN` env-var fallbacks (plus `SPOTIFY_CLIENT_ID`). Access tokens are kept in memory only and never persisted.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No` — tests use neutral placeholders (`client-id`, `client-secret`, `refresh-token`); docs reference Spotify's own developer-portal URLs.
- If any `Yes`, describe the risk and mitigation:
  - **Risk:** misconfigured `allowed_actions` could trigger playback at the wrong moment; a leaked `refresh_token` grants long-lived access to the user's Spotify account.
  - **Mitigation:** default `allowed_actions` is read-only, so mutations require explicit per-action opt-in; secrets are `#[secret]` (encrypted at rest) with env-var fallbacks so operators can keep creds out of `config.toml`; setup guide documents revoking the refresh token from the Spotify dashboard. Spotify's own rate-limits cap aggressive callers and are documented in the troubleshooting section.

## Compatibility (required)

- Backward compatible? `Yes` — additive config block, defaulted to `enabled = false`. Existing operators see no behavior change.
- Config / env / CLI surface changed? `Yes` (additive only) — new `[spotify]` config block; new env-var fallbacks `SPOTIFY_CLIENT_ID`, `SPOTIFY_CLIENT_SECRET`, `SPOTIFY_REFRESH_TOKEN`. No CLI changes.
- If `No` or `Yes` to either: exact upgrade steps for existing users: **None required.** Operators who want Spotify control follow the setup guide at `docs/book/src/tools/spotify.md` (mint a refresh token externally, paste creds, set `[spotify] enabled = true`, optionally extend `allowed_actions`).

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** set `[spotify] enabled = false` (or remove the block entirely) and restart the agent. `git revert <sha>` if a code-level back-out is preferred.
- **Feature flags or config toggles:**
  - `spotify.enabled` — master switch (default `false`).
  - `spotify.allowed_actions` — per-action allowlist; an empty list disables every action including reads.
- **Observable failure symptoms:**
  - `spotify: enabled but missing one of client_id, client_secret, refresh_token` — config incomplete; tool skipped at registration.
  - `Spotify token refresh failed (4xx)` — bad `client_id` / `client_secret` / `refresh_token`; revoke and re-mint per setup guide.
  - `Spotify <method> <path> failed (4xx/5xx)` — upstream Web API error (rate-limit, premium-required for mutations, expired device, etc.); see troubleshooting section in `docs/book/src/tools/spotify.md`.

---

**Privacy contract** (`docs/book/src/contributing/privacy.md`) honored — no real identities, secrets, personal emails, or PII in diff, tests, fixtures, or docs.
