### PR TITLE
fix(runtime): require shell approval in direct sessions

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/acp_server.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/acp_server.rs
@@ -560,7 +560,7 @@ impl AcpServer {
         // the file/shell sandbox boundary. The agent's data directory
         // (memory DB, identity, scheduled tasks) still lives under
         // `config.workspace_dir`.
-        let agent = Agent::from_config_with_session_cwd_and_mcp(
+        let agent = Agent::from_config_with_session_cwd_and_mcp_backchannel(
             &self.config,
             Some(std::path::Path::new(&workspace_dir)),
             false,

--- a/crates/zeroclaw-gateway/src/ws.rs
+++ b/crates/zeroclaw-gateway/src/ws.rs
@@ -328,32 +328,34 @@ async fn handle_socket(
     // Build a persistent Agent for this connection so history is maintained
     // across turns. The session cwd becomes the security sandbox root; config
     // workspace remains the daemon data directory.
-    let mut agent = match zeroclaw_runtime::agent::Agent::from_config_with_session_cwd(
-        &config,
-        Some(&session_cwd),
-    )
-    .await
-    {
-        Ok(a) => a,
-        Err(e) => {
-            tracing::error!(error = %e, "Agent initialization failed");
-            let err = serde_json::json!({
-                "type": "error",
-                "message": format!("Failed to initialise agent: {e}"),
-                "code": "AGENT_INIT_FAILED"
-            });
-            let _ = sender.send(Message::Text(err.to_string().into())).await;
-            let _ = sender
-                .send(Message::Close(Some(axum::extract::ws::CloseFrame {
-                    code: 1011,
-                    reason: axum::extract::ws::Utf8Bytes::from_static(
-                        "Agent initialization failed",
-                    ),
-                })))
-                .await;
-            return;
-        }
-    };
+    let mut agent =
+        match zeroclaw_runtime::agent::Agent::from_config_with_session_cwd_and_mcp_backchannel(
+            &config,
+            Some(&session_cwd),
+            true,
+        )
+        .await
+        {
+            Ok(a) => a,
+            Err(e) => {
+                tracing::error!(error = %e, "Agent initialization failed");
+                let err = serde_json::json!({
+                    "type": "error",
+                    "message": format!("Failed to initialise agent: {e}"),
+                    "code": "AGENT_INIT_FAILED"
+                });
+                let _ = sender.send(Message::Text(err.to_string().into())).await;
+                let _ = sender
+                    .send(Message::Close(Some(axum::extract::ws::CloseFrame {
+                        code: 1011,
+                        reason: axum::extract::ws::Utf8Bytes::from_static(
+                            "Agent initialization failed",
+                        ),
+                    })))
+                    .await;
+                return;
+            }
+        };
     agent.set_memory_session_id(Some(memory_session_id));
     if !stored_messages.is_empty() {
         agent.seed_history(&stored_messages);

--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -4,7 +4,7 @@ use crate::agent::dispatcher::{
 use crate::agent::eval::AutoClassifyExt;
 use crate::agent::memory_loader::{DefaultMemoryLoader, MemoryLoader};
 use crate::agent::prompt::{PromptContext, SystemPromptBuilder};
-use crate::approval::{ApprovalManager, ApprovalRequest, ApprovalResponse};
+use crate::approval::{ApprovalManager, ApprovalRequest, ApprovalRequirement, ApprovalResponse};
 use crate::observability::{self, Observer, ObserverEvent};
 use crate::platform;
 use crate::security::SecurityPolicy;
@@ -475,6 +475,37 @@ impl Agent {
         session_cwd: Option<&Path>,
         initialize_mcp: bool,
     ) -> Result<Self> {
+        Self::from_config_with_session_cwd_and_mcp_approval_mode(
+            config,
+            session_cwd,
+            initialize_mcp,
+            false,
+        )
+        .await
+    }
+
+    /// Build an Agent for direct ACP/WS sessions that have a client approval
+    /// back-channel. This keeps shell approval on the runtime-controlled path.
+    pub async fn from_config_with_session_cwd_and_mcp_backchannel(
+        config: &Config,
+        session_cwd: Option<&Path>,
+        initialize_mcp: bool,
+    ) -> Result<Self> {
+        Self::from_config_with_session_cwd_and_mcp_approval_mode(
+            config,
+            session_cwd,
+            initialize_mcp,
+            true,
+        )
+        .await
+    }
+
+    async fn from_config_with_session_cwd_and_mcp_approval_mode(
+        config: &Config,
+        session_cwd: Option<&Path>,
+        initialize_mcp: bool,
+        approval_backchannel: bool,
+    ) -> Result<Self> {
         let observer: Arc<dyn Observer> =
             Arc::from(observability::create_observer(&config.observability));
         let runtime: Arc<dyn platform::RuntimeAdapter> =
@@ -686,6 +717,12 @@ impl Agent {
         let skills = crate::skills::load_skills_with_config(&config.workspace_dir, config);
         tools::register_skill_tools(&mut tools, &skills, security.clone());
 
+        let approval_manager = if approval_backchannel {
+            ApprovalManager::for_non_interactive_backchannel(&config.autonomy)
+        } else {
+            ApprovalManager::for_non_interactive(&config.autonomy)
+        };
+
         let mut agent = Agent::builder()
             .provider(provider)
             .tools(tools)
@@ -730,9 +767,7 @@ impl Agent {
             } else {
                 None
             })
-            .approval_manager(Some(Arc::new(ApprovalManager::for_non_interactive(
-                &config.autonomy,
-            ))))
+            .approval_manager(Some(Arc::new(approval_manager)))
             .build()?;
 
         agent.channel_handles = AgentChannelHandles {
@@ -837,12 +872,19 @@ impl Agent {
             }
         }
 
+        super::set_runtime_approved_arg(&tool_name, &mut tool_args, false);
+
         // ── Approval hook ──────────────────────────────────────
         // The ACP/WebSocket Agent path executes tools directly instead of
         // going through run_tool_call_loop. Keep its policy behavior aligned
         // with the shared loop by honoring auto_approve / always_ask here too.
+        let mut approval_requirement = self
+            .approval_manager
+            .as_deref()
+            .map(|mgr| mgr.approval_requirement(&tool_name))
+            .unwrap_or(ApprovalRequirement::NotRequired);
         if let Some(mgr) = self.approval_manager.as_deref()
-            && mgr.needs_approval(&tool_name)
+            && approval_requirement == ApprovalRequirement::Prompt
         {
             let request = ApprovalRequest {
                 tool_name: tool_name.clone(),
@@ -927,7 +969,16 @@ impl Agent {
                     tool_call_id: call.tool_call_id.clone(),
                 };
             }
+
+            if matches!(decision, ApprovalResponse::Yes | ApprovalResponse::Always) {
+                approval_requirement = ApprovalRequirement::Approved;
+            }
         }
+        super::set_runtime_approved_arg(
+            &tool_name,
+            &mut tool_args,
+            approval_requirement == ApprovalRequirement::Approved,
+        );
 
         // First try to find tool in static registry, then in activated MCP tools.
         let (result, success) =
@@ -1848,6 +1899,38 @@ mod tests {
         }
     }
 
+    struct CapturingApprovalArgTool {
+        name: &'static str,
+        output: &'static str,
+        calls: Arc<AtomicUsize>,
+        last_args: Arc<std::sync::Mutex<Option<serde_json::Value>>>,
+    }
+
+    #[async_trait]
+    impl Tool for CapturingApprovalArgTool {
+        fn name(&self) -> &str {
+            self.name
+        }
+
+        fn description(&self) -> &str {
+            self.name
+        }
+
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object"})
+        }
+
+        async fn execute(&self, args: serde_json::Value) -> Result<crate::tools::ToolResult> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            *self.last_args.lock().unwrap() = Some(args);
+            Ok(crate::tools::ToolResult {
+                success: true,
+                output: self.output.into(),
+                error: None,
+            })
+        }
+    }
+
     struct ApprovalChannel {
         response: zeroclaw_api::channel::ChannelApprovalResponse,
         requests: Arc<AtomicUsize>,
@@ -2027,6 +2110,265 @@ mod tests {
         assert_eq!(result.output, "Denied by user.");
         assert_eq!(approval_requests.load(Ordering::SeqCst), 1);
         assert_eq!(tool_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn direct_agent_shell_does_not_trust_model_supplied_approved_arg() {
+        let provider = Box::new(MockProvider {
+            responses: Mutex::new(vec![]),
+        });
+        let memory_cfg = zeroclaw_config::schema::MemoryConfig {
+            backend: "none".into(),
+            ..zeroclaw_config::schema::MemoryConfig::default()
+        };
+        let mem: Arc<dyn Memory> = Arc::from(
+            zeroclaw_memory::create_memory(&memory_cfg, std::path::Path::new("/tmp"), None)
+                .expect("memory creation should succeed with valid config"),
+        );
+        let observer: Arc<dyn Observer> = Arc::from(crate::observability::NoopObserver {});
+        let tool_calls = Arc::new(AtomicUsize::new(0));
+        let approval_requests = Arc::new(AtomicUsize::new(0));
+        let captured_args = Arc::new(std::sync::Mutex::new(None));
+        let approval_cfg = zeroclaw_config::schema::AutonomyConfig::default();
+        let mut agent = Agent::builder()
+            .provider(provider)
+            .tools(vec![Box::new(CapturingApprovalArgTool {
+                name: "shell",
+                output: "shell-out",
+                calls: Arc::clone(&tool_calls),
+                last_args: Arc::clone(&captured_args),
+            })])
+            .memory(mem)
+            .observer(observer)
+            .tool_dispatcher(Box::new(NativeToolDispatcher))
+            .workspace_dir(std::path::PathBuf::from("/tmp"))
+            .approval_manager(Some(Arc::new(
+                ApprovalManager::for_non_interactive_backchannel(&approval_cfg),
+            )))
+            .build()
+            .expect("agent builder should succeed with valid config");
+
+        let handle: tools::ChannelMapHandle = Arc::new(parking_lot::RwLock::new(HashMap::new()));
+        agent.channel_handles.ask_user = Some(Arc::clone(&handle));
+        let channel: Arc<dyn zeroclaw_api::channel::Channel> = Arc::new(ApprovalChannel {
+            response: zeroclaw_api::channel::ChannelApprovalResponse::Deny,
+            requests: Arc::clone(&approval_requests),
+        });
+        handle.write().insert("acp".to_string(), channel);
+
+        let result = agent
+            .execute_tool_call(&ParsedToolCall {
+                name: "shell".into(),
+                arguments: serde_json::json!({
+                    "command": "touch should-not-run",
+                    "approved": true
+                }),
+                tool_call_id: Some("tc1".into()),
+            })
+            .await;
+
+        assert!(!result.success);
+        assert_eq!(result.output, "Denied by user.");
+        assert_eq!(approval_requests.load(Ordering::SeqCst), 1);
+        assert_eq!(tool_calls.load(Ordering::SeqCst), 0);
+        assert!(captured_args.lock().unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn direct_agent_shell_marks_args_approved_after_backchannel_approval() {
+        let provider = Box::new(MockProvider {
+            responses: Mutex::new(vec![]),
+        });
+        let memory_cfg = zeroclaw_config::schema::MemoryConfig {
+            backend: "none".into(),
+            ..zeroclaw_config::schema::MemoryConfig::default()
+        };
+        let mem: Arc<dyn Memory> = Arc::from(
+            zeroclaw_memory::create_memory(&memory_cfg, std::path::Path::new("/tmp"), None)
+                .expect("memory creation should succeed with valid config"),
+        );
+        let observer: Arc<dyn Observer> = Arc::from(crate::observability::NoopObserver {});
+        let tool_calls = Arc::new(AtomicUsize::new(0));
+        let approval_requests = Arc::new(AtomicUsize::new(0));
+        let captured_args = Arc::new(std::sync::Mutex::new(None));
+        let approval_cfg = zeroclaw_config::schema::AutonomyConfig::default();
+        let mut agent = Agent::builder()
+            .provider(provider)
+            .tools(vec![Box::new(CapturingApprovalArgTool {
+                name: "shell",
+                output: "shell-out",
+                calls: Arc::clone(&tool_calls),
+                last_args: Arc::clone(&captured_args),
+            })])
+            .memory(mem)
+            .observer(observer)
+            .tool_dispatcher(Box::new(NativeToolDispatcher))
+            .workspace_dir(std::path::PathBuf::from("/tmp"))
+            .approval_manager(Some(Arc::new(
+                ApprovalManager::for_non_interactive_backchannel(&approval_cfg),
+            )))
+            .build()
+            .expect("agent builder should succeed with valid config");
+
+        let handle: tools::ChannelMapHandle = Arc::new(parking_lot::RwLock::new(HashMap::new()));
+        agent.channel_handles.ask_user = Some(Arc::clone(&handle));
+        let channel: Arc<dyn zeroclaw_api::channel::Channel> = Arc::new(ApprovalChannel {
+            response: zeroclaw_api::channel::ChannelApprovalResponse::Approve,
+            requests: Arc::clone(&approval_requests),
+        });
+        handle.write().insert("acp".to_string(), channel);
+
+        let result = agent
+            .execute_tool_call(&ParsedToolCall {
+                name: "shell".into(),
+                arguments: serde_json::json!({
+                    "command": "touch should-run-after-human-approval",
+                    "approved": false
+                }),
+                tool_call_id: Some("tc1".into()),
+            })
+            .await;
+
+        assert!(result.success);
+        assert_eq!(result.output, "shell-out");
+        assert_eq!(approval_requests.load(Ordering::SeqCst), 1);
+        assert_eq!(tool_calls.load(Ordering::SeqCst), 1);
+        let args = captured_args
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("shell tool should capture executed args");
+        assert_eq!(args["approved"], true);
+    }
+
+    #[tokio::test]
+    async fn direct_agent_shell_keeps_runtime_approval_from_always_allowlist() {
+        let provider = Box::new(MockProvider {
+            responses: Mutex::new(vec![]),
+        });
+        let memory_cfg = zeroclaw_config::schema::MemoryConfig {
+            backend: "none".into(),
+            ..zeroclaw_config::schema::MemoryConfig::default()
+        };
+        let mem: Arc<dyn Memory> = Arc::from(
+            zeroclaw_memory::create_memory(&memory_cfg, std::path::Path::new("/tmp"), None)
+                .expect("memory creation should succeed with valid config"),
+        );
+        let observer: Arc<dyn Observer> = Arc::from(crate::observability::NoopObserver {});
+        let tool_calls = Arc::new(AtomicUsize::new(0));
+        let approval_requests = Arc::new(AtomicUsize::new(0));
+        let captured_args = Arc::new(std::sync::Mutex::new(None));
+        let approval_cfg = zeroclaw_config::schema::AutonomyConfig::default();
+        let mut agent = Agent::builder()
+            .provider(provider)
+            .tools(vec![Box::new(CapturingApprovalArgTool {
+                name: "shell",
+                output: "shell-out",
+                calls: Arc::clone(&tool_calls),
+                last_args: Arc::clone(&captured_args),
+            })])
+            .memory(mem)
+            .observer(observer)
+            .tool_dispatcher(Box::new(NativeToolDispatcher))
+            .workspace_dir(std::path::PathBuf::from("/tmp"))
+            .approval_manager(Some(Arc::new(
+                ApprovalManager::for_non_interactive_backchannel(&approval_cfg),
+            )))
+            .build()
+            .expect("agent builder should succeed with valid config");
+
+        let handle: tools::ChannelMapHandle = Arc::new(parking_lot::RwLock::new(HashMap::new()));
+        agent.channel_handles.ask_user = Some(Arc::clone(&handle));
+        let channel: Arc<dyn zeroclaw_api::channel::Channel> = Arc::new(ApprovalChannel {
+            response: zeroclaw_api::channel::ChannelApprovalResponse::AlwaysApprove,
+            requests: Arc::clone(&approval_requests),
+        });
+        handle.write().insert("acp".to_string(), channel);
+
+        let first_result = agent
+            .execute_tool_call(&ParsedToolCall {
+                name: "shell".into(),
+                arguments: serde_json::json!({
+                    "command": "touch should-run-after-always-approval",
+                    "approved": false
+                }),
+                tool_call_id: Some("tc1".into()),
+            })
+            .await;
+        let second_result = agent
+            .execute_tool_call(&ParsedToolCall {
+                name: "shell".into(),
+                arguments: serde_json::json!({
+                    "command": "touch should-run-from-allowlist",
+                    "approved": false
+                }),
+                tool_call_id: Some("tc2".into()),
+            })
+            .await;
+
+        assert!(first_result.success);
+        assert!(second_result.success);
+        assert_eq!(approval_requests.load(Ordering::SeqCst), 1);
+        assert_eq!(tool_calls.load(Ordering::SeqCst), 2);
+        let args = captured_args
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("shell tool should capture executed args");
+        assert_eq!(args["approved"], true);
+    }
+
+    #[tokio::test]
+    async fn direct_agent_cron_add_does_not_trust_model_supplied_approved_arg() {
+        let provider = Box::new(MockProvider {
+            responses: Mutex::new(vec![]),
+        });
+        let memory_cfg = zeroclaw_config::schema::MemoryConfig {
+            backend: "none".into(),
+            ..zeroclaw_config::schema::MemoryConfig::default()
+        };
+        let mem: Arc<dyn Memory> = Arc::from(
+            zeroclaw_memory::create_memory(&memory_cfg, std::path::Path::new("/tmp"), None)
+                .expect("memory creation should succeed with valid config"),
+        );
+        let observer: Arc<dyn Observer> = Arc::from(crate::observability::NoopObserver {});
+        let tool_calls = Arc::new(AtomicUsize::new(0));
+        let captured_args = Arc::new(std::sync::Mutex::new(None));
+        let agent = Agent::builder()
+            .provider(provider)
+            .tools(vec![Box::new(CapturingApprovalArgTool {
+                name: "cron_add",
+                output: "cron-out",
+                calls: Arc::clone(&tool_calls),
+                last_args: Arc::clone(&captured_args),
+            })])
+            .memory(mem)
+            .observer(observer)
+            .tool_dispatcher(Box::new(NativeToolDispatcher))
+            .workspace_dir(std::path::PathBuf::from("/tmp"))
+            .build()
+            .expect("agent builder should succeed with valid config");
+
+        let result = agent
+            .execute_tool_call(&ParsedToolCall {
+                name: "cron_add".into(),
+                arguments: serde_json::json!({
+                    "command": "echo should-not-be-model-approved",
+                    "approved": true
+                }),
+                tool_call_id: Some("tc1".into()),
+            })
+            .await;
+
+        assert!(result.success);
+        assert_eq!(result.output, "cron-out");
+        assert_eq!(tool_calls.load(Ordering::SeqCst), 1);
+        let args = captured_args
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("cron_add tool should capture executed args");
+        assert_eq!(args["approved"], false);
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -1,4 +1,4 @@
-use crate::approval::{ApprovalManager, ApprovalRequest, ApprovalResponse};
+use crate::approval::{ApprovalManager, ApprovalRequest, ApprovalRequirement, ApprovalResponse};
 
 /// CLI channel factory, injected by the binary. Returns a `Box<dyn Channel>` for interactive mode.
 pub static CLI_CHANNEL_FN: std::sync::OnceLock<
@@ -1593,9 +1593,14 @@ pub async fn run_tool_call_loop(
                 channel_reply_target,
             );
 
+            super::set_runtime_approved_arg(&tool_name, &mut tool_args, false);
+
             // ── Approval hook ────────────────────────────────
+            let mut approval_requirement = approval
+                .map(|mgr| mgr.approval_requirement(&tool_name))
+                .unwrap_or(ApprovalRequirement::NotRequired);
             if let Some(mgr) = approval
-                && mgr.needs_approval(&tool_name)
+                && approval_requirement == ApprovalRequirement::Prompt
             {
                 let request = ApprovalRequest {
                     tool_name: tool_name.clone(),
@@ -1680,7 +1685,16 @@ pub async fn run_tool_call_loop(
                     ));
                     continue;
                 }
+
+                if matches!(decision, ApprovalResponse::Yes | ApprovalResponse::Always) {
+                    approval_requirement = ApprovalRequirement::Approved;
+                }
             }
+            super::set_runtime_approved_arg(
+                &tool_name,
+                &mut tool_args,
+                approval_requirement == ApprovalRequirement::Approved,
+            );
 
             let signature = {
                 let canonical_args = canonicalize_json_for_tool_signature(&tool_args);

--- a/crates/zeroclaw-runtime/src/agent/mod.rs
+++ b/crates/zeroclaw-runtime/src/agent/mod.rs
@@ -19,6 +19,25 @@ pub mod thinking;
 pub mod tool_execution;
 pub mod tool_receipts;
 
+pub(crate) fn is_runtime_approved_arg_tool(tool_name: &str) -> bool {
+    matches!(
+        tool_name,
+        "shell" | "schedule" | "cron_add" | "cron_update" | "cron_run"
+    )
+}
+
+pub(crate) fn set_runtime_approved_arg(
+    tool_name: &str,
+    args: &mut serde_json::Value,
+    approved: bool,
+) {
+    if is_runtime_approved_arg_tool(tool_name)
+        && let Some(args) = args.as_object_mut()
+    {
+        args.insert("approved".to_string(), serde_json::Value::Bool(approved));
+    }
+}
+
 #[cfg(test)]
 mod tests;
 

--- a/crates/zeroclaw-runtime/src/approval/mod.rs
+++ b/crates/zeroclaw-runtime/src/approval/mod.rs
@@ -42,6 +42,13 @@ pub struct ApprovalLogEntry {
     pub channel: String,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApprovalRequirement {
+    Prompt,
+    Approved,
+    NotRequired,
+}
+
 // ── ApprovalManager ──────────────────────────────────────────────
 
 /// Manages the approval workflow for tool calls.
@@ -56,6 +63,8 @@ pub struct ApprovalLogEntry {
 ///   because there is no interactive operator to approve them. `auto_approve`
 ///   policy is still enforced, and `always_ask` / supervised-default tools are
 ///   denied rather than silently allowed.
+/// - **Non-interactive back-channel** (ACP/WS): tools needing approval are sent
+///   through a client approval channel instead of trusting tool arguments.
 pub struct ApprovalManager {
     /// Tools that never need approval (from config).
     auto_approve: HashSet<String>,
@@ -66,6 +75,9 @@ pub struct ApprovalManager {
     /// When `true`, tools that would require interactive approval are
     /// auto-denied instead. Used for channel-driven (non-CLI) runs.
     non_interactive: bool,
+    /// When `true`, shell calls in non-interactive mode still enter the outer
+    /// approval flow because a real client approval channel exists.
+    non_interactive_shell_requires_approval: bool,
     /// Session-scoped allowlist built from "Always" responses.
     session_allowlist: Mutex<HashSet<String>>,
     /// Audit trail of approval decisions.
@@ -80,6 +92,7 @@ impl ApprovalManager {
             always_ask: config.always_ask.iter().cloned().collect(),
             autonomy_level: config.level,
             non_interactive: false,
+            non_interactive_shell_requires_approval: false,
             session_allowlist: Mutex::new(HashSet::new()),
             audit_log: Mutex::new(Vec::new()),
         }
@@ -96,6 +109,21 @@ impl ApprovalManager {
             always_ask: config.always_ask.iter().cloned().collect(),
             autonomy_level: config.level,
             non_interactive: true,
+            non_interactive_shell_requires_approval: false,
+            session_allowlist: Mutex::new(HashSet::new()),
+            audit_log: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Create a non-interactive manager for direct agents with a human
+    /// approval back-channel, such as ACP and the web dashboard WebSocket.
+    pub fn for_non_interactive_backchannel(config: &AutonomyConfig) -> Self {
+        Self {
+            auto_approve: config.auto_approve.iter().cloned().collect(),
+            always_ask: config.always_ask.iter().cloned().collect(),
+            autonomy_level: config.level,
+            non_interactive: true,
+            non_interactive_shell_requires_approval: true,
             session_allowlist: Mutex::new(HashSet::new()),
             audit_log: Mutex::new(Vec::new()),
         }
@@ -111,19 +139,23 @@ impl ApprovalManager {
     ///
     /// Returns `true` if the call needs a prompt, `false` if it can proceed.
     pub fn needs_approval(&self, tool_name: &str) -> bool {
+        self.approval_requirement(tool_name) == ApprovalRequirement::Prompt
+    }
+
+    pub fn approval_requirement(&self, tool_name: &str) -> ApprovalRequirement {
         // Full autonomy never prompts.
         if self.autonomy_level == AutonomyLevel::Full {
-            return false;
+            return ApprovalRequirement::Approved;
         }
 
         // ReadOnly blocks everything — handled elsewhere; no prompt needed.
         if self.autonomy_level == AutonomyLevel::ReadOnly {
-            return false;
+            return ApprovalRequirement::NotRequired;
         }
 
         // always_ask overrides everything.
         if self.always_ask.contains("*") || self.always_ask.contains(tool_name) {
-            return true;
+            return ApprovalRequirement::Prompt;
         }
 
         // Channel-driven shell execution is still guarded by the shell tool's
@@ -131,23 +163,26 @@ impl ApprovalManager {
         // gate here lets low-risk allowlisted commands (e.g. `ls`) work in
         // non-interactive channels without silently allowing medium/high-risk
         // commands.
-        if self.non_interactive && tool_name == "shell" {
-            return false;
+        if self.non_interactive
+            && tool_name == "shell"
+            && !self.non_interactive_shell_requires_approval
+        {
+            return ApprovalRequirement::NotRequired;
         }
 
         // auto_approve skips the prompt.
         if self.auto_approve.contains("*") || self.auto_approve.contains(tool_name) {
-            return false;
+            return ApprovalRequirement::Approved;
         }
 
         // Session allowlist (from prior "Always" responses).
         let allowlist = self.session_allowlist.lock();
         if allowlist.contains(tool_name) {
-            return false;
+            return ApprovalRequirement::Approved;
         }
 
         // Default: supervised mode requires approval.
-        true
+        ApprovalRequirement::Prompt
     }
 
     /// Record an approval decision and update session state.
@@ -505,6 +540,13 @@ mod tests {
     fn non_interactive_shell_skips_outer_approval_by_default() {
         let mgr = ApprovalManager::for_non_interactive(&AutonomyConfig::default());
         assert!(!mgr.needs_approval("shell"));
+    }
+
+    #[test]
+    fn non_interactive_backchannel_shell_requires_outer_approval() {
+        let mgr = ApprovalManager::for_non_interactive_backchannel(&AutonomyConfig::default());
+        assert!(mgr.is_non_interactive());
+        assert!(mgr.needs_approval("shell"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Builds ACP sessions and web dashboard WebSocket sessions with a non-interactive approval manager that can use the client approval back-channel, so direct-session `shell` calls no longer skip the outer approval flow.
  - Treats `approved` as a runtime-owned argument for `shell`, `schedule`, `cron_add`, `cron_update`, and `cron_run`. The model-supplied value is cleared before approval checks and restored only when runtime policy or a human decision actually approves the call.
  - Splits approval policy into prompt / already-approved / not-required outcomes so auto-approved tools and prior `Always` decisions still run without regressing to `approved=false`.
  - Adds focused regressions for denied web/ACP shell calls, approved shell calls, prior `Always` shell allowlists, and `cron_add` rejecting model-supplied `approved=true`.
- **Scope boundary:** This PR does not redesign the web approval UI, change shell risk classification, change command allowlists, or alter the CLI/Telegram prompt UX. It relies on the existing client approval back-channel plumbing and fixes the remaining direct-agent shell/approved-argument gap.
- **Blast radius:** Runtime tool execution, direct ACP/WS agent construction, the gateway WebSocket path, and approval-bearing command tools that read an `approved` argument.
- **Linked issue(s):** Closes #6207
- **Labels:** `bug`, `risk: high`, `size: M`, `gateway`, `runtime`, `security`.

## Validation Evidence (required)

Local validation is the signal CI cannot replace. Run the full battery and paste literal output (tails, failures, warnings — not "all passed").

```text
cargo test -p zeroclaw-runtime direct_agent -- --nocapture
Sandboxed post-rebase run failed before the test runner with `Operation not permitted` while writing under `target/`; reran the same command outside the sandbox.
running 6 tests
test agent::agent::tests::direct_agent_tool_execution_denies_when_acp_rejects ... ok
test agent::agent::tests::direct_agent_cron_add_does_not_trust_model_supplied_approved_arg ... ok
test agent::agent::tests::direct_agent_shell_marks_args_approved_after_backchannel_approval ... ok
test agent::agent::tests::direct_agent_shell_does_not_trust_model_supplied_approved_arg ... ok
test agent::agent::tests::direct_agent_shell_keeps_runtime_approval_from_always_allowlist ... ok
test agent::agent::tests::direct_agent_tool_execution_requests_acp_approval ... ok
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 1632 filtered out; finished in 0.03s

cargo test -p zeroclaw-runtime non_interactive_backchannel_shell_requires_outer_approval -- --nocapture
test approval::tests::non_interactive_backchannel_shell_requires_outer_approval ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1637 filtered out; finished in 0.03s

cargo fmt --all -- --check
cargo fmt --all -- --check 2>&1  5.88s user 0.51s system 68% cpu 9.286 total

cargo check -p zeroclaw-runtime -p zeroclaw-gateway -p zeroclaw-channels
Checking zeroclaw-runtime v0.7.5
Checking zeroclaw-hardware v0.7.5
Checking zeroclaw-channels v0.7.5
Finished `dev` profile [unoptimized + debuginfo] target(s) in 3m 46s

git diff --check
Result: passed.
```

- **Commands run and tail output:** Included above.
- **Public CI status at ready-for-review pass:** All listed GitHub checks are passing, including Lint, Security, Test, platform builds, all-features check, benchmarks compile, and CI Required Gate.
- **Beyond CI — what did you manually verify?** I checked that the rebased branch has exactly one commit over `origin/master` and that the diff is limited to the six intended runtime/gateway/channel files. I also ran the simplify review before committing and applied its important finding: already-approved shell calls from `auto_approve` or a prior `Always` response must still receive runtime-owned `approved=true`.
- **If any command was intentionally skipped, why:** Full workspace `cargo test` / full clippy were not run because this is a focused high-risk runtime/gateway fix and the narrower commands cover the changed crates and new regressions without a multi-hour full workspace run. CodeRabbit was skipped because `cr auth status` reports the CLI is not logged in.

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: No new access is added. This change tightens an approval boundary by preventing model-authored tool arguments from satisfying human approval for shell and cron-style command tools.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No upgrade steps. Existing supervised configurations keep the same keys; direct ACP/WS sessions now honor the intended approval semantics.

## Rollback (required for `risk: medium` and `risk: high`)

Medium/high-risk PRs must fill:

- **Fast rollback command/path:** `git revert 300a742`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** In web dashboard or ACP sessions, supervised `shell` calls may be denied unexpectedly, approval requests may stop reaching the client, or approved shell/cron-style command tools may receive `approved=false` even after a human approves or chooses `Always`. Look for tool results containing `Denied by user.` or `Command requires explicit approval`, and for missing `approval_request` frames in gateway/ACP sessions.

