### PR TITLE
feat(slack): add unfurl config option to suppress URL preview cards

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -4396,6 +4396,7 @@ fn build_channel_by_id(config: &Config, channel_id: &str) -> Result<Arc<dyn Chan
                 )
                 .with_workspace_dir(config.workspace_dir.clone())
                 .with_markdown_blocks(sl.use_markdown_blocks)
+                .with_unfurl(sl.unfurl)
                 .with_transcription(config.transcription.clone())
                 .with_streaming(sl.stream_drafts, sl.draft_update_interval_ms)
                 .with_cancel_reaction(sl.cancel_reaction.clone())
@@ -4903,6 +4904,7 @@ fn collect_configured_channels(
                     .with_strict_mention_in_thread(sl.strict_mention_in_thread)
                     .with_workspace_dir(config.workspace_dir.clone())
                     .with_markdown_blocks(sl.use_markdown_blocks)
+                    .with_unfurl(sl.unfurl)
                     .with_proxy_url(sl.proxy_url.clone())
                     .with_transcription(config.transcription.clone())
                     .with_streaming(sl.stream_drafts, sl.draft_update_interval_ms)
@@ -6322,7 +6324,9 @@ pub async fn deliver_announcement(
                 sl.channel_ids.clone(),
                 sl.allowed_users.clone(),
             )
-            .with_workspace_dir(config.workspace_dir.clone());
+            .with_workspace_dir(config.workspace_dir.clone())
+            .with_markdown_blocks(sl.use_markdown_blocks)
+            .with_unfurl(sl.unfurl);
             zeroclaw_api::channel::Channel::send(&ch, &make_msg(&safe_output)).await?;
         }
         "signal" => {

--- a/crates/zeroclaw-channels/src/slack.rs
+++ b/crates/zeroclaw-channels/src/slack.rs
@@ -38,6 +38,9 @@ pub struct SlackChannel {
     active_assistant_thread: Mutex<HashMap<String, String>>,
     /// Use the newer `markdown` block type (richer formatting, 12k char limit).
     use_markdown_blocks: bool,
+    /// Whether Slack should auto-generate URL preview cards (unfurls) on
+    /// outbound messages. Defaults to true (Slack's native behavior).
+    unfurl: bool,
     /// Per-channel proxy URL override.
     proxy_url: Option<String>,
     /// Voice transcription config — when set, audio file attachments are
@@ -180,6 +183,7 @@ impl SlackChannel {
             workspace_dir: None,
             active_assistant_thread: Mutex::new(HashMap::new()),
             use_markdown_blocks: false,
+            unfurl: true,
             proxy_url: None,
             transcription: None,
             transcription_manager: None,
@@ -230,6 +234,12 @@ impl SlackChannel {
     /// Only use this if your Slack workspace supports it.
     pub fn with_markdown_blocks(mut self, enabled: bool) -> Self {
         self.use_markdown_blocks = enabled;
+        self
+    }
+
+    /// Configure whether Slack should auto-generate URL preview cards (unfurls).
+    pub fn with_unfurl(mut self, enabled: bool) -> Self {
+        self.unfurl = enabled;
         self
     }
 
@@ -3396,6 +3406,12 @@ impl Channel for SlackChannel {
             }
             body
         };
+
+        let mut body = body;
+        if !self.unfurl {
+            body["unfurl_links"] = serde_json::Value::Bool(false);
+            body["unfurl_media"] = serde_json::Value::Bool(false);
+        }
 
         let resp = self
             .http_client()

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -7451,6 +7451,12 @@ pub struct SlackConfig {
     /// Enable this only if your Slack workspace supports the `markdown` block type.
     #[serde(default)]
     pub use_markdown_blocks: bool,
+    /// Whether Slack should auto-generate URL preview cards (unfurls) for
+    /// outbound messages. Defaults to true (Slack's native behavior). Set to
+    /// false when the bot frequently posts mrkdwn link references
+    /// (`<url|text>`) and the preview cards add noise.
+    #[serde(default = "default_true")]
+    pub unfurl: bool,
     /// Per-channel proxy URL (http, https, socks5, socks5h).
     /// Overrides the global `[proxy]` setting for this channel only.
     #[serde(default)]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - New `[channels.slack] unfurl` config field (default `true` — preserves existing behavior). Setting `unfurl = false` sets `unfurl_links` and `unfurl_media` to `false` on the `chat.postMessage` payload, suppressing Slack's automatic URL preview cards.
  - Useful when the bot posts digest-style messages with mrkdwn link references where the link text already conveys the destination (`<url|label>`); auto-unfurl just adds noise.
  - Also wires `use_markdown_blocks` and `unfurl` through the standalone `SlackChannel` construction in `deliver_announcement`, so cron-driven Slack deliveries (when no live channel registry exists) honor the same config as the orchestrator-managed channel.
- **Scope boundary:** Slack only; no change to other channels.
- **Blast radius:** Slack outbound message payload only. Default value preserves prior behavior.
- **Linked issue(s):** none.
- **Labels:** intent — `type: feat`, `risk: low`, `size: XS`.

## Validation Evidence (required)

Local validation on macOS arm64, Rust 1.93.0, against fresh `master`.

```bash
cargo fmt --all -- --check
cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
cargo nextest run --locked --workspace --exclude zeroclaw-desktop
cargo deny check
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` — clean.
  - `cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings` — `Finished dev profile [unoptimized + debuginfo] target(s) in 44.38s`.
  - `cargo nextest run --locked --workspace --exclude zeroclaw-desktop` — `Summary [ 844.983s] 7482 tests run: 7482 passed, 10 skipped`.
  - `cargo deny check` — advisories ok, bans ok, licenses ok, sources ok.
- **Beyond CI — what did you manually verify?** Live-tested on an OCI deployment with `unfurl = false`: cron-driven Slack announcements containing `<https://…|label>` markdown no longer trigger preview cards. I did NOT verify the orchestrator-managed channel path with `unfurl = false` end-to-end (only the cron-fallback `deliver_announcement` path in production), but both code paths funnel through the same `SlackChannel::with_unfurl` builder.
- **If any command was intentionally skipped, why:** None skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? Yes — new optional `[channels.slack] unfurl` field, defaults to `true`.
- Upgrade steps for existing users: None. Set `unfurl = false` to opt in.

## Rollback (required for `risk: medium` and `risk: high`)

Low risk — `git revert <sha>` is the plan.