### PR TITLE
fix(providers): use --prompt for gemini-cli (replaces removed --print) (#6520)

### DIFF
--- a/crates/zeroclaw-providers/src/gemini_cli.rs
+++ b/crates/zeroclaw-providers/src/gemini_cli.rs
@@ -11,9 +11,12 @@
 //!
 //! Gemini CLI is invoked as:
 //! ```text
-//! gemini --print -
+//! gemini --prompt ""
 //! ```
-//! with prompt content written to stdin.
+//! with prompt content written to stdin. The empty `--prompt ""` is the
+//! headless-mode trigger; the CLI appends stdin to it, so the actual prompt
+//! is never visible in `ps` / `/proc/<pid>/cmdline`. Older CLI builds used
+//! `--print -` for this; that flag was removed in Gemini CLI v0.40.x.
 //!
 //! # Limitations
 //!
@@ -119,18 +122,26 @@ impl GeminiCliProvider {
         format!("{clipped}...")
     }
 
+    /// Build the argv tail (excluding the binary itself) for a CLI invocation.
+    ///
+    /// `--prompt ""` is the headless-mode trigger; the CLI appends stdin to
+    /// it, so the actual prompt stays out of `ps` / `/proc/<pid>/cmdline`.
+    /// The pre-v0.40 syntax `--print -` was removed upstream in #6520.
+    fn build_cli_args(model: &str) -> Vec<String> {
+        let mut args = vec!["--prompt".to_string(), String::new()];
+        if Self::should_forward_model(model) {
+            args.push("--model".to_string());
+            args.push(model.to_string());
+        }
+        args
+    }
+
     /// Invoke the gemini binary with the given prompt and optional model.
     /// Returns the trimmed stdout output as the assistant response.
     async fn invoke_cli(&self, message: &str, model: &str) -> anyhow::Result<String> {
         let mut cmd = Command::new(&self.binary_path);
-        cmd.arg("--print");
+        cmd.args(Self::build_cli_args(model));
 
-        if Self::should_forward_model(model) {
-            cmd.arg("--model").arg(model);
-        }
-
-        // Read prompt from stdin to avoid exposing sensitive content in process args.
-        cmd.arg("-");
         cmd.kill_on_drop(true);
         cmd.stdin(std::process::Stdio::piped());
         cmd.stdout(std::process::Stdio::piped());
@@ -311,6 +322,33 @@ mod tests {
             err.to_string()
                 .contains("temperature unsupported by Gemini CLI")
         );
+    }
+
+    // Regression for #6520. Gemini CLI v0.40.x removed `--print`; the
+    // headless-mode flag is now `--prompt`. The argv must (a) carry
+    // `--prompt ""` so stdin still feeds the prompt content (keeping the
+    // user message out of `ps`) and (b) NEVER carry `--print` or `-`.
+    #[test]
+    fn build_cli_args_uses_prompt_flag_with_empty_token_default_model() {
+        let args = GeminiCliProvider::build_cli_args(DEFAULT_MODEL_MARKER);
+        assert_eq!(args, vec!["--prompt".to_string(), String::new()]);
+        assert!(!args.iter().any(|a| a == "--print"));
+        assert!(!args.iter().any(|a| a == "-"));
+    }
+
+    #[test]
+    fn build_cli_args_forwards_explicit_model_after_prompt() {
+        let args = GeminiCliProvider::build_cli_args("gemini-2.5-pro");
+        assert_eq!(
+            args,
+            vec![
+                "--prompt".to_string(),
+                String::new(),
+                "--model".to_string(),
+                "gemini-2.5-pro".to_string(),
+            ]
+        );
+        assert!(!args.iter().any(|a| a == "--print"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `GeminiCliProvider::invoke_cli` spawned `gemini --print -`, which had been the headless-mode invocation up through Gemini CLI v0.39. Upstream v0.40.x removed `--print` entirely; the headless-mode flag is now `-p` / `--prompt`. Pre-PR, the subprocess exits immediately with `Unknown argument: print` and the agent fails the first turn.
  - This is **not** the reporter's suggested fix (`--prompt <message>` with the prompt inlined into argv). @Audacity88 explicitly raised the privacy concern on the issue thread: *"Passing the full prompt via `--prompt <text>` may expose user/conversation content in process arguments on some systems. The fix should preserve ZeroClaw's prompt privacy expectations if Gemini CLI still offers a stdin or file-based headless path."* The fresh CLI's `--help` shows it does still accept stdin — `-p, --prompt … Appended to input on stdin (if any)` — so this PR passes `--prompt ""` as the headless trigger and keeps the existing stdin write path. Net effect: the bug is fixed and the privacy property the original code went out of its way to maintain is preserved.
  - Argv construction is extracted into `GeminiCliProvider::build_cli_args(model)` so a unit test can assert the exact argv shape without spawning a subprocess. Two regression tests assert `--prompt ""` is emitted, that `--print` and `-` are never present, and that the model forwarding ordering is stable.
  - Doc-comment header updated from `gemini --print -` to `gemini --prompt ""` with a note pointing at #6520 so future readers don't think the empty string is accidental.

- **Scope boundary:** One file (`crates/zeroclaw-providers/src/gemini_cli.rs`), one function plus a tiny helper extraction, two regression tests. No new dependencies.
- **Blast radius:** Only the `gemini-cli` provider's subprocess invocation. All other provider crates and call sites are untouched. Existing test surface (10 unit tests on this provider) continues to pass.
- **Linked issue(s):** Fixes #6520.

## Validation Evidence (required)

```
$ cargo fmt --all -- --check
(clean — no diff)

$ cargo test -p zeroclaw-providers --lib gemini_cli
test result: ok. 12 passed; 0 failed; 0 ignored
  (10 baseline + 2 new regression tests:
   build_cli_args_uses_prompt_flag_with_empty_token_default_model,
   build_cli_args_forwards_explicit_model_after_prompt)

$ cargo test -p zeroclaw-providers --lib
test result: ok. 868 passed; 0 failed; 0 ignored
  (866 baseline on master + 2 new)
```

- **Commands run and tail output:** as above.
- **Beyond CI — what I manually verified:**
  - Pulled the latest Gemini CLI (`npm install -g @google/gemini-cli` under Node 25) and ran `gemini --help` to confirm the upstream flag surface: `--prompt` is documented as "Run in non-interactive (headless) mode with the given prompt. Appended to input on stdin (if any)." `--print` does not appear. This matches the reporter's failure mode exactly.
  - Confirmed `gemini --prompt "hi"` invokes the new flag parser cleanly (the trust-directory guard fires next, not an argument error), proving `--prompt` is the right token. Could not run an end-to-end prompt against the live CLI from this dev env because the bundled CLI has a Node-version incompatibility with the Node binaries I have available; the failure surface for this PR is argument parsing, which I verified above. The actual stdin-append behavior is a property of the Gemini CLI itself, asserted by its `--help` documentation rather than re-asserted in our tests.
- **If any command was intentionally skipped:** `cargo test --workspace` and `cargo clippy --workspace --all-targets -- -D warnings` deferred to CI.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No.**
- New external network calls? **No.**
- Secrets / tokens / credentials handling changed? **No.** The CLI handles its own credential store (unchanged from pre-PR).
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No.**

**Prompt-privacy property preserved.** The pre-PR code chose `--print -` specifically to keep prompt content out of `ps` / `/proc/<pid>/cmdline`. This PR preserves that property by using `--prompt ""` (empty string) as the headless trigger and continuing to write the actual message to stdin. A naive port to `--prompt <message>` would have regressed this; that regression is what @Audacity88 flagged on the issue thread and this PR addresses head-on.

## Compatibility (required)

- Backward compatible? **Behaviour widening on the upstream CLI side:** users on Gemini CLI v0.40.x and later now get a working provider where pre-PR they got an immediate crash. Users on Gemini CLI v0.39 and earlier (which only knew `--print`) would now see "Unknown argument: prompt." That CLI generation pre-dates the v1.0 launch and is no longer the upstream-recommended channel; the issue reporter is on v0.41.2.
- Config / env / CLI surface changed? **No** within ZeroClaw — `GEMINI_CLI_PATH_ENV` and config keys are unchanged.

## Rollback

- **Fast rollback command/path:** `git revert <commit>` (single commit, one file).
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** If a future Gemini CLI release renames or removes `--prompt`, the same crash signature returns (`Unknown argument: prompt`). The fix would mirror this PR: identify the new headless trigger from `gemini --help` and update `build_cli_args`. The extracted helper makes the future fix a one-line edit.

---

**Labels:** `bug`, `risk: medium`, `provider`, `provider:gemini`, `size: S` (set in the GitHub UI).

**Diff stat:** 1 file changed, +47 / -9.
