### PR TITLE
test(runtime): cover workspace profile registration

### DIFF
--- a/crates/zeroclaw-config/src/workspace.rs
+++ b/crates/zeroclaw-config/src/workspace.rs
@@ -7,6 +7,7 @@
 use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::fs;
 use std::path::{Path, PathBuf};
 
 /// A single client workspace profile.
@@ -114,17 +115,7 @@ impl WorkspaceManager {
                 continue;
             }
             match tokio::fs::read_to_string(&profile_path).await {
-                Ok(contents) => match toml::from_str::<WorkspaceProfile>(&contents) {
-                    Ok(profile) => {
-                        self.profiles.insert(profile.name.clone(), profile);
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            "skipping malformed workspace profile {}: {e}",
-                            profile_path.display()
-                        );
-                    }
-                },
+                Ok(contents) => self.load_profile_contents(&profile_path, &contents),
                 Err(e) => {
                     tracing::warn!(
                         "skipping unreadable workspace profile {}: {e}",
@@ -148,12 +139,11 @@ impl WorkspaceManager {
             return Ok(());
         }
 
-        let entries = std::fs::read_dir(dir)
+        let entries = fs::read_dir(dir)
             .with_context(|| format!("reading workspaces directory: {}", dir.display()))?;
 
         for entry in entries {
-            let entry = entry?;
-            let path = entry.path();
+            let path = entry?.path();
             if !path.is_dir() {
                 continue;
             }
@@ -161,18 +151,8 @@ impl WorkspaceManager {
             if !profile_path.exists() {
                 continue;
             }
-            match std::fs::read_to_string(&profile_path) {
-                Ok(contents) => match toml::from_str::<WorkspaceProfile>(&contents) {
-                    Ok(profile) => {
-                        self.profiles.insert(profile.name.clone(), profile);
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            "skipping malformed workspace profile {}: {e}",
-                            profile_path.display()
-                        );
-                    }
-                },
+            match fs::read_to_string(&profile_path) {
+                Ok(contents) => self.load_profile_contents(&profile_path, &contents),
                 Err(e) => {
                     tracing::warn!(
                         "skipping unreadable workspace profile {}: {e}",
@@ -183,6 +163,20 @@ impl WorkspaceManager {
         }
 
         Ok(())
+    }
+
+    fn load_profile_contents(&mut self, profile_path: &Path, contents: &str) {
+        match toml::from_str::<WorkspaceProfile>(contents) {
+            Ok(profile) => {
+                self.profiles.insert(profile.name.clone(), profile);
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "skipping malformed workspace profile {}: {e}",
+                    profile_path.display()
+                );
+            }
+        }
     }
 
     /// Switch to the named workspace. Returns an error if it does not exist.

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -1434,4 +1434,55 @@ mod tests {
         let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
         assert!(!names.contains(&"read_skill"));
     }
+
+    #[tokio::test]
+    async fn all_tools_workspace_loads_existing_profiles() {
+        let tmp = TempDir::new().unwrap();
+        let security = Arc::new(SecurityPolicy::default());
+        let mem_cfg = MemoryConfig {
+            backend: "markdown".into(),
+            ..MemoryConfig::default()
+        };
+        let mem: Arc<dyn Memory> =
+            Arc::from(zeroclaw_memory::create_memory(&mem_cfg, tmp.path(), None).unwrap());
+
+        let browser = BrowserConfig::default();
+        let http = zeroclaw_config::schema::HttpRequestConfig::default();
+        let workspaces_dir = tmp.path().join("workspaces");
+        let mut cfg = test_config(&tmp);
+        cfg.workspace.enabled = true;
+        cfg.workspace.workspaces_dir = workspaces_dir.to_string_lossy().to_string();
+
+        let mut manager = zeroclaw_config::workspace::WorkspaceManager::new(workspaces_dir);
+        manager.create("preloaded").await.unwrap();
+
+        let (tools, _, _, _, _, _) = all_tools(
+            Arc::new(cfg.clone()),
+            &security,
+            mem,
+            None,
+            None,
+            &browser,
+            &http,
+            &zeroclaw_config::schema::WebFetchConfig::default(),
+            tmp.path(),
+            &HashMap::new(),
+            None,
+            &cfg,
+            None,
+        );
+
+        let workspace_tool = tools
+            .iter()
+            .find(|tool| tool.name() == "workspace")
+            .expect("workspace tool should be registered");
+        let result = workspace_tool
+            .execute(serde_json::json!({ "action": "list" }))
+            .await
+            .unwrap();
+
+        assert!(result.success);
+        assert!(result.output.contains("preloaded"));
+        assert!(!result.output.contains("No workspaces configured."));
+    }
 }


### PR DESCRIPTION
## Summary

- follow up on workspace startup behavior with a runtime-level regression test for pre-existing profiles
- dedupe async and blocking workspace profile parsing through a shared helper
- keep this as test/refactor coverage without claiming to close #6419

## Verification

- `cargo fmt --check`
- `git diff --check origin/master...HEAD`
- `cargo test -p zeroclaw-config workspace_manager_load_profiles_blocking_matches_async -- --nocapture`
- `cargo test -p zeroclaw-runtime all_tools_workspace_loads_existing_profiles -- --nocapture`
