### PR TITLE
fix(runtime): add strict tool parsing mode

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -95,9 +95,9 @@ use zeroclaw_memory::{self, MEMORY_CONTEXT_CLOSE, MEMORY_CONTEXT_OPEN, Memory};
 use zeroclaw_providers::reliable::{scope_provider_fallback, take_last_provider_fallback};
 use zeroclaw_providers::{self, ChatMessage, ModelProvider};
 use zeroclaw_runtime::agent::loop_::{
-    build_tool_instructions_for_names, clear_model_switch_request, get_model_switch_state,
-    is_model_switch_requested, run_tool_call_loop, scope_session_key, scope_thread_id,
-    scrub_credentials,
+    apply_text_tool_prompt_policy, build_tool_instructions_for_names, clear_model_switch_request,
+    get_model_switch_state, is_model_switch_requested, run_tool_call_loop, scope_session_key,
+    scope_thread_id, scrub_credentials,
 };
 use zeroclaw_runtime::approval::ApprovalManager;
 use zeroclaw_runtime::observability::traits::{ObserverEvent, ObserverMetric};
@@ -3829,6 +3829,9 @@ async fn process_channel_message_body(
                         ctx.activated_tools.as_ref(),
                         Some(model_switch_callback.clone()),
                         &ctx.pacing,
+                        ctx.prompt_config
+                            .agent(ctx.agent_alias.as_str())
+                            .is_some_and(|agent| agent.strict_tool_parsing),
                         ctx.max_tool_result_chars,
                         ctx.context_token_budget,
                         None, // shared_budget
@@ -6971,6 +6974,12 @@ pub async fn start_channels(
             None
         };
         let native_tools = model_provider.supports_native_tools();
+        let expose_text_tool_protocol = apply_text_tool_prompt_policy(
+            native_tools,
+            agent.strict_tool_parsing,
+            &mut tool_descs,
+            &mut deferred_section,
+        );
         let mut system_prompt = build_system_prompt_with_mode_and_autonomy(
             &workspace,
             &model,
@@ -6984,7 +6993,7 @@ pub async fn start_channels(
             agent.compact_context,
             agent.max_system_prompt_chars,
         );
-        if !native_tools {
+        if expose_text_tool_protocol {
             system_prompt.push_str(&build_tool_instructions_for_names(
                 tools_registry.as_ref(),
                 &effective_tool_names,
@@ -12038,6 +12047,49 @@ BTC is currently around $65,000 based on latest tool output."#
             1,
             "protocol block should appear exactly once in the final prompt"
         );
+    }
+
+    #[test]
+    fn channel_strict_non_native_prompt_hides_text_tool_protocol() {
+        let ws = make_workspace();
+        let mut tool_descs = vec![("shell", "Run commands")];
+        let mut deferred_section = "## Deferred MCP Tools\n\n- mcp__example".to_string();
+
+        let expose_text_protocol =
+            apply_text_tool_prompt_policy(false, true, &mut tool_descs, &mut deferred_section);
+
+        let mut prompt = build_system_prompt_with_mode_and_autonomy(
+            ws.path(),
+            "gpt-4o",
+            &tool_descs,
+            &[],
+            None,
+            None,
+            None,
+            false,
+            zeroclaw_config::schema::SkillsPromptInjectionMode::Full,
+            false,
+            0,
+        );
+        if expose_text_protocol {
+            let tools_registry: Vec<Box<dyn Tool>> = vec![Box::new(MockPriceTool)];
+            let effective_tool_names: HashSet<&str> =
+                tools_registry.iter().map(|tool| tool.name()).collect();
+            prompt.push_str(&build_tool_instructions_for_names(
+                &tools_registry,
+                &effective_tool_names,
+            ));
+        }
+        if !deferred_section.is_empty() {
+            prompt.push('\n');
+            prompt.push_str(&deferred_section);
+        }
+
+        assert!(!expose_text_protocol);
+        assert!(!prompt.contains("## Tools"));
+        assert!(!prompt.contains("## Tool Use Protocol"));
+        assert!(!prompt.contains("<tool_call>"));
+        assert!(!prompt.contains("mcp__example"));
     }
 
     #[test]

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -2802,6 +2802,11 @@ pub struct AliasedAgentConfig {
     /// Tool dispatch strategy (e.g. `"auto"`). Default: `"auto"`.
     #[serde(default = "default_agent_tool_dispatcher")]
     pub tool_dispatcher: String,
+    /// When true, only native provider tool calls are executable. Text fallback
+    /// parsing remains disabled, so XML/markdown/GLM-looking text is treated as
+    /// final assistant text.
+    #[serde(default)]
+    pub strict_tool_parsing: bool,
     /// Tools exempt from the within-turn duplicate-call dedup check. Default: `[]`.
     #[serde(default)]
     pub tool_call_dedup_exempt: Vec<String>,
@@ -2910,6 +2915,7 @@ impl Default for AliasedAgentConfig {
             max_context_tokens: default_agent_max_context_tokens(),
             parallel_tools: false,
             tool_dispatcher: default_agent_tool_dispatcher(),
+            strict_tool_parsing: false,
             tool_call_dedup_exempt: Vec::new(),
             tool_filter_groups: Vec::new(),
             max_system_prompt_chars: default_max_system_prompt_chars(),
@@ -16363,6 +16369,7 @@ reasoning_effort = "turbo"
         assert_eq!(cfg.max_history_messages, 50);
         assert!(!cfg.parallel_tools);
         assert_eq!(cfg.tool_dispatcher, "auto");
+        assert!(!cfg.strict_tool_parsing);
     }
 
     #[test]
@@ -16375,6 +16382,7 @@ max_tool_iterations = 20
 max_history_messages = 80
 parallel_tools = true
 tool_dispatcher = "xml"
+strict_tool_parsing = true
 "#;
         let parsed = parse_test_config(raw);
         let agent = parsed
@@ -16386,6 +16394,7 @@ tool_dispatcher = "xml"
         assert_eq!(agent.max_history_messages, 80);
         assert!(agent.parallel_tools);
         assert_eq!(agent.tool_dispatcher, "xml");
+        assert!(agent.strict_tool_parsing);
     }
 
     #[test]

--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -507,10 +507,11 @@ impl Agent {
         response: &zeroclaw_providers::ChatResponse,
     ) -> (String, Vec<ParsedToolCall>) {
         if self.tool_specs.is_empty() {
-            return (
-                strip_think_tags(&response.text.clone().unwrap_or_default()),
-                Vec::new(),
-            );
+            return (strip_think_tags(response.text_or_empty()), Vec::new());
+        }
+
+        if self.config.strict_tool_parsing && response.tool_calls.is_empty() {
+            return (strip_think_tags(response.text_or_empty()), Vec::new());
         }
 
         self.tool_dispatcher.parse_response(response)
@@ -1014,17 +1015,26 @@ impl Agent {
     }
 
     fn build_system_prompt(&self) -> Result<String> {
-        let instructions = self.tool_dispatcher.prompt_instructions(&self.tools);
+        let expose_text_tool_protocol =
+            !self.config.strict_tool_parsing || self.tool_dispatcher.should_send_tool_specs();
+        let no_tools: Vec<Box<dyn Tool>> = Vec::new();
+        let prompt_tools = if expose_text_tool_protocol {
+            &self.tools
+        } else {
+            &no_tools
+        };
+        let instructions = self.tool_dispatcher.prompt_instructions(prompt_tools);
         let ctx = PromptContext {
             workspace_dir: &self.workspace_dir,
             agent_workspace_dir: &self.agent_workspace_dir,
             model_name: &self.model_name,
-            tools: &self.tools,
+            tools: prompt_tools,
             skills: &self.skills,
             skills_prompt_mode: self.skills_prompt_mode,
             identity_config: Some(&self.identity_config),
             dispatcher_instructions: &instructions,
-            sends_native_tool_specs: self.tool_dispatcher.should_send_tool_specs(),
+            sends_native_tool_specs: self.tool_dispatcher.should_send_tool_specs()
+                && !prompt_tools.is_empty(),
             security_summary: self.security_summary.clone(),
             autonomy_level: self.autonomy_level,
         };
@@ -2353,6 +2363,65 @@ mod tests {
 
         let response = agent.turn("hi").await.unwrap();
         assert_eq!(response, "hello");
+    }
+
+    #[tokio::test]
+    async fn direct_agent_strict_tool_parsing_ignores_xml_dispatcher_calls() {
+        let provider = Box::new(MockModelProvider {
+            responses: Mutex::new(vec![zeroclaw_providers::ChatResponse {
+                text: Some(
+                    r#"<tool_call>{"name":"echo","arguments":{"value":"ignored"}}</tool_call>"#
+                        .into(),
+                ),
+                tool_calls: vec![],
+                usage: None,
+                reasoning_content: None,
+            }]),
+        });
+
+        let memory_cfg = zeroclaw_config::schema::MemoryConfig {
+            backend: "none".into(),
+            ..zeroclaw_config::schema::MemoryConfig::default()
+        };
+        let mem: Arc<dyn Memory> = Arc::from(
+            zeroclaw_memory::create_memory(&memory_cfg, std::path::Path::new("/tmp"), None)
+                .expect("memory creation should succeed with valid config"),
+        );
+        let observer: Arc<dyn Observer> = Arc::from(crate::observability::NoopObserver {});
+        let calls = Arc::new(AtomicUsize::new(0));
+        let agent_config = zeroclaw_config::schema::AliasedAgentConfig {
+            strict_tool_parsing: true,
+            ..zeroclaw_config::schema::AliasedAgentConfig::default()
+        };
+        let mut agent = Agent::builder()
+            .model_provider(provider)
+            .tools(vec![Box::new(CountingTool {
+                calls: Arc::clone(&calls),
+            })])
+            .memory(mem)
+            .observer(observer)
+            .tool_dispatcher(Box::new(XmlToolDispatcher))
+            .config(agent_config)
+            .workspace_dir(std::path::PathBuf::from("/tmp"))
+            .build()
+            .expect("agent builder should succeed with valid config");
+
+        let system_prompt = agent
+            .build_system_prompt()
+            .expect("system prompt should render");
+        assert!(
+            !system_prompt.contains("## Tools"),
+            "strict parsing should not advertise text tool instructions"
+        );
+        assert!(
+            !system_prompt.contains("<tool_call"),
+            "strict parsing should not advertise XML tool calls"
+        );
+
+        let response = agent.turn("hi").await.unwrap();
+
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+        assert!(response.contains("<tool_call>"));
     }
 
     #[test]

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -990,6 +990,7 @@ async fn consume_provider_streaming_response(
     temperature: Option<f64>,
     cancellation_token: Option<&CancellationToken>,
     on_delta: Option<&tokio::sync::mpsc::Sender<DraftEvent>>,
+    strict_tool_parsing: bool,
 ) -> Result<StreamedChatOutcome> {
     let mut provider_stream = model_provider.stream_chat(
         ChatRequest {
@@ -1070,6 +1071,16 @@ async fn consume_provider_streaming_response(
                     continue;
                 }
 
+                if strict_tool_parsing {
+                    if let Some(tx) = delta_sender {
+                        outcome.forwarded_live_deltas = true;
+                        if tx.send(StreamDelta::Text(chunk.delta)).await.is_err() {
+                            delta_sender = None;
+                        }
+                    }
+                    continue;
+                }
+
                 let Some(forward_text) = text_guard.push(&chunk.delta) else {
                     continue;
                 };
@@ -1117,6 +1128,7 @@ pub async fn agent_turn(
     dedup_exempt_tools: &[String],
     activated_tools: Option<&std::sync::Arc<std::sync::Mutex<crate::tools::ActivatedToolSet>>>,
     model_switch_callback: Option<ModelSwitchCallback>,
+    strict_tool_parsing: bool,
     channel: Option<&dyn Channel>,
 ) -> Result<String> {
     run_tool_call_loop(
@@ -1141,6 +1153,7 @@ pub async fn agent_turn(
         activated_tools,
         model_switch_callback,
         &zeroclaw_config::schema::PacingConfig::default(),
+        strict_tool_parsing,
         0,    // max_tool_result_chars: 0 = disabled (legacy callers)
         0,    // context_token_budget: 0 = disabled (legacy callers)
         None, // shared_budget: no shared budget for legacy callers
@@ -1283,6 +1296,7 @@ pub async fn run_tool_call_loop(
     activated_tools: Option<&std::sync::Arc<std::sync::Mutex<crate::tools::ActivatedToolSet>>>,
     model_switch_callback: Option<ModelSwitchCallback>,
     pacing: &zeroclaw_config::schema::PacingConfig,
+    strict_tool_parsing: bool,
     max_tool_result_chars: usize,
     context_token_budget: usize,
     shared_budget: Option<Arc<std::sync::atomic::AtomicUsize>>,
@@ -1583,6 +1597,7 @@ pub async fn run_tool_call_loop(
                 temperature,
                 cancellation_token.as_ref(),
                 on_delta.as_ref(),
+                strict_tool_parsing,
             )
             .await
             {
@@ -1731,7 +1746,7 @@ pub async fn run_tool_call_loop(
                     .as_ref()
                     .and_then(|usage| record_tool_loop_cost_usage(provider_name, model, usage));
 
-                let response_text = if tool_specs.is_empty() {
+                let mut response_text = if tool_specs.is_empty() {
                     strip_think_tags(resp.text_or_empty())
                 } else {
                     resp.text_or_empty().to_string()
@@ -1757,8 +1772,13 @@ pub async fn run_tool_call_loop(
                 };
                 let mut parsed_text = String::new();
 
+                if strict_tool_parsing && calls.is_empty() {
+                    response_text = strip_think_tags(&response_text);
+                }
+
                 if calls.is_empty()
                     && !tool_specs.is_empty()
+                    && !strict_tool_parsing
                     && !looks_like_tool_protocol_example(&response_text)
                 {
                     let (fallback_text, fallback_calls) = parse_tool_calls(&response_text);
@@ -1772,7 +1792,9 @@ pub async fn run_tool_call_loop(
                     calls = filtered_calls;
                 }
 
-                let parse_issue = if tool_specs.is_empty() {
+                let parse_issue = if strict_tool_parsing {
+                    None
+                } else if tool_specs.is_empty() {
                     detect_internal_protocol_without_tools(&response_text).or_else(|| {
                         streamed_protocol_suppressed.then(|| {
                             "streaming text guard suppressed an internal tool protocol envelope"
@@ -2766,6 +2788,20 @@ fn retain_registered_tool_descriptions(
     tool_descs.retain(|(name, _)| registered_tool_names.contains(name));
 }
 
+pub fn apply_text_tool_prompt_policy(
+    native_tools: bool,
+    strict_tool_parsing: bool,
+    tool_descs: &mut Vec<(&str, &str)>,
+    deferred_section: &mut String,
+) -> bool {
+    let expose_text_tool_protocol = !native_tools && !strict_tool_parsing;
+    if !native_tools && strict_tool_parsing {
+        tool_descs.clear();
+        deferred_section.clear();
+    }
+    expose_text_tool_protocol
+}
+
 // ── CLI Entrypoint ───────────────────────────────────────────────────────
 // Wires up all subsystems (observer, runtime, security, memory, tools,
 // model_provider, hardware RAG, peripherals) and enters either single-shot or
@@ -3308,6 +3344,12 @@ pub async fn run(
             None
         };
         let native_tools = model_provider.supports_native_tools();
+        let expose_text_tool_protocol = apply_text_tool_prompt_policy(
+            native_tools,
+            agent.strict_tool_parsing,
+            &mut tool_descs,
+            &mut deferred_section,
+        );
         let agent_workspace = config.agent_workspace_dir(agent_alias);
         let mut system_prompt =
             crate::agent::system_prompt::build_system_prompt_with_mode_and_autonomy(
@@ -3325,7 +3367,7 @@ pub async fn run(
             );
 
         // Append structured tool-use instructions with schemas (only for non-native model_providers)
-        if !native_tools {
+        if expose_text_tool_protocol {
             system_prompt.push_str(&build_tool_instructions(&tools_registry));
         }
 
@@ -3516,6 +3558,7 @@ pub async fn run(
                             activated_handle.as_ref(),
                             Some(model_switch_callback.clone()),
                             &config.pacing,
+                            agent.strict_tool_parsing,
                             agent.max_tool_result_chars,
                             agent.max_context_tokens,
                             None, // shared_budget
@@ -3900,6 +3943,7 @@ pub async fn run(
                                 activated_handle.as_ref(),
                                 Some(model_switch_callback.clone()),
                                 &config.pacing,
+                                agent.strict_tool_parsing,
                                 agent.max_tool_result_chars,
                                 agent.max_context_tokens,
                                 None, // shared_budget
@@ -4465,6 +4509,12 @@ pub async fn process_message(
             None
         };
         let native_tools = model_provider.supports_native_tools();
+        let expose_text_tool_protocol = apply_text_tool_prompt_policy(
+            native_tools,
+            agent.strict_tool_parsing,
+            &mut tool_descs,
+            &mut deferred_section,
+        );
         let agent_workspace = config.agent_workspace_dir(agent_alias);
         let mut system_prompt =
             crate::agent::system_prompt::build_system_prompt_with_mode_and_autonomy(
@@ -4480,7 +4530,7 @@ pub async fn process_message(
                 agent.compact_context,
                 agent.max_system_prompt_chars,
             );
-        if !native_tools {
+        if expose_text_tool_protocol {
             system_prompt.push_str(&build_tool_instructions_for_names(
                 &tools_registry,
                 &effective_tool_names,
@@ -4593,6 +4643,7 @@ pub async fn process_message(
             &agent.tool_call_dedup_exempt,
             activated_handle_pm.as_ref(),
             None,
+            agent.strict_tool_parsing,
             None, // channel: process_message path has no channel ref
         )
         .await
@@ -4606,8 +4657,9 @@ pub async fn process_message(
 #[cfg(test)]
 mod tests {
     use super::{
-        emergency_history_trim, estimate_history_tokens, fast_trim_tool_results,
-        load_interactive_session_history, save_interactive_session_history, truncate_tool_result,
+        apply_text_tool_prompt_policy, emergency_history_trim, estimate_history_tokens,
+        fast_trim_tool_results, load_interactive_session_history, save_interactive_session_history,
+        truncate_tool_result,
     };
     use crate::agent::history::{DEFAULT_MAX_HISTORY_MESSAGES, InteractiveSessionState};
     use crate::agent::tool_execution::execute_one_tool;
@@ -5982,6 +6034,7 @@ mod tests {
             None,
             None,
             &zeroclaw_config::schema::PacingConfig::default(),
+            false,
             0,
             0,
             None,
@@ -6038,6 +6091,7 @@ mod tests {
             None,
             None,
             &zeroclaw_config::schema::PacingConfig::default(),
+            false,
             0,
             0,
             None,
@@ -6098,6 +6152,7 @@ mod tests {
             None,
             None,
             &zeroclaw_config::schema::PacingConfig::default(),
+            false,
             0,
             0,
             None,
@@ -6149,6 +6204,7 @@ mod tests {
             None,
             None,
             &zeroclaw_config::schema::PacingConfig::default(),
+            false,
             0,
             0,
             None,
@@ -6207,6 +6263,7 @@ mod tests {
             None,
             None,
             &zeroclaw_config::schema::PacingConfig::default(),
+            false,
             0,
             0,
             None,
@@ -6266,6 +6323,7 @@ mod tests {
             None,
             None,
             &zeroclaw_config::schema::PacingConfig::default(),
+            false,
             0,
             0,
             None,
@@ -6325,6 +6383,7 @@ mod tests {
             None,
             None,
             &zeroclaw_config::schema::PacingConfig::default(),
+            false,
             0,
             0,
             None,
@@ -6383,6 +6442,7 @@ mod tests {
             None,
             None,
             &zeroclaw_config::schema::PacingConfig::default(),
+            false,
             0,
             0,
             None,
@@ -6440,6 +6500,7 @@ mod tests {
             None,
             None,
             &zeroclaw_config::schema::PacingConfig::default(),
+            false,
             0,
             0,
             None,
@@ -6581,6 +6642,7 @@ mod tests {
             None,
             None,
             &zeroclaw_config::schema::PacingConfig::default(),
+            false,
             0,
             0,
             None,
@@ -6661,6 +6723,7 @@ mod tests {
             None,
             None,
             &zeroclaw_config::schema::PacingConfig::default(),
+            false,
             0,
             0,
             None,
@@ -6733,6 +6796,7 @@ mod tests {
             None,
             None,
             &zeroclaw_config::schema::PacingConfig::default(),
+            false,
             0,
             0,
             None,
@@ -6800,6 +6864,7 @@ mod tests {
             None,
             None,
             &zeroclaw_config::schema::PacingConfig::default(),
+            false,
             0,
             0,
             None,
@@ -6880,6 +6945,7 @@ mod tests {
             None,
             None,
             &zeroclaw_config::schema::PacingConfig::default(),
+            false,
             0,
             0,
             None,
@@ -6950,6 +7016,7 @@ mod tests {
             None,
             None,
             &zeroclaw_config::schema::PacingConfig::default(),
+            false,
             0,
             0,
             None,
@@ -7040,6 +7107,7 @@ mod tests {
             None,
             None,
             &zeroclaw_config::schema::PacingConfig::default(),
+            false,
             0,
             0,
             None,
@@ -7104,6 +7172,7 @@ mod tests {
             None,
             None,
             &zeroclaw_config::schema::PacingConfig::default(),
+            false,
             0,
             0,
             None,
@@ -7172,6 +7241,7 @@ mod tests {
             None,
             None,
             &zeroclaw_config::schema::PacingConfig::default(),
+            false,
             0,
             0,
             None,
@@ -7235,6 +7305,7 @@ mod tests {
             None,
             None,
             &zeroclaw_config::schema::PacingConfig::default(),
+            false,
             0,
             0,
             None,
@@ -7296,6 +7367,7 @@ mod tests {
             None,
             None,
             &zeroclaw_config::schema::PacingConfig::default(),
+            false,
             0,
             0,
             None,
@@ -7360,6 +7432,7 @@ mod tests {
             None,
             None,
             &zeroclaw_config::schema::PacingConfig::default(),
+            false,
             0,
             0,
             None,
@@ -7421,6 +7494,7 @@ mod tests {
             None,
             None,
             &zeroclaw_config::schema::PacingConfig::default(),
+            false,
             0,
             0,
             None,
@@ -7481,6 +7555,7 @@ mod tests {
             None,
             None,
             &zeroclaw_config::schema::PacingConfig::default(),
+            false,
             0,
             0,
             None,
@@ -7533,6 +7608,7 @@ mod tests {
             None,
             None,
             &zeroclaw_config::schema::PacingConfig::default(),
+            false,
             0,
             0,
             None,
@@ -7586,6 +7662,7 @@ mod tests {
             None,
             None,
             &zeroclaw_config::schema::PacingConfig::default(),
+            false,
             0,
             0,
             None,
@@ -7639,6 +7716,7 @@ mod tests {
             None,
             None,
             &zeroclaw_config::schema::PacingConfig::default(),
+            false,
             0,
             0,
             None,
@@ -7694,6 +7772,7 @@ This is an example, not an invocation."#;
             None,
             None,
             &zeroclaw_config::schema::PacingConfig::default(),
+            false,
             0,
             0,
             None,
@@ -7754,6 +7833,7 @@ This is an example, not an invocation."#;
             None,
             None,
             &zeroclaw_config::schema::PacingConfig::default(),
+            false,
             0,
             0,
             None,
@@ -7826,6 +7906,7 @@ This is an example, not an invocation."#;
             None,
             None,
             &zeroclaw_config::schema::PacingConfig::default(),
+            false,
             0,
             0,
             None,
@@ -7881,6 +7962,7 @@ Done."#;
             None,
             None,
             &zeroclaw_config::schema::PacingConfig::default(),
+            false,
             0,
             0,
             None,
@@ -7939,6 +8021,7 @@ Done."#;
             None,
             None,
             &zeroclaw_config::schema::PacingConfig::default(),
+            false,
             0,
             0,
             None,
@@ -7995,6 +8078,7 @@ Done."#;
             None,
             None,
             &zeroclaw_config::schema::PacingConfig::default(),
+            false,
             0,
             0,
             None,
@@ -8052,6 +8136,7 @@ This is an example, not an invocation."#;
             None,
             None,
             &zeroclaw_config::schema::PacingConfig::default(),
+            false,
             0,
             0,
             None,
@@ -8166,6 +8251,7 @@ This is an example, not an invocation."#;
             None,
             None,
             &zeroclaw_config::schema::PacingConfig::default(),
+            false,
             0,
             0,
             None,
@@ -8231,6 +8317,7 @@ This is an example, not an invocation."#;
             None,
             None,
             &zeroclaw_config::schema::PacingConfig::default(),
+            false,
             0,
             0,
             None,
@@ -8300,6 +8387,7 @@ This is an example, not an invocation."#;
             None,
             None,
             &zeroclaw_config::schema::PacingConfig::default(),
+            false,
             0,
             0,
             None,
@@ -8389,6 +8477,7 @@ This is an example, not an invocation."#;
             None,
             None,
             &zeroclaw_config::schema::PacingConfig::default(),
+            false,
             0,
             0,
             None,
@@ -8457,6 +8546,7 @@ This is an example, not an invocation."#;
             None,
             None,
             &zeroclaw_config::schema::PacingConfig::default(),
+            false,
             0,
             0,
             None,
@@ -8528,6 +8618,7 @@ This is an example, not an invocation."#;
             None,
             None,
             &zeroclaw_config::schema::PacingConfig::default(),
+            false,
             0,
             0,
             None,
@@ -8628,6 +8719,7 @@ This is an example, not an invocation."#;
             Some(0.0),
             None,
             Some(&tx),
+            false,
         )
         .await
         .expect("streaming should finish");
@@ -8712,6 +8804,7 @@ This is an example, not an invocation."#;
             Some(0.0),
             None,
             Some(&tx),
+            false,
         )
         .await
         .expect("streaming should finish");
@@ -8747,6 +8840,7 @@ This is an example, not an invocation."#;
             Some(0.0),
             None,
             Some(&tx),
+            false,
         )
         .await
         .expect("streaming should finish");
@@ -8785,6 +8879,7 @@ This is an example, not an invocation."#;
             Some(0.0),
             None,
             Some(&tx),
+            false,
         )
         .await
         .expect("streaming should finish");
@@ -8823,6 +8918,7 @@ This is an example, not an invocation."#;
             Some(0.0),
             None,
             Some(&tx),
+            false,
         )
         .await
         .expect("streaming should finish");
@@ -8905,6 +9001,7 @@ This is an example, not an invocation."#;
             Some(0.0),
             None,
             Some(&tx),
+            false,
         )
         .await
         .expect("streaming should finish");
@@ -8985,6 +9082,7 @@ This is an example, not an invocation."#;
             Some(0.0),
             None,
             Some(&tx),
+            false,
         )
         .await
         .expect("streaming should finish");
@@ -9068,6 +9166,7 @@ This is an example, not an invocation."#;
             Some(0.0),
             None,
             Some(&tx),
+            false,
         )
         .await
         .expect("streaming should finish");
@@ -9154,6 +9253,7 @@ This is an example, not an invocation."#;
             Some(0.0),
             None,
             Some(&tx),
+            false,
         )
         .await
         .expect("streaming should finish");
@@ -9235,6 +9335,7 @@ This is an example, not an invocation."#;
             Some(0.0),
             None,
             Some(&tx),
+            false,
         )
         .await
         .expect("streaming should finish");
@@ -9319,6 +9420,7 @@ This is an example, not an invocation."#;
             Some(0.0),
             None,
             Some(&tx),
+            false,
         )
         .await
         .expect("streaming should finish");
@@ -9383,6 +9485,7 @@ This is an example, not an invocation."#;
             None,
             None,
             &zeroclaw_config::schema::PacingConfig::default(),
+            false,
             0,
             0,
             None,
@@ -9474,6 +9577,7 @@ This is an example, not an invocation."#;
             None,
             None,
             &zeroclaw_config::schema::PacingConfig::default(),
+            false,
             0,
             0,
             None,
@@ -9563,6 +9667,7 @@ This is an example, not an invocation."#;
                 &[],
                 Some(&activated),
                 None,
+                false,
                 None, // channel
             )
             .await
@@ -9573,6 +9678,75 @@ This is an example, not an invocation."#;
                 "result should end with 'done', got: {result}"
             );
             assert_eq!(invocations.load(Ordering::SeqCst), 1);
+        });
+    }
+
+    #[test]
+    fn agent_turn_strict_tool_parsing_ignores_activated_tool_text_from_wrapper() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime should initialize");
+
+        runtime.block_on(async {
+            let model_provider = ScriptedModelProvider::from_text_responses(vec![
+                r#"<think>private reasoning</think>
+<tool_call>
+{"name":"pixel__get_api_health","arguments":{"value":"ignored"}}
+</tool_call>"#,
+            ]);
+
+            let invocations = Arc::new(AtomicUsize::new(0));
+            let activated = Arc::new(std::sync::Mutex::new(crate::tools::ActivatedToolSet::new()));
+            let activated_tool: Arc<dyn Tool> = Arc::new(CountingTool::new(
+                "pixel__get_api_health",
+                Arc::clone(&invocations),
+            ));
+            activated
+                .lock()
+                .unwrap()
+                .activate("pixel__get_api_health".into(), activated_tool);
+
+            let tools_registry: Vec<Box<dyn Tool>> = Vec::new();
+            let mut history = vec![
+                ChatMessage::system("test-system"),
+                ChatMessage::user("do not infer activated tool calls from text"),
+            ];
+            let observer = NoopObserver;
+
+            let result = agent_turn(
+                &model_provider,
+                &mut history,
+                &tools_registry,
+                &observer,
+                "mock-provider",
+                "mock-model",
+                Some(0.0),
+                true,
+                "daemon",
+                None,
+                &zeroclaw_config::schema::MultimodalConfig::default(),
+                4,
+                None,
+                &[],
+                &[],
+                Some(&activated),
+                None,
+                true,
+                None, // channel
+            )
+            .await
+            .expect("strict wrapper path should preserve fallback-looking text");
+
+            assert_eq!(invocations.load(Ordering::SeqCst), 0);
+            assert!(
+                result.contains("<tool_call>"),
+                "strict parser should return fallback-looking text, got: {result}"
+            );
+            assert!(
+                !result.contains("private reasoning"),
+                "strict parser should still strip think tags from final text, got: {result}"
+            );
         });
     }
 
@@ -10320,6 +10494,25 @@ Let me check the result."#;
         );
     }
 
+    #[test]
+    fn strict_non_native_prompt_policy_hides_text_tool_protocol_inputs() {
+        let mut tool_descs = vec![("shell", "Run commands")];
+        let mut deferred_section = "## Deferred MCP Tools\n\n- mcp__example".to_string();
+
+        let expose_text_protocol =
+            apply_text_tool_prompt_policy(false, true, &mut tool_descs, &mut deferred_section);
+
+        assert!(!expose_text_protocol);
+        assert!(
+            tool_descs.is_empty(),
+            "strict non-native prompt paths must not advertise text tools"
+        );
+        assert!(
+            deferred_section.is_empty(),
+            "strict non-native prompt paths must not advertise deferred text tools"
+        );
+    }
+
     // ── Cross-Alias & GLM Shortened Body Tests ──────────────────────────
 
     #[test]
@@ -10508,6 +10701,7 @@ Let me check the result."#;
             Some(0.2),
             None,
             None,
+            false,
         )
         .await
         .expect("streaming should succeed");
@@ -10600,6 +10794,7 @@ Let me check the result."#;
             Some(0.2),
             None,
             None,
+            false,
         )
         .await
         .expect("streaming should succeed");
@@ -10801,6 +10996,7 @@ Let me check the result."#;
             None,
             None,
             &zeroclaw_config::schema::PacingConfig::default(),
+            false,
             0,
             0,
             None,
@@ -10957,6 +11153,7 @@ Let me check the result."#;
                     None,
                     None,
                     &zeroclaw_config::schema::PacingConfig::default(),
+                    false,
                     0,
                     0,
                     None,
@@ -11013,6 +11210,7 @@ Let me check the result."#;
             None,
             None,
             &zeroclaw_config::schema::PacingConfig::default(),
+            false,
             0,
             0,
             None,
@@ -11107,6 +11305,7 @@ Let me check the result."#;
                     None,
                     None,
                     &zeroclaw_config::schema::PacingConfig::default(),
+                    false,
                     0,
                     0,
                     None,
@@ -11168,6 +11367,7 @@ Let me check the result."#;
             None,
             None,
             &zeroclaw_config::schema::PacingConfig::default(),
+            false,
             0,
             0,
             None,

--- a/crates/zeroclaw-runtime/src/tools/delegate.rs
+++ b/crates/zeroclaw-runtime/src/tools/delegate.rs
@@ -793,6 +793,7 @@ impl DelegateTool {
             &model,
             &[],
             &self.workspace_dir,
+            false,
         );
         let system_prompt_ref = enriched_system_prompt.as_deref();
 
@@ -1439,6 +1440,7 @@ impl DelegateTool {
         model_name: &str,
         sub_tools: &[Box<dyn Tool>],
         workspace_dir: &Path,
+        sends_native_tool_specs: bool,
     ) -> Option<String> {
         // Resolve skill bundle directories. With one or more configured
         // bundles, load + concat skills from each. With none, fall back to
@@ -1458,7 +1460,14 @@ impl DelegateTool {
 
         // Determine shell policy instructions when the `shell` tool is in the
         // effective tool list.
-        let has_shell = sub_tools.iter().any(|t| t.name() == "shell");
+        let empty_tools: &[Box<dyn Tool>] = &[];
+        let expose_text_tools = sends_native_tool_specs || !agent_config.strict_tool_parsing;
+        let prompt_tools = if expose_text_tools {
+            sub_tools
+        } else {
+            empty_tools
+        };
+        let has_shell = prompt_tools.iter().any(|t| t.name() == "shell");
         let shell_policy = if has_shell {
             "## Shell Policy\n\n\
              - Prefer non-destructive commands. Use `trash` over `rm` where possible.\n\
@@ -1475,12 +1484,12 @@ impl DelegateTool {
             workspace_dir,
             agent_workspace_dir: workspace_dir,
             model_name,
-            tools: sub_tools,
+            tools: prompt_tools,
             skills: &skills,
             skills_prompt_mode: zeroclaw_config::schema::SkillsPromptInjectionMode::Full,
             identity_config: None,
             dispatcher_instructions: "",
-            sends_native_tool_specs: false,
+            sends_native_tool_specs: sends_native_tool_specs && !prompt_tools.is_empty(),
 
             security_summary: None,
             autonomy_level: crate::security::AutonomyLevel::default(),
@@ -1592,6 +1601,7 @@ impl DelegateTool {
             model,
             &sub_tools,
             &self.workspace_dir,
+            model_provider.supports_native_tools(),
         );
 
         let mut history = Vec::new();
@@ -1640,6 +1650,7 @@ impl DelegateTool {
                 None,
                 None,
                 &zeroclaw_config::schema::PacingConfig::default(),
+                agent_config.strict_tool_parsing,
                 0,    // max_tool_result_chars: inherit from parent config in future
                 0,    // context_token_budget: 0 = disabled for subagents
                 None, // shared_budget: TODO thread from parent in future
@@ -1891,6 +1902,50 @@ mod tests {
         }
         fn alias(&self) -> &str {
             "OneToolThenFinalModelProvider"
+        }
+    }
+
+    struct TextFallbackToolModelProvider;
+
+    #[async_trait]
+    impl ModelProvider for TextFallbackToolModelProvider {
+        async fn chat_with_system(
+            &self,
+            _system_prompt: Option<&str>,
+            _message: &str,
+            _model: &str,
+            _temperature: Option<f64>,
+        ) -> anyhow::Result<String> {
+            Ok("unused".to_string())
+        }
+
+        async fn chat(
+            &self,
+            _request: ChatRequest<'_>,
+            _model: &str,
+            _temperature: Option<f64>,
+        ) -> anyhow::Result<ChatResponse> {
+            Ok(ChatResponse {
+                text: Some(
+                    r#"<tool_call>{"name":"echo_tool","arguments":{"value":"ignored"}}</tool_call>"#
+                        .to_string(),
+                ),
+                tool_calls: Vec::new(),
+                usage: None,
+                reasoning_content: None,
+            })
+        }
+    }
+    impl ::zeroclaw_api::attribution::Attributable for TextFallbackToolModelProvider {
+        fn role(&self) -> ::zeroclaw_api::attribution::Role {
+            ::zeroclaw_api::attribution::Role::Provider(
+                ::zeroclaw_api::attribution::ProviderKind::Model(
+                    ::zeroclaw_api::attribution::ModelProviderKind::Custom,
+                ),
+            )
+        }
+        fn alias(&self) -> &str {
+            "TextFallbackToolModelProvider"
         }
     }
 
@@ -2386,6 +2441,60 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn execute_agentic_strict_tool_parsing_uses_target_agent_policy() {
+        let mut config = agentic_agent_config();
+        config.strict_tool_parsing = true;
+        let prompt_tools: Vec<Box<dyn Tool>> = vec![Box::new(EchoTool)];
+        let tool = DelegateTool::new(HashMap::new(), None, test_security())
+            .with_runtime_profiles(agentic_runtime_profiles(10))
+            .with_risk_profiles(agentic_risk_profiles(vec!["echo_tool".to_string()]))
+            .with_parent_tools(Arc::new(RwLock::new(vec![Arc::new(EchoTool)])));
+
+        let prompt = tool
+            .build_enriched_system_prompt(
+                "agentic",
+                &config,
+                "model-test",
+                &prompt_tools,
+                Path::new("/tmp"),
+                false,
+            )
+            .expect("prompt should render");
+        assert!(
+            !prompt.contains("## Tools"),
+            "strict delegate prompt should not advertise text tool instructions"
+        );
+        assert!(
+            !prompt.contains("echo_tool"),
+            "strict delegate prompt should hide text-only tool schemas"
+        );
+
+        let model_provider = TextFallbackToolModelProvider;
+        let result = tool
+            .execute_agentic(
+                "agentic",
+                &config,
+                "openrouter",
+                "model-test",
+                &model_provider,
+                "run",
+                Some(0.2),
+            )
+            .await
+            .unwrap();
+
+        assert!(result.success);
+        assert!(
+            result.output.contains("<tool_call>"),
+            "strict subagent should return fallback-looking text unchanged"
+        );
+        assert!(
+            !result.output.contains("echo:ignored"),
+            "strict subagent must not execute text fallback tool calls"
+        );
+    }
+
+    #[tokio::test]
     async fn execute_agentic_excludes_delegate_even_if_allowlisted() {
         let config = agentic_agent_config();
         let tool = DelegateTool::new(HashMap::new(), None, test_security())
@@ -2736,7 +2845,7 @@ mod tests {
             .with_workspace_dir(workspace.clone());
 
         let prompt = tool
-            .build_enriched_system_prompt("alpha", &config, "test-model", &tools, &workspace)
+            .build_enriched_system_prompt("alpha", &config, "test-model", &tools, &workspace, false)
             .unwrap();
 
         assert!(prompt.contains("## Tools"), "should contain tools section");
@@ -2804,7 +2913,7 @@ mod tests {
             .with_workspace_dir(workspace.to_path_buf());
 
         let prompt = tool
-            .build_enriched_system_prompt("alpha", &config, "test-model", &tools, &workspace)
+            .build_enriched_system_prompt("alpha", &config, "test-model", &tools, &workspace, false)
             .unwrap();
 
         assert!(
@@ -2854,7 +2963,7 @@ mod tests {
             .with_workspace_dir(workspace.to_path_buf());
 
         let prompt = tool
-            .build_enriched_system_prompt("alpha", &config, "test-model", &tools, &workspace)
+            .build_enriched_system_prompt("alpha", &config, "test-model", &tools, &workspace, false)
             .unwrap();
 
         assert!(
@@ -2926,7 +3035,7 @@ mod tests {
             .with_workspace_dir(workspace.clone());
 
         let prompt = tool
-            .build_enriched_system_prompt("alpha", &config, "test-model", &tools, &workspace)
+            .build_enriched_system_prompt("alpha", &config, "test-model", &tools, &workspace, false)
             .unwrap();
 
         assert!(
@@ -2959,7 +3068,7 @@ mod tests {
             .with_workspace_dir(workspace.clone());
 
         let prompt = tool
-            .build_enriched_system_prompt("alpha", &config, "test-model", &tools, &workspace)
+            .build_enriched_system_prompt("alpha", &config, "test-model", &tools, &workspace, false)
             .unwrap();
 
         assert!(


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Adds `strict_tool_parsing` to each `[agents.<alias>]` config entry so mixed-provider installs can opt individual agents into native-only tool execution.
  - Keeps XML/JSON/text fallback-looking tool calls as final assistant text in strict mode instead of dispatching them through the permissive fallback parser.
  - Hides text tool-use prompt instructions from direct Agent, CLI/runtime, process_message, channel orchestrator, and delegate prompt paths when strict parsing is enabled and native tool specs are unavailable.
  - Carries the target agent's strict parser policy into agentic delegate subloops so subagents do not silently inherit or re-enable the wrong parser behavior.
  - Preserves native-tool behavior, including native-mode fallback history compatibility for providers that expose structured tool calls.
- **Scope boundary:** This PR implements the strict parser option slice only. It does not add a full local-first runtime profile, compact no-tools preset, truncation marker redesign, or provider-specific Ollama profile.
- **Blast radius:** Runtime agent loops, direct Agent prompt construction, gateway/process_message execution, channel orchestrator prompt and execution paths, delegate agentic subloops, and config deserialization. Native provider tool calls should keep working; text fallback tool dispatch changes only for agents with `strict_tool_parsing = true`.
- **Linked issue(s):** Related #5287
- **Labels:** Current labels: `enhancement`, `risk: high`, `size: M`, `agent`, `channel`, `config`, `runtime`.

## Validation Evidence (required)

- **Commands run and tail output:**

```text
cargo fmt --all -- --check
Result: passed.

git diff --check
Result: passed.

cargo check -p zeroclaw-runtime
Result: passed.

cargo test -p zeroclaw-runtime strict_tool_parsing --lib -- --nocapture
Result: passed. 3 passed; 0 failed.

cargo test -p zeroclaw-runtime strict_non_native_prompt_policy_hides_text_tool_protocol_inputs --lib -- --nocapture
Result: passed. 1 passed; 0 failed.

cargo test -p zeroclaw-channels channel_strict_non_native_prompt_hides_text_tool_protocol --lib -- --nocapture
Result: passed. 1 passed; 0 failed.

cargo test -p zeroclaw-config agent_config --lib -- --nocapture
Result: passed. 2 passed; 0 failed.

cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
Result: passed.

cargo nextest run --locked --workspace --exclude zeroclaw-desktop
Result: passed. 7834 passed; 10 skipped. Nextest reported 1 leaky test and returned success.
```

- **Beyond CI — what did you manually verify?** I checked the strict parsing behavior across the direct Agent path, the main runtime loop, streaming response forwarding, prompt construction for non-native tool protocols, channel orchestrator propagation, and delegate agentic subloops, and verified the `process_message` propagation in the diff. The regression coverage verifies that fallback-looking text stays visible as text in strict mode while native tool-call behavior remains intact.
- **If any command was intentionally skipped, why:** No required local validation command was intentionally skipped. The nextest run reported 10 skipped tests and returned success.

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: Not applicable.

This change narrows tool execution in strict mode. Tool-looking text is no longer enough to trigger tool execution when an agent has `strict_tool_parsing = true`; the provider must return native or structured tool calls for the runtime to execute tools.

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`Yes`)
- If `No` or `Yes` to either: Existing configs keep the default `strict_tool_parsing = false`, so current fallback parsing behavior remains unchanged. Users who want strict behavior can enable it per configured agent:

```toml
[agents.assistant]
strict_tool_parsing = true
```

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert 835de4cda`
- **Feature flags or config toggles:** Set or leave `[agents.<alias>].strict_tool_parsing = false` to keep legacy fallback parsing behavior. The default is `false`.
- **Observable failure symptoms:** Strict-mode users would see tools not executing unless the active provider supports native tool calls and returns structured tool calls. Watch for logs or user reports around missing tool dispatch in strict mode, unexpected final text containing `<tool_call>`, or delegate subagents not executing allowlisted tools under non-native providers.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): Not applicable.
- Scope materially carried forward: Not applicable.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`No`)
- If `No`, why (inspiration-only, no direct code/design carry-over): Not applicable.
