### PR TITLE
fix(providers): support `reasoning` field as fallback for OpenAI-compatible providers

### DIFF
--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -3026,6 +3026,7 @@ mod tests {
                 extra_content: None,
             }]),
             reasoning_content: None,
+            reasoning: None,
         };
 
         let parsed = provider.parse_native_response(message);
@@ -3053,6 +3054,7 @@ mod tests {
                 extra_content: None,
             }]),
             reasoning_content: None,
+            reasoning: None,
         };
 
         let parsed = provider.parse_native_response(message);
@@ -3080,6 +3082,7 @@ mod tests {
                 extra_content: None,
             }]),
             reasoning_content: None,
+            reasoning: None,
         };
 
         let parsed = provider.parse_native_response(message);
@@ -3121,6 +3124,7 @@ mod tests {
                 },
             ]),
             reasoning_content: None,
+            reasoning: None,
         };
 
         let parsed = provider.parse_native_response(message);
@@ -4132,6 +4136,7 @@ mod tests {
         let message = ResponseMessage {
             content: Some("answer".to_string()),
             reasoning_content: Some("thinking step".to_string()),
+            reasoning: None,
             tool_calls: Some(vec![ToolCall {
                 id: Some("call_1".to_string()),
                 kind: Some("function".to_string()),
@@ -4158,6 +4163,7 @@ mod tests {
         let message = ResponseMessage {
             content: Some("hello".to_string()),
             reasoning_content: None,
+            reasoning: None,
             tool_calls: None,
         };
 

--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -650,6 +650,10 @@ struct ResponseMessage {
     /// in `reasoning_content` instead of `content`. Used as automatic fallback.
     #[serde(default)]
     reasoning_content: Option<String>,
+    /// vLLM, OpenRouter, and others use `reasoning` instead of `reasoning_content`.
+    /// Used as fallback when `reasoning_content` is absent.
+    #[serde(default)]
+    reasoning: Option<String>,
     #[serde(default)]
     tool_calls: Option<Vec<ToolCall>>,
 }
@@ -660,6 +664,14 @@ impl ResponseMessage {
     /// often return their output solely in `reasoning_content`.
     /// Strips `<think>...</think>` blocks that some models (e.g. MiniMax) embed
     /// inline in `content` instead of using a separate field.
+    /// Returns reasoning content, preferring `reasoning_content` and falling back to `reasoning`.
+    fn reasoning(&self) -> Option<String> {
+        self.reasoning_content
+            .as_ref()
+            .or(self.reasoning.as_ref())
+            .cloned()
+    }
+
     fn effective_content(&self) -> String {
         if let Some(content) = self.content.as_ref().filter(|c| !c.is_empty()) {
             let stripped = strip_think_tags(content);
@@ -668,7 +680,7 @@ impl ResponseMessage {
             }
         }
 
-        self.reasoning_content
+        self.reasoning()
             .as_ref()
             .map(|c| strip_think_tags(c))
             .filter(|c| !c.is_empty())
@@ -683,7 +695,7 @@ impl ResponseMessage {
             }
         }
 
-        self.reasoning_content
+        self.reasoning()
             .as_ref()
             .map(|c| strip_think_tags(c))
             .filter(|c| !c.is_empty())
@@ -831,6 +843,9 @@ struct StreamDelta {
     /// Reasoning/thinking models may stream output via `reasoning_content`.
     #[serde(default)]
     reasoning_content: Option<String>,
+    /// vLLM, OpenRouter, and others use `reasoning` instead of `reasoning_content`.
+    #[serde(default)]
+    reasoning: Option<String>,
     /// Native tool-calling deltas in OpenAI chat-completions streaming format.
     #[serde(default)]
     tool_calls: Option<Vec<StreamToolCallDelta>>,
@@ -1011,6 +1026,7 @@ fn extract_sse_reasoning_delta(choice: &StreamChoice) -> Option<String> {
         .delta
         .reasoning_content
         .as_ref()
+        .or(choice.delta.reasoning.as_ref())
         .filter(|value| !value.is_empty())
         .cloned()
 }
@@ -1098,8 +1114,12 @@ fn parse_sse_line(line: &str) -> StreamResult<Option<StreamChunk>> {
         {
             return Ok(Some(StreamChunk::delta(content.clone())));
         }
-        if let Some(reasoning) = &choice.delta.reasoning_content
-            && !reasoning.is_empty()
+        if let Some(reasoning) = choice
+            .delta
+            .reasoning_content
+            .as_ref()
+            .or(choice.delta.reasoning.as_ref())
+            .filter(|r| !r.is_empty())
         {
             return Ok(Some(StreamChunk::reasoning(reasoning.clone())));
         }
@@ -1500,6 +1520,7 @@ impl OpenAiCompatibleProvider {
 
                     let reasoning_content = value
                         .get("reasoning_content")
+                        .or(value.get("reasoning"))
                         .and_then(serde_json::Value::as_str)
                         .map(ToString::to_string);
 
@@ -1675,7 +1696,7 @@ impl OpenAiCompatibleProvider {
 
     fn parse_native_response(&self, message: ResponseMessage) -> ProviderChatResponse {
         let text = message.effective_content_optional();
-        let reasoning_content = message.reasoning_content.clone();
+        let reasoning_content = message.reasoning();
         let mut used_tool_call_ids = std::collections::HashSet::new();
         let tool_calls = message
             .tool_calls
@@ -2020,7 +2041,7 @@ impl Provider for OpenAiCompatibleProvider {
             .ok_or_else(|| anyhow::anyhow!("No response from {}", self.name))?;
 
         let text = choice.message.effective_content_optional();
-        let reasoning_content = choice.message.reasoning_content;
+        let reasoning_content = choice.message.reasoning();
         let mut used_tool_call_ids = std::collections::HashSet::new();
         let tool_calls = choice
             .message
@@ -2978,6 +2999,7 @@ mod tests {
                 extra_content: None,
             }]),
             reasoning_content: None,
+            reasoning: None,
         };
 
         let parsed = provider.parse_native_response(message);


### PR DESCRIPTION
## Problem

OpenAI-compatible providers (vLLM, OpenRouter, and others) use the `reasoning` field in chat completion responses instead of `reasoning_content` for reasoning/thinking output. ZeroClaw only reads `reasoning_content`, causing reasoning content to be silently dropped for these providers.

Closes #6584

## Fix

- Added `reasoning: Option<String>` to `ResponseMessage` and `StreamDelta` structs (with `#[serde(default)]`)
- Added `ResponseMessage::reasoning()` helper that returns `reasoning_content` with fallback to `reasoning`
- Updated `extract_sse_reasoning_delta()` to check both fields
- Updated `parse_sse_line()` to check both fields
- Updated `convert_messages_for_native()` to extract reasoning from both fields in history replay
- Updated `parse_native_response()` and non-streaming `chat_with_tools()` to use the new helper

Priority: `reasoning_content` is checked first (backward compatible), `reasoning` used as fallback.

## Testing

- `cargo check -p zeroclaw-providers` passes
- Existing tests updated to include the new `reasoning: None` field

## Compatibility

- Fully backward compatible — providers using `reasoning_content` are unaffected
- No config changes required
- No new dependencies