### PR TITLE
fix(providers): supports_vision() must reflect default/primary, not .any() (#6589)

### DIFF
--- a/crates/zeroclaw-providers/src/reliable.rs
+++ b/crates/zeroclaw-providers/src/reliable.rs
@@ -763,8 +763,9 @@ impl Provider for ReliableProvider {
 
     fn supports_vision(&self) -> bool {
         self.providers
-            .iter()
-            .any(|(_, provider)| provider.supports_vision())
+            .first()
+            .map(|(_, p)| p.supports_vision())
+            .unwrap_or(false)
     }
 
     async fn chat_with_tools(
@@ -2993,5 +2994,67 @@ mod tests {
             assert!(take_last_provider_fallback().is_none());
         })
         .await;
+    }
+
+    // Regression for #6589: ReliableProvider::supports_vision() must reflect the
+    // primary (first) provider, not .any() across the fallback chain. This mirrors
+    // supports_native_tools() which already uses .first().
+    #[test]
+    fn supports_vision_reflects_first_provider_not_any_fallback() {
+        struct VisionMock(bool);
+
+        #[async_trait]
+        impl Provider for VisionMock {
+            async fn chat_with_system(
+                &self,
+                _system_prompt: Option<&str>,
+                _message: &str,
+                _model: &str,
+                _temperature: Option<f64>,
+            ) -> anyhow::Result<String> {
+                Ok(String::new())
+            }
+
+            fn supports_vision(&self) -> bool {
+                self.0
+            }
+        }
+
+        let provider = ReliableProvider::new(
+            vec![
+                (
+                    "primary".into(),
+                    Box::new(VisionMock(false)) as Box<dyn Provider>,
+                ),
+                (
+                    "fallback".into(),
+                    Box::new(VisionMock(true)) as Box<dyn Provider>,
+                ),
+            ],
+            0,
+            0,
+        );
+
+        assert!(
+            !provider.supports_vision(),
+            "ReliableProvider with non-vision primary must report supports_vision()=false even when a fallback supports vision"
+        );
+
+        let provider = ReliableProvider::new(
+            vec![
+                (
+                    "primary".into(),
+                    Box::new(VisionMock(true)) as Box<dyn Provider>,
+                ),
+                (
+                    "fallback".into(),
+                    Box::new(VisionMock(false)) as Box<dyn Provider>,
+                ),
+            ],
+            0,
+            0,
+        );
+
+        assert!(provider.supports_vision());
     }
 }

--- a/crates/zeroclaw-providers/src/router.rs
+++ b/crates/zeroclaw-providers/src/router.rs
@@ -300,8 +300,9 @@ impl Provider for RouterProvider {
 
     fn supports_vision(&self) -> bool {
         self.providers
-            .iter()
-            .any(|(_, provider)| provider.supports_vision())
+            .get(self.default_index)
+            .map(|(_, p)| p.supports_vision())
+            .unwrap_or(false)
     }
 
     async fn warmup(&self) -> anyhow::Result<()> {
@@ -327,6 +328,7 @@ mod tests {
         calls: Arc<AtomicUsize>,
         response: &'static str,
         last_model: parking_lot::Mutex<String>,
+        vision: bool,
     }
 
     impl MockProvider {
@@ -335,7 +337,13 @@ mod tests {
                 calls: Arc::new(AtomicUsize::new(0)),
                 response,
                 last_model: parking_lot::Mutex::new(String::new()),
+                vision: false,
             }
+        }
+
+        fn with_vision(mut self, vision: bool) -> Self {
+            self.vision = vision;
+            self
         }
 
         fn call_count(&self) -> usize {
@@ -359,6 +367,10 @@ mod tests {
             self.calls.fetch_add(1, Ordering::SeqCst);
             *self.last_model.lock() = model.to_string();
             Ok(self.response.to_string())
+        }
+
+        fn supports_vision(&self) -> bool {
+            self.vision
         }
     }
 
@@ -1105,5 +1117,52 @@ mod tests {
         assert_eq!(streaming.stream_calls.load(Ordering::SeqCst), 1);
         assert_eq!(streaming.tool_event_calls.load(Ordering::SeqCst), 1);
         assert_eq!(*streaming.last_stream_model.lock(), "claude-opus");
+    }
+
+    // Regression for #6589: supports_vision() must reflect the default provider,
+    // not .any() across all sub-providers. Otherwise the multimodal.vision_provider
+    // fallback in run_tool_call_loop and the image-marker stripping in the context
+    // compressor are silently bypassed in mixed-provider configurations.
+    #[test]
+    fn supports_vision_reflects_default_provider_not_any_route() {
+        let default_provider = Box::new(MockProvider::new("nope").with_vision(false));
+        let vision_route_provider = Box::new(MockProvider::new("ok").with_vision(true));
+
+        let router = RouterProvider::new(
+            vec![
+                ("default".into(), default_provider as Box<dyn Provider>),
+                ("vision".into(), vision_route_provider as Box<dyn Provider>),
+            ],
+            vec![(
+                "hint:vision".into(),
+                Route {
+                    provider_name: "vision".into(),
+                    model: "vision-model".into(),
+                },
+            )],
+            "default-model".into(),
+        );
+
+        assert!(
+            !router.supports_vision(),
+            "router with non-vision default must report supports_vision()=false even when a vision-capable route exists"
+        );
+    }
+
+    #[test]
+    fn supports_vision_true_when_default_provider_supports_vision() {
+        let default_provider = Box::new(MockProvider::new("ok").with_vision(true));
+        let aux_provider = Box::new(MockProvider::new("nope").with_vision(false));
+
+        let router = RouterProvider::new(
+            vec![
+                ("default".into(), default_provider as Box<dyn Provider>),
+                ("aux".into(), aux_provider as Box<dyn Provider>),
+            ],
+            vec![],
+            "default-model".into(),
+        );
+
+        assert!(router.supports_vision());
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `RouterProvider::supports_vision()` and `ReliableProvider::supports_vision()` both returned `true` whenever *any* sub-provider supported vision. The vision guard in `run_tool_call_loop` (`agent/loop_.rs:1016-1017`) and the image-marker stripping in the context compressor (`agent/context_compressor.rs:312`, fix from #6189) both consume `supports_vision()` to decide whether to invoke the `multimodal.vision_provider` fallback or to strip image markers before summarization. With `.any()` semantics, these checks silently passed for mixed-provider configurations where the *default* sub-provider does not support vision but a *routed* or *fallback* sub-provider does — exactly the configuration `multimodal.vision_provider` is designed to handle.
  - Mirror the existing `supports_native_tools()` contract:
    - `RouterProvider`: report the capability of `providers[default_index]`.
    - `ReliableProvider`: report the capability of `providers.first()` (the primary).
  - Streaming-capability methods (`supports_streaming`, `supports_streaming_tool_events`) correctly remain `.any()` — streaming is **additive** across the fallback chain, but vision gating is **restrictive**: the guard needs to know whether the path that will actually receive the request can handle images.

- **Scope boundary:** Two-function change. No new dependencies, no API surface change. The dead `RouterProvider::resolve_cost_optimized` mentioned in the issue is intentionally out of scope — that's a separate cleanup.
- **Blast radius:** Affects only mixed-provider configurations where the default/primary sub-provider differs in vision support from a routed/fallback sub-provider. Single-provider and all-vision-capable setups are unaffected (both old and new code return the same value).
- **Linked issue(s):** Fixes #6589. Related: #5897 (original report), #6189 (compressor image-marker fix), #3802.

## Validation Evidence (required)

```
$ cargo fmt --all -- --check
(clean — no diff)

$ cargo test -p zeroclaw-providers --lib supports_vision
running 6 tests
test azure_openai::tests::supports_vision_returns_true ........................... ok
test reliable::tests::supports_vision_reflects_first_provider_not_any_fallback ... ok
test router::tests::supports_vision_true_when_default_provider_supports_vision ... ok
test tests::glm_provider_supports_vision ........................................ ok
test tests::qwen_provider_supports_vision ....................................... ok
test router::tests::supports_vision_reflects_default_provider_not_any_route ..... ok
test result: ok. 6 passed; 0 failed

$ cargo test -p zeroclaw-providers --lib
test result: ok. 869 passed; 0 failed; 0 ignored
```

- **Commands run and tail output:** as above.
- **Beyond CI — what I manually verified:** confirmed the three new regression tests (`supports_vision_reflects_default_provider_not_any_route`, `supports_vision_true_when_default_provider_supports_vision`, `supports_vision_reflects_first_provider_not_any_fallback`) exercise the exact mixed-provider configuration from the issue (non-vision default/primary paired with a vision-capable route/fallback). Did **not** verify the end-to-end reproduction with Telegram + Together AI + Anthropic route from the issue's "Steps to reproduce" — the unit tests cover the capability-reporting layer that gates both downstream consumers.
- **If any command was intentionally skipped:** `cargo test --workspace` and `cargo clippy --workspace --all-targets -- -D warnings` deferred to CI.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No.**
- New external network calls? **No.**
- Secrets / tokens / credentials handling changed? **No.**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No.**

This change narrows two capability-reporting methods to match the documented contract of `supports_native_tools()`. The narrowing **strengthens** existing security/policy gates by ensuring vision-guard and image-marker-stripping checks correctly fire in mixed-provider setups.

## Compatibility (required)

- Backward compatible? **Yes** for single-provider setups and for setups where all sub-providers have the same vision capability. **Behaviour change** in mixed-provider setups: a router/reliable provider whose default/primary lacks vision but whose routes/fallbacks include vision-capable providers will now correctly report `supports_vision() == false`, which (a) re-enables the `multimodal.vision_provider` fallback for image inputs and (b) re-enables image-marker stripping in the summarization compressor. This is the *intended* behaviour — the previous `.any()` was the bug.
- Config / env / CLI surface changed? **No.**

## Rollback (required for `risk: medium`)

- **Fast rollback command/path:** `git revert f7659f92` (single commit).
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** If users on mixed-provider setups suddenly see vision requests routed differently than before (i.e., the `multimodal.vision_provider` fallback firing where it previously did not, or image markers being stripped before summarization), that's the *intended* behaviour. A regression of this fix would manifest as image inputs being sent to a non-vision default provider and either erroring or being silently dropped.

---

**Labels:** `bug`, `risk: medium`, `size: S`, `provider` (set in the GitHub UI).

**Diff stat:** 2 files changed, +126 / -4.
