### PR TITLE
fix: keep system messages at the start of chat history

### DIFF
--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -313,32 +313,41 @@ impl OpenAiCompatibleProvider {
         self
     }
 
-    /// Collect all `system` role messages, concatenate their content,
-    /// and prepend to the first `user` message. Drop all system messages.
-    /// Used for providers (e.g. MiniMax) that reject `role: system`.
+    /// Collect all `system` role messages and keep them in a provider-safe
+    /// shape. Strict OpenAI-compatible endpoints accept a leading system
+    /// message but reject system messages later in the history.
     fn flatten_system_messages(messages: &[ChatMessage], merge: bool) -> Vec<ChatMessage> {
+        let mut saw_system = false;
+        let mut system_content = String::new();
+        let mut result: Vec<ChatMessage> = Vec::with_capacity(messages.len());
+
+        for message in messages {
+            if message.role == "system" {
+                saw_system = true;
+                if !message.content.is_empty() {
+                    if !system_content.is_empty() {
+                        system_content.push_str("\n\n");
+                    }
+                    system_content.push_str(&message.content);
+                }
+            } else {
+                result.push(message.clone());
+            }
+        }
+
+        if !saw_system {
+            return messages.to_vec();
+        }
+
         if !merge {
-            return messages.to_vec();
+            result.insert(0, ChatMessage::system(system_content));
+            return result;
         }
-        let system_content: String = messages
-            .iter()
-            .filter(|m| m.role == "system")
-            .map(|m| m.content.as_str())
-            .collect::<Vec<_>>()
-            .join("\n\n");
-
-        if system_content.is_empty() {
-            return messages.to_vec();
-        }
-
-        let mut result: Vec<ChatMessage> = messages
-            .iter()
-            .filter(|m| m.role != "system")
-            .cloned()
-            .collect();
 
         if let Some(first_user) = result.iter_mut().find(|m| m.role == "user") {
-            first_user.content = format!("{system_content}\n\n{}", first_user.content);
+            if !system_content.is_empty() {
+                first_user.content = format!("{system_content}\n\n{}", first_user.content);
+            }
         } else {
             // No user message found: insert a synthetic user message with system content
             result.insert(0, ChatMessage::user(&system_content));
@@ -3851,6 +3860,35 @@ mod tests {
         assert_eq!(flattened[1].role, "user");
         assert_eq!(flattened[2].role, "tool");
         assert!(!flattened.iter().any(|m| m.role == "system"));
+    }
+
+    #[test]
+    fn flatten_system_messages_keeps_system_only_at_start_without_user_merge() {
+        let messages = vec![
+            ChatMessage::system("System A"),
+            ChatMessage::user("User turn"),
+            ChatMessage::assistant("Assistant turn"),
+            ChatMessage::system("System B"),
+            ChatMessage::user("Follow-up"),
+        ];
+
+        let flattened = OpenAiCompatibleProvider::flatten_system_messages(&messages, false);
+        assert_eq!(
+            flattened
+                .iter()
+                .map(|message| message.role.as_str())
+                .collect::<Vec<_>>(),
+            vec!["system", "user", "assistant", "user"]
+        );
+        assert_eq!(
+            flattened
+                .iter()
+                .filter(|message| message.role == "system")
+                .count(),
+            1
+        );
+        assert!(flattened[0].content.contains("System A"));
+        assert!(flattened[0].content.contains("System B"));
     }
 
     #[test]

--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -339,6 +339,10 @@ impl OpenAiCompatibleProvider {
             return messages.to_vec();
         }
 
+        if system_content.is_empty() {
+            return result;
+        }
+
         if !merge {
             result.insert(0, ChatMessage::system(system_content));
             return result;
@@ -3889,6 +3893,21 @@ mod tests {
         );
         assert!(flattened[0].content.contains("System A"));
         assert!(flattened[0].content.contains("System B"));
+    }
+
+    #[test]
+    fn flatten_system_messages_drops_empty_system_messages() {
+        let messages = vec![
+            ChatMessage::system(""),
+            ChatMessage::user("User turn"),
+            ChatMessage::system(""),
+        ];
+
+        let flattened = OpenAiCompatibleProvider::flatten_system_messages(&messages, false);
+
+        assert_eq!(flattened.len(), 1);
+        assert_eq!(flattened[0].role, "user");
+        assert_eq!(flattened[0].content, "User turn");
     }
 
     #[test]

--- a/crates/zeroclaw-runtime/src/agent/history.rs
+++ b/crates/zeroclaw-runtime/src/agent/history.rs
@@ -290,7 +290,7 @@ pub fn normalize_system_messages(history: &mut Vec<ChatMessage>) {
         }
     }
 
-    if saw_system {
+    if saw_system && !system_content.is_empty() {
         history.push(ChatMessage::system(system_content));
     }
     history.extend(non_system);
@@ -298,8 +298,13 @@ pub fn normalize_system_messages(history: &mut Vec<ChatMessage>) {
 
 pub fn append_or_merge_system_message(history: &mut Vec<ChatMessage>, content: impl Into<String>) {
     let content = content.into();
+    if content.is_empty() {
+        normalize_system_messages(history);
+        return;
+    }
+
     if let Some(system_message) = history.iter_mut().find(|message| message.role == "system") {
-        if !system_message.content.is_empty() && !content.is_empty() {
+        if !system_message.content.is_empty() {
             system_message.content.push_str("\n\n");
         }
         system_message.content.push_str(&content);
@@ -362,6 +367,9 @@ pub fn load_interactive_session_history(
         state.history.insert(0, ChatMessage::system(system_prompt));
     }
     normalize_system_messages(&mut state.history);
+    if state.history.first().map(|msg| msg.role.as_str()) != Some("system") {
+        state.history.insert(0, ChatMessage::system(system_prompt));
+    }
 
     // Self-heal persisted sessions that were written with orphaned
     // tool_result messages (e.g. a crash mid-compaction, or a trim that

--- a/crates/zeroclaw-runtime/src/agent/history.rs
+++ b/crates/zeroclaw-runtime/src/agent/history.rs
@@ -271,6 +271,44 @@ pub fn estimate_history_tokens(history: &[ChatMessage]) -> usize {
         .sum()
 }
 
+pub fn normalize_system_messages(history: &mut Vec<ChatMessage>) {
+    let mut saw_system = false;
+    let mut system_content = String::new();
+    let mut non_system = Vec::with_capacity(history.len());
+
+    for message in history.drain(..) {
+        if message.role == "system" {
+            saw_system = true;
+            if !message.content.is_empty() {
+                if !system_content.is_empty() {
+                    system_content.push_str("\n\n");
+                }
+                system_content.push_str(&message.content);
+            }
+        } else {
+            non_system.push(message);
+        }
+    }
+
+    if saw_system {
+        history.push(ChatMessage::system(system_content));
+    }
+    history.extend(non_system);
+}
+
+pub fn append_or_merge_system_message(history: &mut Vec<ChatMessage>, content: impl Into<String>) {
+    let content = content.into();
+    if let Some(system_message) = history.iter_mut().find(|message| message.role == "system") {
+        if !system_message.content.is_empty() && !content.is_empty() {
+            system_message.content.push_str("\n\n");
+        }
+        system_message.content.push_str(&content);
+    } else {
+        history.insert(0, ChatMessage::system(content));
+    }
+    normalize_system_messages(history);
+}
+
 /// Trim conversation history to prevent unbounded growth.
 /// Preserves the system prompt (first message if role=system) and the most recent messages.
 pub fn trim_history(history: &mut Vec<ChatMessage>, max_history: usize) {
@@ -290,6 +328,7 @@ pub fn trim_history(history: &mut Vec<ChatMessage>, max_history: usize) {
     let to_remove = non_system_count - max_history;
     history.drain(start..start + to_remove);
     remove_orphaned_tool_messages(history);
+    normalize_system_messages(history);
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -322,6 +361,7 @@ pub fn load_interactive_session_history(
     } else if state.history.first().map(|msg| msg.role.as_str()) != Some("system") {
         state.history.insert(0, ChatMessage::system(system_prompt));
     }
+    normalize_system_messages(&mut state.history);
 
     // Self-heal persisted sessions that were written with orphaned
     // tool_result messages (e.g. a crash mid-compaction, or a trim that

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -74,10 +74,10 @@ const DEFAULT_MAX_TOOL_ITERATIONS: usize = 10;
 
 // History management moved to `super::history`.
 pub use super::history::{
-    append_or_merge_system_message, canonicalize_tool_result_media_markers,
-    emergency_history_trim, estimate_history_tokens, fast_trim_tool_results,
-    load_interactive_session_history, normalize_system_messages, save_interactive_session_history,
-    trim_history, truncate_tool_result,
+    append_or_merge_system_message, canonicalize_tool_result_media_markers, emergency_history_trim,
+    estimate_history_tokens, fast_trim_tool_results, load_interactive_session_history,
+    normalize_system_messages, save_interactive_session_history, trim_history,
+    truncate_tool_result,
 };
 
 /// Minimum user-message length (in chars) for auto-save to memory.
@@ -3941,6 +3941,32 @@ mod tests {
                 .map(|message| message.role.as_str())
                 .collect::<Vec<_>>(),
             vec!["system", "user", "assistant", "user"]
+        );
+    }
+
+    #[test]
+    fn load_interactive_session_replaces_empty_system_messages_with_fallback() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("session.json");
+        let payload = serde_json::to_string_pretty(&InteractiveSessionState {
+            version: 1,
+            history: vec![
+                ChatMessage::system(""),
+                ChatMessage::user("follow-up"),
+                ChatMessage::system(""),
+            ],
+        })
+        .unwrap();
+        std::fs::write(&path, payload).unwrap();
+
+        let restored = load_interactive_session_history(&path, "fallback system").unwrap();
+
+        assert_eq!(
+            restored
+                .iter()
+                .map(|message| (message.role.as_str(), message.content.as_str()))
+                .collect::<Vec<_>>(),
+            vec![("system", "fallback system"), ("user", "follow-up")]
         );
     }
 

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -74,8 +74,9 @@ const DEFAULT_MAX_TOOL_ITERATIONS: usize = 10;
 
 // History management moved to `super::history`.
 pub use super::history::{
-    canonicalize_tool_result_media_markers, emergency_history_trim, estimate_history_tokens,
-    fast_trim_tool_results, load_interactive_session_history, save_interactive_session_history,
+    append_or_merge_system_message, canonicalize_tool_result_media_markers,
+    emergency_history_trim, estimate_history_tokens, fast_trim_tool_results,
+    load_interactive_session_history, normalize_system_messages, save_interactive_session_history,
     trim_history, truncate_tool_result,
 };
 
@@ -971,6 +972,7 @@ pub async fn run_tool_call_loop(
         // or session history reloading.  Without this, providers like MiniMax
         // reject the request with "tool result's tool id not found" (bug #5743).
         crate::agent::history_pruner::remove_orphaned_tool_messages(history);
+        normalize_system_messages(history);
 
         // Check if model switch was requested via model_switch tool
         if let Some(ref callback) = model_switch_callback
@@ -1906,16 +1908,16 @@ pub async fn run_tool_call_loop(
                     crate::agent::loop_detector::LoopDetectionResult::Ok => {}
                     crate::agent::loop_detector::LoopDetectionResult::Warning(ref msg) => {
                         tracing::warn!(tool = %tool_name, %msg, "loop detector warning");
-                        // Inject a system nudge so the LLM adjusts strategy.
-                        history.push(ChatMessage::system(format!("[Loop Detection] {msg}")));
+                        append_or_merge_system_message(history, format!("[Loop Detection] {msg}"));
                     }
                     crate::agent::loop_detector::LoopDetectionResult::Block(ref msg) => {
                         tracing::warn!(tool = %tool_name, %msg, "loop detector blocked tool call");
                         // Replace the tool output with the block message.
                         // We still continue the loop so the LLM sees the block feedback.
-                        history.push(ChatMessage::system(format!(
-                            "[Loop Detection — BLOCKED] {msg}"
-                        )));
+                        append_or_merge_system_message(
+                            history,
+                            format!("[Loop Detection — BLOCKED] {msg}"),
+                        );
                     }
                     crate::agent::loop_detector::LoopDetectionResult::Break(msg) => {
                         runtime_trace::record_event(
@@ -3899,6 +3901,49 @@ mod tests {
         assert_eq!(restored[1].content, "orphan");
     }
 
+    #[test]
+    fn load_interactive_session_merges_non_leading_system_messages() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("session.json");
+        let payload = serde_json::to_string_pretty(&InteractiveSessionState {
+            version: 1,
+            history: vec![
+                ChatMessage::system("base system"),
+                ChatMessage::user("first question"),
+                ChatMessage::assistant("first answer"),
+                ChatMessage::system("late loop-detection guidance"),
+                ChatMessage::user("follow-up"),
+            ],
+        })
+        .unwrap();
+        std::fs::write(&path, payload).unwrap();
+
+        let restored = load_interactive_session_history(&path, "fallback").unwrap();
+
+        assert_eq!(
+            restored
+                .iter()
+                .filter(|message| message.role == "system")
+                .count(),
+            1,
+            "loaded session must not contain non-leading system messages: {:?}",
+            restored
+                .iter()
+                .map(|message| message.role.as_str())
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(restored[0].role, "system");
+        assert!(restored[0].content.contains("base system"));
+        assert!(restored[0].content.contains("late loop-detection guidance"));
+        assert_eq!(
+            restored
+                .iter()
+                .map(|message| message.role.as_str())
+                .collect::<Vec<_>>(),
+            vec!["system", "user", "assistant", "user"]
+        );
+    }
+
     /// Regression test for issue #5813: a persisted session whose assistant
     /// (tool_use) was lost to compaction must self-heal on load so the next
     /// API call doesn't fail with "unexpected tool_use_id found in tool_result
@@ -4170,6 +4215,49 @@ mod tests {
             responses
                 .pop_front()
                 .ok_or_else(|| anyhow::anyhow!("scripted provider exhausted responses"))
+        }
+    }
+
+    struct RecordingProvider {
+        requests: Arc<Mutex<Vec<Vec<ChatMessage>>>>,
+    }
+
+    impl RecordingProvider {
+        fn new() -> Self {
+            Self {
+                requests: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Provider for RecordingProvider {
+        async fn chat_with_system(
+            &self,
+            _system_prompt: Option<&str>,
+            _message: &str,
+            _model: &str,
+            _temperature: Option<f64>,
+        ) -> anyhow::Result<String> {
+            anyhow::bail!("chat_with_system should not be used in recording provider tests");
+        }
+
+        async fn chat(
+            &self,
+            request: ChatRequest<'_>,
+            _model: &str,
+            _temperature: Option<f64>,
+        ) -> anyhow::Result<ChatResponse> {
+            self.requests
+                .lock()
+                .expect("requests lock should be valid")
+                .push(request.messages.to_vec());
+            Ok(ChatResponse {
+                text: Some("done".to_string()),
+                tool_calls: Vec::new(),
+                usage: None,
+                reasoning_content: None,
+            })
         }
     }
 
@@ -7721,6 +7809,70 @@ Let me check the result."#;
         assert_eq!(summary.request_count, 1);
         assert_eq!(summary.total_tokens, 1_200);
         assert!(summary.session_cost_usd > 0.0);
+    }
+
+    #[tokio::test]
+    async fn tool_loop_normalizes_non_leading_system_messages_before_provider_request() {
+        let provider = RecordingProvider::new();
+        let requests = Arc::clone(&provider.requests);
+        let observer = NoopObserver;
+        let mut history = vec![
+            ChatMessage::system("base system"),
+            ChatMessage::user("first question"),
+            ChatMessage::assistant("first answer"),
+            ChatMessage::system("late loop-detection guidance"),
+            ChatMessage::user("follow-up"),
+        ];
+
+        let result = run_tool_call_loop(
+            &provider,
+            &mut history,
+            &[],
+            &observer,
+            "recording-provider",
+            "mock-model",
+            0.0,
+            true,
+            None,
+            "test",
+            None,
+            &zeroclaw_config::schema::MultimodalConfig::default(),
+            2,
+            None,
+            None,
+            None,
+            &[],
+            &[],
+            None,
+            None,
+            &zeroclaw_config::schema::PacingConfig::default(),
+            0,
+            0,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("tool loop should complete");
+
+        assert_eq!(result, "done");
+        let requests = requests.lock().expect("requests lock should be valid");
+        assert_eq!(requests.len(), 1);
+        let sent = &requests[0];
+        assert_eq!(sent[0].role, "system");
+        assert_eq!(
+            sent.iter().filter(|msg| msg.role == "system").count(),
+            1,
+            "provider request must not contain non-leading system messages: {:?}",
+            sent.iter().map(|msg| msg.role.as_str()).collect::<Vec<_>>()
+        );
+        assert!(sent[0].content.contains("base system"));
+        assert!(sent[0].content.contains("late loop-detection guidance"));
+        assert_eq!(
+            sent.iter().map(|msg| msg.role.as_str()).collect::<Vec<_>>(),
+            vec!["system", "user", "assistant", "user"]
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Normalize runtime chat history so all `system` messages are merged into the first message before provider dispatch.
  - Make loop-detection feedback merge into the leading `system` message instead of appending a non-leading `system` message.
  - Self-heal persisted interactive session history with non-leading `system` messages on load.
  - Canonicalize OpenAI-compatible provider requests so `merge_system_into_user = false` still sends at most one leading `system` message.
- **Scope boundary:** No new config, no provider-specific workaround requirement, no changes to custom fork patch tracks or ops metadata.
- **Blast radius:** Runtime history/session normalization, the agent tool-loop request path, and OpenAI-compatible provider message serialization.
- **Linked issue(s):** Closes #6551

## Validation Evidence (required)

Local validation is the signal CI cannot replace. Run the full battery and paste literal output (tails, failures, warnings — not "all passed").

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

Docs-only changes: replace with markdown lint + link-integrity (`scripts/ci/docs_quality_gate.sh`). Bootstrap scripts: add `bash -n install.sh`.

- **Commands run and tail output:**

```text
$ cargo test -p zeroclaw-runtime system_messages -- --nocapture
running 2 tests
test agent::loop_::tests::load_interactive_session_merges_non_leading_system_messages ... ok
test agent::loop_::tests::tool_loop_normalizes_non_leading_system_messages_before_provider_request ... ok
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 1625 filtered out
```

```text
$ cargo test -p zeroclaw-providers flatten_system_messages -- --nocapture
running 5 tests
test compatible::tests::flatten_system_messages_inserts_synthetic_user_when_no_user_exists ... ok
test compatible::tests::flatten_system_messages_inserts_user_when_missing ... ok
test compatible::tests::flatten_system_messages_keeps_system_only_at_start_without_user_merge ... ok
test compatible::tests::flatten_system_messages_merges_into_first_user_and_removes_system_roles ... ok
test compatible::tests::flatten_system_messages_merges_into_first_user ... ok
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 817 filtered out
```

```text
$ git diff --check HEAD^ HEAD
exit 0
```

```text
$ cargo fmt --all -- --check
exit 0
```

```text
$ cargo clippy --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 56.30s
```

```text
$ cargo test
Root unit/integration/system tests completed before doctests:
- 237 lib tests passed
- 236 main tests passed
- 159 integration tests passed
- 7 live tests ignored
- 5 system tests passed

Doctest failure:
Doc-tests zeroclaw
error: Option 'default-theme' given more than once
error: doctest failed, to rerun pass `--doc`

The failing rustdoc invocation included duplicate flags:
--default-theme=ayu --default-theme=ayu
```

- **GitHub CI status:** Required gate passed for this PR head. Passing checks include `CI Required Gate`, `Test`, `Lint`, `Security`, `Check (all features)`, `Check (no default features)`, `Check (32-bit)`, Linux/macOS/Windows builds, and `Benchmarks Compile`.
- **Beyond CI — what did you manually verify?** The new regression tests were written first and failed on the pre-fix code with histories shaped `system,user,assistant,system,user`. After the fix, the runtime provider request and session load paths contain only one leading `system` message and preserve both system contents. A self-review of commit `ff7da168` found no blocking issues; focused runtime/provider regression tests and `git diff --check` were rerun after review.
- **If any command was intentionally skipped, why:** None. `cargo test` was run, but the local doctest phase failed because rustdoc received duplicate `--default-theme=ayu` flags from the current local configuration.

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: `N/A`

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: exact upgrade steps for existing users: `N/A`

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PRs: `git revert <sha>` is the plan unless otherwise noted.

Medium/high-risk PRs must fill:

- **Fast rollback command/path:** `git revert <squash-merge-sha>` after merge.
- **Feature flags or config toggles:** `None`
- **Observable failure symptoms:** Strict OpenAI-compatible endpoints may again reject requests with `System message must be at the beginning.` if non-leading system messages reappear.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): `N/A`
- Scope materially carried forward: `N/A`
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`No`)
- If `No`, why (inspiration-only, no direct code/design carry-over): `No superseded PR or external contributor code was incorporated.`

---

**Labels** live in the GitHub label UI, not in the body. Set `risk:*`, `size:*`, and scope labels via the sidebar. Auto-label corrections: add `risk: manual` and the intended label.

**Privacy contract** (`docs/book/src/contributing/privacy.md`) is a merge gate. Never commit real identities, secrets, personal emails, or PII in diff, tests, fixtures, or docs.

