### PR TITLE
perf(cron): persist run results in one transaction

### DIFF
--- a/crates/zeroclaw-runtime/src/cron/scheduler.rs
+++ b/crates/zeroclaw-runtime/src/cron/scheduler.rs
@@ -1,7 +1,7 @@
+use crate::cron::store::{RunCompletionAction, persist_run_completion_state, persist_run_result};
 use crate::cron::{
-    CronJob, CronJobPatch, DeliveryConfig, JobType, Schedule, SessionTarget, all_overdue_jobs,
-    due_jobs, next_run_for_schedule, record_last_run_with_status, record_run, remove_job,
-    reschedule_after_run_with_status, sync_declarative_jobs, update_job,
+    CronJob, DeliveryConfig, JobType, Schedule, SessionTarget, all_overdue_jobs, due_jobs,
+    next_run_for_schedule, sync_declarative_jobs,
 };
 use crate::security::SecurityPolicy;
 use anyhow::Result;
@@ -408,56 +408,61 @@ async fn persist_job_result(
         }
     }
 
-    let _ = record_run(
+    let action = if is_one_shot_auto_delete(job) && success {
+        RunCompletionAction::Delete
+    } else if matches!(job.schedule, Schedule::At { .. }) {
+        RunCompletionAction::Disable
+    } else {
+        RunCompletionAction::Reschedule
+    };
+
+    let job_state_at = Utc::now();
+    if let Err(e) = persist_run_result(
         config,
-        &job.id,
+        job,
         started_at,
         finished_at,
+        job_state_at,
         &persisted_status,
         Some(&persisted_output),
         duration_ms,
-    );
+        action,
+    ) {
+        tracing::warn!("Failed to persist scheduler run result: {e}");
 
-    if is_one_shot_auto_delete(job) {
-        if success {
-            if let Err(e) = remove_job(config, &job.id) {
-                tracing::warn!("Failed to remove one-shot cron job after success: {e}");
-                // Fall back to disabling the job so it won't re-trigger.
-                let _ = update_job(
-                    config,
-                    &job.id,
-                    CronJobPatch {
-                        enabled: Some(false),
-                        ..CronJobPatch::default()
-                    },
+        if action == RunCompletionAction::Delete {
+            // Best-effort fallback for the legacy behavior: a successful
+            // auto-delete one-shot should not be picked up again if the
+            // combined history+state transaction fails while inserting or
+            // pruning the run row.
+            if let Err(disable_err) = persist_run_completion_state(
+                config,
+                job,
+                job_state_at,
+                &persisted_status,
+                Some(&persisted_output),
+                RunCompletionAction::Disable,
+            ) {
+                tracing::warn!(
+                    "Failed to disable one-shot cron job after history persistence failure: {disable_err}"
                 );
             }
         } else {
-            let _ = record_last_run_with_status(
+            // For recurring jobs and non-delete one-shots, keep the scheduler
+            // moving even if run-history persistence fails.
+            if let Err(state_err) = persist_run_completion_state(
                 config,
-                &job.id,
-                finished_at,
+                job,
+                job_state_at,
                 &persisted_status,
-                &persisted_output,
-            );
-            if let Err(e) = update_job(
-                config,
-                &job.id,
-                CronJobPatch {
-                    enabled: Some(false),
-                    ..CronJobPatch::default()
-                },
+                Some(&persisted_output),
+                action,
             ) {
-                tracing::warn!("Failed to disable failed one-shot cron job: {e}");
+                tracing::warn!(
+                    "Failed to update cron job state after history persistence failure: {state_err}"
+                );
             }
         }
-        return success;
-    }
-
-    if let Err(e) =
-        reschedule_after_run_with_status(config, job, &persisted_status, &persisted_output)
-    {
-        tracing::warn!("Failed to persist scheduler run result: {e}");
     }
 
     success
@@ -1111,6 +1116,85 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn persist_job_result_uses_one_write_connection_for_recurring_job() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(&tmp).await;
+        let job = cron::add_job(&config, "*/5 * * * *", "echo ok").unwrap();
+        let started = Utc::now();
+        let finished = started + ChronoDuration::milliseconds(10);
+
+        crate::cron::store::reset_write_connection_count_for_tests(&config);
+        let success = persist_job_result(&config, &job, true, "ok", started, finished).await;
+
+        assert!(success);
+        assert_eq!(
+            crate::cron::store::write_connection_count_for_tests(&config),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn persist_job_result_prunes_run_history_and_updates_last_fields() {
+        let tmp = TempDir::new().unwrap();
+        let mut config = test_config(&tmp).await;
+        config.cron.max_run_history = 2;
+        let job = cron::add_job(&config, "*/5 * * * *", "echo ok").unwrap();
+        let base = Utc::now();
+
+        for idx in 0..3 {
+            let started = base + ChronoDuration::seconds(idx);
+            let finished = started + ChronoDuration::milliseconds(10);
+            let output = format!("run-{idx}");
+
+            let success = persist_job_result(&config, &job, true, &output, started, finished).await;
+            assert!(success);
+        }
+
+        let runs = cron::list_runs(&config, &job.id, 10).unwrap();
+        assert_eq!(runs.len(), 2);
+        assert_eq!(runs[0].output.as_deref(), Some("run-2"));
+        assert_eq!(runs[1].output.as_deref(), Some("run-1"));
+
+        let updated = cron::get_job(&config, &job.id).unwrap();
+        assert_eq!(updated.last_status.as_deref(), Some("ok"));
+        assert_eq!(updated.last_output.as_deref(), Some("run-2"));
+        assert!(updated.last_run.is_some());
+    }
+
+    #[tokio::test]
+    async fn persist_job_result_rolls_back_run_history_when_job_state_update_fails() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(&tmp).await;
+        let job = cron::add_job(&config, "*/5 * * * *", "echo ok").unwrap();
+        let original_next_run = job.next_run;
+        let started = Utc::now();
+        let finished = started + ChronoDuration::milliseconds(10);
+
+        let conn =
+            rusqlite::Connection::open(config.workspace_dir.join("cron").join("jobs.db")).unwrap();
+        conn.execute_batch(
+            "CREATE TRIGGER fail_cron_job_update
+             BEFORE UPDATE ON cron_jobs
+             BEGIN
+                 SELECT RAISE(ABORT, 'blocked update');
+             END;",
+        )
+        .unwrap();
+        drop(conn);
+
+        let success = persist_job_result(&config, &job, true, "ok", started, finished).await;
+
+        assert!(success);
+        assert!(cron::list_runs(&config, &job.id, 10).unwrap().is_empty());
+
+        let stored = cron::get_job(&config, &job.id).unwrap();
+        assert_eq!(stored.next_run, original_next_run);
+        assert!(stored.last_run.is_none());
+        assert!(stored.last_status.is_none());
+        assert!(stored.last_output.is_none());
+    }
+
+    #[tokio::test]
     async fn persist_job_result_success_deletes_one_shot() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(&tmp).await;
@@ -1161,6 +1245,119 @@ mod tests {
         let updated = cron::get_job(&config, &job.id).unwrap();
         assert!(!updated.enabled);
         assert_eq!(updated.last_status.as_deref(), Some("error"));
+    }
+
+    #[tokio::test]
+    async fn persist_job_result_uses_one_write_connection_for_failed_one_shot_disable() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(&tmp).await;
+        let at = Utc::now() + ChronoDuration::minutes(10);
+        let job = cron::add_agent_job(
+            &config,
+            Some("one-shot".into()),
+            crate::cron::Schedule::At { at },
+            "Hello",
+            SessionTarget::Isolated,
+            None,
+            None,
+            true,
+            None,
+        )
+        .unwrap();
+        let started = Utc::now();
+        let finished = started + ChronoDuration::milliseconds(10);
+
+        crate::cron::store::reset_write_connection_count_for_tests(&config);
+        let success = persist_job_result(&config, &job, false, "boom", started, finished).await;
+
+        assert!(!success);
+        assert_eq!(
+            crate::cron::store::write_connection_count_for_tests(&config),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn persist_job_result_falls_back_to_state_update_when_history_prune_fails() {
+        let tmp = TempDir::new().unwrap();
+        let mut config = test_config(&tmp).await;
+        config.cron.max_run_history = 1;
+        let job = cron::add_job(&config, "*/5 * * * *", "echo ok").unwrap();
+        let original_next_run = job.next_run;
+        let seed_started = Utc::now() - ChronoDuration::minutes(20);
+        let seed_finished = seed_started + ChronoDuration::milliseconds(10);
+        let started = Utc::now();
+        let finished = started + ChronoDuration::milliseconds(10);
+
+        let conn =
+            rusqlite::Connection::open(config.workspace_dir.join("cron").join("jobs.db")).unwrap();
+        conn.execute(
+            "INSERT INTO cron_runs (job_id, started_at, finished_at, status, output, duration_ms)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            rusqlite::params![
+                job.id,
+                seed_started.to_rfc3339(),
+                seed_finished.to_rfc3339(),
+                "seed",
+                "seed",
+                10,
+            ],
+        )
+        .unwrap();
+        conn.execute_batch(
+            "CREATE TRIGGER fail_cron_run_prune
+             BEFORE DELETE ON cron_runs
+             BEGIN
+                 SELECT RAISE(ABORT, 'blocked prune');
+             END;",
+        )
+        .unwrap();
+        drop(conn);
+
+        let success = persist_job_result(&config, &job, true, "ok", started, finished).await;
+        assert!(success);
+
+        let runs = cron::list_runs(&config, &job.id, 10).unwrap();
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].status, "seed");
+
+        let updated = cron::get_job(&config, &job.id).unwrap();
+        assert_eq!(updated.last_status.as_deref(), Some("ok"));
+        assert_eq!(updated.last_output.as_deref(), Some("ok"));
+        assert!(updated.last_run.is_some());
+        assert!(updated.next_run >= original_next_run);
+    }
+
+    #[tokio::test]
+    async fn persist_job_result_falls_back_to_disable_when_auto_delete_history_insert_fails() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(&tmp).await;
+        let at = Utc::now() + ChronoDuration::minutes(10);
+        let job = cron::add_once_at(&config, at, "echo one-shot-shell").unwrap();
+        assert!(job.delete_after_run);
+        let started = Utc::now();
+        let finished = started + ChronoDuration::milliseconds(10);
+
+        let conn =
+            rusqlite::Connection::open(config.workspace_dir.join("cron").join("jobs.db")).unwrap();
+        conn.execute_batch(
+            "CREATE TRIGGER fail_cron_run_insert
+             BEFORE INSERT ON cron_runs
+             BEGIN
+                 SELECT RAISE(ABORT, 'blocked insert');
+             END;",
+        )
+        .unwrap();
+        drop(conn);
+
+        let success = persist_job_result(&config, &job, true, "ok", started, finished).await;
+        assert!(success);
+
+        let updated = cron::get_job(&config, &job.id).unwrap();
+        assert!(!updated.enabled);
+        assert_eq!(updated.last_status.as_deref(), Some("ok"));
+        assert_eq!(updated.last_output.as_deref(), Some("ok"));
+        assert!(cron::list_runs(&config, &job.id, 10).unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-runtime/src/cron/store.rs
+++ b/crates/zeroclaw-runtime/src/cron/store.rs
@@ -12,6 +12,34 @@ use zeroclaw_config::schema::Config;
 const MAX_CRON_OUTPUT_BYTES: usize = 16 * 1024;
 const TRUNCATED_OUTPUT_MARKER: &str = "\n...[truncated]";
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum RunCompletionAction {
+    Reschedule,
+    Disable,
+    Delete,
+}
+
+#[cfg(test)]
+static WRITE_CONNECTION_COUNTS_FOR_TESTS: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::HashMap<std::path::PathBuf, usize>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+
+#[cfg(test)]
+pub(crate) fn reset_write_connection_count_for_tests(config: &Config) {
+    let mut counts = WRITE_CONNECTION_COUNTS_FOR_TESTS
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    counts.insert(cron_db_path(config), 0);
+}
+
+#[cfg(test)]
+pub(crate) fn write_connection_count_for_tests(config: &Config) -> usize {
+    let counts = WRITE_CONNECTION_COUNTS_FOR_TESTS
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    counts.get(&cron_db_path(config)).copied().unwrap_or(0)
+}
+
 impl rusqlite::types::FromSql for JobType {
     fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
         let text = value.as_str()?;
@@ -430,38 +458,124 @@ pub fn record_run(
         // cannot grow unboundedly.
         let tx = conn.unchecked_transaction()?;
 
-        tx.execute(
-            "INSERT INTO cron_runs (job_id, started_at, finished_at, status, output, duration_ms)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-            params![
-                job_id,
-                started_at.to_rfc3339(),
-                finished_at.to_rfc3339(),
-                status,
-                bounded_output.as_deref(),
-                duration_ms,
-            ],
-        )
-        .context("Failed to insert cron run")?;
-
-        let keep = i64::from(config.cron.max_run_history.max(1));
-        tx.execute(
-            "DELETE FROM cron_runs
-             WHERE job_id = ?1
-               AND id NOT IN (
-                 SELECT id FROM cron_runs
-                 WHERE job_id = ?1
-                 ORDER BY started_at DESC, id DESC
-                 LIMIT ?2
-               )",
-            params![job_id, keep],
-        )
-        .context("Failed to prune cron run history")?;
+        insert_run_and_prune(
+            &tx,
+            config,
+            job_id,
+            started_at,
+            finished_at,
+            status,
+            bounded_output.as_deref(),
+            duration_ms,
+        )?;
 
         tx.commit()
             .context("Failed to commit cron run transaction")?;
         Ok(())
     })
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn persist_run_result(
+    config: &Config,
+    job: &CronJob,
+    started_at: DateTime<Utc>,
+    finished_at: DateTime<Utc>,
+    job_state_at: DateTime<Utc>,
+    status: &str,
+    output: Option<&str>,
+    duration_ms: i64,
+    action: RunCompletionAction,
+) -> Result<()> {
+    let bounded_output = output.map(truncate_cron_output);
+
+    with_initialized_connection(config, |conn| {
+        let tx = conn.unchecked_transaction()?;
+
+        insert_run_and_prune(
+            &tx,
+            config,
+            &job.id,
+            started_at,
+            finished_at,
+            status,
+            bounded_output.as_deref(),
+            duration_ms,
+        )?;
+
+        apply_run_completion_state(
+            &tx,
+            job,
+            job_state_at,
+            status,
+            bounded_output.as_deref(),
+            action,
+        )?;
+
+        tx.commit()
+            .context("Failed to commit cron run result transaction")?;
+        Ok(())
+    })
+}
+
+/// Persist only the job-state side of a completed cron run.
+///
+/// This is intentionally separate from `persist_run_result` so the scheduler
+/// can recover job state even when run-history persistence fails. The SQL
+/// mutation itself stays in the store layer.
+pub(crate) fn persist_run_completion_state(
+    config: &Config,
+    job: &CronJob,
+    job_state_at: DateTime<Utc>,
+    status: &str,
+    output: Option<&str>,
+    action: RunCompletionAction,
+) -> Result<()> {
+    with_initialized_connection(config, |conn| {
+        apply_run_completion_state(conn, job, job_state_at, status, output, action)
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn insert_run_and_prune(
+    conn: &Connection,
+    config: &Config,
+    job_id: &str,
+    started_at: DateTime<Utc>,
+    finished_at: DateTime<Utc>,
+    status: &str,
+    output: Option<&str>,
+    duration_ms: i64,
+) -> Result<()> {
+    conn.execute(
+        "INSERT INTO cron_runs (job_id, started_at, finished_at, status, output, duration_ms)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        params![
+            job_id,
+            started_at.to_rfc3339(),
+            finished_at.to_rfc3339(),
+            status,
+            output,
+            duration_ms,
+        ],
+    )
+    .context("Failed to insert cron run")?;
+
+    let keep = i64::from(config.cron.max_run_history.max(1));
+    conn.execute(
+        "DELETE FROM cron_runs
+         WHERE job_id = ?1
+           AND id NOT IN (
+             SELECT id FROM cron_runs
+             WHERE job_id = ?1
+             ORDER BY started_at DESC, id DESC
+             LIMIT ?2
+           )",
+        params![job_id, keep],
+    )
+    .context("Failed to prune cron run history")?;
+
+    Ok(())
 }
 
 fn truncate_cron_output(output: &str) -> String {
@@ -967,6 +1081,16 @@ fn with_initialized_connection<T>(
     f: impl FnOnce(&Connection) -> Result<T>,
 ) -> Result<T> {
     let db_path = cron_db_path(config);
+    #[cfg(test)]
+    {
+        let mut counts = WRITE_CONNECTION_COUNTS_FOR_TESTS
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        if let Some(count) = counts.get_mut(&db_path) {
+            *count += 1;
+        }
+    }
+
     if let Some(parent) = db_path.parent() {
         std::fs::create_dir_all(parent)
             .with_context(|| format!("Failed to create cron directory: {}", parent.display()))?;
@@ -978,6 +1102,73 @@ fn with_initialized_connection<T>(
     initialize_schema(&conn)?;
 
     f(&conn)
+}
+
+/// Apply the completion state change for a cron job inside an existing connection.
+///
+/// This keeps the scheduler's normal path and the fallback path using the same
+/// SQL mutation logic while allowing the caller to decide whether the
+/// run-history write should be attempted first.
+fn apply_run_completion_state(
+    conn: &Connection,
+    job: &CronJob,
+    job_state_at: DateTime<Utc>,
+    status: &str,
+    output: Option<&str>,
+    action: RunCompletionAction,
+) -> Result<()> {
+    let bounded_output = output.map(truncate_cron_output);
+
+    match action {
+        RunCompletionAction::Reschedule => {
+            let next_run = next_run_for_schedule(&job.schedule, job_state_at)?;
+            let changed = conn
+                .execute(
+                    "UPDATE cron_jobs
+                     SET next_run = ?1, last_run = ?2, last_status = ?3, last_output = ?4
+                     WHERE id = ?5",
+                    params![
+                        next_run.to_rfc3339(),
+                        job_state_at.to_rfc3339(),
+                        status,
+                        bounded_output.as_deref(),
+                        job.id,
+                    ],
+                )
+                .context("Failed to update cron job run state")?;
+            if changed == 0 {
+                anyhow::bail!("Cron job '{}' not found", job.id);
+            }
+        }
+        RunCompletionAction::Disable => {
+            let changed = conn
+                .execute(
+                    "UPDATE cron_jobs
+                     SET enabled = 0, last_run = ?1, last_status = ?2, last_output = ?3
+                     WHERE id = ?4",
+                    params![
+                        job_state_at.to_rfc3339(),
+                        status,
+                        bounded_output.as_deref(),
+                        job.id,
+                    ],
+                )
+                .context("Failed to disable completed one-shot cron job")?;
+            if changed == 0 {
+                anyhow::bail!("Cron job '{}' not found", job.id);
+            }
+        }
+        RunCompletionAction::Delete => {
+            let changed = conn
+                .execute("DELETE FROM cron_jobs WHERE id = ?1", params![job.id])
+                .context("Failed to delete completed one-shot cron job")?;
+            if changed == 0 {
+                anyhow::bail!("Cron job '{}' not found", job.id);
+            }
+        }
+    }
+
+    Ok(())
 }
 
 fn initialize_schema(conn: &Connection) -> Result<()> {


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Adds a store-layer scheduler write path that persists a completed cron run, run-history pruning, and the resulting job-state change inside one SQLite transaction.
  - Keeps job-state SQL in `cron::store`: the normal path calls one transactional helper, while scheduler fallback calls a state-only store helper if run-history insert/prune fails.
  - Keeps the existing run-history table format and `cron.max_run_history` behavior while avoiding the previous separate writes for `record_run` and reschedule/disable/delete.
  - Preserves one-shot semantics: successful auto-delete jobs are removed, failed one-shot jobs are disabled, and non-delete `At` jobs are disabled after execution.
  - Leaves the existing public `record_run` and reschedule helpers in place for non-scheduler callers.
- **Scope boundary:** Does not change cron API responses, config keys, schedule parsing, scheduler polling, delivery behavior, run history retention format, DB schema, or dashboard/gateway contracts. This builds on merged PR #6655 and does not rework the read-only fast path.
- **Blast radius:** Runtime cron scheduler persistence only. Affected consumers are recurring cron executions, one-shot cron executions, and run history queries after scheduler execution. SQL mutation remains in the cron store module; the scheduler only orchestrates execution and fallback. No channel, SOP, memory, provider, or gateway API behavior is intended to change.
- **Linked issue(s):** Builds on merged #6655. Related #6654.
- **Labels:** `risk: high`, `size: M`, `runtime`, `cron`, `cron:scheduler`, `cron:store`

## Validation Evidence (required)

Local validation is the signal CI cannot replace. Run the full battery and paste literal output (tails, failures, warnings — not "all passed").

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- **Commands run and tail output:**

```bash
cargo test -p zeroclaw-runtime cron::scheduler::tests::persist_job_result_uses_one_write_connection -- --nocapture
```

Initial RED result before implementation:

```text
running 2 tests
thread 'cron::scheduler::tests::persist_job_result_uses_one_write_connection_for_recurring_job' panicked ...
assertion `left == right` failed
  left: 3
 right: 1
thread 'cron::scheduler::tests::persist_job_result_uses_one_write_connection_for_failed_one_shot_disable' panicked ...
assertion `left == right` failed
  left: 4
 right: 1
test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 1658 filtered out
```

Final targeted result:

```text
running 2 tests
test cron::scheduler::tests::persist_job_result_uses_one_write_connection_for_failed_one_shot_disable ... ok
test cron::scheduler::tests::persist_job_result_uses_one_write_connection_for_recurring_job ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 1658 filtered out
```

```bash
cargo test -p zeroclaw-runtime cron::scheduler::tests::persist_job_result -- --nocapture
cargo test -p zeroclaw-runtime cron::store::tests -- --nocapture
```

Tail output:

```text
running 14 tests
... persist_job_result_* ... ok

test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 1652 filtered out

running 36 tests
... cron::store::tests::* ... ok

test result: ok. 36 passed; 0 failed; 0 ignored; 0 measured; 1630 filtered out
```

```bash
cargo fmt --all -- --check
```

Tail output: no output, exit code 0.

```bash
cargo clippy --all-targets -- -D warnings
```

Tail output:

```text
Checking zeroclaw-channels v0.7.5 (...)
Checking zeroclaw-gateway v0.7.5 (...)
Checking zeroclawlabs v0.7.5 (...)
Finished `dev` profile [unoptimized + debuginfo] target(s) in 20.29s
```

```bash
cargo test --lib --bins --tests
```

Tail output:

```text
running 7 tests
... ignored, requires live ...
test result: ok. 0 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out

running 5 tests
test system::full_stack::system_simple_text_response ... ok
test system::full_stack::system_tool_execution_flow ... ok
test system::full_stack::system_multi_turn_conversation ... ok
test system::full_stack::system_tool_arguments_passed_correctly ... ok
test system::full_stack::system_parallel_tool_execution ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

```bash
cargo test
```

The normal unit, integration, live-ignored, and system test stages passed. The final doctest stage failed in this local nested worktree because rustdoc received duplicate theme arguments from merged Cargo config:

```text
Doc-tests zeroclaw
error: Option 'default-theme' given more than once
...
--default-theme=ayu --default-theme=ayu
error: doctest failed, to rerun pass `--doc`
```

- **Beyond CI — what did you manually verify?**
  - Verified the scheduler path now uses exactly one write connection for recurring run completion and failed one-shot disable.
  - Verified run history pruning still honors `cron.max_run_history`, last run fields are preserved, and one-shot success/delete and failure/disable behavior still pass existing scheduler tests.
  - Verified run-history insert failure and prune failure both fall back through the store-level state-only helper so recurring jobs advance and auto-delete one-shots disable instead of re-running.
  - Verified the merged transaction rolls back the run-history insert if the job-state update fails.
- **If any command was intentionally skipped, why:** None intentionally skipped. `cargo test` was run; only doctests failed due to the duplicate rustdoc `--default-theme=ayu` local worktree configuration issue described above. `cargo test --lib --bins --tests` was run to cover non-doctest tests.

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: None.

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: Existing users do not need migration steps; existing cron DB schema, `cron_jobs` rows, `cron_runs` rows, and run-history retention format are unchanged.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PRs: `git revert <sha>` is the plan unless otherwise noted.

Medium/high-risk PRs must fill:

- **Fast rollback command/path:** `git revert f6916d4c4f90ff235a86b22ee8229d9a224b147e`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Cron jobs not recording run history, recurring jobs not advancing `next_run`, one-shot jobs re-running unexpectedly, or scheduler logs containing `Failed to persist scheduler run result`.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): None.
- Scope materially carried forward: None.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`No`)
- If `No`, why (inspiration-only, no direct code/design carry-over): No superseded PR or incorporated contributor patch.
