### PR TITLE
fix(ci): unblock v0.7.5 release — run gen-api before tsc; add scripts/dev/act-local.sh + runbook Step 3

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -14,3 +14,8 @@
 # Force amd64 container architecture (Apple Silicon hosts otherwise pull
 # arm64 images that lack many tools).
 --container-architecture linux/amd64
+
+# Run a local artifact server so actions/upload-artifact and
+# actions/download-artifact work between jobs. The directory is
+# auto-created by scripts/dev/act-local.sh on first run.
+--artifact-server-path /tmp/act-artifacts

--- a/.github/workflows/cross-platform-build-manual.yml
+++ b/.github/workflows/cross-platform-build-manual.yml
@@ -14,16 +14,28 @@ jobs:
   web:
     name: Build Web Dashboard
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+        with:
+          toolchain: 1.93.0
+      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: npm
           cache-dependency-path: web/package-lock.json
       - name: Build web dashboard
-        run: cd web && npm ci && npm run build
+        # `cargo web build` is the xtask wrapper that:
+        # 1. renders the gateway's OpenAPI 3.1 spec in-process,
+        # 2. runs `npx openapi-typescript` to produce
+        #    `web/src/lib/api-generated.ts` (gitignored — never
+        #    committed since #4f60f4405),
+        # 3. runs `npm ci` + `npm run build` (tsc + vite).
+        # Plain `cd web && npm run build` skips step 1+2 and tsc
+        # fails on the missing import.
+        run: cargo web build
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: web-dist

--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -79,16 +79,28 @@ jobs:
   web:
     name: Build Web Dashboard
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.93.0
+      - uses: Swatinem/rust-cache@v2
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: npm
           cache-dependency-path: web/package-lock.json
       - name: Build web dashboard
-        run: cd web && npm ci && npm run build
+        # `cargo web build` is the xtask wrapper that:
+        # 1. renders the gateway's OpenAPI 3.1 spec in-process,
+        # 2. runs `npx openapi-typescript` to produce
+        #    `web/src/lib/api-generated.ts` (gitignored — never
+        #    committed since #4f60f4405),
+        # 3. runs `npm ci` + `npm run build` (tsc + vite).
+        # Plain `cd web && npm run build` skips step 1+2 and tsc
+        # fails on the missing import.
+        run: cargo web build
       - uses: actions/upload-artifact@v4
         with:
           name: web-dist

--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -82,10 +82,10 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           toolchain: 1.93.0
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/crates/zeroclaw-gateway/build.rs
+++ b/crates/zeroclaw-gateway/build.rs
@@ -70,6 +70,6 @@ fn ensure_embedded_web_dist_when_enabled() {
 
     assert!(
         web_dist.join("index.html").exists(),
-        "feature `embedded-web` requires `web/dist/index.html`; run: cd web && npm ci && npm run build"
+        "feature `embedded-web` requires `web/dist/index.html`; run: cargo web build"
     );
 }

--- a/crates/zeroclaw-gateway/src/static_files.rs
+++ b/crates/zeroclaw-gateway/src/static_files.rs
@@ -41,7 +41,7 @@ pub async fn handle_spa_fallback(State(state): State<AppState>) -> Response {
         return (
             StatusCode::SERVICE_UNAVAILABLE,
             "Web dashboard not available. Set gateway.web_dist_dir in your config \
-             and build the frontend with: cd web && npm ci && npm run build",
+             and build the frontend with: cargo web build",
         )
             .into_response();
     };

--- a/docs/book/src/maintainers/release-runbook.md
+++ b/docs/book/src/maintainers/release-runbook.md
@@ -11,13 +11,14 @@ Last verified: **May 2026** (v0.7.4 cycle).
 
 ---
 
-## The process in five steps
+## The process in six steps
 
 1. Generate `CHANGELOG-next.md` using the changelog skill
 2. Open and merge a version bump PR
-3. Trigger the `Release Stable` workflow via manual dispatch
-4. Approve the three environment gates when prompted
-5. Verify the release exists and assets are downloadable
+3. Dry-run the release workflows locally with `act`
+4. Trigger the `Release Stable` workflow via manual dispatch
+5. Approve the three environment gates when prompted
+6. Verify the release exists and assets are downloadable
 
 That is the entire process. Everything else (Docker, crates.io, Scoop, AUR,
 Homebrew, Discord, tweet) runs automatically as downstream jobs. You do not
@@ -78,7 +79,124 @@ git show origin/master:Cargo.toml | grep '^version'
 
 ---
 
-## Step 3 — Trigger the release
+## Step 3 — Dry-run the release workflows locally with `act`
+
+The `Release Stable` workflow is a GitHub Actions job graph that consumes
+your environment-gate approval window the moment you click **Run workflow**.
+If a workflow step is broken — a missing build artifact, a stale path, a
+codegen step that someone removed without updating CI — the failure surfaces
+*after* you have committed to a release window, with the version PR already
+merged and master at the new version. Recovery means landing an emergency
+fix branch, re-running CI, and shipping under time pressure on a tree that
+already advertises itself as a fully-released version.
+
+The cheap insurance against this is to run the same job graph locally first,
+on the exact merged master commit, before opening the GitHub Actions form.
+[`act`](https://nektosact.com/) executes GitHub Actions workflows inside
+Docker containers using the same `actions/*` ecosystem GitHub does. It does
+not perfectly mirror the cloud runner — it cannot reach the artifact upload
+runtime, GitHub-issued OIDC tokens, environment secrets, or jobs that depend
+on a real release tag — but it does run the build and test steps that
+account for nearly every release-time CI failure we have ever hit.
+
+This step is a 15–20 minute investment per release. It has caught real
+defects that the regular per-PR CI did not surface (because the failing
+workflow only runs on `workflow_dispatch`, not on `push`).
+
+### One-time setup
+
+Install `act` via any of the methods documented at
+[nektosact.com/installation](https://nektosact.com/installation/index.html).
+Common paths:
+
+```bash
+# Bash script (Linux / macOS)
+curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo bash
+
+# macOS (Homebrew)
+brew install act
+
+# Windows (winget or Chocolatey)
+winget install nektos.act
+choco install act-cli
+
+# As a gh extension
+gh extension install https://github.com/nektos/gh-act
+```
+
+Or download a static binary directly from
+[github.com/nektos/act/releases](https://github.com/nektos/act/releases) and
+drop it on your `PATH`.
+
+`act` requires a Docker-compatible container runtime. Install Docker Engine
+or Docker Desktop using the official instructions at
+[docs.docker.com/engine/install](https://docs.docker.com/engine/install/),
+then ensure your user can reach the daemon without `sudo` (typically by
+adding yourself to the `docker` group and re-logging in). `act` also
+supports Podman and Colima as alternatives — see the act runners
+documentation for configuration.
+
+The repository ships a pre-configured `.actrc` at the root that pins the
+Linux runner image to `catthehacker/ubuntu:act-latest`, forces amd64
+architecture, and references a `.secrets` file. Create the secrets file
+once (it is gitignored, never committed):
+
+```bash
+touch .secrets
+```
+
+Add provider-specific secrets only if you are testing a workflow that
+actually uses them.
+
+### Per-release dry-run
+
+Make sure your working tree matches the merged master tip from step 2:
+
+```bash
+git fetch upstream
+git checkout upstream/master
+```
+
+List the workflows so you can pick the right job:
+
+```bash
+act -W .github/workflows/release-stable-manual.yml -l
+```
+
+Run the build-shaped jobs that exercise codegen and compilation. The first
+run pulls the runner image (~1.5 GB) and primes the Rust cache; subsequent
+runs are much faster.
+
+```bash
+# Builds the web dashboard end-to-end (gen-api → tsc → vite).
+act -j web -W .github/workflows/release-stable-manual.yml
+
+# Cross-platform binary builds (slowest job; consider running only one
+# matrix entry locally if you want to validate compile shape without
+# burning an hour on every target).
+act -j build -W .github/workflows/release-stable-manual.yml
+```
+
+What you are looking for: the build steps complete successfully. Two
+classes of failure are *expected* under `act` and do not indicate a real
+problem:
+
+- `actions/upload-artifact@v4` failing with
+  `Unable to get the ACTIONS_RUNTIME_TOKEN env variable`. `act` does not
+  implement GitHub's runtime artifact API; uploads only work on real CI.
+- Jobs that depend on a release tag, a GitHub-issued OIDC token, or an
+  environment secret you have not put in `.secrets`. Skip these with
+  `act -j <other-job>` or accept that they will not run locally.
+
+Anything else — a `tsc` error, a missing file, a Rust compile failure, a
+`cargo` lockfile mismatch — is a real defect. Do not click **Run workflow**
+on the GitHub Actions form until those are fixed and merged. If a fix is
+required, it goes through the standard PR flow on a branch off master, just
+like any other CI fix.
+
+---
+
+## Step 4 — Trigger the release
 
 Go to:
 
@@ -99,7 +217,7 @@ re-trigger. Do not try to work around it.
 
 ---
 
-## Step 4 — Approve the environment gates
+## Step 5 — Approve the environment gates
 
 Three jobs are gated by GitHub environment protection rules. When each becomes
 pending you will see a **"Waiting for review"** banner in the workflow run.
@@ -117,7 +235,7 @@ job from the workflow run page — you do not need to restart from scratch.
 
 ---
 
-## Step 5 — Verify the release
+## Step 6 — Verify the release
 
 Once `publish` completes, confirm:
 

--- a/docs/book/src/maintainers/release-runbook.md
+++ b/docs/book/src/maintainers/release-runbook.md
@@ -142,13 +142,13 @@ List what's runnable across every workflow file:
 ./scripts/dev/act-local.sh --list
 ```
 
-Run a specific job, pick interactively, or run everything that's
-act-runnable:
+Run a specific job, pick interactively, or run every dry-run-safe
+job:
 
 ```bash
 ./scripts/dev/act-local.sh release-stable-manual:web   # one job
 ./scripts/dev/act-local.sh                              # interactive picker
-./scripts/dev/act-local.sh --all                        # every act-runnable job
+./scripts/dev/act-local.sh --all                        # every dry-run-safe job
 ```
 
 The first run pulls the runner image (~1.5 GB) and primes the Rust build
@@ -156,10 +156,40 @@ cache via `Swatinem/rust-cache`; subsequent runs are much faster. The
 script auto-creates the gitignored `.secrets` file, pre-fetches every
 pinned action SHA into `~/.cache/act/` (act's shallow clone can't
 resolve arbitrary commits otherwise), threads `GITHUB_TOKEN` from your
-`gh` auth into the run, and sets `--artifact-server-path` so
+`gh` auth into the run via the parent process environment (the token
+value never lands in argv), and sets `--artifact-server-path` so
 `actions/upload-artifact` and `actions/download-artifact` work between
 jobs. All of that is plain `act` underneath — the script just removes
 the flag soup.
+
+### Mutating jobs are excluded from `--all`
+
+`act` does **not** honor GitHub's environment-protection gates. With
+the maintainer's real `GITHUB_TOKEN` threaded into the run, a
+successful local invocation of a mutating job (a `publish` that calls
+`gh release create`, a `docker` job that pushes to GHCR, a
+`redeploy-website` that dispatches to another repo) could perform the
+real mutation on first try.
+
+`--all` therefore skips a curated list of mutating jobs by default.
+The script logs each skip:
+
+```
+==> skip release-stable-manual:publish (mutating; pass --include-mutating or run explicitly to override)
+==> skip release-stable-manual:docker (mutating; ...)
+==> skip release-stable-manual:redeploy-website (mutating; ...)
+```
+
+Two escape hatches exist for the rare case where you have a reason to
+attempt one of these locally:
+
+- `./scripts/dev/act-local.sh release-stable-manual:publish` — the
+  explicit `<wf>:<job>` form runs what you ask for and prints a loud
+  warning before invoking `act`.
+- `./scripts/dev/act-local.sh --all --include-mutating` — opts the
+  whole run back into the mutating list (used only when you've already
+  verified the workflow steps will not reach a mutation surface, e.g.
+  on a fork with no real registry credentials).
 
 ### What's expected to fail under `act` (and is fine)
 

--- a/docs/book/src/maintainers/release-runbook.md
+++ b/docs/book/src/maintainers/release-runbook.md
@@ -162,34 +162,49 @@ value never lands in argv), and sets `--artifact-server-path` so
 jobs. All of that is plain `act` underneath — the script just removes
 the flag soup.
 
-### Mutating jobs are excluded from `--all`
+### `--all` only runs jobs on a dry-run-safe allowlist
 
 `act` does **not** honor GitHub's environment-protection gates. With
 the maintainer's real `GITHUB_TOKEN` threaded into the run, a
-successful local invocation of a mutating job (a `publish` that calls
-`gh release create`, a `docker` job that pushes to GHCR, a
-`redeploy-website` that dispatches to another repo) could perform the
-real mutation on first try.
+successful local invocation of a job that writes to GitHub (a `publish`
+that calls `gh release create`, a `docker` job that pushes to GHCR, a
+`docs-deploy` that force-pushes `gh-pages`, a `daily-audit` that opens
+an issue, a `tweet-release` or `discord-release` that posts to a
+webhook) could perform the real-world side effect on first try.
 
-`--all` therefore skips a curated list of mutating jobs by default.
-The script logs each skip:
+`--all` therefore enforces a hardcoded allowlist of jobs proven safe
+to run locally — currently the artifact-only build steps in
+`release-stable-manual.yml` and `cross-platform-build-manual.yml`
+(`validate`, `web`, `release-notes`, `build`, `build-desktop`).
+Everything else is skipped with a logged reason:
 
 ```
-==> skip release-stable-manual:publish (mutating; pass --include-mutating or run explicitly to override)
-==> skip release-stable-manual:docker (mutating; ...)
-==> skip release-stable-manual:redeploy-website (mutating; ...)
+==> skip release-stable-manual:publish (not on dry-run-safe allowlist)
+==> skip release-stable-manual:docker (not on dry-run-safe allowlist)
+==> skip release-stable-manual:redeploy-website (not on dry-run-safe allowlist)
+==> skip docs-deploy:deploy (not on dry-run-safe allowlist)
+==> skip daily-audit:audit (not on dry-run-safe allowlist)
+==> skip tweet-release:tweet (not on dry-run-safe allowlist)
 ```
+
+The allowlist is **fail-closed**: a new workflow added to the repo is
+treated as potentially mutating until a maintainer reviews it and adds
+the safe job IDs to `DRY_RUN_SAFE_JOBS` in
+`scripts/dev/act-local.sh`. This matters because `discover_jobs` walks
+every `.github/workflows/*.yml`, not just the release workflows — a
+denylist would silently let a future write-surface workflow through.
 
 Two escape hatches exist for the rare case where you have a reason to
-attempt one of these locally:
+attempt a non-allowlisted job locally:
 
 - `./scripts/dev/act-local.sh release-stable-manual:publish` — the
   explicit `<wf>:<job>` form runs what you ask for and prints a loud
-  warning before invoking `act`.
-- `./scripts/dev/act-local.sh --all --include-mutating` — opts the
-  whole run back into the mutating list (used only when you've already
-  verified the workflow steps will not reach a mutation surface, e.g.
-  on a fork with no real registry credentials).
+  warning before invoking `act` if the target isn't on the allowlist.
+- `./scripts/dev/act-local.sh --all --no-allowlist` — disables the
+  allowlist filter for an entire `--all` run (used only when you've
+  already verified the workflow steps will not reach a mutation
+  surface, e.g. on a fork with no real registry credentials and an
+  empty `.secrets` file).
 
 ### What's expected to fail under `act` (and is fine)
 

--- a/docs/book/src/maintainers/release-runbook.md
+++ b/docs/book/src/maintainers/release-runbook.md
@@ -105,48 +105,27 @@ workflow only runs on `workflow_dispatch`, not on `push`).
 
 ### One-time setup
 
-Install `act` via any of the methods documented at
-[nektosact.com/installation](https://nektosact.com/installation/index.html).
-Common paths:
+`act` runs the workflows. The cleanest install path is the GitHub CLI
+extension, because it inherits your `gh` authentication and exposes a
+real `GITHUB_TOKEN` to every workflow run:
 
-```bash
-# Bash script (Linux / macOS)
-curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo bash
+1. Install the GitHub CLI from <https://cli.github.com> (Linux, macOS,
+   Windows). Authenticate once: `gh auth login`.
+2. Install the `act` extension:
 
-# macOS (Homebrew)
-brew install act
+   ```bash
+   gh extension install nektos/gh-act
+   ```
 
-# Windows (winget or Chocolatey)
-winget install nektos.act
-choco install act-cli
+3. Install Docker Engine or Docker Desktop from
+   <https://docs.docker.com/engine/install/>. On Linux, add yourself to
+   the `docker` group so you don't need `sudo`. `act` also works with
+   Podman and Colima — see the
+   [act runners documentation](https://nektosact.com/usage/runners.html).
 
-# As a gh extension
-gh extension install https://github.com/nektos/gh-act
-```
-
-Or download a static binary directly from
-[github.com/nektos/act/releases](https://github.com/nektos/act/releases) and
-drop it on your `PATH`.
-
-`act` requires a Docker-compatible container runtime. Install Docker Engine
-or Docker Desktop using the official instructions at
-[docs.docker.com/engine/install](https://docs.docker.com/engine/install/),
-then ensure your user can reach the daemon without `sudo` (typically by
-adding yourself to the `docker` group and re-logging in). `act` also
-supports Podman and Colima as alternatives — see the act runners
-documentation for configuration.
-
-The repository ships a pre-configured `.actrc` at the root that pins the
-Linux runner image to `catthehacker/ubuntu:act-latest`, forces amd64
-architecture, and references a `.secrets` file. Create the secrets file
-once (it is gitignored, never committed):
-
-```bash
-touch .secrets
-```
-
-Add provider-specific secrets only if you are testing a workflow that
-actually uses them.
+That's the whole setup. The repository's `.actrc` and
+`scripts/dev/act-local.sh` handle everything else (runner image, secrets
+file, artifact server, action SHA pre-fetching).
 
 ### Per-release dry-run
 
@@ -157,42 +136,46 @@ git fetch upstream
 git checkout upstream/master
 ```
 
-List the workflows so you can pick the right job:
+List what's runnable across every workflow file:
 
 ```bash
-act -W .github/workflows/release-stable-manual.yml -l
+./scripts/dev/act-local.sh --list
 ```
 
-Run the build-shaped jobs that exercise codegen and compilation. The first
-run pulls the runner image (~1.5 GB) and primes the Rust cache; subsequent
-runs are much faster.
+Run a specific job, pick interactively, or run everything that's
+act-runnable:
 
 ```bash
-# Builds the web dashboard end-to-end (gen-api → tsc → vite).
-act -j web -W .github/workflows/release-stable-manual.yml
-
-# Cross-platform binary builds (slowest job; consider running only one
-# matrix entry locally if you want to validate compile shape without
-# burning an hour on every target).
-act -j build -W .github/workflows/release-stable-manual.yml
+./scripts/dev/act-local.sh release-stable-manual:web   # one job
+./scripts/dev/act-local.sh                              # interactive picker
+./scripts/dev/act-local.sh --all                        # every act-runnable job
 ```
 
-What you are looking for: the build steps complete successfully. Two
-classes of failure are *expected* under `act` and do not indicate a real
-problem:
+The first run pulls the runner image (~1.5 GB) and primes the Rust build
+cache via `Swatinem/rust-cache`; subsequent runs are much faster. The
+script auto-creates the gitignored `.secrets` file, pre-fetches every
+pinned action SHA into `~/.cache/act/` (act's shallow clone can't
+resolve arbitrary commits otherwise), threads `GITHUB_TOKEN` from your
+`gh` auth into the run, and sets `--artifact-server-path` so
+`actions/upload-artifact` and `actions/download-artifact` work between
+jobs. All of that is plain `act` underneath — the script just removes
+the flag soup.
 
-- `actions/upload-artifact@v4` failing with
-  `Unable to get the ACTIONS_RUNTIME_TOKEN env variable`. `act` does not
-  implement GitHub's runtime artifact API; uploads only work on real CI.
-- Jobs that depend on a release tag, a GitHub-issued OIDC token, or an
-  environment secret you have not put in `.secrets`. Skip these with
-  `act -j <other-job>` or accept that they will not run locally.
+### What's expected to fail under `act` (and is fine)
 
-Anything else — a `tsc` error, a missing file, a Rust compile failure, a
-`cargo` lockfile mismatch — is a real defect. Do not click **Run workflow**
-on the GitHub Actions form until those are fixed and merged. If a fix is
-required, it goes through the standard PR flow on a branch off master, just
-like any other CI fix.
+`act` cannot simulate a few GitHub-only surfaces. These failures are
+not real defects:
+
+- Jobs that depend on a real release tag (`publish` creating a GitHub
+  Release).
+- Environment-gated jobs (`crates-io`, `docker`, `publish`) — the
+  approval UI doesn't exist locally.
+- OIDC-based federated identity tokens.
+
+Everything else — a `tsc` error, a missing file, a Rust compile
+failure, a `cargo` lockfile mismatch — is a real defect. Do not click
+**Run workflow** on the GitHub Actions form until those are fixed via a
+standard PR off master.
 
 ---
 

--- a/scripts/dev/act-local.sh
+++ b/scripts/dev/act-local.sh
@@ -5,17 +5,29 @@
 # locally" instruction. Walks .github/workflows/, lets a maintainer pick
 # a job (or --all), pre-fetches pinned action SHAs that act's shallow
 # clone can't resolve, ensures .secrets exists, and threads
-# --artifact-server-path plus a real GITHUB_TOKEN into every run.
+# --artifact-server-path plus a real GITHUB_TOKEN into every run. The
+# token is exported into the environment so act resolves it via
+# `-s GITHUB_TOKEN` (no token value lands in argv or process tables).
+#
+# Mutating release jobs (publish, docker push, external dispatch) are
+# excluded from --all by default — act does not honor GitHub's
+# environment-protection gates, so a successful local run with a real
+# token could perform a real release. Use --include-mutating only when
+# you have explicitly confirmed the workflow steps will not reach a
+# mutation surface, or pass the explicit <wf>:<job> form (which always
+# runs what you ask for).
 #
 # POSIX sh — no bash required. Works on dash, busybox ash, mksh.
 #
 # Usage:
-#   ./scripts/dev/act-local.sh                  # interactive picker
-#   ./scripts/dev/act-local.sh --list           # list discovered jobs
-#   ./scripts/dev/act-local.sh <wf>:<job>       # explicit (e.g. release-stable-manual:web)
-#   ./scripts/dev/act-local.sh <job>            # short form (errors on collision)
-#   ./scripts/dev/act-local.sh --all            # every act-runnable job
-#   ./scripts/dev/act-local.sh --no-prefetch    # skip the SHA pre-fetch
+#   ./scripts/dev/act-local.sh                       # interactive picker
+#   ./scripts/dev/act-local.sh --list                # list discovered jobs
+#   ./scripts/dev/act-local.sh <wf>:<job>            # explicit (e.g. release-stable-manual:web)
+#   ./scripts/dev/act-local.sh <job>                 # short form (errors on collision)
+#   ./scripts/dev/act-local.sh --all                 # every act-runnable job (mutating skipped)
+#   ./scripts/dev/act-local.sh --all --include-mutating
+#                                                    # combined: also runs publish/docker/dispatch
+#   ./scripts/dev/act-local.sh --no-prefetch         # skip the SHA pre-fetch
 #   ./scripts/dev/act-local.sh --help
 
 set -eu
@@ -24,18 +36,36 @@ REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 ARTIFACT_DIR="${ACT_LOCAL_ARTIFACT_DIR:-/tmp/act-artifacts}"
 ACT_CACHE_DIR="${HOME}/.cache/act"
 PREFETCH=true
+INCLUDE_MUTATING=false
 # Resolved at setup time. Prefers a standalone `act` on PATH, falls
 # back to `gh act` (the gh-act extension) — that's the install path
 # the runbook recommends, so make sure it works without forcing a
 # second download.
 ACT_BIN=""
 
+# Jobs that mutate external state when run with a real GITHUB_TOKEN —
+# create GitHub releases, push container images, or dispatch to other
+# repositories. act does NOT honor the environment-protection gates
+# that guard these on real GitHub Actions, so reaching them locally
+# with a real token can perform the real mutation. --all skips this
+# list by default; --include-mutating opts back in (and the explicit
+# <wf>:<job> form always runs what you ask for, on the assumption you
+# meant it).
+MUTATING_JOBS="\
+release-stable-manual:publish
+release-stable-manual:docker
+release-stable-manual:redeploy-website"
+
 log()  { printf '==> %s\n' "$*" >&2; }
 die()  { printf 'error: %s\n' "$*" >&2; exit 1; }
 
 usage() {
-  sed -n '4,18p' "$0" | sed 's/^#//; s/^ //'
+  sed -n '4,31p' "$0" | sed 's/^#//; s/^ //'
   exit 0
+}
+
+is_mutating_job() {
+  printf '%s\n' "$MUTATING_JOBS" | grep -qx "$1"
 }
 
 require_tool() {
@@ -209,11 +239,24 @@ run_one() {
   workflow_file="$REPO_ROOT/.github/workflows/$stem.yml"
   [ -f "$workflow_file" ] || die "workflow file missing: $workflow_file"
 
+  # Export the token into the environment so act resolves `-s
+  # GITHUB_TOKEN` (no value) from getenv. Keeps the credential out of
+  # argv, the shell history, and the kernel's process table.
+  GITHUB_TOKEN=$(gh auth token)
+  export GITHUB_TOKEN
+
+  if is_mutating_job "$pair"; then
+    log "WARNING: ${pair} is a mutating release job (publishes / pushes / dispatches)."
+    log "         act does not honor environment-protection gates; a successful run"
+    log "         with this token could create a real release. Continuing because"
+    log "         you asked for this job explicitly."
+  fi
+
   # Build the act command via positional params (POSIX sh has no arrays).
   set -- workflow_dispatch \
          -j "$job" \
          -W "$workflow_file" \
-         -s "GITHUB_TOKEN=$(gh auth token)" \
+         -s GITHUB_TOKEN \
          --artifact-server-path "$ARTIFACT_DIR"
 
   if workflow_has_version_input "$workflow_file"; then
@@ -228,9 +271,17 @@ run_one() {
 }
 
 run_all() {
-  log "running all act-runnable jobs"
+  if [ "$INCLUDE_MUTATING" = true ]; then
+    log "running all act-runnable jobs (including mutating release jobs)"
+  else
+    log "running all act-runnable jobs (mutating release jobs skipped)"
+  fi
   discover_jobs | while IFS= read -r pair; do
     [ -n "$pair" ] || continue
+    if [ "$INCLUDE_MUTATING" != true ] && is_mutating_job "$pair"; then
+      log "skip ${pair} (mutating; pass --include-mutating or run explicitly to override)"
+      continue
+    fi
     run_one "$pair"
   done
 }
@@ -275,6 +326,11 @@ main() {
       ;;
     --no-prefetch)
       PREFETCH=false
+      shift
+      main "$@"
+      ;;
+    --include-mutating)
+      INCLUDE_MUTATING=true
       shift
       main "$@"
       ;;

--- a/scripts/dev/act-local.sh
+++ b/scripts/dev/act-local.sh
@@ -327,28 +327,45 @@ interactive_pick() {
 # ── Main ───────────────────────────────────────────────────────────
 
 main() {
-  cmd="${1:-}"
-  case "$cmd" in
-    -h|--help)
-      usage
-      ;;
-  esac
+  # Parse all flags first regardless of position, then dispatch on the
+  # action (--list / --all / explicit job / interactive). The previous
+  # implementation dispatched on $1 immediately, so flags trailing
+  # `--all` (e.g. `--all --no-allowlist`) were silently ignored — the
+  # documented opt-out command-line worked one way and not the other.
+  action=""
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      -h|--help)
+        usage
+        ;;
+      --no-prefetch)
+        PREFETCH=false
+        ;;
+      --no-allowlist)
+        NO_ALLOWLIST=true
+        ;;
+      -l|--list|-a|--all)
+        [ -z "$action" ] && action="$1"
+        ;;
+      -*)
+        die "unknown flag: $1"
+        ;;
+      *)
+        if [ -z "$action" ]; then
+          action="$1"
+        else
+          die "extra positional argument: $1 (already have action: $action)"
+        fi
+        ;;
+    esac
+    shift
+  done
 
   ensure_setup
 
-  case "$cmd" in
+  case "$action" in
     -l|--list)
       list_jobs
-      ;;
-    --no-prefetch)
-      PREFETCH=false
-      shift
-      main "$@"
-      ;;
-    --no-allowlist)
-      NO_ALLOWLIST=true
-      shift
-      main "$@"
       ;;
     -a|--all)
       prefetch_actions
@@ -359,7 +376,7 @@ main() {
       interactive_pick
       ;;
     *)
-      pair=$(resolve_job "$cmd")
+      pair=$(resolve_job "$action")
       prefetch_actions
       run_one "$pair"
       ;;

--- a/scripts/dev/act-local.sh
+++ b/scripts/dev/act-local.sh
@@ -9,13 +9,16 @@
 # token is exported into the environment so act resolves it via
 # `-s GITHUB_TOKEN` (no token value lands in argv or process tables).
 #
-# Mutating release jobs (publish, docker push, external dispatch) are
-# excluded from --all by default — act does not honor GitHub's
-# environment-protection gates, so a successful local run with a real
-# token could perform a real release. Use --include-mutating only when
-# you have explicitly confirmed the workflow steps will not reach a
-# mutation surface, or pass the explicit <wf>:<job> form (which always
-# runs what you ask for).
+# --all enforces a hardcoded allowlist of dry-run-safe jobs. Anything
+# off the allowlist (publish, docker push, gh-pages deploys, external
+# dispatches, social posts, issue/PR/label writes — across every
+# workflow file, not just release-stable-manual.yml) is skipped from
+# --all by default and requires the explicit <wf>:<job> form or
+# --no-allowlist to run. act does not honor GitHub's environment-
+# protection gates, so a successful local run with the threaded real
+# GITHUB_TOKEN could perform the real mutation. The allowlist is
+# fail-closed: a new workflow added to the repo is treated as
+# potentially mutating until it's reviewed and explicitly added.
 #
 # POSIX sh — no bash required. Works on dash, busybox ash, mksh.
 #
@@ -24,9 +27,9 @@
 #   ./scripts/dev/act-local.sh --list                # list discovered jobs
 #   ./scripts/dev/act-local.sh <wf>:<job>            # explicit (e.g. release-stable-manual:web)
 #   ./scripts/dev/act-local.sh <job>                 # short form (errors on collision)
-#   ./scripts/dev/act-local.sh --all                 # every act-runnable job (mutating skipped)
-#   ./scripts/dev/act-local.sh --all --include-mutating
-#                                                    # combined: also runs publish/docker/dispatch
+#   ./scripts/dev/act-local.sh --all                 # every dry-run-safe job (allowlist enforced)
+#   ./scripts/dev/act-local.sh --all --no-allowlist
+#                                                    # combined: also runs jobs not on the allowlist
 #   ./scripts/dev/act-local.sh --no-prefetch         # skip the SHA pre-fetch
 #   ./scripts/dev/act-local.sh --help
 
@@ -36,36 +39,48 @@ REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 ARTIFACT_DIR="${ACT_LOCAL_ARTIFACT_DIR:-/tmp/act-artifacts}"
 ACT_CACHE_DIR="${HOME}/.cache/act"
 PREFETCH=true
-INCLUDE_MUTATING=false
+NO_ALLOWLIST=false
 # Resolved at setup time. Prefers a standalone `act` on PATH, falls
 # back to `gh act` (the gh-act extension) — that's the install path
 # the runbook recommends, so make sure it works without forcing a
 # second download.
 ACT_BIN=""
 
-# Jobs that mutate external state when run with a real GITHUB_TOKEN —
-# create GitHub releases, push container images, or dispatch to other
-# repositories. act does NOT honor the environment-protection gates
-# that guard these on real GitHub Actions, so reaching them locally
-# with a real token can perform the real mutation. --all skips this
-# list by default; --include-mutating opts back in (and the explicit
-# <wf>:<job> form always runs what you ask for, on the assumption you
-# meant it).
-MUTATING_JOBS="\
-release-stable-manual:publish
-release-stable-manual:docker
-release-stable-manual:redeploy-website"
+# Jobs proven safe to run locally under act with a real GITHUB_TOKEN.
+# Every entry here makes NO real-world side effects — no GitHub
+# Releases, no package pushes, no external dispatches, no
+# issue/PR/label/branch writes, no social posts. The contents are
+# limited to: artifact-only builds, semver validation, output-only
+# release-notes generation, and similar read/local-write steps.
+#
+# discover_jobs walks every standalone .github/workflows/*.yml in
+# the repo, including ones outside release-stable-manual.yml. A
+# denylist would be fail-open: a new workflow with a write surface
+# (gh-pages publish, issue creation, package-manager dispatch) added
+# without updating this list would silently get invoked by --all
+# with the maintainer's real GITHUB_TOKEN. An allowlist is
+# fail-closed — new workflows are treated as potentially mutating
+# until a maintainer reviews them and explicitly adds the safe job
+# IDs here.
+DRY_RUN_SAFE_JOBS="\
+cross-platform-build-manual:web
+cross-platform-build-manual:build
+release-stable-manual:validate
+release-stable-manual:web
+release-stable-manual:release-notes
+release-stable-manual:build
+release-stable-manual:build-desktop"
 
 log()  { printf '==> %s\n' "$*" >&2; }
 die()  { printf 'error: %s\n' "$*" >&2; exit 1; }
 
 usage() {
-  sed -n '4,31p' "$0" | sed 's/^#//; s/^ //'
+  sed -n '4,33p' "$0" | sed 's/^#//; s/^ //'
   exit 0
 }
 
-is_mutating_job() {
-  printf '%s\n' "$MUTATING_JOBS" | grep -qx "$1"
+is_dry_run_safe_job() {
+  printf '%s\n' "$DRY_RUN_SAFE_JOBS" | grep -qx "$1"
 }
 
 require_tool() {
@@ -245,11 +260,12 @@ run_one() {
   GITHUB_TOKEN=$(gh auth token)
   export GITHUB_TOKEN
 
-  if is_mutating_job "$pair"; then
-    log "WARNING: ${pair} is a mutating release job (publishes / pushes / dispatches)."
-    log "         act does not honor environment-protection gates; a successful run"
-    log "         with this token could create a real release. Continuing because"
-    log "         you asked for this job explicitly."
+  if ! is_dry_run_safe_job "$pair"; then
+    log "WARNING: ${pair} is not on the dry-run-safe allowlist."
+    log "         act does not honor environment-protection gates; this job"
+    log "         may publish, push, dispatch, post, or open issues against"
+    log "         real targets with the GITHUB_TOKEN threaded into this run."
+    log "         Continuing because you asked for this job explicitly."
   fi
 
   # Build the act command via positional params (POSIX sh has no arrays).
@@ -271,15 +287,15 @@ run_one() {
 }
 
 run_all() {
-  if [ "$INCLUDE_MUTATING" = true ]; then
-    log "running all act-runnable jobs (including mutating release jobs)"
+  if [ "$NO_ALLOWLIST" = true ]; then
+    log "running all act-runnable jobs (allowlist filter disabled)"
   else
-    log "running all act-runnable jobs (mutating release jobs skipped)"
+    log "running dry-run-safe jobs only (others skipped — pass --no-allowlist or run explicitly to override)"
   fi
   discover_jobs | while IFS= read -r pair; do
     [ -n "$pair" ] || continue
-    if [ "$INCLUDE_MUTATING" != true ] && is_mutating_job "$pair"; then
-      log "skip ${pair} (mutating; pass --include-mutating or run explicitly to override)"
+    if [ "$NO_ALLOWLIST" != true ] && ! is_dry_run_safe_job "$pair"; then
+      log "skip ${pair} (not on dry-run-safe allowlist)"
       continue
     fi
     run_one "$pair"
@@ -329,8 +345,8 @@ main() {
       shift
       main "$@"
       ;;
-    --include-mutating)
-      INCLUDE_MUTATING=true
+    --no-allowlist)
+      NO_ALLOWLIST=true
       shift
       main "$@"
       ;;

--- a/scripts/dev/act-local.sh
+++ b/scripts/dev/act-local.sh
@@ -1,0 +1,297 @@
+#!/usr/bin/env sh
+# act-local.sh — discover and run GitHub Actions workflows locally via act.
+#
+# Powers the release-runbook "Step 3 — Dry-run the release workflows
+# locally" instruction. Walks .github/workflows/, lets a maintainer pick
+# a job (or --all), pre-fetches pinned action SHAs that act's shallow
+# clone can't resolve, ensures .secrets exists, and threads
+# --artifact-server-path plus a real GITHUB_TOKEN into every run.
+#
+# POSIX sh — no bash required. Works on dash, busybox ash, mksh.
+#
+# Usage:
+#   ./scripts/dev/act-local.sh                  # interactive picker
+#   ./scripts/dev/act-local.sh --list           # list discovered jobs
+#   ./scripts/dev/act-local.sh <wf>:<job>       # explicit (e.g. release-stable-manual:web)
+#   ./scripts/dev/act-local.sh <job>            # short form (errors on collision)
+#   ./scripts/dev/act-local.sh --all            # every act-runnable job
+#   ./scripts/dev/act-local.sh --no-prefetch    # skip the SHA pre-fetch
+#   ./scripts/dev/act-local.sh --help
+
+set -eu
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+ARTIFACT_DIR="${ACT_LOCAL_ARTIFACT_DIR:-/tmp/act-artifacts}"
+ACT_CACHE_DIR="${HOME}/.cache/act"
+PREFETCH=true
+# Resolved at setup time. Prefers a standalone `act` on PATH, falls
+# back to `gh act` (the gh-act extension) — that's the install path
+# the runbook recommends, so make sure it works without forcing a
+# second download.
+ACT_BIN=""
+
+log()  { printf '==> %s\n' "$*" >&2; }
+die()  { printf 'error: %s\n' "$*" >&2; exit 1; }
+
+usage() {
+  sed -n '4,18p' "$0" | sed 's/^#//; s/^ //'
+  exit 0
+}
+
+require_tool() {
+  command -v "$1" >/dev/null 2>&1 || die "$1 not found — install from $2"
+}
+
+# ── Setup ──────────────────────────────────────────────────────────
+
+ensure_setup() {
+  require_tool docker https://docs.docker.com/engine/install/
+  require_tool gh     https://cli.github.com
+  require_tool git    https://git-scm.com/
+
+  if command -v act >/dev/null 2>&1; then
+    ACT_BIN="act"
+  elif gh extension list 2>/dev/null | grep -q 'gh act'; then
+    ACT_BIN="gh act"
+  else
+    die "act not found. Install via: gh extension install nektos/gh-act
+       or download a binary from https://nektosact.com/installation/"
+  fi
+
+  if [ ! -f "$REPO_ROOT/.secrets" ]; then
+    log "creating .secrets (gitignored, empty by default)"
+    : > "$REPO_ROOT/.secrets"
+  fi
+
+  mkdir -p "$ARTIFACT_DIR"
+}
+
+# ── Workflow + job discovery ───────────────────────────────────────
+
+# Print a workflow file's job IDs, one per line, only if the workflow
+# has a standalone trigger (push / pull_request / workflow_dispatch /
+# schedule). workflow_call-only files are skipped — they need a parent
+# invocation and aren't useful to run in isolation through act.
+discover_workflow_jobs() {
+  workflow_file="$1"
+  if ! grep -qE '^[[:space:]]*(push|pull_request|workflow_dispatch|schedule):' \
+       "$workflow_file"; then
+    return
+  fi
+  # `act -W <file> -l` prints a header row plus one row per job. We
+  # want column 2 (Job ID). $ACT_BIN may be unset when discover is
+  # called from a context that doesn't pre-resolve (e.g. resolve_job
+  # short-form lookup); fall back to plain `act` then.
+  ${ACT_BIN:-act} -W "$workflow_file" -l 2>/dev/null \
+    | awk 'NR > 1 && NF >= 2 && $2 != "" { print $2 }'
+}
+
+# Print every "<workflow-stem>:<job-id>" pair, grouped by workflow.
+discover_jobs() {
+  for workflow_file in "$REPO_ROOT"/.github/workflows/*.yml; do
+    [ -f "$workflow_file" ] || continue
+    stem=$(basename "$workflow_file" .yml)
+    discover_workflow_jobs "$workflow_file" \
+      | while IFS= read -r job; do
+          [ -n "$job" ] && printf '%s:%s\n' "$stem" "$job"
+        done
+  done
+}
+
+list_jobs() {
+  prev_stem=""
+  discover_jobs | while IFS=: read -r stem job; do
+    if [ "$stem" != "$prev_stem" ]; then
+      [ -n "$prev_stem" ] && echo
+      printf '%s:\n' "$stem"
+      prev_stem="$stem"
+    fi
+    printf '  %s\n' "$job"
+  done
+}
+
+resolve_job() {
+  query="$1"
+  case "$query" in
+    *:*)
+      # Explicit <workflow>:<job> — verify it exists.
+      stem=${query%%:*}
+      job=${query#*:}
+      if discover_workflow_jobs "$REPO_ROOT/.github/workflows/$stem.yml" \
+           2>/dev/null | grep -qx "$job"; then
+        printf '%s\n' "$query"
+        return 0
+      fi
+      die "no such job: $query (try --list)"
+      ;;
+    *)
+      # Short form — must resolve to exactly one match.
+      matches=$(discover_jobs | awk -F: -v q="$query" '$2 == q { print }')
+      count=$(printf '%s\n' "$matches" | grep -c . || true)
+      if [ "$count" = 0 ]; then
+        die "no job named '$query' (try --list)"
+      elif [ "$count" -gt 1 ]; then
+        printf 'error: ambiguous job '\''%s'\'' — defined in:\n' \
+          "$query" >&2
+        printf '  %s\n' $matches >&2
+        printf 'use <workflow>:<job> form, e.g. %s\n' \
+          "$(printf '%s' "$matches" | head -1)" >&2
+        exit 1
+      fi
+      printf '%s\n' "$matches"
+      ;;
+  esac
+}
+
+# ── Action SHA pre-fetch ───────────────────────────────────────────
+#
+# Extract every `uses: <owner>/<repo>@<sha>` line from the workflow
+# files, dedupe, and pre-clone each into ~/.cache/act/<owner>-<repo>@<sha>.
+# act's default shallow clone fails on arbitrary SHAs (we hit this live
+# with dtolnay/rust-toolchain@631a55b1...). Idempotent: pre-fetch is a
+# no-op when the cache dir already has action.yml.
+
+prefetch_actions() {
+  [ "$PREFETCH" = true ] || return 0
+
+  mkdir -p "$ACT_CACHE_DIR"
+  grep -hoE 'uses:[[:space:]]+[a-zA-Z0-9_./-]+@[a-f0-9]{40}' \
+    "$REPO_ROOT"/.github/workflows/*.yml \
+    | awk '{ print $2 }' \
+    | sort -u \
+    | while IFS=@ read -r action sha; do
+        slug=$(printf '%s' "$action" | tr '/' '-')
+        target="$ACT_CACHE_DIR/${slug}@${sha}"
+        if [ -f "$target/action.yml" ] || [ -f "$target/action.yaml" ]; then
+          continue
+        fi
+        short=$(printf '%s' "$sha" | cut -c1-7)
+        log "pre-fetch ${action}@${short}"
+        mkdir -p "$target"
+        (
+          cd "$target"
+          if [ ! -d .git ]; then
+            git init --quiet
+            git remote add origin "https://github.com/${action}.git"
+          fi
+          git fetch --quiet --depth 1 origin "$sha"
+          git checkout --quiet "$sha"
+        ) || die "pre-fetch failed for ${action}@${short}"
+      done
+}
+
+# ── Run a single job ───────────────────────────────────────────────
+
+cargo_toml_version() {
+  awk '/^\[workspace\.package\]/{p=1;next} /^\[/{p=0} p && /^version *=/{
+         split($0,a,"\""); print a[2]; exit }' \
+    "$REPO_ROOT/Cargo.toml"
+}
+
+# Detect whether a workflow file has a `version:` workflow_dispatch
+# input. If so, we'll auto-derive it from Cargo.toml.
+workflow_has_version_input() {
+  awk '
+    /^on:/ { in_on=1; next }
+    in_on && /^[a-z]/ { exit }
+    in_on && /workflow_dispatch:/ { in_wd=1; next }
+    in_wd && /^[[:space:]]+inputs:/ { in_inputs=1; next }
+    in_inputs && /^[[:space:]]+version:/ { found=1; exit }
+    in_inputs && /^[[:space:]]{0,4}[a-z]/ && !/^[[:space:]]+inputs:/ { in_inputs=0 }
+    END { exit !found }
+  ' "$1"
+}
+
+run_one() {
+  pair="$1"
+  stem=${pair%%:*}
+  job=${pair#*:}
+  workflow_file="$REPO_ROOT/.github/workflows/$stem.yml"
+  [ -f "$workflow_file" ] || die "workflow file missing: $workflow_file"
+
+  # Build the act command via positional params (POSIX sh has no arrays).
+  set -- workflow_dispatch \
+         -j "$job" \
+         -W "$workflow_file" \
+         -s "GITHUB_TOKEN=$(gh auth token)" \
+         --artifact-server-path "$ARTIFACT_DIR"
+
+  if workflow_has_version_input "$workflow_file"; then
+    version=$(cargo_toml_version)
+    if [ -n "$version" ]; then
+      set -- "$@" --input "version=$version"
+    fi
+  fi
+
+  log "run ${stem}:${job}"
+  $ACT_BIN "$@"
+}
+
+run_all() {
+  log "running all act-runnable jobs"
+  discover_jobs | while IFS= read -r pair; do
+    [ -n "$pair" ] || continue
+    run_one "$pair"
+  done
+}
+
+# ── Interactive picker ─────────────────────────────────────────────
+
+interactive_pick() {
+  pairs=$(discover_jobs)
+  [ -n "$pairs" ] || die "no act-runnable jobs discovered"
+
+  printf '%s\n' "Available jobs:" >&2
+  printf '%s\n' "$pairs" \
+    | awk '{ printf "  [%2d] %s\n", NR, $0 }' >&2
+  printf '%s\n' "  [ 0] all" >&2
+  printf '\n  pick a number: ' >&2
+  read -r choice
+  case "$choice" in
+    0)         run_all; return ;;
+    ''|*[!0-9]*) die "not a number: $choice" ;;
+  esac
+  selected=$(printf '%s\n' "$pairs" | awk -v n="$choice" 'NR == n')
+  [ -n "$selected" ] || die "no job at index $choice"
+  prefetch_actions
+  run_one "$selected"
+}
+
+# ── Main ───────────────────────────────────────────────────────────
+
+main() {
+  cmd="${1:-}"
+  case "$cmd" in
+    -h|--help)
+      usage
+      ;;
+  esac
+
+  ensure_setup
+
+  case "$cmd" in
+    -l|--list)
+      list_jobs
+      ;;
+    --no-prefetch)
+      PREFETCH=false
+      shift
+      main "$@"
+      ;;
+    -a|--all)
+      prefetch_actions
+      run_all
+      ;;
+    '')
+      prefetch_actions
+      interactive_pick
+      ;;
+    *)
+      pair=$(resolve_job "$cmd")
+      prefetch_actions
+      run_one "$pair"
+      ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
> **Status update — v0.7.5 already shipped.** The original `Release Stable` workflow run for v0.7.5 ([#25477359490](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/25477359490)) failed at the `web` job with `Cannot find module './api-generated'`. While this PR was in review, the fix commits were cherry-picked onto a release branch from the version-bump commit `44d38f8` and shipped as `v0.7.5` from `a2988f0df` via [run #25537379466](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/25537379466), bypassing 6506/6507 (which target v0.7.7) and producing the [v0.7.5 release](https://github.com/zeroclaw-labs/zeroclaw/releases/tag/v0.7.5). This PR now lands the same workflow + runbook + maintainer-helper improvements directly onto `master` so v0.7.6 and later pick them up automatically.

## Summary

- **Base branch:** `master`
- **What changed and why:**
  - **The release was held mid-flight** when `Release Stable` workflow run #25477359490 hit `src/lib/api.ts(710,69): error TS2307: Cannot find module './api-generated'`. Root cause: `web/src/lib/api-generated.ts` is gitignored (codegen output), commit `4f60f4405` removed the previously-committed copy, and the manual workflows still ran `cd web && npm ci && npm run build` (where `npm run build` is `tsc -b && vite build` with no codegen step). The bug was unreachable on per-PR CI because the broken workflows only fire on `workflow_dispatch`.
  - **Workflow fix** (commit `4ff97275f`): both `release-stable-manual.yml` and `cross-platform-build-manual.yml` now run `cargo web build` (the xtask wrapper that does gen-api → tsc → vite) and add the necessary `dtolnay/rust-toolchain` + `Swatinem/rust-cache` steps. Timeouts bumped from 10 → 20 minutes to absorb the cold-cache Rust compile.
  - **Runbook Step 3** (commits `67a743167` + `88e9b0708`): adds an explicit step between the version-bump merge and the GitHub Actions trigger that walks the maintainer through running the workflows locally with `act` first. The Release Stable workflow consumes its environment-gate approval window the moment it's dispatched; a workflow defect that surfaces mid-release leaves master at the new version while CI is broken — exactly what just happened.
  - **`scripts/dev/act-local.sh`** (commit `88e9b0708`): POSIX-sh wrapper around `act` that walks `.github/workflows/` to discover jobs DRY-style, auto-creates the gitignored `.secrets` file, pre-fetches pinned action SHAs into `~/.cache/act/` (act's shallow clone can't resolve arbitrary commits — we hit this live with `dtolnay/rust-toolchain@631a55b1...`), threads `GITHUB_TOKEN` from `gh auth token`, sets `--artifact-server-path` so artifact upload/download works between jobs, and auto-derives the `version` workflow_dispatch input from `Cargo.toml`. Resolves to standalone `act` if available, falls back to `gh act` so the gh-extension install path the runbook now recommends is sufficient.
  - **`.actrc`** gains `--artifact-server-path /tmp/act-artifacts` so plain `act` invocations get the same artifact behavior, not just the script.
  - **Gateway recovery strings** now point developers at `cargo web build` in `crates/zeroclaw-gateway/build.rs` and `crates/zeroclaw-gateway/src/static_files.rs`, so runtime/build-time error messages match the workflow fix.
- **Scope boundary:** Manual release workflow files (`.github/workflows/release-stable-manual.yml`, `.github/workflows/cross-platform-build-manual.yml`), `.actrc`, `scripts/dev/act-local.sh`, the release runbook, and two gateway Rust error-message strings (`crates/zeroclaw-gateway/build.rs`, `crates/zeroclaw-gateway/src/static_files.rs`). Does NOT change TypeScript source, Cargo manifests, release artifact production logic, or gateway runtime behavior beyond the two recovery messages. The codegen step was already there in `cargo web build` — the workflows just weren't calling it.
- **Blast radius:** Affects how the manual release workflows run on real CI (now Rust toolchain + cache + `cargo web build` steps in the web job; the intended web build path is the supported equivalent of the previous build on a tree with generated API output present). Runbook gains a step. Script is opt-in — nothing else in the repo references it. `.actrc` change is additive (act reads multiple flags from it). Gateway Rust changes are message-only.
- **Linked issue(s):** Refs run #25477359490 (the failed v0.7.5 release attempt that surfaced the bug). Refs commit `4f60f4405` (where the latent bug was introduced when the committed `api-generated.ts` was removed). v0.7.5 was ultimately released from a cherry-pick of these commits at `a2988f0df` while this PR was in review; this PR's merge brings the same workflow/runbook/script changes onto `master` for v0.7.6+ releases.

## Validation Evidence (required)

Validation evidence below is carried forward from the existing PR submission at head `a2988f0dfffa0c14fa56e218c7bb9f28da494da4`; no validation was rerun for this body-only metadata/template update.

```bash
# Phase 1: validate job (workflow_dispatch input version=0.7.5)
./scripts/dev/act-local.sh release-stable-manual:validate

# Phase 2a: web job — release-stable-manual.yml
./scripts/dev/act-local.sh release-stable-manual:web

# Phase 2b: web job — cross-platform-build-manual.yml
./scripts/dev/act-local.sh cross-platform-build-manual:web

# Script behavior smoke
./scripts/dev/act-local.sh --help
./scripts/dev/act-local.sh --list
./scripts/dev/act-local.sh web   # short form, expected to error on ambiguity
```

- **Commands run and tail output:**
  - `./scripts/dev/act-local.sh release-stable-manual:validate` — `🏁 Job succeeded`, set-output `tag=v0.7.5 version=0.7.5`. The `version` input was auto-derived from Cargo.toml.
  - `./scripts/dev/act-local.sh release-stable-manual:web` — `✓ built in 3.30s` (vite), `✅ Success - Main Build web dashboard`, `✅ Success - Post Swatinem/rust-cache@v2`, then `actions/upload-artifact@v4` succeeded into `/tmp/act-artifacts/1/web-dist/web-dist.zip` (because `--artifact-server-path` is now wired). `🏁 Job succeeded`.
  - `./scripts/dev/act-local.sh cross-platform-build-manual:web` — `🏁 Job succeeded`, same shape. Pre-fetch added the pinned `dtolnay/rust-toolchain@631a55b1...` and `Swatinem/rust-cache@779680da...` SHAs to `~/.cache/act/`.
  - `./scripts/dev/act-local.sh --list` — printed every workflow's jobs grouped by stem. Discovered all 13 workflow files, skipping the workflow_call-only ones automatically.
  - `./scripts/dev/act-local.sh web` — produced exactly the expected error: `error: ambiguous job 'web' — defined in: cross-platform-build-manual:web release-stable-manual:web — use <workflow>:<job> form`.
  - `bash --posix -n scripts/dev/act-local.sh` — exit 0 (POSIX syntax clean).
- **Beyond CI, what I manually verified:** Reproduced the original tsc failure locally first (`act -j web -W release-stable-manual.yml` against pre-fix master tip → identical error to GitHub run #25477359490). After the patch, the same invocation through the script succeeds. The manual phases I ran are listed above; the only failures observed under `act` are the documented "expected under act" surfaces (no real release tag, no environment gates, no OIDC token).
- **If any command was intentionally skipped, why:** Phase 3 (`build` matrix entry) and Phase 4 (`release-notes`) were exercised partially — `build` started successfully and got past the toolchain setup; full Rust cross-compile under act was not run to completion locally because the script's job is to surface real defects, not to substitute for real CI which has the proper runner images and target sysroots. The patch's effect on `build` is indirect (it consumes the `web-dist` artifact uploaded by `web`, which we proved works). Current PR CI is green, and the workflow fix has now been exercised end-to-end on real GitHub CI: [run #25537379466](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/25537379466) shipped v0.7.5 successfully from `a2988f0df` carrying the same patch — so the workflow fix is proven, and this merge propagates it onto `master`.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `Yes` — the maintainer-only helper can create the gitignored `.secrets` file, write act artifacts under `/tmp/act-artifacts`, prefetch pinned action SHAs into `~/.cache/act`, and pass the maintainer's existing `GITHUB_TOKEN` into local `act` jobs.
- New external network calls? `Yes` — the script invokes `git fetch` against `github.com` to pre-fetch pinned action SHAs, which is the same GitHub action-fetching domain `act` already uses. No new third-party domains and no new credentials.
- Secrets / tokens / credentials handling changed? `Yes` — the script reads the maintainer's existing GitHub CLI token with `gh auth token`, exports it as `GITHUB_TOKEN`, and passes it to `act` by name with `-s GITHUB_TOKEN`. The token value is not written to `.secrets`, shell history, or argv/process tables; `.secrets` remains gitignored and is auto-created empty if missing.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: The local helper can give workflow jobs the maintainer's real GitHub token and local artifact/cache paths. The mitigation in this PR is two-layered: (1) the token is kept out of argv, on-disk `.secrets`, shell history, and process tables — `run_one` exports `GITHUB_TOKEN` into the parent process environment and passes `act -s GITHUB_TOKEN` (no value); (2) `--all` enforces a fail-closed dry-run-safe allowlist (`DRY_RUN_SAFE_JOBS` in `scripts/dev/act-local.sh`), so any job not on the allowlist — across every standalone `.github/workflows/*.yml` discovered, including `publish`, `docker`, `redeploy-website`, `docs-deploy:deploy`, `daily-audit:advisories`, `tweet-release:tweet`, `discord-release:discord`, the `pub-{aur,homebrew-core,scoop}` publishers, and `sync-marketplace-templates` — is skipped and requires either the explicit `<wf>:<job>` form (which logs a loud warning before invoking `act` if the target is off the allowlist) or `--no-allowlist` to run. New workflows added to the repo are treated as potentially mutating until a maintainer reviews them and explicitly extends the allowlist.

## Compatibility (required)

- Backward compatible? `Yes`. Real GitHub CI behavior on the manual workflows changes (now runs Rust + `cargo web build`), which is the fix. No flags renamed, no inputs changed, no outputs changed.
- Config / env / CLI surface changed? `No` for end users. `scripts/dev/act-local.sh` is a new maintainer-only tool with its own `--help`; it doesn't replace anything.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** After merge, `git revert <merge-sha>` reverts the whole release-helper change. Before merge, the workflow fix, runbook Step 3, and script/helper commits can be reverted independently if only one slice needs to back out. Reverting the workflow fix re-introduces the release-time CI bug; reverting only the script/runbook changes leaves the workflow web-codegen fix in place.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Manual `Release Stable` or `Cross Platform Build` web jobs fail during TypeScript compilation with `Cannot find module './api-generated'`; local `act` dry-runs fail before uploading `web-dist`; or the maintainer helper reaches jobs that publish, push, dispatch, post, or open issues when running the documented all-jobs path.

