### PR TITLE
fix(channels): close Discord media send/receive gaps

### DIFF
--- a/crates/zeroclaw-channels/src/discord.rs
+++ b/crates/zeroclaw-channels/src/discord.rs
@@ -1014,6 +1014,33 @@ fn split_message_for_discord_multi(content: &str, max_len: usize) -> Vec<String>
     }
 }
 
+/// Choose the chunks to deliver for an outbound Discord message.
+///
+/// `split_message_for_discord_multi` returns an empty vec for empty input
+/// (its paragraph splitter has no segments to emit); the non-multi
+/// splitter returns `vec![""]`. When MultiMessage stream mode hands
+/// `send()` a paragraph that collapses to empty text after marker strip,
+/// the chunk loop would iterate zero times and silently skip an attached
+/// file upload. Force a single empty chunk in exactly that case so the
+/// multipart POST fires.
+fn chunks_for_send(
+    content: &str,
+    stream_mode: zeroclaw_config::schema::StreamMode,
+    max_len: usize,
+    has_local_files: bool,
+) -> Vec<String> {
+    let mut chunks = match stream_mode {
+        zeroclaw_config::schema::StreamMode::MultiMessage => {
+            split_message_for_discord_multi(content, max_len)
+        }
+        _ => split_message_for_discord(content),
+    };
+    if chunks.is_empty() && has_local_files {
+        chunks.push(String::new());
+    }
+    chunks
+}
+
 fn pick_uniform_index(len: usize) -> usize {
     debug_assert!(len > 0);
     let upper = len as u64;
@@ -1159,11 +1186,12 @@ impl Channel for DiscordChannel {
         let reactions = decide_failure_reactions(&failures);
 
         let client = self.http_client();
-        let chunks = if self.stream_mode == zeroclaw_config::schema::StreamMode::MultiMessage {
-            split_message_for_discord_multi(&content, DISCORD_MAX_MESSAGE_LENGTH)
-        } else {
-            split_message_for_discord(&content)
-        };
+        let chunks = chunks_for_send(
+            &content,
+            self.stream_mode,
+            DISCORD_MAX_MESSAGE_LENGTH,
+            !local_files.is_empty(),
+        );
         let inter_chunk_delay_ms =
             if self.stream_mode == zeroclaw_config::schema::StreamMode::MultiMessage {
                 self.multi_message_delay_ms
@@ -3016,6 +3044,51 @@ mod tests {
     fn split_message_for_discord_multi_empty_input() {
         let chunks = split_message_for_discord_multi("", 2000);
         assert!(chunks.is_empty());
+    }
+
+    // Regression lock for the marker-only paragraph in MultiMessage stream
+    // mode. Before the fix this produced an empty chunk vec and the chunk
+    // loop in send() iterated zero times, silently skipping the file
+    // upload.
+    #[test]
+    fn chunks_for_send_emits_empty_chunk_when_multi_message_paragraph_collapses_to_only_a_file() {
+        use zeroclaw_config::schema::StreamMode;
+
+        let chunks = chunks_for_send("", StreamMode::MultiMessage, 2000, true);
+        assert_eq!(chunks, vec![String::new()]);
+    }
+
+    // Inverse guard: no file to upload means no empty chunk to send, so we
+    // do not accidentally POST an empty Discord message that Discord would
+    // reject for having no content, attachments, or embeds.
+    #[test]
+    fn chunks_for_send_does_not_emit_empty_chunk_when_no_files_to_upload() {
+        use zeroclaw_config::schema::StreamMode;
+
+        let chunks = chunks_for_send("", StreamMode::MultiMessage, 2000, false);
+        assert!(chunks.is_empty());
+    }
+
+    // The normal path with body text is left untouched in both stream
+    // modes, regardless of whether files are attached.
+    #[test]
+    fn chunks_for_send_passes_through_non_empty_content() {
+        use zeroclaw_config::schema::StreamMode;
+
+        for mode in [
+            StreamMode::MultiMessage,
+            StreamMode::Partial,
+            StreamMode::Off,
+        ] {
+            for has_files in [true, false] {
+                let chunks = chunks_for_send("hello", mode, 2000, has_files);
+                assert_eq!(
+                    chunks,
+                    vec!["hello".to_string()],
+                    "mode={mode:?} has_files={has_files}"
+                );
+            }
+        }
     }
 
     fn make_discord_channel() -> DiscordChannel {

--- a/crates/zeroclaw-channels/src/discord.rs
+++ b/crates/zeroclaw-channels/src/discord.rs
@@ -182,39 +182,43 @@ impl DiscordChannel {
             }
         }
 
+        // Only a successful API response is cached. A transient network blip
+        // or 429 must not poison the cache for the channel's lifetime; the
+        // next message should retry the lookup. Failure paths return `false`
+        // (the safe default) without writing to the cache.
         let url = format!("https://discord.com/api/v10/channels/{channel_id}");
-        let is_thread = match client
+        let resp = match client
             .get(&url)
             .header("Authorization", format!("Bot {}", self.bot_token))
             .send()
             .await
         {
-            Ok(resp) if resp.status().is_success() => {
-                match resp.json::<serde_json::Value>().await {
-                    Ok(body) => body
-                        .get("type")
-                        .and_then(serde_json::Value::as_u64)
-                        .map(is_thread_channel_type)
-                        .unwrap_or(false),
-                    Err(e) => {
-                        tracing::debug!(channel_id, error = %e, "discord: channel lookup body parse failed");
-                        false
-                    }
-                }
-            }
-            Ok(resp) => {
-                tracing::debug!(
-                    channel_id,
-                    status = %resp.status(),
-                    "discord: channel lookup non-success status"
-                );
-                false
-            }
+            Ok(resp) => resp,
             Err(e) => {
                 tracing::debug!(channel_id, error = %e, "discord: channel lookup request failed");
-                false
+                return false;
             }
         };
+        if !resp.status().is_success() {
+            tracing::debug!(
+                channel_id,
+                status = %resp.status(),
+                "discord: channel lookup non-success status"
+            );
+            return false;
+        }
+        let body: serde_json::Value = match resp.json().await {
+            Ok(body) => body,
+            Err(e) => {
+                tracing::debug!(channel_id, error = %e, "discord: channel lookup body parse failed");
+                return false;
+            }
+        };
+        let is_thread = body
+            .get("type")
+            .and_then(serde_json::Value::as_u64)
+            .map(is_thread_channel_type)
+            .unwrap_or(false);
 
         self.thread_channels
             .lock()

--- a/crates/zeroclaw-channels/src/discord.rs
+++ b/crates/zeroclaw-channels/src/discord.rs
@@ -185,40 +185,47 @@ impl DiscordChannel {
         // Only a successful API response is cached. A transient network blip
         // or 429 must not poison the cache for the channel's lifetime; the
         // next message should retry the lookup. Failure paths return `false`
-        // (the safe default) without writing to the cache.
+        // (the safe default) without writing to the cache. The whole request
+        // is wrapped in an explicit timeout so a hung Discord API call can
+        // never stall the listener; the shared channel HTTP client may not
+        // carry a request-level timeout.
         let url = format!("https://discord.com/api/v10/channels/{channel_id}");
-        let resp = match client
-            .get(&url)
-            .header("Authorization", format!("Bot {}", self.bot_token))
-            .send()
-            .await
-        {
-            Ok(resp) => resp,
-            Err(e) => {
-                tracing::debug!(channel_id, error = %e, "discord: channel lookup request failed");
+        let lookup = async {
+            let resp = client
+                .get(&url)
+                .header("Authorization", format!("Bot {}", self.bot_token))
+                .send()
+                .await
+                .map_err(|e| anyhow!("request failed: {e}"))?;
+            if !resp.status().is_success() {
+                anyhow::bail!("non-success status {}", resp.status());
+            }
+            let body: serde_json::Value = resp
+                .json()
+                .await
+                .map_err(|e| anyhow!("body parse failed: {e}"))?;
+            Ok::<bool, anyhow::Error>(
+                body.get("type")
+                    .and_then(serde_json::Value::as_u64)
+                    .map(is_thread_channel_type)
+                    .unwrap_or(false),
+            )
+        };
+        let is_thread = match tokio::time::timeout(THREAD_LOOKUP_TIMEOUT, lookup).await {
+            Ok(Ok(value)) => value,
+            Ok(Err(e)) => {
+                tracing::debug!(channel_id, error = %e, "discord: channel lookup failed");
+                return false;
+            }
+            Err(_) => {
+                tracing::debug!(
+                    channel_id,
+                    timeout_secs = THREAD_LOOKUP_TIMEOUT.as_secs(),
+                    "discord: channel lookup timed out"
+                );
                 return false;
             }
         };
-        if !resp.status().is_success() {
-            tracing::debug!(
-                channel_id,
-                status = %resp.status(),
-                "discord: channel lookup non-success status"
-            );
-            return false;
-        }
-        let body: serde_json::Value = match resp.json().await {
-            Ok(body) => body,
-            Err(e) => {
-                tracing::debug!(channel_id, error = %e, "discord: channel lookup body parse failed");
-                return false;
-            }
-        };
-        let is_thread = body
-            .get("type")
-            .and_then(serde_json::Value::as_u64)
-            .map(is_thread_channel_type)
-            .unwrap_or(false);
 
         self.thread_channels
             .lock()
@@ -258,6 +265,11 @@ impl DiscordChannel {
 const fn is_thread_channel_type(channel_type: u64) -> bool {
     matches!(channel_type, 10..=12)
 }
+
+/// Hard cap on `GET /channels/{id}` while resolving whether an inbound
+/// channel is a thread. Discord normally responds in under 200 ms; this
+/// is a safety bound so a hung request cannot stall the listener.
+const THREAD_LOOKUP_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Process Discord message attachments in a single pass.
 ///
@@ -337,15 +349,7 @@ async fn process_attachments(
             continue;
         }
 
-        let marker_kind = if ct.starts_with("image/") {
-            "IMAGE"
-        } else if is_audio {
-            "AUDIO"
-        } else if ct.starts_with("video/") {
-            "VIDEO"
-        } else {
-            "DOCUMENT"
-        };
+        let marker_kind = marker_kind_for(ct, is_audio);
 
         let bytes = match download_attachment_bytes(client, url, name).await {
             Some(b) => b,
@@ -438,6 +442,22 @@ fn is_discord_audio_attachment(content_type: &str, filename: &str) -> bool {
         return DISCORD_AUDIO_EXTENSIONS.contains(&ext.to_ascii_lowercase().as_str());
     }
     false
+}
+
+/// Map a Discord attachment's content type plus audio-detection result to
+/// the canonical outbound marker kind. Pulled out of `process_attachments`
+/// so the MIME-to-marker dispatch can be unit-tested without a live HTTP
+/// download.
+fn marker_kind_for(content_type: &str, is_audio: bool) -> &'static str {
+    if content_type.starts_with("image/") {
+        "IMAGE"
+    } else if is_audio {
+        "AUDIO"
+    } else if content_type.starts_with("video/") {
+        "VIDEO"
+    } else {
+        "DOCUMENT"
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1093,15 +1113,19 @@ fn contains_bot_mention(content: &str, bot_user_id: &str) -> bool {
     content.contains(&tags[0]) || content.contains(&tags[1])
 }
 
-fn normalize_incoming_content(
+/// Decide whether an inbound Discord message passes the listener gate.
+/// Returns the cleaned text body when admitted, or `None` to drop the
+/// message. Attachment-only messages (empty `content` plus at least one
+/// attachment) are admitted as long as the mention requirement is
+/// satisfied; otherwise a Discord message that contained only an image,
+/// PDF, ZIP, video, or audio with no caption would never reach the
+/// media pipeline.
+fn admit_discord_message(
     content: &str,
+    has_attachments: bool,
     mention_only: bool,
     bot_user_id: &str,
 ) -> Option<String> {
-    if content.is_empty() {
-        return None;
-    }
-
     if mention_only && !contains_bot_mention(content, bot_user_id) {
         return None;
     }
@@ -1112,9 +1136,9 @@ fn normalize_incoming_content(
             normalized = normalized.replace(&tag, " ");
         }
     }
-
     let normalized = normalized.trim().to_string();
-    if normalized.is_empty() {
+
+    if normalized.is_empty() && !has_attachments {
         return None;
     }
 
@@ -1456,18 +1480,22 @@ impl Channel for DiscordChannel {
                     // the mention gate — requiring a @mention in a DM is never correct.
                     let is_dm = d.get("guild_id").is_none();
                     let effective_mention_only = self.mention_only && !is_dm;
-                    let Some(clean_content) =
-                        normalize_incoming_content(content, effective_mention_only, &bot_user_id)
-                    else {
-                        continue;
-                    };
-
-                    let client = self.http_client();
                     let atts = d
                         .get("attachments")
                         .and_then(|a| a.as_array())
                         .cloned()
                         .unwrap_or_default();
+                    let has_attachments = !atts.is_empty();
+                    let Some(clean_content) = admit_discord_message(
+                        content,
+                        has_attachments,
+                        effective_mention_only,
+                        &bot_user_id,
+                    ) else {
+                        continue;
+                    };
+
+                    let client = self.http_client();
                     let (attachment_text, media_attachments) = process_attachments(
                         &atts,
                         &client,
@@ -1526,6 +1554,18 @@ impl Channel for DiscordChannel {
                         });
                     }
 
+                    // Thread context decides `thread_ts` plus `interruption_scope_id`,
+                    // which the orchestrator uses as part of the conversation-history
+                    // key and the cancellation scope. When the lookup fails it falls
+                    // back to `None` and the failure is not cached, so the next
+                    // message in the same Discord thread will retry. The trade-off:
+                    // the first message after a transient lookup miss is keyed
+                    // without the thread suffix; once the cache warms, subsequent
+                    // messages are keyed with it. History for that thread can split
+                    // across two scopes until the warm-up completes. Acceptable
+                    // because the lookup is bounded by `THREAD_LOOKUP_TIMEOUT` and
+                    // the alternative (stalling the listener on a hung Discord call)
+                    // is worse.
                     let thread_ts = if channel_id.is_empty() {
                         None
                     } else if self.is_thread_channel(&client, &channel_id).await {
@@ -2154,21 +2194,57 @@ mod tests {
     }
 
     #[test]
-    fn normalize_incoming_content_requires_mention_when_enabled() {
-        let cleaned = normalize_incoming_content("hello there", true, "12345");
+    fn admit_discord_message_requires_mention_when_enabled() {
+        let cleaned = admit_discord_message("hello there", false, true, "12345");
         assert!(cleaned.is_none());
     }
 
     #[test]
-    fn normalize_incoming_content_strips_mentions_and_trims() {
-        let cleaned = normalize_incoming_content("  <@!12345> run status  ", true, "12345");
+    fn admit_discord_message_strips_mentions_and_trims() {
+        let cleaned = admit_discord_message("  <@!12345> run status  ", false, true, "12345");
         assert_eq!(cleaned.as_deref(), Some("run status"));
     }
 
     #[test]
-    fn normalize_incoming_content_rejects_empty_after_strip() {
-        let cleaned = normalize_incoming_content("<@12345>", true, "12345");
+    fn admit_discord_message_rejects_empty_text_and_no_attachments() {
+        let cleaned = admit_discord_message("<@12345>", false, true, "12345");
         assert!(cleaned.is_none());
+    }
+
+    #[test]
+    fn admit_discord_message_attachment_only_in_dm_is_admitted() {
+        // DM (effective_mention_only=false), empty text body, at least one
+        // attachment. Previously dropped at the empty-text gate; now passes
+        // through so process_attachments can run on the media.
+        let cleaned = admit_discord_message("", true, false, "12345");
+        assert_eq!(cleaned.as_deref(), Some(""));
+    }
+
+    #[test]
+    fn admit_discord_message_attachment_only_with_mention_in_guild_is_admitted() {
+        // Guild channel with mention_only=true. Caption is just the @mention
+        // tag with no other text, but the message has a media attachment.
+        // Mention requirement is satisfied; cleaned text is empty but the
+        // attachment alone is enough input.
+        let cleaned = admit_discord_message("<@12345>", true, true, "12345");
+        assert_eq!(cleaned.as_deref(), Some(""));
+    }
+
+    #[test]
+    fn admit_discord_message_attachment_only_without_mention_in_guild_is_rejected() {
+        // Guild channel with mention_only=true, attachment but no mention
+        // anywhere in the caption. The mention gate is orthogonal to
+        // attachment presence: no mention signal means drop.
+        let cleaned = admit_discord_message("", true, true, "12345");
+        assert!(cleaned.is_none());
+    }
+
+    #[test]
+    fn admit_discord_message_drops_when_no_text_and_no_attachments() {
+        // Completely empty payload with attachments absent is always dropped,
+        // regardless of mention_only setting.
+        assert!(admit_discord_message("", false, false, "12345").is_none());
+        assert!(admit_discord_message("", false, true, "12345").is_none());
     }
 
     // mention_only DM-bypass tests
@@ -2180,7 +2256,7 @@ mod tests {
         let mention_only = true;
         let is_dm = true;
         let effective = mention_only && !is_dm;
-        let cleaned = normalize_incoming_content("hello without mention", effective, "12345");
+        let cleaned = admit_discord_message("hello without mention", false, effective, "12345");
         assert_eq!(cleaned.as_deref(), Some("hello without mention"));
     }
 
@@ -2191,7 +2267,7 @@ mod tests {
         let mention_only = true;
         let is_dm = false;
         let effective = mention_only && !is_dm;
-        let cleaned = normalize_incoming_content("hello without mention", effective, "12345");
+        let cleaned = admit_discord_message("hello without mention", false, effective, "12345");
         assert!(cleaned.is_none());
     }
 
@@ -2202,7 +2278,7 @@ mod tests {
         let mention_only = true;
         let is_dm = false;
         let effective = mention_only && !is_dm;
-        let cleaned = normalize_incoming_content("<@12345> run status", effective, "12345");
+        let cleaned = admit_discord_message("<@12345> run status", false, effective, "12345");
         assert_eq!(cleaned.as_deref(), Some("run status"));
     }
 
@@ -2622,6 +2698,32 @@ mod tests {
         let (text, media) = process_attachments(&[], &client, None, None).await;
         assert!(text.is_empty());
         assert!(media.is_empty());
+    }
+
+    #[test]
+    fn marker_kind_for_classifies_each_mime_family() {
+        assert_eq!(marker_kind_for("image/png", false), "IMAGE");
+        assert_eq!(marker_kind_for("image/jpeg", false), "IMAGE");
+        assert_eq!(marker_kind_for("video/mp4", false), "VIDEO");
+        assert_eq!(marker_kind_for("application/pdf", false), "DOCUMENT");
+        assert_eq!(marker_kind_for("application/zip", false), "DOCUMENT");
+        assert_eq!(marker_kind_for("", false), "DOCUMENT");
+    }
+
+    #[test]
+    fn marker_kind_for_treats_audio_flag_as_audio_regardless_of_content_type() {
+        // Filename-detected audio with no content_type should still classify
+        // as AUDIO, matching the unified inbound pipeline.
+        assert_eq!(marker_kind_for("", true), "AUDIO");
+        assert_eq!(marker_kind_for("application/octet-stream", true), "AUDIO");
+    }
+
+    #[test]
+    fn marker_kind_for_prefers_image_over_audio_when_content_type_is_image() {
+        // Defensive: if a Discord attachment somehow tripped both heuristics,
+        // image MIME wins so vision-capable providers still receive image
+        // bytes through the MediaAttachment path.
+        assert_eq!(marker_kind_for("image/png", true), "IMAGE");
     }
 
     #[test]

--- a/crates/zeroclaw-channels/src/discord.rs
+++ b/crates/zeroclaw-channels/src/discord.rs
@@ -1,3 +1,4 @@
+use anyhow::{Context as _, anyhow};
 use async_trait::async_trait;
 use futures_util::{SinkExt, StreamExt};
 use parking_lot::Mutex;
@@ -14,6 +15,7 @@ use uuid::Uuid;
 use zeroclaw_api::channel::{
     Channel, ChannelApprovalRequest, ChannelApprovalResponse, ChannelMessage, SendMessage,
 };
+use zeroclaw_api::media::MediaAttachment;
 
 /// Discord channel — connects via Gateway WebSocket for real-time messages
 pub struct DiscordChannel {
@@ -49,6 +51,11 @@ pub struct DiscordChannel {
     /// Seconds to wait for an operator reply to a `request_approval` prompt
     /// before treating the silence as a deny. Default 300.
     approval_timeout_secs: u64,
+    /// Cached `channel_id -> is_thread` lookups. Populated lazily on first
+    /// inbound message from a channel via `GET /channels/{id}`. Thread type
+    /// is stable for the channel's lifetime so the cache lives as long as
+    /// the channel instance.
+    thread_channels: Arc<AsyncMutex<HashMap<String, bool>>>,
 }
 
 impl DiscordChannel {
@@ -79,6 +86,7 @@ impl DiscordChannel {
             stall_timeout_secs: 0,
             pending_approvals: Arc::new(AsyncMutex::new(HashMap::new())),
             approval_timeout_secs: 300,
+            thread_channels: Arc::new(AsyncMutex::new(HashMap::new())),
         }
     }
 
@@ -159,19 +167,88 @@ impl DiscordChannel {
         let part = token.split('.').next()?;
         base64_decode(part)
     }
+
+    /// Resolve whether `channel_id` is a Discord thread (ANNOUNCEMENT,
+    /// PUBLIC, or PRIVATE thread) via `GET /channels/{id}`. Results are
+    /// cached for the channel instance's lifetime: thread-ness is stable
+    /// for a given channel ID, so one lookup per ID per process. Failures
+    /// (network, 429, missing `type` field) fall through to `false` so a
+    /// transient API hiccup never blocks inbound delivery.
+    async fn is_thread_channel(&self, client: &reqwest::Client, channel_id: &str) -> bool {
+        {
+            let cache = self.thread_channels.lock().await;
+            if let Some(&value) = cache.get(channel_id) {
+                return value;
+            }
+        }
+
+        let url = format!("https://discord.com/api/v10/channels/{channel_id}");
+        let is_thread = match client
+            .get(&url)
+            .header("Authorization", format!("Bot {}", self.bot_token))
+            .send()
+            .await
+        {
+            Ok(resp) if resp.status().is_success() => {
+                match resp.json::<serde_json::Value>().await {
+                    Ok(body) => body
+                        .get("type")
+                        .and_then(serde_json::Value::as_u64)
+                        .map(is_thread_channel_type)
+                        .unwrap_or(false),
+                    Err(e) => {
+                        tracing::debug!(channel_id, error = %e, "discord: channel lookup body parse failed");
+                        false
+                    }
+                }
+            }
+            Ok(resp) => {
+                tracing::debug!(
+                    channel_id,
+                    status = %resp.status(),
+                    "discord: channel lookup non-success status"
+                );
+                false
+            }
+            Err(e) => {
+                tracing::debug!(channel_id, error = %e, "discord: channel lookup request failed");
+                false
+            }
+        };
+
+        self.thread_channels
+            .lock()
+            .await
+            .insert(channel_id.to_string(), is_thread);
+        is_thread
+    }
 }
 
-/// Process Discord message attachments and return a string to append to the
-/// agent message context.
+/// Whether a Discord channel type integer identifies a thread.
+/// Discord channel types `10` (ANNOUNCEMENT_THREAD), `11` (PUBLIC_THREAD),
+/// and `12` (PRIVATE_THREAD) per the Channel Types documentation.
+const fn is_thread_channel_type(channel_type: u64) -> bool {
+    matches!(channel_type, 10..=12)
+}
+
+/// Process Discord message attachments in a single pass.
 ///
-/// Only `text/*` MIME types are fetched and inlined. All other types are
-/// silently skipped. Fetch errors are logged as warnings.
+/// Returns the text block appended to the agent's prompt and the structured
+/// `MediaAttachment` list consumed by the media pipeline. Each attachment is
+/// downloaded at most once: text/* is inlined as text, audio is transcribed
+/// inline when a transcription manager is configured (otherwise it goes
+/// through the media pipeline), and image/video/document attachments are
+/// saved to the workspace and emitted as `[KIND:<path>]` markers plus a
+/// `MediaAttachment` for vision-capable providers.
 async fn process_attachments(
     attachments: &[serde_json::Value],
     client: &reqwest::Client,
     workspace_dir: Option<&Path>,
-) -> String {
-    let mut parts: Vec<String> = Vec::new();
+    transcription_manager: Option<&super::transcription::TranscriptionManager>,
+) -> (String, Vec<MediaAttachment>) {
+    let mut text_parts: Vec<String> = Vec::new();
+    let mut media: Vec<MediaAttachment> = Vec::new();
+
     for att in attachments {
         let ct = att
             .get("content_type")
@@ -185,11 +262,12 @@ async fn process_attachments(
             tracing::warn!(name, "discord: attachment has no url, skipping");
             continue;
         };
+
         if ct.starts_with("text/") {
             match client.get(url).send().await {
                 Ok(resp) if resp.status().is_success() => {
                     if let Ok(text) = resp.text().await {
-                        parts.push(format!("[{name}]\n{text}"));
+                        text_parts.push(format!("[{name}]\n{text}"));
                     }
                 }
                 Ok(resp) => {
@@ -199,46 +277,112 @@ async fn process_attachments(
                     tracing::warn!(name, error = %e, "discord attachment fetch error");
                 }
             }
-        } else if ct.starts_with("image/") {
-            let marker = if let Some(workspace) = workspace_dir {
-                match download_discord_attachment_to_workspace(client, workspace, url, name).await {
-                    Ok(local_path) => format!("[IMAGE:{}]", local_path.display()),
-                    Err(e) => {
-                        tracing::warn!(name, error = %e, "discord: image attachment download failed");
-                        format!("[IMAGE:{url}]")
+            continue;
+        }
+
+        let is_audio = is_discord_audio_attachment(ct, name);
+
+        // Audio with channel-level transcription configured: transcribe
+        // inline so the agent receives `[Voice] <transcript>` text rather
+        // than opaque bytes through the media pipeline.
+        if is_audio && let Some(manager) = transcription_manager {
+            let bytes = match download_attachment_bytes(client, url, name).await {
+                Some(b) => b,
+                None => continue,
+            };
+            match manager.transcribe(&bytes, name).await {
+                Ok(text) => {
+                    let trimmed = text.trim();
+                    if !trimmed.is_empty() {
+                        tracing::info!(
+                            "Discord: transcribed audio attachment {} ({} chars)",
+                            name,
+                            trimmed.len()
+                        );
+                        text_parts.push(format!("[Voice] {trimmed}"));
                     }
                 }
-            } else {
-                format!("[IMAGE:{url}]")
-            };
-            parts.push(marker);
-        } else {
-            tracing::debug!(
-                name,
-                content_type = ct,
-                "discord: skipping unsupported attachment type"
-            );
+                Err(e) => {
+                    tracing::warn!(name, error = %e, "discord: voice transcription failed");
+                }
+            }
+            continue;
         }
+
+        let marker_kind = if ct.starts_with("image/") {
+            "IMAGE"
+        } else if is_audio {
+            "AUDIO"
+        } else if ct.starts_with("video/") {
+            "VIDEO"
+        } else {
+            "DOCUMENT"
+        };
+
+        let bytes = match download_attachment_bytes(client, url, name).await {
+            Some(b) => b,
+            None => continue,
+        };
+
+        let marker_target = match workspace_dir {
+            Some(dir) => match save_attachment_bytes_to_workspace(dir, name, &bytes).await {
+                Ok(local_path) => local_path.display().to_string(),
+                Err(e) => {
+                    tracing::warn!(name, kind = marker_kind, error = %e, "discord: attachment save failed, falling back to url");
+                    url.to_string()
+                }
+            },
+            None => url.to_string(),
+        };
+        text_parts.push(format!("[{marker_kind}:{marker_target}]"));
+
+        media.push(MediaAttachment {
+            file_name: name.to_string(),
+            data: bytes,
+            mime_type: if ct.is_empty() {
+                None
+            } else {
+                Some(ct.to_string())
+            },
+        });
     }
-    parts.join("\n---\n")
+
+    (text_parts.join("\n---\n"), media)
 }
 
-async fn download_discord_attachment_to_workspace(
+/// Download an attachment URL into memory, with structured warn-logging on
+/// each failure mode. Returns `None` when the attachment should be skipped.
+async fn download_attachment_bytes(
     client: &reqwest::Client,
-    workspace_dir: &Path,
     url: &str,
+    name: &str,
+) -> Option<Vec<u8>> {
+    match client.get(url).send().await {
+        Ok(resp) if resp.status().is_success() => match resp.bytes().await {
+            Ok(b) => Some(b.to_vec()),
+            Err(e) => {
+                tracing::warn!(name, error = %e, "discord: failed to read attachment bytes");
+                None
+            }
+        },
+        Ok(resp) => {
+            tracing::warn!(name, status = %resp.status(), "discord: attachment download failed");
+            None
+        }
+        Err(e) => {
+            tracing::warn!(name, error = %e, "discord: attachment fetch error");
+            None
+        }
+    }
+}
+
+async fn save_attachment_bytes_to_workspace(
+    workspace_dir: &Path,
     filename: &str,
+    bytes: &[u8],
 ) -> anyhow::Result<PathBuf> {
     let save_dir = workspace_dir.join("discord_files");
     tokio::fs::create_dir_all(&save_dir).await?;
-
-    let bytes = client
-        .get(url)
-        .send()
-        .await?
-        .error_for_status()?
-        .bytes()
-        .await?;
 
     let safe_name = Path::new(filename)
         .file_name()
@@ -248,7 +392,7 @@ async fn download_discord_attachment_to_workspace(
     let local_name = format!("{}_{}", Uuid::new_v4(), safe_name);
     let local_path = save_dir.join(local_name);
 
-    tokio::fs::write(&local_path, &bytes).await?;
+    tokio::fs::write(&local_path, bytes).await?;
     Ok(local_path)
 }
 
@@ -266,72 +410,6 @@ fn is_discord_audio_attachment(content_type: &str, filename: &str) -> bool {
         return DISCORD_AUDIO_EXTENSIONS.contains(&ext.to_ascii_lowercase().as_str());
     }
     false
-}
-
-/// Download and transcribe audio attachments from a Discord message.
-///
-/// Returns transcribed text blocks for any audio attachments found.
-/// Non-audio attachments and failures are silently skipped.
-async fn transcribe_discord_audio_attachments(
-    attachments: &[serde_json::Value],
-    client: &reqwest::Client,
-    manager: &super::transcription::TranscriptionManager,
-) -> String {
-    let mut parts: Vec<String> = Vec::new();
-    for att in attachments {
-        let ct = att
-            .get("content_type")
-            .and_then(|v| v.as_str())
-            .unwrap_or("");
-        let name = att
-            .get("filename")
-            .and_then(|v| v.as_str())
-            .unwrap_or("file");
-
-        if !is_discord_audio_attachment(ct, name) {
-            continue;
-        }
-
-        let Some(url) = att.get("url").and_then(|v| v.as_str()) else {
-            continue;
-        };
-
-        let audio_data = match client.get(url).send().await {
-            Ok(resp) if resp.status().is_success() => match resp.bytes().await {
-                Ok(bytes) => bytes.to_vec(),
-                Err(e) => {
-                    tracing::warn!(name, error = %e, "discord: failed to read audio attachment bytes");
-                    continue;
-                }
-            },
-            Ok(resp) => {
-                tracing::warn!(name, status = %resp.status(), "discord: audio attachment download failed");
-                continue;
-            }
-            Err(e) => {
-                tracing::warn!(name, error = %e, "discord: audio attachment fetch error");
-                continue;
-            }
-        };
-
-        match manager.transcribe(&audio_data, name).await {
-            Ok(text) => {
-                let trimmed = text.trim();
-                if !trimmed.is_empty() {
-                    tracing::info!(
-                        "Discord: transcribed audio attachment {} ({} chars)",
-                        name,
-                        trimmed.len()
-                    );
-                    parts.push(format!("[Voice] {trimmed}"));
-                }
-            }
-            Err(e) => {
-                tracing::warn!(name, error = %e, "discord: voice transcription failed");
-            }
-        }
-    }
-    parts.join("\n")
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -417,46 +495,106 @@ fn parse_attachment_markers(message: &str) -> (String, Vec<DiscordAttachment>) {
     (cleaned.trim().to_string(), attachments)
 }
 
-fn classify_outgoing_attachments(
-    attachments: &[DiscordAttachment],
-) -> (Vec<PathBuf>, Vec<String>, Vec<String>) {
-    let mut local_files = Vec::new();
-    let mut remote_urls = Vec::new();
-    let mut unresolved_markers = Vec::new();
-
-    for attachment in attachments {
-        let target = attachment.target.trim();
-        if target.starts_with("https://") || target.starts_with("http://") {
-            remote_urls.push(target.to_string());
-            continue;
-        }
-
-        let path = Path::new(target);
-        if path.exists() && path.is_file() {
-            local_files.push(path.to_path_buf());
-            continue;
-        }
-
-        unresolved_markers.push(format!("[{}:{}]", attachment.kind.marker_name(), target));
-    }
-
-    (local_files, remote_urls, unresolved_markers)
+/// Resolved outbound attachment target after sandbox validation.
+#[derive(Debug)]
+enum DiscordMarkerTarget {
+    Local(PathBuf),
+    Http(String),
 }
 
-fn with_inline_attachment_urls(
-    content: &str,
-    remote_urls: &[String],
-    unresolved_markers: &[String],
-) -> String {
+/// Validate an outbound marker target against Discord's trust-boundary policy.
+///
+/// The orchestrator system prompt mandates absolute paths for media markers
+/// (`crates/zeroclaw-channels/src/orchestrator/mod.rs`), and the workspace
+/// is the only directory the agent is authorised to expose to chatters:
+///
+/// * `http`/`https` URLs are accepted and inlined as links.
+/// * Any other URL scheme (`file:`, `data:`, custom `://`) is refused.
+/// * Local paths must be absolute. Relative paths are agent
+///   misconfiguration and dropped, not silently resolved against cwd.
+/// * Absolute paths are canonicalised and must resolve inside
+///   `workspace_dir`. Anything outside, traversal escapes, or
+///   non-existent files are refused.
+/// * When `workspace_dir` is not configured, no local path can be safely
+///   bounded, so all local targets are refused.
+fn validate_marker_target(
+    target: &str,
+    workspace_dir: Option<&Path>,
+) -> anyhow::Result<DiscordMarkerTarget> {
+    if target.starts_with("http://") || target.starts_with("https://") {
+        return Ok(DiscordMarkerTarget::Http(target.to_string()));
+    }
+    if target.contains("://") {
+        let scheme = target.split("://").next().unwrap_or("?");
+        anyhow::bail!(
+            "discord: marker target uses disallowed scheme {scheme:?}; only http/https and absolute workspace paths are accepted"
+        );
+    }
+    if target.starts_with("data:") || target.starts_with("file:") {
+        anyhow::bail!(
+            "discord: marker target uses disallowed scheme; only http/https and absolute workspace paths are accepted"
+        );
+    }
+
+    let target_path = Path::new(target);
+    if !target_path.is_absolute() {
+        anyhow::bail!(
+            "discord: marker target {target} is not an absolute path; the agent must emit absolute paths inside workspace_dir"
+        );
+    }
+
+    let workspace = workspace_dir.ok_or_else(|| {
+        anyhow!(
+            "discord: marker target {target} is a local path but the channel was started without a workspace_dir, refusing for safety"
+        )
+    })?;
+    let workspace_canon = std::fs::canonicalize(workspace)
+        .with_context(|| format!("canonicalize workspace {}", workspace.display()))?;
+    let target_canon = std::fs::canonicalize(target_path)
+        .with_context(|| format!("canonicalize marker target {target}"))?;
+
+    if !target_canon.starts_with(&workspace_canon) {
+        anyhow::bail!(
+            "discord: marker target {target} resolves to {} which is outside workspace_dir {}; refusing",
+            target_canon.display(),
+            workspace_canon.display(),
+        );
+    }
+    Ok(DiscordMarkerTarget::Local(target_canon))
+}
+
+fn classify_outgoing_attachments(
+    attachments: &[DiscordAttachment],
+    workspace_dir: Option<&Path>,
+) -> (Vec<PathBuf>, Vec<String>) {
+    let mut local_files = Vec::new();
+    let mut remote_urls = Vec::new();
+
+    for attachment in attachments {
+        match validate_marker_target(&attachment.target, workspace_dir) {
+            Ok(DiscordMarkerTarget::Local(path)) => local_files.push(path),
+            Ok(DiscordMarkerTarget::Http(url)) => remote_urls.push(url),
+            Err(e) => {
+                tracing::warn!(
+                    kind = attachment.kind.marker_name(),
+                    target = %attachment.target,
+                    error = %e,
+                    "discord: dropping unresolved outbound attachment marker"
+                );
+            }
+        }
+    }
+
+    (local_files, remote_urls)
+}
+
+fn with_inline_attachment_urls(content: &str, remote_urls: &[String]) -> String {
     let mut lines = Vec::new();
     if !content.trim().is_empty() {
         lines.push(content.trim().to_string());
     }
     if !remote_urls.is_empty() {
         lines.extend(remote_urls.iter().cloned());
-    }
-    if !unresolved_markers.is_empty() {
-        lines.extend(unresolved_markers.iter().cloned());
     }
     lines.join("\n")
 }
@@ -884,15 +1022,8 @@ impl Channel for DiscordChannel {
     async fn send(&self, message: &SendMessage) -> anyhow::Result<()> {
         let raw_content = crate::util::strip_tool_call_tags(&message.content);
         let (cleaned_content, parsed_attachments) = parse_attachment_markers(&raw_content);
-        let (mut local_files, remote_urls, unresolved_markers) =
-            classify_outgoing_attachments(&parsed_attachments);
-
-        if !unresolved_markers.is_empty() {
-            tracing::warn!(
-                unresolved = ?unresolved_markers,
-                "discord: unresolved attachment markers were sent as plain text"
-            );
-        }
+        let (mut local_files, remote_urls) =
+            classify_outgoing_attachments(&parsed_attachments, self.workspace_dir.as_deref());
 
         // Discord accepts max 10 files per message.
         if local_files.len() > 10 {
@@ -903,8 +1034,7 @@ impl Channel for DiscordChannel {
             local_files.truncate(10);
         }
 
-        let content =
-            with_inline_attachment_urls(&cleaned_content, &remote_urls, &unresolved_markers);
+        let content = with_inline_attachment_urls(&cleaned_content, &remote_urls);
 
         // MultiMessage mode: split at paragraph boundaries and send each as a
         // separate message with a configurable delay between them.
@@ -1199,37 +1329,19 @@ impl Channel for DiscordChannel {
                         continue;
                     };
 
-                    let attachment_text = {
-                        let atts = d
-                            .get("attachments")
-                            .and_then(|a| a.as_array())
-                            .cloned()
-                            .unwrap_or_default();
-                        let client = self.http_client();
-                        let mut text_parts =
-                            process_attachments(&atts, &client, self.workspace_dir.as_deref())
-                                .await;
-
-                        // Transcribe audio attachments when transcription is configured
-                        if let Some(ref transcription_manager) = self.transcription_manager {
-                            let voice_text = transcribe_discord_audio_attachments(
-                                &atts,
-                                &client,
-                                transcription_manager,
-                            )
-                            .await;
-                            if !voice_text.is_empty() {
-                                if text_parts.is_empty() {
-                                    text_parts = voice_text;
-                                } else {
-                                    text_parts = format!("{text_parts}
-            {voice_text}");
-                                }
-                            }
-                        }
-
-                        text_parts
-                    };
+                    let client = self.http_client();
+                    let atts = d
+                        .get("attachments")
+                        .and_then(|a| a.as_array())
+                        .cloned()
+                        .unwrap_or_default();
+                    let (attachment_text, media_attachments) = process_attachments(
+                        &atts,
+                        &client,
+                        self.workspace_dir.as_deref(),
+                        self.transcription_manager.as_deref(),
+                    )
+                    .await;
                     let final_content = if attachment_text.is_empty() {
                         clean_content
                     } else {
@@ -1281,6 +1393,14 @@ impl Channel for DiscordChannel {
                         });
                     }
 
+                    let thread_ts = if channel_id.is_empty() {
+                        None
+                    } else if self.is_thread_channel(&client, &channel_id).await {
+                        Some(channel_id.clone())
+                    } else {
+                        None
+                    };
+
                     let channel_msg = ChannelMessage {
                         id: if message_id.is_empty() {
                             Uuid::new_v4().to_string()
@@ -1299,9 +1419,9 @@ impl Channel for DiscordChannel {
                             .duration_since(std::time::UNIX_EPOCH)
                             .unwrap_or_default()
                             .as_secs(),
-                        thread_ts: None,
-                        interruption_scope_id: None,
-                    attachments: vec![],
+                        interruption_scope_id: thread_ts.clone(),
+                        thread_ts,
+                        attachments: media_attachments,
                     };
 
                     if tx.send(channel_msg).await.is_err() {
@@ -1588,10 +1708,9 @@ impl Channel for DiscordChannel {
 
         let text = &crate::util::strip_tool_call_tags(text);
         let (cleaned_content, parsed_attachments) = parse_attachment_markers(text);
-        let (mut local_files, remote_urls, unresolved_markers) =
-            classify_outgoing_attachments(&parsed_attachments);
-        let content =
-            with_inline_attachment_urls(&cleaned_content, &remote_urls, &unresolved_markers);
+        let (mut local_files, remote_urls) =
+            classify_outgoing_attachments(&parsed_attachments, self.workspace_dir.as_deref());
+        let content = with_inline_attachment_urls(&cleaned_content, &remote_urls);
 
         let client = self.http_client();
 
@@ -2340,35 +2459,24 @@ mod tests {
     #[tokio::test]
     async fn process_attachments_empty_list_returns_empty() {
         let client = reqwest::Client::new();
-        let result = process_attachments(&[], &client, None).await;
-        assert!(result.is_empty());
+        let (text, media) = process_attachments(&[], &client, None, None).await;
+        assert!(text.is_empty());
+        assert!(media.is_empty());
     }
 
-    #[tokio::test]
-    async fn process_attachments_skips_unsupported_types() {
-        let client = reqwest::Client::new();
-        let attachments = vec![serde_json::json!({
-            "url": "https://cdn.discordapp.com/attachments/123/456/doc.pdf",
-            "filename": "doc.pdf",
-            "content_type": "application/pdf"
-        })];
-        let result = process_attachments(&attachments, &client, None).await;
-        assert!(result.is_empty());
-    }
-
-    #[tokio::test]
-    async fn process_attachments_emits_image_marker_without_workspace() {
-        let client = reqwest::Client::new();
-        let attachments = vec![serde_json::json!({
-            "url": "https://cdn.discordapp.com/attachments/123/456/photo.jpg",
-            "filename": "photo.jpg",
-            "content_type": "image/jpeg"
-        })];
-        let result = process_attachments(&attachments, &client, None).await;
-        assert_eq!(
-            result,
-            "[IMAGE:https://cdn.discordapp.com/attachments/123/456/photo.jpg]"
-        );
+    #[test]
+    fn is_thread_channel_type_matches_only_thread_types() {
+        // Thread types per Discord docs: 10/11/12.
+        assert!(is_thread_channel_type(10));
+        assert!(is_thread_channel_type(11));
+        assert!(is_thread_channel_type(12));
+        // Non-thread channel types must not be classified as threads.
+        for non_thread in [0u64, 1, 2, 3, 4, 5, 13, 14, 15, 16] {
+            assert!(
+                !is_thread_channel_type(non_thread),
+                "type {non_thread} must not classify as thread"
+            );
+        }
     }
 
     #[test]
@@ -2394,7 +2502,7 @@ mod tests {
     }
 
     #[test]
-    fn classify_outgoing_attachments_splits_local_remote_and_unresolved() {
+    fn classify_outgoing_attachments_keeps_workspace_locals_and_http() {
         let temp = tempfile::tempdir().expect("tempdir");
         let file_path = temp.path().join("image.png");
         std::fs::write(&file_path, b"fake").expect("write fixture");
@@ -2408,33 +2516,128 @@ mod tests {
                 kind: DiscordAttachmentKind::Image,
                 target: "https://example.com/remote.png".to_string(),
             },
-            DiscordAttachment {
-                kind: DiscordAttachmentKind::Video,
-                target: "/tmp/does-not-exist.mp4".to_string(),
-            },
         ];
 
-        let (locals, remotes, unresolved) = classify_outgoing_attachments(&attachments);
+        let (locals, remotes) = classify_outgoing_attachments(&attachments, Some(temp.path()));
         assert_eq!(locals.len(), 1);
-        assert_eq!(locals[0], file_path);
+        let canonical_file = std::fs::canonicalize(&file_path).expect("canonicalize fixture");
+        assert_eq!(locals[0], canonical_file);
         assert_eq!(remotes, vec!["https://example.com/remote.png".to_string()]);
-        assert_eq!(
-            unresolved,
-            vec!["[VIDEO:/tmp/does-not-exist.mp4]".to_string()]
-        );
     }
 
     #[test]
-    fn with_inline_attachment_urls_appends_urls_and_unresolved_markers() {
+    fn classify_outgoing_attachments_drops_missing_absolute_paths() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let attachments = vec![DiscordAttachment {
+            kind: DiscordAttachmentKind::Video,
+            target: temp
+                .path()
+                .join("does-not-exist.mp4")
+                .to_string_lossy()
+                .to_string(),
+        }];
+
+        let (locals, remotes) = classify_outgoing_attachments(&attachments, Some(temp.path()));
+        assert!(locals.is_empty());
+        assert!(remotes.is_empty());
+    }
+
+    #[test]
+    fn classify_outgoing_attachments_drops_paths_outside_workspace() {
+        let workspace = tempfile::tempdir().expect("workspace tempdir");
+        let outside = tempfile::tempdir().expect("outside tempdir");
+        let outside_file = outside.path().join("escape.png");
+        std::fs::write(&outside_file, b"fake").expect("write fixture");
+
+        let attachments = vec![DiscordAttachment {
+            kind: DiscordAttachmentKind::Image,
+            target: outside_file.to_string_lossy().to_string(),
+        }];
+
+        let (locals, remotes) = classify_outgoing_attachments(&attachments, Some(workspace.path()));
+        assert!(
+            locals.is_empty(),
+            "absolute paths outside workspace must be refused"
+        );
+        assert!(remotes.is_empty());
+    }
+
+    #[test]
+    fn classify_outgoing_attachments_drops_relative_paths() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let attachments = vec![DiscordAttachment {
+            kind: DiscordAttachmentKind::Document,
+            target: "relative/report.pdf".to_string(),
+        }];
+
+        let (locals, remotes) = classify_outgoing_attachments(&attachments, Some(temp.path()));
+        assert!(locals.is_empty(), "relative paths must be refused");
+        assert!(remotes.is_empty());
+    }
+
+    #[test]
+    fn classify_outgoing_attachments_drops_disallowed_schemes() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let attachments = vec![
+            DiscordAttachment {
+                kind: DiscordAttachmentKind::Image,
+                target: "file:///etc/hostname".to_string(),
+            },
+            DiscordAttachment {
+                kind: DiscordAttachmentKind::Document,
+                target: "data:text/plain;base64,aGk=".to_string(),
+            },
+            DiscordAttachment {
+                kind: DiscordAttachmentKind::Video,
+                target: "ftp://example.com/clip.mp4".to_string(),
+            },
+        ];
+
+        let (locals, remotes) = classify_outgoing_attachments(&attachments, Some(temp.path()));
+        assert!(locals.is_empty());
+        assert!(remotes.is_empty());
+    }
+
+    #[test]
+    fn classify_outgoing_attachments_refuses_local_without_workspace() {
+        let attachments = vec![DiscordAttachment {
+            kind: DiscordAttachmentKind::Image,
+            target: "/some/absolute/path.png".to_string(),
+        }];
+
+        let (locals, remotes) = classify_outgoing_attachments(&attachments, None);
+        assert!(
+            locals.is_empty(),
+            "local paths must be refused without workspace_dir"
+        );
+        assert!(remotes.is_empty());
+    }
+
+    #[test]
+    fn classify_outgoing_attachments_passes_http_without_workspace() {
+        let attachments = vec![DiscordAttachment {
+            kind: DiscordAttachmentKind::Image,
+            target: "https://example.com/x.png".to_string(),
+        }];
+
+        let (locals, remotes) = classify_outgoing_attachments(&attachments, None);
+        assert!(locals.is_empty());
+        assert_eq!(remotes, vec!["https://example.com/x.png".to_string()]);
+    }
+
+    #[test]
+    fn with_inline_attachment_urls_appends_remote_urls_only() {
         let content = "Done";
         let remote_urls = vec!["https://example.com/a.png".to_string()];
-        let unresolved = vec!["[IMAGE:/tmp/missing.png]".to_string()];
 
-        let rendered = with_inline_attachment_urls(content, &remote_urls, &unresolved);
-        assert_eq!(
-            rendered,
-            "Done\nhttps://example.com/a.png\n[IMAGE:/tmp/missing.png]"
-        );
+        let rendered = with_inline_attachment_urls(content, &remote_urls);
+        assert_eq!(rendered, "Done\nhttps://example.com/a.png");
+    }
+
+    #[test]
+    fn with_inline_attachment_urls_keeps_content_when_no_urls() {
+        let rendered = with_inline_attachment_urls("Done", &[]);
+        assert_eq!(rendered, "Done");
     }
 
     // ── Streaming mode tests ──────────────────────────────────────────

--- a/crates/zeroclaw-channels/src/discord.rs
+++ b/crates/zeroclaw-channels/src/discord.rs
@@ -226,6 +226,30 @@ impl DiscordChannel {
             .insert(channel_id.to_string(), is_thread);
         is_thread
     }
+
+    /// Apply the trust-boundary / delivery-failure emoji reactions to the
+    /// bot's just-sent message. Best-effort: reaction failures are debug
+    /// logged but never propagated. `message_id` being `None` (e.g. when
+    /// every chunk failed to post) skips the reaction step entirely.
+    async fn apply_failure_reactions(
+        &self,
+        channel_id: &str,
+        message_id: Option<&str>,
+        reactions: &[&'static str],
+    ) {
+        let Some(message_id) = message_id else {
+            return;
+        };
+        for emoji in reactions {
+            if let Err(e) = self.add_reaction(channel_id, message_id, emoji).await {
+                tracing::debug!(
+                    emoji,
+                    error = %e,
+                    "discord: failed to add failure reaction to outgoing message"
+                );
+            }
+        }
+    }
 }
 
 /// Whether a Discord channel type integer identifies a thread.
@@ -506,63 +530,114 @@ enum DiscordMarkerTarget {
     Http(String),
 }
 
+/// Why a marker target was rejected. Drives the user-facing emoji reaction
+/// on the bot's outgoing message: `Refused` (trust-boundary rejection) maps
+/// to 🚫, `NotFound` (path didn't resolve on disk) maps to ⚠️. The
+/// distinction matters because a chatter should see at a glance that the
+/// bot deliberately declined a target rather than tried and failed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DiscordMarkerFailure {
+    /// Trust-boundary refusal: disallowed scheme, relative path, missing
+    /// workspace_dir, or canonicalised path outside the workspace.
+    Refused,
+    /// Path passed scheme/absolute/workspace checks but did not resolve
+    /// to anything on disk.
+    NotFound,
+}
+
+#[derive(Debug)]
+enum DiscordMarkerError {
+    Refused(anyhow::Error),
+    NotFound(anyhow::Error),
+}
+
+impl DiscordMarkerError {
+    fn kind(&self) -> DiscordMarkerFailure {
+        match self {
+            Self::Refused(_) => DiscordMarkerFailure::Refused,
+            Self::NotFound(_) => DiscordMarkerFailure::NotFound,
+        }
+    }
+}
+
+impl std::fmt::Display for DiscordMarkerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Refused(e) | Self::NotFound(e) => write!(f, "{e}"),
+        }
+    }
+}
+
 /// Validate an outbound marker target against Discord's trust-boundary policy.
 ///
-/// The orchestrator system prompt mandates absolute paths for media markers
-/// (`crates/zeroclaw-channels/src/orchestrator/mod.rs`), and the workspace
-/// is the only directory the agent is authorised to expose to chatters:
+/// The orchestrator system prompt mandates absolute paths for media markers,
+/// and the workspace is the only directory the agent is authorised to
+/// expose to chatters:
 ///
 /// * `http`/`https` URLs are accepted and inlined as links.
 /// * Any other URL scheme (`file:`, `data:`, custom `://`) is refused.
 /// * Local paths must be absolute. Relative paths are agent
 ///   misconfiguration and dropped, not silently resolved against cwd.
 /// * Absolute paths are canonicalised and must resolve inside
-///   `workspace_dir`. Anything outside, traversal escapes, or
-///   non-existent files are refused.
+///   `workspace_dir`. Anything outside or any traversal escape is
+///   refused; a path that simply doesn't exist on disk returns
+///   `NotFound`, which the caller renders differently from a refusal.
 /// * When `workspace_dir` is not configured, no local path can be safely
 ///   bounded, so all local targets are refused.
 fn validate_marker_target(
     target: &str,
     workspace_dir: Option<&Path>,
-) -> anyhow::Result<DiscordMarkerTarget> {
+) -> Result<DiscordMarkerTarget, DiscordMarkerError> {
     if target.starts_with("http://") || target.starts_with("https://") {
         return Ok(DiscordMarkerTarget::Http(target.to_string()));
     }
     if target.contains("://") {
         let scheme = target.split("://").next().unwrap_or("?");
-        anyhow::bail!(
+        return Err(DiscordMarkerError::Refused(anyhow!(
             "discord: marker target uses disallowed scheme {scheme:?}; only http/https and absolute workspace paths are accepted"
-        );
+        )));
     }
     if target.starts_with("data:") || target.starts_with("file:") {
-        anyhow::bail!(
+        return Err(DiscordMarkerError::Refused(anyhow!(
             "discord: marker target uses disallowed scheme; only http/https and absolute workspace paths are accepted"
-        );
+        )));
     }
 
     let target_path = Path::new(target);
     if !target_path.is_absolute() {
-        anyhow::bail!(
+        return Err(DiscordMarkerError::Refused(anyhow!(
             "discord: marker target {target} is not an absolute path; the agent must emit absolute paths inside workspace_dir"
-        );
+        )));
     }
 
     let workspace = workspace_dir.ok_or_else(|| {
-        anyhow!(
+        DiscordMarkerError::Refused(anyhow!(
             "discord: marker target {target} is a local path but the channel was started without a workspace_dir, refusing for safety"
-        )
+        ))
     })?;
     let workspace_canon = std::fs::canonicalize(workspace)
-        .with_context(|| format!("canonicalize workspace {}", workspace.display()))?;
-    let target_canon = std::fs::canonicalize(target_path)
-        .with_context(|| format!("canonicalize marker target {target}"))?;
+        .with_context(|| format!("canonicalize workspace {}", workspace.display()))
+        .map_err(DiscordMarkerError::Refused)?;
+    let target_canon = match std::fs::canonicalize(target_path) {
+        Ok(p) => p,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Err(DiscordMarkerError::NotFound(anyhow!(
+                "discord: marker target {target} not found on disk"
+            )));
+        }
+        Err(e) => {
+            return Err(DiscordMarkerError::Refused(
+                anyhow::Error::from(e).context(format!("canonicalize marker target {target}")),
+            ));
+        }
+    };
 
     if !target_canon.starts_with(&workspace_canon) {
-        anyhow::bail!(
+        return Err(DiscordMarkerError::Refused(anyhow!(
             "discord: marker target {target} resolves to {} which is outside workspace_dir {}; refusing",
             target_canon.display(),
             workspace_canon.display(),
-        );
+        )));
     }
     Ok(DiscordMarkerTarget::Local(target_canon))
 }
@@ -570,26 +645,88 @@ fn validate_marker_target(
 fn classify_outgoing_attachments(
     attachments: &[DiscordAttachment],
     workspace_dir: Option<&Path>,
-) -> (Vec<PathBuf>, Vec<String>) {
+) -> (
+    Vec<PathBuf>,
+    Vec<String>,
+    Vec<(String, DiscordMarkerFailure)>,
+) {
     let mut local_files = Vec::new();
     let mut remote_urls = Vec::new();
+    let mut failures = Vec::new();
 
     for attachment in attachments {
         match validate_marker_target(&attachment.target, workspace_dir) {
             Ok(DiscordMarkerTarget::Local(path)) => local_files.push(path),
             Ok(DiscordMarkerTarget::Http(url)) => remote_urls.push(url),
             Err(e) => {
+                let kind_label = match e.kind() {
+                    DiscordMarkerFailure::Refused => "trust boundary",
+                    DiscordMarkerFailure::NotFound => "not found",
+                };
                 tracing::warn!(
                     kind = attachment.kind.marker_name(),
                     target = %attachment.target,
+                    reason = kind_label,
                     error = %e,
                     "discord: dropping unresolved outbound attachment marker"
                 );
+                failures.push((attachment.target.clone(), e.kind()));
             }
         }
     }
 
-    (local_files, remote_urls)
+    (local_files, remote_urls, failures)
+}
+
+/// Build the Matrix-style "(note: I couldn't deliver ...)" tail appended
+/// to the bot's reply when at least one marker was dropped. Returns
+/// `None` when the failure list is empty so callers can keep the body
+/// untouched.
+fn delivery_failure_note(failures: &[(String, DiscordMarkerFailure)]) -> Option<String> {
+    if failures.is_empty() {
+        return None;
+    }
+    let targets: Vec<&str> = failures.iter().map(|(t, _)| t.as_str()).collect();
+    Some(if targets.len() == 1 {
+        format!("(note: I couldn't deliver the file at {}.)", targets[0])
+    } else {
+        format!(
+            "(note: I couldn't deliver these files: {}.)",
+            targets.join(", ")
+        )
+    })
+}
+
+/// Compose the final reply body with the delivery-failure note appended.
+/// When the marker-stripped content is empty the note replaces the body;
+/// otherwise the note follows the content separated by a blank line.
+fn compose_body_with_failure_note(content: &str, note: Option<&str>) -> String {
+    match note {
+        Some(note) if content.trim().is_empty() => note.to_string(),
+        Some(note) => format!("{content}\n\n{note}"),
+        None => content.to_string(),
+    }
+}
+
+/// Emoji reactions applied to the bot's own outgoing message based on which
+/// kinds of marker failures occurred. 🚫 signals a trust-boundary refusal,
+/// ⚠️ signals a post-validation delivery failure. Both can fire on the
+/// same message when a batch mixes refusals and not-found targets.
+fn decide_failure_reactions(failures: &[(String, DiscordMarkerFailure)]) -> Vec<&'static str> {
+    let mut out = Vec::new();
+    if failures
+        .iter()
+        .any(|(_, k)| matches!(k, DiscordMarkerFailure::Refused))
+    {
+        out.push("🚫");
+    }
+    if failures
+        .iter()
+        .any(|(_, k)| matches!(k, DiscordMarkerFailure::NotFound))
+    {
+        out.push("⚠️");
+    }
+    out
 }
 
 fn with_inline_attachment_urls(content: &str, remote_urls: &[String]) -> String {
@@ -603,12 +740,14 @@ fn with_inline_attachment_urls(content: &str, remote_urls: &[String]) -> String 
     lines.join("\n")
 }
 
+/// POST a plain-text message and return the new message's ID. Callers
+/// that don't need the ID (e.g. non-first chunks) can discard it.
 async fn send_discord_message_json(
     client: &reqwest::Client,
     bot_token: &str,
     recipient: &str,
     content: &str,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<String> {
     let url = format!("https://discord.com/api/v10/channels/{recipient}/messages");
     let body = json!({ "content": content });
 
@@ -628,16 +767,18 @@ async fn send_discord_message_json(
         anyhow::bail!("Discord send message failed ({status}): {err}");
     }
 
-    Ok(())
+    extract_message_id(resp).await
 }
 
+/// POST a message with file attachments via multipart, returning the new
+/// message's ID. Callers that don't need the ID can discard it.
 async fn send_discord_message_with_files(
     client: &reqwest::Client,
     bot_token: &str,
     recipient: &str,
     content: &str,
     files: &[PathBuf],
-) -> anyhow::Result<()> {
+) -> anyhow::Result<String> {
     let url = format!("https://discord.com/api/v10/channels/{recipient}/messages");
 
     let mut form = Form::new().text("payload_json", json!({ "content": content }).to_string());
@@ -676,38 +817,12 @@ async fn send_discord_message_with_files(
         anyhow::bail!("Discord send message with files failed ({status}): {err}");
     }
 
-    Ok(())
+    extract_message_id(resp).await
 }
 
-/// Send a message and return the Discord message ID from the response.
-async fn send_discord_message_json_with_id(
-    client: &reqwest::Client,
-    bot_token: &str,
-    recipient: &str,
-    content: &str,
-) -> anyhow::Result<String> {
-    let url = format!("https://discord.com/api/v10/channels/{recipient}/messages");
-    let body = json!({ "content": content });
-
-    let resp = client
-        .post(&url)
-        .header("Authorization", format!("Bot {bot_token}"))
-        .json(&body)
-        .send()
-        .await?;
-
-    if !resp.status().is_success() {
-        let status = resp.status();
-        let err = resp
-            .text()
-            .await
-            .unwrap_or_else(|e| format!("<failed to read response body: {e}>"));
-        anyhow::bail!("Discord send message failed ({status}): {err}");
-    }
-
-    let resp_json: serde_json::Value = resp.json().await?;
-    resp_json
-        .get("id")
+async fn extract_message_id(resp: reqwest::Response) -> anyhow::Result<String> {
+    let body: serde_json::Value = resp.json().await?;
+    body.get("id")
         .and_then(|v| v.as_str())
         .map(|s| s.to_string())
         .ok_or_else(|| anyhow::anyhow!("Discord send response missing 'id' field"))
@@ -1026,7 +1141,7 @@ impl Channel for DiscordChannel {
     async fn send(&self, message: &SendMessage) -> anyhow::Result<()> {
         let raw_content = crate::util::strip_tool_call_tags(&message.content);
         let (cleaned_content, parsed_attachments) = parse_attachment_markers(&raw_content);
-        let (mut local_files, remote_urls) =
+        let (mut local_files, remote_urls, failures) =
             classify_outgoing_attachments(&parsed_attachments, self.workspace_dir.as_deref());
 
         // Discord accepts max 10 files per message.
@@ -1038,59 +1153,27 @@ impl Channel for DiscordChannel {
             local_files.truncate(10);
         }
 
-        let content = with_inline_attachment_urls(&cleaned_content, &remote_urls);
+        let body = with_inline_attachment_urls(&cleaned_content, &remote_urls);
+        let note = delivery_failure_note(&failures);
+        let content = compose_body_with_failure_note(&body, note.as_deref());
+        let reactions = decide_failure_reactions(&failures);
 
-        // MultiMessage mode: split at paragraph boundaries and send each as a
-        // separate message with a configurable delay between them.
-        if self.stream_mode == zeroclaw_config::schema::StreamMode::MultiMessage {
-            let chunks = split_message_for_discord_multi(&content, DISCORD_MAX_MESSAGE_LENGTH);
-            let client = self.http_client();
-
-            for (i, chunk) in chunks.iter().enumerate() {
-                if i == 0 && !local_files.is_empty() {
-                    send_discord_message_with_files(
-                        &client,
-                        &self.bot_token,
-                        &message.recipient,
-                        chunk,
-                        &local_files,
-                    )
-                    .await?;
-                } else {
-                    send_discord_message_json(&client, &self.bot_token, &message.recipient, chunk)
-                        .await?;
-                }
-
-                if i < chunks.len() - 1 {
-                    // Check cancellation between chunks so interruption stops delivery.
-                    if message
-                        .cancellation_token
-                        .as_ref()
-                        .is_some_and(|t| t.is_cancelled())
-                    {
-                        tracing::debug!(
-                            "MultiMessage delivery interrupted after chunk {}/{}",
-                            i + 1,
-                            chunks.len()
-                        );
-                        break;
-                    }
-                    tokio::time::sleep(std::time::Duration::from_millis(
-                        self.multi_message_delay_ms,
-                    ))
-                    .await;
-                }
-            }
-
-            return Ok(());
-        }
-
-        // Default / Partial fallback: single chunked message delivery.
-        let chunks = split_message_for_discord(&content);
         let client = self.http_client();
+        let chunks = if self.stream_mode == zeroclaw_config::schema::StreamMode::MultiMessage {
+            split_message_for_discord_multi(&content, DISCORD_MAX_MESSAGE_LENGTH)
+        } else {
+            split_message_for_discord(&content)
+        };
+        let inter_chunk_delay_ms =
+            if self.stream_mode == zeroclaw_config::schema::StreamMode::MultiMessage {
+                self.multi_message_delay_ms
+            } else {
+                500
+            };
 
+        let mut first_message_id: Option<String> = None;
         for (i, chunk) in chunks.iter().enumerate() {
-            if i == 0 && !local_files.is_empty() {
+            let message_id = if i == 0 && !local_files.is_empty() {
                 send_discord_message_with_files(
                     &client,
                     &self.bot_token,
@@ -1098,16 +1181,34 @@ impl Channel for DiscordChannel {
                     chunk,
                     &local_files,
                 )
-                .await?;
+                .await?
             } else {
                 send_discord_message_json(&client, &self.bot_token, &message.recipient, chunk)
-                    .await?;
+                    .await?
+            };
+            if first_message_id.is_none() {
+                first_message_id = Some(message_id);
             }
 
             if i < chunks.len() - 1 {
-                tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                if message
+                    .cancellation_token
+                    .as_ref()
+                    .is_some_and(|t| t.is_cancelled())
+                {
+                    tracing::debug!(
+                        "Discord delivery interrupted after chunk {}/{}",
+                        i + 1,
+                        chunks.len()
+                    );
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(inter_chunk_delay_ms)).await;
             }
         }
+
+        self.apply_failure_reactions(&message.recipient, first_message_id.as_deref(), &reactions)
+            .await;
 
         Ok(())
     }
@@ -1511,7 +1612,7 @@ impl Channel for DiscordChannel {
                 };
 
                 let client = self.http_client();
-                let msg_id = send_discord_message_json_with_id(
+                let msg_id = send_discord_message_json(
                     &client,
                     &self.bot_token,
                     &message.recipient,
@@ -1712,9 +1813,12 @@ impl Channel for DiscordChannel {
 
         let text = &crate::util::strip_tool_call_tags(text);
         let (cleaned_content, parsed_attachments) = parse_attachment_markers(text);
-        let (mut local_files, remote_urls) =
+        let (mut local_files, remote_urls, failures) =
             classify_outgoing_attachments(&parsed_attachments, self.workspace_dir.as_deref());
-        let content = with_inline_attachment_urls(&cleaned_content, &remote_urls);
+        let body = with_inline_attachment_urls(&cleaned_content, &remote_urls);
+        let note = delivery_failure_note(&failures);
+        let content = compose_body_with_failure_note(&body, note.as_deref());
+        let reactions = decide_failure_reactions(&failures);
 
         let client = self.http_client();
 
@@ -1726,8 +1830,9 @@ impl Channel for DiscordChannel {
                 local_files.truncate(10);
             }
             let chunks = split_message_for_discord(&content);
+            let mut first_message_id: Option<String> = None;
             for (i, chunk) in chunks.iter().enumerate() {
-                if i == 0 {
+                let new_id = if i == 0 {
                     send_discord_message_with_files(
                         &client,
                         &self.bot_token,
@@ -1735,14 +1840,19 @@ impl Channel for DiscordChannel {
                         chunk,
                         &local_files,
                     )
-                    .await?;
+                    .await?
                 } else {
-                    send_discord_message_json(&client, &self.bot_token, recipient, chunk).await?;
+                    send_discord_message_json(&client, &self.bot_token, recipient, chunk).await?
+                };
+                if first_message_id.is_none() {
+                    first_message_id = Some(new_id);
                 }
                 if i < chunks.len() - 1 {
                     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
                 }
             }
+            self.apply_failure_reactions(recipient, first_message_id.as_deref(), &reactions)
+                .await;
             return Ok(());
         }
 
@@ -1751,23 +1861,41 @@ impl Channel for DiscordChannel {
             let _ = delete_discord_message(&client, &self.bot_token, recipient, message_id).await;
 
             let chunks = split_message_for_discord(&content);
+            let mut first_message_id: Option<String> = None;
             for (i, chunk) in chunks.iter().enumerate() {
-                send_discord_message_json(&client, &self.bot_token, recipient, chunk).await?;
+                let new_id =
+                    send_discord_message_json(&client, &self.bot_token, recipient, chunk).await?;
+                if first_message_id.is_none() {
+                    first_message_id = Some(new_id);
+                }
                 if i < chunks.len() - 1 {
                     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
                 }
             }
+            self.apply_failure_reactions(recipient, first_message_id.as_deref(), &reactions)
+                .await;
             return Ok(());
         }
 
         // Path 3: simple case — edit in-place; fall back to delete + POST on failure.
-        if let Err(e) =
-            edit_discord_message(&client, &self.bot_token, recipient, message_id, &content).await
-        {
-            tracing::warn!("Discord finalize_draft edit failed: {e}; falling back to delete+send");
-            let _ = delete_discord_message(&client, &self.bot_token, recipient, message_id).await;
-            send_discord_message_json(&client, &self.bot_token, recipient, &content).await?;
-        }
+        // The reaction target is the draft message_id when the edit lands;
+        // when the fallback fires it's the freshly posted message instead.
+        let reaction_target =
+            match edit_discord_message(&client, &self.bot_token, recipient, message_id, &content)
+                .await
+            {
+                Ok(()) => message_id.to_string(),
+                Err(e) => {
+                    tracing::warn!(
+                        "Discord finalize_draft edit failed: {e}; falling back to delete+send"
+                    );
+                    let _ = delete_discord_message(&client, &self.bot_token, recipient, message_id)
+                        .await;
+                    send_discord_message_json(&client, &self.bot_token, recipient, &content).await?
+                }
+            };
+        self.apply_failure_reactions(recipient, Some(&reaction_target), &reactions)
+            .await;
 
         Ok(())
     }
@@ -2522,11 +2650,13 @@ mod tests {
             },
         ];
 
-        let (locals, remotes) = classify_outgoing_attachments(&attachments, Some(temp.path()));
+        let (locals, remotes, failures) =
+            classify_outgoing_attachments(&attachments, Some(temp.path()));
         assert_eq!(locals.len(), 1);
         let canonical_file = std::fs::canonicalize(&file_path).expect("canonicalize fixture");
         assert_eq!(locals[0], canonical_file);
         assert_eq!(remotes, vec!["https://example.com/remote.png".to_string()]);
+        assert!(failures.is_empty());
     }
 
     #[test]
@@ -2541,9 +2671,12 @@ mod tests {
                 .to_string(),
         }];
 
-        let (locals, remotes) = classify_outgoing_attachments(&attachments, Some(temp.path()));
+        let (locals, remotes, failures) =
+            classify_outgoing_attachments(&attachments, Some(temp.path()));
         assert!(locals.is_empty());
         assert!(remotes.is_empty());
+        assert_eq!(failures.len(), 1);
+        assert_eq!(failures[0].1, DiscordMarkerFailure::NotFound);
     }
 
     #[test]
@@ -2558,12 +2691,15 @@ mod tests {
             target: outside_file.to_string_lossy().to_string(),
         }];
 
-        let (locals, remotes) = classify_outgoing_attachments(&attachments, Some(workspace.path()));
+        let (locals, remotes, failures) =
+            classify_outgoing_attachments(&attachments, Some(workspace.path()));
         assert!(
             locals.is_empty(),
             "absolute paths outside workspace must be refused"
         );
         assert!(remotes.is_empty());
+        assert_eq!(failures.len(), 1);
+        assert_eq!(failures[0].1, DiscordMarkerFailure::Refused);
     }
 
     #[test]
@@ -2574,9 +2710,12 @@ mod tests {
             target: "relative/report.pdf".to_string(),
         }];
 
-        let (locals, remotes) = classify_outgoing_attachments(&attachments, Some(temp.path()));
+        let (locals, remotes, failures) =
+            classify_outgoing_attachments(&attachments, Some(temp.path()));
         assert!(locals.is_empty(), "relative paths must be refused");
         assert!(remotes.is_empty());
+        assert_eq!(failures.len(), 1);
+        assert_eq!(failures[0].1, DiscordMarkerFailure::Refused);
     }
 
     #[test]
@@ -2597,9 +2736,14 @@ mod tests {
             },
         ];
 
-        let (locals, remotes) = classify_outgoing_attachments(&attachments, Some(temp.path()));
+        let (locals, remotes, failures) =
+            classify_outgoing_attachments(&attachments, Some(temp.path()));
         assert!(locals.is_empty());
         assert!(remotes.is_empty());
+        assert_eq!(failures.len(), 3);
+        for (_, kind) in &failures {
+            assert_eq!(*kind, DiscordMarkerFailure::Refused);
+        }
     }
 
     #[test]
@@ -2609,12 +2753,14 @@ mod tests {
             target: "/some/absolute/path.png".to_string(),
         }];
 
-        let (locals, remotes) = classify_outgoing_attachments(&attachments, None);
+        let (locals, remotes, failures) = classify_outgoing_attachments(&attachments, None);
         assert!(
             locals.is_empty(),
             "local paths must be refused without workspace_dir"
         );
         assert!(remotes.is_empty());
+        assert_eq!(failures.len(), 1);
+        assert_eq!(failures[0].1, DiscordMarkerFailure::Refused);
     }
 
     #[test]
@@ -2624,9 +2770,10 @@ mod tests {
             target: "https://example.com/x.png".to_string(),
         }];
 
-        let (locals, remotes) = classify_outgoing_attachments(&attachments, None);
+        let (locals, remotes, failures) = classify_outgoing_attachments(&attachments, None);
         assert!(locals.is_empty());
         assert_eq!(remotes, vec!["https://example.com/x.png".to_string()]);
+        assert!(failures.is_empty());
     }
 
     #[test]
@@ -2642,6 +2789,91 @@ mod tests {
     fn with_inline_attachment_urls_keeps_content_when_no_urls() {
         let rendered = with_inline_attachment_urls("Done", &[]);
         assert_eq!(rendered, "Done");
+    }
+
+    #[test]
+    fn delivery_failure_note_is_none_when_no_failures() {
+        assert!(delivery_failure_note(&[]).is_none());
+    }
+
+    #[test]
+    fn delivery_failure_note_singular_for_one_failure() {
+        let note = delivery_failure_note(&[(
+            "/workspace/missing.png".to_string(),
+            DiscordMarkerFailure::NotFound,
+        )])
+        .expect("one failure should produce a note");
+        assert_eq!(
+            note,
+            "(note: I couldn't deliver the file at /workspace/missing.png.)"
+        );
+    }
+
+    #[test]
+    fn delivery_failure_note_plural_lists_targets_in_order() {
+        let note = delivery_failure_note(&[
+            ("a.png".to_string(), DiscordMarkerFailure::Refused),
+            ("b.pdf".to_string(), DiscordMarkerFailure::NotFound),
+            ("c.mp4".to_string(), DiscordMarkerFailure::Refused),
+        ])
+        .expect("multiple failures should produce a note");
+        assert_eq!(
+            note,
+            "(note: I couldn't deliver these files: a.png, b.pdf, c.mp4.)"
+        );
+    }
+
+    #[test]
+    fn compose_body_with_failure_note_uses_note_alone_when_content_empty() {
+        let composed = compose_body_with_failure_note("", Some("(note: ...)"));
+        assert_eq!(composed, "(note: ...)");
+    }
+
+    #[test]
+    fn compose_body_with_failure_note_appends_note_to_existing_content() {
+        let composed = compose_body_with_failure_note("Hello.", Some("(note: ...)"));
+        assert_eq!(composed, "Hello.\n\n(note: ...)");
+    }
+
+    #[test]
+    fn compose_body_with_failure_note_returns_content_when_no_note() {
+        let composed = compose_body_with_failure_note("Hello.", None);
+        assert_eq!(composed, "Hello.");
+    }
+
+    #[test]
+    fn compose_body_with_failure_note_returns_empty_when_no_content_and_no_note() {
+        let composed = compose_body_with_failure_note("", None);
+        assert_eq!(composed, "");
+    }
+
+    #[test]
+    fn decide_failure_reactions_empty_for_no_failures() {
+        assert!(decide_failure_reactions(&[]).is_empty());
+    }
+
+    #[test]
+    fn decide_failure_reactions_emits_refused_only() {
+        let r = decide_failure_reactions(&[
+            ("a".to_string(), DiscordMarkerFailure::Refused),
+            ("b".to_string(), DiscordMarkerFailure::Refused),
+        ]);
+        assert_eq!(r, vec!["🚫"]);
+    }
+
+    #[test]
+    fn decide_failure_reactions_emits_not_found_only() {
+        let r = decide_failure_reactions(&[("a".to_string(), DiscordMarkerFailure::NotFound)]);
+        assert_eq!(r, vec!["\u{26A0}\u{FE0F}"]);
+    }
+
+    #[test]
+    fn decide_failure_reactions_emits_both_when_mixed() {
+        let r = decide_failure_reactions(&[
+            ("a".to_string(), DiscordMarkerFailure::Refused),
+            ("b".to_string(), DiscordMarkerFailure::NotFound),
+        ]);
+        assert_eq!(r, vec!["🚫", "\u{26A0}\u{FE0F}"]);
     }
 
     // ── Streaming mode tests ──────────────────────────────────────────

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -609,6 +609,15 @@ fn channel_delivery_instructions(channel_name: &str) -> Option<&'static str> {
              - When you receive a [Voice message], the user spoke to you. Respond naturally as in conversation.\n\
              - Your text reply will automatically be converted to audio and sent back as a voice message.\n",
         ),
+        "discord" => Some(
+            "When responding on Discord:\n\
+             - Use Markdown formatting (bold, italic, code blocks)\n\
+             - Be concise and direct\n\
+             - For media attachments use markers: [IMAGE:<absolute-path>], [DOCUMENT:<absolute-path>], [VIDEO:<absolute-path>], [AUDIO:<absolute-path>], or [VOICE:<absolute-path>]\n\
+             - Paths inside markers MUST be absolute (starting with /) and live inside the configured workspace directory. Never use relative paths.\n\
+             - Remote media is also accepted via http:// or https:// URLs in the same marker form.\n\
+             - Keep normal text outside markers and never wrap markers in code fences.\n",
+        ),
         "telegram" => Some(
             "When responding on Telegram:\n\
              - Include media markers for files or URLs that should be sent as attachments\n\
@@ -11427,6 +11436,32 @@ BTC is currently around $65,000 based on latest tool output."#
             "telegram media marker guidance should live in the system prompt"
         );
         assert!(!calls[0].iter().skip(1).any(|(role, _)| role == "system"));
+    }
+
+    #[test]
+    fn channel_delivery_instructions_for_discord_mandates_absolute_paths() {
+        let block = channel_delivery_instructions("discord")
+            .expect("discord channel must have a delivery-instructions block");
+        assert!(
+            block.contains("When responding on Discord:"),
+            "discord block must identify itself"
+        );
+        assert!(
+            block.contains("For media attachments use markers:"),
+            "discord block must describe marker syntax"
+        );
+        assert!(
+            block.contains("MUST be absolute"),
+            "discord block must mandate absolute paths"
+        );
+        assert!(
+            block.contains("workspace"),
+            "discord block must reference workspace bounds"
+        );
+        assert!(
+            block.contains("[IMAGE:<absolute-path>]"),
+            "discord block must show the absolute-path marker form"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Inbound: the two parallel attachment passes (text inline plus per-channel transcription) are collapsed into one. Each attachment downloads at most once. Image, video, audio, and document types now populate `ChannelMessage.attachments` as `MediaAttachment` entries so the media pipeline and vision-capable providers actually see them; the field was previously hardcoded to `vec![]` regardless of what Discord sent. Audio still transcribes inline when a transcription manager is configured, and otherwise flows through the same `MediaAttachment` path.
  - Inbound admission gate: a new `admit_discord_message` replaces the old `normalize_incoming_content` so a Discord message that contains *only* an attachment (image, PDF, ZIP, video, or audio with no caption) is admitted to `process_attachments` and `ChannelMessage.attachments`. The mention-only gate is preserved orthogonally: a guild channel with `mention_only = true` still requires the bot to be @-mentioned, attachment or no. DMs continue to bypass the mention requirement entirely.
  - Outbound validation: marker targets are sandbox-validated against `workspace_dir` before any upload. Absolute paths that canonicalise inside the workspace are uploaded as files, http(s) URLs are inlined as links, and everything else (relative paths, `file:`/`data:`/etc. schemes, paths outside the workspace, missing files) is logged at warn and dropped. The validator now discriminates `Refused` (trust-boundary rejection) from `NotFound` (canonicalise hit ENOENT) so the user-facing surface can distinguish refusal from delivery failure.
  - Outbound visibility: when any marker is dropped, the bot's reply now carries a Matrix-style `(note: I couldn't deliver the file at <target>.)` (singular) or `(note: I couldn't deliver these files: a, b, c.)` (plural) note, and the bot reacts to its own outgoing message with 🚫 (trust-boundary refusal) or ⚠️ (file not found on disk). When the marker-stripped content would otherwise be empty, the note replaces the body so the chatter never sees silence after a refused delivery.
  - MultiMessage file uploads: a `chunks_for_send` helper now emits a single empty chunk when a MultiMessage paragraph collapses to empty text after marker strip but still has a file to upload. The two splitters disagreed on empty input (`split_message_for_discord("")` returned `vec![""]`, `split_message_for_discord_multi("")` returned `vec![]`); the multi-paragraph path therefore iterated the chunk loop zero times and silently skipped `send_discord_message_with_files` for marker-only paragraphs. The fix routes those uploads through the same multipart POST as the non-multi path.
  - Threads: a cached `GET /channels/{channel_id}` lookup classifies each seen channel and populates `thread_ts` plus `interruption_scope_id` when the type is 10, 11, or 12 (ANNOUNCEMENT_THREAD, PUBLIC_THREAD, PRIVATE_THREAD per the Discord channel-type docs). Cache holds for the channel instance lifetime; lookup failures fall through to non-thread so a transient API hiccup cannot block inbound delivery. Failure paths no longer cache `false`, so a transient 429 or network blip does not permanently poison the cache. The request itself is bounded by an explicit `THREAD_LOOKUP_TIMEOUT` (5 s) via `tokio::time::timeout`, so a hung Discord call cannot stall the listener even if the shared channel HTTP client carries no request-level timeout. The scope-fragmentation trade-off (a transient miss can briefly split history/cancellation scope before the cache warms) is documented at the `ChannelMessage` construction site.
  - System prompt: `channel_delivery_instructions` previously had no Discord arm, so the agent received no marker-format guidance and emitted relative paths. Added a Discord block mirroring Matrix's strictness: `[IMAGE:<absolute-path>]` etc., paths MUST be absolute and live inside the workspace directory, http(s) URLs accepted in the same marker form.
  - DRY: consolidated `send_discord_message_json` and `send_discord_message_with_files` to return the new message ID (needed for the failure-reaction surface). Removed the redundant `send_discord_message_json_with_id` variant.
- **Scope boundary:** Discord channel plus the Discord arm in `channel_delivery_instructions`. No other channel behaviour changes. No schema, config, or runtime-agent changes.
- **Blast radius:** Discord channel only, and the orchestrator system-prompt block delivered to Discord agents. The trust-boundary validation refuses targets the channel previously rendered as plaintext, a deliberate user-visible behaviour change (no more raw marker leaks; new note + emoji reactions on failures).
- **Linked issue(s):** Closes #6556

## Validation Evidence (required)

Local validation matches the pre-push gate, with one substitution: workspace `--features ci-all` clippy fails on this host due to an unrelated `matrix-sdk` 0.16 recursion-limit overflow at the channels-crate compile site under rustc 1.95.0; the failure is present on `upstream/master` regardless of this branch and is not in any code path this PR touches. The same feature set with `channel-matrix` removed exercises every crate Discord depends on.

```bash
cargo +nightly fmt --all -- --check
cargo clippy --workspace --exclude zeroclaw-desktop --all-targets \
  --features "agent-runtime,channel-nostr,whatsapp-web,observability-prometheus,observability-otel,hardware,peripheral-rpi,sandbox-landlock,sandbox-bubblewrap,browser-native,plugins-wasm,probe,rag-pdf,webauthn,memory-postgres" \
  -- -D warnings
cargo test --workspace --exclude zeroclaw-desktop \
  --features "agent-runtime,channel-nostr,whatsapp-web,observability-prometheus,observability-otel,hardware,peripheral-rpi,sandbox-landlock,sandbox-bubblewrap,browser-native,plugins-wasm,probe,rag-pdf,webauthn,memory-postgres"
```

- **Commands run and tail output:**
  - `cargo +nightly fmt --all -- --check` → exit 0
  - `cargo clippy ... -- -D warnings` → exit 0
  - `cargo test ...` → exit 0; 47 test binaries across the workspace, 0 failed. The Discord-side suite covers: validator failure-kind split, classifier with failure tuples, note builder singular and plural, body composition with and without note, reaction decision table (refused-only, not-found-only, mixed), the thread-type purity helper, the orchestrator's Discord delivery-instructions block, the `chunks_for_send` empty-with-files / empty-no-files / non-empty-passthrough triples across MultiMessage / Partial / Off stream modes, the `admit_discord_message` mention-gate and attachment-only admission cases (DM bypass, guild mention-required, attachment-only in mention-only guild dropped, attachment-only in DM admitted, attachment + mention admitted, empty-everything dropped), and `marker_kind_for` MIME-to-marker dispatch for image / video / document fallback / audio-by-filename / image-wins-over-audio.

- **Beyond CI, what did you manually verify?** Ran the live test plan against a Discord bot (workspace at `/path/to/workspace`, vision-capable provider, transcription disabled, `stream_mode = multi_message`).

| Test | Surface | Outcome |
|------|---------|---------|
| T1 | PNG sent in a guild channel | Vision provider describes the image content correctly. Confirms inbound image → `MediaAttachment` → provider. |
| T2 | JPEG sent in a DM | Same path; meme correctly identified. |
| T3 | PDF attachment | Agent acknowledges the document by filename and offers to extract text. Previously silently dropped. |
| T4 | MP4 video | Agent describes resolution, duration, codec. |
| T5 | ZIP attachment | Agent reads the contents and summarises. |
| T8 / T12 / T13 | Agent asked to send nonexistent file, `/etc/passwd`, or `file://` | Agent-policy refusal at the model layer; the validator path remains exercised by the unit tests. |
| T15 | Casual message inside a Discord thread | Agent classified as ambient and skipped; thread detection ran without error. |
| T16 | Image attached inside the thread from T15 | Image described correctly; reply landed in the thread (joint coverage for inbound media plus thread routing). |
| Multi-image | Three screenshots in one message, asked "How many screenshots can you see?" | Bot replied "Three." Multiple `MediaAttachment` entries surfaced together. |
| Attachment-only inbound | `@<bot>` plus an image with no caption, in a guild channel with `mention_only = true` | Vision provider described the image content correctly. Confirms `admit_discord_message` admits empty-text + attachment when mention is satisfied (post-fix; previously dropped at the empty-content gate). |
| Single-doc upload | "Send me another random tailored resume" with `stream_mode = multi_message` | Bot replied prose with a resume PDF attached on the same Discord message, followed by the trailing tool-receipts block as its own message. Locks the `chunks_for_send` MultiMessage fix end-to-end. |
| Multi-doc upload | "Send me two random tailored resumes" with `stream_mode = multi_message` | Bot replied prose with both PDFs attached in a single Discord message (one multipart POST with two entries in `local_files`). |
| T10 / earlier | Agent asked to send a real workspace file | Surfaced the relative-path emission gap that motivated the third commit: the agent emitted a relative-path `[DOCUMENT:example_file.md]` marker, the validator correctly refused it, but the reply collapsed to empty content and the user saw silence. Fixed by the new Discord system-prompt block (agent now receives the absolute-paths-only directive) plus the failure note + 🚫 reaction. Post-fix, refused markers surface as `(note: I couldn't deliver the file at <target>.)` plus the emoji reaction, and properly-instructed sessions land their files as actual attachments. |

- **If any command was intentionally skipped, why:** `channel-matrix` was excluded from the local clippy and test run because of a pre-existing `matrix-sdk` 0.16 recursion-limit overflow at the channels-crate compile site under rustc 1.95.0. The exclusion does not touch any path this PR modifies.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `Yes`. One additional `GET /channels/{id}` call against `discord.com/api/v10` on first sighting of each channel, used only to classify whether the channel is a thread (types 10/11/12). Mitigations: reuses the existing Discord API host and the channel's existing bot token, no new third-party integration, cached for the channel instance lifetime on success only, bounded by an explicit 5 s `tokio::time::timeout` so a hung Discord call cannot stall the listener.
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

The change tightens the outbound trust boundary: marker targets that canonicalise outside `workspace_dir`, use disallowed schemes, or are relative are no longer rendered as chat text. This closes the path-disclosure surface called out in #6556. The new delivery-failure note exposes the agent-emitted target string back to the user, which is the same string the agent already chose to put into chat; no additional surface is created.

## Compatibility (required)

- Backward compatible? `Yes` for end users; media that was silently broken now works, and refused deliveries now produce a visible note plus emoji reaction instead of an empty message.
- Config / env / CLI surface changed? `No`
- Upgrade steps: none for operators. Agents in older sessions that emit relative-path markers will see those markers refused (logged at warn, dropped from outbound, surfaced to the user as a delivery-failure note). The new system-prompt block instructs Discord agents to emit absolute paths inside the workspace.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <merge-sha>` on master.
- **Feature flags or config toggles:** None. The work is gated by the existing `channel-discord` feature; no new flag is introduced.
- **Observable failure symptoms:**
  - `discord: dropping unresolved outbound attachment marker` warnings in logs when an agent emits a path that fails sandbox validation; the `reason` field distinguishes "trust boundary" from "not found".
  - `discord: failed to add failure reaction to outgoing message` debug lines if Discord rejects the emoji reaction (best-effort; never propagated).
  - `discord: channel lookup ...` debug lines on first message from a new channel; absence after warm-up may indicate the thread cache is mis-populated, or a transient lookup failure (which no longer poisons the cache).
  - `discord: channel lookup timed out` debug lines indicate the thread-lookup timeout fired; the channel falls back to non-thread classification for that message and retries on the next inbound.
  - Regression of the original bug shows up as inbound images / PDFs / videos not reaching providers, attachment-only inbound messages being silently dropped at the empty-content gate, raw `[IMAGE:/...]` text appearing in user chat, files posted by the bot landing in the parent channel root instead of the thread the user started in, or marker-only MultiMessage paragraphs being silently dropped.
