### PR TITLE
feat(web): tool approval UI for supervised-mode tool execution

### DIFF
--- a/crates/zeroclaw-gateway/src/ws.rs
+++ b/crates/zeroclaw-gateway/src/ws.rs
@@ -727,9 +727,28 @@ async fn process_chat_message(
     // tool approval could neither be sent to the client nor answered before
     // the timeout fired.
     let forward_fut = async {
+        let mut cancel_drained = false;
         loop {
             tokio::select! {
                 biased;
+                // ── Cancellation arm ─────────────────────────────
+                // When `/abort` cancels the token, immediately drop every
+                // parked oneshot sender so any in-flight `request_approval`
+                // unblocks via the "sender dropped → deny" path in
+                // `WsApprovalChannel`. Without this, the approval future
+                // races only its own `timeout_secs` (default 120s) and
+                // ignores the cancel token, so the abort sits idle for up
+                // to two minutes before the tool loop even gets a chance
+                // to observe the cancellation.
+                _ = cancel_token.cancelled(), if !cancel_drained => {
+                    let drained: Vec<_> = pending_approvals.lock().drain().collect();
+                    drop(drained);
+                    cancel_drained = true;
+                    // Fall through; the agent loop will now wake from the
+                    // approval await, see the cancel token, and propagate
+                    // a ToolLoopCancelled error which closes event_rx and
+                    // breaks this loop on the `event_rx.recv()` arm below.
+                }
                 client_msg = receiver.next() => {
                     let Some(Ok(Message::Text(text))) = client_msg else { continue };
                     let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&text) else {

--- a/web/src/components/ApprovalBanner.tsx
+++ b/web/src/components/ApprovalBanner.tsx
@@ -21,7 +21,8 @@ export default function ApprovalBanner({ pending, onRespond }: ApprovalBannerPro
 
   return (
     <div
-      role="alertdialog"
+      role="alert"
+      aria-live="assertive"
       aria-labelledby="approval-banner-title"
       className="border-b px-4 py-3 animate-fade-in"
       style={{
@@ -47,7 +48,7 @@ export default function ApprovalBanner({ pending, onRespond }: ApprovalBannerPro
               <span
                 className="text-xs font-mono"
                 style={{ color: 'var(--pc-text-muted)' }}
-                aria-live="polite"
+                aria-hidden="true"
               >
                 {t('agent.approval_timeout_in')}: {remainingSec}s
               </span>

--- a/web/src/components/ApprovalBanner.tsx
+++ b/web/src/components/ApprovalBanner.tsx
@@ -1,0 +1,113 @@
+import { useEffect, useState } from 'react';
+import { AlertTriangle, Check, X, ShieldCheck } from 'lucide-react';
+import type { ApprovalDecision, PendingApproval } from '@/types/api';
+import { t } from '@/lib/i18n';
+
+interface ApprovalBannerProps {
+  pending: PendingApproval;
+  onRespond: (decision: ApprovalDecision) => void;
+}
+
+export default function ApprovalBanner({ pending, onRespond }: ApprovalBannerProps) {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const elapsedMs = now - pending.receivedAt;
+  const remainingSec = Math.max(0, Math.ceil(pending.timeoutSecs - elapsedMs / 1000));
+
+  return (
+    <div
+      role="alertdialog"
+      aria-labelledby="approval-banner-title"
+      className="border-b px-4 py-3 animate-fade-in"
+      style={{
+        background: 'var(--color-status-warning-alpha-08, rgba(245, 158, 11, 0.08))',
+        borderColor: 'var(--color-status-warning-alpha-20, rgba(245, 158, 11, 0.2))',
+      }}
+    >
+      <div className="max-w-4xl mx-auto flex flex-col gap-2">
+        <div className="flex items-start gap-3">
+          <AlertTriangle
+            className="h-5 w-5 shrink-0 mt-0.5"
+            style={{ color: 'var(--color-status-warning, #f59e0b)' }}
+          />
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center justify-between gap-2 flex-wrap">
+              <p
+                id="approval-banner-title"
+                className="text-sm font-semibold"
+                style={{ color: 'var(--pc-text-primary)' }}
+              >
+                {t('agent.approval_title')}
+              </p>
+              <span
+                className="text-xs font-mono"
+                style={{ color: 'var(--pc-text-muted)' }}
+                aria-live="polite"
+              >
+                {t('agent.approval_timeout_in')}: {remainingSec}s
+              </span>
+            </div>
+            <p className="text-xs mt-1" style={{ color: 'var(--pc-text-secondary)' }}>
+              <span style={{ color: 'var(--pc-text-muted)' }}>{t('agent.approval_tool')}:</span>{' '}
+              <span className="font-mono">{pending.toolName}</span>
+            </p>
+            {pending.argumentsSummary && (
+              <>
+                <p
+                  className="text-xs mt-1"
+                  style={{ color: 'var(--pc-text-muted)' }}
+                  id="approval-banner-args-label"
+                >
+                  {t('agent.approval_arguments')}:
+                </p>
+                <pre
+                  className="text-xs mt-1 whitespace-pre-wrap break-words leading-relaxed p-2 rounded-lg max-h-40 overflow-auto"
+                  style={{ background: 'var(--pc-bg-surface)', color: 'var(--pc-text-secondary)' }}
+                  aria-labelledby="approval-banner-args-label"
+                >
+                  {pending.argumentsSummary}
+                </pre>
+              </>
+            )}
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2 justify-end">
+          <button
+            type="button"
+            onClick={() => onRespond('deny')}
+            className="btn-secondary flex items-center gap-1.5 text-xs"
+            style={{ padding: '0.35rem 0.85rem', borderRadius: '0.5rem' }}
+          >
+            <X className="h-3.5 w-3.5" />
+            {t('agent.approval_deny')}
+          </button>
+          <button
+            type="button"
+            onClick={() => onRespond('approve')}
+            className="btn-electric flex items-center gap-1.5 text-xs"
+            style={{ padding: '0.35rem 0.85rem', borderRadius: '0.5rem', color: 'white' }}
+          >
+            <Check className="h-3.5 w-3.5" />
+            {t('agent.approval_approve')}
+          </button>
+          <button
+            type="button"
+            onClick={() => onRespond('always')}
+            className="btn-secondary flex items-center gap-1.5 text-xs"
+            style={{ padding: '0.35rem 0.85rem', borderRadius: '0.5rem' }}
+            title={t('agent.approval_always_hint')}
+          >
+            <ShieldCheck className="h-3.5 w-3.5" />
+            {t('agent.approval_always')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/contexts/AgentContext.tsx
+++ b/web/src/contexts/AgentContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useEffect, useRef, useState, useCallback } from 'react';
-import type { WsMessage } from '@/types/api';
+import type { ApprovalDecision, PendingApproval, WsMessage } from '@/types/api';
 import { WebSocketClient, getOrCreateSessionId } from '@/lib/ws';
 import { generateUUID } from '@/lib/uuid';
 import { t } from '@/lib/i18n';
@@ -40,6 +40,13 @@ interface AgentContextValue {
   deleteMessage: (id: string) => void;
   clearAllMessages: () => void;
   abortSession: () => Promise<void>;
+  /**
+   * Pending supervised-mode tool-approval prompt, or null. Populated when the
+   * gateway emits an `approval_request` frame; cleared once the user responds
+   * or a fresh `approval_request` arrives. See #6522.
+   */
+  pendingApproval: PendingApproval | null;
+  respondToApproval: (decision: ApprovalDecision) => void;
 }
 
 const AgentContext = createContext<AgentContextValue | null>(null);
@@ -68,6 +75,7 @@ export function AgentProvider({ children }: { children: React.ReactNode }) {
   const [availableModels, setAvailableModels] = useState<string[]>([]);
   const [modelLoading, setModelLoading] = useState(false);
   const [modelInfoVersion, setModelInfoVersion] = useState(0);
+  const [pendingApproval, setPendingApproval] = useState<PendingApproval | null>(null);
 
   const wsRef = useRef<WebSocketClient | null>(null);
   const pendingContentRef = useRef('');
@@ -120,6 +128,26 @@ export function AgentProvider({ children }: { children: React.ReactNode }) {
     if (!historyReady) return;
     saveChatHistory(sessionIdRef.current, uiMessagesToPersisted(messages));
   }, [messages, historyReady]);
+
+  // Auto-clear a pending approval when its timeout elapses on the backend.
+  // The gateway auto-denies after `timeout_secs`; without this effect the
+  // banner would linger indefinitely if the user just walked away. Add a
+  // small grace buffer so the user is not penalised for last-second clicks.
+  useEffect(() => {
+    if (!pendingApproval) return;
+    const elapsed = Date.now() - pendingApproval.receivedAt;
+    const remainingMs = pendingApproval.timeoutSecs * 1000 - elapsed + 500;
+    if (remainingMs <= 0) {
+      setPendingApproval(null);
+      return;
+    }
+    const id = setTimeout(() => {
+      setPendingApproval((current) =>
+        current && current.requestId === pendingApproval.requestId ? null : current,
+      );
+    }, remainingMs);
+    return () => clearTimeout(id);
+  }, [pendingApproval]);
 
   // Centralised WebSocket message handler — reused across initial connect and reconnects.
   const handleWsMessage = useCallback((msg: WsMessage) => {
@@ -248,6 +276,21 @@ export function AgentProvider({ children }: { children: React.ReactNode }) {
         break;
       }
 
+      case 'approval_request': {
+        // Supervised-mode tool consent prompt. Backend parks on a oneshot
+        // until we send `approval_response`; if the socket closes or the
+        // timeout elapses, the backend auto-denies on its side.
+        if (!msg.request_id) break;
+        setPendingApproval({
+          requestId: msg.request_id,
+          toolName: msg.tool ?? 'unknown',
+          argumentsSummary: msg.arguments_summary ?? '',
+          timeoutSecs: msg.timeout_secs ?? 120,
+          receivedAt: Date.now(),
+        });
+        break;
+      }
+
       case 'error':
         setMessages((prev) => [
           ...prev,
@@ -268,6 +311,7 @@ export function AgentProvider({ children }: { children: React.ReactNode }) {
         pendingThinkingRef.current = '';
         setStreamingContent('');
         setStreamingThinking('');
+        setPendingApproval(null);
         break;
     }
   }, []);
@@ -297,6 +341,9 @@ export function AgentProvider({ children }: { children: React.ReactNode }) {
     ws.onClose = (ev: CloseEvent) => {
       if (version !== wsVersionRef.current) return;
       setConnected(false);
+      // Backend auto-denies pending approvals when the socket closes; clear
+      // local UI so the user is not staring at a stale banner.
+      setPendingApproval(null);
 
       if (pendingModelSwitchRef.current) {
         // We intentionally closed the old socket; non-normal codes mean the reconnect failed.
@@ -499,6 +546,18 @@ export function AgentProvider({ children }: { children: React.ReactNode }) {
     setMessages([]);
   }, []);
 
+  const respondToApproval = useCallback((decision: ApprovalDecision) => {
+    setPendingApproval((current) => {
+      if (!current) return null;
+      try {
+        wsRef.current?.sendApprovalResponse(current.requestId, decision);
+      } catch {
+        // Socket closed mid-prompt; backend will auto-deny on its side.
+      }
+      return null;
+    });
+  }, []);
+
   const value: AgentContextValue = {
     messages,
     sendMessage,
@@ -521,6 +580,8 @@ export function AgentProvider({ children }: { children: React.ReactNode }) {
         // Best-effort abort
       }
     },
+    pendingApproval,
+    respondToApproval,
   };
 
   return <AgentContext.Provider value={value}>{children}</AgentContext.Provider>;

--- a/web/src/contexts/AgentContext.tsx
+++ b/web/src/contexts/AgentContext.tsx
@@ -291,6 +291,20 @@ export function AgentProvider({ children }: { children: React.ReactNode }) {
         break;
       }
 
+      case 'aborted': {
+        // Gateway sends this after a cancelled turn; the parked approval (if
+        // any) is no longer valid because its request_id belongs to the old
+        // turn. Clear so the banner does not linger across the abort.
+        pendingContentRef.current = '';
+        pendingThinkingRef.current = '';
+        capturedThinkingRef.current = '';
+        setStreamingContent('');
+        setStreamingThinking('');
+        setTyping(false);
+        setPendingApproval(null);
+        break;
+      }
+
       case 'error':
         setMessages((prev) => [
           ...prev,
@@ -339,11 +353,13 @@ export function AgentProvider({ children }: { children: React.ReactNode }) {
     };
 
     ws.onClose = (ev: CloseEvent) => {
+      // Clear pending approval ahead of the version guard: even if this is a
+      // stale socket whose other state we don't want to write, the parked
+      // request_id is gone on the server side regardless and the banner must
+      // not survive the close.
+      setPendingApproval(null);
       if (version !== wsVersionRef.current) return;
       setConnected(false);
-      // Backend auto-denies pending approvals when the socket closes; clear
-      // local UI so the user is not staring at a stale banner.
-      setPendingApproval(null);
 
       if (pendingModelSwitchRef.current) {
         // We intentionally closed the old socket; non-normal codes mean the reconnect failed.
@@ -510,6 +526,10 @@ export function AgentProvider({ children }: { children: React.ReactNode }) {
       setStreamingContent('');
       setStreamingThinking('');
       setTyping(false);
+      // The old socket's request_id no longer maps to anything on the server
+      // after we tear it down. Clear here explicitly because we null out the
+      // old socket's callbacks below, so its onClose will not fire to do it.
+      setPendingApproval(null);
 
       // Tear down the old socket and create a fresh one.
       // The backend will read the updated config when the new socket opens
@@ -574,6 +594,11 @@ export function AgentProvider({ children }: { children: React.ReactNode }) {
     deleteMessage,
     clearAllMessages,
     abortSession: async () => {
+      // Clear local approval state immediately — the in-flight request_id
+      // belongs to the turn we're cancelling and will be rejected by the
+      // backend on a late click anyway. Don't wait for the `aborted` frame
+      // to round-trip; the user clicked Stop and expects the UI to follow.
+      setPendingApproval(null);
       try {
         await abortSession(sessionIdRef.current);
       } catch {

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -72,6 +72,16 @@ const translations: Record<Locale, Record<string, string>> = {
     'agent.failed_switch_model': '切换模型失败',
     'agent.model_switch_timeout': '模型切换超时，请检查网络后重试',
 
+    // Supervised-mode tool approval (#6522)
+    'agent.approval_title': '需要授权工具调用',
+    'agent.approval_tool': '工具',
+    'agent.approval_arguments': '参数',
+    'agent.approval_timeout_in': '超时自动拒绝',
+    'agent.approval_approve': '批准',
+    'agent.approval_deny': '拒绝',
+    'agent.approval_always': '始终批准',
+    'agent.approval_always_hint': '本会话内自动批准此工具',
+
     // Tools
     'tools.title': '可用工具',
     'tools.name': '名称',
@@ -458,6 +468,15 @@ const translations: Record<Locale, Record<string, string>> = {
     'agent.tool_activity_show': 'Show tool activity',
     'agent.tool_activity_hide': 'Hide tool activity',
     'agent.running': 'Running…',
+    // Supervised-mode tool approval (#6522)
+    'agent.approval_title': 'Tool approval required',
+    'agent.approval_tool': 'Tool',
+    'agent.approval_arguments': 'Arguments',
+    'agent.approval_timeout_in': 'Auto-deny in',
+    'agent.approval_approve': 'Approve',
+    'agent.approval_deny': 'Deny',
+    'agent.approval_always': 'Always approve',
+    'agent.approval_always_hint': 'Approve this tool automatically for the rest of this session',
     'agent.stop': 'Stop',
 
     // Tools

--- a/web/src/lib/ws.ts
+++ b/web/src/lib/ws.ts
@@ -1,4 +1,4 @@
-import type { WsMessage } from '../types/api';
+import type { ApprovalDecision, WsMessage } from '../types/api';
 import { getToken } from './auth';
 import { apiOrigin, basePath } from './basePath';
 import { isTauri } from './tauri';
@@ -113,6 +113,19 @@ export class WebSocketClient {
       throw new Error('WebSocket is not connected');
     }
     this.ws.send(JSON.stringify({ type: 'message', content }));
+  }
+
+  /**
+   * Reply to a supervised-mode tool `approval_request`. The backend matches
+   * the response by `request_id` and resolves the parked approval oneshot.
+   * If the socket is closed the request will auto-deny on the server side
+   * after the timeout, so we silently no-op rather than throwing.
+   */
+  sendApprovalResponse(requestId: string, decision: ApprovalDecision): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+    this.ws.send(
+      JSON.stringify({ type: 'approval_response', request_id: requestId, decision }),
+    );
   }
 
   /** Close the connection without auto-reconnecting. */

--- a/web/src/pages/AgentChat.tsx
+++ b/web/src/pages/AgentChat.tsx
@@ -7,6 +7,7 @@ import { useDraft } from '@/hooks/useDraft';
 import { t } from '@/lib/i18n';
 
 import ToolCallCard from '@/components/ToolCallCard';
+import ApprovalBanner from '@/components/ApprovalBanner';
 
 const DRAFT_KEY = 'agent-chat';
 
@@ -26,6 +27,8 @@ export default function AgentChat() {
     deleteMessage,
     clearAllMessages,
     abortSession,
+    pendingApproval,
+    respondToApproval,
   } = useAgent();
 
   const { draft, saveDraft, clearDraft } = useDraft(DRAFT_KEY);
@@ -359,6 +362,11 @@ export default function AgentChat() {
 
         <div ref={messagesEndRef} />
       </div>
+
+      {/* Tool approval banner — supervised-mode consent prompt (#6522). */}
+      {pendingApproval && (
+        <ApprovalBanner pending={pendingApproval} onRespond={respondToApproval} />
+      )}
 
       {/* Input area */}
       <div className="border-t p-4" style={{ borderColor: 'var(--pc-border)', background: 'var(--pc-bg-surface)' }}>

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -147,7 +147,8 @@ export interface WsMessage {
     | 'session_start'
     | 'connected'
     | 'cron_result'
-    | 'approval_request';
+    | 'approval_request'
+    | 'aborted';
   content?: string;
   full_response?: string;
   name?: string;

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -146,7 +146,8 @@ export interface WsMessage {
     | 'error'
     | 'session_start'
     | 'connected'
-    | 'cron_result';
+    | 'cron_result'
+    | 'approval_request';
   content?: string;
   full_response?: string;
   name?: string;
@@ -160,6 +161,22 @@ export interface WsMessage {
   timestamp?: string;
   job_id?: string;
   success?: boolean;
+  // Supervised-mode tool approval (server → client). See #6522.
+  request_id?: string;
+  tool?: string;
+  arguments_summary?: string;
+  timeout_secs?: number;
+}
+
+export type ApprovalDecision = 'approve' | 'deny' | 'always';
+
+export interface PendingApproval {
+  requestId: string;
+  toolName: string;
+  argumentsSummary: string;
+  timeoutSecs: number;
+  /** Wall-clock millis when the request arrived; used to compute remaining time. */
+  receivedAt: number;
 }
 
 /** Row from GET /api/sessions/{id}/messages */


### PR DESCRIPTION
## Summary

Closes #6522. The gateway already implemented the WebSocket approval protocol (`approval_request` / `approval_response`), but the web frontend silently ignored the frames — every supervised tool was auto-denied after the 120s timeout without the operator ever being asked.

This PR contains two commits:

1. **`feat(web): tool approval UI for supervised-mode tool execution`** — adds the missing frontend piece.
2. **`fix(web,gateway): clear pending approval on abort + cancel-aware approval await`** — follow-up addressing review feedback on stale-banner edge cases, accessibility semantics, and a backend-side wait-state leak that kept the turn alive for up to 120 s after Stop.

### Frontend changes

- **`web/src/types/api.ts`** — extends `WsMessage` with `'approval_request'` and `'aborted'`, plus the `request_id` / `tool` / `arguments_summary` / `timeout_secs` fields; exports `ApprovalDecision` and `PendingApproval` types.
- **`web/src/lib/ws.ts`** — adds `WebSocketClient.sendApprovalResponse(requestId, decision)` matching the wire protocol; no-ops when the socket is closed (backend auto-denies on its side).
- **`web/src/contexts/AgentContext.tsx`** — adds `pendingApproval` state and a `respondToApproval` callback. The state is cleared:
  - when the user responds (race-safe `setPendingApproval(current => …)` form),
  - synchronously inside `abortSession` and `switchModel` (the old socket's callbacks are nulled before disconnect, so its `onClose` cannot do the cleanup),
  - ahead of the `wsVersionRef` guard in `onClose` (the parked `request_id` is gone server-side regardless of socket version),
  - on the gateway's terminal `aborted` frame,
  - on hard error frames, and
  - when the local timeout matches the backend's auto-deny grace.
- **`web/src/components/ApprovalBanner.tsx`** *(new)* — non-modal inline banner above the chat input with tool name, labelled arguments preview, live countdown, and Approve / Deny / Always-approve buttons. Uses `role="alert"` + `aria-live="assertive"` (no focus-trap contract); the per-second countdown is hidden from assistive tech so it is not announced 120 times.
- **`web/src/pages/AgentChat.tsx`** — renders the banner directly above the input area whenever `pendingApproval` is non-null.
- **`web/src/lib/i18n.ts`** — adds `agent.approval_*` keys for `en` and `zh`. Other locales fall back through the existing `t()` en fallback, matching how `agent.tool_activity_show` / `agent.clear_all` / `agent.model_switch_timeout` already behave.

### Backend change

- **`crates/zeroclaw-gateway/src/ws.rs`** — the forward loop now selects on the turn's cancel token and drains `pending_approvals` when it fires. Dropping the oneshot senders trips the existing "sender dropped → Deny" path in `WsApprovalChannel`, so the agent loop wakes immediately on Stop instead of waiting out the full `timeout_secs` (default 120 s) before observing cancellation.

## Validation

Build:

- `cd web && npx tsc -b && npx vite build` — clean (no type errors, no build warnings introduced by this PR).

Manually exercised against a local gateway with supervised-mode tools:

- Trigger a supervised tool from the web chat → banner appears above the input with tool name, labelled args preview, and live countdown.
- **Approve** → tool executes; banner disappears.
- **Deny** → backend reports denial; banner disappears.
- **Always approve** → tool executes; subsequent invocations of the same tool in the same session no longer prompt.
- Wait 120 s without responding → backend auto-denies, frontend banner clears (no stale UI).
- Kill the gateway mid-prompt → banner clears via `onClose`.
- Click Stop while the banner is showing → banner clears immediately; the turn ends within a second (verifying the cancel-aware approval await on the backend).
- Switch model while the banner is showing → banner clears before the old socket is torn down; new socket starts clean.
- Existing chat / tool_call / tool_result rendering and streaming continue to work unchanged.

Screenshot of the banner in use:
<img width="1656" height="857" alt="image" src="https://github.com/user-attachments/assets/4d3924ea-084c-4f36-92aa-212599831ebb" />


## Related

- #6321 — desktop menu-bar tool approval (Tauri counterpart)
- #6349 — desktop tool_call inline rendering parity
