### PR TITLE
fix(matrix): keep root timeline messages as root messages

### DIFF
--- a/crates/zeroclaw-channels/src/matrix.rs
+++ b/crates/zeroclaw-channels/src/matrix.rs
@@ -1497,16 +1497,10 @@ mod inbound {
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap_or_default()
                 .as_secs(),
-            // Reply anchor: use the existing thread root when present,
-            // otherwise (when reply_in_thread is on) anchor a brand-new thread
-            // on this very event so the bot's reply opens a thread.
-            thread_ts: thread_id.as_ref().map(|t| t.to_string()).or_else(|| {
-                if ctx.config.reply_in_thread {
-                    Some(ev.event_id.to_string())
-                } else {
-                    None
-                }
-            }),
+            // Reply anchor: only use an existing thread root. Plain root
+            // timeline messages stay root messages so consecutive turns in
+            // the same room share the same conversation history key.
+            thread_ts: thread_id.as_ref().map(|t| t.to_string()),
             // Interruption scope is for cancellation grouping — only set when
             // the inbound is genuinely *inside* a reply thread.
             interruption_scope_id: thread_id.as_ref().map(|t| t.to_string()),

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -456,7 +456,7 @@ pub fn conversation_history_key(msg: &zeroclaw_api::channel::ChannelMessage) -> 
 }
 
 fn followup_thread_id(msg: &zeroclaw_api::channel::ChannelMessage) -> Option<String> {
-    msg.thread_ts.clone().or_else(|| Some(msg.id.clone()))
+    msg.thread_ts.clone()
 }
 
 fn interruption_scope_key(msg: &zeroclaw_api::channel::ChannelMessage) -> String {
@@ -10615,7 +10615,7 @@ BTC is currently around $65,000 based on latest tool output."#
     }
 
     #[test]
-    fn followup_thread_id_falls_back_to_message_id() {
+    fn followup_thread_id_returns_none_when_no_thread_ts() {
         let msg = zeroclaw_api::channel::ChannelMessage {
             id: "msg_abc123".into(),
             sender: "U123".into(),
@@ -10628,7 +10628,7 @@ BTC is currently around $65,000 based on latest tool output."#
             attachments: vec![],
         };
 
-        assert_eq!(followup_thread_id(&msg).as_deref(), Some("msg_abc123"));
+        assert_eq!(followup_thread_id(&msg), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes a bug where plain Matrix root timeline messages were incorrectly
treated as thread roots when `reply_in_thread = true`, causing each
root message to open a separate conversation session and break
multi-turn context.

## Root cause

In `matrix::inbound`, `ChannelMessage.thread_ts` was set to the
current event id whenever `reply_in_thread` was enabled and the
message was not already inside a Matrix thread. Because the
orchestrator uses `thread_ts` as part of `conversation_history_key`,
consecutive root messages from the same user got different keys and
lost each other's context.

The orchestrator's `followup_thread_id` compounded the issue by
falling back from an empty `thread_ts` to `msg.id`, threading tool
notifications and final replies under the inbound root event id.

## Changes

- `crates/zeroclaw-channels/src/matrix.rs`: Remove the `or_else`
  fallback that placed `ev.event_id` into `thread_ts` for plain root
  messages. `thread_ts` is now set only when the inbound event carries
  a genuine `m.thread` relation.
- `crates/zeroclaw-channels/src/orchestrator/mod.rs`: Simplify
  `followup_thread_id` to return `thread_ts` without a fallback to
  `msg.id`.
- Update the existing `followup_thread_id` unit test to assert `None`
  instead of the old fallback behavior.

## Verification

- `cargo fmt` passes.
- No logic or control-flow changes beyond removing the two fallbacks.
- Genuine Matrix thread replies continue to use the thread root as
  `thread_ts`, preserving existing thread isolation.

Fixes #6524