### PR TITLE
fix(channels): scope session key for channel tools

### DIFF
--- a/crates/zeroclaw-api/src/lib.rs
+++ b/crates/zeroclaw-api/src/lib.rs
@@ -36,6 +36,6 @@ tokio::task_local! {
     pub static TOOL_CHOICE_OVERRIDE: Option<String>;
 
     /// Session key for the currently active session.
-    /// Set by the gateway WebSocket handler, read by SessionsCurrentTool.
+    /// Scoped by gateway and channel turns, read by SessionsCurrentTool.
     pub static TOOL_LOOP_SESSION_KEY: Option<String>;
 }

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -93,9 +93,8 @@ use zeroclaw_memory::{self, MEMORY_CONTEXT_CLOSE, MEMORY_CONTEXT_OPEN, Memory};
 use zeroclaw_providers::reliable::{scope_provider_fallback, take_last_provider_fallback};
 use zeroclaw_providers::{self, ChatMessage, Provider};
 use zeroclaw_runtime::agent::loop_::{
-    build_tool_instructions, clear_model_switch_request, get_model_switch_state,
-    is_model_switch_requested, run_tool_call_loop, scope_session_key, scope_thread_id,
-    scrub_credentials,
+    clear_model_switch_request, get_model_switch_state, is_model_switch_requested,
+    run_tool_call_loop, scope_session_key, scope_thread_id, scrub_credentials,
 };
 use zeroclaw_runtime::approval::ApprovalManager;
 #[cfg(not(feature = "whatsapp-web"))]
@@ -5727,7 +5726,9 @@ pub async fn start_channels(
         config.agent.max_system_prompt_chars,
     );
     if !native_tools {
-        system_prompt.push_str(&build_tool_instructions(tools_registry.as_ref()));
+        system_prompt.push_str(&zeroclaw_runtime::agent::loop_::build_tool_instructions(
+            tools_registry.as_ref(),
+        ));
     }
 
     // Append deferred MCP tool names so the LLM knows what is available
@@ -9935,7 +9936,7 @@ BTC is currently around $65,000 based on latest tool output."#
             "build_system_prompt should not emit protocol block directly"
         );
 
-        prompt.push_str(&build_tool_instructions(&[]));
+        prompt.push_str(&zeroclaw_runtime::agent::loop_::build_tool_instructions(&[]));
 
         assert_eq!(
             prompt.matches("## Tool Use Protocol").count(),

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -94,7 +94,8 @@ use zeroclaw_providers::reliable::{scope_provider_fallback, take_last_provider_f
 use zeroclaw_providers::{self, ChatMessage, Provider};
 use zeroclaw_runtime::agent::loop_::{
     build_tool_instructions, clear_model_switch_request, get_model_switch_state,
-    is_model_switch_requested, run_tool_call_loop, scope_thread_id, scrub_credentials,
+    is_model_switch_requested, run_tool_call_loop, scope_session_key, scope_thread_id,
+    scrub_credentials,
 };
 use zeroclaw_runtime::approval::ApprovalManager;
 #[cfg(not(feature = "whatsapp-web"))]
@@ -3263,6 +3264,8 @@ async fn process_channel_message(
                         msg.interruption_scope_id.clone()
                             .or_else(|| msg.thread_ts.clone())
                             .or_else(|| Some(msg.id.clone())),
+                    scope_session_key(
+                        Some(history_key.clone()),
                         zeroclaw_runtime::agent::loop_::TOOL_LOOP_COST_TRACKING_CONTEXT.scope(
                             cost_tracking_context.clone(),
                         zeroclaw_runtime::agent::tool_receipts::TOOL_LOOP_RECEIPT_CONTEXT.scope(
@@ -3306,6 +3309,7 @@ async fn process_channel_message(
                         ctx.receipt_generator
                             .as_ref()
                             .map(|_| tool_receipts_collector.as_ref()),
+                    ),
                     ),
                     ),
                     ),
@@ -7180,6 +7184,40 @@ mod tests {
         }
     }
 
+    struct SessionsCurrentProvider;
+
+    #[async_trait::async_trait]
+    impl Provider for SessionsCurrentProvider {
+        async fn chat_with_system(
+            &self,
+            _system_prompt: Option<&str>,
+            _message: &str,
+            _model: &str,
+            _temperature: Option<f64>,
+        ) -> anyhow::Result<String> {
+            Ok(r#"<tool_call>
+{"name":"sessions_current","arguments":{}}
+</tool_call>"#
+                .to_string())
+        }
+
+        async fn chat_with_history(
+            &self,
+            messages: &[ChatMessage],
+            _model: &str,
+            _temperature: Option<f64>,
+        ) -> anyhow::Result<String> {
+            if let Some(tool_results) = messages
+                .iter()
+                .find(|msg| msg.role == "user" && msg.content.contains("[Tool results]"))
+            {
+                Ok(format!("session result:\n{}", tool_results.content))
+            } else {
+                self.chat_with_system(None, "", "", None).await
+            }
+        }
+    }
+
     struct ToolCallingAliasProvider;
 
     #[async_trait::async_trait]
@@ -7515,6 +7553,106 @@ BTC is currently around $65,000 based on latest tool output."#
         assert!(reply.contains("BTC is currently around"));
         assert!(!reply.contains("\"tool_calls\""));
         assert!(!reply.contains("mock_price"));
+    }
+
+    #[tokio::test]
+    async fn process_channel_message_scopes_sender_session_key_for_sessions_current_tool() {
+        let channel_impl = Arc::new(RecordingChannel::default());
+        let channel: Arc<dyn Channel> = channel_impl.clone();
+
+        let mut channels_by_name = HashMap::new();
+        channels_by_name.insert(channel.name().to_string(), channel);
+
+        let tmp = TempDir::new().unwrap();
+        let session_store: Arc<dyn zeroclaw_infra::session_backend::SessionBackend> =
+            Arc::new(zeroclaw_infra::session_store::SessionStore::new(tmp.path()).unwrap());
+
+        let runtime_ctx = Arc::new(ChannelRuntimeContext {
+            channels_by_name: Arc::new(channels_by_name),
+            provider: Arc::new(SessionsCurrentProvider),
+            default_provider: Arc::new("test-provider".to_string()),
+            memory: Arc::new(NoopMemory),
+            tools_registry: Arc::new(vec![Box::new(
+                zeroclaw_runtime::tools::SessionsCurrentTool::new(Arc::clone(&session_store)),
+            )]),
+            observer: Arc::new(NoopObserver),
+            system_prompt: Arc::new("test-system-prompt".to_string()),
+            model: Arc::new("test-model".to_string()),
+            temperature: 0.0,
+            auto_save_memory: false,
+            max_tool_iterations: 10,
+            min_relevance_score: 0.0,
+            conversation_histories: Arc::new(Mutex::new(lru::LruCache::new(
+                std::num::NonZeroUsize::new(MAX_CONVERSATION_SENDERS).unwrap(),
+            ))),
+            pending_new_sessions: Arc::new(Mutex::new(HashSet::new())),
+            provider_cache: Arc::new(Mutex::new(HashMap::new())),
+            route_overrides: Arc::new(Mutex::new(HashMap::new())),
+            api_key: None,
+            api_url: None,
+            reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
+            provider_runtime_options: zeroclaw_providers::ProviderRuntimeOptions::default(),
+            workspace_dir: Arc::new(std::env::temp_dir()),
+            prompt_config: Arc::new(zeroclaw_config::schema::Config::default()),
+            message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
+            interrupt_on_new_message: InterruptOnNewMessageConfig {
+                telegram: false,
+                slack: false,
+                discord: false,
+                mattermost: false,
+                matrix: false,
+            },
+            non_cli_excluded_tools: Arc::new(Vec::new()),
+            autonomy_level: AutonomyLevel::default(),
+            tool_call_dedup_exempt: Arc::new(Vec::new()),
+            multimodal: zeroclaw_config::schema::MultimodalConfig::default(),
+            media_pipeline: zeroclaw_config::schema::MediaPipelineConfig::default(),
+            transcription_config: zeroclaw_config::schema::TranscriptionConfig::default(),
+            hooks: None,
+            model_routes: Arc::new(Vec::new()),
+            query_classification: zeroclaw_config::schema::QueryClassificationConfig::default(),
+            ack_reactions: true,
+            show_tool_calls: true,
+            session_store: Some(Arc::clone(&session_store)),
+            approval_manager: Arc::new(ApprovalManager::for_non_interactive(&{
+                let mut autonomy = zeroclaw_config::schema::AutonomyConfig::default();
+                autonomy.auto_approve.push("sessions_current".to_string());
+                autonomy
+            })),
+            activated_tools: None,
+            cost_tracking: None,
+            pacing: zeroclaw_config::schema::PacingConfig::default(),
+            max_tool_result_chars: 0,
+            context_token_budget: 0,
+            debouncer: Arc::new(zeroclaw_infra::debounce::MessageDebouncer::new(
+                Duration::ZERO,
+            )),
+            receipt_generator: None,
+            show_receipts_in_response: false,
+        });
+
+        process_channel_message(
+            runtime_ctx,
+            zeroclaw_api::channel::ChannelMessage {
+                id: "msg-1".to_string(),
+                sender: "alice".to_string(),
+                reply_target: "chat-42".to_string(),
+                content: "Which session is this?".to_string(),
+                channel: "test-channel".to_string(),
+                timestamp: 1,
+                thread_ts: None,
+                interruption_scope_id: None,
+                attachments: vec![],
+            },
+            CancellationToken::new(),
+        )
+        .await;
+
+        let sent_messages = channel_impl.sent_messages.lock().await;
+        assert!(!sent_messages.is_empty());
+        let reply = sent_messages.last().unwrap();
+        assert!(reply.contains("Current session: test-channel_chat-42_alice"));
+        assert!(reply.contains("Messages: 1"));
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-runtime/src/tools/delegate.rs
+++ b/crates/zeroclaw-runtime/src/tools/delegate.rs
@@ -1,4 +1,4 @@
-use crate::agent::loop_::run_tool_call_loop;
+use crate::agent::loop_::{TOOL_LOOP_SESSION_KEY, run_tool_call_loop};
 use crate::agent::prompt::{PromptContext, SystemPromptBuilder};
 use crate::observability::traits::{Observer, ObserverEvent, ObserverMetric};
 use crate::security::SecurityPolicy;
@@ -20,6 +20,17 @@ use zeroclaw_providers::{self, ChatMessage, Provider};
 /// leaves it unset; matches the longstanding agentic default that balances
 /// coherence with enough variety to explore tool options.
 const DELEGATE_AGENTIC_DEFAULT_TEMPERATURE: f64 = 0.7;
+
+fn current_tool_loop_session_key() -> Option<String> {
+    TOOL_LOOP_SESSION_KEY.try_with(Clone::clone).ok().flatten()
+}
+
+async fn scope_delegate_session_key<F>(session_key: Option<String>, future: F) -> F::Output
+where
+    F: std::future::Future,
+{
+    TOOL_LOOP_SESSION_KEY.scope(session_key, future).await
+}
 
 /// Serializable result of a background delegate task.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -645,80 +656,84 @@ impl DelegateTool {
         let workspace_dir = self.workspace_dir.clone();
         let child_token = self.cancellation_token.child_token();
         let task_id_clone = task_id.clone();
+        let parent_session_key = current_tool_loop_session_key();
 
         tokio::spawn(async move {
-            // Build an inner DelegateTool for the spawned context
-            let inner = DelegateTool {
-                agents,
-                security,
-                fallback_credential,
-                provider_runtime_options,
-                depth,
-                parent_tools,
-                multimodal_config,
-                delegate_config,
-                workspace_dir: workspace_dir.clone(),
-                cancellation_token: child_token.clone(),
-                memory: None,
-            };
+            scope_delegate_session_key(parent_session_key, async move {
+                // Build an inner DelegateTool for the spawned context
+                let inner = DelegateTool {
+                    agents,
+                    security,
+                    fallback_credential,
+                    provider_runtime_options,
+                    depth,
+                    parent_tools,
+                    multimodal_config,
+                    delegate_config,
+                    workspace_dir: workspace_dir.clone(),
+                    cancellation_token: child_token.clone(),
+                    memory: None,
+                };
 
-            let args_inner = json!({
-                "agent": agent_name_owned,
-                "prompt": full_prompt,
-            });
+                let args_inner = json!({
+                    "agent": agent_name_owned,
+                    "prompt": full_prompt,
+                });
 
-            // Race the delegation against cancellation
-            let outcome = tokio::select! {
-                () = child_token.cancelled() => {
-                    Err("Cancelled by parent session".to_string())
-                }
-                result = Box::pin(inner.execute_sync(&agent_name_owned, &full_prompt, &args_inner)) => {
-                    match result {
-                        Ok(tool_result) => {
-                            if tool_result.success {
-                                Ok(tool_result.output)
-                            } else {
-                                Err(tool_result.error.unwrap_or_else(|| "Unknown error".into()))
-                            }
-                        }
-                        Err(e) => Err(e.to_string()),
+                // Race the delegation against cancellation
+                let outcome = tokio::select! {
+                    () = child_token.cancelled() => {
+                        Err("Cancelled by parent session".to_string())
                     }
-                }
-            };
+                    result = Box::pin(inner.execute_sync(&agent_name_owned, &full_prompt, &args_inner)) => {
+                        match result {
+                            Ok(tool_result) => {
+                                if tool_result.success {
+                                    Ok(tool_result.output)
+                                } else {
+                                    Err(tool_result.error.unwrap_or_else(|| "Unknown error".into()))
+                                }
+                            }
+                            Err(e) => Err(e.to_string()),
+                        }
+                    }
+                };
 
-            let finished_at = chrono::Utc::now().to_rfc3339();
-            let final_result = match outcome {
-                Ok(output) => BackgroundDelegateResult {
-                    task_id: task_id_clone.clone(),
-                    agent: agent_name_owned,
-                    status: BackgroundTaskStatus::Completed,
-                    output: Some(output),
-                    error: None,
-                    started_at,
-                    finished_at: Some(finished_at),
-                },
-                Err(err) => {
-                    let status = if err.contains("Cancelled") {
-                        BackgroundTaskStatus::Cancelled
-                    } else {
-                        BackgroundTaskStatus::Failed
-                    };
-                    BackgroundDelegateResult {
+                let finished_at = chrono::Utc::now().to_rfc3339();
+                let final_result = match outcome {
+                    Ok(output) => BackgroundDelegateResult {
                         task_id: task_id_clone.clone(),
                         agent: agent_name_owned,
-                        status,
-                        output: None,
-                        error: Some(err),
+                        status: BackgroundTaskStatus::Completed,
+                        output: Some(output),
+                        error: None,
                         started_at,
                         finished_at: Some(finished_at),
+                    },
+                    Err(err) => {
+                        let status = if err.contains("Cancelled") {
+                            BackgroundTaskStatus::Cancelled
+                        } else {
+                            BackgroundTaskStatus::Failed
+                        };
+                        BackgroundDelegateResult {
+                            task_id: task_id_clone.clone(),
+                            agent: agent_name_owned,
+                            status,
+                            output: None,
+                            error: Some(err),
+                            started_at,
+                            finished_at: Some(finished_at),
+                        }
                     }
-                }
-            };
+                };
 
-            let result_path = results_dir.join(format!("{}.json", task_id_clone));
-            if let Ok(bytes) = serde_json::to_vec_pretty(&final_result) {
-                let _ = tokio::fs::write(&result_path, &bytes).await;
-            }
+                let result_path = results_dir.join(format!("{}.json", task_id_clone));
+                if let Ok(bytes) = serde_json::to_vec_pretty(&final_result) {
+                    let _ = tokio::fs::write(&result_path, &bytes).await;
+                }
+            })
+            .await;
         });
 
         Ok(ToolResult {
@@ -799,6 +814,7 @@ impl DelegateTool {
             .try_with(Clone::clone)
             .ok()
             .flatten();
+        let parent_session_key = current_tool_loop_session_key();
 
         // Spawn all agents concurrently
         let mut handles = Vec::with_capacity(agent_names.len());
@@ -817,6 +833,7 @@ impl DelegateTool {
             let prompt = prompt.to_string();
             let args_clone = args.clone();
             let receipt_scope = parent_receipt_scope.clone();
+            let session_key = parent_session_key.clone();
 
             handles.push(tokio::spawn(async move {
                 let inner = DelegateTool {
@@ -833,11 +850,14 @@ impl DelegateTool {
                     memory: None,
                 };
                 let agent_name_for_return = agent_name.clone();
-                let result = crate::agent::tool_receipts::TOOL_LOOP_RECEIPT_CONTEXT
-                    .scope(receipt_scope, async move {
-                        Box::pin(inner.execute_sync(&agent_name, &prompt, &args_clone)).await
-                    })
-                    .await;
+                let result = scope_delegate_session_key(session_key, async move {
+                    crate::agent::tool_receipts::TOOL_LOOP_RECEIPT_CONTEXT
+                        .scope(receipt_scope, async move {
+                            Box::pin(inner.execute_sync(&agent_name, &prompt, &args_clone)).await
+                        })
+                        .await
+                })
+                .await;
                 (agent_name_for_return, result)
             }));
         }
@@ -1979,6 +1999,25 @@ mod tests {
             "sub-tool receipt must be tagged with the tool name and a zc-receipt- HMAC token, got: {}",
             receipts[0]
         );
+    }
+
+    #[tokio::test]
+    async fn delegate_spawn_helper_forwards_session_key() {
+        let seen = TOOL_LOOP_SESSION_KEY
+            .scope(Some("channel_session".to_string()), async {
+                let session_key = current_tool_loop_session_key();
+                tokio::spawn(async move {
+                    scope_delegate_session_key(session_key, async {
+                        current_tool_loop_session_key()
+                    })
+                    .await
+                })
+                .await
+                .unwrap()
+            })
+            .await;
+
+        assert_eq!(seen.as_deref(), Some("channel_session"));
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-tools/src/sessions.rs
+++ b/crates/zeroclaw-tools/src/sessions.rs
@@ -322,7 +322,7 @@ impl Tool for SessionsSendTool {
 
 /// Returns the session key and metadata for the currently active session.
 /// Reads the session key from the `TOOL_LOOP_SESSION_KEY` task-local,
-/// which is scoped by the gateway WebSocket handler around each agent turn.
+/// which is scoped around gateway and channel agent turns.
 pub struct SessionsCurrentTool {
     backend: Arc<dyn SessionBackend>,
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Scope `TOOL_LOOP_SESSION_KEY` around channel orchestrator tool loops using the existing sender-derived channel session key, so `sessions_current` can identify the active channel session.
  - Add a channel regression that drives a real `sessions_current` tool call through `process_channel_message` and verifies it reports the channel session key plus persisted message count.
  - Forward the scoped session key into background and parallel delegate `tokio::spawn` paths, matching the existing receipt-scope propagation pattern so channel-launched delegated work does not lose session context.
  - Use fully qualified tool-instruction helper calls in the channel orchestrator so the `ci-all` feature set does not trip an unused-import lint.
  - Update comments that still described the session task-local as gateway-only.
- **Scope boundary:** This PR does not change session key format, session backend selection, approval policy, channel routing, or the public `sessions_current` tool schema.
- **Blast radius:** Channel turns, delegate tool background/parallel execution, and session tools. The change is limited to task-local scoping and tests, but it affects runtime/channels behavior for any tool that reads `TOOL_LOOP_SESSION_KEY`.
- **Linked issue(s):** Closes #6030.
- **Labels:** `bug`, `risk: medium`, `size: S`, `channel: core`, `tool: delegate`, `tool: core`

## Validation Evidence (required)

- **Commands run and tail output:**

```text
cargo test -p zeroclaw-runtime delegate_spawn_helper_forwards_session_key -- --nocapture
Result: passed (7m45.83s)

cargo test -p zeroclaw-channels process_channel_message_scopes_sender_session_key_for_sessions_current_tool -- --nocapture
Result: passed before and after the CI import-lint follow-up (1m19.62s, then 14.36s)

cargo check -p zeroclaw-channels
Result: passed (12.51s)

cargo fmt --all -- --check
Result: passed

git diff --check
Result: passed

GitHub CI on head 28a59e39522ceb32eb593345570951918d83a447
Result: passed
Checks: CI Required Gate, Lint, Test, Security, all feature/build checks, benchmarks compile, path labels
```

- **Beyond CI — what did you manually verify?** Verified the new channel regression fails before the scope fix with `No active session context`, then passes after the channel session key is scoped. Ran `zeroclaw-simplify-review`; follow-up fixed spawned delegate task-local propagation and stale comments.
- **If any command was intentionally skipped, why:** Full local `cargo clippy --all-targets -- -D warnings` was not run because GitHub `Lint` and `Check (all features)` passed on the current head. Full local `cargo test` was attempted and failed in an unrelated ACP bridge cached-token unit test outside this PR's diff; GitHub `Test` passed on the current head.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: No security or privacy expansion. This only carries an already-derived session key through existing task-local scope so tools can identify the active session.

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: Existing users do not need upgrade steps. Channel session keys keep their current format and persistence behavior.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <merge-commit>`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Channel turns or delegated channel work could report the wrong active session, fail `sessions_current`, or show unexpected `Current session:` output. Grep logs or tool transcripts for `sessions_current`, `No active session context`, and unexpected channel session keys.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): Not applicable.
- Scope materially carried forward: Not applicable.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`No`)
- If `No`, why (inspiration-only, no direct code/design carry-over): No superseded PR or contributor code was incorporated.
