### PR TITLE
fix(provider): restrict compatible reasoning effort models

### DIFF
--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -535,11 +535,22 @@ impl OpenAiCompatibleProvider {
     }
 
     fn reasoning_effort_for_model(&self, model: &str) -> Option<String> {
-        let id = model.rsplit('/').next().unwrap_or(model);
-        let supports_reasoning_effort = id.starts_with("gpt-5") || id.contains("codex");
-        supports_reasoning_effort
-            .then(|| self.reasoning_effort.clone())
-            .flatten()
+        let effort = self.reasoning_effort.as_ref()?;
+        let id = model
+            .rsplit('/')
+            .next()
+            .unwrap_or(model)
+            .to_ascii_lowercase();
+        let is_openai_reasoning_model = id == "o1"
+            || id.starts_with("o1-")
+            || id == "o3"
+            || id.starts_with("o3-")
+            || id == "o4"
+            || id.starts_with("o4-")
+            || id.starts_with("gpt-5");
+        let is_likely_codex_supported = id.contains("codex") && id.starts_with("gpt-");
+
+        (is_openai_reasoning_model || is_likely_codex_supported).then(|| effort.clone())
     }
 }
 
@@ -3290,10 +3301,26 @@ mod tests {
     }
 
     #[test]
-    fn reasoning_effort_only_applies_to_gpt5_and_codex_models() {
+    fn reasoning_effort_only_applies_to_openai_and_selected_codex_models() {
         let provider = make_provider("test", "https://example.com", None)
             .with_reasoning_effort(Some("high".to_string()));
 
+        assert_eq!(
+            provider.reasoning_effort_for_model("o1-preview"),
+            Some("high".to_string())
+        );
+        assert_eq!(
+            provider.reasoning_effort_for_model("openai/o3-mini"),
+            Some("high".to_string())
+        );
+        assert_eq!(
+            provider.reasoning_effort_for_model("o4-mini"),
+            Some("high".to_string())
+        );
+        assert_eq!(
+            provider.reasoning_effort_for_model("gpt-5"),
+            Some("high".to_string())
+        );
         assert_eq!(
             provider.reasoning_effort_for_model("gpt-5.3-codex"),
             Some("high".to_string())
@@ -3301,6 +3328,15 @@ mod tests {
         assert_eq!(
             provider.reasoning_effort_for_model("openai/gpt-5"),
             Some("high".to_string())
+        );
+        assert_eq!(
+            provider.reasoning_effort_for_model("gpt-4-codex"),
+            Some("high".to_string())
+        );
+        assert_eq!(
+            provider.reasoning_effort_for_model("llama-3-codex"),
+            None,
+            "generic codex-like model names must not receive OpenAI-only reasoning_effort",
         );
         assert_eq!(provider.reasoning_effort_for_model("llama-3.3-70b"), None);
     }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Recover the #4310 provider fix on the current `zeroclaw-providers` crate layout.
  - Limit OpenAI-compatible `reasoning_effort` requests to known OpenAI reasoning model ids: `o1`, `o3`, `o4`, `gpt-5*`, and GPT-prefixed Codex model ids.
  - Stop sending `reasoning_effort` to generic model names that merely contain `codex`, such as `llama-3-codex`.
  - Add regression coverage for the allowed and rejected model-id cases.
- **Scope boundary:** This does not add per-provider reasoning configuration, change the OpenAI Codex provider, or alter response parsing for `reasoning` / `reasoning_content`.
- **Blast radius:** OpenAI-compatible chat-completions providers that receive `reasoning_effort` from runtime config. Non-reasoning models should see fewer unsupported request fields; supported OpenAI reasoning models continue receiving the configured effort.
- **Linked issue(s):** Related #6074. Supersedes #4310.
- **Labels:** `bug`, `risk: medium`, `size: XS`, `provider`, `provider:compatible`.

## Validation Evidence (required)

- **Commands run and tail output:**

```text
cargo fmt --all -- --check
Result: passed; no output.

git diff --check
Result: passed; no output.

time cargo test -p zeroclaw-providers reasoning_effort_only_applies_to_openai_and_selected_codex_models --lib 2>&1 | tail -80
Result: passed.
Tail:
running 1 test
test compatible::tests::reasoning_effort_only_applies_to_openai_and_selected_codex_models ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 865 filtered out; finished in 0.00s

time cargo clippy --all-targets -- -D warnings 2>&1 | tail -80
Result: passed.
Tail:
Checking zeroclaw-providers v0.7.5
Checking zeroclaw-memory v0.7.5
Checking zeroclaw-tui v0.7.5
Checking zeroclaw-tools v0.7.5
Checking zeroclaw-runtime v0.7.5
Checking zeroclaw-hardware v0.7.5
Checking zeroclaw-channels v0.7.5
Finished `dev` profile [unoptimized + debuginfo] target(s) in 4m 27s
```

- **Beyond CI — what did you manually verify?** Reviewed the PR diff against the #4310 recovery scope and confirmed the regression test covers the allowed OpenAI reasoning ids plus the rejected `llama-3-codex` case.
- **If any command was intentionally skipped, why:** Full workspace `cargo test` was not run. This is a one-file medium-risk provider change with focused regression coverage and workspace-shaped clippy.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: None.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: Existing users do not need to change config. Existing `reasoning_effort` settings still apply to known OpenAI reasoning models, but generic OpenAI-compatible model ids such as `llama-3-codex` no longer receive the OpenAI-only request field.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <merge-sha>`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** OpenAI-compatible reasoning models may stop receiving the configured `reasoning_effort`, or non-OpenAI-compatible endpoints may reject requests with unsupported `reasoning_effort`. Check provider error logs for messages about unsupported or unknown request parameters.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line):
  - #4310 by @ninenox
- Scope materially carried forward: The OpenAI-compatible provider `reasoning_effort` model filter and regression coverage, adapted to the current crate layout and extended for the current `o4` model family.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `Yes`
- If `No`, why (inspiration-only, no direct code/design carry-over): Not applicable.
