### PR TITLE
fix(cron,channels): carry thread_id through cron announce delivery

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -6282,6 +6282,22 @@ pub async fn deliver_announcement(
         "wechat" => {
             anyhow::bail!("WeChat channel requires the `channel-wechat` feature");
         }
+        "webhook" => {
+            let wh = config
+                .channels
+                .webhook
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("webhook channel not configured"))?;
+            let ch = WebhookChannel::new(
+                wh.port,
+                wh.listen_path.clone(),
+                wh.send_url.clone(),
+                wh.send_method.clone(),
+                wh.auth_header.clone(),
+                wh.secret.clone(),
+            );
+            zeroclaw_api::channel::Channel::send(&ch, &make_msg(&safe_output)).await?;
+        }
         other => anyhow::bail!("unsupported delivery channel: {other}"),
     }
     Ok(())

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -693,14 +693,31 @@ fn build_channel_system_prompt(
     }
 
     if !reply_target.is_empty() {
+        // For most channels, `reply_target` is the address to send to (channel/room
+        // ID for Slack/Discord/Matrix, peer ID for Telegram/Signal). The webhook
+        // channel is the exception: its outbound JSON has both `recipient` and
+        // `thread_id`, and downstream services routing through it expect the
+        // *sender* as the recipient and the *thread/conversation* identifier in
+        // `thread_id`. Reusing `reply_target` as `to` for webhook would strip the
+        // thread context and the receiver would discard the callback.
+        let delivery_hint = if channel_name.eq_ignore_ascii_case("webhook") {
+            format!(
+                "delivery={{\"mode\":\"announce\",\"channel\":\"{channel_name}\",\
+                 \"to\":\"{sender}\",\"thread_id\":\"{reply_target}\"}}"
+            )
+        } else {
+            format!(
+                "delivery={{\"mode\":\"announce\",\"channel\":\"{channel_name}\",\
+                 \"to\":\"{reply_target}\"}}"
+            )
+        };
         let context = format!(
             "\n\nChannel context: You are currently responding on channel={channel_name}, \
              reply_target={reply_target}, sender={sender}. \
              The sender field is the platform-specific user ID of the person who sent \
              this message. Use it to distinguish between different users. \
              When scheduling delayed messages or reminders \
-             via cron_add for this conversation, use delivery={{\"mode\":\"announce\",\
-             \"channel\":\"{channel_name}\",\"to\":\"{reply_target}\"}} so the message \
+             via cron_add for this conversation, use {delivery_hint} so the message \
              reaches the user."
         );
         prompt.push_str(&context);
@@ -6152,10 +6169,16 @@ pub async fn start_channels(
 
 /// Deliver a cron job announcement to a configured channel.
 /// Scans for credential leaks before delivery.
+///
+/// `thread_id` is forwarded to channels whose outbound `thread_id` is distinct
+/// from the recipient (notably the webhook channel, which serialises both into
+/// the JSON callback). For channels that do not honour `thread_ts` it is a
+/// harmless no-op.
 pub async fn deliver_announcement(
     config: &zeroclaw_config::schema::Config,
     channel: &str,
     target: &str,
+    thread_id: Option<String>,
     output: &str,
 ) -> anyhow::Result<()> {
     use zeroclaw_api::channel::SendMessage;
@@ -6167,12 +6190,14 @@ pub async fn deliver_announcement(
         zeroclaw_runtime::security::LeakResult::Clean => output.to_string(),
     };
 
+    let make_msg = |s: &str| SendMessage::new(s, target).in_thread(thread_id.clone());
+
     // Use the live channel instance when available — critical for Matrix E2EE which must
     // reuse the authenticated client rather than re-running session restore per delivery.
     if let Some(registry) = CRON_CHANNEL_REGISTRY.get()
         && let Some(ch) = registry.get(channel.to_ascii_lowercase().as_str())
     {
-        return ch.send(&SendMessage::new(&safe_output, target)).await;
+        return ch.send(&make_msg(&safe_output)).await;
     }
 
     match channel.to_ascii_lowercase().as_str() {
@@ -6188,8 +6213,7 @@ pub async fn deliver_announcement(
                 tg.allowed_users.clone(),
                 tg.mention_only,
             );
-            zeroclaw_api::channel::Channel::send(&ch, &SendMessage::new(&safe_output, target))
-                .await?;
+            zeroclaw_api::channel::Channel::send(&ch, &make_msg(&safe_output)).await?;
         }
         "discord" => {
             let dc = config
@@ -6205,8 +6229,7 @@ pub async fn deliver_announcement(
                 dc.mention_only,
             )
             .with_workspace_dir(config.workspace_dir.clone());
-            zeroclaw_api::channel::Channel::send(&ch, &SendMessage::new(&safe_output, target))
-                .await?;
+            zeroclaw_api::channel::Channel::send(&ch, &make_msg(&safe_output)).await?;
         }
         "slack" => {
             let sl = config
@@ -6221,8 +6244,7 @@ pub async fn deliver_announcement(
                 sl.allowed_users.clone(),
             )
             .with_workspace_dir(config.workspace_dir.clone());
-            zeroclaw_api::channel::Channel::send(&ch, &SendMessage::new(&safe_output, target))
-                .await?;
+            zeroclaw_api::channel::Channel::send(&ch, &make_msg(&safe_output)).await?;
         }
         "signal" => {
             let sg = config
@@ -6238,8 +6260,7 @@ pub async fn deliver_announcement(
                 sg.ignore_attachments,
                 sg.ignore_stories,
             );
-            zeroclaw_api::channel::Channel::send(&ch, &SendMessage::new(&safe_output, target))
-                .await?;
+            zeroclaw_api::channel::Channel::send(&ch, &make_msg(&safe_output)).await?;
         }
         #[cfg(feature = "channel-wechat")]
         "wechat" => {
@@ -6255,8 +6276,7 @@ pub async fn deliver_announcement(
                 wc.state_dir.as_ref().map(std::path::PathBuf::from),
             )?
             .with_workspace_dir(config.workspace_dir.clone());
-            zeroclaw_api::channel::Channel::send(&ch, &SendMessage::new(&safe_output, target))
-                .await?;
+            zeroclaw_api::channel::Channel::send(&ch, &make_msg(&safe_output)).await?;
         }
         #[cfg(not(feature = "channel-wechat"))]
         "wechat" => {
@@ -13449,5 +13469,44 @@ This is an example JSON object for profile settings."#;
         assert!(prompt_a.contains("sender=user_aaa"));
         assert!(prompt_b.contains("sender=user_bbb"));
         assert_ne!(prompt_a, prompt_b);
+    }
+
+    #[test]
+    fn build_channel_system_prompt_webhook_cron_hint_carries_thread_id() {
+        // On the webhook channel `reply_target` is the inbound thread/conversation
+        // id, not a recipient. Using it as `delivery.to` would strip the thread
+        // context from the cron-announce callback (see #6634). The hint must
+        // place the sender in `to` and the reply_target in `thread_id`.
+        let prompt = build_channel_system_prompt(
+            "Base.",
+            "webhook",
+            "agent-chat:agent-1:thread-7",
+            "user:abc",
+        );
+        assert!(
+            prompt.contains("\"to\":\"user:abc\""),
+            "webhook cron hint must use sender as `to`: {prompt}"
+        );
+        assert!(
+            prompt.contains("\"thread_id\":\"agent-chat:agent-1:thread-7\""),
+            "webhook cron hint must carry the reply_target as `thread_id`: {prompt}"
+        );
+        assert!(
+            !prompt.contains("\"to\":\"agent-chat:agent-1:thread-7\""),
+            "webhook cron hint must not put the thread id in `to`: {prompt}"
+        );
+    }
+
+    #[test]
+    fn build_channel_system_prompt_non_webhook_cron_hint_keeps_to_as_reply_target() {
+        let prompt = build_channel_system_prompt("Base.", "slack", "C12345", "U67890");
+        assert!(
+            prompt.contains("\"to\":\"C12345\""),
+            "non-webhook cron hint should keep reply_target as `to`: {prompt}"
+        );
+        assert!(
+            !prompt.contains("\"thread_id\""),
+            "non-webhook cron hint should not emit a thread_id field: {prompt}"
+        );
     }
 }

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -6543,6 +6543,11 @@ pub struct DeliveryConfigDecl {
     /// Target/recipient identifier.
     #[serde(default)]
     pub to: Option<String>,
+    /// Optional thread/conversation identifier carried into the outbound send.
+    /// Required by channels that route on a separate `thread_id` field (e.g.
+    /// webhook callbacks bridging into agent-chat platforms).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thread_id: Option<String>,
     /// Best-effort delivery. Default: `true`.
     #[serde(default = "default_true")]
     pub best_effort: bool,

--- a/crates/zeroclaw-gateway/src/api.rs
+++ b/crates/zeroclaw-gateway/src/api.rs
@@ -356,7 +356,11 @@ pub async fn handle_api_cron_run(
         && let (Some(channel), Some(target)) =
             (job.delivery.channel.as_deref(), job.delivery.to.as_deref())
         && let Err(e) = zeroclaw_runtime::cron::scheduler::deliver_announcement(
-            &config, channel, target, &output,
+            &config,
+            channel,
+            target,
+            job.delivery.thread_id.as_deref(),
+            &output,
         )
         .await
     {

--- a/crates/zeroclaw-runtime/src/cron/mod.rs
+++ b/crates/zeroclaw-runtime/src/cron/mod.rs
@@ -63,7 +63,8 @@ pub fn validate_delivery_config(delivery: Option<&DeliveryConfig>) -> Result<()>
         bail!("delivery.channel is required for announce mode");
     };
     match channel.to_ascii_lowercase().as_str() {
-        "telegram" | "discord" | "slack" | "mattermost" | "signal" | "matrix" | "qq" => {}
+        "telegram" | "discord" | "slack" | "mattermost" | "signal" | "matrix" | "qq"
+        | "webhook" => {}
         other => bail!("unsupported delivery channel: {other}"),
     }
 
@@ -743,5 +744,48 @@ mod tests {
         assert_eq!(jobs.len(), 1);
         assert_eq!(jobs[0].job_type, JobType::Shell);
         assert_eq!(jobs[0].command, "echo ok");
+    }
+}
+
+#[cfg(test)]
+mod validate_delivery_tests {
+    use super::*;
+    use crate::cron::types::DeliveryConfig;
+
+    #[test]
+    fn validate_delivery_accepts_webhook_with_thread_id() {
+        let delivery = DeliveryConfig {
+            mode: "announce".into(),
+            channel: Some("webhook".into()),
+            to: Some("user-42".into()),
+            thread_id: Some("conv-99".into()),
+            best_effort: true,
+        };
+        validate_delivery_config(Some(&delivery)).expect("webhook with thread_id must validate");
+    }
+
+    #[test]
+    fn validate_delivery_accepts_webhook_without_thread_id() {
+        let delivery = DeliveryConfig {
+            mode: "announce".into(),
+            channel: Some("webhook".into()),
+            to: Some("user-42".into()),
+            thread_id: None,
+            best_effort: true,
+        };
+        validate_delivery_config(Some(&delivery)).expect("webhook without thread_id must validate");
+    }
+
+    #[test]
+    fn validate_delivery_rejects_unknown_channel() {
+        let delivery = DeliveryConfig {
+            mode: "announce".into(),
+            channel: Some("imaginary".into()),
+            to: Some("user-42".into()),
+            thread_id: None,
+            best_effort: true,
+        };
+        let err = validate_delivery_config(Some(&delivery)).expect_err("unknown channel must fail");
+        assert!(err.to_string().contains("unsupported delivery channel"));
     }
 }

--- a/crates/zeroclaw-runtime/src/cron/scheduler.rs
+++ b/crates/zeroclaw-runtime/src/cron/scheduler.rs
@@ -505,15 +505,25 @@ async fn deliver_if_configured(config: &Config, job: &CronJob, output: &str) -> 
         .as_deref()
         .ok_or_else(|| anyhow::anyhow!("delivery.to is required for announce mode"))?;
 
-    deliver_announcement(config, channel, target, output).await
+    deliver_announcement(
+        config,
+        channel,
+        target,
+        delivery.thread_id.as_deref(),
+        output,
+    )
+    .await
 }
 
 /// Delivery function type — takes owned values so the returned future is 'static.
+/// The fourth `Option<String>` is the optional thread/conversation id propagated
+/// to channels whose outbound `thread_id` is distinct from the recipient (webhook).
 pub type DeliveryFn = Box<
     dyn Fn(
             Config,
             String,
             String,
+            Option<String>,
             String,
         ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<()>> + Send>>
         + Send
@@ -532,6 +542,7 @@ pub async fn deliver_announcement(
     config: &Config,
     channel: &str,
     target: &str,
+    thread_id: Option<&str>,
     output: &str,
 ) -> Result<()> {
     if let Some(f) = DELIVERY_FN.get() {
@@ -539,6 +550,7 @@ pub async fn deliver_announcement(
             config.clone(),
             channel.to_string(),
             target.to_string(),
+            thread_id.map(str::to_string),
             output.to_string(),
         )
         .await
@@ -1201,6 +1213,7 @@ mod tests {
                 mode: "announce".into(),
                 channel: Some("telegram".into()),
                 to: Some("123456".into()),
+                thread_id: None,
                 best_effort: false,
             }),
             false,
@@ -1226,19 +1239,22 @@ mod tests {
     async fn persist_job_result_delivery_failure_best_effort_marks_degraded() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(&tmp).await;
-        register_delivery_fn(Box::new(|_config, channel, _target, _output| {
-            Box::pin(async move {
-                if channel == "fail-delivery" {
-                    anyhow::bail!("synthetic delivery failure");
-                }
-                Ok(())
-            })
-        }));
+        register_delivery_fn(Box::new(
+            |_config, channel, _target, _thread_id, _output| {
+                Box::pin(async move {
+                    if channel == "fail-delivery" {
+                        anyhow::bail!("synthetic delivery failure");
+                    }
+                    Ok(())
+                })
+            },
+        ));
         let mut job = cron::add_job(&config, "*/5 * * * *", "echo ok").unwrap();
         job.delivery = DeliveryConfig {
             mode: "announce".into(),
             channel: Some("fail-delivery".into()),
             to: Some("123456".into()),
+            thread_id: None,
             best_effort: true,
         };
         let started = Utc::now();
@@ -1315,7 +1331,7 @@ mod tests {
         // failure. The caller (persist_job_result) should record the job
         // execution as successful; the missing handler is logged via
         // tracing::warn for operator visibility.
-        deliver_announcement(&config, "telegram", "chat-id", "payload")
+        deliver_announcement(&config, "telegram", "chat-id", None, "payload")
             .await
             .expect("missing delivery handler should be Ok with a warn log");
     }

--- a/crates/zeroclaw-runtime/src/cron/store.rs
+++ b/crates/zeroclaw-runtime/src/cron/store.rs
@@ -867,6 +867,7 @@ fn convert_delivery_decl(decl: &zeroclaw_config::schema::DeliveryConfigDecl) -> 
         mode: decl.mode.clone(),
         channel: decl.channel.clone(),
         to: decl.to.clone(),
+        thread_id: decl.thread_id.clone(),
         best_effort: decl.best_effort,
     }
 }
@@ -1040,6 +1041,7 @@ mod tests {
                 mode: "announce".into(),
                 channel: Some("discord".into()),
                 to: Some("1234567890".into()),
+                thread_id: None,
                 best_effort: true,
             }),
         )
@@ -1074,6 +1076,7 @@ mod tests {
                 mode: "announce".into(),
                 channel: Some("discord".into()),
                 to: None,
+                thread_id: None,
                 best_effort: true,
             }),
             false,
@@ -1101,6 +1104,7 @@ mod tests {
                 mode: "annouce".into(),
                 channel: Some("discord".into()),
                 to: Some("1234567890".into()),
+                thread_id: None,
                 best_effort: true,
             }),
         )

--- a/crates/zeroclaw-runtime/src/cron/types.rs
+++ b/crates/zeroclaw-runtime/src/cron/types.rs
@@ -108,6 +108,13 @@ pub struct DeliveryConfig {
     pub channel: Option<String>,
     #[serde(default)]
     pub to: Option<String>,
+    /// Optional thread/conversation identifier carried into the outbound send.
+    /// Used by channels whose recipient and thread-of-conversation are distinct
+    /// (notably webhook, where a callback service routes on `thread_id`).
+    /// Persisted via the `delivery` JSON column, so existing rows without this
+    /// field deserialize as `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thread_id: Option<String>,
     #[serde(default = "default_true")]
     pub best_effort: bool,
 }
@@ -118,6 +125,7 @@ impl Default for DeliveryConfig {
             mode: "none".to_string(),
             channel: None,
             to: None,
+            thread_id: None,
             best_effort: true,
         }
     }

--- a/crates/zeroclaw-runtime/src/daemon/mod.rs
+++ b/crates/zeroclaw-runtime/src/daemon/mod.rs
@@ -413,7 +413,7 @@ async fn run_heartbeat_worker(config: Config) -> Result<()> {
                         continue;
                     };
                     let delivery_fut = crate::cron::scheduler::deliver_announcement(
-                        &dm_config, &channel, &target, &alert,
+                        &dm_config, &channel, &target, None, &alert,
                     );
                     match tokio::time::timeout(Duration::from_secs(30), delivery_fut).await {
                         Ok(Err(e)) => {
@@ -681,6 +681,7 @@ async fn run_heartbeat_worker(config: Config) -> Result<()> {
                                 &config,
                                 channel,
                                 target,
+                                None,
                                 &announcement,
                             ),
                         )

--- a/crates/zeroclaw-runtime/src/tools/cron_add.rs
+++ b/crates/zeroclaw-runtime/src/tools/cron_add.rs
@@ -60,8 +60,10 @@ impl Tool for CronAddTool {
     fn description(&self) -> &str {
         "Create a scheduled cron job (shell or agent) with cron/at/every schedules. \
          Use job_type='agent' with a prompt to run the AI agent on schedule. \
-         To deliver output to a channel (Discord, Telegram, Slack, Mattermost, Matrix, QQ), set \
+         To deliver output to a channel (Discord, Telegram, Slack, Mattermost, Matrix, QQ, Webhook), set \
          delivery={\"mode\":\"announce\",\"channel\":\"discord\",\"to\":\"<channel_id_or_chat_id>\"}. \
+         For webhook deliveries that must thread through the originating conversation, also set \
+         delivery.thread_id=\"<reply_target>\". \
          This is the preferred tool for sending scheduled/delayed messages to users via channels."
     }
 
@@ -148,12 +150,16 @@ impl Tool for CronAddTool {
                         },
                         "channel": {
                             "type": "string",
-                            "enum": ["telegram", "discord", "slack", "mattermost", "matrix", "qq"],
+                            "enum": ["telegram", "discord", "slack", "mattermost", "matrix", "qq", "webhook"],
                             "description": "Channel type to deliver output to"
                         },
                         "to": {
                             "type": "string",
-                            "description": "Destination ID: Discord channel ID, Telegram chat ID, Slack channel name, etc."
+                            "description": "Destination ID: Discord channel ID, Telegram chat ID, Slack channel name, webhook recipient, etc."
+                        },
+                        "thread_id": {
+                            "type": "string",
+                            "description": "Optional thread/conversation identifier. Used by the webhook channel to route callbacks to the originating conversation; ignored by channels whose threading is implied by `to`."
                         },
                         "best_effort": {
                             "type": "boolean",
@@ -762,6 +768,63 @@ mod tests {
                 .unwrap_or_default();
 
         assert!(values.iter().any(|value| value == "matrix"));
+    }
+
+    #[tokio::test]
+    async fn delivery_schema_includes_webhook_and_thread_id() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = test_config(&tmp).await;
+        let tool = CronAddTool::new(cfg.clone(), test_security(&cfg));
+        let schema = tool.parameters_schema();
+
+        let channel_enum = schema["properties"]["delivery"]["properties"]["channel"]["enum"]
+            .as_array()
+            .cloned()
+            .unwrap_or_default();
+        assert!(
+            channel_enum.iter().any(|value| value == "webhook"),
+            "delivery.channel enum must include webhook"
+        );
+
+        let delivery_props = schema["properties"]["delivery"]["properties"]
+            .as_object()
+            .expect("delivery must have properties");
+        assert!(
+            delivery_props.contains_key("thread_id"),
+            "delivery schema must expose thread_id so the webhook channel can route callbacks"
+        );
+    }
+
+    #[tokio::test]
+    async fn webhook_announce_job_persists_thread_id() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = test_config(&tmp).await;
+        let tool = CronAddTool::new(cfg.clone(), test_security(&cfg));
+        let result = tool
+            .execute(json!({
+                "schedule": { "kind": "cron", "expr": "*/5 * * * *" },
+                "job_type": "shell",
+                "command": "echo ok",
+                "delivery": {
+                    "mode": "announce",
+                    "channel": "webhook",
+                    "to": "user-42",
+                    "thread_id": "conv-99",
+                    "best_effort": true
+                }
+            }))
+            .await
+            .unwrap();
+
+        assert!(result.success, "{:?}", result.error);
+
+        let jobs = cron::list_jobs(&cfg).unwrap();
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(jobs[0].delivery.mode, "announce");
+        assert_eq!(jobs[0].delivery.channel.as_deref(), Some("webhook"));
+        assert_eq!(jobs[0].delivery.to.as_deref(), Some("user-42"));
+        assert_eq!(jobs[0].delivery.thread_id.as_deref(), Some("conv-99"));
+        assert!(jobs[0].delivery.best_effort);
     }
 
     #[test]

--- a/crates/zeroclaw-runtime/src/tools/cron_run.rs
+++ b/crates/zeroclaw-runtime/src/tools/cron_run.rs
@@ -123,8 +123,14 @@ impl Tool for CronRunTool {
         if job.delivery.mode.eq_ignore_ascii_case("announce")
             && let (Some(channel), Some(target)) =
                 (job.delivery.channel.as_deref(), job.delivery.to.as_deref())
-            && let Err(e) =
-                cron::scheduler::deliver_announcement(&self.config, channel, target, &output).await
+            && let Err(e) = cron::scheduler::deliver_announcement(
+                &self.config,
+                channel,
+                target,
+                job.delivery.thread_id.as_deref(),
+                &output,
+            )
+            .await
         {
             if job.delivery.best_effort {
                 tracing::warn!(

--- a/crates/zeroclaw-runtime/src/tools/cron_update.rs
+++ b/crates/zeroclaw-runtime/src/tools/cron_update.rs
@@ -138,12 +138,16 @@ impl Tool for CronUpdateTool {
                                 },
                                 "channel": {
                                     "type": "string",
-                                    "enum": ["telegram", "discord", "slack", "mattermost", "matrix"],
+                                    "enum": ["telegram", "discord", "slack", "mattermost", "matrix", "qq", "webhook"],
                                     "description": "Channel type to deliver output to"
                                 },
                                 "to": {
                                     "type": "string",
-                                    "description": "Destination ID: Discord channel ID, Telegram chat ID, Slack channel name, etc."
+                                    "description": "Destination ID: Discord channel ID, Telegram chat ID, Slack channel name, webhook recipient, etc."
+                                },
+                                "thread_id": {
+                                    "type": "string",
+                                    "description": "Optional thread/conversation identifier. Used by the webhook channel to route callbacks to the originating conversation; ignored by channels whose threading is implied by `to`."
                                 },
                                 "best_effort": {
                                     "type": "boolean",
@@ -462,9 +466,27 @@ mod tests {
             .as_array()
             .expect("patch.delivery.channel must have an enum");
         let channel_strs: Vec<&str> = channel_enum.iter().filter_map(|v| v.as_str()).collect();
-        for ch in &["telegram", "discord", "slack", "mattermost", "matrix"] {
+        for ch in &[
+            "telegram",
+            "discord",
+            "slack",
+            "mattermost",
+            "matrix",
+            "qq",
+            "webhook",
+        ] {
             assert!(channel_strs.contains(ch), "delivery.channel missing: {ch}");
         }
+
+        // patch.delivery exposes thread_id so the webhook channel can route callbacks
+        // back to the originating conversation.
+        let delivery_props = schema["properties"]["patch"]["properties"]["delivery"]["properties"]
+            .as_object()
+            .expect("patch.delivery must have properties");
+        assert!(
+            delivery_props.contains_key("thread_id"),
+            "patch.delivery missing thread_id"
+        );
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1505,10 +1505,10 @@ async fn main() -> Result<()> {
         // registered"). `register_delivery_fn` is idempotent (backed by
         // `OnceLock::set`), so calling it once here is safe.
         zeroclaw_runtime::cron::scheduler::register_delivery_fn(Box::new(
-            |config, channel, target, output| {
+            |config, channel, target, thread_id, output| {
                 Box::pin(async move {
                     zeroclaw_channels::orchestrator::deliver_announcement(
-                        &config, &channel, &target, &output,
+                        &config, &channel, &target, thread_id, &output,
                     )
                     .await
                 })


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `orchestrator::deliver_announcement` now chains `.in_thread(thread_id.clone())` on every `SendMessage::new` call — both the live-registry fast path and each per-channel fallback. Without this, cron-announce sends always set `thread_ts = None`, and the webhook channel stripped `thread_id` from the outbound JSON. Downstream services routing on `thread_id` discarded those callbacks.
  - `DeliveryConfig` (`cron/types.rs`) and `DeliveryConfigDecl` (`config/schema.rs`) gain an optional `thread_id: Option<String>` field, threaded through `convert_delivery_decl`, the `DeliveryFn` typedef, `deliver_if_configured`, all `deliver_announcement` callers (cron_run tool, gateway api, daemon deadman/heartbeat, main wiring), and the orchestrator entry point.
  - The per-message cron hint inside `build_channel_system_prompt` is now channel-aware: for webhook it recommends `to: <sender>, thread_id: <reply_target>`; for everything else it keeps `to: <reply_target>` exactly as before. The webhook channel is the one whose outbound JSON has *both* fields and whose receivers route on `thread_id`; for other channels `reply_target` already names the destination room/chat and threading semantics are handled by the channel itself.

- **Scope boundary:**
  - This PR does not touch the inbound webhook path, the non-cron reply paths, `notify_no_reply`, or any other channel's send code. Those already carry `thread_ts` correctly today.
  - Only the webhook-channel hint string changes; other channels' cron hints are byte-identical to master.

- **Blast radius:**
  - `DeliveryConfig` is persisted as a JSON blob in the existing `delivery` sqlite column (`cron/store.rs`). `#[serde(default, skip_serializing_if = "Option::is_none")]` keeps old rows readable as `None` and old serialisations omit the field, so this is a transparent schema extension.
  - The `DeliveryFn` typedef gains an extra `Option<String>` parameter. The only registrant is `src/main.rs`, updated in this PR. External binaries that re-implement `register_delivery_fn` (none in-tree, but worth flagging for downstream consumers) would need to update the closure signature.

- **Linked issue(s):** Fixes #6634

- **Labels:** `bug`, `risk: medium` (touches the cron delivery hot path + a public `DeliveryConfig` field), expected auto `size: S`.

## Validation Evidence (required)

```bash
CARGO_TARGET_DIR=/Users/maks/zeroclaw-fix-target cargo fmt --all -- --check
CARGO_TARGET_DIR=/Users/maks/zeroclaw-fix-target cargo clippy --all-targets \
  -p zeroclaw-runtime -p zeroclaw-channels -p zeroclaw-gateway -p zeroclaw-config \
  -- -D warnings
CARGO_TARGET_DIR=/Users/maks/zeroclaw-fix-target cargo test --lib \
  -p zeroclaw-channels build_channel_system_prompt
CARGO_TARGET_DIR=/Users/maks/zeroclaw-fix-target cargo test --lib \
  -p zeroclaw-runtime cron::
CARGO_TARGET_DIR=/Users/maks/zeroclaw-fix-target cargo check --workspace --tests
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check`: clean after applying suggested format on the two touched files.
  - `cargo clippy ...`: `Finished dev profile in 58.72s`, no warnings.
  - `cargo test ... build_channel_system_prompt`: `test result: ok. 5 passed; 0 failed; 0 ignored` — three existing tests still pass, two new tests (`build_channel_system_prompt_webhook_cron_hint_carries_thread_id`, `build_channel_system_prompt_non_webhook_cron_hint_keeps_to_as_reply_target`) cover both branches of the channel-aware hint.
  - `cargo test ... cron::`: `test result: ok. 94 passed; 0 failed; 0 ignored` — every cron-module test (including the announce-delivery persistence tests that construct `DeliveryConfig` literals) still passes.
  - `cargo check --workspace --tests`: `Finished dev profile in 1m 24s`, no errors across the workspace.
- **Beyond CI — what did you manually verify?**
  - Traced every caller of `deliver_announcement` and confirmed each now passes either the cron's `delivery.thread_id` or `None` (for deadman/heartbeat, which have no thread context).
  - Spot-checked the webhook outbound payload shape (`crates/zeroclaw-channels/src/webhook.rs:120-135`) to confirm `thread_id` is now serialised when present.
- **If any command was intentionally skipped, why:** `cargo test --workspace` was skipped to keep iteration time bounded; instead I ran the two crates the diff touches plus the broader workspace `cargo check --tests`. If maintainers want a full `cargo test --workspace` run before merge, happy to oblige in a comment.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No** — same webhook POST, additional populated field.
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No** — the issue's redacted UUIDs are not reproduced here; the new tests use placeholder identifiers.

## Compatibility (required)

- Backward compatible? **Yes** — both at the persisted-config layer (serde defaults absorb old rows / old JSON) and at the LLM tool-args layer (existing cron jobs continue to work; `thread_id` is optional).
- Config / env / CLI surface changed? **Yes (additive only)** — `DeliveryConfigDecl` accepts a new optional `thread_id` key in `[cron.jobs.<id>.delivery]`. Existing configs without the key keep their current behavior. Tool callers (`cron_add`, gateway `POST /api/cron`) can now pass `delivery.thread_id`; omitting it preserves master behavior on every channel except webhook, where the system-prompt hint already wires it correctly.
- If `No` or `Yes` to either: exact upgrade steps for existing users: **None required.**

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <merge-sha>`. The change is contained in nine files and additive at the schema level.
- **Feature flags or config toggles:** None — the channel-aware hint is unconditional. If maintainers prefer this gated, happy to add a `cron.webhook_threaded_hints` toggle in a follow-up.
- **Observable failure symptoms:**
  - Pre-fix: downstream webhook services log "callback missing thread_id" and discard the message (this PR's repro).
  - Post-fix regression would surface as: cron-announce sends on non-webhook channels suddenly include an unexpected `thread_id` payload (would have to come from a future `delivery.thread_id` set on a non-webhook job). Grep ZeroClaw logs for `Failed to send message via` or downstream-channel-specific receipt failures.
