### PR TITLE
fix(cron): support dingtalk delivery channel

### DIFF
--- a/crates/zeroclaw-gateway/src/api.rs
+++ b/crates/zeroclaw-gateway/src/api.rs
@@ -1313,7 +1313,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cron_api_shell_roundtrip_includes_delivery() {
+    async fn cron_api_accepts_dingtalk_delivery() {
         let tmp = tempfile::TempDir::new().unwrap();
         let config = zeroclaw_config::schema::Config {
             workspace_dir: tmp.path().join("workspace"),
@@ -1333,8 +1333,8 @@ mod tests {
                     "command": "echo hello",
                     "delivery": {
                         "mode": "announce",
-                        "channel": "discord",
-                        "to": "1234567890",
+                        "channel": "dingtalk",
+                        "to": "conversation-id",
                         "best_effort": true
                     }
                 }))
@@ -1347,8 +1347,8 @@ mod tests {
         let add_json = response_json(add_response).await;
         assert_eq!(add_json["status"], "ok");
         assert_eq!(add_json["job"]["delivery"]["mode"], "announce");
-        assert_eq!(add_json["job"]["delivery"]["channel"], "discord");
-        assert_eq!(add_json["job"]["delivery"]["to"], "1234567890");
+        assert_eq!(add_json["job"]["delivery"]["channel"], "dingtalk");
+        assert_eq!(add_json["job"]["delivery"]["to"], "conversation-id");
 
         let list_response = handle_api_cron_list(State(state), HeaderMap::new())
             .await
@@ -1357,8 +1357,8 @@ mod tests {
         let jobs = list_json["jobs"].as_array().expect("jobs array");
         assert_eq!(jobs.len(), 1);
         assert_eq!(jobs[0]["delivery"]["mode"], "announce");
-        assert_eq!(jobs[0]["delivery"]["channel"], "discord");
-        assert_eq!(jobs[0]["delivery"]["to"], "1234567890");
+        assert_eq!(jobs[0]["delivery"]["channel"], "dingtalk");
+        assert_eq!(jobs[0]["delivery"]["to"], "conversation-id");
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-runtime/src/cron/mod.rs
+++ b/crates/zeroclaw-runtime/src/cron/mod.rs
@@ -22,6 +22,17 @@ pub use types::{
     deserialize_maybe_stringified,
 };
 
+pub const SUPPORTED_DELIVERY_CHANNELS: &[&str] = &[
+    "telegram",
+    "discord",
+    "slack",
+    "mattermost",
+    "signal",
+    "matrix",
+    "qq",
+    "dingtalk",
+];
+
 /// Validate a shell command against the full security policy (allowlist + risk gate).
 ///
 /// Returns `Ok(())` if the command passes all checks, or an error describing
@@ -61,9 +72,9 @@ pub fn validate_delivery_config(delivery: Option<&DeliveryConfig>) -> Result<()>
     let Some(channel) = channel.filter(|value| !value.is_empty()) else {
         bail!("delivery.channel is required for announce mode");
     };
-    match channel.to_ascii_lowercase().as_str() {
-        "telegram" | "discord" | "slack" | "mattermost" | "signal" | "matrix" | "qq" => {}
-        other => bail!("unsupported delivery channel: {other}"),
+    let normalized = channel.to_ascii_lowercase();
+    if !SUPPORTED_DELIVERY_CHANNELS.contains(&normalized.as_str()) {
+        bail!("unsupported delivery channel: {normalized}");
     }
 
     let has_target = delivery

--- a/crates/zeroclaw-runtime/src/cron/store.rs
+++ b/crates/zeroclaw-runtime/src/cron/store.rs
@@ -1037,6 +1037,17 @@ mod tests {
     }
 
     #[test]
+    fn validate_delivery_config_accepts_dingtalk() {
+        validate_delivery_config(Some(&DeliveryConfig {
+            mode: "announce".into(),
+            channel: Some("dingtalk".into()),
+            to: Some("conversation-id".into()),
+            best_effort: true,
+        }))
+        .unwrap();
+    }
+
+    #[test]
     fn add_agent_job_rejects_invalid_announce_delivery() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(&tmp);

--- a/crates/zeroclaw-runtime/src/tools/cron_add.rs
+++ b/crates/zeroclaw-runtime/src/tools/cron_add.rs
@@ -58,7 +58,7 @@ impl Tool for CronAddTool {
     fn description(&self) -> &str {
         "Create a scheduled cron job (shell or agent) with cron/at/every schedules. \
          Use job_type='agent' with a prompt to run the AI agent on schedule. \
-         To deliver output to a channel (Discord, Telegram, Slack, Mattermost, Matrix, QQ), set \
+         To deliver output to a channel, set \
          delivery={\"mode\":\"announce\",\"channel\":\"discord\",\"to\":\"<channel_id_or_chat_id>\"}. \
          This is the preferred tool for sending scheduled/delayed messages to users via channels."
     }
@@ -146,7 +146,7 @@ impl Tool for CronAddTool {
                         },
                         "channel": {
                             "type": "string",
-                            "enum": ["telegram", "discord", "slack", "mattermost", "matrix", "qq"],
+                            "enum": cron::SUPPORTED_DELIVERY_CHANNELS,
                             "description": "Channel type to deliver output to"
                         },
                         "to": {
@@ -735,18 +735,20 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn delivery_schema_includes_matrix_channel() {
+    async fn delivery_schema_uses_supported_delivery_channels() {
         let tmp = TempDir::new().unwrap();
         let cfg = test_config(&tmp).await;
         let tool = CronAddTool::new(cfg.clone(), test_security(&cfg));
 
-        let values =
+        let values: Vec<&str> =
             tool.parameters_schema()["properties"]["delivery"]["properties"]["channel"]["enum"]
                 .as_array()
-                .cloned()
-                .unwrap_or_default();
+                .expect("delivery.channel must have an enum")
+                .iter()
+                .filter_map(|value| value.as_str())
+                .collect();
 
-        assert!(values.iter().any(|value| value == "matrix"));
+        assert_eq!(values.as_slice(), cron::SUPPORTED_DELIVERY_CHANNELS);
     }
 
     #[test]

--- a/crates/zeroclaw-runtime/src/tools/cron_update.rs
+++ b/crates/zeroclaw-runtime/src/tools/cron_update.rs
@@ -151,7 +151,7 @@ impl Tool for CronUpdateTool {
                                 },
                                 "channel": {
                                     "type": "string",
-                                    "enum": ["telegram", "discord", "slack", "mattermost", "matrix"],
+                                    "enum": cron::SUPPORTED_DELIVERY_CHANNELS,
                                     "description": "Channel type to deliver output to"
                                 },
                                 "to": {
@@ -245,6 +245,7 @@ impl Tool for CronUpdateTool {
 mod tests {
     use super::*;
     use crate::security::AutonomyLevel;
+    use crate::tools::cron_add::CronAddTool;
     use tempfile::TempDir;
     use zeroclaw_config::schema::Config;
 
@@ -475,9 +476,31 @@ mod tests {
             .as_array()
             .expect("patch.delivery.channel must have an enum");
         let channel_strs: Vec<&str> = channel_enum.iter().filter_map(|v| v.as_str()).collect();
-        for ch in &["telegram", "discord", "slack", "mattermost", "matrix"] {
+        for ch in cron::SUPPORTED_DELIVERY_CHANNELS {
             assert!(channel_strs.contains(ch), "delivery.channel missing: {ch}");
         }
+    }
+
+    #[tokio::test]
+    async fn delivery_channel_schema_matches_cron_add() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = test_config(&tmp).await;
+        let security = test_security(&cfg);
+        let add_tool = CronAddTool::new(cfg.clone(), security.clone());
+        let update_tool = CronUpdateTool::new(cfg, security);
+
+        let add_channels =
+            &add_tool.parameters_schema()["properties"]["delivery"]["properties"]["channel"]
+                ["enum"];
+        let update_channels = &update_tool.parameters_schema()["properties"]["patch"]["properties"]
+            ["delivery"]["properties"]["channel"]["enum"];
+
+        assert_eq!(add_channels, update_channels);
+        assert!(add_channels
+            .as_array()
+            .expect("delivery.channel must have an enum")
+            .iter()
+            .any(|value| value == "dingtalk"));
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-runtime/src/tools/cron_update.rs
+++ b/crates/zeroclaw-runtime/src/tools/cron_update.rs
@@ -489,18 +489,19 @@ mod tests {
         let add_tool = CronAddTool::new(cfg.clone(), security.clone());
         let update_tool = CronUpdateTool::new(cfg, security);
 
-        let add_channels =
-            &add_tool.parameters_schema()["properties"]["delivery"]["properties"]["channel"]
-                ["enum"];
+        let add_channels = &add_tool.parameters_schema()["properties"]["delivery"]["properties"]["channel"]
+            ["enum"];
         let update_channels = &update_tool.parameters_schema()["properties"]["patch"]["properties"]
             ["delivery"]["properties"]["channel"]["enum"];
 
         assert_eq!(add_channels, update_channels);
-        assert!(add_channels
-            .as_array()
-            .expect("delivery.channel must have an enum")
-            .iter()
-            .any(|value| value == "dingtalk"));
+        assert!(
+            add_channels
+                .as_array()
+                .expect("delivery.channel must have an enum")
+                .iter()
+                .any(|value| value == "dingtalk")
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Added `dingtalk` to the cron delivery channel allowlist so scheduled job results can be delivered to DingTalk.
  - Centralized cron delivery channel IDs in `SUPPORTED_DELIVERY_CHANNELS` so runtime validation, `cron_add`, and `cron_update` schemas stay in sync.
  - Added regression coverage for DingTalk delivery validation, tool schema consistency, and the gateway cron API path.
- **Scope boundary:** Does not migrate existing cron jobs whose delivery channel was previously saved as `qq`; QQ remains an independent supported channel.
- **Blast radius:** Cron delivery validation, agent-callable cron tool schemas, and gateway cron job creation.
- **Linked issue(s):** None

## Validation Evidence (required)

Local validation is the signal CI cannot replace. Run the full battery and paste literal output (tails, failures, warnings — not "all passed").

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

Docs-only changes: replace with markdown lint + link-integrity (`scripts/ci/docs_quality_gate.sh`). Bootstrap scripts: add `bash -n install.sh`.

- **Commands run and tail output:**
  - `cargo fmt --all -- --check`
    ```text
    <no output>
    ```
  - `cargo clippy --all-targets -- -D warnings`
    ```text
    Checking zeroclaw-config v0.7.5 (/Users/archergu/Code/OpenSource/zeroclaw-fork/crates/zeroclaw-config)
    Checking zeroclaw-memory v0.7.5 (/Users/archergu/Code/OpenSource/zeroclaw-fork/crates/zeroclaw-memory)
    Checking zeroclaw-providers v0.7.5 (/Users/archergu/Code/OpenSource/zeroclaw-fork/crates/zeroclaw-providers)
    Checking zeroclaw-tui v0.7.5 (/Users/archergu/Code/OpenSource/zeroclaw-fork/crates/zeroclaw-tui)
    Checking zeroclaw-tools v0.7.5 (/Users/archergu/Code/OpenSource/zeroclaw-fork/crates/zeroclaw-tools)
    Checking zeroclaw-runtime v0.7.5 (/Users/archergu/Code/OpenSource/zeroclaw-fork/crates/zeroclaw-runtime)
    Checking zeroclaw-hardware v0.7.5 (/Users/archergu/Code/OpenSource/zeroclaw-fork/crates/zeroclaw-hardware)
    Checking zeroclaw-channels v0.7.5 (/Users/archergu/Code/OpenSource/zeroclaw-fork/crates/zeroclaw-channels)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 23s
    ```
  - `cargo test`
    ```text
    test result: ok. 159 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.17s

    Running tests/test_live.rs (target/debug/deps/live-34bc71163d387cfc)
    test result: ok. 0 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 0.00s

    Running tests/test_system.rs (target/debug/deps/system-568c236c06b69d21)
    test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s

    Doc-tests zeroclaw
    test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
    ```
- **Beyond CI — what did you manually verify?** Confirmed the diff only touches cron delivery validation/schema/API tests, `ReadLints` reported no diagnostics for the edited Rust files, and the PR lint failure was reproduced locally as a rustfmt-only diff before applying `cargo fmt --all`.
- **If any command was intentionally skipped, why:** None

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: None

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`Yes`)
- If `No` or `Yes` to either: `delivery.channel` now accepts `dingtalk` consistently for cron delivery schema and runtime validation. Existing jobs and existing supported channels are unchanged; no upgrade steps required.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PRs: `git revert <sha>` is the plan unless otherwise noted.

Medium/high-risk PRs must fill:

- **Fast rollback command/path:** `git revert 01b106f4 5fc5b36f`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Cron job creation/update rejects previously accepted delivery configs, or scheduled announcements log `unsupported delivery channel` unexpectedly.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Scope materially carried forward: N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`No`)
- If `No`, why (inspiration-only, no direct code/design carry-over): No superseded PR.

---

**Labels** live in the GitHub label UI, not in the body. Set `risk:*`, `size:*`, and scope labels via the sidebar. Auto-label corrections: add `risk: manual` and the intended label.

**Commit trailers** capture AI-assisted collaboration (`Co-Authored-By: Claude ...`) — no separate section needed.

**Privacy contract** (`docs/book/src/contributing/privacy.md`) is a merge gate. Never commit real identities, secrets, personal emails, or PII in diff, tests, fixtures, or docs.