### PR TITLE
fix(provider): recover Codex non-streaming fallback

### DIFF
--- a/crates/zeroclaw-providers/src/openai_codex.rs
+++ b/crates/zeroclaw-providers/src/openai_codex.rs
@@ -655,12 +655,23 @@ fn emit_tool_call(
     }
 }
 
+#[derive(Debug)]
+struct ResponsesStreamApiError(String);
+
+impl std::fmt::Display for ResponsesStreamApiError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "OpenAI Codex stream error: {}", self.0)
+    }
+}
+
+impl std::error::Error for ResponsesStreamApiError {}
+
 fn process_responses_stream_event(
     event: Value,
     state: &mut ResponsesStreamState,
 ) -> anyhow::Result<Vec<StreamEvent>> {
     if let Some(message) = extract_stream_error_message(&event) {
-        anyhow::bail!("OpenAI Codex stream error: {message}");
+        return Err(ResponsesStreamApiError(message).into());
     }
 
     let mut emitted = Vec::new();
@@ -859,9 +870,13 @@ fn process_sse_chunk(
         if line.is_empty() || line == "[DONE]" {
             continue;
         }
-        if let Ok(event) = serde_json::from_str::<Value>(line) {
-            emitted.extend(process_responses_stream_event(event, state)?);
-        }
+        let event = serde_json::from_str::<Value>(line).map_err(|err| {
+            anyhow::anyhow!(
+                "OpenAI Codex SSE data parse failed: {err}. Payload: {}",
+                super::sanitize_api_error(line)
+            )
+        })?;
+        emitted.extend(process_responses_stream_event(event, state)?);
     }
 
     Ok(emitted)
@@ -1065,6 +1080,42 @@ async fn decode_responses_body(response: reqwest::Response) -> anyhow::Result<Re
 }
 
 impl OpenAiCodexProvider {
+    fn responses_request_builder(
+        &self,
+        bearer_token: &str,
+        account_id: Option<&str>,
+        access_token: Option<&str>,
+        use_gateway_api_key_auth: bool,
+        request: &ResponsesRequest,
+    ) -> reqwest::RequestBuilder {
+        let mut request_builder = self
+            .client
+            .post(&self.responses_url)
+            .header("Authorization", format!("Bearer {bearer_token}"))
+            .header("OpenAI-Beta", "responses=experimental")
+            .header("originator", "pi")
+            .header("Content-Type", "application/json");
+
+        if request.stream {
+            request_builder = request_builder.header("accept", "text/event-stream");
+        }
+
+        if let Some(account_id) = account_id {
+            request_builder = request_builder.header("chatgpt-account-id", account_id);
+        }
+
+        if use_gateway_api_key_auth {
+            if let Some(access_token) = access_token {
+                request_builder = request_builder.header("x-openai-access-token", access_token);
+            }
+            if let Some(account_id) = account_id {
+                request_builder = request_builder.header("x-openai-account-id", account_id);
+            }
+        }
+
+        request_builder
+    }
+
     async fn send_responses_request(
         &self,
         input: Vec<Value>,
@@ -1130,7 +1181,7 @@ impl OpenAiCodexProvider {
         let normalized_model = normalize_model_id(model);
 
         let has_tools = tools.is_some();
-        let request = ResponsesRequest {
+        let mut request = ResponsesRequest {
             model: normalized_model.to_string(),
             input,
             instructions,
@@ -1158,27 +1209,13 @@ impl OpenAiCodexProvider {
             access_token.as_deref().unwrap_or_default()
         };
 
-        let mut request_builder = self
-            .client
-            .post(&self.responses_url)
-            .header("Authorization", format!("Bearer {bearer_token}"))
-            .header("OpenAI-Beta", "responses=experimental")
-            .header("originator", "pi")
-            .header("accept", "text/event-stream")
-            .header("Content-Type", "application/json");
-
-        if let Some(account_id) = account_id.as_deref() {
-            request_builder = request_builder.header("chatgpt-account-id", account_id);
-        }
-
-        if use_gateway_api_key_auth {
-            if let Some(access_token) = access_token.as_deref() {
-                request_builder = request_builder.header("x-openai-access-token", access_token);
-            }
-            if let Some(account_id) = account_id.as_deref() {
-                request_builder = request_builder.header("x-openai-account-id", account_id);
-            }
-        }
+        let request_builder = self.responses_request_builder(
+            bearer_token,
+            account_id.as_deref(),
+            access_token.as_deref(),
+            use_gateway_api_key_auth,
+            &request,
+        );
 
         let response = request_builder.json(&request).send().await?;
 
@@ -1186,7 +1223,47 @@ impl OpenAiCodexProvider {
             return Err(super::api_error("OpenAI Codex", response).await);
         }
 
-        decode_responses_body(response).await
+        match decode_responses_body(response).await {
+            Ok(result) => Ok(result),
+            Err(stream_err) => {
+                if stream_err
+                    .downcast_ref::<ResponsesStreamApiError>()
+                    .is_some()
+                {
+                    return Err(stream_err);
+                }
+
+                tracing::warn!(
+                    error = %stream_err,
+                    "OpenAI Codex streaming response decode failed, retrying without streaming"
+                );
+
+                request.stream = false;
+                let non_streaming_response = self
+                    .responses_request_builder(
+                        bearer_token,
+                        account_id.as_deref(),
+                        access_token.as_deref(),
+                        use_gateway_api_key_auth,
+                        &request,
+                    )
+                    .json(&request)
+                    .send()
+                    .await?;
+
+                if !non_streaming_response.status().is_success() {
+                    return Err(super::api_error("OpenAI Codex", non_streaming_response).await);
+                }
+
+                decode_responses_body(non_streaming_response)
+                    .await
+                    .map_err(|fallback_err| {
+                        anyhow::anyhow!(
+                            "OpenAI Codex streaming response decode failed ({stream_err}); non-streaming retry failed ({fallback_err})"
+                        )
+                    })
+            }
+        }
     }
 }
 
@@ -1357,6 +1434,80 @@ mod tests {
     use super::*;
     use crate::test_util::{EnvGuard, env_lock};
 
+    enum MockCodexReply {
+        Sse(&'static str),
+        Json(serde_json::Value),
+        Status(axum::http::StatusCode, &'static str),
+    }
+
+    async fn mock_codex_provider(
+        replies: Vec<MockCodexReply>,
+    ) -> (
+        OpenAiCodexProvider,
+        std::sync::Arc<std::sync::Mutex<Vec<serde_json::Value>>>,
+        tokio::task::JoinHandle<()>,
+        tempfile::TempDir,
+    ) {
+        use axum::http::header;
+        use axum::response::IntoResponse;
+        use axum::{Json, Router, routing::post};
+        use std::collections::VecDeque;
+        use std::sync::{Arc, Mutex};
+        use tokio::net::TcpListener;
+
+        let captured: Arc<Mutex<Vec<serde_json::Value>>> = Arc::new(Mutex::new(Vec::new()));
+        let captured_clone = Arc::clone(&captured);
+        let replies = Arc::new(Mutex::new(VecDeque::from(replies)));
+        let replies_clone = Arc::clone(&replies);
+
+        let app = Router::new().route(
+            "/responses",
+            post(move |Json(body): Json<serde_json::Value>| {
+                let captured = Arc::clone(&captured_clone);
+                let replies = Arc::clone(&replies_clone);
+                async move {
+                    captured.lock().unwrap().push(body);
+                    match replies
+                        .lock()
+                        .unwrap()
+                        .pop_front()
+                        .unwrap_or(MockCodexReply::Status(
+                            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                            "",
+                        )) {
+                        MockCodexReply::Sse(body) => (
+                            axum::http::StatusCode::OK,
+                            [(header::CONTENT_TYPE, "text/event-stream")],
+                            body.to_string(),
+                        )
+                            .into_response(),
+                        MockCodexReply::Json(body) => Json(body).into_response(),
+                        MockCodexReply::Status(status, body) => {
+                            (status, body.to_string()).into_response()
+                        }
+                    }
+                }
+            }),
+        );
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server_handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let options = ProviderRuntimeOptions {
+            provider_api_url: Some(format!("http://{addr}")),
+            zeroclaw_dir: Some(temp_dir.path().to_path_buf()),
+            secrets_encrypt: false,
+            ..ProviderRuntimeOptions::default()
+        };
+        let provider = OpenAiCodexProvider::new(&options, Some("test-key")).unwrap();
+
+        (provider, captured, server_handle, temp_dir)
+    }
+
     #[test]
     fn extracts_output_text_first() {
         let response = ResponsesResponse {
@@ -1460,6 +1611,135 @@ mod tests {
         let provider = OpenAiCodexProvider::new(&options, Some("test-key")).unwrap();
         assert!(provider.custom_endpoint);
         assert_eq!(provider.gateway_api_key.as_deref(), Some("test-key"));
+    }
+
+    #[tokio::test]
+    async fn codex_retries_non_streaming_when_stream_decode_fails() {
+        let (provider, captured, server_handle, _temp_dir) = mock_codex_provider(vec![
+            MockCodexReply::Sse("data: not-json\n\ndata: [DONE]\n"),
+            MockCodexReply::Json(serde_json::json!({
+                "output_text": "fallback ok",
+                "output": []
+            })),
+        ])
+        .await;
+
+        let messages = vec![ChatMessage::user("hello")];
+        let response = provider
+            .chat(
+                ProviderChatRequest {
+                    messages: &messages,
+                    tools: None,
+                },
+                "gpt-5-codex",
+                None,
+            )
+            .await
+            .expect("provider should retry with stream=false after streaming decode failure");
+
+        assert_eq!(response.text.as_deref(), Some("fallback ok"));
+
+        let requests = captured.lock().unwrap();
+        assert_eq!(requests.len(), 2, "expected one retry request");
+        assert_eq!(requests[0]["stream"], true);
+        assert_eq!(requests[1]["stream"], false);
+
+        server_handle.abort();
+    }
+
+    #[tokio::test]
+    async fn codex_retries_non_streaming_when_stream_contains_malformed_frame_after_text() {
+        let (provider, captured, server_handle, _temp_dir) = mock_codex_provider(vec![
+            MockCodexReply::Sse(
+                "data: {\"type\":\"response.output_text.delta\",\"delta\":\"partial\"}\ndata: not-json\n\ndata: [DONE]\n",
+            ),
+            MockCodexReply::Json(serde_json::json!({
+                "output_text": "fallback after partial",
+                "output": []
+            })),
+        ])
+        .await;
+
+        let messages = vec![ChatMessage::user("hello")];
+        let response = provider
+            .chat(
+                ProviderChatRequest {
+                    messages: &messages,
+                    tools: None,
+                },
+                "gpt-5-codex",
+                None,
+            )
+            .await
+            .expect("provider should retry after malformed stream frame");
+
+        assert_eq!(response.text.as_deref(), Some("fallback after partial"));
+
+        let requests = captured.lock().unwrap();
+        assert_eq!(requests.len(), 2, "expected one retry request");
+        assert_eq!(requests[0]["stream"], true);
+        assert_eq!(requests[1]["stream"], false);
+
+        server_handle.abort();
+    }
+
+    #[tokio::test]
+    async fn codex_does_not_retry_stream_api_error_events() {
+        let (provider, captured, server_handle, _temp_dir) = mock_codex_provider(vec![
+            MockCodexReply::Sse(
+                "data: {\"type\":\"response.failed\",\"response\":{\"error\":{\"message\":\"quota exceeded\"}}}\n\ndata: [DONE]\n",
+            ),
+        ])
+        .await;
+
+        let messages = vec![ChatMessage::user("hello")];
+        let err = provider
+            .chat(
+                ProviderChatRequest {
+                    messages: &messages,
+                    tools: None,
+                },
+                "gpt-5-codex",
+                None,
+            )
+            .await
+            .expect_err("stream API errors should not be retried");
+
+        assert!(
+            err.to_string()
+                .contains("OpenAI Codex stream error: quota exceeded"),
+            "{err}"
+        );
+        assert_eq!(captured.lock().unwrap().len(), 1);
+
+        server_handle.abort();
+    }
+
+    #[tokio::test]
+    async fn codex_does_not_retry_failed_http_status() {
+        let (provider, captured, server_handle, _temp_dir) =
+            mock_codex_provider(vec![MockCodexReply::Status(
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                "server down",
+            )])
+            .await;
+
+        let messages = vec![ChatMessage::user("hello")];
+        provider
+            .chat(
+                ProviderChatRequest {
+                    messages: &messages,
+                    tools: None,
+                },
+                "gpt-5-codex",
+                None,
+            )
+            .await
+            .expect_err("HTTP errors should not be retried");
+
+        assert_eq!(captured.lock().unwrap().len(), 1);
+
+        server_handle.abort();
     }
 
     #[test]
@@ -1583,7 +1863,7 @@ data: [DONE]
         let err = parse_responses_body(payload).expect_err("empty SSE should fail closed");
         assert!(
             err.to_string()
-                .contains("No response from OpenAI Codex stream payload"),
+                .contains("OpenAI Codex SSE data parse failed"),
             "{err}"
         );
     }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Restores the lost OpenAI Codex recovery behavior from #4538 for the current `OpenAiCodexProvider`.
  - Retries a successful but undecodable streaming Responses body once with `stream: false`, so malformed SSE payloads can still recover through the normal JSON response path.
  - Keeps real provider failures single-shot: failed HTTP statuses and decoded stream API error events are returned without retrying the same request.
  - Tightens SSE parsing so malformed non-empty `data:` frames fail closed instead of silently returning partial text.
- **Scope boundary:** This PR only changes the OpenAI Codex Responses request/parse path. It does not advertise live provider streaming support, change model routing, or alter non-Codex providers.
- **Blast radius:** OpenAI Codex users may see successful recovery when a streaming Responses body is malformed. The main risk is duplicate requests, so the fallback is limited to decode/parsing failures and covered by no-retry tests for HTTP and stream API errors.
- **Linked issue(s):** Related #6074. Supersedes #4538.
- **Labels:** `bug`, `risk: medium`, `size: S`, `provider`, `provider:openai`

## Validation Evidence (required)

- **Commands run and results:**

```text
time cargo test --locked -p zeroclaw-providers codex_retries_non_streaming_when_stream_decode_fails -- --nocapture 2>&1 | tail -80
Result: failed as expected before implementation.

time cargo test --locked -p zeroclaw-providers codex_retries_non_streaming_when_stream_decode_fails -- --nocapture 2>&1 | tail -80
Result: passed; 1 focused regression test passed.

time cargo test --locked -p zeroclaw-providers openai_codex -- --nocapture 2>&1 | tail -100
Result: passed; 39 openai_codex tests passed.

time cargo fmt --all -- --check 2>&1 | tail -50
Result: passed.

time cargo clippy --locked -p zeroclaw-providers --all-targets -- -D warnings 2>&1 | tail -80
Result: passed.

time cargo clippy --locked --all-targets -- -D warnings 2>&1 | tail -80
Result: passed; workspace-shaped clippy passed.

git diff --check
Result: passed.
```

- **Beyond CI — what did you manually verify?** Verified the fallback only runs after successful HTTP responses that fail stream decoding/parsing. Verified HTTP error statuses are not retried. Verified decoded stream API errors such as `response.failed` are not retried. Verified malformed SSE frames after valid text now trigger fallback instead of returning partial text.
- **If any command was intentionally skipped, why:** Full workspace `cargo test` is not required for this `risk: medium` PR. The touched code is isolated to `zeroclaw-providers/src/openai_codex.rs`, and the focused provider module tests plus workspace-shaped clippy cover the changed behavior.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `Yes, the fallback can issue one retry POST to the existing OpenAI Codex Responses endpoint after a successful streaming response fails decoding/parsing. No new endpoint or destination is introduced.`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: The retry is a single non-streaming request after a successful streaming HTTP response fails decoding/parsing. Failed HTTP statuses and decoded stream API error events are not retried.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No upgrade steps required.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <merge-sha>`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** OpenAI Codex requests could be sent twice on malformed stream payloads, or malformed Codex stream responses could fail instead of recovering. Look for `OpenAI Codex streaming response decode failed, retrying without streaming` and `OpenAI Codex SSE data parse failed` in provider logs.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line):
  - #4538 by @TJUEZ
- Scope materially carried forward: Restores the streaming-to-non-streaming fallback for OpenAI Codex Responses requests, ported from the old monolithic provider path into the current provider crate and tightened with no-retry regressions.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `Yes`
- If `No`, why (inspiration-only, no direct code/design carry-over): N/A.
