### PR TITLE
fix(runtime): omit empty tool_calls array from assistant history (#6298)

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -7229,6 +7229,31 @@ Let me check the result."#;
         assert!(parsed.get("reasoning_content").is_none());
     }
 
+    /// Regression: when the model returns a plain text reply with no tool
+    /// calls (neither native nor parsed) under `use_native_tools = true`,
+    /// the assistant history that we replay on the next turn must NOT
+    /// contain `"tool_calls": []`. Strict OpenAI-compatible validators
+    /// (DeepSeek V4 thinking mode, NVIDIA NIM) reject empty arrays as
+    ///   "Invalid 'messages[*].tool_calls': empty array. Expected an
+    ///    array with minimum length 1"
+    /// (#6298). The parser-crate fix returns `None` for empty `calls`,
+    /// and the call site at loop_.rs:1366 falls back to plain text via
+    /// `unwrap_or_else(|| response_text.clone())`. This test pins the
+    /// parser-side contract that drives that fallback.
+    #[test]
+    fn no_native_history_when_calls_empty_for_strict_validator_compat() {
+        let calls: Vec<ParsedToolCall> = Vec::new();
+        // With reasoning, without reasoning — both must elect the fallback.
+        assert!(
+            build_native_assistant_history_from_parsed_calls("hi", &calls, None).is_none(),
+            "empty calls must yield None so the call site replays plain text (#6298)"
+        );
+        assert!(
+            build_native_assistant_history_from_parsed_calls("hi", &calls, Some("think")).is_none(),
+            "empty calls must yield None even with reasoning_content (#6298)"
+        );
+    }
+
     /// Regression test for issue #6059 — DeepSeek V4 thinking-mode tool-call
     /// replay rejected with `400` because the assistant's prior
     /// `reasoning_content` was missing from the next request.

--- a/crates/zeroclaw-tool-call-parser/src/lib.rs
+++ b/crates/zeroclaw-tool-call-parser/src/lib.rs
@@ -1513,6 +1513,16 @@ pub fn build_native_assistant_history_from_parsed_calls(
     tool_calls: &[ParsedToolCall],
     reasoning_content: Option<&str>,
 ) -> Option<String> {
+    // No tool calls → no native tool history. Returning Some(...) with
+    // an empty `tool_calls` array makes strict providers (DeepSeek V4
+    // thinking mode, NVIDIA NIM, etc.) reject the message with
+    //   "Invalid 'messages[*].tool_calls': empty array. Expected an
+    //    array with minimum length 1"
+    // (#6298). None lets the caller fall back to plain assistant text.
+    if tool_calls.is_empty() {
+        return None;
+    }
+
     let calls_json = tool_calls
         .iter()
         .map(|tc| {
@@ -2751,6 +2761,42 @@ Let me check the result."#;
         let parsed: serde_json::Value = serde_json::from_str(result.as_deref().unwrap()).unwrap();
         assert_eq!(parsed["content"].as_str(), Some("answer"));
         assert!(parsed.get("reasoning_content").is_none());
+    }
+
+    // #6298: returning Some({..., "tool_calls": []}) for an empty `tool_calls`
+    // slice serialized into the chat history as `"tool_calls": []`, which
+    // strict OpenAI-compatible validators reject with:
+    //   "Invalid 'messages[*].tool_calls': empty array. Expected an array
+    //    with minimum length 1"
+    // The function must return None when there are no calls, so the call
+    // site falls back to plain assistant text and the `tool_calls` field is
+    // omitted entirely from the next provider request.
+    #[test]
+    fn build_native_assistant_history_from_parsed_calls_returns_none_for_empty_tool_calls() {
+        let calls: Vec<ParsedToolCall> = Vec::new();
+        let result = build_native_assistant_history_from_parsed_calls("answer text", &calls, None);
+        assert!(
+            result.is_none(),
+            "empty tool_calls slice must return None so the caller omits the empty array (#6298); got {result:?}"
+        );
+    }
+
+    #[test]
+    fn build_native_assistant_history_from_parsed_calls_returns_none_for_empty_tool_calls_with_reasoning()
+     {
+        // Even with reasoning_content present, the gate must hold: no tool
+        // calls means no native tool history; reasoning text is preserved
+        // by the caller's fallback path on the plain assistant message.
+        let calls: Vec<ParsedToolCall> = Vec::new();
+        let result = build_native_assistant_history_from_parsed_calls(
+            "answer text",
+            &calls,
+            Some("inner monologue"),
+        );
+        assert!(
+            result.is_none(),
+            "empty tool_calls must return None even when reasoning_content is provided (#6298); got {result:?}"
+        );
     }
 
     // ═══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Fixes #6298

## Summary

When `use_native_tools` is enabled and the model returns a response with no tool calls (neither native on `resp.tool_calls` nor parsed in `calls`), `build_native_assistant_history_from_parsed_calls` happily emitted `{"content": "...", "tool_calls": []}`. Strict OpenAI-compatible validators reject this with:

```
Invalid 'messages[*].tool_calls': empty array. Expected an array with minimum length 1
```

Observed in the wild on **DeepSeek V4 thinking mode** and **NVIDIA NIM** (issue body). The empty array also orphans subsequent `role=tool` messages on providers that key follow-ups off the assistant's prior `tool_calls`, contributing to the family of provider-400 reports listed in #6298 (#5475, #2405, #5941, #2232 — non-fixing relationship; this PR addresses the root-cause emission, not those downstream symptoms individually).

**Fix:** guard the parser-crate function at `crates/zeroclaw-tool-call-parser/src/lib.rs:1511` to return `None` for an empty `tool_calls` slice. The call site at `crates/zeroclaw-runtime/src/agent/loop_.rs:1366` already falls back to plain `response_text` via `.unwrap_or_else(|| response_text.clone())`, so the `tool_calls` field is omitted from the assistant message entirely — which is what strict validators expect for a plain reply.

This narrows the function's contract to match its name: it builds a *native tool history*. Absence of tool calls means there is no native tool history to build, so `None` is the right return value.

## Validation Evidence

- `cargo test -p zeroclaw-tool-call-parser --lib`: **110 passed, 0 failed**, including two new tests:
  - `..._returns_none_for_empty_tool_calls` — pins the gate at the function boundary.
  - `..._returns_none_for_empty_tool_calls_with_reasoning` — pins that reasoning_content doesn't relax the gate.
- `cargo test -p zeroclaw-runtime --lib`: **1652 passed, 1 failed (pre-existing flake)**, 1 ignored. The new test `no_native_history_when_calls_empty_for_strict_validator_compat` passes. The single failure is `tools::delegate::tests::background_task_result_persisted_to_disk` — confirmed pre-existing on master at the same commit (race in unrelated background-task persistence), not caused by this PR.
- `cargo fmt --all -- --check`: clean.

## Security & Privacy Impact

- No new data flow, no new logging, no new credential handling.
- The change only *removes* an empty container from the request body sent to providers — strictly less information transmitted in the affected branch.
- No change to which prompt content or tool results are sent; only the empty-array placeholder is dropped.

## Compatibility

- Lenient providers (most OpenAI-compatible endpoints) accept both shapes — they ignore an empty `tool_calls` array. They will continue to work after this change because the message now simply omits the field.
- Strict providers (DeepSeek V4 thinking mode, NVIDIA NIM, and the others listed in #6298) move from "always 400 on this turn" to "accepted as a normal assistant message." Strictly fewer 400s.
- Session history: existing on-disk sessions that already contain `"tool_calls": []` are not rewritten by this PR. The follow-up comment on the issue (Svtter, 2026-05-03) calls out that point; addressing it cleanly would mean a stand-alone history-cleanup migration and is intentionally out of scope here — this PR is the *root-cause emission fix*, not a history rewriter. Operators who hit the issue can delete the affected session file or wait for the next turn, which now emits the right shape.
- No public API surface change. The parser function's signature is identical; only the gate condition is tightened.

## Rollback

Revert the commit. No data migrations, no persisted state changes, no config knobs. The next agent turn will resume emitting `tool_calls: []` and strict validators will resume rejecting it.

## Related

- #6354 — diagnostic improvements only; no overlap.
- #5475, #2405, #5941, #5584, #2232, #5825 — listed in #6298 as members of the same provider-400 family; this PR removes one of the contributing factors, but each ticket likely has its own surface and isn't claimed closed here.
