### PR TITLE
docs(skills/pr-review): refine Phase 3.5 milestone alignment — break-fix + docs fallback, Jordan trapdoor for features

### DIFF
--- a/.claude/skills/github-pr-review-session/SKILL.md
+++ b/.claude/skills/github-pr-review-session/SKILL.md
@@ -143,14 +143,14 @@ the handoff.
    - **Break-fix** — commit title prefix is `fix:` (any scope, e.g. `fix(agent):`) **or** the PR carries a `bug` label. The commit prefix is the primary signal; the label is a secondary confirmation.
    - **Docs** — commit title prefix is `docs:` (any scope). Treated identically to break-fix for milestone purposes: scope-match first, then fall back to earliest open milestone by version. Documentation supports ongoing milestone work and should ship with it, not queue Jordan.
    - **Feature** — commit title prefix is `feat:` and no `bug` label.
+   - **Other** — any other conventional type (`refactor:`, `perf:`, `test:`, `ci:`, `build:`, etc.). Treat as break-fix for milestone routing: scope-match first, then fall back to the earliest open milestone. Do not route to @JordanTheJet.
    - When the prefix and label contradict (e.g. `fix(agent):` title + `enhancement` label), the commit prefix wins.
 
 3. **Compare scope against every open milestone.** Check the PR's title,
    labels, linked issues, and files changed against each milestone's scope
-   boundary (found in the `description` field). Run this step for **both**
-   break-fix and feature PRs — a fix that repairs something introduced by a
-   specific milestone's work belongs in that milestone, not automatically in
-   the earliest one.
+   boundary (found in the `description` field). Run this step for **all
+   classified PR types** — a fix or doc that's tied to a specific milestone's
+   work belongs there, not automatically in the earliest one.
 
    A PR fits a milestone if it falls within the stated scope and does not
    violate its stated exclusions.

--- a/.claude/skills/github-pr-review-session/SKILL.md
+++ b/.claude/skills/github-pr-review-session/SKILL.md
@@ -136,13 +136,38 @@ the handoff.
    gh api repos/zeroclaw-labs/zeroclaw/milestones \
      --jq '.[] | select(.state=="open") | {number: .number, title: .title, description: .description}'
    ```
+   Sort milestones by version order (semver ascending on the title) so
+   "earliest open milestone" is unambiguous in step 4 below.
 
-2. **Compare scope.** Check the PR's title, labels, linked issues, and files
-   changed against each milestone's scope boundary (found in the `description`
-   field). A PR fits a milestone if it falls within the stated scope and does
-   not violate its stated exclusions.
+2. **Classify the PR** before comparing scope:
+   - **Break-fix** — commit title prefix is `fix:` (any scope, e.g. `fix(agent):`) **or** the PR carries a `bug` label. The commit prefix is the primary signal; the label is a secondary confirmation.
+   - **Docs** — commit title prefix is `docs:` (any scope). Treated identically to break-fix for milestone purposes: scope-match first, then fall back to earliest open milestone by version. Documentation supports ongoing milestone work and should ship with it, not queue Jordan.
+   - **Feature** — commit title prefix is `feat:` and no `bug` label.
+   - When the prefix and label contradict (e.g. `fix(agent):` title + `enhancement` label), the commit prefix wins.
 
-3. **If the PR fits a milestone:**
+3. **Compare scope against every open milestone.** Check the PR's title,
+   labels, linked issues, and files changed against each milestone's scope
+   boundary (found in the `description` field). Run this step for **both**
+   break-fix and feature PRs — a fix that repairs something introduced by a
+   specific milestone's work belongs in that milestone, not automatically in
+   the earliest one.
+
+   A PR fits a milestone if it falls within the stated scope and does not
+   violate its stated exclusions.
+
+4. **Apply the decision tree:**
+
+   | Situation | Action |
+   |---|---|
+   | PR fits a milestone (any type) | Assign that milestone → go to step 5 |
+   | No scope match + break-fix or docs | Assign the **earliest open milestone** by version order → go to step 5 |
+   | No scope match + feature | Tag @JordanTheJet → go to step 6 |
+
+   "Earliest open milestone" means the lowest semver among all currently open
+   milestones (e.g. v0.7.6 before v0.7.7 before v0.8.0). Sort by the version
+   number in the title, not by creation date.
+
+5. **After assigning a milestone:**
 
    a. Set the milestone on the PR:
       ```bash
@@ -156,9 +181,8 @@ the handoff.
         --milestone "<milestone-title>" --state open \
         --search "milestone tracking" --json number,title
       ```
-      If the search returns zero results, skip the body update and fall
-      through to step 4 — treat a missing tracking issue the same as no
-      matching milestone.
+      If the search returns zero results, skip the body update and record
+      "no tracking issue found" in the handoff.
 
    c. Derive the entry format, section placement, and verdict emoji directly
       from the existing entries in the tracking issue body — the live content
@@ -180,7 +204,7 @@ the handoff.
         --body-file tmp/tracking-<milestone-title>.md
       ```
 
-4. **If the PR does not fit any open milestone:**
+6. **Jordan trapdoor — feature with no scope match:**
 
    Post a comment on the PR tagging @JordanTheJet for milestone alignment:
    ```bash
@@ -253,7 +277,11 @@ These norms are documented in
    block unless the active reviewer explicitly asks for that format.
 7. **Always run milestone alignment after posting**, unless the PR is a
    documented no-milestone type (`chore:`/`deps:` prefix or deps-only diff).
-   Note the skip reason in the handoff when bypassing.
+   Note the skip reason in the handoff when bypassing. Break-fix (`fix:`
+   prefix or `bug` label) and docs (`docs:` prefix) PRs with no scope match
+   are assigned the earliest open milestone by version order — do not tag
+   @JordanTheJet for those. @JordanTheJet is only the fallback for feature
+   PRs with no scope match.
 8. **Always update `tmp/handoff.md` after posting.** The handoff is useless if
    it's not current. Include the milestone alignment outcome.
 9. **Never merge.** Never push to contributor branches.


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Replaces the binary scope-match-or-Jordan path in Phase 3.5 with a four-step decision tree.
  - Adds a **PR classification step** (break-fix / docs / feature) before scope comparison — commit prefix is the primary signal; a conflicting label is secondary.
  - Scope-match runs first for **all** PR types so a fix or doc that's tied to a specific milestone lands there correctly.
  - **Break-fix** (`fix:` prefix or `bug` label) with no scope match falls back to the earliest open milestone by semver.
  - **Docs** (`docs:` prefix) with no scope match falls back the same way — docs support ongoing milestone work and should ship with it, not queue Jordan. This was found as a gap during the first live application of the rule (this PR itself).
  - **Feature** (`feat:` prefix, no `bug` label) with no scope match remains the only case that routes to @JordanTheJet.
  - Execution rule 7 updated to match.
- **Scope boundary:** Only `.claude/skills/github-pr-review-session/SKILL.md` is changed. No production code, CI, or config surface is touched.
- **Blast radius:** Future PR review sessions run by this skill will use the revised milestone alignment logic. Previously posted reviews are unaffected.
- **Linked issue(s):** None. Policy derived from reviewer session on 2026-05-10.
- **Labels:** `type: docs`, `risk: low`, `size: XS`, `docs`

## Validation Evidence (required)

```
npx markdownlint-cli2@0.20.0 .claude/skills/github-pr-review-session/SKILL.md
markdownlint-cli2 v0.20.0 (markdownlint v0.40.0)
Finding: .claude/skills/github-pr-review-session/SKILL.md
Linting: 1 file(s)
Summary: 0 error(s)
```

No external links added to the diff.

- **Beyond CI — what did you manually verify?** Applied the revised logic live to six PRs in the same session (#6542, #6541, #6544, #6546, #6539, #6554). The `docs:` gap was discovered when applying the rule to this PR itself — proof that the gap was real and the fix is correct.
- **If any command was intentionally skipped, why:** Full Rust battery skipped — docs-only change in `.claude/skills/`, per `AGENTS.md` guidance.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (No)
- New external network calls? (No)
- Secrets / tokens / credentials handling changed? (No)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (No)

## Compatibility (required)

- Backward compatible? (Yes)
- Config / env / CLI surface changed? (No)