### PR TITLE
fix(providers): defensively omit Anthropic temperature for Opus 4.7 (#6147)

### DIFF
--- a/crates/zeroclaw-providers/src/anthropic.rs
+++ b/crates/zeroclaw-providers/src/anthropic.rs
@@ -71,12 +71,11 @@ struct NativeChatRequest<'a> {
     stream: Option<bool>,
 }
 
-/// Some Anthropic models (the Claude opus-4-7 family) may reject `temperature`
-/// the way Bedrock does for the same family (see #6095 / #6144 for the
-/// Bedrock-side carve-out). Until the native API behavior is confirmed by a
-/// live repro (#6147), defensively omit `temperature` for opus-4-7 so the
-/// shape change is backward-compatible and forward-safe. Substring match
-/// covers any future inference-profile or version-suffix variants.
+/// Claude opus-4-7 rejects `temperature` with a 400 on the native Anthropic API,
+/// matching the Bedrock behavior fixed in #6144. Omit `temperature` for the
+/// opus-4-7 family so that confirmed #6147 requests use the model default.
+/// Substring match covers any future inference-profile or version-suffix
+/// variants.
 fn anthropic_model_omits_temperature(model: &str) -> bool {
     model.contains("claude-opus-4-7")
 }

--- a/crates/zeroclaw-providers/src/anthropic.rs
+++ b/crates/zeroclaw-providers/src/anthropic.rs
@@ -61,13 +61,24 @@ struct NativeChatRequest<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     system: Option<SystemPrompt>,
     messages: Vec<NativeMessage>,
-    temperature: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    temperature: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tools: Option<Vec<NativeToolSpec<'a>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tool_choice: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     stream: Option<bool>,
+}
+
+/// Some Anthropic models (the Claude opus-4-7 family) may reject `temperature`
+/// the way Bedrock does for the same family (see #6095 / #6144 for the
+/// Bedrock-side carve-out). Until the native API behavior is confirmed by a
+/// live repro (#6147), defensively omit `temperature` for opus-4-7 so the
+/// shape change is backward-compatible and forward-safe. Substring match
+/// covers any future inference-profile or version-suffix variants.
+fn anthropic_model_omits_temperature(model: &str) -> bool {
+    model.contains("claude-opus-4-7")
 }
 
 #[derive(Debug, Serialize)]
@@ -843,7 +854,11 @@ impl Provider for AnthropicProvider {
                     cache_control: None,
                 }],
             }],
-            temperature,
+            temperature: if anthropic_model_omits_temperature(model) {
+                None
+            } else {
+                Some(temperature)
+            },
             tools: None,
             tool_choice: None,
             stream: None,
@@ -916,7 +931,11 @@ impl Provider for AnthropicProvider {
             max_tokens: self.max_tokens,
             system: system_prompt,
             messages,
-            temperature,
+            temperature: if anthropic_model_omits_temperature(model) {
+                None
+            } else {
+                Some(temperature)
+            },
             tools: native_tools,
             tool_choice,
             stream: None,
@@ -1077,7 +1096,11 @@ impl Provider for AnthropicProvider {
             max_tokens: self.max_tokens,
             system: system_prompt,
             messages,
-            temperature,
+            temperature: if anthropic_model_omits_temperature(model) {
+                None
+            } else {
+                Some(temperature)
+            },
             tools: native_tools,
             tool_choice,
             stream: Some(true),
@@ -1491,6 +1514,63 @@ data: {\"type\":\"message_stop\"}\n\n";
         }
     }
 
+    // ── Opus 4.7 temperature-omission tests (issue #6147) ────────
+
+    #[test]
+    fn anthropic_model_omits_temperature_matches_opus_4_7() {
+        assert!(anthropic_model_omits_temperature("claude-opus-4-7"));
+        assert!(anthropic_model_omits_temperature(
+            "claude-opus-4-7-20260101"
+        ));
+    }
+
+    #[test]
+    fn anthropic_model_omits_temperature_skips_other_models() {
+        assert!(!anthropic_model_omits_temperature("claude-opus-4-6"));
+        assert!(!anthropic_model_omits_temperature("claude-sonnet-4-6"));
+        assert!(!anthropic_model_omits_temperature("claude-haiku-4-5"));
+        assert!(!anthropic_model_omits_temperature("claude-3-opus"));
+    }
+
+    #[test]
+    fn native_chat_request_serializes_without_temperature_when_none() {
+        let req = NativeChatRequest {
+            model: "claude-opus-4-7".to_string(),
+            max_tokens: 4096,
+            system: None,
+            messages: vec![],
+            temperature: None,
+            tools: None,
+            tool_choice: None,
+            stream: None,
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("max_tokens"));
+        assert!(
+            !json.contains("temperature"),
+            "expected temperature to be omitted, got: {json}"
+        );
+    }
+
+    #[test]
+    fn native_chat_request_serializes_with_temperature_when_some() {
+        let req = NativeChatRequest {
+            model: "claude-sonnet-4-6".to_string(),
+            max_tokens: 4096,
+            system: None,
+            messages: vec![],
+            temperature: Some(0.7),
+            tools: None,
+            tool_choice: None,
+            stream: None,
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(
+            json.contains("\"temperature\":0.7"),
+            "expected temperature to be present, got: {json}"
+        );
+    }
+
     #[test]
     fn detects_auth_from_jwt_shape() {
         let kind = detect_auth_kind("a.b.c", None);
@@ -1863,7 +1943,7 @@ data: {\"type\":\"message_stop\"}\n\n";
                     cache_control: None,
                 }],
             }],
-            temperature: 0.7,
+            temperature: Some(0.7),
             tools: None,
             tool_choice: None,
             stream: None,


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Mirror PR #6144's Bedrock-side `temperature` carve-out on the native Anthropic provider. `NativeChatRequest.temperature` was a plain `f64`, so serde always emitted it on the wire — there was no code path that could omit `temperature` for any model. The native Anthropic API has now been confirmed in #6147 to reject `temperature` for `claude-opus-4-7` the way Bedrock's Converse API does, producing a non-retryable 400 on opus-4-7.
  - This change is backward-compatible: non-opus-4-7 models continue to emit `temperature` byte-for-byte the same as before; opus-4-7 models omit the field, which the API treats as "use the model default."

- **Specifics:**
  - `NativeChatRequest.temperature: Option<f64>` with `#[serde(skip_serializing_if = "Option::is_none")]`.
  - New private `anthropic_model_omits_temperature(model) -> bool` predicate. **Substring** (not exact) match is intentional: it covers any future inference-profile or version-suffix variants, mirroring the Bedrock-side predicate.
  - Three production call sites (`chat_with_system`, `chat`, `stream_chat`) now pass `None` for opus-4-7 and `Some(temperature)` for everything else.
  - 4 new unit tests: predicate true/false matrix across opus-4-7 / opus-4-6 / sonnet-4-6 / haiku-4-5 / claude-3-opus, plus serde proof that `temperature: None` is omitted from JSON and `Some(0.7)` is present.
  - One existing test (`native_chat_request_with_blocks_system`) updated to wrap `temperature: 0.7` in `Some(0.7)` for the new shape.

- **Scope boundary:** Native Anthropic provider only. Bedrock got the same fix in #6144. Does **not** touch the `Provider` trait, config schema, model catalog, retry classification, or any other provider. No `retry-after-strip` behaviour added.
- **Blast radius:** Confined to `crates/zeroclaw-providers/src/anthropic.rs`. Non-opus-4-7 models keep emitting `temperature` byte-for-byte the same as before (verified by the `native_chat_request_serializes_with_temperature_when_some` test). No change to streaming, tool use, caching heuristics, or auth paths.
- **Linked issue(s):** `Fixes #6147`. Related: #6095 (original Bedrock report), #6144 (Bedrock fix this mirrors). Supersedes #6591.

## Validation Evidence (required)

```
$ cargo fmt --all -- --check
(clean — no diff)

$ cargo test -p zeroclaw-providers --lib anthropic::
test result: ok. 62 passed; 0 failed; 0 ignored
  (includes 4 new tests:
   anthropic_model_omits_temperature_matches_opus_4_7
   anthropic_model_omits_temperature_skips_other_models
   native_chat_request_serializes_without_temperature_when_none
   native_chat_request_serializes_with_temperature_when_some)

$ cargo test -p zeroclaw-providers --lib
test result: ok. 870 passed; 0 failed; 0 ignored
```

- **Commands run and tail output:** as above.
- **Beyond CI — what I manually verified:**
  - Predicate behaviour across realistic Anthropic model IDs (`claude-opus-4-7`, hypothetical date-stamped variant `claude-opus-4-7-20260101`, and the negative cases for opus-4-6 / sonnet-4-6 / haiku-4-5 / claude-3-opus) — covered by the predicate-matrix tests.
  - Wire-format proof via serde: `NativeChatRequest { temperature: None, .. }` produces JSON without the `temperature` key; `Some(0.7)` produces `"temperature":0.7`. This is the actual bug surface (the field was always serialized) so it's asserted directly rather than via a live HTTP call.
  - Did **not** run a live `api.anthropic.com/v1/messages` call against `claude-opus-4-7` from this machine — no Anthropic credentials in the dev env. The issue-level repro in #6147 confirms the native API rejects the old payload shape, and this PR's load-bearing check is that serde omits the field from the new payload.
- **If any command was intentionally skipped:** `cargo test --workspace` and `cargo clippy --workspace --all-targets -- -D warnings` deferred to CI.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No.**
- New external network calls? **No.**
- Secrets / tokens / credentials handling changed? **No.**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No.**

## Compatibility (required)

- Backward compatible? **Yes.** Non-opus-4-7 models keep their wire format byte-for-byte. Opus-4-7 users previously hit a confirmed 400 when the native Anthropic path sent `temperature`; this change omits the field for that model family so those requests can succeed.
- Config / env / CLI surface changed? **No.**

## Rollback (required for `risk: medium`)

- **Fast rollback command/path:** revert the eventual squash-merge commit for this PR.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** If a future Anthropic model joins the opus-4-7 family but is not yet covered by the substring match (extremely unlikely given `contains("claude-opus-4-7")` is broad), users would see a 400 with "temperature is deprecated for this model" — same symptom Bedrock hit pre-#6144. Mitigation: extend the predicate to cover the new family.

## Supersede Attribution

- **Superseded PRs + authors:** #6591 by @Alix-007.
- **Scope materially carried forward:** Same #6147 native Anthropic Opus 4.7 temperature omission fix. No direct code was copied from #6591; #6598 carries the selected implementation and current maintainer cleanup.
- **Co-authored-by trailers added in commit messages for incorporated contributors?** No.
- **If No, why:** supersession only; the selected PR was developed independently and does not incorporate #6591 code.

---

**Labels:** `bug`, `risk: medium`, `provider`, `provider:anthropic`, `size: S` (set in the GitHub UI).

**Diff stat:** 1 file changed, +84 / -5.
