### PR TITLE
fix(providers/glm): mark GLM provider as vision-capable

### DIFF
--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -1381,11 +1381,17 @@ fn create_provider_with_url_and_options(
             AuthStyle::ZhipuJwt,
         ))),
         name if glm_base_url(name).is_some() => {
-            Ok(compat(OpenAiCompatibleProvider::new_no_responses_fallback(
+            // GLM offers vision-capable models (e.g. `glm-4.5v`). Mark the
+            // provider as vision-capable so multimodal routing accepts it.
+            // The specific model still has to be a vision-capable one;
+            // text-only models will return an API error if given an image,
+            // matching the behaviour of other multi-modal providers.
+            Ok(compat(OpenAiCompatibleProvider::new_with_vision(
                 "GLM",
                 glm_base_url(name).expect("checked in guard"),
                 key,
                 AuthStyle::ZhipuJwt,
+                true,
             )))
         }
         name if minimax_base_url(name).is_some() => Ok(compat(
@@ -3167,6 +3173,21 @@ mod tests {
         let oauth_provider =
             create_provider("qwen-code", Some("key")).expect("qwen oauth provider should build");
         assert!(oauth_provider.supports_vision());
+    }
+
+    #[test]
+    fn glm_provider_supports_vision() {
+        // GLM exposes vision-capable models (e.g. `glm-4.5v`). The provider
+        // must therefore report `supports_vision()` so multimodal routing
+        // can target it; the model field selects the actual variant.
+        for alias in ["glm", "zhipu", "glm-cn", "zhipu-cn"] {
+            let provider =
+                create_provider(alias, Some("id.secret")).expect("glm provider should build");
+            assert!(
+                provider.supports_vision(),
+                "alias `{alias}` should report vision capability"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
GLM exposes vision-capable models (e.g. `glm-4.5v`), but the provider factory previously constructed it without the vision flag, leaving `supports_vision()` at `false`. As a result the multimodal routing rejected GLM as a `vision_provider`, even when the user had explicitly configured `glm-4.5v` as the vision model.

This matches the existing behaviour for sibling providers like Qwen and Bailian, where the provider is marked vision-capable at the factory level and the specific model decides whether an image is actually accepted upstream.

## Summary

- **Base branch:** `master`
- **What changed and why:**
  - GLM offers vision-capable models (e.g. `glm-4.5v`), but the factory previously constructed the provider without the vision flag, so `supports_vision()` returned `false`.
  - As a result, multimodal routing rejected GLM as a `vision_provider`, even when the user explicitly set `vision_model = glm-4.5v` in config. The orchestrator returned `provider_capability_error{capability=vision, message="configured vision_provider 'glm' does not support vision input"}`.
  - This change marks GLM vision-capable at the factory level, matching the existing pattern for sibling providers (Qwen, Bailian). The actual model selection still decides whether an image will be accepted — text-only GLM variants will fail upstream the same way an unsupported Qwen variant would.
- **Scope boundary:** does NOT change Z.AI (sibling Zhipu provider — handled separately), does NOT touch model-aware capability logic, does NOT change `multimodal` config schema.
- **Blast radius:** any user who has configured `vision_provider = glm`. Previously this errored on every image; with this change, image messages will be routed to GLM. Text-only flows are unaffected.
- **Linked issue(s):** None — discovered while configuring GLM as a vision fallback for a DeepSeek-based agent.
- **Labels:** `scope:providers`, `risk:low`, `size:XS`, `type:bug` (auto-labels expected).

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy -p zeroclaw-providers --lib --locked -- -D warnings
cargo test -p zeroclaw-providers --lib --locked
```

Tail output:

```
$ cargo fmt --all -- --check
(no output — clean)

$ cargo clippy -p zeroclaw-providers --lib --locked -- -D warnings
    Checking zeroclaw-providers v0.7.5 (...)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 14.01s

$ cargo test -p zeroclaw-providers --lib --locked
test tests::glm_provider_supports_vision ... ok
...
test result: ok. 822 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.91s
```

The pre-push hook (`./scripts/ci/rust_quality_gate.sh`) was run before push and passed.

- **Manual verification:** confirmed the symptom against `https://open.bigmodel.cn/api/paas/v4/chat/completions` with `model=glm-4.5v` — the GLM API itself accepts vision input correctly, the failure was purely in the zeroclaw capability gate. New unit test `glm_provider_supports_vision` covers all four aliases (`glm`, `zhipu`, `glm-cn`, `zhipu-cn`).
- **Not verified locally:** end-to-end image routing through a live agent — covered by the existing `run_tool_call_loop_*_vision` test family in `zeroclaw-runtime` which mocks the provider. I did not modify those tests.
- **Commands intentionally skipped:** `cargo test` for the full workspace was not re-run after the providers crate passed. The change is confined to one factory branch in `zeroclaw-providers/src/lib.rs`; consumers depend on the `Provider` trait rather than the concrete builder, so workspace-wide tests would not exercise the flag change.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No` — same GLM endpoint as before; only a local capability flag flips.
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes` — `supports_vision()` going from `false` → `true` only widens the accepted set of messages. Users not sending image markers are unaffected.
- Config / env / CLI surface changed? `No`
- Upgrade steps: none required. Users who previously hit the `configured vision_provider 'glm' does not support vision input` error will see GLM accept the routing after upgrading.

## Rollback

Low-risk PR: `git revert <sha>` is the plan. If a regression surfaces, reverting the single ~15-line factory change restores the previous behaviour (image messages refused at the capability gate).
