### PR TITLE
docs(security): point sandboxing example at the actually-pullable default image (#6500)

### DIFF
--- a/docs/book/src/ops/troubleshooting.md
+++ b/docs/book/src/ops/troubleshooting.md
@@ -245,7 +245,7 @@ See [Security → Autonomy levels](../security/autonomy.md).
 
 ### Tool invocations fail inside Docker sandbox
 
-- Container image isn't pulled — `docker pull zeroclawlabs/tool-runner`
+- Container image isn't pulled — run `docker pull <image>` for whatever you have configured under `[security.sandbox].image` (default: `alpine:latest`)
 - Docker daemon not reachable from the ZeroClaw user — check `docker info`
 - Tool needs a device that's not passed through — extend `allow_devices`
 

--- a/docs/book/src/security/sandboxing.md
+++ b/docs/book/src/security/sandboxing.md
@@ -91,12 +91,24 @@ Firejail's default profile is fairly permissive; we apply a custom profile bundl
 
 ### Docker
 
-Works anywhere Docker does. Runs each tool invocation in an ephemeral container (the `zeroclawlabs/tool-runner` image).
+Works anywhere Docker does. Runs each tool invocation in an ephemeral container. The default image is `alpine:latest` (matches `DockerSandbox::default()` in `crates/zeroclaw-runtime/src/security/docker.rs`); set `image` to any other public image you have access to, or build your own.
 
 ```toml
 [security.sandbox]
 backend = "docker"
-image = "zeroclawlabs/tool-runner:latest"
+image = "alpine:latest"
+```
+
+For a richer toolkit (Node 20, Python 3, build-essentials, common CLIs), this repository ships a Dockerfile under `dev/sandbox/Dockerfile` that you can build locally and reference by tag:
+
+```bash
+docker build -t zeroclaw-sandbox:local dev/sandbox/
+```
+
+```toml
+[security.sandbox]
+backend = "docker"
+image = "zeroclaw-sandbox:local"
 ```
 
 Pros: strong isolation, works on any OS. Cons: per-invocation container startup cost (100–500 ms). Best for production deployments where the overhead is acceptable.
@@ -126,7 +138,7 @@ Lock this down to only the devices your agent actually needs.
 
 - **"Sandbox backend unavailable"** on startup — check `zeroclaw service status` and the journal; the auto-detect logs which backends it tried.
 - **Tools working on dev, failing in service** — the service user often differs from the CLI user. Verify both have whatever sandbox-adjacent permissions are needed (Landlock: nothing; Bubblewrap: userns enabled; Docker: service user in `docker` group).
-- **Slow tool invocations** on Docker — first invocation pulls the image, subsequent are fast. Pre-pull with `docker pull zeroclawlabs/tool-runner`.
+- **Slow tool invocations** on Docker — first invocation pulls the image, subsequent are fast. Pre-pull with `docker pull alpine:latest` (or whatever image you set under `[security.sandbox].image`).
 
 ## Code reference
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - The sandboxing documentation page and the Docker troubleshooting bullet both told operators to use `zeroclawlabs/tool-runner:latest`. That image is not published — `docker pull zeroclawlabs/tool-runner:latest` returns "not found." Operators following the published instructions hit a wall on first run.
  - @Audacity88's triage on the issue laid out two paths: publish the documented image, or update the docs to a supported image name. Publishing requires registry credentials and CI release pipeline work outside the scope of a PR; this PR takes the docs path.
  - The in-code default is `alpine:latest` — see `DockerSandbox::default()` at `crates/zeroclaw-runtime/src/security/docker.rs:17`. That image is publicly pullable and matches what the sandbox actually launches when no `image` is configured. Update the example config block, the runtime explanation, and the troubleshooting bullet to match.
  - For operators who *want* the richer Node 20 / Python 3 / build-essentials toolkit the original `tool-runner` image was implying, the repo already ships `dev/sandbox/Dockerfile`. Add a snippet showing the `docker build` + `image = "zeroclaw-sandbox:local"` flow so users can roll their own with no extra registry dependency.

- **Scope boundary:** Docs-only change. Two files touched: `docs/book/src/security/sandboxing.md` (config example + new "build your own" snippet + troubleshooting line) and `docs/book/src/ops/troubleshooting.md` (one bullet). No code changes. Translation `.po` files under `docs/book/po/` left untouched — they regenerate from the English source via the existing Fluent / `mdbook-i18n` pipeline, and editing them by hand here would create translation drift.
- **Blast radius:** Documentation-only. No runtime behavior change. The default image was already `alpine:latest` in code; this PR just stops misdocumenting it.
- **Linked issue(s):** Fixes #6500.

## Validation Evidence (required)

```
$ grep -rn "zeroclawlabs/tool-runner" docs/book/src/
(no matches — all primary-language doc references removed)

$ grep -rn "zeroclawlabs/tool-runner" --include="*.rs" .
(no matches — the missing image was never referenced from code)

$ git diff --stat
 docs/book/src/ops/troubleshooting.md |  2 +-
 docs/book/src/security/sandboxing.md | 18 +++++++++++++++---
 2 files changed, 16 insertions(+), 4 deletions(-)
```

- **Commands run and tail output:** as above.
- **Beyond CI — what I manually verified:**
  - Confirmed the in-code default at `crates/zeroclaw-runtime/src/security/docker.rs:17` is `image: "alpine:latest".to_string()` — i.e. what an operator following the published example *now* sees would match what the binary actually does.
  - Confirmed `dev/sandbox/Dockerfile` exists and builds the Node 20 / Python 3 / build-essentials toolkit the docs previously implied. The "build your own" snippet in the new docs walks operators through the exact `docker build -t zeroclaw-sandbox:local dev/sandbox/` flow.
  - Did **not** rebuild the rendered mdBook — the source-markdown change is the load-bearing piece; mdBook rendering happens in CI.
- **If any command was intentionally skipped:** Translation `.po` regeneration is the i18n pipeline's job, not this PR's. The translations currently reference a non-existent image too; the i18n cycle will pick up the English source change.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No.** Docs-only.
- New external network calls? **No.**
- Secrets / tokens / credentials handling changed? **No.**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No.**

The change reduces a security risk, not introduces one: operators following the broken docs likely concluded the sandbox didn't work and dropped to `backend = "none"` or to looser configurations to make tool calls succeed. Pointing them at a real image — and a build path for a richer one — makes the documented secure setup actually achievable.

## Compatibility (required)

- Backward compatible? **Yes.** No runtime behavior change. Any operator who had hard-coded `image = "zeroclawlabs/tool-runner:latest"` in their config was hitting a not-found error today; they get the same error after this PR (because the image still doesn't exist), but now the docs guide them to a working configuration.
- Config / env / CLI surface changed? **No.**

## Rollback

- **Fast rollback command/path:** `git revert <commit>` (single commit, docs-only).
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** If a future image-publication PR lands `zeroclawlabs/tool-runner:latest` on Docker Hub, the docs would become *under*-specified (pointing at `alpine` when a richer image exists). The fix would be to revert this PR or update the docs to recommend the published image once it's live.

---

**Labels:** `bug`, `docs`, `risk: low`, `priority: p1`, `size: XS` (set in the GitHub UI).

**Diff stat:** 2 files changed, +16 / -4.
