### PR TITLE
fix(runtime): omit native tool prompt catalog

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -799,6 +799,7 @@ impl Agent {
             skills_prompt_mode: self.skills_prompt_mode,
             identity_config: Some(&self.identity_config),
             dispatcher_instructions: &instructions,
+            sends_native_tool_specs: self.tool_dispatcher.should_send_tool_specs(),
             security_summary: self.security_summary.clone(),
             autonomy_level: self.autonomy_level,
         };
@@ -1913,6 +1914,51 @@ mod tests {
 
         let response = agent.turn("hi").await.unwrap();
         assert_eq!(response, "hello");
+    }
+
+    #[test]
+    fn native_agent_prompt_omits_duplicate_tools_section() {
+        let memory_cfg = zeroclaw_config::schema::MemoryConfig {
+            backend: "none".into(),
+            ..zeroclaw_config::schema::MemoryConfig::default()
+        };
+        let workspace = tempfile::TempDir::new().expect("temp dir");
+        let mem: Arc<dyn Memory> = Arc::from(
+            zeroclaw_memory::create_memory(&memory_cfg, workspace.path(), None)
+                .expect("memory creation should succeed with valid config"),
+        );
+        let observer: Arc<dyn Observer> = Arc::from(crate::observability::NoopObserver {});
+
+        let native_agent = Agent::builder()
+            .provider(Box::new(MockProvider {
+                responses: Mutex::new(vec![]),
+            }))
+            .tools(vec![Box::new(MockTool)])
+            .memory(Arc::clone(&mem))
+            .observer(Arc::clone(&observer))
+            .tool_dispatcher(Box::new(NativeToolDispatcher))
+            .workspace_dir(workspace.path().to_path_buf())
+            .build()
+            .expect("agent builder should succeed with valid config");
+        let native_prompt = native_agent.build_system_prompt().unwrap();
+        assert!(!native_prompt.contains("## Tools"));
+        assert!(!native_prompt.contains("echo"));
+
+        let xml_agent = Agent::builder()
+            .provider(Box::new(MockProvider {
+                responses: Mutex::new(vec![]),
+            }))
+            .tools(vec![Box::new(MockTool)])
+            .memory(mem)
+            .observer(observer)
+            .tool_dispatcher(Box::new(XmlToolDispatcher))
+            .workspace_dir(workspace.path().to_path_buf())
+            .build()
+            .expect("agent builder should succeed with valid config");
+        let xml_prompt = xml_agent.build_system_prompt().unwrap();
+        assert!(xml_prompt.contains("## Tools"));
+        assert!(xml_prompt.contains("echo"));
+        assert!(xml_prompt.contains("## Tool Use Protocol"));
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -6885,20 +6885,20 @@ Let me check the result."#;
     }
 
     /// When `build_system_prompt_with_mode` is called with `native_tools = true`,
-    /// the output must contain ZERO XML protocol artifacts. In the native path
-    /// `build_tool_instructions` is never called, so the system prompt alone
-    /// must be clean of XML tool-call protocol.
+    /// the output must contain ZERO XML protocol artifacts and must not inject
+    /// the duplicate non-native tools summary.
     #[test]
     fn native_tools_system_prompt_contains_zero_xml() {
         use crate::agent::system_prompt::build_system_prompt_with_mode;
 
+        let workspace = tempdir().unwrap();
         let tool_summaries: Vec<(&str, &str)> = vec![
             ("shell", "Execute shell commands"),
             ("file_read", "Read files"),
         ];
 
         let system_prompt = build_system_prompt_with_mode(
-            std::path::Path::new("/tmp"),
+            workspace.path(),
             "test-model",
             &tool_summaries,
             &[],  // no skills
@@ -6931,10 +6931,10 @@ Let me check the result."#;
             "Native prompt must not contain XML protocol header"
         );
 
-        // Positive: native prompt should still list tools and contain task instructions
+        // Positive: native prompt should still contain native-task framing.
         assert!(
-            system_prompt.contains("shell"),
-            "Native prompt must list tool names"
+            !system_prompt.contains("## Tools"),
+            "Native prompt should skip the duplicate tools summary"
         );
         assert!(
             system_prompt.contains("## Your Task"),

--- a/crates/zeroclaw-runtime/src/agent/prompt.rs
+++ b/crates/zeroclaw-runtime/src/agent/prompt.rs
@@ -17,6 +17,9 @@ pub struct PromptContext<'a> {
     pub skills_prompt_mode: zeroclaw_config::schema::SkillsPromptInjectionMode,
     pub identity_config: Option<&'a IdentityConfig>,
     pub dispatcher_instructions: &'a str,
+    /// True when the provider request carries native tool specs. In that mode
+    /// the prompt must not duplicate the same tool catalog in prose.
+    pub sends_native_tool_specs: bool,
     /// Pre-rendered security policy summary for inclusion in the Safety
     /// prompt section.  When present, the LLM sees the concrete constraints
     /// (allowed commands, forbidden paths, autonomy level) so it can plan
@@ -140,6 +143,10 @@ impl PromptSection for ToolsSection {
     }
 
     fn build(&self, ctx: &PromptContext<'_>) -> Result<String> {
+        if ctx.sends_native_tool_specs {
+            return Ok(ctx.dispatcher_instructions.to_string());
+        }
+
         let mut out = String::from("## Tools\n\n");
         for tool in ctx.tools {
             let i18n_description = crate::i18n::get_tool_description(tool.name());
@@ -349,6 +356,7 @@ mod tests {
             skills_prompt_mode: zeroclaw_config::schema::SkillsPromptInjectionMode::Full,
             identity_config: Some(&identity_config),
             dispatcher_instructions: "",
+            sends_native_tool_specs: false,
 
             security_summary: None,
             autonomy_level: AutonomyLevel::Supervised,
@@ -380,6 +388,7 @@ mod tests {
             skills_prompt_mode: zeroclaw_config::schema::SkillsPromptInjectionMode::Full,
             identity_config: None,
             dispatcher_instructions: "instr",
+            sends_native_tool_specs: false,
 
             security_summary: None,
             autonomy_level: AutonomyLevel::Supervised,
@@ -388,6 +397,28 @@ mod tests {
         assert!(prompt.contains("## Tools"));
         assert!(prompt.contains("test_tool"));
         assert!(prompt.contains("instr"));
+    }
+
+    #[test]
+    fn prompt_builder_skips_tools_section_for_native_tool_specs() {
+        let tools: Vec<Box<dyn Tool>> = vec![Box::new(TestTool)];
+        let ctx = PromptContext {
+            workspace_dir: Path::new("/tmp"),
+            model_name: "test-model",
+            tools: &tools,
+            skills: &[],
+            skills_prompt_mode: zeroclaw_config::schema::SkillsPromptInjectionMode::Full,
+            identity_config: None,
+            dispatcher_instructions: "",
+            sends_native_tool_specs: true,
+
+            security_summary: None,
+            autonomy_level: AutonomyLevel::Supervised,
+        };
+        let prompt = SystemPromptBuilder::with_defaults().build(&ctx).unwrap();
+        assert!(!prompt.contains("## Tools"));
+        assert!(!prompt.contains("test_tool"));
+        assert!(prompt.contains("## Safety"));
     }
 
     #[test]
@@ -418,6 +449,7 @@ mod tests {
             skills_prompt_mode: zeroclaw_config::schema::SkillsPromptInjectionMode::Full,
             identity_config: None,
             dispatcher_instructions: "",
+            sends_native_tool_specs: false,
 
             security_summary: None,
             autonomy_level: AutonomyLevel::Supervised,
@@ -460,6 +492,7 @@ mod tests {
             skills_prompt_mode: zeroclaw_config::schema::SkillsPromptInjectionMode::Compact,
             identity_config: None,
             dispatcher_instructions: "",
+            sends_native_tool_specs: false,
 
             security_summary: None,
             autonomy_level: AutonomyLevel::Supervised,
@@ -488,6 +521,7 @@ mod tests {
             skills_prompt_mode: zeroclaw_config::schema::SkillsPromptInjectionMode::Full,
             identity_config: None,
             dispatcher_instructions: "instr",
+            sends_native_tool_specs: false,
 
             security_summary: None,
             autonomy_level: AutonomyLevel::Supervised,
@@ -529,6 +563,7 @@ mod tests {
             skills_prompt_mode: zeroclaw_config::schema::SkillsPromptInjectionMode::Full,
             identity_config: None,
             dispatcher_instructions: "",
+            sends_native_tool_specs: false,
 
             security_summary: None,
             autonomy_level: AutonomyLevel::Supervised,
@@ -563,6 +598,7 @@ mod tests {
             skills_prompt_mode: zeroclaw_config::schema::SkillsPromptInjectionMode::Full,
             identity_config: None,
             dispatcher_instructions: "",
+            sends_native_tool_specs: false,
 
             security_summary: Some(summary.clone()),
             autonomy_level: AutonomyLevel::Supervised,
@@ -598,6 +634,7 @@ mod tests {
             skills_prompt_mode: zeroclaw_config::schema::SkillsPromptInjectionMode::Full,
             identity_config: None,
             dispatcher_instructions: "",
+            sends_native_tool_specs: false,
 
             security_summary: None,
             autonomy_level: AutonomyLevel::Supervised,
@@ -625,6 +662,7 @@ mod tests {
             skills_prompt_mode: zeroclaw_config::schema::SkillsPromptInjectionMode::Full,
             identity_config: None,
             dispatcher_instructions: "",
+            sends_native_tool_specs: false,
 
             security_summary: None,
             autonomy_level: AutonomyLevel::Full,
@@ -660,6 +698,7 @@ mod tests {
             skills_prompt_mode: zeroclaw_config::schema::SkillsPromptInjectionMode::Full,
             identity_config: None,
             dispatcher_instructions: "",
+            sends_native_tool_specs: false,
 
             security_summary: None,
             autonomy_level: AutonomyLevel::Supervised,

--- a/crates/zeroclaw-runtime/src/agent/system_prompt.rs
+++ b/crates/zeroclaw-runtime/src/agent/system_prompt.rs
@@ -139,7 +139,7 @@ pub fn build_system_prompt_with_mode_and_autonomy(
     );
 
     // ── 1. Tooling ──────────────────────────────────────────────
-    if !tools.is_empty() {
+    if !tools.is_empty() && !native_tools {
         prompt.push_str("## Tools\n\n");
         if compact_context {
             // Compact mode: tool names only, no descriptions/schemas

--- a/crates/zeroclaw-runtime/src/tools/delegate.rs
+++ b/crates/zeroclaw-runtime/src/tools/delegate.rs
@@ -1077,6 +1077,7 @@ impl DelegateTool {
             skills_prompt_mode: zeroclaw_config::schema::SkillsPromptInjectionMode::Full,
             identity_config: None,
             dispatcher_instructions: "",
+            sends_native_tool_specs: false,
 
             security_summary: None,
             autonomy_level: crate::security::AutonomyLevel::default(),


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Recover the native-tools prompt cleanup from the reverted #4499 / `74a94a1c` work.
  - Skip the prose `## Tools` catalog when the active dispatcher already sends provider-native tool specs.
  - Keep XML/non-native tool dispatchers on the existing textual tool section and protocol instructions.
  - Add focused regressions for the modular `Agent` prompt path and the legacy prompt builder.
- **Scope boundary:** This PR does not change provider tool-spec serialization, tool execution, XML parsing, delegate behavior, or channel routing.
- **Blast radius:** `zeroclaw-runtime` system prompt construction for native-tool-capable agent sessions; XML/non-native prompt construction remains covered by the existing tools section.
- **Risk note:** Native-tool prompts no longer include tool names in prose; provider-native tool specs remain unchanged, and focused tests cover both native and XML prompt paths.
- **Linked issue(s):** Related #6074, Supersedes #4499
- **Labels:** `bug`, `risk: high`, `size: S`, `agent`, `agent:agent`, `agent:loop_`, `agent:prompt`, `tool:delegate`

## Validation Evidence (required)

- **Commands run and tail output:**

  ```text
  cargo fmt --check
  Result: passed

  cargo fmt --all -- --check
  Result: passed

  git diff --check
  Result: passed

  cargo test -p zeroclaw-runtime native_agent_prompt_omits_duplicate_tools_section --lib
  Result: passed; 1 passed, 1634 filtered out

  cargo test -p zeroclaw-runtime prompt_builder_skips_tools_section_for_native_tool_specs --lib
  Result: passed; 1 passed, 1634 filtered out

  cargo test -p zeroclaw-runtime native_tools_system_prompt_contains_zero_xml --lib
  Result: passed; 1 passed, 1634 filtered out
  ```

- **Beyond CI — what did you manually verify?** Checked the old `74a94a1c` behavior against the current split prompt stack. Verified the current `Agent` path sends native tool specs separately, so the prompt should omit the duplicate prose tool catalog only when `should_send_tool_specs()` is true.
- **If any command was intentionally skipped, why:** Full workspace `cargo test` / clippy were skipped because this is a narrow runtime prompt recovery and the focused tests cover the changed native/XML prompt paths.

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: None.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No upgrade steps. Existing native-tool-capable sessions keep receiving provider-native tool specs; they just stop duplicating the same catalog in prose.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <merge-sha>`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Native-tool-capable agents missing tool-use awareness in prompts, XML/non-native agents missing `## Tools` or `## Tool Use Protocol`, or regressions in prompt-related tests under `zeroclaw-runtime`.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line):
  - #4499 by @whtiehack
- Scope materially carried forward: The original fix skipped the non-native tools summary when native tools are available. This PR ports that behavior to the current `zeroclaw-runtime` prompt architecture.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `Yes`
- If `No`, why (inspiration-only, no direct code/design carry-over): N/A.
