### PR TITLE
fix(tools): resolve gws via PATH so Windows .cmd shims work

### DIFF
--- a/crates/zeroclaw-tools/src/google_workspace.rs
+++ b/crates/zeroclaw-tools/src/google_workspace.rs
@@ -384,7 +384,12 @@ impl Tool for GoogleWorkspaceTool {
             });
         }
 
-        let mut cmd = tokio::process::Command::new("gws");
+        // Resolve `gws` via PATH so Windows `.cmd` shims (e.g. npm-installed
+        // `gws.cmd`) are picked up — `Command::new` on Windows does not append
+        // PATHEXT itself. Falls back to bare "gws" so the not-found error path
+        // below still fires when the binary is genuinely missing.
+        let gws_path: std::path::PathBuf = which::which("gws").unwrap_or_else(|_| "gws".into());
+        let mut cmd = tokio::process::Command::new(gws_path);
         cmd.args(&cmd_args);
         cmd.env_clear();
         // gws needs PATH to find itself and HOME/APPDATA for credential storage
@@ -482,6 +487,16 @@ mod tests {
             workspace_dir: std::env::temp_dir(),
             ..SecurityPolicy::default()
         })
+    }
+
+    // Regression for #6410: PATH resolution must produce a usable PathBuf
+    // even when `gws` is not installed, so the executor can still emit the
+    // documented "Failed to execute gws" error rather than panicking.
+    #[test]
+    fn gws_path_resolution_falls_back_when_not_on_path() {
+        let resolved: std::path::PathBuf =
+            which::which("definitely-not-a-real-binary-zc6410").unwrap_or_else(|_| "gws".into());
+        assert_eq!(resolved.as_os_str(), "gws");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `GoogleWorkspaceTool::execute` called `tokio::process::Command::new("gws")` directly. Rust's `std::process::Command` on Windows does **not** append `PATHEXT` when resolving a bare binary name, so an npm-installed `gws.cmd` (the standard installation form on Windows from `npm install -g @googleworkspace/cli`) is invisible to the tool. The call always errors with "program not found," and the agent then falls back to the shell tool — where PowerShell double-escapes the JSON in `--params {"calendarId":"primary"}` and the call fails again, producing the 15+ retry loop documented in the issue.
  - Resolve `gws` via `which::which("gws")` before constructing the `Command`. `which` walks `PATH` with explicit `PATHEXT` expansion on Windows, so `gws.cmd` is picked up the same way `cmd.exe` would resolve it. On Unix this is functionally equivalent to the existing lookup: `which` resolves the same `gws` found in `PATH`, but passes the resolved path to `Command`.
  - Falls back to `PathBuf::from("gws")` on `which` failure so the existing "Failed to execute gws … Run: npm install -g @googleworkspace/cli" error path at `google_workspace.rs:457` still surfaces when the binary is genuinely missing. No new intended failure mode is introduced; the main possible difference is a more specific OS error if `which` returns a stale or otherwise unexecutable path.
  - **About the `--params` double-escaping (issue bug #2):** the tool itself passes `--params` as a single argv element via `cmd_args.push(params.to_string())` and `cmd.args(&cmd_args)` — `Command::args` never invokes a shell. The PowerShell double-escape only happens after this tool fails and the agent falls back to the *shell* tool. Fixing the Windows `gws` resolution removes the trigger for that fallback, addressing the symptom at its root.

- **Scope boundary:** One function in one file. The `which` crate is already a direct dependency of `zeroclaw-tools` (`Cargo.toml` line 23: `which = "8.0"`), so no new deps.
- **Blast radius:** Windows-specific bug fix for npm-installed `.cmd` shims. On Unix/macOS the spawned `gws` command remains PATH-based and effectively equivalent to the pre-PR behavior, apart from using the resolved executable path rather than the literal `gws` token.
- **Linked issue(s):** Fixes #6410.

## Validation Evidence (required)

```
$ cargo fmt --all -- --check
(clean — no diff)

$ cargo test -p zeroclaw-tools --lib google_workspace
test result: ok. 32 passed; 0 failed; 0 ignored
  (includes new regression: gws_path_resolution_falls_back_when_not_on_path)

$ cargo check -p zeroclaw-tools
    Finished `dev` profile [unoptimized + debuginfo] target(s)
```

- **Commands run and tail output:** as above.
- **Beyond CI — what I manually verified:**
  - The new `gws_path_resolution_falls_back_when_not_on_path` test asserts that the `unwrap_or_else(|_| "gws".into())` branch produces a valid `PathBuf("gws")` when `which::which` returns `Err(NotFound)`. This is the load-bearing fallback that preserves the existing "Failed to execute gws" error contract.
  - Did **not** run the live Windows reproduction from the issue — no Windows host in this dev env. The bug surface is the `Command::new("gws")` call that ignored PATHEXT; the fix routes through `which::which`, which is documented to expand PATHEXT on Windows (see [which crate docs, PATHEXT section](https://docs.rs/which/8.0.0/which/#windows)). That contract is the load-bearing piece, asserted by the `which` crate's own test suite rather than re-asserted here.
- **If any command was intentionally skipped:** `cargo test --workspace` and `cargo clippy --workspace --all-targets -- -D warnings` deferred to CI. Pre-existing failures in `swarm::tests::{router,sequential}_invalid_provider_returns_error` reproduce on master at the same SHA and are unrelated to this change.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No.** `which::which` walks the existing `PATH` environment variable — the same lookup `Command::new` was already attempting, just with PATHEXT expansion on Windows. No new directory source is added.
- New external network calls? **No.**
- Secrets / tokens / credentials handling changed? **No.** Credentials path and account flags are passed identically to the resolved binary.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No.**

The resolved path is **only used as the executable** for `tokio::process::Command::new`, not interpolated into a shell, not logged, not exposed in tool output. An attacker who can plant a `gws.cmd` shim earlier on `PATH` than the legitimate one could already hijack the tool through the pre-PR lookup boundary (`Command::new` consults PATH); this PR does not widen that trust boundary.

## Compatibility (required)

- Backward compatible? **Yes** on Unix in the behavior that matters for users. **Behaviour change** on Windows: previously failed with "program not found" for npm-installed `gws`; now succeeds when `gws.cmd` is on `PATH`. This is the intended fix.
- Config / env / CLI surface changed? **No.**

## Rollback

- **Fast rollback command/path:** `git revert <commit>` (single commit, one file, +16 / -1).
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** If `which::which("gws")` ever returns a path that `tokio::process::Command::new` cannot execute (e.g., a stale symlink to a removed binary), users would see "Failed to execute gws: \<OS error\>" — the same shape as today's not-found error, just with a slightly different inner cause. The fallback branch ensures `which` returning `Err` reproduces today's exact error text.

---

**Labels:** `bug`, `risk: high`, `risk: manual`, `tool`, `tool:google-workspace`, `size: XS` (set in the GitHub UI).

**Diff stat:** 1 file changed, +16 / -1.
