### PR TITLE
fix(tools): report DuckDuckGo search blocks

### DIFF
--- a/crates/zeroclaw-tools/src/web_search_tool.rs
+++ b/crates/zeroclaw-tools/src/web_search_tool.rs
@@ -132,8 +132,20 @@ impl WebSearchTool {
     }
 
     async fn search_duckduckgo(&self, query: &str) -> anyhow::Result<String> {
+        self.search_duckduckgo_at("https://html.duckduckgo.com/html/", query)
+            .await
+    }
+
+    /// Inner DuckDuckGo request implementation, parameterized on the endpoint URL
+    /// so request-flow tests can target a local mock server. Production calls
+    /// always go through [`Self::search_duckduckgo`].
+    async fn search_duckduckgo_at(
+        &self,
+        endpoint_url: &str,
+        query: &str,
+    ) -> anyhow::Result<String> {
         let encoded_query = urlencoding::encode(query);
-        let search_url = format!("https://html.duckduckgo.com/html/?q={}", encoded_query);
+        let search_url = format!("{}?q={}", endpoint_url, encoded_query);
 
         let builder = reqwest::Client::builder()
             .timeout(Duration::from_secs(self.timeout_secs))
@@ -143,15 +155,24 @@ impl WebSearchTool {
         let client = builder.build()?;
 
         let response = client.get(&search_url).send().await?;
+        let status = response.status();
+        let final_url_is_block =
+            contains_ascii_case_insensitive(response.url().as_str(), "/wr.do?");
 
-        if !response.status().is_success() {
-            anyhow::bail!(
-                "DuckDuckGo search failed with status: {}",
-                response.status()
-            );
+        if !status.is_success() {
+            if let Some(message) = duckduckgo_block_message(status, final_url_is_block, false) {
+                anyhow::bail!(message);
+            }
+            anyhow::bail!("DuckDuckGo search failed with status: {}", status);
         }
 
         let html = response.text().await?;
+        let html_contains_block = contains_ascii_case_insensitive(&html, "/wr.do?");
+        if let Some(message) =
+            duckduckgo_block_message(status, final_url_is_block, html_contains_block)
+        {
+            anyhow::bail!(message);
+        }
         self.parse_duckduckgo_results(&html, query)
     }
 
@@ -507,6 +528,27 @@ fn decode_ddg_redirect_url(raw_url: &str) -> String {
     raw_url.to_string()
 }
 
+const DUCKDUCKGO_BLOCK_MESSAGE: &str = "DuckDuckGo blocked the automated search request. Try configuring SearXNG, Brave, or Tavily as the web search provider.";
+
+fn duckduckgo_block_message(
+    status: reqwest::StatusCode,
+    final_url_is_block: bool,
+    html_contains_block: bool,
+) -> Option<&'static str> {
+    if status == reqwest::StatusCode::FORBIDDEN || final_url_is_block || html_contains_block {
+        Some(DUCKDUCKGO_BLOCK_MESSAGE)
+    } else {
+        None
+    }
+}
+
+fn contains_ascii_case_insensitive(haystack: &str, needle: &str) -> bool {
+    haystack
+        .as_bytes()
+        .windows(needle.len())
+        .any(|window| window.eq_ignore_ascii_case(needle.as_bytes()))
+}
+
 fn strip_tags(content: &str) -> String {
     let re = Regex::new(r"<[^>]+>").unwrap();
     re.replace_all(content, "").to_string()
@@ -632,6 +674,151 @@ mod tests {
         let result = tool.parse_duckduckgo_results(html, "test").unwrap();
         assert!(result.contains("https://example.com/path?a=1"));
         assert!(!result.contains("rut=test"));
+    }
+
+    #[test]
+    fn test_duckduckgo_block_detection_reports_forbidden_status() {
+        let message = duckduckgo_block_message(reqwest::StatusCode::FORBIDDEN, false, false)
+            .expect("403 responses should be classified as a DuckDuckGo block");
+
+        assert!(message.contains("DuckDuckGo blocked"));
+        assert!(message.contains("SearXNG"));
+    }
+
+    #[test]
+    fn test_duckduckgo_block_detection_reports_verification_redirect() {
+        let message = duckduckgo_block_message(reqwest::StatusCode::OK, true, false)
+            .expect("verification redirects should be classified as a DuckDuckGo block");
+
+        assert!(message.contains("DuckDuckGo blocked"));
+        assert!(message.contains("SearXNG"));
+    }
+
+    #[test]
+    fn test_duckduckgo_block_detection_reports_verification_form_in_html() {
+        let message = duckduckgo_block_message(reqwest::StatusCode::OK, false, true)
+            .expect("verification form HTML should be classified as a DuckDuckGo block");
+
+        assert!(message.contains("DuckDuckGo blocked"));
+        assert!(message.contains("SearXNG"));
+    }
+
+    #[test]
+    fn test_duckduckgo_block_detection_ignores_normal_empty_results() {
+        let message = duckduckgo_block_message(reqwest::StatusCode::OK, false, false);
+
+        assert!(message.is_none());
+    }
+
+    #[test]
+    fn test_duckduckgo_block_detection_is_case_insensitive_without_allocating_html() {
+        assert!(contains_ascii_case_insensitive(
+            r#"<form action="/WR.DO?u=https%3A%2F%2Fhtml.duckduckgo.com%2Fhtml%2F"></form>"#,
+            "/wr.do?"
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_duckduckgo_request_reports_forbidden_status() {
+        use wiremock::matchers::{method, path, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/html/"))
+            .and(query_param("q", "test"))
+            .respond_with(ResponseTemplate::new(403))
+            .mount(&server)
+            .await;
+
+        let tool = WebSearchTool::new("duckduckgo".to_string(), None, 5, 15);
+        let err = tool
+            .search_duckduckgo_at(&format!("{}/html/", server.uri()), "test")
+            .await
+            .expect_err("403 should be reported as a DuckDuckGo block");
+
+        assert!(err.to_string().contains("DuckDuckGo blocked"));
+        assert!(err.to_string().contains("SearXNG"));
+    }
+
+    #[tokio::test]
+    async fn test_duckduckgo_request_reports_verification_redirect_url() {
+        use wiremock::matchers::{method, path, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/html/"))
+            .and(query_param("q", "test"))
+            .respond_with(
+                ResponseTemplate::new(302)
+                    .insert_header("location", format!("{}/wr.do?u=blocked", server.uri())),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/wr.do"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("<html></html>"))
+            .mount(&server)
+            .await;
+
+        let tool = WebSearchTool::new("duckduckgo".to_string(), None, 5, 15);
+        let err = tool
+            .search_duckduckgo_at(&format!("{}/html/", server.uri()), "test")
+            .await
+            .expect_err("verification redirects should be reported as a DuckDuckGo block");
+
+        assert!(err.to_string().contains("DuckDuckGo blocked"));
+        assert!(err.to_string().contains("SearXNG"));
+    }
+
+    #[tokio::test]
+    async fn test_duckduckgo_request_reports_verification_form_html() {
+        use wiremock::matchers::{method, path, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/html/"))
+            .and(query_param("q", "test"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(
+                r#"<form action="/wr.do?u=https%3A%2F%2Fhtml.duckduckgo.com%2Fhtml%2F"></form>"#,
+            ))
+            .mount(&server)
+            .await;
+
+        let tool = WebSearchTool::new("duckduckgo".to_string(), None, 5, 15);
+        let err = tool
+            .search_duckduckgo_at(&format!("{}/html/", server.uri()), "test")
+            .await
+            .expect_err("verification HTML should be reported as a DuckDuckGo block");
+
+        assert!(err.to_string().contains("DuckDuckGo blocked"));
+        assert!(err.to_string().contains("SearXNG"));
+    }
+
+    #[tokio::test]
+    async fn test_duckduckgo_request_preserves_normal_empty_results() {
+        use wiremock::matchers::{method, path, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/html/"))
+            .and(query_param("q", "test"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_string("<html>No results here</html>"),
+            )
+            .mount(&server)
+            .await;
+
+        let tool = WebSearchTool::new("duckduckgo".to_string(), None, 5, 15);
+        let result = tool
+            .search_duckduckgo_at(&format!("{}/html/", server.uri()), "test")
+            .await
+            .expect("normal empty result HTML should still parse");
+
+        assert!(result.contains("No results found"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Detect DuckDuckGo HTTP 403 responses as automated-search blocks instead of returning a generic status failure.
  - Detect DuckDuckGo verification `/wr.do?` redirects and verification form HTML before result parsing.
  - Return actionable guidance to use another configured search provider when DuckDuckGo blocks the request.
  - Add request-path tests so the detection is covered where the HTTP response is handled, not only in the parser.
- **Scope boundary:** This PR only handles DuckDuckGo block/CAPTCHA detection. It does not add SearXNG auth, language, engine, safesearch, retry, or health-check options.
- **Blast radius:** Limited to the DuckDuckGo branch of `web_search_tool`; successful DuckDuckGo result parsing and normal empty-result parsing remain unchanged.
- **Linked issue(s):** Related #5316
- **Labels:** `risk: high`, `size: S`, `tool`, `tool:web`.

## Validation Evidence (required)

- **Commands run and results:**

```text
time cargo test -p zeroclaw-tools duckduckgo_block_detection --lib 2>&1 | tail -60
```

Failed as expected before implementation because the block-detection helper did not exist.

```text
time cargo test -p zeroclaw-tools duckduckgo_block_detection --lib 2>&1 | tail -60
```

Passed after the initial helper implementation. Four tests passed.

```text
time cargo fmt --all -- --check 2>&1 | tail -30
cargo fmt --all
time cargo fmt --all -- --check 2>&1 | tail -30
```

The first formatting check found mechanical formatting changes in the new tests. `cargo fmt --all` applied them, and the second formatting check passed.

```text
time cargo test -p zeroclaw-tools duckduckgo --lib 2>&1 | tail -80
```

Passed. Thirteen DuckDuckGo-related tests passed, including parser tests and wiremock request-path tests.

```text
time cargo clippy -p zeroclaw-tools --all-targets -- -D warnings 2>&1 | tail -80
```

Passed.

```text
git diff --check
```

Passed.

- **Beyond CI — what did you manually verify?** Reviewed the diff after Simplify feedback. Verified the new request seam is only used to point tests at a mock endpoint, while production still calls the DuckDuckGo HTML endpoint. Verified normal empty-result HTML still reaches the existing parser and returns “No results found.”
- **If any command was intentionally skipped, why:** Full workspace `cargo test` was not run because this is a narrow `zeroclaw-tools` web-search error handling change and the focused parser/request-path tests plus focused clippy cover the touched code.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: Not applicable.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No upgrade steps needed. Existing DuckDuckGo successful and empty-result behavior remains compatible; blocked responses now produce a clearer error.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** Revert this commit.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** DuckDuckGo web-search calls that previously returned generic HTTP errors or “No results found” for verification pages would return the new block guidance; if this is too broad, users would see unexpected “DuckDuckGo blocked” errors in `web_search_tool` output.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): Not applicable.
- Scope materially carried forward: Not applicable.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why (inspiration-only, no direct code/design carry-over): No superseded PR scope was incorporated.
