### PR TITLE
docs(sandbox): correct Docker image name in sandboxing docs

### DIFF
--- a/docs/book/src/ops/troubleshooting.md
+++ b/docs/book/src/ops/troubleshooting.md
@@ -245,7 +245,7 @@ See [Security → Autonomy levels](../security/autonomy.md).
 
 ### Tool invocations fail inside Docker sandbox
 
-- Container image isn't pulled — `docker pull zeroclawlabs/tool-runner`
+- Container image isn't pulled — `docker pull ghcr.io/zeroclaw-labs/zeroclaw:latest`
 - Docker daemon not reachable from the ZeroClaw user — check `docker info`
 - Tool needs a device that's not passed through — extend `allow_devices`
 

--- a/docs/book/src/security/sandboxing.md
+++ b/docs/book/src/security/sandboxing.md
@@ -91,12 +91,12 @@ Firejail's default profile is fairly permissive; we apply a custom profile bundl
 
 ### Docker
 
-Works anywhere Docker does. Runs each tool invocation in an ephemeral container (the `zeroclawlabs/tool-runner` image).
+Works anywhere Docker does. Runs each tool invocation in an ephemeral container (the `ghcr.io/zeroclaw-labs/zeroclaw` image).
 
 ```toml
 [security.sandbox]
 backend = "docker"
-image = "zeroclawlabs/tool-runner:latest"
+image = "ghcr.io/zeroclaw-labs/zeroclaw:latest"
 ```
 
 Pros: strong isolation, works on any OS. Cons: per-invocation container startup cost (100–500 ms). Best for production deployments where the overhead is acceptable.


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - The sandboxing and troubleshooting docs still referenced the outdated `zeroclawlabs/tool-runner` image on Docker Hub.
  - ZeroClaw publishes container images to GitHub Container Registry (`ghcr.io/zeroclaw-labs/zeroclaw`).
  - Updated both `sandboxing.md` and `troubleshooting.md` to use the correct GHCR image name.
- **Scope boundary:** Docs-only change. No runtime or build logic is modified.
- **Blast radius:** Only affects developer-facing documentation for sandboxed tool execution.
- **Linked issue(s):** Fixes #6500
- **Labels:** `type: docs`, `risk: low`, `docs`

## Validation Evidence (required)

Docs-only change. Verified with markdown lint:

```bash
./scripts/ci/docs_quality_gate.sh
```

- **Commands run and tail output:** Docs quality gate passed with no new warnings.
- **Beyond CI — what did you manually verify?** Confirmed the updated image string matches the registry path listed in `docs/book/src/setup/container.md`.
- **If any command was intentionally skipped, why:** N/A

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (No)
- New external network calls? (No)
- Secrets / tokens / credentials handling changed? (No)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (No)

## Compatibility (required)

- Backward compatible? (Yes)
- Config / env / CLI surface changed? (No)

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PR: `git revert <sha>` is the plan.
