### PR TITLE
fix(gateway,runtime): broadcast agent observer events to /api/events SSE

### DIFF
--- a/crates/zeroclaw-gateway/src/lib.rs
+++ b/crates/zeroclaw-gateway/src/lib.rs
@@ -953,13 +953,19 @@ pub async fn run_gateway(
         hooks.fire_gateway_start(host, actual_port).await;
     }
 
-    // Wrap observer with broadcast capability for SSE
-    let broadcast_observer: Arc<dyn zeroclaw_runtime::observability::Observer> =
-        Arc::new(sse::BroadcastObserver::new(
-            zeroclaw_runtime::observability::create_observer(&config.observability),
-            event_tx.clone(),
-            event_buffer.clone(),
-        ));
+    // Install the SSE broadcast hook before building any observer so that
+    // events emitted by the agent's per-call observer (built inside
+    // `process_message`) also reach `/api/events`. The state-level observer
+    // is just the configured backend — `TeeObserver` (created by
+    // `create_observer`) tees its events into the hook automatically.
+    let broadcast_layer: Arc<dyn zeroclaw_runtime::observability::Observer> = Arc::new(
+        sse::BroadcastObserver::new(event_tx.clone(), event_buffer.clone()),
+    );
+    zeroclaw_runtime::observability::set_broadcast_hook(broadcast_layer);
+
+    let broadcast_observer: Arc<dyn zeroclaw_runtime::observability::Observer> = Arc::from(
+        zeroclaw_runtime::observability::create_observer(&config.observability),
+    );
 
     let (shutdown_tx, mut shutdown_rx) = tokio::sync::watch::channel(false);
 
@@ -1391,20 +1397,12 @@ fn prometheus_disabled_hint() -> String {
 fn prometheus_observer_from_state(
     observer: &dyn zeroclaw_runtime::observability::Observer,
 ) -> Option<&zeroclaw_runtime::observability::PrometheusObserver> {
+    // `TeeObserver::as_any` returns the primary observer, so a single direct
+    // downcast finds the PrometheusObserver whether the state observer is the
+    // raw backend or wrapped by the factory tee.
     observer
         .as_any()
         .downcast_ref::<zeroclaw_runtime::observability::PrometheusObserver>()
-        .or_else(|| {
-            observer
-                .as_any()
-                .downcast_ref::<sse::BroadcastObserver>()
-                .and_then(|broadcast| {
-                    broadcast
-                        .inner()
-                        .as_any()
-                        .downcast_ref::<zeroclaw_runtime::observability::PrometheusObserver>()
-                })
-        })
 }
 
 /// GET /metrics — Prometheus text exposition format
@@ -2862,18 +2860,13 @@ mod tests {
     #[tokio::test]
     async fn metrics_endpoint_renders_prometheus_output() {
         let event_tx = tokio::sync::broadcast::channel(16).0;
-        let event_buffer = Arc::new(sse::EventBuffer::new(16));
-        let wrapped = sse::BroadcastObserver::new(
-            Box::new(zeroclaw_runtime::observability::PrometheusObserver::new()),
-            event_tx.clone(),
-            event_buffer,
-        );
+        let prom = zeroclaw_runtime::observability::PrometheusObserver::new();
         zeroclaw_runtime::observability::Observer::record_event(
-            &wrapped,
+            &prom,
             &zeroclaw_runtime::observability::ObserverEvent::HeartbeatTick,
         );
 
-        let observer: Arc<dyn zeroclaw_runtime::observability::Observer> = Arc::new(wrapped);
+        let observer: Arc<dyn zeroclaw_runtime::observability::Observer> = Arc::new(prom);
         let state = AppState {
             config: Arc::new(Mutex::new(Config::default())),
             provider: Arc::new(MockProvider::default()),

--- a/crates/zeroclaw-gateway/src/lib.rs
+++ b/crates/zeroclaw-gateway/src/lib.rs
@@ -963,7 +963,11 @@ pub async fn run_gateway(
     );
     zeroclaw_runtime::observability::set_broadcast_hook(broadcast_layer);
 
-    let broadcast_observer: Arc<dyn zeroclaw_runtime::observability::Observer> = Arc::from(
+    // Bound into AppState. Not a broadcaster — the broadcaster is the
+    // `broadcast_layer` installed above as the global hook. This is the
+    // configured backend (Log/Prometheus/...) wrapped by `TeeObserver`,
+    // which tees events into the hook on every record.
+    let state_observer: Arc<dyn zeroclaw_runtime::observability::Observer> = Arc::from(
         zeroclaw_runtime::observability::create_observer(&config.observability),
     );
 
@@ -1009,7 +1013,7 @@ pub async fn run_gateway(
         nextcloud_talk_webhook_secret,
         wati: wati_channel,
         gmail_push: gmail_push_channel,
-        observer: broadcast_observer,
+        observer: state_observer,
         tools_registry,
         cost_tracker,
         event_tx,

--- a/crates/zeroclaw-gateway/src/sse.rs
+++ b/crates/zeroclaw-gateway/src/sse.rs
@@ -108,13 +108,16 @@ pub async fn handle_events_history(
 /// `observability::create_observer` — including the per-call observer the
 /// agent loop creates inside `process_message` — also reach `/api/events`
 /// clients.
-pub struct BroadcastObserver {
+///
+/// Crate-private: the constructor signature is intentionally not part of any
+/// stable surface, since it is wired directly into `run_gateway`.
+pub(crate) struct BroadcastObserver {
     tx: tokio::sync::broadcast::Sender<serde_json::Value>,
     buffer: Arc<EventBuffer>,
 }
 
 impl BroadcastObserver {
-    pub fn new(
+    pub(crate) fn new(
         tx: tokio::sync::broadcast::Sender<serde_json::Value>,
         buffer: Arc<EventBuffer>,
     ) -> Self {
@@ -264,5 +267,56 @@ mod tests {
 
         assert!(rx.try_recv().is_err(), "heartbeat should not broadcast");
         assert!(buffer.snapshot().is_empty());
+    }
+
+    /// End-to-end coverage of the wiring `run_gateway` performs at startup:
+    /// installing `BroadcastObserver` as the process-wide broadcast hook and
+    /// then building an observer through `create_observer` (the path the
+    /// agent loop takes inside `process_message`) must surface events on the
+    /// SSE broadcast channel. Codifies the load-bearing ordering so that
+    /// reordering or dropping `set_broadcast_hook` in `run_gateway` is caught
+    /// by `cargo test`, not by a silent regression in production.
+    #[test]
+    fn factory_observer_events_reach_broadcast_hook() {
+        // The broadcast hook is process-wide; serialize hook-touching tests
+        // within this test binary so they don't observe each other's state.
+        static HOOK_TEST_LOCK: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
+        let _guard = HOOK_TEST_LOCK.lock();
+
+        zeroclaw_runtime::observability::clear_broadcast_hook();
+
+        let (tx, mut rx) = tokio::sync::broadcast::channel(16);
+        let buffer = Arc::new(EventBuffer::new(16));
+        let bo: Arc<dyn Observer> = Arc::new(BroadcastObserver::new(tx, buffer.clone()));
+        zeroclaw_runtime::observability::set_broadcast_hook(bo);
+
+        // Same factory call site as `process_message` in the agent loop.
+        let cfg = zeroclaw_config::schema::ObservabilityConfig {
+            backend: "noop".into(),
+            ..Default::default()
+        };
+        let observer = zeroclaw_runtime::observability::create_observer(&cfg);
+
+        observer.record_event(&ObserverEvent::ToolCall {
+            tool: "shell".into(),
+            duration: std::time::Duration::from_millis(7),
+            success: true,
+        });
+
+        let value = rx
+            .try_recv()
+            .expect("factory-built observer event must reach the SSE broadcast channel");
+        assert_eq!(value["type"], "tool_call");
+        assert_eq!(value["tool"], "shell");
+        assert_eq!(value["success"], true);
+
+        let snap = buffer.snapshot();
+        assert_eq!(
+            snap.len(),
+            1,
+            "broadcast events must also land in the buffer"
+        );
+
+        zeroclaw_runtime::observability::clear_broadcast_hook();
     }
 }

--- a/crates/zeroclaw-gateway/src/sse.rs
+++ b/crates/zeroclaw-gateway/src/sse.rs
@@ -101,33 +101,33 @@ pub async fn handle_events_history(
     Json(serde_json::json!({ "events": events })).into_response()
 }
 
-/// Broadcast observer that forwards events to the SSE broadcast channel.
+/// Broadcast observer that fans events out to SSE subscribers.
+///
+/// Installed as the process-wide broadcast hook by [`crate::run_gateway`] so
+/// that events recorded by *any* observer built through
+/// `observability::create_observer` — including the per-call observer the
+/// agent loop creates inside `process_message` — also reach `/api/events`
+/// clients.
 pub struct BroadcastObserver {
-    inner: Box<dyn zeroclaw_runtime::observability::Observer>,
     tx: tokio::sync::broadcast::Sender<serde_json::Value>,
     buffer: Arc<EventBuffer>,
 }
 
 impl BroadcastObserver {
     pub fn new(
-        inner: Box<dyn zeroclaw_runtime::observability::Observer>,
         tx: tokio::sync::broadcast::Sender<serde_json::Value>,
         buffer: Arc<EventBuffer>,
     ) -> Self {
-        Self { inner, tx, buffer }
-    }
-
-    pub fn inner(&self) -> &dyn zeroclaw_runtime::observability::Observer {
-        self.inner.as_ref()
+        Self { tx, buffer }
     }
 }
 
 impl zeroclaw_runtime::observability::Observer for BroadcastObserver {
     fn record_event(&self, event: &zeroclaw_runtime::observability::ObserverEvent) {
-        // Forward to inner observer
-        self.inner.record_event(event);
-
-        // Broadcast to SSE subscribers
+        // Recording into the primary observer (logs / Prometheus) is the
+        // responsibility of whoever built the event source; `TeeObserver`
+        // takes care of that fan-out. Here we only translate to JSON and
+        // ship to SSE subscribers.
         let json = match event {
             zeroclaw_runtime::observability::ObserverEvent::LlmRequest {
                 provider, model, ..
@@ -193,12 +193,8 @@ impl zeroclaw_runtime::observability::Observer for BroadcastObserver {
         let _ = self.tx.send(json);
     }
 
-    fn record_metric(&self, metric: &zeroclaw_runtime::observability::traits::ObserverMetric) {
-        self.inner.record_metric(metric);
-    }
-
-    fn flush(&self) {
-        self.inner.flush();
+    fn record_metric(&self, _metric: &zeroclaw_runtime::observability::traits::ObserverMetric) {
+        // Metrics are not broadcast over SSE; the primary observer records them.
     }
 
     fn name(&self) -> &str {
@@ -207,5 +203,66 @@ impl zeroclaw_runtime::observability::Observer for BroadcastObserver {
 
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zeroclaw_runtime::observability::{Observer, ObserverEvent};
+
+    fn make_broadcast() -> (
+        Arc<BroadcastObserver>,
+        tokio::sync::broadcast::Receiver<serde_json::Value>,
+        Arc<EventBuffer>,
+    ) {
+        let (tx, rx) = tokio::sync::broadcast::channel(16);
+        let buffer = Arc::new(EventBuffer::new(16));
+        let obs = Arc::new(BroadcastObserver::new(tx, buffer.clone()));
+        (obs, rx, buffer)
+    }
+
+    #[test]
+    fn tool_call_event_is_broadcast_and_buffered() {
+        let (obs, mut rx, buffer) = make_broadcast();
+
+        obs.record_event(&ObserverEvent::ToolCall {
+            tool: "shell".into(),
+            duration: std::time::Duration::from_millis(42),
+            success: true,
+        });
+
+        let value = rx.try_recv().expect("event should be broadcast");
+        assert_eq!(value["type"], "tool_call");
+        assert_eq!(value["tool"], "shell");
+        assert_eq!(value["success"], true);
+
+        let snap = buffer.snapshot();
+        assert_eq!(snap.len(), 1);
+        assert_eq!(snap[0]["type"], "tool_call");
+    }
+
+    #[test]
+    fn tool_call_start_event_is_broadcast() {
+        let (obs, mut rx, _buffer) = make_broadcast();
+
+        obs.record_event(&ObserverEvent::ToolCallStart {
+            tool: "mcp_filesystem__read_file".into(),
+            arguments: None,
+        });
+
+        let value = rx.try_recv().expect("event should be broadcast");
+        assert_eq!(value["type"], "tool_call_start");
+        assert_eq!(value["tool"], "mcp_filesystem__read_file");
+    }
+
+    #[test]
+    fn unmapped_events_are_skipped() {
+        let (obs, mut rx, buffer) = make_broadcast();
+
+        obs.record_event(&ObserverEvent::HeartbeatTick);
+
+        assert!(rx.try_recv().is_err(), "heartbeat should not broadcast");
+        assert!(buffer.snapshot().is_empty());
     }
 }

--- a/crates/zeroclaw-runtime/src/observability/mod.rs
+++ b/crates/zeroclaw-runtime/src/observability/mod.rs
@@ -23,10 +23,82 @@ pub use traits::{Observer, ObserverEvent};
 #[allow(unused_imports)]
 pub use verbose::VerboseObserver;
 
+use std::any::Any;
+use std::sync::{Arc, OnceLock, RwLock};
+
+use traits::ObserverMetric;
 use zeroclaw_config::schema::ObservabilityConfig;
+
+/// Process-wide broadcast hook installed by long-running subsystems (today: the
+/// gateway) so that events emitted by observers built in *other* subsystems —
+/// notably the agent loop's `process_message` — also fan out to the SSE
+/// broadcast channel. Without this, observers created per call site stay
+/// isolated and `/api/events` only sees the gateway's own direct emissions.
+static BROADCAST_HOOK: OnceLock<RwLock<Option<Arc<dyn Observer>>>> = OnceLock::new();
+
+fn broadcast_hook_slot() -> &'static RwLock<Option<Arc<dyn Observer>>> {
+    BROADCAST_HOOK.get_or_init(|| RwLock::new(None))
+}
+
+/// Install a process-wide observer that will receive every event recorded
+/// through observers built by [`create_observer`]. Calling this again replaces
+/// the previous hook.
+pub fn set_broadcast_hook(observer: Arc<dyn Observer>) {
+    *broadcast_hook_slot().write().unwrap() = Some(observer);
+}
+
+/// Remove the broadcast hook, if any. Intended for tests and orderly shutdown.
+pub fn clear_broadcast_hook() {
+    *broadcast_hook_slot().write().unwrap() = None;
+}
+
+fn current_broadcast_hook() -> Option<Arc<dyn Observer>> {
+    broadcast_hook_slot().read().unwrap().clone()
+}
+
+/// Wrapper that forwards every event to a primary observer plus the
+/// process-wide broadcast hook (when set). Metrics flow only to the primary.
+struct TeeObserver {
+    primary: Box<dyn Observer>,
+}
+
+impl Observer for TeeObserver {
+    fn record_event(&self, event: &ObserverEvent) {
+        self.primary.record_event(event);
+        if let Some(hook) = current_broadcast_hook() {
+            hook.record_event(event);
+        }
+    }
+
+    fn record_metric(&self, metric: &ObserverMetric) {
+        self.primary.record_metric(metric);
+    }
+
+    fn flush(&self) {
+        self.primary.flush();
+    }
+
+    fn name(&self) -> &str {
+        // Delegate so callers (and tests) see the underlying backend name,
+        // not the internal wrapper.
+        self.primary.name()
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        // Expose the primary so downcasts (e.g. to PrometheusObserver in the
+        // gateway's /metrics handler) keep working transparently.
+        self.primary.as_any()
+    }
+}
 
 /// Factory: create the right observer from config
 pub fn create_observer(config: &ObservabilityConfig) -> Box<dyn Observer> {
+    Box::new(TeeObserver {
+        primary: create_primary_observer(config),
+    })
+}
+
+fn create_primary_observer(config: &ObservabilityConfig) -> Box<dyn Observer> {
     match config.backend.as_str() {
         "log" => Box::new(LogObserver::new()),
         "verbose" => Box::new(VerboseObserver::new()),
@@ -211,5 +283,118 @@ mod tests {
             ..ObservabilityConfig::default()
         };
         assert_eq!(create_observer(&cfg).name(), "noop");
+    }
+
+    use parking_lot::Mutex as PlMutex;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Test observer that counts events and metrics, used to verify the
+    /// broadcast hook fan-out and that downcasts pass through `TeeObserver`.
+    #[derive(Default)]
+    struct CountingObserver {
+        events: AtomicUsize,
+        metrics: AtomicUsize,
+    }
+
+    impl Observer for CountingObserver {
+        fn record_event(&self, _event: &ObserverEvent) {
+            self.events.fetch_add(1, Ordering::SeqCst);
+        }
+
+        fn record_metric(&self, _metric: &ObserverMetric) {
+            self.metrics.fetch_add(1, Ordering::SeqCst);
+        }
+
+        fn name(&self) -> &str {
+            "counting"
+        }
+
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+    }
+
+    /// Serialize tests that touch the process-wide broadcast hook so they
+    /// don't observe each other's installations.
+    static HOOK_TEST_LOCK: PlMutex<()> = PlMutex::new(());
+
+    #[test]
+    fn broadcast_hook_receives_events_from_factory_observer() {
+        let _guard = HOOK_TEST_LOCK.lock();
+        clear_broadcast_hook();
+
+        let hook = Arc::new(CountingObserver::default());
+        set_broadcast_hook(hook.clone());
+
+        let cfg = ObservabilityConfig {
+            backend: "noop".into(),
+            ..ObservabilityConfig::default()
+        };
+        let observer = create_observer(&cfg);
+
+        observer.record_event(&ObserverEvent::HeartbeatTick);
+        observer.record_event(&ObserverEvent::Error {
+            component: "x".into(),
+            message: "y".into(),
+        });
+
+        assert_eq!(hook.events.load(Ordering::SeqCst), 2);
+
+        clear_broadcast_hook();
+    }
+
+    #[test]
+    fn broadcast_hook_does_not_receive_metrics() {
+        let _guard = HOOK_TEST_LOCK.lock();
+        clear_broadcast_hook();
+
+        let hook = Arc::new(CountingObserver::default());
+        set_broadcast_hook(hook.clone());
+
+        let cfg = ObservabilityConfig {
+            backend: "noop".into(),
+            ..ObservabilityConfig::default()
+        };
+        let observer = create_observer(&cfg);
+
+        observer.record_metric(&ObserverMetric::TokensUsed(10));
+        observer.record_metric(&ObserverMetric::TokensUsed(20));
+
+        assert_eq!(hook.events.load(Ordering::SeqCst), 0);
+        assert_eq!(hook.metrics.load(Ordering::SeqCst), 0);
+
+        clear_broadcast_hook();
+    }
+
+    #[test]
+    fn broadcast_hook_unset_means_only_primary_runs() {
+        let _guard = HOOK_TEST_LOCK.lock();
+        clear_broadcast_hook();
+
+        let cfg = ObservabilityConfig {
+            backend: "noop".into(),
+            ..ObservabilityConfig::default()
+        };
+        let observer = create_observer(&cfg);
+
+        // No hook installed; recording must not panic and must be a no-op.
+        observer.record_event(&ObserverEvent::HeartbeatTick);
+        observer.record_metric(&ObserverMetric::TokensUsed(1));
+    }
+
+    #[test]
+    fn factory_observer_downcasts_through_tee() {
+        let _guard = HOOK_TEST_LOCK.lock();
+        clear_broadcast_hook();
+
+        let cfg = ObservabilityConfig {
+            backend: "log".into(),
+            ..ObservabilityConfig::default()
+        };
+        let observer = create_observer(&cfg);
+
+        // `as_any` must surface the primary observer so existing downcasts
+        // (e.g. PrometheusObserver in /metrics) keep working through the tee.
+        assert!(observer.as_any().downcast_ref::<LogObserver>().is_some());
     }
 }

--- a/crates/zeroclaw-runtime/src/observability/mod.rs
+++ b/crates/zeroclaw-runtime/src/observability/mod.rs
@@ -24,8 +24,9 @@ pub use traits::{Observer, ObserverEvent};
 pub use verbose::VerboseObserver;
 
 use std::any::Any;
-use std::sync::{Arc, OnceLock, RwLock};
+use std::sync::{Arc, OnceLock};
 
+use parking_lot::RwLock;
 use traits::ObserverMetric;
 use zeroclaw_config::schema::ObservabilityConfig;
 
@@ -34,6 +35,10 @@ use zeroclaw_config::schema::ObservabilityConfig;
 /// notably the agent loop's `process_message` — also fan out to the SSE
 /// broadcast channel. Without this, observers created per call site stay
 /// isolated and `/api/events` only sees the gateway's own direct emissions.
+///
+/// Uses `parking_lot::RwLock` so the event-recording path never has to handle
+/// lock poisoning: a panic inside a hook would not silently disable the entire
+/// observability channel on subsequent calls.
 static BROADCAST_HOOK: OnceLock<RwLock<Option<Arc<dyn Observer>>>> = OnceLock::new();
 
 fn broadcast_hook_slot() -> &'static RwLock<Option<Arc<dyn Observer>>> {
@@ -44,16 +49,16 @@ fn broadcast_hook_slot() -> &'static RwLock<Option<Arc<dyn Observer>>> {
 /// through observers built by [`create_observer`]. Calling this again replaces
 /// the previous hook.
 pub fn set_broadcast_hook(observer: Arc<dyn Observer>) {
-    *broadcast_hook_slot().write().unwrap() = Some(observer);
+    *broadcast_hook_slot().write() = Some(observer);
 }
 
 /// Remove the broadcast hook, if any. Intended for tests and orderly shutdown.
 pub fn clear_broadcast_hook() {
-    *broadcast_hook_slot().write().unwrap() = None;
+    *broadcast_hook_slot().write() = None;
 }
 
 fn current_broadcast_hook() -> Option<Arc<dyn Observer>> {
-    broadcast_hook_slot().read().unwrap().clone()
+    broadcast_hook_slot().read().clone()
 }
 
 /// Wrapper that forwards every event to a primary observer plus the


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Tool-call and other observer events emitted inside `process_message` never reached `/api/events` SSE subscribers because the gateway's `BroadcastObserver` only wrapped the per-state observer. Each call to `create_observer` (notably the per-call observer the agent loop builds in `process_message`) returned a fresh, isolated backend, so events from channels and webhook agent turns logged to Prometheus but were silently dropped at the SSE boundary. This PR plumbs a process-wide broadcast hook so events flowing through *any* factory-built observer also reach `/api/events`.
- **Approach:**
  - `crates/zeroclaw-runtime/src/observability/mod.rs`: introduce `set_broadcast_hook` / `clear_broadcast_hook` and an internal `TeeObserver` wrapper. `create_observer` now returns the configured backend wrapped in `TeeObserver`, which records every event to the primary backend *and* — when set — to the broadcast hook. `TeeObserver::as_any` returns the primary observer, so existing downcasts (PrometheusObserver) keep working transparently. Metrics are not broadcast.
  - `crates/zeroclaw-gateway/src/sse.rs`: `BroadcastObserver` becomes a pure broadcaster (no `inner` field, no metric forwarding). It is installed once as the broadcast hook on gateway startup.
  - `crates/zeroclaw-gateway/src/lib.rs`: gateway startup installs the broadcast hook, then builds its state-level observer through the regular factory; `prometheus_observer_from_state` simplifies to a single direct downcast.
- **Scope boundary:** No changes to the wire format of `/api/events` events, no new event types, no public API surface of `Observer`. This PR does not extend the SSE schema with MCP-server attribution or full tool I/O — those are tracked separately.
- **Blast radius:** Anything that calls `observability::create_observer` now produces a `TeeObserver`. Behavior is identical when the broadcast hook is unset (the default outside `run_gateway`). Inside `run_gateway`, agent-emitted events that previously reached only the configured backend now *also* reach SSE subscribers. The Prometheus `/metrics` endpoint, all observer downcasts, all log/Prometheus emission paths, and all existing event types remain unchanged.
- **Linked issue(s):** Closes [#6526](https://github.com/zeroclaw-labs/zeroclaw/issues/6526)

## Validation Evidence

```bash
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test -p zeroclaw-runtime --lib
cargo test -p zeroclaw-gateway --lib
```

- **`cargo fmt --all -- --check`** — clean (no diff).
- **`cargo clippy --workspace --all-targets -- -D warnings`** — clean. Tail:
  ```
  Checking zeroclaw-gateway v0.7.5 ...
  Checking zeroclawlabs v0.7.5 ...
  Checking xtask v0.7.5 ...
  Finished `dev` profile [unoptimized + debuginfo] target(s) in 7.37s
  ```
- **`cargo test -p zeroclaw-runtime --lib`** — `1634 passed; 0 failed; 1 ignored`. New tests in `observability::tests`:
  - `broadcast_hook_receives_events_from_factory_observer`
  - `broadcast_hook_does_not_receive_metrics`
  - `broadcast_hook_unset_means_only_primary_runs`
  - `factory_observer_downcasts_through_tee`
- **`cargo test -p zeroclaw-gateway --lib`** — `174 passed; 0 failed`. New tests in `sse::tests`:
  - `tool_call_event_is_broadcast_and_buffered`
  - `tool_call_start_event_is_broadcast`
  - `unmapped_events_are_skipped`
- **`cargo test -p zeroclaw-channels --lib`** — `942 passed; 2 failed` for `orchestrator::tests::build_channel_by_id_*_telegram_*`. **These two failures pre-exist on `origin/master` (verified by running them on a clean detached worktree at `465ec0c8b`)** and are unrelated to this change — the error is `Unknown channel 'telegram'`, which suggests a feature-gate or fixture issue in the channel registry test setup.

- **Beyond CI — what did you manually verify?**
  - Bug reproduces on `origin/master`: built `zeroclaw daemon`, paired a client, subscribed to `/api/events`, sent a chat through `/ws/chat` that triggered a shell tool — only `agent_start` / `agent_end` arrived (gateway-direct), no `tool_call` events.
  - With this fix on the same setup, `tool_call_start` and `tool_call` events now arrive in the SSE stream for the same agent turns, and `EventBuffer` retains them for `/api/events/history`.
  - Spot-checked that `/metrics` still returns the configured Prometheus backend (verified via the existing `metrics_endpoint_renders_prometheus_output` test on the new code path).
- **What I did NOT verify:** the OTel backend path (no local OTLP collector); behavior when multiple `run_gateway` instances are spawned in the same process (not a supported configuration today).

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

The broadcast hook only fans events that *already* reach `/api/events` clients today via the gateway's direct emission path. SSE auth (`require_pairing` + bearer token) is unchanged — the same `Authorization: Bearer <token>` check at `crates/zeroclaw-gateway/src/sse.rs:56-70` continues to gate subscribers. No new event content is exposed; the JSON payload schema (event names, fields, timestamp format) is byte-identical to before.

## Compatibility

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`

`Observer`, `ObserverEvent`, and `ObserverMetric` are unchanged. `create_observer` keeps the same signature; the wrapper is internal. The only public additions are `observability::set_broadcast_hook` and `observability::clear_broadcast_hook`. Existing crates that consume `create_observer` continue to compile and behave identically when the broadcast hook is unset (i.e. outside the gateway).

`BroadcastObserver::new` signature changed (`inner` argument dropped), and the `inner()` accessor was removed. The type is `pub(crate)` and only used inside `run_gateway`; the only external call sites in this workspace were the gateway itself and one in-tree test, both updated.

## Rollback

Risk classification: **high** (touches `crates/zeroclaw-gateway/src/**` and `crates/zeroclaw-runtime/src/**`, but the change is observably scoped to event fan-out and exercised by new tests).

- **Fast rollback:** `git revert <commit-shas>`. The change spans three commits on this branch — revert in reverse order, or revert the squash-merge commit on `master`.
- **Feature flags or config toggles:** none. The behavior can also be effectively disabled at runtime by not calling `set_broadcast_hook`, which restores pre-PR semantics for the agent observer path.
- **Observable failure symptoms:**
  - `/api/events` subscribers stop receiving events (regression of the fix) — would surface as the dashboard `/logs` view going silent during agent turns.
  - Prometheus `/metrics` returns "Prometheus backend not enabled" when the configured backend is `prometheus` — would indicate the `as_any` delegation in `TeeObserver` is broken.
  - Heap growth on the gateway broadcast channel — would indicate metrics or unmapped events are being shipped over SSE; covered by the new `unmapped_events_are_skipped` and `broadcast_hook_does_not_receive_metrics` tests.


