### PR TITLE
docs(container): correct image registry and add onboarding/re-auth steps

### DIFF
--- a/docs/book/src/ops/service.md
+++ b/docs/book/src/ops/service.md
@@ -113,7 +113,7 @@ Compose:
 ```yaml
 services:
   zeroclaw:
-    image: zeroclawlabs/zeroclaw:latest
+    image: ghcr.io/zeroclaw-labs/zeroclaw:latest
     mem_limit: 2g
     cpus: 2.0
     ulimits:

--- a/docs/book/src/setup/container.md
+++ b/docs/book/src/setup/container.md
@@ -4,13 +4,15 @@ Run ZeroClaw in Docker, Podman, Kubernetes, or any OCI runtime.
 
 ## Official images
 
-Pushed to Docker Hub on every stable release:
+Pushed to GitHub Container Registry (`ghcr.io`) on every stable release:
 
-- `zeroclawlabs/zeroclaw:latest` — latest stable
-- `zeroclawlabs/zeroclaw:v0.7.5` — pinned
-- `zeroclawlabs/zeroclaw:debian` — Debian-based image (larger, broader glibc support)
+- `ghcr.io/zeroclaw-labs/zeroclaw:latest` — latest stable
+- `ghcr.io/zeroclaw-labs/zeroclaw:v0.7.5` — pinned
+- `ghcr.io/zeroclaw-labs/zeroclaw:debian` — Debian-based image (larger, broader glibc support)
 
 Multi-arch: `linux/amd64`, `linux/arm64`.
+
+> **Note on shell access:** The default `latest` image is intentionally distroless and does not include `sh`, `ash`, or `bash`. Use the `debian` tag if you need a shell inside the container (for example, to run `docker exec` for debugging).
 
 ## Minimum run
 
@@ -19,7 +21,7 @@ docker run -d \
   --name zeroclaw \
   -v zeroclaw-data:/zeroclaw-data \
   -p 42617:42617 \
-  zeroclawlabs/zeroclaw:latest
+  ghcr.io/zeroclaw-labs/zeroclaw:latest
 ```
 
 The image expects persistent state at `/zeroclaw-data`. On first run, it bootstraps a default config — you still need to onboard before it's useful:
@@ -35,7 +37,7 @@ A minimal `docker-compose.yml`:
 ```yaml
 services:
   zeroclaw:
-    image: zeroclawlabs/zeroclaw:latest
+    image: ghcr.io/zeroclaw-labs/zeroclaw:latest
     restart: unless-stopped
     ports:
       - "42617:42617"      # gateway
@@ -43,6 +45,12 @@ services:
       - ./data:/zeroclaw-data
     environment:
       ZEROCLAW_ALLOW_PUBLIC_BIND: "1"   # only if the gateway must be reachable on the LAN
+```
+
+After the container starts, run onboarding:
+
+```bash
+docker compose exec zeroclaw zeroclaw onboard
 ```
 
 Drop `ZEROCLAW_ALLOW_PUBLIC_BIND` if you only need local access.
@@ -56,7 +64,7 @@ docker run -d --name zeroclaw \
   -v $(pwd)/my-config.toml:/zeroclaw-data/.zeroclaw/config.toml:ro \
   -v zeroclaw-state:/zeroclaw-data/workspace \
   -p 42617:42617 \
-  zeroclawlabs/zeroclaw:latest
+  ghcr.io/zeroclaw-labs/zeroclaw:latest
 ```
 
 For container workloads, the onboarding wizard detects Docker/Podman/Kubernetes and rewrites `localhost` references in the config to `host.docker.internal` (Docker) or other container-appropriate aliases.
@@ -91,7 +99,7 @@ spec:
     spec:
       containers:
         - name: zeroclaw
-          image: zeroclawlabs/zeroclaw:v0.7.5
+          image: ghcr.io/zeroclaw-labs/zeroclaw:v0.7.5
           ports:
             - containerPort: 42617
           volumeMounts:
@@ -107,6 +115,20 @@ spec:
 ```
 
 **Scaling:** ZeroClaw is single-writer per workspace. Don't scale horizontally — run one instance per agent.
+
+## Re-authenticating after logout
+
+If you log out of the web UI while running in a container, the existing paircode becomes invalid. Generate a new one to log back in:
+
+```bash
+docker exec -it zeroclaw zeroclaw gateway get-paircode --new
+```
+
+For Compose deployments, use `docker compose exec` instead:
+
+```bash
+docker compose exec zeroclaw zeroclaw gateway get-paircode --new
+```
 
 ## Gotchas
 


### PR DESCRIPTION
## Summary

Corrects Docker installation documentation to use the actual image registry and adds missing operational steps.

## What changed and why

1. **Image registry correction** — The docs referenced Docker Hub (), but the official images are published to GitHub Container Registry (). Updated all image references across the minimum run, Compose, config, and Kubernetes sections.

2. **Added missing Compose onboarding step** — The Compose example did not mention running  after the container starts, which is required before the agent is usable. Added the command right after the compose file.

3. **Added re-authentication guidance** — Users who log out of the web UI in a container need to regenerate their paircode. Added a new section explaining .

## Scope boundary

Docs-only change. No runtime, CI, or build changes.

## Validation Evidence

- Verified all image strings were updated consistently.
- Verified the new onboarding and re-auth commands match the issue description.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No

## Compatibility

- Backward compatible? Yes
- Config / env / CLI surface changed? No

## Rollback

`git revert ea2d5233722900c63864a1be2c1c978f9bea4329`

Closes #6393