### PR TITLE
fix(matrix): include attachment media metadata

### DIFF
--- a/crates/zeroclaw-channels/src/matrix.rs
+++ b/crates/zeroclaw-channels/src/matrix.rs
@@ -1849,13 +1849,16 @@ mod outbound {
     use futures_util::StreamExt;
     use matrix_sdk::{
         Client, Room, RoomState,
-        attachment::AttachmentConfig,
+        attachment::{
+            AttachmentConfig, AttachmentInfo, BaseAudioInfo, BaseFileInfo, BaseImageInfo,
+            BaseVideoInfo,
+        },
         room::{
             edit::EditedContent,
             reply::{EnforceThread, Reply},
         },
         ruma::{
-            OwnedEventId, OwnedRoomId,
+            OwnedEventId, OwnedRoomId, UInt,
             events::{
                 reaction::ReactionEventContent,
                 relation::Annotation,
@@ -2455,7 +2458,8 @@ mod outbound {
         Ok(room)
     }
 
-    enum AttachmentKind {
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    pub(super) enum AttachmentKind {
         Auto,
         Image,
         Audio,
@@ -2470,18 +2474,25 @@ mod outbound {
         kind: AttachmentKind,
         thread_anchor: Option<&OwnedEventId>,
     ) -> Result<OwnedEventId> {
-        let mime: mime_guess::Mime = match att.mime_type.as_deref() {
-            Some(m) => m
-                .parse()
-                .unwrap_or(mime_guess::mime::APPLICATION_OCTET_STREAM),
-            None => mime_guess::from_path(&att.file_name)
-                .first()
-                .unwrap_or(mime_guess::mime::APPLICATION_OCTET_STREAM),
-        };
+        let mime = attachment_mime(att);
         if matches!(kind, AttachmentKind::Voice) {
             return upload_voice(room, att, &mime, thread_anchor).await;
         }
-        let mut config = AttachmentConfig::new();
+        let config = attachment_config_for(att, kind, &mime, thread_anchor);
+        let resp = room
+            .send_attachment(att.file_name.clone(), &mime, att.data.clone(), config)
+            .await
+            .map_err(|e| anyhow!("send_attachment failed: {e}"))?;
+        Ok(resp.event_id)
+    }
+
+    pub(super) fn attachment_config_for(
+        att: &MediaAttachment,
+        kind: AttachmentKind,
+        mime: &mime_guess::Mime,
+        thread_anchor: Option<&OwnedEventId>,
+    ) -> AttachmentConfig {
+        let mut config = AttachmentConfig::new().info(attachment_info_for(att, kind, mime));
         if let Some(anchor) = thread_anchor {
             config = config.reply(Some(Reply {
                 event_id: anchor.clone(),
@@ -2489,11 +2500,59 @@ mod outbound {
                 add_mentions: AddMentions::No,
             }));
         }
-        let resp = room
-            .send_attachment(att.file_name.clone(), &mime, att.data.clone(), config)
-            .await
-            .map_err(|e| anyhow!("send_attachment failed: {e}"))?;
-        Ok(resp.event_id)
+        config
+    }
+
+    pub(super) fn attachment_mime(att: &MediaAttachment) -> mime_guess::Mime {
+        match att.mime_type.as_deref() {
+            Some(m) => m
+                .parse()
+                .unwrap_or(mime_guess::mime::APPLICATION_OCTET_STREAM),
+            None => mime_guess::from_path(&att.file_name)
+                .first()
+                .unwrap_or(mime_guess::mime::APPLICATION_OCTET_STREAM),
+        }
+    }
+
+    fn attachment_info_for(
+        att: &MediaAttachment,
+        kind: AttachmentKind,
+        mime: &mime_guess::Mime,
+    ) -> AttachmentInfo {
+        let size = UInt::try_from(att.data.len()).ok();
+        match attachment_info_kind(kind, mime) {
+            AttachmentKind::Image => AttachmentInfo::Image(BaseImageInfo {
+                size,
+                ..Default::default()
+            }),
+            AttachmentKind::Audio => AttachmentInfo::Audio(BaseAudioInfo {
+                size,
+                ..Default::default()
+            }),
+            AttachmentKind::Video => AttachmentInfo::Video(BaseVideoInfo {
+                size,
+                ..Default::default()
+            }),
+            AttachmentKind::Voice => AttachmentInfo::Voice(BaseAudioInfo {
+                size,
+                ..Default::default()
+            }),
+            AttachmentKind::File | AttachmentKind::Auto => {
+                AttachmentInfo::File(BaseFileInfo { size })
+            }
+        }
+    }
+
+    fn attachment_info_kind(kind: AttachmentKind, mime: &mime_guess::Mime) -> AttachmentKind {
+        if kind == AttachmentKind::Voice {
+            return AttachmentKind::Voice;
+        }
+        match mime.type_() {
+            mime_guess::mime::IMAGE => AttachmentKind::Image,
+            mime_guess::mime::AUDIO => AttachmentKind::Audio,
+            mime_guess::mime::VIDEO => AttachmentKind::Video,
+            _ => AttachmentKind::File,
+        }
     }
 
     /// Voice messages need the `org.matrix.msc3245.voice` flag, which the
@@ -4385,6 +4444,110 @@ mod tests {
         fn empty_text_without_attachment_is_error() {
             // True empty-message case: nothing to deliver, surface the error.
             assert_eq!(decide_send_outcome(true, false), SendOutcome::EmptyError);
+        }
+    }
+
+    mod outbound_attachment_info {
+        use super::super::outbound::{AttachmentKind, attachment_config_for};
+        use matrix_sdk::{attachment::AttachmentInfo, ruma::UInt};
+        use zeroclaw_api::media::MediaAttachment;
+
+        fn attachment(file_name: &str, mime_type: &str, len: usize) -> MediaAttachment {
+            MediaAttachment {
+                file_name: file_name.to_string(),
+                data: vec![0; len],
+                mime_type: Some(mime_type.to_string()),
+            }
+        }
+
+        fn info_size(info: AttachmentInfo) -> Option<UInt> {
+            match info {
+                AttachmentInfo::Image(info) => info.size,
+                AttachmentInfo::Video(info) => info.size,
+                AttachmentInfo::Audio(info) | AttachmentInfo::Voice(info) => info.size,
+                AttachmentInfo::File(info) => info.size,
+            }
+        }
+
+        #[test]
+        fn structured_file_attachment_carries_matrix_size_info() {
+            let att = attachment("report.pdf", "application/pdf", 4096);
+
+            let mime = super::super::outbound::attachment_mime(&att);
+            let config = attachment_config_for(&att, AttachmentKind::Auto, &mime, None);
+
+            let info = config.info.expect("attachment info is populated");
+            assert!(matches!(info, AttachmentInfo::File(_)));
+            assert_eq!(info_size(info), UInt::try_from(4096usize).ok());
+        }
+
+        #[test]
+        fn media_markers_use_type_specific_matrix_info_with_size() {
+            let cases = [
+                (
+                    AttachmentKind::Image,
+                    attachment("photo.png", "image/png", 17),
+                    "image",
+                ),
+                (
+                    AttachmentKind::Audio,
+                    attachment("clip.ogg", "audio/ogg", 23),
+                    "audio",
+                ),
+                (
+                    AttachmentKind::Video,
+                    attachment("movie.mp4", "video/mp4", 31),
+                    "video",
+                ),
+            ];
+
+            for (kind, att, expected_kind) in cases {
+                let mime = super::super::outbound::attachment_mime(&att);
+                let config = attachment_config_for(&att, kind, &mime, None);
+                let info = config.info.expect("attachment info is populated");
+                match (&info, expected_kind) {
+                    (AttachmentInfo::Image(_), "image") => {}
+                    (AttachmentInfo::Audio(_), "audio") => {}
+                    (AttachmentInfo::Video(_), "video") => {}
+                    _ => panic!("unexpected attachment info kind {info:?}"),
+                }
+                assert_eq!(info_size(info), UInt::try_from(att.data.len()).ok());
+            }
+        }
+
+        #[test]
+        fn attachment_info_kind_matches_final_mime_type() {
+            let image_named_as_file = attachment("photo.png", "image/png", 47);
+            let mime = super::super::outbound::attachment_mime(&image_named_as_file);
+            let config =
+                attachment_config_for(&image_named_as_file, AttachmentKind::File, &mime, None);
+            let info = config.info.expect("attachment info is populated");
+            assert!(
+                matches!(info, AttachmentInfo::Image(_)),
+                "info must match the MIME-selected Matrix event type"
+            );
+            assert_eq!(
+                info_size(info),
+                UInt::try_from(image_named_as_file.data.len()).ok()
+            );
+
+            let image_marker_with_file_mime = attachment("report.pdf", "application/pdf", 53);
+            let mime = super::super::outbound::attachment_mime(&image_marker_with_file_mime);
+            let config = attachment_config_for(
+                &image_marker_with_file_mime,
+                AttachmentKind::Image,
+                &mime,
+                None,
+            );
+            let info = config.info.expect("attachment info is populated");
+            assert!(
+                matches!(info, AttachmentInfo::File(_)),
+                "file MIME should use file info so SDK preserves size"
+            );
+            assert_eq!(
+                info_size(info),
+                UInt::try_from(image_marker_with_file_mime.data.len()).ok()
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Matrix outbound file/image/audio/video attachments now pass type-specific `AttachmentInfo` to `room.send_attachment`.
  - The metadata includes `info.size` derived from the in-memory attachment byte length, fixing clients that displayed delivered files as unknown size.
  - The metadata variant is selected from the final upload MIME type, matching the Matrix SDK's `m.image` / `m.audio` / `m.video` / `m.file` event selection so the SDK preserves the size.
  - Regression tests cover structured attachments, marker attachments, and MIME/kind mismatch cases.
- **Scope boundary:** This PR does not decode media or synthesize dimensions, durations, thumbnails, blurhashes, or waveforms. Those require media parsing and policy beyond the current `MediaAttachment` boundary. Voice-note raw JSON already carried size metadata and is not changed.
- **Blast radius:** Matrix outbound attachments only. Other channels, inbound media handling, and public `zeroclaw_api::media::MediaAttachment` stay unchanged.
- **Linked issue(s):** Closes #6609
- **Labels:** `bug`, `risk: medium`, `risk: manual`, `channel`, `channel:matrix`, `size: S`, `priority:p2` (set in the GitHub UI).

## Validation Evidence (required)

- **Commands run and tail output:**

```bash
$ cargo fmt --all -- --check
# exited 0

$ cargo clippy --all-targets -- -D warnings
# tail:
#     Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 03s

$ cargo test
# tail:
#      Running tests/test_system.rs (target/debug/deps/system-cfe2c53a77913a7b)
#
# running 5 tests
# test system::full_stack::system_simple_text_response ... ok
# test system::full_stack::system_parallel_tool_execution ... ok
# test system::full_stack::system_tool_arguments_passed_correctly ... ok
# test system::full_stack::system_multi_turn_conversation ... ok
# test system::full_stack::system_tool_execution_flow ... ok
#
# test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
#
#    Doc-tests zeroclaw
#
# running 0 tests
#
# test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

- **Beyond CI — what did you manually verify?** Reviewed matrix-sdk 0.16 attachment handling: `info.mimetype` is assigned from the upload content type, while `AttachmentInfo` must match the MIME-selected Matrix event type for `size` to survive conversion. The new tests include mismatched marker kind/MIME cases to cover that behavior.
- **If any command was intentionally skipped, why:** None.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: Existing Matrix attachment sends continue using the same send path; clients receive additional standard media metadata.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert 2be2579610f899a30b9c4e43241821b3880d81ba`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Matrix outbound attachments would again arrive without reliable `content.info.size` metadata, or Matrix sends would fail on attachment upload/send if the SDK metadata variant selection regressed.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A
