### PR TITLE
fix(vscode): remove duplicate --all-targets from rust-analyzer extraArgs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,7 +15,7 @@
   "files.autoSave": "afterDelay",
   "files.autoSaveDelay": 1000,
   "rust-analyzer.check.command": "clippy",
-  "rust-analyzer.check.extraArgs": ["--all-targets", "--", "-D", "warnings"],
+  "rust-analyzer.check.extraArgs": ["--", "-D", "warnings"],
   "window.title": "${activeRepositoryBranchName}",
   "coverage-gutters.coverageFileNames": ["lcov.info"],
   "git.postCommitCommand": "push"


### PR DESCRIPTION
## Summary

Removes the redundant `--all-targets` argument from `.vscode/settings.json` rust-analyzer extraArgs.

## What changed and why

rust-analyzer already passes `--all-targets` automatically when running clippy. Including it in `rust-analyzer.check.extraArgs` causes the argument to be duplicated, which makes cargo fail with:

```
error: the argument '--all-targets' cannot be used multiple times
```

This breaks rust-analyzer flycheck for anyone opening the project in VS Code.

## Scope boundary

Only touches `.vscode/settings.json`. No runtime or CI changes.

## Validation Evidence

- Verified that `.vscode/settings.json` no longer contains the duplicate `--all-targets` flag.
- The remaining `-- -D warnings` extraArgs are preserved.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No

## Compatibility

- Backward compatible? Yes
- Config / env / CLI surface changed? No

## Rollback

`git revert 22d5d9c3f8460be3d1ae6c0b7b00774d7e90f174`

Closes #5687