### PR TITLE
docs(skills): add user-facing skills guide

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -58,6 +58,7 @@
 - [Overview](./tools/overview.md)
 - [MCP (Model Context Protocol)](./tools/mcp.md)
 - [Browser automation](./tools/browser.md)
+- [Skills](./tools/skills.md)
 
 # Security
 

--- a/docs/book/src/tools/skills.md
+++ b/docs/book/src/tools/skills.md
@@ -1,0 +1,150 @@
+# Skills
+
+Skills are reusable instructions and optional tool definitions that ZeroClaw can load into an agent session. Use them for repeatable workflows such as code review checklists, deployment runbooks, support playbooks, or domain-specific tool wrappers.
+
+Skills live in the workspace under `skills/<name>/`. With the default workspace this is:
+
+```text
+~/.zeroclaw/workspace/skills/<name>/
+```
+
+For hand-authored local skills, use `SKILL.md` or `SKILL.toml`. Use `SKILL.md` for instructions plus simple metadata. Use `SKILL.toml` when the skill needs structured prompts or tool definitions. ZeroClaw also understands `manifest.toml` for registry-style skill packages, but `SKILL.md` and `SKILL.toml` are the recommended local authoring formats.
+
+## Create a Markdown skill
+
+A minimal instruction-only skill can be just a Markdown file:
+
+```bash
+mkdir -p ~/.zeroclaw/workspace/skills/release-check
+$EDITOR ~/.zeroclaw/workspace/skills/release-check/SKILL.md
+```
+
+```markdown
+# Release check
+
+Review the release notes, changelog, version tags, and migration notes before confirming that a release is ready.
+```
+
+The directory name becomes the skill name. ZeroClaw uses the first non-heading paragraph as the description when no frontmatter description is present.
+
+`SKILL.md` also supports simple frontmatter for metadata:
+
+```markdown
+---
+name: release-check
+description: Check release readiness before tagging
+version: 0.1.0
+author: zeroclaw_user
+tags: [release, docs]
+---
+
+# Release check
+
+Review the release notes, changelog, version tags, and migration notes before confirming that a release is ready.
+```
+
+Supported frontmatter fields are `name`, `description`, `version`, `author`, and `tags`.
+
+## Create a TOML skill
+
+Here is the same skill as a structured TOML manifest:
+
+```toml
+[skill]
+name = "release-check"
+description = "Check release readiness before tagging"
+version = "0.1.0"
+author = "zeroclaw_user"
+tags = ["release", "docs"]
+prompts = [
+  "Review the release notes, changelog, version tags, and migration notes before confirming that a release is ready."
+]
+
+[[tools]]
+name = "show_latest_tag"
+description = "Print the latest local git tag"
+kind = "shell"
+command = "git describe --tags --abbrev=0"
+```
+
+The `[skill]` table requires `name` and `description`. `version` defaults to `0.1.0` when omitted. `author`, `tags`, and `prompts` are optional.
+
+Tool entries may use `kind = "shell"`, `kind = "http"`, or `kind = "script"`. Keep tool descriptions narrow and concrete so the model knows when to use them.
+
+## Manage installed skills
+
+List installed skills:
+
+```bash
+zeroclaw skills list
+```
+
+Audit an installed skill or a local skill directory:
+
+```bash
+zeroclaw skills audit release-check
+zeroclaw skills audit ./release-check
+```
+
+Install a skill from a local directory, Git URL, registry name, or ClawHub source:
+
+```bash
+zeroclaw skills install ./release-check
+zeroclaw skills install https://example.com/zeroclaw-release-check.git
+zeroclaw skills install release-check
+zeroclaw skills install clawhub:release-check
+```
+
+Remove an installed skill:
+
+```bash
+zeroclaw skills remove release-check
+```
+
+Run `TEST.sh` validation for one skill, or omit the name to test all installed skills:
+
+```bash
+zeroclaw skills test release-check
+zeroclaw skills test --verbose
+```
+
+`zeroclaw skills test` runs the skill's `TEST.sh` file when one exists. Inspect `TEST.sh` before running tests from a skill source you do not already trust.
+
+## Script safety
+
+ZeroClaw audits skills before loading or installing them. Script-like files such as `.sh`, `.bash`, `.ps1`, and files with shell shebangs are blocked by default.
+
+If you intentionally use script-bearing skills, enable them in the ZeroClaw config:
+
+```toml
+[skills]
+allow_scripts = true
+```
+
+Keep this disabled unless you trust the skill source and have reviewed what the scripts do.
+
+## Loading community skills
+
+Community open-skills loading is opt-in:
+
+```toml
+[skills]
+open_skills_enabled = true
+```
+
+When enabled, ZeroClaw loads skills from the configured `open_skills_dir`, or from `$HOME/open-skills` when no directory is set. If that directory does not exist, ZeroClaw may clone the community open-skills repository; if it does exist and is a git checkout, ZeroClaw may pull updates. Enable this only for community sources you trust, or point `open_skills_dir` at a reviewed local copy.
+
+## Advanced config
+
+The default prompt injection mode is `full`, which includes full skill instructions in the system prompt. Use `compact` to keep only compact metadata in context and load skill details on demand:
+
+```toml
+[skills]
+prompt_injection_mode = "compact"
+```
+
+## See also
+
+- [Tools overview](./overview.md)
+- [Security overview](../security/overview.md)
+- [Tool receipts](../security/tool-receipts.md)


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Adds a user-facing Skills page to the docs book so operators have one place to learn where skills live, how `SKILL.md` and `SKILL.toml` differ, and which `zeroclaw skills` commands manage them.
  - Links the new page from the Tools section in `SUMMARY.md`.
  - Documents current script-safety behavior, including `skills.allow_scripts = true` and the fact that `zeroclaw skills test` runs `TEST.sh` when present.
  - Notes community open-skills loading as opt-in and calls out its trust/network behavior.
- **Scope boundary:** This PR does not change skill loading behavior, CLI behavior, registry behavior, prompt injection behavior, or generated reference docs.
- **Blast radius:** Docs navigation and user-facing skills guidance only. Runtime behavior is unchanged.
- **Linked issue(s):** Closes #5863.
- **Labels:** `type: docs`, `risk: low`, `size: S`, `docs`.

## Validation Evidence (required)

- **Commands run and tail output:**

```text
git diff --check
cargo fmt --all -- --check
cargo mdbook check
npx --yes markdownlint-cli2@0.20.0 docs/book/src/tools/skills.md
DOCS_FILES='docs/book/src/tools/skills.md' scripts/ci/docs_quality_gate.sh
scripts/ci/docs_quality_gate.sh
Supplemental relative-link check over docs/book/src/tools/skills.md

Result: passed.

Notes:
- `cargo mdbook check` and the focused docs quality gate first hit sandbox DNS failures while downloading dependencies, then passed on escalated retry.
- The full docs quality gate reported only pre-existing `SUMMARY.md` MD025 baseline warnings outside changed lines and no blocking markdown issues on changed lines.
- `scripts/ci/docs_links_gate.sh` was blocked locally because `lychee` is not installed; the added relative links were checked directly and passed.
```

- **Beyond CI — what did you manually verify?** Read the skills implementation and config schema paths that back the documented behavior, including skill file formats, `allow_scripts`, open-skills loading, ClawHub source handling, and prompt injection mode.
- **If any command was intentionally skipped, why:** Rust clippy/test were skipped because this is docs-only and the repository guidance replaces the Rust battery with docs validation for docs-only changes.

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: No code or config behavior changes. The docs use neutral placeholders such as `zeroclaw_user` and `example.com`.

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: No upgrade steps required. This PR documents existing skills behavior only.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PRs: `git revert <sha>` is the plan unless otherwise noted.

Medium/high-risk PRs must fill:

- **Fast rollback command/path:** `git revert <sha>`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Broken docs page or navigation link in the mdBook output.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): Not applicable.
- Scope materially carried forward: Not applicable.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`No`)
- If `No`, why (inspiration-only, no direct code/design carry-over): No superseded PR scope is carried forward.
