### PR TITLE
fix(gateway): return onboarding error from ws chat

### DIFF
--- a/crates/zeroclaw-gateway/src/ws.rs
+++ b/crates/zeroclaw-gateway/src/ws.rs
@@ -325,6 +325,11 @@ async fn handle_socket(
         }
     };
 
+    if let Some(err) = needs_onboarding_ws_error(&config) {
+        let _ = sender.send(Message::Text(err.to_string().into())).await;
+        return;
+    }
+
     // Build a persistent Agent for this connection so history is maintained
     // across turns. The session cwd becomes the security sandbox root; config
     // workspace remains the daemon data directory.
@@ -606,6 +611,20 @@ fn resolve_session_cwd(
         .unwrap_or_else(|| default_workspace.to_path_buf());
     std::fs::canonicalize(&cwd)
         .map_err(|e| anyhow::anyhow!("cwd is not a usable directory ({}): {e}", cwd.display()))
+}
+
+fn needs_onboarding_ws_error(
+    config: &zeroclaw_config::schema::Config,
+) -> Option<serde_json::Value> {
+    let model = config.providers.resolve_default_model().unwrap_or_default();
+    crate::needs_onboarding_for(&model)?;
+    Some(serde_json::json!({
+        "type": "error",
+        "error": "needs_onboarding",
+        "code": "NEEDS_ONBOARDING",
+        "message": crate::needs_onboarding_channel_reply(),
+        "url": "/onboard",
+    }))
 }
 
 /// Process a single chat message through the agent and send the response.
@@ -1198,5 +1217,45 @@ mod tests {
             .expect_err("missing cwd should be rejected");
 
         assert!(err.to_string().contains("cwd is not a usable directory"));
+    }
+
+    #[test]
+    fn needs_onboarding_ws_error_points_to_onboard() {
+        let config = zeroclaw_config::schema::Config::default();
+        let frame = needs_onboarding_ws_error(&config)
+            .expect("empty model must produce a WS onboarding error");
+
+        assert_eq!(frame["type"], "error");
+        assert_eq!(frame["error"], "needs_onboarding");
+        assert_eq!(frame["code"], "NEEDS_ONBOARDING");
+        assert_eq!(frame["url"], "/onboard");
+        let message = frame["message"]
+            .as_str()
+            .expect("onboarding WS error must include a message");
+        assert!(
+            !message.starts_with('{') && !message.ends_with('}'),
+            "missing Fluent key fallback leaked into WS error message: {message:?}"
+        );
+        assert!(
+            message.to_lowercase().contains("onboarding"),
+            "WS onboarding message must explain the setup gap: {message:?}"
+        );
+    }
+
+    #[test]
+    fn needs_onboarding_ws_error_uses_current_configured_model() {
+        let mut config = zeroclaw_config::schema::Config {
+            providers: zeroclaw_config::providers::ProvidersConfig {
+                fallback: Some("openai".to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        config.ensure_fallback_provider().model = Some("openai/gpt-4o-mini".to_string());
+
+        assert!(
+            needs_onboarding_ws_error(&config).is_none(),
+            "current configured model must allow WebSocket agent construction to continue"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Return the existing structured `needs_onboarding` WebSocket error before constructing a gateway chat agent when the current config has no usable model.
  - Reuse the same onboarding message and `/onboard` URL used by the gateway/channel no-model path so browser chat clients get operator-facing setup guidance instead of a raw agent initialization failure.
  - Add focused gateway tests for the empty-config path and the configured-model path so the guard does not stale-block a config that gained a model.
- **Scope boundary:** This PR does not change onboarding UI, provider config loading, REST `/webhook` behavior, or Eyrie's adapter behavior. It only aligns `/ws/chat` with the existing no-model onboarding contract.
- **Blast radius:** `crates/zeroclaw-gateway/src/ws.rs`; gateway WebSocket chat clients, including the dashboard and [Eyrie](https://github.com/Audacity88/eyrie), see a different error frame only when no model is configured.
- **Linked issue(s):** Related #6493.
- **Labels:** `bug`, `gateway`, `risk: high`, `size: S`.

## Validation Evidence (required)

- **Commands run and tail output:**

```text
git diff --check
Result: passed.

cargo fmt --all -- --check
Result: passed in 2.898s after rebasing onto origin/master at c522344e1.

cargo test -p zeroclaw-gateway needs_onboarding_ws_error --lib
Result: passed in 3m31.23s after the Simplify correction and cold target rebuild.
Tests: 2 passed; 0 failed; 171 filtered out.

cargo build --bin zeroclaw
Result: passed in 2m24.19s after cold target rebuild.

node tmp/ws-probe/no_model_ws_probe.mjs
Result: passed against the patched gateway after running the localhost gateway/probe outside the sandbox.
Observed: session_start followed by {"code":"NEEDS_ONBOARDING","error":"needs_onboarding","url":"/onboard",...}.

ZEROCLAW_TEST_PORT=49185 node tmp/ws-probe/no_model_ws_probe.mjs
Result: unpatched comparison reproduced the old behavior.
Observed: session_start followed by {"code":"AGENT_INIT_FAILED","message":"Failed to initialise agent: no model configured...",...}.
```

- **Beyond CI — what did you manually verify?** With the same no-model scratch config, the patched gateway on `/ws/chat` returned `NEEDS_ONBOARDING` with `/onboard`. A live Eyrie UI check displayed: `This agent isn't fully set up yet. The operator needs to complete onboarding before I can reply.` The unpatched binary was then run through the same Eyrie setup and reproduced the old red `Failed to initialise agent: no model configured...` UI error.
- **Post-rebase note:** The focused test, build, direct probe, and Eyrie UI checks ran before the final rebase. After rebasing onto `c522344e1`, which did not touch `crates/zeroclaw-gateway/src/ws.rs`, I reran `git diff --check` and `cargo fmt --all -- --check`.
- **If any command was intentionally skipped, why:** Full workspace `cargo test` and full workspace clippy were not run because this is a one-file gateway WebSocket guard and focused gateway tests plus live patched/unpatched probes cover the changed behavior.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: `N/A`

This change fails earlier in an existing local gateway WebSocket path. It does not relax pairing, bearer-token handling, sandbox scope, provider credential handling, or tool execution policy.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: exact upgrade steps for existing users: Existing users do not need to change config. In the no-model state, `/ws/chat` now returns the same structured onboarding error shape as the gateway/channel no-model path instead of exposing the lower-level agent initialization failure.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <merge-commit-or-squash-sha>`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** WebSocket chat clients fail to start normal configured-model conversations, or gateway logs show unexpected `needs_onboarding` errors for configs that contain a valid `[providers.models.<name>] model = "..."`.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): `N/A`
- Scope materially carried forward: `N/A`
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why (inspiration-only, no direct code/design carry-over): This is a narrow follow-up to the #6493 behavior gap, not a superseding PR.
