### PR TITLE
fix(config): warn on unknown security.otp.gated_actions entries (#5810)

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -8516,6 +8516,55 @@ fn default_otp_gated_actions() -> Vec<String> {
     ]
 }
 
+/// Curated list of action / tool identifiers `security.otp.gated_actions` may
+/// reference. Used at config-validation time to warn operators when an entry
+/// does not match any known action — so a typo or stale name cannot silently
+/// promise a TOTP gate that the runtime can never enforce. See issue #5810.
+///
+/// Names mirror the `Tool::name()` strings registered by the runtime tool
+/// catalog. The list is intentionally a static superset of the
+/// `default_otp_gated_actions()` baseline so operators can author entries for
+/// destructive tools that aren't on by default. Add new entries whenever a
+/// destructive tool ships.
+pub fn known_otp_gated_actions() -> &'static [&'static str] {
+    &[
+        // baseline (mirrored from default_otp_gated_actions)
+        "shell",
+        "file_write",
+        "browser_open",
+        "browser",
+        "memory_forget",
+        // additional destructive / state-mutating tools registered by the
+        // runtime catalog that an operator may reasonably want to gate
+        "file_edit",
+        "backup_tool",
+        "cloud_ops",
+        "git_operations",
+        "google_workspace",
+        "microsoft365",
+        "notion_tool",
+        "jira_tool",
+        "claude_code_runner",
+        "codex_cli",
+        "gemini_cli",
+        "composio",
+        "linkedin",
+        "discord_search",
+        "web_search_tool",
+        "content_search",
+        "calculator",
+        "mcp_tool",
+        "proxy_config",
+    ]
+}
+
+/// `true` when `action` (after the same trim/normalize that
+/// `validate()` applies) matches one of the known gated-action identifiers.
+pub fn is_known_otp_gated_action(action: &str) -> bool {
+    let normalized = action.trim();
+    known_otp_gated_actions().contains(&normalized)
+}
+
 impl Default for OtpConfig {
     fn default() -> Self {
         Self {
@@ -10707,6 +10756,14 @@ impl Config {
             {
                 anyhow::bail!(
                     "security.otp.gated_actions[{i}] contains invalid characters: {normalized}"
+                );
+            }
+            if !is_known_otp_gated_action(normalized) {
+                tracing::warn!(
+                    "security.otp.gated_actions[{i}] = {normalized:?} does not match any known \
+                     action — the entry is a no-op and will not gate any tool execution. \
+                     Known actions: {known}. See issue #5810.",
+                    known = known_otp_gated_actions().join(", "),
                 );
             }
         }
@@ -16913,6 +16970,47 @@ require_otp_to_resume = true
 
         let err = config.validate().expect_err("expected invalid domain glob");
         assert!(err.to_string().contains("gated_domains"));
+    }
+
+    #[test]
+    async fn known_otp_gated_actions_includes_all_defaults() {
+        // Regression for #5810: every entry in `default_otp_gated_actions`
+        // must also pass `is_known_otp_gated_action`, otherwise the warning
+        // path would fire spuriously on a stock config.
+        for action in default_otp_gated_actions() {
+            assert!(
+                is_known_otp_gated_action(&action),
+                "{action:?} is a default gated action but not on the known-actions allowlist",
+            );
+        }
+    }
+
+    #[test]
+    async fn is_known_otp_gated_action_rejects_unknown_names() {
+        assert!(!is_known_otp_gated_action("kubectl_write"));
+        assert!(!is_known_otp_gated_action("this_is_not_a_real_action"));
+        assert!(!is_known_otp_gated_action(""));
+        // trim is applied so whitespace-padded variants of known actions hit.
+        assert!(is_known_otp_gated_action("  shell  "));
+    }
+
+    #[test]
+    async fn security_validation_warns_but_accepts_unknown_gated_actions() {
+        // Regression for #5810: an unknown action like `kubectl_write` must
+        // not fail validation (operators may have stale entries we don't
+        // want to break on upgrade), but the warning path is exercised by
+        // the validate() call so operators get a `tracing::warn!` at
+        // daemon start. Backward-compat: stock defaults still validate.
+        let mut config = Config::default();
+        config.security.otp.gated_actions = vec![
+            "shell".into(),
+            "kubectl_write".into(),
+            "this_is_not_a_real_action".into(),
+        ];
+
+        config
+            .validate()
+            .expect("unknown gated_actions must warn, not fail");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #5810. `security.otp.gated_actions` accepted any arbitrary string without feedback — the example from the issue,

```toml
[security.otp]
enabled = true
gated_actions = ["kubectl_write"]
```

loads cleanly even though `kubectl_write` corresponds to no registered tool, so the operator believes they've added a TOTP gate on a destructive action that cannot in fact be gated. This is a silent failure mode on a knob operators specifically reach for to harden destructive flows.

This PR adds the **name-validation** half from the issue's suggested fix. The tool-execution enforcement gap remains tracked in #3767 / #1159 and is explicitly out of scope.

Changes in `crates/zeroclaw-config/src/schema.rs`:

1. New curated registry `known_otp_gated_actions() -> &'static [&'static str]` next to `default_otp_gated_actions()`. It's a static superset of the baseline plus the rest of the destructive / state-mutating tools registered by the runtime catalog (`file_edit`, `backup_tool`, `cloud_ops`, `git_operations`, `google_workspace`, `microsoft365`, `notion_tool`, `jira_tool`, `claude_code_runner`, `codex_cli`, `gemini_cli`, `composio`, `linkedin`, `discord_search`, `web_search_tool`, `content_search`, `calculator`, `mcp_tool`, `proxy_config`).
2. New helper `is_known_otp_gated_action(&str) -> bool` that trims and checks against the registry.
3. Extends the existing `gated_actions` validation loop at `Config::validate()` (the same loop that rejects empty / invalid-character entries) to emit a `tracing::warn!` line — with the index, the offending value, and the full known-actions list — for each entry that doesn't match the registry. **Warning, not error**: per the issue, the safer default. Upgrades with stale entries continue to start, but the operator sees a clear log line at daemon start.

## Validation Evidence

- New regression tests in the `schema::tests` module:
  - `known_otp_gated_actions_includes_all_defaults` — every `default_otp_gated_actions()` entry must pass `is_known_otp_gated_action`, otherwise stock configs would spuriously warn.
  - `is_known_otp_gated_action_rejects_unknown_names` — pins that `kubectl_write` / `this_is_not_a_real_action` / `""` return false and that whitespace-padded known names still match (the same trim applied by the validator).
  - `security_validation_warns_but_accepts_unknown_gated_actions` — pins the warn-don't-fail contract: a config containing both a known (`shell`) and two unknown actions must still pass `validate()`.
- `cargo test -p zeroclaw-config --lib` — **626 passed; 0 failed**.
- `cargo fmt --all -- --check` — clean.

## Security & Privacy Impact

- **Improves operator visibility** into a security-relevant config knob. No prior behavior tightens or loosens; the registry is a warning-only signal layered on top of the existing empty / invalid-character checks.
- No new outbound surfaces, no secrets touched, no env var reads.
- Tool-execution enforcement (the deeper #3767 gap) is untouched — this PR explicitly does not claim to fix it.

## Compatibility

- No breaking change. Existing configs with known entries (the stock default, or any of the curated tool names) validate exactly as before with no warning.
- Configs with unknown entries continue to load and run; the only delta is a `tracing::warn!` line at daemon start.
- New `pub` helpers (`known_otp_gated_actions`, `is_known_otp_gated_action`) are additive and ready to be reused once the #3767 enforcement layer lands.

## Rollback

Single commit, single file. Revert `fix(config): warn on unknown security.otp.gated_actions entries (#5810)` to restore prior silent behavior.
