### PR TITLE
fix(providers): trust system CA roots for provider HTTPS requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8088,6 +8088,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",

--- a/crates/zeroclaw-providers/Cargo.toml
+++ b/crates/zeroclaw-providers/Cargo.toml
@@ -21,7 +21,7 @@ hmac = "0.12"
 parking_lot = "0.12"
 rand = "0.10"
 regex = "1.10"
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-webpki-roots-no-provider", "__rustls-ring", "blocking", "multipart", "stream", "socks"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-webpki-roots-no-provider", "rustls-tls-native-roots-no-provider", "__rustls-ring", "blocking", "multipart", "stream", "socks"] }
 ring = "0.17"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["std"] }

--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -2729,6 +2729,19 @@ mod tests {
     use super::test_util::{EnvGuard, env_lock};
     use super::*;
 
+    // Compile-time proof that both reqwest TLS-root features are enabled.
+    // `tls_built_in_webpki_certs` is gated on `rustls-tls-webpki-roots-no-provider`;
+    // `tls_built_in_native_certs` is gated on `rustls-tls-native-roots-no-provider`.
+    // If either feature were dropped, this test would fail to compile.
+    #[test]
+    fn provider_http_client_trusts_both_webpki_and_native_roots() {
+        let _client = reqwest::Client::builder()
+            .tls_built_in_webpki_certs(true)
+            .tls_built_in_native_certs(true)
+            .build()
+            .expect("client builder should succeed with both root sets enabled");
+    }
+
     #[test]
     fn resolve_provider_credential_prefers_explicit_argument() {
         let resolved = resolve_provider_credential("openrouter", Some("  explicit-key  "));


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `crates/zeroclaw-providers/Cargo.toml` configured reqwest with `rustls-tls-webpki-roots-no-provider` only — the bundled Mozilla WebPKI roots — so provider HTTPS requests refused to validate certificates issued by CAs in the OS trust store, even after the operator added the CA to e.g. the macOS keychain or `/etc/ssl/certs`. This breaks selfhosted/corporate users running providers behind a self-signed gateway (the exact symptom described in #6528).
  - Add `rustls-tls-native-roots-no-provider` alongside the existing webpki feature. reqwest's rustls backend [composes both](https://github.com/seanmonstar/reqwest/blob/v0.12.28/src/async_impl/client.rs#L189-L195) into a single `RootCertStore` — public-CA chains continue to validate via WebPKI; private/corporate chains validate via `rustls-native-certs` reading the OS trust store. Both `tls_built_in_webpki_certs(true)` and `tls_built_in_native_certs(true)` are the defaults when their respective features are present, so no Rust code changes are needed at the call sites (14 call sites across 9 provider files all use `Client::builder()` with default TLS settings).
  - Scope deliberately narrowed to the provider crate. Other crates (`zeroclaw-runtime`, `zeroclaw-channels`, `zeroclaw-memory`, `zeroclaw-tools`) make outbound HTTPS for non-provider reasons (memory APIs, public web fetches, etc.); the issue is explicitly about *provider* requests with custom CAs, and broadening scope would balloon the diff to ~10 Cargo.toml edits without a reported user need.

- **Scope boundary:** One Cargo.toml edit, one compile-time test. No code changes to `ClientBuilder` call sites. No new crates added — `rustls-native-certs` is already in the Cargo.lock dependency tree under `tokio-tungstenite` and `hyper-rustls`.
- **Blast radius:** Provider HTTPS path only. Existing public-CA chains continue to validate identically (WebPKI roots are still loaded). Users who previously hit "self-signed certificate in chain" errors connecting to selfhosted providers behind a corporate CA now succeed. The native-cert load happens once per `Client::build()` and is cheap (`rustls-native-certs` reads the OS trust store lazily).
- **Linked issue(s):** Fixes #6528.

## Validation Evidence (required)

```
$ cargo fmt --all -- --check
(clean — no diff)

$ cargo test -p zeroclaw-providers --lib provider_http_client_trusts_both
test result: ok. 1 passed; 0 failed; 0 ignored
  (new compile-time proof: tls_built_in_webpki_certs and
   tls_built_in_native_certs are both callable on ClientBuilder;
   either feature being dropped would fail this test to compile)

$ cargo test -p zeroclaw-providers --lib
test result: ok. 867 passed; 0 failed; 0 ignored
  (866 baseline on master + 1 new test)

$ cargo tree -p zeroclaw-providers --depth 4 | rg "rustls-native|webpki-roots"
│   │   ├── rustls-native-certs v0.8.3
│   │   └── webpki-roots v1.0.7
  (both root sets confirmed in dep graph)
```

- **Commands run and tail output:** as above.
- **Beyond CI — what I manually verified:**
  - Confirmed via reqwest 0.12.28 source (`src/async_impl/client.rs:189-195`) that `tls_built_in_certs_webpki` and `tls_built_in_certs_native` are independent fields in `ClientBuilder` state and both default to `true` when their respective features are enabled — so reqwest will additively merge both root sets into one `RootCertStore` at `build()` time. No code changes to call sites required.
  - Did **not** run a live HTTPS request against a server with a self-signed cert in the OS trust store — no provider/cert in this dev env. The compile-time test asserts the feature switches are wired correctly; the runtime behavior (rustls accepting both root sets) is a property of reqwest itself, asserted by reqwest's own test suite.
- **If any command was intentionally skipped:** `cargo test --workspace` and `cargo clippy --workspace --all-targets -- -D warnings` deferred to CI.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **Indirectly yes**, via the well-established `rustls-native-certs` crate which reads the OS trust store at HTTP-client construction time. On Linux this means `/etc/ssl/certs`; on macOS the system keychain; on Windows the Windows certificate store. Read-only, no writes. This is the standard pattern for trusting OS-managed CAs.
- New external network calls? **No.** The set of hosts a `Client` may connect to is unchanged; only the set of CA roots it will accept widens to include OS-trusted CAs.
- Secrets / tokens / credentials handling changed? **No.**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No.**

This change **does** widen trust: any cert chain that chains to an OS-trusted CA (e.g. an attacker-installed CA on a compromised system) will now be accepted by provider requests where it previously would have been rejected. This is the intended behavior — operators who add a CA to their system trust store have, by definition, decided to trust it. Users on systems where they do not control the OS trust store should rely on the WebPKI bundle only, which is unchanged by this PR.

## Compatibility (required)

- Backward compatible? **Yes** for public-CA chains (WebPKI roots are still loaded). **Behaviour widening** for chains rooted in OS-trusted CAs: previously rejected with "self-signed certificate in chain" errors, now accepted. This is the intended fix.
- Config / env / CLI surface changed? **No.**

## Rollback (required for `risk: medium`)

- **Fast rollback command/path:** `git revert <commit>` (single commit; touches only Cargo.toml and a test).
- **Feature flags or config toggles:** None at runtime. The Cargo feature `rustls-tls-native-roots-no-provider` could be removed to restore pre-PR behavior, but this would re-break the reported #6528 use case.
- **Observable failure symptoms:** If `rustls-native-certs` fails to read the OS trust store on a given platform (e.g. permissions issue), the client would fail at build time with a `rustls_native_certs::Error`. The fall-back to WebPKI-only would still cover all public-CA chains, so the failure mode degrades to "selfhosted provider with custom CA returns the original TLS error," matching pre-PR behavior. Public-CA traffic remains unaffected.

---

**Labels:** `bug`, `risk: medium`, `dependencies`, `provider`, `size: XS` (set in the GitHub UI).

**Diff stat:** 2 files changed, +14 / -1.

