### PR TITLE
fix(config): respect ZEROCLAW_CONFIG_DIR in path field defaults

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -9667,6 +9667,13 @@ struct ActiveWorkspaceState {
 }
 
 fn default_config_dir() -> Result<PathBuf> {
+    if let Ok(custom) = std::env::var("ZEROCLAW_CONFIG_DIR") {
+        let custom = custom.trim();
+        if !custom.is_empty() {
+            return Ok(expand_tilde_path(custom));
+        }
+    }
+
     if let Ok(home) = std::env::var("HOME")
         && !home.is_empty()
     {
@@ -15302,6 +15309,25 @@ model = "primary-model"
         assert_eq!(resolved_workspace_dir, default_workspace_dir);
 
         let _ = fs::remove_dir_all(default_config_dir).await;
+    }
+
+    #[test]
+    async fn default_path_under_config_dir_respects_zeroclaw_config_dir() {
+        let _env_guard = env_override_lock().await;
+        let custom_dir = std::env::temp_dir().join("zeroclaw-test-profile");
+        // SAFETY: test-only, single-threaded test runner.
+        unsafe { std::env::set_var("ZEROCLAW_CONFIG_DIR", &custom_dir) };
+
+        let result = default_path_under_config_dir("knowledge.db");
+
+        // SAFETY: test-only, single-threaded test runner.
+        unsafe { std::env::remove_var("ZEROCLAW_CONFIG_DIR") };
+
+        assert_eq!(
+            result,
+            custom_dir.join("knowledge.db").to_string_lossy().as_ref(),
+            "expected path under ZEROCLAW_CONFIG_DIR, got: {result}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
default_config_dir() now checks ZEROCLAW_CONFIG_DIR before falling back to ~/.zeroclaw, so all seven path-field defaults (knowledge.db_path, workspace.workspaces_dir, plugins.dir, project_intel.report_dir, security_ops.estop_state_file, playbooks_dir, report_output_dir) point into the active profile when a custom config dir is set.

## Summary

  - **Base branch:** `master` (all contributions)
  - **What changed and why:**
    - `default_config_dir()` in `crates/zeroclaw-config/src/schema.rs` now checks `ZEROCLAW_CONFIG_DIR` before falling back to `~/.zeroclaw`. Previously
  the env var was honoured for config *file* discovery but ignored when computing path-field *defaults*, so setting a custom config dir only half-worked.
    - All seven path-field serde defaults — `knowledge.db_path`, `workspace.workspaces_dir`, `plugins.dir`, `project_intel.report_dir`,
  `security_ops.estop_state_file`, `playbooks_dir`, and `report_output_dir` — now resolve under the active config dir instead of always resolving under
  `~/.zeroclaw`.
    - A unit test (`default_path_under_config_dir_respects_zeroclaw_config_dir`) verifies the new behaviour under `ZEROCLAW_CONFIG_DIR`.
  - **Scope boundary:** Does not change how the config *file* itself is located, does not affect `ZEROCLAW_WORKSPACE` or any other env variable, and does
  not modify any stored config values — only the computed default when a field is absent from the TOML.
  - **Blast radius:** Any deployment that sets `ZEROCLAW_CONFIG_DIR` and omits one or more of the seven path fields from their TOML will now get paths
  under the custom dir instead of `~/.zeroclaw`. Deployments that use an explicit value for every path field are unaffected.
  - **Linked issue(s):** Closes #5605

  ## Validation Evidence (required)

  **Commands run and tail output:**

  ```
  $ cargo fmt --all -- --check
  (no output — clean)

  $ cargo clippy -p zeroclaw-config --all-targets -- -D warnings
      Finished `dev` profile [unoptimized + debuginfo] target(s) in 16.55s
  (no warnings)


  $ cargo test -p zeroclaw-config -- --test-threads=1
  test schema::tests::config_dir_creation_error_mentions_openrc_and_path ... ok
  test schema::tests::persist_active_workspace_marker_is_cleared_for_default_config_dir ... ok
  test schema::tests::resolve_runtime_config_dirs_falls_back_to_default_layout ... ok
  test schema::tests::resolve_runtime_config_dirs_uses_active_workspace_marker ... ok
  test schema::tests::resolve_runtime_config_dirs_uses_env_config_dir_first ... ok
  test schema::tests::resolve_runtime_config_dirs_uses_env_workspace_first ... ok
  test result: ok. 620 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.54s
  ```

  **Beyond CI — what did you manually verify?**
  - Set `ZEROCLAW_CONFIG_DIR=/tmp/test-profile` and confirmed a fresh `load_or_init` places `knowledge.db`, workspaces dir, and plugins dir under
  `/tmp/test-profile/` rather than `~/.zeroclaw/`.
  - Verified that unsetting `ZEROCLAW_CONFIG_DIR` restores the `~/.zeroclaw` default.
  - Verified that a TOML with an explicit `knowledge.db_path` value is unaffected (serde default is never invoked).
  - Did NOT verify behaviour when `ZEROCLAW_CONFIG_DIR` is set to a path requiring `~` expansion — `expand_tilde_path` is called, but this was not
  exercised end-to-end.

  **If any command was intentionally skipped, why:** Full `cargo test` (all crates) was not run against this branch because the change is isolated to
  `zeroclaw-config` and the full config-crate suite passed.

  ## Security & Privacy Impact (required)

  - New permissions, capabilities, or file system access scope? **Yes** — the daemon will now read/write the DB and workspace files under
  `$ZEROCLAW_CONFIG_DIR` when set, rather than always under `~/.zeroclaw`. This is the intended behaviour; the env var is operator-controlled and already
  gates config file access.
  - New external network calls? **No**
  - Secrets / tokens / credentials handling changed? **No**
  - PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

  ## Compatibility (required)

  - Backward compatible? **Yes** — deployments that do not set `ZEROCLAW_CONFIG_DIR` are unaffected; the fallback path is unchanged.
  - Config / env / CLI surface changed? **Yes** — `ZEROCLAW_CONFIG_DIR` now has the additional effect of redirecting path-field defaults. Operators who
  set this variable expecting *only* the config file to move will see data paths move as well.
  - Exact upgrade steps for existing users who set `ZEROCLAW_CONFIG_DIR`: confirm that the seven defaulted paths now point to the custom dir and that any
  data previously written to `~/.zeroclaw/` is migrated or symlinked if needed.

  ## Rollback

  `git revert 19419865` is the plan. No feature flags. Symptom of regression: daemon fails to find `knowledge.db` or workspaces dir when
  `ZEROCLAW_CONFIG_DIR` is set, with a file-not-found or permission error at startup.

