### PR TITLE
fix(docs): generate lang switcher before mdbook sync

### DIFF
--- a/xtask/src/cmd/mdbook/sync.rs
+++ b/xtask/src/cmd/mdbook/sync.rs
@@ -26,6 +26,7 @@ pub fn run(
 
     // Step 1: extract English msgids
     println!("==> Extracting English msgids → {}", pot.display());
+    crate::cmd::mdbook::build::inject_lang_switcher_locales(&book, &locale_entries())?;
     run_cmd(
         Command::new(mdbook_program()?)
             .args(["build", "-d", "po-extract"])


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - `cargo mdbook sync` now generates `docs/book/theme/lang-switcher.js` from the tracked template before running the gettext extraction build.
  - This reuses the same `inject_lang_switcher_locales` helper already used by the mdBook build and serve paths.
  - The sync path otherwise stays unchanged; it still extracts English msgids, merges per-locale `.po` files, and optionally fills translation deltas.
- **Scope boundary:** This does not change locale metadata, translation contents, mdBook build output, or the lang-switcher template. It only makes `sync` run the existing generation step before mdBook reads `book.toml`.
- **Blast radius:** Limited to the `cargo mdbook sync` xtask path. The build and serve paths already called the same helper.
- **Linked issue(s):** Related #6473.

## Validation Evidence (required)

```text
cargo fmt --all -- --check
PASS in 4.523s

cargo mdbook sync --locale en
PASS in 2.212s
Confirmed gettext extraction completed after generating lang-switcher.js. No translation files changed.

clean missing-file repro:
Moved ignored docs/book/theme/lang-switcher.js aside, verified it was absent, then ran cargo mdbook sync --locale en.
PASS in 3.186s
Confirmed sync regenerated lang-switcher.js and completed gettext extraction with no tracked diff.

cargo clippy -p xtask --bin mdbook -- -D warnings
PASS in 1:29.62

git diff --check
PASS
```

- **Commands run and tail output:** The command/result summary above is copied from local validation.
- **Beyond CI — what did you manually verify?** Verified the patch is a one-line reuse of the existing mdBook build helper, and verified `cargo mdbook sync --locale en` regenerates a missing ignored `lang-switcher.js` before gettext extraction.
- **If any command was intentionally skipped, why:** Full `cargo test` was skipped because this is a docs xtask path and the focused sync command plus focused xtask clippy cover the changed behavior.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: Not applicable.

This reuses an existing repo-local generated-asset helper. It does not read secrets, call external services, or change runtime behavior.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No upgrade steps required. Existing `cargo mdbook sync` usage now succeeds from a clean checkout when `lang-switcher.js` has not already been generated.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PR: `git revert 11e8c6e6589f367aa9f7ce0a6bf2db7a8eb04efe` is the rollback plan.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): Not applicable.
- Scope materially carried forward: Not applicable.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why: No superseded PR or incorporated contributor patch.
