### PR TITLE
fix(gateway,channels): boot without configured model so /onboard stays reachable

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -5394,6 +5394,22 @@ pub async fn start_channels(
     config: Config,
     canvas_store: Option<zeroclaw_runtime::tools::CanvasStore>,
 ) -> Result<()> {
+    // No model resolves yet — the user has channels configured but hasn't
+    // finished onboarding their provider. Returning Ok() here lets the
+    // daemon supervisor mark the channels component "done" instead of
+    // restart-looping on the bail in `resolved_default_model`. The user
+    // completes onboarding at /onboard and reloads via /admin/reload to
+    // bring channels up.
+    if resolved_default_model(&config).is_err() {
+        tracing::warn!(
+            "Channels supervisor exiting: no model configured but \
+             channels are present. Complete browser onboarding at \
+             /onboard (or set [providers.models.<name>] model = \"...\" \
+             and reload the daemon) before channels can route messages."
+        );
+        return Ok(());
+    }
+
     let provider_name = resolved_default_provider(&config);
     let provider_runtime_options =
         zeroclaw_providers::provider_runtime_options_from_config(&config);

--- a/crates/zeroclaw-gateway/src/lib.rs
+++ b/crates/zeroclaw-gateway/src/lib.rs
@@ -1521,6 +1521,21 @@ fn needs_onboarding_for(model: &str) -> Option<anyhow::Error> {
     }
 }
 
+/// True when `e` carries the marker produced by `needs_onboarding_for`.
+/// Used by chat-dispatch error paths to map the marker to a 503
+/// `needs_onboarding` HTTP response or a more accurate channel-side
+/// reply, instead of the generic 500 / "sorry" catch-all.
+fn is_needs_onboarding_err(e: &anyhow::Error) -> bool {
+    e.to_string().contains("needs_onboarding")
+}
+
+/// Reply text sent over a channel SDK when chat dispatch refuses
+/// because the gateway has no model configured. More informative
+/// than the generic LLM-error fallback so the end user understands
+/// why nothing is happening.
+const NEEDS_ONBOARDING_CHANNEL_REPLY: &str = "This agent isn't fully set up yet. The operator needs to complete \
+     onboarding before I can reply.";
+
 /// Full-featured chat with tools for channel and webhook handlers.
 async fn run_gateway_chat_with_tools(
     state: &AppState,
@@ -1810,9 +1825,21 @@ async fn handle_webhook(
                 },
             );
 
-            tracing::error!("Webhook provider error: {}", sanitized);
-            let err = serde_json::json!({"error": "LLM request failed"});
-            (StatusCode::INTERNAL_SERVER_ERROR, Json(err))
+            if is_needs_onboarding_err(&e) {
+                tracing::warn!(
+                    "Webhook chat refused: gateway has no model configured; \
+                     visit /onboard"
+                );
+                let body = serde_json::json!({
+                    "error": "needs_onboarding",
+                    "url": "/onboard"
+                });
+                (StatusCode::SERVICE_UNAVAILABLE, Json(body))
+            } else {
+                tracing::error!("Webhook provider error: {}", sanitized);
+                let err = serde_json::json!({"error": "LLM request failed"});
+                (StatusCode::INTERNAL_SERVER_ERROR, Json(err))
+            }
         }
     }
 }
@@ -1984,13 +2011,17 @@ async fn handle_whatsapp_message(
                 }
             }
             Err(e) => {
-                tracing::error!("LLM error for WhatsApp message: {e:#}");
-                let _ = wa
-                    .send(&SendMessage::new(
-                        "Sorry, I couldn't process your message right now.",
-                        &msg.reply_target,
-                    ))
-                    .await;
+                let reply = if is_needs_onboarding_err(&e) {
+                    tracing::warn!(
+                        "WhatsApp chat refused: gateway has no model configured; \
+                         visit /onboard"
+                    );
+                    NEEDS_ONBOARDING_CHANNEL_REPLY
+                } else {
+                    tracing::error!("LLM error for WhatsApp message: {e:#}");
+                    "Sorry, I couldn't process your message right now."
+                };
+                let _ = wa.send(&SendMessage::new(reply, &msg.reply_target)).await;
             }
         }
     }
@@ -2104,13 +2135,17 @@ async fn handle_linq_webhook(
                 }
             }
             Err(e) => {
-                tracing::error!("LLM error for Linq message: {e:#}");
-                let _ = linq
-                    .send(&SendMessage::new(
-                        "Sorry, I couldn't process your message right now.",
-                        &msg.reply_target,
-                    ))
-                    .await;
+                let reply = if is_needs_onboarding_err(&e) {
+                    tracing::warn!(
+                        "Linq chat refused: gateway has no model configured; \
+                         visit /onboard"
+                    );
+                    NEEDS_ONBOARDING_CHANNEL_REPLY
+                } else {
+                    tracing::error!("LLM error for Linq message: {e:#}");
+                    "Sorry, I couldn't process your message right now."
+                };
+                let _ = linq.send(&SendMessage::new(reply, &msg.reply_target)).await;
             }
         }
     }
@@ -2219,13 +2254,17 @@ async fn handle_wati_webhook(State(state): State<AppState>, body: Bytes) -> impl
                 }
             }
             Err(e) => {
-                tracing::error!("LLM error for WATI message: {e:#}");
-                let _ = wati
-                    .send(&SendMessage::new(
-                        "Sorry, I couldn't process your message right now.",
-                        &msg.reply_target,
-                    ))
-                    .await;
+                let reply = if is_needs_onboarding_err(&e) {
+                    tracing::warn!(
+                        "WATI chat refused: gateway has no model configured; \
+                         visit /onboard"
+                    );
+                    NEEDS_ONBOARDING_CHANNEL_REPLY
+                } else {
+                    tracing::error!("LLM error for WATI message: {e:#}");
+                    "Sorry, I couldn't process your message right now."
+                };
+                let _ = wati.send(&SendMessage::new(reply, &msg.reply_target)).await;
             }
         }
     }
@@ -2334,12 +2373,18 @@ async fn handle_nextcloud_talk_webhook(
                 }
             }
             Err(e) => {
-                tracing::error!("LLM error for Nextcloud Talk message: {e:#}");
+                let reply = if is_needs_onboarding_err(&e) {
+                    tracing::warn!(
+                        "Nextcloud Talk chat refused: gateway has no model configured; \
+                         visit /onboard"
+                    );
+                    NEEDS_ONBOARDING_CHANNEL_REPLY
+                } else {
+                    tracing::error!("LLM error for Nextcloud Talk message: {e:#}");
+                    "Sorry, I couldn't process your message right now."
+                };
                 let _ = nextcloud_talk
-                    .send(&SendMessage::new(
-                        "Sorry, I couldn't process your message right now.",
-                        &msg.reply_target,
-                    ))
+                    .send(&SendMessage::new(reply, &msg.reply_target))
                     .await;
             }
         }
@@ -4202,5 +4247,34 @@ mod tests {
             needs_onboarding_for("  gpt-4  ").is_none(),
             "leading/trailing whitespace around a real model id must not be flagged"
         );
+    }
+
+    #[test]
+    fn is_needs_onboarding_err_detects_marker_from_helper() {
+        let err = needs_onboarding_for("").expect("empty model produces marker");
+        assert!(
+            is_needs_onboarding_err(&err),
+            "the marker emitted by needs_onboarding_for must be detected"
+        );
+    }
+
+    #[test]
+    fn is_needs_onboarding_err_ignores_unrelated_errors() {
+        let err = anyhow::anyhow!("upstream timeout: provider returned 504");
+        assert!(
+            !is_needs_onboarding_err(&err),
+            "unrelated errors must not be misclassified as needs_onboarding"
+        );
+        let err = anyhow::anyhow!("invalid api key");
+        assert!(!is_needs_onboarding_err(&err));
+    }
+
+    #[test]
+    fn is_needs_onboarding_err_detects_via_substring() {
+        // Defends the contract that the substring marker is the
+        // detection key — not the exact string. Wrappers (e.g.
+        // anyhow::Error::context) must not break the check.
+        let err = anyhow::anyhow!("provider call failed").context("needs_onboarding: empty model");
+        assert!(is_needs_onboarding_err(&err));
     }
 }

--- a/crates/zeroclaw-gateway/src/lib.rs
+++ b/crates/zeroclaw-gateway/src/lib.rs
@@ -61,6 +61,7 @@ use zeroclaw_infra::session_backend::SessionBackend;
 use zeroclaw_memory::{self, Memory, MemoryCategory};
 use zeroclaw_providers::{self, Provider};
 use zeroclaw_runtime::cost::CostTracker;
+use zeroclaw_runtime::i18n;
 use zeroclaw_runtime::platform;
 use zeroclaw_runtime::security::pairing::{PairingGuard, constant_time_eq, is_public_bind};
 use zeroclaw_runtime::tools;
@@ -1530,11 +1531,13 @@ fn is_needs_onboarding_err(e: &anyhow::Error) -> bool {
 }
 
 /// Reply text sent over a channel SDK when chat dispatch refuses
-/// because the gateway has no model configured. More informative
-/// than the generic LLM-error fallback so the end user understands
-/// why nothing is happening.
-const NEEDS_ONBOARDING_CHANNEL_REPLY: &str = "This agent isn't fully set up yet. The operator needs to complete \
-     onboarding before I can reply.";
+/// because the gateway has no model configured. Resolved through the
+/// shared Fluent catalog (`channel-needs-onboarding-reply` in
+/// `crates/zeroclaw-runtime/locales/<locale>/cli.ftl`) so non-English
+/// operators see localized text instead of a Rust-side English literal.
+fn needs_onboarding_channel_reply() -> String {
+    i18n::get_required_cli_string("channel-needs-onboarding-reply")
+}
 
 /// Full-featured chat with tools for channel and webhook handlers.
 async fn run_gateway_chat_with_tools(
@@ -2016,10 +2019,10 @@ async fn handle_whatsapp_message(
                         "WhatsApp chat refused: gateway has no model configured; \
                          visit /onboard"
                     );
-                    NEEDS_ONBOARDING_CHANNEL_REPLY
+                    needs_onboarding_channel_reply()
                 } else {
                     tracing::error!("LLM error for WhatsApp message: {e:#}");
-                    "Sorry, I couldn't process your message right now."
+                    "Sorry, I couldn't process your message right now.".to_string()
                 };
                 let _ = wa.send(&SendMessage::new(reply, &msg.reply_target)).await;
             }
@@ -2140,10 +2143,10 @@ async fn handle_linq_webhook(
                         "Linq chat refused: gateway has no model configured; \
                          visit /onboard"
                     );
-                    NEEDS_ONBOARDING_CHANNEL_REPLY
+                    needs_onboarding_channel_reply()
                 } else {
                     tracing::error!("LLM error for Linq message: {e:#}");
-                    "Sorry, I couldn't process your message right now."
+                    "Sorry, I couldn't process your message right now.".to_string()
                 };
                 let _ = linq.send(&SendMessage::new(reply, &msg.reply_target)).await;
             }
@@ -2259,10 +2262,10 @@ async fn handle_wati_webhook(State(state): State<AppState>, body: Bytes) -> impl
                         "WATI chat refused: gateway has no model configured; \
                          visit /onboard"
                     );
-                    NEEDS_ONBOARDING_CHANNEL_REPLY
+                    needs_onboarding_channel_reply()
                 } else {
                     tracing::error!("LLM error for WATI message: {e:#}");
-                    "Sorry, I couldn't process your message right now."
+                    "Sorry, I couldn't process your message right now.".to_string()
                 };
                 let _ = wati.send(&SendMessage::new(reply, &msg.reply_target)).await;
             }
@@ -2378,10 +2381,10 @@ async fn handle_nextcloud_talk_webhook(
                         "Nextcloud Talk chat refused: gateway has no model configured; \
                          visit /onboard"
                     );
-                    NEEDS_ONBOARDING_CHANNEL_REPLY
+                    needs_onboarding_channel_reply()
                 } else {
                     tracing::error!("LLM error for Nextcloud Talk message: {e:#}");
-                    "Sorry, I couldn't process your message right now."
+                    "Sorry, I couldn't process your message right now.".to_string()
                 };
                 let _ = nextcloud_talk
                     .send(&SendMessage::new(reply, &msg.reply_target))
@@ -4276,5 +4279,24 @@ mod tests {
         // anyhow::Error::context) must not break the check.
         let err = anyhow::anyhow!("provider call failed").context("needs_onboarding: empty model");
         assert!(is_needs_onboarding_err(&err));
+    }
+
+    #[test]
+    fn needs_onboarding_channel_reply_resolves_via_fluent() {
+        // The Fluent key channel-needs-onboarding-reply must resolve
+        // to real text from the embedded en/cli.ftl, not the missing-
+        // key fallback `{channel-needs-onboarding-reply}` that
+        // `missing_cli_string` produces. Guarding this in a test
+        // keeps the i18n contract from quietly drifting if the key
+        // gets renamed in lib.rs without a matching ftl edit.
+        let reply = needs_onboarding_channel_reply();
+        assert!(
+            !reply.starts_with('{') && !reply.ends_with('}'),
+            "fluent missing-key fallback leaked into channel reply: {reply:?}"
+        );
+        assert!(
+            reply.to_lowercase().contains("onboarding"),
+            "channel reply must mention onboarding so users know what's missing: {reply:?}"
+        );
     }
 }

--- a/crates/zeroclaw-gateway/src/lib.rs
+++ b/crates/zeroclaw-gateway/src/lib.rs
@@ -485,8 +485,13 @@ pub async fn run_gateway(
         )?);
     // Three-step model resolution mirroring agent::Agent::from_config (#6099):
     // (1) the fallback provider's `model`, (2) the first configured
-    // `[providers.models.*]` model with a WARN naming what to set, (3) hard
-    // fail with an actionable error. No silent vendor-default substitution.
+    // `[providers.models.*]` model with a WARN naming what to set, (3) leave
+    // the model empty so the gateway boots and the dashboard can complete
+    // browser-based onboarding at /onboard. The chat-dispatch path checks
+    // `state.model.is_empty()` and returns a structured needs-onboarding
+    // error before any provider call, so the original "no silent vendor-
+    // default substitution" guarantee from #6099 is preserved at request-
+    // time rather than at boot.
     let model = match fallback
         .and_then(|e| e.model.as_deref())
         .map(str::trim)
@@ -505,13 +510,14 @@ pub async fn run_gateway(
                 m
             }
             None => {
-                anyhow::bail!(
-                    "no model configured: providers.fallback = {:?} resolves with no model, \
-                     and no [providers.models.*] entry has a `model` field set. \
-                     Configure at least one [providers.models.<name>] model = \"...\" \
-                     before starting the gateway.",
-                    config.providers.fallback,
-                )
+                tracing::warn!(
+                    "Gateway booting without a configured model. Visit \
+                     http://{display_addr}/onboard to complete browser \
+                     onboarding. Chat endpoints will return 503 \
+                     needs_onboarding until at least one \
+                     [providers.models.<name>] model = \"...\" is set."
+                );
+                String::new()
             }
         },
     };
@@ -1497,12 +1503,34 @@ struct GatewayChatOutcome {
     cost_usd: Option<f64>,
 }
 
+/// Returns a structured `needs_onboarding` error when `model` is empty
+/// or whitespace-only, otherwise `None`. Empty model means the gateway
+/// booted with nothing configured (fresh install). Callers refuse the
+/// dispatch with this marker instead of calling the provider with an
+/// empty model id. Mirrors `agent::Agent::from_config` (#6099) at
+/// request-time so `/onboard` stays reachable.
+fn needs_onboarding_for(model: &str) -> Option<anyhow::Error> {
+    if model.trim().is_empty() {
+        Some(anyhow::anyhow!(
+            "needs_onboarding: gateway has no model configured. Complete \
+             browser onboarding at /onboard, or set [providers.models.<name>] \
+             model = \"...\" before sending messages."
+        ))
+    } else {
+        None
+    }
+}
+
 /// Full-featured chat with tools for channel and webhook handlers.
 async fn run_gateway_chat_with_tools(
     state: &AppState,
     message: &str,
     session_id: Option<&str>,
 ) -> anyhow::Result<GatewayChatOutcome> {
+    if let Some(err) = needs_onboarding_for(&state.model) {
+        return Err(err);
+    }
+
     // Tests exercise webhook infrastructure (idempotency, auth, autosave)
     // through handle_webhook, so dispatch to the mock provider directly
     // instead of bootstrapping the full agent runtime. The mock path
@@ -4135,5 +4163,44 @@ mod tests {
         ));
         let err = require_localhost(&peer).unwrap_err();
         assert_eq!(err.0, StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn needs_onboarding_for_flags_empty_model() {
+        let err =
+            needs_onboarding_for("").expect("empty model must produce a needs_onboarding error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("needs_onboarding"),
+            "error must carry the needs_onboarding marker for callers to map to 503; got: {msg}"
+        );
+        assert!(
+            msg.contains("/onboard"),
+            "error must point the user at /onboard; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn needs_onboarding_for_flags_whitespace_only_model() {
+        assert!(
+            needs_onboarding_for("   ").is_some(),
+            "whitespace-only model must be treated as empty"
+        );
+        assert!(
+            needs_onboarding_for("\n\t ").is_some(),
+            "tabs and newlines count as empty too"
+        );
+    }
+
+    #[test]
+    fn needs_onboarding_for_passes_real_model() {
+        assert!(
+            needs_onboarding_for("anthropic/claude-sonnet-4").is_none(),
+            "a real model id must not be flagged"
+        );
+        assert!(
+            needs_onboarding_for("  gpt-4  ").is_none(),
+            "leading/trailing whitespace around a real model id must not be flagged"
+        );
     }
 }

--- a/crates/zeroclaw-runtime/locales/en/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/en/cli.ftl
@@ -295,3 +295,8 @@ cli-desktop-long-about =
     Examples:
       zeroclaw desktop              # launch the companion app
       zeroclaw desktop --install    # download and install it
+
+# Channel-side reply emitted when chat dispatch refuses because the
+# gateway has no model configured. Used by the gateway crate channel
+# webhook handlers (WhatsApp, Linq, WATI, Nextcloud Talk).
+channel-needs-onboarding-reply = This agent isn't fully set up yet. The operator needs to complete onboarding before I can reply.


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Gateway startup no longer bails when no model resolves. It logs a `WARN` pointing at `/onboard` and boots with an empty model id. The chat-dispatch funnel (`run_gateway_chat_with_tools`) refuses with a structured `needs_onboarding` marker via a new free function (`needs_onboarding_for`).
  - **Webhook chat handlers map the marker to a real 503**: `handle_webhook` returns `503 SERVICE_UNAVAILABLE` with `{"error":"needs_onboarding","url":"/onboard"}` when the gateway has no model configured. The 4 platform handlers (WhatsApp / Linq / WATI / Nextcloud Talk) still 200-ack their platform webhook so the platform doesn't retry-loop, but they now send a more honest user-facing reply (resolved via Fluent at request time, key `channel-needs-onboarding-reply`) instead of the generic "Sorry, I couldn't process your message right now." Detection lives in a small `is_needs_onboarding_err` helper that substring-matches the marker so wrapping via `anyhow::Error::context` doesn't break it.
  - **The localized channel reply lives in `crates/zeroclaw-runtime/locales/en/cli.ftl`** as `channel-needs-onboarding-reply`. Non-English locales (fr / ja / zh-CN) automatically fall back to the embedded English baseline via `format_ftl_messages`; proper translations can land via `tools/fill-translations` as a follow-up. The gateway crate uses the same `zeroclaw_runtime::i18n` module already used by `crates/zeroclaw-gateway/src/api.rs:116` and the established `wechat_cli_string` helper in `crates/zeroclaw-channels/src/wechat.rs` (#6242).
  - Channels orchestrator (`start_channels`) early-exits with a `WARN` when `resolved_default_model` returns `Err`, so the daemon supervisor marks the component done instead of restart-looping.
  - The agent-time `bail!` from #6099 (in `agent.rs:614` and `loop_.rs:3259`) stays as defense in depth, so the "no silent vendor-default substitution" guarantee from #6099 is preserved at request-time rather than at boot.
- **Scope boundary:** Does NOT touch the agent-level fail-loud sites (#6099). Does NOT change provider construction. Does NOT alter the model-resolution priority (fallback.model > resolve_default_model > empty/needs_onboarding). The third step changes from `bail!` to `String::new()` only. The 503 mapping is read-only on the chat-dispatch error surface — it doesn't change which errors propagate, only how `handle_webhook` and the platform handlers translate them.
- **Blast radius:** Two crates (`zeroclaw-gateway`, `zeroclaw-channels`) plus one Fluent file in `zeroclaw-runtime`. Behavior changes: (1) the daemon now boots in the misconfigured-without-model state instead of crash-looping; (2) `POST /webhook` returns 503 + structured body instead of 500 + generic body when the cause is needs_onboarding; (3) platform webhooks send a Fluent-localized user-facing reply for the same cause; (4) WS chat handler is unchanged (already returns a structured close frame on agent-init failure via the agent-time bail).
- **Linked issue(s):** Refs #6215 (regression source, partially reversed). Unblocks #6179 (web onboarding flow) and #6492 (v0.7.5 release). Closes the `/webhook` 500-vs-503 gap and the Fluent localization gap raised by @Audacity88 in PR review.

## Validation Evidence (required)

```bash
cargo +nightly fmt --all -- --check
cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
cargo test -p zeroclaw-gateway --all-features needs_onboarding
```

- **Commands run and tail output:**
  - `cargo +nightly fmt --all -- --check`, exit 0, clean.
  - `cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings`, exit 0, no warnings.
  - `cargo test -p zeroclaw-gateway --all-features needs_onboarding`, **all 7 tests pass**:
    ```
    test tests::needs_onboarding_for_flags_empty_model ... ok
    test tests::needs_onboarding_for_flags_whitespace_only_model ... ok
    test tests::needs_onboarding_for_passes_real_model ... ok
    test tests::is_needs_onboarding_err_detects_marker_from_helper ... ok
    test tests::is_needs_onboarding_err_ignores_unrelated_errors ... ok
    test tests::is_needs_onboarding_err_detects_via_substring ... ok
    test tests::needs_onboarding_channel_reply_resolves_via_fluent ... ok
    ```
    The new `needs_onboarding_channel_reply_resolves_via_fluent` test asserts the Fluent key resolves to real text rather than the missing-key fallback `{channel-needs-onboarding-reply}`.
  - Full `cargo test` deferred to CI per workflow preference.
- **Beyond CI, what I manually verified:**
  - Built with `cargo build --profile ci --features gateway`, ran `target/ci/zeroclaw daemon` against the real `~/.zeroclaw/config.toml` which has `providers.fallback = "xai"` set but no `model` field on any `[providers.models.*]` block (the exact misconfigured shape #6215 was meant to catch). Daemon booted, the new WARN line fired with the correct `/onboard` URL, gateway listener bound, web dashboard served, browser pairing succeeded.
  - @Audacity88 verified end-to-end via PR review on commit a80d85d1: `/health`, `/`, and `/onboard` all return 200 with no config and with a misconfigured-known-provider config; daemon starts and logs the WARN; `POST /webhook` returns 503 with the expected `needs_onboarding` body. The Fluent localization on commit 6d9a0e76 addresses his blocking finding without changing the verified HTTP-side behavior.
  - Pre-fix: same config crashed the gateway component with `Daemon component 'gateway' failed: no model configured: providers.fallback = Some("xai") resolves with no model ...`, restart-looping every 2 seconds.
  - Did NOT verify: end-to-end chat after onboarding completes (would require finishing the `/onboard` flow with real provider credentials).
- **If any command was intentionally skipped, why:** Full `cargo test` skipped locally; CI runs it. The new tests are scoped to free functions that don't touch `AppState` or any I/O.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes`. Existing fully-configured deployments (`fallback` set with a `model` field, or any `[providers.models.*]` block carrying a `model` field) hit the same first/second resolution branches as before, no behavior change. The third branch (no model anywhere) changes from "daemon dies" to "daemon boots, chat refuses with a clear marker that maps to 503 on `/webhook` and a Fluent-localized reply on platform handlers". Strictly an improvement.
- Config / env / CLI surface changed? `No`. No new keys, no renamed keys, no env vars, no CLI flags.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <sha>` — each of the three commits on this branch can be reverted independently:
  - `af0b0f87d` (boot-without-model) — reverting re-introduces the fresh-install crash. Most disruptive revert.
  - `a80d85d1a` (503 mapping) — reverting re-introduces the generic 500 on `/webhook` when no model is configured. Daemon still boots; only the HTTP shape changes.
  - `6d9a0e765` (Fluent localization) — reverting restores the hardcoded English literal at the channel-handler call sites. Re-introduces the AGENTS.md rule violation flagged by @Audacity88; safe to revert in isolation if a Fluent-side regression is found.
- **Feature flags or config toggles:** None. The behavior change is unconditional — gated only on whether a model is configured at boot. No feature gate, no config toggle.
- **Observable failure symptoms:**
  - **Boot regression:** daemon log shows `Daemon component 'gateway' failed: no model configured: providers.fallback = … resolves with no model` repeating every ~2 seconds (the supervisor restart loop). `curl -s http://127.0.0.1:42617/health` returns connection refused.
  - **HTTP shape regression on `/webhook`:** `POST /webhook` returns `500 {"error": "LLM request failed"}` instead of `503 {"error": "needs_onboarding", "url": "/onboard"}`. Daemon log shows `Webhook provider error: ...needs_onboarding...` instead of `Webhook chat refused: gateway has no model configured; visit /onboard`.
  - **Fluent regression:** WhatsApp / Linq / WATI / Nextcloud Talk channel replies show `{channel-needs-onboarding-reply}` (literal curly-brace key) instead of the localized text. Daemon log shows `missing CLI Fluent string` from `zeroclaw_runtime::i18n`.
  - **Channels supervisor regression:** if a deployment has channels configured but no model, `daemon` log shows `channels` component restart-looping with `no model configured: ... before starting channels` instead of the expected `Channels supervisor exiting: no model configured but channels are present` one-shot WARN.