### PR TITLE
fix(channels,deps): bump matrix-sdk 0.16 → 0.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,6 +402,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-once-cell"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288f83726785267c6f2ef073a3d83dc3f9b81464e9f99898240cced85fce35a"
+
+[[package]]
 name = "async-process"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2234,8 +2240,19 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
 dependencies = [
- "deadpool-runtime",
+ "deadpool-runtime 0.1.4",
  "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883466cb8db62725aee5f4a6011e8a5d42912b42632df32aad57fc91127c6e04"
+dependencies = [
+ "deadpool-runtime 0.3.1",
  "num_cpus",
  "tokio",
 ]
@@ -2245,17 +2262,23 @@ name = "deadpool-runtime"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2657f61fb1dd8bf37a8d51093cc7cee4e77125b22f7753f49b289f831bec2bae"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "deadpool-sync"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524bc3df0d57e98ecd022e21ba31166c2625e7d3e5bcc4510efaeeab4abcab04"
+checksum = "e385cc95d3d582c328b36d1ff90feac061102b001894b555e6b465a2e0eaabbf"
 dependencies = [
- "deadpool-runtime",
+ "deadpool-runtime 0.3.1",
 ]
 
 [[package]]
@@ -2272,10 +2295,6 @@ name = "decancer"
 version = "3.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9244323129647178bf41ac861a2cdb9d9c81b9b09d3d0d1de9cd302b33b8a1d"
-dependencies = [
- "lazy_static",
- "regex",
-]
 
 [[package]]
 name = "deku"
@@ -2923,7 +2942,7 @@ dependencies = [
  "base64 0.22.1",
  "bytemuck",
  "extism-convert-macros",
- "prost 0.14.3",
+ "prost",
  "rmp-serde",
  "serde",
  "serde_json",
@@ -3581,11 +3600,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3894,30 +3915,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "headers"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "headers-core",
- "http 1.4.0",
- "httpdate",
- "mime",
- "sha1",
-]
-
-[[package]]
-name = "headers-core"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
-dependencies = [
- "http 1.4.0",
-]
-
-[[package]]
 name = "heapless"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4022,18 +4019,7 @@ dependencies = [
  "log",
  "mac",
  "markup5ever 0.14.1",
- "match_token 0.1.0",
-]
-
-[[package]]
-name = "html5ever"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55d958c2f74b664487a2035fe1dadb032c48718a03b63f3ab0b8537db8549ed4"
-dependencies = [
- "log",
- "markup5ever 0.35.0",
- "match_token 0.35.0",
+ "match_token",
 ]
 
 [[package]]
@@ -4044,6 +4030,16 @@ checksum = "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2"
 dependencies = [
  "log",
  "markup5ever 0.38.0",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
+dependencies = [
+ "log",
+ "markup5ever 0.39.0",
 ]
 
 [[package]]
@@ -4065,15 +4061,6 @@ checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
  "itoa",
-]
-
-[[package]]
-name = "http-auth"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "150fa4a9462ef926824cf4519c84ed652ca8f4fbae34cb8af045b5cbcaf98822"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -4910,21 +4897,11 @@ dependencies = [
 
 [[package]]
 name = "konst"
-version = "0.3.17"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97feab15b395d1860944abe6a8dd8ed9f8eadfae01750fada8427abda531d887"
+checksum = "f660d5f887e3562f9ab6f4a14988795b694099d66b4f5dedc02d197ba9becb1d"
 dependencies = [
  "const_panic",
- "konst_kernel",
- "typewit",
-]
-
-[[package]]
-name = "konst_kernel"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4b1eb7788f3824c629b1116a7a9060d6e898c358ebff59070093d51103dcc3c"
-dependencies = [
  "typewit",
 ]
 
@@ -5316,24 +5293,24 @@ dependencies = [
 
 [[package]]
 name = "markup5ever"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "311fe69c934650f8f19652b3946075f0fc41ad8757dbb68f1ca14e7900ecc1c3"
-dependencies = [
- "log",
- "tendril 0.4.3",
- "web_atoms 0.1.3",
-]
-
-[[package]]
-name = "markup5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862"
 dependencies = [
  "log",
  "tendril 0.5.0",
- "web_atoms 0.2.4",
+ "web_atoms",
+]
+
+[[package]]
+name = "markup5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
+dependencies = [
+ "log",
+ "tendril 0.5.0",
+ "web_atoms",
 ]
 
 [[package]]
@@ -5341,17 +5318,6 @@ name = "match_token"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "match_token"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac84fd3f360fcc43dc5f5d186f02a94192761a080e8bc58621ad4d12296a58cf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5404,14 +5370,15 @@ dependencies = [
 
 [[package]]
 name = "matrix-sdk"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b33f9bc45edd7f8e25161521fdd30654da5c55e6749be6afa1aa9d6cf838ace0"
+checksum = "3bd53c36a55668a96eed57633a1347046271a9f9ce542a07f30e6a840e26f31f"
 dependencies = [
  "anymap2",
  "aquamarine",
  "as_variant",
  "async-channel 2.5.0",
+ "async-once-cell",
  "async-stream",
  "async-trait",
  "backon",
@@ -5437,11 +5404,14 @@ dependencies = [
  "mime",
  "mime2ext",
  "oauth2",
- "once_cell",
+ "oauth2-reqwest",
  "percent-encoding",
  "pin-project-lite",
- "reqwest 0.12.28",
+ "reqwest 0.13.2",
  "ruma",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
  "serde",
  "serde_html_form",
  "serde_json",
@@ -5455,14 +5425,15 @@ dependencies = [
  "url",
  "urlencoding",
  "vodozemac",
+ "webpki-roots 1.0.7",
  "zeroize",
 ]
 
 [[package]]
 name = "matrix-sdk-base"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70f404a390ff98a73c426b1496b169be60ce6a93723a9a664e579d978a84c5e4"
+checksum = "5a70b7aacc8429de35940f73ac1cff9679a764205f7c51d4e8f236b538442d79"
 dependencies = [
  "as_variant",
  "async-trait",
@@ -5475,7 +5446,6 @@ dependencies = [
  "matrix-sdk-common",
  "matrix-sdk-crypto",
  "matrix-sdk-store-encryption",
- "once_cell",
  "regex",
  "ruma",
  "serde",
@@ -5488,9 +5458,9 @@ dependencies = [
 
 [[package]]
 name = "matrix-sdk-common"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54fae2bdfc3d760d21a84d6d2036b5db5c48d9a3dee3794119e3fb9c4cc4ccc5"
+checksum = "697b45015c5b7128027fee8adf9f9f32a75a97ba8326bb9c7265fb90bcf2d766"
 dependencies = [
  "eyeball-im",
  "futures-core",
@@ -5512,9 +5482,9 @@ dependencies = [
 
 [[package]]
 name = "matrix-sdk-crypto"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "304fc576810a9618bb831c4ad6403c758ec424f677668a49a196e3cde4b8f99f"
+checksum = "948582d5461fa4066117e0a08828df16c3041d5f0c17aca679041fed30b4284a"
 dependencies = [
  "aes",
  "aquamarine",
@@ -5533,7 +5503,7 @@ dependencies = [
  "js_option",
  "matrix-sdk-common",
  "pbkdf2",
- "rand 0.8.6",
+ "rand 0.10.1",
  "rmp-serde",
  "ruma",
  "serde",
@@ -5553,14 +5523,14 @@ dependencies = [
 
 [[package]]
 name = "matrix-sdk-indexeddb"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b6096084cc8d339c03e269ca25534d0f1e88d0097c35a215eb8c311797ec3e9"
+checksum = "6484e88308cfdf6deff13122a6b927c03936ec262d0fbb03bac7a0c73ae95c89"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
  "futures-util",
- "getrandom 0.2.17",
+ "getrandom 0.4.2",
  "gloo-utils",
  "hkdf",
  "js-sys",
@@ -5585,13 +5555,13 @@ dependencies = [
 
 [[package]]
 name = "matrix-sdk-sqlite"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4325742fc06b7f75c80eec39e8fb32b06ea4b09b7aa1d432b67b01d08fbacc28"
+checksum = "4d797f59498ea3db5341742fcf3765e3cf7418f6ddf667526b5ed12cb4aba6dc"
 dependencies = [
  "as_variant",
  "async-trait",
- "deadpool",
+ "deadpool 0.13.0",
  "deadpool-sync",
  "itertools 0.14.0",
  "matrix-sdk-base",
@@ -5613,17 +5583,18 @@ dependencies = [
 
 [[package]]
 name = "matrix-sdk-store-encryption"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162a93e83114d5cef25c0ebaea72aa01b9f233df6ec4a2af45f175d01ec26323"
+checksum = "1728926a2bcdd33329c87c0da9d832d8eb610ecd4676ca5d38c108fab91b0102"
 dependencies = [
  "base64 0.22.1",
  "blake3",
  "chacha20poly1305",
  "getrandom 0.2.17",
+ "getrandom 0.4.2",
  "hmac 0.12.1",
  "pbkdf2",
- "rand 0.8.6",
+ "rand 0.10.1",
  "rmp-serde",
  "serde",
  "serde_json",
@@ -6210,13 +6181,22 @@ dependencies = [
  "getrandom 0.2.17",
  "http 1.4.0",
  "rand 0.8.6",
- "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_path_to_error",
  "sha2 0.10.9",
  "thiserror 1.0.69",
  "url",
+]
+
+[[package]]
+name = "oauth2-reqwest"
+version = "0.1.0-alpha.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234fb5c965bbce983ee5de636a7a51d6a3223da8067ea02f9ab2d2d78ac08be2"
+dependencies = [
+ "oauth2",
+ "reqwest 0.13.2",
 ]
 
 [[package]]
@@ -6551,7 +6531,7 @@ dependencies = [
  "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
- "prost 0.14.3",
+ "prost",
  "reqwest 0.12.28",
  "thiserror 2.0.18",
 ]
@@ -6564,7 +6544,7 @@ checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
- "prost 0.14.3",
+ "prost",
  "tonic",
  "tonic-prost",
 ]
@@ -7470,22 +7450,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
-dependencies = [
- "bytes",
- "prost-derive 0.13.5",
-]
-
-[[package]]
-name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
- "prost-derive 0.14.3",
+ "prost-derive",
 ]
 
 [[package]]
@@ -7499,23 +7469,10 @@ dependencies = [
  "log",
  "multimap",
  "petgraph 0.8.3",
- "prost 0.14.3",
+ "prost",
  "prost-types",
  "regex",
  "tempfile",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
-dependencies = [
- "anyhow",
- "itertools 0.14.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -7537,7 +7494,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
- "prost 0.14.3",
+ "prost",
 ]
 
 [[package]]
@@ -7651,6 +7608,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -8117,7 +8075,6 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
  "http 1.4.0",
  "http-body",
  "http-body-util",
@@ -8160,19 +8117,26 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
+ "h2",
  "http 1.4.0",
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -8228,9 +8192,9 @@ dependencies = [
 
 [[package]]
 name = "ruma"
-version = "0.14.1"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9f620a2116d0d3082f9256e61dcdf67f2ec266d3f6bb9d2f9c8a20ec5a1fabb"
+checksum = "e420da038fd6529af5abffe21df50ba122e1b4a84db05c02ec05b5ab0a21a320"
 dependencies = [
  "assign",
  "js_int",
@@ -8238,21 +8202,19 @@ dependencies = [
  "ruma-client-api",
  "ruma-common",
  "ruma-events",
- "ruma-federation-api",
  "ruma-html",
  "web-time",
 ]
 
 [[package]]
 name = "ruma-client-api"
-version = "0.22.1"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc977d1a91ea15dcf896cbd7005ed4a253784468833638998109ffceaee53e7"
+checksum = "3a793e13cc9c354385e4f635b5eca581abe76169a9fafd8c530918f9b19f8d63"
 dependencies = [
  "as_variant",
  "assign",
  "bytes",
- "date_header",
  "http 1.4.0",
  "js_int",
  "js_option",
@@ -8269,22 +8231,22 @@ dependencies = [
 
 [[package]]
 name = "ruma-common"
-version = "0.17.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a01993f22d291320b7c9267675e7395775e95269ff526e2c8c3ed5e13175b"
+checksum = "b69b11cb6ccf0e27c3c44c50e2e4799337921c66d4e6a490c084f18c5b4481ec"
 dependencies = [
  "as_variant",
  "base64 0.22.1",
  "bytes",
+ "date_header",
  "form_urlencoded",
- "getrandom 0.2.17",
+ "getrandom 0.4.2",
  "http 1.4.0",
  "indexmap 2.14.0",
- "js-sys",
  "js_int",
  "konst",
  "percent-encoding",
- "rand 0.8.6",
+ "rand 0.10.1",
  "regex",
  "ruma-identifiers-validation",
  "ruma-macros",
@@ -8303,58 +8265,34 @@ dependencies = [
 
 [[package]]
 name = "ruma-events"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dbdeccb62cb4ffe3282325de8ba28cbc0fdce7c78a3f11b7241fbfdb9cb9907"
+checksum = "c96e3c39ab1b692086d02513fe0c24400d864060880bbd2716cb5544f5923131"
 dependencies = [
  "as_variant",
  "indexmap 2.14.0",
  "js_int",
  "js_option",
- "percent-encoding",
  "pulldown-cmark",
- "regex",
  "ruma-common",
- "ruma-identifiers-validation",
  "ruma-macros",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tracing",
- "url",
  "web-time",
  "wildmatch",
  "zeroize",
 ]
 
 [[package]]
-name = "ruma-federation-api"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb45c15badbf4299c6113a6b90df3e7cb64edbe756bbd8e0224144b56b38305"
-dependencies = [
- "headers",
- "http 1.4.0",
- "http-auth",
- "js_int",
- "mime",
- "ruma-common",
- "ruma-events",
- "ruma-signatures",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
 name = "ruma-html"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6dcd6e9823e177d15460d3cd3a413f38a2beea381f26aca1001c05cd6954ff"
+checksum = "c1d81a7300e8623dbf5e6d73e700f0277fce6824849d77779ed997ec4e280b97"
 dependencies = [
  "as_variant",
- "html5ever 0.35.0",
+ "html5ever 0.39.0",
  "tracing",
  "wildmatch",
 ]
@@ -8371,9 +8309,9 @@ dependencies = [
 
 [[package]]
 name = "ruma-macros"
-version = "0.17.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a0753312ad577ac462de1742bf2e326b6ba9856ff6f13343aeb17d423fd5426"
+checksum = "6ac022103cd7829721476d3df79d16125be159e99527c8ddb27f125e7b674e5c"
 dependencies = [
  "as_variant",
  "cfg-if",
@@ -8383,23 +8321,7 @@ dependencies = [
  "ruma-identifiers-validation",
  "serde",
  "syn 2.0.117",
- "toml 0.9.12+spec-1.1.0",
-]
-
-[[package]]
-name = "ruma-signatures"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146ace2cd59b60ec80d3e801a84e7e6a91e3e01d18a9f5d896ea7ca16a6b8e08"
-dependencies = [
- "base64 0.22.1",
- "ed25519-dalek",
- "pkcs8",
- "rand 0.8.6",
- "ruma-common",
- "serde_json",
- "sha2 0.10.9",
- "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]
@@ -8546,6 +8468,33 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki 0.103.13",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -8907,9 +8856,9 @@ dependencies = [
 
 [[package]]
 name = "serde_html_form"
-version = "0.2.8"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2f2d7ff8a2140333718bb329f5c40fc5f0865b84c426183ce14c97d2ab8154f"
+checksum = "0946d52b4b7e28823148aebbeceb901012c595ad737920d504fa8634bb099e6f"
 dependencies = [
  "form_urlencoded",
  "indexmap 2.14.0",
@@ -10494,7 +10443,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
 dependencies = [
  "bytes",
- "prost 0.14.3",
+ "prost",
  "tonic",
 ]
 
@@ -10754,15 +10703,6 @@ name = "typewit"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "214ca0b2191785cbc06209b9ca1861e048e39b5ba33574b3cedd58363d5bb5f6"
-dependencies = [
- "typewit_proc_macros",
-]
-
-[[package]]
-name = "typewit_proc_macros"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36a83ea2b3c704935a01b4642946aadd445cea40b10935e3f8bd8052b8193d6"
 
 [[package]]
 name = "ucd-trie"
@@ -11099,9 +11039,9 @@ checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "vodozemac"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c022a277687e4e8685d72b95a7ca3ccfec907daa946678e715f8badaa650883d"
+checksum = "b98bf83c0992966775b8012f194b07b44928996163e5a05b741b43891571ae5b"
 dependencies = [
  "aes",
  "arrayvec",
@@ -11115,7 +11055,7 @@ dependencies = [
  "hkdf",
  "hmac 0.12.1",
  "matrix-pickle",
- "prost 0.13.5",
+ "prost",
  "rand 0.8.6",
  "serde",
  "serde_bytes",
@@ -11173,7 +11113,7 @@ dependencies = [
  "hex",
  "log",
  "moka",
- "prost 0.14.3",
+ "prost",
  "rand 0.9.4",
  "rand_core 0.10.1",
  "scopeguard",
@@ -11197,7 +11137,7 @@ dependencies = [
  "hex",
  "hkdf",
  "log",
- "prost 0.14.3",
+ "prost",
  "serde",
  "serde-big-array",
  "serde_json",
@@ -11244,7 +11184,7 @@ dependencies = [
  "md5",
  "once_cell",
  "pbkdf2",
- "prost 0.14.3",
+ "prost",
  "protobuf",
  "rand 0.9.4",
  "rand_core 0.10.1",
@@ -11295,7 +11235,7 @@ dependencies = [
  "hmac 0.12.1",
  "itertools 0.14.0",
  "log",
- "prost 0.14.3",
+ "prost",
  "rand 0.9.4",
  "serde",
  "sha1",
@@ -11318,7 +11258,7 @@ dependencies = [
  "bytes",
  "hkdf",
  "log",
- "prost 0.14.3",
+ "prost",
  "rand 0.9.4",
  "rand_core 0.10.1",
  "sha2 0.10.9",
@@ -11334,7 +11274,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ada50ee03752f0e66ada8cf415ed5f90d572d34039b058ce23d8b13493e510"
 dependencies = [
- "prost 0.14.3",
+ "prost",
  "prost-build",
  "serde",
 ]
@@ -11989,18 +11929,6 @@ dependencies = [
 
 [[package]]
 name = "web_atoms"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ffde1dc01240bdf9992e3205668b235e59421fd085e8a317ed98da0178d414"
-dependencies = [
- "phf 0.11.3",
- "phf_codegen 0.11.3",
- "string_cache 0.8.9",
- "string_cache_codegen 0.5.4",
-]
-
-[[package]]
-name = "web_atoms"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7cff6eef815df1834fd250e3a2ff436044d82a9f1bc1980ca1dbdf07effc538"
@@ -12073,6 +12001,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -12820,7 +12757,7 @@ checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
 dependencies = [
  "assert-json-diff",
  "base64 0.22.1",
- "deadpool",
+ "deadpool 0.12.3",
  "futures",
  "http 1.4.0",
  "http-body-util",
@@ -13250,7 +13187,7 @@ dependencies = [
  "nostr-sdk",
  "parking_lot",
  "portable-atomic",
- "prost 0.14.3",
+ "prost",
  "qrcode",
  "rand 0.10.1",
  "regex",

--- a/crates/zeroclaw-channels/Cargo.toml
+++ b/crates/zeroclaw-channels/Cargo.toml
@@ -28,7 +28,7 @@ hmac = "0.12"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png"], optional = true }
 lettre = { version = "0.11.19", default-features = false, features = ["builder", "smtp-transport", "rustls-tls"], optional = true }
 mail-parser = { version = "0.11.2", optional = true }
-matrix-sdk = { version = "0.16", optional = true, default-features = false, features = ["e2e-encryption", "rustls-tls", "markdown", "sqlite"] }
+matrix-sdk = { version = "0.17", optional = true, default-features = false, features = ["e2e-encryption", "markdown", "sqlite"] }
 mime_guess = { version = "2", optional = true }
 nostr-sdk = { version = "0.44", default-features = false, features = ["nip04", "nip59"], optional = true }
 parking_lot = "0.12"

--- a/crates/zeroclaw-channels/src/lib.rs
+++ b/crates/zeroclaw-channels/src/lib.rs
@@ -1,5 +1,7 @@
 //! Channel implementations and orchestration for messaging platform integrations.
 
+#![cfg_attr(feature = "channel-matrix", recursion_limit = "256")]
+
 pub mod orchestrator;
 pub mod util;
 

--- a/crates/zeroclaw-channels/src/matrix.rs
+++ b/crates/zeroclaw-channels/src/matrix.rs
@@ -1860,7 +1860,7 @@ mod outbound {
                 reaction::ReactionEventContent,
                 relation::Annotation,
                 room::message::{
-                    MessageType, ReplyWithinThread, RoomMessageEventContent,
+                    AddMentions, MessageType, ReplyWithinThread, RoomMessageEventContent,
                     RoomMessageEventContentWithoutRelation, TextMessageEventContent,
                 },
             },
@@ -2314,7 +2314,7 @@ mod outbound {
         ) {
             send_threaded_reply(&room, content, anchor, outbox.threads_seen).await?
         } else {
-            room.send(content).await?.event_id
+            room.send(content).await?.response.event_id
         };
 
         let kinds = delivery.failure_kinds();
@@ -2357,13 +2357,14 @@ mod outbound {
                 Reply {
                     event_id: anchor.clone(),
                     enforce_thread: EnforceThread::Threaded(ReplyWithinThread::No),
+                    add_mentions: AddMentions::No,
                 },
             )
             .await
             .map_err(|e| anyhow!("make_reply_event failed: {e}"))?;
         ctx_mod::mark_seen(threads_seen, anchor).await;
         let resp = room.send(reply_event).await?;
-        Ok(resp.event_id)
+        Ok(resp.response.event_id)
     }
 
     pub(super) async fn edit(
@@ -2415,7 +2416,7 @@ mod outbound {
                 event_id.clone(),
                 emoji.to_string(),
             ),
-            resp.event_id,
+            resp.response.event_id,
         );
         Ok(())
     }
@@ -2485,6 +2486,7 @@ mod outbound {
             config = config.reply(Some(Reply {
                 event_id: anchor.clone(),
                 enforce_thread: EnforceThread::Threaded(ReplyWithinThread::No),
+                add_mentions: AddMentions::No,
             }));
         }
         let resp = room
@@ -2538,7 +2540,7 @@ mod outbound {
             );
         }
         let resp = room.send_raw("m.room.message", event).await?;
-        Ok(resp.event_id)
+        Ok(resp.response.event_id)
     }
 
     fn derive_file_name(target: &str) -> String {

--- a/install.sh
+++ b/install.sh
@@ -452,6 +452,32 @@ build_web_dashboard() {
   info "Web dashboard built at $src_dir/web/dist"
 }
 
+# ── Low-memory build heuristic ────────────────────────────────────
+#
+# [profile.release] in Cargo.toml uses fat LTO + codegen-units = 1.
+# With heavy crates in the graph (matrix-sdk-crypto, ruma, vodozemac)
+# a single rustc process can peak past 7 GB RSS during the cross-crate
+# type pass, OOM-ing 8 GB ARM devices. Thin LTO trades a small
+# binary-size hit for a much lower build-time RAM peak. Apply it as
+# a default on Linux hosts with under ~12 GiB MemTotal, but only when
+# the user has not already pinned CARGO_PROFILE_RELEASE_LTO.
+apply_low_mem_lto_default() {
+  [ "$(uname -s)" = "Linux" ] || return 0
+  [ -r /proc/meminfo ] || return 0
+  [ -n "${CARGO_PROFILE_RELEASE_LTO:-}" ] && return 0
+
+  mem_kb=$(awk '/^MemTotal:/{print $2; exit}' /proc/meminfo 2>/dev/null)
+  case "$mem_kb" in
+    ''|*[!0-9]*) return 0 ;;
+  esac
+  # 12 GiB in KiB = 12 * 1024 * 1024
+  if [ "$mem_kb" -lt 12582912 ]; then
+    mem_gib=$((mem_kb / 1048576))
+    export CARGO_PROFILE_RELEASE_LTO=thin
+    info "Low-memory device detected (${mem_gib} GiB RAM): using thin LTO to keep build RAM bounded. Set CARGO_PROFILE_RELEASE_LTO=fat to override."
+  fi
+}
+
 # ── Parse arguments ───────────────────────────────────────────────
 
 MINIMAL=false
@@ -764,6 +790,10 @@ if [ -n "$PATH_BIN" ]; then
   fi
 fi
 
+# ── Build profile RAM heuristic (Linux low-mem hosts) ─────────────
+
+apply_low_mem_lto_default
+
 # ── Dry run ───────────────────────────────────────────────────────
 
 if [ "$DRY_RUN" = true ]; then
@@ -775,6 +805,9 @@ if [ "$DRY_RUN" = true ]; then
   info "Config:   $PREFIX/.zeroclaw/"
   info "Rust:     $CARGO_HOME (CARGO_HOME), $RUSTUP_HOME (RUSTUP_HOME)"
   echo
+  if [ -n "${CARGO_PROFILE_RELEASE_LTO:-}" ]; then
+    info "env:      CARGO_PROFILE_RELEASE_LTO=$CARGO_PROFILE_RELEASE_LTO"
+  fi
   if [ -n "$CARGO_FLAGS" ]; then
     info "cargo install --path . --locked --force $CARGO_FLAGS"
   else


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Bump matrix-sdk 0.16 to 0.17 to pick up upstream PR matrix-org/matrix-rust-sdk#6489, which raises the recursion-limit attribute inside the matrix-sdk crate from 128 to 256.
  - Raise zeroclaw-channels' own crate-level `recursion_limit` to 256 (gated on `channel-matrix`). The matrix-sdk crate bump alone is NOT sufficient on rustc 1.95.0: the Send-bound proof for our boxed `listen()` future is checked at zeroclaw-channels' compile site, where the default limit of 128 is still in effect. rustc must walk the entire type chain from matrix-sdk-crypto's `Store::get_user_devices` up through ~20 layers of `Instrumented<ManuallyDrop<MaybeDangling<...>>>` wrappers into our `run_sync_loop` and `listen`, which overflows with E0275 without the attribute.
  - Drop the `rustls-tls` feature flag (removed in matrix-sdk 0.17; rustls is now the only supported TLS backend, native-tls support was eliminated upstream).
  - Adjust four call sites for the new `SendMessageLikeEventResult` shape (`.response.event_id` instead of `.event_id`); the wrapper exposes `EncryptionInfo` on encrypted sends.
  - Add the new mandatory `add_mentions: AddMentions::No` field on the two `Reply` constructions; both are bot thread-continuation replies with no specific in-reply-to user, so `No` preserves prior no-extra-mentions behavior.
  - **install.sh**: default `CARGO_PROFILE_RELEASE_LTO=thin` on Linux hosts with under 12 GiB MemTotal. This is in scope for this PR because v0.16 fit on a Pi 5 8 GB and v0.17 provably does not. `[profile.release]` uses `lto = "fat"` + `codegen-units = 1`, tuned for 1 GB Pi 3s; through v0.7.5 with matrix-sdk 0.16 the cross-crate LTO type pass stayed under the 8 GB ceiling. matrix-sdk 0.17 grew the graph (ruma 0.14 → 0.15.1, more `#[instrument]` wrappers in matrix-sdk-crypto, expanded OAuth surface, vodozemac 0.9 → 0.10); fat LTO now peaks a single rustc process past 7.4 GB RSS and OOM-kills a Pi 5 8 GB mid-link (observed twice on this PR's SDK-bump-only branch before the install.sh change). Without this default the matrix-sdk 0.17 bump in this PR silently regresses the official Pi install path. User-set `CARGO_PROFILE_RELEASE_LTO` is respected; the script prints a one-line info() naming the choice and the override knob.
- **Scope boundary:** no behavioral changes to the matrix channel itself, no new features, no other 0.17 API surfaces adopted (DM rooms, Latest Event overhaul, OAuth metadata, sliding-sync, live location, `report_content` score, etc. all left untouched). The install.sh change is an environment-default tweak, not a profile redefinition: `[profile.release]` in `Cargo.toml` is unchanged. A more aggressive tier for 4 GiB devices (LTO=off + capped jobs) was considered and deferred to a follow-up Issue; this PR's job is to keep parity with the v0.16 install path, which is the 8 GiB Pi 5 case.
- **Blast radius:**
  - Matrix code path: only `channel-matrix` users (the feature is opt-in). The `recursion_limit` attribute is gated on the same feature so non-matrix builds are unaffected. Ruma bumps 0.14 to 0.15.1 transitively, but our event-handling code (`OwnedEventId`, `OwnedRoomId`, `serde::Raw`, raw JSON) is unaffected.
  - install.sh change: Linux hosts with under 12 GiB MemTotal now build with thin LTO by default (binary marginally larger, build RAM bounded). x86_64 workstations, macOS, Windows, and any host at or above 12 GiB are unaffected.
- **Linked issue(s):** Closes #6530
- **Labels:** `type: dependencies`, `risk: low`, `channel`, `channel:matrix`, `dependencies`

## Validation Evidence (required)

```bash
cargo +nightly fmt --all -- --check
cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
cargo test -p zeroclaw-channels --features channel-matrix matrix
cargo build --release --features channel-matrix   # rustc 1.95.0
sh -n install.sh
./install.sh --dry-run --minimal                  # heuristic integration check
./install.sh                                      # full source install, Pi 5 8 GB
```

- **Commands run and tail output:**
  - `cargo +nightly fmt --all -- --check`: clean (no output).
  - `cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings`: clean, finished in 2m00s.
  - `cargo test -p zeroclaw-channels --features channel-matrix matrix`: `test result: ok. 110 passed; 0 failed; 0 ignored`.
  - `cargo build --release --features channel-matrix` on rustc 1.95.0: see Before/After below.
  - `sh -n install.sh`: syntax ok.
  - install.sh threshold logic: verified on 5 inputs (Pi 5 8 GB triggers thin, Pi 4 4 GB triggers thin, 11 GiB triggers thin, exactly 12 GiB does NOT trigger, 16 GB does NOT trigger). User override path: `CARGO_PROFILE_RELEASE_LTO=fat ./install.sh --dry-run` correctly skips the auto-default and echoes the env var in the dry-run summary. On a 30 GiB host the function correctly does NOT inject.
  - `./install.sh` on a Pi 5 8 GB (rustc 1.95.0, aarch64): build completed successfully. Heuristic detected 7 GiB MemTotal and applied `CARGO_PROFILE_RELEASE_LTO=thin`. Peak single-process rustc RSS during the zeroclaw-channels link held at ~2.8 GB; total system RAM at the peak was 3.45 GiB / 7.87 GiB. Final binary installed as `~/.cargo/bin/zeroclaw v0.7.5` (34 MB).

### Before (rustc 1.95.0, SDK-bump-only, default `recursion_limit = 128`)

<details><summary>E0275 verbatim (trimmed; full chain spans ~20 frames)</summary>

```
error[E0275]: overflow evaluating the requirement `{coroutine witness@matrix_sdk_crypto::store::Store::get_user_devices::{closure#0}}: std::marker::Send`
    --> crates/zeroclaw-channels/src/matrix.rs:2730:5
     |
2730 |     async fn listen(&self, tx: mpsc::Sender<ChannelMessage>) -> Result<()> {
     |     ^^^^^
     |
     = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`zeroclaw_channels`)
note: required because it's used within this `async` fn body
    --> .../matrix-sdk-crypto-0.17.0/src/store/mod.rs:821:90
     |
 821 |   pub(crate) async fn get_user_devices(&self, user_id: &UserId) -> Result<UserDevices> { ... }
...
note: required because it appears within the type `Instrumented<...>`
    --> .../tracing-0.1.44/src/instrument.rs:266:16
     |
 266 |     pub struct Instrumented<T> {
...
note: required because it's used within this `async` fn body
    --> .../matrix-sdk-0.17.0/src/client/mod.rs:2919:95
     |
2919 |   pub async fn sync(&self, sync_settings: crate::config::SyncSettings) -> Result<(), Error> { ... }
...
note: required because it's used within this `async` fn body
    --> crates/zeroclaw-channels/src/matrix.rs:1259:94
     |
1259 |   pub(super) async fn run_sync_loop(client: Client, ctx: HandlerCtx) -> anyhow::Result<()> { ... }
note: required because it's used within this `async` block
    --> crates/zeroclaw-channels/src/matrix.rs:2730:5
     |
2730 |     async fn listen(&self, tx: mpsc::Sender<ChannelMessage>) -> Result<()> {
     |     ^^^^^
     = note: required for the cast from `std::pin::Pin<Box<{async block@crates/zeroclaw-channels/src/matrix.rs:2730:5: 2730:10}>>` to `Pin<Box<dyn Future<Output = Result<(), Error>> + Send>>`
     = note: the full name for the type has been written to 'target/release/deps/zeroclaw_channels-...long-type-...txt'
     = note: this error originates in the attribute macro `instrument`

For more information about this error, try `rustc --explain E0275`.
error: could not compile `zeroclaw-channels` (lib) due to 1 previous error
```

</details>

### After (rustc 1.95.0, with `#![cfg_attr(feature = "channel-matrix", recursion_limit = "256")]`)

No errors. `cargo build --release --features channel-matrix` completes cleanly.

- **Beyond CI, what did you manually verify?**
  - Audited every `matrix_sdk::` and `ruma::` import in the channel against the 0.17 release notes for breaking-change exposure.
  - Confirmed `send_attachment` return shape did NOT change (still has `.event_id` directly; only `Room::send` / `Room::send_raw` wrap through `.response`).
  - Reproduced E0275 on rustc 1.95.0 against the SDK-bump-only branch and confirmed the `recursion_limit` attribute resolves it; release build then completes with no errors.
  - Verified install.sh heuristic on multiple memory inputs and confirmed the user-override path; integration tested via `./install.sh --dry-run`.
  - Reproduced the OOM kill on a Pi 5 8 GB against the SDK-bump-only branch (fat LTO mid-link), and confirmed that the install.sh thin-LTO default fits the same build well inside RAM (peak 3.45 GiB / 7.87 GiB).
  - Did NOT exercise this against a live Matrix homeserver. A live smoke (send, reply-in-thread, reaction, attachment, voice) would be valuable before the next release cuts.
- **If any command was intentionally skipped, why:** none.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`. install.sh now reads `/proc/meminfo` (world-readable, no privilege gain).
- New external network calls? `No`.
- Secrets / tokens / credentials handling changed? `No`. The TLS backend was already rustls in practice; only the redundant feature flag selecting rustls was removed.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`.

## Compatibility (required)

- Backward compatible? `Yes`.
- Config / env / CLI surface changed? `No` for the matrix channel. install.sh now honors `CARGO_PROFILE_RELEASE_LTO` if pre-set by the operator; previously it was ignored by the script (cargo would still consume it from the environment, but the script never opined). The new default-injection on low-mem Linux hosts is the only behavior change visible to operators, and it is announced via an info() line at build start.
- Existing Matrix bot deployments continue to work; the SDK upgrade and recursion-limit attribute are both internal to the channel implementation.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PR. `git revert <sha>` per commit if needed; the three commits are independent and revertible in any order.