### PR TITLE
feat(desktop): take_screenshot and run_applescript Tauri commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13337,6 +13337,7 @@ name = "zeroclaw-desktop"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",

--- a/apps/tauri/Cargo.toml
+++ b/apps/tauri/Cargo.toml
@@ -18,6 +18,7 @@ serde_json = "1.0"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-webpki-roots"] }
 tokio = { version = "1.50", features = ["rt-multi-thread", "macros", "sync", "time"] }
 anyhow = "1.0"
+base64 = "0.22"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"

--- a/apps/tauri/src/capabilities/applescript.rs
+++ b/apps/tauri/src/capabilities/applescript.rs
@@ -1,0 +1,41 @@
+//! AppleScript capability — runs arbitrary AppleScript via osascript, gated by
+//! the macOS Automation TCC permission (per-target-app prompts handled by the
+//! system). This is a *risky* capability and will be wrapped behind a per-app
+//! approval allowlist when the full NodeClient lands (#6321 / #6499).
+//!
+//! For now, callers (the dashboard devtools console during testing) take
+//! responsibility for not running scripts they wouldn't run themselves.
+
+use std::process::Command;
+
+/// Run an AppleScript snippet via `osascript -e`.
+///
+/// Returns the trimmed stdout on success, or the stderr from osascript on
+/// failure (which usually surfaces the per-app TCC prompt rejection).
+#[tauri::command]
+pub fn run_applescript(code: String) -> Result<String, String> {
+    #[cfg(target_os = "macos")]
+    {
+        let output = Command::new("/usr/bin/osascript")
+            .args(["-e", &code])
+            .output()
+            .map_err(|e| format!("osascript spawn failed: {e}"))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            return Err(if stderr.is_empty() {
+                format!("osascript exited with {}", output.status)
+            } else {
+                stderr
+            });
+        }
+
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = code;
+        Err("AppleScript capability is currently macOS-only".into())
+    }
+}

--- a/apps/tauri/src/capabilities/mod.rs
+++ b/apps/tauri/src/capabilities/mod.rs
@@ -1,0 +1,7 @@
+//! Capability handlers — Tauri commands the agent (or the dashboard webview)
+//! can invoke to act on the local machine. v1 minimal scope: a single
+//! read-only capability (screenshot) and a single risky capability (AppleScript)
+//! to prove the dispatch path end-to-end before the full WS NodeClient lands.
+
+pub mod applescript;
+pub mod screenshot;

--- a/apps/tauri/src/capabilities/screenshot.rs
+++ b/apps/tauri/src/capabilities/screenshot.rs
@@ -1,0 +1,70 @@
+//! Screenshot capability — captures the current display(s) using the system
+//! `screencapture` tool, which respects the Screen Recording TCC permission.
+//!
+//! Returns a base64-encoded PNG. The agent (or the dashboard webview during
+//! testing) can render this directly via a `data:image/png;base64,…` URL.
+
+use base64::Engine;
+use serde::Serialize;
+use std::process::Command;
+
+#[derive(Debug, Serialize)]
+pub struct ScreenshotResult {
+    pub format: String,
+    pub data: String,
+}
+
+/// Capture the screen and return a base64-encoded PNG.
+///
+/// Returns `permission_denied("screen_recording")` when TCC blocks the capture.
+#[tauri::command]
+pub fn take_screenshot() -> Result<ScreenshotResult, String> {
+    #[cfg(target_os = "macos")]
+    {
+        use crate::macos::permissions;
+        if permissions::check_screen_recording() != "granted" {
+            return Err("permission_denied(screen_recording)".into());
+        }
+
+        let tmp = std::env::temp_dir().join(format!(
+            "zeroclaw-screenshot-{}-{}.png",
+            std::process::id(),
+            chrono_ish_nanos()
+        ));
+
+        // -x silences shutter sound. -t png writes a PNG. -C captures cursor.
+        let status = Command::new("/usr/sbin/screencapture")
+            .args(["-x", "-t", "png"])
+            .arg(&tmp)
+            .status()
+            .map_err(|e| format!("screencapture spawn failed: {e}"))?;
+
+        if !status.success() {
+            return Err(format!("screencapture exited with {status}"));
+        }
+
+        let bytes =
+            std::fs::read(&tmp).map_err(|e| format!("failed to read captured image: {e}"))?;
+        let _ = std::fs::remove_file(&tmp);
+
+        let encoded = base64::engine::general_purpose::STANDARD.encode(&bytes);
+        Ok(ScreenshotResult {
+            format: "png".into(),
+            data: encoded,
+        })
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        Err("Screenshot capability is currently macOS-only".into())
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn chrono_ish_nanos() -> u128 {
+    // Avoid pulling chrono into this module just for a tmpfile suffix.
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0)
+}

--- a/apps/tauri/src/lib.rs
+++ b/apps/tauri/src/lib.rs
@@ -1,5 +1,6 @@
 //! ZeroClaw Desktop — Tauri application library.
 
+pub mod capabilities;
 pub mod commands;
 pub mod gateway_client;
 pub mod health;
@@ -110,6 +111,8 @@ pub fn run() {
             commands::onboarding::get_onboarding_state,
             commands::onboarding::complete_onboarding,
             commands::onboarding::reset_onboarding,
+            capabilities::screenshot::take_screenshot,
+            capabilities::applescript::run_applescript,
         ])
         .setup(move |app| {
             // Set macOS dock icon (needed for dev builds without .app bundle).


### PR DESCRIPTION
## Summary

- **Base branch:** `feat/desktop-onboarding` (PR #6506) — this PR is stacked on top so the diff stays focused. Will rebase onto `master` after the parent merges.
- **What changed and why:**
  - Adds two minimal capability handlers in a new `apps/tauri/src/capabilities/` module to prove the Mac-control dispatch path ahead of the full WebSocket NodeClient (#6498):
    - `take_screenshot` — shells out to `/usr/sbin/screencapture` (gated by Screen Recording TCC), reads the PNG, returns it base64-encoded.
    - `run_applescript` — shells out to `/usr/bin/osascript -e <code>`, surfacing osascript stderr on failure (which is where Automation TCC denials show up).
  - Both commands are macOS-only at the implementation level. Non-macOS callers receive `"currently macOS-only"` instead of a stub.
  - Both can be invoked from the dashboard webview's devtools console today, since `withGlobalTauri:true` makes `window.__TAURI__.core.invoke()` available inside the gateway-served chat-ui.
- **Scope boundary:**
  - Approval gating (per-app whitelist for risky commands like AppleScript) is intentionally deferred to the NodeClient PR where it will live alongside gateway-driven dispatch (per #6321 / #6499).
  - The agent on the gateway cannot yet *automatically* invoke these commands — that requires the persistent `/ws/nodes` connection (#6498). For now, dashboard-side JS can call them.
  - No changes to the gateway crate.
- **Blast radius:**
  - Adds two new Tauri commands on macOS only. Both honor TCC and surface denials as clear errors.
  - Adds `base64 = \"0.22\"` as a new dependency.
- **Linked issue(s):**
  - Partial: #6499 (capability handlers — first two of many)
  - Stacked on #6506 (parent PR)

## Validation Evidence

- **Commands run:** `cargo check` clean.
- **Beyond CI — what was manually verified:**
  - From the dashboard devtools console after granting Screen Recording: `await window.__TAURI__.core.invoke('take_screenshot')` returns `{ format: 'png', data: '<base64>' }` with the expected screen contents.
  - `await window.__TAURI__.core.invoke('run_applescript', { code: 'display notification \"Hello\"' })` shows a system notification.
  - `await window.__TAURI__.core.invoke('run_applescript', { code: 'tell application \"Finder\" to get name of startup disk' })` triggers the Automation TCC prompt the first time (per-app), returns the disk name after approval.
  - Revoking Screen Recording in System Settings → next `take_screenshot` returns `permission_denied(screen_recording)` instead of silently failing.

## Security & Privacy Impact

- **New permissions / capabilities / file system access scope?** Yes. Two new Tauri commands available to the `default` and `desktop` capability sets. Both are macOS-only and rely on the OS-level TCC permissions granted in PR #6506.
- **New external network calls?** No. Both commands run locally and return data to the calling webview.
- **Secrets / tokens / credentials handling changed?** No.
- **PII, real identities, or personal data in diff, tests, fixtures, or docs?** No.
- **Risk and mitigation:** `run_applescript` runs arbitrary AppleScript — by design — so it inherits the full power Automation grants. The agent dispatch path (#6498) will gate this behind a per-app approval allowlist; until that lands, only the dashboard webview's own JS can call it (which the user controls). Failures surface stderr from osascript so denials are explicit.

## Compatibility

- **Backward compatible?** Yes. Adds new commands; no existing behavior changes.
- **Config / env / CLI surface changed?** No.

## Rollback

- **Fast rollback:** `git revert <commit-sha>` on whichever base branch this lands on. Removes the two commands; no schema or persistent-state changes to undo.
- **Observable failure symptoms:** `screencapture` not found at `/usr/sbin/screencapture` (impossible on stock macOS) or `osascript` not at `/usr/bin/osascript` would surface as `\"spawn failed\"` errors. TCC denials show up as `permission_denied(<service>)` for screenshot or stderr text from osascript for AppleScript.

## Test plan

- [x] take_screenshot returns base64 PNG when Screen Recording is granted
- [x] take_screenshot returns permission_denied(screen_recording) when revoked
- [x] run_applescript runs and returns trimmed stdout
- [x] run_applescript triggers per-app Automation prompt on first use
- [x] cargo check clean on zeroclaw-desktop
- [ ] Wire approval gating in the NodeClient PR (#6498)