### PR TITLE
chore: re-attempt v0.7.5 release after CI fix (#6502 must merge first)

### DIFF
--- a/CHANGELOG-next.md
+++ b/CHANGELOG-next.md
@@ -272,6 +272,7 @@
 | Channels (Matrix) | Require explicit device identity for access-token sessions (21d0c5d6b); derive identity from `whoami` (242ef2404). |
 | Channels (WhatsApp) | Scope `fromMe` replies to self-chat or trigger prefixes (#6353); surface LID→phone resolution failures in logs (#6354). |
 | CI / docs build | Track `lang-switcher.js.tpl`, generate `.js` at build time (#6395); set workspace `default-run` to unblock docs CI (46235824e); remove the obsolete `CHANGELOG-next.md` cleanup step (#6265). |
+| CI / release | Run `cargo web build` (codegen → tsc → vite) instead of bare `npm run build` in `release-stable-manual.yml` and `cross-platform-build-manual.yml`, so workflow_dispatch release runs don't fail on the gitignored `web/src/lib/api-generated.ts`; add `scripts/dev/act-local.sh` so maintainers dry-run release workflows locally before triggering on GitHub (#6502). |
 | Config | Preserve dotted provider map keys (#6317); surface `.secret_key` mismatch on enc2 decrypt (#6379). |
 | Docker | Unbreak workspace-member resolution in `Dockerfile` and `Dockerfile.debian` (#6305). |
 | Gateway | Record cost and token usage on every turn (#6159); evict `cancel_tokens` when a session is deleted mid-turn (#6216); fail-loud model resolution mirrored across gateway and channels (#6215); daemon boots without a configured model so `/onboard` stays reachable on fresh installs and partially-configured states, with `POST /webhook` returning `503 needs_onboarding` and channel handlers sending a Fluent-localized reply (#6493). |


### PR DESCRIPTION
> **🚨 REQUIRES #6502 MERGED FIRST.** This PR re-attempts the v0.7.5 release after the first attempt (`Release Stable` workflow run [#25477359490](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/25477359490)) was held mid-flight by a workflow_dispatch-only CI defect (manual release workflows ran bare `npm run build` against a tree where `web/src/lib/api-generated.ts` is gitignored). Master is currently at v0.7.5 (commit `44d38f8`) but no release artifacts exist for that tag, and the v0.7.5 tag itself has not been pushed yet. **#6502 is the workflow fix and the act-based local-dry-run scaffolding that prevents this from recurring; it MUST land on master before this PR merges.** Once #6502 is in and this PR follows, re-trigger `Release Stable` with `version=0.7.5` per `docs/book/src/maintainers/release-runbook.md`.

## Summary

- **Base branch:** `master`
- **What changed and why:**
  - **CHANGELOG-next.md** gains one row in the bug-fixes table covering #6502 (workflow fix + `scripts/dev/act-local.sh` + runbook Step 3). The existing v0.7.4 → v0.7.5 narrative — highlights, what's new by area, the rest of the bug-fix table, contributors — is the curated #6492 changelog and stays byte-identical; only the `CI / release` row is new. Per the runbook the changelog is what the publish job ships as release notes, so it has to reflect the surface that will actually be on the v0.7.5 tag.
  - **No version bump, no docs sweep, no marketplace template changes.** Master already carries those from #6492 (Cargo.toml at v0.7.5, marketplace templates pinned to `zeroclawlabs/zeroclaw:v0.7.5`, docs example tags bumped). This PR is purely the missing changelog entry on top of master's existing release-prep state.
- **Scope boundary:** One file (`CHANGELOG-next.md`), one row added. No code, no config, no scripts, no workflows. The `Release Stable` trigger remains a manual `workflow_dispatch` on master after this lands; nothing in the PR auto-triggers a release.
- **Blast radius:** Documentation only. The added row references a #6502 link that resolves only after #6502 merges; ordering is enforced by the dependency callout above (this PR will not be merged until #6502 is on master).
- **Linked issue(s):** Refs run #25477359490 (the held v0.7.5 release attempt). Depends on #6502 (the workflow + tooling fix this PR depends on). Refs #6492 (the original v0.7.5 bump, already merged) for the curated changelog this PR builds on.

## Validation Evidence (required)

```bash
cargo +nightly fmt --all -- --check
cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
git show upstream/master:Cargo.toml | grep '^version'   # local fork uses `upstream` for the canonical zeroclaw-labs/zeroclaw remote; runbook says `origin` because most maintainer clones don't fork
git diff --stat upstream/master..HEAD
```

- **Commands run and tail output:**
  - `cargo +nightly fmt --all -- --check` — exit 0, clean.
  - `cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings` — exit 0, no warnings. (The clippy gate is run because runbook step 2 requires CI to be green; this PR's diff is changelog-only so the result is identical to master's, but the gate is what the project's pre-push protocol mandates.)
  - `git show upstream/master:Cargo.toml | grep '^version'` — `version = "0.7.5"` ✓ (runbook step 2 verification, adapted to use `upstream` instead of `origin` since this fork's `upstream` is `zeroclaw-labs/zeroclaw`).
  - `git diff --stat upstream/master..HEAD` — `CHANGELOG-next.md | 1 +`, one file changed.
- **Beyond CI, what I manually verified:**
  - **Diff is the single intended row.** `git diff upstream/master..HEAD -- CHANGELOG-next.md` shows exactly one added line under `## Bug Fixes`, immediately after the existing `CI / docs build` row, formatted to match the surrounding `| Area | Fix |` shape.
  - **Cargo.toml on master is already v0.7.5.** Confirmed via `git show upstream/master:Cargo.toml`. Runbook Step 2's "the version bump landed correctly" gate is satisfied by the existing #6492 merge; this PR doesn't re-do it.
  - **Tag has not been published.** Confirmed via `gh release view v0.7.5` (404) and `git ls-remote upstream refs/tags/v0.7.5` (empty). The `Release Stable` workflow's first action is to create the tag, so re-triggering after #6502 + this PR land is the same as triggering for the first time — no rollback of a partially-shipped tag is needed.
  - **#6502 verified via `act` dry-run.** Per #6502's own validation evidence, both `release-stable-manual:web` and `cross-platform-build-manual:web` succeed under `act` against the patched workflows; the same script path (`scripts/dev/act-local.sh`) will be run against master after both PRs merge as a final pre-trigger check.
- **If any command was intentionally skipped, why:** Full `cargo test` skipped — diff is a single Markdown row in `CHANGELOG-next.md`. CI runs the full suite as the merge gate.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes` — documentation-only PR.
- Config / env / CLI surface changed? `No`

## Rollback

Low-risk PR: `git revert <sha>` against master. No infrastructure or runtime impact. The `Release Stable` workflow trigger is a manual step that happens after this lands, so an unwanted state is "didn't trigger yet" — recoverable by simply not clicking Run.

---

### Why a separate PR (and not just retrigger)

The runbook frames the changelog as the source of release notes — `CHANGELOG-next.md` ships verbatim as the GitHub Release body, then the publish job removes the file from master. The v0.7.5 tag publishes whatever `CHANGELOG-next.md` says at trigger time. If we re-trigger without adding the #6502 row, the v0.7.5 release notes would omit the workflow fix even though that fix is on the tag's commit. Adding the row in a tracked PR keeps the release notes accurate and the master history honest about why the second attempt was needed.

