### PR TITLE
fix(tool-call-parser): omit assistant history when no parsed tool calls (#6298)

### DIFF
--- a/crates/zeroclaw-tool-call-parser/src/lib.rs
+++ b/crates/zeroclaw-tool-call-parser/src/lib.rs
@@ -1513,6 +1513,14 @@ pub fn build_native_assistant_history_from_parsed_calls(
     tool_calls: &[ParsedToolCall],
     reasoning_content: Option<&str>,
 ) -> Option<String> {
+    // Strict provider validators (DeepSeek V4, NVIDIA NIM, ...) reject
+    // assistant messages that carry `tool_calls: []`. When there are no
+    // parsed calls, return None so the caller falls through to a plain
+    // text assistant message. See #6298.
+    if tool_calls.is_empty() {
+        return None;
+    }
+
     let calls_json = tool_calls
         .iter()
         .map(|tc| {
@@ -1548,6 +1556,52 @@ pub fn build_native_assistant_history_from_parsed_calls(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn build_native_assistant_history_returns_none_for_empty_calls() {
+        // Regression: strict providers (DeepSeek V4, NVIDIA NIM) reject
+        // assistant messages carrying `tool_calls: []`. Empty input must
+        // not produce a serialised assistant message with an empty array.
+        // See #6298.
+        let result = build_native_assistant_history_from_parsed_calls("answer text", &[], None);
+        assert!(
+            result.is_none(),
+            "expected None for empty tool_calls slice, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn build_native_assistant_history_returns_none_for_empty_calls_with_reasoning() {
+        // Even with reasoning_content set, an empty tool_calls slice must
+        // collapse to None — the caller falls back to a plain assistant
+        // message, and the reasoning round-trip happens through a separate
+        // path that does not produce `tool_calls: []`.
+        let result = build_native_assistant_history_from_parsed_calls(
+            "answer text",
+            &[],
+            Some("deep thought"),
+        );
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn build_native_assistant_history_emits_tool_calls_when_non_empty() {
+        // No-regression check: the normal path with a real parsed call
+        // still produces a serialised assistant message and the
+        // `tool_calls` field is a non-empty array.
+        let calls = vec![ParsedToolCall {
+            name: "shell".into(),
+            arguments: serde_json::json!({"command": "pwd"}),
+            tool_call_id: Some("call_1".into()),
+        }];
+        let result = build_native_assistant_history_from_parsed_calls("answer", &calls, None);
+        let s = result.expect("Some(_) for non-empty tool_calls");
+        let parsed: serde_json::Value = serde_json::from_str(&s).unwrap();
+        assert_eq!(parsed["content"].as_str(), Some("answer"));
+        let arr = parsed["tool_calls"].as_array().expect("tool_calls array");
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["name"].as_str(), Some("shell"));
+    }
 
     #[test]
     fn parse_arguments_value_unwraps_nested_object_string() {


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `build_native_assistant_history_from_parsed_calls` at `crates/zeroclaw-tool-call-parser/src/lib.rs:1511` produced a serialised assistant message of shape `{"content":"...","tool_calls":[]}` whenever it was called with an empty `ParsedToolCall` slice. Strict provider validators reject that payload outright — the reporter on #6298 captured the exact DeepSeek V4 response:
    > `Invalid 'messages[6].tool_calls': empty array. Expected an array with minimum length 1.`
  - NVIDIA NIM hits the same class of error (issue #2405 — *"Message has tool role, but there was no previous assistant message with a tool call"*) because once `tool_calls: []` is silently rejected or dropped, subsequent `role: tool` messages have no parent to point at.
  - The call site is already designed for the helper to decline: at `crates/zeroclaw-runtime/src/agent/loop_.rs:1359` the branch is taken when `resp.tool_calls.is_empty()`, then it does `build_native_assistant_history_from_parsed_calls(...).unwrap_or_else(|| response_text.clone())`. The `.unwrap_or_else` arm is the fallback for "no usable native history — use plain text." Today that arm fires when any `ParsedToolCall` lacks an `id` (the `.collect::<Option<Vec<_>>>()?` short-circuit on line 1525), but **not** when the slice itself is empty. Adding the empty-slice short-circuit makes the helper return `None` so the existing fallback emits a normal text assistant message instead of an invalid `tool_calls: []` payload.
  - **Why "return `None`" rather than "omit the field"**: keeping the `tool_calls` key out of the JSON would still produce a `build_native_assistant_history`-style object with `content: "..."` only — which is equivalent in API semantics to a plain text response, but in practice the caller's fallback path (`response_text.clone()`) is what other code paths already use for "no native history needed." Routing through the existing fallback keeps the post-fix behaviour identical to the existing not-tool-call assistant code path, with no new serialisation shape introduced.
  - **Scope note (deferred work):** @Svtter pointed out in the issue thread that the code fix only prevents *new* messages from carrying `tool_calls: []`. Existing session-history files persisted before the fix can keep replaying the invalid payload on every subsequent turn until the user runs `/new` or the operator wipes session state. The right place for that cleanup is either (a) a session-store migration or (b) a payload-time strip in the provider serialisation layer. Either is a separate, larger change with its own test surface — bundling it here would balloon the diff and conflict with the v0.8.0 provider-family rework called out on @singlerider's recent comments. This PR is the code-fix half; the migration half can land independently against either approach.
  - **Scope note (DeepSeek `reasoning_content` empty-string requirement):** the same issue thread mentions DeepSeek V4 thinking-mode also requires `reasoning_content: ""` (even empty) be present on assistant messages with `tool_calls`. That is a distinct API-payload normalisation concern handled in the provider serialisation layer, not in `tool-call-parser`. Out of scope for this PR — see #6059 (which already lands the reasoning-content round-trip on the streaming consumer); the empty-string defaulting on outbound DeepSeek payloads is the natural next layer to add.

- **Scope boundary:** One file (`crates/zeroclaw-tool-call-parser/src/lib.rs`). One early-return guard (5 lines) plus three regression tests. No code paths outside the helper are touched. No new dependencies, no schema changes, no behavioural change for the non-empty path.
- **Blast radius:** Helper-internal. The function is called from exactly one site (`agent/loop_.rs:1361`), which already handles `None` by falling back to a plain text assistant message. Non-strict providers (Anthropic, OpenAI, OpenRouter, most others) that tolerated `tool_calls: []` in the past will now see a plain text assistant message instead — identical content, just without the empty array. No callers depend on the empty-array shape.
- **Linked issue(s):** Partially addresses #6298. Likely contributes to (but does not by itself fix): #5475, #2405, #5941, #5584, #2232, #5825 — each names a downstream symptom of the same root cause; please re-test those against this PR before closing. Keep #6298 open for the stale-session payload cleanup/migration follow-up called out above.

## Validation Evidence (required)

```
$ cargo test -p zeroclaw-tool-call-parser --lib
test result: ok. 111 passed; 0 failed; 0 ignored
  (108 baseline + 3 new:
   build_native_assistant_history_returns_none_for_empty_calls,
   build_native_assistant_history_returns_none_for_empty_calls_with_reasoning,
   build_native_assistant_history_emits_tool_calls_when_non_empty)

$ cargo test -p zeroclaw-runtime --lib build_native_assistant_history
test result: ok. 4 passed; 0 failed; 0 ignored
  (the two existing reasoning_content-round-trip tests at
   loop_.rs:7200 and 7219 use non-empty calls slices and are
   unchanged by this fix.)

$ cargo test -p zeroclaw-runtime --lib
test result: 1651 passed; 1 failed; 1 ignored
  (1 pre-existing flake: tools::delegate::tests::background_task_result_persisted_to_disk
   — confirmed flaky on master with this fix reverted.)

$ cargo fmt --all -- --check
(clean — no diff)

$ git diff --stat HEAD~1
 crates/zeroclaw-tool-call-parser/src/lib.rs | 54 +++++++++++++++++++++++++++++
 1 file changed, 54 insertions(+)
```

- **Commands run and tail output:** as above.
- **Beyond CI — what I manually verified:**
  - `build_native_assistant_history_returns_none_for_empty_calls`: passes `&[]` and asserts `None`. This is the exact contract the call site relies on for its `.unwrap_or_else(|| response_text.clone())` fallback to engage.
  - `build_native_assistant_history_returns_none_for_empty_calls_with_reasoning`: same shape but with `reasoning_content = Some("deep thought")`. Confirms that the early-return guard fires *before* the `reasoning_content` insertion, so reasoning content does not accidentally smuggle a `tool_calls: []` field through.
  - `build_native_assistant_history_emits_tool_calls_when_non_empty`: passes a real `ParsedToolCall` and asserts the result has a `tool_calls` array with `len == 1`. No-regression check for the normal path.
  - I also re-ran the two pre-existing tests at `agent/loop_.rs:7200`/`7219` (the reasoning-content round-trip tests) — they use non-empty `calls` slices and pass unchanged. Confirms the fix is surgical: only the empty-slice case is altered.
  - Did **not** run a live request against DeepSeek V4 / NVIDIA NIM in this dev env. The serialisation contract (no `tool_calls: []` is emitted) is the load-bearing piece, asserted by the three tests. Live confirmation that the 400 is resolved is best done by the issue reporter or by maintainers with provider creds.
- **If any command was intentionally skipped:** `cargo test --workspace` and `cargo clippy --workspace --all-targets -- -D warnings` deferred to CI.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No.**
- New external network calls? **No.**
- Secrets / tokens / credentials handling changed? **No.**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No.**

The diff narrows what JSON shapes the runtime serialises. No new attack surface; the bytes were always passing through `serde_json::to_string`, this PR just stops emitting an invalid-by-validator shape. Tool-call semantics (which calls run, with what arguments, gated by which approval) are entirely unchanged — this function only constructs *history* entries for prior assistant turns, not the dispatch path.

## Compatibility (required)

- Backward compatible? **Yes.** Non-strict providers (Anthropic, OpenAI, OpenRouter, ...) that previously accepted `tool_calls: []` now receive a plain text assistant message instead — semantically equivalent (the model said something, called no tools) but more strictly correct. Strict providers (DeepSeek V4 thinking mode, NVIDIA NIM, ...) stop getting 400s. Sessions started before this PR that already have `tool_calls: []` baked into their history files are *not* fixed by this PR — that is the deferred migration work called out in the scope notes.
- Config / env / CLI surface changed? **No.**

## Rollback

- **Fast rollback command/path:** `git revert <commit>` (single commit, one file, +54 / -0).
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** If a future refactor reintroduced the empty-array emission, the three regression tests would fail at CI time. The original DeepSeek/NIM 400 would resurface in live traffic before the test signal — but the test signal is the first line of defence.

---

**Labels:** `bug`, `runtime`, `provider`, `provider:compatible`, `provider:deepseek`, `priority:p1`, `risk: low` (the issue is labelled `risk: high` because the blast radius of the *bug* is provider-breaking; the *fix* is a single early-return in a helper, scope-bounded — set in the GitHub UI).

**Diff stat:** 1 file changed, +54 / -0.

