### PR TITLE
test(skills): fix heredoc manifest fixture

### DIFF
--- a/crates/zeroclaw-runtime/src/skills/audit.rs
+++ b/crates/zeroclaw-runtime/src/skills/audit.rs
@@ -687,7 +687,9 @@ description = \"test heredoc\"
 name = \"write-file\"
 description = \"write a config file\"
 kind = \"shell\"
-command = \"cat <<'EOF'\nsome content\nEOF\"
+command = \"\"\"cat <<'EOF'
+some content
+EOF\"\"\"
 ",
         )
         .unwrap();


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Encodes the `audit_allows_heredoc_in_manifest_command` fixture as a valid TOML multiline string.
  - Keeps the regression focused on whether skills audit accepts heredoc shell commands in manifest tools.
  - Fixes the heredoc fixture so the regression reaches the audit-policy assertion instead of failing during TOML parsing.
- **Scope boundary:** This is a test-fixture fix only. It does not change skills audit behavior, command execution policy, install flow, or runtime code paths.
- **Blast radius:** Skills audit unit tests and CI signal only.
- **Linked issue(s):** None. Related PRs: #5952, #6673, #6674, #6675, #6676.
- **Labels:** Current labels: `bug`, `risk: low`, `risk: manual`, `size: XS`, `runtime`, `skills`.

## Validation Evidence (required)

- **Commands run and tail output:**

```text
cargo test -p zeroclaw-runtime audit_allows_heredoc_in_manifest_command
Result: passed. The focused heredoc manifest regression now passes.

cargo test -p zeroclaw-runtime skills::audit::tests
Result: passed. All 14 skills audit unit tests passed.

cargo fmt --all -- --check
Result: passed.

git diff --check
Result: passed.
```

- **Beyond CI — what did you manually verify?** I checked that the production audit parser still uses TOML parsing unchanged, and that the fixture now uses valid TOML syntax for a multiline heredoc command.
- **If any command was intentionally skipped, why:** Full workspace `cargo test` and workspace-shaped clippy were skipped because this is a test-only fixture correction with focused coverage of the failing skills audit module.

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: Not applicable.

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: Not applicable; this only changes a unit-test fixture.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PRs: `git revert 4baa79c3b` is the rollback path.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): Not applicable.
- Scope materially carried forward: Not applicable.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`No`)
- If `No`, why (inspiration-only, no direct code/design carry-over): Not applicable.
