### PR TITLE
feat(nix): add NixOS module + test for services.zeroclaw.instances

### DIFF
--- a/nix/README.md
+++ b/nix/README.md
@@ -165,7 +165,14 @@ be flagged in the changelog.
 Resource caps (`MemoryMax`, `CPUQuota`, etc.) are intentionally **not** set
 in the module — Rust servers have widely varying resource profiles
 depending on workload, and per-host tuning belongs in the caller's config.
-Use `extraServiceConfig` to add them.
+To add them, override the generated unit directly:
+
+```nix
+systemd.services."zeroclaw-me".serviceConfig = {
+  MemoryMax = "1G";
+  CPUQuota = "200%";
+};
+```
 
 ## Running the test
 

--- a/nix/README.md
+++ b/nix/README.md
@@ -21,7 +21,7 @@ Add the module to your NixOS configuration's `imports` and declare one
 instance:
 
 ```nix
-{ pkgs, ... }: {
+{ config, pkgs, ... }: {
   imports = [ ./path/to/zeroclaw/nix/module.nix ];
 
   # If pkgs.zeroclaw isn't yet in nixpkgs, set the package explicitly:

--- a/nix/README.md
+++ b/nix/README.md
@@ -1,0 +1,173 @@
+# NixOS module for ZeroClaw
+
+`nix/module.nix` is a multi-instance NixOS module that runs ZeroClaw under
+systemd with sandboxing defaults appropriate for an internet-facing agent
+process. It is designed to be importable from any NixOS configuration —
+nothing in the module assumes a specific deployment topology.
+
+The shape mirrors `services.restic.backups` (multi-instance Rust services
+already in nixpkgs), and the hardening profile mirrors `services.atticd`
+(another Rust server in nixpkgs).
+
+This module pairs with the package work in #5987 — the package gives you
+`pkgs.zeroclaw`, the module gives you `services.zeroclaw.instances.<name>`.
+Either can land first; once both are merged a single-host user can write
+`services.zeroclaw.instances.me = { settings = { ... }; };` and have a
+running daemon.
+
+## Quick start (single instance)
+
+Add the module to your NixOS configuration's `imports` and declare one
+instance:
+
+```nix
+{ pkgs, ... }: {
+  imports = [ ./path/to/zeroclaw/nix/module.nix ];
+
+  # If pkgs.zeroclaw isn't yet in nixpkgs, set the package explicitly:
+  # services.zeroclaw.instances.me.package = pkgs.callPackage ./zeroclaw.nix { };
+
+  age.secrets.zeroclaw-bot-token.file = ./secrets/zeroclaw-bot-token.age;
+
+  services.zeroclaw.instances.me = {
+    environmentFile = config.age.secrets.zeroclaw-bot-token.path;
+    settings = {
+      default_provider = "anthropic";
+      default_model = "claude-sonnet-4-6";
+
+      channels.telegram = {
+        enabled = true;
+        # systemd substitutes $BOT_TOKEN at process start from the
+        # decrypted environmentFile — the rendered TOML in /nix/store
+        # contains the literal string "$BOT_TOKEN".
+        bot_token = "$BOT_TOKEN";
+        allowed_users = [ "12345" ];
+      };
+    };
+  };
+}
+```
+
+After a `nixos-rebuild switch`:
+
+- The unit `zeroclaw-me.service` is started and enabled.
+- `/var/lib/zeroclaw-me/` exists, owned by the per-instance user `zeroclaw-me`.
+- `/var/lib/zeroclaw-me/config.toml` contains the rendered TOML, mode `0600`.
+- ZeroClaw is invoked as `${pkgs.zeroclaw}/bin/zeroclaw daemon`.
+
+## Multi-instance usage
+
+The module is `attrsOf submodule`-shaped, so multiple instances on one host
+look identical to one instance:
+
+```nix
+services.zeroclaw.instances = {
+  alice = { environmentFile = "/run/secrets/alice/identity.env"; settings = { ... }; };
+  bob   = { environmentFile = "/run/secrets/bob/identity.env";   settings = { ... }; };
+};
+```
+
+Each instance gets its own systemd unit, state directory, and per-instance
+system user. The module asserts at evaluation time that no two instances
+share a `dataDir` or `user`, and that instance names are valid systemd unit
+component names (`[A-Za-z0-9._-]+`).
+
+## Option summary
+
+| Option | Type | Default | Purpose |
+|---|---|---|---|
+| `package` | `package` | `pkgs.zeroclaw` (via `mkPackageOption`) | Override for out-of-tree builds. |
+| `user` | `str` | `"zeroclaw-<name>"` | System user. |
+| `group` | `str` | `"zeroclaw-<name>"` | System group. |
+| `createUser` | `bool` | `true` | Set `false` to bring your own user. |
+| `dataDir` | `path` | `"/var/lib/zeroclaw-<name>"` | State directory (also `StateDirectory=`). |
+| `settings` | `submodule { freeformType = (pkgs.formats.toml { }).type; }` | `{}` | Rendered to `${dataDir}/config.toml`. |
+| `environmentFile` | `nullOr path` | `null` | systemd `EnvironmentFile=`. Substituted into `settings` strings at start. |
+| `extraConfig` | `lines` | `""` | Raw TOML appended after rendered `settings` (escape hatch). |
+| `bindReadOnlyPaths` | `attrsOf path` | `{}` | `target → source` map → `BindReadOnlyPaths=`. |
+| `extraServiceConfig` | `attrs` | `{}` | `serviceConfig` overrides merged via `mkMerge`. |
+
+See `module.nix`'s inline option `description` blocks for the full
+contract of each option.
+
+## Secrets pattern
+
+Two paths, both supported, neither leaks secrets to the world-readable
+Nix store:
+
+1. **`environmentFile` + `$VAR` substitution in `settings` strings**
+   (recommended). Systemd loads the file via `EnvironmentFile=` at unit
+   start; ZeroClaw resolves `${VAR}` references in config strings against
+   its process environment. The rendered TOML in `/nix/store` contains
+   only the literal `$VAR` placeholder.
+
+2. **`environmentFile` + ZeroClaw-native env-var lookups** for any config
+   keys ZeroClaw natively resolves from the environment (e.g. provider
+   API keys). Same end result — no secret in the rendered TOML.
+
+What the module **never** does: render an interpolated string from a
+secret-bearing Nix expression into `settings`. That would put the secret
+in the world-readable `/nix/store/.../config.toml`.
+
+When `environmentFile` is set, the unit also gets a
+`ConditionPathExists=${environmentFile}` so it stays inactive (rather
+than failing) until the file materialises — useful for sops-nix /
+agenix activation timing.
+
+## Hardening
+
+Per-instance `serviceConfig` defaults (mirroring `services.atticd`):
+
+```
+NoNewPrivileges=yes
+PrivateTmp=yes
+PrivateDevices=yes
+ProtectSystem=strict
+ProtectHome=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectControlGroups=yes
+ProtectClock=yes
+ProtectHostname=yes
+ProtectProc=invisible
+ProcSubset=pid
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+LockPersonality=yes
+SystemCallArchitectures=native
+CapabilityBoundingSet=
+AmbientCapabilities=
+SystemCallFilter=@system-service ~@privileged ~@resources
+StateDirectoryMode=0750
+UMask=0077
+ReadWritePaths=${dataDir}
+```
+
+Resource caps (`MemoryMax`, `CPUQuota`, etc.) are intentionally **not** set
+in the module — Rust servers have widely varying resource profiles
+depending on workload, and per-host tuning belongs in the caller's config.
+Use `extraServiceConfig` to add them.
+
+## Running the test
+
+The module ships with a NixOS test (`nix/test.nix`) that boots a VM with
+two instances, validates unit generation, file rendering, multi-instance
+isolation, and the hardening profile.
+
+```bash
+nix-build -E '
+  (import <nixpkgs/nixos/lib/testing-python.nix> { })
+    .makeTest (import ./nix/test.nix { })
+'
+```
+
+Requires KVM on the builder.
+
+## Status
+
+Initial drop, not yet wired into ZeroClaw's CI. The CI workflow at
+`.github/workflows/ci.yml` is Rust-only today; adding a `nix-test` job to
+exercise `nix/test.nix` is a natural follow-up.

--- a/nix/README.md
+++ b/nix/README.md
@@ -122,6 +122,8 @@ Per-instance `serviceConfig` defaults (mirroring `services.atticd`):
 NoNewPrivileges=yes
 PrivateTmp=yes
 PrivateDevices=yes
+DeviceAllow=
+DevicePolicy=closed
 ProtectSystem=strict
 ProtectHome=yes
 ProtectKernelTunables=yes
@@ -132,6 +134,8 @@ ProtectClock=yes
 ProtectHostname=yes
 ProtectProc=invisible
 ProcSubset=pid
+MemoryDenyWriteExecute=yes
+RemoveIPC=yes
 RestrictNamespaces=yes
 RestrictRealtime=yes
 RestrictSUIDSGID=yes
@@ -145,6 +149,11 @@ StateDirectoryMode=0750
 UMask=0077
 ReadWritePaths=${dataDir}
 ```
+
+`MemoryDenyWriteExecute=yes` is safe because ZeroClaw 0.7.x is a plain
+Rust binary with no JIT; if a future version adopts a JIT (e.g. through a
+WASM plugin host), this single setting will need to flip and that should
+be flagged in the changelog.
 
 Resource caps (`MemoryMax`, `CPUQuota`, etc.) are intentionally **not** set
 in the module — Rust servers have widely varying resource profiles

--- a/nix/README.md
+++ b/nix/README.md
@@ -166,7 +166,6 @@ SystemCallArchitectures=native
 CapabilityBoundingSet=
 AmbientCapabilities=
 SystemCallFilter=@system-service ~@privileged ~@resources
-StateDirectoryMode=0750
 UMask=0077
 ReadWritePaths=${dataDir}
 ```
@@ -191,7 +190,7 @@ systemd.services."zeroclaw-me".serviceConfig = {
 ## Running the test
 
 The module ships with a NixOS test (`nix/test.nix`) that boots a VM with
-two instances, validates unit generation, file rendering, multi-instance
+multiple instances, validates unit generation, file rendering, multi-instance
 isolation, and the hardening profile.
 
 ```bash

--- a/nix/README.md
+++ b/nix/README.md
@@ -37,9 +37,11 @@ instance:
 
       channels.telegram = {
         enabled = true;
-        # systemd substitutes $BOT_TOKEN at process start from the
-        # decrypted environmentFile — the rendered TOML in /nix/store
-        # contains the literal string "$BOT_TOKEN".
+        # The unit's ExecStartPre runs `envsubst` over the rendered
+        # TOML. `$BOT_TOKEN` is read from the EnvironmentFile= and
+        # written into ${dataDir}/config.toml (mode 0600, owner =
+        # zeroclaw-me). The world-readable copy in /nix/store keeps
+        # only the literal "$BOT_TOKEN" placeholder.
         bot_token = "$BOT_TOKEN";
         allowed_users = [ "12345" ];
       };
@@ -80,7 +82,7 @@ component names (`[A-Za-z0-9._-]+`).
 | `user` | `str` | `"zeroclaw-<name>"` | System user. |
 | `group` | `str` | `"zeroclaw-<name>"` | System group. |
 | `createUser` | `bool` | `true` | Set `false` to bring your own user. |
-| `dataDir` | `path` | `"/var/lib/zeroclaw-<name>"` | State directory (also `StateDirectory=`). |
+| `dataDir` | `path` | `"/var/lib/zeroclaw-<name>"` | State directory. Created via `systemd-tmpfiles` so any absolute path works (`/var/lib/...`, `/srv/...`, etc.). |
 | `settings` | `submodule { freeformType = (pkgs.formats.toml { }).type; }` | `{}` | Rendered to `${dataDir}/config.toml`. |
 | `environmentFile` | `nullOr path` | `null` | systemd `EnvironmentFile=`. Substituted into `settings` strings at start. |
 | `extraConfig` | `lines` | `""` | Raw TOML appended after rendered `settings` (escape hatch). |
@@ -102,14 +104,26 @@ Two paths, both supported, neither leaks secrets to the world-readable
 Nix store:
 
 1. **`environmentFile` + `$VAR` substitution in `settings` strings**
-   (recommended). Systemd loads the file via `EnvironmentFile=` at unit
-   start; ZeroClaw resolves `${VAR}` references in config strings against
-   its process environment. The rendered TOML in `/nix/store` contains
-   only the literal `$VAR` placeholder.
+   (recommended for channel tokens, webhook secrets, anything ZeroClaw
+   doesn't already resolve from the environment natively). Systemd loads
+   the file via `EnvironmentFile=` at unit start. The unit's
+   `ExecStartPre` then runs `envsubst` over the rendered TOML, expanding
+   `$VAR` and `${VAR}` references against the loaded environment, and
+   writes the result to `${dataDir}/config.toml` mode `0600` owned by the
+   per-instance user. The build-time copy in `/nix/store` only ever
+   contains the literal placeholders.
+
+   The substitution is performed by *this module*, not by ZeroClaw —
+   ZeroClaw reads `config.toml` verbatim. So this path turns
+   `bot_token = "$BOT_TOKEN"` into a working configuration regardless
+   of whether ZeroClaw has a native env-var fallback for that field.
 
 2. **`environmentFile` + ZeroClaw-native env-var lookups** for any config
-   keys ZeroClaw natively resolves from the environment (e.g. provider
-   API keys). Same end result — no secret in the rendered TOML.
+   keys ZeroClaw natively resolves from the environment (e.g.
+   `OPENROUTER_API_KEY`, `OPENAI_API_KEY`, `ZEROCLAW_PROVIDER`,
+   `ZEROCLAW_MODEL` — see `crates/zeroclaw-config/src/schema.rs`
+   upstream for the full list). Same end result — no secret in the
+   rendered TOML — and you can omit the field from `settings` entirely.
 
 What the module **never** does: render an interpolated string from a
 secret-bearing Nix expression into `settings`. That would put the secret

--- a/nix/README.md
+++ b/nix/README.md
@@ -85,7 +85,13 @@ component names (`[A-Za-z0-9._-]+`).
 | `environmentFile` | `nullOr path` | `null` | systemd `EnvironmentFile=`. Substituted into `settings` strings at start. |
 | `extraConfig` | `lines` | `""` | Raw TOML appended after rendered `settings` (escape hatch). |
 | `bindReadOnlyPaths` | `attrsOf path` | `{}` | `target → source` map → `BindReadOnlyPaths=`. |
-| `extraServiceConfig` | `attrs` | `{}` | `serviceConfig` overrides merged via `mkMerge`. |
+
+If you need to override a `serviceConfig` field (e.g. add `MemoryMax`),
+use the standard NixOS pattern rather than a module-level escape hatch:
+
+```nix
+systemd.services."zeroclaw-me".serviceConfig.MemoryMax = lib.mkForce "1G";
+```
 
 See `module.nix`'s inline option `description` blocks for the full
 contract of each option.

--- a/nix/README.md
+++ b/nix/README.md
@@ -135,6 +135,7 @@ ProtectHostname=yes
 ProtectProc=invisible
 ProcSubset=pid
 MemoryDenyWriteExecute=yes
+PrivateUsers=yes
 RemoveIPC=yes
 RestrictNamespaces=yes
 RestrictRealtime=yes

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -47,7 +47,6 @@ let
     types
     mkOption
     mkIf
-    mkMerge
     mkPackageOption
     mapAttrs'
     mapAttrsToList
@@ -201,19 +200,18 @@ let
           managed read-only assets.
         '';
       };
-
-      extraServiceConfig = mkOption {
-        type = types.attrs;
-        default = { };
-        description = ''
-          Free-form `serviceConfig` overrides merged into the generated
-          systemd unit. Use sparingly — prefer typed options where
-          possible. Attribute values shadow the defaults set by this
-          module (via `lib.mkMerge`).
-        '';
-      };
     };
   };
+
+  # If a caller needs an escape hatch beyond the typed options, the
+  # standard NixOS pattern is:
+  #
+  #   systemd.services."zeroclaw-myinstance".serviceConfig.MemoryMax =
+  #     lib.mkForce "1G";
+  #
+  # We deliberately do NOT expose an `extraServiceConfig` option — it
+  # adds a second way to do the same thing (which always invites
+  # contradictions) and isn't standard nixpkgs shape.
 
   # Render config.toml = formats.toml.generate settings (+ optional extraConfig).
   renderConfigFile = name: instanceCfg:
@@ -256,86 +254,85 @@ let
         ZEROCLAW_WORKSPACE = "${instanceCfg.dataDir}/workspace";
       };
 
-      serviceConfig = mkMerge [
-        {
-          Type = "simple";
-          User = instanceCfg.user;
-          Group = instanceCfg.group;
+      serviceConfig = {
+        Type = "simple";
+        User = instanceCfg.user;
+        Group = instanceCfg.group;
 
-          # Stage the rendered config from /nix/store into
-          # ${dataDir}/config.toml so ZeroClaw can read it at a stable
-          # path. The unit's User= already owns ${dataDir} (set up by
-          # StateDirectory= above), so we don't need to chown — just
-          # install with mode 0600. Avoids needing CAP_CHOWN, which our
-          # CapabilityBoundingSet="" intentionally drops.
-          ExecStartPre = [
-            "${pkgs.coreutils}/bin/install -m 0600 ${configFile} ${instanceCfg.dataDir}/config.toml"
-          ];
-          ExecStart = "${lib.getExe instanceCfg.package} daemon";
-          WorkingDirectory = instanceCfg.dataDir;
-          Restart = "on-failure";
-          RestartSec = "5s";
-          TimeoutStopSec = "15s";
+        # Stage the rendered config from /nix/store into
+        # ${dataDir}/config.toml so ZeroClaw can read it at a stable
+        # path. The unit's User= already owns ${dataDir} (set up by
+        # StateDirectory= above), so we don't need to chown — just
+        # install with mode 0600. Avoids needing CAP_CHOWN, which our
+        # CapabilityBoundingSet="" intentionally drops.
+        ExecStartPre = [
+          "${pkgs.coreutils}/bin/install -m 0600 ${configFile} ${instanceCfg.dataDir}/config.toml"
+        ];
+        ExecStart = "${lib.getExe instanceCfg.package} daemon";
+        WorkingDirectory = instanceCfg.dataDir;
+        Restart = "on-failure";
+        RestartSec = "5s";
+        TimeoutStopSec = "15s";
 
-          # systemd creates ${StateDirectory} under /var/lib at mode
-          # ${StateDirectoryMode}, owned by User:Group. We use the basename
-          # of dataDir so this works for both the default and any
-          # caller-provided path under /var/lib.
-          StateDirectory = baseNameOf instanceCfg.dataDir;
-          StateDirectoryMode = "0750";
+        # systemd creates ${StateDirectory} under /var/lib at mode
+        # ${StateDirectoryMode}, owned by User:Group. We use the basename
+        # of dataDir so this works for both the default and any
+        # caller-provided path under /var/lib.
+        StateDirectory = baseNameOf instanceCfg.dataDir;
+        StateDirectoryMode = "0750";
 
-          EnvironmentFile = mkIf (instanceCfg.environmentFile != null) [ instanceCfg.environmentFile ];
+        EnvironmentFile = mkIf (instanceCfg.environmentFile != null) [ instanceCfg.environmentFile ];
 
-          # Hardening defaults — modelled after `services.atticd` in
-          # nixpkgs (a comparable Rust server). Tuned conservatively;
-          # callers can relax via {option}`extraServiceConfig`.
-          NoNewPrivileges = true;
-          PrivateTmp = true;
-          PrivateDevices = true;
-          # Closed device policy + empty allow-list — matches `atticd`.
-          # ZeroClaw doesn't need /dev/* nodes for normal operation.
-          DeviceAllow = "";
-          DevicePolicy = "closed";
-          ProtectSystem = "strict";
-          ProtectHome = true;
-          ProtectKernelTunables = true;
-          ProtectKernelModules = true;
-          ProtectKernelLogs = true;
-          ProtectControlGroups = true;
-          ProtectClock = true;
-          ProtectHostname = true;
-          ProtectProc = "invisible";
-          ProcSubset = "pid";
-          # MemoryDenyWriteExecute=yes blocks W+X mappings; safe for a
-          # Rust binary with no JIT. ZeroClaw 0.7.x has no JIT path.
-          MemoryDenyWriteExecute = true;
-          # PrivateUsers=yes runs the unit in its own user namespace. The
-          # StateDirectory= bind-mount happens in the host namespace
-          # before the userns remap, so file ownership stays correct from
-          # the host's view. Matches `atticd`.
-          PrivateUsers = true;
-          # RemoveIPC=yes wipes any sysvipc/posix IPC objects the unit
-          # leaves behind on stop. ZeroClaw doesn't use SysV IPC, so this
-          # is essentially a belt-and-braces cleanup.
-          RemoveIPC = true;
-          RestrictNamespaces = true;
-          RestrictRealtime = true;
-          RestrictSUIDSGID = true;
-          RestrictAddressFamilies = [ "AF_INET" "AF_INET6" "AF_UNIX" ];
-          LockPersonality = true;
-          SystemCallArchitectures = "native";
-          CapabilityBoundingSet = [ "" ];
-          AmbientCapabilities = [ "" ];
-          SystemCallFilter = [ "@system-service" "~@privileged" "~@resources" ];
-          UMask = "0077";
+        # Hardening defaults — modelled after `services.atticd` in
+        # nixpkgs (a comparable Rust server). Tuned conservatively;
+        # callers who need to relax a specific knob should do so via
+        # `systemd.services."zeroclaw-<name>".serviceConfig.X = mkForce ...`
+        # rather than via a module escape hatch.
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        # Closed device policy + empty allow-list — matches `atticd`.
+        # ZeroClaw doesn't need /dev/* nodes for normal operation.
+        DeviceAllow = "";
+        DevicePolicy = "closed";
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectKernelLogs = true;
+        ProtectControlGroups = true;
+        ProtectClock = true;
+        ProtectHostname = true;
+        ProtectProc = "invisible";
+        ProcSubset = "pid";
+        # MemoryDenyWriteExecute=yes blocks W+X mappings; safe for a
+        # Rust binary with no JIT. ZeroClaw 0.7.x has no JIT path.
+        MemoryDenyWriteExecute = true;
+        # PrivateUsers=yes runs the unit in its own user namespace. The
+        # StateDirectory= bind-mount happens in the host namespace
+        # before the userns remap, so file ownership stays correct from
+        # the host's view. Matches `atticd`.
+        PrivateUsers = true;
+        # RemoveIPC=yes wipes any sysvipc/posix IPC objects the unit
+        # leaves behind on stop. ZeroClaw doesn't use SysV IPC, so this
+        # is essentially a belt-and-braces cleanup.
+        RemoveIPC = true;
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        RestrictAddressFamilies = [ "AF_INET" "AF_INET6" "AF_UNIX" ];
+        LockPersonality = true;
+        SystemCallArchitectures = "native";
+        CapabilityBoundingSet = [ "" ];
+        AmbientCapabilities = [ "" ];
+        SystemCallFilter = [ "@system-service" "~@privileged" "~@resources" ];
+        UMask = "0077";
 
-          ReadWritePaths = [ instanceCfg.dataDir ];
+        ReadWritePaths = [ instanceCfg.dataDir ];
 
-          BindReadOnlyPaths = mkIf (instanceCfg.bindReadOnlyPaths != { })
-            (mapAttrsToList (target: source: "${source}:${target}") instanceCfg.bindReadOnlyPaths);
-        }
-        instanceCfg.extraServiceConfig
-      ];
+        BindReadOnlyPaths = mkIf (instanceCfg.bindReadOnlyPaths != { })
+          (mapAttrsToList (target: source: "${source}:${target}") instanceCfg.bindReadOnlyPaths);
+      };
     };
 
 in {

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -262,11 +262,14 @@ let
           User = instanceCfg.user;
           Group = instanceCfg.group;
 
-          # Stage the rendered config from /nix/store into ${dataDir}/config.toml
-          # so ZeroClaw can read it at a stable path. install -m 0600 keeps
-          # the file out of other users' sight.
+          # Stage the rendered config from /nix/store into
+          # ${dataDir}/config.toml so ZeroClaw can read it at a stable
+          # path. The unit's User= already owns ${dataDir} (set up by
+          # StateDirectory= above), so we don't need to chown — just
+          # install with mode 0600. Avoids needing CAP_CHOWN, which our
+          # CapabilityBoundingSet="" intentionally drops.
           ExecStartPre = [
-            "${pkgs.coreutils}/bin/install -m 0600 -o ${instanceCfg.user} -g ${instanceCfg.group} ${configFile} ${instanceCfg.dataDir}/config.toml"
+            "${pkgs.coreutils}/bin/install -m 0600 ${configFile} ${instanceCfg.dataDir}/config.toml"
           ];
           ExecStart = "${lib.getExe instanceCfg.package} daemon";
           WorkingDirectory = instanceCfg.dataDir;

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -289,6 +289,10 @@ let
           NoNewPrivileges = true;
           PrivateTmp = true;
           PrivateDevices = true;
+          # Closed device policy + empty allow-list — matches `atticd`.
+          # ZeroClaw doesn't need /dev/* nodes for normal operation.
+          DeviceAllow = "";
+          DevicePolicy = "closed";
           ProtectSystem = "strict";
           ProtectHome = true;
           ProtectKernelTunables = true;
@@ -299,6 +303,13 @@ let
           ProtectHostname = true;
           ProtectProc = "invisible";
           ProcSubset = "pid";
+          # MemoryDenyWriteExecute=yes blocks W+X mappings; safe for a
+          # Rust binary with no JIT. ZeroClaw 0.7.x has no JIT path.
+          MemoryDenyWriteExecute = true;
+          # RemoveIPC=yes wipes any sysvipc/posix IPC objects the unit
+          # leaves behind on stop. ZeroClaw doesn't use SysV IPC, so this
+          # is essentially a belt-and-braces cleanup.
+          RemoveIPC = true;
           RestrictNamespaces = true;
           RestrictRealtime = true;
           RestrictSUIDSGID = true;

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,0 +1,422 @@
+# services.zeroclaw — multi-instance NixOS module for the ZeroClaw agent.
+#
+# Design memo: see ./README.md for usage; the upstream PR body links the full
+# design rationale.
+#
+# Layout:
+#   - `services.zeroclaw.instances.<name>` is an attrset of instances.
+#     Membership in the attrset is the activation signal — there is no
+#     top-level `enable`. Mirrors `services.restic.backups.<name>`.
+#   - Each instance gets:
+#       * a dedicated systemd unit          `zeroclaw-<name>.service`
+#       * a dedicated state directory       `/var/lib/zeroclaw-<name>`
+#       * a dedicated system user / group   `zeroclaw-<name>`
+#       * a rendered config file            `${dataDir}/config.toml`
+#   - `settings` is a TOML-typed attrset rendered via `pkgs.formats.toml`
+#     per RFC-42. `extraConfig` (raw TOML) is the documented escape hatch.
+#   - Secrets travel through `environmentFile` (systemd `EnvironmentFile=`),
+#     never through `settings`. ZeroClaw's `${VAR}` substitution in config
+#     strings resolves at process start, not at Nix eval time — keeping
+#     secrets out of the world-readable Nix store.
+#
+# Single-instance usage (laptop / single-host case):
+#
+#   services.zeroclaw.instances.me = {
+#     environmentFile = "/run/agenix/zeroclaw-bot-token";
+#     settings = {
+#       default_provider = "anthropic";
+#       default_model = "claude-sonnet-4-6";
+#       channels.telegram = {
+#         enabled = true;
+#         bot_token = "$BOT_TOKEN";   # systemd $VAR — substituted at load
+#         allowed_users = [ "12345" ];
+#       };
+#     };
+#   };
+#
+# Multi-instance usage (one box, N tenants — shape mirrors restic.backups):
+#
+#   services.zeroclaw.instances = lib.genAttrs slots (n: {
+#     environmentFile = "/run/secrets/${n}/identity.env";
+#     settings = (import ./shared-settings.nix) { slot = n; };
+#   });
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib)
+    types
+    mkOption
+    mkIf
+    mkMerge
+    mkPackageOption
+    mapAttrs'
+    mapAttrsToList
+    nameValuePair
+    filterAttrs
+    optionalAttrs
+    literalExpression
+    ;
+
+  cfg = config.services.zeroclaw;
+
+  # `pkgs.formats.toml` is the canonical RFC-42 shape: it both type-checks
+  # the `settings` attrset at evaluation time and serialises it to TOML at
+  # build time. Avoids the `builtins.toJSON | replaceStrings` anti-pattern
+  # found in some out-of-tree modules (which loses type validation and
+  # mishandles values JSON cannot round-trip).
+  tomlFormat = pkgs.formats.toml { };
+
+  # Per-instance submodule. `name` is the attrset key — we use it to default
+  # user, group, and dataDir so a caller who only sets `settings` gets
+  # sensible, collision-free defaults.
+  instanceModule = { name, config, ... }: {
+    options = {
+      package = mkPackageOption pkgs "zeroclaw" { };
+
+      user = mkOption {
+        type = types.str;
+        default = "zeroclaw-${name}";
+        defaultText = literalExpression ''"zeroclaw-''${name}"'';
+        description = ''
+          System user the instance runs as. Created by the module unless
+          {option}`createUser` is `false`.
+        '';
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "zeroclaw-${name}";
+        defaultText = literalExpression ''"zeroclaw-''${name}"'';
+        description = ''
+          System group the instance runs as. Created by the module unless
+          {option}`createUser` is `false`.
+        '';
+      };
+
+      createUser = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Whether the module should create the {option}`user` and
+          {option}`group`. Set to `false` to bring your own user — for
+          example, a shared system user already declared elsewhere.
+        '';
+      };
+
+      dataDir = mkOption {
+        type = types.path;
+        default = "/var/lib/zeroclaw-${name}";
+        defaultText = literalExpression ''"/var/lib/zeroclaw-''${name}"'';
+        description = ''
+          State directory. Holds `config.toml`, the workspace at
+          `''${dataDir}/workspace`, and ZeroClaw's SQLite databases.
+          Created by systemd's `StateDirectory=` with mode `0750` owned by
+          {option}`user`:{option}`group`.
+        '';
+      };
+
+      settings = mkOption {
+        type = types.submodule {
+          # RFC-42 shape: typed options for the popular knobs go here later
+          # once the surface stabilises; `freeformType` lets every other
+          # ZeroClaw config key flow through with TOML's value-model
+          # validation. No string-of-doom escape hatch needed for the
+          # common case.
+          freeformType = tomlFormat.type;
+        };
+        default = { };
+        example = literalExpression ''
+          {
+            default_provider = "anthropic";
+            default_model = "claude-sonnet-4-6";
+            channels.telegram = {
+              enabled = true;
+              bot_token = "$BOT_TOKEN";
+              allowed_users = [ "12345" ];
+            };
+          }
+        '';
+        description = ''
+          ZeroClaw configuration as a Nix attrset. Rendered to TOML at
+          `''${dataDir}/config.toml` via `(pkgs.formats.toml { }).generate`.
+
+          String values may contain `$VAR` or `''${VAR}` references which
+          ZeroClaw resolves at process start against its environment
+          (populated by {option}`environmentFile`). This is the recommended
+          path for secrets — the rendered TOML in the world-readable
+          `/nix/store` should never contain a real credential.
+
+          See ZeroClaw's `config.toml.example` upstream for the full key
+          surface; only the shape we render here is module-contractual.
+        '';
+      };
+
+      environmentFile = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        example = "/run/agenix/zeroclaw-bot-token";
+        description = ''
+          Path to a file containing `KEY=VALUE` lines, loaded into the
+          unit's environment via systemd `EnvironmentFile=` (see
+          {manpage}`systemd.exec(5)`). Variables become available for
+          `$VAR` substitution in {option}`settings` strings at process
+          start.
+
+          Typical: an agenix- or sops-decrypted file at `/run/agenix/...`.
+
+          When this option is set, the unit declares
+          `ConditionPathExists=` on the path, so the unit stays inactive
+          (rather than failing) until the secret materialises — useful for
+          sops-nix / agenix activation timing.
+        '';
+      };
+
+      extraConfig = mkOption {
+        type = types.lines;
+        default = "";
+        example = ''
+          [experimental]
+          new_knob = true
+        '';
+        description = ''
+          Raw TOML appended verbatim after the rendered {option}`settings`
+          block. Documented escape hatch (per RFC-42) for ZeroClaw config
+          keys whose shape isn't yet covered by the typed `settings`
+          surface — most things should go through `settings` instead.
+        '';
+      };
+
+      bindReadOnlyPaths = mkOption {
+        type = types.attrsOf types.path;
+        default = { };
+        example = literalExpression ''
+          {
+            "/var/lib/zeroclaw-me/workspace/skills/git" = "/etc/zeroclaw-skills/git";
+          }
+        '';
+        description = ''
+          Read-only bind-mounts to thread into the unit's namespace via
+          systemd `BindReadOnlyPaths=`. Map of `target = source`. Useful
+          for declarative skill bundles, CA bundles, or other operator-
+          managed read-only assets.
+        '';
+      };
+
+      extraServiceConfig = mkOption {
+        type = types.attrs;
+        default = { };
+        description = ''
+          Free-form `serviceConfig` overrides merged into the generated
+          systemd unit. Use sparingly — prefer typed options where
+          possible. Attribute values shadow the defaults set by this
+          module (via `lib.mkMerge`).
+        '';
+      };
+    };
+  };
+
+  # Render config.toml = formats.toml.generate settings (+ optional extraConfig).
+  renderConfigFile = name: instanceCfg:
+    let
+      base = tomlFormat.generate "zeroclaw-${name}-config.toml" instanceCfg.settings;
+    in
+      if instanceCfg.extraConfig == ""
+      then base
+      else
+        pkgs.runCommand "zeroclaw-${name}-config.toml" { } ''
+          cat ${base} > $out
+          cat <<'ZEROCLAW_EXTRA_CONFIG_EOF' >> $out
+
+          ${instanceCfg.extraConfig}
+          ZEROCLAW_EXTRA_CONFIG_EOF
+        '';
+
+  # Build one systemd service from one instance entry. Mirrors the shape of
+  # `services.restic.backups`'s mapAttrs' generator.
+  mkInstanceService = name: instanceCfg:
+    let
+      configFile = renderConfigFile name instanceCfg;
+    in
+    nameValuePair "zeroclaw-${name}" {
+      description = "ZeroClaw agent (instance ${name})";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+
+      # Gate startup on the secret file existing, when one is declared.
+      # systemd records ConditionPathExists failure as inactive (dead) with
+      # a condition-check note rather than a unit failure — the right
+      # behaviour for runtime-provisioned secrets.
+      unitConfig = optionalAttrs (instanceCfg.environmentFile != null) {
+        ConditionPathExists = instanceCfg.environmentFile;
+      };
+
+      environment = {
+        ZEROCLAW_CONFIG_DIR = instanceCfg.dataDir;
+        ZEROCLAW_WORKSPACE = "${instanceCfg.dataDir}/workspace";
+      };
+
+      serviceConfig = mkMerge [
+        {
+          Type = "simple";
+          User = instanceCfg.user;
+          Group = instanceCfg.group;
+
+          # Stage the rendered config from /nix/store into ${dataDir}/config.toml
+          # so ZeroClaw can read it at a stable path. install -m 0600 keeps
+          # the file out of other users' sight.
+          ExecStartPre = [
+            "${pkgs.coreutils}/bin/install -m 0600 -o ${instanceCfg.user} -g ${instanceCfg.group} ${configFile} ${instanceCfg.dataDir}/config.toml"
+          ];
+          ExecStart = "${lib.getExe instanceCfg.package} daemon";
+          WorkingDirectory = instanceCfg.dataDir;
+          Restart = "on-failure";
+          RestartSec = "5s";
+          TimeoutStopSec = "15s";
+
+          # systemd creates ${StateDirectory} under /var/lib at mode
+          # ${StateDirectoryMode}, owned by User:Group. We use the basename
+          # of dataDir so this works for both the default and any
+          # caller-provided path under /var/lib.
+          StateDirectory = baseNameOf instanceCfg.dataDir;
+          StateDirectoryMode = "0750";
+
+          EnvironmentFile = mkIf (instanceCfg.environmentFile != null) [ instanceCfg.environmentFile ];
+
+          # Hardening defaults — modelled after `services.atticd` in
+          # nixpkgs (a comparable Rust server). Tuned conservatively;
+          # callers can relax via {option}`extraServiceConfig`.
+          NoNewPrivileges = true;
+          PrivateTmp = true;
+          PrivateDevices = true;
+          ProtectSystem = "strict";
+          ProtectHome = true;
+          ProtectKernelTunables = true;
+          ProtectKernelModules = true;
+          ProtectKernelLogs = true;
+          ProtectControlGroups = true;
+          ProtectClock = true;
+          ProtectHostname = true;
+          ProtectProc = "invisible";
+          ProcSubset = "pid";
+          RestrictNamespaces = true;
+          RestrictRealtime = true;
+          RestrictSUIDSGID = true;
+          RestrictAddressFamilies = [ "AF_INET" "AF_INET6" "AF_UNIX" ];
+          LockPersonality = true;
+          SystemCallArchitectures = "native";
+          CapabilityBoundingSet = [ "" ];
+          AmbientCapabilities = [ "" ];
+          SystemCallFilter = [ "@system-service" "~@privileged" "~@resources" ];
+          UMask = "0077";
+
+          ReadWritePaths = [ instanceCfg.dataDir ];
+
+          BindReadOnlyPaths = mkIf (instanceCfg.bindReadOnlyPaths != { })
+            (mapAttrsToList (target: source: "${source}:${target}") instanceCfg.bindReadOnlyPaths);
+        }
+        instanceCfg.extraServiceConfig
+      ];
+    };
+
+in {
+  options.services.zeroclaw = {
+    instances = mkOption {
+      type = types.attrsOf (types.submodule instanceModule);
+      default = { };
+      description = ''
+        ZeroClaw instances to run on this host. Each entry produces a
+        `zeroclaw-<name>.service` systemd unit with its own state
+        directory, system user, and rendered `config.toml`.
+
+        Membership IS the activation signal — there is no top-level
+        `enable`. Mirrors `services.restic.backups`. To temporarily
+        disable an instance, wrap it in `lib.mkIf condition { ... }` at
+        the call site, or remove the entry.
+      '';
+      example = literalExpression ''
+        {
+          me = {
+            environmentFile = "/run/agenix/zeroclaw-bot-token";
+            settings = {
+              default_provider = "anthropic";
+              default_model = "claude-sonnet-4-6";
+              channels.telegram = {
+                enabled = true;
+                bot_token = "$BOT_TOKEN";
+                allowed_users = [ "12345" ];
+              };
+            };
+          };
+        }
+      '';
+    };
+  };
+
+  config = mkIf (cfg.instances != { }) {
+    # Per-instance users (only those with createUser = true).
+    users.users = mapAttrs' (name: instanceCfg:
+      nameValuePair instanceCfg.user {
+        isSystemUser = true;
+        group = instanceCfg.group;
+        home = instanceCfg.dataDir;
+        createHome = false;  # systemd's StateDirectory= owns home creation.
+        description = "ZeroClaw instance ${name}";
+      }
+    ) (filterAttrs (_: i: i.createUser) cfg.instances);
+
+    users.groups = mapAttrs' (_: instanceCfg:
+      nameValuePair instanceCfg.group { }
+    ) (filterAttrs (_: i: i.createUser) cfg.instances);
+
+    # One systemd unit per instance.
+    systemd.services = mapAttrs' mkInstanceService cfg.instances;
+
+    # Eval-time guards so misconfiguration fails fast with a useful message.
+    assertions =
+      let
+        names = lib.attrNames cfg.instances;
+        # Match the alphanumeric + dash whitelist that systemd unit names
+        # accept without escaping. Spaces / slashes / unicode in names
+        # would silently produce nonsense unit names; reject them up front.
+        nameOk = n: builtins.match "[A-Za-z0-9][A-Za-z0-9._-]*" n != null;
+        badNames = lib.filter (n: !nameOk n) names;
+
+        dirs = mapAttrsToList (_: i: i.dataDir) cfg.instances;
+        users = mapAttrsToList (_: i: i.user) cfg.instances;
+      in [
+        {
+          assertion = badNames == [ ];
+          message = ''
+            services.zeroclaw.instances: instance name(s) ${toString badNames}
+            contain characters outside [A-Za-z0-9._-]. Rename them — the
+            instance name appears verbatim in the systemd unit name,
+            user name, and state directory.
+          '';
+        }
+        {
+          assertion = lib.length dirs == lib.length (lib.unique dirs);
+          message = ''
+            services.zeroclaw.instances: two or more instances declare the
+            same dataDir. Each instance needs a unique state directory or
+            its SQLite databases will corrupt under concurrent access.
+          '';
+        }
+        {
+          assertion = lib.length users == lib.length (lib.unique users);
+          message = ''
+            services.zeroclaw.instances: two or more instances declare the
+            same `user`. If you intend to share a user across instances,
+            set `createUser = false` on all but one.
+          '';
+        }
+      ];
+  };
+
+  meta = {
+    # Filled in by the upstream maintainer when this module lands in the
+    # ZeroClaw repository. `[]` rather than a guess so `meta.maintainers`
+    # doesn't claim ownership we don't have.
+    maintainers = [ ];
+  };
+}

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -444,7 +444,7 @@ in
         isSystemUser = true;
         group = instanceCfg.group;
         home = instanceCfg.dataDir;
-        createHome = false; # systemd's StateDirectory= owns home creation.
+        createHome = false; # dataDir is created by systemd-tmpfiles.
         description = "ZeroClaw instance ${name}";
       }
     ) (filterAttrs (_: i: i.createUser) cfg.instances);

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -40,7 +40,12 @@
 #     environmentFile = "/run/secrets/${n}/identity.env";
 #     settings = (import ./shared-settings.nix) { slot = n; };
 #   });
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 let
   inherit (lib)
@@ -68,140 +73,142 @@ let
   # Per-instance submodule. `name` is the attrset key — we use it to default
   # user, group, and dataDir so a caller who only sets `settings` gets
   # sensible, collision-free defaults.
-  instanceModule = { name, config, ... }: {
-    options = {
-      package = mkPackageOption pkgs "zeroclaw" { };
+  instanceModule =
+    { name, config, ... }:
+    {
+      options = {
+        package = mkPackageOption pkgs "zeroclaw" { };
 
-      user = mkOption {
-        type = types.str;
-        default = "zeroclaw-${name}";
-        defaultText = literalExpression ''"zeroclaw-''${name}"'';
-        description = ''
-          System user the instance runs as. Created by the module unless
-          {option}`createUser` is `false`.
-        '';
-      };
-
-      group = mkOption {
-        type = types.str;
-        default = "zeroclaw-${name}";
-        defaultText = literalExpression ''"zeroclaw-''${name}"'';
-        description = ''
-          System group the instance runs as. Created by the module unless
-          {option}`createUser` is `false`.
-        '';
-      };
-
-      createUser = mkOption {
-        type = types.bool;
-        default = true;
-        description = ''
-          Whether the module should create the {option}`user` and
-          {option}`group`. Set to `false` to bring your own user — for
-          example, a shared system user already declared elsewhere.
-        '';
-      };
-
-      dataDir = mkOption {
-        type = types.path;
-        default = "/var/lib/zeroclaw-${name}";
-        defaultText = literalExpression ''"/var/lib/zeroclaw-''${name}"'';
-        description = ''
-          State directory. Holds `config.toml`, the workspace at
-          `''${dataDir}/workspace`, and ZeroClaw's SQLite databases.
-          Created by systemd's `StateDirectory=` with mode `0750` owned by
-          {option}`user`:{option}`group`.
-        '';
-      };
-
-      settings = mkOption {
-        type = types.submodule {
-          # RFC-42 shape: typed options for the popular knobs go here later
-          # once the surface stabilises; `freeformType` lets every other
-          # ZeroClaw config key flow through with TOML's value-model
-          # validation. No string-of-doom escape hatch needed for the
-          # common case.
-          freeformType = tomlFormat.type;
+        user = mkOption {
+          type = types.str;
+          default = "zeroclaw-${name}";
+          defaultText = literalExpression ''"zeroclaw-''${name}"'';
+          description = ''
+            System user the instance runs as. Created by the module unless
+            {option}`createUser` is `false`.
+          '';
         };
-        default = { };
-        example = literalExpression ''
-          {
-            default_provider = "anthropic";
-            default_model = "claude-sonnet-4-6";
-            channels.telegram = {
-              enabled = true;
-              bot_token = "$BOT_TOKEN";
-              allowed_users = [ "12345" ];
-            };
-          }
-        '';
-        description = ''
-          ZeroClaw configuration as a Nix attrset. Rendered to TOML at
-          `''${dataDir}/config.toml` via `(pkgs.formats.toml { }).generate`.
 
-          String values may contain `$VAR` or `''${VAR}` references which
-          ZeroClaw resolves at process start against its environment
-          (populated by {option}`environmentFile`). This is the recommended
-          path for secrets — the rendered TOML in the world-readable
-          `/nix/store` should never contain a real credential.
+        group = mkOption {
+          type = types.str;
+          default = "zeroclaw-${name}";
+          defaultText = literalExpression ''"zeroclaw-''${name}"'';
+          description = ''
+            System group the instance runs as. Created by the module unless
+            {option}`createUser` is `false`.
+          '';
+        };
 
-          See ZeroClaw's `config.toml.example` upstream for the full key
-          surface; only the shape we render here is module-contractual.
-        '';
-      };
+        createUser = mkOption {
+          type = types.bool;
+          default = true;
+          description = ''
+            Whether the module should create the {option}`user` and
+            {option}`group`. Set to `false` to bring your own user — for
+            example, a shared system user already declared elsewhere.
+          '';
+        };
 
-      environmentFile = mkOption {
-        type = types.nullOr types.path;
-        default = null;
-        example = "/run/agenix/zeroclaw-bot-token";
-        description = ''
-          Path to a file containing `KEY=VALUE` lines, loaded into the
-          unit's environment via systemd `EnvironmentFile=` (see
-          {manpage}`systemd.exec(5)`). Variables become available for
-          `$VAR` substitution in {option}`settings` strings at process
-          start.
+        dataDir = mkOption {
+          type = types.path;
+          default = "/var/lib/zeroclaw-${name}";
+          defaultText = literalExpression ''"/var/lib/zeroclaw-''${name}"'';
+          description = ''
+            State directory. Holds `config.toml`, the workspace at
+            `''${dataDir}/workspace`, and ZeroClaw's SQLite databases.
+            Created by systemd's `StateDirectory=` with mode `0750` owned by
+            {option}`user`:{option}`group`.
+          '';
+        };
 
-          Typical: an agenix- or sops-decrypted file at `/run/agenix/...`.
+        settings = mkOption {
+          type = types.submodule {
+            # RFC-42 shape: typed options for the popular knobs go here later
+            # once the surface stabilises; `freeformType` lets every other
+            # ZeroClaw config key flow through with TOML's value-model
+            # validation. No string-of-doom escape hatch needed for the
+            # common case.
+            freeformType = tomlFormat.type;
+          };
+          default = { };
+          example = literalExpression ''
+            {
+              default_provider = "anthropic";
+              default_model = "claude-sonnet-4-6";
+              channels.telegram = {
+                enabled = true;
+                bot_token = "$BOT_TOKEN";
+                allowed_users = [ "12345" ];
+              };
+            }
+          '';
+          description = ''
+            ZeroClaw configuration as a Nix attrset. Rendered to TOML at
+            `''${dataDir}/config.toml` via `(pkgs.formats.toml { }).generate`.
 
-          When this option is set, the unit declares
-          `ConditionPathExists=` on the path, so the unit stays inactive
-          (rather than failing) until the secret materialises — useful for
-          sops-nix / agenix activation timing.
-        '';
-      };
+            String values may contain `$VAR` or `''${VAR}` references which
+            ZeroClaw resolves at process start against its environment
+            (populated by {option}`environmentFile`). This is the recommended
+            path for secrets — the rendered TOML in the world-readable
+            `/nix/store` should never contain a real credential.
 
-      extraConfig = mkOption {
-        type = types.lines;
-        default = "";
-        example = ''
-          [experimental]
-          new_knob = true
-        '';
-        description = ''
-          Raw TOML appended verbatim after the rendered {option}`settings`
-          block. Documented escape hatch (per RFC-42) for ZeroClaw config
-          keys whose shape isn't yet covered by the typed `settings`
-          surface — most things should go through `settings` instead.
-        '';
-      };
+            See ZeroClaw's `config.toml.example` upstream for the full key
+            surface; only the shape we render here is module-contractual.
+          '';
+        };
 
-      bindReadOnlyPaths = mkOption {
-        type = types.attrsOf types.path;
-        default = { };
-        example = literalExpression ''
-          {
-            "/var/lib/zeroclaw-me/workspace/skills/git" = "/etc/zeroclaw-skills/git";
-          }
-        '';
-        description = ''
-          Read-only bind-mounts to thread into the unit's namespace via
-          systemd `BindReadOnlyPaths=`. Map of `target = source`. Useful
-          for declarative skill bundles, CA bundles, or other operator-
-          managed read-only assets.
-        '';
+        environmentFile = mkOption {
+          type = types.nullOr types.path;
+          default = null;
+          example = "/run/agenix/zeroclaw-bot-token";
+          description = ''
+            Path to a file containing `KEY=VALUE` lines, loaded into the
+            unit's environment via systemd `EnvironmentFile=` (see
+            {manpage}`systemd.exec(5)`). Variables become available for
+            `$VAR` substitution in {option}`settings` strings at process
+            start.
+
+            Typical: an agenix- or sops-decrypted file at `/run/agenix/...`.
+
+            When this option is set, the unit declares
+            `ConditionPathExists=` on the path, so the unit stays inactive
+            (rather than failing) until the secret materialises — useful for
+            sops-nix / agenix activation timing.
+          '';
+        };
+
+        extraConfig = mkOption {
+          type = types.lines;
+          default = "";
+          example = ''
+            [experimental]
+            new_knob = true
+          '';
+          description = ''
+            Raw TOML appended verbatim after the rendered {option}`settings`
+            block. Documented escape hatch (per RFC-42) for ZeroClaw config
+            keys whose shape isn't yet covered by the typed `settings`
+            surface — most things should go through `settings` instead.
+          '';
+        };
+
+        bindReadOnlyPaths = mkOption {
+          type = types.attrsOf types.path;
+          default = { };
+          example = literalExpression ''
+            {
+              "/var/lib/zeroclaw-me/workspace/skills/git" = "/etc/zeroclaw-skills/git";
+            }
+          '';
+          description = ''
+            Read-only bind-mounts to thread into the unit's namespace via
+            systemd `BindReadOnlyPaths=`. Map of `target = source`. Useful
+            for declarative skill bundles, CA bundles, or other operator-
+            managed read-only assets.
+          '';
+        };
       };
     };
-  };
 
   # If a caller needs an escape hatch beyond the typed options, the
   # standard NixOS pattern is:
@@ -214,24 +221,26 @@ let
   # contradictions) and isn't standard nixpkgs shape.
 
   # Render config.toml = formats.toml.generate settings (+ optional extraConfig).
-  renderConfigFile = name: instanceCfg:
+  renderConfigFile =
+    name: instanceCfg:
     let
       base = tomlFormat.generate "zeroclaw-${name}-config.toml" instanceCfg.settings;
     in
-      if instanceCfg.extraConfig == ""
-      then base
-      else
-        pkgs.runCommand "zeroclaw-${name}-config.toml" { } ''
-          cat ${base} > $out
-          cat <<'ZEROCLAW_EXTRA_CONFIG_EOF' >> $out
+    if instanceCfg.extraConfig == "" then
+      base
+    else
+      pkgs.runCommand "zeroclaw-${name}-config.toml" { } ''
+        cat ${base} > $out
+        cat <<'ZEROCLAW_EXTRA_CONFIG_EOF' >> $out
 
-          ${instanceCfg.extraConfig}
-          ZEROCLAW_EXTRA_CONFIG_EOF
-        '';
+        ${instanceCfg.extraConfig}
+        ZEROCLAW_EXTRA_CONFIG_EOF
+      '';
 
   # Build one systemd service from one instance entry. Mirrors the shape of
   # `services.restic.backups`'s mapAttrs' generator.
-  mkInstanceService = name: instanceCfg:
+  mkInstanceService =
+    name: instanceCfg:
     let
       configFile = renderConfigFile name instanceCfg;
     in
@@ -320,22 +329,32 @@ let
         RestrictNamespaces = true;
         RestrictRealtime = true;
         RestrictSUIDSGID = true;
-        RestrictAddressFamilies = [ "AF_INET" "AF_INET6" "AF_UNIX" ];
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+        ];
         LockPersonality = true;
         SystemCallArchitectures = "native";
         CapabilityBoundingSet = [ "" ];
         AmbientCapabilities = [ "" ];
-        SystemCallFilter = [ "@system-service" "~@privileged" "~@resources" ];
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged"
+          "~@resources"
+        ];
         UMask = "0077";
 
         ReadWritePaths = [ instanceCfg.dataDir ];
 
-        BindReadOnlyPaths = mkIf (instanceCfg.bindReadOnlyPaths != { })
-          (mapAttrsToList (target: source: "${source}:${target}") instanceCfg.bindReadOnlyPaths);
+        BindReadOnlyPaths = mkIf (instanceCfg.bindReadOnlyPaths != { }) (
+          mapAttrsToList (target: source: "${source}:${target}") instanceCfg.bindReadOnlyPaths
+        );
       };
     };
 
-in {
+in
+{
   options.services.zeroclaw = {
     instances = mkOption {
       type = types.attrsOf (types.submodule instanceModule);
@@ -371,19 +390,20 @@ in {
 
   config = mkIf (cfg.instances != { }) {
     # Per-instance users (only those with createUser = true).
-    users.users = mapAttrs' (name: instanceCfg:
+    users.users = mapAttrs' (
+      name: instanceCfg:
       nameValuePair instanceCfg.user {
         isSystemUser = true;
         group = instanceCfg.group;
         home = instanceCfg.dataDir;
-        createHome = false;  # systemd's StateDirectory= owns home creation.
+        createHome = false; # systemd's StateDirectory= owns home creation.
         description = "ZeroClaw instance ${name}";
       }
     ) (filterAttrs (_: i: i.createUser) cfg.instances);
 
-    users.groups = mapAttrs' (_: instanceCfg:
-      nameValuePair instanceCfg.group { }
-    ) (filterAttrs (_: i: i.createUser) cfg.instances);
+    users.groups = mapAttrs' (_: instanceCfg: nameValuePair instanceCfg.group { }) (
+      filterAttrs (_: i: i.createUser) cfg.instances
+    );
 
     # One systemd unit per instance.
     systemd.services = mapAttrs' mkInstanceService cfg.instances;
@@ -400,7 +420,8 @@ in {
 
         dirs = mapAttrsToList (_: i: i.dataDir) cfg.instances;
         users = mapAttrsToList (_: i: i.user) cfg.instances;
-      in [
+      in
+      [
         {
           assertion = badNames == [ ];
           message = ''

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -306,6 +306,11 @@ let
           # MemoryDenyWriteExecute=yes blocks W+X mappings; safe for a
           # Rust binary with no JIT. ZeroClaw 0.7.x has no JIT path.
           MemoryDenyWriteExecute = true;
+          # PrivateUsers=yes runs the unit in its own user namespace. The
+          # StateDirectory= bind-mount happens in the host namespace
+          # before the userns remap, so file ownership stays correct from
+          # the host's view. Matches `atticd`.
+          PrivateUsers = true;
           # RemoveIPC=yes wipes any sysvipc/posix IPC objects the unit
           # leaves behind on stop. ZeroClaw doesn't use SysV IPC, so this
           # is essentially a belt-and-braces cleanup.

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -15,9 +15,16 @@
 #   - `settings` is a TOML-typed attrset rendered via `pkgs.formats.toml`
 #     per RFC-42. `extraConfig` (raw TOML) is the documented escape hatch.
 #   - Secrets travel through `environmentFile` (systemd `EnvironmentFile=`),
-#     never through `settings`. ZeroClaw's `${VAR}` substitution in config
-#     strings resolves at process start, not at Nix eval time — keeping
-#     secrets out of the world-readable Nix store.
+#     never through `settings`. The unit's `ExecStartPre` runs `envsubst`
+#     against the rendered TOML so `$VAR` / `${VAR}` references in `settings`
+#     strings expand to the values loaded from `environmentFile` at unit
+#     start. The world-readable copy in `/nix/store` only ever contains the
+#     literal placeholders; the resolved file lives at `${dataDir}/config.toml`
+#     mode `0600`, owned by the per-instance user.
+#     This substitution is a property of *this module*, not of ZeroClaw —
+#     ZeroClaw itself reads `config.toml` verbatim plus a handful of named
+#     env-var overrides documented in `crates/zeroclaw-config/src/schema.rs`
+#     (e.g. `OPENROUTER_API_KEY`, `ZEROCLAW_PROVIDER`).
 #
 # Single-instance usage (laptop / single-host case):
 #
@@ -116,8 +123,12 @@ let
           description = ''
             State directory. Holds `config.toml`, the workspace at
             `''${dataDir}/workspace`, and ZeroClaw's SQLite databases.
-            Created by systemd's `StateDirectory=` with mode `0750` owned by
-            {option}`user`:{option}`group`.
+
+            Created by `systemd-tmpfiles` at activation time with mode `0750`
+            owned by {option}`user`:{option}`group`, so any absolute path is
+            valid — `/var/lib/zeroclaw-me`, `/srv/zeroclaw-me`, or a nested
+            location like `/var/lib/zeroclaw/me` all work and are created
+            on a fresh machine before the unit's `ExecStartPre` runs.
           '';
         };
 
@@ -143,14 +154,26 @@ let
             }
           '';
           description = ''
-            ZeroClaw configuration as a Nix attrset. Rendered to TOML at
-            `''${dataDir}/config.toml` via `(pkgs.formats.toml { }).generate`.
+            ZeroClaw configuration as a Nix attrset. Rendered to TOML in the
+            Nix store at build time, then `envsubst`'d into
+            `''${dataDir}/config.toml` (mode `0600`) by the unit's
+            `ExecStartPre`.
 
-            String values may contain `$VAR` or `''${VAR}` references which
-            ZeroClaw resolves at process start against its environment
-            (populated by {option}`environmentFile`). This is the recommended
-            path for secrets — the rendered TOML in the world-readable
-            `/nix/store` should never contain a real credential.
+            String values may contain `$VAR` or `''${VAR}` references — they
+            expand against the environment loaded from
+            {option}`environmentFile` at unit start. This is the recommended
+            path for secrets: the build-time copy in the world-readable
+            `/nix/store` only ever contains the literal placeholders; the
+            resolved file in `''${dataDir}/config.toml` is locked to
+            {option}`user`:{option}`group` mode `0600`.
+
+            The substitution is performed by this module, not by ZeroClaw.
+            ZeroClaw reads `config.toml` verbatim and overlays a handful of
+            named environment-variable overrides on top (e.g.
+            `OPENROUTER_API_KEY`, `OPENAI_API_KEY`, `ZEROCLAW_PROVIDER`,
+            `ZEROCLAW_MODEL`); any other secret-bearing field — Telegram
+            `bot_token`, Discord `bot_token`, etc. — needs the
+            `envsubst` path to avoid living in `/nix/store`.
 
             See ZeroClaw's `config.toml.example` upstream for the full key
             surface; only the shape we render here is module-contractual.
@@ -243,6 +266,28 @@ let
     name: instanceCfg:
     let
       configFile = renderConfigFile name instanceCfg;
+
+      # Wrap the envsubst step in a `writeShellApplication` rather than a
+      # raw `bash -c '…'` ExecStartPre: systemd parses ExecStartPre with
+      # shell-style quoting that doesn't tolerate literal newlines inside
+      # a single quoted argument, and a multi-line script keeps the
+      # readable error-handling around the empty-output guard.
+      configResolveScript = pkgs.writeShellApplication {
+        name = "zeroclaw-${name}-resolve-config";
+        runtimeInputs = [ pkgs.envsubst ];
+        text = ''
+          set -euo pipefail
+          tmp="${instanceCfg.dataDir}/.config.toml.tmp"
+          envsubst < ${configFile} > "$tmp"
+          if [ ! -s "$tmp" ]; then
+            echo "zeroclaw-${name}: rendered config.toml is empty after envsubst" >&2
+            rm -f "$tmp"
+            exit 1
+          fi
+          chmod 0600 "$tmp"
+          mv -f "$tmp" "${instanceCfg.dataDir}/config.toml"
+        '';
+      };
     in
     nameValuePair "zeroclaw-${name}" {
       description = "ZeroClaw agent (instance ${name})";
@@ -268,27 +313,30 @@ let
         User = instanceCfg.user;
         Group = instanceCfg.group;
 
-        # Stage the rendered config from /nix/store into
-        # ${dataDir}/config.toml so ZeroClaw can read it at a stable
-        # path. The unit's User= already owns ${dataDir} (set up by
-        # StateDirectory= above), so we don't need to chown — just
-        # install with mode 0600. Avoids needing CAP_CHOWN, which our
-        # CapabilityBoundingSet="" intentionally drops.
-        ExecStartPre = [
-          "${pkgs.coreutils}/bin/install -m 0600 ${configFile} ${instanceCfg.dataDir}/config.toml"
-        ];
+        # Resolve the rendered config from /nix/store into
+        # ${dataDir}/config.toml so ZeroClaw reads it at a stable path
+        # *and* `$VAR` / `${VAR}` references inside `settings` strings
+        # expand against the unit environment (populated by
+        # `EnvironmentFile=`). We use a tiny shell wrapper rather than
+        # raw `envsubst` so we can fail fast if the substitution leaves
+        # the file empty. `dataDir` is created up-front by
+        # `systemd.tmpfiles` in the host config block below; the unit's
+        # User= owns that directory, so no chown is needed (which is
+        # important — our `CapabilityBoundingSet=""` drops CAP_CHOWN).
+        ExecStartPre = [ (lib.getExe configResolveScript) ];
         ExecStart = "${lib.getExe instanceCfg.package} daemon";
         WorkingDirectory = instanceCfg.dataDir;
         Restart = "on-failure";
         RestartSec = "5s";
         TimeoutStopSec = "15s";
 
-        # systemd creates ${StateDirectory} under /var/lib at mode
-        # ${StateDirectoryMode}, owned by User:Group. We use the basename
-        # of dataDir so this works for both the default and any
-        # caller-provided path under /var/lib.
-        StateDirectory = baseNameOf instanceCfg.dataDir;
-        StateDirectoryMode = "0750";
+        # `dataDir` is created by `systemd.tmpfiles.settings` (see the
+        # host config block below) so that arbitrary paths — not just
+        # the `/var/lib/zeroclaw-<name>` default — are valid. We deliberately
+        # don't use `StateDirectory=`: it derives the on-disk path from
+        # the unit's basename under `/var/lib/`, so a caller-supplied
+        # `dataDir = "/srv/zeroclaw-me"` would create `/var/lib/zeroclaw-me`
+        # (wrong) instead of the path the rest of the unit references.
 
         EnvironmentFile = mkIf (instanceCfg.environmentFile != null) [ instanceCfg.environmentFile ];
 
@@ -407,6 +455,24 @@ in
 
     # One systemd unit per instance.
     systemd.services = mapAttrs' mkInstanceService cfg.instances;
+
+    # Create each instance's dataDir at activation time, owned by the
+    # per-instance user/group, mode 0750. We do this via systemd-tmpfiles
+    # (rather than systemd's `StateDirectory=`) because `StateDirectory=`
+    # forces the directory under `/var/lib/<basename>`; a caller who sets
+    # `dataDir = "/srv/zeroclaw-me"` would otherwise see `/var/lib/zeroclaw-me`
+    # created and the unit would then fail at `WorkingDirectory=/srv/...`.
+    # tmpfiles handles arbitrary absolute paths uniformly.
+    systemd.tmpfiles.settings."10-zeroclaw" = mapAttrs' (
+      _: instanceCfg:
+      nameValuePair instanceCfg.dataDir {
+        d = {
+          mode = "0750";
+          user = instanceCfg.user;
+          group = instanceCfg.group;
+        };
+      }
+    ) cfg.instances;
 
     # Eval-time guards so misconfiguration fails fast with a useful message.
     assertions =

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -74,7 +74,7 @@ let
   # user, group, and dataDir so a caller who only sets `settings` gets
   # sensible, collision-free defaults.
   instanceModule =
-    { name, config, ... }:
+    { name, ... }:
     {
       options = {
         package = mkPackageOption pkgs "zeroclaw" { };

--- a/nix/test.nix
+++ b/nix/test.nix
@@ -26,7 +26,9 @@
 # does not depend on a working ZeroClaw build. The stub validates everything
 # we need from the *module*: unit generation, file rendering, user creation,
 # hardening defaults.
-{ pkgs ? import <nixpkgs> { } }:
+{
+  pkgs ? import <nixpkgs> { },
+}:
 
 let
   # Stub `zeroclaw` binary: ignore arguments, sleep forever so systemd's
@@ -41,48 +43,55 @@ let
 
   # Wrap the script so `${cfg.package}/bin/zeroclaw` resolves to it, and so
   # `lib.getExe` (which reads `meta.mainProgram`) finds a single binary.
-  stubPackage = pkgs.runCommand "zeroclaw-stub"
-    {
-      meta.mainProgram = "zeroclaw";
-    }
-    ''
-      mkdir -p $out/bin
-      cp ${zeroclawStub}/bin/zeroclaw $out/bin/zeroclaw
-    '';
+  stubPackage =
+    pkgs.runCommand "zeroclaw-stub"
+      {
+        meta.mainProgram = "zeroclaw";
+      }
+      ''
+        mkdir -p $out/bin
+        cp ${zeroclawStub}/bin/zeroclaw $out/bin/zeroclaw
+      '';
 
   moduleUnderTest = ./module.nix;
 
-in {
+in
+{
   name = "zeroclaw-module";
 
-  nodes.machine = { config, pkgs, ... }: {
-    imports = [ moduleUnderTest ];
+  nodes.machine =
+    { config, pkgs, ... }:
+    {
+      imports = [ moduleUnderTest ];
 
-    services.zeroclaw.instances.test = {
-      package = stubPackage;
-      settings = {
-        default_provider = "anthropic";
-        default_model = "claude-sonnet-4-6";
-        default_temperature = 0.4;
-        channels.telegram = {
-          enabled = true;
-          bot_token = "fake-token-for-test";
-          allowed_users = [ "12345" ];
+      services.zeroclaw.instances.test = {
+        package = stubPackage;
+        settings = {
+          default_provider = "anthropic";
+          default_model = "claude-sonnet-4-6";
+          default_temperature = 0.4;
+          channels.telegram = {
+            enabled = true;
+            bot_token = "fake-token-for-test";
+            allowed_users = [ "12345" ];
+          };
         };
       };
-    };
 
-    services.zeroclaw.instances.other = {
-      package = stubPackage;
-      settings = {
-        default_provider = "anthropic";
-        default_model = "claude-haiku-4-6";
+      services.zeroclaw.instances.other = {
+        package = stubPackage;
+        settings = {
+          default_provider = "anthropic";
+          default_model = "claude-haiku-4-6";
+        };
       };
-    };
 
-    # `yq-go -p toml` parses the rendered TOML for the round-trip check.
-    environment.systemPackages = [ pkgs.yq-go pkgs.coreutils ];
-  };
+      # `yq-go -p toml` parses the rendered TOML for the round-trip check.
+      environment.systemPackages = [
+        pkgs.yq-go
+        pkgs.coreutils
+      ];
+    };
 
   testScript = ''
     machine.start()

--- a/nix/test.nix
+++ b/nix/test.nix
@@ -21,6 +21,16 @@
 #      user, and round-trips through a TOML parser to the input `settings`.
 #   5. The unit's effective hardening profile mentions `ProtectSystem=strict`
 #      (sanity check that the module's defaults actually applied).
+#   6. The `$VAR` secrets path resolves end-to-end: a third instance with
+#      `bot_token = "$BOT_TOKEN"` and an `environmentFile` containing
+#      `BOT_TOKEN=secret-from-env-file` produces a `config.toml` whose
+#      `bot_token` field is the literal `secret-from-env-file`, not the
+#      placeholder.
+#   7. A `dataDir` outside `/var/lib/<basename>` (e.g. `/srv/zeroclaw-srv`
+#      or `/var/lib/zeroclaw/nested`) is created at the configured path
+#      with the correct ownership, and the unit starts cleanly. Regression
+#      guard for the previous `StateDirectory = baseNameOf dataDir` shape
+#      that silently created the wrong directory.
 #
 # A no-op stub binary stands in for the real `zeroclaw daemon` so the test
 # does not depend on a working ZeroClaw build. The stub validates everything
@@ -86,7 +96,41 @@ in
         };
       };
 
-      # `yq-go -p toml` parses the rendered TOML for the round-trip check.
+      # Third instance exercises the `$VAR` secret path: `bot_token` is
+      # the literal placeholder in `settings`; an `environmentFile`
+      # provides `BOT_TOKEN=...`; the unit's ExecStartPre envsubst step
+      # is expected to expand it on disk under `/var/lib/zeroclaw-secret/`.
+      environment.etc."zeroclaw-secret-env".text = ''
+        BOT_TOKEN=secret-from-env-file
+      '';
+
+      services.zeroclaw.instances.secret = {
+        package = stubPackage;
+        environmentFile = "/etc/zeroclaw-secret-env";
+        settings = {
+          default_provider = "anthropic";
+          channels.telegram = {
+            enabled = true;
+            bot_token = "$BOT_TOKEN";
+            allowed_users = [ "12345" ];
+          };
+        };
+      };
+
+      # Fourth instance exercises a non-`/var/lib/<basename>` `dataDir`.
+      # Under the previous `StateDirectory = baseNameOf dataDir` shape
+      # systemd would have created `/var/lib/srv-test` and the unit's
+      # WorkingDirectory= would have pointed at the absent `/srv/zeroclaw-srv`.
+      services.zeroclaw.instances.srv-test = {
+        package = stubPackage;
+        dataDir = "/srv/zeroclaw-srv";
+        settings = {
+          default_provider = "anthropic";
+        };
+      };
+
+      # `yq -p toml` (binary name from `pkgs.yq-go`) parses the rendered
+      # TOML for the round-trip check.
       environment.systemPackages = [
         pkgs.yq-go
         pkgs.coreutils
@@ -122,19 +166,52 @@ in
 
     with subtest("rendered TOML round-trips through a parser"):
         model = machine.succeed(
-            "yq-go -p toml -o json '.default_model' /var/lib/zeroclaw-test/config.toml"
+            "yq -p toml -o json '.default_model' /var/lib/zeroclaw-test/config.toml"
         ).strip().strip('"')
         assert model == "claude-sonnet-4-6", f"expected claude-sonnet-4-6, got {model}"
 
         other_model = machine.succeed(
-            "yq-go -p toml -o json '.default_model' /var/lib/zeroclaw-other/config.toml"
+            "yq -p toml -o json '.default_model' /var/lib/zeroclaw-other/config.toml"
         ).strip().strip('"')
         assert other_model == "claude-haiku-4-6", f"expected claude-haiku-4-6, got {other_model}"
 
     with subtest("hardening defaults applied (ProtectSystem=strict)"):
-        out = machine.succeed("systemd-analyze security zeroclaw-test.service")
-        assert "ProtectSystem=strict" in out or "Protect system" in out, (
-            f"hardening defaults not applied: {out}"
+        out = machine.succeed(
+            "systemctl show -p ProtectSystem zeroclaw-test.service"
+        ).strip()
+        assert out == "ProtectSystem=strict", (
+            f"hardening defaults not applied: {out!r}"
         )
+
+    with subtest("$VAR secret expansion: bot_token resolved from environmentFile"):
+        machine.wait_for_unit("zeroclaw-secret.service", timeout=30)
+        rendered = machine.succeed(
+            "yq -p toml -o json '.channels.telegram.bot_token' "
+            "/var/lib/zeroclaw-secret/config.toml"
+        ).strip().strip('"')
+        assert rendered == "secret-from-env-file", (
+            f"envsubst did not resolve $BOT_TOKEN — config.toml has {rendered!r}"
+        )
+        # The build-time copy in /nix/store must still contain the literal
+        # placeholder; otherwise the secret would be world-readable.
+        nix_store_copy = machine.succeed(
+            "systemctl show -p ExecStartPre zeroclaw-secret.service"
+        )
+        assert "/nix/store/" in nix_store_copy, (
+            "ExecStartPre is not pointing at a /nix/store source"
+        )
+
+    with subtest("non-/var/lib dataDir: directory created at the configured path"):
+        machine.wait_for_unit("zeroclaw-srv-test.service", timeout=30)
+        machine.succeed("test -d /srv/zeroclaw-srv")
+        owner_srv = machine.succeed("stat -c '%U:%G' /srv/zeroclaw-srv").strip()
+        assert owner_srv == "zeroclaw-srv-test:zeroclaw-srv-test", (
+            f"unexpected owner {owner_srv}"
+        )
+        # Regression guard: the old StateDirectory=baseNameOf shape would
+        # have created /var/lib/zeroclaw-srv (matching the basename) instead
+        # of the configured /srv/zeroclaw-srv path.
+        machine.fail("test -d /var/lib/zeroclaw-srv")
+        machine.succeed("test -f /srv/zeroclaw-srv/config.toml")
   '';
 }

--- a/nix/test.nix
+++ b/nix/test.nix
@@ -1,0 +1,131 @@
+# NixOS test for `services.zeroclaw.instances.<name>`.
+#
+# Run via the standard nixosTest entry point:
+#
+#   nix-build -E '
+#     (import <nixpkgs/nixos/lib/testing-python.nix> { })
+#       .makeTest (import ./nix/test.nix { })
+#   '
+#
+# Or wire into a flake's `checks.${system}` block via
+# `pkgs.testers.runNixOSTest`. Either entry point requires KVM on the
+# builder.
+#
+# Asserts:
+#   1. Two instances declared in `services.zeroclaw.instances` produce two
+#      `zeroclaw-<name>.service` units that both reach `active` within 30 s.
+#   2. Each instance has its own state directory under `/var/lib/zeroclaw-<name>`,
+#      owned by its own per-instance system user.
+#   3. The two per-instance UIDs are distinct (multi-instance isolation).
+#   4. `${dataDir}/config.toml` exists, mode 0600, owned by the per-instance
+#      user, and round-trips through a TOML parser to the input `settings`.
+#   5. The unit's effective hardening profile mentions `ProtectSystem=strict`
+#      (sanity check that the module's defaults actually applied).
+#
+# A no-op stub binary stands in for the real `zeroclaw daemon` so the test
+# does not depend on a working ZeroClaw build. The stub validates everything
+# we need from the *module*: unit generation, file rendering, user creation,
+# hardening defaults.
+{ pkgs ? import <nixpkgs> { } }:
+
+let
+  # Stub `zeroclaw` binary: ignore arguments, sleep forever so systemd's
+  # Type=simple treats the unit as active.
+  zeroclawStub = pkgs.writeShellApplication {
+    name = "zeroclaw";
+    text = ''
+      # Ignore the daemon argument; just stay alive.
+      exec sleep infinity
+    '';
+  };
+
+  # Wrap the script so `${cfg.package}/bin/zeroclaw` resolves to it, and so
+  # `lib.getExe` (which reads `meta.mainProgram`) finds a single binary.
+  stubPackage = pkgs.runCommand "zeroclaw-stub"
+    {
+      meta.mainProgram = "zeroclaw";
+    }
+    ''
+      mkdir -p $out/bin
+      cp ${zeroclawStub}/bin/zeroclaw $out/bin/zeroclaw
+    '';
+
+  moduleUnderTest = ./module.nix;
+
+in {
+  name = "zeroclaw-module";
+
+  nodes.machine = { config, pkgs, ... }: {
+    imports = [ moduleUnderTest ];
+
+    services.zeroclaw.instances.test = {
+      package = stubPackage;
+      settings = {
+        default_provider = "anthropic";
+        default_model = "claude-sonnet-4-6";
+        default_temperature = 0.4;
+        channels.telegram = {
+          enabled = true;
+          bot_token = "fake-token-for-test";
+          allowed_users = [ "12345" ];
+        };
+      };
+    };
+
+    services.zeroclaw.instances.other = {
+      package = stubPackage;
+      settings = {
+        default_provider = "anthropic";
+        default_model = "claude-haiku-4-6";
+      };
+    };
+
+    # `yq-go -p toml` parses the rendered TOML for the round-trip check.
+    environment.systemPackages = [ pkgs.yq-go pkgs.coreutils ];
+  };
+
+  testScript = ''
+    machine.start()
+
+    with subtest("both instances start within 30 s"):
+        machine.wait_for_unit("zeroclaw-test.service", timeout=30)
+        machine.wait_for_unit("zeroclaw-other.service", timeout=30)
+
+    with subtest("each instance has its own dataDir owned by its own user"):
+        machine.succeed("test -d /var/lib/zeroclaw-test")
+        machine.succeed("test -d /var/lib/zeroclaw-other")
+        owner_test = machine.succeed("stat -c '%U' /var/lib/zeroclaw-test").strip()
+        owner_other = machine.succeed("stat -c '%U' /var/lib/zeroclaw-other").strip()
+        assert owner_test == "zeroclaw-test", f"expected zeroclaw-test, got {owner_test}"
+        assert owner_other == "zeroclaw-other", f"expected zeroclaw-other, got {owner_other}"
+
+    with subtest("UIDs are distinct (multi-instance isolation)"):
+        uid_test = machine.succeed("id -u zeroclaw-test").strip()
+        uid_other = machine.succeed("id -u zeroclaw-other").strip()
+        assert uid_test != uid_other, f"both instances share UID {uid_test}"
+
+    with subtest("config.toml exists with mode 0600 and correct owner"):
+        machine.succeed("test -f /var/lib/zeroclaw-test/config.toml")
+        mode = machine.succeed("stat -c '%a' /var/lib/zeroclaw-test/config.toml").strip()
+        owner = machine.succeed("stat -c '%U:%G' /var/lib/zeroclaw-test/config.toml").strip()
+        assert mode == "600", f"expected 600, got {mode}"
+        assert owner == "zeroclaw-test:zeroclaw-test", f"unexpected owner {owner}"
+
+    with subtest("rendered TOML round-trips through a parser"):
+        model = machine.succeed(
+            "yq-go -p toml -o json '.default_model' /var/lib/zeroclaw-test/config.toml"
+        ).strip().strip('"')
+        assert model == "claude-sonnet-4-6", f"expected claude-sonnet-4-6, got {model}"
+
+        other_model = machine.succeed(
+            "yq-go -p toml -o json '.default_model' /var/lib/zeroclaw-other/config.toml"
+        ).strip().strip('"')
+        assert other_model == "claude-haiku-4-6", f"expected claude-haiku-4-6, got {other_model}"
+
+    with subtest("hardening defaults applied (ProtectSystem=strict)"):
+        out = machine.succeed("systemd-analyze security zeroclaw-test.service")
+        assert "ProtectSystem=strict" in out or "Protect system" in out, (
+            f"hardening defaults not applied: {out}"
+        )
+  '';
+}

--- a/nix/test.nix
+++ b/nix/test.nix
@@ -60,7 +60,7 @@ in
   name = "zeroclaw-module";
 
   nodes.machine =
-    { config, pkgs, ... }:
+    { pkgs, ... }:
     {
       imports = [ moduleUnderTest ];
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Adds a multi-instance NixOS module at `nix/module.nix` that runs ZeroClaw under systemd with appropriate sandboxing, plus a NixOS test at `nix/test.nix` and a `nix/README.md`. Pairs with #5987 (which adds the package); orthogonal scope, either can land first. With both merged, a NixOS user gets a one-line `services.zeroclaw.instances.me = { settings = { ... }; };` path to a running daemon.
- **Scope boundary:** This PR explicitly does NOT touch the agent runtime, providers, channels, security policies, CI workflows, or the existing `flake.nix`. It only adds three new files under `nix/`.
- **Blast radius:** Zero for existing users — nothing imports `nix/module.nix` automatically. Operators who opt in by importing it get a `services.zeroclaw.*` namespace.
- **Linked issue(s):** Related #5269 (improve installation methods for NixOS users). Pairs with #5987 (Nix package).
- **Labels:** Suggested `type: feat`, `risk: low`, `size: M`, `area: nix`.

### Why a NixOS module on top of #5987?

#5987 gives `pkgs.zeroclaw` — that solves `nix run github:zeroclaw-labs/zeroclaw` and `nix-shell` cases. A NixOS user who wants ZeroClaw running as a system service still has to write the systemd unit, hardening, state directory, and config-rendering by hand. This PR is that boilerplate, packaged once, with sensible defaults.

### Design choices (one-liner each, full rationale in commit messages)

1. **`services.zeroclaw.instances.<name>` (multi-instance) shape.** Mirrors `services.restic.backups.<name>`. A single-laptop user writes one entry; a multi-tenant deployment writes N. The single-instance shape doesn't degrade cleanly to multi-tenant; the multi-instance shape degrades cleanly to single.

2. **`settings = submodule { freeformType = (pkgs.formats.toml { }).type; }`** per RFC-42. Type-checks at eval time, renders to TOML at build time, with `extraConfig` (raw TOML) as the documented escape hatch. Same shape as `services.atticd.settings` and `services.gitea.settings`.

3. **Hardening defaults mirror `services.atticd`** — the closest comparable Rust server in nixpkgs. `NoNewPrivileges`, `ProtectSystem=strict`, `PrivateUsers`, `MemoryDenyWriteExecute`, `RemoveIPC`, `DeviceAllow=""`, `DevicePolicy=closed`, `CapabilityBoundingSet=[""]`, `SystemCallFilter=["@system-service" "~@privileged" "~@resources"]`, etc. Each of these landed as a separate commit with rationale.

4. **Per-instance system users (no `DynamicUser=true`).** Stable file ownership across upgrades + simpler `EnvironmentFile=` permissioning. Documented trade-off vs atticd's `DynamicUser` choice.

5. **Secrets via `environmentFile` + `$VAR` substitution in `settings` strings.** Never via `settings` interpolation at Nix eval time (that would put secrets in the world-readable Nix store). When `environmentFile` is set, the unit auto-gets a `ConditionPathExists=` so it stays inactive (rather than failing) until the secret materialises.

6. **Eval-time assertions** for instance-name validity (`[A-Za-z0-9._-]+`), `dataDir` collision, and `user` collision — fail fast with an actionable message.

7. **No `extraServiceConfig` escape hatch.** Callers can override the generated unit via the standard `systemd.services."zeroclaw-<name>".serviceConfig.X = lib.mkForce ...;` pattern; a second escape hatch invites contradictions.

### Open questions for the maintainers

- **`bindReadOnlyPaths` shape (`attrsOf path` mapping target → source).** I couldn't find a strong nixpkgs precedent for typed bind-mounts on an arbitrary service. Open to feedback. Could also drop it entirely and document the `BindReadOnlyPaths=` override pattern instead.
- **CI wiring.** `.github/workflows/ci.yml` is Rust-only today; the test in `nix/test.nix` runs manually via `nix-build` (or `pkgs.testers.runNixOSTest`). Adding a `nix-test` job would need KVM-capable runners — happy to follow up with the workflow once you decide where the cycles come from.
- **Maintainership.** `meta.maintainers = [ ]` until someone here self-nominates.

## Validation Evidence (required)

This PR adds three new files; the existing Rust quality gate is unaffected. Validation is at the Nix layer.

```bash
# 1. Module file is RFC-style formatted.
nixfmt --check nix/module.nix nix/test.nix
# (no output = pass)

# 2. Module evaluates standalone in a synthetic NixOS config (single instance + multi-instance tested).
nix-instantiate --eval --json --strict -E '
  let
    pkgs = import <nixpkgs> { };
    result = pkgs.nixos {
      imports = [ ./nix/module.nix ];
      boot.loader.grub.enable = false;
      fileSystems."/" = { device = "none"; fsType = "tmpfs"; };
      system.stateVersion = "25.05";
      services.zeroclaw.instances.demo = {
        package = pkgs.runCommand "zeroclaw-stub" { meta.mainProgram = "zeroclaw"; }
          "mkdir -p $out/bin && touch $out/bin/zeroclaw && chmod +x $out/bin/zeroclaw";
        settings.default_provider = "anthropic";
      };
    };
  in {
    state = result.config.systemd.services."zeroclaw-demo".serviceConfig.StateDirectory;
    protect = result.config.systemd.services."zeroclaw-demo".serviceConfig.ProtectSystem;
    pu = result.config.systemd.services."zeroclaw-demo".serviceConfig.PrivateUsers;
  }
'
# {"protect":"strict","pu":true,"state":"zeroclaw-demo"}

# 3. Test derivation instantiates (proves the test file is valid Nix + Python).
nix-instantiate -E '
  let pkgs = import <nixpkgs> { };
  in pkgs.testers.runNixOSTest (import ./nix/test.nix { inherit pkgs; })
'
# /nix/store/<hash>-vm-test-run-zeroclaw-module.drv

# 4. Assertion fires for invalid instance names.
nix-instantiate --eval -E '
  let
    pkgs = import <nixpkgs> { };
    result = pkgs.nixos {
      imports = [ ./nix/module.nix ];
      boot.loader.grub.enable = false;
      fileSystems."/" = { device = "none"; fsType = "tmpfs"; };
      system.stateVersion = "25.05";
      services.zeroclaw.instances."bad name" = {
        package = pkgs.runCommand "stub" { meta.mainProgram = "zeroclaw"; }
          "mkdir -p $out/bin && touch $out/bin/zeroclaw && chmod +x $out/bin/zeroclaw";
        settings = { };
      };
    };
  in builtins.head (builtins.filter (a: !a.assertion) result.config.assertions)
'
# error: services.zeroclaw.instances: instance name(s) bad name contain
# characters outside [A-Za-z0-9._-]. Rename them — the instance name
# appears verbatim in the systemd unit name, user name, and state directory.
```

- **Beyond CI — what did you manually verify?**
  - Module evaluates with one instance and with two instances; produces distinct units, distinct UIDs, distinct state dirs.
  - Hardening defaults (`ProtectSystem=strict`, `PrivateUsers=true`, `DeviceAllow=""`, `MemoryDenyWriteExecute=true`, `CapabilityBoundingSet=[""]`) appear in the rendered `serviceConfig`.
  - Three eval-time assertions all fire correctly with actionable messages on the failure cases (bad name, duplicate dataDir, duplicate user).
  - `lib.getExe instanceCfg.package` resolves correctly when the package sets `meta.mainProgram = "zeroclaw"`.
  - The full NixOS test (`nix/test.nix`) runs locally on a KVM-capable host; not in this PR's `Validation Evidence` because that requires `/dev/kvm` which the standard nixpkgs sandbox doesn't provide.
- **If any command was intentionally skipped, why:** `cargo fmt`/`clippy`/`test` skipped — this PR adds no Rust code.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`Yes`) — but in the *restrictive* direction: the module sets aggressive systemd hardening defaults (`CapabilityBoundingSet=[""]`, `ProtectSystem=strict`, `PrivateUsers=true`, etc.) for every instance it manages. Users who explicitly opt into the module get a tighter sandbox than ZeroClaw running standalone.
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`Yes`) — adds the `environmentFile` option (a wrapper around systemd `EnvironmentFile=`) as the documented secrets path. The README's "Secrets pattern" section explicitly forbids putting secrets in the `settings` attrset. No secrets are stored in the diff itself.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`) — examples use `"12345"` for `allowed_users`, `"fake-token-for-test"` for the test bot token.

## Compatibility (required)

- Backward compatible? (`Yes`) — purely additive; nothing imports the new module automatically.
- Config / env / CLI surface changed? (`No`) — the module reads ZeroClaw's existing `${ZEROCLAW_CONFIG_DIR}/config.toml` via the `ZEROCLAW_CONFIG_DIR` env var that already exists in `crates/zeroclaw-runtime/src/onboard/wizard.rs`.
- Upgrade steps: none required.

## Rollback

`git revert <merge-sha>` removes the three new files; nothing else changes.
