### PR TITLE
fix(runtime,channels): keep malformed tool protocol internal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13228,6 +13228,7 @@ dependencies = [
  "zeroclaw-memory",
  "zeroclaw-providers",
  "zeroclaw-runtime",
+ "zeroclaw-tool-call-parser",
  "zeroclaw-tools",
 ]
 

--- a/crates/zeroclaw-channels/Cargo.toml
+++ b/crates/zeroclaw-channels/Cargo.toml
@@ -14,6 +14,7 @@ zeroclaw-log.workspace = true
 zeroclaw-memory.workspace = true
 zeroclaw-providers.workspace = true
 zeroclaw-runtime.workspace = true
+zeroclaw-tool-call-parser.workspace = true
 zeroclaw-tools.workspace = true
 anyhow = "1.0"
 lru = "0.16"

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -2409,6 +2409,50 @@ fn strip_think_tags_inline(s: &str) -> String {
     result.trim().to_string()
 }
 
+fn starts_with_visible_tool_call_tag_example(response: &str) -> bool {
+    let lower = response.trim_start().to_ascii_lowercase();
+    let starts_with_tool_tag = lower.starts_with("<tool_call")
+        || lower.starts_with("<toolcall")
+        || lower.starts_with("<tool-call")
+        || lower.starts_with("<invoke");
+
+    starts_with_tool_tag && zeroclaw_tool_call_parser::looks_like_tool_protocol_example(response)
+}
+
+fn should_suppress_top_level_tool_protocol_response(
+    response: &str,
+    known_tool_names: &HashSet<String>,
+) -> bool {
+    if zeroclaw_tool_call_parser::looks_like_tool_protocol_example(response) {
+        return false;
+    }
+
+    if zeroclaw_tool_call_parser::looks_like_malformed_tool_protocol_envelope_for_known_tools(
+        response,
+        known_tool_names,
+    ) {
+        return true;
+    }
+
+    if let Some(kind) = zeroclaw_tool_call_parser::classify_tool_protocol_envelope(response) {
+        return matches!(
+            kind,
+            zeroclaw_tool_call_parser::ToolProtocolEnvelopeKind::TaggedToolCall
+        ) || (!known_tool_names.is_empty()
+            && (matches!(
+                kind,
+                zeroclaw_tool_call_parser::ToolProtocolEnvelopeKind::ToolResult
+            ) || zeroclaw_tool_call_parser::tool_protocol_envelope_mentions_known_tool(
+                response,
+                known_tool_names,
+            )));
+    }
+
+    // If the broad envelope detector still matches after classification failed,
+    // this is malformed internal protocol JSON rather than ordinary content.
+    zeroclaw_tool_call_parser::looks_like_tool_protocol_envelope(response)
+}
+
 fn sanitize_channel_response(response: &str, tools: &[Box<dyn Tool>]) -> String {
     let known_tool_names: HashSet<String> = tools
         .iter()
@@ -2417,11 +2461,23 @@ fn sanitize_channel_response(response: &str, tools: &[Box<dyn Tool>]) -> String 
     // Strip any [Used tools: ...] prefix that the LLM may have echoed from
     // history context. Trim first to handle leading/trailing whitespace.
     let trimmed_response = response.trim();
+    // Final channel guardrail: reuse the parser classifier so channel cleanup
+    // cannot drift from runtime tool-protocol detection.
+    if should_suppress_top_level_tool_protocol_response(trimmed_response, &known_tool_names) {
+        return String::new();
+    }
     let stripped_summary = strip_tool_summary_prefix(trimmed_response);
     // Strip XML-style tool-call tags (e.g. <tool_call>...</tool_call>)
-    let stripped_xml = strip_tool_call_tags(&stripped_summary);
+    let stripped_xml = if starts_with_visible_tool_call_tag_example(&stripped_summary) {
+        stripped_summary
+    } else {
+        strip_tool_call_tags(&stripped_summary)
+    };
     // Strip isolated tool-call JSON artifacts
-    let stripped_json = strip_isolated_tool_json_artifacts(&stripped_xml, &known_tool_names);
+    let stripped_fenced_json =
+        strip_fenced_tool_protocol_artifacts(&stripped_xml, &known_tool_names);
+    let stripped_json =
+        strip_isolated_tool_json_artifacts(&stripped_fenced_json, &known_tool_names);
     // Strip leading narration lines that announce tool usage
     let sanitized = strip_tool_narration(&stripped_json);
 
@@ -2549,6 +2605,31 @@ fn sanitize_tool_json_value(
     known_tool_names: &HashSet<String>,
     saw_tool_call_payload: bool,
 ) -> Option<(String, bool)> {
+    if let Some(kind) =
+        zeroclaw_tool_call_parser::classify_tool_protocol_envelope(&value.to_string())
+    {
+        if known_tool_names.is_empty() {
+            return None;
+        }
+
+        if matches!(
+            kind,
+            zeroclaw_tool_call_parser::ToolProtocolEnvelopeKind::ToolResult
+        ) {
+            return Some((String::new(), true));
+        }
+
+        if !zeroclaw_tool_call_parser::tool_protocol_envelope_mentions_known_tool(
+            &value.to_string(),
+            known_tool_names,
+        ) {
+            return None;
+        }
+
+        let content = safe_protocol_envelope_content(value);
+        return Some((content, true));
+    }
+
     if is_tool_call_payload(value, known_tool_names) {
         return Some((String::new(), true));
     }
@@ -2588,6 +2669,23 @@ fn sanitize_tool_json_value(
     None
 }
 
+fn safe_protocol_envelope_content(value: &serde_json::Value) -> String {
+    let content = value
+        .get("content")
+        .and_then(|value| value.as_str())
+        .unwrap_or("")
+        .trim();
+
+    if content.is_empty()
+        || zeroclaw_tool_call_parser::looks_like_tool_protocol_envelope(content)
+        || zeroclaw_tool_call_parser::looks_like_malformed_tool_protocol_envelope(content)
+    {
+        return String::new();
+    }
+
+    content.to_string()
+}
+
 fn is_line_isolated_json_segment(message: &str, start: usize, end: usize) -> bool {
     let line_start = message[..start].rfind('\n').map_or(0, |idx| idx + 1);
     let line_end = message[end..]
@@ -2595,6 +2693,119 @@ fn is_line_isolated_json_segment(message: &str, start: usize, end: usize) -> boo
         .map_or(message.len(), |idx| end + idx);
 
     message[line_start..start].trim().is_empty() && message[end..line_end].trim().is_empty()
+}
+
+fn is_inside_markdown_code_fence(message: &str, index: usize) -> bool {
+    // This intentionally uses a lightweight fence parity check. The sanitizer only
+    // needs to avoid re-processing JSON in ordinary triple-backtick fences that
+    // `strip_fenced_tool_protocol_artifacts` already handles; it is not a full
+    // Markdown parser for inline code spans or longer fence runs.
+    let mut in_fence = false;
+    let mut cursor = 0usize;
+    while let Some(rel_pos) = message[cursor..index].find("```") {
+        in_fence = !in_fence;
+        cursor += rel_pos + 3;
+    }
+    in_fence
+}
+
+fn isolated_malformed_tool_protocol_segment_end(
+    message: &str,
+    start: usize,
+    known_tool_names: &HashSet<String>,
+) -> Option<usize> {
+    let line_start = message[..start].rfind('\n').map_or(0, |idx| idx + 1);
+    if !message[line_start..start].trim().is_empty() {
+        return None;
+    }
+
+    let mut end = start;
+    // Malformed JSON has no serde byte offset. Scan forward from an isolated
+    // JSON candidate start, but stop before ordinary prose resumes.
+    for line in message[start..].split_inclusive('\n') {
+        let trimmed = line.trim();
+        if end > start
+            && !trimmed.is_empty()
+            && !trimmed.starts_with(['{', '[', ']', '}'])
+            && !trimmed.starts_with('"')
+        {
+            break;
+        }
+        end += line.len();
+        let candidate = &message[start..end];
+        if zeroclaw_tool_call_parser::looks_like_malformed_tool_protocol_envelope_for_known_tools(
+            candidate,
+            known_tool_names,
+        ) {
+            return Some(end);
+        }
+    }
+
+    None
+}
+
+fn is_tool_protocol_fence_language(language: &str) -> bool {
+    let lower = language.trim().to_ascii_lowercase();
+    lower == "tool_call"
+        || lower == "toolcall"
+        || lower == "tool-call"
+        || lower == "invoke"
+        || lower
+            .strip_prefix("tool")
+            .is_some_and(|rest| rest.starts_with(char::is_whitespace) && !rest.trim().is_empty())
+}
+
+fn strip_fenced_tool_protocol_artifacts(
+    message: &str,
+    known_tool_names: &HashSet<String>,
+) -> String {
+    if zeroclaw_tool_call_parser::looks_like_tool_protocol_example(message) {
+        return message.to_string();
+    }
+
+    let mut cleaned = String::with_capacity(message.len());
+    let mut cursor = 0usize;
+
+    while let Some(rel_open) = message[cursor..].find("```") {
+        let open_start = cursor + rel_open;
+        let language_start = open_start + 3;
+        let Some(line_end_rel) = message[language_start..].find('\n') else {
+            break;
+        };
+        let line_end = language_start + line_end_rel;
+        let language = message[language_start..line_end]
+            .trim()
+            .trim_end_matches('\r');
+        let body_start = line_end + 1;
+        let Some(close_rel) = message[body_start..].find("```") else {
+            break;
+        };
+        let close_start = body_start + close_rel;
+        let close_end = close_start + 3;
+
+        let fence_block = &message[open_start..close_end];
+        let should_strip = if language.eq_ignore_ascii_case("json") {
+            should_suppress_top_level_tool_protocol_response(
+                message[body_start..close_start].trim(),
+                known_tool_names,
+            )
+        } else {
+            is_tool_protocol_fence_language(language)
+                && zeroclaw_tool_call_parser::contains_tool_protocol_tag_call(fence_block)
+        };
+
+        if should_strip {
+            cleaned.push_str(&message[cursor..open_start]);
+            cursor = close_end;
+            continue;
+        }
+
+        cleaned.push_str(&message[cursor..close_end]);
+        cursor = close_end;
+    }
+
+    cleaned.push_str(&message[cursor..]);
+    cleaned
 }
 
 fn strip_isolated_tool_json_artifacts(message: &str, known_tool_names: &HashSet<String>) -> String {
@@ -2610,6 +2821,14 @@ fn strip_isolated_tool_json_artifacts(message: &str, known_tool_names: &HashSet<
 
         let start = cursor + rel_start;
         cleaned.push_str(&message[cursor..start]);
+        if is_inside_markdown_code_fence(message, start) {
+            let Some(ch) = message[start..].chars().next() else {
+                break;
+            };
+            cleaned.push(ch);
+            cursor = start + ch.len_utf8();
+            continue;
+        }
 
         let candidate = &message[start..];
         let mut stream =
@@ -2633,6 +2852,13 @@ fn strip_isolated_tool_json_artifacts(message: &str, known_tool_names: &HashSet<
                     continue;
                 }
             }
+        }
+
+        if let Some(end) =
+            isolated_malformed_tool_protocol_segment_end(message, start, known_tool_names)
+        {
+            cursor = end;
+            continue;
         }
 
         let Some(ch) = message[start..].chars().next() else {
@@ -15202,6 +15428,299 @@ This is an example JSON object for profile settings."#;
         let result = sanitize_channel_response(clean_text, &tools);
 
         assert_eq!(result, clean_text);
+    }
+
+    #[test]
+    fn sanitize_channel_response_preserves_schema_json_array_without_tools() {
+        let tools: Vec<Box<dyn Tool>> = Vec::new();
+        let schema = r#"[{"name":"planner","parameters":{"goal":"string"}}]"#;
+
+        let result = sanitize_channel_response(schema, &tools);
+
+        assert_eq!(result, schema);
+    }
+
+    #[test]
+    fn sanitize_channel_response_preserves_tool_calls_audit_json() {
+        let tools: Vec<Box<dyn Tool>> = Vec::new();
+        let audit_json =
+            r#"{"tool_calls":[{"id":"case-1","status":"queued","service":"billing"}]}"#;
+
+        let result = sanitize_channel_response(audit_json, &tools);
+
+        assert_eq!(result, audit_json);
+    }
+
+    #[test]
+    fn sanitize_channel_response_preserves_reference_function_call_json_without_tools() {
+        let tools: Vec<Box<dyn Tool>> = Vec::new();
+        let reference_json =
+            r#"{"type":"function_call","name":"support_case","arguments":{"id":"A1"}}"#;
+
+        let result = sanitize_channel_response(reference_json, &tools);
+
+        assert_eq!(result, reference_json);
+    }
+
+    #[test]
+    fn sanitize_channel_response_preserves_reference_function_call_json_with_tools() {
+        let tools: Vec<Box<dyn Tool>> = vec![Box::new(MockPriceTool)];
+        let reference_json =
+            r#"{"type":"function_call","name":"support_case","arguments":{"id":"A1"}}"#;
+
+        let result = sanitize_channel_response(reference_json, &tools);
+
+        assert_eq!(result, reference_json);
+    }
+
+    #[test]
+    fn sanitize_channel_response_preserves_unknown_tool_calls_json_with_tools() {
+        let tools: Vec<Box<dyn Tool>> = vec![Box::new(MockPriceTool)];
+        let business_json = r#"{"tool_calls":[{"name":"support_case","arguments":{"id":"A1"}}]}"#;
+
+        let result = sanitize_channel_response(business_json, &tools);
+
+        assert_eq!(result, business_json);
+    }
+
+    #[test]
+    fn sanitize_channel_response_preserves_malformed_unknown_tool_calls_json_with_tools() {
+        let tools: Vec<Box<dyn Tool>> = vec![Box::new(MockPriceTool)];
+        let business_json = r#"{"tool_calls":[{"name":"support_case","arguments":{"id":"A1"}}"#;
+
+        let result = sanitize_channel_response(business_json, &tools);
+
+        assert_eq!(result, business_json);
+    }
+
+    #[test]
+    fn sanitize_channel_response_preserves_json_fenced_tool_protocol_example() {
+        let tools: Vec<Box<dyn Tool>> = Vec::new();
+        let example = r#"Here is a protocol example:
+```json
+{"tool_calls":[{"name":"shell","arguments":{"command":"pwd"}}]}
+```"#;
+
+        let result = sanitize_channel_response(example, &tools);
+
+        assert_eq!(result, example);
+    }
+
+    #[test]
+    fn sanitize_channel_response_removes_registered_tool_json_array() {
+        let tools: Vec<Box<dyn Tool>> = vec![Box::new(MockPriceTool)];
+        let internal = r#"[{"name":"mock_price","parameters":{"symbol":"BTC"}}]"#;
+
+        let result = sanitize_channel_response(internal, &tools);
+
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn sanitize_channel_response_removes_internal_tool_protocol_envelopes() {
+        let tools: Vec<Box<dyn Tool>> = vec![Box::new(MockPriceTool)];
+        let internal = r#"{"toolcalls":[{"name":"mock_price","arguments":{"symbol":"BTC"}}]}"#;
+
+        let result = sanitize_channel_response(internal, &tools);
+
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn sanitize_channel_response_removes_json_fenced_internal_tool_protocol() {
+        let tools: Vec<Box<dyn Tool>> = vec![Box::new(MockPriceTool)];
+        let internal = r#"```json
+{"tool_calls":[{"name":"mock_price","arguments":{"symbol":"BTC"}}]}
+```"#;
+
+        let result = sanitize_channel_response(internal, &tools);
+
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn sanitize_channel_response_removes_embedded_json_fenced_internal_tool_protocol() {
+        let tools: Vec<Box<dyn Tool>> = vec![Box::new(MockPriceTool)];
+        let response = r#"Intro
+```json
+{"tool_calls":[{"name":"mock_price","arguments":{"symbol":"BTC"}}]}
+```
+Done."#;
+
+        let result = sanitize_channel_response(response, &tools);
+
+        assert!(result.contains("Intro"));
+        assert!(result.contains("Done."));
+        assert!(!result.contains("tool_calls"));
+        assert!(!result.contains("mock_price"));
+    }
+
+    #[test]
+    fn sanitize_channel_response_removes_embedded_tool_call_fence() {
+        let tools: Vec<Box<dyn Tool>> = Vec::new();
+        let response = r#"Let me call it:
+```tool_call
+{"name":"shell","arguments":{"command":"pwd"}}
+```
+Done."#;
+
+        let result = sanitize_channel_response(response, &tools);
+
+        assert!(result.contains("Done."));
+        assert!(!result.contains("tool_call"));
+        assert!(!result.contains("shell"));
+        assert!(!result.contains("command"));
+    }
+
+    #[test]
+    fn sanitize_channel_response_preserves_tool_call_fenced_example() {
+        let tools: Vec<Box<dyn Tool>> = Vec::new();
+        let example = r#"```tool_call
+{"name":"shell","arguments":{"command":"pwd"}}
+```
+This is an example, not an invocation."#;
+
+        let result = sanitize_channel_response(example, &tools);
+
+        assert_eq!(result, example);
+    }
+
+    #[test]
+    fn sanitize_channel_response_removes_standalone_tool_call_fence() {
+        let tools: Vec<Box<dyn Tool>> = Vec::new();
+        let internal = r#"```tool_call
+{"name":"shell","arguments":{"command":"pwd"}}
+```"#;
+
+        let result = sanitize_channel_response(internal, &tools);
+
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn sanitize_channel_response_removes_standalone_tool_name_fence() {
+        let tools: Vec<Box<dyn Tool>> = Vec::new();
+        let internal = r#"```tool shell
+{"command":"pwd"}
+```"#;
+
+        let result = sanitize_channel_response(internal, &tools);
+
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn sanitize_channel_response_preserves_tool_call_tag_example() {
+        let tools: Vec<Box<dyn Tool>> = Vec::new();
+        let example = r#"<tool_call>
+{"name":"shell","arguments":{"command":"pwd"}}
+</tool_call>
+This is an example, not an invocation."#;
+
+        let result = sanitize_channel_response(example, &tools);
+
+        assert_eq!(result, example);
+    }
+
+    #[test]
+    fn sanitize_channel_response_strips_tagged_tool_call_before_trailing_text() {
+        let tools: Vec<Box<dyn Tool>> = Vec::new();
+        let response = r#"<tool_call>
+{"name":"shell","arguments":{"command":"pwd"}}
+</tool_call>
+Done."#;
+
+        let result = sanitize_channel_response(response, &tools);
+
+        assert_eq!(result, "Done.");
+    }
+
+    #[test]
+    fn sanitize_channel_response_removes_malformed_top_level_protocol() {
+        let tools: Vec<Box<dyn Tool>> = Vec::new();
+        let internal = r#"{"tool_call_id":"call_1","content":"raw"#;
+
+        let result = sanitize_channel_response(internal, &tools);
+
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn sanitize_channel_response_removes_embedded_malformed_protocol_json() {
+        let tools: Vec<Box<dyn Tool>> = Vec::new();
+        let response =
+            "Intro\n{\"tool_calls\":[{\"call_id\":\"call_1\",\"arguments\":{\"value\":\"X\"}\nDone";
+
+        let result = sanitize_channel_response(response, &tools);
+
+        assert!(result.contains("Intro"));
+        assert!(result.contains("Done"));
+        assert!(!result.contains("tool_calls"));
+        assert!(!result.contains("arguments"));
+    }
+
+    #[test]
+    fn sanitize_channel_response_removes_multiline_embedded_malformed_protocol_json() {
+        let tools: Vec<Box<dyn Tool>> = Vec::new();
+        let response = "Intro\n{\n  \"tool_calls\": [{\"call_id\":\"call_1\",\"arguments\":{\"value\":\"X\"}}\nDone";
+
+        let result = sanitize_channel_response(response, &tools);
+
+        assert!(result.contains("Intro"));
+        assert!(result.contains("Done"));
+        assert!(!result.contains("tool_calls"));
+        assert!(!result.contains("arguments"));
+    }
+
+    #[test]
+    fn sanitize_channel_response_keeps_protocol_explanation_text() {
+        let tools: Vec<Box<dyn Tool>> = Vec::new();
+        let explanation =
+            "A markdown block starting with ```tool can be used in protocol examples.";
+
+        let result = sanitize_channel_response(explanation, &tools);
+
+        assert_eq!(result, explanation);
+    }
+
+    #[test]
+    fn sanitize_channel_response_keeps_safe_protocol_envelope_content_with_tools() {
+        let tools: Vec<Box<dyn Tool>> = vec![Box::new(MockPriceTool)];
+        let response = "Intro text\n{\"content\":\"A markdown block starting with ```tool can be used in examples.\",\"tool_calls\":[{\"name\":\"mock_price\",\"arguments\":{\"symbol\":\"BTC\"}}]}\nDone.";
+
+        let result = sanitize_channel_response(response, &tools);
+
+        assert!(result.contains("Intro text"));
+        assert!(result.contains("A markdown block starting with ```tool"));
+        assert!(result.contains("Done."));
+        assert!(!result.contains("tool_calls"));
+    }
+
+    #[test]
+    fn sanitize_channel_response_removes_isolated_tool_result_envelope_content_with_tools() {
+        let tools: Vec<Box<dyn Tool>> = vec![Box::new(MockPriceTool)];
+        let response =
+            "Intro text\n{\"tool_call_id\":\"call_1\",\"content\":\"raw tool output\"}\nDone.";
+
+        let result = sanitize_channel_response(response, &tools);
+
+        assert!(result.contains("Intro text"));
+        assert!(result.contains("Done."));
+        assert!(!result.contains("tool_call_id"));
+        assert!(!result.contains("raw tool output"));
+    }
+
+    #[test]
+    fn sanitize_channel_response_removes_nested_protocol_content_with_tools() {
+        let tools: Vec<Box<dyn Tool>> = vec![Box::new(MockPriceTool)];
+        let response = "Intro text\n{\"content\":\"{\\\"toolcalls\\\":[{\\\"name\\\":\\\"mock_price\\\",\\\"arguments\\\":{\\\"symbol\\\":\\\"BTC\\\"}}]}\",\"tool_calls\":[{\"name\":\"mock_price\",\"arguments\":{\"symbol\":\"BTC\"}}]}\nDone.";
+
+        let result = sanitize_channel_response(response, &tools);
+
+        assert!(result.contains("Intro text"));
+        assert!(result.contains("Done."));
+        assert!(!result.contains("toolcalls"));
+        assert!(!result.contains("shell"));
     }
 
     // ── Tests for strip_think_tags_inline (streaming draft sanitization) ──

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -65,8 +65,8 @@ pub use super::cost::{
 
 /// Minimum characters per chunk when relaying LLM text to a streaming draft.
 const STREAM_CHUNK_MIN_CHARS: usize = 80;
-/// Rolling window size for detecting streamed tool-call payload markers.
-const STREAM_TOOL_MARKER_WINDOW_CHARS: usize = 512;
+/// Maximum malformed internal tool-protocol retries before returning a safe fallback.
+const MAX_MALFORMED_TOOL_PROTOCOL_RETRIES: usize = 2;
 
 /// Default maximum agentic tool-use iterations per user message to prevent runaway loops.
 /// Used as a safe fallback when `max_tool_iterations` is unset or configured as zero.
@@ -216,9 +216,13 @@ pub use zeroclaw_api::TOOL_LOOP_THREAD_ID;
 
 // Re-export tool call parsing from the standalone parser crate.
 pub use zeroclaw_tool_call_parser::{
-    ParsedToolCall, build_native_assistant_history_from_parsed_calls,
-    canonicalize_json_for_tool_signature, detect_tool_call_parse_issue, parse_tool_calls,
-    strip_think_tags, strip_tool_result_blocks,
+    ParsedToolCall, ToolProtocolEnvelopeKind, build_native_assistant_history_from_parsed_calls,
+    canonicalize_json_for_tool_signature, classify_tool_protocol_envelope,
+    contains_tool_protocol_tag_call, detect_tool_call_parse_issue,
+    looks_like_malformed_tool_protocol_envelope,
+    looks_like_malformed_tool_protocol_envelope_for_known_tools, looks_like_tool_protocol_envelope,
+    looks_like_tool_protocol_example, parse_tool_calls, strip_think_tags, strip_tool_result_blocks,
+    tool_protocol_envelope_mentions_known_tool,
 };
 
 /// Run a future with the thread ID set in task-local storage.
@@ -599,7 +603,383 @@ struct StreamedChatOutcome {
     reasoning_content: String,
     tool_calls: Vec<ToolCall>,
     forwarded_live_deltas: bool,
+    suppressed_protocol: bool,
     usage: Option<zeroclaw_providers::traits::TokenUsage>,
+}
+
+#[derive(Debug, Default)]
+struct StreamTextGuard {
+    // Suspicious leading chunks can split `"toolcalls"` / `<tool_call>` across
+    // deltas. Buffer just that prefix until it is clearly protocol or normal JSON.
+    pending: String,
+    pending_candidate_start: Option<usize>,
+    known_tool_names: HashSet<String>,
+    has_active_tools: bool,
+    suppress_forwarding: bool,
+    suppressed_protocol: bool,
+}
+
+impl StreamTextGuard {
+    fn new(available_tools: Option<&[crate::tools::ToolSpec]>) -> Self {
+        let available_tools = available_tools.unwrap_or(&[]);
+        let known_tool_names = available_tools
+            .iter()
+            .map(|tool| tool.name.to_ascii_lowercase())
+            .collect();
+        Self {
+            known_tool_names,
+            has_active_tools: !available_tools.is_empty(),
+            ..Self::default()
+        }
+    }
+
+    fn push(&mut self, chunk: &str) -> Option<String> {
+        if self.suppress_forwarding || chunk.is_empty() {
+            return None;
+        }
+
+        if self.pending.is_empty() && !starts_suspicious_protocol_prefix(chunk) {
+            if let Some(start) = find_embedded_protocol_candidate_start(chunk) {
+                self.pending_candidate_start = Some(start);
+                self.pending.push_str(&chunk[start..]);
+                return if self.should_suppress_protocol_candidate(&self.pending) {
+                    self.suppress_protocol();
+                    None
+                } else {
+                    self.pending.insert_str(0, &chunk[..start]);
+                    self.evaluate_pending(false)
+                };
+            }
+            if let Some(start) = find_incomplete_protocol_candidate_start(chunk) {
+                self.pending_candidate_start = Some(start);
+                self.pending.push_str(chunk);
+                return None;
+            }
+            return Some(chunk.to_string());
+        }
+
+        self.pending.push_str(chunk);
+        self.evaluate_pending(false)
+    }
+
+    fn finish(&mut self) -> Option<String> {
+        if self.suppress_forwarding || self.pending.is_empty() {
+            return None;
+        }
+        if let Some(release) = self.evaluate_pending(true) {
+            return Some(release);
+        }
+        if self.suppressed_protocol || self.pending.is_empty() {
+            return None;
+        }
+        if looks_like_malformed_tool_protocol_envelope_for_known_tools(
+            &self.pending,
+            &self.known_tool_names,
+        ) {
+            self.suppress_protocol();
+            return None;
+        }
+        Some(std::mem::take(&mut self.pending))
+    }
+
+    fn evaluate_pending(&mut self, finalizing: bool) -> Option<String> {
+        let candidate = self
+            .pending_candidate_start
+            .and_then(|start| self.pending.get(start..))
+            .unwrap_or(&self.pending);
+
+        if !finalizing && starts_suspicious_tag_or_fence_prefix(candidate) {
+            return None;
+        }
+
+        if self.should_suppress_protocol_candidate(candidate) {
+            self.suppress_protocol();
+            return None;
+        }
+
+        if let Some(is_protocol) =
+            complete_json_fence_protocol_state(candidate, &self.known_tool_names)
+        {
+            if is_protocol && self.has_active_tools {
+                self.suppress_protocol();
+                return None;
+            }
+            self.pending_candidate_start = None;
+            return Some(std::mem::take(&mut self.pending));
+        }
+
+        if complete_non_protocol_json(candidate, &self.known_tool_names) {
+            self.pending_candidate_start = None;
+            return Some(std::mem::take(&mut self.pending));
+        }
+
+        None
+    }
+
+    fn suppress_protocol(&mut self) {
+        self.pending.clear();
+        self.pending_candidate_start = None;
+        self.suppress_forwarding = true;
+        self.suppressed_protocol = true;
+    }
+
+    fn looks_like_active_tool_json(&self, text: &str) -> bool {
+        if self.known_tool_names.is_empty() {
+            return false;
+        }
+
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(text.trim()) else {
+            return false;
+        };
+
+        match value {
+            serde_json::Value::Array(items) => {
+                !items.is_empty() && items.iter().all(|item| self.is_known_tool_payload(item))
+            }
+            serde_json::Value::Object(_) => self.is_known_tool_payload(&value),
+            _ => false,
+        }
+    }
+
+    fn is_known_tool_payload(&self, value: &serde_json::Value) -> bool {
+        let Some(object) = value.as_object() else {
+            return false;
+        };
+
+        let (name, has_args) =
+            if let Some(function) = object.get("function").and_then(|value| value.as_object()) {
+                (
+                    function
+                        .get("name")
+                        .and_then(serde_json::Value::as_str)
+                        .or_else(|| object.get("name").and_then(serde_json::Value::as_str)),
+                    function.contains_key("arguments")
+                        || function.contains_key("parameters")
+                        || object.contains_key("arguments")
+                        || object.contains_key("parameters"),
+                )
+            } else {
+                (
+                    object.get("name").and_then(serde_json::Value::as_str),
+                    object.contains_key("arguments") || object.contains_key("parameters"),
+                )
+            };
+
+        let Some(name) = name.map(str::trim).filter(|name| !name.is_empty()) else {
+            return false;
+        };
+
+        has_args && self.known_tool_names.contains(&name.to_ascii_lowercase())
+    }
+
+    fn should_suppress_protocol_candidate(&self, text: &str) -> bool {
+        if looks_like_tool_protocol_example(text) {
+            return false;
+        }
+
+        if looks_like_malformed_tool_protocol_envelope_for_known_tools(text, &self.known_tool_names)
+            || contains_tool_protocol_tag_call(text)
+        {
+            return true;
+        }
+
+        if let Some(kind) = classify_tool_protocol_envelope(text) {
+            return matches!(kind, ToolProtocolEnvelopeKind::TaggedToolCall)
+                || (self.has_active_tools
+                    && (matches!(kind, ToolProtocolEnvelopeKind::ToolResult)
+                        || tool_protocol_envelope_mentions_known_tool(
+                            text,
+                            &self.known_tool_names,
+                        )));
+        }
+
+        // Parsed JSON that carries protocol-only fields but cannot yield a valid
+        // tool call is an internal protocol failure, not user-facing text.
+        if looks_like_tool_protocol_envelope(text) {
+            return true;
+        }
+
+        self.looks_like_active_tool_json(text)
+    }
+}
+
+fn find_embedded_protocol_candidate_start(text: &str) -> Option<usize> {
+    let lower = text.to_ascii_lowercase();
+    let mut earliest: Option<usize> = None;
+
+    for pattern in [
+        "<tool_call",
+        "<toolcall",
+        "<tool-call",
+        "<invoke",
+        "<function",
+        "```tool",
+        "```invoke",
+        "```json",
+    ] {
+        if let Some(idx) = lower.find(pattern) {
+            earliest = Some(earliest.map_or(idx, |current| current.min(idx)));
+        }
+    }
+
+    for key in ["\"tool_calls\"", "\"toolcalls\"", "\"function_call\""] {
+        if let Some(key_idx) = lower.find(key)
+            && let Some(json_start) = text[..key_idx].rfind(['{', '['])
+        {
+            earliest = Some(earliest.map_or(json_start, |current| current.min(json_start)));
+        }
+    }
+
+    earliest
+}
+
+fn find_incomplete_protocol_candidate_start(text: &str) -> Option<usize> {
+    let lower = text.to_ascii_lowercase();
+    let mut earliest: Option<usize> = None;
+
+    for pattern in [
+        "<tool",
+        "<invoke",
+        "<function",
+        "```tool",
+        "```invoke",
+        "```json",
+    ] {
+        if let Some(idx) = lower.rfind(pattern) {
+            earliest = Some(earliest.map_or(idx, |current| current.min(idx)));
+        }
+    }
+
+    for delimiter in ['{', '['] {
+        if let Some(idx) = text.rfind(delimiter) {
+            let tail = &lower[idx..];
+            if tail.contains("\"tool")
+                || tail.contains("\"function")
+                || tail.contains("\"call")
+                || tail.len() <= 16
+            {
+                earliest = Some(earliest.map_or(idx, |current| current.min(idx)));
+            }
+        }
+    }
+
+    earliest
+}
+
+fn starts_suspicious_protocol_prefix(text: &str) -> bool {
+    let trimmed = text.trim_start();
+    if trimmed.is_empty() {
+        return false;
+    }
+    let lower = trimmed.to_ascii_lowercase();
+    lower.starts_with('{')
+        || lower.starts_with('[')
+        || lower.starts_with("<tool")
+        || lower.starts_with("<invoke")
+        || lower.starts_with("<function")
+        || lower.starts_with("```tool")
+        || lower.starts_with("```invoke")
+        || lower.starts_with("```json")
+}
+
+fn starts_suspicious_tag_or_fence_prefix(text: &str) -> bool {
+    let lower = text.trim_start().to_ascii_lowercase();
+    lower.starts_with("<tool")
+        || lower.starts_with("<invoke")
+        || lower.starts_with("<function")
+        || lower.starts_with("```tool")
+        || lower.starts_with("```invoke")
+        || lower.starts_with("```json")
+        || lower.starts_with("[tool_call]")
+}
+
+fn complete_non_protocol_json(text: &str, known_tool_names: &HashSet<String>) -> bool {
+    let trimmed = text.trim();
+    (trimmed.starts_with('{') || trimmed.starts_with('['))
+        && serde_json::from_str::<serde_json::Value>(trimmed).is_ok()
+        && (!looks_like_tool_protocol_envelope(trimmed)
+            || !tool_protocol_envelope_mentions_known_tool(trimmed, known_tool_names))
+}
+
+fn complete_json_fence_protocol_state(
+    text: &str,
+    known_tool_names: &HashSet<String>,
+) -> Option<bool> {
+    let trimmed = text.trim();
+    let body = json_fence_body(trimmed)?;
+    Some(
+        looks_like_tool_protocol_envelope(body)
+            && tool_protocol_envelope_mentions_known_tool(body, known_tool_names),
+    )
+}
+
+fn detect_internal_protocol_without_tools(response: &str) -> Option<String> {
+    let trimmed = response.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if looks_like_tool_protocol_example(trimmed) {
+        return None;
+    }
+
+    (looks_like_malformed_tool_protocol_envelope(trimmed)
+        || contains_tool_protocol_tag_call(trimmed)
+        || classify_tool_protocol_envelope(trimmed)
+            .is_some_and(|kind| matches!(kind, ToolProtocolEnvelopeKind::TaggedToolCall))
+        || (classify_tool_protocol_envelope(trimmed).is_none()
+            && looks_like_tool_protocol_envelope(trimmed)))
+    .then(|| {
+        "response resembled an internal tool protocol envelope but no tools were enabled".into()
+    })
+}
+
+fn detect_tool_call_parse_issue_for_known_tools(
+    response: &str,
+    parsed_calls: &[ParsedToolCall],
+    known_tool_names: &HashSet<String>,
+) -> Option<String> {
+    if !parsed_calls.is_empty() {
+        return None;
+    }
+
+    let trimmed = response.trim();
+    if trimmed.is_empty() || looks_like_tool_protocol_example(trimmed) {
+        return None;
+    }
+
+    let message = "response resembled an internal tool protocol envelope but no valid tool call could be parsed";
+
+    if looks_like_malformed_tool_protocol_envelope_for_known_tools(trimmed, known_tool_names)
+        || contains_tool_protocol_tag_call(trimmed)
+    {
+        return Some(message.into());
+    }
+
+    if let Some(kind) = classify_tool_protocol_envelope(trimmed) {
+        return (matches!(
+            kind,
+            ToolProtocolEnvelopeKind::TaggedToolCall | ToolProtocolEnvelopeKind::ToolResult
+        ) || tool_protocol_envelope_mentions_known_tool(trimmed, known_tool_names))
+        .then(|| message.into());
+    }
+
+    looks_like_tool_protocol_envelope(trimmed).then(|| message.into())
+}
+
+fn json_fence_body(trimmed: &str) -> Option<&str> {
+    let rest = trimmed.strip_prefix("```")?;
+    let first_newline = rest.find('\n')?;
+    let language = rest[..first_newline].trim().trim_end_matches('\r');
+    if !language.eq_ignore_ascii_case("json") {
+        return None;
+    }
+
+    let body_with_close = &rest[first_newline + 1..];
+    let close_start = body_with_close.rfind("```")?;
+    if !body_with_close[close_start + 3..].trim().is_empty() {
+        return None;
+    }
+    Some(body_with_close[..close_start].trim())
 }
 
 async fn consume_provider_streaming_response(
@@ -623,7 +1003,7 @@ async fn consume_provider_streaming_response(
     let mut outcome = StreamedChatOutcome::default();
     let mut delta_sender = on_delta;
     let mut suppress_forwarding = false;
-    let mut marker_window = String::new();
+    let mut text_guard = StreamTextGuard::new(request_tools);
 
     loop {
         let next_chunk = if let Some(token) = cancellation_token {
@@ -657,6 +1037,7 @@ async fn consume_provider_streaming_response(
             StreamEvent::ToolCall(tool_call) => {
                 outcome.tool_calls.push(tool_call);
                 suppress_forwarding = true;
+                text_guard.suppress_forwarding = true;
             }
             StreamEvent::PreExecutedToolCall { .. } | StreamEvent::PreExecutedToolResult { .. } => {
                 // Pre-executed tool events are for observability only.
@@ -684,39 +1065,32 @@ async fn consume_provider_streaming_response(
                 }
 
                 outcome.response_text.push_str(&chunk.delta);
-                marker_window.push_str(&chunk.delta);
-
-                if marker_window.len() > STREAM_TOOL_MARKER_WINDOW_CHARS {
-                    let keep_from = marker_window.len() - STREAM_TOOL_MARKER_WINDOW_CHARS;
-                    let boundary = marker_window
-                        .char_indices()
-                        .find(|(idx, _)| *idx >= keep_from)
-                        .map_or(0, |(idx, _)| idx);
-                    marker_window.drain(..boundary);
-                }
-
-                if !suppress_forwarding && {
-                    let lowered = marker_window.to_ascii_lowercase();
-                    lowered.contains("<tool_call")
-                        || lowered.contains("<toolcall")
-                        || lowered.contains("\"tool_calls\"")
-                } {
-                    suppress_forwarding = true;
-                }
 
                 if suppress_forwarding {
                     continue;
                 }
 
+                let Some(forward_text) = text_guard.push(&chunk.delta) else {
+                    continue;
+                };
+
                 if let Some(tx) = delta_sender {
                     outcome.forwarded_live_deltas = true;
-                    if tx.send(StreamDelta::Text(chunk.delta)).await.is_err() {
+                    if tx.send(StreamDelta::Text(forward_text)).await.is_err() {
                         delta_sender = None;
                     }
                 }
             }
         }
     }
+
+    if let Some(forward_text) = text_guard.finish()
+        && let Some(tx) = delta_sender
+    {
+        outcome.forwarded_live_deltas = true;
+        let _ = tx.send(StreamDelta::Text(forward_text)).await;
+    }
+    outcome.suppressed_protocol = text_guard.suppressed_protocol;
 
     Ok(outcome)
 }
@@ -942,6 +1316,7 @@ pub async fn run_tool_call_loop(
 
     // Accumulated display text across all tool-loop calls.
     let mut accumulated_display_text = String::new();
+    let mut malformed_tool_protocol_retries: usize = 0;
 
     for iteration in 0..max_iterations {
         let mut seen_tool_signatures: HashSet<(String, String)> = HashSet::new();
@@ -1043,6 +1418,10 @@ pub async fn run_tool_call_loop(
                 }
             }
         }
+        let known_tool_names: HashSet<String> = tool_specs
+            .iter()
+            .map(|tool| tool.name.to_ascii_lowercase())
+            .collect();
         let use_native_tools = model_provider.supports_native_tools() && !tool_specs.is_empty();
 
         let image_marker_count = multimodal::count_image_markers(history);
@@ -1193,6 +1572,7 @@ pub async fn run_tool_call_loop(
             && (request_tools.is_none() || model_provider.supports_streaming_tool_events());
         ::zeroclaw_log::record!(DEBUG, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(::serde_json::json!({"has_on_delta": on_delta.is_some(), "supports_streaming": model_provider.supports_streaming(), "should_consume_provider_stream": should_consume_provider_stream})), &format!("Streaming decision for iteration {}", iteration + 1));
         let mut streamed_live_deltas = false;
+        let mut streamed_protocol_suppressed = false;
 
         let chat_result = if should_consume_provider_stream {
             match consume_provider_streaming_response(
@@ -1208,6 +1588,7 @@ pub async fn run_tool_call_loop(
             {
                 Ok(streamed) => {
                     streamed_live_deltas = streamed.forwarded_live_deltas;
+                    streamed_protocol_suppressed = streamed.suppressed_protocol;
                     let reasoning_content = if streamed.reasoning_content.is_empty() {
                         None
                     } else {
@@ -1323,7 +1704,8 @@ pub async fn run_tool_call_loop(
             tool_calls,
             assistant_history_content,
             native_tool_calls,
-            _parse_issue_detected,
+            parse_issue_detected,
+            protocol_suppressed,
             response_streamed_live,
         ) = match chat_result {
             Ok(resp) => {
@@ -1375,18 +1757,40 @@ pub async fn run_tool_call_loop(
                 };
                 let mut parsed_text = String::new();
 
-                if calls.is_empty() && !tool_specs.is_empty() {
+                if calls.is_empty()
+                    && !tool_specs.is_empty()
+                    && !looks_like_tool_protocol_example(&response_text)
+                {
                     let (fallback_text, fallback_calls) = parse_tool_calls(&response_text);
-                    if !fallback_text.is_empty() {
+                    let filtered_calls: Vec<ParsedToolCall> = fallback_calls
+                        .into_iter()
+                        .filter(|call| known_tool_names.contains(&call.name.to_ascii_lowercase()))
+                        .collect();
+                    if !fallback_text.is_empty() && !filtered_calls.is_empty() {
                         parsed_text = fallback_text;
                     }
-                    calls = fallback_calls;
+                    calls = filtered_calls;
                 }
 
                 let parse_issue = if tool_specs.is_empty() {
-                    None
+                    detect_internal_protocol_without_tools(&response_text).or_else(|| {
+                        streamed_protocol_suppressed.then(|| {
+                            "streaming text guard suppressed an internal tool protocol envelope"
+                                .to_string()
+                        })
+                    })
                 } else {
-                    detect_tool_call_parse_issue(&response_text, &calls)
+                    detect_tool_call_parse_issue_for_known_tools(
+                        &response_text,
+                        &calls,
+                        &known_tool_names,
+                    )
+                    .or_else(|| {
+                        streamed_protocol_suppressed.then(|| {
+                            "streaming text guard suppressed an internal tool protocol envelope"
+                                .to_string()
+                        })
+                    })
                 };
                 if let Some(ref issue) = parse_issue {
                     ::zeroclaw_log::record!(
@@ -1454,6 +1858,7 @@ pub async fn run_tool_call_loop(
                     assistant_history_content,
                     native_calls,
                     parse_issue.is_some(),
+                    streamed_protocol_suppressed,
                     streamed_live_deltas,
                 )
             }
@@ -1543,6 +1948,62 @@ pub async fn run_tool_call_loop(
             !tool_calls.is_empty(),
             !native_tool_calls.is_empty(),
         );
+
+        // Native provider tool_calls are converted into parsed `tool_calls`
+        // above; if this branch is reached there is no valid native call to run.
+        if tool_calls.is_empty() && parse_issue_detected {
+            malformed_tool_protocol_retries += 1;
+            ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                    .with_attrs(serde_json::json!({
+                        "channel": channel_name,
+                        "model_provider": provider_name,
+                        "model": model,
+                        "trace_id": turn_id,
+                        "error": "malformed internal tool protocol omitted from channel output",
+                    })),
+                "tool_call_parse_feedback"
+            );
+            ::zeroclaw_log::record!(
+                DEBUG,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_attrs(serde_json::json!({
+                    "iteration": iteration + 1,
+                    "retry": malformed_tool_protocol_retries,
+                    "max_retries": MAX_MALFORMED_TOOL_PROTOCOL_RETRIES,
+                    "response_excerpt": truncate_with_ellipsis(
+                        &scrub_credentials(&response_text),
+                        600
+                    ),
+                    })),
+                "tool_call_parse_feedback_details"
+            );
+
+            if malformed_tool_protocol_retries <= MAX_MALFORMED_TOOL_PROTOCOL_RETRIES {
+                // This is model feedback, not a tool result: malformed protocol
+                // output has no valid tool_call_id to attach a role=tool message to.
+                history.push(ChatMessage::user(
+                    "[Tool call parse error]\n\
+                     Your previous response looked like an internal tool-call protocol payload, \
+                     but ZeroClaw could not parse it into a valid tool call. Use the supported \
+                     tool-call schema, or answer in natural language if no tool is needed."
+                        .to_string(),
+                ));
+                continue;
+            }
+
+            let fallback =
+                crate::i18n::get_required_cli_string("channel-runtime-malformed-tool-output");
+            accumulated_display_text.push_str(&fallback);
+            if let Some(ref tx) = on_delta {
+                let _ = tx.send(StreamDelta::Text(fallback.to_string())).await;
+            }
+            history.push(ChatMessage::assistant(fallback.to_string()));
+            return Ok(accumulated_display_text);
+        }
+
         // ── Progress: LLM responded ─────────────────────────────
         if let Some(ref tx) = on_delta {
             let llm_secs = llm_started_at.elapsed().as_secs();
@@ -1576,6 +2037,7 @@ pub async fn run_tool_call_loop(
             // When streamed live, the channel already received the deltas.
             if let Some(ref tx) = on_delta
                 && !response_streamed_live
+                && !protocol_suppressed
             {
                 let mut chunk = String::new();
                 for word in display_text.split_inclusive(char::is_whitespace) {
@@ -4693,6 +5155,24 @@ mod tests {
     use zeroclaw_providers::ChatResponse;
     use zeroclaw_providers::router::{Route, RouterModelProvider};
 
+    macro_rules! impl_test_model_provider_attribution {
+        ($ty:ty) => {
+            impl ::zeroclaw_api::attribution::Attributable for $ty {
+                fn role(&self) -> ::zeroclaw_api::attribution::Role {
+                    ::zeroclaw_api::attribution::Role::Provider(
+                        ::zeroclaw_api::attribution::ProviderKind::Model(
+                            ::zeroclaw_api::attribution::ModelProviderKind::Custom,
+                        ),
+                    )
+                }
+
+                fn alias(&self) -> &str {
+                    stringify!($ty)
+                }
+            }
+        };
+    }
+
     struct NonVisionModelProvider {
         calls: Arc<AtomicUsize>,
     }
@@ -6654,6 +7134,1199 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn run_tool_call_loop_retries_malformed_tool_protocol_without_leaking_json() {
+        let provider = ScriptedModelProvider::from_text_responses(vec![
+            r#"{"toolcalls":[{"name":"count_tool","arguments":{"value":"X"}}]}"#,
+            "Recovered answer.",
+        ]);
+        let invocations = Arc::new(AtomicUsize::new(0));
+        let tools_registry: Vec<Box<dyn Tool>> = vec![Box::new(CountingTool::new(
+            "count_tool",
+            Arc::clone(&invocations),
+        ))];
+        let mut history = vec![
+            ChatMessage::system("test-system"),
+            ChatMessage::user("run tool calls"),
+        ];
+        let observer = NoopObserver;
+
+        let result = run_tool_call_loop(
+            &provider,
+            &mut history,
+            &tools_registry,
+            &observer,
+            "mock-provider",
+            "mock-model",
+            Some(0.0),
+            true,
+            None,
+            "matrix",
+            None,
+            &zeroclaw_config::schema::MultimodalConfig::default(),
+            4,
+            None,
+            None,
+            None,
+            &[],
+            &[],
+            None,
+            None,
+            &zeroclaw_config::schema::PacingConfig::default(),
+            0,
+            0,
+            None,
+            None, // channel
+            None, // receipt_generator
+            None, // collected_receipts
+        )
+        .await
+        .expect("malformed tool protocol should retry and recover");
+
+        assert_eq!(result, "Recovered answer.");
+        assert!(!result.contains("toolcalls"));
+        assert_eq!(
+            invocations.load(Ordering::SeqCst),
+            0,
+            "malformed alias payload should not execute as a tool call"
+        );
+        assert!(
+            history
+                .iter()
+                .any(|msg| msg.role == "user" && msg.content.contains("[Tool call parse error]")),
+            "history should include internal parser feedback for the model"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_tool_call_loop_preserves_unknown_function_call_json_with_tools() {
+        let business_json =
+            r#"{"type":"function_call","name":"support_case","arguments":{"id":"A1"}}"#;
+        let provider = ScriptedModelProvider::from_text_responses(vec![business_json]);
+        let invocations = Arc::new(AtomicUsize::new(0));
+        let tools_registry: Vec<Box<dyn Tool>> = vec![Box::new(CountingTool::new(
+            "count_tool",
+            Arc::clone(&invocations),
+        ))];
+        let mut history = vec![
+            ChatMessage::system("test-system"),
+            ChatMessage::user("return a support case JSON object"),
+        ];
+        let observer = NoopObserver;
+
+        let result = run_tool_call_loop(
+            &provider,
+            &mut history,
+            &tools_registry,
+            &observer,
+            "mock-provider",
+            "mock-model",
+            Some(0.0),
+            true,
+            None,
+            "matrix",
+            None,
+            &zeroclaw_config::schema::MultimodalConfig::default(),
+            4,
+            None,
+            None,
+            None,
+            &[],
+            &[],
+            None,
+            None,
+            &zeroclaw_config::schema::PacingConfig::default(),
+            0,
+            0,
+            None,
+            None, // channel
+            None, // receipt_generator
+            None, // collected_receipts
+        )
+        .await
+        .expect("business JSON should be returned as normal text");
+
+        assert_eq!(result, business_json);
+        assert_eq!(
+            invocations.load(Ordering::SeqCst),
+            0,
+            "business JSON must not execute any runtime tool"
+        );
+        assert!(
+            history
+                .iter()
+                .all(|msg| !msg.content.contains("[Tool call parse error]")),
+            "business JSON must not trigger internal parser feedback"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_tool_call_loop_preserves_malformed_unknown_tool_calls_json_with_tools() {
+        let business_json = r#"{"tool_calls":[{"name":"support_case","arguments":{"id":"A1"}}"#;
+        let provider = ScriptedModelProvider::from_text_responses(vec![business_json]);
+        let invocations = Arc::new(AtomicUsize::new(0));
+        let tools_registry: Vec<Box<dyn Tool>> = vec![Box::new(CountingTool::new(
+            "count_tool",
+            Arc::clone(&invocations),
+        ))];
+        let mut history = vec![
+            ChatMessage::system("test-system"),
+            ChatMessage::user("return a partial support case JSON object"),
+        ];
+        let observer = NoopObserver;
+
+        let result = run_tool_call_loop(
+            &provider,
+            &mut history,
+            &tools_registry,
+            &observer,
+            "mock-provider",
+            "mock-model",
+            Some(0.0),
+            true,
+            None,
+            "matrix",
+            None,
+            &zeroclaw_config::schema::MultimodalConfig::default(),
+            4,
+            None,
+            None,
+            None,
+            &[],
+            &[],
+            None,
+            None,
+            &zeroclaw_config::schema::PacingConfig::default(),
+            0,
+            0,
+            None,
+            None, // channel
+            None, // receipt_generator
+            None, // collected_receipts
+        )
+        .await
+        .expect("unknown business JSON should be returned as normal text");
+
+        assert_eq!(result, business_json);
+        assert_eq!(
+            invocations.load(Ordering::SeqCst),
+            0,
+            "business JSON must not execute any runtime tool"
+        );
+        assert!(
+            history
+                .iter()
+                .all(|msg| !msg.content.contains("[Tool call parse error]")),
+            "business JSON must not trigger internal parser feedback"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_tool_call_loop_falls_back_after_repeated_malformed_tool_protocol() {
+        let provider = ScriptedModelProvider::from_text_responses(vec![
+            r#"{"toolcalls":[{"call_id":"call_1","arguments":{"value":"X"}}]}"#,
+            r#"{"toolcalls":[{"call_id":"call_2","arguments":{"value":"Y"}}]}"#,
+            r#"{"toolcalls":[{"call_id":"call_3","arguments":{"value":"Z"}}]}"#,
+        ]);
+        let invocations = Arc::new(AtomicUsize::new(0));
+        let tools_registry: Vec<Box<dyn Tool>> = vec![Box::new(CountingTool::new(
+            "count_tool",
+            Arc::clone(&invocations),
+        ))];
+        let mut history = vec![
+            ChatMessage::system("test-system"),
+            ChatMessage::user("run tool calls"),
+        ];
+        let observer = NoopObserver;
+
+        let result = run_tool_call_loop(
+            &provider,
+            &mut history,
+            &tools_registry,
+            &observer,
+            "mock-provider",
+            "mock-model",
+            Some(0.0),
+            true,
+            None,
+            "matrix",
+            None,
+            &zeroclaw_config::schema::MultimodalConfig::default(),
+            6,
+            None,
+            None,
+            None,
+            &[],
+            &[],
+            None,
+            None,
+            &zeroclaw_config::schema::PacingConfig::default(),
+            0,
+            0,
+            None,
+            None, // channel
+            None, // receipt_generator
+            None, // collected_receipts
+        )
+        .await
+        .expect("malformed tool protocol should return a safe fallback");
+
+        assert_eq!(
+            result,
+            crate::i18n::get_required_cli_string("channel-runtime-malformed-tool-output")
+        );
+        assert!(!result.contains("toolcalls"));
+        assert_eq!(
+            invocations.load(Ordering::SeqCst),
+            0,
+            "malformed protocol should never be executed as a tool call"
+        );
+        let feedback_count = history
+            .iter()
+            .filter(|msg| msg.role == "user" && msg.content.contains("[Tool call parse error]"))
+            .count();
+        assert_eq!(feedback_count, MAX_MALFORMED_TOOL_PROTOCOL_RETRIES);
+    }
+
+    #[tokio::test]
+    async fn run_tool_call_loop_streams_toolcalls_reference_json_when_no_tools_are_enabled() {
+        let reference_json = r#"{"toolcalls":[{"name":"count_tool","arguments":{"value":"X"}}]}"#;
+        let provider = StreamingScriptedModelProvider::from_text_responses(vec![reference_json]);
+        let tools_registry: Vec<Box<dyn Tool>> = Vec::new();
+        let mut history = vec![
+            ChatMessage::system("test-system"),
+            ChatMessage::user("return a toolcalls reference JSON object"),
+        ];
+        let observer = NoopObserver;
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<DraftEvent>(16);
+
+        let result = run_tool_call_loop(
+            &provider,
+            &mut history,
+            &tools_registry,
+            &observer,
+            "mock-provider",
+            "mock-model",
+            Some(0.0),
+            true,
+            None,
+            "matrix",
+            None,
+            &zeroclaw_config::schema::MultimodalConfig::default(),
+            4,
+            None,
+            Some(tx),
+            None,
+            &[],
+            &[],
+            None,
+            None,
+            &zeroclaw_config::schema::PacingConfig::default(),
+            0,
+            0,
+            None,
+            None, // channel
+            None, // receipt_generator
+            None, // collected_receipts
+        )
+        .await
+        .expect("toolcalls reference JSON should remain visible without tools");
+
+        let mut visible_deltas = String::new();
+        while let Some(delta) = rx.recv().await {
+            if let StreamDelta::Text(text) = delta {
+                visible_deltas.push_str(&text);
+            }
+        }
+
+        assert_eq!(result, reference_json);
+        assert_eq!(visible_deltas, reference_json);
+        assert!(
+            history
+                .iter()
+                .all(|msg| !msg.content.contains("[Tool call parse error]")),
+            "toolcalls reference JSON must not trigger internal parser feedback"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_tool_call_loop_returns_toolcalls_reference_json_when_no_tools_are_enabled() {
+        let reference_json = r#"{"toolcalls":[{"name":"count_tool","arguments":{"value":"X"}}]}"#;
+        let provider = ScriptedModelProvider::from_text_responses(vec![reference_json]);
+        let tools_registry: Vec<Box<dyn Tool>> = Vec::new();
+        let mut history = vec![
+            ChatMessage::system("test-system"),
+            ChatMessage::user("return a toolcalls reference JSON object"),
+        ];
+        let observer = NoopObserver;
+
+        let result = run_tool_call_loop(
+            &provider,
+            &mut history,
+            &tools_registry,
+            &observer,
+            "mock-provider",
+            "mock-model",
+            Some(0.0),
+            true,
+            None,
+            "cli",
+            None,
+            &zeroclaw_config::schema::MultimodalConfig::default(),
+            4,
+            None,
+            None,
+            None,
+            &[],
+            &[],
+            None,
+            None,
+            &zeroclaw_config::schema::PacingConfig::default(),
+            0,
+            0,
+            None,
+            None, // channel
+            None, // receipt_generator
+            None, // collected_receipts
+        )
+        .await
+        .expect("toolcalls reference JSON should remain visible without tools");
+
+        assert_eq!(result, reference_json);
+        assert!(
+            history
+                .iter()
+                .all(|msg| !msg.content.contains("[Tool call parse error]")),
+            "toolcalls reference JSON must not trigger internal parser feedback"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_tool_call_loop_returns_schema_json_array_when_no_tools_are_enabled() {
+        let schema = r#"[{"name":"planner","parameters":{"goal":"string"}}]"#;
+        let provider = ScriptedModelProvider::from_text_responses(vec![schema]);
+        let tools_registry: Vec<Box<dyn Tool>> = Vec::new();
+        let mut history = vec![
+            ChatMessage::system("test-system"),
+            ChatMessage::user("return a JSON schema array"),
+        ];
+        let observer = NoopObserver;
+
+        let result = run_tool_call_loop(
+            &provider,
+            &mut history,
+            &tools_registry,
+            &observer,
+            "mock-provider",
+            "mock-model",
+            Some(0.0),
+            true,
+            None,
+            "cli",
+            None,
+            &zeroclaw_config::schema::MultimodalConfig::default(),
+            4,
+            None,
+            None,
+            None,
+            &[],
+            &[],
+            None,
+            None,
+            &zeroclaw_config::schema::PacingConfig::default(),
+            0,
+            0,
+            None,
+            None, // channel
+            None, // receipt_generator
+            None, // collected_receipts
+        )
+        .await
+        .expect("schema JSON should remain visible without tools");
+
+        assert_eq!(result, schema);
+        assert!(
+            history
+                .iter()
+                .all(|msg| !msg.content.contains("[Tool call parse error]")),
+            "plain schema JSON must not trigger internal parser feedback"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_tool_call_loop_returns_tool_calls_audit_json_when_no_tools_are_enabled() {
+        let audit_json =
+            r#"{"tool_calls":[{"id":"case-1","status":"queued","service":"billing"}]}"#;
+        let provider = ScriptedModelProvider::from_text_responses(vec![audit_json]);
+        let tools_registry: Vec<Box<dyn Tool>> = Vec::new();
+        let mut history = vec![
+            ChatMessage::system("test-system"),
+            ChatMessage::user("return a tool call audit JSON object"),
+        ];
+        let observer = NoopObserver;
+
+        let result = run_tool_call_loop(
+            &provider,
+            &mut history,
+            &tools_registry,
+            &observer,
+            "mock-provider",
+            "mock-model",
+            Some(0.0),
+            true,
+            None,
+            "cli",
+            None,
+            &zeroclaw_config::schema::MultimodalConfig::default(),
+            4,
+            None,
+            None,
+            None,
+            &[],
+            &[],
+            None,
+            None,
+            &zeroclaw_config::schema::PacingConfig::default(),
+            0,
+            0,
+            None,
+            None, // channel
+            None, // receipt_generator
+            None, // collected_receipts
+        )
+        .await
+        .expect("audit JSON should remain visible without tools");
+
+        assert_eq!(result, audit_json);
+        assert!(
+            history
+                .iter()
+                .all(|msg| !msg.content.contains("[Tool call parse error]")),
+            "business tool_calls JSON must not trigger internal parser feedback"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_tool_call_loop_returns_function_call_reference_json_when_no_tools_are_enabled() {
+        let reference_json =
+            r#"{"type":"function_call","name":"support_case","arguments":{"id":"A1"}}"#;
+        let provider = ScriptedModelProvider::from_text_responses(vec![reference_json]);
+        let tools_registry: Vec<Box<dyn Tool>> = Vec::new();
+        let mut history = vec![
+            ChatMessage::system("test-system"),
+            ChatMessage::user("return a function_call reference JSON object"),
+        ];
+        let observer = NoopObserver;
+
+        let result = run_tool_call_loop(
+            &provider,
+            &mut history,
+            &tools_registry,
+            &observer,
+            "mock-provider",
+            "mock-model",
+            Some(0.0),
+            true,
+            None,
+            "cli",
+            None,
+            &zeroclaw_config::schema::MultimodalConfig::default(),
+            4,
+            None,
+            None,
+            None,
+            &[],
+            &[],
+            None,
+            None,
+            &zeroclaw_config::schema::PacingConfig::default(),
+            0,
+            0,
+            None,
+            None, // channel
+            None, // receipt_generator
+            None, // collected_receipts
+        )
+        .await
+        .expect("reference JSON should remain visible without tools");
+
+        assert_eq!(result, reference_json);
+        assert!(
+            history
+                .iter()
+                .all(|msg| !msg.content.contains("[Tool call parse error]")),
+            "reference function_call JSON must not trigger internal parser feedback"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_tool_call_loop_returns_tool_call_tag_example_when_no_tools_are_enabled() {
+        let example = r#"<tool_call>
+{"name":"shell","arguments":{"command":"pwd"}}
+</tool_call>
+This is an example, not an invocation."#;
+        let provider = ScriptedModelProvider::from_text_responses(vec![example]);
+        let tools_registry: Vec<Box<dyn Tool>> = Vec::new();
+        let mut history = vec![
+            ChatMessage::system("test-system"),
+            ChatMessage::user("show a tool_call tag example"),
+        ];
+        let observer = NoopObserver;
+
+        let result = run_tool_call_loop(
+            &provider,
+            &mut history,
+            &tools_registry,
+            &observer,
+            "mock-provider",
+            "mock-model",
+            Some(0.0),
+            true,
+            None,
+            "cli",
+            None,
+            &zeroclaw_config::schema::MultimodalConfig::default(),
+            4,
+            None,
+            None,
+            None,
+            &[],
+            &[],
+            None,
+            None,
+            &zeroclaw_config::schema::PacingConfig::default(),
+            0,
+            0,
+            None,
+            None, // channel
+            None, // receipt_generator
+            None, // collected_receipts
+        )
+        .await
+        .expect("tool_call tag examples should remain visible without tools");
+
+        assert_eq!(result, example);
+        assert!(
+            history
+                .iter()
+                .all(|msg| !msg.content.contains("[Tool call parse error]")),
+            "tool_call tag examples must not trigger internal parser feedback"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_tool_call_loop_streams_tool_call_fenced_example_with_registered_tool() {
+        let example = r#"```tool_call
+{"name":"count_tool","arguments":{"value":"X"}}
+```
+This is an example, not an invocation."#;
+        let provider = StreamingScriptedModelProvider::from_text_responses(vec![example]);
+        let invocations = Arc::new(AtomicUsize::new(0));
+        let tools_registry: Vec<Box<dyn Tool>> = vec![Box::new(CountingTool::new(
+            "count_tool",
+            Arc::clone(&invocations),
+        ))];
+        let mut history = vec![
+            ChatMessage::system("test-system"),
+            ChatMessage::user("show a registered tool_call fenced example"),
+        ];
+        let observer = NoopObserver;
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<DraftEvent>(16);
+
+        let result = run_tool_call_loop(
+            &provider,
+            &mut history,
+            &tools_registry,
+            &observer,
+            "mock-provider",
+            "mock-model",
+            Some(0.0),
+            true,
+            None,
+            "matrix",
+            None,
+            &zeroclaw_config::schema::MultimodalConfig::default(),
+            4,
+            None,
+            Some(tx),
+            None,
+            &[],
+            &[],
+            None,
+            None,
+            &zeroclaw_config::schema::PacingConfig::default(),
+            0,
+            0,
+            None,
+            None, // channel
+            None, // receipt_generator
+            None, // collected_receipts
+        )
+        .await
+        .expect("registered tool_call fenced examples should remain visible");
+
+        let mut visible_deltas = String::new();
+        while let Some(delta) = rx.recv().await {
+            if let StreamDelta::Text(text) = delta {
+                visible_deltas.push_str(&text);
+            }
+        }
+
+        assert_eq!(result, example);
+        assert_eq!(visible_deltas, example);
+        assert_eq!(
+            invocations.load(Ordering::SeqCst),
+            0,
+            "tool-call examples must not execute registered tools"
+        );
+        assert!(
+            history
+                .iter()
+                .all(|msg| !msg.content.contains("[Tool call parse error]")),
+            "tool-call examples must not trigger internal parser feedback"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_tool_call_loop_returns_tool_call_tag_example_with_registered_tool() {
+        let example = r#"<tool_call>
+{"name":"count_tool","arguments":{"value":"X"}}
+</tool_call>
+This is an example, not an invocation."#;
+        let provider = ScriptedModelProvider::from_text_responses(vec![example]);
+        let invocations = Arc::new(AtomicUsize::new(0));
+        let tools_registry: Vec<Box<dyn Tool>> = vec![Box::new(CountingTool::new(
+            "count_tool",
+            Arc::clone(&invocations),
+        ))];
+        let mut history = vec![
+            ChatMessage::system("test-system"),
+            ChatMessage::user("show a registered tool_call tag example"),
+        ];
+        let observer = NoopObserver;
+
+        let result = run_tool_call_loop(
+            &provider,
+            &mut history,
+            &tools_registry,
+            &observer,
+            "mock-provider",
+            "mock-model",
+            Some(0.0),
+            true,
+            None,
+            "cli",
+            None,
+            &zeroclaw_config::schema::MultimodalConfig::default(),
+            4,
+            None,
+            None,
+            None,
+            &[],
+            &[],
+            None,
+            None,
+            &zeroclaw_config::schema::PacingConfig::default(),
+            0,
+            0,
+            None,
+            None, // channel
+            None, // receipt_generator
+            None, // collected_receipts
+        )
+        .await
+        .expect("registered tool_call tag examples should remain visible");
+
+        assert_eq!(result, example);
+        assert_eq!(
+            invocations.load(Ordering::SeqCst),
+            0,
+            "tool-call tag examples must not execute registered tools"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_tool_call_loop_retries_tagged_tool_call_with_trailing_text_without_tools() {
+        let leaked = r#"<tool_call>
+{"name":"shell","arguments":{"command":"pwd"}}
+</tool_call>
+Done."#;
+        let provider =
+            ScriptedModelProvider::from_text_responses(vec![leaked, "Recovered answer."]);
+        let tools_registry: Vec<Box<dyn Tool>> = Vec::new();
+        let mut history = vec![
+            ChatMessage::system("test-system"),
+            ChatMessage::user("run without tools"),
+        ];
+        let observer = NoopObserver;
+
+        let result = run_tool_call_loop(
+            &provider,
+            &mut history,
+            &tools_registry,
+            &observer,
+            "mock-provider",
+            "mock-model",
+            Some(0.0),
+            true,
+            None,
+            "cli",
+            None,
+            &zeroclaw_config::schema::MultimodalConfig::default(),
+            4,
+            None,
+            None,
+            None,
+            &[],
+            &[],
+            None,
+            None,
+            &zeroclaw_config::schema::PacingConfig::default(),
+            0,
+            0,
+            None,
+            None, // channel
+            None, // receipt_generator
+            None, // collected_receipts
+        )
+        .await
+        .expect("tagged tool protocol with trailing text should retry and recover");
+
+        assert_eq!(result, "Recovered answer.");
+        assert!(!result.contains("<tool_call>"));
+        assert!(
+            history
+                .iter()
+                .any(|msg| msg.role == "user" && msg.content.contains("[Tool call parse error]")),
+            "tagged tool protocol with trailing text must trigger internal parser feedback"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_tool_call_loop_retries_embedded_fenced_tool_call_without_tools() {
+        let leaked = r#"Let me call it:
+```tool_call
+{"name":"shell","arguments":{"command":"pwd"}}
+```
+Done."#;
+        let provider =
+            ScriptedModelProvider::from_text_responses(vec![leaked, "Recovered answer."]);
+        let tools_registry: Vec<Box<dyn Tool>> = Vec::new();
+        let mut history = vec![
+            ChatMessage::system("test-system"),
+            ChatMessage::user("run without tools"),
+        ];
+        let observer = NoopObserver;
+
+        let result = run_tool_call_loop(
+            &provider,
+            &mut history,
+            &tools_registry,
+            &observer,
+            "mock-provider",
+            "mock-model",
+            Some(0.0),
+            true,
+            None,
+            "matrix",
+            None,
+            &zeroclaw_config::schema::MultimodalConfig::default(),
+            4,
+            None,
+            None,
+            None,
+            &[],
+            &[],
+            None,
+            None,
+            &zeroclaw_config::schema::PacingConfig::default(),
+            0,
+            0,
+            None,
+            None, // channel
+            None, // receipt_generator
+            None, // collected_receipts
+        )
+        .await
+        .expect("embedded fenced tool protocol should retry and recover");
+
+        assert_eq!(result, "Recovered answer.");
+        assert!(!result.contains("```tool_call"));
+        assert!(
+            history
+                .iter()
+                .any(|msg| msg.role == "user" && msg.content.contains("[Tool call parse error]")),
+            "embedded fenced tool protocol must trigger internal parser feedback"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_tool_call_loop_retries_malformed_tool_protocol_fenced_call_without_tools() {
+        let leaked = r#"```tool_call
+{"name":"shell","arguments":{"command":"pwd"}}
+```"#;
+        let provider =
+            ScriptedModelProvider::from_text_responses(vec![leaked, "Recovered answer."]);
+        let tools_registry: Vec<Box<dyn Tool>> = Vec::new();
+        let mut history = vec![
+            ChatMessage::system("test-system"),
+            ChatMessage::user("run without tools"),
+        ];
+        let observer = NoopObserver;
+
+        let result = run_tool_call_loop(
+            &provider,
+            &mut history,
+            &tools_registry,
+            &observer,
+            "mock-provider",
+            "mock-model",
+            Some(0.0),
+            true,
+            None,
+            "cli",
+            None,
+            &zeroclaw_config::schema::MultimodalConfig::default(),
+            4,
+            None,
+            None,
+            None,
+            &[],
+            &[],
+            None,
+            None,
+            &zeroclaw_config::schema::PacingConfig::default(),
+            0,
+            0,
+            None,
+            None, // channel
+            None, // receipt_generator
+            None, // collected_receipts
+        )
+        .await
+        .expect("standalone tool_call fence should retry and recover without tools");
+
+        assert_eq!(result, "Recovered answer.");
+        assert!(!result.contains("```tool_call"));
+        assert!(
+            history
+                .iter()
+                .any(|msg| msg.role == "user" && msg.content.contains("[Tool call parse error]")),
+            "standalone tool_call fence must trigger internal parser feedback"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_tool_call_loop_streams_tool_call_fenced_example_when_no_tools_are_enabled() {
+        let example = r#"```tool_call
+{"name":"shell","arguments":{"command":"pwd"}}
+```
+This is an example, not an invocation."#;
+        let provider = StreamingScriptedModelProvider::from_text_responses(vec![example]);
+        let tools_registry: Vec<Box<dyn Tool>> = Vec::new();
+        let mut history = vec![
+            ChatMessage::system("test-system"),
+            ChatMessage::user("show a tool_call fenced example"),
+        ];
+        let observer = NoopObserver;
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<DraftEvent>(16);
+
+        let result = run_tool_call_loop(
+            &provider,
+            &mut history,
+            &tools_registry,
+            &observer,
+            "mock-provider",
+            "mock-model",
+            Some(0.0),
+            true,
+            None,
+            "matrix",
+            None,
+            &zeroclaw_config::schema::MultimodalConfig::default(),
+            4,
+            None,
+            Some(tx),
+            None,
+            &[],
+            &[],
+            None,
+            None,
+            &zeroclaw_config::schema::PacingConfig::default(),
+            0,
+            0,
+            None,
+            None, // channel
+            None, // receipt_generator
+            None, // collected_receipts
+        )
+        .await
+        .expect("tool_call fenced examples should remain visible without tools");
+
+        let mut visible_deltas = String::new();
+        while let Some(delta) = rx.recv().await {
+            if let StreamDelta::Text(text) = delta {
+                visible_deltas.push_str(&text);
+            }
+        }
+
+        assert_eq!(result, example);
+        assert_eq!(visible_deltas, example);
+        assert!(
+            history
+                .iter()
+                .all(|msg| !msg.content.contains("[Tool call parse error]")),
+            "tool_call fenced examples must not trigger internal parser feedback"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_tool_call_loop_streams_split_tool_call_fenced_example_when_no_tools_are_enabled() {
+        struct SplitFencedExampleProvider;
+        impl_test_model_provider_attribution!(SplitFencedExampleProvider);
+
+        #[async_trait]
+        impl ModelProvider for SplitFencedExampleProvider {
+            async fn chat_with_system(
+                &self,
+                _system_prompt: Option<&str>,
+                _message: &str,
+                _model: &str,
+                _temperature: Option<f64>,
+            ) -> anyhow::Result<String> {
+                anyhow::bail!("not used in this test")
+            }
+
+            async fn chat(
+                &self,
+                _request: ChatRequest<'_>,
+                _model: &str,
+                _temperature: Option<f64>,
+            ) -> anyhow::Result<ChatResponse> {
+                anyhow::bail!("chat should not be called when streaming succeeds")
+            }
+
+            fn supports_streaming(&self) -> bool {
+                true
+            }
+
+            fn stream_chat(
+                &self,
+                _request: ChatRequest<'_>,
+                _model: &str,
+                _temperature: Option<f64>,
+                _options: StreamOptions,
+            ) -> futures_util::stream::BoxStream<
+                'static,
+                zeroclaw_providers::traits::StreamResult<StreamEvent>,
+            > {
+                Box::pin(futures_util::stream::iter(vec![
+                    Ok(StreamEvent::TextDelta(StreamChunk::delta(
+                        "```tool_call\n{\"name\":\"shell\",\"arguments\":{\"command\":\"pwd\"}}\n```",
+                    ))),
+                    Ok(StreamEvent::TextDelta(StreamChunk::delta(
+                        "\nThis is an example, not an invocation.",
+                    ))),
+                    Ok(StreamEvent::Final),
+                ]))
+            }
+        }
+
+        let example = r#"```tool_call
+{"name":"shell","arguments":{"command":"pwd"}}
+```
+This is an example, not an invocation."#;
+        let provider = SplitFencedExampleProvider;
+        let tools_registry: Vec<Box<dyn Tool>> = Vec::new();
+        let mut history = vec![
+            ChatMessage::system("test-system"),
+            ChatMessage::user("show a split tool_call fenced example"),
+        ];
+        let observer = NoopObserver;
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<DraftEvent>(16);
+
+        let result = run_tool_call_loop(
+            &provider,
+            &mut history,
+            &tools_registry,
+            &observer,
+            "mock-provider",
+            "mock-model",
+            Some(0.0),
+            true,
+            None,
+            "matrix",
+            None,
+            &zeroclaw_config::schema::MultimodalConfig::default(),
+            4,
+            None,
+            Some(tx),
+            None,
+            &[],
+            &[],
+            None,
+            None,
+            &zeroclaw_config::schema::PacingConfig::default(),
+            0,
+            0,
+            None,
+            None, // channel
+            None, // receipt_generator
+            None, // collected_receipts
+        )
+        .await
+        .expect("split tool_call fenced examples should remain visible without tools");
+
+        let mut visible_deltas = String::new();
+        while let Some(delta) = rx.recv().await {
+            if let StreamDelta::Text(text) = delta {
+                visible_deltas.push_str(&text);
+            }
+        }
+
+        assert_eq!(result, example);
+        assert_eq!(visible_deltas, example);
+        assert!(
+            history
+                .iter()
+                .all(|msg| !msg.content.contains("[Tool call parse error]")),
+            "split tool_call fenced examples must not trigger internal parser feedback"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_tool_call_loop_streams_json_fenced_tool_protocol_example_when_no_tools_are_enabled()
+     {
+        let example = r#"```json
+{"tool_calls":[{"name":"shell","arguments":{"command":"pwd"}}]}
+```
+This is an example, not an invocation."#;
+        let provider = StreamingScriptedModelProvider::from_text_responses(vec![example]);
+        let tools_registry: Vec<Box<dyn Tool>> = Vec::new();
+        let mut history = vec![
+            ChatMessage::system("test-system"),
+            ChatMessage::user("show a JSON tool_calls example"),
+        ];
+        let observer = NoopObserver;
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<DraftEvent>(16);
+
+        let result = run_tool_call_loop(
+            &provider,
+            &mut history,
+            &tools_registry,
+            &observer,
+            "mock-provider",
+            "mock-model",
+            Some(0.0),
+            true,
+            None,
+            "matrix",
+            None,
+            &zeroclaw_config::schema::MultimodalConfig::default(),
+            4,
+            None,
+            Some(tx),
+            None,
+            &[],
+            &[],
+            None,
+            None,
+            &zeroclaw_config::schema::PacingConfig::default(),
+            0,
+            0,
+            None,
+            None, // channel
+            None, // receipt_generator
+            None, // collected_receipts
+        )
+        .await
+        .expect("JSON-fenced tool protocol examples should remain visible without tools");
+
+        let mut visible_deltas = String::new();
+        while let Some(delta) = rx.recv().await {
+            if let StreamDelta::Text(text) = delta {
+                visible_deltas.push_str(&text);
+            }
+        }
+
+        assert_eq!(result, example);
+        assert_eq!(visible_deltas, example);
+        assert!(
+            history
+                .iter()
+                .all(|msg| !msg.content.contains("[Tool call parse error]")),
+            "JSON-fenced tool protocol examples must not trigger internal parser feedback"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_tool_call_loop_executes_streamed_tool_call_fence_without_draft_leak() {
+        let provider = StreamingScriptedModelProvider::from_text_responses(vec![
+            r#"```tool_call
+{"name":"count_tool","arguments":{"value":"X"}}
+```"#,
+            "Final answer.",
+        ]);
+        let invocations = Arc::new(AtomicUsize::new(0));
+        let tools_registry: Vec<Box<dyn Tool>> = vec![Box::new(CountingTool::new(
+            "count_tool",
+            Arc::clone(&invocations),
+        ))];
+        let mut history = vec![
+            ChatMessage::system("test-system"),
+            ChatMessage::user("use the tool"),
+        ];
+        let observer = NoopObserver;
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<DraftEvent>(16);
+
+        let result = run_tool_call_loop(
+            &provider,
+            &mut history,
+            &tools_registry,
+            &observer,
+            "mock-provider",
+            "mock-model",
+            Some(0.0),
+            true,
+            None,
+            "matrix",
+            None,
+            &zeroclaw_config::schema::MultimodalConfig::default(),
+            4,
+            None,
+            Some(tx),
+            None,
+            &[],
+            &[],
+            None,
+            None,
+            &zeroclaw_config::schema::PacingConfig::default(),
+            0,
+            0,
+            None,
+            None, // channel
+            None, // receipt_generator
+            None, // collected_receipts
+        )
+        .await
+        .expect("streamed fenced tool call should execute and continue");
+
+        let mut visible_deltas = String::new();
+        while let Some(delta) = rx.recv().await {
+            if let StreamDelta::Text(text) = delta {
+                visible_deltas.push_str(&text);
+            }
+        }
+
+        assert_eq!(result, "Final answer.");
+        assert_eq!(invocations.load(Ordering::SeqCst), 1);
+        assert_eq!(visible_deltas, "Final answer.");
+        assert!(
+            !visible_deltas.contains("```tool_call"),
+            "streamed fenced tool call must not reach draft updates before execution"
+        );
+    }
+
+    #[tokio::test]
     async fn run_tool_call_loop_relays_native_tool_call_text_via_on_delta() {
         let model_provider = ScriptedModelProvider {
             responses: Arc::new(Mutex::new(VecDeque::from(vec![
@@ -6886,6 +8559,782 @@ mod tests {
         assert!(
             !visible_deltas.contains("<tool_call"),
             "draft text should not leak streamed tool payload markers"
+        );
+    }
+
+    #[tokio::test]
+    async fn consume_provider_streaming_response_buffers_split_tool_protocol_markers() {
+        struct SplitToolProtocolProvider;
+        impl_test_model_provider_attribution!(SplitToolProtocolProvider);
+
+        #[async_trait]
+        impl ModelProvider for SplitToolProtocolProvider {
+            async fn chat_with_system(
+                &self,
+                _system_prompt: Option<&str>,
+                _message: &str,
+                _model: &str,
+                _temperature: Option<f64>,
+            ) -> anyhow::Result<String> {
+                anyhow::bail!("not used in this test")
+            }
+
+            async fn chat(
+                &self,
+                _request: ChatRequest<'_>,
+                _model: &str,
+                _temperature: Option<f64>,
+            ) -> anyhow::Result<ChatResponse> {
+                anyhow::bail!("not used in this test")
+            }
+
+            fn supports_streaming(&self) -> bool {
+                true
+            }
+
+            fn stream_chat(
+                &self,
+                _request: ChatRequest<'_>,
+                _model: &str,
+                _temperature: Option<f64>,
+                _options: StreamOptions,
+            ) -> futures_util::stream::BoxStream<
+                'static,
+                zeroclaw_providers::traits::StreamResult<StreamEvent>,
+            > {
+                Box::pin(futures_util::stream::iter(vec![
+                    Ok(StreamEvent::TextDelta(StreamChunk::delta(r#"{"tool"#))),
+                    Ok(StreamEvent::TextDelta(StreamChunk::delta(
+                        r#"calls":[{"name":"count_tool","arguments":{"value":"X"}}]}"#,
+                    ))),
+                    Ok(StreamEvent::Final),
+                ]))
+            }
+        }
+
+        let provider = SplitToolProtocolProvider;
+        let messages = vec![ChatMessage::user("hi")];
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<DraftEvent>(8);
+
+        let outcome = consume_provider_streaming_response(
+            &provider,
+            &messages,
+            Some(&[crate::tools::ToolSpec {
+                name: "count_tool".to_string(),
+                description: "Count values".to_string(),
+                parameters: serde_json::json!({"type": "object"}),
+            }]),
+            "mock-model",
+            Some(0.0),
+            None,
+            Some(&tx),
+        )
+        .await
+        .expect("streaming should finish");
+        drop(tx);
+
+        let mut visible_deltas = String::new();
+        while let Some(delta) = rx.recv().await {
+            if let StreamDelta::Text(text) = delta {
+                visible_deltas.push_str(&text);
+            }
+        }
+
+        assert!(outcome.response_text.contains("\"toolcalls\""));
+        assert_eq!(
+            visible_deltas, "",
+            "split internal protocol markers must not reach draft updates"
+        );
+    }
+
+    #[tokio::test]
+    async fn consume_provider_streaming_response_buffers_top_level_tool_call_array() {
+        struct TopLevelToolArrayProvider;
+        impl_test_model_provider_attribution!(TopLevelToolArrayProvider);
+
+        #[async_trait]
+        impl ModelProvider for TopLevelToolArrayProvider {
+            async fn chat_with_system(
+                &self,
+                _system_prompt: Option<&str>,
+                _message: &str,
+                _model: &str,
+                _temperature: Option<f64>,
+            ) -> anyhow::Result<String> {
+                anyhow::bail!("not used in this test")
+            }
+
+            async fn chat(
+                &self,
+                _request: ChatRequest<'_>,
+                _model: &str,
+                _temperature: Option<f64>,
+            ) -> anyhow::Result<ChatResponse> {
+                anyhow::bail!("not used in this test")
+            }
+
+            fn supports_streaming(&self) -> bool {
+                true
+            }
+
+            fn stream_chat(
+                &self,
+                _request: ChatRequest<'_>,
+                _model: &str,
+                _temperature: Option<f64>,
+                _options: StreamOptions,
+            ) -> futures_util::stream::BoxStream<
+                'static,
+                zeroclaw_providers::traits::StreamResult<StreamEvent>,
+            > {
+                Box::pin(futures_util::stream::iter(vec![
+                    Ok(StreamEvent::TextDelta(StreamChunk::delta(
+                        r#"[{"name":"count_tool","arguments":{"value":"X"}}]"#,
+                    ))),
+                    Ok(StreamEvent::Final),
+                ]))
+            }
+        }
+
+        let provider = TopLevelToolArrayProvider;
+        let messages = vec![ChatMessage::user("hi")];
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<DraftEvent>(8);
+
+        let outcome = consume_provider_streaming_response(
+            &provider,
+            &messages,
+            Some(&[crate::tools::ToolSpec {
+                name: "count_tool".to_string(),
+                description: "Count values".to_string(),
+                parameters: serde_json::json!({"type": "object"}),
+            }]),
+            "mock-model",
+            Some(0.0),
+            None,
+            Some(&tx),
+        )
+        .await
+        .expect("streaming should finish");
+        drop(tx);
+
+        let mut visible_deltas = String::new();
+        while let Some(delta) = rx.recv().await {
+            if let StreamDelta::Text(text) = delta {
+                visible_deltas.push_str(&text);
+            }
+        }
+
+        assert!(outcome.response_text.contains("\"name\""));
+        assert_eq!(
+            visible_deltas, "",
+            "top-level tool-call arrays must not reach draft updates"
+        );
+    }
+
+    #[tokio::test]
+    async fn consume_provider_streaming_response_preserves_schema_array_without_tools() {
+        let provider = StreamingScriptedModelProvider::from_text_responses(vec![
+            r#"[{"name":"planner","parameters":{"goal":"string"}}]"#,
+        ]);
+        let messages = vec![ChatMessage::user("return a JSON schema array")];
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<DraftEvent>(8);
+
+        let outcome = consume_provider_streaming_response(
+            &provider,
+            &messages,
+            None,
+            "mock-model",
+            Some(0.0),
+            None,
+            Some(&tx),
+        )
+        .await
+        .expect("streaming should finish");
+        drop(tx);
+
+        let mut visible_deltas = String::new();
+        while let Some(delta) = rx.recv().await {
+            if let StreamDelta::Text(text) = delta {
+                visible_deltas.push_str(&text);
+            }
+        }
+
+        assert_eq!(
+            outcome.response_text,
+            r#"[{"name":"planner","parameters":{"goal":"string"}}]"#
+        );
+        assert_eq!(visible_deltas, outcome.response_text);
+    }
+
+    #[tokio::test]
+    async fn consume_provider_streaming_response_preserves_unknown_function_call_json_with_tools() {
+        let response = r#"{"type":"function_call","name":"support_case","arguments":{"id":"A1"}}"#;
+        let provider = StreamingScriptedModelProvider::from_text_responses(vec![response]);
+        let messages = vec![ChatMessage::user("return a support case JSON object")];
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<DraftEvent>(8);
+
+        let outcome = consume_provider_streaming_response(
+            &provider,
+            &messages,
+            Some(&[crate::tools::ToolSpec {
+                name: "count_tool".to_string(),
+                description: "Count values".to_string(),
+                parameters: serde_json::json!({"type": "object"}),
+            }]),
+            "mock-model",
+            Some(0.0),
+            None,
+            Some(&tx),
+        )
+        .await
+        .expect("streaming should finish");
+        drop(tx);
+
+        let mut visible_deltas = String::new();
+        while let Some(delta) = rx.recv().await {
+            if let StreamDelta::Text(text) = delta {
+                visible_deltas.push_str(&text);
+            }
+        }
+
+        assert_eq!(outcome.response_text, response);
+        assert_eq!(visible_deltas, response);
+    }
+
+    #[tokio::test]
+    async fn consume_provider_streaming_response_preserves_malformed_unknown_tool_calls_json_with_tools()
+     {
+        let response = r#"{"tool_calls":[{"name":"support_case","arguments":{"id":"A1"}}"#;
+        let provider = StreamingScriptedModelProvider::from_text_responses(vec![response]);
+        let messages = vec![ChatMessage::user(
+            "return a partial support case JSON object",
+        )];
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<DraftEvent>(8);
+
+        let outcome = consume_provider_streaming_response(
+            &provider,
+            &messages,
+            Some(&[crate::tools::ToolSpec {
+                name: "count_tool".to_string(),
+                description: "Count values".to_string(),
+                parameters: serde_json::json!({"type": "object"}),
+            }]),
+            "mock-model",
+            Some(0.0),
+            None,
+            Some(&tx),
+        )
+        .await
+        .expect("streaming should finish");
+        drop(tx);
+
+        let mut visible_deltas = String::new();
+        while let Some(delta) = rx.recv().await {
+            if let StreamDelta::Text(text) = delta {
+                visible_deltas.push_str(&text);
+            }
+        }
+
+        assert_eq!(outcome.response_text, response);
+        assert_eq!(visible_deltas, response);
+        assert!(
+            !outcome.suppressed_protocol,
+            "unknown business JSON must not be suppressed as internal protocol"
+        );
+    }
+
+    #[tokio::test]
+    async fn consume_provider_streaming_response_buffers_malformed_tool_protocol_json() {
+        struct MalformedToolProtocolProvider;
+        impl_test_model_provider_attribution!(MalformedToolProtocolProvider);
+
+        #[async_trait]
+        impl ModelProvider for MalformedToolProtocolProvider {
+            async fn chat_with_system(
+                &self,
+                _system_prompt: Option<&str>,
+                _message: &str,
+                _model: &str,
+                _temperature: Option<f64>,
+            ) -> anyhow::Result<String> {
+                anyhow::bail!("not used in this test")
+            }
+
+            async fn chat(
+                &self,
+                _request: ChatRequest<'_>,
+                _model: &str,
+                _temperature: Option<f64>,
+            ) -> anyhow::Result<ChatResponse> {
+                anyhow::bail!("not used in this test")
+            }
+
+            fn supports_streaming(&self) -> bool {
+                true
+            }
+
+            fn stream_chat(
+                &self,
+                _request: ChatRequest<'_>,
+                _model: &str,
+                _temperature: Option<f64>,
+                _options: StreamOptions,
+            ) -> futures_util::stream::BoxStream<
+                'static,
+                zeroclaw_providers::traits::StreamResult<StreamEvent>,
+            > {
+                Box::pin(futures_util::stream::iter(vec![
+                    Ok(StreamEvent::TextDelta(StreamChunk::delta(r#"{"tool_"#))),
+                    Ok(StreamEvent::TextDelta(StreamChunk::delta(
+                        r#"calls":[{"call_id":"call_1","arguments":{"value":"X"}}]}"#,
+                    ))),
+                    Ok(StreamEvent::Final),
+                ]))
+            }
+        }
+
+        let provider = MalformedToolProtocolProvider;
+        let messages = vec![ChatMessage::user("hi")];
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<DraftEvent>(8);
+
+        let outcome = consume_provider_streaming_response(
+            &provider,
+            &messages,
+            None,
+            "mock-model",
+            Some(0.0),
+            None,
+            Some(&tx),
+        )
+        .await
+        .expect("streaming should finish");
+        drop(tx);
+
+        let mut visible_deltas = String::new();
+        while let Some(delta) = rx.recv().await {
+            if let StreamDelta::Text(text) = delta {
+                visible_deltas.push_str(&text);
+            }
+        }
+
+        assert!(outcome.response_text.contains("\"tool_calls\""));
+        assert_eq!(
+            visible_deltas, "",
+            "malformed internal protocol JSON must not reach draft updates"
+        );
+    }
+
+    #[tokio::test]
+    async fn consume_provider_streaming_response_drops_truncated_protocol_at_finish() {
+        struct TruncatedProtocolProvider;
+        impl_test_model_provider_attribution!(TruncatedProtocolProvider);
+
+        #[async_trait]
+        impl ModelProvider for TruncatedProtocolProvider {
+            async fn chat_with_system(
+                &self,
+                _system_prompt: Option<&str>,
+                _message: &str,
+                _model: &str,
+                _temperature: Option<f64>,
+            ) -> anyhow::Result<String> {
+                anyhow::bail!("not used in this test")
+            }
+
+            async fn chat(
+                &self,
+                _request: ChatRequest<'_>,
+                _model: &str,
+                _temperature: Option<f64>,
+            ) -> anyhow::Result<ChatResponse> {
+                anyhow::bail!("not used in this test")
+            }
+
+            fn supports_streaming(&self) -> bool {
+                true
+            }
+
+            fn stream_chat(
+                &self,
+                _request: ChatRequest<'_>,
+                _model: &str,
+                _temperature: Option<f64>,
+                _options: StreamOptions,
+            ) -> futures_util::stream::BoxStream<
+                'static,
+                zeroclaw_providers::traits::StreamResult<StreamEvent>,
+            > {
+                Box::pin(futures_util::stream::iter(vec![
+                    Ok(StreamEvent::TextDelta(StreamChunk::delta(
+                        r#"{"tool_call_id":"call_1","content":"raw"#,
+                    ))),
+                    Ok(StreamEvent::Final),
+                ]))
+            }
+        }
+
+        let provider = TruncatedProtocolProvider;
+        let messages = vec![ChatMessage::user("hi")];
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<DraftEvent>(8);
+
+        let outcome = consume_provider_streaming_response(
+            &provider,
+            &messages,
+            None,
+            "mock-model",
+            Some(0.0),
+            None,
+            Some(&tx),
+        )
+        .await
+        .expect("streaming should finish");
+        drop(tx);
+
+        let mut visible_deltas = String::new();
+        while let Some(delta) = rx.recv().await {
+            if let StreamDelta::Text(text) = delta {
+                visible_deltas.push_str(&text);
+            }
+        }
+
+        assert!(outcome.response_text.contains("\"tool_call_id\""));
+        assert_eq!(
+            visible_deltas, "",
+            "truncated internal protocol must not be released at stream finish"
+        );
+    }
+
+    #[tokio::test]
+    async fn consume_provider_streaming_response_preserves_json_fenced_tool_protocol_without_tools()
+    {
+        struct JsonFencedToolProtocolProvider;
+        impl_test_model_provider_attribution!(JsonFencedToolProtocolProvider);
+
+        #[async_trait]
+        impl ModelProvider for JsonFencedToolProtocolProvider {
+            async fn chat_with_system(
+                &self,
+                _system_prompt: Option<&str>,
+                _message: &str,
+                _model: &str,
+                _temperature: Option<f64>,
+            ) -> anyhow::Result<String> {
+                anyhow::bail!("not used in this test")
+            }
+
+            async fn chat(
+                &self,
+                _request: ChatRequest<'_>,
+                _model: &str,
+                _temperature: Option<f64>,
+            ) -> anyhow::Result<ChatResponse> {
+                anyhow::bail!("not used in this test")
+            }
+
+            fn supports_streaming(&self) -> bool {
+                true
+            }
+
+            fn stream_chat(
+                &self,
+                _request: ChatRequest<'_>,
+                _model: &str,
+                _temperature: Option<f64>,
+                _options: StreamOptions,
+            ) -> futures_util::stream::BoxStream<
+                'static,
+                zeroclaw_providers::traits::StreamResult<StreamEvent>,
+            > {
+                Box::pin(futures_util::stream::iter(vec![
+                    Ok(StreamEvent::TextDelta(StreamChunk::delta("```json\n"))),
+                    Ok(StreamEvent::TextDelta(StreamChunk::delta(
+                        r#"{"tool_calls":[{"name":"count_tool","arguments":{"value":"X"}}]}"#,
+                    ))),
+                    Ok(StreamEvent::TextDelta(StreamChunk::delta("\n```"))),
+                    Ok(StreamEvent::Final),
+                ]))
+            }
+        }
+
+        let provider = JsonFencedToolProtocolProvider;
+        let messages = vec![ChatMessage::user("hi")];
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<DraftEvent>(8);
+
+        let outcome = consume_provider_streaming_response(
+            &provider,
+            &messages,
+            None,
+            "mock-model",
+            Some(0.0),
+            None,
+            Some(&tx),
+        )
+        .await
+        .expect("streaming should finish");
+        drop(tx);
+
+        let mut visible_deltas = String::new();
+        while let Some(delta) = rx.recv().await {
+            if let StreamDelta::Text(text) = delta {
+                visible_deltas.push_str(&text);
+            }
+        }
+
+        assert!(outcome.response_text.contains("\"tool_calls\""));
+        assert_eq!(
+            visible_deltas, outcome.response_text,
+            "json-fenced protocol-shaped JSON should remain visible when no tools are active"
+        );
+    }
+
+    #[tokio::test]
+    async fn consume_provider_streaming_response_buffers_tool_call_fence_with_tools() {
+        struct ToolCallFenceProvider;
+        impl_test_model_provider_attribution!(ToolCallFenceProvider);
+
+        #[async_trait]
+        impl ModelProvider for ToolCallFenceProvider {
+            async fn chat_with_system(
+                &self,
+                _system_prompt: Option<&str>,
+                _message: &str,
+                _model: &str,
+                _temperature: Option<f64>,
+            ) -> anyhow::Result<String> {
+                anyhow::bail!("not used in this test")
+            }
+
+            async fn chat(
+                &self,
+                _request: ChatRequest<'_>,
+                _model: &str,
+                _temperature: Option<f64>,
+            ) -> anyhow::Result<ChatResponse> {
+                anyhow::bail!("not used in this test")
+            }
+
+            fn supports_streaming(&self) -> bool {
+                true
+            }
+
+            fn stream_chat(
+                &self,
+                _request: ChatRequest<'_>,
+                _model: &str,
+                _temperature: Option<f64>,
+                _options: StreamOptions,
+            ) -> futures_util::stream::BoxStream<
+                'static,
+                zeroclaw_providers::traits::StreamResult<StreamEvent>,
+            > {
+                Box::pin(futures_util::stream::iter(vec![
+                    Ok(StreamEvent::TextDelta(StreamChunk::delta("```tool_call\n"))),
+                    Ok(StreamEvent::TextDelta(StreamChunk::delta(
+                        r#"{"name":"count_tool","arguments":{"value":"X"}}"#,
+                    ))),
+                    Ok(StreamEvent::TextDelta(StreamChunk::delta("\n```"))),
+                    Ok(StreamEvent::Final),
+                ]))
+            }
+        }
+
+        let provider = ToolCallFenceProvider;
+        let messages = vec![ChatMessage::user("hi")];
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<DraftEvent>(8);
+
+        let outcome = consume_provider_streaming_response(
+            &provider,
+            &messages,
+            Some(&[crate::tools::ToolSpec {
+                name: "count_tool".to_string(),
+                description: "Count values".to_string(),
+                parameters: serde_json::json!({"type": "object"}),
+            }]),
+            "mock-model",
+            Some(0.0),
+            None,
+            Some(&tx),
+        )
+        .await
+        .expect("streaming should finish");
+        drop(tx);
+
+        let mut visible_deltas = String::new();
+        while let Some(delta) = rx.recv().await {
+            if let StreamDelta::Text(text) = delta {
+                visible_deltas.push_str(&text);
+            }
+        }
+
+        assert!(outcome.response_text.contains("```tool_call"));
+        assert_eq!(
+            visible_deltas, "",
+            "streamed tool_call fences with registered tools must not reach draft updates"
+        );
+    }
+
+    #[tokio::test]
+    async fn consume_provider_streaming_response_preserves_plain_prefix_before_protocol_without_tools()
+     {
+        struct PrefixedToolProtocolProvider;
+        impl_test_model_provider_attribution!(PrefixedToolProtocolProvider);
+
+        #[async_trait]
+        impl ModelProvider for PrefixedToolProtocolProvider {
+            async fn chat_with_system(
+                &self,
+                _system_prompt: Option<&str>,
+                _message: &str,
+                _model: &str,
+                _temperature: Option<f64>,
+            ) -> anyhow::Result<String> {
+                anyhow::bail!("not used in this test")
+            }
+
+            async fn chat(
+                &self,
+                _request: ChatRequest<'_>,
+                _model: &str,
+                _temperature: Option<f64>,
+            ) -> anyhow::Result<ChatResponse> {
+                anyhow::bail!("not used in this test")
+            }
+
+            fn supports_streaming(&self) -> bool {
+                true
+            }
+
+            fn stream_chat(
+                &self,
+                _request: ChatRequest<'_>,
+                _model: &str,
+                _temperature: Option<f64>,
+                _options: StreamOptions,
+            ) -> futures_util::stream::BoxStream<
+                'static,
+                zeroclaw_providers::traits::StreamResult<StreamEvent>,
+            > {
+                Box::pin(futures_util::stream::iter(vec![
+                    Ok(StreamEvent::TextDelta(StreamChunk::delta(
+                        r#"Visible prefix {"toolcalls":[{"name":"count_tool","arguments":{"value":"X"}}]}"#,
+                    ))),
+                    Ok(StreamEvent::Final),
+                ]))
+            }
+        }
+
+        let provider = PrefixedToolProtocolProvider;
+        let messages = vec![ChatMessage::user("hi")];
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<DraftEvent>(8);
+
+        let outcome = consume_provider_streaming_response(
+            &provider,
+            &messages,
+            None,
+            "mock-model",
+            Some(0.0),
+            None,
+            Some(&tx),
+        )
+        .await
+        .expect("streaming should finish");
+        drop(tx);
+
+        let mut visible_deltas = String::new();
+        while let Some(delta) = rx.recv().await {
+            if let StreamDelta::Text(text) = delta {
+                visible_deltas.push_str(&text);
+            }
+        }
+
+        assert!(outcome.response_text.contains("\"toolcalls\""));
+        assert_eq!(
+            visible_deltas, outcome.response_text,
+            "prefixed protocol-shaped JSON should remain visible when no tools are active"
+        );
+    }
+
+    #[tokio::test]
+    async fn consume_provider_streaming_response_preserves_split_protocol_after_plain_prefix_without_tools()
+     {
+        struct SplitPrefixedToolProtocolProvider;
+        impl_test_model_provider_attribution!(SplitPrefixedToolProtocolProvider);
+
+        #[async_trait]
+        impl ModelProvider for SplitPrefixedToolProtocolProvider {
+            async fn chat_with_system(
+                &self,
+                _system_prompt: Option<&str>,
+                _message: &str,
+                _model: &str,
+                _temperature: Option<f64>,
+            ) -> anyhow::Result<String> {
+                anyhow::bail!("not used in this test")
+            }
+
+            async fn chat(
+                &self,
+                _request: ChatRequest<'_>,
+                _model: &str,
+                _temperature: Option<f64>,
+            ) -> anyhow::Result<ChatResponse> {
+                anyhow::bail!("not used in this test")
+            }
+
+            fn supports_streaming(&self) -> bool {
+                true
+            }
+
+            fn stream_chat(
+                &self,
+                _request: ChatRequest<'_>,
+                _model: &str,
+                _temperature: Option<f64>,
+                _options: StreamOptions,
+            ) -> futures_util::stream::BoxStream<
+                'static,
+                zeroclaw_providers::traits::StreamResult<StreamEvent>,
+            > {
+                Box::pin(futures_util::stream::iter(vec![
+                    Ok(StreamEvent::TextDelta(StreamChunk::delta(
+                        r#"Visible prefix {"tool"#,
+                    ))),
+                    Ok(StreamEvent::TextDelta(StreamChunk::delta(
+                        r#"calls":[{"name":"count_tool","arguments":{"value":"X"}}]}"#,
+                    ))),
+                    Ok(StreamEvent::Final),
+                ]))
+            }
+        }
+
+        let provider = SplitPrefixedToolProtocolProvider;
+        let messages = vec![ChatMessage::user("hi")];
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<DraftEvent>(8);
+
+        let outcome = consume_provider_streaming_response(
+            &provider,
+            &messages,
+            None,
+            "mock-model",
+            Some(0.0),
+            None,
+            Some(&tx),
+        )
+        .await
+        .expect("streaming should finish");
+        drop(tx);
+
+        let mut visible_deltas = String::new();
+        while let Some(delta) = rx.recv().await {
+            if let StreamDelta::Text(text) = delta {
+                visible_deltas.push_str(&text);
+            }
+        }
+
+        assert!(outcome.response_text.contains("\"toolcalls\""));
+        assert_eq!(
+            visible_deltas, outcome.response_text,
+            "split prefixed protocol-shaped JSON should remain visible when no tools are active"
         );
     }
 

--- a/crates/zeroclaw-tool-call-parser/src/lib.rs
+++ b/crates/zeroclaw-tool-call-parser/src/lib.rs
@@ -9,7 +9,7 @@
 //! It is pure text transformation.
 
 use regex::Regex;
-use std::sync::LazyLock;
+use std::{collections::HashSet, sync::LazyLock};
 
 /// A single parsed tool call extracted from LLM output.
 #[derive(Debug, Clone)]
@@ -17,6 +17,18 @@ pub struct ParsedToolCall {
     pub name: String,
     pub arguments: serde_json::Value,
     pub tool_call_id: Option<String>,
+}
+
+/// Internal tool protocol envelope variants that must not be treated as
+/// user-visible channel text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolProtocolEnvelopeKind {
+    ToolCalls,
+    ToolCallsAlias,
+    FunctionCall,
+    ToolResult,
+    ResponsesFunctionCall,
+    TaggedToolCall,
 }
 
 fn parse_arguments_value(raw: Option<&serde_json::Value>) -> serde_json::Value {
@@ -171,6 +183,529 @@ fn parse_tool_calls_from_json_value(value: &serde_json::Value) -> Vec<ParsedTool
     }
 
     calls
+}
+
+fn has_non_empty_string(value: &serde_json::Value, key: &str) -> bool {
+    value
+        .get(key)
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|s| !s.trim().is_empty())
+}
+
+fn has_arguments_signal(value: &serde_json::Value) -> bool {
+    value.get("arguments").is_some() || value.get("parameters").is_some()
+}
+
+fn looks_like_tool_call_object(value: &serde_json::Value) -> bool {
+    if let Some(function) = value.get("function").and_then(serde_json::Value::as_object) {
+        let function = serde_json::Value::Object(function.clone());
+        return has_non_empty_string(&function, "name") && has_arguments_signal(&function);
+    }
+
+    has_non_empty_string(value, "name") && has_arguments_signal(value)
+}
+
+fn tool_call_array_has_protocol_shape(value: &serde_json::Value, key: &str) -> bool {
+    value
+        .get(key)
+        .and_then(serde_json::Value::as_array)
+        .is_some_and(|items| !items.is_empty() && items.iter().any(looks_like_tool_call_object))
+}
+
+fn has_tool_protocol_object_signal(value: &serde_json::Value) -> bool {
+    let Some(object) = value.as_object() else {
+        return false;
+    };
+
+    let has_args = has_arguments_signal(value);
+    let has_call_id = has_non_empty_string(value, "id")
+        || has_non_empty_string(value, "call_id")
+        || has_non_empty_string(value, "tool_call_id");
+
+    object
+        .get("function")
+        .and_then(serde_json::Value::as_object)
+        .is_some()
+        || (has_non_empty_string(value, "name") && has_args)
+        || (has_args && has_call_id)
+}
+
+fn tool_call_array_has_malformed_protocol_signal(value: &serde_json::Value, key: &str) -> bool {
+    value
+        .get(key)
+        .and_then(serde_json::Value::as_array)
+        .is_some_and(|items| !items.is_empty() && items.iter().any(has_tool_protocol_object_signal))
+}
+
+fn classify_tool_protocol_json_value(
+    value: &serde_json::Value,
+) -> Option<ToolProtocolEnvelopeKind> {
+    if value
+        .get("type")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|ty| ty == "function_call")
+        && has_non_empty_string(value, "name")
+        && (has_arguments_signal(value) || has_non_empty_string(value, "call_id"))
+    {
+        return Some(ToolProtocolEnvelopeKind::ResponsesFunctionCall);
+    }
+
+    if tool_call_array_has_protocol_shape(value, "tool_calls") {
+        return Some(ToolProtocolEnvelopeKind::ToolCalls);
+    }
+
+    if tool_call_array_has_protocol_shape(value, "toolcalls") {
+        return Some(ToolProtocolEnvelopeKind::ToolCallsAlias);
+    }
+
+    if value
+        .get("function_call")
+        .is_some_and(looks_like_tool_call_object)
+    {
+        return Some(ToolProtocolEnvelopeKind::FunctionCall);
+    }
+
+    if has_non_empty_string(value, "tool_call_id")
+        && (value.get("content").is_some()
+            || value.get("result").is_some()
+            || value.get("output").is_some())
+    {
+        return Some(ToolProtocolEnvelopeKind::ToolResult);
+    }
+
+    None
+}
+
+fn json_value_mentions_known_tool(
+    value: &serde_json::Value,
+    known_tool_names: &HashSet<String>,
+) -> bool {
+    if known_tool_names.is_empty() {
+        return false;
+    }
+
+    let Some(object) = value.as_object() else {
+        return value.as_array().is_some_and(|items| {
+            items
+                .iter()
+                .any(|item| json_value_mentions_known_tool(item, known_tool_names))
+        });
+    };
+
+    let name_matches = |candidate: Option<&serde_json::Value>| {
+        candidate
+            .and_then(serde_json::Value::as_str)
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+            .is_some_and(|name| known_tool_names.contains(&name.to_ascii_lowercase()))
+    };
+
+    if name_matches(object.get("name")) {
+        return true;
+    }
+
+    if let Some(function) = object
+        .get("function")
+        .and_then(serde_json::Value::as_object)
+    {
+        let function = serde_json::Value::Object(function.clone());
+        if json_value_mentions_known_tool(&function, known_tool_names) {
+            return true;
+        }
+    }
+
+    if let Some(function_call) = object.get("function_call")
+        && json_value_mentions_known_tool(function_call, known_tool_names)
+    {
+        return true;
+    }
+
+    ["tool_calls", "toolcalls"].iter().any(|key| {
+        object
+            .get(*key)
+            .and_then(serde_json::Value::as_array)
+            .is_some_and(|items| {
+                items
+                    .iter()
+                    .any(|item| json_value_mentions_known_tool(item, known_tool_names))
+            })
+    })
+}
+
+pub fn tool_protocol_envelope_mentions_known_tool(
+    text: &str,
+    known_tool_names: &HashSet<String>,
+) -> bool {
+    if known_tool_names.is_empty() {
+        return false;
+    }
+
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+
+    if let Some(body) = json_fence_body(trimmed) {
+        return tool_protocol_envelope_mentions_known_tool(body, known_tool_names);
+    }
+
+    if starts_with_tool_protocol_tag_or_fence(trimmed) || contains_tool_protocol_tag_marker(trimmed)
+    {
+        let (_, calls) = parse_tool_calls(trimmed);
+        if calls
+            .iter()
+            .any(|call| known_tool_names.contains(&call.name.to_ascii_lowercase()))
+        {
+            return true;
+        }
+    }
+
+    serde_json::from_str::<serde_json::Value>(trimmed)
+        .is_ok_and(|value| json_value_mentions_known_tool(&value, known_tool_names))
+}
+
+fn has_malformed_tool_protocol_json_signal(value: &serde_json::Value) -> bool {
+    // Empty `tool_calls: []` is a valid strict-provider compatibility case;
+    // similar business JSON must also carry protocol-shaped fields before it
+    // is withheld from user-visible output.
+    tool_call_array_has_malformed_protocol_signal(value, "tool_calls")
+        || tool_call_array_has_malformed_protocol_signal(value, "toolcalls")
+        || value
+            .get("function_call")
+            .is_some_and(has_tool_protocol_object_signal)
+        || (value
+            .get("type")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|ty| ty == "function_call")
+            && (has_non_empty_string(value, "name")
+                || has_non_empty_string(value, "call_id")
+                || has_arguments_signal(value)))
+        || (has_non_empty_string(value, "tool_call_id")
+            && (value.get("content").is_some()
+                || value.get("result").is_some()
+                || value.get("output").is_some()))
+}
+
+fn starts_with_tool_protocol_tag_or_fence(text: &str) -> bool {
+    let lower = text.trim_start().to_ascii_lowercase();
+    lower.starts_with("<tool_call")
+        || lower.starts_with("<toolcall")
+        || lower.starts_with("<tool-call")
+        || lower.starts_with("<invoke")
+        || lower.starts_with("<functioncall")
+        || lower.starts_with("<function_call")
+        || starts_with_tool_protocol_fence_lower(&lower)
+        || lower.starts_with("[tool_call]")
+}
+
+fn starts_with_tool_protocol_fence(text: &str) -> bool {
+    let lower = text.trim_start().to_ascii_lowercase();
+    starts_with_tool_protocol_fence_lower(&lower)
+}
+
+fn starts_with_tool_protocol_fence_lower(lower: &str) -> bool {
+    lower.starts_with("```tool_call")
+        || lower.starts_with("```toolcall")
+        || lower.starts_with("```tool-call")
+        || lower.starts_with("```invoke")
+        || starts_with_tool_name_fence_lower(lower)
+}
+
+fn starts_with_tool_name_fence_lower(lower: &str) -> bool {
+    let Some(rest) = lower.strip_prefix("```tool") else {
+        return false;
+    };
+    matches!(rest.chars().next(), Some(c) if c.is_whitespace() && c != '\n' && c != '\r')
+}
+
+fn contains_tool_protocol_tag_marker(text: &str) -> bool {
+    let lower = text.to_ascii_lowercase();
+    lower.contains("<tool_call")
+        || lower.contains("<toolcall")
+        || lower.contains("<tool-call")
+        || lower.contains("<invoke")
+        || lower.contains("<functioncall")
+        || lower.contains("<function_call")
+        || lower.contains("```tool_call")
+        || lower.contains("```toolcall")
+        || lower.contains("```tool-call")
+        || lower.contains("```invoke")
+        || lower.contains("```tool ")
+        || lower.contains("[tool_call]")
+}
+
+pub fn looks_like_tool_protocol_example(text: &str) -> bool {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+
+    if let Some((body, visible_text)) = leading_json_fence_body_and_trailing_text(trimmed)
+        && classify_tool_protocol_envelope(body).is_some()
+        && has_example_context(visible_text)
+    {
+        return true;
+    }
+
+    if starts_with_tool_protocol_fence(trimmed) || contains_tool_protocol_tag_marker(trimmed) {
+        let (visible_text, calls) = parse_tool_calls(trimmed);
+        if !calls.is_empty() && has_example_context(&visible_text) {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn has_example_context(text: &str) -> bool {
+    let lower = text.to_ascii_lowercase();
+    lower.contains("example")
+        || lower.contains("sample")
+        || lower.contains("示例")
+        // Common Chinese "for example" / "sample" markers. We keep this list
+        // intentionally small to avoid accidentally exempting real protocol leaks.
+        || lower.contains("例如")
+        || lower.contains("比如")
+        || lower.contains("举例")
+        || lower.contains("例子")
+        || lower.contains("比方说")
+        || lower.contains("譬如")
+}
+
+fn leading_json_fence_body_and_trailing_text(trimmed: &str) -> Option<(&str, &str)> {
+    let rest = trimmed.strip_prefix("```")?;
+    let first_newline = rest.find('\n')?;
+    let language = rest[..first_newline].trim().trim_end_matches('\r');
+    if !language.eq_ignore_ascii_case("json") {
+        return None;
+    }
+
+    let body_with_close = &rest[first_newline + 1..];
+    let close_start = body_with_close.find("```")?;
+    let body = body_with_close[..close_start].trim();
+    let trailing = body_with_close[close_start + 3..].trim();
+    (!body.is_empty() && !trailing.is_empty()).then_some((body, trailing))
+}
+
+pub fn contains_tool_protocol_tag_call(text: &str) -> bool {
+    if !contains_tool_protocol_tag_marker(text) || looks_like_tool_protocol_example(text) {
+        return false;
+    }
+
+    let (_, calls) = parse_tool_calls(text);
+    !calls.is_empty()
+}
+
+fn classify_tagged_tool_protocol_envelope(text: &str) -> Option<ToolProtocolEnvelopeKind> {
+    if !starts_with_tool_protocol_tag_or_fence(text) {
+        return None;
+    }
+    if looks_like_tool_protocol_example(text) {
+        return None;
+    }
+
+    let is_fence = starts_with_tool_protocol_fence(text);
+    let (visible_text, calls) = parse_tool_calls(text);
+    (!calls.is_empty() && (is_fence || visible_text.trim().is_empty()))
+        .then_some(ToolProtocolEnvelopeKind::TaggedToolCall)
+}
+
+fn looks_like_malformed_tagged_tool_protocol_envelope(text: &str) -> bool {
+    if !starts_with_tool_protocol_tag_or_fence(text) {
+        return false;
+    }
+    if looks_like_tool_protocol_example(text) {
+        return false;
+    }
+
+    let (visible_text, calls) = parse_tool_calls(text);
+    if !calls.is_empty() || !visible_text.trim().is_empty() {
+        return false;
+    }
+
+    let lower = text.to_ascii_lowercase();
+    lower.contains("arguments")
+        || lower.contains("parameters")
+        || lower.contains("function")
+        || lower.contains("name")
+        || lower.contains("call_id")
+        || lower.contains("tool_call_id")
+}
+
+fn has_malformed_tool_protocol_text_signal(text: &str) -> bool {
+    let trimmed = text.trim_start();
+    let lower = trimmed.to_ascii_lowercase();
+    let json_like =
+        trimmed.starts_with('{') || trimmed.starts_with('[') || lower.starts_with("```json");
+    if !json_like {
+        return false;
+    }
+
+    // Malformed text cannot be parsed into a Value, so keep the tool-result
+    // signal close to the valid-envelope shape to avoid business JSON false positives.
+    let has_tool_result_shape = text.contains("\"tool_call_id\"")
+        && (text.contains("\"content\"")
+            || text.contains("\"result\"")
+            || text.contains("\"output\""));
+    let has_protocol_container = text.contains("\"tool_calls\"")
+        || text.contains("\"toolcalls\"")
+        || text.contains("\"function_call\"");
+    let has_arguments = text.contains("\"arguments\"") || text.contains("\"parameters\"");
+    let has_call_id = text.contains("\"call_id\"") || text.contains("\"tool_call_id\"");
+
+    has_tool_result_shape || (has_protocol_container && has_arguments && has_call_id)
+}
+
+fn malformed_text_mentions_known_tool(text: &str, known_tool_names: &HashSet<String>) -> bool {
+    if known_tool_names.is_empty() {
+        return false;
+    }
+
+    static JSON_NAME_FIELD_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r#""name"\s*:\s*"([^"]+)""#).unwrap());
+
+    JSON_NAME_FIELD_RE.captures_iter(text).any(|cap| {
+        cap.get(1)
+            .map(|name| name.as_str().trim().to_ascii_lowercase())
+            .is_some_and(|name| known_tool_names.contains(&name))
+    })
+}
+
+fn has_malformed_tool_protocol_text_signal_for_known_tools(
+    text: &str,
+    known_tool_names: &HashSet<String>,
+) -> bool {
+    if has_malformed_tool_protocol_text_signal(text) {
+        return true;
+    }
+
+    let trimmed = text.trim_start();
+    let lower = trimmed.to_ascii_lowercase();
+    let json_like =
+        trimmed.starts_with('{') || trimmed.starts_with('[') || lower.starts_with("```json");
+    if !json_like {
+        return false;
+    }
+
+    let has_protocol_container = text.contains("\"tool_calls\"")
+        || text.contains("\"toolcalls\"")
+        || text.contains("\"function_call\"");
+    let has_arguments = text.contains("\"arguments\"") || text.contains("\"parameters\"");
+
+    has_protocol_container
+        && has_arguments
+        && malformed_text_mentions_known_tool(text, known_tool_names)
+}
+
+fn json_fence_body(trimmed: &str) -> Option<&str> {
+    let rest = trimmed.strip_prefix("```")?;
+    let first_newline = rest.find('\n')?;
+    let language = rest[..first_newline].trim().trim_end_matches('\r');
+    if !language.eq_ignore_ascii_case("json") {
+        return None;
+    }
+
+    let body_with_close = &rest[first_newline + 1..];
+    let close_start = body_with_close.rfind("```")?;
+    if !body_with_close[close_start + 3..].trim().is_empty() {
+        return None;
+    }
+    Some(body_with_close[..close_start].trim())
+}
+
+pub fn classify_tool_protocol_envelope(text: &str) -> Option<ToolProtocolEnvelopeKind> {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    if let Some(kind) = classify_tagged_tool_protocol_envelope(trimmed) {
+        return Some(kind);
+    }
+
+    if let Some(body) = json_fence_body(trimmed) {
+        return classify_tool_protocol_envelope(body);
+    }
+
+    let value = serde_json::from_str::<serde_json::Value>(trimmed).ok()?;
+    classify_tool_protocol_json_value(&value)
+}
+
+pub fn looks_like_tool_protocol_envelope(text: &str) -> bool {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+
+    if classify_tool_protocol_envelope(trimmed).is_some() {
+        return true;
+    }
+
+    if let Some(body) = json_fence_body(trimmed) {
+        return looks_like_tool_protocol_envelope(body);
+    }
+
+    serde_json::from_str::<serde_json::Value>(trimmed)
+        .is_ok_and(|value| has_malformed_tool_protocol_json_signal(&value))
+}
+
+pub fn looks_like_malformed_tool_protocol_envelope(text: &str) -> bool {
+    let trimmed = text.trim();
+    if looks_like_tool_protocol_example(trimmed) {
+        return false;
+    }
+
+    if looks_like_malformed_tagged_tool_protocol_envelope(trimmed) {
+        return true;
+    }
+
+    let lower = trimmed.to_ascii_lowercase();
+    let json_like =
+        trimmed.starts_with('{') || trimmed.starts_with('[') || lower.starts_with("```json");
+    if trimmed.is_empty() || !json_like {
+        return false;
+    }
+
+    if let Some(body) = json_fence_body(trimmed) {
+        return looks_like_malformed_tool_protocol_envelope(body);
+    }
+
+    if serde_json::from_str::<serde_json::Value>(trimmed).is_ok() {
+        return false;
+    }
+
+    has_malformed_tool_protocol_text_signal(trimmed)
+}
+
+pub fn looks_like_malformed_tool_protocol_envelope_for_known_tools(
+    text: &str,
+    known_tool_names: &HashSet<String>,
+) -> bool {
+    let trimmed = text.trim();
+    if looks_like_tool_protocol_example(trimmed) {
+        return false;
+    }
+
+    if looks_like_malformed_tool_protocol_envelope(trimmed) {
+        return true;
+    }
+
+    let lower = trimmed.to_ascii_lowercase();
+    let json_like =
+        trimmed.starts_with('{') || trimmed.starts_with('[') || lower.starts_with("```json");
+    if trimmed.is_empty() || !json_like {
+        return false;
+    }
+
+    if let Some(body) = json_fence_body(trimmed) {
+        return looks_like_malformed_tool_protocol_envelope_for_known_tools(body, known_tool_names);
+    }
+
+    if serde_json::from_str::<serde_json::Value>(trimmed).is_ok() {
+        return false;
+    }
+
+    has_malformed_tool_protocol_text_signal_for_known_tools(trimmed, known_tool_names)
 }
 
 fn is_xml_meta_tag(tag: &str) -> bool {
@@ -1484,7 +2019,28 @@ pub fn detect_tool_call_parse_issue(
         return None;
     }
 
-    let looks_like_tool_payload = trimmed.contains("<tool_call")
+    if looks_like_tool_protocol_envelope(trimmed) {
+        return Some(
+            "response resembled an internal tool protocol envelope but no valid tool call could be parsed"
+                .into(),
+        );
+    }
+
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(trimmed) {
+        return has_malformed_tool_protocol_json_signal(&value).then(|| {
+            "response resembled an internal tool protocol envelope but no valid tool call could be parsed"
+                .into()
+        });
+    }
+
+    if has_malformed_tool_protocol_text_signal(trimmed) {
+        return Some(
+            "response resembled an internal tool protocol envelope but no valid tool call could be parsed"
+                .into(),
+        );
+    }
+
+    let contains_tool_payload_marker = trimmed.contains("<tool_call")
         || trimmed.contains("<toolcall")
         || trimmed.contains("<tool-call")
         || trimmed.contains("```tool_call")
@@ -1495,12 +2051,34 @@ pub fn detect_tool_call_parse_issue(
         || trimmed.contains("```tool web_")
         || trimmed.contains("```tool memory_")
         || trimmed.contains("```tool ") // Generic ```tool <name> pattern
-        || trimmed.contains("\"tool_calls\"")
         || trimmed.contains("TOOL_CALL")
         || trimmed.contains("[TOOL_CALL]")
         || trimmed.contains("<FunctionCall>");
 
-    if looks_like_tool_payload {
+    if contains_tool_payload_marker {
+        if looks_like_tool_protocol_example(trimmed) {
+            return None;
+        }
+        if contains_tool_protocol_tag_call(trimmed) {
+            return Some(
+                "response resembled a tool-call payload but no valid tool call could be parsed"
+                    .into(),
+            );
+        }
+
+        let (visible_text, recovered_calls) = parse_tool_calls(trimmed);
+        if !recovered_calls.is_empty() && !visible_text.trim().is_empty() {
+            return None;
+        }
+        if !recovered_calls.is_empty() || visible_text.trim().is_empty() {
+            return Some(
+                "response resembled a tool-call payload but no valid tool call could be parsed"
+                    .into(),
+            );
+        }
+    }
+
+    if looks_like_malformed_tool_protocol_envelope(trimmed) {
         Some("response resembled a tool-call payload but no valid tool call could be parsed".into())
     } else {
         None
@@ -2365,6 +2943,308 @@ Final answer."#;
     fn detect_tool_call_parse_issue_ignores_normal_text() {
         let issue = detect_tool_call_parse_issue("Thanks, done.", &[]);
         assert!(issue.is_none());
+    }
+
+    #[test]
+    fn detect_tool_call_parse_issue_ignores_empty_tool_calls_array() {
+        let issue = detect_tool_call_parse_issue(r#"{"content":"Hello","tool_calls":[]}"#, &[]);
+        assert!(issue.is_none());
+    }
+
+    #[test]
+    fn detect_tool_call_parse_issue_ignores_json_fenced_business_tool_calls() {
+        let response = r#"```json
+{"tool_calls":[{"service":"billing","count":2}]}
+```"#;
+        let issue = detect_tool_call_parse_issue(response, &[]);
+        assert!(issue.is_none());
+    }
+
+    #[test]
+    fn detect_tool_call_parse_issue_ignores_tool_call_fenced_example() {
+        let response = r#"```tool_call
+{"name":"shell","arguments":{"command":"pwd"}}
+```
+This is an example, not an invocation."#;
+
+        let issue = detect_tool_call_parse_issue(response, &[]);
+
+        assert!(issue.is_none());
+    }
+
+    #[test]
+    fn detect_tool_call_parse_issue_flags_standalone_tool_call_fence() {
+        let response = r#"```tool_call
+{"name":"shell","arguments":{"command":"pwd"}}
+```"#;
+
+        let issue = detect_tool_call_parse_issue(response, &[]);
+
+        assert!(issue.is_some());
+    }
+
+    #[test]
+    fn detect_tool_call_parse_issue_ignores_tool_call_tag_example() {
+        let response = r#"<tool_call>
+{"name":"shell","arguments":{"command":"pwd"}}
+</tool_call>
+This is an example, not an invocation."#;
+
+        let issue = detect_tool_call_parse_issue(response, &[]);
+
+        assert!(issue.is_none());
+    }
+
+    #[test]
+    fn detect_tool_call_parse_issue_flags_tagged_tool_call_with_trailing_text() {
+        let response = r#"<tool_call>
+{"name":"shell","arguments":{"command":"pwd"}}
+</tool_call>
+Done."#;
+
+        let issue = detect_tool_call_parse_issue(response, &[]);
+
+        assert!(issue.is_some());
+    }
+
+    #[test]
+    fn detect_tool_call_parse_issue_flags_json_fenced_tool_protocol() {
+        let response = r#"```json
+{"tool_calls":[{"name":"shell","arguments":{"command":"pwd"}}]}
+```"#;
+        let issue = detect_tool_call_parse_issue(response, &[]);
+        assert!(issue.is_some());
+    }
+
+    #[test]
+    fn detect_tool_call_parse_issue_flags_malformed_tool_result_envelope() {
+        let response = r#"{"tool_call_id":"call_1","content":"raw tool output""#;
+        let issue = detect_tool_call_parse_issue(response, &[]);
+        assert!(issue.is_some());
+    }
+
+    #[test]
+    fn detect_tool_call_parse_issue_ignores_malformed_tool_call_id_only_json() {
+        let response = r#"{"tool_call_id":"support-case-1""#;
+        let issue = detect_tool_call_parse_issue(response, &[]);
+        assert!(issue.is_none());
+    }
+
+    #[test]
+    fn detect_tool_call_parse_issue_flags_malformed_nonempty_tool_calls_array() {
+        let issue = detect_tool_call_parse_issue(
+            r#"{"content":null,"tool_calls":[{"call_id":"call_1","arguments":"{}"}]}"#,
+            &[],
+        );
+        assert!(issue.is_some());
+    }
+
+    #[test]
+    fn detect_tool_call_parse_issue_ignores_malformed_business_tool_calls_without_call_id() {
+        for response in [
+            r#"{"tool_calls":[{"name":"support_case","arguments":{"id":"A1"}}"#,
+            r#"{"toolcalls":[{"name":"support_case","arguments":{"id":"A1"}}"#,
+        ] {
+            let issue = detect_tool_call_parse_issue(response, &[]);
+
+            assert!(
+                issue.is_none(),
+                "business JSON without a tool call id must not be treated as internal protocol: {response}"
+            );
+            assert!(
+                !looks_like_malformed_tool_protocol_envelope(response),
+                "business JSON without a tool call id must not be classified as malformed protocol: {response}"
+            );
+        }
+    }
+
+    #[test]
+    fn looks_like_tool_protocol_envelope_flags_malformed_nonempty_tool_calls_array() {
+        assert!(looks_like_tool_protocol_envelope(
+            r#"{"content":null,"tool_calls":[{"call_id":"call_1","arguments":"{}"}]}"#
+        ));
+        assert!(!looks_like_tool_protocol_envelope(
+            r#"{"content":"Hello","tool_calls":[]}"#
+        ));
+    }
+
+    #[test]
+    fn classify_tool_protocol_envelope_flags_internal_json_variants() {
+        assert_eq!(
+            classify_tool_protocol_envelope(
+                r#"{"content":null,"tool_calls":[{"id":"call_1","name":"shell","arguments":"{}"}]}"#
+            ),
+            Some(ToolProtocolEnvelopeKind::ToolCalls)
+        );
+        assert_eq!(
+            classify_tool_protocol_envelope(
+                r#"{"toolcalls":[{"name":"shell","arguments":{"command":"pwd"}}]}"#
+            ),
+            Some(ToolProtocolEnvelopeKind::ToolCallsAlias)
+        );
+        assert_eq!(
+            classify_tool_protocol_envelope(r#"{"tool_calls":[{"name":"shell","arguments":{}}]}"#),
+            Some(ToolProtocolEnvelopeKind::ToolCalls)
+        );
+        assert_eq!(
+            classify_tool_protocol_envelope(r#"{"toolcalls":[{"name":"shell","arguments":{}}]}"#),
+            Some(ToolProtocolEnvelopeKind::ToolCallsAlias)
+        );
+        assert_eq!(
+            classify_tool_protocol_envelope(
+                r#"{"function_call":{"name":"shell","arguments":"{\"command\":\"pwd\"}"}}"#
+            ),
+            Some(ToolProtocolEnvelopeKind::FunctionCall)
+        );
+        assert_eq!(
+            classify_tool_protocol_envelope(
+                r#"{"tool_call_id":"call_1","content":"command output"}"#
+            ),
+            Some(ToolProtocolEnvelopeKind::ToolResult)
+        );
+        assert_eq!(
+            classify_tool_protocol_envelope(
+                r#"{"type":"function_call","call_id":"call_1","name":"shell","arguments":"{}"}"#
+            ),
+            Some(ToolProtocolEnvelopeKind::ResponsesFunctionCall)
+        );
+        assert_eq!(
+            classify_tool_protocol_envelope(
+                r#"```json
+{"tool_calls":[{"name":"shell","arguments":{"command":"pwd"}}]}
+```"#
+            ),
+            Some(ToolProtocolEnvelopeKind::ToolCalls)
+        );
+    }
+
+    #[test]
+    fn classify_tool_protocol_envelope_preserves_tool_call_examples() {
+        let fenced_example = r#"```tool_call
+{"name":"shell","arguments":{"command":"pwd"}}
+```
+This is an example, not an invocation."#;
+        let embedded_fenced_example = r#"Here is an example:
+```tool_call
+{"name":"shell","arguments":{"command":"pwd"}}
+```"#;
+        let embedded_fenced_example_cn = r#"例如：
+```tool_call
+{"name":"shell","arguments":{"command":"pwd"}}
+```"#;
+        let tag_example = r#"<tool_call>
+{"name":"shell","arguments":{"command":"pwd"}}
+</tool_call>
+This is an example, not an invocation."#;
+        let tag_example_cn = r#"比如：
+<tool_call>
+{"name":"shell","arguments":{"command":"pwd"}}
+</tool_call>"#;
+
+        assert_eq!(classify_tool_protocol_envelope(fenced_example), None);
+        assert!(!looks_like_tool_protocol_envelope(fenced_example));
+        assert_eq!(
+            classify_tool_protocol_envelope(embedded_fenced_example),
+            None
+        );
+        assert!(!looks_like_tool_protocol_envelope(embedded_fenced_example));
+        assert!(looks_like_tool_protocol_example(embedded_fenced_example));
+        assert_eq!(
+            classify_tool_protocol_envelope(embedded_fenced_example_cn),
+            None
+        );
+        assert!(!looks_like_tool_protocol_envelope(
+            embedded_fenced_example_cn
+        ));
+        assert!(looks_like_tool_protocol_example(embedded_fenced_example_cn));
+        assert_eq!(classify_tool_protocol_envelope(tag_example), None);
+        assert!(!looks_like_tool_protocol_envelope(tag_example));
+        assert_eq!(classify_tool_protocol_envelope(tag_example_cn), None);
+        assert!(!looks_like_tool_protocol_envelope(tag_example_cn));
+        assert!(looks_like_tool_protocol_example(tag_example_cn));
+    }
+
+    #[test]
+    fn contains_tool_protocol_tag_call_flags_embedded_tool_call_fences() {
+        let embedded = r#"Let me call it:
+```tool_call
+{"name":"shell","arguments":{"command":"pwd"}}
+```
+Done."#;
+
+        assert!(contains_tool_protocol_tag_call(embedded));
+    }
+
+    #[test]
+    fn classify_tool_protocol_envelope_flags_standalone_tool_fences() {
+        let tool_call_fence = r#"```tool_call
+{"name":"shell","arguments":{"command":"pwd"}}
+```"#;
+        let invoke_fence = r#"```invoke
+{"name":"shell","arguments":{"command":"pwd"}}
+```"#;
+        let tool_name_fence = r#"```tool shell
+{"command":"pwd"}
+```"#;
+
+        assert_eq!(
+            classify_tool_protocol_envelope(tool_call_fence),
+            Some(ToolProtocolEnvelopeKind::TaggedToolCall)
+        );
+        assert!(looks_like_tool_protocol_envelope(tool_call_fence));
+        assert_eq!(
+            classify_tool_protocol_envelope(invoke_fence),
+            Some(ToolProtocolEnvelopeKind::TaggedToolCall)
+        );
+        assert!(looks_like_tool_protocol_envelope(invoke_fence));
+        assert_eq!(
+            classify_tool_protocol_envelope(tool_name_fence),
+            Some(ToolProtocolEnvelopeKind::TaggedToolCall)
+        );
+        assert!(looks_like_tool_protocol_envelope(tool_name_fence));
+    }
+
+    #[test]
+    fn classify_tool_protocol_envelope_preserves_top_level_arrays_without_protocol_marker() {
+        assert!(!looks_like_tool_protocol_envelope(
+            r#"[{"service":"billing","count":2}]"#
+        ));
+
+        assert!(!looks_like_tool_protocol_envelope(
+            r#"[{"name":"shell","arguments":{}}]"#
+        ));
+    }
+
+    #[test]
+    fn classify_tool_protocol_envelope_preserves_top_level_schema_array() {
+        let schema = r#"[{"name":"planner","parameters":{"goal":"string"}}]"#;
+
+        assert_eq!(classify_tool_protocol_envelope(schema), None);
+        assert!(!looks_like_tool_protocol_envelope(schema));
+    }
+
+    #[test]
+    fn classify_tool_protocol_envelope_preserves_plain_user_json() {
+        let profile = r#"{"name":"profile","parameters":{"timezone":"UTC"}}"#;
+        assert_eq!(classify_tool_protocol_envelope(profile), None);
+        assert!(!looks_like_tool_protocol_envelope(profile));
+    }
+
+    #[test]
+    fn looks_like_tool_protocol_envelope_preserves_plain_json_with_similar_keys() {
+        let config = r#"{"function_call":false,"description":"disable the feature"}"#;
+        assert!(!looks_like_tool_protocol_envelope(config));
+
+        let audit_log = r#"{"tool_calls":[{"service":"billing","count":2}]}"#;
+        assert!(!looks_like_tool_protocol_envelope(audit_log));
+
+        let queued_case =
+            r#"{"tool_calls":[{"id":"case-1","status":"queued","service":"billing"}]}"#;
+        assert!(!looks_like_tool_protocol_envelope(queued_case));
+
+        let named_record =
+            r#"{"tool_calls":[{"name":"planner","status":"queued","service":"workflow"}]}"#;
+        assert!(!looks_like_tool_protocol_envelope(named_record));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Extend the existing `zeroclaw-tool-call-parser` crate with a shared classifier for internal tool-call protocol envelopes, including `tool_calls`, `toolcalls`, `function_call`, `tool_call_id`, fenced tool calls, and tag-style tool calls.
  - Use that classifier in the runtime so malformed/alias internal protocol emitted as text is handled as an internal parse issue with bounded retry instead of returned as assistant text.
  - Suppress internal protocol chunks before channel streaming draft updates, then reuse the classifier in final channel sanitization as a last guardrail.
  - Add false-positive coverage for ordinary business JSON and explicit protocol examples so the guard does not over-filter user-visible content.
  - Keep the change scoped to the three leak points from #6734: parser/runtime classification, streaming draft suppression, and final response sanitization.
- **Scope boundary:** Does not change provider authentication, tool schemas, Matrix draft-state keying, `show_tool_calls=true` debug behavior, or channel transport APIs.
- **Blast radius:** Existing tool-call parser crate, runtime agent loop, channel streaming draft output, and final channel response sanitization. This can affect channel-visible agent replies if classification false positives occur, so tests cover business JSON/examples as well as internal-protocol suppression.
- **Linked issue(s):** Closes #6734. Related #3079.
- **Labels:** Current labels: `bug`, `size: L`, `risk: high`, `dependencies`, `agent`, `channel`, `runtime`.

## Validation Evidence (required)

Local validation is the signal CI cannot replace. Run the full battery and paste literal output (tails, failures, warnings — not "all passed").

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

Docs-only changes: replace with markdown lint + link-integrity (`scripts/ci/docs_quality_gate.sh`). Bootstrap scripts: add `bash -n install.sh`.

- **Commands run and tail output:**

```bash
$ cargo fmt --all -- --check
# no output; exit 0

$ cargo clippy --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 54.95s

$ cargo test
...
test result: ok. 243 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.17s
...
test result: ok. 159 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.32s
...
test result: ok. 0 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 0.00s
...
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
   Doc-tests zeroclaw
error: Option 'default-theme' given more than once

$ cargo test --lib --bins --tests
...
test result: ok. 243 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.16s
...
test result: ok. 207 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.06s
...
test result: ok. 159 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.30s
...
test result: ok. 0 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 0.00s
...
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
```

- **Beyond CI — what did you manually verify?** Reviewed the Qwen 3.6 35B A3B failure shape from #6734 against the new parser/runtime/channel boundaries. Confirmed the guard covers raw `{"content":null,"tool_calls":[...]}`, alias `toolcalls`, malformed protocol JSON, fenced tool-call blocks, and tag-style tool calls while preserving business JSON and explicit examples.

Additional validation after resolving the 2026-05-20 `master` conflict on head `9ed71450c`:

```bash
$ cargo fmt --all -- --check
# no output; exit 0

$ cargo test -p zeroclaw-tool-call-parser tool_protocol --lib
test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 121 filtered out; finished in 0.00s

$ cargo test -p zeroclaw-runtime malformed_tool_protocol --lib
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 1820 filtered out; finished in 0.02s

$ cargo test -p zeroclaw-channels sanitize_channel_response --lib
test result: ok. 27 passed; 0 failed; 0 ignored; 0 measured; 1059 filtered out; finished in 0.02s
```

Previously recorded gateway smoke on head `8f86be3efdeb`:

```bash
$ gateway webhook smoke with local mock OpenAI-compatible provider
PASS gateway webhook smoke for PR #6736
head=8f86be3efdeb
mock_provider_calls=3
malformed_visible_response="Recovered gateway smoke answer."
example_visible_response="Here is an explicit protocol example that should remain visible:\n```json\n{\"toolcalls\":[{\"name\":\"shell\",\"arguments\":{\"command\":\"echo example only\"}}]}\n```"
```

Gateway smoke setup: started a real `zeroclaw gateway start` on localhost with pairing disabled, pointed it at a local mock OpenAI-compatible provider, then posted to `/webhook` twice. The first turn made the provider return a malformed `toolcalls` payload and verified the visible gateway response recovered without exposing `toolcalls` or the raw command. The second turn returned an explicit protocol example and verified the example JSON remained visible. The 2026-05-20 refresh rebased onto `master` at `18622d91b`, resolved the runtime `ModelProvider` conflict, and kept the mock gateway smoke result as previously recorded; fresh GitHub required checks passed on the pushed head, including CI Required Gate.

- **If any command was intentionally skipped, why:** Full `cargo test` reached doctests after unit/integration/system tests passed, then failed locally because rustdoc received duplicate `--default-theme=ayu` from the repository rustdoc configuration. `cargo test --lib --bins --tests` was run to cover the non-doctest test suite.

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: N/A. The change reduces user-visible exposure of internal tool protocol payloads; it does not alter credential handling.

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: Existing users do not need migration steps. Behavior change is limited to suppressing/retrying malformed internal tool protocol that should not have been channel-visible text.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PRs: `git revert <sha>` is the plan unless otherwise noted.

Medium/high-risk PRs must fill:

- **Fast rollback command/path:** `git revert 9ed71450ce7ecfa15117f346f871a61491bc8816`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Natural-language JSON examples unexpectedly removed from channel replies, valid tool calls no longer executed, or repeated fallback replies after malformed tool-call retry exhaustion.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Scope materially carried forward: N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`No`)
- If `No`, why (inspiration-only, no direct code/design carry-over): No superseded PR scope was incorporated.



