### PR TITLE
fix(gateway/nextcloud-talk): process webhook async to avoid 5s cancel (#6156)

### DIFF
--- a/crates/zeroclaw-gateway/src/lib.rs
+++ b/crates/zeroclaw-gateway/src/lib.rs
@@ -2343,58 +2343,66 @@ async fn handle_nextcloud_talk_webhook(
         return (StatusCode::OK, Json(serde_json::json!({"status": "ok"})));
     }
 
-    for msg in &messages {
-        tracing::info!(
-            "Nextcloud Talk message from {}: {}",
-            msg.sender,
-            truncate_with_ellipsis(&msg.content, 50)
-        );
-        let session_id = sender_session_id("nextcloud_talk", msg);
+    // Spawn per-message processing so the webhook returns 200 quickly.
+    // Nextcloud Talk cancels webhook requests that don't complete within ~5s
+    // (see #6156); slow local models routinely exceed that. Each message gets
+    // its own task — the LLM call and reply are independent of the ack.
+    for msg in messages {
+        let state = state.clone();
+        let nextcloud_talk = Arc::clone(nextcloud_talk);
+        tokio::spawn(async move {
+            tracing::info!(
+                "Nextcloud Talk message from {}: {}",
+                msg.sender,
+                truncate_with_ellipsis(&msg.content, 50)
+            );
+            let session_id = sender_session_id("nextcloud_talk", &msg);
 
-        if state.auto_save && !zeroclaw_memory::should_skip_autosave_content(&msg.content) {
-            let key = nextcloud_talk_memory_key(msg);
-            let _ = state
-                .mem
-                .store(
-                    &key,
-                    &msg.content,
-                    MemoryCategory::Conversation,
-                    Some(&session_id),
-                )
-                .await;
-        }
-
-        match Box::pin(run_gateway_chat_with_tools(
-            &state,
-            &msg.content,
-            Some(&session_id),
-        ))
-        .await
-        {
-            Ok(GatewayChatOutcome { response, .. }) => {
-                if let Err(e) = nextcloud_talk
-                    .send(&SendMessage::new(response, &msg.reply_target))
-                    .await
-                {
-                    tracing::error!("Failed to send Nextcloud Talk reply: {e}");
-                }
-            }
-            Err(e) => {
-                let reply = if is_needs_onboarding_err(&e) {
-                    tracing::warn!(
-                        "Nextcloud Talk chat refused: gateway has no model configured; \
-                         visit /onboard"
-                    );
-                    needs_onboarding_channel_reply()
-                } else {
-                    tracing::error!("LLM error for Nextcloud Talk message: {e:#}");
-                    "Sorry, I couldn't process your message right now.".to_string()
-                };
-                let _ = nextcloud_talk
-                    .send(&SendMessage::new(reply, &msg.reply_target))
+            if state.auto_save && !zeroclaw_memory::should_skip_autosave_content(&msg.content) {
+                let key = nextcloud_talk_memory_key(&msg);
+                let _ = state
+                    .mem
+                    .store(
+                        &key,
+                        &msg.content,
+                        MemoryCategory::Conversation,
+                        Some(&session_id),
+                    )
                     .await;
             }
-        }
+
+            match Box::pin(run_gateway_chat_with_tools(
+                &state,
+                &msg.content,
+                Some(&session_id),
+            ))
+            .await
+            {
+                Ok(GatewayChatOutcome { response, .. }) => {
+                    if let Err(e) = nextcloud_talk
+                        .send(&SendMessage::new(response, &msg.reply_target))
+                        .await
+                    {
+                        tracing::error!("Failed to send Nextcloud Talk reply: {e}");
+                    }
+                }
+                Err(e) => {
+                    let reply = if is_needs_onboarding_err(&e) {
+                        tracing::warn!(
+                            "Nextcloud Talk chat refused: gateway has no model configured; \
+                             visit /onboard"
+                        );
+                        needs_onboarding_channel_reply()
+                    } else {
+                        tracing::error!("LLM error for Nextcloud Talk message: {e:#}");
+                        "Sorry, I couldn't process your message right now.".to_string()
+                    };
+                    let _ = nextcloud_talk
+                        .send(&SendMessage::new(reply, &msg.reply_target))
+                        .await;
+                }
+            }
+        });
     }
 
     (StatusCode::OK, Json(serde_json::json!({"status": "ok"})))
@@ -3798,6 +3806,124 @@ mod tests {
         .into_response();
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
         assert_eq!(provider_impl.calls.load(Ordering::SeqCst), 0);
+    }
+
+    // Regression for #6156: handler must return 200 OK before the (potentially
+    // slow) LLM call completes, so Nextcloud Talk doesn't cancel the webhook
+    // request at its ~5s timeout.
+    #[derive(Default)]
+    struct SlowProvider {
+        calls: AtomicUsize,
+        started_tx: Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
+    }
+
+    #[async_trait]
+    impl Provider for SlowProvider {
+        async fn chat_with_system(
+            &self,
+            _system_prompt: Option<&str>,
+            _message: &str,
+            _model: &str,
+            _temperature: Option<f64>,
+        ) -> anyhow::Result<String> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            if let Some(tx) = self.started_tx.lock().take() {
+                let _ = tx.send(());
+            }
+            tokio::time::sleep(Duration::from_secs(30)).await;
+            Ok("slow ok".into())
+        }
+    }
+
+    #[tokio::test]
+    async fn nextcloud_talk_webhook_returns_before_llm_call_completes() {
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let provider_impl = Arc::new(SlowProvider {
+            calls: AtomicUsize::new(0),
+            started_tx: Mutex::new(Some(started_tx)),
+        });
+        let provider: Arc<dyn Provider> = provider_impl.clone();
+        let memory: Arc<dyn Memory> = Arc::new(MockMemory);
+
+        let channel = Arc::new(NextcloudTalkChannel::new(
+            "https://cloud.example.com".into(),
+            "app-token".into(),
+            String::new(),
+            vec!["*".into()],
+        ));
+
+        let body = r#"{"type":"message","object":{"token":"room-token"},"actor":{"id":"user_a","name":"User A"},"message":{"actorType":"users","actorId":"user_a","message":"hello"}}"#;
+
+        let state = AppState {
+            config: Arc::new(Mutex::new(Config::default())),
+            provider,
+            model: "test-model".into(),
+            temperature: 0.0,
+            mem: memory,
+            auto_save: false,
+            webhook_secret_hash: None,
+            pairing: Arc::new(PairingGuard::new(false, &[])),
+            trust_forwarded_headers: false,
+            rate_limiter: Arc::new(GatewayRateLimiter::new(100, 100, 100)),
+            auth_limiter: Arc::new(auth_rate_limit::AuthRateLimiter::new()),
+            idempotency_store: Arc::new(IdempotencyStore::new(Duration::from_secs(300), 1000)),
+            whatsapp: None,
+            whatsapp_app_secret: None,
+            linq: None,
+            linq_signing_secret: None,
+            nextcloud_talk: Some(channel),
+            nextcloud_talk_webhook_secret: None,
+            wati: None,
+            gmail_push: None,
+            observer: Arc::new(zeroclaw_runtime::observability::NoopObserver),
+            tools_registry: Arc::new(Vec::new()),
+            cost_tracker: None,
+            event_tx: tokio::sync::broadcast::channel(16).0,
+            event_buffer: Arc::new(sse::EventBuffer::new(16)),
+            shutdown_tx: tokio::sync::watch::channel(false).0,
+            reload_tx: None,
+            node_registry: Arc::new(nodes::NodeRegistry::new(16)),
+            path_prefix: String::new(),
+            web_dist_dir: None,
+            session_backend: None,
+            session_queue: std::sync::Arc::new(crate::session_queue::SessionActorQueue::new(
+                8, 30, 600,
+            )),
+            device_registry: None,
+            pending_pairings: None,
+            canvas_store: CanvasStore::new(),
+            cancel_tokens: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+            #[cfg(feature = "webauthn")]
+            webauthn: None,
+        };
+
+        let start = std::time::Instant::now();
+        let response = tokio::time::timeout(
+            Duration::from_secs(2),
+            Box::pin(handle_nextcloud_talk_webhook(
+                State(state),
+                HeaderMap::new(),
+                Bytes::from(body),
+            )),
+        )
+        .await
+        .expect("webhook must return before 2s deadline (regression #6156)")
+        .into_response();
+
+        let elapsed = start.elapsed();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "handler returned after {elapsed:?}; expected fast return for #6156"
+        );
+
+        // Confirm the spawned task actually started the LLM call (i.e., the
+        // ack didn't just skip processing). The 30s sleep is still in flight.
+        tokio::time::timeout(Duration::from_secs(2), started_rx)
+            .await
+            .expect("spawned LLM call did not start within 2s")
+            .expect("started_tx sender was dropped");
+        assert_eq!(provider_impl.calls.load(Ordering::SeqCst), 1);
     }
 
     // ══════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **Fixes #6156** — Nextcloud Talk webhook cancels the LLM turn after ~5 s when the model is slow.
- **What changed and why:**
  - `handle_nextcloud_talk_webhook` (`crates/zeroclaw-gateway/src/lib.rs`) awaited `run_gateway_chat_with_tools` inline for each parsed message before returning `200 OK`. Slow local models (issue reporter cited LocalAI) routinely exceed Nextcloud Talk's ~5 s webhook timeout, at which point Nextcloud cancels the HTTP request and the bot reply never arrives. ZeroClaw logged nothing because the cancellation happens server-side on Nextcloud, not in our LLM client.
  - **Fix:** wrap the per-message processing (`auto_save` + `run_gateway_chat_with_tools` + reply send) in `tokio::spawn`, then return `200 OK` immediately. This mirrors the existing Gmail-push pattern in the same file (`handle_gmail_push_webhook`, ~lines 2459-2468) which already uses this shape for the same reason.
  - **Signature verification stays synchronous and stays before the spawn.** Unauthenticated requests are rejected with `401 Unauthorized` before any background work is dispatched — no change to the security posture.
  - One regression test using a `SlowProvider` (30 s `chat_with_system`) confirms the handler returns `200 OK` within a 2 s timeout while the LLM call is still in flight. A `oneshot::channel` "started" signal ensures we are testing that the LLM call really *began* in the background rather than that the ack skipped processing entirely.

- **Scope boundary:** One file, one function (`handle_nextcloud_talk_webhook`). No new dependencies. One new test (`nextcloud_talk_webhook_returns_before_llm_call_completes`) plus one new test-only `SlowProvider` mock.
- **Blast radius:** Webhook handler returns earlier; LLM call still runs to completion in the background. Reply behaviour, retry semantics, signature verification, auto-save, idempotency are unchanged. Errors from the spawned task are logged via the existing `tracing::error!` paths — they just no longer surface as a `500` to Nextcloud (which was a misleading signal anyway, since Nextcloud had already cancelled).
- **Issue reporter's proposed solution:** rhinterndorfer commented a near-identical diff on the issue thread (clone `state` + `nextcloud_talk` Arcs, `tokio::spawn` the match block). Audacity88's triage flagged the Gmail webhook as the template. This PR implements exactly that pattern, plus the regression test.

## Validation Evidence (required)

```
$ cargo fmt --all -- --check
(clean — no diff)

$ cargo test -p zeroclaw-gateway --lib nextcloud_talk_webhook
test tests::nextcloud_talk_webhook_returns_not_found_when_not_configured ... ok
test tests::nextcloud_talk_webhook_rejects_invalid_signature ... ok
test tests::nextcloud_talk_webhook_returns_before_llm_call_completes ... ok
test result: ok. 3 passed; 0 failed; 0 ignored

$ cargo test -p zeroclaw-gateway --lib
test result: ok. 174 passed; 0 failed; 0 ignored
  (173 baseline + 1 new)

$ cargo clippy -p zeroclaw-gateway --lib --tests --no-deps -- -D warnings
(clean)
```

- **Beyond CI — what I manually verified:**
  - The regression test pins the load-bearing property: the handler must finish before the LLM call does. It uses a 2 s timeout on the handler (well under the 5 s Nextcloud cancel threshold) against a provider that sleeps 30 s. If the spawn is removed, the test fails by timeout.
  - The `oneshot::channel` "started" signal from inside `SlowProvider::chat_with_system` is awaited *after* the handler returns. This proves the LLM call really started in the spawned task — not that the handler short-circuited and never dispatched anything.
  - `provider_impl.calls.load(Ordering::SeqCst) == 1` after the started signal fires.
  - Existing `nextcloud_talk_webhook_rejects_invalid_signature` still passes — signature verification continues to happen before the spawn, so an invalid signature still returns `401` and the spawned task is never dispatched.
  - Did **not** spin up a real Nextcloud server with a slow LocalAI backend in this dev env. The handler-return-timing contract is the load-bearing piece; the regression test asserts it.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No.**
- New external network calls? **No.** Same outbound POST to Nextcloud's bot endpoint, same `run_gateway_chat_with_tools` LLM dispatch.
- Secrets / tokens / credentials handling changed? **No.** HMAC verification stays in the synchronous path.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No.** Test payload uses `user_a` / `hello`.

The webhook still authenticates the caller before any background work starts. Spawning is post-auth, so this does not enable any unauthenticated work to be triggered.

## Compatibility (required)

- Backward compatible? **Yes.** The webhook contract from Nextcloud's perspective is unchanged (still `200 OK`, still after signature check). The only observable difference is that the `200` arrives sooner — Nextcloud Talk explicitly prefers this and is the reason it cancels at ~5 s.
- Config / env / CLI surface changed? **No.**

## Rollback

- **Fast rollback command/path:** `git revert <commit>` (single commit, one file).
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** If a future refactor accidentally re-introduced the synchronous `await`, the regression test would fail. If `tokio::spawn` started panicking on spawn (it can't on a live runtime, but hypothetically), the per-message task would never run and replies would silently stop — `tracing::error!` from the spawned task remains the same, and the per-message log line `"Nextcloud Talk message from {} : {}"` would still appear on dispatch.

---

**Labels:** `bug`, `risk: high`, `priority:p2`, `channel`, `channel: nextcloud_talk`, `gateway`, `size: S` (set in the GitHub UI; matches issue labels).

**Diff stat:** 1 file changed, +175 / -49 (net structural shift into a spawned closure + the new test + `SlowProvider` mock).
