### PR TITLE
feat(skills): background review fork (Hermes-style) + skill_manage tool

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -1869,23 +1869,44 @@ impl Default for SkillCreationConfig {
     }
 }
 
-/// Skill self-improvement configuration (`[skills.auto_improve]` section).
+/// Skill self-improvement configuration (`[skills.skill-improvement]` section).
+///
+/// Controls the post-turn background review fork that may patch, expand, or
+/// archive skills based on what the conversation revealed. The fork runs in a
+/// restricted toolset (only `skills_list`, `skill_view`, `skill_manage`, plus
+/// memory tools) and never touches the user-visible conversation.
 #[derive(Debug, Clone, Serialize, Deserialize, Configurable)]
 #[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
 #[prefix = "skills.skill-improvement"]
 pub struct SkillImprovementConfig {
-    /// Enable automatic skill improvement after successful skill usage.
-    /// Default: `true`.
+    /// Enable the background skill-review fork. Default: `true`.
     #[serde(default = "default_true")]
     pub enabled: bool,
-    /// Minimum interval (in seconds) between improvements for the same skill.
-    /// Default: `3600` (1 hour).
+    /// Minimum interval (in seconds) between reviews for the same skill.
+    /// Acts as a durable rate limit on patches to any one skill. Default: `3600`.
     #[serde(default = "default_skill_improvement_cooldown")]
     pub cooldown_secs: u64,
+    /// Spawn a review fork once at least this many tool-call iterations have
+    /// accumulated in the current run. `0` disables iteration-based triggering
+    /// (fork only fires on explicit nudge). Default: `10`.
+    #[serde(default = "default_nudge_interval_iterations")]
+    pub nudge_interval_iterations: u32,
+    /// Maximum tool-call iterations the review fork itself is allowed to make.
+    /// Caps the fork's LLM cost. Default: `8`.
+    #[serde(default = "default_max_review_iterations")]
+    pub max_review_iterations: u32,
 }
 
 fn default_skill_improvement_cooldown() -> u64 {
     3600
+}
+
+fn default_nudge_interval_iterations() -> u32 {
+    10
+}
+
+fn default_max_review_iterations() -> u32 {
+    8
 }
 
 impl Default for SkillImprovementConfig {
@@ -1893,6 +1914,8 @@ impl Default for SkillImprovementConfig {
         Self {
             enabled: true,
             cooldown_secs: 3600,
+            nudge_interval_iterations: 10,
+            max_review_iterations: 8,
         }
     }
 }

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -2760,6 +2760,37 @@ pub async fn run(
                 }
             }
         }
+
+        // Background skill review fork — spawned post-turn when configured.
+        // Runs a forked agent with restricted toolset (skills_list, skill_view,
+        // skill_manage, memory tools) over a snapshot of the conversation. The
+        // fork decides whether to patch, expand, or archive skills, or do nothing.
+        // See `crate::skills::review::maybe_run_skill_review`.
+        if config.skills.skill_improvement.enabled {
+            let workspace_dir = config.workspace_dir.clone();
+            let review_config = config.skills.skill_improvement.clone();
+            let history_snapshot = history.clone();
+            let failed_slugs: Vec<String> =
+                crate::skills::improver::extract_skill_executions_from_history(&history)
+                    .into_iter()
+                    .filter_map(|(slug, ok)| if ok { None } else { Some(slug) })
+                    .collect();
+            crate::skills::review::maybe_run_skill_review(
+                workspace_dir,
+                review_config,
+                history_snapshot,
+                failed_slugs,
+                provider.as_ref(),
+                &provider_name,
+                &model_name,
+                observer.as_ref(),
+                &config.multimodal,
+                &config.pacing,
+                config.agent.max_tool_result_chars,
+                config.agent.max_context_tokens,
+            )
+            .await;
+        }
         final_output = response.clone();
         println!("{response}");
         observer.record_event(&ObserverEvent::TurnComplete);

--- a/crates/zeroclaw-runtime/src/skills/improver.rs
+++ b/crates/zeroclaw-runtime/src/skills/improver.rs
@@ -1,13 +1,20 @@
-// Skill self-improvement: atomically updates existing skill documents
-// after the agent uses them successfully.
+// Skill self-improvement: atomic writer + history-scanning helpers for the
+// background review fork (see `agent::loop_` post-turn hook + `tools::skill_manage`).
 //
-// in `src/skills/mod.rs`.
+// This module owns:
+// - `SkillImprover` — atomic temp+validate+rename for SKILL.toml plus cooldown
+//   tracking (in-memory and durable on-disk via the `updated_at` field).
+// - `extract_skill_executions_from_history` / `looks_like_failure` — surface a
+//   list of failed skill slugs from history that the review prompt can pass
+//   along as a hint ("these skills failed this run"), without those failures
+//   *gating* whether the fork runs.
 
 use anyhow::{Context, Result, bail};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::Instant;
 use zeroclaw_config::schema::SkillImprovementConfig;
+use zeroclaw_providers::ChatMessage;
 
 /// Manages skill self-improvement with cooldown tracking.
 pub struct SkillImprover {
@@ -26,33 +33,65 @@ impl SkillImprover {
     }
 
     /// Check whether a skill is eligible for improvement (enabled + cooldown expired).
+    ///
+    /// Combines an in-memory cooldown (fast path, per-process) with a durable
+    /// on-disk cooldown (`updated_at` field in `SKILL.toml`) so cooldowns survive
+    /// process restarts.
     pub fn should_improve_skill(&self, slug: &str) -> bool {
         if !self.config.enabled {
             return false;
         }
         if let Some(last) = self.cooldowns.get(slug) {
             let elapsed = Instant::now().saturating_duration_since(*last);
-            elapsed.as_secs() >= self.config.cooldown_secs
-        } else {
-            true
+            if elapsed.as_secs() < self.config.cooldown_secs {
+                return false;
+            }
         }
+        if self.is_on_disk_cooldown(slug) {
+            return false;
+        }
+        true
+    }
+
+    // SKILL.toml `updated_at` is bumped on every successful improvement, so its
+    // age is a durable proxy for "improved recently."
+    fn is_on_disk_cooldown(&self, slug: &str) -> bool {
+        let toml_path = self.skills_dir().join(slug).join("SKILL.toml");
+        let Ok(content) = std::fs::read_to_string(&toml_path) else {
+            return false;
+        };
+        let Ok(parsed) = content.parse::<toml::Table>() else {
+            return false;
+        };
+        let Some(updated_at) = parsed
+            .get("skill")
+            .and_then(|v| v.as_table())
+            .and_then(|t| t.get("updated_at"))
+            .and_then(|v| v.as_str())
+        else {
+            return false;
+        };
+        let Ok(ts) = chrono::DateTime::parse_from_rfc3339(updated_at) else {
+            return false;
+        };
+        let elapsed = chrono::Utc::now().signed_duration_since(ts);
+        elapsed.num_seconds() < self.config.cooldown_secs as i64
     }
 
     /// Improve an existing skill file atomically.
     ///
     /// Writes to a temp file first, validates, then renames over the original.
-    /// Returns `Ok(Some(slug))` if the skill was improved, `Ok(None)` if skipped
-    /// (disabled, cooldown active, or validation failed).
+    /// Returns `Ok(Some(slug))` if the skill was improved.
+    ///
+    /// **Caller-gated:** this does NOT check `should_improve_skill` — callers
+    /// must check that themselves before invoking, so they can also skip the
+    /// (expensive) LLM call that produces `improved_content`.
     pub async fn improve_skill(
         &mut self,
         slug: &str,
         improved_content: &str,
         improvement_reason: &str,
     ) -> Result<Option<String>> {
-        if !self.should_improve_skill(slug) {
-            return Ok(None);
-        }
-
         // Validate the improved content before writing.
         validate_skill_content(improved_content)?;
 
@@ -121,6 +160,130 @@ impl SkillImprover {
     }
 }
 
+/// Heuristic: does tool-result content look like a failure?
+///
+/// Catches the common shapes — explicit error/failure strings, panics,
+/// exceptions, "not found", and shell exit-code lines.
+fn looks_like_failure(content: &str) -> bool {
+    let lower = content.to_lowercase();
+    lower.contains("error")
+        || lower.contains("failed")
+        || lower.contains("panic")
+        || lower.contains("exception")
+        || lower.contains("not found")
+        || lower.starts_with("exit code")
+}
+
+/// Extract skill tool executions from conversation history.
+///
+/// Returns `(skill_slug, succeeded)` pairs, one per dotted tool-result found.
+/// Handles two emission formats:
+/// - XML: `<tool_result name="slug.tool">…content…</tool_result>` (prompt-guided
+///   tool-calling)
+/// - Native: a `tool`-role message preceded by an `assistant` message whose
+///   content embeds a JSON tool-call with a dotted `"name": "slug.tool"`
+///
+/// Deduplicates on `(slug, succeeded)` so the same skill can appear twice if
+/// it both succeeded and failed within the same window.
+pub fn extract_skill_executions_from_history(history: &[ChatMessage]) -> Vec<(String, bool)> {
+    let mut results: Vec<(String, bool)> = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+
+    for (i, msg) in history.iter().enumerate() {
+        let content = &msg.content;
+
+        // Format 1: XML <tool_result name="slug.tool">…</tool_result>.
+        let open_marker = "<tool_result name=\"";
+        let close_marker = "</tool_result>";
+        let mut pos = 0;
+        while pos < content.len() {
+            let Some(start) = content[pos..].find(open_marker) else {
+                break;
+            };
+            let abs = pos + start + open_marker.len();
+            let Some(end) = content[abs..].find('"') else {
+                break;
+            };
+            let name = &content[abs..abs + end];
+            if let Some(dot_pos) = name.find('.') {
+                let slug = name[..dot_pos].to_string();
+                let after_tag = abs + end + 1;
+                let body_start = content[after_tag..].find('>').map(|p| after_tag + p + 1);
+                let body_end = content[after_tag..].find(close_marker);
+                let body = match (body_start, body_end) {
+                    (Some(s), Some(e)) if s <= after_tag + e => &content[s..after_tag + e],
+                    _ => "",
+                };
+                let succeeded = !looks_like_failure(body);
+                let key = (slug.clone(), succeeded);
+                if seen.insert(key) {
+                    results.push((slug, succeeded));
+                }
+            }
+            pos = abs + end + 1;
+        }
+
+        // Format 2: native tool-role message preceded by an assistant message
+        // whose JSON tool-call carries a dotted `"name": "slug.tool"`.
+        if msg.role == "tool" && i > 0 {
+            let prev = &history[i - 1];
+            if prev.role == "assistant" {
+                let prev_content = &prev.content;
+                let name_marker = "\"name\"";
+                let mut pos = 0;
+                while pos < prev_content.len() {
+                    let Some(start) = prev_content[pos..].find(name_marker) else {
+                        break;
+                    };
+                    let after = pos + start + name_marker.len();
+                    let rest = prev_content[after..].trim_start();
+                    let Some(rest) = rest.strip_prefix(':') else {
+                        pos = after + 1;
+                        continue;
+                    };
+                    let rest = rest.trim_start();
+                    let Some(rest) = rest.strip_prefix('"') else {
+                        pos = after + 1;
+                        continue;
+                    };
+                    let Some(end) = rest.find('"') else {
+                        break;
+                    };
+                    let name = &rest[..end];
+                    if let Some(dot_pos) = name.find('.') {
+                        let slug = name[..dot_pos].to_string();
+                        let succeeded = !looks_like_failure(content);
+                        let key = (slug.clone(), succeeded);
+                        if seen.insert(key) {
+                            results.push((slug, succeeded));
+                        }
+                    }
+                    // Advance past this name occurrence.
+                    let consumed = prev_content.len() - rest.len() + end + 1;
+                    pos = consumed;
+                }
+            }
+        }
+    }
+
+    results
+}
+
+/// Unique skill slugs seen in `history`, regardless of success/failure.
+pub fn extract_skill_slugs_from_history(history: &[ChatMessage]) -> Vec<String> {
+    let mut seen = std::collections::HashSet::new();
+    extract_skill_executions_from_history(history)
+        .into_iter()
+        .filter_map(|(slug, _)| {
+            if seen.insert(slug.clone()) {
+                Some(slug)
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
 /// Validate skill content: must be non-empty, valid UTF-8 (already a &str),
 /// and contain parseable TOML front-matter with a `[skill]` section.
 pub fn validate_skill_content(content: &str) -> Result<()> {
@@ -159,13 +322,16 @@ fn append_improvement_metadata(content: &str, timestamp: &str, reason: &str) -> 
         None => (content, ""),
     };
 
-    // Check if updated_at already exists; if so, replace it.
-    let skill_section = if skill_section.contains("updated_at") {
+    // Strip any existing `updated_at` / `improvement_reason` keys to avoid
+    // emitting them twice (TOML rejects duplicate keys, so leaving the old
+    // lines in place would break parsing on the next read).
+    let skill_section = {
         let mut lines: Vec<&str> = skill_section.lines().collect();
-        lines.retain(|line| !line.trim_start().starts_with("updated_at"));
+        lines.retain(|line| {
+            let trimmed = line.trim_start();
+            !trimmed.starts_with("updated_at") && !trimmed.starts_with("improvement_reason")
+        });
         lines.join("\n") + "\n"
-    } else {
-        skill_section.to_string()
     };
 
     let escaped_reason = reason.replace('"', "\\\"").replace('\n', " ");
@@ -370,7 +536,11 @@ version = "0.1.0"
     }
 
     #[tokio::test]
-    async fn improve_skill_cooldown_returns_none() {
+    async fn improve_skill_writes_when_cooldown_not_checked_by_caller() {
+        // `improve_skill` is caller-gated: it writes whenever given valid
+        // content, even if `should_improve_skill` would return false. This
+        // mirrors how the agent loop must check cooldown itself before
+        // paying for the LLM call.
         let dir = tempfile::tempdir().unwrap();
         let skill_dir = dir.path().join("skills").join("test-skill");
         tokio::fs::create_dir_all(&skill_dir).await.unwrap();
@@ -388,7 +558,6 @@ version = "0.1.0"
                 cooldown_secs: 9999,
             },
         );
-        // Record a recent cooldown.
         improver
             .cooldowns
             .insert("test-skill".to_string(), Instant::now());
@@ -401,7 +570,7 @@ version = "0.1.0"
             )
             .await
             .unwrap();
-        assert!(result.is_none());
+        assert_eq!(result, Some("test-skill".to_string()));
     }
 
     // ── Metadata appending ──────────────────────────────────
@@ -457,5 +626,157 @@ name = "test"
         let content = "[skill]\nname = \"test\"\n";
         let trail = extract_audit_trail(content);
         assert!(trail.is_empty());
+    }
+
+    // ── Duplicate-key handling on repeat improvements ───────
+
+    #[test]
+    fn append_metadata_replaces_existing_improvement_reason() {
+        // A previously-improved skill carries both `updated_at` and
+        // `improvement_reason`. Appending again must strip both before
+        // emitting new values so the resulting TOML stays valid.
+        let already_improved = r#"[skill]
+name = "test"
+description = "A skill"
+version = "0.1.0"
+updated_at = "2025-12-01T00:00:00Z"
+improvement_reason = "first pass"
+"#;
+        let result = append_improvement_metadata(
+            already_improved,
+            "2026-01-01T00:00:00Z",
+            "second pass",
+        );
+        let new_section = result.split("[[tools]]").next().unwrap_or(&result);
+        assert_eq!(new_section.matches("updated_at").count(), 1);
+        assert_eq!(new_section.matches("improvement_reason").count(), 1);
+        assert!(new_section.contains("2026-01-01T00:00:00Z"));
+        assert!(new_section.contains("second pass"));
+        assert!(!new_section.contains("first pass"));
+        // The rewritten section must still parse as TOML.
+        let parsed: Result<toml::Table, _> = new_section.parse();
+        assert!(parsed.is_ok(), "rewritten section should be valid TOML");
+    }
+
+    // ── Failure heuristic ───────────────────────────────────
+
+    #[test]
+    fn looks_like_failure_detects_common_shapes() {
+        assert!(looks_like_failure("Error: file not found"));
+        assert!(looks_like_failure("Command failed with status 1"));
+        assert!(looks_like_failure("thread 'main' panicked at ..."));
+        assert!(looks_like_failure("Exception in user code"));
+        assert!(looks_like_failure("not found"));
+        assert!(looks_like_failure("exit code 137"));
+    }
+
+    #[test]
+    fn looks_like_failure_passes_clean_output() {
+        assert!(!looks_like_failure("Done. Wrote 12 lines."));
+        assert!(!looks_like_failure("ok"));
+        assert!(!looks_like_failure(""));
+    }
+
+    // ── History extraction ──────────────────────────────────
+
+    #[test]
+    fn extract_executions_xml_marks_failure() {
+        let history = vec![
+            ChatMessage::user("run my-skill"),
+            ChatMessage::assistant(
+                "<tool_result name=\"my-skill.run\">Error: command not found</tool_result>",
+            ),
+        ];
+        let executions = extract_skill_executions_from_history(&history);
+        assert_eq!(executions, vec![("my-skill".to_string(), false)]);
+    }
+
+    #[test]
+    fn extract_executions_xml_marks_success() {
+        let history = vec![
+            ChatMessage::user("run my-skill"),
+            ChatMessage::assistant(
+                "<tool_result name=\"my-skill.run\">Done. Wrote 3 files.</tool_result>",
+            ),
+        ];
+        let executions = extract_skill_executions_from_history(&history);
+        assert_eq!(executions, vec![("my-skill".to_string(), true)]);
+    }
+
+    #[test]
+    fn extract_executions_native_format() {
+        let history = vec![
+            ChatMessage::user("run it"),
+            ChatMessage::assistant(
+                "{\"tool_calls\": [{\"name\": \"deploy.run\", \"args\": {}}]}",
+            ),
+            ChatMessage {
+                role: "tool".into(),
+                content: "Error: connection refused".into(),
+            },
+        ];
+        let executions = extract_skill_executions_from_history(&history);
+        assert_eq!(executions, vec![("deploy".to_string(), false)]);
+    }
+
+    #[test]
+    fn extract_slugs_dedupes() {
+        let history = vec![
+            ChatMessage::user("run my-skill"),
+            ChatMessage::assistant(
+                "<tool_result name=\"my-skill.run\">ok</tool_result>\
+                 <tool_result name=\"my-skill.run\">Error</tool_result>",
+            ),
+        ];
+        let slugs = extract_skill_slugs_from_history(&history);
+        assert_eq!(slugs, vec!["my-skill".to_string()]);
+    }
+
+    // ── On-disk cooldown ────────────────────────────────────
+
+    #[tokio::test]
+    async fn should_improve_blocks_when_updated_at_recent() {
+        let dir = tempfile::tempdir().unwrap();
+        let skill_dir = dir.path().join("skills").join("test-skill");
+        tokio::fs::create_dir_all(&skill_dir).await.unwrap();
+        let recent = chrono::Utc::now().to_rfc3339();
+        tokio::fs::write(
+            skill_dir.join("SKILL.toml"),
+            format!("[skill]\nname = \"test-skill\"\nupdated_at = \"{recent}\"\n"),
+        )
+        .await
+        .unwrap();
+
+        let improver = SkillImprover::new(
+            dir.path().to_path_buf(),
+            SkillImprovementConfig {
+                enabled: true,
+                cooldown_secs: 9999,
+            },
+        );
+        assert!(!improver.should_improve_skill("test-skill"));
+    }
+
+    #[tokio::test]
+    async fn should_improve_allows_when_updated_at_stale() {
+        let dir = tempfile::tempdir().unwrap();
+        let skill_dir = dir.path().join("skills").join("test-skill");
+        tokio::fs::create_dir_all(&skill_dir).await.unwrap();
+        let stale = (chrono::Utc::now() - chrono::Duration::seconds(10_000)).to_rfc3339();
+        tokio::fs::write(
+            skill_dir.join("SKILL.toml"),
+            format!("[skill]\nname = \"test-skill\"\nupdated_at = \"{stale}\"\n"),
+        )
+        .await
+        .unwrap();
+
+        let improver = SkillImprover::new(
+            dir.path().to_path_buf(),
+            SkillImprovementConfig {
+                enabled: true,
+                cooldown_secs: 3600,
+            },
+        );
+        assert!(improver.should_improve_skill("test-skill"));
     }
 }

--- a/crates/zeroclaw-runtime/src/skills/improver.rs
+++ b/crates/zeroclaw-runtime/src/skills/improver.rs
@@ -414,6 +414,7 @@ version = "0.1.0"
             SkillImprovementConfig {
                 enabled: true,
                 cooldown_secs: 3600,
+                ..Default::default()
             },
         );
         assert!(improver.should_improve_skill("test-skill"));
@@ -426,6 +427,7 @@ version = "0.1.0"
             SkillImprovementConfig {
                 enabled: true,
                 cooldown_secs: 3600,
+                ..Default::default()
             },
         );
         improver
@@ -441,6 +443,7 @@ version = "0.1.0"
             SkillImprovementConfig {
                 enabled: false,
                 cooldown_secs: 0,
+                ..Default::default()
             },
         );
         assert!(!improver.should_improve_skill("test-skill"));
@@ -470,6 +473,7 @@ tags = ["auto-generated"]
             SkillImprovementConfig {
                 enabled: true,
                 cooldown_secs: 0,
+                ..Default::default()
             },
         );
 
@@ -519,6 +523,7 @@ version = "0.1.0"
             SkillImprovementConfig {
                 enabled: true,
                 cooldown_secs: 0,
+                ..Default::default()
             },
         );
 
@@ -556,6 +561,7 @@ version = "0.1.0"
             SkillImprovementConfig {
                 enabled: true,
                 cooldown_secs: 9999,
+                ..Default::default()
             },
         );
         improver
@@ -752,6 +758,7 @@ improvement_reason = "first pass"
             SkillImprovementConfig {
                 enabled: true,
                 cooldown_secs: 9999,
+                ..Default::default()
             },
         );
         assert!(!improver.should_improve_skill("test-skill"));
@@ -775,6 +782,7 @@ improvement_reason = "first pass"
             SkillImprovementConfig {
                 enabled: true,
                 cooldown_secs: 3600,
+                ..Default::default()
             },
         );
         assert!(improver.should_improve_skill("test-skill"));

--- a/crates/zeroclaw-runtime/src/skills/mod.rs
+++ b/crates/zeroclaw-runtime/src/skills/mod.rs
@@ -15,6 +15,7 @@ use zip::ZipArchive;
 pub mod audit;
 pub mod creator;
 pub mod improver;
+pub mod review;
 pub mod testing;
 
 const OPEN_SKILLS_REPO_URL: &str = "https://github.com/besoeasy/open-skills";

--- a/crates/zeroclaw-runtime/src/skills/review.rs
+++ b/crates/zeroclaw-runtime/src/skills/review.rs
@@ -1,0 +1,320 @@
+// Background skill review fork — post-turn hook that wakes a forked agent
+// loop in a restricted toolset to decide whether the just-finished
+// conversation should change the installed skill library.
+//
+// Inspired by hermes-agent's `_spawn_background_review` pattern (see
+// nousresearch/hermes-agent at run_agent.py). ZeroClaw differs in that the
+// fork runs inline (no background thread — Rust async lets us await it on
+// the same task) and writes through dedicated `skill_manage`/`skill_view`
+// tools we own rather than a generic shell tool.
+
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use tokio::task_local;
+use zeroclaw_api::tool::Tool;
+use zeroclaw_config::schema::{MultimodalConfig, PacingConfig, SkillImprovementConfig};
+use zeroclaw_providers::{ChatMessage, Provider};
+
+use crate::observability::Observer;
+use crate::tools::skill_manage::{SkillManageTool, SkillViewTool, SkillsListTool};
+
+const REVIEW_PROMPT: &str = include_str!("review_prompt.md");
+
+task_local! {
+    /// Set inside the review fork so a *nested* `maybe_run_skill_review` call
+    /// returns immediately. Without this, a review fork that itself triggers
+    /// the post-turn hook would recurse and burn LLM tokens until it timed out.
+    static SKILL_REVIEW_ACTIVE: ();
+}
+
+/// Decide whether to fire the review fork, and run it if so.
+///
+/// Gating (in this order):
+/// 1. `config.enabled == true`
+/// 2. Not already inside a review (recursion guard)
+/// 3. History accumulated at least `nudge_interval_iterations` tool-result messages
+///
+/// The "failed_slugs" list is passed as a *hint* in the review prompt so the
+/// fork can spend its budget where the user just got hurt — but failure is NOT
+/// the trigger condition. Routine improvements (user corrections, novel
+/// techniques) happen on successful sessions too.
+#[allow(clippy::too_many_arguments)]
+pub async fn maybe_run_skill_review(
+    workspace_dir: PathBuf,
+    config: SkillImprovementConfig,
+    history: Vec<ChatMessage>,
+    failed_slugs: Vec<String>,
+    provider: &dyn Provider,
+    provider_name: &str,
+    model_name: &str,
+    observer: &dyn Observer,
+    multimodal: &MultimodalConfig,
+    pacing: &PacingConfig,
+    max_tool_result_chars: usize,
+    max_context_tokens: usize,
+) {
+    if !config.enabled {
+        return;
+    }
+    if SKILL_REVIEW_ACTIVE.try_with(|()| ()).is_ok() {
+        tracing::debug!("Skill review: recursion guard tripped, skipping nested review");
+        return;
+    }
+    if !should_trigger(&history, config.nudge_interval_iterations) {
+        tracing::debug!(
+            iters = count_tool_iterations(&history),
+            threshold = config.nudge_interval_iterations,
+            "Skill review: iteration budget not reached, skipping"
+        );
+        return;
+    }
+
+    let tools: Vec<Box<dyn Tool>> = build_review_tools(workspace_dir.clone());
+    let review_input = build_review_input(&failed_slugs);
+
+    let mut review_history = history;
+    review_history.push(ChatMessage::user(&review_input));
+
+    let receipts: Mutex<Vec<String>> = Mutex::new(Vec::new());
+
+    let result = SKILL_REVIEW_ACTIVE
+        .scope((), async {
+            crate::agent::loop_::run_tool_call_loop(
+                provider,
+                &mut review_history,
+                &tools,
+                observer,
+                provider_name,
+                model_name,
+                0.3, // temperature — low so the fork doesn't ramble
+                true, // silent
+                None, // approval: no human in the loop here
+                "skill_review", // channel_name
+                None, // channel_reply_target
+                multimodal,
+                config.max_review_iterations as usize,
+                None, // cancellation_token
+                None, // on_delta
+                None, // hooks
+                &[],  // excluded_tools
+                &[],  // dedup_exempt_tools
+                None, // activated_tools
+                None, // model_switch_callback
+                pacing,
+                max_tool_result_chars,
+                max_context_tokens,
+                None, // shared_budget
+                None, // channel
+                None, // receipt_generator
+                Some(&receipts),
+            )
+            .await
+        })
+        .await;
+
+    match result {
+        Ok(final_text) => {
+            let summary = summarize_actions(&receipts, &final_text);
+            if !summary.is_empty() {
+                // User-visible: one-line surface for the fork's actions.
+                println!("  💾 Skill review: {summary}");
+            }
+        }
+        Err(e) => {
+            tracing::warn!("Skill review fork failed: {e}");
+        }
+    }
+}
+
+fn build_review_tools(workspace_dir: PathBuf) -> Vec<Box<dyn Tool>> {
+    let wd = Arc::new(workspace_dir);
+    vec![
+        Box::new(SkillsListTool::new((*wd).clone())),
+        Box::new(SkillViewTool::new((*wd).clone())),
+        Box::new(SkillManageTool::new((*wd).clone())),
+    ]
+}
+
+fn build_review_input(failed_slugs: &[String]) -> String {
+    let hint = if failed_slugs.is_empty() {
+        "Hint: no skill executions failed this session.".to_string()
+    } else {
+        format!(
+            "Hint: these skills FAILED this session — investigate before patching: {}",
+            failed_slugs.join(", ")
+        )
+    };
+    format!("{REVIEW_PROMPT}\n\n---\n\n{hint}\n")
+}
+
+/// `nudge_interval_iterations == 0` disables iteration-based triggering.
+/// Otherwise, count `role == "tool"` messages in history — each represents a
+/// completed tool call. Fire if we've crossed the threshold.
+fn should_trigger(history: &[ChatMessage], threshold: u32) -> bool {
+    if threshold == 0 {
+        return false;
+    }
+    count_tool_iterations(history) >= threshold as usize
+}
+
+fn count_tool_iterations(history: &[ChatMessage]) -> usize {
+    history.iter().filter(|m| m.role == "tool").count()
+}
+
+/// Convert the review's tool receipts + final text into a one-line summary
+/// for the user. Returns "" if the fork did nothing notable.
+fn summarize_actions(receipts: &Mutex<Vec<String>>, final_text: &str) -> String {
+    let receipts = receipts.lock().ok();
+    let actions: Vec<String> = receipts
+        .as_ref()
+        .map(|v| {
+            v.iter()
+                .filter_map(|r| extract_action_summary(r))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    if !actions.is_empty() {
+        return actions.join(" · ");
+    }
+
+    // If no structured receipts, fall back to scanning the final text.
+    let trimmed = final_text.trim();
+    if trimmed.eq_ignore_ascii_case("nothing to save.") || trimmed.is_empty() {
+        return String::new();
+    }
+    // Anything else: surface a compact prefix so the user knows the fork
+    // emitted *something* even if we can't parse it.
+    let first_line = trimmed.lines().next().unwrap_or("").trim();
+    if first_line.is_empty() {
+        String::new()
+    } else {
+        let max = first_line.len().min(80);
+        first_line[..max].to_string()
+    }
+}
+
+/// Pull a "Verb slug" summary out of a tool receipt, e.g.
+/// "Patched skill 'deploy'." → "patched deploy".
+fn extract_action_summary(receipt: &str) -> Option<String> {
+    // Receipts follow the shape "Verb skill 'slug'..." emitted by
+    // SkillManageTool. Be lenient with case + punctuation.
+    let lower = receipt.to_lowercase();
+    let verb = if lower.contains("patched skill") {
+        "patched"
+    } else if lower.contains("wrote") && lower.contains("for skill") {
+        "wrote file for"
+    } else if lower.contains("archived skill") {
+        "archived"
+    } else {
+        return None;
+    };
+    let slug = extract_quoted_slug(receipt)?;
+    Some(format!("{verb} {slug}"))
+}
+
+fn extract_quoted_slug(s: &str) -> Option<String> {
+    let start = s.find('\'')?;
+    let rest = &s[start + 1..];
+    let end = rest.find('\'')?;
+    Some(rest[..end].to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn msg(role: &str, content: &str) -> ChatMessage {
+        ChatMessage {
+            role: role.into(),
+            content: content.into(),
+        }
+    }
+
+    #[test]
+    fn count_tool_iterations_counts_only_tool_role() {
+        let history = vec![
+            msg("system", "..."),
+            msg("user", "go"),
+            msg("assistant", "..."),
+            msg("tool", "ok"),
+            msg("assistant", "..."),
+            msg("tool", "ok"),
+        ];
+        assert_eq!(count_tool_iterations(&history), 2);
+    }
+
+    #[test]
+    fn should_trigger_zero_threshold_disables() {
+        let history = vec![msg("tool", "ok"); 10];
+        assert!(!should_trigger(&history, 0));
+    }
+
+    #[test]
+    fn should_trigger_fires_at_threshold() {
+        let history = vec![msg("tool", "ok"); 10];
+        assert!(should_trigger(&history, 10));
+    }
+
+    #[test]
+    fn should_trigger_holds_below_threshold() {
+        let history = vec![msg("tool", "ok"); 9];
+        assert!(!should_trigger(&history, 10));
+    }
+
+    #[test]
+    fn build_review_input_includes_failure_hint_when_present() {
+        let input = build_review_input(&["deploy".to_string(), "test-runner".to_string()]);
+        assert!(input.contains("FAILED"));
+        assert!(input.contains("deploy"));
+        assert!(input.contains("test-runner"));
+    }
+
+    #[test]
+    fn build_review_input_says_no_failures_when_empty() {
+        let input = build_review_input(&[]);
+        assert!(input.to_lowercase().contains("no skill executions failed"));
+    }
+
+    #[test]
+    fn summarize_actions_picks_up_patch_receipts() {
+        let receipts = Mutex::new(vec![
+            "Patched skill 'deploy'.".to_string(),
+            "Wrote references/staging.md for skill 'deploy'.".to_string(),
+        ]);
+        let summary = summarize_actions(&receipts, "");
+        assert!(summary.contains("patched deploy"));
+        assert!(summary.contains("wrote file for deploy"));
+    }
+
+    #[test]
+    fn summarize_actions_empty_for_nothing_to_save() {
+        let receipts = Mutex::new(Vec::new());
+        let summary = summarize_actions(&receipts, "Nothing to save.");
+        assert_eq!(summary, "");
+    }
+
+    #[test]
+    fn summarize_actions_empty_when_no_receipts_and_no_text() {
+        let receipts = Mutex::new(Vec::new());
+        let summary = summarize_actions(&receipts, "");
+        assert_eq!(summary, "");
+    }
+
+    #[test]
+    fn summarize_actions_falls_back_to_first_line() {
+        let receipts = Mutex::new(Vec::new());
+        let summary = summarize_actions(&receipts, "Noted that deploy needs DEPLOY_TOKEN.\nMore details below.");
+        assert!(summary.starts_with("Noted that deploy"));
+    }
+
+    #[test]
+    fn extract_action_summary_handles_archive() {
+        let receipt = "Archived skill 'old-thing' to /tmp/...";
+        assert_eq!(
+            extract_action_summary(receipt),
+            Some("archived old-thing".to_string())
+        );
+    }
+}

--- a/crates/zeroclaw-runtime/src/skills/review_prompt.md
+++ b/crates/zeroclaw-runtime/src/skills/review_prompt.md
@@ -1,0 +1,58 @@
+You are running as ZeroClaw's background SKILL REVIEW agent. Your job is to look at the conversation that just finished and decide whether anything that happened should change the installed skill library.
+
+You are NOT continuing the user-visible conversation. The user does not see your output directly — only a one-line summary of which actions you took. Use that budget wisely: make the changes worth surfacing, or do nothing.
+
+# Target shape of the library
+
+ZeroClaw skills live under `~/.zeroclaw/workspace/skills/<slug>/` with a `SKILL.toml` and optional `references/`, `templates/`, and `scripts/` directories. The goal is a small set of CLASS-LEVEL skills, each rich and well-documented, NOT a sprawling list of single-session entries. A skill named `fix-bug-with-foo-on-tuesday` is wrong; a skill named `debugging` with a `references/foo-quirks.md` is right.
+
+This shapes HOW you update, not WHETHER you update.
+
+# Signals to act on
+
+Any one of these is enough to warrant an action:
+
+- **User corrected your style, tone, format, or verbosity.** Phrases like "stop doing X", "this is too verbose", "don't format like this", "just give me the answer", "you always do Y and I hate it", or an explicit "remember this" are first-class skill signals. The skill that governs that class of task needs to carry the lesson so the next session starts already knowing.
+- **User corrected your workflow or sequence of steps.** Encode the correction as a pitfall or an explicit step in the relevant skill.
+- **A non-trivial technique, fix, workaround, debugging path, or tool-usage pattern emerged.** Capture it where a future session would look for it.
+- **A skill that got consulted this session turned out to be wrong, missing a step, or outdated.** Patch it now.
+
+If a skill FAILED during this session (the hint below will tell you which), that's a strong but not sole signal. Look at *why* it failed before deciding: was the skill wrong, or was the environment wrong? Only the former is a skill problem.
+
+# Preference order
+
+Pick the earliest action that fits the signal:
+
+1. **PATCH a currently-loaded or recently-consulted skill.** Look back through the conversation for skills the agent invoked. If any covers the territory of the new learning, patch THAT one first — it was the skill in play.
+2. **PATCH an existing umbrella.** Use `skills_list` and `skill_view` to find a class-level skill that covers the territory. Add a subsection, a pitfall, or broaden a trigger.
+3. **ADD A SUPPORT FILE under an existing umbrella** via `skill_manage` `action=write_file` with a path under `references/`, `templates/`, or `scripts/`. The umbrella's SKILL.toml should also gain a one-line pointer to the new file so future agents know it exists. Three valid kinds:
+   - `references/<topic>.md` — session-specific detail (error transcripts, reproduction recipes, provider quirks) OR condensed knowledge banks (quoted research, API docs, domain notes). Concise and task-shaped, not a full mirror of upstream docs.
+   - `templates/<name>.<ext>` — starter files meant to be copied and modified (boilerplate configs, scaffolding, known-good examples).
+   - `scripts/<name>.<ext>` — re-runnable actions the skill can invoke directly (verification scripts, fixture generators, deterministic probes).
+4. **CREATE A NEW CLASS-LEVEL UMBRELLA SKILL.** Only when no existing skill covers the class. The name MUST be at the class level. It MUST NOT be a specific PR number, error string, feature codename, library-alone name, or `fix-X / debug-Y / audit-Z-today` session artifact. If the proposed name only makes sense for today's task, it's wrong — fall back to (1), (2), or (3).
+
+# Do NOT capture these
+
+These become persistent self-imposed constraints that bite later when the environment changes:
+
+- **Environment-dependent failures:** missing binaries, fresh-install errors, post-migration path mismatches, "command not found", unconfigured credentials, uninstalled packages. The user can fix these — they are not durable rules.
+- **Negative claims about tools or features:** "browser tools do not work", "X is broken", "cannot use Y from execute_code". These harden into refusals the agent cites against itself for months after the original problem was fixed.
+- **Session-specific transient errors that resolved before the conversation ended.** If retrying worked, the lesson is the retry pattern, not the original failure.
+- **One-off task narratives.** A user asking "summarize today's market" or "analyze this PR" is not a class of work that warrants a skill.
+
+If a tool failed because of setup state, capture the FIX (install command, config step, env var to set) under an existing setup or troubleshooting skill — never "this tool does not work" as a standalone constraint.
+
+# "Nothing to save."
+
+This is a real option, but it should NOT be the default. If the session ran smoothly with no corrections and produced no new technique, just reply with `Nothing to save.` and stop. Otherwise, act.
+
+# How to act
+
+Available tools:
+- `skills_list` — see what's installed.
+- `skill_view` (slug) — read SKILL.toml + list support files.
+- `skill_manage` (action, slug, ...) — `patch` (rewrite SKILL.toml), `write_file` (add `references/`, `templates/`, or `scripts/` file), `archive` (move to `.archive/`).
+
+Be specific in your `reason` field on `patch` — it becomes part of the skill's audit trail.
+
+If you notice two existing skills that obviously overlap, mention it in your final reply — a separate maintenance pass handles consolidation at scale, you do not need to do it yourself.

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -29,6 +29,7 @@ pub mod schedule;
 pub mod security_ops;
 pub mod shell;
 pub mod skill_http;
+pub mod skill_manage;
 pub mod skill_tool;
 pub mod sop_advance;
 pub mod sop_approve;

--- a/crates/zeroclaw-runtime/src/tools/skill_manage.rs
+++ b/crates/zeroclaw-runtime/src/tools/skill_manage.rs
@@ -1,0 +1,905 @@
+//! Skill management tools for the background review fork.
+//!
+//! Three Tool impls exposed to the forked review agent:
+//! - `skills_list`: enumerate installed skills (name, description, version).
+//! - `skill_view`: read a single skill's SKILL.toml + directory layout.
+//! - `skill_manage`: mutating actions — patch SKILL.toml, write a support file
+//!   under `references/|templates/|scripts/`, or archive a skill.
+//!
+//! These tools are NOT registered in the default tool registry. They're built
+//! on-demand for the review fork (see `agent::loop_` post-turn hook) so the
+//! main agent can't accidentally invoke them.
+
+use anyhow::{Result, bail};
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use std::path::{Path, PathBuf};
+use zeroclaw_api::tool::{Tool, ToolResult};
+
+const ARCHIVE_DIRNAME: &str = ".archive";
+const ALLOWED_FILE_PREFIXES: &[&str] = &["references/", "templates/", "scripts/"];
+const MAX_FILE_BYTES: usize = 256 * 1024;
+
+fn skills_root(workspace_dir: &Path) -> PathBuf {
+    workspace_dir.join("skills")
+}
+
+fn resolve_skill_dir(workspace_dir: &Path, slug: &str) -> Result<PathBuf> {
+    if slug.is_empty()
+        || slug.contains("..")
+        || slug.contains('/')
+        || slug.contains('\\')
+        || slug.starts_with('.')
+    {
+        bail!("Invalid skill slug: {slug}");
+    }
+    Ok(skills_root(workspace_dir).join(slug))
+}
+
+/// Read-only: list installed skills.
+pub struct SkillsListTool {
+    workspace_dir: PathBuf,
+}
+
+impl SkillsListTool {
+    pub fn new(workspace_dir: PathBuf) -> Self {
+        Self { workspace_dir }
+    }
+}
+
+#[async_trait]
+impl Tool for SkillsListTool {
+    fn name(&self) -> &str {
+        "skills_list"
+    }
+
+    fn description(&self) -> &str {
+        "List installed skills with their name, version, and one-line description. \
+         Read-only. Use before `skill_view` or `skill_manage` to find candidate \
+         slugs."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({ "type": "object", "properties": {}, "additionalProperties": false })
+    }
+
+    async fn execute(&self, _args: Value) -> Result<ToolResult> {
+        let root = skills_root(&self.workspace_dir);
+        let entries = match list_skill_entries(&root).await {
+            Ok(e) => e,
+            Err(e) => {
+                return Ok(ToolResult {
+                    success: false,
+                    output: String::new(),
+                    error: Some(format!("Failed to read skills directory: {e}")),
+                });
+            }
+        };
+
+        if entries.is_empty() {
+            return Ok(ToolResult {
+                success: true,
+                output: "0 installed skills.".to_string(),
+                error: None,
+            });
+        }
+
+        let mut out = format!("{} installed skills:\n\n", entries.len());
+        for (slug, name, description, version) in entries {
+            let display_name = if name.is_empty() { &slug } else { &name };
+            out.push_str(&format!("- {display_name} v{version} ({slug})\n"));
+            if !description.is_empty() {
+                out.push_str(&format!("    {description}\n"));
+            }
+        }
+        Ok(ToolResult {
+            success: true,
+            output: out,
+            error: None,
+        })
+    }
+}
+
+async fn list_skill_entries(
+    skills_dir: &Path,
+) -> std::io::Result<Vec<(String, String, String, String)>> {
+    let mut rd = match tokio::fs::read_dir(skills_dir).await {
+        Ok(rd) => rd,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => return Err(e),
+    };
+
+    let mut out = Vec::new();
+    while let Some(entry) = rd.next_entry().await? {
+        let slug = entry.file_name().to_string_lossy().into_owned();
+        if slug.starts_with('.') {
+            continue;
+        }
+        if !entry.file_type().await?.is_dir() {
+            continue;
+        }
+        let toml_path = entry.path().join("SKILL.toml");
+        let Ok(content) = tokio::fs::read_to_string(&toml_path).await else {
+            continue;
+        };
+        let Ok(parsed) = content.parse::<toml::Table>() else {
+            continue;
+        };
+        let skill = parsed.get("skill").and_then(|v| v.as_table());
+        let name = skill
+            .and_then(|t| t.get("name"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let description = skill
+            .and_then(|t| t.get("description"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let version = skill
+            .and_then(|t| t.get("version"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("0.0.0")
+            .to_string();
+        out.push((slug, name, description, version));
+    }
+    out.sort_by(|a, b| a.0.cmp(&b.0));
+    Ok(out)
+}
+
+/// Read-only: view a single skill.
+pub struct SkillViewTool {
+    workspace_dir: PathBuf,
+}
+
+impl SkillViewTool {
+    pub fn new(workspace_dir: PathBuf) -> Self {
+        Self { workspace_dir }
+    }
+}
+
+#[async_trait]
+impl Tool for SkillViewTool {
+    fn name(&self) -> &str {
+        "skill_view"
+    }
+
+    fn description(&self) -> &str {
+        "Read a single skill's SKILL.toml content plus the names of its \
+         support files (references/, templates/, scripts/). Use this before \
+         deciding whether to patch the skill or add a support file."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "slug": {
+                    "type": "string",
+                    "description": "Skill slug (directory name under workspace/skills/)."
+                }
+            },
+            "required": ["slug"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, args: Value) -> Result<ToolResult> {
+        let slug = args
+            .get("slug")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow::anyhow!("missing `slug` argument"))?;
+
+        let skill_dir = match resolve_skill_dir(&self.workspace_dir, slug) {
+            Ok(p) => p,
+            Err(e) => {
+                return Ok(ToolResult {
+                    success: false,
+                    output: String::new(),
+                    error: Some(e.to_string()),
+                });
+            }
+        };
+
+        let toml_path = skill_dir.join("SKILL.toml");
+        let toml = match tokio::fs::read_to_string(&toml_path).await {
+            Ok(s) => s,
+            Err(e) => {
+                return Ok(ToolResult {
+                    success: false,
+                    output: String::new(),
+                    error: Some(format!("Skill '{slug}' not found: {e}")),
+                });
+            }
+        };
+
+        let support_files = collect_support_files(&skill_dir).await;
+        let mut output = format!("# Skill '{slug}'\n\n## SKILL.toml\n\n{toml}");
+        if !support_files.is_empty() {
+            output.push_str("\n## Support files\n");
+            for path in &support_files {
+                output.push_str(&format!("- {path}\n"));
+            }
+        }
+
+        Ok(ToolResult {
+            success: true,
+            output,
+            error: None,
+        })
+    }
+}
+
+async fn collect_support_files(skill_dir: &Path) -> Vec<String> {
+    let mut out = Vec::new();
+    for sub in ["references", "templates", "scripts"] {
+        let dir = skill_dir.join(sub);
+        let mut rd = match tokio::fs::read_dir(&dir).await {
+            Ok(rd) => rd,
+            Err(_) => continue,
+        };
+        while let Ok(Some(entry)) = rd.next_entry().await {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            out.push(format!("{sub}/{name}"));
+        }
+    }
+    out.sort();
+    out
+}
+
+/// Mutating: patch a SKILL.toml, write a support file, or archive a skill.
+pub struct SkillManageTool {
+    workspace_dir: PathBuf,
+}
+
+impl SkillManageTool {
+    pub fn new(workspace_dir: PathBuf) -> Self {
+        Self { workspace_dir }
+    }
+}
+
+#[async_trait]
+impl Tool for SkillManageTool {
+    fn name(&self) -> &str {
+        "skill_manage"
+    }
+
+    fn description(&self) -> &str {
+        "Mutating operations on installed skills. Actions: `patch` (atomically \
+         rewrite SKILL.toml), `write_file` (add a file under references/, \
+         templates/, or scripts/), `archive` (move to .archive/). All writes \
+         go through atomic temp-rename and TOML validation where applicable."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["patch", "write_file", "archive"],
+                    "description": "Which mutation to perform."
+                },
+                "slug": {
+                    "type": "string",
+                    "description": "Skill slug to operate on."
+                },
+                "content": {
+                    "type": "string",
+                    "description": "For `patch`: new SKILL.toml body. For `write_file`: file contents."
+                },
+                "file_path": {
+                    "type": "string",
+                    "description": "For `write_file` only: relative path starting with `references/`, `templates/`, or `scripts/`."
+                },
+                "reason": {
+                    "type": "string",
+                    "description": "Short human-readable reason recorded in the skill's audit trail."
+                }
+            },
+            "required": ["action", "slug"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, args: Value) -> Result<ToolResult> {
+        let action = args
+            .get("action")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow::anyhow!("missing `action` argument"))?;
+        let slug = args
+            .get("slug")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow::anyhow!("missing `slug` argument"))?;
+
+        match action {
+            "patch" => self.patch(slug, &args).await,
+            "write_file" => self.write_file(slug, &args).await,
+            "archive" => self.archive(slug).await,
+            other => Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!(
+                    "Unknown action '{other}'. Valid: patch, write_file, archive"
+                )),
+            }),
+        }
+    }
+}
+
+impl SkillManageTool {
+    async fn patch(&self, slug: &str, args: &Value) -> Result<ToolResult> {
+        let skill_dir = match resolve_skill_dir(&self.workspace_dir, slug) {
+            Ok(p) => p,
+            Err(e) => {
+                return Ok(ToolResult {
+                    success: false,
+                    output: String::new(),
+                    error: Some(e.to_string()),
+                });
+            }
+        };
+        if !skill_dir.join("SKILL.toml").exists() {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!("Skill '{slug}' not found")),
+            });
+        }
+        let content = args
+            .get("content")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow::anyhow!("`patch` requires `content`"))?;
+        let reason = args
+            .get("reason")
+            .and_then(|v| v.as_str())
+            .unwrap_or("Skill review");
+
+        // Delegate to SkillImprover for atomic write + audit metadata.
+        let mut improver = crate::skills::improver::SkillImprover::new(
+            self.workspace_dir.clone(),
+            zeroclaw_config::schema::SkillImprovementConfig {
+                enabled: true,
+                cooldown_secs: 0,
+                ..Default::default()
+            },
+        );
+        match improver.improve_skill(slug, content, reason).await {
+            Ok(_) => Ok(ToolResult {
+                success: true,
+                output: format!("Patched skill '{slug}'."),
+                error: None,
+            }),
+            Err(e) => Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!("Patch failed: {e}")),
+            }),
+        }
+    }
+
+    async fn write_file(&self, slug: &str, args: &Value) -> Result<ToolResult> {
+        let skill_dir = match resolve_skill_dir(&self.workspace_dir, slug) {
+            Ok(p) => p,
+            Err(e) => {
+                return Ok(ToolResult {
+                    success: false,
+                    output: String::new(),
+                    error: Some(e.to_string()),
+                });
+            }
+        };
+        if !skill_dir.exists() {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!("Skill '{slug}' not found")),
+            });
+        }
+        let file_path = args
+            .get("file_path")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow::anyhow!("`write_file` requires `file_path`"))?;
+        let content = args
+            .get("content")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow::anyhow!("`write_file` requires `content`"))?;
+
+        if !ALLOWED_FILE_PREFIXES
+            .iter()
+            .any(|prefix| file_path.starts_with(prefix))
+        {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!(
+                    "file_path must start with one of: {}",
+                    ALLOWED_FILE_PREFIXES.join(", ")
+                )),
+            });
+        }
+        if file_path.contains("..") || file_path.contains('\0') {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some("file_path contains forbidden segment".to_string()),
+            });
+        }
+        if content.len() > MAX_FILE_BYTES {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!(
+                    "content exceeds {MAX_FILE_BYTES} bytes ({} given)",
+                    content.len()
+                )),
+            });
+        }
+
+        let target = skill_dir.join(file_path);
+        if let Some(parent) = target.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+        // Reject anything that escapes the skill directory after canonicalisation.
+        let canonical_skill_dir = skill_dir
+            .canonicalize()
+            .unwrap_or_else(|_| skill_dir.clone());
+        let canonical_target_parent = target
+            .parent()
+            .and_then(|p| p.canonicalize().ok())
+            .unwrap_or_else(|| skill_dir.clone());
+        if !canonical_target_parent.starts_with(&canonical_skill_dir) {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some("file_path escapes skill directory".to_string()),
+            });
+        }
+
+        tokio::fs::write(&target, content.as_bytes()).await?;
+        Ok(ToolResult {
+            success: true,
+            output: format!("Wrote {file_path} for skill '{slug}'."),
+            error: None,
+        })
+    }
+
+    async fn archive(&self, slug: &str) -> Result<ToolResult> {
+        let skill_dir = match resolve_skill_dir(&self.workspace_dir, slug) {
+            Ok(p) => p,
+            Err(e) => {
+                return Ok(ToolResult {
+                    success: false,
+                    output: String::new(),
+                    error: Some(e.to_string()),
+                });
+            }
+        };
+        if !skill_dir.exists() {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!("Skill '{slug}' not found")),
+            });
+        }
+        let archive_dir = skills_root(&self.workspace_dir).join(ARCHIVE_DIRNAME);
+        tokio::fs::create_dir_all(&archive_dir).await?;
+        let target = archive_dir.join(slug);
+        // If a previous archive exists, suffix with a timestamp to avoid clobbering.
+        let final_target = if target.exists() {
+            let stamp = chrono::Utc::now().format("%Y%m%dT%H%M%SZ");
+            archive_dir.join(format!("{slug}-{stamp}"))
+        } else {
+            target
+        };
+        tokio::fs::rename(&skill_dir, &final_target).await?;
+        Ok(ToolResult {
+            success: true,
+            output: format!(
+                "Archived skill '{slug}' to {}",
+                final_target.display()
+            ),
+            error: None,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tempdir() -> tempfile::TempDir {
+        tempfile::tempdir().unwrap()
+    }
+
+    async fn write_skill(workspace: &Path, slug: &str, toml: &str) {
+        let dir = workspace.join("skills").join(slug);
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+        tokio::fs::write(dir.join("SKILL.toml"), toml).await.unwrap();
+    }
+
+    const VALID_SKILL: &str = r#"[skill]
+name = "deploy"
+description = "Run a production deploy"
+version = "0.1.0"
+"#;
+
+    // ─── skill_manage: patch ────────────────────────────────
+
+    const IMPROVED_SKILL: &str = r#"[skill]
+name = "deploy"
+description = "Run a production deploy (now with a pre-flight check)"
+version = "0.1.1"
+"#;
+
+    #[tokio::test]
+    async fn skill_manage_patch_atomically_updates_toml() {
+        let dir = tempdir();
+        write_skill(dir.path(), "deploy", VALID_SKILL).await;
+        let tool = SkillManageTool::new(dir.path().to_path_buf());
+
+        let result = tool
+            .execute(json!({
+                "action": "patch",
+                "slug": "deploy",
+                "content": IMPROVED_SKILL,
+                "reason": "User noted missing pre-flight check",
+            }))
+            .await
+            .unwrap();
+        assert!(result.success, "patch failed: {:?}", result.error);
+
+        let on_disk = tokio::fs::read_to_string(
+            dir.path().join("skills").join("deploy").join("SKILL.toml"),
+        )
+        .await
+        .unwrap();
+        assert!(on_disk.contains("pre-flight check"));
+        assert!(on_disk.contains("0.1.1"));
+        assert!(on_disk.contains("updated_at"));
+        assert!(on_disk.contains("improvement_reason"));
+        assert!(on_disk.contains("User noted missing pre-flight check"));
+        // Temp file cleaned up.
+        assert!(
+            !dir.path()
+                .join("skills")
+                .join("deploy")
+                .join(".SKILL.toml.tmp")
+                .exists()
+        );
+    }
+
+    #[tokio::test]
+    async fn skill_manage_patch_rejects_invalid_toml() {
+        let dir = tempdir();
+        write_skill(dir.path(), "deploy", VALID_SKILL).await;
+        let tool = SkillManageTool::new(dir.path().to_path_buf());
+
+        let result = tool
+            .execute(json!({
+                "action": "patch",
+                "slug": "deploy",
+                "content": "this is not valid toml {{",
+                "reason": "broken",
+            }))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        // Original must be untouched.
+        let on_disk = tokio::fs::read_to_string(
+            dir.path().join("skills").join("deploy").join("SKILL.toml"),
+        )
+        .await
+        .unwrap();
+        assert_eq!(on_disk, VALID_SKILL);
+    }
+
+    #[tokio::test]
+    async fn skill_manage_patch_rejects_missing_skill() {
+        let dir = tempdir();
+        let tool = SkillManageTool::new(dir.path().to_path_buf());
+        let result = tool
+            .execute(json!({
+                "action": "patch",
+                "slug": "nonexistent",
+                "content": IMPROVED_SKILL,
+                "reason": "n/a",
+            }))
+            .await
+            .unwrap();
+        assert!(!result.success);
+    }
+
+    // ─── skill_manage: write_file ───────────────────────────
+
+    #[tokio::test]
+    async fn skill_manage_write_file_creates_references_md() {
+        let dir = tempdir();
+        write_skill(dir.path(), "deploy", VALID_SKILL).await;
+        let tool = SkillManageTool::new(dir.path().to_path_buf());
+
+        let result = tool
+            .execute(json!({
+                "action": "write_file",
+                "slug": "deploy",
+                "file_path": "references/staging-quirks.md",
+                "content": "# Staging quirks\n\n- env DEPLOY_TOKEN must be set\n",
+            }))
+            .await
+            .unwrap();
+        assert!(result.success, "{:?}", result.error);
+
+        let written = tokio::fs::read_to_string(
+            dir.path()
+                .join("skills")
+                .join("deploy")
+                .join("references")
+                .join("staging-quirks.md"),
+        )
+        .await
+        .unwrap();
+        assert!(written.contains("DEPLOY_TOKEN"));
+    }
+
+    #[tokio::test]
+    async fn skill_manage_write_file_rejects_bad_prefix() {
+        let dir = tempdir();
+        write_skill(dir.path(), "deploy", VALID_SKILL).await;
+        let tool = SkillManageTool::new(dir.path().to_path_buf());
+
+        for bad in [
+            "SKILL.toml",
+            "../../etc/passwd",
+            "secrets/key.pem",
+            "references/../../etc/passwd",
+            "/etc/passwd",
+        ] {
+            let result = tool
+                .execute(json!({
+                    "action": "write_file",
+                    "slug": "deploy",
+                    "file_path": bad,
+                    "content": "nope",
+                }))
+                .await
+                .unwrap();
+            assert!(!result.success, "expected rejection for {bad:?}");
+        }
+        // SKILL.toml must not have been overwritten.
+        let toml = tokio::fs::read_to_string(
+            dir.path().join("skills").join("deploy").join("SKILL.toml"),
+        )
+        .await
+        .unwrap();
+        assert_eq!(toml, VALID_SKILL);
+    }
+
+    #[tokio::test]
+    async fn skill_manage_write_file_enforces_size_cap() {
+        let dir = tempdir();
+        write_skill(dir.path(), "deploy", VALID_SKILL).await;
+        let tool = SkillManageTool::new(dir.path().to_path_buf());
+
+        let oversized = "x".repeat(MAX_FILE_BYTES + 1);
+        let result = tool
+            .execute(json!({
+                "action": "write_file",
+                "slug": "deploy",
+                "file_path": "references/big.md",
+                "content": oversized,
+            }))
+            .await
+            .unwrap();
+        assert!(!result.success);
+    }
+
+    // ─── skill_manage: archive ──────────────────────────────
+
+    #[tokio::test]
+    async fn skill_manage_archive_moves_skill() {
+        let dir = tempdir();
+        write_skill(dir.path(), "obsolete", VALID_SKILL).await;
+        let tool = SkillManageTool::new(dir.path().to_path_buf());
+
+        let result = tool
+            .execute(json!({ "action": "archive", "slug": "obsolete" }))
+            .await
+            .unwrap();
+        assert!(result.success, "{:?}", result.error);
+
+        assert!(
+            !dir.path().join("skills").join("obsolete").exists(),
+            "original location should be gone"
+        );
+        assert!(
+            dir.path()
+                .join("skills")
+                .join(".archive")
+                .join("obsolete")
+                .join("SKILL.toml")
+                .exists(),
+            "archived copy should exist"
+        );
+    }
+
+    #[tokio::test]
+    async fn skill_manage_archive_does_not_clobber_existing_archive() {
+        let dir = tempdir();
+        write_skill(dir.path(), "obsolete", VALID_SKILL).await;
+        // Pre-existing archive.
+        let archive_dir = dir
+            .path()
+            .join("skills")
+            .join(".archive")
+            .join("obsolete");
+        tokio::fs::create_dir_all(&archive_dir).await.unwrap();
+        tokio::fs::write(archive_dir.join("SKILL.toml"), VALID_SKILL)
+            .await
+            .unwrap();
+
+        let tool = SkillManageTool::new(dir.path().to_path_buf());
+        let result = tool
+            .execute(json!({ "action": "archive", "slug": "obsolete" }))
+            .await
+            .unwrap();
+        assert!(result.success);
+
+        // Original archive still there.
+        assert!(archive_dir.join("SKILL.toml").exists());
+        // Plus a suffixed copy.
+        let entries: Vec<_> = std::fs::read_dir(dir.path().join("skills").join(".archive"))
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .collect();
+        assert!(entries.iter().any(|e| e.starts_with("obsolete-")));
+    }
+
+    #[tokio::test]
+    async fn skill_manage_rejects_unknown_action() {
+        let dir = tempdir();
+        write_skill(dir.path(), "deploy", VALID_SKILL).await;
+        let tool = SkillManageTool::new(dir.path().to_path_buf());
+        let result = tool
+            .execute(json!({ "action": "nuke", "slug": "deploy" }))
+            .await
+            .unwrap();
+        assert!(!result.success);
+    }
+
+    // ─── skills_list ────────────────────────────────────────
+
+    #[tokio::test]
+    async fn skills_list_empty_when_no_skills() {
+        let dir = tempdir();
+        let tool = SkillsListTool::new(dir.path().to_path_buf());
+        let result = tool.execute(json!({})).await.unwrap();
+        assert!(result.success);
+        assert!(
+            result.output.to_lowercase().contains("no skills")
+                || result.output.trim().is_empty()
+                || result.output.contains("0 installed"),
+            "expected an empty-list indicator, got: {}",
+            result.output
+        );
+    }
+
+    #[tokio::test]
+    async fn skills_list_enumerates_installed_skills() {
+        let dir = tempdir();
+        write_skill(dir.path(), "deploy", VALID_SKILL).await;
+        write_skill(
+            dir.path(),
+            "test-runner",
+            r#"[skill]
+name = "test-runner"
+description = "Run the test suite"
+version = "0.2.0"
+"#,
+        )
+        .await;
+
+        let tool = SkillsListTool::new(dir.path().to_path_buf());
+        let result = tool.execute(json!({})).await.unwrap();
+        assert!(result.success);
+        assert!(result.output.contains("deploy"));
+        assert!(result.output.contains("test-runner"));
+        assert!(result.output.contains("0.1.0"));
+        assert!(result.output.contains("0.2.0"));
+    }
+
+    #[tokio::test]
+    async fn skills_list_skips_archive_dir() {
+        let dir = tempdir();
+        write_skill(dir.path(), "active", VALID_SKILL).await;
+        let archive_path = dir
+            .path()
+            .join("skills")
+            .join(".archive")
+            .join("old-skill");
+        tokio::fs::create_dir_all(&archive_path).await.unwrap();
+        tokio::fs::write(archive_path.join("SKILL.toml"), VALID_SKILL)
+            .await
+            .unwrap();
+
+        let tool = SkillsListTool::new(dir.path().to_path_buf());
+        let result = tool.execute(json!({})).await.unwrap();
+        assert!(result.success);
+        assert!(result.output.contains("active"));
+        assert!(
+            !result.output.contains("old-skill"),
+            "archive should be excluded: {}",
+            result.output
+        );
+    }
+
+    // ─── skill_view ─────────────────────────────────────────
+
+    #[tokio::test]
+    async fn skill_view_rejects_path_traversal() {
+        let dir = tempdir();
+        let tool = SkillViewTool::new(dir.path().to_path_buf());
+        for bad in ["../etc/passwd", "..", "foo/bar", ".hidden", ""] {
+            let result = tool
+                .execute(json!({ "slug": bad }))
+                .await
+                .expect("execute should not error");
+            assert!(
+                !result.success,
+                "expected rejection for slug {:?}, got success: {}",
+                bad, result.output
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn skill_view_lists_support_files() {
+        let dir = tempdir();
+        let skill_dir = dir.path().join("skills").join("deploy");
+        tokio::fs::create_dir_all(skill_dir.join("references"))
+            .await
+            .unwrap();
+        tokio::fs::create_dir_all(skill_dir.join("scripts"))
+            .await
+            .unwrap();
+        tokio::fs::write(skill_dir.join("SKILL.toml"), VALID_SKILL)
+            .await
+            .unwrap();
+        tokio::fs::write(skill_dir.join("references").join("api.md"), "...")
+            .await
+            .unwrap();
+        tokio::fs::write(skill_dir.join("scripts").join("verify.sh"), "...")
+            .await
+            .unwrap();
+
+        let tool = SkillViewTool::new(dir.path().to_path_buf());
+        let result = tool.execute(json!({ "slug": "deploy" })).await.unwrap();
+        assert!(result.success);
+        assert!(result.output.contains("references/api.md"));
+        assert!(result.output.contains("scripts/verify.sh"));
+    }
+
+    #[tokio::test]
+    async fn skill_view_returns_toml_content() {
+        let dir = tempdir();
+        write_skill(dir.path(), "deploy", VALID_SKILL).await;
+
+        let tool = SkillViewTool::new(dir.path().to_path_buf());
+        let result = tool
+            .execute(json!({ "slug": "deploy" }))
+            .await
+            .expect("execute should succeed");
+
+        assert!(result.success, "expected success, got {:?}", result.error);
+        assert!(
+            result.output.contains("name = \"deploy\""),
+            "output missing skill name: {}",
+            result.output
+        );
+        assert!(
+            result.output.contains("Run a production deploy"),
+            "output missing description: {}",
+            result.output
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Closes the integration gap from #4619 (`SkillImprover` shipped without a caller, so `skill_improvement.enabled` had no runtime effect) by adopting the **post-turn background review fork** pattern from [nousresearch/hermes-agent](https://github.com/nousresearch/hermes-agent) (`run_agent.py::_spawn_background_review`), adapted to ZeroClaw's workspace layout and Rust async runtime.

After each single-shot agent run, ZeroClaw now spawns a forked agent loop with a restricted toolset (only `skills_list`, `skill_view`, `skill_manage`) over a snapshot of the conversation. The fork decides whether to patch a skill, add a `references/templates/scripts` file, archive a skill, or do nothing. The user sees at most a one-line `💾 Skill review: …` summary.

Supersedes #5420 (DaBlitzStein) — co-authored with credit. The whitelist filter from that PR is intentionally left out and will land as a separate change.

## Why a fork, not an inline LLM call

The original #5420 design called `simple_chat("rewrite this skill")` on each failed skill execution. That has three problems:

1. **Failure-only is too narrow.** The largest source of improvement signal isn't broken skills — it's user corrections ("stop doing X", "this is too verbose"), novel techniques, and workflow lessons that happen on *successful* sessions.
2. **No agency.** The LLM is told to rewrite a specific file; it can't decide that a *different* skill is the right thing to patch, or that the right action is to add a `references/quirks.md` rather than rewrite the parent.
3. **No "do nothing".** Every trigger produces a rewrite, even when the right answer is "leave it alone."

The Hermes pattern addresses all three: iteration-budget trigger, fork-with-agency that uses real tools, "Nothing to save." as a first-class outcome encoded in the prompt.

## What's in the PR

Two commits.

### 1/2 — `feat(skills): harden SkillImprover atomic write + add cooldown durability`

Foundation work. Stands alone as bug fixes regardless of the review fork.

- Durable on-disk cooldown via `SKILL.toml.updated_at` (in-memory `Instant` map alone reset on every restart).
- `improve_skill` is now caller-gated — internal cooldown pre-check removed so it works for both cooldown-respecting paths and explicit-action flows (the new `skill_manage` patch tool).
- **Fix duplicate-key emission** in `append_improvement_metadata`: old code only stripped `updated_at` before re-appending, leaving any prior `improvement_reason` line in place. Two improvements in a row produced two `improvement_reason` lines → TOML parse error on next read.
- `extract_skill_executions_from_history` / `looks_like_failure`: scan history for dotted-name tool results in XML and native formats, classify as success/failure. The review fork uses this to surface a "these skills failed" hint without using failure as the gating trigger.
- +18 improver unit tests covering the new paths.

### 2/2 — `feat(skills): add background skill-review fork + skill_manage tool`

- **`tools::skill_manage`** (one file, three Tool impls, only visible to the review fork):
  - `skills_list` — enumerate installed skills (skips `.archive/`).
  - `skill_view` — read SKILL.toml + list `references/templates/scripts/` files.
  - `skill_manage` — actions: `patch` (atomic SKILL.toml rewrite via SkillImprover plumbing), `write_file` (under `references/|templates/|scripts/` with prefix/size guards), `archive` (move to `.archive/`, timestamp-suffix on collision).
- **`skills::review::maybe_run_skill_review`** — gated on `skill_improvement.enabled`, a tokio task_local recursion flag, and an iteration-budget threshold. Snapshots history, runs `run_tool_call_loop` with `silent=true`, `approval=None`, a restricted tool registry, and capped `max_review_iterations`. Surfaces a one-line summary parsed from tool receipts.
- **`agent::loop_` post-turn hook** — single call to `maybe_run_skill_review` right after the existing SkillCreator block.
- **`SkillImprovementConfig` gains** `nudge_interval_iterations` (u32, default 10) and `max_review_iterations` (u32, default 8). Existing `enabled` and `cooldown_secs` keep their meaning.
- **The review prompt** (`review_prompt.md`, ~3 KB) is ZeroClaw-vocabulary but mirrors Hermes' load-bearing structure: signal list, preference hierarchy (patch loaded → patch umbrella → add support file → create new), explicit "do NOT capture" list, "Nothing to save." as a first-class option.

**Tool name choice:** matches Hermes (`skill_manage`, `skill_view`, `skills_list`) for cross-agent portability. Users moving between agents keep muscle memory; tool-using models trained on `skill_manage` keep working.

## Scope notes

- **Single-shot only.** Same scope as the existing `SkillCreator` hook — interactive REPL doesn't fire the review fork. Sensible follow-up but not in this PR.
- **No memory tools in fork.** Hermes includes `memory` tools in its restricted set; we don't yet — keeping the fork's surface area tight. Easy follow-up if signal warrants.
- **No cost-tracking scope.** The fork's LLM costs are tracked but not attributed to the parent session's cost-tracking context (the context's scope ends when `run_tool_call_loop` returns). TODO.

## Test plan

- [x] `cargo test -p zeroclaw-runtime --lib` — 1695 passed, 0 failed (includes 41 new tests across improver, skill_manage, review)
- [x] `cargo clippy -p zeroclaw-runtime --lib --tests -- -D warnings` — clean
- [x] `cargo check --workspace` — clean
- [x] Commit 1/2 builds and tests pass standalone (verified via `git stash` + `cargo test`)
- [x] End-to-end smoke: skill patch — verified locally with OpenAI `gpt-4o`: created a test SKILL.toml, ran an agent prompt with a "remember this preference" signal + a tool call. Fork patched the SKILL.toml in place — bumped version, added `updated_at` / `improvement_reason`, audit-trail comments appended. (gpt-4o-mini "said it patched" without calling the tool — known small-model limitation.)
- [x] End-to-end smoke: silent path — verified locally with OpenAI `gpt-4o-mini`: ran `agent -m "what is 7 times 8"` with default `nudge_interval_iterations = 10`. Got `DEBUG ... iteration budget not reached, skipping iters=0 threshold=10` and zero `💾` output. Fork made no LLM call.

## Related

- Supersedes #5420
- Closes #3683 (skill self-improvement portion)
- Builds on #4619 (the original SkillImprover that this finally gives a caller)

## Known follow-ups (filed)

- #6644 — `💾` summary parser falls back to LLM text instead of parsed tool receipts (cosmetic; patch still happens correctly)
- #6645 — `SkillImprover` + `skill_manage` only handle `SKILL.toml`, not the `manifest.toml` format used by bundled skills (pre-existing limitation from #4619, more visible now)

