### PR TITLE
fix(deps): update lettre for RUSTSEC-2026-0141

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4960,9 +4960,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lettre"
-version = "0.11.21"
+version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabda5859ee7c06b995b9d1165aa52c39110e079ef609db97178d86aeb051fa7"
+checksum = "0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349"
 dependencies = [
  "base64 0.22.1",
  "email-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,7 +212,7 @@ tokio-rustls = { version = "0.26.4", optional = true }
 webpki-roots = { version = "1.0.6", optional = true }
 
 # email
-lettre = { version = "0.11.19", default-features = false, features = ["builder", "smtp-transport", "rustls-tls"], optional = true }
+lettre = { version = "0.11.22", default-features = false, features = ["builder", "smtp-transport", "rustls-tls"], optional = true }
 mail-parser = { version = "0.11.2", optional = true }
 async-imap = { version = "0.11", features = ["runtime-tokio"], default-features = false, optional = true }
 

--- a/crates/zeroclaw-channels/Cargo.toml
+++ b/crates/zeroclaw-channels/Cargo.toml
@@ -26,7 +26,7 @@ directories = "6.0"
 futures-util = { version = "0.3", default-features = false, features = ["sink"] }
 hmac = "0.12"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png"], optional = true }
-lettre = { version = "0.11.19", default-features = false, features = ["builder", "smtp-transport", "rustls-tls"], optional = true }
+lettre = { version = "0.11.22", default-features = false, features = ["builder", "smtp-transport", "rustls-tls"], optional = true }
 mail-parser = { version = "0.11.2", optional = true }
 matrix-sdk = { version = "0.17", optional = true, default-features = false, features = ["e2e-encryption", "markdown", "sqlite"] }
 mime_guess = { version = "2", optional = true }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Raised the optional `lettre` dependency floor from `0.11.19` to `0.11.22` in the workspace and channel crate manifests.
  - Refreshed `Cargo.lock` so the workspace resolves `lettre 0.11.22` instead of the flagged `0.11.21` package.
  - Restores `cargo deny check` after RUSTSEC-2026-0141 started flagging the locked `lettre` package; the same advisory is also blocking #6655 while that PR still resolves `lettre 0.11.21`.
- **Scope boundary:** This PR does not change email-channel behavior, TLS feature selection, `deny.toml`, or any Rust source.
- **Blast radius:** Dependency resolution for the existing optional email channel / SMTP support. The selected features remain `builder`, `smtp-transport`, and `rustls-tls`.
- **Linked issue(s):** Fixes #6657; Related #6228; related PR #6655; Supersedes #6660
- **Labels:** `bug`, `type: dependencies`, `risk: medium`, `size: XS`, `dependencies`, `security`

## Validation Evidence (required)

- **Commands run and tail output:**

```text
$ cargo update -p lettre --precise 0.11.22
Updating lettre v0.11.21 -> v0.11.22

$ cargo fmt --all -- --check
passed with no output

$ cargo deny fetch db
passed with no output

$ time cargo deny check
advisories ok, bans ok, licenses ok, sources ok
cargo deny check  1.40s user 0.58s system 60% cpu 3.278 total

$ cargo tree -i lettre --features ci-all
lettre v0.11.22
├── zeroclaw-channels v0.7.5
│   ├── zeroclaw-gateway v0.7.5
│   │   └── zeroclawlabs v0.7.5
│   └── zeroclawlabs v0.7.5
└── zeroclawlabs v0.7.5

$ time cargo check -p zeroclaw-channels --features channel-email 2>&1 | tail -60
Checking lettre v0.11.22
Checking zeroclaw-channels v0.7.5
Finished `dev` profile [unoptimized + debuginfo] target(s) in 5m 42s

$ git diff --check -- Cargo.toml crates/zeroclaw-channels/Cargo.toml Cargo.lock
passed with no output
```

- **Beyond CI — what did you manually verify?** Reviewed the diff and confirmed it only changes the `lettre` manifest floors plus the single `lettre` lockfile package. Confirmed the feature declarations still keep `lettre` optional, use `builder`, `smtp-transport`, and `rustls-tls`, route `channel-email` through `zeroclaw-channels`, and include the email path through `ci-all` via `agent-runtime`.
- **If any command was intentionally skipped, why:** Full local `cargo clippy --all-targets` and `cargo test` were not run locally because this is a dependency-only advisory patch with no Rust source changes. The local `cargo deny check`, `cargo tree -i lettre --features ci-all`, and focused `zeroclaw-channels` email-feature check covered the changed dependency path.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: No new runtime surface is added. The security impact is the dependency patch itself: the locked `lettre` package moves to `0.11.22` while preserving ZeroClaw's existing `rustls-tls` feature selection.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No upgrade steps for users. Existing email-channel configuration and behavior are unchanged.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <merge-sha>`
- **Feature flags or config toggles:** None. The dependency remains optional behind existing email-channel features.
- **Observable failure symptoms:** `cargo deny check` returning a new advisory failure, or compile/runtime failures in email-channel paths that depend on `lettre`.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): #6660 by @mn13
- Scope materially carried forward: Same RUSTSEC-2026-0141 dependency resolution, including the `Cargo.lock` update from `lettre 0.11.21` to `0.11.22`. This PR also raises the workspace and channel crate manifest floors so the vulnerable version is no longer allowed by the manifests.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why (inspiration-only, no direct code/design carry-over): The patch was prepared independently before adopting #6660 as superseded context; the overlap is the advisory-recommended lockfile bump, and the broader manifest-floor change is unique to this PR.
