### PR TITLE
fix(matrix): avoid threading root timeline messages

### DIFF
--- a/crates/zeroclaw-channels/src/matrix.rs
+++ b/crates/zeroclaw-channels/src/matrix.rs
@@ -1497,16 +1497,10 @@ mod inbound {
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap_or_default()
                 .as_secs(),
-            // Reply anchor: use the existing thread root when present,
-            // otherwise (when reply_in_thread is on) anchor a brand-new thread
-            // on this very event so the bot's reply opens a thread.
-            thread_ts: thread_id.as_ref().map(|t| t.to_string()).or_else(|| {
-                if ctx.config.reply_in_thread {
-                    Some(ev.event_id.to_string())
-                } else {
-                    None
-                }
-            }),
+            // Reply anchor: only carry an existing Matrix thread root. A root
+            // timeline event is not a thread, even when outbound replies are
+            // configured to preserve thread context.
+            thread_ts: inbound_thread_ts(thread_id.as_ref()),
             // Interruption scope is for cancellation grouping — only set when
             // the inbound is genuinely *inside* a reply thread.
             interruption_scope_id: thread_id.as_ref().map(|t| t.to_string()),
@@ -1543,6 +1537,10 @@ mod inbound {
         }
         let root = relates.get("event_id")?.as_str()?;
         root.parse().ok()
+    }
+
+    pub(super) fn inbound_thread_ts(thread_id: Option<&OwnedEventId>) -> Option<String> {
+        thread_id.map(ToString::to_string)
     }
 
     /// Pull the `m.in_reply_to.event_id` from a raw event. This is Matrix's
@@ -3788,7 +3786,9 @@ mod tests {
     }
 
     mod thread_extraction {
-        use super::super::inbound::{extract_mentions_user_ids, extract_thread_id};
+        use super::super::inbound::{
+            extract_mentions_user_ids, extract_thread_id, inbound_thread_ts,
+        };
         use matrix_sdk::event_handler::RawEvent;
         use matrix_sdk::ruma::serde::Raw;
 
@@ -3819,6 +3819,21 @@ mod tests {
                 "content": { "msgtype": "m.text", "body": "hi" }
             }));
             assert!(extract_thread_id(&r).is_none());
+        }
+
+        #[test]
+        fn root_message_does_not_become_thread_when_reply_in_thread_enabled() {
+            assert_eq!(inbound_thread_ts(None), None);
+        }
+
+        #[test]
+        fn threaded_message_uses_existing_thread_root() {
+            let root_id = "$root:server".parse().expect("event id");
+
+            assert_eq!(
+                inbound_thread_ts(Some(&root_id)).as_deref(),
+                Some("$root:server")
+            );
         }
 
         #[test]

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -456,7 +456,11 @@ pub fn conversation_history_key(msg: &zeroclaw_api::channel::ChannelMessage) -> 
 }
 
 fn followup_thread_id(msg: &zeroclaw_api::channel::ChannelMessage) -> Option<String> {
-    msg.thread_ts.clone().or_else(|| Some(msg.id.clone()))
+    if is_matrix_channel_name(&msg.channel) {
+        msg.thread_ts.clone()
+    } else {
+        msg.thread_ts.clone().or_else(|| Some(msg.id.clone()))
+    }
 }
 
 fn interruption_scope_key(msg: &zeroclaw_api::channel::ChannelMessage) -> String {
@@ -785,6 +789,10 @@ fn strip_tool_summary_prefix(text: &str) -> String {
 
 fn supports_runtime_model_switch(channel_name: &str) -> bool {
     matches!(channel_name, "telegram" | "discord" | "matrix" | "slack")
+}
+
+fn is_matrix_channel_name(channel_name: &str) -> bool {
+    channel_name == "matrix" || channel_name.starts_with("matrix:")
 }
 
 fn parse_runtime_command(channel_name: &str, content: &str) -> Option<ChannelRuntimeCommand> {
@@ -10630,7 +10638,7 @@ BTC is currently around $65,000 based on latest tool output."#
             sender: "U123".into(),
             reply_target: "C456".into(),
             content: "hello".into(),
-            channel: "cli".into(),
+            channel: "slack".into(),
             timestamp: 1,
             thread_ts: None,
             interruption_scope_id: None,
@@ -10638,6 +10646,68 @@ BTC is currently around $65,000 based on latest tool output."#
         };
 
         assert_eq!(followup_thread_id(&msg).as_deref(), Some("msg_abc123"));
+    }
+
+    #[test]
+    fn followup_thread_id_does_not_open_matrix_thread_for_root_message() {
+        let msg = zeroclaw_api::channel::ChannelMessage {
+            id: "$event:server".into(),
+            sender: "@alice:server".into(),
+            reply_target: "!room:server".into(),
+            content: "hello".into(),
+            channel: "matrix".into(),
+            timestamp: 1,
+            thread_ts: None,
+            interruption_scope_id: None,
+            attachments: vec![],
+        };
+
+        assert_eq!(followup_thread_id(&msg), None);
+    }
+
+    #[test]
+    fn matrix_root_conversation_history_key_omits_event_id() {
+        let first = zeroclaw_api::channel::ChannelMessage {
+            id: "$first:server".into(),
+            sender: "@alice:server".into(),
+            reply_target: "!room:server".into(),
+            content: "send a.txt".into(),
+            channel: "matrix".into(),
+            timestamp: 1,
+            thread_ts: None,
+            interruption_scope_id: None,
+            attachments: vec![],
+        };
+        let second = zeroclaw_api::channel::ChannelMessage {
+            id: "$second:server".into(),
+            content: "send it again".into(),
+            timestamp: 2,
+            ..first.clone()
+        };
+
+        let key = conversation_history_key(&first);
+        assert_eq!(key, conversation_history_key(&second));
+        assert!(!key.contains("$first:server"));
+        assert!(!key.contains("$second:server"));
+    }
+
+    #[test]
+    fn matrix_thread_conversation_history_key_uses_thread_root() {
+        let msg = zeroclaw_api::channel::ChannelMessage {
+            id: "$reply:server".into(),
+            sender: "@alice:server".into(),
+            reply_target: "!room:server".into(),
+            content: "thread reply".into(),
+            channel: "matrix".into(),
+            timestamp: 1,
+            thread_ts: Some("$root:server".into()),
+            interruption_scope_id: Some("$root:server".into()),
+            attachments: vec![],
+        };
+
+        let key = conversation_history_key(&msg);
+        assert!(key.contains("$root:server"));
+        assert!(!key.contains("$reply:server"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Matrix root timeline messages no longer auto-open a thread; only existing `m.thread` roots are preserved.
  - Orchestrator follow-up threading now keeps Matrix root messages root-scoped instead of falling back to `msg.id`.
  - Added regression tests for root Matrix messages, threaded Matrix messages, and Matrix follow-up behavior.
- **Scope boundary:** Slack/Discord and other channels keep their existing follow-up fallback to message id.
- **Blast radius:** Matrix inbound mapping, conversation session keys, and tool/multi-message follow-up routing.
- **Linked issue(s):** Closes #6524

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo test -p zeroclaw-channels matrix_ -- --nocapture
RUSTC_BOOTSTRAP=1 RUSTFLAGS='-Zcrate-attr=recursion_limit="256"' cargo test -p zeroclaw-channels --features channel-matrix thread_extraction -- --nocapture
cargo clippy --all-targets -- -D warnings
cargo test
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` -> passed.
  - `cargo test -p zeroclaw-channels matrix_ -- --nocapture` -> 3 tests passed.
  - `cargo test -p zeroclaw-channels --features channel-matrix thread_extraction -- --nocapture` -> 7 tests passed.
  - `cargo clippy --all-targets -- -D warnings` -> passed.
  - `cargo test` -> 237 lib tests, 236 main tests, 159 integration tests, 5 system tests, doc tests all passed.
- **Beyond CI — what did you manually verify?**
  - Reviewed the diff to confirm only `crates/zeroclaw-channels/src/matrix.rs` and `crates/zeroclaw-channels/src/orchestrator/mod.rs` changed.
  - Confirmed the PR base is community `master`.
  - Confirmed issue #6524 is the matching bug report.
  - Did not run live Matrix end-to-end messaging in this session.
- **If any command was intentionally skipped, why:**
  - None.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: exact upgrade steps for existing users:
  - None; existing Matrix thread replies keep their thread root, while Matrix root timeline messages stay root-scoped.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert bac772ae`
- **Feature flags or config toggles:** `None`
- **Observable failure symptoms:** Matrix root messages splitting into separate sessions again, or threaded Matrix replies failing to stay attached to their existing thread root.