### PR TITLE
fix(build): route source web builds through cargo

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,10 @@
 # Rust build artifacts (can be multiple GB)
 target
 
+# Web build artifacts and local dependencies
+web/node_modules
+web/dist
+
 # Documentation and examples (not needed for runtime)
 docs
 examples

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,29 @@
 # syntax=docker/dockerfile:1.7-labs
 
 # ── Stage 0: Frontend build ─────────────────────────────────────
-FROM node:22-alpine AS web-builder
-WORKDIR /web
-COPY web/package.json web/package-lock.json* ./
-RUN npm ci --ignore-scripts 2>/dev/null || npm install --ignore-scripts
-COPY web/ .
-RUN npm run build
+FROM node:22-bookworm-slim AS web-node
+
+FROM rust:1.94-slim@sha256:da9dab7a6b8dd428e71718402e97207bb3e54167d37b5708616050b1e8f60ed6 AS web-builder
+WORKDIR /app
+COPY --from=web-node /usr/local/bin/node /usr/local/bin/node
+COPY --from=web-node /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y \
+        pkg-config \
+    && ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+    && ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx \
+    && rm -rf /var/lib/apt/lists/*
+COPY web/package.json web/package-lock.json web/
+RUN cd web && npm ci --ignore-scripts
+COPY . .
+RUN mkdir -p apps/tauri/src \
+    && echo "fn main() {}" > apps/tauri/src/main.rs \
+    && echo "fn main() {}" > apps/tauri/build.rs
+RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,id=zeroclaw-cargo-git,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,id=zeroclaw-web-target,target=/app/target,sharing=locked \
+    cargo web build
 
 # ── Stage 1: Build ────────────────────────────────────────────
 FROM rust:1.94-slim@sha256:da9dab7a6b8dd428e71718402e97207bb3e54167d37b5708616050b1e8f60ed6 AS builder
@@ -129,7 +146,7 @@ RUN apt-get update && apt-get install -y \
 
 COPY --from=builder /zeroclaw-data /zeroclaw-data
 COPY --from=builder /app/zeroclaw /usr/local/bin/zeroclaw
-COPY --from=web-builder /web/dist /zeroclaw-data/web/dist
+COPY --from=web-builder /app/web/dist /zeroclaw-data/web/dist
 
 # Overwrite minimal config with DEV template (Ollama defaults)
 COPY dev/config.template.toml /zeroclaw-data/.zeroclaw/config.toml
@@ -162,7 +179,7 @@ FROM gcr.io/distroless/cc-debian13:nonroot@sha256:84fcd3c223b144b0cb6edc5ecc7564
 
 COPY --from=builder /app/zeroclaw /usr/local/bin/zeroclaw
 COPY --from=builder /zeroclaw-data /zeroclaw-data
-COPY --from=web-builder /web/dist /zeroclaw-data/web/dist
+COPY --from=web-builder /app/web/dist /zeroclaw-data/web/dist
 
 # Environment setup
 # Ensure UTF-8 locale so CJK / multibyte input is handled correctly

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,12 +1,29 @@
 # syntax=docker/dockerfile:1.7-labs
 
 # ── Stage 0: Frontend build ─────────────────────────────────────
-FROM node:22-alpine AS web-builder
-WORKDIR /web
-COPY web/package.json web/package-lock.json* ./
-RUN npm ci --ignore-scripts 2>/dev/null || npm install --ignore-scripts
-COPY web/ .
-RUN npm run build
+FROM node:22-bookworm-slim AS web-node
+
+FROM rust:1.94-bookworm AS web-builder
+WORKDIR /app
+COPY --from=web-node /usr/local/bin/node /usr/local/bin/node
+COPY --from=web-node /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y \
+        pkg-config \
+    && ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+    && ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx \
+    && rm -rf /var/lib/apt/lists/*
+COPY web/package.json web/package-lock.json web/
+RUN cd web && npm ci --ignore-scripts
+COPY . .
+RUN mkdir -p apps/tauri/src \
+    && echo "fn main() {}" > apps/tauri/src/main.rs \
+    && echo "fn main() {}" > apps/tauri/build.rs
+RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,id=zeroclaw-cargo-git,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,id=zeroclaw-web-target,target=/app/target,sharing=locked \
+    cargo web build
 
 # Dockerfile.debian — Shell-equipped variant of the ZeroClaw container.
 #
@@ -84,7 +101,7 @@ COPY benches/ benches/
 COPY crates/ crates/
 COPY xtask/ xtask/
 COPY tools/fill-translations/ tools/fill-translations/
-COPY --from=web-builder /web/dist web/dist
+COPY --from=web-builder /app/web/dist web/dist
 RUN touch src/main.rs src/lib.rs
 RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,id=zeroclaw-cargo-git,target=/usr/local/cargo/git,sharing=locked \

--- a/dist/aur/PKGBUILD
+++ b/dist/aur/PKGBUILD
@@ -23,11 +23,13 @@ prepare() {
 build() {
   cd "${_reponame}-${pkgver}"
 
-  # Build web dashboard (served from filesystem at runtime)
-  cd web && npm ci && npm run build && cd ..
-
   export RUSTUP_TOOLCHAIN=stable
   export CARGO_TARGET_DIR=target
+
+  # Build web dashboard (served from filesystem at runtime)
+  cd web && npm ci && cd ..
+  cargo web build
+
   cargo build --frozen --release --profile dist --features channel-matrix,channel-lark
 }
 

--- a/install.sh
+++ b/install.sh
@@ -424,7 +424,8 @@ interactive_feature_picker() {
 #
 # When a source build includes the `gateway` feature, the dashboard
 # (`web/dist`) needs to be built so the gateway can serve it. If Node.js
-# is on PATH we run `npm install && npm run build` in `web/`. Without
+# is on PATH we run `cargo web build` from the source root so the
+# generated API client is refreshed before TypeScript compiles. Without
 # Node.js we warn — the gateway still starts but the dashboard route
 # returns 404 until `web/dist` is populated.
 build_web_dashboard() {
@@ -440,11 +441,11 @@ build_web_dashboard() {
   if ! command -v npm >/dev/null 2>&1; then
     warn "npm not found — skipping dashboard build. The gateway will run"
     warn "  in API-only mode until you build the dashboard:"
-    warn "  cd $src_dir/web && npm install && npm run build"
+    warn "  cd $src_dir && cargo web build"
     return 0
   fi
-  info "Building web dashboard (npm install + npm run build)..."
-  (cd "$src_dir/web" && npm install --silent && npm run build --silent) || {
+  info "Building web dashboard (cargo web build)..."
+  (cd "$src_dir" && cargo web build) || {
     warn "Dashboard build failed — gateway will run in API-only mode."
     return 0
   }


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Replaces the remaining raw source-build web dashboard commands with `cargo web build`, so the generated `web/src/lib/api-generated.ts` client is refreshed before TypeScript compiles.
  - Updates both Docker web-builder stages to run the same Cargo xtask path, keep Node 22 explicit by copying Node from a `node:22-bookworm-slim` donor stage, preinstall web dependencies with `npm ci --ignore-scripts`, and copy the generated bundle from `/app/web/dist`.
  - Gives the Docker web-builder stages the Rust workspace context required by `cargo web build`; they create minimal Tauri stubs because the real Tauri source is intentionally excluded from the Docker context while Cargo still has to resolve that workspace member.
  - Updates the AUR package build and source-install dashboard build path to use the codegen-aware web build while preserving AUR's explicit `npm ci` install step.
  - Excludes local `web/node_modules` and `web/dist` from Docker build context so image builds do not depend on checkout artifacts.
- **Scope boundary:** Does not change web source, generated API schema, release workflows, runtime gateway behavior, or package install destinations.
- **Blast radius:** Source-build packaging paths for Docker, Dockerfile.debian, AUR, and source installs that include the gateway dashboard.
- **Linked issue(s):** Follow-up to PR #6502

## Validation Evidence (required)

Local validation is the signal CI cannot replace. Run the full battery and paste literal output (tails, failures, warnings — not "all passed").

```text
bash -n install.sh
Result: passed with no output.

bash -n dist/aur/PKGBUILD
Result: passed with no output.

git diff --check -- Dockerfile Dockerfile.debian .dockerignore dist/aur/PKGBUILD install.sh
Result: passed with no output.

rg -n "npm (install|ci|run build)|npm run build|cargo web build|/web/dist|/app/web/dist|web/node_modules|web/dist|node:22|apps/tauri/build.rs" Dockerfile Dockerfile.debian .dockerignore dist/aur/PKGBUILD install.sh
Result:
Dockerfile.debian:4:FROM node:22-bookworm-slim AS web-node
Dockerfile.debian:18:RUN cd web && npm ci --ignore-scripts
Dockerfile.debian:22:    && echo "fn main() {}" > apps/tauri/build.rs
Dockerfile.debian:26:    cargo web build
Dockerfile.debian:104:COPY --from=web-builder /app/web/dist web/dist
Dockerfile.debian:130:# Also copy the web dashboard bundle into /zeroclaw-data/web/dist so the
Dockerfile.debian:135:    cp -r web/dist /zeroclaw-data/web/dist && \
Dockerfile.debian:148:        'web_dist_dir = "/zeroclaw-data/web/dist"' \
Dockerfile:4:FROM node:22-bookworm-slim AS web-node
Dockerfile:18:RUN cd web && npm ci --ignore-scripts
Dockerfile:22:    && echo "fn main() {}" > apps/tauri/build.rs
Dockerfile:26:    cargo web build
Dockerfile:67:    && echo "fn main() {}" > apps/tauri/build.rs \
Dockerfile:130:        'web_dist_dir = "/zeroclaw-data/web/dist"' \
Dockerfile:149:COPY --from=web-builder /app/web/dist /zeroclaw-data/web/dist
Dockerfile:182:COPY --from=web-builder /app/web/dist /zeroclaw-data/web/dist
.dockerignore:10:web/node_modules
.dockerignore:11:web/dist
.dockerignore:81:apps/tauri/build.rs
dist/aur/PKGBUILD:30:  cd web && npm ci && cd ..
dist/aur/PKGBUILD:31:  cargo web build
dist/aur/PKGBUILD:41:  install -dm0755 "${pkgdir}/usr/share/${pkgname}/web/dist"
dist/aur/PKGBUILD:42:  cp -r web/dist/* "${pkgdir}/usr/share/${pkgname}/web/dist/"
install.sh:181:      web_data_dir="${HOME}/Library/Application Support/zeroclaw/web/dist"
install.sh:184:      web_data_dir="${LOCALAPPDATA}/zeroclaw/web/dist"
install.sh:187:      web_data_dir="${XDG_DATA_HOME:-${PREFIX}/.local/share}/zeroclaw/web/dist"
install.sh:235:  if [ -d "$tmp_dir/web/dist" ]; then
install.sh:237:    cp -r "$tmp_dir/web/dist/." "$web_data_dir/"
install.sh:426:# (`web/dist`) needs to be built so the gateway can serve it. If Node.js
install.sh:427:# is on PATH we run `cargo web build` from the source root so the
install.sh:430:# returns 404 until `web/dist` is populated.
install.sh:437:  if [ -f "$src_dir/web/dist/index.html" ]; then
install.sh:438:    info "Web dashboard already built at $src_dir/web/dist"
install.sh:444:    warn "  cd $src_dir && cargo web build"
install.sh:447:  info "Building web dashboard (cargo web build)..."
install.sh:448:  (cd "$src_dir" && cargo web build) || {
install.sh:452:  info "Web dashboard built at $src_dir/web/dist"
install.sh:808:# When the install includes the `gateway` feature, build `web/dist` so

Applied this PR patch to an isolated validation worktree on current `origin/master`.
Result: passed in isolated validation worktree on current `origin/master`.

git diff --check -- Dockerfile Dockerfile.debian .dockerignore dist/aur/PKGBUILD install.sh
Result: passed in isolated validation worktree.

docker build --progress=plain -f Dockerfile -t zeroclaw:source-web-build .
Result: passed. Evidence tail:
Running `target/debug/web build`
==> gen-api -> /app/web/src/lib/api-generated.ts
openapi-typescript 7.13.0
==> npm run build
vite v6.4.2 building for production...
2125 modules transformed.
built in 4.20s
Finished `release` profile [optimized] target(s) in 3m 44s
naming to docker.io/library/zeroclaw:source-web-build done

docker build --progress=plain -f Dockerfile.debian -t zeroclaw:source-web-build-debian .
Result: passed. Evidence tail:
Running `target/debug/web build`
==> gen-api -> /app/web/src/lib/api-generated.ts
openapi-typescript 7.13.0
==> npm run build
vite v6.4.2 building for production...
2125 modules transformed.
built in 9.27s
Finished `release` profile [optimized] target(s) in 19m 14s
naming to docker.io/library/zeroclaw:source-web-build-debian done
```

- **Commands run and tail output:** See consolidated command/result block above.
- **Beyond CI — what did you manually verify?** Reviewed the four surfaces called out in the #6502 follow-up: `dist/aur/PKGBUILD`, `Dockerfile`, `Dockerfile.debian`, and the source-install dashboard build path in `install.sh`. Confirmed Docker bundle copy paths now match the Cargo xtask working directory, Docker web stages use Node 22, and Docker context excludes local web artifacts. Also validated the patch from an isolated worktree on current `origin/master`; both Docker builds completed and exercised the patched `cargo web build` path, including API generation and the Vite production build. CI covers the normal Rust lint/build/test matrix; the Docker builds, AUR syntax check, and isolated-worktree patch application are local validation evidence for packaging surfaces that CI does not currently rebuild end to end.
- **If any command was intentionally skipped, why:** Did not run AUR `makepkg` or a host `cargo web build` locally because the Docker builds now cover the source-build Cargo xtask path for both container surfaces, and AUR was statically checked plus kept on explicit `npm ci` before `cargo web build`.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `Yes` — build-time Docker context for the web-builder stages expands from `web/` to the repository context required by `cargo web build`; `.dockerignore` keeps local `web/node_modules` and `web/dist` artifacts out of that context, and this does not change runtime file access.
- New external network calls? `Yes` — build-time Docker/source package paths now invoke the Cargo xtask, and Docker/AUR explicitly install web dependencies before that build. This is limited to existing build-time package registry access and does not add runtime network behavior.
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: The only new external access is build-time dependency resolution in paths that already perform source builds. The change aligns those paths with the supported `cargo web build` contract from #6502 so generated API output exists before TypeScript compilation.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: N/A

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <merge-sha>`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Docker, AUR, or source-install dashboard builds fail while running `cargo web build`, or the built package/image lacks `web/dist/index.html`.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Scope materially carried forward: N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`Yes/No`): N/A
- If `No`, why (inspiration-only, no direct code/design carry-over): N/A
