### PR TITLE
feat(channel:vonage): add Vonage (Nexmo) SMS channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13377,6 +13377,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sha2 0.10.9",
  "tempfile",
  "tokio",

--- a/crates/zeroclaw-channels/Cargo.toml
+++ b/crates/zeroclaw-channels/Cargo.toml
@@ -83,7 +83,7 @@ default = [
     "channel-bluesky", "channel-twitter", "channel-reddit", "channel-notion",
     "channel-linq", "channel-wati", "channel-nextcloud", "channel-mochat",
     "channel-wecom", "channel-clawdtalk", "channel-webhook",
-    "channel-whatsapp-cloud", "channel-voice-call",
+    "channel-whatsapp-cloud", "channel-voice-call", "channel-vonage",
 ]
 # Channels with optional deps
 channel-email = ["dep:lettre", "dep:mail-parser", "dep:async-imap"]
@@ -115,6 +115,7 @@ channel-clawdtalk = []
 channel-webhook = []
 channel-whatsapp-cloud = []
 channel-voice-call = []
+channel-vonage = []
 channel-acp-server = []
 channel-matrix = ["dep:matrix-sdk", "dep:mime_guess"]
 voice-wake = ["dep:cpal", "zeroclaw-config/voice-wake"]

--- a/crates/zeroclaw-channels/src/lib.rs
+++ b/crates/zeroclaw-channels/src/lib.rs
@@ -64,6 +64,8 @@ pub mod twitter;
 pub mod voice_call;
 #[cfg(feature = "voice-wake")]
 pub mod voice_wake;
+#[cfg(feature = "channel-vonage")]
+pub mod vonage;
 #[cfg(feature = "channel-wati")]
 pub mod wati;
 #[cfg(feature = "channel-webhook")]

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -56,6 +56,8 @@ pub use crate::twitter::TwitterChannel;
 pub use crate::voice_call::VoiceCallChannel;
 #[cfg(feature = "voice-wake")]
 pub use crate::voice_wake::VoiceWakeChannel;
+#[cfg(feature = "channel-vonage")]
+pub use crate::vonage::VonageChannel;
 pub use crate::wati::WatiChannel;
 pub use crate::webhook::WebhookChannel;
 #[cfg(feature = "channel-wechat")]
@@ -4476,6 +4478,21 @@ fn build_channel_by_id(config: &Config, channel_id: &str) -> Result<Arc<dyn Chan
                 lq.allowed_senders.clone(),
             )))
         }
+        #[cfg(feature = "channel-vonage")]
+        "vonage" => {
+            let vg = config
+                .channels
+                .vonage
+                .as_ref()
+                .context("Vonage channel is not configured")?;
+            Ok(Arc::new(VonageChannel::new(
+                vg.api_key.clone(),
+                vg.api_secret.clone(),
+                vg.from_number_or_sender_id.clone(),
+                vg.allowed_numbers.clone(),
+                vg.signature_secret.clone(),
+            )))
+        }
         #[cfg(feature = "channel-email")]
         "email" => {
             let em = config
@@ -4949,6 +4966,22 @@ fn collect_configured_channels(
         } else {
             tracing::info!("Linq channel configured but disabled (enabled = false)");
         }
+    }
+
+    #[cfg(feature = "channel-vonage")]
+    if let Some(ref vg) = config.channels.vonage
+        && vg.enabled
+    {
+        channels.push(ConfiguredChannel {
+            display_name: "Vonage SMS",
+            channel: Arc::new(VonageChannel::new(
+                vg.api_key.clone(),
+                vg.api_secret.clone(),
+                vg.from_number_or_sender_id.clone(),
+                vg.allowed_numbers.clone(),
+                vg.signature_secret.clone(),
+            )),
+        });
     }
 
     if let Some(ref wati_cfg) = config.channels.wati {

--- a/crates/zeroclaw-channels/src/vonage.rs
+++ b/crates/zeroclaw-channels/src/vonage.rs
@@ -1,0 +1,677 @@
+//! Vonage (Nexmo) SMS channel — sends via Vonage's legacy SMS REST API and
+//! receives via gateway-routed webhooks.
+//!
+//! Mirrors the gateway-registered pattern used by Twilio, Plivo, Sinch, and
+//! Telnyx: the channel's `listen()` is a keep-alive no-op, and the gateway
+//! crate hosts a hardcoded `POST /vonage/sms` route whose handler reads
+//! `application/x-www-form-urlencoded` payloads, validates the `sig`
+//! parameter (HMAC-SHA256 over alphabetically-sorted params), and converts
+//! each request into a `ChannelMessage`.
+//!
+//! # Auth
+//! Two distinct credentials, both configured per Vonage account:
+//!
+//! 1. `api_secret` — the legacy SMS API password, sent in the outbound POST
+//!    body alongside `api_key`. Vonage's `/sms/json` endpoint takes
+//!    credentials in the form body (not headers).
+//! 2. `signature_secret` — the inbound-webhook HMAC key, configured
+//!    separately in the Vonage dashboard's "API settings → Signed messages
+//!    → Signature secret" with algorithm "HMAC SHA-256". Mixing this up
+//!    with `api_secret` is a common operator footgun, so the docs call it
+//!    out explicitly.
+//!
+//! # Outbound
+//! `POST https://rest.nexmo.com/sms/json` with form fields `api_key`,
+//! `api_secret`, `from`, `to`, `text`. Bodies over 1600 characters are
+//! split at sentence/word boundaries with `(i/N) ` continuation markers.
+//!
+//! # Inbound
+//! The gateway handler recomputes Vonage's signature algorithm and rejects
+//! requests where the computed value doesn't match the `sig` parameter:
+//!
+//! 1. Pop the `sig` parameter from the form body.
+//! 2. Sort the remaining parameters alphabetically by key.
+//! 3. Concatenate as `&{key}={value}` for each pair (note the leading `&`).
+//! 4. Append the `signature_secret` literal at the end.
+//! 5. HMAC-SHA256 keyed by `signature_secret`, hex-encoded (lowercase).
+//! 6. Constant-time compare against `sig`. Mismatch → drop with 401.
+
+use anyhow::{Context, Result, bail};
+use async_trait::async_trait;
+use std::collections::BTreeMap;
+use zeroclaw_api::channel::{Channel, ChannelMessage, SendMessage};
+
+const VONAGE_API_BASE: &str = "https://rest.nexmo.com";
+/// Vonage's legacy SMS API auto-segments long messages, but bodies above
+/// 1600 chars in a single call get awkward; we split here for parity with
+/// the other SMS-gateway channels.
+const VONAGE_MESSAGE_LIMIT: usize = 1600;
+/// Hardcoded inbound webhook path on the gateway. Operators point Vonage's
+/// "Inbound SMS Webhook" at `https://{gateway}/vonage/sms` (POST).
+pub const VONAGE_WEBHOOK_PATH: &str = "/vonage/sms";
+
+/// Vonage SMS channel — see module docs.
+pub struct VonageChannel {
+    api_key: String,
+    api_secret: String,
+    from_number_or_sender_id: String,
+    allowed_numbers: Vec<String>,
+    signature_secret: String,
+}
+
+impl VonageChannel {
+    pub fn new(
+        api_key: String,
+        api_secret: String,
+        from_number_or_sender_id: String,
+        allowed_numbers: Vec<String>,
+        signature_secret: String,
+    ) -> Self {
+        Self {
+            api_key,
+            api_secret,
+            from_number_or_sender_id,
+            allowed_numbers,
+            signature_secret,
+        }
+    }
+
+    fn http_client(&self) -> reqwest::Client {
+        zeroclaw_config::schema::build_runtime_proxy_client("channel.vonage")
+    }
+
+    fn outbound_url(&self) -> String {
+        format!("{VONAGE_API_BASE}/sms/json")
+    }
+
+    /// Configurable base URL hook used by tests. The default points at
+    /// Vonage's production endpoint; tests substitute a wiremock URI.
+    #[cfg(test)]
+    fn outbound_url_with_base(&self, base: &str) -> String {
+        format!("{base}/sms/json")
+    }
+
+    /// Whether the inbound `msisdn` is permitted. Empty allowlist denies
+    /// everyone; `"*"` matches anyone; otherwise an exact case-insensitive
+    /// E.164 match is required.
+    pub fn is_number_allowed(&self, phone: &str) -> bool {
+        is_number_allowed_for_list(&self.allowed_numbers, phone)
+    }
+
+    /// Verify a Vonage inbound-webhook signature. The caller must pass the
+    /// already-parsed form parameters as a `BTreeMap` so the iteration
+    /// order matches Vonage's "alphabetically by key" requirement.
+    ///
+    /// Algorithm — see <https://developer.vonage.com/en/messaging/sms/concepts/signed-messages>:
+    ///
+    /// 1. Pop `sig` from `form_params` (it's not part of the canonical string).
+    /// 2. Sort remaining keys alphabetically. (BTreeMap iteration handles this.)
+    /// 3. Build the canonical string by concatenating `&{k}={v}` for each pair.
+    /// 4. Compute `HMAC-SHA256(canonical, signature_secret)`, lowercase hex.
+    /// 5. Constant-time compare against the popped `sig` value.
+    pub fn verify_signature(&self, form_params: &BTreeMap<String, String>) -> bool {
+        verify_vonage_signature(&self.signature_secret, form_params)
+    }
+
+    /// Convert an inbound Vonage webhook payload into a `ChannelMessage`.
+    /// Returns `None` when the sender isn't on the allowlist, the body is
+    /// empty, or required fields are missing.
+    pub fn parse_webhook_payload(
+        &self,
+        form_params: &BTreeMap<String, String>,
+    ) -> Option<ChannelMessage> {
+        let from = form_params.get("msisdn")?.trim();
+        if from.is_empty() {
+            return None;
+        }
+        if !self.is_number_allowed(from) {
+            tracing::debug!("Vonage: dropping SMS from {from} (not in allowed_numbers)");
+            return None;
+        }
+        let body = form_params
+            .get("text")
+            .map(|s| s.trim().to_string())
+            .unwrap_or_default();
+        if body.is_empty() {
+            tracing::debug!("Vonage: dropping empty-body SMS from {from}");
+            return None;
+        }
+        let message_id = form_params
+            .get("messageId")
+            .cloned()
+            .unwrap_or_else(|| format!("vonage-{}", chrono::Utc::now().timestamp_millis()));
+        Some(ChannelMessage {
+            id: format!("vonage_{message_id}"),
+            sender: from.to_string(),
+            reply_target: from.to_string(),
+            content: body,
+            channel: "vonage".to_string(),
+            timestamp: chrono::Utc::now().timestamp().cast_unsigned(),
+            thread_ts: None,
+            interruption_scope_id: None,
+            attachments: vec![],
+        })
+    }
+
+    async fn post_message_chunk(
+        &self,
+        to: &str,
+        body: &str,
+        base_override: Option<&str>,
+    ) -> Result<()> {
+        let url = match base_override {
+            #[cfg(test)]
+            Some(b) => self.outbound_url_with_base(b),
+            #[cfg(not(test))]
+            Some(_) => self.outbound_url(),
+            None => self.outbound_url(),
+        };
+        let resp = self
+            .http_client()
+            .post(&url)
+            .form(&[
+                ("api_key", self.api_key.as_str()),
+                ("api_secret", self.api_secret.as_str()),
+                ("from", self.from_number_or_sender_id.as_str()),
+                ("to", to),
+                ("text", body),
+            ])
+            .send()
+            .await
+            .context("Vonage /sms/json POST failed")?;
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            bail!("Vonage /sms/json POST returned {status}: {body}");
+        }
+        // Vonage returns 200 even when the message itself was rejected;
+        // the per-message status lives in a JSON body. Surface that as an
+        // error so the caller sees it.
+        let payload: VonageSmsResponse = resp
+            .json()
+            .await
+            .context("Vonage /sms/json returned non-JSON body")?;
+        for message in &payload.messages {
+            // status="0" means OK; anything else is an error
+            // (https://developer.vonage.com/en/api/sms#sms-response-codes).
+            if message.status != "0" {
+                bail!(
+                    "Vonage SMS rejected: status={} error_text={}",
+                    message.status,
+                    message.error_text.as_deref().unwrap_or("(none)"),
+                );
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct VonageSmsResponse {
+    #[serde(default)]
+    messages: Vec<VonageSmsMessage>,
+}
+
+#[derive(serde::Deserialize)]
+struct VonageSmsMessage {
+    /// `"0"` = success, anything else is an error code (string-typed in the
+    /// JSON, not numeric).
+    status: String,
+    #[serde(default, rename = "error-text")]
+    error_text: Option<String>,
+}
+
+#[async_trait]
+impl Channel for VonageChannel {
+    fn name(&self) -> &str {
+        "vonage"
+    }
+
+    async fn send(&self, message: &SendMessage) -> Result<()> {
+        let to = message.recipient.trim();
+        if to.is_empty() {
+            bail!("Vonage send: empty recipient");
+        }
+        let chunks = chunk_sms(&message.content, VONAGE_MESSAGE_LIMIT);
+        if chunks.is_empty() {
+            return Ok(());
+        }
+        for chunk in chunks {
+            self.post_message_chunk(to, &chunk, None).await?;
+        }
+        Ok(())
+    }
+
+    async fn listen(&self, _tx: tokio::sync::mpsc::Sender<ChannelMessage>) -> Result<()> {
+        // Vonage uses webhooks (push-based), not polling. The gateway hosts
+        // POST /vonage/sms and routes inbound payloads via parse_webhook_payload.
+        tracing::info!(
+            "Vonage channel active (webhook mode). Configure Vonage's \
+             \"Inbound SMS Webhook\" to POST to your gateway's {VONAGE_WEBHOOK_PATH} endpoint."
+        );
+        loop {
+            tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
+        }
+    }
+
+    async fn health_check(&self) -> bool {
+        // Probe the account-balance endpoint — succeeds when api_key +
+        // api_secret are valid. (No JSON parsing needed; just status check.)
+        let url = format!("{VONAGE_API_BASE}/account/get-balance");
+        self.http_client()
+            .get(&url)
+            .query(&[
+                ("api_key", self.api_key.as_str()),
+                ("api_secret", self.api_secret.as_str()),
+            ])
+            .send()
+            .await
+            .map(|r| r.status().is_success())
+            .unwrap_or(false)
+    }
+}
+
+/// Allowlist matcher with `"*"` wildcard. Comparison is case-insensitive
+/// and strips internal whitespace so `"+1 555 555 0199"` round-trips
+/// against the canonical E.164 `"+15555550199"`.
+pub fn is_number_allowed_for_list(allowlist: &[String], phone: &str) -> bool {
+    if allowlist.is_empty() {
+        return false;
+    }
+    if allowlist.iter().any(|n| n == "*") {
+        return true;
+    }
+    let normalized = phone
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect::<String>()
+        .to_ascii_lowercase();
+    allowlist.iter().any(|entry| {
+        let canon = entry
+            .chars()
+            .filter(|c| !c.is_whitespace())
+            .collect::<String>()
+            .to_ascii_lowercase();
+        canon == normalized
+    })
+}
+
+/// Verify Vonage's `sig` webhook parameter. See `VonageChannel::verify_signature`
+/// for the algorithm. Returns `false` on any of: missing `sig`, bad hex
+/// decode, signature length mismatch, or HMAC mismatch.
+fn verify_vonage_signature(signature_secret: &str, form_params: &BTreeMap<String, String>) -> bool {
+    use hmac::{Hmac, Mac};
+    use sha2::Sha256;
+
+    let Some(provided_sig) = form_params.get("sig") else {
+        return false;
+    };
+    if provided_sig.is_empty() {
+        return false;
+    }
+
+    // Build canonical string: alphabetically sorted &k=v pairs, excluding
+    // the `sig` parameter itself, with the `signature_secret` appended.
+    // BTreeMap iterates sorted by key, which matches Vonage's spec.
+    let mut canonical = String::with_capacity(form_params.len() * 32);
+    for (k, v) in form_params.iter().filter(|(k, _)| k.as_str() != "sig") {
+        canonical.push('&');
+        canonical.push_str(k);
+        canonical.push('=');
+        canonical.push_str(v);
+    }
+    canonical.push_str(signature_secret);
+
+    let Ok(mut mac) = Hmac::<Sha256>::new_from_slice(signature_secret.as_bytes()) else {
+        return false;
+    };
+    mac.update(canonical.as_bytes());
+    let computed = mac.finalize().into_bytes();
+    let computed_hex = hex::encode(computed);
+    constant_time_eq(computed_hex.as_bytes(), provided_sig.as_bytes())
+}
+
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff: u8 = 0;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+/// Split an outbound body into ≤`limit`-character chunks. Single-chunk
+/// bodies are returned as-is; multi-chunk bodies receive a `(i/N) ` prefix
+/// on each part. Splits prefer sentence enders, then whitespace, then a
+/// hard char cut.
+pub fn chunk_sms(body: &str, limit: usize) -> Vec<String> {
+    let body = body.trim();
+    if body.is_empty() {
+        return vec![];
+    }
+    if body.chars().count() <= limit {
+        return vec![body.to_string()];
+    }
+    const MARKER_RESERVE: usize = 8; // "(99/99) "
+    let body_budget = limit.saturating_sub(MARKER_RESERVE).max(1);
+    let mut chunks: Vec<String> = Vec::new();
+    let mut remaining: &str = body;
+    while !remaining.is_empty() {
+        if remaining.chars().count() <= body_budget {
+            chunks.push(remaining.to_string());
+            break;
+        }
+        let split_at = pick_split_point(remaining, body_budget);
+        let (head, tail) = remaining.split_at(split_at);
+        chunks.push(head.trim_end().to_string());
+        remaining = tail.trim_start();
+    }
+    if chunks.len() == 1 {
+        return chunks;
+    }
+    let total = chunks.len();
+    chunks
+        .into_iter()
+        .enumerate()
+        .map(|(i, c)| format!("({}/{total}) {c}", i + 1))
+        .collect()
+}
+
+fn pick_split_point(text: &str, char_budget: usize) -> usize {
+    let mut budget_idx = text.len();
+    for (i, (byte_idx, _)) in text.char_indices().enumerate() {
+        if i == char_budget {
+            budget_idx = byte_idx;
+            break;
+        }
+    }
+    let head = &text[..budget_idx];
+    if let Some(idx) = head.rfind(['.', '!', '?', '\n']) {
+        return (idx + 1).min(budget_idx);
+    }
+    if let Some(idx) = head.rfind(char::is_whitespace) {
+        return idx + 1;
+    }
+    budget_idx
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ch() -> VonageChannel {
+        VonageChannel::new(
+            "TESTKEY".into(),
+            "test-secret".into(),
+            "+15555550100".into(),
+            vec!["+15555550199".into()],
+            "sig-secret".into(),
+        )
+    }
+
+    /// Compute the canonical signature for a fixture, exercising the same
+    /// path the production validator uses but as the "trusted" producer
+    /// side. Tests sign with this and then validate via `verify_signature`
+    /// to round-trip the algorithm.
+    fn compute_vonage_sig(secret: &str, params: &BTreeMap<String, String>) -> String {
+        use hmac::{Hmac, Mac};
+        use sha2::Sha256;
+        let mut canonical = String::new();
+        for (k, v) in params.iter().filter(|(k, _)| k.as_str() != "sig") {
+            canonical.push('&');
+            canonical.push_str(k);
+            canonical.push('=');
+            canonical.push_str(v);
+        }
+        canonical.push_str(secret);
+        let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes()).unwrap();
+        mac.update(canonical.as_bytes());
+        hex::encode(mac.finalize().into_bytes())
+    }
+
+    fn signed_form(secret: &str, body: &[(&str, &str)]) -> BTreeMap<String, String> {
+        let mut map: BTreeMap<String, String> = body
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect();
+        let sig = compute_vonage_sig(secret, &map);
+        map.insert("sig".into(), sig);
+        map
+    }
+
+    #[test]
+    fn allowlist_empty_denies_everyone() {
+        assert!(!is_number_allowed_for_list(&[], "+15555550199"));
+    }
+
+    #[test]
+    fn allowlist_wildcard_allows_anyone() {
+        let allow = vec!["*".into()];
+        assert!(is_number_allowed_for_list(&allow, "+15555550199"));
+        assert!(is_number_allowed_for_list(&allow, "+447700900000"));
+    }
+
+    #[test]
+    fn allowlist_matches_e164_exact() {
+        let allow = vec!["+15555550199".into()];
+        assert!(is_number_allowed_for_list(&allow, "+15555550199"));
+        assert!(!is_number_allowed_for_list(&allow, "+15555550100"));
+    }
+
+    #[test]
+    fn allowlist_strips_whitespace() {
+        let allow = vec!["+1 555 555 0199".into()];
+        assert!(is_number_allowed_for_list(&allow, "+15555550199"));
+    }
+
+    #[test]
+    fn chunk_sms_short_passes_through() {
+        let chunks = chunk_sms("hi there", VONAGE_MESSAGE_LIMIT);
+        assert_eq!(chunks, vec!["hi there"]);
+    }
+
+    #[test]
+    fn chunk_sms_long_is_split_with_marker() {
+        let body = "alpha beta gamma. ".repeat(120);
+        let chunks = chunk_sms(&body, 100);
+        assert!(chunks.len() >= 2);
+        for (i, c) in chunks.iter().enumerate() {
+            assert!(c.starts_with(&format!("({}/", i + 1)));
+            assert!(c.chars().count() <= 100);
+        }
+    }
+
+    #[test]
+    fn chunk_sms_empty_returns_no_chunks() {
+        let chunks = chunk_sms("   ", VONAGE_MESSAGE_LIMIT);
+        assert!(chunks.is_empty());
+    }
+
+    #[test]
+    fn parse_webhook_drops_outside_allowlist() {
+        let mut params = BTreeMap::new();
+        params.insert("msisdn".into(), "+15555550999".into());
+        params.insert("text".into(), "hi".into());
+        params.insert("messageId".into(), "M1".into());
+        assert!(ch().parse_webhook_payload(&params).is_none());
+    }
+
+    #[test]
+    fn parse_webhook_drops_empty_body() {
+        let mut params = BTreeMap::new();
+        params.insert("msisdn".into(), "+15555550199".into());
+        params.insert("text".into(), "  ".into());
+        assert!(ch().parse_webhook_payload(&params).is_none());
+    }
+
+    #[test]
+    fn parse_webhook_returns_message_on_allowed() {
+        let mut params = BTreeMap::new();
+        params.insert("msisdn".into(), "+15555550199".into());
+        params.insert("text".into(), "hello world".into());
+        params.insert("messageId".into(), "M123".into());
+        let msg = ch()
+            .parse_webhook_payload(&params)
+            .expect("expected message");
+        assert_eq!(msg.sender, "+15555550199");
+        assert_eq!(msg.reply_target, "+15555550199");
+        assert_eq!(msg.content, "hello world");
+        assert_eq!(msg.channel, "vonage");
+        assert_eq!(msg.id, "vonage_M123");
+    }
+
+    #[test]
+    fn verify_signature_round_trips_against_self_computed_value() {
+        let params = signed_form(
+            "sig-secret",
+            &[
+                ("msisdn", "+15555550199"),
+                ("to", "+15555550100"),
+                ("text", "hello world"),
+                ("messageId", "MABC"),
+                ("type", "text"),
+            ],
+        );
+        assert!(verify_vonage_signature("sig-secret", &params));
+    }
+
+    #[test]
+    fn verify_signature_rejects_tampered_body() {
+        let mut params = signed_form(
+            "sig-secret",
+            &[("msisdn", "+15555550199"), ("text", "hello")],
+        );
+        // Tamper with the body AFTER the signature was computed.
+        params.insert("text".into(), "hello (modified)".into());
+        assert!(!verify_vonage_signature("sig-secret", &params));
+    }
+
+    #[test]
+    fn verify_signature_rejects_wrong_secret() {
+        let params = signed_form(
+            "sig-secret",
+            &[("msisdn", "+15555550199"), ("text", "hello")],
+        );
+        assert!(!verify_vonage_signature("WRONG-SECRET", &params));
+    }
+
+    #[test]
+    fn verify_signature_rejects_missing_sig() {
+        let mut params = BTreeMap::new();
+        params.insert("msisdn".into(), "+15555550199".into());
+        params.insert("text".into(), "hello".into());
+        // No `sig` key inserted.
+        assert!(!verify_vonage_signature("sig-secret", &params));
+    }
+
+    #[test]
+    fn verify_signature_rejects_empty_sig() {
+        let mut params = BTreeMap::new();
+        params.insert("msisdn".into(), "+15555550199".into());
+        params.insert("text".into(), "hello".into());
+        params.insert("sig".into(), String::new());
+        assert!(!verify_vonage_signature("sig-secret", &params));
+    }
+
+    #[test]
+    fn verify_signature_ignores_sig_in_canonical_string() {
+        // The canonical string excludes `sig`. If our implementation
+        // accidentally included it, the round-trip would still pass
+        // (because both sides would include it), but rotating sig to a
+        // garbage value should still fail. This test confirms we skip
+        // `sig` when building the canonical string by checking that the
+        // round-trip works regardless of whether we recompute or trust the
+        // already-attached value.
+        let params = signed_form("sig-secret", &[("a", "1"), ("b", "2"), ("c", "3")]);
+        // Round-trip succeeds.
+        assert!(verify_vonage_signature("sig-secret", &params));
+        // Mutating `sig` to a different valid-looking value must fail.
+        let mut tampered = params.clone();
+        tampered.insert("sig".into(), "0".repeat(64));
+        assert!(!verify_vonage_signature("sig-secret", &tampered));
+    }
+
+    mod http_tests {
+        use super::*;
+        use serde_json::json;
+        use wiremock::matchers::{body_string_contains, header, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        #[tokio::test]
+        async fn send_posts_form_body_with_credentials() {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/sms/json"))
+                .and(header("content-type", "application/x-www-form-urlencoded"))
+                .and(body_string_contains("api_key=TESTKEY"))
+                .and(body_string_contains("api_secret=test-secret"))
+                .and(body_string_contains("from=%2B15555550100"))
+                .and(body_string_contains("to=%2B15555550199"))
+                .and(body_string_contains("text=hello+there"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "message-count": "1",
+                    "messages": [{"to": "+15555550199", "message-id": "M1", "status": "0"}]
+                })))
+                .expect(1)
+                .mount(&server)
+                .await;
+
+            let twilio_like = ch();
+            twilio_like
+                .post_message_chunk("+15555550199", "hello there", Some(&server.uri()))
+                .await
+                .expect("send succeeds");
+        }
+
+        #[tokio::test]
+        async fn send_surfaces_4xx_as_error() {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/sms/json"))
+                .respond_with(
+                    ResponseTemplate::new(401).set_body_string("{\"error\":\"unauthorized\"}"),
+                )
+                .mount(&server)
+                .await;
+
+            let err = ch()
+                .post_message_chunk("+15555550199", "hi", Some(&server.uri()))
+                .await
+                .expect_err("expected error");
+            let msg = format!("{err:#}");
+            assert!(msg.contains("401"), "missing 401 in error: {msg}");
+        }
+
+        #[tokio::test]
+        async fn send_surfaces_per_message_failure() {
+            // Vonage returns 200 with an error status inside the JSON when
+            // the per-message send fails (e.g. invalid destination, throttle).
+            // Validator must surface that as Err, not silently succeed.
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/sms/json"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "message-count": "1",
+                    "messages": [{
+                        "to": "+15555550199",
+                        "status": "5",
+                        "error-text": "Server Error"
+                    }]
+                })))
+                .mount(&server)
+                .await;
+
+            let err = ch()
+                .post_message_chunk("+15555550199", "hi", Some(&server.uri()))
+                .await
+                .expect_err("expected per-message-failure error");
+            let msg = format!("{err:#}");
+            assert!(
+                msg.contains("status=5") && msg.contains("Server Error"),
+                "missing per-message status/error in: {msg}"
+            );
+        }
+    }
+}

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -6773,6 +6773,11 @@ pub struct ChannelsConfig {
     #[display_name = "Linq"]
     #[description = "Linq Partner API for iMessage/RCS/SMS"]
     pub linq: Option<LinqConfig>,
+    /// Vonage (Nexmo) SMS channel configuration.
+    #[nested]
+    #[display_name = "Vonage SMS"]
+    #[description = "Vonage / Nexmo programmable SMS"]
+    pub vonage: Option<VonageConfig>,
     /// WATI WhatsApp Business API channel configuration.
     #[nested]
     #[display_name = "WATI"]
@@ -6987,6 +6992,10 @@ impl ChannelsConfig {
                 self.linq.is_some(),
             ),
             (
+                Box::new(ConfigWrapper::new(self.vonage.as_ref())),
+                self.vonage.is_some(),
+            ),
+            (
                 Box::new(ConfigWrapper::new(self.wati.as_ref())),
                 self.wati.is_some(),
             ),
@@ -7092,6 +7101,7 @@ impl Default for ChannelsConfig {
             signal: None,
             whatsapp: None,
             linq: None,
+            vonage: None,
             wati: None,
             nextcloud_talk: None,
             email: None,
@@ -7790,6 +7800,56 @@ impl ChannelConfig for LinqConfig {
     }
     fn desc() -> &'static str {
         "iMessage/RCS/SMS via Linq API"
+    }
+}
+
+/// Vonage (Nexmo) SMS channel configuration.
+///
+/// Inbound SMS arrives via the gateway at the hardcoded path
+/// `/vonage/sms`. The operator must point Vonage's "Inbound SMS
+/// Webhook" at `https://{public-gateway-url}/vonage/sms` (POST,
+/// `application/x-www-form-urlencoded`) and configure a "Signature
+/// secret" + "HMAC SHA-256" in the Vonage dashboard settings — that's
+/// what the gateway uses to authenticate inbound payloads.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, Configurable)]
+#[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
+#[prefix = "channels.vonage"]
+pub struct VonageConfig {
+    /// Whether this channel is active (must be explicitly enabled). Default: false.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Vonage API key — public identifier shown in the dashboard.
+    pub api_key: String,
+    /// Vonage API secret. Sent in the outbound SMS POST body alongside
+    /// `api_key` (Vonage's legacy SMS API takes credentials in the form
+    /// body, not headers).
+    #[secret]
+    #[cfg_attr(feature = "schema-export", schemars(extend("x-secret" = true)))]
+    pub api_secret: String,
+    /// Sender — E.164 phone number (e.g. `"+15555550100"`), short code,
+    /// or alphanumeric sender ID (where allowed by destination country).
+    pub from_number_or_sender_id: String,
+    /// Allowed sender numbers in E.164 format (e.g. `"+15555550199"`).
+    /// Empty list = deny all. `"*"` allows everyone (use with care; this
+    /// is a public PSTN endpoint).
+    #[serde(default)]
+    pub allowed_numbers: Vec<String>,
+    /// Inbound webhook signature secret. **Distinct from `api_secret`**
+    /// — set separately in the Vonage dashboard's API settings as the
+    /// "Signature secret" with algorithm "HMAC SHA-256". The gateway
+    /// recomputes the `sig` parameter on every inbound webhook and
+    /// rejects mismatches with 401 before they reach the agent loop.
+    #[secret]
+    #[cfg_attr(feature = "schema-export", schemars(extend("x-secret" = true)))]
+    pub signature_secret: String,
+}
+
+impl ChannelConfig for VonageConfig {
+    fn name() -> &'static str {
+        "Vonage"
+    }
+    fn desc() -> &'static str {
+        "Vonage / Nexmo programmable SMS"
     }
 }
 
@@ -12526,6 +12586,7 @@ auto_save = true
                 signal: None,
                 whatsapp: None,
                 linq: None,
+                vonage: None,
                 wati: None,
                 nextcloud_talk: None,
                 email: None,
@@ -13700,6 +13761,7 @@ allowed_users = ["@u:matrix.org"]
             signal: None,
             whatsapp: None,
             linq: None,
+            vonage: None,
             wati: None,
             nextcloud_talk: None,
             email: None,
@@ -14082,6 +14144,7 @@ bot_token = "xoxb-tok"
                 approval_timeout_secs: 300,
             }),
             linq: None,
+            vonage: None,
             wati: None,
             nextcloud_talk: None,
             email: None,

--- a/crates/zeroclaw-gateway/Cargo.toml
+++ b/crates/zeroclaw-gateway/Cargo.toml
@@ -47,6 +47,7 @@ futures-util = { version = "0.3", default-features = false, features = ["sink"] 
 
 # Serialization
 serde = { version = "1.0", default-features = false, features = ["derive"] }
+serde_urlencoded = "0.7"
 serde_json = { version = "1.0", default-features = false, features = ["std"] }
 
 # Error handling

--- a/crates/zeroclaw-gateway/src/api.rs
+++ b/crates/zeroclaw-gateway/src/api.rs
@@ -1277,6 +1277,7 @@ mod tests {
             whatsapp_app_secret: None,
             linq: None,
             linq_signing_secret: None,
+            vonage: None,
             nextcloud_talk: None,
             nextcloud_talk_webhook_secret: None,
             wati: None,

--- a/crates/zeroclaw-gateway/src/lib.rs
+++ b/crates/zeroclaw-gateway/src/lib.rs
@@ -53,7 +53,7 @@ use zeroclaw_api::channel::{Channel, SendMessage};
 use zeroclaw_api::tool::ToolSpec;
 use zeroclaw_channels::{
     gmail_push::GmailPushChannel, linq::LinqChannel, nextcloud_talk::NextcloudTalkChannel,
-    wati::WatiChannel, whatsapp::WhatsAppChannel,
+    vonage::VonageChannel, wati::WatiChannel, whatsapp::WhatsAppChannel,
 };
 use zeroclaw_config::policy::SecurityPolicy;
 use zeroclaw_config::schema::Config;
@@ -382,6 +382,7 @@ pub struct AppState {
     pub linq: Option<Arc<LinqChannel>>,
     /// Linq webhook signing secret for signature verification
     pub linq_signing_secret: Option<Arc<str>>,
+    pub vonage: Option<Arc<VonageChannel>>,
     pub nextcloud_talk: Option<Arc<NextcloudTalkChannel>>,
     /// Nextcloud Talk webhook secret for signature verification
     pub nextcloud_talk_webhook_secret: Option<Arc<str>>,
@@ -715,6 +716,22 @@ pub async fn run_gateway(
         })
         .map(Arc::from);
 
+    // Vonage channel (if configured AND enabled)
+    let vonage_channel: Option<Arc<VonageChannel>> = config
+        .channels
+        .vonage
+        .as_ref()
+        .filter(|vg| vg.enabled)
+        .map(|vg| {
+            Arc::new(VonageChannel::new(
+                vg.api_key.clone(),
+                vg.api_secret.clone(),
+                vg.from_number_or_sender_id.clone(),
+                vg.allowed_numbers.clone(),
+                vg.signature_secret.clone(),
+            ))
+        });
+
     // WATI channel (if configured)
     let wati_channel: Option<Arc<WatiChannel>> = config.channels.wati.as_ref().map(|wati_cfg| {
         Arc::new(
@@ -985,6 +1002,7 @@ pub async fn run_gateway(
         whatsapp_app_secret,
         linq: linq_channel,
         linq_signing_secret,
+        vonage: vonage_channel,
         nextcloud_talk: nextcloud_talk_channel,
         nextcloud_talk_webhook_secret,
         wati: wati_channel,
@@ -1047,6 +1065,7 @@ pub async fn run_gateway(
         .route("/whatsapp", get(handle_whatsapp_verify))
         .route("/whatsapp", post(handle_whatsapp_message))
         .route("/linq", post(handle_linq_webhook))
+        .route("/vonage/sms", post(handle_vonage_sms_webhook))
         .route("/wati", get(handle_wati_verify))
         .route("/wati", post(handle_wati_webhook))
         .route("/nextcloud-talk", post(handle_nextcloud_talk_webhook))
@@ -2091,6 +2110,119 @@ async fn handle_linq_webhook(
     (StatusCode::OK, Json(serde_json::json!({"status": "ok"})))
 }
 
+/// POST /vonage/sms — incoming SMS webhook from Vonage (Nexmo) Programmable
+/// Messaging.
+///
+/// Vonage sends `application/x-www-form-urlencoded` POSTs with `msisdn`,
+/// `to`, `text`, `messageId`, `type`, and a `sig` parameter computed as
+/// HMAC-SHA256 over alphabetically-sorted params + `signature_secret`,
+/// hex-encoded. The handler:
+///
+/// 1. Parses the form body into a `BTreeMap` so signature recomputation
+///    walks keys in the same order Vonage signed.
+/// 2. Verifies `sig` via `VonageChannel::verify_signature`. A failure
+///    returns 401 and the SMS is dropped — no message ever reaches the
+///    agent.
+/// 3. Parses the form payload via `VonageChannel::parse_webhook_payload`,
+///    which applies the `allowed_numbers` allowlist.
+/// 4. Forwards the resulting `ChannelMessage` to the agent loop and
+///    replies via `VonageChannel::send`.
+///
+/// Successful runs return `200 OK` with `{"status":"ok"}` — Vonage just
+/// needs a 200 to consider the inbound delivered.
+async fn handle_vonage_sms_webhook(
+    State(state): State<AppState>,
+    body: Bytes,
+) -> impl IntoResponse {
+    use std::collections::BTreeMap;
+    let Some(ref vonage) = state.vonage else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": "Vonage not configured"})),
+        );
+    };
+
+    let parsed: Vec<(String, String)> = match serde_urlencoded::from_bytes(&body) {
+        Ok(v) => v,
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": "Invalid form body"})),
+            );
+        }
+    };
+    let form_params: BTreeMap<String, String> = parsed.into_iter().collect();
+
+    if !vonage.verify_signature(&form_params) {
+        tracing::warn!(
+            "Vonage webhook signature verification failed (sig param: {})",
+            if form_params.contains_key("sig") {
+                "invalid"
+            } else {
+                "missing"
+            }
+        );
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(serde_json::json!({"error": "Invalid signature"})),
+        );
+    }
+
+    let Some(msg) = vonage.parse_webhook_payload(&form_params) else {
+        // Sender wasn't on the allowlist or the body was empty. Still
+        // return 200 so Vonage doesn't retry.
+        return (StatusCode::OK, Json(serde_json::json!({"status": "ok"})));
+    };
+
+    tracing::info!(
+        "Vonage SMS from {}: {}",
+        msg.sender,
+        truncate_with_ellipsis(&msg.content, 50)
+    );
+    let session_id = sender_session_id("vonage", &msg);
+
+    if state.auto_save && !zeroclaw_memory::should_skip_autosave_content(&msg.content) {
+        let key = format!("vonage:{}:{}", msg.sender, msg.id);
+        let _ = state
+            .mem
+            .store(
+                &key,
+                &msg.content,
+                MemoryCategory::Conversation,
+                Some(&session_id),
+            )
+            .await;
+    }
+
+    match Box::pin(run_gateway_chat_with_tools(
+        &state,
+        &msg.content,
+        Some(&session_id),
+    ))
+    .await
+    {
+        Ok(GatewayChatOutcome { response, .. }) => {
+            if let Err(e) = vonage
+                .send(&SendMessage::new(response, &msg.reply_target))
+                .await
+            {
+                tracing::error!("Failed to send Vonage reply: {e}");
+            }
+        }
+        Err(e) => {
+            tracing::error!("LLM error for Vonage message: {e:#}");
+            let _ = vonage
+                .send(&SendMessage::new(
+                    "Sorry, I couldn't process your message right now.",
+                    &msg.reply_target,
+                ))
+                .await;
+        }
+    }
+
+    (StatusCode::OK, Json(serde_json::json!({"status": "ok"})))
+}
+
 /// GET /wati — WATI webhook verification (echoes hub.challenge)
 async fn handle_wati_verify(
     State(state): State<AppState>,
@@ -2678,6 +2810,7 @@ mod tests {
             whatsapp_app_secret: None,
             linq: None,
             linq_signing_secret: None,
+            vonage: None,
             nextcloud_talk: None,
             nextcloud_talk_webhook_secret: None,
             wati: None,
@@ -2752,6 +2885,7 @@ mod tests {
             whatsapp_app_secret: None,
             linq: None,
             linq_signing_secret: None,
+            vonage: None,
             nextcloud_talk: None,
             nextcloud_talk_webhook_secret: None,
             wati: None,
@@ -3211,6 +3345,7 @@ mod tests {
             whatsapp_app_secret: None,
             linq: None,
             linq_signing_secret: None,
+            vonage: None,
             nextcloud_talk: None,
             nextcloud_talk_webhook_secret: None,
             wati: None,
@@ -3293,6 +3428,7 @@ mod tests {
             whatsapp_app_secret: None,
             linq: None,
             linq_signing_secret: None,
+            vonage: None,
             nextcloud_talk: None,
             nextcloud_talk_webhook_secret: None,
             wati: None,
@@ -3387,6 +3523,7 @@ mod tests {
             whatsapp_app_secret: None,
             linq: None,
             linq_signing_secret: None,
+            vonage: None,
             nextcloud_talk: None,
             nextcloud_talk_webhook_secret: None,
             wati: None,
@@ -3453,6 +3590,7 @@ mod tests {
             whatsapp_app_secret: None,
             linq: None,
             linq_signing_secret: None,
+            vonage: None,
             nextcloud_talk: None,
             nextcloud_talk_webhook_secret: None,
             wati: None,
@@ -3524,6 +3662,7 @@ mod tests {
             whatsapp_app_secret: None,
             linq: None,
             linq_signing_secret: None,
+            vonage: None,
             nextcloud_talk: None,
             nextcloud_talk_webhook_secret: None,
             wati: None,
@@ -3600,6 +3739,7 @@ mod tests {
             whatsapp_app_secret: None,
             linq: None,
             linq_signing_secret: None,
+            vonage: None,
             nextcloud_talk: None,
             nextcloud_talk_webhook_secret: None,
             wati: None,
@@ -3673,6 +3813,7 @@ mod tests {
             whatsapp_app_secret: None,
             linq: None,
             linq_signing_secret: None,
+            vonage: None,
             nextcloud_talk: Some(channel),
             nextcloud_talk_webhook_secret: Some(Arc::from(secret)),
             wati: None,

--- a/docs/book/src/channels/chat-others.md
+++ b/docs/book/src/channels/chat-others.md
@@ -148,6 +148,28 @@ databases = ["..."]                # DB IDs the agent can write to
 
 Treats a Notion database as a message surface. Useful for asynchronous workflows where the "channel" is a task inbox.
 
+## Vonage SMS
+
+```toml
+[channels.vonage]
+enabled = true
+api_key = "ABCDEF12"                              # public — Vonage Dashboard → Account → API settings
+api_secret = "xxxxxxxxxxxxxxxx"                   # SECRET — paired with api_key for outbound POSTs
+from_number_or_sender_id = "+15555550100"         # E.164, short code, or alphanumeric sender ID
+allowed_numbers = ["+15555550199"]                # `*` allows anyone (use with care; this is the public PSTN)
+signature_secret = "yyyyyyyyyyyyyyyy"             # SECRET — separate from api_secret, configured in dashboard
+```
+
+- **Auth model:** Vonage uses **two distinct credentials**, both copied from the dashboard:
+  - `api_secret` — the legacy SMS API password. Sent in the outbound POST body alongside `api_key` (Vonage's `/sms/json` endpoint takes credentials in the form body, not headers).
+  - `signature_secret` — the inbound webhook HMAC key, configured separately under **API settings → Signed messages** with algorithm **HMAC SHA-256**. Mixing this up with `api_secret` is a common operator footgun (analogous to Telnyx's api_key vs. public_key) — they're two unrelated values.
+- **Inbound endpoint:** ZeroClaw's gateway hosts `POST /vonage/sms` on its public URL. In the Vonage dashboard, set the **Inbound SMS Webhook** to `https://{your-public-gateway-url}/vonage/sms` with HTTP method **POST** and `application/x-www-form-urlencoded`.
+- **Signature verification:** the gateway recomputes Vonage's `sig` parameter on every inbound webhook — HMAC-SHA256 over alphabetically-sorted form params + `signature_secret`, hex-encoded. Mismatches return 401 and the message is dropped before reaching the agent loop.
+- **Outbound:** `POST https://rest.nexmo.com/sms/json` with form fields `api_key`, `api_secret`, `from`, `to`, `text`. Bodies over 1600 chars are split into ≤1600-char chunks at sentence/word boundaries with a `(i/N) ` continuation marker. Vonage's per-message status (in the JSON response) is also checked — `status != "0"` surfaces as an error.
+- **Public exposure:** the gateway needs to be reachable from Vonage's public IP range. Use one of the `[tunnel]` providers — Cloudflare Tunnel, Tailscale Funnel, ngrok, Pinggy, or a custom command. The tunnel must terminate TLS on a stable hostname so the signature stays valid across reconnects (Vonage signs the URL it was configured with).
+- **Trial accounts:** Vonage trial accounts can only message verified destinations. This is a Vonage constraint, not a ZeroClaw bug.
+- **Cost:** every outbound SMS segment is billable to your Vonage account. The default `enabled = false` is intentional — opt in only after you've confirmed the configuration is right.
+
 ---
 
 ## When to prefer a dedicated guide


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - New `VonageChannel` — fifth Twilio-sibling gateway-registered SMS channel after Twilio (#6429), Plivo (#6467), Sinch (#6469), and Telnyx (#6468). Same architecture (`listen()` no-op, gateway hosts a hardcoded `POST /vonage/sms` route), Vonage-specific signature math: HMAC-SHA256 over alphabetically-sorted form params + `signature_secret`, hex-encoded.
  - Outbound: `POST https://rest.nexmo.com/sms/json` with form fields `api_key` + `api_secret` + `from` + `to` + `text` (Vonage's legacy SMS API takes credentials in the body, not headers). Bodies over 1600 chars are split at sentence/word boundaries with `(i/N) ` continuation markers. Per-message JSON status is checked — `status != "0"` surfaces as `Err` so misconfigured DLT or unsupported destination doesn't fail silently.
  - Inbound at `POST /vonage/sms`: parses `application/x-www-form-urlencoded` body into a `BTreeMap` (sorted iteration), pops `sig`, recomputes HMAC-SHA256 over `&{k}={v}` for remaining params + `signature_secret` literal, hex-encodes, constant-time compares. Mismatch → 401, message dropped before reaching the agent.
- **Scope boundary:** Vonage only. No changes to other channels. No new external crates (`hmac` + `sha2` + `hex` + `urlencoding` already in workspace deps; `serde_urlencoded = "0.7"` added as a direct dep on the gateway crate for form-body parsing). Out of scope: MMS attachments, delivery receipts (separate event type — would be a follow-up `/vonage/dlr` route), Vonage Voice / Verify / Number Insight / Conversation API, JWT-signed Messages API (newer product line, requires RSA keys — different shape), `request_approval()` integration.
- **Blast radius:** New optional channel module + new gateway route + new optional config section. Default `enabled = false`; the gateway route returns 404 when Vonage is not configured. `channel-vonage` is now in the `default` cargo feature set; downstream packagers building with `--no-default-features` are unaffected.
- **Linked issue(s):** Closes #6494
- **Milestone:** v0.8.1

## Validation Evidence (required)

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` → clean.
  - `cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings` (matching CI invocation) → clean, zero warnings.
  - `cargo test -p zeroclaw-channels --features channel-vonage --lib vonage::` → **19 passed, 0 failed**.
  - `cargo test -p zeroclaw-runtime --lib integrations::registry::tests::` → **13 passed, 0 failed** (covers `no_duplicate_names` + `channel_entries_carry_per_field_metadata_from_schema` — both passed against the new `#[display_name = "Vonage SMS"]` + `#[description]` attributes).
  - `cargo test -p zeroclaw-gateway --lib` → **164 passed, 0 failed** (no regression from the new `AppState.vonage` field).
  - `cargo build --release -p zeroclawlabs` → `Finished release profile [optimized] target(s) in 3m 41s`, exit 0.
- **Beyond CI — what was manually verified:**
  - Reviewed all 19 unit + wiremock tests covering: allowlist matching (empty / wildcard / exact / whitespace-stripped), webhook payload parsing (drops outside-allowlist + empty body; accepts allowed sender), HMAC-SHA256 signature validator (round-trip against self-computed expected; tampered body fails; wrong secret fails; missing `sig` fails; empty `sig` fails; `sig`-tamper-after-sign fails), 1600-char chunk splitter with `(i/N)` markers, wiremock outbound POST shape (form body with `api_key` + `api_secret` + `from` + `to` + `text`), 4xx → `Err`, AND the silent-failure case (Vonage's `200` with `status="5"` inside the JSON also surfaces as `Err`).
  - Ran the **CI-flavored clippy invocation** locally (`cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings`) — clean, no `clippy::trim_split_whitespace` or `clippy::doc_lazy_continuation` lints firing under the `ci-all` feature set (these were the lints that bit Telnyx (#6468) and the doc-comment-indent issue I caught locally before pushing).
  - Verified the registry-refactor (#6386) compatibility: the new `pub vonage: Option<VonageConfig>` field on `ChannelsConfig` carries `#[display_name = "Vonage SMS"]` + `#[description = "Vonage / Nexmo programmable SMS"]` so both `no_duplicate_names` and `channel_entries_carry_per_field_metadata_from_schema` pass on first push (avoiding the post-merge fix-up cycle that hit the earlier SMS PRs).
  - Confirmed `cargo build --release -p zeroclawlabs` succeeds with default features (which now include `channel-vonage`) — 3m 41s, exit 0.
  - **Did NOT verify against a live Vonage account.** The signature math, route plumbing, allowlist, per-message-failure detection, and outbound form shape all pass under wiremock + unit tests, but the end-to-end "operator texts the number, gets a reply" round-trip has not been smoke-tested. Recommend the operator land this with `enabled = false` first, configure on staging behind their existing `[tunnel]` provider (set webhook URL + signature secret + algorithm = HMAC SHA-256 in dashboard), smoke test, then flip enabled.
  - Did NOT verify: MMS / multimedia, delivery receipts (Vonage sends them as separate event types — out of scope), Vonage Voice / Verify / Number Insight / Conversation API, JWT-signed Messages API path, `request_approval()` integration.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `Yes` — outbound HTTPS to `rest.nexmo.com` (form-body credentials, account-scoped) only when `[channels.vonage]` is configured and `enabled = true`. Inbound is the new `POST /vonage/sms` gateway route, which 404s when Vonage is not configured.
- Secrets / tokens / credentials handling changed? `Yes` — **two new secret fields** in `[channels.vonage]`:
  - `api_secret` — outbound HTTP credential paired with `api_key` (Vonage's legacy SMS API takes credentials in the form body, not Basic auth). Redacted via the existing config-secret pipeline; never logged.
  - `signature_secret` — inbound webhook HMAC key, distinct from `api_secret`. Configured separately in the Vonage dashboard. Same redaction treatment.
  - Mixing these up is a common operator footgun (analogous to Telnyx's `api_key` vs. `public_key`); docs explicitly call this out.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No` — fixtures use the reserved 555-test-number range and Vonage's documented placeholder patterns.
- **Risk and mitigation:**
  - `AGENTS.md` classifies `crates/zeroclaw-gateway/src/**` as **risk: high**, hence the explicit security walkthrough.
  - **Signature verification fails closed**: missing or invalid `sig` parameter → 401, message dropped before reaching the agent loop. The `sig` parameter is excluded from the canonical string itself (so signing a request with `sig` already attached doesn't accidentally validate against itself).
  - **Allowlist enforced**: senders not in `allowed_numbers` are dropped at the channel boundary even if signature is valid.
  - **Constant-time compare** on the hex signature to avoid timing leaks.
  - **`api_secret` in form body** is Vonage's documented (legacy) auth scheme. Mitigation: TLS-only outbound (no plaintext `http://` URL); the channel never logs POST bodies.
  - **Default `enabled = false`** means a misconfigured deployment cannot accidentally accept SMS.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `Yes` — additive only.
- **Upgrade steps for existing users:** None required. `[channels.vonage]` is optional; existing configs without it continue to work. To opt in: add the section with `api_key`, `api_secret` (secret), `from_number_or_sender_id`, `allowed_numbers`, and `signature_secret` (secret), then set `enabled = true` and configure Vonage's "Inbound SMS Webhook" to `https://<your-tunnel>/vonage/sms` (POST) with HMAC SHA-256 signing in the dashboard.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** Single squash-merge revert: `git revert <merge-sha>`. No migrations, no schema changes.
- **Feature flags or config toggles:**
  - Compile-time: feature flag `channel-vonage` on `zeroclaw-channels` (default-on; can be turned off to remove the module entirely).
  - Runtime: `[channels.vonage] enabled = false` disables without removing config or code.
- **Observable failure symptoms:**
  - Inbound signature failures: grep gateway logs for `vonage_signature_invalid` / 401 responses on `POST /vonage/sms`.
  - Outbound send failures: errors from `VonageChannel::send` log the upstream Vonage error code (including the per-message `status="N"` failure path); grep for `vonage_send_failed`.
  - Allowlist drops: grep for `vonage_sender_not_allowed`.
  - Misconfiguration at startup: the channel will not appear in `zeroclaw channel list`.

