### PR TITLE
fix(agent): preserve reasoning_content across turns for DeepSeek reas…

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -1272,10 +1272,22 @@ impl Agent {
                     let _ = cache.put(key, &effective_model, &final_text, token_count as u32);
                 }
 
-                self.history
-                    .push(ConversationMessage::Chat(ChatMessage::assistant(
-                        final_text.clone(),
-                    )));
+                // Preserve reasoning_content even when there are no tool calls.
+                // DeepSeek and other reasoning models require assistant messages
+                // that were generated with reasoning_content to include it when
+                // sent back in subsequent requests.
+                if response.reasoning_content.is_some() {
+                    self.history.push(ConversationMessage::AssistantToolCalls {
+                        text: Some(final_text.clone()),
+                        tool_calls: Vec::new(),
+                        reasoning_content: response.reasoning_content.clone(),
+                    });
+                } else {
+                    self.history
+                        .push(ConversationMessage::Chat(ChatMessage::assistant(
+                            final_text.clone(),
+                        )));
+                }
                 self.trim_history();
 
                 return Ok(final_text);
@@ -1437,6 +1449,7 @@ impl Agent {
             let mut streamed_text = String::new();
             let mut streamed_tool_calls: Vec<zeroclaw_providers::traits::ToolCall> = Vec::new();
             let mut streamed_usage: Option<zeroclaw_providers::traits::TokenUsage> = None;
+            let mut streamed_reasoning = String::new();
             let mut got_stream = false;
             let mut pre_executed_call_ids: HashMap<String, VecDeque<String>> = HashMap::new();
             let mut was_cancelled = false;
@@ -1468,6 +1481,7 @@ impl Agent {
                             if let Some(reasoning) = chunk.reasoning
                                 && !reasoning.is_empty()
                             {
+                                streamed_reasoning.push_str(&reasoning);
                                 let _ = event_tx
                                     .send(TurnEvent::Thinking { delta: reasoning })
                                     .await;
@@ -1550,11 +1564,16 @@ impl Agent {
             // check for tool calls via the dispatcher.
             let response = if got_stream {
                 // Build a synthetic ChatResponse from streamed text
+                let reasoning_content = if streamed_reasoning.is_empty() {
+                    None
+                } else {
+                    Some(streamed_reasoning)
+                };
                 zeroclaw_providers::ChatResponse {
                     text: Some(streamed_text),
                     tool_calls: streamed_tool_calls,
                     usage: streamed_usage.clone(),
-                    reasoning_content: None,
+                    reasoning_content,
                 }
             } else {
                 // Fall back to non-streaming chat, with cancellation guard
@@ -1629,10 +1648,22 @@ impl Agent {
                         .await;
                 }
 
-                self.history
-                    .push(ConversationMessage::Chat(ChatMessage::assistant(
-                        final_text.clone(),
-                    )));
+                // Preserve reasoning_content even when there are no tool calls.
+                // DeepSeek and other reasoning models require assistant messages
+                // that were generated with reasoning_content to include it when
+                // sent back in subsequent requests.
+                if response.reasoning_content.is_some() {
+                    self.history.push(ConversationMessage::AssistantToolCalls {
+                        text: Some(final_text.clone()),
+                        tool_calls: Vec::new(),
+                        reasoning_content: response.reasoning_content.clone(),
+                    });
+                } else {
+                    self.history
+                        .push(ConversationMessage::Chat(ChatMessage::assistant(
+                            final_text.clone(),
+                        )));
+                }
                 self.trim_history();
 
                 return Ok(final_text);

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -1252,6 +1252,7 @@ pub async fn run_tool_call_loop(
             native_tool_calls,
             _parse_issue_detected,
             response_streamed_live,
+            reasoning_content,
         ) = match chat_result {
             Ok(resp) => {
                 let (resp_input_tokens, resp_output_tokens) = resp
@@ -1384,6 +1385,7 @@ pub async fn run_tool_call_loop(
                     native_calls,
                     parse_issue.is_some(),
                     streamed_live_deltas,
+                    reasoning_content,
                 )
             }
             Err(e) => {
@@ -1506,6 +1508,21 @@ pub async fn run_tool_call_loop(
                 }
             }
 
+            // Preserve reasoning_content for thinking models (e.g. DeepSeek).
+            // The model requires assistant messages to include reasoning_content
+            // when sent back in subsequent requests.
+            if let Some(rc) = &reasoning_content {
+                if use_native_tools {
+                    if let Some(json) = build_native_assistant_history_from_parsed_calls(
+                        &response_text,
+                        &[],
+                        Some(rc),
+                    ) {
+                        history.push(ChatMessage::assistant(json));
+                        return Ok(accumulated_display_text);
+                    }
+                }
+            }
             history.push(ChatMessage::assistant(response_text.clone()));
             return Ok(accumulated_display_text);
         }


### PR DESCRIPTION
…oning models

DeepSeek and other reasoning models require reasoning_content from assistant messages to be passed back on subsequent requests. When reasoning_content was not preserved, DeepSeek returned 400: "reasoning_content in the thinking mode must be passed back".

Root cause: three separate code paths were dropping reasoning_content:

1. agent.rs turn() — stored final assistant messages (no tool calls) as plain ChatMessage::assistant(), dropping reasoning_content. Now stores as AssistantToolCalls with reasoning_content preserved.

2. agent.rs turn_streamed() — the streaming path accumulated reasoning deltas from TextDelta chunks but never included them in the synthetic ChatResponse (reasoning_content was hardcoded to None). Now accumulates streamed_reasoning and injects it.

3. loop_.rs run_tool_call_loop() — final response (no tool calls) stored as plain ChatMessage::assistant(response_text), dropping reasoning_content. Now uses build_native_assistant_history_from_ parsed_calls to produce JSON with reasoning_content when present.

Fixes #6059

## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:** (2–5 bullets — the diff shows *what*, you explain *why*)
- **Scope boundary:** (what this PR explicitly does NOT change)
- **Blast radius:** (what other subsystems or consumers could be affected)
- **Linked issue(s):** Use plain text outside backticks. Use `Closes #`,
  `Fixes #`, or `Resolves #` only for issues this PR fully resolves. Use
  `Related #`, `Depends on #`, or `Supersedes #` for non-closing relationships.
- **Labels:** Snapshot the current GitHub labels after labels are applied, for
  example `type: docs`, `risk: low`, `size: S`, `docs`.

## Validation Evidence (required)

Local validation is the signal CI cannot replace. Run the full battery and paste literal output (tails, failures, warnings — not "all passed").

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

Docs-only changes: replace with markdown lint + link-integrity (`scripts/ci/docs_quality_gate.sh`). Bootstrap scripts: add `bash -n install.sh`.

- **Commands run and tail output:**
- **Beyond CI — what did you manually verify?** (scenarios, edge cases, what you did NOT verify)
- **If any command was intentionally skipped, why:**

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? (`Yes/No`)
- New external network calls? (`Yes/No`)
- Secrets / tokens / credentials handling changed? (`Yes/No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`Yes/No`)
- If any `Yes`, describe the risk and mitigation:

## Compatibility (required)

- Backward compatible? (`Yes/No`)
- Config / env / CLI surface changed? (`Yes/No`)
- If `No` or `Yes` to either: exact upgrade steps for existing users:

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PRs: `git revert <sha>` is the plan unless otherwise noted.

Medium/high-risk PRs must fill:

- **Fast rollback command/path:**
- **Feature flags or config toggles:** (or `None`)
- **Observable failure symptoms:** (what to grep logs for, which metric moves, which alert fires)

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line):
- Scope materially carried forward:
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`Yes/No`)
- If `No`, why (inspiration-only, no direct code/design carry-over):

---

**Labels** live in the GitHub label UI, not in the body. Maintainers and reviewers with label permissions set `risk:*`, `size:*`, and scope labels via the sidebar. If auto-labels need correction, add `risk: manual` and the intended label. Contributors without label permission can note the mismatch in a comment.

**Do not add bot/AI attribution footers** such as `Co-authored-by: Claude ...`
or `Created with Claude Code` to the PR body or commit-message tail. Human
co-author trailers are appropriate only for incorporated contributor work under
the supersede-attribution section and privacy contract.

**Privacy contract** (`docs/book/src/contributing/privacy.md`) is a merge gate. Never commit real identities, secrets, personal emails, or PII in diff, tests, fixtures, or docs.
