### PR TITLE
fix(runtime/observability): share PrometheusObserver across subsystems

### DIFF
--- a/crates/zeroclaw-api/src/observability_traits.rs
+++ b/crates/zeroclaw-api/src/observability_traits.rs
@@ -187,6 +187,35 @@ pub trait Observer: Send + Sync + 'static {
     fn as_any(&self) -> &dyn std::any::Any;
 }
 
+/// Blanket implementation: `Arc<T>` delegates all `Observer` methods to `T`.
+///
+/// Lets a singleton observer be handed out as `Arc<MyObserver>` and still be
+/// used wherever `Box<dyn Observer>` is expected (e.g.
+/// `Box::new(MyObserver::shared())`). `as_any` deliberately delegates to the
+/// inner `T` so downcasts in handlers like `/metrics` recover the concrete
+/// type rather than the `Arc` wrapper.
+impl<T: Observer + ?Sized> Observer for std::sync::Arc<T> {
+    fn record_event(&self, event: &ObserverEvent) {
+        self.as_ref().record_event(event);
+    }
+
+    fn record_metric(&self, metric: &ObserverMetric) {
+        self.as_ref().record_metric(metric);
+    }
+
+    fn flush(&self) {
+        self.as_ref().flush();
+    }
+
+    fn name(&self) -> &str {
+        self.as_ref().name()
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self.as_ref().as_any()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/zeroclaw-runtime/src/observability/mod.rs
+++ b/crates/zeroclaw-runtime/src/observability/mod.rs
@@ -110,7 +110,7 @@ fn create_primary_observer(config: &ObservabilityConfig) -> Box<dyn Observer> {
         "prometheus" => {
             #[cfg(feature = "observability-prometheus")]
             {
-                Box::new(PrometheusObserver::new())
+                Box::new(PrometheusObserver::shared())
             }
             #[cfg(not(feature = "observability-prometheus"))]
             {

--- a/crates/zeroclaw-runtime/src/observability/prometheus.rs
+++ b/crates/zeroclaw-runtime/src/observability/prometheus.rs
@@ -2,6 +2,7 @@ use super::traits::{Observer, ObserverEvent, ObserverMetric};
 use prometheus::{
     Encoder, GaugeVec, Histogram, HistogramOpts, HistogramVec, IntCounterVec, Registry, TextEncoder,
 };
+use std::sync::{Arc, OnceLock};
 
 /// Prometheus-backed observer — exposes metrics for scraping via `/metrics`.
 pub struct PrometheusObserver {
@@ -307,6 +308,19 @@ impl PrometheusObserver {
         let mut buf = Vec::new();
         encoder.encode(&families, &mut buf).unwrap_or_default();
         String::from_utf8(buf).unwrap_or_default()
+    }
+
+    /// Process-wide singleton handle. All call sites that obtain a Prometheus
+    /// observer through this function share the same `Registry` and the same
+    /// underlying counters, so events recorded by the channel orchestrator and
+    /// events recorded by the gateway accumulate into the same time series and
+    /// are visible on a single `/metrics` scrape.
+    ///
+    /// `PrometheusObserver::new()` still returns a fresh, isolated instance —
+    /// kept for tests so parallel test cases don't see each other's counts.
+    pub fn shared() -> Arc<Self> {
+        static SINGLETON: OnceLock<Arc<PrometheusObserver>> = OnceLock::new();
+        SINGLETON.get_or_init(|| Arc::new(Self::new())).clone()
     }
 }
 
@@ -849,5 +863,54 @@ mod tests {
         obs.record_event(&ObserverEvent::RecoveryCompleted {
             deploy_id: "d1".into(),
         });
+    }
+
+    #[test]
+    fn shared_returns_the_same_registry_across_calls() {
+        let a = PrometheusObserver::shared();
+        let b = PrometheusObserver::shared();
+        assert!(
+            Arc::ptr_eq(&a, &b),
+            "PrometheusObserver::shared() must hand out the same underlying \
+             instance to every caller, otherwise the gateway's /metrics scrape \
+             cannot see counters incremented by the channel orchestrator"
+        );
+    }
+
+    #[test]
+    fn arc_blanket_observer_impl_routes_to_inner() {
+        let shared_a = PrometheusObserver::shared();
+        let shared_b = PrometheusObserver::shared();
+
+        Observer::record_event(
+            &shared_a,
+            &ObserverEvent::ChannelMessage {
+                channel: "test-channel".into(),
+                direction: "inbound".into(),
+            },
+        );
+
+        let output = shared_b.encode();
+        assert!(
+            output.contains(
+                r#"zeroclaw_channel_messages_total{channel="test-channel",direction="inbound"} 1"#
+            ),
+            "an event recorded through one Arc handle must be visible when \
+             scraping through any other handle — output was: {output}"
+        );
+    }
+
+    #[test]
+    fn arc_blanket_observer_impl_preserves_downcast() {
+        let shared: Arc<PrometheusObserver> = PrometheusObserver::shared();
+        let observer: &dyn Observer = &shared;
+        assert!(
+            observer
+                .as_any()
+                .downcast_ref::<PrometheusObserver>()
+                .is_some(),
+            "the /metrics resolver downcasts through `as_any` — Arc<T> must \
+             surface the inner T, not the Arc wrapper"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `create_observer()` was called independently by the gateway (`crates/zeroclaw-gateway/src/lib.rs:952`) and by the channel orchestrator (`crates/zeroclaw-channels/src/orchestrator/mod.rs:5531`). Each call instantiated a fresh `PrometheusObserver` with its own private `Registry` and its own counters, so the two subsystems recorded into different time series. The `/metrics` HTTP handler reads from the gateway's registry, so events recorded by the channel orchestrator — including every `LlmResponse` carrying input / output token counts — never appeared on scrape. Net effect: `zeroclaw_llm_requests_total`, `zeroclaw_tokens_input_total`, and `zeroclaw_tokens_output_total` were always empty in production despite the orchestrator faithfully recording them.
  - Added a generic `impl<T: Observer + ?Sized> Observer for std::sync::Arc<T>` blanket impl in `zeroclaw-api`, mirroring the `Provider` trait's existing `Arc<T>` impl. `as_any` deliberately delegates to the inner `T` so downcasts in the `/metrics` resolver recover the concrete type rather than the `Arc` wrapper.
  - Added `PrometheusObserver::shared()` — a process-wide singleton handle backed by `OnceLock<Arc<PrometheusObserver>>`. All production callers share the same `Registry` and the same underlying counters.
  - Routed the `"prometheus"` branch of `observability::create_observer` through `shared()` so the singleton is the default in production. `PrometheusObserver::new()` is unchanged and still hands out a fresh, isolated instance for parallel tests.

- **Scope boundary:** does NOT touch `NoopObserver`, `LogObserver`, `VerboseObserver`, `OtelObserver`, or the channel orchestrator's observer plumbing. Three files: `crates/zeroclaw-api/src/observability_traits.rs`, `crates/zeroclaw-runtime/src/observability/mod.rs`, `crates/zeroclaw-runtime/src/observability/prometheus.rs`.
- **Blast radius:** Prometheus backend only. Behaviour for every other backend (`backend = "none" | "log" | "verbose" | "otel"`) is bit-for-bit identical. For `prometheus`, the only observable change is that previously-orphaned counters become visible on `/metrics` — strictly additive.
- **Linked issues:** none yet — flagging this directly via PR. Discovered while debugging Telegram image-leak token burn (separate PR).

## Validation Evidence

```
$ cargo fmt --all -- --check                          # exit 0
$ cargo clippy --all-targets -- -D warnings           # clean across workspace
$ cargo test -p zeroclaw-runtime --lib observability::prometheus
test result: ok. 19 passed; 0 failed                  # 16 pre-existing + 3 new
$ cargo test -p zeroclaw-api                          # 29 passed
$ cargo test -p zeroclaw-gateway --lib                # 173 passed
$ cargo test -p zeroclaw-runtime --lib                # 1624 passed
```

New tests (in `prometheus.rs`):
- `shared_returns_the_same_registry_across_calls` — proves the singleton via `Arc::ptr_eq` on two `shared()` handles.
- `arc_blanket_observer_impl_routes_to_inner` — record an event through one `Arc<PrometheusObserver>` handle, encode through another, confirm the time series shows it.
- `arc_blanket_observer_impl_preserves_downcast` — confirms `as_any` on `Arc<PrometheusObserver>` surfaces the inner `PrometheusObserver`, which is what the `/metrics` resolver in `zeroclaw-gateway` relies on.

### Production reproduction — before and after

Caught while debugging a separate Telegram bug.

**Before this patch:**

1. Set `[observability] backend = "prometheus"` in `~/.zeroclaw/config.toml`, restart daemon.
2. Send a Telegram message that completes through the full LLM path. Log confirms a successful turn:
   ```
   INFO orchestrator: LLM call completed llm_call_ms=26688 total_ms=39743
   🤖 Reply (39746ms): ...
   ```
3. Scrape:
   ```bash
   $ curl -s http://127.0.0.1:42617/metrics | grep -E "tokens|llm_requests" | grep -v "^#"
   zeroclaw_tokens_used_last 0
   ```
   No `zeroclaw_llm_requests_total`. No `zeroclaw_tokens_input_total`. No `zeroclaw_tokens_output_total`. The orchestrator recorded all three, but on a different registry than the one `/metrics` reads from.

**After this patch:**

Same setup, same flow — built and installed from this branch, sent a real Telegram message:

```
$ curl -s http://127.0.0.1:42617/metrics | grep -E "zeroclaw_(llm_requests|tokens_(input|output))_total"
zeroclaw_llm_requests_total{model="claude-opus-4-7",provider="claude-code",success="true"} 1
zeroclaw_tokens_input_total{model="claude-opus-4-7",provider="claude-code"} 16
zeroclaw_tokens_output_total{model="claude-opus-4-7",provider="claude-code"} 872
```

Channel-orchestrator-recorded counters now reach the gateway scrape. Downcast through `BroadcastObserver → Arc<PrometheusObserver> → PrometheusObserver` works as the `/metrics` resolver expects.

### Skipped

- `./dev/ci.sh all` — requires Docker. The `cargo fmt / clippy / test` battery covers the same gates.

## Security & Privacy Impact

- New permissions / capabilities / file system access scope: **No.**
- New external network calls: **No.**
- Secrets / tokens / credentials handling changed: **No.**
- PII in diff / tests / fixtures: **No.** Tests use synthetic `provider` / `model` / `channel` strings.

## Compatibility

- Backward compatible: **Yes.** `PrometheusObserver::new()` is unchanged, all method signatures are unchanged, no public API removed. Other observer backends are unaffected.
- Config / env / CLI surface: **Unchanged.**

## Rollback

- **Fast path:** `git revert <merge-sha>`. Three-file change, no schema or persistent-state migration.
- **Feature flags:** None. The fix is unconditional once compiled in; rolling back restores the prior orphaned-registry behaviour.
- **Failure symptoms:**
  - Pre-PR (the bug being fixed): `/metrics` returns DORA / heartbeat counters but `zeroclaw_llm_requests_total`, `zeroclaw_tokens_input_total`, `zeroclaw_tokens_output_total` are absent even after multiple completed LLM calls.
  - Post-PR regression candidate: a test that constructs `PrometheusObserver::new()` twice and expects fresh registries would still pass — `new()` is unchanged. A test that constructs `PrometheusObserver::shared()` twice and expects isolated registries would fail, but that's the new contract and the test would be wrong.