### PR TITLE
fix(provider): honor LM Studio compatible runtime options

### DIFF
--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -785,29 +785,33 @@ pub fn provider_runtime_options_from_config(
     config: &zeroclaw_config::schema::Config,
 ) -> ProviderRuntimeOptions {
     let fallback = config.providers.fallback_provider();
-    // Resolve merge_system_into_user from the active model provider profile by
-    // matching api_url — apply_named_model_provider_profile() has already run
-    // and rewritten providers.fallback, but providers.models retains all profiles.
-    let merge_system_into_user = fallback
-        .and_then(|e| e.base_url.as_deref())
-        .map(str::trim)
-        .filter(|u| !u.is_empty())
-        .and_then(|active_url| {
-            config.providers.models.values().find(|p| {
-                p.base_url
-                    .as_deref()
-                    .map(str::trim)
-                    .filter(|u| !u.is_empty())
-                    .map(|u| u.trim_end_matches('/'))
-                    == Some(active_url.trim_end_matches('/'))
+    // Prefer the active fallback profile, and keep the URL-match fallback for
+    // compatibility with older loaded configs that only preserved the base URL.
+    let merge_system_into_user = fallback.is_some_and(|entry| entry.merge_system_into_user)
+        || fallback
+            .and_then(|e| e.base_url.as_deref())
+            .map(str::trim)
+            .filter(|u| !u.is_empty())
+            .and_then(|active_url| {
+                config.providers.models.values().find(|p| {
+                    p.base_url
+                        .as_deref()
+                        .map(str::trim)
+                        .filter(|u| !u.is_empty())
+                        .map(|u| u.trim_end_matches('/'))
+                        == Some(active_url.trim_end_matches('/'))
+                })
             })
-        })
-        .map(|p| p.merge_system_into_user)
-        .unwrap_or(false);
+            .map(|p| p.merge_system_into_user)
+            .unwrap_or(false);
 
     ProviderRuntimeOptions {
         auth_profile_override: None,
-        provider_api_url: fallback.and_then(|e| e.base_url.clone()),
+        provider_api_url: fallback
+            .and_then(|e| e.base_url.as_deref())
+            .map(str::trim)
+            .filter(|url| !url.is_empty())
+            .map(ToString::to_string),
         zeroclaw_dir: config.config_path.parent().map(PathBuf::from),
         secrets_encrypt: config.secrets.encrypt,
         reasoning_enabled: config.runtime.reasoning_enabled,
@@ -1123,6 +1127,18 @@ fn parse_custom_provider_url(
             "{provider_label} requires an http:// or https:// URL. Format: {format_hint}"
         ),
     }
+}
+
+fn configured_provider_base_url<'a>(
+    explicit_url: Option<&'a str>,
+    runtime_url: Option<&'a str>,
+    default_url: &'static str,
+) -> &'a str {
+    explicit_url
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .or_else(|| runtime_url.map(str::trim).filter(|value| !value.is_empty()))
+        .unwrap_or(default_url)
 }
 
 /// Factory: create the right provider from config (without custom URL)
@@ -1547,16 +1563,27 @@ fn create_provider_with_url_and_options(
         "gemini-cli" => Ok(Box::new(gemini_cli::GeminiCliProvider::new())),
         "kilocli" | "kilo" => Ok(Box::new(kilocli::KiloCliProvider::new())),
         "lmstudio" | "lm-studio" => {
+            let base_url = configured_provider_base_url(
+                api_url,
+                options.provider_api_url.as_deref(),
+                "http://localhost:1234/v1",
+            );
             let lm_studio_key = key
                 .map(str::trim)
                 .filter(|value| !value.is_empty())
                 .unwrap_or("lm-studio");
-            Ok(compat(OpenAiCompatibleProvider::new(
+            let provider = OpenAiCompatibleProvider::new(
                 "LM Studio",
-                "http://localhost:1234/v1",
+                base_url,
                 Some(lm_studio_key),
                 AuthStyle::Bearer,
-            )))
+            );
+            let provider = if options.merge_system_into_user {
+                provider.with_merge_system_into_user()
+            } else {
+                provider
+            };
+            Ok(compat(provider))
         }
         "llamacpp" | "llama.cpp" => {
             let base_url = api_url
@@ -3176,6 +3203,100 @@ mod tests {
         assert!(create_provider("lmstudio", None).is_ok());
     }
 
+    #[tokio::test]
+    async fn lmstudio_runtime_options_apply_base_url_and_merge_system_messages() {
+        let response_body = r#"{"choices":[{"message":{"content":"ok"}}]}"#;
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind test server");
+        let base_url = format!(
+            "http://{}",
+            listener.local_addr().expect("read test server address")
+        );
+        let (tx, rx) = std::sync::mpsc::channel();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept provider request");
+            stream
+                .set_read_timeout(Some(std::time::Duration::from_secs(2)))
+                .expect("set read timeout");
+
+            let mut bytes = Vec::new();
+            let mut buf = [0_u8; 1024];
+            let header_end = loop {
+                let read = std::io::Read::read(&mut stream, &mut buf).expect("read request");
+                assert!(
+                    read > 0,
+                    "provider closed connection before sending headers"
+                );
+                bytes.extend_from_slice(&buf[..read]);
+                if let Some(pos) = bytes.windows(4).position(|window| window == b"\r\n\r\n") {
+                    break pos + 4;
+                }
+            };
+
+            let headers = String::from_utf8_lossy(&bytes[..header_end]);
+            let content_length = headers
+                .lines()
+                .find_map(|line| {
+                    line.strip_prefix("content-length:")
+                        .or_else(|| line.strip_prefix("Content-Length:"))
+                        .and_then(|value| value.trim().parse::<usize>().ok())
+                })
+                .expect("request includes content-length");
+
+            while bytes.len() < header_end + content_length {
+                let read = std::io::Read::read(&mut stream, &mut buf).expect("read request body");
+                assert!(read > 0, "provider closed connection before sending body");
+                bytes.extend_from_slice(&buf[..read]);
+            }
+
+            let request = String::from_utf8(bytes).expect("request is valid utf-8");
+            tx.send(request).expect("send captured request");
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{}",
+                response_body.len(),
+                response_body
+            );
+            std::io::Write::write_all(&mut stream, response.as_bytes()).expect("write response");
+        });
+
+        let options = ProviderRuntimeOptions {
+            provider_api_url: Some(format!("{base_url}/v1")),
+            merge_system_into_user: true,
+            ..ProviderRuntimeOptions::default()
+        };
+        let provider = create_provider_with_url_and_options("lmstudio", None, None, &options)
+            .expect("create lmstudio provider");
+        let messages = [ChatMessage::system("system-only instruction")];
+        let result = provider
+            .chat(
+                ChatRequest {
+                    messages: &messages,
+                    tools: None,
+                },
+                "local-model",
+                Some(0.0),
+            )
+            .await
+            .expect("lmstudio chat succeeds");
+        assert_eq!(result.text.as_deref(), Some("ok"));
+
+        let request = rx
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .expect("captured provider request");
+        server.join().expect("test server exits cleanly");
+        assert!(request.starts_with("POST /v1/chat/completions "));
+
+        let body = request
+            .split_once("\r\n\r\n")
+            .map(|(_, body)| body)
+            .expect("captured request body");
+        let payload: serde_json::Value =
+            serde_json::from_str(body).expect("provider request body is json");
+        let outbound_messages = payload["messages"].as_array().expect("messages array");
+        assert_eq!(outbound_messages.len(), 1);
+        assert_eq!(outbound_messages[0]["role"], "user");
+        assert_eq!(outbound_messages[0]["content"], "system-only instruction");
+    }
+
     #[test]
     fn factory_llamacpp() {
         assert!(create_provider("llamacpp", Some("key")).is_ok());
@@ -3352,6 +3473,57 @@ mod tests {
             options.native_tools,
             Some(true),
             "native_tools must propagate from the active provider profile to runtime options"
+        );
+    }
+
+    #[test]
+    fn provider_runtime_options_from_config_propagates_lmstudio_system_merge_without_base_url() {
+        let mut config = zeroclaw_config::schema::Config::default();
+        config.providers.models.insert(
+            "lmstudio".to_string(),
+            zeroclaw_config::schema::ModelProviderConfig {
+                merge_system_into_user: true,
+                ..Default::default()
+            },
+        );
+        config.providers.fallback = Some("lmstudio".to_string());
+
+        let options = provider_runtime_options_from_config(&config);
+        assert!(
+            options.merge_system_into_user,
+            "merge_system_into_user must propagate even when LM Studio uses its default base URL"
+        );
+    }
+
+    #[test]
+    fn configured_provider_base_url_ignores_empty_runtime_url() {
+        assert_eq!(
+            configured_provider_base_url(None, Some("   "), "http://localhost:1234/v1"),
+            "http://localhost:1234/v1"
+        );
+        assert_eq!(
+            configured_provider_base_url(
+                Some(" http://explicit.example/v1 "),
+                Some("http://runtime.example/v1"),
+                "http://localhost:1234/v1",
+            ),
+            "http://explicit.example/v1"
+        );
+        assert_eq!(
+            configured_provider_base_url(
+                Some("   "),
+                Some(" http://runtime.example/v1 "),
+                "http://localhost:1234/v1",
+            ),
+            "http://runtime.example/v1"
+        );
+        assert_eq!(
+            configured_provider_base_url(
+                None,
+                Some(" http://runtime.example/v1 "),
+                "http://localhost:1234/v1",
+            ),
+            "http://runtime.example/v1"
         );
     }
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Propagates `merge_system_into_user` from the active provider profile into runtime options even when LM Studio uses its default base URL.
  - Makes the LM Studio factory honor configured provider base URLs and the existing merge-system-into-user runtime option.
  - Normalizes configured provider base URLs so blank or whitespace-only values do not override the LM Studio default.
  - Adds focused regressions for the config path, URL precedence/normalization, and the outgoing OpenAI-compatible request shape.
- **Scope boundary:** This PR does not redesign history pruning, context compression, or all OpenAI-compatible provider message shaping. It fixes the LM Studio/config option path called out in the #6034 follow-up and keeps the existing compatible-provider merge behavior.
- **Blast radius:** `zeroclaw-providers` provider construction for LM Studio and runtime option derivation from `[providers.models.*]`. Other provider factories continue to use their existing paths.
- **Linked issue(s):** Related #6034
- **Labels:** `bug`, `risk: medium`, `size: S`, `provider`, `provider:compatible`.

## Validation Evidence (required)

- **Commands run and tail output:**

```text
cargo fmt --all -- --check
result: passed

git diff --check
result: passed

cargo test -p zeroclaw-providers provider_runtime_options_from_config_propagates_lmstudio_system_merge_without_base_url -- --nocapture
result: passed; 1 test passed

cargo test -p zeroclaw-providers configured_provider_base_url_ignores_empty_runtime_url -- --nocapture
result: passed; 1 test passed

cargo test -p zeroclaw-providers lmstudio_runtime_options_apply_base_url_and_merge_system_messages -- --nocapture
result: passed; 1 test passed
```

- **Beyond CI — what did you manually verify?** No interactive manual testing was performed. The focused provider tests above verify the config-derived runtime option path, URL precedence/normalization, and outgoing LM Studio request shape.
- **If any command was intentionally skipped, why:** Full workspace `cargo test` and full workspace clippy were not run because this is a narrow provider-factory/config patch. The focused tests cover the changed behavior directly.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: None.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No upgrade step is required. Existing LM Studio configs can keep using the same `merge_system_into_user` and `base_url` fields; this PR makes those existing fields reach the LM Studio provider path.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** Revert this PR's squash commit.
- **Feature flags or config toggles:** Existing `merge_system_into_user = false` or an omitted field keeps LM Studio on the prior separate-system-message request shape.
- **Observable failure symptoms:** LM Studio or compatible local servers may reject requests with provider-side 400s such as `No user query found in messages`, or users may report that configured LM Studio `base_url` values are not being used.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Scope materially carried forward: N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why (inspiration-only, no direct code/design carry-over): N/A
