### PR TITLE
fix(providers): preserve compatible reasoning field

### DIFF
--- a/benches/agent_benchmarks.rs
+++ b/benches/agent_benchmarks.rs
@@ -41,6 +41,7 @@ impl BenchModelProvider {
                 tool_calls: vec![],
                 usage: None,
                 reasoning_content: None,
+                reasoning_field: None,
             }]),
         }
     }
@@ -58,12 +59,14 @@ impl BenchModelProvider {
                     }],
                     usage: None,
                     reasoning_content: None,
+                    reasoning_field: None,
                 },
                 ChatResponse {
                     text: Some("done".into()),
                     tool_calls: vec![],
                     usage: None,
                     reasoning_content: None,
+                    reasoning_field: None,
                 },
             ]),
         }
@@ -108,6 +111,7 @@ impl ModelProvider for BenchModelProvider {
                 tool_calls: vec![],
                 usage: None,
                 reasoning_content: None,
+                reasoning_field: None,
             });
         }
         Ok(guard.remove(0))
@@ -177,6 +181,7 @@ Let me know if you need more."#
         tool_calls: vec![],
         usage: None,
         reasoning_content: None,
+        reasoning_field: None,
     };
 
     let multi_tool = ChatResponse {
@@ -195,6 +200,7 @@ Let me know if you need more."#
         tool_calls: vec![],
         usage: None,
         reasoning_content: None,
+        reasoning_field: None,
     };
 
     c.bench_function("xml_parse_single_tool_call", |b| {
@@ -231,6 +237,7 @@ fn bench_native_parsing(c: &mut Criterion) {
         ],
         usage: None,
         reasoning_content: None,
+        reasoning_field: None,
     };
 
     c.bench_function("native_parse_tool_calls", |b| {

--- a/crates/zeroclaw-api/src/model_provider.rs
+++ b/crates/zeroclaw-api/src/model_provider.rs
@@ -79,6 +79,11 @@ pub struct ChatResponse {
     /// sent back in subsequent API requests — some model_providers reject tool-call
     /// history that omits this field.
     pub reasoning_content: Option<String>,
+    /// Provider response field that carried `reasoning_content`.
+    ///
+    /// Most providers use `reasoning_content`; some OpenAI-compatible
+    /// endpoints use `reasoning` and require the same field on replay.
+    pub reasoning_field: Option<String>,
 }
 
 impl ChatResponse {
@@ -120,6 +125,9 @@ pub enum ConversationMessage {
         /// Raw reasoning content from thinking models, preserved for round-trip
         /// fidelity with model_provider APIs that require it.
         reasoning_content: Option<String>,
+        /// Original provider field used for the reasoning payload.
+        #[serde(default)]
+        reasoning_field: Option<String>,
     },
     /// Results of tool executions, fed back to the LLM.
     ToolResults(Vec<ToolResultMessage>),
@@ -132,6 +140,8 @@ pub struct StreamChunk {
     pub delta: String,
     /// Reasoning/thinking delta (chain-of-thought from thinking models).
     pub reasoning: Option<String>,
+    /// Provider field name used for this reasoning delta.
+    pub reasoning_field: Option<String>,
     /// Whether this is the final chunk.
     pub is_final: bool,
     /// Approximate token count for this chunk (estimated).
@@ -144,6 +154,7 @@ impl StreamChunk {
         Self {
             delta: text.into(),
             reasoning: None,
+            reasoning_field: None,
             is_final: false,
             token_count: 0,
         }
@@ -151,9 +162,15 @@ impl StreamChunk {
 
     /// Create a reasoning/thinking chunk.
     pub fn reasoning(text: impl Into<String>) -> Self {
+        Self::reasoning_with_field(text, "reasoning_content")
+    }
+
+    /// Create a reasoning/thinking chunk with the provider's source field name.
+    pub fn reasoning_with_field(text: impl Into<String>, field: impl Into<String>) -> Self {
         Self {
             delta: String::new(),
             reasoning: Some(text.into()),
+            reasoning_field: Some(field.into()),
             is_final: false,
             token_count: 0,
         }
@@ -164,6 +181,7 @@ impl StreamChunk {
         Self {
             delta: String::new(),
             reasoning: None,
+            reasoning_field: None,
             is_final: true,
             token_count: 0,
         }
@@ -174,6 +192,7 @@ impl StreamChunk {
         Self {
             delta: message.into(),
             reasoning: None,
+            reasoning_field: None,
             is_final: true,
             token_count: 0,
         }
@@ -471,6 +490,7 @@ pub trait ModelProvider: Send + Sync + crate::attribution::Attributable {
                 tool_calls: Vec::new(),
                 usage: None,
                 reasoning_content: None,
+                reasoning_field: None,
             });
         }
 
@@ -482,6 +502,7 @@ pub trait ModelProvider: Send + Sync + crate::attribution::Attributable {
             tool_calls: Vec::new(),
             usage: None,
             reasoning_content: None,
+            reasoning_field: None,
         })
     }
 
@@ -515,6 +536,7 @@ pub trait ModelProvider: Send + Sync + crate::attribution::Attributable {
             tool_calls: Vec::new(),
             usage: None,
             reasoning_content: None,
+            reasoning_field: None,
         })
     }
 

--- a/crates/zeroclaw-infra/src/acp_session_store.rs
+++ b/crates/zeroclaw-infra/src/acp_session_store.rs
@@ -314,6 +314,7 @@ mod tests {
                     extra_content: None,
                 }],
                 reasoning_content: None,
+                reasoning_field: None,
             },
             ConversationMessage::ToolResults(vec![ToolResultMessage {
                 tool_call_id: "tc-1".into(),

--- a/crates/zeroclaw-providers/src/anthropic.rs
+++ b/crates/zeroclaw-providers/src/anthropic.rs
@@ -582,6 +582,7 @@ impl AnthropicModelProvider {
             tool_calls,
             usage,
             reasoning_content: None,
+            reasoning_field: None,
         }
     }
 

--- a/crates/zeroclaw-providers/src/azure_openai.rs
+++ b/crates/zeroclaw-providers/src/azure_openai.rs
@@ -306,6 +306,9 @@ impl AzureOpenAiModelProvider {
             text,
             tool_calls,
             usage: None,
+            reasoning_field: reasoning_content
+                .as_ref()
+                .map(|_| "reasoning_content".to_string()),
             reasoning_content,
         }
     }

--- a/crates/zeroclaw-providers/src/bedrock.rs
+++ b/crates/zeroclaw-providers/src/bedrock.rs
@@ -1226,6 +1226,7 @@ impl BedrockModelProvider {
             tool_calls,
             usage,
             reasoning_content: None,
+            reasoning_field: None,
         }
     }
 

--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -730,6 +730,8 @@ struct ResponseMessage {
     /// via `RawResponseMessage`; when both appear in the same payload, the
     /// canonical `reasoning_content` wins. See #6584.
     reasoning_content: Option<String>,
+    #[serde(skip)]
+    reasoning_field: Option<&'static str>,
     tool_calls: Option<Vec<ToolCall>>,
 }
 
@@ -756,10 +758,15 @@ impl From<RawResponseMessage> for ResponseMessage {
     fn from(raw: RawResponseMessage) -> Self {
         // Canonical field wins when both are present; the alias fills in only
         // when the canonical name is absent or null.
-        let reasoning_content = raw.reasoning_content.or(raw.reasoning);
+        let (reasoning_content, reasoning_field) = match (raw.reasoning_content, raw.reasoning) {
+            (Some(value), _) => (Some(value), Some("reasoning_content")),
+            (None, Some(value)) => (Some(value), Some("reasoning")),
+            (None, None) => (None, None),
+        };
         ResponseMessage {
             content: raw.content,
             reasoning_content,
+            reasoning_field,
             tool_calls: raw.tool_calls,
         }
     }
@@ -779,8 +786,7 @@ impl ResponseMessage {
             }
         }
 
-        self.reasoning_content
-            .as_ref()
+        self.reasoning_text()
             .map(|c| strip_think_tags(c))
             .filter(|c| !c.is_empty())
             .unwrap_or_default()
@@ -794,10 +800,27 @@ impl ResponseMessage {
             }
         }
 
-        self.reasoning_content
-            .as_ref()
+        self.reasoning_text()
             .map(|c| strip_think_tags(c))
             .filter(|c| !c.is_empty())
+    }
+
+    fn reasoning_text(&self) -> Option<&str> {
+        self.reasoning_content
+            .as_deref()
+            .filter(|value| !value.is_empty())
+    }
+
+    fn reasoning_text_owned(&self) -> Option<String> {
+        self.reasoning_text().map(ToString::to_string)
+    }
+
+    fn reasoning_field(&self) -> Option<&'static str> {
+        self.reasoning_field
+    }
+
+    fn reasoning_field_owned(&self) -> Option<String> {
+        self.reasoning_field().map(ToString::to_string)
     }
 }
 
@@ -910,6 +933,9 @@ struct NativeMessage {
     /// that require it in assistant tool-call history messages.
     #[serde(skip_serializing_if = "Option::is_none")]
     reasoning_content: Option<String>,
+    /// Alternate raw reasoning field used by some OpenAI-compatible providers.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reasoning: Option<String>,
 }
 
 // ---------------------------------------------------------------
@@ -944,6 +970,7 @@ struct StreamDelta {
     /// appear in the same delta, the canonical `reasoning_content` wins. See
     /// #6584 and review feedback on PR #6615.
     reasoning_content: Option<String>,
+    reasoning_field: Option<&'static str>,
     /// Native tool-calling deltas in OpenAI chat-completions streaming format.
     tool_calls: Option<Vec<StreamToolCallDelta>>,
 }
@@ -971,9 +998,15 @@ impl<'de> Deserialize<'de> for StreamDelta {
         D: serde::Deserializer<'de>,
     {
         let raw = RawStreamDelta::deserialize(deserializer)?;
+        let (reasoning_content, reasoning_field) = match (raw.reasoning_content, raw.reasoning) {
+            (Some(value), _) => (Some(value), Some("reasoning_content")),
+            (None, Some(value)) => (Some(value), Some("reasoning")),
+            (None, None) => (None, None),
+        };
         Ok(StreamDelta {
             content: raw.content,
-            reasoning_content: raw.reasoning_content.or(raw.reasoning),
+            reasoning_content,
+            reasoning_field,
             tool_calls: raw.tool_calls,
         })
     }
@@ -1155,13 +1188,18 @@ fn extract_sse_text_delta(choice: &StreamChoice) -> Option<String> {
     None
 }
 
-fn extract_sse_reasoning_delta(choice: &StreamChoice) -> Option<String> {
+fn extract_sse_reasoning_delta(choice: &StreamChoice) -> Option<(&str, &'static str)> {
     choice
         .delta
         .reasoning_content
-        .as_ref()
+        .as_deref()
         .filter(|value| !value.is_empty())
-        .cloned()
+        .map(|value| {
+            (
+                value,
+                choice.delta.reasoning_field.unwrap_or("reasoning_content"),
+            )
+        })
 }
 
 fn is_valid_mistral_tool_call_id(id: &str) -> bool {
@@ -1247,10 +1285,11 @@ fn parse_sse_line(line: &str) -> StreamResult<Option<StreamChunk>> {
         {
             return Ok(Some(StreamChunk::delta(content.clone())));
         }
-        if let Some(reasoning) = &choice.delta.reasoning_content
-            && !reasoning.is_empty()
-        {
-            return Ok(Some(StreamChunk::reasoning(reasoning.clone())));
+        if let Some((reasoning, field)) = extract_sse_reasoning_delta(choice) {
+            return Ok(Some(StreamChunk::reasoning_with_field(
+                reasoning.to_string(),
+                field,
+            )));
         }
     }
 
@@ -1430,8 +1469,11 @@ fn sse_bytes_to_events_for_contract(
 
                         let mut should_emit_tool_calls = false;
                         for choice in &chunk.choices {
-                            if let Some(reasoning_delta) = extract_sse_reasoning_delta(choice) {
-                                let reasoning_chunk = StreamChunk::reasoning(reasoning_delta);
+                            if let Some((reasoning_delta, field)) =
+                                extract_sse_reasoning_delta(choice)
+                            {
+                                let reasoning_chunk =
+                                    StreamChunk::reasoning_with_field(reasoning_delta, field);
                                 if tx
                                     .send(Ok(StreamEvent::TextDelta(reasoning_chunk)))
                                     .await
@@ -1726,6 +1768,13 @@ impl OpenAiCompatibleModelProvider {
                         .get("reasoning_content")
                         .or_else(|| value.get("reasoning"))
                         .and_then(serde_json::Value::as_str)
+                        .filter(|value| !value.is_empty())
+                        .map(ToString::to_string);
+
+                    let reasoning = value
+                        .get("reasoning")
+                        .and_then(serde_json::Value::as_str)
+                        .filter(|value| !value.is_empty())
                         .map(ToString::to_string);
 
                     return NativeMessage {
@@ -1734,6 +1783,7 @@ impl OpenAiCompatibleModelProvider {
                         tool_call_id: None,
                         tool_calls: Some(tool_calls),
                         reasoning_content,
+                        reasoning,
                     };
                 }
 
@@ -1766,6 +1816,7 @@ impl OpenAiCompatibleModelProvider {
                         tool_call_id,
                         tool_calls: None,
                         reasoning_content: None,
+                        reasoning: None,
                     };
                 }
 
@@ -1779,6 +1830,7 @@ impl OpenAiCompatibleModelProvider {
                     tool_call_id: None,
                     tool_calls: None,
                     reasoning_content: None,
+                    reasoning: None,
                 }
             })
             .collect()
@@ -1900,7 +1952,8 @@ impl OpenAiCompatibleModelProvider {
 
     fn parse_native_response(&self, message: ResponseMessage) -> ProviderChatResponse {
         let text = message.effective_content_optional();
-        let reasoning_content = message.reasoning_content.clone();
+        let reasoning_content = message.reasoning_text_owned();
+        let reasoning_field = message.reasoning_field_owned();
         let mut used_tool_call_ids = std::collections::HashSet::new();
         let tool_calls = message
             .tool_calls
@@ -1939,6 +1992,7 @@ impl OpenAiCompatibleModelProvider {
             tool_calls,
             usage: None,
             reasoning_content,
+            reasoning_field,
         }
     }
 
@@ -2308,6 +2362,7 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
                     tool_calls: vec![],
                     usage: None,
                     reasoning_content: None,
+                    reasoning_field: None,
                 });
             }
         };
@@ -2335,7 +2390,8 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
         })?;
 
         let text = choice.message.effective_content_optional();
-        let reasoning_content = choice.message.reasoning_content;
+        let reasoning_content = choice.message.reasoning_text_owned();
+        let reasoning_field = choice.message.reasoning_field_owned();
         let mut used_tool_call_ids = std::collections::HashSet::new();
         let tool_calls = choice
             .message
@@ -2360,6 +2416,7 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
             tool_calls,
             usage,
             reasoning_content,
+            reasoning_field,
         })
     }
 
@@ -2425,6 +2482,7 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
                     tool_calls: vec![],
                     usage: None,
                     reasoning_content: None,
+                    reasoning_field: None,
                 });
             }
 
@@ -2944,6 +3002,7 @@ mod tests {
                 tool_call_id: None,
                 tool_calls: None,
                 reasoning_content: None,
+                reasoning: None,
             }],
             temperature: 0.7,
             stream: Some(true),
@@ -3391,6 +3450,7 @@ mod tests {
                 extra_content: None,
             }]),
             reasoning_content: None,
+            reasoning_field: None,
         };
 
         let parsed = provider.parse_native_response(message);
@@ -3417,6 +3477,7 @@ mod tests {
                 extra_content: None,
             }]),
             reasoning_content: None,
+            reasoning_field: None,
         };
 
         let parsed = provider.parse_native_response(message);
@@ -3444,6 +3505,7 @@ mod tests {
                 extra_content: None,
             }]),
             reasoning_content: None,
+            reasoning_field: None,
         };
 
         let parsed = provider.parse_native_response(message);
@@ -3471,6 +3533,7 @@ mod tests {
                 extra_content: None,
             }]),
             reasoning_content: None,
+            reasoning_field: None,
         };
 
         let parsed = provider.parse_native_response(message);
@@ -3512,6 +3575,7 @@ mod tests {
                 },
             ]),
             reasoning_content: None,
+            reasoning_field: None,
         };
 
         let parsed = provider.parse_native_response(message);
@@ -4430,6 +4494,35 @@ mod tests {
     }
 
     #[test]
+    fn reasoning_fallback_when_content_empty() {
+        let json = r#"{"choices":[{"message":{"content":"","reasoning":"Thinking output here"}}]}"#;
+        let resp: ApiChatResponse = serde_json::from_str(json).unwrap();
+        let msg = &resp.choices[0].message;
+        assert_eq!(msg.effective_content(), "Thinking output here");
+        assert_eq!(msg.reasoning_text(), Some("Thinking output here"));
+    }
+
+    #[test]
+    fn reasoning_content_empty_falls_back_to_reasoning() {
+        let json = r#"{"choices":[{"message":{"content":"","reasoning_content":"","reasoning":"Fallback reasoning"}}]}"#;
+        let resp: ApiChatResponse = serde_json::from_str(json).unwrap();
+        let msg = &resp.choices[0].message;
+        assert_eq!(msg.effective_content(), "");
+        assert_eq!(msg.reasoning_text(), None);
+        assert_eq!(msg.reasoning_field(), Some("reasoning_content"));
+    }
+
+    #[test]
+    fn reasoning_content_preferred_when_both_reasoning_fields_present() {
+        let json = r#"{"choices":[{"message":{"content":"","reasoning_content":"Existing field","reasoning":"Alternate field"}}]}"#;
+        let resp: ApiChatResponse = serde_json::from_str(json).unwrap();
+        let msg = &resp.choices[0].message;
+        assert_eq!(msg.effective_content(), "Existing field");
+        assert_eq!(msg.reasoning_text(), Some("Existing field"));
+        assert_eq!(msg.reasoning_field(), Some("reasoning_content"));
+    }
+
+    #[test]
     fn reasoning_content_used_when_content_only_think_tags() {
         let json = r#"{"choices":[{"message":{"content":"<think>secret</think>","reasoning_content":"Fallback text"}}]}"#;
         let resp: ApiChatResponse = serde_json::from_str(json).unwrap();
@@ -4481,6 +4574,14 @@ mod tests {
     }
 
     #[test]
+    fn parse_sse_line_with_reasoning() {
+        let line = r#"data: {"choices":[{"delta":{"reasoning":"thinking..."}}]}"#;
+        let result = parse_sse_line(line).unwrap().unwrap();
+        assert!(result.delta.is_empty());
+        assert_eq!(result.reasoning.as_deref(), Some("thinking..."));
+    }
+
+    #[test]
     fn parse_sse_line_with_both_prefers_content() {
         let line = r#"data: {"choices":[{"delta":{"content":"real answer","reasoning_content":"thinking..."}}]}"#;
         let result = parse_sse_line(line).unwrap().unwrap();
@@ -4506,6 +4607,7 @@ mod tests {
         let result = parse_sse_line(line).unwrap().unwrap();
         assert!(result.delta.is_empty());
         assert_eq!(result.reasoning.as_deref(), Some("thinking via vllm..."));
+        assert_eq!(result.reasoning_field.as_deref(), Some("reasoning"));
     }
 
     #[test]
@@ -4514,6 +4616,7 @@ mod tests {
         let result = parse_sse_line(line).unwrap().unwrap();
         assert!(result.delta.is_empty());
         assert_eq!(result.reasoning.as_deref(), Some("vllm thought"));
+        assert_eq!(result.reasoning_field.as_deref(), Some("reasoning"));
     }
 
     #[test]
@@ -4527,6 +4630,7 @@ mod tests {
             Some("chain-of-thought via vllm"),
             "the `reasoning` alias must populate the canonical reasoning_content field",
         );
+        assert_eq!(msg.reasoning_field(), Some("reasoning"));
         // effective_content should also surface the reasoning when content is missing.
         assert_eq!(msg.effective_content(), "chain-of-thought via vllm");
     }
@@ -4537,6 +4641,7 @@ mod tests {
         let json = r#"{"content":null,"reasoning_content":"canonical thought","tool_calls":null}"#;
         let msg: ResponseMessage = serde_json::from_str(json).unwrap();
         assert_eq!(msg.reasoning_content.as_deref(), Some("canonical thought"));
+        assert_eq!(msg.reasoning_field(), Some("reasoning_content"));
     }
 
     // Review feedback on PR #6615 (Audacity88): when a payload carries BOTH
@@ -4555,6 +4660,7 @@ mod tests {
             Some("canonical"),
             "canonical reasoning_content must win when both fields are present",
         );
+        assert_eq!(msg.reasoning_field(), Some("reasoning_content"));
     }
 
     #[test]
@@ -4564,6 +4670,7 @@ mod tests {
         let json = r#"{"content":null,"reasoning":"alias only","tool_calls":null}"#;
         let msg: ResponseMessage = serde_json::from_str(json).unwrap();
         assert_eq!(msg.reasoning_content.as_deref(), Some("alias only"));
+        assert_eq!(msg.reasoning_field(), Some("reasoning"));
     }
 
     #[test]
@@ -4575,6 +4682,7 @@ mod tests {
             .expect("parse must succeed")
             .expect("non-empty chunk");
         assert_eq!(result.reasoning.as_deref(), Some("canonical"));
+        assert_eq!(result.reasoning_field.as_deref(), Some("reasoning_content"));
     }
 
     // The round-trip path at to_native_messages reconstructs reasoning_content
@@ -4604,6 +4712,15 @@ mod tests {
         // behavior for providers that emit `reasoning_content` plus a stray
         // `reasoning` field.
         assert_eq!(extract_reasoning(&both).as_deref(), Some("canonical"));
+    }
+
+    #[test]
+    fn parse_sse_line_with_empty_reasoning_content_falls_back_to_reasoning() {
+        let line =
+            r#"data: {"choices":[{"delta":{"reasoning_content":"","reasoning":"thinking..."}}]}"#;
+        let result = parse_sse_line(line).unwrap().unwrap();
+        assert!(result.delta.is_empty());
+        assert_eq!(result.reasoning.as_deref(), Some("thinking..."));
     }
 
     #[test]
@@ -4726,6 +4843,7 @@ mod tests {
         let message = ResponseMessage {
             content: Some("answer".to_string()),
             reasoning_content: Some("thinking step".to_string()),
+            reasoning_field: Some("reasoning_content"),
             tool_calls: Some(vec![ToolCall {
                 id: Some("call_1".to_string()),
                 kind: Some("function".to_string()),
@@ -4742,8 +4860,53 @@ mod tests {
 
         let parsed = provider.parse_native_response(message);
         assert_eq!(parsed.reasoning_content.as_deref(), Some("thinking step"));
+        assert_eq!(parsed.reasoning_field.as_deref(), Some("reasoning_content"));
         assert_eq!(parsed.text.as_deref(), Some("answer"));
         assert_eq!(parsed.tool_calls.len(), 1);
+    }
+
+    #[test]
+    fn parse_native_response_captures_reasoning() {
+        let provider = make_provider("test", "https://example.com", None);
+        let message = ResponseMessage {
+            content: Some("answer".to_string()),
+            reasoning_content: Some("thinking step".to_string()),
+            reasoning_field: Some("reasoning"),
+            tool_calls: Some(vec![ToolCall {
+                id: Some("call_1".to_string()),
+                kind: Some("function".to_string()),
+                function: Some(Function {
+                    name: Some("shell".to_string()),
+                    arguments: Some(r#"{"cmd":"ls"}"#.to_string()),
+                }),
+                name: None,
+                arguments: None,
+                parameters: None,
+                extra_content: None,
+            }]),
+        };
+
+        let parsed = provider.parse_native_response(message);
+        assert_eq!(parsed.reasoning_content.as_deref(), Some("thinking step"));
+        assert_eq!(parsed.reasoning_field.as_deref(), Some("reasoning"));
+        assert_eq!(parsed.text.as_deref(), Some("answer"));
+        assert_eq!(parsed.tool_calls.len(), 1);
+    }
+
+    #[test]
+    fn parse_native_response_omits_empty_reasoning_content() {
+        let provider = make_provider("test", "https://example.com", None);
+        let message = ResponseMessage {
+            content: Some("answer".to_string()),
+            reasoning_content: Some(String::new()),
+            reasoning_field: Some("reasoning_content"),
+            tool_calls: None,
+        };
+
+        let parsed = provider.parse_native_response(message);
+        assert!(parsed.reasoning_content.is_none());
+        assert_eq!(parsed.reasoning_field.as_deref(), Some("reasoning_content"));
+        assert_eq!(parsed.text.as_deref(), Some("answer"));
     }
 
     #[test]
@@ -4752,6 +4915,7 @@ mod tests {
         let message = ResponseMessage {
             content: Some("hello".to_string()),
             reasoning_content: None,
+            reasoning_field: None,
             tool_calls: None,
         };
 
@@ -4782,12 +4946,47 @@ mod tests {
             native[0].reasoning_content.as_deref(),
             Some("Let me think about this...")
         );
+        assert!(native[0].reasoning.is_none());
         assert!(native[0].tool_calls.is_some());
     }
 
     #[test]
-    fn convert_messages_for_native_no_reasoning_content_when_absent() {
-        // Normal model history without reasoning_content key
+    fn convert_messages_for_native_round_trips_reasoning_field() {
+        // Preserve the original provider field name when replaying assistant history.
+        let history_json = serde_json::json!({
+            "content": "I will check",
+            "tool_calls": [{
+                "id": "tc_1",
+                "name": "shell",
+                "arguments": "{\"cmd\":\"ls\"}"
+            }],
+            "reasoning": "Let me think about this..."
+        });
+
+        let messages = vec![ChatMessage::assistant(history_json.to_string())];
+        let provider = make_provider("test", "https://example.com", None);
+        let native = provider.convert_messages_for_native(&messages, true);
+        assert_eq!(native.len(), 1);
+        assert_eq!(native[0].role, "assistant");
+        assert!(native[0].reasoning_content.is_none());
+        assert_eq!(
+            native[0].reasoning.as_deref(),
+            Some("Let me think about this...")
+        );
+        let serialized = serde_json::to_value(&native[0]).unwrap();
+        assert_eq!(
+            serialized
+                .get("reasoning")
+                .and_then(serde_json::Value::as_str),
+            Some("Let me think about this...")
+        );
+        assert!(serialized.get("reasoning_content").is_none());
+        assert!(native[0].tool_calls.is_some());
+    }
+
+    #[test]
+    fn convert_messages_for_native_no_reasoning_fields_when_absent() {
+        // Normal model history without reasoning keys
         let history_json = serde_json::json!({
             "content": "I will check",
             "tool_calls": [{
@@ -4802,22 +5001,28 @@ mod tests {
         let native = provider.convert_messages_for_native(&messages, true);
         assert_eq!(native.len(), 1);
         assert!(native[0].reasoning_content.is_none());
+        assert!(native[0].reasoning.is_none());
     }
 
     #[test]
-    fn convert_messages_for_native_reasoning_content_serialized_only_when_present() {
-        // Verify skip_serializing_if works: reasoning_content omitted from JSON when None
+    fn convert_messages_for_native_reasoning_fields_serialized_only_when_present() {
+        // Verify skip_serializing_if works: reasoning fields omitted from JSON when None
         let msg_without = NativeMessage {
             role: "assistant".to_string(),
             content: Some(MessageContent::Text("hi".to_string())),
             tool_call_id: None,
             tool_calls: None,
             reasoning_content: None,
+            reasoning: None,
         };
         let json = serde_json::to_string(&msg_without).unwrap();
         assert!(
             !json.contains("reasoning_content"),
             "reasoning_content should be omitted when None"
+        );
+        assert!(
+            !json.contains("\"reasoning\""),
+            "reasoning should be omitted when None"
         );
 
         let msg_with = NativeMessage {
@@ -4826,13 +5031,19 @@ mod tests {
             tool_call_id: None,
             tool_calls: None,
             reasoning_content: Some("thinking...".to_string()),
+            reasoning: Some("alternate...".to_string()),
         };
         let json = serde_json::to_string(&msg_with).unwrap();
         assert!(
             json.contains("reasoning_content"),
             "reasoning_content should be present when Some"
         );
+        assert!(
+            json.contains("\"reasoning\""),
+            "reasoning should be present when Some"
+        );
         assert!(json.contains("thinking..."));
+        assert!(json.contains("alternate..."));
     }
 
     #[test]

--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -787,7 +787,7 @@ impl ResponseMessage {
         }
 
         self.reasoning_text()
-            .map(|c| strip_think_tags(c))
+            .map(strip_think_tags)
             .filter(|c| !c.is_empty())
             .unwrap_or_default()
     }
@@ -801,7 +801,7 @@ impl ResponseMessage {
         }
 
         self.reasoning_text()
-            .map(|c| strip_think_tags(c))
+            .map(strip_think_tags)
             .filter(|c| !c.is_empty())
     }
 

--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -4870,7 +4870,7 @@ mod tests {
 
     #[test]
     fn parse_native_response_captures_reasoning() {
-        let provider = make_provider("test", "https://example.com", None);
+        let provider = make_model_provider("test", "https://example.com", None);
         let message = ResponseMessage {
             content: Some("answer".to_string()),
             reasoning_content: Some("thinking step".to_string()),
@@ -4898,7 +4898,7 @@ mod tests {
 
     #[test]
     fn parse_native_response_omits_empty_reasoning_content() {
-        let provider = make_provider("test", "https://example.com", None);
+        let provider = make_model_provider("test", "https://example.com", None);
         let message = ResponseMessage {
             content: Some("answer".to_string()),
             reasoning_content: Some(String::new()),
@@ -4967,7 +4967,7 @@ mod tests {
         });
 
         let messages = vec![ChatMessage::assistant(history_json.to_string())];
-        let provider = make_provider("test", "https://example.com", None);
+        let provider = make_model_provider("test", "https://example.com", None);
         let native = provider.convert_messages_for_native(&messages, true);
         assert_eq!(native.len(), 1);
         assert_eq!(native[0].role, "assistant");

--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -1762,20 +1762,21 @@ impl OpenAiCompatibleModelProvider {
                         .and_then(serde_json::Value::as_str)
                         .map(|value| MessageContent::Text(value.to_string()));
 
-                    // Accept both `reasoning_content` (canonical) and
-                    // `reasoning` (OpenRouter / vLLM >= v0.16.0). See #6584.
                     let reasoning_content = value
                         .get("reasoning_content")
-                        .or_else(|| value.get("reasoning"))
                         .and_then(serde_json::Value::as_str)
                         .filter(|value| !value.is_empty())
                         .map(ToString::to_string);
 
-                    let reasoning = value
-                        .get("reasoning")
-                        .and_then(serde_json::Value::as_str)
-                        .filter(|value| !value.is_empty())
-                        .map(ToString::to_string);
+                    let reasoning = if reasoning_content.is_some() {
+                        None
+                    } else {
+                        value
+                            .get("reasoning")
+                            .and_then(serde_json::Value::as_str)
+                            .filter(|value| !value.is_empty())
+                            .map(ToString::to_string)
+                    };
 
                     return NativeMessage {
                         role: "assistant".to_string(),

--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -4719,9 +4719,11 @@ mod tests {
     fn parse_sse_line_with_empty_reasoning_content_falls_back_to_reasoning() {
         let line =
             r#"data: {"choices":[{"delta":{"reasoning_content":"","reasoning":"thinking..."}}]}"#;
-        let result = parse_sse_line(line).unwrap().unwrap();
-        assert!(result.delta.is_empty());
-        assert_eq!(result.reasoning.as_deref(), Some("thinking..."));
+        let result = parse_sse_line(line).unwrap();
+        assert!(
+            result.is_none(),
+            "canonical reasoning_content is present, so the reasoning alias must not be used"
+        );
     }
 
     #[test]

--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -4503,7 +4503,7 @@ mod tests {
     }
 
     #[test]
-    fn reasoning_content_empty_falls_back_to_reasoning() {
+    fn reasoning_content_empty_still_wins_over_reasoning_alias() {
         let json = r#"{"choices":[{"message":{"content":"","reasoning_content":"","reasoning":"Fallback reasoning"}}]}"#;
         let resp: ApiChatResponse = serde_json::from_str(json).unwrap();
         let msg = &resp.choices[0].message;

--- a/crates/zeroclaw-providers/src/copilot.rs
+++ b/crates/zeroclaw-providers/src/copilot.rs
@@ -447,6 +447,7 @@ impl CopilotModelProvider {
             tool_calls,
             usage,
             reasoning_content: None,
+            reasoning_field: None,
         })
     }
 

--- a/crates/zeroclaw-providers/src/gemini.rs
+++ b/crates/zeroclaw-providers/src/gemini.rs
@@ -1449,6 +1449,7 @@ impl ModelProvider for GeminiModelProvider {
             tool_calls: Vec::new(),
             usage,
             reasoning_content: None,
+            reasoning_field: None,
         })
     }
 

--- a/crates/zeroclaw-providers/src/gemini_cli.rs
+++ b/crates/zeroclaw-providers/src/gemini_cli.rs
@@ -291,6 +291,7 @@ impl ModelProvider for GeminiCliModelProvider {
             tool_calls: Vec::new(),
             usage: Some(TokenUsage::default()),
             reasoning_content: None,
+            reasoning_field: None,
         })
     }
 }

--- a/crates/zeroclaw-providers/src/kilocli.rs
+++ b/crates/zeroclaw-providers/src/kilocli.rs
@@ -280,6 +280,7 @@ impl ModelProvider for KiloCliModelProvider {
             tool_calls: Vec::new(),
             usage: Some(TokenUsage::default()),
             reasoning_content: None,
+            reasoning_field: None,
         })
     }
 }

--- a/crates/zeroclaw-providers/src/ollama.rs
+++ b/crates/zeroclaw-providers/src/ollama.rs
@@ -960,6 +960,7 @@ impl ModelProvider for OllamaModelProvider {
                 tool_calls,
                 usage,
                 reasoning_content: None,
+                reasoning_field: None,
             });
         }
 
@@ -984,6 +985,7 @@ impl ModelProvider for OllamaModelProvider {
             tool_calls: vec![],
             usage,
             reasoning_content: None,
+            reasoning_field: None,
         })
     }
 
@@ -1036,6 +1038,7 @@ impl ModelProvider for OllamaModelProvider {
             tool_calls: vec![],
             usage: None,
             reasoning_content: None,
+            reasoning_field: None,
         })
     }
 

--- a/crates/zeroclaw-providers/src/openai.rs
+++ b/crates/zeroclaw-providers/src/openai.rs
@@ -348,6 +348,9 @@ impl OpenAiModelProvider {
             text,
             tool_calls,
             usage: None,
+            reasoning_field: reasoning_content
+                .as_ref()
+                .map(|_| "reasoning_content".to_string()),
             reasoning_content,
         }
     }

--- a/crates/zeroclaw-providers/src/openai_codex.rs
+++ b/crates/zeroclaw-providers/src/openai_codex.rs
@@ -1398,12 +1398,17 @@ impl ModelProvider for OpenAiCodexModelProvider {
         let response = self
             .send_responses_request(input, instructions, convert_tools(request.tools), model)
             .await?;
+        let reasoning_field = response
+            .reasoning_content
+            .as_ref()
+            .map(|_| "reasoning_content".to_string());
 
         Ok(ProviderChatResponse {
             text: response.text,
             tool_calls: response.tool_calls,
             usage: None,
             reasoning_content: response.reasoning_content,
+            reasoning_field,
         })
     }
 

--- a/crates/zeroclaw-providers/src/openrouter.rs
+++ b/crates/zeroclaw-providers/src/openrouter.rs
@@ -392,6 +392,9 @@ impl OpenRouterModelProvider {
             text: message.content,
             tool_calls,
             usage: None,
+            reasoning_field: reasoning_content
+                .as_ref()
+                .map(|_| "reasoning_content".to_string()),
             reasoning_content,
         }
     }

--- a/crates/zeroclaw-providers/src/reliable.rs
+++ b/crates/zeroclaw-providers/src/reliable.rs
@@ -2063,6 +2063,7 @@ mod tests {
                 tool_calls: self.tool_calls.clone(),
                 usage: None,
                 reasoning_content: None,
+                reasoning_field: None,
             })
         }
     }
@@ -2280,6 +2281,7 @@ mod tests {
                 tool_calls: vec![],
                 usage: None,
                 reasoning_content: None,
+                reasoning_field: None,
             })
         }
     }

--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -1461,6 +1461,7 @@ impl Agent {
                 text: response.text.clone(),
                 tool_calls: response.tool_calls.clone(),
                 reasoning_content: response.reasoning_content.clone(),
+                reasoning_field: response.reasoning_field.clone(),
             });
 
             let results = self.execute_tools(&calls).await;
@@ -1742,6 +1743,7 @@ impl Agent {
                     tool_calls: streamed_tool_calls,
                     usage: streamed_usage.clone(),
                     reasoning_content: None,
+                    reasoning_field: None,
                 }
             } else {
                 // Fall back to non-streaming chat, with cancellation guard
@@ -1847,6 +1849,7 @@ impl Agent {
                 text: response.text.clone(),
                 tool_calls: response.tool_calls.clone(),
                 reasoning_content: response.reasoning_content.clone(),
+                reasoning_field: response.reasoning_field.clone(),
             };
             new_msgs.push(tool_call_msg.clone());
             self.history.push(tool_call_msg);
@@ -2039,6 +2042,7 @@ mod tests {
                     tool_calls: vec![],
                     usage: None,
                     reasoning_content: None,
+                    reasoning_field: None,
                 });
             }
             Ok(guard.remove(0))
@@ -2088,6 +2092,7 @@ mod tests {
                     tool_calls: vec![],
                     usage: None,
                     reasoning_content: None,
+                    reasoning_field: None,
                 });
             }
             Ok(guard.remove(0))
@@ -2137,6 +2142,7 @@ mod tests {
                 tool_calls: vec![],
                 usage: None,
                 reasoning_content: None,
+                reasoning_field: None,
             })
         }
 
@@ -2162,6 +2168,7 @@ mod tests {
                         delta: "stream-done".into(),
                         is_final: false,
                         reasoning: None,
+                        reasoning_field: None,
                         token_count: 0,
                     },
                 );
@@ -2328,6 +2335,7 @@ mod tests {
                 tool_calls: vec![],
                 usage: None,
                 reasoning_content: None,
+                reasoning_field: None,
             }]),
         });
 
@@ -2787,12 +2795,14 @@ mod tests {
                     }],
                     usage: None,
                     reasoning_content: None,
+                    reasoning_field: None,
                 },
                 zeroclaw_providers::ChatResponse {
                     text: Some("done".into()),
                     tool_calls: vec![],
                     usage: None,
                     reasoning_content: None,
+                    reasoning_field: None,
                 },
             ]),
         });
@@ -2836,6 +2846,7 @@ mod tests {
                 tool_calls: vec![],
                 usage: None,
                 reasoning_content: None,
+                reasoning_field: None,
             }]),
             seen_models: seen_models.clone(),
         });
@@ -3255,6 +3266,7 @@ mod tests {
                     }],
                     usage: None,
                     reasoning_content: None,
+                    reasoning_field: None,
                 })
             } else {
                 Ok(zeroclaw_providers::ChatResponse {
@@ -3262,6 +3274,7 @@ mod tests {
                     tool_calls: vec![],
                     usage: None,
                     reasoning_content: None,
+                    reasoning_field: None,
                 })
             }
         }
@@ -3304,6 +3317,7 @@ mod tests {
                         delta: "stream-done".into(),
                         is_final: false,
                         reasoning: None,
+                        reasoning_field: None,
                         token_count: 0,
                     },
                 );
@@ -3460,6 +3474,7 @@ mod tests {
                 tool_calls: vec![],
                 usage: None,
                 reasoning_content: None,
+                reasoning_field: None,
             })
         }
 
@@ -3741,6 +3756,7 @@ mod tests {
                     extra_content: None,
                 }],
                 reasoning_content: None,
+                reasoning_field: None,
             });
             // Skip the trailing ToolResults for the last AssistantToolCalls
             // so the entry count is 5, not 6, and the drop boundary lands
@@ -3813,6 +3829,7 @@ mod tests {
                 }],
                 usage: None,
                 reasoning_content: None,
+                reasoning_field: None,
             }]),
         });
 
@@ -3875,6 +3892,7 @@ mod tests {
                 tool_calls: vec![],
                 usage: None,
                 reasoning_content: None,
+                reasoning_field: None,
             })
         }
 
@@ -3902,6 +3920,7 @@ mod tests {
                             delta: "I will echo the message.".into(),
                             is_final: false,
                             reasoning: None,
+                            reasoning_field: None,
                             token_count: 0,
                         },
                     )),
@@ -3923,6 +3942,7 @@ mod tests {
                             delta: "done".into(),
                             is_final: false,
                             reasoning: None,
+                            reasoning_field: None,
                             token_count: 0,
                         },
                     )),

--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -3201,6 +3201,7 @@ mod tests {
                     extra_content: None,
                 }],
                 reasoning_content: None,
+                reasoning_field: None,
             },
             ConversationMessage::ToolResults(vec![ToolResultMessage {
                 tool_call_id: "tc-1".into(),

--- a/crates/zeroclaw-runtime/src/agent/dispatcher.rs
+++ b/crates/zeroclaw-runtime/src/agent/dispatcher.rs
@@ -231,13 +231,15 @@ impl ToolDispatcher for NativeToolDispatcher {
                     text,
                     tool_calls,
                     reasoning_content,
+                    reasoning_field,
                 } => {
                     let mut payload = serde_json::json!({
                         "content": text,
                         "tool_calls": tool_calls,
                     });
                     if let Some(rc) = reasoning_content {
-                        payload["reasoning_content"] = serde_json::json!(rc);
+                        let field = reasoning_field.as_deref().unwrap_or("reasoning_content");
+                        payload[field] = serde_json::json!(rc);
                     }
                     vec![ChatMessage::assistant(payload.to_string())]
                 }
@@ -276,6 +278,7 @@ mod tests {
             tool_calls: vec![],
             usage: None,
             reasoning_content: None,
+                    reasoning_field: None,
         };
         let dispatcher = XmlToolDispatcher;
         let (_, calls) = dispatcher.parse_response(&response);
@@ -293,6 +296,7 @@ mod tests {
             tool_calls: vec![],
             usage: None,
             reasoning_content: None,
+                    reasoning_field: None,
         };
         let dispatcher = XmlToolDispatcher;
         let (text, calls) = dispatcher.parse_response(&response);
@@ -311,6 +315,7 @@ mod tests {
             tool_calls: vec![],
             usage: None,
             reasoning_content: None,
+            reasoning_field: None,
         };
         let dispatcher = XmlToolDispatcher;
         let (_, calls) = dispatcher.parse_response(&response);
@@ -329,6 +334,7 @@ mod tests {
             }],
             usage: None,
             reasoning_content: None,
+            reasoning_field: None,
         };
         let dispatcher = NativeToolDispatcher;
         let (_, calls) = dispatcher.parse_response(&response);
@@ -402,6 +408,7 @@ mod tests {
                 extra_content: None,
             }],
             reasoning_content: Some("thinking step".into()),
+            reasoning_field: None,
         }];
 
         let messages = dispatcher.to_provider_messages(&history);
@@ -426,6 +433,7 @@ mod tests {
                 extra_content: None,
             }],
             reasoning_content: None,
+            reasoning_field: None,
         }];
 
         let messages = dispatcher.to_provider_messages(&history);
@@ -447,6 +455,7 @@ mod tests {
                 extra_content: None,
             }],
             reasoning_content: Some("should be ignored".into()),
+            reasoning_field: None,
         }];
 
         let messages = dispatcher.to_provider_messages(&history);

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -5400,6 +5400,7 @@ mod tests {
                 tool_calls: Vec::new(),
                 usage: None,
                 reasoning_content: None,
+                reasoning_field: None,
             })
         }
     }

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -7211,105 +7211,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn run_tool_call_loop_relays_native_tool_call_text_via_on_delta() {
-        let provider = ScriptedProvider {
-            responses: Arc::new(Mutex::new(VecDeque::from(vec![
-                ChatResponse {
-                    text: Some("Task started. Waiting 30 seconds before checking status.".into()),
-                    tool_calls: vec![ToolCall {
-                        id: "call_wait".into(),
-                        name: "count_tool".into(),
-                        arguments: r#"{"value":"A"}"#.into(),
-                        extra_content: None,
-                    }],
-                    usage: None,
-                    reasoning_content: None,
-                    reasoning_field: None,
-                },
-                ChatResponse {
-                    text: Some("Final answer".into()),
-                    tool_calls: Vec::new(),
-                    usage: None,
-                    reasoning_content: None,
-                    reasoning_field: None,
-                },
-            ]))),
-            capabilities: ProviderCapabilities {
-                native_tool_calling: true,
-                ..ProviderCapabilities::default()
-            },
-        };
-
-        let invocations = Arc::new(AtomicUsize::new(0));
-        let tools_registry: Vec<Box<dyn Tool>> = vec![Box::new(CountingTool::new(
-            "count_tool",
-            Arc::clone(&invocations),
-        ))];
-
-        let mut history = vec![
-            ChatMessage::system("test-system"),
-            ChatMessage::user("run tool calls"),
-        ];
-        let observer = NoopObserver;
-        let (tx, mut rx) = tokio::sync::mpsc::channel(16);
-
-        let result = run_tool_call_loop(
-            &provider,
-            &mut history,
-            &tools_registry,
-            &observer,
-            "mock-provider",
-            "mock-model",
-            Some(0.0),
-            true,
-            None,
-            "telegram",
-            None,
-            &zeroclaw_config::schema::MultimodalConfig::default(),
-            4,
-            None,
-            Some(tx),
-            None,
-            &[],
-            &[],
-            None,
-            None,
-            &zeroclaw_config::schema::PacingConfig::default(),
-            0,
-            0,
-            None,
-            None, // channel
-            None, // receipt_generator
-            None, // collected_receipts
-        )
-        .await
-        .expect("native tool-call text should be relayed through on_delta");
-
-        let mut deltas: Vec<DraftEvent> = Vec::new();
-        while let Some(delta) = rx.recv().await {
-            deltas.push(delta);
-        }
-
-        assert!(
-            deltas.iter().any(
-                |delta| matches!(delta, StreamDelta::Text(t) if t == "Task started. Waiting 30 seconds before checking status.\n")
-            ),
-            "native assistant text should be relayed to on_delta"
-        );
-        assert!(
-            deltas
-                .iter()
-                .any(|delta| matches!(delta, StreamDelta::Status(t) if t.starts_with("💬 Got 1 tool call(s)"))),
-            "tool-call progress line should still be relayed"
-        );
-        assert!(
-            result.ends_with("Final answer"),
-            "accumulated result should end with final answer, got: {result}"
-        );
-        assert_eq!(invocations.load(Ordering::SeqCst), 1);
-    }
-
-    #[tokio::test]
     async fn run_tool_call_loop_preserves_unknown_function_call_json_with_tools() {
         let business_json =
             r#"{"type":"function_call","name":"support_case","arguments":{"id":"A1"}}"#;
@@ -8452,12 +8353,14 @@ This is an example, not an invocation."#;
                     }],
                     usage: None,
                     reasoning_content: None,
+                    reasoning_field: None,
                 },
                 ChatResponse {
                     text: Some("Final answer".into()),
                     tool_calls: Vec::new(),
                     usage: None,
                     reasoning_content: None,
+                    reasoning_field: None,
                 },
             ]))),
             capabilities: ProviderCapabilities {
@@ -10726,7 +10629,7 @@ Let me check the result."#;
         struct ReasoningFieldProvider;
 
         #[async_trait]
-        impl Provider for ReasoningFieldProvider {
+        impl ModelProvider for ReasoningFieldProvider {
             async fn chat_with_system(
                 &self,
                 _system_prompt: Option<&str>,
@@ -10770,6 +10673,19 @@ Let me check the result."#;
                 ]))
             }
         }
+        impl ::zeroclaw_api::attribution::Attributable for ReasoningFieldProvider {
+            fn role(&self) -> ::zeroclaw_api::attribution::Role {
+                ::zeroclaw_api::attribution::Role::Provider(
+                    ::zeroclaw_api::attribution::ProviderKind::Model(
+                        ::zeroclaw_api::attribution::ModelProviderKind::Custom,
+                    ),
+                )
+            }
+
+            fn alias(&self) -> &str {
+                "ReasoningFieldProvider"
+            }
+        }
 
         let provider = ReasoningFieldProvider;
         let messages = vec![ChatMessage::user("hi")];
@@ -10779,7 +10695,7 @@ Let me check the result."#;
             &messages,
             None,
             "vllm-model",
-            0.2,
+            Some(0.2),
             None,
             None,
         )

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -493,6 +493,7 @@ fn build_native_assistant_history(
     text: &str,
     tool_calls: &[ToolCall],
     reasoning_content: Option<&str>,
+    reasoning_field: Option<&str>,
 ) -> String {
     let calls_json: Vec<serde_json::Value> = tool_calls
         .iter()
@@ -517,10 +518,10 @@ fn build_native_assistant_history(
     });
 
     if let Some(rc) = reasoning_content {
-        obj.as_object_mut().unwrap().insert(
-            "reasoning_content".to_string(),
-            serde_json::Value::String(rc.to_string()),
-        );
+        let field = reasoning_field.unwrap_or("reasoning_content");
+        obj.as_object_mut()
+            .unwrap()
+            .insert(field.to_string(), serde_json::Value::String(rc.to_string()));
     }
 
     obj.to_string()
@@ -601,6 +602,7 @@ struct StreamedChatOutcome {
     /// prior `reasoning_content` is missing from replayed tool-call turns
     ///.
     reasoning_content: String,
+    reasoning_field: Option<String>,
     tool_calls: Vec<ToolCall>,
     forwarded_live_deltas: bool,
     suppressed_protocol: bool,
@@ -1058,6 +1060,9 @@ async fn consume_provider_streaming_response(
                     && !reasoning.is_empty()
                 {
                     outcome.reasoning_content.push_str(reasoning);
+                    if outcome.reasoning_field.is_none() {
+                        outcome.reasoning_field = chunk.reasoning_field.clone();
+                    }
                 }
 
                 if chunk.delta.is_empty() {
@@ -1594,11 +1599,13 @@ pub async fn run_tool_call_loop(
                     } else {
                         Some(streamed.reasoning_content)
                     };
+                    let reasoning_field = streamed.reasoning_field;
                     Ok(zeroclaw_providers::ChatResponse {
                         text: Some(streamed.response_text),
                         tool_calls: streamed.tool_calls,
                         usage: streamed.usage,
                         reasoning_content,
+                        reasoning_field,
                     })
                 }
                 Err(stream_err) => {
@@ -1831,12 +1838,14 @@ pub async fn run_tool_call_loop(
                 // Preserve native tool call IDs in assistant history so role=tool
                 // follow-up messages can reference the exact call id.
                 let reasoning_content = resp.reasoning_content.clone();
+                let reasoning_field = resp.reasoning_field.clone();
                 let assistant_history_content = if resp.tool_calls.is_empty() {
                     if use_native_tools {
                         build_native_assistant_history_from_parsed_calls(
                             &response_text,
                             &calls,
                             reasoning_content.as_deref(),
+                            reasoning_field.as_deref(),
                         )
                         .unwrap_or_else(|| response_text.clone())
                     } else {
@@ -1847,6 +1856,7 @@ pub async fn run_tool_call_loop(
                         &response_text,
                         &resp.tool_calls,
                         reasoning_content.as_deref(),
+                        reasoning_field.as_deref(),
                     )
                 };
 
@@ -5250,6 +5260,7 @@ mod tests {
                 tool_calls: Vec::new(),
                 usage: None,
                 reasoning_content: None,
+                reasoning_field: None,
             })
         }
     }
@@ -5280,6 +5291,7 @@ mod tests {
                     tool_calls: Vec::new(),
                     usage: None,
                     reasoning_content: None,
+                    reasoning_field: None,
                 })
                 .collect();
             Self {
@@ -7195,6 +7207,105 @@ mod tests {
                 .any(|msg| msg.role == "user" && msg.content.contains("[Tool call parse error]")),
             "history should include internal parser feedback for the model"
         );
+    }
+
+    #[tokio::test]
+    async fn run_tool_call_loop_relays_native_tool_call_text_via_on_delta() {
+        let provider = ScriptedProvider {
+            responses: Arc::new(Mutex::new(VecDeque::from(vec![
+                ChatResponse {
+                    text: Some("Task started. Waiting 30 seconds before checking status.".into()),
+                    tool_calls: vec![ToolCall {
+                        id: "call_wait".into(),
+                        name: "count_tool".into(),
+                        arguments: r#"{"value":"A"}"#.into(),
+                        extra_content: None,
+                    }],
+                    usage: None,
+                    reasoning_content: None,
+                    reasoning_field: None,
+                },
+                ChatResponse {
+                    text: Some("Final answer".into()),
+                    tool_calls: Vec::new(),
+                    usage: None,
+                    reasoning_content: None,
+                    reasoning_field: None,
+                },
+            ]))),
+            capabilities: ProviderCapabilities {
+                native_tool_calling: true,
+                ..ProviderCapabilities::default()
+            },
+        };
+
+        let invocations = Arc::new(AtomicUsize::new(0));
+        let tools_registry: Vec<Box<dyn Tool>> = vec![Box::new(CountingTool::new(
+            "count_tool",
+            Arc::clone(&invocations),
+        ))];
+
+        let mut history = vec![
+            ChatMessage::system("test-system"),
+            ChatMessage::user("run tool calls"),
+        ];
+        let observer = NoopObserver;
+        let (tx, mut rx) = tokio::sync::mpsc::channel(16);
+
+        let result = run_tool_call_loop(
+            &provider,
+            &mut history,
+            &tools_registry,
+            &observer,
+            "mock-provider",
+            "mock-model",
+            Some(0.0),
+            true,
+            None,
+            "telegram",
+            None,
+            &zeroclaw_config::schema::MultimodalConfig::default(),
+            4,
+            None,
+            Some(tx),
+            None,
+            &[],
+            &[],
+            None,
+            None,
+            &zeroclaw_config::schema::PacingConfig::default(),
+            0,
+            0,
+            None,
+            None, // channel
+            None, // receipt_generator
+            None, // collected_receipts
+        )
+        .await
+        .expect("native tool-call text should be relayed through on_delta");
+
+        let mut deltas: Vec<DraftEvent> = Vec::new();
+        while let Some(delta) = rx.recv().await {
+            deltas.push(delta);
+        }
+
+        assert!(
+            deltas.iter().any(
+                |delta| matches!(delta, StreamDelta::Text(t) if t == "Task started. Waiting 30 seconds before checking status.\n")
+            ),
+            "native assistant text should be relayed to on_delta"
+        );
+        assert!(
+            deltas
+                .iter()
+                .any(|delta| matches!(delta, StreamDelta::Status(t) if t.starts_with("💬 Got 1 tool call(s)"))),
+            "tool-call progress line should still be relayed"
+        );
+        assert!(
+            result.ends_with("Final answer"),
+            "accumulated result should end with final answer, got: {result}"
+        );
+        assert_eq!(invocations.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]
@@ -10424,7 +10535,7 @@ Let me check the result."#;
             arguments: "{}".into(),
             extra_content: None,
         }];
-        let result = build_native_assistant_history("answer", &calls, Some("thinking step"));
+        let result = build_native_assistant_history("answer", &calls, Some("thinking step"), None);
         let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
         assert_eq!(parsed["content"].as_str(), Some("answer"));
         assert_eq!(parsed["reasoning_content"].as_str(), Some("thinking step"));
@@ -10439,7 +10550,7 @@ Let me check the result."#;
             arguments: "{}".into(),
             extra_content: None,
         }];
-        let result = build_native_assistant_history("answer", &calls, None);
+        let result = build_native_assistant_history("answer", &calls, None, None);
         let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
         assert_eq!(parsed["content"].as_str(), Some("answer"));
         assert!(parsed.get("reasoning_content").is_none());
@@ -10456,6 +10567,7 @@ Let me check the result."#;
             "answer",
             &calls,
             Some("deep thought"),
+            None,
         );
         assert!(result.is_some());
         let parsed: serde_json::Value = serde_json::from_str(result.as_deref().unwrap()).unwrap();
@@ -10471,7 +10583,7 @@ Let me check the result."#;
             arguments: serde_json::json!({"command": "pwd"}),
             tool_call_id: Some("call_2".into()),
         }];
-        let result = build_native_assistant_history_from_parsed_calls("answer", &calls, None);
+        let result = build_native_assistant_history_from_parsed_calls("answer", &calls, None, None);
         assert!(result.is_some());
         let parsed: serde_json::Value = serde_json::from_str(result.as_deref().unwrap()).unwrap();
         assert_eq!(parsed["content"].as_str(), Some("answer"));
@@ -10606,6 +10718,76 @@ Let me check the result."#;
 
         assert_eq!(outcome.response_text, "Hello there.");
         assert_eq!(outcome.reasoning_content, "Step 1: consider options.");
+    }
+
+    #[tokio::test]
+    async fn consume_provider_streaming_response_preserves_reasoning_field() {
+        struct ReasoningFieldProvider;
+
+        #[async_trait]
+        impl Provider for ReasoningFieldProvider {
+            async fn chat_with_system(
+                &self,
+                _system_prompt: Option<&str>,
+                _message: &str,
+                _model: &str,
+                _temperature: Option<f64>,
+            ) -> anyhow::Result<String> {
+                anyhow::bail!("not used in this test")
+            }
+
+            async fn chat(
+                &self,
+                _request: ChatRequest<'_>,
+                _model: &str,
+                _temperature: Option<f64>,
+            ) -> anyhow::Result<ChatResponse> {
+                anyhow::bail!("not used in this test")
+            }
+
+            fn supports_streaming(&self) -> bool {
+                true
+            }
+
+            fn stream_chat(
+                &self,
+                _request: ChatRequest<'_>,
+                _model: &str,
+                _temperature: Option<f64>,
+                _options: StreamOptions,
+            ) -> futures_util::stream::BoxStream<
+                'static,
+                zeroclaw_providers::traits::StreamResult<StreamEvent>,
+            > {
+                Box::pin(futures_util::stream::iter(vec![
+                    Ok(StreamEvent::TextDelta(StreamChunk::reasoning_with_field(
+                        "alias reasoning",
+                        "reasoning",
+                    ))),
+                    Ok(StreamEvent::TextDelta(StreamChunk::delta("visible"))),
+                    Ok(StreamEvent::Final),
+                ]))
+            }
+        }
+
+        let provider = ReasoningFieldProvider;
+        let messages = vec![ChatMessage::user("hi")];
+
+        let outcome = consume_provider_streaming_response(
+            &provider,
+            &messages,
+            None,
+            "vllm-model",
+            0.2,
+            None,
+            None,
+        )
+        .await
+        .expect("streaming should succeed");
+
+        assert_eq!(outcome.response_text, "visible");
+        assert_eq!(outcome.reasoning_content, "alias reasoning");
+        assert_eq!(outcome.reasoning_field.as_deref(), Some("reasoning"));
     }
 
     // ── glob_match tests ──────────────────────────────────────────────────────
@@ -10914,6 +11096,7 @@ Let me check the result."#;
                     cached_input_tokens: None,
                 }),
                 reasoning_content: None,
+                reasoning_field: None,
             }]))),
             capabilities: ProviderCapabilities::default(),
         };
@@ -11140,6 +11323,7 @@ Let me check the result."#;
                     cached_input_tokens: None,
                 }),
                 reasoning_content: None,
+                reasoning_field: None,
             }]))),
             capabilities: ProviderCapabilities::default(),
         };

--- a/crates/zeroclaw-runtime/src/agent/tests.rs
+++ b/crates/zeroclaw-runtime/src/agent/tests.rs
@@ -98,6 +98,7 @@ impl ModelProvider for ScriptedModelProvider {
                 tool_calls: vec![],
                 usage: None,
                 reasoning_content: None,
+                reasoning_field: None,
             });
         }
         Ok(guard.remove(0))
@@ -423,6 +424,7 @@ fn tool_response(calls: Vec<ToolCall>) -> ChatResponse {
         tool_calls: calls,
         usage: None,
         reasoning_content: None,
+        reasoning_field: None,
     }
 }
 
@@ -433,6 +435,7 @@ fn text_response(text: &str) -> ChatResponse {
         tool_calls: vec![],
         usage: None,
         reasoning_content: None,
+        reasoning_field: None,
     }
 }
 
@@ -445,6 +448,7 @@ fn xml_tool_response(name: &str, args: &str) -> ChatResponse {
         tool_calls: vec![],
         usage: None,
         reasoning_content: None,
+        reasoning_field: None,
     }
 }
 
@@ -896,6 +900,7 @@ async fn turn_handles_empty_text_response() {
         tool_calls: vec![],
         usage: None,
         reasoning_content: None,
+        reasoning_field: None,
     }]));
 
     let mut agent = build_agent_with(model_provider, vec![], Box::new(NativeToolDispatcher));
@@ -911,6 +916,7 @@ async fn turn_handles_none_text_response() {
         tool_calls: vec![],
         usage: None,
         reasoning_content: None,
+        reasoning_field: None,
     }]));
 
     let mut agent = build_agent_with(model_provider, vec![], Box::new(NativeToolDispatcher));
@@ -937,6 +943,7 @@ async fn turn_preserves_text_alongside_tool_calls() {
             }],
             usage: None,
             reasoning_content: None,
+            reasoning_field: None,
         },
         text_response("Here are the results"),
     ]));
@@ -1186,6 +1193,7 @@ async fn native_dispatcher_handles_stringified_arguments() {
         }],
         usage: None,
         reasoning_content: None,
+        reasoning_field: None,
     };
 
     let (_, calls) = dispatcher.parse_response(&response);
@@ -1213,6 +1221,7 @@ fn xml_dispatcher_handles_nested_json() {
         tool_calls: vec![],
         usage: None,
         reasoning_content: None,
+        reasoning_field: None,
     };
 
     let dispatcher = XmlToolDispatcher;
@@ -1232,6 +1241,7 @@ fn xml_dispatcher_handles_empty_tool_call_tag() {
         tool_calls: vec![],
         usage: None,
         reasoning_content: None,
+        reasoning_field: None,
     };
 
     let dispatcher = XmlToolDispatcher;
@@ -1247,6 +1257,7 @@ fn xml_dispatcher_handles_unclosed_tool_call() {
         tool_calls: vec![],
         usage: None,
         reasoning_content: None,
+        reasoning_field: None,
     };
 
     let dispatcher = XmlToolDispatcher;
@@ -1274,6 +1285,7 @@ fn conversation_message_serialization_roundtrip() {
                 extra_content: None,
             }],
             reasoning_content: None,
+            reasoning_field: None,
         },
         ConversationMessage::ToolResults(vec![ToolResultMessage {
             tool_call_id: "tc1".into(),
@@ -1437,6 +1449,7 @@ fn xml_dispatcher_converts_history_to_provider_messages() {
                 extra_content: None,
             }],
             reasoning_content: None,
+            reasoning_field: None,
         },
         ConversationMessage::ToolResults(vec![ToolResultMessage {
             tool_call_id: "tc1".into(),

--- a/crates/zeroclaw-runtime/src/tools/delegate.rs
+++ b/crates/zeroclaw-runtime/src/tools/delegate.rs
@@ -1865,6 +1865,7 @@ mod tests {
                     tool_calls: Vec::new(),
                     usage: None,
                     reasoning_content: None,
+                    reasoning_field: None,
                 })
             } else {
                 Ok(ChatResponse {
@@ -1877,6 +1878,7 @@ mod tests {
                     }],
                     usage: None,
                     reasoning_content: None,
+                    reasoning_field: None,
                 })
             }
         }
@@ -1924,6 +1926,7 @@ mod tests {
                 }],
                 usage: None,
                 reasoning_content: None,
+                reasoning_field: None,
             })
         }
     }
@@ -2654,6 +2657,7 @@ mod tests {
                     tool_calls: Vec::new(),
                     usage: None,
                     reasoning_content: None,
+                    reasoning_field: None,
                 })
             } else {
                 Ok(ChatResponse {
@@ -2666,6 +2670,7 @@ mod tests {
                     }],
                     usage: None,
                     reasoning_content: None,
+                    reasoning_field: None,
                 })
             }
         }

--- a/crates/zeroclaw-runtime/src/tools/file_read.rs
+++ b/crates/zeroclaw-runtime/src/tools/file_read.rs
@@ -780,6 +780,7 @@ mod tests {
                         tool_calls: vec![],
                         usage: None,
                         reasoning_content: None,
+                        reasoning_field: None,
                     });
                 }
                 Ok(guard.remove(0))
@@ -853,6 +854,7 @@ mod tests {
                 }],
                 usage: None,
                 reasoning_content: None,
+                reasoning_field: None,
             },
             // Turn 1 continued: model_provider sees tool result and answers
             ChatResponse {
@@ -860,6 +862,7 @@ mod tests {
                 tool_calls: vec![],
                 usage: None,
                 reasoning_content: None,
+                reasoning_field: None,
             },
         ]);
 
@@ -947,12 +950,14 @@ mod tests {
                 }],
                 usage: None,
                 reasoning_content: None,
+                reasoning_field: None,
             },
             ChatResponse {
                 text: Some("The file appears to be binary data.".into()),
                 tool_calls: vec![],
                 usage: None,
                 reasoning_content: None,
+                reasoning_field: None,
             },
         ]);
 

--- a/crates/zeroclaw-tool-call-parser/src/lib.rs
+++ b/crates/zeroclaw-tool-call-parser/src/lib.rs
@@ -2089,6 +2089,7 @@ pub fn build_native_assistant_history_from_parsed_calls(
     text: &str,
     tool_calls: &[ParsedToolCall],
     reasoning_content: Option<&str>,
+    reasoning_field: Option<&str>,
 ) -> Option<String> {
     // Strict provider validators (DeepSeek V4, NVIDIA NIM, ...) reject
     // assistant messages that carry `tool_calls: []`. When there are no
@@ -2121,10 +2122,10 @@ pub fn build_native_assistant_history_from_parsed_calls(
     });
 
     if let Some(rc) = reasoning_content {
-        obj.as_object_mut().unwrap().insert(
-            "reasoning_content".to_string(),
-            serde_json::Value::String(rc.to_string()),
-        );
+        let field = reasoning_field.unwrap_or("reasoning_content");
+        obj.as_object_mut()
+            .unwrap()
+            .insert(field.to_string(), serde_json::Value::String(rc.to_string()));
     }
 
     Some(obj.to_string())
@@ -3664,11 +3665,33 @@ Let me check the result."#;
             "answer",
             &calls,
             Some("deep thought"),
+            None,
         );
         assert!(result.is_some());
         let parsed: serde_json::Value = serde_json::from_str(result.as_deref().unwrap()).unwrap();
         assert_eq!(parsed["content"].as_str(), Some("answer"));
         assert_eq!(parsed["reasoning_content"].as_str(), Some("deep thought"));
+        assert!(parsed["tool_calls"].is_array());
+    }
+
+    #[test]
+    fn build_native_assistant_history_from_parsed_calls_preserves_reasoning_field() {
+        let calls = vec![ParsedToolCall {
+            name: "shell".into(),
+            arguments: serde_json::json!({"command": "pwd"}),
+            tool_call_id: Some("call_2".into()),
+        }];
+        let result = build_native_assistant_history_from_parsed_calls(
+            "answer",
+            &calls,
+            Some("deep thought"),
+            Some("reasoning"),
+        );
+        assert!(result.is_some());
+        let parsed: serde_json::Value = serde_json::from_str(result.as_deref().unwrap()).unwrap();
+        assert_eq!(parsed["content"].as_str(), Some("answer"));
+        assert_eq!(parsed["reasoning"].as_str(), Some("deep thought"));
+        assert!(parsed.get("reasoning_content").is_none());
         assert!(parsed["tool_calls"].is_array());
     }
 
@@ -3679,7 +3702,7 @@ Let me check the result."#;
             arguments: serde_json::json!({"command": "pwd"}),
             tool_call_id: Some("call_2".into()),
         }];
-        let result = build_native_assistant_history_from_parsed_calls("answer", &calls, None);
+        let result = build_native_assistant_history_from_parsed_calls("answer", &calls, None, None);
         assert!(result.is_some());
         let parsed: serde_json::Value = serde_json::from_str(result.as_deref().unwrap()).unwrap();
         assert_eq!(parsed["content"].as_str(), Some("answer"));

--- a/crates/zeroclaw-tool-call-parser/src/lib.rs
+++ b/crates/zeroclaw-tool-call-parser/src/lib.rs
@@ -2141,7 +2141,8 @@ mod tests {
         // assistant messages carrying `tool_calls: []`. Empty input must
         // not produce a serialised assistant message with an empty array.
         // See #6298.
-        let result = build_native_assistant_history_from_parsed_calls("answer text", &[], None);
+        let result =
+            build_native_assistant_history_from_parsed_calls("answer text", &[], None, None);
         assert!(
             result.is_none(),
             "expected None for empty tool_calls slice, got {result:?}"
@@ -2158,6 +2159,7 @@ mod tests {
             "answer text",
             &[],
             Some("deep thought"),
+            None,
         );
         assert!(result.is_none());
     }
@@ -2172,7 +2174,7 @@ mod tests {
             arguments: serde_json::json!({"command": "pwd"}),
             tool_call_id: Some("call_1".into()),
         }];
-        let result = build_native_assistant_history_from_parsed_calls("answer", &calls, None);
+        let result = build_native_assistant_history_from_parsed_calls("answer", &calls, None, None);
         let s = result.expect("Some(_) for non-empty tool_calls");
         let parsed: serde_json::Value = serde_json::from_str(&s).unwrap();
         assert_eq!(parsed["content"].as_str(), Some("answer"));

--- a/src/providers/traits.rs
+++ b/src/providers/traits.rs
@@ -75,6 +75,7 @@ mod tests {
             tool_calls: vec![],
             usage: None,
             reasoning_content: None,
+            reasoning_field: None,
         };
         assert!(!empty.has_tool_calls());
         assert_eq!(empty.text_or_empty(), "");
@@ -89,6 +90,7 @@ mod tests {
             }],
             usage: None,
             reasoning_content: None,
+            reasoning_field: None,
         };
         assert!(with_tools.has_tool_calls());
         assert_eq!(with_tools.text_or_empty(), "Let me check");
@@ -112,6 +114,7 @@ mod tests {
                 cached_input_tokens: None,
             }),
             reasoning_content: None,
+            reasoning_field: None,
         };
         assert_eq!(resp.usage.as_ref().unwrap().input_tokens, Some(100));
         assert_eq!(resp.usage.as_ref().unwrap().output_tokens, Some(50));

--- a/tests/component/provider_schema.rs
+++ b/tests/component/provider_schema.rs
@@ -158,6 +158,7 @@ fn chat_response_text_only() {
         tool_calls: vec![],
         usage: None,
         reasoning_content: None,
+        reasoning_field: None,
     };
 
     assert_eq!(resp.text_or_empty(), "Hello world");
@@ -176,6 +177,7 @@ fn chat_response_with_tool_calls() {
         }],
         usage: None,
         reasoning_content: None,
+        reasoning_field: None,
     };
 
     assert!(resp.has_tool_calls());
@@ -190,6 +192,7 @@ fn chat_response_text_or_empty_handles_none() {
         tool_calls: vec![],
         usage: None,
         reasoning_content: None,
+        reasoning_field: None,
     };
 
     assert_eq!(resp.text_or_empty(), "");
@@ -215,6 +218,7 @@ fn chat_response_multiple_tool_calls() {
         ],
         usage: None,
         reasoning_content: None,
+        reasoning_field: None,
     };
 
     assert!(resp.has_tool_calls());

--- a/tests/integration/agent.rs
+++ b/tests/integration/agent.rs
@@ -96,6 +96,7 @@ async fn e2e_xml_dispatcher_tool_call() {
             tool_calls: vec![],
             usage: None,
             reasoning_content: None,
+            reasoning_field: None,
         },
         text_response("XML tool executed"),
     ]));

--- a/tests/integration/agent_robustness.rs
+++ b/tests/integration/agent_robustness.rs
@@ -174,6 +174,7 @@ async fn agent_handles_empty_provider_response() {
         tool_calls: vec![],
         usage: None,
         reasoning_content: None,
+        reasoning_field: None,
     }]));
 
     let mut agent = build_agent(model_provider, vec![Box::new(EchoTool)]);
@@ -189,6 +190,7 @@ async fn agent_handles_none_text_response() {
         tool_calls: vec![],
         usage: None,
         reasoning_content: None,
+        reasoning_field: None,
     }]));
 
     let mut agent = build_agent(model_provider, vec![Box::new(EchoTool)]);

--- a/tests/support/helpers.rs
+++ b/tests/support/helpers.rs
@@ -34,6 +34,7 @@ pub fn text_response(text: &str) -> ChatResponse {
         tool_calls: vec![],
         usage: None,
         reasoning_content: None,
+        reasoning_field: None,
     }
 }
 
@@ -44,6 +45,7 @@ pub fn tool_response(calls: Vec<ToolCall>) -> ChatResponse {
         tool_calls: calls,
         usage: None,
         reasoning_content: None,
+        reasoning_field: None,
     }
 }
 

--- a/tests/support/mock_model_provider.rs
+++ b/tests/support/mock_model_provider.rs
@@ -51,6 +51,7 @@ impl ModelProvider for MockModelProvider {
                 tool_calls: vec![],
                 usage: None,
                 reasoning_content: None,
+                reasoning_field: None,
             });
         }
         Ok(guard.remove(0))
@@ -116,6 +117,7 @@ impl ModelProvider for RecordingModelProvider {
                 tool_calls: vec![],
                 usage: None,
                 reasoning_content: None,
+                reasoning_field: None,
             });
         }
         Ok(guard.remove(0))
@@ -198,6 +200,7 @@ impl ModelProvider for TraceLlmModelProvider {
                     cached_input_tokens: None,
                 }),
                 reasoning_content: None,
+                reasoning_field: None,
             }),
             TraceResponse::ToolCalls {
                 tool_calls,
@@ -222,6 +225,7 @@ impl ModelProvider for TraceLlmModelProvider {
                         cached_input_tokens: None,
                     }),
                     reasoning_content: None,
+                    reasoning_field: None,
                 })
             }
         }


### PR DESCRIPTION
## Summary

- Preserve the original compatible-provider reasoning field name (`reasoning_content` vs `reasoning`) when responses are stored for later assistant-tool-call replay.
- Thread that field name through sync responses, streaming reasoning chunks, runtime history builders, and native compatible-provider message reconstruction.
- Add focused coverage for streaming aggregation so `StreamChunk.reasoning_field` is retained before the runtime synthesizes the final `ChatResponse`.

## Relationship to #6615

#6615 has already been merged and is the canonical immediate read-direction fix for #6584: compatible providers now accept both `reasoning_content` and the `reasoning` alias on incoming responses.

This PR is not competing to close #6584. It is a follow-up for replay preservation only: when a provider originally returned `reasoning`, subsequent assistant history replay should use `reasoning` instead of rewriting it to `reasoning_content`.

## Scope boundary

- Keeps #6615's canonical read behavior: `reasoning_content` wins when both keys are present; `reasoning` is only the alias fallback.
- Does not add new provider-specific reasoning semantics.
- Only preserves the field name required to round-trip compatible-provider assistant tool-call history.

## Verification

- `cargo fmt --check`
- `git diff --check origin/master...HEAD`
- `cargo test -p zeroclaw-providers compatible::tests::reasoning --lib`
- `cargo test -p zeroclaw-providers parse_sse_line_with_reasoning --lib`
- `cargo test -p zeroclaw-providers convert_messages_for_native_round_trips_reasoning_field --lib`
- `cargo test -p zeroclaw-providers convert_messages_for_native --lib`
- `cargo test -p zeroclaw-tool-call-parser build_native_assistant_history_from_parsed_calls --lib`
- `cargo test -p zeroclaw-runtime consume_provider_streaming_response_preserves_reasoning_field --lib`
- `cargo test -p zeroclaw-runtime build_native_assistant_history --lib`
