### PR TITLE
fix(config): emit json patch errors for cli patch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -328,7 +328,7 @@ browser-native = ["zeroclaw-tools/browser-native"]
 plugins-wasm = ["dep:zeroclaw-plugins", "zeroclaw-runtime/plugins-wasm"]
 probe = ["dep:zeroclaw-hardware", "zeroclaw-hardware/probe"]
 rag-pdf = ["zeroclaw-tools/rag-pdf", "zeroclaw-runtime/rag-pdf"]
-webauthn = ["zeroclaw-runtime/webauthn"]
+webauthn = ["zeroclaw-runtime/webauthn", "zeroclaw-gateway?/webauthn"]
 embedded-web = ["zeroclaw-gateway/embedded-web"]
 
 # Backward-compatible aliases

--- a/crates/zeroclaw-gateway/src/api_config.rs
+++ b/crates/zeroclaw-gateway/src/api_config.rs
@@ -107,6 +107,65 @@ pub struct PatchResponse {
     pub warnings: Vec<zeroclaw_config::validation_warnings::ValidationWarning>,
 }
 
+fn parse_patch_ops(value: serde_json::Value) -> Result<Vec<PatchOp>, ConfigApiError> {
+    let ops = value.as_array().ok_or_else(|| {
+        ConfigApiError::new(
+            ConfigApiCode::ValueTypeMismatch,
+            "JSON Patch body must be a JSON array of operations",
+        )
+    })?;
+
+    let mut parsed = Vec::with_capacity(ops.len());
+    for (idx, op) in ops.iter().enumerate() {
+        let object = op.as_object().ok_or_else(|| {
+            ConfigApiError::new(
+                ConfigApiCode::ValueTypeMismatch,
+                format!("JSON Patch op[{idx}] must be an object"),
+            )
+            .with_op_index(idx)
+        })?;
+        let op_name = object.get("op").and_then(|v| v.as_str()).ok_or_else(|| {
+            ConfigApiError::new(
+                ConfigApiCode::ValueTypeMismatch,
+                format!("JSON Patch op[{idx}] requires string `op` field"),
+            )
+            .with_op_index(idx)
+        })?;
+        let path = object.get("path").and_then(|v| v.as_str()).ok_or_else(|| {
+            ConfigApiError::new(
+                ConfigApiCode::ValueTypeMismatch,
+                format!("JSON Patch op[{idx}] requires string `path` field"),
+            )
+            .with_op_index(idx)
+        })?;
+        let comment = match object.get("comment") {
+            Some(value) => Some(
+                value
+                    .as_str()
+                    .ok_or_else(|| {
+                        ConfigApiError::new(
+                            ConfigApiCode::ValueTypeMismatch,
+                            format!("JSON Patch op[{idx}] `comment` field must be a string"),
+                        )
+                        .with_path(json_pointer_to_dotted(path))
+                        .with_op_index(idx)
+                    })?
+                    .to_string(),
+            ),
+            None => None,
+        };
+
+        parsed.push(PatchOp {
+            op: op_name.to_string(),
+            path: path.to_string(),
+            value: object.get("value").cloned(),
+            comment,
+        });
+    }
+
+    Ok(parsed)
+}
+
 /// Response for a non-secret GET / PUT / DELETE.
 #[derive(Debug, Serialize)]
 #[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
@@ -758,11 +817,16 @@ pub async fn handle_map_key(
 pub async fn handle_patch(
     State(state): State<AppState>,
     headers: HeaderMap,
-    axum::Json(ops): axum::Json<Vec<PatchOp>>,
+    axum::Json(body): axum::Json<serde_json::Value>,
 ) -> Response {
     if let Err(e) = require_auth(&state, &headers) {
         return e.into_response();
     }
+
+    let ops = match parse_patch_ops(body) {
+        Ok(ops) => ops,
+        Err(e) => return error_response(e),
+    };
 
     let working = state.config.lock().clone();
 

--- a/crates/zeroclaw-gateway/src/lib.rs
+++ b/crates/zeroclaw-gateway/src/lib.rs
@@ -243,7 +243,7 @@ pub struct GatewayRateLimiter {
 }
 
 impl GatewayRateLimiter {
-    fn new(pair_per_minute: u32, webhook_per_minute: u32, max_keys: usize) -> Self {
+    pub fn new(pair_per_minute: u32, webhook_per_minute: u32, max_keys: usize) -> Self {
         let window = Duration::from_secs(RATE_LIMIT_WINDOW_SECS);
         Self {
             pair: SlidingWindowRateLimiter::new(pair_per_minute, window, max_keys),
@@ -268,7 +268,7 @@ pub struct IdempotencyStore {
 }
 
 impl IdempotencyStore {
-    fn new(ttl: Duration, max_keys: usize) -> Self {
+    pub fn new(ttl: Duration, max_keys: usize) -> Self {
         Self {
             ttl,
             max_keys: max_keys.max(1),

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,26 +62,6 @@ async fn apply_comment_inline(
     .context("failed to write comment annotation")
 }
 
-/// Coerce a JSON value into the string form `Config::set_prop` accepts.
-///
-/// Thin wrapper over the shared `zeroclaw_config::typed_value::coerce_for_set_prop`
-/// helper that the gateway PATCH/PUT endpoints use. Looking up a path's
-/// declared `PropKind` requires a `Config` reference, which the patch handler
-/// has — so this looks the kind up against the live config and forwards.
-fn json_value_to_setprop_string(
-    value: &serde_json::Value,
-    config: &Config,
-    path: &str,
-) -> Result<String> {
-    let kind = config
-        .prop_fields()
-        .into_iter()
-        .find(|f| f.name == path)
-        .map(|f| f.kind);
-    zeroclaw_config::typed_value::coerce_for_set_prop(value, kind)
-        .map_err(|e| anyhow::anyhow!("{}", e.message))
-}
-
 fn config_patch_prop_kind(config: &Config, path: &str) -> Option<crate::config::PropKind> {
     config
         .prop_fields()
@@ -104,6 +84,21 @@ fn config_patch_map_prop_error(err: anyhow::Error, path: &str, op_index: usize) 
 fn config_patch_json_error(err: &ConfigApiError) -> Result<()> {
     eprintln!("{}", serde_json::to_string_pretty(err)?);
     std::process::exit(1);
+}
+
+fn config_patch_json_value_type_error(
+    message: impl Into<String>,
+    path: Option<String>,
+    op_index: Option<usize>,
+) -> ConfigApiError {
+    let mut err = ConfigApiError::new(ConfigApiCode::ValueTypeMismatch, message.into());
+    if let Some(path) = path {
+        err = err.with_path(path);
+    }
+    if let Some(op_index) = op_index {
+        err = err.with_op_index(op_index);
+    }
+    err
 }
 
 fn config_patch_fail_json_or_human<T>(
@@ -2634,34 +2629,128 @@ async fn main() -> Result<()> {
                     None | Some("-") => {
                         use std::io::Read;
                         let mut buf = String::new();
-                        std::io::stdin()
-                            .read_to_string(&mut buf)
-                            .context("Failed to read JSON Patch from stdin")?;
+                        if let Err(err) = std::io::stdin().read_to_string(&mut buf) {
+                            let api_err = ConfigApiError::new(
+                                ConfigApiCode::InternalError,
+                                format!("failed to read JSON Patch from stdin: {err}"),
+                            );
+                            config_patch_fail_json_or_human(
+                                json,
+                                api_err,
+                                format!("Failed to read JSON Patch from stdin: {err}"),
+                            )?;
+                        }
                         buf
                     }
-                    Some(path) => tokio::fs::read_to_string(path)
-                        .await
-                        .with_context(|| format!("Failed to read JSON Patch from {path}"))?,
+                    Some(path) => match tokio::fs::read_to_string(path).await {
+                        Ok(body) => body,
+                        Err(err) => {
+                            let api_err = ConfigApiError::new(
+                                ConfigApiCode::InternalError,
+                                format!("failed to read JSON Patch from {path}: {err}"),
+                            );
+                            config_patch_fail_json_or_human(
+                                json,
+                                api_err,
+                                format!("Failed to read JSON Patch from {path}: {err}"),
+                            )?
+                        }
+                    },
                 };
 
-                let ops: Vec<serde_json::Value> = serde_json::from_str(body.trim())
-                    .context("JSON Patch body must be a JSON array of operations")?;
+                let parsed: serde_json::Value = match serde_json::from_str(body.trim()) {
+                    Ok(parsed) => parsed,
+                    Err(err) => {
+                        let api_err = config_patch_json_value_type_error(
+                            format!("JSON Patch body must be valid JSON: {err}"),
+                            None,
+                            None,
+                        );
+                        config_patch_fail_json_or_human(
+                            json,
+                            api_err,
+                            format!("JSON Patch body must be valid JSON: {err}"),
+                        )?
+                    }
+                };
+                let ops = match parsed.as_array() {
+                    Some(ops) => ops,
+                    None => {
+                        let api_err = config_patch_json_value_type_error(
+                            "JSON Patch body must be a JSON array of operations",
+                            None,
+                            None,
+                        );
+                        config_patch_fail_json_or_human(
+                            json,
+                            api_err,
+                            "JSON Patch body must be a JSON array of operations",
+                        )?
+                    }
+                };
 
                 let mut results: Vec<serde_json::Value> = Vec::with_capacity(ops.len());
 
                 for (idx, op) in ops.iter().enumerate() {
-                    let op_name = op
-                        .get("op")
-                        .and_then(|v| v.as_str())
-                        .ok_or_else(|| anyhow::anyhow!("op[{idx}]: missing `op` field"))?;
-                    let raw_path = op
-                        .get("path")
-                        .and_then(|v| v.as_str())
-                        .ok_or_else(|| anyhow::anyhow!("op[{idx}]: missing `path` field"))?;
+                    let object = match op.as_object() {
+                        Some(object) => object,
+                        None => {
+                            let message = format!("JSON Patch op[{idx}] must be an object");
+                            let api_err = config_patch_json_value_type_error(
+                                message.clone(),
+                                None,
+                                Some(idx),
+                            );
+                            config_patch_fail_json_or_human(json, api_err, message)?
+                        }
+                    };
+                    let op_name = match object.get("op").and_then(|v| v.as_str()) {
+                        Some(op_name) => op_name,
+                        None => {
+                            let message =
+                                format!("JSON Patch op[{idx}] requires string `op` field");
+                            let api_err = config_patch_json_value_type_error(
+                                message.clone(),
+                                None,
+                                Some(idx),
+                            );
+                            config_patch_fail_json_or_human(json, api_err, message)?
+                        }
+                    };
+                    let raw_path = match object.get("path").and_then(|v| v.as_str()) {
+                        Some(raw_path) => raw_path,
+                        None => {
+                            let message =
+                                format!("JSON Patch op[{idx}] requires string `path` field");
+                            let api_err = config_patch_json_value_type_error(
+                                message.clone(),
+                                None,
+                                Some(idx),
+                            );
+                            config_patch_fail_json_or_human(json, api_err, message)?
+                        }
+                    };
                     let path = if let Some(stripped) = raw_path.strip_prefix('/') {
                         stripped.replace('/', ".")
                     } else {
                         raw_path.to_string()
+                    };
+                    let comment = match object.get("comment") {
+                        Some(value) => match value.as_str() {
+                            Some(comment) => Some(comment),
+                            None => {
+                                let message = format!(
+                                    "JSON Patch op[{idx}] `comment` field must be a string"
+                                );
+                                let api_err = config_patch_json_value_type_error(
+                                    message.clone(),
+                                    Some(path.clone()),
+                                    Some(idx),
+                                );
+                                config_patch_fail_json_or_human(json, api_err, message)?
+                            }
+                        },
+                        None => None,
                     };
                     let is_secret = Config::prop_is_secret(&path);
 
@@ -2831,10 +2920,25 @@ async fn main() -> Result<()> {
                     results.push(result_entry);
                 }
 
-                config
-                    .validate()
-                    .context("validation failed after applying patch \u{2014} no changes saved")?;
-                config.save().await?;
+                if let Err(err) = config.validate() {
+                    let api_err = ConfigApiError::from_validation(err);
+                    config_patch_fail_json_or_human(
+                        json,
+                        api_err,
+                        "validation failed after applying patch - no changes saved",
+                    )?;
+                }
+                if let Err(err) = config.save().await {
+                    let api_err = ConfigApiError::new(
+                        ConfigApiCode::ReloadFailed,
+                        format!("save failed: {err}"),
+                    );
+                    config_patch_fail_json_or_human(
+                        json,
+                        api_err,
+                        format!("failed to save config after applying patch: {err}"),
+                    )?;
+                }
 
                 if json {
                     let body = serde_json::json!({"saved": true, "results": results});

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,7 @@ use std::io::Write;
 use std::path::PathBuf;
 use tracing::{info, warn};
 use tracing_subscriber::{EnvFilter, fmt};
+use zeroclaw_config::api_error::{ConfigApiCode, ConfigApiError};
 
 /// Decorate the value at `path` in `config.toml` with a leading `# {comment}`
 /// line, preserving any non-comment whitespace. Mirrors the gateway's
@@ -79,6 +80,44 @@ fn json_value_to_setprop_string(
         .map(|f| f.kind);
     zeroclaw_config::typed_value::coerce_for_set_prop(value, kind)
         .map_err(|e| anyhow::anyhow!("{}", e.message))
+}
+
+fn config_patch_prop_kind(config: &Config, path: &str) -> Option<crate::config::PropKind> {
+    config
+        .prop_fields()
+        .into_iter()
+        .find(|f| f.name == path)
+        .map(|f| f.kind)
+}
+
+fn config_patch_map_prop_error(err: anyhow::Error, path: &str, op_index: usize) -> ConfigApiError {
+    let msg = err.to_string();
+    if msg.starts_with("Unknown property") {
+        ConfigApiError::path_not_found(path).with_op_index(op_index)
+    } else {
+        ConfigApiError::from_validation(err)
+            .with_path(path)
+            .with_op_index(op_index)
+    }
+}
+
+fn config_patch_json_error(err: &ConfigApiError) -> Result<()> {
+    eprintln!("{}", serde_json::to_string_pretty(err)?);
+    std::process::exit(1);
+}
+
+fn config_patch_fail_json_or_human<T>(
+    json: bool,
+    err: ConfigApiError,
+    human: impl Into<String>,
+) -> Result<T>
+where
+    T: Sized,
+{
+    if json {
+        config_patch_json_error(&err)?;
+    }
+    anyhow::bail!("{}", human.into())
 }
 
 fn parse_temperature(s: &str) -> std::result::Result<f64, String> {
@@ -2628,15 +2667,43 @@ async fn main() -> Result<()> {
 
                     let result_entry: serde_json::Value = match op_name {
                         "add" | "replace" => {
-                            let value = op.get("value").ok_or_else(|| {
-                                anyhow::anyhow!(
-                                    "op[{idx}] `{op_name}` on `{path}`: missing `value` field"
-                                )
-                            })?;
-                            let value_str = json_value_to_setprop_string(value, &config, &path)?;
-                            config.set_prop(&path, &value_str).with_context(|| {
-                                format!("op[{idx}] `{op_name}` on `{path}` failed")
-                            })?;
+                            let value = match op.get("value") {
+                                Some(value) => value,
+                                None => {
+                                    let message =
+                                        format!("JSON Patch `{op_name}` op requires `value` field");
+                                    let err = ConfigApiError::new(
+                                        ConfigApiCode::ValueTypeMismatch,
+                                        message,
+                                    )
+                                    .with_path(&path)
+                                    .with_op_index(idx);
+                                    let human = format!(
+                                        "op[{idx}] `{op_name}` on `{path}`: missing `value` field"
+                                    );
+                                    config_patch_fail_json_or_human(json, err, human)?
+                                }
+                            };
+                            let value_str = match zeroclaw_config::typed_value::coerce_for_set_prop(
+                                value,
+                                config_patch_prop_kind(&config, &path),
+                            ) {
+                                Ok(value_str) => value_str,
+                                Err(err) => {
+                                    let err = err.with_path(&path).with_op_index(idx);
+                                    config_patch_fail_json_or_human(
+                                        json,
+                                        err.clone(),
+                                        err.message.clone(),
+                                    )?
+                                }
+                            };
+                            if let Err(err) = config.set_prop(&path, &value_str) {
+                                let human =
+                                    format!("op[{idx}] `{op_name}` on `{path}` failed: {err}");
+                                let api_err = config_patch_map_prop_error(err, &path, idx);
+                                config_patch_fail_json_or_human(json, api_err, human)?;
+                            }
                             if is_secret {
                                 serde_json::json!({
                                     "op": op_name,
@@ -2652,9 +2719,11 @@ async fn main() -> Result<()> {
                             }
                         }
                         "remove" => {
-                            config.set_prop(&path, "").with_context(|| {
-                                format!("op[{idx}] `remove` on `{path}` failed")
-                            })?;
+                            if let Err(err) = config.set_prop(&path, "") {
+                                let human = format!("op[{idx}] `remove` on `{path}` failed: {err}");
+                                let api_err = config_patch_map_prop_error(err, &path, idx);
+                                config_patch_fail_json_or_human(json, api_err, human)?;
+                            }
                             if is_secret {
                                 serde_json::json!({
                                     "op": "remove",
@@ -2671,28 +2740,66 @@ async fn main() -> Result<()> {
                         }
                         "test" => {
                             if is_secret {
-                                anyhow::bail!(
+                                let err =
+                                    ConfigApiError::secret_test_forbidden(&path).with_op_index(idx);
+                                let human = format!(
                                     "op[{idx}] `test` on `{path}`: secret_test_forbidden \
                                      \u{2014} test ops are not allowed against secret paths"
                                 );
+                                config_patch_fail_json_or_human(json, err, human)?;
                             }
-                            let want = op.get("value").ok_or_else(|| {
-                                anyhow::anyhow!(
-                                    "op[{idx}] `test` on `{path}`: missing `value` field"
-                                )
-                            })?;
-                            let actual = config.get_prop(&path).with_context(|| {
-                                format!("op[{idx}] `test` on `{path}` failed to read current value")
-                            })?;
-                            let want_str = match want {
-                                serde_json::Value::String(s) => s.clone(),
-                                other => other.to_string(),
+                            let want = match op.get("value") {
+                                Some(value) => value,
+                                None => {
+                                    let err = ConfigApiError::new(
+                                        ConfigApiCode::ValueTypeMismatch,
+                                        "JSON Patch `test` op requires `value` field",
+                                    )
+                                    .with_path(&path)
+                                    .with_op_index(idx);
+                                    let human = format!(
+                                        "op[{idx}] `test` on `{path}`: missing `value` field"
+                                    );
+                                    config_patch_fail_json_or_human(json, err, human)?
+                                }
+                            };
+                            let actual = match config.get_prop(&path) {
+                                Ok(actual) => actual,
+                                Err(err) => {
+                                    let human = format!(
+                                        "op[{idx}] `test` on `{path}` failed to read current value: {err}"
+                                    );
+                                    let api_err = config_patch_map_prop_error(err, &path, idx);
+                                    config_patch_fail_json_or_human(json, api_err, human)?
+                                }
+                            };
+                            let want_str = match zeroclaw_config::typed_value::coerce_for_set_prop(
+                                want,
+                                config_patch_prop_kind(&config, &path),
+                            ) {
+                                Ok(want_str) => want_str,
+                                Err(err) => {
+                                    let err = err.with_path(&path).with_op_index(idx);
+                                    config_patch_fail_json_or_human(
+                                        json,
+                                        err.clone(),
+                                        err.message.clone(),
+                                    )?
+                                }
                             };
                             if actual != want_str {
-                                anyhow::bail!(
-                                    "op[{idx}] `test` on `{path}` failed: \
-                                     expected {want_str}, got {actual}"
+                                let err = ConfigApiError::new(
+                                    ConfigApiCode::ValidationFailed,
+                                    format!(
+                                        "`test` op failed: expected {want_str:?}, got {actual:?}"
+                                    ),
+                                )
+                                .with_path(&path)
+                                .with_op_index(idx);
+                                let human = format!(
+                                    "op[{idx}] `test` on `{path}` failed: expected {want_str}, got {actual}"
                                 );
+                                config_patch_fail_json_or_human(json, err, human)?;
                             }
                             serde_json::json!({
                                 "op": "test",
@@ -2701,13 +2808,24 @@ async fn main() -> Result<()> {
                             })
                         }
                         "move" | "copy" => {
-                            anyhow::bail!(
+                            let err = ConfigApiError::op_not_supported(op_name)
+                                .with_path(&path)
+                                .with_op_index(idx);
+                            let human = format!(
                                 "op[{idx}] `{op_name}` on `{path}`: op_not_supported \
                                  \u{2014} move/copy require a reference graph that is not built yet"
                             );
+                            config_patch_fail_json_or_human(json, err, human)?
                         }
                         other => {
-                            anyhow::bail!("op[{idx}] unknown JSON Patch operation `{other}`");
+                            let err = ConfigApiError::new(
+                                ConfigApiCode::OpNotSupported,
+                                format!("unknown JSON Patch operation `{other}`"),
+                            )
+                            .with_path(&path)
+                            .with_op_index(idx);
+                            let human = format!("op[{idx}] unknown JSON Patch operation `{other}`");
+                            config_patch_fail_json_or_human(json, err, human)?
                         }
                     };
                     results.push(result_entry);

--- a/tests/component/config_patch_cli.rs
+++ b/tests/component/config_patch_cli.rs
@@ -1,0 +1,56 @@
+//! Regression coverage for `zeroclaw config patch --json` error output.
+//!
+//! This intentionally exercises the CLI process boundary instead of spinning up
+//! the gateway. HTTP parity comes from using the same `ConfigApiError` envelope
+//! shape and field semantics as `PATCH /api/config`; a gateway fixture would add
+//! auth/server setup without increasing coverage for this CLI-only regression.
+
+use std::process::{Command, Stdio};
+
+#[test]
+fn config_patch_json_failed_op_emits_structured_error_envelope() {
+    let bin = env!("CARGO_BIN_EXE_zeroclaw");
+    let config_dir = tempfile::tempdir().expect("temp config dir");
+
+    let output = Command::new(bin)
+        .env("ZEROCLAW_CONFIG_DIR", config_dir.path())
+        .env("RUST_LOG", "off")
+        .args(["config", "patch", "--json", "-"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            {
+                use std::io::Write;
+                child
+                    .stdin
+                    .as_mut()
+                    .expect("child stdin")
+                    .write_all(br#"[{"op":"replace","path":"/not/a/path","value":"x"}]"#)?;
+            }
+            child.wait_with_output()
+        })
+        .expect("run zeroclaw config patch");
+
+    assert!(!output.status.success(), "patch should fail");
+    assert!(
+        output.stdout.is_empty(),
+        "failed --json patch should not emit success stdout: {}",
+        String::from_utf8_lossy(&output.stdout),
+    );
+
+    let stderr = String::from_utf8(output.stderr).expect("stderr utf8");
+    let envelope: serde_json::Value =
+        serde_json::from_str(&stderr).expect("stderr should be JSON error envelope");
+    assert_eq!(envelope["code"], "path_not_found");
+    assert_eq!(envelope["path"], "not.a.path");
+    assert_eq!(envelope["op_index"], 0);
+    assert!(
+        envelope["message"]
+            .as_str()
+            .expect("message")
+            .contains("not.a.path"),
+        "message should identify path: {envelope}"
+    );
+}

--- a/tests/component/config_patch_cli.rs
+++ b/tests/component/config_patch_cli.rs
@@ -1,19 +1,82 @@
 //! Regression coverage for `zeroclaw config patch --json` error output.
-//!
-//! This intentionally exercises the CLI process boundary instead of spinning up
-//! the gateway. HTTP parity comes from using the same `ConfigApiError` envelope
-//! shape and field semantics as `PATCH /api/config`; a gateway fixture would add
-//! auth/server setup without increasing coverage for this CLI-only regression.
 
+use axum::{Router, routing::patch};
+use parking_lot::Mutex;
 use std::process::{Command, Stdio};
+use std::sync::Arc;
+use std::time::Duration;
+use tower::ServiceExt;
+use zeroclaw::gateway::{self, AppState};
+use zeroclaw::providers::Provider;
+use zeroclaw_config::schema::Config;
+use zeroclaw_memory::NoneMemory;
+use zeroclaw_runtime::security::PairingGuard;
 
-#[test]
-fn config_patch_json_failed_op_emits_structured_error_envelope() {
+struct MockProvider;
+
+#[async_trait::async_trait]
+impl Provider for MockProvider {
+    async fn chat_with_system(
+        &self,
+        _system_prompt: Option<&str>,
+        _message: &str,
+        _model: &str,
+        _temperature: Option<f64>,
+    ) -> anyhow::Result<String> {
+        Ok("ok".to_string())
+    }
+}
+
+fn test_state(config: Config) -> AppState {
+    AppState {
+        config: Arc::new(Mutex::new(config)),
+        provider: Arc::new(MockProvider),
+        model: "test-model".into(),
+        temperature: 0.0,
+        mem: Arc::new(NoneMemory::new()),
+        auto_save: false,
+        webhook_secret_hash: None,
+        pairing: Arc::new(PairingGuard::new(false, &[])),
+        trust_forwarded_headers: false,
+        rate_limiter: Arc::new(gateway::GatewayRateLimiter::new(100, 100, 100)),
+        auth_limiter: Arc::new(gateway::auth_rate_limit::AuthRateLimiter::new()),
+        idempotency_store: Arc::new(gateway::IdempotencyStore::new(
+            Duration::from_secs(300),
+            1000,
+        )),
+        whatsapp: None,
+        whatsapp_app_secret: None,
+        linq: None,
+        linq_signing_secret: None,
+        nextcloud_talk: None,
+        nextcloud_talk_webhook_secret: None,
+        wati: None,
+        gmail_push: None,
+        observer: Arc::new(zeroclaw_runtime::observability::NoopObserver),
+        tools_registry: Arc::new(Vec::new()),
+        cost_tracker: None,
+        event_tx: tokio::sync::broadcast::channel(16).0,
+        event_buffer: Arc::new(gateway::sse::EventBuffer::new(16)),
+        shutdown_tx: tokio::sync::watch::channel(false).0,
+        reload_tx: None,
+        node_registry: Arc::new(gateway::nodes::NodeRegistry::new(16)),
+        path_prefix: String::new(),
+        web_dist_dir: None,
+        session_backend: None,
+        session_queue: Arc::new(gateway::session_queue::SessionActorQueue::new(8, 30, 600)),
+        device_registry: None,
+        pending_pairings: None,
+        canvas_store: zeroclaw_runtime::tools::CanvasStore::new(),
+        #[cfg(feature = "webauthn")]
+        webauthn: None,
+        cancel_tokens: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+    }
+}
+
+fn run_cli_patch(config_dir: &std::path::Path, patch_doc: &[u8]) -> serde_json::Value {
     let bin = env!("CARGO_BIN_EXE_zeroclaw");
-    let config_dir = tempfile::tempdir().expect("temp config dir");
-
     let output = Command::new(bin)
-        .env("ZEROCLAW_CONFIG_DIR", config_dir.path())
+        .env("ZEROCLAW_CONFIG_DIR", config_dir)
         .env("RUST_LOG", "off")
         .args(["config", "patch", "--json", "-"])
         .stdin(Stdio::piped())
@@ -27,7 +90,7 @@ fn config_patch_json_failed_op_emits_structured_error_envelope() {
                     .stdin
                     .as_mut()
                     .expect("child stdin")
-                    .write_all(br#"[{"op":"replace","path":"/not/a/path","value":"x"}]"#)?;
+                    .write_all(patch_doc)?;
             }
             child.wait_with_output()
         })
@@ -41,16 +104,102 @@ fn config_patch_json_failed_op_emits_structured_error_envelope() {
     );
 
     let stderr = String::from_utf8(output.stderr).expect("stderr utf8");
-    let envelope: serde_json::Value =
-        serde_json::from_str(&stderr).expect("stderr should be JSON error envelope");
-    assert_eq!(envelope["code"], "path_not_found");
-    assert_eq!(envelope["path"], "not.a.path");
+    serde_json::from_str(&stderr).expect("stderr should be JSON error envelope")
+}
+
+async fn run_http_patch(config_dir: &std::path::Path, patch_doc: &[u8]) -> serde_json::Value {
+    let config = Config {
+        config_path: config_dir.join("config.toml"),
+        ..Config::default()
+    };
+    config.save().await.expect("save initial config");
+
+    let app = Router::new()
+        .route("/api/config", patch(gateway::api_config::handle_patch))
+        .with_state(test_state(config));
+    let response = app
+        .oneshot(
+            axum::http::Request::builder()
+                .method(axum::http::Method::PATCH)
+                .uri("/api/config")
+                .header(axum::http::header::CONTENT_TYPE, "application/json")
+                .body(axum::body::Body::from(patch_doc.to_vec()))
+                .expect("request"),
+        )
+        .await
+        .expect("http patch response");
+
+    assert_eq!(response.status(), axum::http::StatusCode::NOT_FOUND);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read response body");
+    serde_json::from_slice(&body).expect("http body should be JSON error envelope")
+}
+
+#[tokio::test]
+async fn config_patch_json_failed_op_matches_http_error_envelope() {
+    let patch_doc = br#"[{"op":"replace","path":"/not/a/path","value":"x"}]"#;
+    let cli_config_dir = tempfile::tempdir().expect("temp cli config dir");
+    let http_config_dir = tempfile::tempdir().expect("temp http config dir");
+
+    let cli_envelope = run_cli_patch(cli_config_dir.path(), patch_doc);
+    let http_envelope = run_http_patch(http_config_dir.path(), patch_doc).await;
+
+    for field in ["code", "path", "op_index"] {
+        assert_eq!(
+            cli_envelope[field], http_envelope[field],
+            "CLI and HTTP mismatch on `{field}`:\nCLI:  {cli_envelope}\nHTTP: {http_envelope}",
+        );
+    }
+    assert_eq!(cli_envelope["code"], "path_not_found");
+    assert_eq!(cli_envelope["path"], "not.a.path");
+    assert_eq!(cli_envelope["op_index"], 0);
+    assert!(
+        cli_envelope["message"]
+            .as_str()
+            .expect("message")
+            .contains("not.a.path"),
+        "message should identify path: {cli_envelope}"
+    );
+    assert_eq!(cli_envelope["message"], http_envelope["message"]);
+}
+
+#[test]
+fn config_patch_json_malformed_operation_emits_structured_error_envelope() {
+    let config_dir = tempfile::tempdir().expect("temp config dir");
+    let envelope = run_cli_patch(
+        config_dir.path(),
+        br#"[{"path":"/gateway/host","value":"x"}]"#,
+    );
+
+    assert_eq!(envelope["code"], "value_type_mismatch");
     assert_eq!(envelope["op_index"], 0);
+    assert!(envelope.get("path").is_none());
     assert!(
         envelope["message"]
             .as_str()
             .expect("message")
-            .contains("not.a.path"),
-        "message should identify path: {envelope}"
+            .contains("requires string `op` field"),
+        "message should describe malformed operation: {envelope}"
+    );
+}
+
+#[test]
+fn config_patch_json_post_apply_validation_emits_structured_error_envelope() {
+    let config_dir = tempfile::tempdir().expect("temp config dir");
+    let envelope = run_cli_patch(
+        config_dir.path(),
+        br#"[{"op":"replace","path":"/gateway/host","value":""}]"#,
+    );
+
+    assert_eq!(envelope["code"], "required_field_empty");
+    assert_eq!(envelope["path"], "gateway.host");
+    assert!(envelope.get("op_index").is_none());
+    assert!(
+        envelope["message"]
+            .as_str()
+            .expect("message")
+            .contains("gateway.host must not be empty"),
+        "message should describe validation failure: {envelope}"
     );
 }

--- a/tests/component/mod.rs
+++ b/tests/component/mod.rs
@@ -1,4 +1,5 @@
 mod config_migration;
+mod config_patch_cli;
 mod config_persistence;
 mod config_schema;
 mod dockerignore_test;


### PR DESCRIPTION
Closes #6252.

## Summary
- emit structured JSON error envelopes for `config patch --json` failures
- add CLI-vs-HTTP parity coverage for the same failing patch document, comparing `code`, `path`, `op_index`, and `message`
- normalize malformed patch operation records into structured `ConfigApiError` JSON envelopes instead of raw anyhow output
- normalize post-apply validation and save failures for `config patch --json`
- forward the root `webauthn` feature to the optional gateway crate so component tests compile under `gateway,webauthn`

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test component config_patch_json --features gateway`
- `cargo test --test component config_patch_json`
- `cargo test -p zeroclaw-gateway api_config`
- reviewer rerun: `cargo test -p zeroclawlabs --test component config_patch_json --features ci-all,gateway`
- reviewer rerun: `cargo clippy -p zeroclawlabs --test component --features ci-all,gateway --no-deps -- -D warnings`
- final rebase rerun: `cargo clippy --features gateway,webauthn --all-targets -- -D warnings`

## Security & Privacy Impact
- No new network calls, credentials, permissions, or persistence surfaces.
- The change only normalizes local CLI error serialization to match existing gateway error envelopes.

## Compatibility
- Successful `config patch` behavior is unchanged.
- Non-json failures remain human-readable.
- `--json` failures now consistently emit structured JSON envelopes and non-zero exit codes.

## Rollback
- Revert this PR to return `config patch --json` failure handling to the previous CLI-only behavior.

Independent reviewer PASS recorded locally after addressing maintainer changes and CI failure.