### PR TITLE
fix(channels): gate telegram tests behind channel-telegram feature

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -12834,6 +12834,7 @@ This is an example JSON object for profile settings."#;
         );
     }
 
+    #[cfg(feature = "channel-telegram")]
     #[test]
     fn build_channel_by_id_unconfigured_telegram_returns_error() {
         let config = Config::default();
@@ -12849,6 +12850,7 @@ This is an example JSON object for profile settings."#;
         }
     }
 
+    #[cfg(feature = "channel-telegram")]
     #[test]
     fn build_channel_by_id_configured_telegram_succeeds() {
         let mut config = Config::default();


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Two `build_channel_by_id` telegram tests in `crates/zeroclaw-channels/src/orchestrator/mod.rs` run unconditionally, but the corresponding dispatch arm is `#[cfg(feature = "channel-telegram")]`-gated. Since `channel-telegram` is not in the default feature set, these tests always hit the "Unknown channel" error path and fail under default features.
- **Scope boundary:** Only adds cfg gates to existing test functions. No production code or test logic changed.
- **Blast radius:** Minimal — only affects which tests compile under default features. With `channel-telegram` enabled, behavior is identical.
- **Linked issue(s):** Closes #6347

## Validation Evidence

- **Commands run and tail output:**

Verified the fix follows the exact same pattern as the adjacent voice-call tests (lines 12875, 12891) which already use `#[cfg(feature = "channel-voice-call")]`:

```rust
// Before (fails under default features):
#[test]
fn build_channel_by_id_unconfigured_telegram_returns_error() { ... }

// After (gated, matching voice-call pattern):
#[cfg(feature = "channel-telegram")]
#[test]
fn build_channel_by_id_unconfigured_telegram_returns_error() { ... }
```

- **Beyond CI — what did you manually verify?** Confirmed that `channel-telegram` is absent from the default features in `crates/zeroclaw-channels/Cargo.toml`, and that the `build_channel_by_id` dispatch arm for telegram at line ~4040 is gated with `#[cfg(feature = "channel-telegram")]`.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No

## Compatibility

- Backward compatible? Yes — only affects test compilation, no runtime change
- Config / env / CLI surface changed? No