### PR TITLE
chore(build): pin Docker web-builder base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.7-labs
 
 # ── Stage 0: Frontend build ─────────────────────────────────────
-FROM node:22-bookworm-slim AS web-node
+FROM node:22-bookworm-slim@sha256:9f6d5975c7dca860947d3915877f85607946403fc55349f39b4bc3688448bb6e AS web-node
 
 FROM rust:1.94-slim@sha256:da9dab7a6b8dd428e71718402e97207bb3e54167d37b5708616050b1e8f60ed6 AS web-builder
 WORKDIR /app

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,9 +1,9 @@
 # syntax=docker/dockerfile:1.7-labs
 
 # ── Stage 0: Frontend build ─────────────────────────────────────
-FROM node:22-bookworm-slim AS web-node
+FROM node:22-bookworm-slim@sha256:9f6d5975c7dca860947d3915877f85607946403fc55349f39b4bc3688448bb6e AS web-node
 
-FROM rust:1.94-bookworm AS web-builder
+FROM rust:1.94-bookworm@sha256:6ae102bdbf528294bc79ad6e1fae682f6f7c2a6e6621506ba959f9685b308a55 AS web-builder
 WORKDIR /app
 COPY --from=web-node /usr/local/bin/node /usr/local/bin/node
 COPY --from=web-node /usr/local/lib/node_modules /usr/local/lib/node_modules
@@ -41,7 +41,7 @@ RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/regist
 #   docker compose -f docker-compose.yml -f docker-compose.debian.yml up
 
 # ── Stage 1: Build (match runtime glibc baseline) ───────────
-FROM rust:1.94-bookworm AS builder
+FROM rust:1.94-bookworm@sha256:6ae102bdbf528294bc79ad6e1fae682f6f7c2a6e6621506ba959f9685b308a55 AS builder
 
 WORKDIR /app
 ARG ZEROCLAW_CARGO_FEATURES="rag-pdf"


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Pins the shared `node:22-bookworm-slim` donor image by digest in both Dockerfiles.
  - Pins the `rust:1.94-bookworm` build stages in `Dockerfile.debian` by digest.
  - Reduces drift from mutable Docker Hub tags during reproducible container builds.
- **Scope boundary:** This PR does not change the distroless runtime base, the Debian runtime base, Docker build commands, Cargo features, or application behavior.
- **Blast radius:** Container build reproducibility only; runtime behavior should be unchanged.
- **Linked issue(s):** Related #6540.
- **Labels:** `type: dependencies`, `dependencies`, `risk: low`, `size: XS`.

## Validation Evidence (required)

- **Commands run and tail output:**

  ```text
  cargo fmt --all -- --check
  Result: passed with no output.

  git diff --cached --check
  Result: passed with no output before commit.

  docker buildx imagetools inspect node:22-bookworm-slim --format '{{json .Manifest.Digest}}'
  Result: "sha256:9f6d5975c7dca860947d3915877f85607946403fc55349f39b4bc3688448bb6e"

  docker buildx imagetools inspect rust:1.94-bookworm --format '{{json .Manifest.Digest}}'
  Result: "sha256:6ae102bdbf528294bc79ad6e1fae682f6f7c2a6e6621506ba959f9685b308a55"

  docker buildx build --progress=plain --target web-node -f Dockerfile .
  Result: passed; loaded docker/dockerfile:1.7-labs and resolved the pinned node digest.

  docker buildx build --progress=plain --target web-node -f Dockerfile.debian .
  Result: passed; loaded docker/dockerfile:1.7-labs and resolved the pinned node digest.

  docker buildx build --check --progress=plain -f Dockerfile .
  docker buildx build --check --progress=plain -f Dockerfile.debian .
  Result: blocked by pre-existing COPY --parents parser behavior in the stable build-check frontend, before validating this patch.
  ```

- **Beyond CI — what did you manually verify?** Confirmed the pinned digest values match Docker Hub manifest digests for the referenced tags, and confirmed both Dockerfiles still parse far enough to resolve the pinned `web-node` stage with the labs frontend.
- **If any command was intentionally skipped, why:** Full Docker image builds were not run because this PR only pins base-image references and the narrow target builds verified digest resolution without spending full build time.

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: None.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No user upgrade steps required.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PRs: `git revert 42ccb79b361797e99b47c6094a5aaaa6ea4f82b4`.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): None.
- Scope materially carried forward: None.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why (inspiration-only, no direct code/design carry-over): No superseded PR content is incorporated.
