### PR TITLE
feat(skills): add pr-architecture-check advisory review skill

### DIFF
--- a/.claude/skills/pr-architecture-check/SKILL.md
+++ b/.claude/skills/pr-architecture-check/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: pr-architecture-check
+description: "Advisory architecture review of a PR diff. Validates dependency direction, trait boundary compliance, extension pattern conformance, and crate placement against AGENTS.md and FND-001. Posts a non-blocking comment; never gates merge. Trigger on: 'arch-check #N', 'architecture check #N'."
+---
+
+# ZeroClaw PR Architecture Check — Advisory Review
+
+You perform an advisory architecture review of a pull request against the
+project's documented architecture constraints. Your output is informational
+only — it helps contributors and reviewers spot structural issues early.
+
+> **This check is advisory only — not a merge gate.**
+> Per FND-003 §6.4: "AI belongs in the development loop, not the merge gate."
+> Human reviewers make the final call. This skill does not block merges, does
+> not approve or request changes, and does not modify labels.
+
+---
+
+## Invocation
+
+```
+arch-check #1234
+architecture check #1234
+```
+
+---
+
+## Workflow
+
+### Step 1 — Fetch PR data
+
+Run these in parallel:
+
+```bash
+gh pr diff <N> --repo zeroclaw-labs/zeroclaw
+```
+
+```bash
+gh pr view <N> --repo zeroclaw-labs/zeroclaw --json files,title,baseRefName,labels,number
+```
+
+### Step 2 — Load architecture references
+
+**Always load (unconditionally):**
+
+- `AGENTS.md` — repository map, core constraints, risk tiers, anti-patterns
+- `docs/book/src/foundations/fnd-001-intentional-architecture.md` — the
+  canonical architecture RFC: dependency direction rule, crate responsibilities,
+  two-layer model, phased roadmap
+
+**Load conditionally based on files changed:**
+
+| Files touched | Also load |
+|---|---|
+| `crates/zeroclaw-api/` | Extension examples: `docs/book/src/developing/extension-examples.md` |
+| `crates/zeroclaw-runtime/` | FND-001 §Phase 2 (runtime extraction) |
+| `crates/zeroclaw-gateway/` | FND-001 §Phase 3 (gateway separation) |
+| `crates/zeroclaw-plugins/` | FND-001 §Phase 4 (plugin platform) |
+| `crates/zeroclaw-channels/` or `crates/zeroclaw-tools/` | Extension examples doc |
+| `crates/zeroclaw-config/` or `crates/zeroclaw-macros/` | Config schema conventions in AGENTS.md |
+| `.github/workflows/` | FND-003 governance, CI risk tier (high risk per AGENTS.md) |
+
+### Step 3 — Analyze
+
+Apply the full checklist from `references/arch-checklist.md`. For each
+category, determine one of:
+
+- **Pass** — no issues found
+- **Advisory** — potential concern worth reviewer attention
+- **Flag** — likely violation of a documented constraint
+
+### Step 4 — Write artifact
+
+Write the analysis to `tmp/arch-review-<N>.md` with this structure:
+
+```markdown
+# Architecture Review — PR #<N>: <title>
+
+> Advisory only — not a merge gate (FND-003 §6.4)
+
+## Summary
+<1-3 sentence overview of architectural impact>
+
+## Findings
+
+### Dependency Direction
+<pass/advisory/flag + explanation>
+
+### Trait Boundary Compliance
+<pass/advisory/flag + explanation>
+
+### Extension Pattern Conformance
+<pass/advisory/flag + explanation>
+
+### Crate Placement
+<pass/advisory/flag + explanation>
+
+### Core Constraints
+<pass/advisory/flag per constraint, only list those relevant to the diff>
+
+## Files Analyzed
+<list of files from the diff>
+```
+
+### Step 5 — Post advisory comment
+
+Post as a PR comment. The comment must include the advisory header.
+
+```bash
+gh pr comment <N> --repo zeroclaw-labs/zeroclaw \
+  --body-file tmp/arch-review-<N>.md
+```
+
+### Step 6 — Label policy
+
+This skill does not add, remove, or modify any labels. Label management is
+the responsibility of triage and review skills.
+
+---
+
+## Execution Rules
+
+1. **Always load AGENTS.md and FND-001.** These are the authoritative
+   architecture references. Do not skip them.
+2. **Always write to `tmp/arch-review-<N>.md` before posting.** The artifact
+   is consumed by `github-pr-review-session` if it exists.
+3. **Always include the advisory header** in the posted comment and the
+   artifact file. Per FND-003 §6.4, this output is advisory only.
+4. **Never approve, request changes, or use `gh pr review`.** This skill
+   posts a comment, not a formal review verdict.
+5. **Never modify labels.** No label additions, removals, or changes.
+6. **Never block a merge.** If the analysis finds issues, they are reported
+   as advisory findings for the human reviewer to evaluate.
+7. **Be specific.** Reference the exact file, line range, crate, and
+   constraint. Vague findings waste reviewer time.
+8. **Skip irrelevant checks.** If a PR only touches docs, do not flag
+   dependency direction. Only report checks relevant to the diff.

--- a/.claude/skills/pr-architecture-check/SKILL.md
+++ b/.claude/skills/pr-architecture-check/SKILL.md
@@ -102,16 +102,36 @@ Write the analysis to `tmp/arch-review-<N>.md` with this structure:
 <list of files from the diff>
 ```
 
-### Step 5 — Post advisory comment
+### Step 5 — Show the artifact and wait for approval
 
-Post as a PR comment. The comment must include the advisory header.
+The artifact is generated advisory output. Do **not** post it automatically.
+Show it to the human first and get explicit approval, exactly as the
+PR-review, PR-submission, and issue-filing skills do before any public-state
+mutation.
+
+1. Show the human the generated artifact — prefer a link to
+   `tmp/arch-review-<N>.md` plus a short summary of the findings; if the full
+   text needs to be inline, paste it as regular text rather than a fenced
+   block.
+2. Ask the reviewer to review it and confirm before anything is posted, for
+   example: "Here's the advisory architecture review for #<N>. Review it and
+   say 'post' to comment it on the PR, or tell me what to change." Iterate on
+   edits until they approve.
+3. **Wait for explicit approval.** Do not run `gh pr comment` until the human
+   has approved posting. If they decline, leave the artifact in `tmp/` and stop
+   — posting is optional and reviewer-owned.
+
+### Step 6 — Post advisory comment (only after approval)
+
+Once, and only once, the human has explicitly approved, post the artifact as a
+PR comment. The comment must include the advisory header.
 
 ```bash
 gh pr comment <N> --repo zeroclaw-labs/zeroclaw \
   --body-file tmp/arch-review-<N>.md
 ```
 
-### Step 6 — Label policy
+### Step 7 — Label policy
 
 This skill does not add, remove, or modify any labels. Label management is
 the responsibility of triage and review skills.
@@ -124,14 +144,19 @@ the responsibility of triage and review skills.
    architecture references. Do not skip them.
 2. **Always write to `tmp/arch-review-<N>.md` before posting.** The artifact
    is consumed by `github-pr-review-session` if it exists.
-3. **Always include the advisory header** in the posted comment and the
+3. **Always show the artifact to the human and wait for explicit approval
+   before posting.** Never run `gh pr comment` automatically. Posting is
+   optional and reviewer-owned — same human-approval checkpoint the PR-review,
+   PR-submission, and issue-filing skills use before any public-state mutation.
+   If the reviewer declines, leave the artifact in `tmp/` and stop.
+4. **Always include the advisory header** in the posted comment and the
    artifact file. Per FND-003 §6.4, this output is advisory only.
-4. **Never approve, request changes, or use `gh pr review`.** This skill
+5. **Never approve, request changes, or use `gh pr review`.** This skill
    posts a comment, not a formal review verdict.
-5. **Never modify labels.** No label additions, removals, or changes.
-6. **Never block a merge.** If the analysis finds issues, they are reported
+6. **Never modify labels.** No label additions, removals, or changes.
+7. **Never block a merge.** If the analysis finds issues, they are reported
    as advisory findings for the human reviewer to evaluate.
-7. **Be specific.** Reference the exact file, line range, crate, and
+8. **Be specific.** Reference the exact file, line range, crate, and
    constraint. Vague findings waste reviewer time.
-8. **Skip irrelevant checks.** If a PR only touches docs, do not flag
+9. **Skip irrelevant checks.** If a PR only touches docs, do not flag
    dependency direction. Only report checks relevant to the diff.

--- a/.claude/skills/pr-architecture-check/references/arch-checklist.md
+++ b/.claude/skills/pr-architecture-check/references/arch-checklist.md
@@ -1,0 +1,132 @@
+# Architecture Checklist — PR Review Criteria
+
+This checklist is the reference for the `pr-architecture-check` skill. Apply
+each category to the PR diff. Skip categories that are irrelevant to the
+files changed.
+
+---
+
+## 1. Dependency Direction
+
+> "Dependencies flow inward. The runtime knows nothing about the plugins.
+> Plugins know about the API. Nothing knows about everything."
+> — FND-001 §4.1
+
+- Imports must flow inward toward `zeroclaw-api`
+- `zeroclaw-api` must have no dependencies on runtime, tools, channels, providers, or any implementation crate
+- Implementation crates (`zeroclaw-channels`, `zeroclaw-tools`, `zeroclaw-providers`, `zeroclaw-memory`) depend on `zeroclaw-api` — not on each other
+- `zeroclaw-runtime` depends on `zeroclaw-api` and foundation crates — it has no knowledge of specific channel, tool, or provider implementations
+- Plugins depend on `zeroclaw-api` (not the runtime)
+- New `use` / `extern crate` / `Cargo.toml` dependency additions that point outward (from API toward implementations) are violations
+
+**Check:** Review `Cargo.toml` changes and `use` statements in the diff. Flag any dependency that flows outward (from a lower-layer crate toward a higher-layer one).
+
+---
+
+## 2. Trait Boundary Compliance
+
+> Core architecture is trait-driven and modular. — AGENTS.md
+
+- New functionality that crosses a trait boundary must go through the trait, not around it
+- No hardcoding around trait boundaries (e.g., matching on a specific provider name instead of using the `Provider` trait interface)
+- No type-casting or downcasting to bypass a trait abstraction
+- Extension points are defined in `zeroclaw-api`:
+  - `Provider` (`crates/zeroclaw-api/src/provider.rs`)
+  - `Channel` (`crates/zeroclaw-api/src/channel.rs`)
+  - `Tool` (`crates/zeroclaw-api/src/tool.rs`)
+  - `Memory` (`crates/zeroclaw-api/src/memory_traits.rs`)
+  - `Observer` (`crates/zeroclaw-api/src/observability_traits.rs`)
+  - `RuntimeAdapter` (`crates/zeroclaw-api/src/runtime_traits.rs`)
+  - `Peripheral` (`crates/zeroclaw-api/src/peripherals_traits.rs`)
+
+**Check:** Look for string matching on implementation names, `downcast_ref`, concrete type assertions, or `match` arms that enumerate specific implementations where a trait method should be used.
+
+---
+
+## 3. Extension Pattern Conformance
+
+> Extend by implementing traits and registering in factory modules. — AGENTS.md
+
+- New providers, channels, tools, memory backends, observers, and peripherals must follow the factory registration pattern
+- New implementations should:
+  1. Implement the relevant trait from `zeroclaw-api`
+  2. Register in the corresponding factory module
+  3. Be discoverable via configuration, not hardcoded into the runtime
+- Adding a new implementation should not require modifying the runtime or other existing implementations
+
+**Check:** If the PR adds a new implementation of an extension point, verify it registers via the factory pattern and does not require changes to unrelated crates.
+
+---
+
+## 4. Crate Responsibility (Placement)
+
+> Each crate has a defined responsibility. — AGENTS.md Repository Map
+
+New code must land in the correct crate per the repository map:
+
+| Crate | Responsibility |
+|---|---|
+| `zeroclaw-api` | Public trait definitions only — no implementations, no heavy dependencies |
+| `zeroclaw-config` | Schema, config loading/merging |
+| `zeroclaw-macros` | `Configurable` derive macro |
+| `zeroclaw-providers` | Model provider implementations and resilient wrapper |
+| `zeroclaw-channels` | Messaging platform integrations, orchestrator, media pipeline |
+| `zeroclaw-tools` | Tool execution surface (shell, file, memory, browser) |
+| `zeroclaw-runtime` | Agent loop, security, cron, SOP, skills, observability |
+| `zeroclaw-memory` | Memory backends (markdown, sqlite, embeddings, vector merge) |
+| `zeroclaw-infra` | Shared infrastructure (debounce, session, stall watchdog) |
+| `zeroclaw-gateway` | Webhook/gateway server (separate binary) |
+| `zeroclaw-hardware` | USB discovery, peripherals, serial, GPIO |
+| `zeroclaw-tui` | TUI onboarding wizard |
+| `zeroclaw-plugins` | WASM plugin system |
+| `zeroclaw-tool-call-parser` | Tool call parsing |
+
+**Check:** Verify new modules/files are placed in the crate whose responsibility matches the functionality. Flag code that belongs in one crate but is placed in another.
+
+---
+
+## 5. Core Engineering Constraints
+
+These 7 constraints from AGENTS.md are non-negotiable. A PR that violates one
+should be flagged.
+
+### 5.1 Single static binary
+The project ships as a single static binary. Flag changes that introduce
+mandatory runtime dependencies, require external services for core
+functionality, or cause significant binary size growth without proportional
+value.
+
+### 5.2 Trait-driven pluggability
+All extension points use traits. Flag changes that bypass or hardcode around
+trait boundaries.
+
+### 5.3 Minimal footprint
+Target is <5 MB binary, minimal RAM/CPU. Flag changes that add significant
+overhead (heavy dependencies, unbounded caches, expensive default paths).
+
+### 5.4 Runs on anything (RPi Zero hardware floor)
+Must run on edge targets including Raspberry Pi Zero. Flag changes that
+require hardware or OS features unavailable on constrained devices.
+
+### 5.5 Secure by default
+Deny-by-default security posture. Flag changes that weaken security policy,
+broaden the attack surface, or add default-allow rules.
+
+### 5.6 No vendor lock-in
+No provider gets privilege outside the trait boundary. Flag changes that
+grant special treatment to a specific vendor or provider.
+
+### 5.7 Zero external infrastructure
+Core functionality must work without third-party services. Flag changes that
+make an external service a hard dependency for core features.
+
+---
+
+## Usage Notes
+
+- **Pass**: No issues found for this category.
+- **Advisory**: Potential concern — worth reviewer attention but may be intentional.
+- **Flag**: Likely violation of a documented constraint — reviewer should evaluate.
+
+Only report categories relevant to the PR diff. A docs-only PR needs no
+dependency direction check.

--- a/.claude/skills/pr-architecture-check/references/arch-checklist.md
+++ b/.claude/skills/pr-architecture-check/references/arch-checklist.md
@@ -91,32 +91,39 @@ These 7 constraints from AGENTS.md are non-negotiable. A PR that violates one
 should be flagged.
 
 ### 5.1 Single static binary
+
 The project ships as a single static binary. Flag changes that introduce
 mandatory runtime dependencies, require external services for core
 functionality, or cause significant binary size growth without proportional
 value.
 
 ### 5.2 Trait-driven pluggability
+
 All extension points use traits. Flag changes that bypass or hardcode around
 trait boundaries.
 
 ### 5.3 Minimal footprint
+
 Target is <5 MB binary, minimal RAM/CPU. Flag changes that add significant
 overhead (heavy dependencies, unbounded caches, expensive default paths).
 
 ### 5.4 Runs on anything (RPi Zero hardware floor)
+
 Must run on edge targets including Raspberry Pi Zero. Flag changes that
 require hardware or OS features unavailable on constrained devices.
 
 ### 5.5 Secure by default
+
 Deny-by-default security posture. Flag changes that weaken security policy,
 broaden the attack surface, or add default-allow rules.
 
 ### 5.6 No vendor lock-in
+
 No provider gets privilege outside the trait boundary. Flag changes that
 grant special treatment to a specific vendor or provider.
 
 ### 5.7 Zero external infrastructure
+
 Core functionality must work without third-party services. Flag changes that
 make an external service a hard dependency for core features.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,7 @@ AI coding assistant skills live in `.claude/skills/`. Use the right one for the 
 
 - `.claude/skills/github-pr-review-session/SKILL.md` — PR review co-pilot; assists **you** as the human reviewer. Resolves the active reviewer from session state or `gh`, uses the RFC feedback taxonomy (🔴/🟡/✅/🔵/🟢), and formats formal review findings as H3 headings that start with the taxonomy emoji. Trigger: `review 1234`, `re-review 1234`, `go through the queue`.
 - `.claude/skills/changelog-generation/SKILL.md` — generates `CHANGELOG-next.md` between stable tags, resolves contributors via GraphQL, feeds the release workflow. Trigger: `generate changelog`, `release notes for v0.7.x`.
+- `.claude/skills/pr-architecture-check/SKILL.md` — Advisory architecture review of a PR diff; validates dependency direction, trait boundaries, extension patterns, crate placement, and core constraints against AGENTS.md and FND-001. Posts a non-blocking comment. Trigger: `arch-check #N`, `architecture check #N`.
 - `.claude/skills/github-issue-triage/SKILL.md` — Issue triage and lifecycle management; manages the backlog, labels, and stale policies. Trigger: `triage issues`, `sweep issues`, `handle issue #N`.
 - `.claude/skills/github-issue/SKILL.md` — Interactively files structured GitHub issues (bug reports or feature requests) using repo templates. Trigger: `file issue`, `report bug`, `feature request`.
 - `.claude/skills/github-pr/SKILL.md` — Opens or updates GitHub PRs, handles validation evidence, and manages PR descriptions. Trigger: `open PR`, `update PR`, `submit for review`.

--- a/dev/test-pr-arch-check-skill.sh
+++ b/dev/test-pr-arch-check-skill.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# TDD acceptance tests for the PR Architecture Check skill
+# Run from repo root: bash dev/test-pr-arch-check-skill.sh
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+pass() { ((PASS++)); echo "  ✓ $1"; }
+fail() { ((FAIL++)); ERRORS+=("$1"); echo "  ✗ $1"; }
+
+echo "=== PR Architecture Check Skill — Acceptance Tests ==="
+echo ""
+
+# ─── 1. File existence ───────────────────────────────────────────────
+echo "1. File existence"
+
+SKILL=".claude/skills/pr-architecture-check/SKILL.md"
+CHECKLIST=".claude/skills/pr-architecture-check/references/arch-checklist.md"
+REVIEW_SKILL=".claude/skills/github-pr-review-session/SKILL.md"
+TRIAGE_SKILL=".claude/skills/github-issue-triage/SKILL.md"
+
+[ -f "$SKILL" ]     && pass "SKILL.md exists"          || fail "SKILL.md missing"
+[ -f "$CHECKLIST" ] && pass "arch-checklist.md exists"  || fail "arch-checklist.md missing"
+
+# ─── 2. SKILL.md frontmatter ─────────────────────────────────────────
+echo "2. SKILL.md frontmatter"
+
+if [ -f "$SKILL" ]; then
+  head -5 "$SKILL" | grep -q '^---'             && pass "has frontmatter"            || fail "missing frontmatter delimiter"
+  grep -q '^name:'        "$SKILL"               && pass "has name field"             || fail "missing name field"
+  grep -q '^description:' "$SKILL"               && pass "has description field"      || fail "missing description field"
+  grep -qi 'arch-check'   "$SKILL"               && pass "trigger phrase present"     || fail "trigger phrase 'arch-check' missing"
+  grep -qi 'architecture check' "$SKILL"         && pass "alt trigger present"        || fail "trigger phrase 'architecture check' missing"
+fi
+
+# ─── 3. Advisory framing (FND-003 §6.4) ──────────────────────────────
+echo "3. Advisory framing"
+
+if [ -f "$SKILL" ]; then
+  grep -qi 'advisory'       "$SKILL"             && pass "mentions advisory"          || fail "'advisory' not found in SKILL.md"
+  grep -qi 'not.*merge.*gate\|never.*gate.*merge\|non-blocking' "$SKILL" \
+                                                  && pass "non-blocking stated"        || fail "non-blocking/non-gate language missing"
+  grep -qi 'FND-003'        "$SKILL"             && pass "references FND-003"         || fail "FND-003 reference missing"
+fi
+
+# ─── 4. Workflow steps ────────────────────────────────────────────────
+echo "4. Workflow steps"
+
+if [ -f "$SKILL" ]; then
+  grep -q  'gh pr diff'     "$SKILL"             && pass "fetches PR diff"            || fail "gh pr diff step missing"
+  grep -q  'gh pr view'     "$SKILL"             && pass "fetches PR metadata"        || fail "gh pr view step missing"
+  grep -q  'AGENTS.md'      "$SKILL"             && pass "loads AGENTS.md"            || fail "AGENTS.md load missing"
+  grep -qi 'FND-001\|fnd-001' "$SKILL"           && pass "loads FND-001"              || fail "FND-001 load missing"
+  grep -q  'tmp/arch-review' "$SKILL"            && pass "writes tmp artifact"        || fail "tmp/arch-review artifact missing"
+  grep -qi 'comment'        "$SKILL"             && pass "posts PR comment"           || fail "PR comment posting missing"
+  grep -qi 'label'          "$SKILL"             && pass "label policy mentioned"     || fail "label policy not mentioned"
+fi
+
+# ─── 5. Checklist content ────────────────────────────────────────────
+echo "5. Checklist content (arch-checklist.md)"
+
+if [ -f "$CHECKLIST" ]; then
+  grep -qi 'dependency direction\|dependencies flow' "$CHECKLIST" \
+                                                  && pass "dependency direction"       || fail "dependency direction check missing"
+  grep -qi 'trait boundar'  "$CHECKLIST"          && pass "trait boundary"             || fail "trait boundary check missing"
+  grep -qi 'factory\|registration' "$CHECKLIST"   && pass "extension pattern"          || fail "extension/factory pattern check missing"
+  grep -qi 'crate.*responsib\|crate.*placement'  "$CHECKLIST" \
+                                                  && pass "crate placement"            || fail "crate placement check missing"
+  grep -qi 'core.*constraint\|engineering.*constraint' "$CHECKLIST" \
+                                                  && pass "core constraints"           || fail "core constraints section missing"
+  # The 7 core constraints from AGENTS.md
+  grep -qi 'single.*static.*binary\|static binary' "$CHECKLIST" \
+                                                  && pass "constraint: static binary"  || fail "static binary constraint missing"
+  grep -qi 'pluggab'        "$CHECKLIST"          && pass "constraint: pluggability"   || fail "pluggability constraint missing"
+  grep -qi 'minimal.*footprint\|footprint'        "$CHECKLIST" \
+                                                  && pass "constraint: footprint"      || fail "footprint constraint missing"
+  grep -qi 'RPi\|raspberry\|edge\|runs on anything' "$CHECKLIST" \
+                                                  && pass "constraint: hardware floor" || fail "hardware floor constraint missing"
+  grep -qi 'secure.*default\|security'           "$CHECKLIST" \
+                                                  && pass "constraint: secure default" || fail "secure default constraint missing"
+  grep -qi 'vendor.*lock\|lock.in'               "$CHECKLIST" \
+                                                  && pass "constraint: no vendor lock" || fail "vendor lock-in constraint missing"
+  grep -qi 'external.*infra\|zero.*external'     "$CHECKLIST" \
+                                                  && pass "constraint: no ext infra"   || fail "external infra constraint missing"
+fi
+
+# ─── 6. PR review session integration ────────────────────────────────
+echo "6. PR review session integration"
+
+if [ -f "$REVIEW_SKILL" ]; then
+  grep -q  'tmp/arch-review' "$REVIEW_SKILL"     && pass "reads arch-review artifact" || fail "arch-review artifact read missing from review skill"
+  grep -qi 'arch-check'     "$REVIEW_SKILL"      && pass "suggests arch-check"        || fail "arch-check suggestion missing from review skill"
+fi
+
+# ─── 7. Issue triage work queue ───────────────────────────────────────
+echo "7. Issue triage work queue"
+
+if [ -f "$TRIAGE_SKILL" ]; then
+  grep -q 'status:accepted' "$TRIAGE_SKILL"      && pass "work queue label present"   || fail "status:accepted label missing from triage skill"
+  grep -q '\-\-no-assignee'  "$TRIAGE_SKILL"     && pass "no-assignee filter"         || fail "--no-assignee filter missing from triage skill"
+fi
+
+# ─── 8. No new labels created ────────────────────────────────────────
+echo "8. Guardrails"
+
+if [ -f "$SKILL" ]; then
+  # Must not add labels
+  grep -qi 'does not.*label\|never.*label\|no.*label' "$SKILL" \
+                                                  && pass "no-label policy"            || fail "no-label policy not stated"
+fi
+
+# ─── Summary ──────────────────────────────────────────────────────────
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+
+if [ ${#ERRORS[@]} -gt 0 ]; then
+  echo ""
+  echo "Failures:"
+  for e in "${ERRORS[@]}"; do
+    echo "  - $e"
+  done
+  exit 1
+fi
+
+echo "All tests passed."

--- a/dev/test-pr-arch-check-skill.sh
+++ b/dev/test-pr-arch-check-skill.sh
@@ -19,8 +19,6 @@ echo "1. File existence"
 
 SKILL=".claude/skills/pr-architecture-check/SKILL.md"
 CHECKLIST=".claude/skills/pr-architecture-check/references/arch-checklist.md"
-REVIEW_SKILL=".claude/skills/github-pr-review-session/SKILL.md"
-TRIAGE_SKILL=".claude/skills/github-issue-triage/SKILL.md"
 
 [ -f "$SKILL" ]     && pass "SKILL.md exists"          || fail "SKILL.md missing"
 [ -f "$CHECKLIST" ] && pass "arch-checklist.md exists"  || fail "arch-checklist.md missing"
@@ -56,6 +54,8 @@ if [ -f "$SKILL" ]; then
   grep -qi 'FND-001\|fnd-001' "$SKILL"           && pass "loads FND-001"              || fail "FND-001 load missing"
   grep -q  'tmp/arch-review' "$SKILL"            && pass "writes tmp artifact"        || fail "tmp/arch-review artifact missing"
   grep -qi 'comment'        "$SKILL"             && pass "posts PR comment"           || fail "PR comment posting missing"
+  grep -qi 'wait for.*approval\|explicit approval\|before posting' "$SKILL" \
+                                                  && pass "human-approval checkpoint"  || fail "human-approval checkpoint before posting missing"
   grep -qi 'label'          "$SKILL"             && pass "label policy mentioned"     || fail "label policy not mentioned"
 fi
 
@@ -87,24 +87,8 @@ if [ -f "$CHECKLIST" ]; then
                                                   && pass "constraint: no ext infra"   || fail "external infra constraint missing"
 fi
 
-# ─── 6. PR review session integration ────────────────────────────────
-echo "6. PR review session integration"
-
-if [ -f "$REVIEW_SKILL" ]; then
-  grep -q  'tmp/arch-review' "$REVIEW_SKILL"     && pass "reads arch-review artifact" || fail "arch-review artifact read missing from review skill"
-  grep -qi 'arch-check'     "$REVIEW_SKILL"      && pass "suggests arch-check"        || fail "arch-check suggestion missing from review skill"
-fi
-
-# ─── 7. Issue triage work queue ───────────────────────────────────────
-echo "7. Issue triage work queue"
-
-if [ -f "$TRIAGE_SKILL" ]; then
-  grep -q 'status:accepted' "$TRIAGE_SKILL"      && pass "work queue label present"   || fail "status:accepted label missing from triage skill"
-  grep -q '\-\-no-assignee'  "$TRIAGE_SKILL"     && pass "no-assignee filter"         || fail "--no-assignee filter missing from triage skill"
-fi
-
-# ─── 8. No new labels created ────────────────────────────────────────
-echo "8. Guardrails"
+# ─── 6. No new labels created ────────────────────────────────────────
+echo "6. Guardrails"
 
 if [ -f "$SKILL" ]; then
   # Must not add labels


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Adds a new `pr-architecture-check` skill that performs an *advisory* architecture review of a PR diff — validating dependency direction, trait boundary compliance, extension-pattern conformance, crate placement, and the 7 core engineering constraints against `AGENTS.md` and FND-001. The skill is non-blocking by design (FND-003 §6.4: "AI belongs in the development loop, not the merge gate"). It writes its findings to `tmp/arch-review-<N>.md`, then shows them to the reviewer and waits for explicit approval before optionally posting a PR comment. Registers the skill in `AGENTS.md` and ships TDD acceptance tests in `dev/test-pr-arch-check-skill.sh`.
- **Scope boundary:** This PR adds only the `pr-architecture-check` skill and its tests. It does NOT wire the artifact into the PR-review session (that is #6717) and does NOT touch the issue-triage skill (that is #6718). The acceptance script is scoped to only this skill's behavior.
- **Blast radius:** Skill-markdown and a one-line `AGENTS.md` registration plus a dev test script. No Rust, no runtime, no CI workflow changes. The skill posts only non-blocking comments and never mutates labels or merge state.
- **Linked issue(s):** Part 1/3 of the dev-workflow pipeline work. Related #6717, Related #6718.
- **Labels:** `enhancement`, `docs`, `dev`, `risk:medium`, `risk:manual`, `size:M`.

## Validation Evidence (required)

Docs/skill-markdown only — Rust battery not applicable. Ran the docs quality gate and the skill's TDD acceptance suite.

```bash
bash scripts/ci/docs_quality_gate.sh
bash dev/test-pr-arch-check-skill.sh
```

- **Commands run and tail output:**

`scripts/ci/docs_quality_gate.sh`:

```
Linting docs files: .claude/skills/pr-architecture-check/SKILL.md .claude/skills/pr-architecture-check/references/arch-checklist.md AGENTS.md
markdownlint-cli2 v0.20.0 (markdownlint v0.40.0)
Finding: .claude/skills/pr-architecture-check/SKILL.md .claude/skills/pr-architecture-check/references/arch-checklist.md AGENTS.md !target/**
Linting: 3 file(s)
Summary: 0 error(s)
```

`dev/test-pr-arch-check-skill.sh`:

```
=== Results: 31 passed, 0 failed ===
All tests passed.
```

- **Beyond CI — what did you manually verify?** Confirmed the acceptance script now passes fully on this branch after scoping it to this PR's behavior (the four cross-part assertions that asserted later-PR behavior were removed). Verified the skill's posting step requires an explicit human-approval checkpoint before any `gh pr comment`, matching the PR-review / PR-submission / issue-filing skills. Fixed MD022 blank-line violations on the constraint headings so the docs gate passes clean. Did not exercise the skill against a live PR comment (no public-state mutation performed).
- **If any command was intentionally skipped, why:** `cargo fmt` / `cargo clippy` / `cargo test` skipped — no Rust sources changed (docs/skill-markdown only), per the template's docs-only guidance.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: N/A. The skill is advisory, posts only non-blocking comments after explicit human approval, and never modifies labels or merge state.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: exact upgrade steps for existing users: None — this only adds a new opt-in skill and a dev test script; no existing behavior changes.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <sha>` of the skill-addition commits, or simply delete `.claude/skills/pr-architecture-check/` and revert the one-line `AGENTS.md` registration. No data migration or state to unwind.
- **Feature flags or config toggles:** None — the skill is invoked explicitly (`arch-check #N`); not invoking it is the off switch.
- **Observable failure symptoms:** None at runtime — the change is documentation/skill-markdown. If the skill misbehaved in use, the symptom would be an unwanted advisory PR comment, which requires explicit human approval to post.

## Labels snapshot

`enhancement`, `docs`, `dev`, `risk:medium`, `risk:manual`, `size:M`