### PR TITLE
feat(debug): restore --log-llm payload tracing

### DIFF
--- a/crates/zeroclaw-providers/src/reliable.rs
+++ b/crates/zeroclaw-providers/src/reliable.rs
@@ -6,6 +6,7 @@ use async_trait::async_trait;
 use futures_util::{StreamExt, stream};
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::sync::atomic::AtomicBool;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
@@ -30,6 +31,16 @@ pub struct ProviderFallbackInfo {
 
 tokio::task_local! {
     static PROVIDER_FALLBACK: RefCell<Option<ProviderFallbackInfo>>;
+}
+
+static LLM_PAYLOAD_TRACING_ENABLED: AtomicBool = AtomicBool::new(false);
+
+/// Enable or disable raw LLM payload tracing.
+///
+/// This is separate from `RUST_LOG` so ordinary TRACE diagnostics cannot dump
+/// prompts, history, or tool output unless the CLI explicitly opts in.
+pub fn set_llm_payload_tracing_enabled(enabled: bool) -> bool {
+    LLM_PAYLOAD_TRACING_ENABLED.swap(enabled, Ordering::Relaxed)
 }
 
 /// Take (consume) the last provider fallback info, if any.
@@ -340,6 +351,60 @@ fn truncate_for_context(messages: &mut Vec<ChatMessage>) -> usize {
     drop_count
 }
 
+fn llm_payload_trace_json(messages: &[ChatMessage]) -> String {
+    serde_json::to_string_pretty(messages)
+        .unwrap_or_else(|err| format!("<message payload serialization failed: {err}>"))
+}
+
+fn llm_payload_trace_should_emit(trace_enabled: bool) -> bool {
+    LLM_PAYLOAD_TRACING_ENABLED.load(Ordering::Relaxed) && trace_enabled
+}
+
+fn should_trace_llm_payload() -> bool {
+    llm_payload_trace_should_emit(tracing::enabled!(
+        target: "zeroclaw_providers::reliable",
+        tracing::Level::TRACE
+    ))
+}
+
+fn trace_llm_payload(provider: &str, model: &str, messages: &[ChatMessage], attempt: u32) {
+    if !should_trace_llm_payload() {
+        return;
+    }
+    let payload = llm_payload_trace_json(messages);
+    tracing::trace!(
+        target: "zeroclaw_providers::reliable",
+        provider = %provider,
+        model = %model,
+        attempt,
+        message_count = messages.len(),
+        "\n{payload}\n"
+    );
+}
+
+fn system_chat_messages(system_prompt: Option<&str>, message: &str) -> Vec<ChatMessage> {
+    let mut messages = Vec::with_capacity(usize::from(system_prompt.is_some()) + 1);
+    if let Some(system_prompt) = system_prompt {
+        messages.push(ChatMessage::system(system_prompt));
+    }
+    messages.push(ChatMessage::user(message));
+    messages
+}
+
+fn trace_system_chat_payload(
+    provider: &str,
+    model: &str,
+    system_prompt: Option<&str>,
+    message: &str,
+    attempt: u32,
+) {
+    if !should_trace_llm_payload() {
+        return;
+    }
+    let messages = system_chat_messages(system_prompt, message);
+    trace_llm_payload(provider, model, &messages, attempt);
+}
+
 fn push_failure(
     failures: &mut Vec<String>,
     provider_name: &str,
@@ -464,6 +529,14 @@ impl Provider for ReliableProvider {
                 let mut backoff_ms = self.base_backoff_ms;
 
                 for attempt in 0..=self.max_retries {
+                    trace_system_chat_payload(
+                        provider_name,
+                        current_model,
+                        system_prompt,
+                        message,
+                        attempt + 1,
+                    );
+
                     match provider
                         .chat_with_system(system_prompt, message, current_model, temperature)
                         .await
@@ -613,6 +686,13 @@ impl Provider for ReliableProvider {
                 let mut backoff_ms = self.base_backoff_ms;
 
                 for attempt in 0..=self.max_retries {
+                    trace_llm_payload(
+                        provider_name,
+                        current_model,
+                        &effective_messages,
+                        attempt + 1,
+                    );
+
                     match provider
                         .chat_with_history(&effective_messages, current_model, temperature)
                         .await
@@ -785,6 +865,13 @@ impl Provider for ReliableProvider {
                 let mut backoff_ms = self.base_backoff_ms;
 
                 for attempt in 0..=self.max_retries {
+                    trace_llm_payload(
+                        provider_name,
+                        current_model,
+                        &effective_messages,
+                        attempt + 1,
+                    );
+
                     match provider
                         .chat_with_tools(&effective_messages, tools, current_model, temperature)
                         .await
@@ -942,6 +1029,13 @@ impl Provider for ReliableProvider {
                 let mut backoff_ms = self.base_backoff_ms;
 
                 for attempt in 0..=self.max_retries {
+                    trace_llm_payload(
+                        provider_name,
+                        current_model,
+                        &effective_messages,
+                        attempt + 1,
+                    );
+
                     let req = ChatRequest {
                         messages: &effective_messages,
                         tools: request.tools,
@@ -1133,6 +1227,7 @@ impl Provider for ReliableProvider {
                 messages: request.messages,
                 tools: request.tools,
             };
+            trace_llm_payload(provider_name, &current_model, req.messages, 1);
             let stream = provider.stream_chat(req, &current_model, temperature, options);
             let (tx, rx) = tokio::sync::mpsc::channel::<StreamResult<StreamEvent>>(100);
 
@@ -1192,6 +1287,7 @@ impl Provider for ReliableProvider {
 
             // For streaming, we attempt once and propagate errors
             // The caller can retry the entire request if needed
+            trace_system_chat_payload(provider_name, &current_model, system_prompt, message, 1);
             let stream = provider.stream_chat_with_system(
                 system_prompt,
                 message,
@@ -1257,6 +1353,7 @@ impl Provider for ReliableProvider {
                 None => model.to_string(),
             };
 
+            trace_llm_payload(provider_name, &current_model, messages, 1);
             let stream =
                 provider.stream_chat_with_history(messages, &current_model, temperature, options);
 
@@ -2169,6 +2266,61 @@ mod tests {
         assert_eq!(result.tool_calls.len(), 1);
         assert_eq!(result.tool_calls[0].name, "shell");
         assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn llm_payload_trace_json_preserves_roles_and_content() {
+        let messages = vec![
+            ChatMessage::system("system prompt"),
+            ChatMessage::user("hello"),
+            ChatMessage::tool(r#"{"result":"ok"}"#),
+        ];
+
+        let json = llm_payload_trace_json(&messages);
+
+        assert!(json.contains("\"role\": \"system\""));
+        assert!(json.contains("\"content\": \"system prompt\""));
+        assert!(json.contains("\"role\": \"tool\""));
+        assert!(json.contains(r#""content": "{\"result\":\"ok\"}""#));
+    }
+
+    #[test]
+    fn llm_payload_trace_requires_explicit_opt_in() {
+        let previous = set_llm_payload_tracing_enabled(false);
+        let _reset = scopeguard::guard(previous, |previous| {
+            set_llm_payload_tracing_enabled(previous);
+        });
+
+        assert!(
+            !llm_payload_trace_should_emit(true),
+            "TRACE logging alone must not emit raw payloads"
+        );
+
+        set_llm_payload_tracing_enabled(true);
+
+        assert!(
+            llm_payload_trace_should_emit(true),
+            "explicit opt-in plus TRACE should emit raw payloads"
+        );
+        assert!(
+            !llm_payload_trace_should_emit(false),
+            "explicit opt-in still needs the trace target enabled"
+        );
+    }
+
+    #[test]
+    fn system_chat_messages_preserve_optional_system_prompt() {
+        let with_system = system_chat_messages(Some("system prompt"), "hello");
+        assert_eq!(with_system.len(), 2);
+        assert_eq!(with_system[0].role, "system");
+        assert_eq!(with_system[0].content, "system prompt");
+        assert_eq!(with_system[1].role, "user");
+        assert_eq!(with_system[1].content, "hello");
+
+        let without_system = system_chat_messages(None, "hello");
+        assert_eq!(without_system.len(), 1);
+        assert_eq!(without_system[0].role, "user");
+        assert_eq!(without_system[0].content, "hello");
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -249,6 +249,11 @@ struct Cli {
     #[arg(long, global = true)]
     config_dir: Option<String>,
 
+    /// Print raw LLM message payloads for local debugging; may include prompts,
+    /// history, and tool output.
+    #[arg(long, global = true)]
+    log_llm: bool,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -1257,11 +1262,20 @@ async fn main() -> Result<()> {
         "info,matrix_sdk=warn,matrix_sdk_base=warn,matrix_sdk_crypto=warn"
     };
 
+    let mut filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_log_level));
+    if cli.log_llm {
+        zeroclaw_providers::reliable::set_llm_payload_tracing_enabled(true);
+        filter = filter.add_directive(
+            "zeroclaw_providers::reliable=trace"
+                .parse()
+                .expect("valid log-llm tracing directive"),
+        );
+    }
+
     let subscriber = fmt::Subscriber::builder()
         .with_writer(std::io::stderr)
-        .with_env_filter(
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_log_level)),
-        )
+        .with_env_filter(filter)
         .finish();
 
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
@@ -3907,6 +3921,36 @@ mod tests {
             has_model_flag,
             "onboard help should include --model for quick setup overrides"
         );
+    }
+
+    #[test]
+    #[cfg(feature = "agent-runtime")]
+    fn log_llm_is_global_flag_for_agent_debugging() {
+        for args in [
+            ["zeroclaw", "--log-llm", "agent", "--message", "hello"],
+            ["zeroclaw", "agent", "--log-llm", "--message", "hello"],
+        ] {
+            let cli = Cli::try_parse_from(args).expect("--log-llm should parse globally");
+
+            assert!(
+                cli.log_llm,
+                "--log-llm should opt in to provider payload tracing"
+            );
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "agent-runtime")]
+    fn log_llm_help_warns_about_raw_payloads() {
+        let mut help = Vec::new();
+        Cli::command()
+            .write_long_help(&mut help)
+            .expect("help should render");
+        let help = String::from_utf8(help).expect("help should be utf8");
+
+        assert!(help.contains("--log-llm"));
+        assert!(help.contains("Print raw LLM message payloads"));
+        assert!(help.contains("may include prompts, history, and tool output"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -249,8 +249,9 @@ struct Cli {
     #[arg(long, global = true)]
     config_dir: Option<String>,
 
-    /// Print raw LLM message payloads for local debugging; may include prompts,
-    /// history, and tool output.
+    /// Emit raw LLM message payload trace events for local debugging; default
+    /// logging writes them to stderr, but custom subscribers may route them
+    /// elsewhere. May include prompts, history, and tool output.
     #[arg(long, global = true)]
     log_llm: bool,
 
@@ -3949,8 +3950,10 @@ mod tests {
         let help = String::from_utf8(help).expect("help should be utf8");
 
         assert!(help.contains("--log-llm"));
-        assert!(help.contains("Print raw LLM message payloads"));
-        assert!(help.contains("may include prompts, history, and tool output"));
+        assert!(help.contains("Emit raw LLM message payload trace events"));
+        assert!(help.contains("default logging writes them to stderr"));
+        assert!(help.contains("custom subscribers may route them elsewhere"));
+        assert!(help.contains("May include prompts, history, and tool output"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Restores the reverted `--log-llm` debug flag from #4213 for #6074 recovery work.
  - Makes the flag add a targeted `zeroclaw_providers::reliable=trace` directive and separately opt in to raw payload tracing, so `RUST_LOG=trace` alone cannot dump prompts, history, or tool output.
  - Logs the raw provider message payload as pretty JSON at the `ReliableProvider` boundary across system chat, history, tools, structured chat, legacy streaming, and structured streaming paths.
  - Adds focused regressions for global flag parsing/help text, explicit opt-in gating, JSON payload shape, and system/user payload shaping.
- **Scope boundary:** This does not change prompt construction, provider request semantics, config schema, persisted state, or add OpenTelemetry/exporter configuration.
- **Blast radius:** Affects the root CLI surface and `ReliableProvider` tracing only when `--log-llm` is explicitly passed.
- **Linked issue(s):** Related #6074. Supersedes #4213.
- **Labels:** `enhancement`, `core`, `provider`, `provider:reliable`, `risk: medium`, `size: S`

## Validation Evidence (required)

- **Commands run and result summary:**

```text
git diff --check
pass, no output

cargo fmt --all -- --check
pass

cargo test -p zeroclaw-providers llm_payload_trace
pass; 2 tests passed

cargo test -p zeroclaw-providers system_chat_messages_preserve_optional_system_prompt
pass; 1 test passed

cargo test -p zeroclawlabs log_llm
pass; 2 tests passed

cargo clippy -p zeroclawlabs -p zeroclaw-providers --all-targets -- -D warnings
pass

cargo clippy --all-targets -- -D warnings
pass

cargo test
pass; 159 tests passed in the main test binary, 5 system tests passed, and 7 live tests were ignored because they require live credentials

After reviewer wording clarification:

cargo fmt --all -- --check
pass

cargo test -p zeroclawlabs log_llm
pass; 2 tests passed

git diff --check
pass
```

- **Beyond CI — what did you manually verify?** Reviewed the reliable-provider call paths so `chat_with_system`, `chat_with_history`, `chat_with_tools`, `chat`, `stream_chat_with_system`, `stream_chat_with_history`, and `stream_chat` all pass through the raw-payload tracing helper. Verified by source review that `RUST_LOG=trace` is not enough to emit raw payloads without the explicit flag-controlled provider opt-in.
- **If any command was intentionally skipped, why:** None for the repo-standard local validation set. Live credential tests remained ignored under the repository's normal `cargo test` behavior.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No` — no credential storage or retrieval handling changed. When explicitly enabled, raw payload tracing may expose any secrets already present in prompts, history, or tool output.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: The feature intentionally exposes raw prompt/history/tool-output payloads as tracing events only when an operator passes `--log-llm`. In ZeroClaw's default subscriber configuration those events are written to local stderr; deployments with custom tracing subscribers or appenders may route them to other sinks. The mitigation is explicit CLI opt-in, a separate provider-level opt-in beyond `RUST_LOG`, and help text warning that the output may include prompts, history, and tool output and may be routed by custom subscribers.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `Yes`
- If `No` or `Yes` to either: Existing users do not need to change anything. Omitting `--log-llm` preserves previous behavior; passing it enables raw local debug payload tracing for that process.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <merge-sha>`
- **Feature flags or config toggles:** Do not pass `--log-llm`; there is no persisted config toggle.
- **Observable failure symptoms:** Unexpected raw payload trace lines under target `zeroclaw_providers::reliable`, or missing raw payload traces when running a command with `--log-llm`.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line):
  - #4213 by @mminkus
- Scope materially carried forward:
  - Restores the global `--log-llm` debug flag and reliable-provider raw message payload tracing from the reverted #4213 idea.
  - Updates the implementation for current master by adding explicit raw-payload opt-in gating, broader reliable-provider path coverage, and focused regressions.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `Yes`
- If `No`, why (inspiration-only, no direct code/design carry-over): N/A
