### PR TITLE
fix(agent): suppress tool protocol when no tools are available

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -93,8 +93,9 @@ use zeroclaw_memory::{self, MEMORY_CONTEXT_CLOSE, MEMORY_CONTEXT_OPEN, Memory};
 use zeroclaw_providers::reliable::{scope_provider_fallback, take_last_provider_fallback};
 use zeroclaw_providers::{self, ChatMessage, Provider};
 use zeroclaw_runtime::agent::loop_::{
-    clear_model_switch_request, get_model_switch_state, is_model_switch_requested,
-    run_tool_call_loop, scope_session_key, scope_thread_id, scrub_credentials,
+    build_tool_instructions_for_names, clear_model_switch_request, get_model_switch_state,
+    is_model_switch_requested, run_tool_call_loop, scope_session_key, scope_thread_id,
+    scrub_credentials,
 };
 use zeroclaw_runtime::approval::ApprovalManager;
 #[cfg(not(feature = "whatsapp-web"))]
@@ -5745,6 +5746,15 @@ pub async fn start_channels(
     if !excluded.is_empty() && config.autonomy.level != AutonomyLevel::Full {
         tool_descs.retain(|(name, _)| !excluded.iter().any(|ex| ex == name));
     }
+    let effective_tool_names: HashSet<&str> = tools_registry
+        .iter()
+        .map(|tool| tool.name())
+        .filter(|name| {
+            config.autonomy.level == AutonomyLevel::Full
+                || !excluded.iter().any(|excluded| excluded.as_str() == *name)
+        })
+        .collect();
+    tool_descs.retain(|(name, _)| effective_tool_names.contains(name));
 
     let bootstrap_max_chars = if config.agent.compact_context {
         Some(6000)
@@ -5766,8 +5776,9 @@ pub async fn start_channels(
         config.agent.max_system_prompt_chars,
     );
     if !native_tools {
-        system_prompt.push_str(&zeroclaw_runtime::agent::loop_::build_tool_instructions(
+        system_prompt.push_str(&build_tool_instructions_for_names(
             tools_registry.as_ref(),
+            &effective_tool_names,
         ));
     }
 
@@ -6244,6 +6255,7 @@ mod tests {
     use tempfile::TempDir;
     use zeroclaw_memory::{Memory, MemoryCategory, SqliteMemory};
     use zeroclaw_providers::{ChatMessage, Provider};
+    use zeroclaw_runtime::agent::loop_::build_tool_instructions;
     use zeroclaw_runtime::observability::NoopObserver;
     use zeroclaw_runtime::tools::{Tool, ToolResult};
 
@@ -10104,7 +10116,8 @@ BTC is currently around $65,000 based on latest tool output."#
             "build_system_prompt should not emit protocol block directly"
         );
 
-        prompt.push_str(&zeroclaw_runtime::agent::loop_::build_tool_instructions(&[]));
+        let tools_registry: Vec<Box<dyn Tool>> = vec![Box::new(MockPriceTool)];
+        prompt.push_str(&build_tool_instructions(&tools_registry));
 
         assert_eq!(
             prompt.matches("## Tool Use Protocol").count(),

--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -19,6 +19,7 @@ use std::time::Instant;
 use zeroclaw_config::schema::Config;
 use zeroclaw_memory::{self, Memory, MemoryCategory};
 use zeroclaw_providers::{self, ChatMessage, ChatRequest, ConversationMessage, Provider};
+use zeroclaw_tool_call_parser::strip_think_tags;
 
 // Re-export TurnEvent from zeroclaw-types for backwards compatibility.
 pub use zeroclaw_api::agent::TurnEvent;
@@ -419,6 +420,24 @@ impl Agent {
 
     pub fn clear_history(&mut self) {
         self.history.clear();
+    }
+
+    fn should_send_tool_specs(&self) -> bool {
+        self.tool_dispatcher.should_send_tool_specs() && !self.tool_specs.is_empty()
+    }
+
+    fn parse_response_for_effective_tools(
+        &self,
+        response: &zeroclaw_providers::ChatResponse,
+    ) -> (String, Vec<ParsedToolCall>) {
+        if self.tool_specs.is_empty() {
+            return (
+                strip_think_tags(&response.text.clone().unwrap_or_default()),
+                Vec::new(),
+            );
+        }
+
+        self.tool_dispatcher.parse_response(response)
     }
 
     pub fn set_memory_session_id(&mut self, session_id: Option<String>) {
@@ -1168,7 +1187,7 @@ impl Agent {
                 .chat(
                     ChatRequest {
                         messages: &messages,
-                        tools: if self.tool_dispatcher.should_send_tool_specs() {
+                        tools: if self.should_send_tool_specs() {
                             Some(&self.tool_specs)
                         } else {
                             None
@@ -1183,9 +1202,9 @@ impl Agent {
                 Err(err) => return Err(err),
             };
 
-            let (text, calls) = self.tool_dispatcher.parse_response(&response);
+            let (text, calls) = self.parse_response_for_effective_tools(&response);
             if calls.is_empty() {
-                let final_text = if text.is_empty() {
+                let final_text = if text.is_empty() && !self.tool_specs.is_empty() {
                     response.text.unwrap_or_default()
                 } else {
                     text
@@ -1353,7 +1372,7 @@ impl Agent {
             let mut stream = self.provider.stream_chat(
                 zeroclaw_providers::ChatRequest {
                     messages: &messages,
-                    tools: if self.tool_dispatcher.should_send_tool_specs() {
+                    tools: if self.should_send_tool_specs() {
                         Some(&self.tool_specs)
                     } else {
                         None
@@ -1491,7 +1510,7 @@ impl Agent {
                 let chat_fut = self.provider.chat(
                     ChatRequest {
                         messages: &messages,
-                        tools: if self.tool_dispatcher.should_send_tool_specs() {
+                        tools: if self.should_send_tool_specs() {
                             Some(&self.tool_specs)
                         } else {
                             None
@@ -1531,9 +1550,9 @@ impl Agent {
                     .await;
             }
 
-            let (text, mut calls) = self.tool_dispatcher.parse_response(&response);
+            let (text, mut calls) = self.parse_response_for_effective_tools(&response);
             if calls.is_empty() {
-                let final_text = if text.is_empty() {
+                let final_text = if text.is_empty() && !self.tool_specs.is_empty() {
                     response.text.unwrap_or_default()
                 } else {
                     text

--- a/crates/zeroclaw-runtime/src/agent/dispatcher.rs
+++ b/crates/zeroclaw-runtime/src/agent/dispatcher.rs
@@ -128,7 +128,11 @@ impl ToolDispatcher for XmlToolDispatcher {
         ConversationMessage::Chat(ChatMessage::user(format!("[Tool results]\n{content}")))
     }
 
-    fn prompt_instructions(&self, _tools: &[Box<dyn Tool>]) -> String {
+    fn prompt_instructions(&self, tools: &[Box<dyn Tool>]) -> String {
+        if tools.is_empty() {
+            return String::new();
+        }
+
         let mut instructions = String::new();
         instructions.push_str("## Tool Use Protocol\n\n");
         instructions

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -1276,24 +1276,33 @@ pub async fn run_tool_call_loop(
                     .as_ref()
                     .and_then(|usage| record_tool_loop_cost_usage(provider_name, model, usage));
 
-                let response_text = resp.text_or_empty().to_string();
+                let response_text = if tool_specs.is_empty() {
+                    strip_think_tags(resp.text_or_empty())
+                } else {
+                    resp.text_or_empty().to_string()
+                };
                 // First try native structured tool calls (OpenAI-format).
                 // Fall back to text-based parsing (XML tags, markdown blocks,
                 // GLM format) only if the provider returned no native calls —
                 // this ensures we support both native and prompt-guided models.
-                let mut calls: Vec<ParsedToolCall> = resp
-                    .tool_calls
-                    .iter()
-                    .map(|call| ParsedToolCall {
-                        name: call.name.clone(),
-                        arguments: serde_json::from_str::<serde_json::Value>(&call.arguments)
-                            .unwrap_or_else(|_| serde_json::Value::Object(serde_json::Map::new())),
-                        tool_call_id: Some(call.id.clone()),
-                    })
-                    .collect();
+                let mut calls: Vec<ParsedToolCall> = if tool_specs.is_empty() {
+                    Vec::new()
+                } else {
+                    resp.tool_calls
+                        .iter()
+                        .map(|call| ParsedToolCall {
+                            name: call.name.clone(),
+                            arguments: serde_json::from_str::<serde_json::Value>(&call.arguments)
+                                .unwrap_or_else(|_| {
+                                    serde_json::Value::Object(serde_json::Map::new())
+                                }),
+                            tool_call_id: Some(call.id.clone()),
+                        })
+                        .collect()
+                };
                 let mut parsed_text = String::new();
 
-                if calls.is_empty() {
+                if calls.is_empty() && !tool_specs.is_empty() {
                     let (fallback_text, fallback_calls) = parse_tool_calls(&response_text);
                     if !fallback_text.is_empty() {
                         parsed_text = fallback_text;
@@ -1301,7 +1310,11 @@ pub async fn run_tool_call_loop(
                     calls = fallback_calls;
                 }
 
-                let parse_issue = detect_tool_call_parse_issue(&response_text, &calls);
+                let parse_issue = if tool_specs.is_empty() {
+                    None
+                } else {
+                    detect_tool_call_parse_issue(&response_text, &calls)
+                };
                 if let Some(ref issue) = parse_issue {
                     runtime_trace::record_event(
                         "tool_call_parse_issue",
@@ -2060,6 +2073,29 @@ pub async fn run_tool_call_loop(
 /// Build the tool instruction block for the system prompt so the LLM knows
 /// how to invoke tools.
 pub fn build_tool_instructions(tools_registry: &[Box<dyn Tool>]) -> String {
+    build_tool_instructions_for_tools(tools_registry.iter().map(|tool| tool.as_ref()))
+}
+
+/// Build tool instructions for the subset of registered tools that are
+/// effective for the current prompt.
+pub fn build_tool_instructions_for_names(
+    tools_registry: &[Box<dyn Tool>],
+    effective_tool_names: &HashSet<&str>,
+) -> String {
+    build_tool_instructions_for_tools(
+        tools_registry
+            .iter()
+            .map(|tool| tool.as_ref())
+            .filter(|tool| effective_tool_names.contains(tool.name())),
+    )
+}
+
+fn build_tool_instructions_for_tools<'a>(tools: impl IntoIterator<Item = &'a dyn Tool>) -> String {
+    let tools: Vec<&dyn Tool> = tools.into_iter().collect();
+    if tools.is_empty() {
+        return String::new();
+    }
+
     let mut instructions = String::new();
     instructions.push_str("\n## Tool Use Protocol\n\n");
     instructions.push_str("To use a tool, wrap a JSON object in <tool_call></tool_call> tags:\n\n");
@@ -2074,7 +2110,7 @@ pub fn build_tool_instructions(tools_registry: &[Box<dyn Tool>]) -> String {
         .push_str("Continue reasoning with the results until you can give a final answer.\n\n");
     instructions.push_str("### Available Tools\n\n");
 
-    for tool in tools_registry {
+    for tool in tools {
         let desc = tool.description();
         let _ = writeln!(
             instructions,
@@ -2086,6 +2122,15 @@ pub fn build_tool_instructions(tools_registry: &[Box<dyn Tool>]) -> String {
     }
 
     instructions
+}
+
+fn retain_registered_tool_descriptions(
+    tool_descs: &mut Vec<(&str, &str)>,
+    tools_registry: &[Box<dyn Tool>],
+) {
+    let registered_tool_names: HashSet<&str> =
+        tools_registry.iter().map(|tool| tool.name()).collect();
+    tool_descs.retain(|(name, _)| registered_tool_names.contains(name));
 }
 
 // ── CLI Entrypoint ───────────────────────────────────────────────────────
@@ -2452,6 +2497,7 @@ pub async fn run(
             "Query connected hardware for reported GPIO pins and LED pin. Use when: user asks what pins are available.",
         ));
     }
+    retain_registered_tool_descriptions(&mut tool_descs, &tools_registry);
     let bootstrap_max_chars = if config.agent.compact_context {
         Some(6000)
     } else {
@@ -3377,6 +3423,19 @@ pub async fn process_message(
             tool_descs.retain(|(name, _)| !excluded.iter().any(|ex| ex == name));
         }
     }
+    let effective_tool_names: HashSet<&str> = tools_registry
+        .iter()
+        .map(|tool| tool.name())
+        .filter(|name| {
+            config.autonomy.level == AutonomyLevel::Full
+                || !config
+                    .autonomy
+                    .non_cli_excluded_tools
+                    .iter()
+                    .any(|excluded| excluded.as_str() == *name)
+        })
+        .collect();
+    tool_descs.retain(|(name, _)| effective_tool_names.contains(name));
 
     let bootstrap_max_chars = if config.agent.compact_context {
         Some(6000)
@@ -3398,7 +3457,10 @@ pub async fn process_message(
         config.agent.max_system_prompt_chars,
     );
     if !native_tools {
-        system_prompt.push_str(&build_tool_instructions(&tools_registry));
+        system_prompt.push_str(&build_tool_instructions_for_names(
+            &tools_registry,
+            &effective_tool_names,
+        ));
     }
     if !deferred_section.is_empty() {
         system_prompt.push('\n');
@@ -6302,6 +6364,14 @@ mod tests {
     }
 
     #[test]
+    fn build_tool_instructions_empty_registry_returns_empty() {
+        let tools: Vec<Box<dyn Tool>> = vec![];
+        let instructions = build_tool_instructions(&tools);
+
+        assert!(instructions.is_empty());
+    }
+
+    #[test]
     fn tools_to_openai_format_produces_valid_schema() {
         use crate::security::SecurityPolicy;
         let security = Arc::new(SecurityPolicy::from_config(
@@ -6939,6 +7009,50 @@ Let me check the result."#;
         assert!(
             system_prompt.contains("## Your Task"),
             "Native prompt should contain task instructions"
+        );
+    }
+
+    #[test]
+    fn non_native_system_prompt_with_no_tools_contains_zero_tool_protocol() {
+        use crate::agent::system_prompt::build_system_prompt_with_mode;
+
+        let tool_summaries: Vec<(&str, &str)> = vec![];
+
+        let system_prompt = build_system_prompt_with_mode(
+            std::path::Path::new("/tmp"),
+            "test-model",
+            &tool_summaries,
+            &[],
+            None,
+            None,
+            false,
+            zeroclaw_config::schema::SkillsPromptInjectionMode::Full,
+            crate::security::AutonomyLevel::default(),
+        );
+
+        assert!(
+            !system_prompt.contains("## Tools"),
+            "No-tools prompt must not include a Tools section"
+        );
+        assert!(
+            !system_prompt.contains("## Tool Use Protocol"),
+            "No-tools prompt must not include tool protocol"
+        );
+        assert!(
+            !system_prompt.contains("<tool_call>"),
+            "No-tools prompt must not mention XML tool calls"
+        );
+        assert!(
+            !system_prompt.contains("<tool_result>"),
+            "No-tools prompt must not mention XML tool results"
+        );
+        assert!(
+            !system_prompt.contains("Use the tools"),
+            "No-tools prompt must not instruct the model to use unavailable tools"
+        );
+        assert!(
+            system_prompt.contains("No tools are available for this turn"),
+            "No-tools prompt should explicitly describe the current capability boundary"
         );
     }
 

--- a/crates/zeroclaw-runtime/src/agent/prompt.rs
+++ b/crates/zeroclaw-runtime/src/agent/prompt.rs
@@ -126,7 +126,11 @@ impl PromptSection for ToolHonestySection {
         "tool_honesty"
     }
 
-    fn build(&self, _ctx: &PromptContext<'_>) -> Result<String> {
+    fn build(&self, ctx: &PromptContext<'_>) -> Result<String> {
+        if ctx.tools.is_empty() {
+            return Ok(String::new());
+        }
+
         Ok(
             "## CRITICAL: Tool Honesty\n\n\
              - NEVER fabricate, invent, or guess tool results. If a tool returns empty results, say \"No results found.\"\n\
@@ -143,6 +147,9 @@ impl PromptSection for ToolsSection {
     }
 
     fn build(&self, ctx: &PromptContext<'_>) -> Result<String> {
+        if ctx.tools.is_empty() {
+            return Ok(String::new());
+        }
         if ctx.sends_native_tool_specs {
             return Ok(ctx.dispatcher_instructions.to_string());
         }
@@ -419,6 +426,34 @@ mod tests {
         assert!(!prompt.contains("## Tools"));
         assert!(!prompt.contains("test_tool"));
         assert!(prompt.contains("## Safety"));
+    }
+
+    #[test]
+    fn prompt_builder_omits_tool_sections_when_no_tools_available() {
+        let tools: Vec<Box<dyn Tool>> = vec![];
+        let ctx = PromptContext {
+            workspace_dir: Path::new("/tmp"),
+            model_name: "test-model",
+            tools: &tools,
+            skills: &[],
+            skills_prompt_mode: zeroclaw_config::schema::SkillsPromptInjectionMode::Full,
+            identity_config: None,
+            dispatcher_instructions: "",
+            sends_native_tool_specs: false,
+
+            security_summary: None,
+            autonomy_level: AutonomyLevel::Supervised,
+        };
+
+        let prompt = SystemPromptBuilder::with_defaults().build(&ctx).unwrap();
+
+        assert!(!prompt.contains("## Tools"));
+        assert!(!prompt.contains("## CRITICAL: Tool Honesty"));
+        assert!(!prompt.contains("## Tool Use Protocol"));
+        assert!(!prompt.contains("<tool_call>"));
+        assert!(prompt.contains("## Project Context"));
+        assert!(prompt.contains("## Workspace"));
+        assert!(prompt.contains("## Runtime"));
     }
 
     #[test]

--- a/crates/zeroclaw-runtime/src/agent/system_prompt.rs
+++ b/crates/zeroclaw-runtime/src/agent/system_prompt.rs
@@ -118,25 +118,30 @@ pub fn build_system_prompt_with_mode_and_autonomy(
 ) -> String {
     use std::fmt::Write;
     let mut prompt = String::with_capacity(8192);
+    let has_tools = !tools.is_empty();
 
     // ── 0. Anti-narration (top priority) ───────────────────────
-    prompt.push_str(
-        "## CRITICAL: No Tool Narration\n\n\
-         NEVER narrate, announce, describe, or explain your tool usage to the user. \
-         Do NOT say things like 'Let me check...', 'I will use http_request to...', \
-         'I'll fetch that for you', 'Searching now...', or 'Using the web_search tool'. \
-         The user must ONLY see the final answer. Tool calls are invisible infrastructure — \
-         never reference them. If you catch yourself starting a sentence about what tool \
-         you are about to use or just used, DELETE it and give the answer directly.\n\n",
-    );
+    if has_tools {
+        prompt.push_str(
+            "## CRITICAL: No Tool Narration\n\n\
+             NEVER narrate, announce, describe, or explain your tool usage to the user. \
+             Do NOT say things like 'Let me check...', 'I will use http_request to...', \
+             'I'll fetch that for you', 'Searching now...', or 'Using the web_search tool'. \
+             The user must ONLY see the final answer. Tool calls are invisible infrastructure — \
+             never reference them. If you catch yourself starting a sentence about what tool \
+             you are about to use or just used, DELETE it and give the answer directly.\n\n",
+        );
+    }
 
     // ── 0b. Tool Honesty ───────────────────────────────────────
-    prompt.push_str(
-        "## CRITICAL: Tool Honesty\n\n\
-         - NEVER fabricate, invent, or guess tool results. If a tool returns empty results, say \"No results found.\"\n\
-         - If a tool call fails, report the error — never make up data to fill the gap.\n\
-         - When unsure whether a tool call succeeded, ask the user rather than guessing.\n\n",
-    );
+    if has_tools {
+        prompt.push_str(
+            "## CRITICAL: Tool Honesty\n\n\
+             - NEVER fabricate, invent, or guess tool results. If a tool returns empty results, say \"No results found.\"\n\
+             - If a tool call fails, report the error — never make up data to fill the gap.\n\
+             - When unsure whether a tool call succeeded, ask the user rather than guessing.\n\n",
+        );
+    }
 
     // ── 1. Tooling ──────────────────────────────────────────────
     if !tools.is_empty() && !native_tools {
@@ -178,7 +183,14 @@ pub fn build_system_prompt_with_mode_and_autonomy(
     }
 
     // ── 1c. Action instruction (avoid meta-summary) ───────────────
-    if native_tools {
+    if !has_tools {
+        prompt.push_str(
+            "## Your Task\n\n\
+             When the user sends a message, respond naturally and answer directly from conversation context.\n\
+             No tools are available for this turn, so do not emit tool calls or describe unavailable actions.\n\
+             Do NOT: summarize this configuration, describe your capabilities, or output step-by-step meta-commentary.\n\n",
+        );
+    } else if native_tools {
         prompt.push_str(
             "## Your Task\n\n\
              When the user sends a message, respond naturally. Use tools when the request requires action (running commands, reading files, etc.).\n\

--- a/crates/zeroclaw-runtime/src/agent/tests.rs
+++ b/crates/zeroclaw-runtime/src/agent/tests.rs
@@ -253,6 +253,58 @@ impl Tool for CountingTool {
     }
 }
 
+struct ToolSpecCaptureProvider {
+    tools_received: Arc<Mutex<Vec<bool>>>,
+    responses: Mutex<Vec<ChatResponse>>,
+}
+
+impl ToolSpecCaptureProvider {
+    fn new(responses: Vec<ChatResponse>) -> (Self, Arc<Mutex<Vec<bool>>>) {
+        let tools_received = Arc::new(Mutex::new(Vec::new()));
+        (
+            Self {
+                tools_received: tools_received.clone(),
+                responses: Mutex::new(responses),
+            },
+            tools_received,
+        )
+    }
+}
+
+#[async_trait]
+impl Provider for ToolSpecCaptureProvider {
+    async fn chat_with_system(
+        &self,
+        _system_prompt: Option<&str>,
+        _message: &str,
+        _model: &str,
+        _temperature: Option<f64>,
+    ) -> Result<String> {
+        Ok("fallback".into())
+    }
+
+    async fn chat(
+        &self,
+        request: ChatRequest<'_>,
+        _model: &str,
+        _temperature: Option<f64>,
+    ) -> Result<ChatResponse> {
+        self.tools_received
+            .lock()
+            .unwrap()
+            .push(request.tools.is_some());
+        let mut guard = self.responses.lock().unwrap();
+        if guard.is_empty() {
+            return Ok(text_response("done"));
+        }
+        Ok(guard.remove(0))
+    }
+
+    fn supports_native_tools(&self) -> bool {
+        true
+    }
+}
+
 fn make_memory() -> Arc<dyn Memory> {
     let cfg = MemoryConfig {
         backend: "none".into(),
@@ -375,6 +427,54 @@ async fn turn_returns_text_when_no_tools_called() {
     assert!(
         !response.is_empty(),
         "Expected non-empty text response from provider"
+    );
+}
+
+#[tokio::test]
+async fn turn_with_no_effective_tools_treats_xml_tool_call_as_text() {
+    let provider = Box::new(ScriptedProvider::new(vec![xml_tool_response(
+        "echo",
+        r#"{"message":"hi"}"#,
+    )]));
+    let mut agent = build_agent_with(provider, vec![], Box::new(XmlToolDispatcher));
+
+    let response = agent.turn("hi").await.unwrap();
+
+    assert!(
+        response.contains("<tool_call>"),
+        "no-tools turns should preserve tool-like text instead of executing it"
+    );
+    assert!(
+        response.contains("\"name\": \"echo\""),
+        "tool-like payload should remain visible as ordinary response text"
+    );
+}
+
+#[tokio::test]
+async fn turn_with_no_effective_tools_still_strips_reasoning_tags() {
+    let provider = Box::new(ScriptedProvider::new(vec![text_response(
+        "<think>hidden scratchpad</think>visible answer",
+    )]));
+    let mut agent = build_agent_with(provider, vec![], Box::new(XmlToolDispatcher));
+
+    let response = agent.turn("hi").await.unwrap();
+
+    assert_eq!(response, "visible answer");
+}
+
+#[tokio::test]
+async fn turn_with_no_effective_tools_does_not_send_empty_native_tool_specs() {
+    let (provider, tools_received) =
+        ToolSpecCaptureProvider::new(vec![text_response("plain response")]);
+    let mut agent = build_agent_with(Box::new(provider), vec![], Box::new(NativeToolDispatcher));
+
+    let response = agent.turn("hi").await.unwrap();
+
+    assert_eq!(response, "plain response");
+    assert_eq!(
+        tools_received.lock().unwrap().as_slice(),
+        &[false],
+        "native providers should receive no tools field when the effective tool list is empty"
     );
 }
 
@@ -1308,6 +1408,15 @@ fn xml_dispatcher_generates_tool_instructions() {
         !instructions.contains("echo"),
         "dispatcher should not duplicate tool listing"
     );
+}
+
+#[test]
+fn xml_dispatcher_omits_tool_instructions_without_tools() {
+    let tools: Vec<Box<dyn Tool>> = vec![];
+    let dispatcher = XmlToolDispatcher;
+    let instructions = dispatcher.prompt_instructions(&tools);
+
+    assert!(instructions.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Suppresses no-tools prompt scaffolding when the effective tool set is empty, so small/local models are not told about unavailable tools or XML tool syntax.
  - Stops direct Agent turns and runtime tool-loop turns from parsing/executing native or XML tool calls when no tool specs are effective.
  - Keeps channel/runtime prompt tool descriptions aligned with the effective registered tool set after allowlist or non-CLI exclusion filtering.
  - Preserves `<think>...</think>` stripping in no-tools responses so reasoning scratchpad text does not leak just because tool parsing is disabled.
  - Adds focused regressions for no-effective-tools native request shape, XML text preservation, reasoning-tag stripping, prompt sections, and protocol-block behavior.
- **Scope boundary:** This is the first narrow slice of #5287. It does not add a `runtime_profile = "ollama_local"` config surface, a strict-parser config knob, provider-specific local-model profiles, or a full local-first mode. Those remain follow-up design/work items.
- **Blast radius:** High-risk agent/runtime prompt and tool-call behavior. The touched paths affect direct `Agent` turns, the CLI/runtime tool loop, XML dispatcher prompt instructions, reusable prompt sections, and the channel orchestrator's non-native prompt assembly.
- **Linked issue(s):** Related #5287
- **Labels:** Current labels: `enhancement`, `risk: high`, `size: M`, `agent:agent`, `agent:dispatcher`, `agent:loop`, `agent:prompt`, `agent: tests`, `channel:core`.

## Validation Evidence (required)

- **Commands run and tail output:**

```text
cargo fmt --all
Result: passed.

git diff --check
Result: passed.

cargo test -p zeroclaw-runtime turn_with_no_effective_tools --lib
Result: passed.
Tests: 3 passed; 0 failed; 1637 filtered out.

cargo test -p zeroclaw-channels prompt_includes_single_tool_protocol_block_after_append --lib
Result: passed.
Tests: 1 passed; 0 failed; 951 filtered out.

cargo test -p zeroclaw-runtime no_tools --lib
Result: passed.
Tests: 3 passed; 0 failed; 1637 filtered out.

Post-#6544 rebase cargo fmt --all -- --check
Result: passed.

Post-#6544 rebase git diff --check
Result: passed.

Post-#6544 rebase cargo test -p zeroclaw-runtime no_tools --lib
Result: passed.
Tests: 3 passed; 0 failed; 1642 filtered out.

Post-#6544 rebase cargo test -p zeroclaw-runtime turn_with_no_effective_tools --lib
Result: passed.
Tests: 3 passed; 0 failed; 1642 filtered out.

Post-#6544 rebase cargo test -p zeroclaw-channels prompt_includes_single_tool_protocol_block_after_append --lib
Result: passed.
Tests: 1 passed; 0 failed; 959 filtered out.

Post-#6544 rebase cargo clippy -p zeroclaw-channels --all-targets -- -D warnings
Result: passed.

GitHub Actions on current head
Result: passed.
Checks: Lint, Test, Security, Build, Check, Benchmarks Compile, and CI Required Gate passed on head 275ddcb489a97c85f54abb7f1a014dbefe5b603e.
```

- **Beyond CI — what did you manually verify?** I checked the direct Agent path, runtime loop path, XML dispatcher prompt path, reusable prompt-builder path, and channel orchestrator path so prompt text, provider tool specs, parser behavior, and executable tool availability agree when the effective tool set is empty or filtered. During the post-#6544 rebase, I also verified the conflict resolution preserves both the native-tool prompt-catalog suppression from #6544 and this PR's no-effective-tools filtering.
- **If any command was intentionally skipped, why:** CodeRabbit was skipped by reviewer instruction. Full `cargo test`, workspace `cargo clippy --all-targets -- -D warnings`, and `./dev/ci.sh all` were not run locally because this is a focused high-risk slice with targeted runtime/channel tests plus CI coverage. After the CI lint failures, I moved the test-only import into the test module and verified the affected lint class locally with `cargo clippy -p zeroclaw-channels --all-targets -- -D warnings`.

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: No new permissions, network calls, credential handling, or PII are introduced. The security impact is intended to be defensive: when no tools are effective, the model is no longer prompted to emit tool calls and no longer has tool-like output parsed as executable action.

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: No user action is required. Existing configured tools still work; this only changes behavior when the effective tool list for a turn is empty or when prompt descriptions previously drifted from filtered tool availability.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** Revert this PR's squash commit with `git revert <squash-commit-sha>`.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Local/no-tools agents might stop receiving expected prompt guidance, tool-capable channels might show missing tool instructions, or logs/tests around no-effective-tools turns may show unexpected tool-call parsing. Check agent responses for missing tool affordances and runtime/channel logs around prompt assembly and tool-call parsing.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Scope materially carried forward: N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`No`)
- If `No`, why (inspiration-only, no direct code/design carry-over): No superseded PR is incorporated.
