### PR TITLE
feat(browser): add agent-browser headed config

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -5622,6 +5622,9 @@ pub struct BrowserConfig {
     /// Browser automation backend: "agent_browser" | "rust_native" | "computer_use" | "auto"
     #[serde(default = "default_browser_backend")]
     pub backend: String,
+    /// Show browser window for agent_browser backend. When unset, inherits AGENT_BROWSER_HEADED.
+    #[serde(default)]
+    pub headed: Option<bool>,
     /// Headless mode for rust-native backend
     #[serde(default = "default_true")]
     pub native_headless: bool,
@@ -5656,6 +5659,7 @@ impl Default for BrowserConfig {
             allowed_domains: vec!["*".into()],
             session_name: None,
             backend: default_browser_backend(),
+            headed: None,
             native_headless: default_true(),
             native_webdriver_url: default_browser_webdriver_url(),
             native_chrome_path: None,
@@ -17850,6 +17854,7 @@ default_temperature = 0.7
         assert!(b.enabled);
         assert_eq!(b.allowed_domains, vec!["*".to_string()]);
         assert_eq!(b.backend, "agent_browser");
+        assert_eq!(b.headed, None);
         assert!(b.native_headless);
         assert_eq!(b.native_webdriver_url, "http://127.0.0.1:9515");
         assert!(b.native_chrome_path.is_none());
@@ -17868,6 +17873,7 @@ default_temperature = 0.7
             allowed_domains: vec!["example.com".into(), "docs.example.com".into()],
             session_name: None,
             backend: "auto".into(),
+            headed: Some(true),
             native_headless: false,
             native_webdriver_url: "http://localhost:4444".into(),
             native_chrome_path: Some("/usr/bin/chromium".into()),
@@ -17887,6 +17893,7 @@ default_temperature = 0.7
         assert_eq!(parsed.allowed_domains.len(), 2);
         assert_eq!(parsed.allowed_domains[0], "example.com");
         assert_eq!(parsed.backend, "auto");
+        assert_eq!(parsed.headed, Some(true));
         assert!(!parsed.native_headless);
         assert_eq!(parsed.native_webdriver_url, "http://localhost:4444");
         assert_eq!(
@@ -17903,6 +17910,21 @@ default_temperature = 0.7
         assert_eq!(parsed.computer_use.window_allowlist.len(), 2);
         assert_eq!(parsed.computer_use.max_coordinate_x, Some(3840));
         assert_eq!(parsed.computer_use.max_coordinate_y, Some(2160));
+    }
+
+    #[test]
+    async fn browser_config_parses_headed_true() {
+        let parsed: BrowserConfig = toml::from_str(
+            r#"
+backend = "agent_browser"
+headed = true
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(parsed.backend, "agent_browser");
+        assert_eq!(parsed.headed, Some(true));
+        assert!(parsed.native_headless);
     }
 
     #[test]

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -574,6 +574,7 @@ pub fn all_tools_with_runtime(
                 browser_config.allowed_domains.clone(),
                 browser_config.session_name.clone(),
                 browser_config.backend.clone(),
+                browser_config.headed,
                 browser_config.native_headless,
                 browser_config.native_webdriver_url.clone(),
                 browser_config.native_chrome_path.clone(),

--- a/crates/zeroclaw-tools/src/browser.rs
+++ b/crates/zeroclaw-tools/src/browser.rs
@@ -62,6 +62,7 @@ pub struct BrowserTool {
     allowed_domains: Vec<String>,
     session_name: Option<String>,
     backend: String,
+    headed: Option<bool>,
     #[allow(dead_code)] // read only with browser-native feature
     native_headless: bool,
     #[allow(dead_code)]
@@ -209,6 +210,7 @@ impl BrowserTool {
             allowed_domains,
             session_name,
             "agent_browser".into(),
+            None,
             true,
             "http://127.0.0.1:9515".into(),
             None,
@@ -222,6 +224,7 @@ impl BrowserTool {
         allowed_domains: Vec<String>,
         session_name: Option<String>,
         backend: String,
+        headed: Option<bool>,
         native_headless: bool,
         native_webdriver_url: String,
         native_chrome_path: Option<String>,
@@ -232,6 +235,7 @@ impl BrowserTool {
             allowed_domains: normalize_domains(allowed_domains),
             session_name,
             backend,
+            headed,
             native_headless,
             native_webdriver_url,
             native_chrome_path,
@@ -463,23 +467,7 @@ impl BrowserTool {
 
     /// Execute an agent-browser command
     async fn run_command(&self, args: &[&str]) -> anyhow::Result<AgentBrowserResponse> {
-        let agent_browser_bin = if cfg!(target_os = "windows") {
-            "agent-browser.cmd"
-        } else {
-            "agent-browser"
-        };
-        let mut cmd = Command::new(agent_browser_bin);
-
-        // When running as a service (systemd/OpenRC), the process may lack
-        // HOME which browsers need for profile directories.
-        if is_service_environment() {
-            ensure_browser_env(&mut cmd);
-        }
-
-        // Add session if configured
-        if let Some(ref session) = self.session_name {
-            cmd.arg("--session").arg(session);
-        }
+        let mut cmd = self.agent_browser_command();
 
         // Add --json for machine-readable output
         cmd.args(args).arg("--json");
@@ -526,6 +514,38 @@ impl BrowserTool {
                 error: Some(stderr.trim().to_string()),
             })
         }
+    }
+
+    fn agent_browser_command(&self) -> Command {
+        let agent_browser_bin = if cfg!(target_os = "windows") {
+            "agent-browser.cmd"
+        } else {
+            "agent-browser"
+        };
+        let mut cmd = Command::new(agent_browser_bin);
+
+        match self.headed {
+            Some(true) => {
+                cmd.env("AGENT_BROWSER_HEADED", "1");
+            }
+            Some(false) => {
+                cmd.env_remove("AGENT_BROWSER_HEADED");
+            }
+            None => {}
+        }
+
+        // When running as a service (systemd/OpenRC), the process may lack
+        // HOME which browsers need for profile directories.
+        if is_service_environment() {
+            ensure_browser_env(&mut cmd);
+        }
+
+        // Add session if configured
+        if let Some(ref session) = self.session_name {
+            cmd.arg("--session").arg(session);
+        }
+
+        cmd
     }
 
     /// Execute a browser action via agent-browser CLI
@@ -2511,6 +2531,75 @@ mod tests {
     }
 
     #[test]
+    fn agent_browser_command_inherits_headed_env_by_default() {
+        let headed_key = std::ffi::OsStr::new("AGENT_BROWSER_HEADED");
+        let security = Arc::new(SecurityPolicy::default());
+        let tool = BrowserTool::new(security, vec!["example.com".into()], None);
+        let cmd = tool.agent_browser_command();
+
+        assert_eq!(
+            cmd.as_std()
+                .get_envs()
+                .find(|(key, _)| *key == headed_key)
+                .map(|(_, value)| value),
+            None
+        );
+    }
+
+    #[test]
+    fn agent_browser_command_clears_headed_env_when_configured_false() {
+        let headed_key = std::ffi::OsStr::new("AGENT_BROWSER_HEADED");
+        let security = Arc::new(SecurityPolicy::default());
+        let tool = BrowserTool::new_with_backend(
+            security,
+            vec!["example.com".into()],
+            None,
+            "agent_browser".into(),
+            Some(false),
+            true,
+            "http://127.0.0.1:9515".into(),
+            None,
+            ComputerUseConfig::default(),
+        );
+        let cmd = tool.agent_browser_command();
+
+        assert_eq!(
+            cmd.as_std()
+                .get_envs()
+                .find(|(key, _)| *key == headed_key)
+                .map(|(_, value)| value),
+            Some(None)
+        );
+    }
+
+    #[test]
+    fn agent_browser_command_sets_headed_env_when_configured() {
+        let headed_key = std::ffi::OsStr::new("AGENT_BROWSER_HEADED");
+        let security = Arc::new(SecurityPolicy::default());
+        let tool = BrowserTool::new_with_backend(
+            security,
+            vec!["example.com".into()],
+            None,
+            "agent_browser".into(),
+            Some(true),
+            true,
+            "http://127.0.0.1:9515".into(),
+            None,
+            ComputerUseConfig::default(),
+        );
+        let cmd = tool.agent_browser_command();
+
+        assert_eq!(
+            cmd.as_std()
+                .get_envs()
+                .find(|(key, _)| *key == headed_key)
+                .and_then(|(_, value)| value)
+                .and_then(|value| value.to_str()),
+            Some("1")
+        );
+    }
+
+    #[test]
     fn browser_tool_accepts_auto_backend_config() {
         let security = Arc::new(SecurityPolicy::default());
         let tool = BrowserTool::new_with_backend(
@@ -2518,6 +2607,7 @@ mod tests {
             vec!["example.com".into()],
             None,
             "auto".into(),
+            None,
             true,
             "http://127.0.0.1:9515".into(),
             None,
@@ -2534,6 +2624,7 @@ mod tests {
             vec!["example.com".into()],
             None,
             "computer_use".into(),
+            None,
             true,
             "http://127.0.0.1:9515".into(),
             None,
@@ -2553,6 +2644,7 @@ mod tests {
             vec!["example.com".into()],
             None,
             "computer_use".into(),
+            None,
             true,
             "http://127.0.0.1:9515".into(),
             None,
@@ -2573,6 +2665,7 @@ mod tests {
             vec!["example.com".into()],
             None,
             "computer_use".into(),
+            None,
             true,
             "http://127.0.0.1:9515".into(),
             None,
@@ -2594,6 +2687,7 @@ mod tests {
             vec!["example.com".into()],
             None,
             "computer_use".into(),
+            None,
             true,
             "http://127.0.0.1:9515".into(),
             None,

--- a/docs/book/src/tools/browser.md
+++ b/docs/book/src/tools/browser.md
@@ -34,6 +34,8 @@ zeroclaw config set browser.allowed-domains '["example.com", "docs.example.com"]
 zeroclaw config set browser.enabled false
 ```
 
+For the `agent_browser` backend, set `browser.headed = true` to launch the browser in headed mode for debugging or first-time login setup, or `browser.headed = false` to force headless mode. When `browser.headed` is unset, Zeroclaw preserves the inherited `AGENT_BROWSER_HEADED` environment behavior. The rust-native backend continues to use `browser.native_headless`.
+
 See the [Config reference](../reference/config.md) for all browser fields and defaults.
 
 ### 3. Test


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Adds an optional `[browser].headed` config field for the `agent_browser` backend.
  - Lets users run `agent_browser` in headed mode for debugging or first-time login setup without launching Zeroclaw with a process-level environment override.
  - Preserves existing `AGENT_BROWSER_HEADED` inheritance when `browser.headed` is unset.
  - Keeps `browser.native_headless` scoped to the rust-native backend.
- **Scope boundary:**
  - Does not change rust-native browser behavior.
  - Does not change computer-use backend behavior.
  - Does not change domain allowlists, SSRF protections, or browser action semantics.
  - Does not add a CLI flag.
- **Blast radius:**
  - `[browser]` config parsing/schema.
  - Runtime browser-tool registration.
  - `agent-browser` subprocess environment handling.
  - Browser tool documentation.
- **Linked issue(s):** Closes #6241.
- **Labels:** `size: S`, `risk: medium`, `docs`, `config`, `runtime`, `tool`, `tool:browser`.

## Validation Evidence

- **Commands run and tail output:**

```text
cargo fmt --check
Result: PASS
Tail:
<no output>

git diff --check origin/master...HEAD
Result: PASS
Tail:
<no output>

cargo test -p zeroclaw-config browser_config
Result: PASS
Tail:
running 4 tests
test schema::tests::browser_config_default_enabled ... ok
test schema::tests::browser_config_backward_compat_missing_section ... ok
test schema::tests::browser_config_serde_roundtrip ... ok
test schema::tests::browser_config_parses_headed_true ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 635 filtered out; finished in 0.02s

cargo test -p zeroclaw-tools agent_browser_command
Result: PASS
Tail:
running 3 tests
test browser::tests::agent_browser_command_sets_headed_env_when_configured ... ok
test browser::tests::agent_browser_command_clears_headed_env_when_configured_false ... ok
test browser::tests::agent_browser_command_inherits_headed_env_by_default ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 1160 filtered out; finished in 0.00s

cargo test -p zeroclaw-runtime all_tools_includes_browser_when_enabled
Result: PASS
Tail:
running 1 test
test tools::tests::all_tools_includes_browser_when_enabled ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1701 filtered out; finished in 0.02s

cargo test -p zeroclaw-runtime all_tools_excludes_browser_when_disabled
Result: PASS
Tail:
running 1 test
test tools::tests::all_tools_excludes_browser_when_disabled ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1701 filtered out; finished in 0.03s
```

- **Beyond CI — what did you manually verify?** The diff shows `BrowserConfig::headed` defaults to `None`, TOML parsing accepts `headed = true`, runtime tool construction passes the option into `BrowserTool`, and `agent_browser_command()` preserves unset env inheritance, sets `AGENT_BROWSER_HEADED=1` for `true`, and removes it for `false`.
- **If any command was intentionally skipped, why:** `cargo clippy --all-targets -- -D warnings` and full `cargo test` were not run locally for this focused config/tool change. The current GitHub Quality Gate is green on this head, including Lint, Test, Security, and CI Required Gate.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? `Yes`. This adds a config-level way to request headed `agent_browser`; it does not broaden file-system scope, domain allowlists, SSRF policy, or browser action permissions.
- New external network calls? `No`.
- Secrets / tokens / credentials handling changed? `No`.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`.
- If any `Yes`, describe the risk and mitigation: `browser.headed = true` can show active browser UI on the host display. The behavior is opt-in, documented, and scoped to the existing `agent_browser` backend.

## Compatibility

- Backward compatible? `Yes`.
- Config / env / CLI surface changed? `Yes`. This adds optional `[browser].headed`.
- If `No` or `Yes` to either: No upgrade is required. Missing `browser.headed` preserves existing inherited `AGENT_BROWSER_HEADED` behavior; `browser.headed = true` forces headed mode for the spawned `agent-browser` command; `browser.headed = false` removes inherited headed mode to force headless behavior. The rust-native backend remains controlled by `browser.native_headless`.

## Rollback

- **Fast rollback command/path:** Revert the PR commit.
- **Feature flags or config toggles:** Remove `browser.headed` to return to inherited environment behavior, or set `browser.headed = false` to force headless mode without reverting.
- **Observable failure symptoms:** `agent-browser` launches with the wrong headed/headless behavior for a configured `[browser]` section; inspect browser tool behavior and `AGENT_BROWSER_HEADED` subprocess environment handling.
