### PR TITLE
feat(tools): shazam tool (RapidAPI wrapper)

### DIFF
--- a/CHANGELOG-next.md
+++ b/CHANGELOG-next.md
@@ -116,6 +116,7 @@
 
 - `SessionResetTool` and `SessionDeleteTool` for in-agent session management (#5696).
 - `SessionsCurrentTool` exposes the active session identity (#6033).
+- `shazam` tool — Shazam catalogue lookup via a third-party RapidAPI Shazam service. Read-only (`search_track`, `get_track_details`); audio-fingerprint deferred to a follow-up (#6476).
 
 ### Plugins
 

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -385,6 +385,11 @@ pub struct Config {
     #[nested]
     pub jira: JiraConfig,
 
+    /// Shazam integration configuration (`[shazam]`).
+    #[serde(default)]
+    #[nested]
+    pub shazam: ShazamConfig,
+
     /// Secure inter-node transport configuration (`[node_transport]`).
     #[serde(default)]
     #[nested]
@@ -9316,6 +9321,76 @@ impl Default for JiraConfig {
     }
 }
 
+/// Shazam integration configuration (`[shazam]`).
+///
+/// Shazam does not publish a free public API; this integration wraps a
+/// third-party RapidAPI Shazam service (default host
+/// `shazam.p.rapidapi.com`). The wrapping service may rate-limit, change
+/// response shapes, or sunset endpoints — treat as best-effort.
+///
+/// When `enabled = true`, registers the `shazam` tool which can search
+/// the Shazam catalogue by text query and fetch detailed metadata for
+/// a given track key. Audio-fingerprint identification is **not**
+/// included in v1 (the multipart/audio surface is the most fragile path
+/// on a third-party wrapper).
+///
+/// ## Defaults
+/// - `enabled`: `false`
+/// - `rapidapi_host`: `shazam.p.rapidapi.com`
+/// - `request_timeout_secs`: `15`
+///
+/// ## Auth
+/// Sign up at <https://rapidapi.com/>, subscribe to a Shazam service
+/// (the default points at the most common one), and copy your RapidAPI
+/// key. Set `rapidapi_key` (or export `SHAZAM_RAPIDAPI_KEY`). The key
+/// is encrypted at rest when `[secrets] encrypt = true`.
+#[derive(Debug, Clone, Serialize, Deserialize, Configurable)]
+#[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
+#[prefix = "shazam"]
+#[integration(
+    category = "ToolsAutomation",
+    display_name = "Shazam",
+    description = "Song recognition (via RapidAPI)",
+    status_field = "enabled"
+)]
+pub struct ShazamConfig {
+    /// Enable the `shazam` tool. Default: `false`.
+    #[serde(default)]
+    pub enabled: bool,
+    /// RapidAPI key. Encrypted at rest. Falls back to
+    /// `SHAZAM_RAPIDAPI_KEY` env var.
+    #[serde(default)]
+    #[secret]
+    #[cfg_attr(feature = "schema-export", schemars(extend("x-secret" = true)))]
+    pub rapidapi_key: String,
+    /// RapidAPI host header. Override only if you've subscribed to a
+    /// different Shazam-compatible service.
+    #[serde(default = "default_shazam_rapidapi_host")]
+    pub rapidapi_host: String,
+    /// Request timeout in seconds. Default: `15`.
+    #[serde(default = "default_shazam_timeout_secs")]
+    pub request_timeout_secs: u64,
+}
+
+fn default_shazam_rapidapi_host() -> String {
+    "shazam.p.rapidapi.com".into()
+}
+
+fn default_shazam_timeout_secs() -> u64 {
+    15
+}
+
+impl Default for ShazamConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            rapidapi_key: String::new(),
+            rapidapi_host: default_shazam_rapidapi_host(),
+            request_timeout_secs: default_shazam_timeout_secs(),
+        }
+    }
+}
+
 ///
 /// Controls the read-only cloud transformation analysis tools:
 /// IaC review, migration assessment, cost analysis, and architecture review.
@@ -9634,6 +9709,7 @@ impl Default for Config {
             onboard_state: OnboardStateConfig::default(),
             notion: NotionConfig::default(),
             jira: JiraConfig::default(),
+            shazam: ShazamConfig::default(),
             node_transport: NodeTransportConfig::default(),
             knowledge: KnowledgeConfig::default(),
             linkedin: LinkedInConfig::default(),
@@ -12595,6 +12671,7 @@ auto_save = true
             onboard_state: OnboardStateConfig::default(),
             notion: NotionConfig::default(),
             jira: JiraConfig::default(),
+            shazam: ShazamConfig::default(),
             node_transport: NodeTransportConfig::default(),
             knowledge: KnowledgeConfig::default(),
             linkedin: LinkedInConfig::default(),
@@ -13166,6 +13243,7 @@ default_temperature = 0.7
             onboard_state: OnboardStateConfig::default(),
             notion: NotionConfig::default(),
             jira: JiraConfig::default(),
+            shazam: ShazamConfig::default(),
             node_transport: NodeTransportConfig::default(),
             knowledge: KnowledgeConfig::default(),
             linkedin: LinkedInConfig::default(),

--- a/crates/zeroclaw-runtime/src/integrations/mod.rs
+++ b/crates/zeroclaw-runtime/src/integrations/mod.rs
@@ -148,6 +148,16 @@ pub fn show_integration_info(config: &Config, name: &str) -> Result<()> {
             println!("    Supports city names, IATA airport codes, GPS coordinates,");
             println!("    postal/zip codes, and Unicode location names.");
         }
+        "Shazam" => {
+            println!("  Setup (unofficial, via RapidAPI):");
+            println!("    1. Sign up at https://rapidapi.com/ and subscribe to a Shazam service.");
+            println!("    2. Add to config:");
+            println!("       [shazam]");
+            println!("       enabled = true");
+            println!("       rapidapi_key = \"...\"  # or SHAZAM_RAPIDAPI_KEY");
+            println!("       rapidapi_host = \"shazam.p.rapidapi.com\"  # default");
+            println!("    3. v1 supports search_track and get_track_details only.");
+        }
         _ if entry.category == IntegrationCategory::Chat => {
             println!("  Setup:");
             println!("    Run: zeroclaw onboard --channels-only");

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -102,6 +102,7 @@ pub use zeroclaw_tools::sessions::{
     SessionDeleteTool, SessionResetTool, SessionsCurrentTool, SessionsHistoryTool,
     SessionsListTool, SessionsSendTool,
 };
+pub use zeroclaw_tools::shazam::ShazamTool;
 pub use zeroclaw_tools::swarm::SwarmTool;
 pub use zeroclaw_tools::text_browser::TextBrowserTool;
 pub use zeroclaw_tools::tool_search::ToolSearchTool;
@@ -599,6 +600,31 @@ pub fn all_tools_with_runtime(
                 root_config.jira.allowed_actions.clone(),
                 security.clone(),
                 root_config.jira.timeout_secs,
+            )));
+        }
+    }
+
+    // Shazam integration (config-gated, RapidAPI wrapper)
+    if root_config.shazam.enabled {
+        let rapidapi_key = if root_config.shazam.rapidapi_key.trim().is_empty() {
+            std::env::var("SHAZAM_RAPIDAPI_KEY").unwrap_or_default()
+        } else {
+            root_config.shazam.rapidapi_key.trim().to_string()
+        };
+        if rapidapi_key.trim().is_empty() {
+            tracing::warn!(
+                "shazam: enabled but no RapidAPI key found (set shazam.rapidapi_key or SHAZAM_RAPIDAPI_KEY env var) — skipping registration"
+            );
+        } else if root_config.shazam.rapidapi_host.trim().is_empty() {
+            tracing::warn!(
+                "shazam: enabled but shazam.rapidapi_host is empty — skipping registration"
+            );
+        } else {
+            tool_arcs.push(Arc::new(ShazamTool::new(
+                rapidapi_key,
+                root_config.shazam.rapidapi_host.trim().to_string(),
+                root_config.shazam.request_timeout_secs,
+                security.clone(),
             )));
         }
     }

--- a/crates/zeroclaw-tools/src/lib.rs
+++ b/crates/zeroclaw-tools/src/lib.rs
@@ -63,6 +63,7 @@ pub mod report_template_tool;
 pub mod report_templates;
 pub mod screenshot;
 pub mod sessions;
+pub mod shazam;
 pub mod swarm;
 pub mod text_browser;
 pub mod tool_search;

--- a/crates/zeroclaw-tools/src/shazam.rs
+++ b/crates/zeroclaw-tools/src/shazam.rs
@@ -1,0 +1,389 @@
+//! Shazam tool — track lookup via a RapidAPI Shazam service.
+//!
+//! **Unofficial wrapper.** Shazam does not publish a free public API;
+//! this tool talks to a third-party service hosted on RapidAPI (default
+//! host `shazam.p.rapidapi.com`). The wrapping service may rate-limit,
+//! change response shapes, or sunset endpoints without notice — treat
+//! as best-effort.
+//!
+//! Two read actions are supported:
+//!
+//! - `search_track` — search the Shazam catalogue by text query.
+//! - `get_track_details` — fetch full metadata for a track by its
+//!   Shazam track key (returned by `search_track`).
+//!
+//! Audio-fingerprint identification is intentionally out of scope for
+//! v1 — the multipart/audio surface is the most fragile path on a
+//! third-party wrapper and ships in a follow-up if there's demand.
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use std::sync::Arc;
+use std::time::Duration;
+use zeroclaw_api::tool::{Tool, ToolResult};
+use zeroclaw_config::policy::{SecurityPolicy, ToolOperation};
+
+const MAX_ERROR_BODY_CHARS: usize = 500;
+const SEARCH_LIMIT_MIN: u64 = 1;
+const SEARCH_LIMIT_MAX: u64 = 25;
+
+/// Tool for interacting with a RapidAPI Shazam service.
+pub struct ShazamTool {
+    rapidapi_key: String,
+    rapidapi_host: String,
+    request_timeout_secs: u64,
+    http: reqwest::Client,
+    security: Arc<SecurityPolicy>,
+}
+
+impl ShazamTool {
+    pub fn new(
+        rapidapi_key: String,
+        rapidapi_host: String,
+        request_timeout_secs: u64,
+        security: Arc<SecurityPolicy>,
+    ) -> Self {
+        let rapidapi_host = rapidapi_host.trim().to_string();
+        Self {
+            rapidapi_key,
+            rapidapi_host,
+            request_timeout_secs,
+            http: reqwest::Client::new(),
+            security,
+        }
+    }
+
+    fn timeout(&self) -> Duration {
+        Duration::from_secs(self.request_timeout_secs.max(1))
+    }
+
+    fn headers(&self) -> anyhow::Result<reqwest::header::HeaderMap> {
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(
+            "X-RapidAPI-Key",
+            self.rapidapi_key
+                .parse()
+                .map_err(|e| anyhow::anyhow!("Invalid RapidAPI key header: {e}"))?,
+        );
+        headers.insert(
+            "X-RapidAPI-Host",
+            self.rapidapi_host
+                .parse()
+                .map_err(|e| anyhow::anyhow!("Invalid RapidAPI host header: {e}"))?,
+        );
+        Ok(headers)
+    }
+
+    fn base_url(&self) -> String {
+        format!("https://{}", self.rapidapi_host)
+    }
+
+    async fn get_json(&self, path_and_query: &str) -> anyhow::Result<Value> {
+        let url = format!("{}{path_and_query}", self.base_url());
+        let resp = self
+            .http
+            .get(&url)
+            .headers(self.headers()?)
+            .timeout(self.timeout())
+            .send()
+            .await?;
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            let truncated =
+                crate::util_helpers::truncate_with_ellipsis(&body, MAX_ERROR_BODY_CHARS);
+            anyhow::bail!("Shazam {path_and_query} failed ({status}): {truncated}");
+        }
+        resp.json().await.map_err(Into::into)
+    }
+}
+
+#[async_trait]
+impl Tool for ShazamTool {
+    fn name(&self) -> &str {
+        "shazam"
+    }
+
+    fn description(&self) -> &str {
+        "Look up tracks in the Shazam catalogue via a RapidAPI Shazam \
+         service. search_track does a text search by title/artist; \
+         get_track_details fetches full metadata for a Shazam track key. \
+         Note: this is an unofficial third-party wrapper and may rate-\
+         limit or change shape without notice. Audio-fingerprint \
+         identification is not supported in v1."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["search_track", "get_track_details"],
+                    "description": "The Shazam operation to perform."
+                },
+                "query": {
+                    "type": "string",
+                    "description": "Text query (e.g. 'shape of you ed sheeran'). Required for search_track."
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": SEARCH_LIMIT_MIN,
+                    "maximum": SEARCH_LIMIT_MAX,
+                    "description": "Max results for search_track (1-25). Default: 5."
+                },
+                "track_key": {
+                    "type": "string",
+                    "description": "Shazam track key (returned by search_track). Required for get_track_details."
+                },
+                "locale": {
+                    "type": "string",
+                    "description": "BCP-47 locale (e.g. 'en-US'). Default: 'en-US'."
+                }
+            },
+            "required": ["action"]
+        })
+    }
+
+    async fn execute(&self, args: Value) -> anyhow::Result<ToolResult> {
+        let action = match args.get("action").and_then(|v| v.as_str()) {
+            Some(a) => a,
+            None => {
+                return Ok(ToolResult {
+                    success: false,
+                    output: String::new(),
+                    error: Some("Missing required parameter: action".into()),
+                });
+            }
+        };
+
+        if !matches!(action, "search_track" | "get_track_details") {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!(
+                    "Unknown action: {action}. Valid actions: search_track, get_track_details"
+                )),
+            });
+        }
+
+        if let Err(error) = self
+            .security
+            .enforce_tool_operation(ToolOperation::Read, "shazam")
+        {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(error),
+            });
+        }
+
+        let locale = args
+            .get("locale")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or("en-US");
+
+        let result = match action {
+            "search_track" => {
+                let query = match args.get("query").and_then(|v| v.as_str()) {
+                    Some(q) if !q.trim().is_empty() => q.trim().to_string(),
+                    _ => {
+                        return Ok(ToolResult {
+                            success: false,
+                            output: String::new(),
+                            error: Some("search_track requires query parameter".into()),
+                        });
+                    }
+                };
+                let limit = args
+                    .get("limit")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(5)
+                    .clamp(SEARCH_LIMIT_MIN, SEARCH_LIMIT_MAX);
+                self.get_json(&format!(
+                    "/search?term={}&locale={}&offset=0&limit={limit}",
+                    urlencoding(&query),
+                    urlencoding(locale)
+                ))
+                .await
+            }
+            "get_track_details" => {
+                let track_key = match args.get("track_key").and_then(|v| v.as_str()) {
+                    Some(k) if !k.trim().is_empty() => k.trim().to_string(),
+                    _ => {
+                        return Ok(ToolResult {
+                            success: false,
+                            output: String::new(),
+                            error: Some("get_track_details requires track_key parameter".into()),
+                        });
+                    }
+                };
+                self.get_json(&format!(
+                    "/songs/get-details?key={}&locale={}",
+                    urlencoding(&track_key),
+                    urlencoding(locale)
+                ))
+                .await
+            }
+            _ => unreachable!(),
+        };
+
+        match result {
+            Ok(value) => Ok(ToolResult {
+                success: true,
+                output: serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string()),
+                error: None,
+            }),
+            Err(e) => Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(e.to_string()),
+            }),
+        }
+    }
+}
+
+/// Minimal application/x-www-form-urlencoded encoding for query-string
+/// values. Avoids a `urlencoding` crate dependency for one helper.
+fn urlencoding(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.bytes() {
+        match ch {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(ch as char);
+            }
+            _ => {
+                out.push_str(&format!("%{ch:02X}"));
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zeroclaw_config::policy::SecurityPolicy;
+
+    fn test_tool() -> ShazamTool {
+        ShazamTool::new(
+            "test-key".into(),
+            "shazam.p.rapidapi.com".into(),
+            15,
+            Arc::new(SecurityPolicy::default()),
+        )
+    }
+
+    #[test]
+    fn name_is_shazam() {
+        assert_eq!(test_tool().name(), "shazam");
+    }
+
+    #[test]
+    fn description_warns_unofficial() {
+        let tool = test_tool();
+        let d = tool.description();
+        assert!(d.to_lowercase().contains("unofficial"));
+    }
+
+    #[test]
+    fn parameters_schema_requires_action() {
+        let schema = test_tool().parameters_schema();
+        let required = schema["required"].as_array().unwrap();
+        assert!(required.iter().any(|v| v.as_str() == Some("action")));
+    }
+
+    #[test]
+    fn parameters_schema_lists_actions() {
+        let schema = test_tool().parameters_schema();
+        let actions = schema["properties"]["action"]["enum"].as_array().unwrap();
+        let names: Vec<&str> = actions.iter().filter_map(|v| v.as_str()).collect();
+        for expected in &["search_track", "get_track_details"] {
+            assert!(names.contains(expected), "missing action: {expected}");
+        }
+    }
+
+    #[test]
+    fn parameters_schema_limit_bounds() {
+        let schema = test_tool().parameters_schema();
+        let limit = &schema["properties"]["limit"];
+        assert_eq!(limit["minimum"], SEARCH_LIMIT_MIN);
+        assert_eq!(limit["maximum"], SEARCH_LIMIT_MAX);
+    }
+
+    #[test]
+    fn base_url_uses_configured_host() {
+        let tool = ShazamTool::new(
+            "k".into(),
+            "  custom.host.example  ".into(),
+            15,
+            Arc::new(SecurityPolicy::default()),
+        );
+        assert_eq!(tool.base_url(), "https://custom.host.example");
+    }
+
+    #[test]
+    fn headers_include_rapidapi_key_and_host() {
+        let tool = test_tool();
+        let headers = tool.headers().unwrap();
+        assert_eq!(headers.get("X-RapidAPI-Key").unwrap(), "test-key");
+        assert_eq!(
+            headers.get("X-RapidAPI-Host").unwrap(),
+            "shazam.p.rapidapi.com"
+        );
+    }
+
+    #[test]
+    fn urlencoding_handles_unsafe_chars() {
+        assert_eq!(urlencoding("ed sheeran"), "ed%20sheeran");
+        assert_eq!(urlencoding("a&b=c"), "a%26b%3Dc");
+        assert_eq!(urlencoding("ABCabc019-_.~"), "ABCabc019-_.~");
+    }
+
+    #[tokio::test]
+    async fn execute_missing_action_returns_error() {
+        let result = test_tool().execute(json!({})).await.unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("action"));
+    }
+
+    #[tokio::test]
+    async fn execute_unknown_action_returns_error() {
+        let result = test_tool()
+            .execute(json!({"action": "nope"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("Unknown action"));
+    }
+
+    #[tokio::test]
+    async fn execute_search_missing_query_returns_error() {
+        let result = test_tool()
+            .execute(json!({"action": "search_track"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("query"));
+    }
+
+    #[tokio::test]
+    async fn execute_get_track_details_missing_key_returns_error() {
+        let result = test_tool()
+            .execute(json!({"action": "get_track_details"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("track_key"));
+    }
+
+    #[test]
+    fn spec_reflects_metadata() {
+        let tool = test_tool();
+        let spec = tool.spec();
+        assert_eq!(spec.name, "shazam");
+        assert_eq!(spec.description, tool.description());
+        assert!(spec.parameters.is_object());
+    }
+}

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -58,6 +58,7 @@
 - [Overview](./tools/overview.md)
 - [MCP (Model Context Protocol)](./tools/mcp.md)
 - [Browser automation](./tools/browser.md)
+- [Shazam](./tools/shazam.md)
 
 # Security
 

--- a/docs/book/src/tools/shazam.md
+++ b/docs/book/src/tools/shazam.md
@@ -1,0 +1,73 @@
+# Shazam
+
+The `shazam` tool looks up tracks in the Shazam catalogue via a third-party RapidAPI Shazam service.
+
+> **Unofficial wrapper.** Shazam does not publish a free public API. This tool talks to a service hosted on [RapidAPI](https://rapidapi.com) (default host `shazam.p.rapidapi.com`). The wrapping service may rate-limit, change response shapes, or sunset endpoints without notice — treat as best-effort.
+
+When enabled, the agent can:
+
+- `search_track` — text-search the Shazam catalogue (by title, artist, or both).
+- `get_track_details` — fetch full metadata for a track by its Shazam track key.
+
+Audio-fingerprint identification is **not** supported in v1.
+
+## Configuration
+
+```toml
+[shazam]
+enabled = true
+rapidapi_key = "..."                    # or set SHAZAM_RAPIDAPI_KEY
+rapidapi_host = "shazam.p.rapidapi.com" # default
+request_timeout_secs = 15
+```
+
+Defaults:
+
+| Field | Default |
+| --- | --- |
+| `enabled` | `false` |
+| `rapidapi_host` | `shazam.p.rapidapi.com` |
+| `request_timeout_secs` | `15` |
+
+`rapidapi_key` carries `#[secret]` so it's encrypted at rest when `[secrets] encrypt = true`.
+
+## Setup (one-time)
+
+1. Sign up at <https://rapidapi.com/>.
+2. Subscribe to a Shazam service. The most common is "Shazam" (host `shazam.p.rapidapi.com`); search the marketplace if you want a different wrapper.
+3. Copy your RapidAPI key from the dashboard.
+4. Either paste it into `[shazam] rapidapi_key`, or export `SHAZAM_RAPIDAPI_KEY`.
+
+Different RapidAPI Shazam services have slightly different endpoint shapes. The default host is the most common; if you subscribe to a different one and the response shape doesn't match what you expect, set `rapidapi_host` to the alternative service's host.
+
+## Examples
+
+```jsonc
+// Search for a track
+{
+  "action": "search_track",
+  "query": "shape of you ed sheeran",
+  "limit": 5
+}
+
+// Fetch details for a specific track key (returned by search_track)
+{
+  "action": "get_track_details",
+  "track_key": "40286312"
+}
+```
+
+## Out of scope (v1)
+
+- **Audio-fingerprint recognition.** The multipart/audio endpoint exists on most Shazam wrappers but is the most fragile path on a third-party API and was not safe to ship without per-wrapper testing. Deferred until there's demand and a reliable wrapper to verify against.
+- **Charts, top-tracks, location-based discovery.** v1 keeps the surface tight to two well-defined ops.
+
+## Troubleshooting
+
+- **`Shazam ... failed (401)` or `(403)`** — RapidAPI key is wrong, expired, or the subscription has lapsed. Check the RapidAPI dashboard.
+- **`Shazam ... failed (429)`** — Rate-limited. Free RapidAPI tiers are aggressive about this; either upgrade or back off.
+- **Empty / unexpected response shape** — The wrapping service may have changed its schema. Compare against the service's own documentation in the RapidAPI marketplace.
+
+## Rollback
+
+Set `[shazam] enabled = false` (or delete the block) and restart the agent.


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:** Adds a `shazam` Tool that looks up tracks in the Shazam catalogue. v1 supports `search_track` (text search) and `get_track_details` (by Shazam track key) — two read actions over a third-party RapidAPI Shazam service. Audio-fingerprint identification is intentionally deferred: the multipart/audio surface is the most fragile path on a third-party wrapper and benefits from a follow-up that can verify against a known-good service.
- **Why a RapidAPI wrapper instead of an official client:** Shazam does not publish a free public API. The tool talks to a third-party service (default host `shazam.p.rapidapi.com`) and the description warns the LLM that the wrapper is unofficial and best-effort.
- **Operator surface:** New `[shazam]` config block (disabled by default). `rapidapi_key` carries `#[secret]` so it's encrypted at rest when `[secrets] encrypt = true`, and falls back to `SHAZAM_RAPIDAPI_KEY`. `rapidapi_host` is configurable so operators can point at an alternative wrapper service if the default sunsets.
- **Discoverability:** Setup-guide doc under `docs/book/src/tools/shazam.md`, a `Shazam` arm in `zeroclaw integrations info`, and a `CHANGELOG-next` entry under Tools & Skills.
- **Scope boundary:** No audio-fingerprint identification. No charts / top-tracks / location-discovery endpoints. Tool is registered only when `[shazam] enabled = true` AND a non-empty key+host are configured — otherwise registration is skipped with a `tracing::warn!`.
- **Blast radius:** Tool registry only when explicitly enabled. No changes to existing tools, providers, channels, memory, or gateway. The schema gains one new optional `[shazam]` block (default-constructed everywhere a `Config` is materialised, so existing config files load unchanged).
- **Linked issue(s):** Closes #6476

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` — clean (no diff).
  - `cargo clippy --all-targets -- -D warnings` — clean across the touched crates (`zeroclaw-tools`, `zeroclaw-config`, `zeroclaw-runtime`).
  - `cargo test -p zeroclaw-tools shazam` — all unit tests in `crates/zeroclaw-tools/src/shazam.rs` pass: name, description-warns-unofficial, schema bounds (`limit` 1..=25), `base_url` honours configured host (and trims whitespace), headers carry `X-RapidAPI-Key` and `X-RapidAPI-Host`, urlencoding handles unsafe chars, and `execute` returns structured errors for missing/invalid `action`, missing `query`, and missing `track_key`.
- **Beyond CI — what did you manually verify?**
  - Read-path through `all_tools_with_runtime` (`crates/zeroclaw-runtime/src/tools/mod.rs`): registration is gated on `root_config.shazam.enabled` and a non-empty `rapidapi_key` (env-var fallback applied) AND non-empty `rapidapi_host` — empty cases warn and skip rather than panic.
  - `zeroclaw integrations info Shazam` prints the new setup guide (RapidAPI signup, config snippet, action surface).
  - The `#[integration(...)]` attribute on `ShazamConfig` puts the integration in the `ToolsAutomation` category with `status_field = "enabled"`, so the integrations registry surfaces it as `Available` until configured and `Active` once `enabled = true`.
  - Did NOT verify: live RapidAPI call against the real `shazam.p.rapidapi.com` (requires a paid key); error-body truncation at 500 chars is exercised by the code path but not by a network test.
- **If any command was intentionally skipped, why:** None skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `Yes` — outbound HTTPS to the configured `rapidapi_host` (default `shazam.p.rapidapi.com`) on `/search` and `/songs/get-details`. Only when the operator opts in via `[shazam] enabled = true` and supplies a key.
- Secrets / tokens / credentials handling changed? `Yes` — new `rapidapi_key` field carries `#[secret]` (encrypted at rest under `[secrets] encrypt = true`) and falls back to the `SHAZAM_RAPIDAPI_KEY` env var. The key is sent only as the `X-RapidAPI-Key` header to the configured host; it is never logged. Failed-response bodies are truncated to 500 chars before bubbling up in the error message.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No` — tests use a synthetic `"test-key"` and `"shape of you ed sheeran"` as a benign query string; the docs reference public Shazam catalogue search by track title only.
- If any `Yes`, describe the risk and mitigation: A misconfigured `rapidapi_host` could direct the bearer key at an attacker-controlled host. Mitigation: the host is operator-controlled config (not user-supplied at runtime), defaults to the well-known `shazam.p.rapidapi.com`, and the docs explicitly call out when to override.

## Compatibility (required)

- Backward compatible? `Yes` — new optional `[shazam]` config block, defaults to `enabled = false`. Existing config files load unchanged.
- Config / env / CLI surface changed? `Yes` — adds `[shazam]` config block (`enabled`, `rapidapi_key`, `rapidapi_host`, `request_timeout_secs`) and a new `SHAZAM_RAPIDAPI_KEY` env var. No CLI surface change.
- If `No` or `Yes` to either: exact upgrade steps for existing users: No upgrade required. To opt in: subscribe to a Shazam service on RapidAPI, then add `[shazam] enabled = true` and `rapidapi_key = "..."` (or export `SHAZAM_RAPIDAPI_KEY`) to `config.toml` and restart the agent.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PR: `git revert <sha>` is the plan. For operators who have enabled the feature: set `[shazam] enabled = false` (or delete the block) and restart — no migrations or persisted state to clean up.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A — this PR does not supersede a previous one.
