### PR TITLE
fix(agents): delegate agents respect skills.prompt_injection_mode config

### DIFF
--- a/crates/zeroclaw-runtime/src/tools/delegate.rs
+++ b/crates/zeroclaw-runtime/src/tools/delegate.rs
@@ -89,6 +89,8 @@ pub struct DelegateTool {
     cancellation_token: CancellationToken,
     /// Optional memory instance for namespace isolation on delegate agents.
     memory: Option<Arc<dyn Memory>>,
+    /// Skills prompt injection mode inherited from root config.
+    skills_prompt_mode: zeroclaw_config::schema::SkillsPromptInjectionMode,
 }
 
 impl DelegateTool {
@@ -123,6 +125,7 @@ impl DelegateTool {
             workspace_dir: PathBuf::new(),
             cancellation_token: CancellationToken::new(),
             memory: None,
+            skills_prompt_mode: zeroclaw_config::schema::SkillsPromptInjectionMode::Full,
         }
     }
 
@@ -163,7 +166,17 @@ impl DelegateTool {
             workspace_dir: PathBuf::new(),
             cancellation_token: CancellationToken::new(),
             memory: None,
+            skills_prompt_mode: zeroclaw_config::schema::SkillsPromptInjectionMode::Full,
         }
+    }
+
+    /// Attach skills prompt injection mode from root config.
+    pub fn with_skills_prompt_mode(
+        mut self,
+        mode: zeroclaw_config::schema::SkillsPromptInjectionMode,
+    ) -> Self {
+        self.skills_prompt_mode = mode;
+        self
     }
 
     /// Attach parent tools used to build sub-agent allowlist registries.
@@ -655,6 +668,7 @@ impl DelegateTool {
         let delegate_config = self.delegate_config.clone();
         let workspace_dir = self.workspace_dir.clone();
         let child_token = self.cancellation_token.child_token();
+        let skills_prompt_mode = self.skills_prompt_mode;
         let task_id_clone = task_id.clone();
         let parent_session_key = current_tool_loop_session_key();
 
@@ -673,6 +687,7 @@ impl DelegateTool {
                     workspace_dir: workspace_dir.clone(),
                     cancellation_token: child_token.clone(),
                     memory: None,
+                    skills_prompt_mode,
                 };
 
                 let args_inner = json!({
@@ -829,6 +844,7 @@ impl DelegateTool {
             let delegate_config = self.delegate_config.clone();
             let workspace_dir = self.workspace_dir.clone();
             let cancellation_token = self.cancellation_token.child_token();
+            let skills_prompt_mode = self.skills_prompt_mode;
             let agent_name = agent_name.clone();
             let prompt = prompt.to_string();
             let args_clone = args.clone();
@@ -848,6 +864,7 @@ impl DelegateTool {
                     workspace_dir,
                     cancellation_token,
                     memory: None,
+                    skills_prompt_mode,
                 };
                 let agent_name_for_return = agent_name.clone();
                 let result = scope_delegate_session_key(session_key, async move {
@@ -1094,7 +1111,7 @@ impl DelegateTool {
             model_name: &agent_config.model,
             tools: sub_tools,
             skills: &skills,
-            skills_prompt_mode: zeroclaw_config::schema::SkillsPromptInjectionMode::Full,
+            skills_prompt_mode: self.skills_prompt_mode.clone(),
             identity_config: None,
             dispatcher_instructions: "",
             sends_native_tool_specs: false,
@@ -2685,6 +2702,81 @@ mod tests {
         assert!(
             prompt.contains("deploy"),
             "should contain skills from default workspace skills/ directory"
+        );
+
+        let _ = std::fs::remove_dir_all(workspace);
+    }
+
+    #[test]
+    fn enriched_prompt_respects_compact_skills_prompt_mode() {
+        let workspace = std::env::temp_dir().join(format!(
+            "zeroclaw_delegate_compact_test_{}",
+            uuid::Uuid::new_v4()
+        ));
+        let default_skills_dir = workspace.join("skills");
+        std::fs::create_dir_all(default_skills_dir.join("review")).unwrap();
+        std::fs::write(
+            default_skills_dir.join("review/SKILL.toml"),
+            "[skill]\nname = \"review\"\ndescription = \"Code review\"\nversion = \"1.0.0\"\nprompts = [\"Always check for security issues\"]\n",
+        )
+        .unwrap();
+
+        let config = DelegateAgentConfig {
+            provider: "openrouter".to_string(),
+            model: "test-model".to_string(),
+            system_prompt: None,
+            api_key: None,
+            temperature: None,
+            max_depth: 3,
+            agentic: true,
+            allowed_tools: vec!["echo_tool".to_string()],
+            max_iterations: 10,
+            timeout_secs: None,
+            agentic_timeout_secs: None,
+            skills_directory: None,
+            memory_namespace: None,
+        };
+
+        let tools: Vec<Box<dyn Tool>> = vec![Box::new(EchoTool)];
+
+        // Compact mode: should NOT inline <instructions>, should mention on-demand loading.
+        let compact_tool = DelegateTool::new(HashMap::new(), None, test_security())
+            .with_workspace_dir(workspace.clone())
+            .with_skills_prompt_mode(
+                zeroclaw_config::schema::SkillsPromptInjectionMode::Compact,
+            );
+
+        let compact_prompt = compact_tool
+            .build_enriched_system_prompt(&config, &tools, &workspace)
+            .unwrap();
+
+        assert!(
+            compact_prompt.contains("review"),
+            "compact mode should still list the skill"
+        );
+        assert!(
+            !compact_prompt.contains("<instructions>"),
+            "compact mode must not inline skill instructions"
+        );
+        assert!(
+            compact_prompt.contains("Skill summaries are preloaded"),
+            "compact mode should use the compact header"
+        );
+
+        // Full mode: should inline <instructions>.
+        let full_tool = DelegateTool::new(HashMap::new(), None, test_security())
+            .with_workspace_dir(workspace.clone())
+            .with_skills_prompt_mode(
+                zeroclaw_config::schema::SkillsPromptInjectionMode::Full,
+            );
+
+        let full_prompt = full_tool
+            .build_enriched_system_prompt(&config, &tools, &workspace)
+            .unwrap();
+
+        assert!(
+            full_prompt.contains("<instructions>"),
+            "full mode should inline skill instructions"
         );
 
         let _ = std::fs::remove_dir_all(workspace);

--- a/crates/zeroclaw-runtime/src/tools/delegate.rs
+++ b/crates/zeroclaw-runtime/src/tools/delegate.rs
@@ -1111,7 +1111,7 @@ impl DelegateTool {
             model_name: &agent_config.model,
             tools: sub_tools,
             skills: &skills,
-            skills_prompt_mode: self.skills_prompt_mode.clone(),
+            skills_prompt_mode: self.skills_prompt_mode,
             identity_config: None,
             dispatcher_instructions: "",
             sends_native_tool_specs: false,

--- a/crates/zeroclaw-runtime/src/tools/delegate.rs
+++ b/crates/zeroclaw-runtime/src/tools/delegate.rs
@@ -2742,9 +2742,7 @@ mod tests {
         // Compact mode: should NOT inline <instructions>, should mention on-demand loading.
         let compact_tool = DelegateTool::new(HashMap::new(), None, test_security())
             .with_workspace_dir(workspace.clone())
-            .with_skills_prompt_mode(
-                zeroclaw_config::schema::SkillsPromptInjectionMode::Compact,
-            );
+            .with_skills_prompt_mode(zeroclaw_config::schema::SkillsPromptInjectionMode::Compact);
 
         let compact_prompt = compact_tool
             .build_enriched_system_prompt(&config, &tools, &workspace)
@@ -2766,9 +2764,7 @@ mod tests {
         // Full mode: should inline <instructions>.
         let full_tool = DelegateTool::new(HashMap::new(), None, test_security())
             .with_workspace_dir(workspace.clone())
-            .with_skills_prompt_mode(
-                zeroclaw_config::schema::SkillsPromptInjectionMode::Full,
-            );
+            .with_skills_prompt_mode(zeroclaw_config::schema::SkillsPromptInjectionMode::Full);
 
         let full_prompt = full_tool
             .build_enriched_system_prompt(&config, &tools, &workspace)

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -964,7 +964,7 @@ pub fn all_tools_with_runtime(
         .with_delegate_config(root_config.delegate.clone())
         .with_workspace_dir(workspace_dir.to_path_buf())
         .with_memory(memory.clone())
-        .with_skills_prompt_mode(root_config.skills.prompt_injection_mode.clone());
+        .with_skills_prompt_mode(root_config.skills.prompt_injection_mode);
         tool_arcs.push(Arc::new(delegate_tool));
         Some(parent_tools)
     };

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -963,7 +963,8 @@ pub fn all_tools_with_runtime(
         .with_multimodal_config(root_config.multimodal.clone())
         .with_delegate_config(root_config.delegate.clone())
         .with_workspace_dir(workspace_dir.to_path_buf())
-        .with_memory(memory.clone());
+        .with_memory(memory.clone())
+        .with_skills_prompt_mode(root_config.skills.prompt_injection_mode.clone());
         tool_arcs.push(Arc::new(delegate_tool));
         Some(parent_tools)
     };


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Delegate agents previously hardcoded `SkillsPromptInjectionMode::Full` when building enriched prompts, ignoring the `[skills].prompt_injection_mode` config. Users running smaller-context delegate models with many skills hit context overflow (e.g. ~139K tokens into a 32K window) even when they had set `compact`.
  - Thread `root_config.skills.prompt_injection_mode` into `DelegateTool` via a `with_skills_prompt_mode` builder method and use the stored mode in `build_enriched_system_prompt` instead of the hardcoded `Full`.
  - Propagate the configured mode through the background and parallel delegate paths so compact/full behavior is consistent across delegate execution modes.
  - Add regression test asserting compact mode lists the skill without inlining `<instructions>`, while full mode keeps inlining.
- **Scope boundary:** Does not change the skill loader, the `compact` vs `full` rendering itself, the default mode (still `Full` for direct/test constructors), or any non-delegate tool's prompt construction.
- **Blast radius:** `DelegateTool` enriched-prompt construction only. No effect on top-level agent prompts, non-delegate tools, or providers. Behavior for users on the existing default (`full`) is byte-identical.
- **Linked issue(s):** Closes #5155. Supersedes #5763 by @perlowjanv (revived after accidental branch-cleanup close; approach unchanged).
- **Labels:** `bug`, `agent`, `runtime`, `skills`, `tool`, `tool:delegate`, `size: S`, `risk: medium`.

## Validation Evidence (required)

- **Commands run and tail output:**

```text
$ cargo fmt --all -- --check
(no output; exit 0)

$ cargo clippy --all-targets -- -D warnings
    Checking zeroclaw-tool-call-parser v0.7.5 (crates/zeroclaw-tool-call-parser)
    Checking zeroclaw-config v0.7.5 (crates/zeroclaw-config)
    Checking zeroclaw-providers v0.7.5 (crates/zeroclaw-providers)
    Checking zeroclaw-memory v0.7.5 (crates/zeroclaw-memory)
    Checking zeroclaw-tools v0.7.5 (crates/zeroclaw-tools)
    Checking zeroclaw-runtime v0.7.5 (crates/zeroclaw-runtime)
    Checking zeroclaw-hardware v0.7.5 (crates/zeroclaw-hardware)
    Checking zeroclaw-channels v0.7.5 (crates/zeroclaw-channels)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 47s
(exit 0; 0 warnings)

$ cargo test -p zeroclaw-runtime enriched_prompt
running 6 tests
test tools::delegate::tests::enriched_prompt_includes_tools_workspace_datetime ... ok
test tools::delegate::tests::enriched_prompt_includes_shell_policy_when_shell_present ... ok
test tools::delegate::tests::enriched_prompt_omits_shell_policy_without_shell_tool ... ok
test tools::delegate::tests::enriched_prompt_falls_back_to_default_skills_dir ... ok
test tools::delegate::tests::enriched_prompt_loads_skills_from_scoped_directory ... ok
test tools::delegate::tests::enriched_prompt_respects_compact_skills_prompt_mode ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 1698 filtered out
```

CI on the previous head `e2074ad5` (same code; this branch was just rebased to strip bot-attribution trailers from commit messages — no diff change): Lint, Test, Build (linux/macOS/windows), Check (all/no-default/32-bit), Security, Benchmarks Compile, CI Required Gate — all pass.

- **Beyond CI — what did you manually verify?** Inspected the enriched prompt produced by the new test under both modes (`compact` produces compact header with no `<instructions>` block; `full` inlines `<instructions>`). Verified the mode is also threaded through the background and parallel delegate construction paths by reading the struct-literal sites in `delegate.rs`. **Not** verified end-to-end against a real provider with a large skill set; the regression covers the prompt-construction boundary, which is where #5155 manifests.
- **If any command was intentionally skipped, why:** None skipped. One pre-existing flake observed during local workspace `cargo test`: `zeroclaw-acp-bridge tests::write_cached_token_persists_for_future_bridge_starts` failed when run in parallel with the rest of the suite, then passed in isolation (`cargo test --bin zeroclaw-acp-bridge tests::write_cached_token_persists_for_future_bridge_starts` → `1 passed`). The file `src/bin/zeroclaw-acp-bridge.rs` is untouched on this branch (`git log origin/master..HEAD -- src/bin/zeroclaw-acp-bridge.rs` is empty); last touched on master by `7deb9f147 fix(channels/acp): implement ACP protocol v1 …`. Token-cache parallel contention, unrelated to this PR.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

This PR changes only how an existing config value flows into prompt construction. No new I/O, no new surfaces.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- The `[skills].prompt_injection_mode` config field already exists; this PR makes the delegate path honor it instead of ignoring it. Users on the default (`full`) see byte-identical prompts. Users who had explicitly set `compact` get the behavior they were already configuring (a bugfix, not a behavior change to opt into). No upgrade steps required.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert f02ccaf06 ea84e0547 d1dd97071` (or revert the squash-merge commit if squash-merged). Three small commits, no migrations, no persisted state — revert is safe at any time.
- **Feature flags or config toggles:** No flag. Per-user workaround pre-revert: set `[skills] prompt_injection_mode = "full"` in config to restore prior delegate behavior (the hardcoded value this PR replaced). This is functionally equivalent to the pre-PR state.
- **Observable failure symptoms:** Delegate calls failing with provider context-window errors immediately after merge, especially on smaller-context delegate models with many skills configured. Grep delegate/provider logs for context-length / token-limit errors and 4xx responses from the delegate model. No specific metric or alert is wired to this path; user reports on #5155-class symptoms are the primary signal.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors:
  - #5763 by @perlowjanv
- Scope materially carried forward: Yes — same approach (thread `prompt_injection_mode` through `DelegateTool` and replace the hardcoded `Full`). Test coverage added on top.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `Yes` — `Co-Authored-By: perlowjanv` is on the main fix commit (`f02ccaf06`).
- If `No`, why: n/a.
