### PR TITLE
fix(install): picker prompts go to stderr so they actually appear

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -376,22 +376,27 @@ interactive_feature_picker() {
   done
 
   selected=""
-  echo
-  printf "  %s\n" "$(bold "Optional features (off by default):")"
-  printf "  %s\n" "Type the numbers to toggle, blank line to confirm."
-  printf "  %s\n" "Default features (agent runtime, gateway, …) are always on."
-  echo
+  # Prompt-side output goes to stderr so the picker's stdout — captured
+  # by the caller's `PICKED=$(interactive_feature_picker …)` — only
+  # carries the final selection. Without this redirect every prompt
+  # silently disappears into the variable and the user sees a frozen
+  # terminal.
+  echo >&2
+  printf "  %s\n" "$(bold "Optional features (off by default):")" >&2
+  printf "  %s\n" "Type the numbers to toggle, blank line to confirm." >&2
+  printf "  %s\n" "Default features (agent runtime, gateway, …) are always on." >&2
+  echo >&2
 
   while :; do
     i=1
     for feat in $picker_features; do
       mark=" "
       case " $selected " in *" $feat "*) mark="✓" ;; esac
-      printf "    [%2d] %s %s\n" "$i" "$mark" "$feat"
+      printf "    [%2d] %s %s\n" "$i" "$mark" "$feat" >&2
       i=$((i + 1))
     done
-    echo
-    printf "  toggle (e.g. \"1 3 5\"), %s confirm: " "$(bold "Enter to")"
+    echo >&2
+    printf "  toggle (e.g. \"1 3 5\"), %s confirm: " "$(bold "Enter to")" >&2
     read -r choices
     [ -z "$choices" ] && break
     for n in $choices; do


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** The interactive feature picker (`interactive_feature_picker` in `install.sh`, introduced in #6385) is invoked as `PICKED=$(interactive_feature_picker …)`. Command substitution captures the function's stdout, and every prompt the picker emitted (menu header, feature list, toggle prompt) was on stdout — so all of it disappeared into the variable. The user saw an empty terminal after the source-build banner, the script silently waited on `read -r`, and any input went into the picker without visible feedback. Bug presents as "interactive install hangs" or "build only works when `--features` is passed on the CLI" because passing `--features` on the CLI bypasses the picker entirely. Fix: write every prompt-side output (`echo`, `printf "menu …\n"`, `printf "toggle …: "`) to stderr via `>&2`. The final `printf '%s' "$selected" | tr ' ' ','` stays on stdout — it is the function's return value, the only thing the caller's command substitution should capture.
- **Scope boundary:** `install.sh` only — `interactive_feature_picker` and nothing else. Does NOT touch the picker's selection logic, the post-picker normalize/validate block, the `cargo install` invocation, or any other part of the installer (`--preset`, `--minimal`, `--with-gateway`, `--without-gateway`, `--features`, `--dry-run`, prebuilt binary path). Does NOT touch any Rust code.
- **Blast radius:** Behaviour change is visible only on the `./install.sh` interactive source-build path when no `--features` / `--minimal` / `--preset` / `--with-gateway` / `--without-gateway` flag is passed (the only path that invokes the picker). All flag-pinned and non-TTY runs (curl-pipe, CI) are unchanged because they short-circuit before the picker.
- **Linked issue(s):** Refs #6292 (originating installer-overhaul issue; closed by #6385). Refs #6385 (introducing PR for the TTY feature picker — the freeze bug shipped here).

## Before / After

**Before:**

```
$ ./install.sh
  How would you like to install ZeroClaw?
  [P] Pre-built binary  — fast, no Rust required  (default)
  [s] Build from source — custom features, latest code

  Choice [P/s]: s

ZeroClaw — source install

  ✓ Building from /home/shane/git/zeroclaw
  Version: 0.7.4 (MSRV: 1.87, edition: 2024)
  ✓ Rust 1.93.1 (>= 1.87)

   ← cursor blinks here, terminal silent. No menu, no prompt. Script
     is waiting on read -r but every prompt was captured by $(). User
     assumes hang. Eventually hits Enter blind, picker returns empty,
     cargo install runs with default features only.
```

Workaround that "worked": pass `--features X,Y` on the CLI, which short-circuits the picker entirely.

**After:**

```
$ ./install.sh
  …same banner, version, Rust check…

  Optional features (off by default):
  Type the numbers to toggle, blank line to confirm.
  Default features (agent runtime, gateway, …) are always on.

    [ 1]   channel-email
    [ 2]   channel-telegram
    [ 3]   channel-lark
    …
    [39]   webauthn

  toggle (e.g. "1 3 5"), Enter to confirm: ▮
```

Menu appears, prompt is visible, operator can interact normally.

## Validation Evidence (required)

```bash
bash -n install.sh
# Empty-input harness (mirrors install.sh's $() invocation pattern):
echo "" | sh -c '... interactive_feature_picker Cargo.toml ...' 2>/tmp/err.log
# Toggled-input harness:
printf "1\n30\n\n" | sh -c '... interactive_feature_picker Cargo.toml ...' 2>/tmp/err.log
```

- **Commands run and tail output:**
  - `bash -n install.sh`: exit 0, syntax clean.
  - **Empty-input harness** (user hits Enter immediately): stdout returns `<>`; stderr carries 45 lines of menu (header + 39 features + blanks + prompt).
  - **Toggle harness** (`1\n30\n\n` — toggle features 1 and 30, then confirm): stdout returns `<channel-email,observability-prometheus>`.
- **Beyond CI, what I manually verified:**
  - **T1 empty selection:** menu appears, Enter returns empty selection cleanly.
  - **T2 single toggle:** toggling a number correctly flips the checkmark in the next render.
  - **T6 mixed valid + invalid input:** `1 abc 99 5` correctly toggles only 1 and 5 (out-of-range and non-numeric tokens silently skipped, no display artifacts).
  - Pre-fix: same harness with original `install.sh` reproduces the silent freeze (no menu visible until input received).
- **If any command was intentionally skipped, why:** No `cargo` commands relevant — this PR is `install.sh` only.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes`. Same flags, same return value contract, same picker selection logic. The only observable difference is that prompts now appear on the terminal (they were silently captured before).
- Config / env / CLI surface changed? `No`. No new flags, no renamed flags, no env vars.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PR: `git revert <sha>` is the plan unless otherwise noted.