### PR TITLE
fix(cron): align timezone contract with scheduler behavior

### DIFF
--- a/crates/zeroclaw-runtime/src/tools/cron_add.rs
+++ b/crates/zeroclaw-runtime/src/tools/cron_add.rs
@@ -1,6 +1,7 @@
-use crate::cron::{
-    self, DeliveryConfig, JobType, Schedule, SessionTarget, deserialize_maybe_stringified,
+use super::cron_common::{
+    AT_DESCRIPTION, CRON_TZ_DESCRIPTION, cron_add_output, deserialize_schedule_arg,
 };
+use crate::cron::{self, DeliveryConfig, JobType, Schedule, SessionTarget};
 use crate::security::SecurityPolicy;
 use async_trait::async_trait;
 use serde_json::json;
@@ -88,16 +89,16 @@ impl Tool for CronAddTool {
                             "properties": {
                                 "kind": { "type": "string", "enum": ["cron"] },
                                 "expr": { "type": "string", "description": "Standard 5-field cron expression, e.g. '*/5 * * * *'" },
-                                "tz": { "type": "string", "description": "Optional IANA timezone name, e.g. 'America/New_York'. Defaults to UTC." }
+                                "tz": { "type": "string", "description": CRON_TZ_DESCRIPTION }
                             },
                             "required": ["kind", "expr"]
                         },
                         {
                             "type": "object",
-                            "description": "One-shot schedule at a specific UTC datetime. Example: {\"kind\":\"at\",\"at\":\"2025-12-31T23:59:00Z\"}",
+                            "description": "One-shot schedule at a specific RFC3339 timestamp with explicit Z or offset. Example: {\"kind\":\"at\",\"at\":\"2025-12-31T23:59:00Z\"}",
                             "properties": {
                                 "kind": { "type": "string", "enum": ["at"] },
-                                "at": { "type": "string", "description": "ISO 8601 UTC datetime string, e.g. '2025-12-31T23:59:00Z'" }
+                                "at": { "type": "string", "description": AT_DESCRIPTION }
                             },
                             "required": ["kind", "at"]
                         },
@@ -200,24 +201,24 @@ impl Tool for CronAddTool {
                     });
                 }
 
-                match deserialize_maybe_stringified::<Schedule>(v) {
+                match deserialize_schedule_arg(v) {
                     Ok(schedule) => schedule,
-                    Err(e) => {
+                    Err(error) => {
                         return Ok(ToolResult {
                             success: false,
                             output: String::new(),
-                            error: Some(format!("Invalid schedule: {e}")),
+                            error: Some(error),
                         });
                     }
                 }
             }
-            Some(v) => match deserialize_maybe_stringified::<Schedule>(v) {
+            Some(v) => match deserialize_schedule_arg(v) {
                 Ok(schedule) => schedule,
-                Err(e) => {
+                Err(error) => {
                     return Ok(ToolResult {
                         success: false,
                         output: String::new(),
-                        error: Some(format!("Invalid schedule: {e}")),
+                        error: Some(error),
                     });
                 }
             },
@@ -382,15 +383,7 @@ impl Tool for CronAddTool {
         match result {
             Ok(job) => Ok(ToolResult {
                 success: true,
-                output: serde_json::to_string_pretty(&json!({
-                    "id": job.id,
-                    "name": job.name,
-                    "job_type": job.job_type,
-                    "schedule": job.schedule,
-                    "next_run": job.next_run,
-                    "enabled": job.enabled,
-                    "allowed_tools": job.allowed_tools
-                }))?,
+                output: serde_json::to_string_pretty(&cron_add_output(&job))?,
                 error: None,
             }),
             Err(e) => Ok(ToolResult {
@@ -444,6 +437,57 @@ mod tests {
 
         assert!(result.success, "{:?}", result.error);
         assert!(result.output.contains("next_run"));
+    }
+
+    #[tokio::test]
+    async fn output_includes_timezone_confirmation_fields_for_explicit_cron_timezone() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = test_config(&tmp).await;
+        let tool = CronAddTool::new(cfg.clone(), test_security(&cfg));
+        let result = tool
+            .execute(json!({
+                "schedule": { "kind": "cron", "expr": "0 9 * * 1-5", "tz": "America/New_York" },
+                "job_type": "shell",
+                "command": "echo ok"
+            }))
+            .await
+            .unwrap();
+
+        assert!(result.success, "{:?}", result.error);
+        let output: serde_json::Value = serde_json::from_str(&result.output).unwrap();
+        assert_eq!(output["next_run"], output["next_run_utc"]);
+        assert_eq!(output["schedule_timezone"], "America/New_York");
+        assert_eq!(output["timezone_source"], "explicit");
+        assert!(
+            output["next_run_local"]
+                .as_str()
+                .is_some_and(|value| value.contains("T09:00:00")),
+            "next_run_local should display the next run in the explicit schedule timezone: {output}"
+        );
+    }
+
+    #[tokio::test]
+    async fn output_identifies_runtime_local_fallback_when_cron_timezone_is_omitted() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = test_config(&tmp).await;
+        let tool = CronAddTool::new(cfg.clone(), test_security(&cfg));
+        let result = tool
+            .execute(json!({
+                "schedule": { "kind": "cron", "expr": "*/5 * * * *" },
+                "job_type": "shell",
+                "command": "echo ok"
+            }))
+            .await
+            .unwrap();
+
+        assert!(result.success, "{:?}", result.error);
+        let output: serde_json::Value = serde_json::from_str(&result.output).unwrap();
+        assert_eq!(output["timezone_source"], "runtime_local");
+        assert_eq!(output["schedule_timezone"], "runtime local timezone");
+        assert!(
+            output["next_run_local"].as_str().is_some(),
+            "next_run_local should be present for runtime-local cron schedules: {output}"
+        );
     }
 
     #[tokio::test]
@@ -682,6 +726,31 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn rejects_at_timestamp_without_explicit_offset_with_actionable_error() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = test_config(&tmp).await;
+        let tool = CronAddTool::new(cfg.clone(), test_security(&cfg));
+
+        let result = tool
+            .execute(json!({
+                "schedule": { "kind": "at", "at": "2026-05-18T09:00:00" },
+                "job_type": "shell",
+                "command": "echo at"
+            }))
+            .await
+            .unwrap();
+
+        assert!(!result.success);
+        let error = result.error.unwrap_or_default();
+        assert!(
+            error.contains("RFC3339 timestamp with explicit Z or offset"),
+            "error should explain the explicit offset requirement: {error}"
+        );
+        assert!(error.contains("2026-05-18T09:00:00Z"));
+        assert!(error.contains("2026-05-18T09:00:00-04:00"));
+    }
+
+    #[tokio::test]
     async fn agent_job_requires_prompt() {
         let tmp = TempDir::new().unwrap();
         let cfg = test_config(&tmp).await;
@@ -892,5 +961,37 @@ mod tests {
                 _ => panic!("unexpected kind: {kind}"),
             }
         }
+
+        let cron_variant = one_of
+            .iter()
+            .find(|variant| variant["properties"]["kind"]["enum"][0] == "cron")
+            .expect("cron variant");
+        let cron_tz_description = cron_variant["properties"]["tz"]["description"]
+            .as_str()
+            .expect("cron tz description");
+        assert!(
+            cron_tz_description.contains("runtime local timezone"),
+            "cron tz description must match scheduler fallback: {cron_tz_description}"
+        );
+        assert!(
+            cron_tz_description.contains("explicit IANA timezone"),
+            "cron tz description should recommend explicit IANA timezones: {cron_tz_description}"
+        );
+        assert!(
+            !cron_tz_description.contains("Defaults to UTC"),
+            "cron tz description must not claim a UTC default"
+        );
+
+        let at_variant = one_of
+            .iter()
+            .find(|variant| variant["properties"]["kind"]["enum"][0] == "at")
+            .expect("at variant");
+        let at_description = at_variant["properties"]["at"]["description"]
+            .as_str()
+            .expect("at description");
+        assert!(
+            at_description.contains("RFC3339 timestamp with explicit Z or offset"),
+            "at description should require explicit Z or offset: {at_description}"
+        );
     }
 }

--- a/crates/zeroclaw-runtime/src/tools/cron_common.rs
+++ b/crates/zeroclaw-runtime/src/tools/cron_common.rs
@@ -1,0 +1,123 @@
+use crate::cron::{CronJob, CronJobPatch, Schedule, deserialize_maybe_stringified};
+use chrono::DateTime;
+use serde_json::{Value, json};
+use std::str::FromStr;
+
+pub(crate) const CRON_TZ_DESCRIPTION: &str = "Optional explicit IANA timezone name, e.g. 'America/New_York'. If omitted, the schedule uses the runtime local timezone. For user-facing schedules, pass an explicit IANA timezone.";
+
+pub(crate) const AT_DESCRIPTION: &str = "RFC3339 timestamp with explicit Z or offset, e.g. '2025-12-31T23:59:00Z' or '2025-12-31T18:59:00-05:00'.";
+
+pub(crate) fn deserialize_schedule_arg(value: &Value) -> Result<Schedule, String> {
+    reject_at_without_explicit_offset(value)?;
+    deserialize_maybe_stringified::<Schedule>(value)
+        .map_err(|err| format!("Invalid schedule: {err}"))
+}
+
+pub(crate) fn deserialize_patch_arg(value: &Value) -> Result<CronJobPatch, String> {
+    if let Some(normalized) = normalize_maybe_stringified_json(value)
+        && let Some(schedule) = normalized.get("schedule")
+    {
+        reject_at_without_explicit_offset(schedule)
+            .map_err(|err| err.replacen("Invalid schedule", "Invalid patch payload", 1))?;
+    }
+
+    deserialize_maybe_stringified::<CronJobPatch>(value)
+        .map_err(|err| format!("Invalid patch payload: {err}"))
+}
+
+pub(crate) fn cron_add_output(job: &CronJob) -> Value {
+    let fields = timezone_confirmation_fields(job);
+    json!({
+        "id": job.id,
+        "name": job.name,
+        "job_type": job.job_type,
+        "schedule": job.schedule,
+        "next_run": job.next_run,
+        "next_run_utc": job.next_run,
+        "schedule_timezone": fields.schedule_timezone,
+        "timezone_source": fields.timezone_source,
+        "next_run_local": fields.next_run_local,
+        "enabled": job.enabled,
+        "allowed_tools": job.allowed_tools
+    })
+}
+
+pub(crate) fn cron_job_output(job: &CronJob) -> serde_json::Result<Value> {
+    let mut output = serde_json::to_value(job)?;
+    if let Value::Object(ref mut object) = output {
+        let fields = timezone_confirmation_fields(job);
+        object.insert("next_run_utc".to_string(), json!(job.next_run));
+        object.insert("schedule_timezone".to_string(), fields.schedule_timezone);
+        object.insert("timezone_source".to_string(), fields.timezone_source);
+        object.insert("next_run_local".to_string(), fields.next_run_local);
+    }
+    Ok(output)
+}
+
+struct TimezoneConfirmationFields {
+    schedule_timezone: Value,
+    timezone_source: Value,
+    next_run_local: Value,
+}
+
+fn timezone_confirmation_fields(job: &CronJob) -> TimezoneConfirmationFields {
+    match &job.schedule {
+        Schedule::Cron { tz: Some(tz), .. } => {
+            let next_run_local = chrono_tz::Tz::from_str(tz).map_or(Value::Null, |timezone| {
+                json!(job.next_run.with_timezone(&timezone).to_rfc3339())
+            });
+            TimezoneConfirmationFields {
+                schedule_timezone: json!(tz),
+                timezone_source: json!("explicit"),
+                next_run_local,
+            }
+        }
+        Schedule::Cron { tz: None, .. } => TimezoneConfirmationFields {
+            schedule_timezone: json!("runtime local timezone"),
+            timezone_source: json!("runtime_local"),
+            next_run_local: json!(job.next_run.with_timezone(&chrono::Local).to_rfc3339()),
+        },
+        Schedule::At { .. } | Schedule::Every { .. } => TimezoneConfirmationFields {
+            schedule_timezone: Value::Null,
+            timezone_source: json!("not_applicable"),
+            next_run_local: Value::Null,
+        },
+    }
+}
+
+fn reject_at_without_explicit_offset(value: &Value) -> Result<(), String> {
+    let Some(normalized) = normalize_maybe_stringified_json(value) else {
+        return Ok(());
+    };
+
+    if normalized.get("kind").and_then(Value::as_str) != Some("at") {
+        return Ok(());
+    }
+
+    let Some(raw_at) = normalized.get("at").and_then(Value::as_str) else {
+        return Ok(());
+    };
+
+    DateTime::parse_from_rfc3339(raw_at)
+        .map(|_| ())
+        .map_err(|err| {
+            format!(
+                "Invalid schedule: 'at' must be an RFC3339 timestamp with explicit Z or offset, \
+                 e.g. 2026-05-18T09:00:00Z or 2026-05-18T09:00:00-04:00; got '{raw_at}': {err}"
+            )
+        })
+}
+
+fn normalize_maybe_stringified_json(value: &Value) -> Option<Value> {
+    match value {
+        Value::String(raw) => {
+            let trimmed = raw.trim();
+            if trimmed.starts_with('{') || trimmed.starts_with('[') {
+                serde_json::from_str(trimmed).ok()
+            } else {
+                None
+            }
+        }
+        other => Some(other.clone()),
+    }
+}

--- a/crates/zeroclaw-runtime/src/tools/cron_list.rs
+++ b/crates/zeroclaw-runtime/src/tools/cron_list.rs
@@ -1,3 +1,4 @@
+use super::cron_common::cron_job_output;
 use crate::cron;
 use async_trait::async_trait;
 use serde_json::json;
@@ -45,7 +46,12 @@ impl Tool for CronListTool {
         match cron::list_jobs(&self.config) {
             Ok(jobs) => Ok(ToolResult {
                 success: true,
-                output: serde_json::to_string_pretty(&jobs)?,
+                output: serde_json::to_string_pretty(
+                    &jobs
+                        .iter()
+                        .map(cron_job_output)
+                        .collect::<serde_json::Result<Vec<_>>>()?,
+                )?,
                 error: None,
             }),
             Err(e) => Ok(ToolResult {
@@ -84,6 +90,38 @@ mod tests {
         let result = tool.execute(json!({})).await.unwrap();
         assert!(result.success);
         assert_eq!(result.output.trim(), "[]");
+    }
+
+    #[tokio::test]
+    async fn output_includes_timezone_confirmation_fields_for_cron_jobs() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = test_config(&tmp).await;
+        cron::add_shell_job(
+            &cfg,
+            None,
+            cron::Schedule::Cron {
+                expr: "0 9 * * 1-5".into(),
+                tz: Some("America/New_York".into()),
+            },
+            "echo ok",
+        )
+        .unwrap();
+        let tool = CronListTool::new(cfg);
+
+        let result = tool.execute(json!({})).await.unwrap();
+
+        assert!(result.success, "{:?}", result.error);
+        let output: serde_json::Value = serde_json::from_str(&result.output).unwrap();
+        let job = &output[0];
+        assert_eq!(job["next_run"], job["next_run_utc"]);
+        assert_eq!(job["schedule_timezone"], "America/New_York");
+        assert_eq!(job["timezone_source"], "explicit");
+        assert!(
+            job["next_run_local"]
+                .as_str()
+                .is_some_and(|value| value.contains("T09:00:00")),
+            "next_run_local should display the next run in the explicit schedule timezone: {job}"
+        );
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-runtime/src/tools/cron_update.rs
+++ b/crates/zeroclaw-runtime/src/tools/cron_update.rs
@@ -1,4 +1,7 @@
-use crate::cron::{self, CronJobPatch, deserialize_maybe_stringified};
+use super::cron_common::{
+    AT_DESCRIPTION, CRON_TZ_DESCRIPTION, cron_job_output, deserialize_patch_arg,
+};
+use crate::cron;
 use crate::security::SecurityPolicy;
 use async_trait::async_trait;
 use serde_json::json;
@@ -103,16 +106,16 @@ impl Tool for CronUpdateTool {
                                     "properties": {
                                         "kind": { "type": "string", "enum": ["cron"] },
                                         "expr": { "type": "string", "description": "Standard 5-field cron expression, e.g. '*/5 * * * *'" },
-                                        "tz": { "type": "string", "description": "Optional IANA timezone name, e.g. 'America/New_York'. Defaults to UTC." }
+                                        "tz": { "type": "string", "description": CRON_TZ_DESCRIPTION }
                                     },
                                     "required": ["kind", "expr"]
                                 },
                                 {
                                     "type": "object",
-                                    "description": "One-shot schedule at a specific UTC datetime. Example: {\"kind\":\"at\",\"at\":\"2025-12-31T23:59:00Z\"}",
+                                    "description": "One-shot schedule at a specific RFC3339 timestamp with explicit Z or offset. Example: {\"kind\":\"at\",\"at\":\"2025-12-31T23:59:00Z\"}",
                                     "properties": {
                                         "kind": { "type": "string", "enum": ["at"] },
-                                        "at": { "type": "string", "description": "ISO 8601 UTC datetime string, e.g. '2025-12-31T23:59:00Z'" }
+                                        "at": { "type": "string", "description": AT_DESCRIPTION }
                                     },
                                     "required": ["kind", "at"]
                                 },
@@ -198,13 +201,13 @@ impl Tool for CronUpdateTool {
             }
         };
 
-        let patch = match deserialize_maybe_stringified::<CronJobPatch>(&patch_val) {
+        let patch = match deserialize_patch_arg(&patch_val) {
             Ok(patch) => patch,
-            Err(e) => {
+            Err(error) => {
                 return Ok(ToolResult {
                     success: false,
                     output: String::new(),
-                    error: Some(format!("Invalid patch payload: {e}")),
+                    error: Some(error),
                 });
             }
         };
@@ -220,7 +223,7 @@ impl Tool for CronUpdateTool {
         match cron::update_shell_job_with_approval(&self.config, job_id, patch, approved) {
             Ok(job) => Ok(ToolResult {
                 success: true,
-                output: serde_json::to_string_pretty(&job)?,
+                output: serde_json::to_string_pretty(&cron_job_output(&job)?)?,
                 error: None,
             }),
             Err(e) => Ok(ToolResult {
@@ -275,6 +278,40 @@ mod tests {
 
         assert!(result.success, "{:?}", result.error);
         assert!(result.output.contains("\"enabled\": false"));
+    }
+
+    #[tokio::test]
+    async fn output_includes_timezone_confirmation_fields_for_explicit_cron_timezone() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = test_config(&tmp).await;
+        let job = cron::add_job(&cfg, "*/5 * * * *", "echo ok").unwrap();
+        let tool = CronUpdateTool::new(cfg.clone(), test_security(&cfg));
+
+        let result = tool
+            .execute(json!({
+                "job_id": job.id,
+                "patch": {
+                    "schedule": {
+                        "kind": "cron",
+                        "expr": "0 9 * * 1-5",
+                        "tz": "America/New_York"
+                    }
+                }
+            }))
+            .await
+            .unwrap();
+
+        assert!(result.success, "{:?}", result.error);
+        let output: serde_json::Value = serde_json::from_str(&result.output).unwrap();
+        assert_eq!(output["next_run"], output["next_run_utc"]);
+        assert_eq!(output["schedule_timezone"], "America/New_York");
+        assert_eq!(output["timezone_source"], "explicit");
+        assert!(
+            output["next_run_local"]
+                .as_str()
+                .is_some_and(|value| value.contains("T09:00:00")),
+            "next_run_local should display the next run in the explicit schedule timezone: {output}"
+        );
     }
 
     #[tokio::test]
@@ -370,6 +407,36 @@ mod tests {
         assert!(approved.success, "{:?}", approved.error);
     }
 
+    #[tokio::test]
+    async fn rejects_at_timestamp_without_explicit_offset_with_actionable_error() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = test_config(&tmp).await;
+        let job = cron::add_job(&cfg, "*/5 * * * *", "echo ok").unwrap();
+        let tool = CronUpdateTool::new(cfg.clone(), test_security(&cfg));
+
+        let result = tool
+            .execute(json!({
+                "job_id": job.id,
+                "patch": {
+                    "schedule": {
+                        "kind": "at",
+                        "at": "2026-05-18T09:00:00"
+                    }
+                }
+            }))
+            .await
+            .unwrap();
+
+        assert!(!result.success);
+        let error = result.error.unwrap_or_default();
+        assert!(
+            error.contains("RFC3339 timestamp with explicit Z or offset"),
+            "error should explain the explicit offset requirement: {error}"
+        );
+        assert!(error.contains("2026-05-18T09:00:00Z"));
+        assert!(error.contains("2026-05-18T09:00:00-04:00"));
+    }
+
     #[test]
     fn patch_schema_covers_all_cronjobpatch_fields_and_schedule_is_oneof() {
         let tmp = TempDir::new().unwrap();
@@ -459,6 +526,38 @@ mod tests {
                 _ => panic!("unexpected schedule kind: {kind}"),
             }
         }
+
+        let cron_variant = one_of
+            .iter()
+            .find(|variant| variant["properties"]["kind"]["enum"][0] == "cron")
+            .expect("cron variant");
+        let cron_tz_description = cron_variant["properties"]["tz"]["description"]
+            .as_str()
+            .expect("cron tz description");
+        assert!(
+            cron_tz_description.contains("runtime local timezone"),
+            "cron tz description must match scheduler fallback: {cron_tz_description}"
+        );
+        assert!(
+            cron_tz_description.contains("explicit IANA timezone"),
+            "cron tz description should recommend explicit IANA timezones: {cron_tz_description}"
+        );
+        assert!(
+            !cron_tz_description.contains("Defaults to UTC"),
+            "cron tz description must not claim a UTC default"
+        );
+
+        let at_variant = one_of
+            .iter()
+            .find(|variant| variant["properties"]["kind"]["enum"][0] == "at")
+            .expect("at variant");
+        let at_description = at_variant["properties"]["at"]["description"]
+            .as_str()
+            .expect("at description");
+        assert!(
+            at_description.contains("RFC3339 timestamp with explicit Z or offset"),
+            "at description should require explicit Z or offset: {at_description}"
+        );
 
         // patch.delivery.channel enum covers all supported channels
         let channel_enum = schema["properties"]["patch"]["properties"]["delivery"]["properties"]

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -16,6 +16,7 @@
 //! [`all_tools_with_runtime`]. See `AGENTS.md` §7.3 for the full change playbook.
 
 pub mod cron_add;
+pub(crate) mod cron_common;
 pub mod cron_list;
 pub mod cron_remove;
 pub mod cron_run;

--- a/src/cron/mod.rs
+++ b/src/cron/mod.rs
@@ -3,6 +3,16 @@ pub use zeroclaw_runtime::cron::*;
 use crate::config::Config;
 use anyhow::{Result, bail};
 
+fn parse_explicit_rfc3339_utc(raw: &str) -> Result<chrono::DateTime<chrono::Utc>> {
+    chrono::DateTime::parse_from_rfc3339(raw)
+        .map(|timestamp| timestamp.with_timezone(&chrono::Utc))
+        .map_err(|err| {
+            anyhow::anyhow!(
+                "Invalid RFC3339 timestamp for --at: expected RFC3339 timestamp with explicit Z or offset, e.g. 2026-05-18T09:00:00Z or 2026-05-18T09:00:00-04:00; got '{raw}': {err}"
+            )
+        })
+}
+
 pub fn handle_command(command: crate::CronCommands, config: &Config) -> Result<()> {
     match command {
         crate::CronCommands::List => {
@@ -86,9 +96,7 @@ pub fn handle_command(command: crate::CronCommands, config: &Config) -> Result<(
             allowed_tools,
             command,
         } => {
-            let at = chrono::DateTime::parse_from_rfc3339(&at)
-                .map_err(|e| anyhow::anyhow!("Invalid RFC3339 timestamp for --at: {e}"))?
-                .with_timezone(&chrono::Utc);
+            let at = parse_explicit_rfc3339_utc(&at)?;
             let schedule = Schedule::At { at };
             if agent {
                 let job = add_agent_job(
@@ -284,5 +292,46 @@ pub fn handle_command(command: crate::CronCommands, config: &Config) -> Result<(
             println!("▶️  Resumed cron job {id}");
             Ok(())
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn test_config(tmp: &TempDir) -> Config {
+        let config = Config {
+            workspace_dir: tmp.path().join("workspace"),
+            config_path: tmp.path().join("config.toml"),
+            ..Config::default()
+        };
+        std::fs::create_dir_all(&config.workspace_dir).unwrap();
+        config
+    }
+
+    #[test]
+    fn cli_add_at_rejects_timestamp_without_explicit_offset_with_actionable_error() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(&tmp);
+
+        let result = handle_command(
+            crate::CronCommands::AddAt {
+                at: "2026-05-18T09:00:00".into(),
+                agent: false,
+                allowed_tools: vec![],
+                command: "echo at".into(),
+            },
+            &config,
+        );
+
+        let error = result.expect_err("bare local timestamp must be rejected");
+        let message = error.to_string();
+        assert!(
+            message.contains("RFC3339 timestamp with explicit Z or offset"),
+            "error should explain the explicit offset requirement: {message}"
+        );
+        assert!(message.contains("2026-05-18T09:00:00Z"));
+        assert!(message.contains("2026-05-18T09:00:00-04:00"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -341,8 +341,8 @@ pub enum CronCommands {
 Add a new recurring scheduled task.
 
 Uses standard 5-field cron syntax: 'min hour day month weekday'. \
-Times are evaluated in UTC by default; use --tz with an IANA \
-timezone name to override.
+When --tz is omitted, cron schedules use the runtime local timezone. \
+For user-facing schedules, pass --tz with an explicit IANA timezone.
 
 Examples:
   zeroclaw cron add '0 9 * * 1-5' 'Good morning' --tz America/New_York --agent
@@ -363,17 +363,18 @@ Examples:
         /// Command (shell) or prompt (agent) to run
         command: String,
     },
-    /// Add a one-shot scheduled task at an RFC3339 timestamp
+    /// Add a one-shot scheduled task at an RFC3339 timestamp with explicit Z or offset
     #[command(long_about = "\
-Add a one-shot task that fires at a specific UTC timestamp.
+Add a one-shot task that fires at a specific RFC3339 timestamp with explicit Z or offset.
 
-The timestamp must be in RFC 3339 format (e.g. 2025-01-15T14:00:00Z).
+The timestamp must include an explicit Z or numeric offset \
+(e.g. 2025-01-15T14:00:00Z or 2025-01-15T09:00:00-05:00).
 
 Examples:
   zeroclaw cron add-at 2025-01-15T14:00:00Z 'Send reminder'
   zeroclaw cron add-at 2025-12-31T23:59:00Z 'Happy New Year!'")]
     AddAt {
-        /// One-shot timestamp in RFC3339 format
+        /// One-shot RFC3339 timestamp with explicit Z or offset
         at: String,
         /// Treat the argument as an agent prompt instead of a shell command
         #[arg(long)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -482,11 +482,13 @@ Examples:
 Configure and manage scheduled tasks.
 
 Schedule recurring, one-shot, or interval-based tasks using cron \
-expressions, RFC 3339 timestamps, durations, or fixed intervals.
+expressions, RFC3339 timestamps with explicit Z or offsets, durations, \
+or fixed intervals.
 
 Cron expressions use the standard 5-field format: \
-'min hour day month weekday'. Timezones default to UTC; \
-override with --tz and an IANA timezone name.
+'min hour day month weekday'. When --tz is omitted, cron schedules use \
+the runtime local timezone. For user-facing schedules, pass --tz with \
+an explicit IANA timezone.
 
 Examples:
   zeroclaw cron list
@@ -3956,6 +3958,30 @@ mod tests {
         assert!(help.contains("default logging writes them to stderr"));
         assert!(help.contains("custom subscribers may route them elsewhere"));
         assert!(help.contains("May include prompts, history, and tool output"));
+    }
+
+    #[test]
+    #[cfg(feature = "agent-runtime")]
+    fn cron_help_describes_runtime_local_timezone_fallback() {
+        let mut cmd = Cli::command();
+        let cron = cmd
+            .find_subcommand_mut("cron")
+            .expect("cron subcommand must exist");
+        let help = cron.render_long_help().to_string();
+
+        assert!(
+            help.contains("runtime local timezone"),
+            "cron help should describe the scheduler fallback: {help}"
+        );
+        assert!(
+            help.contains("explicit IANA timezone"),
+            "cron help should recommend explicit user-facing timezones: {help}"
+        );
+        assert!(
+            !help.contains("Timezones default to UTC")
+                && !help.contains("Times are evaluated in UTC by default"),
+            "cron help must not claim a UTC default: {help}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Aligns the `cron_add` and `cron_update` tool schemas with scheduler behavior: omitted `tz` means the runtime local timezone fallback, while user-facing recurring schedules should pass an explicit IANA timezone.
  - Describes one-shot `at` schedules as RFC3339 timestamps with an explicit `Z` or offset, and returns a clearer validation error for offset-less timestamps without parsing them as runtime local time.
  - Updates CLI help and validation feedback so `--tz` no longer claims a UTC default for cron expressions.
  - Adds backward-compatible timezone confirmation fields to `cron_add`, `cron_update`, and `cron_list` outputs while preserving the existing `next_run` field.
- **Scope boundary:** This PR does not change cron storage, scheduler next-run calculation, the existing `tz: None` runtime local fallback, Gateway/Web API timezone propagation, browser-provided IANA timezone handling, run history, delivery behavior, channel narration, or natural-language parsing.
- **Blast radius:** Cron tool callers and CLI users may see clearer schema/help/error text and additive JSON fields. Existing `next_run` consumers remain compatible.
- **Linked issue(s):** Related #6739
- **Labels:** `bug`, `risk: high`, `size: M`, `core`, `cron`, `runtime`.

## Validation Evidence (required)

Local validation is the signal CI cannot replace. Run the full battery and paste literal output (tails, failures, warnings — not "all passed").

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

Docs-only changes: replace with markdown lint + link-integrity (`scripts/ci/docs_quality_gate.sh`). Bootstrap scripts: add `bash -n install.sh`.

- **Commands run and tail output:**

```bash
$ cargo fmt --all -- --check
# exit 0

$ cargo clippy -p zeroclaw-runtime --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.28s

$ cargo clippy --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 49.12s

$ cargo test -p zeroclawlabs cron_help_describes_runtime_local_timezone_fallback -- --nocapture
running 1 test
test tests::cron_help_describes_runtime_local_timezone_fallback ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 249 filtered out; finished in 0.00s

$ cargo test -p zeroclaw-runtime cron::schedule -- --nocapture
test result: ok. 61 passed; 0 failed; 0 ignored; 0 measured; 1640 filtered out; finished in 1.95s

$ cargo test -p zeroclaw-runtime cron::types -- --nocapture
test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 1694 filtered out; finished in 0.00s

$ cargo test -p zeroclaw-runtime tools::cron_add -- --nocapture
test result: ok. 20 passed; 0 failed; 0 ignored; 0 measured; 1681 filtered out; finished in 0.10s

$ cargo test -p zeroclaw-runtime tools::cron_update -- --nocapture
test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 1692 filtered out; finished in 0.07s

$ cargo test -p zeroclaw-runtime tools::cron_list -- --nocapture
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 1698 filtered out; finished in 0.04s

$ cargo test -p zeroclaw -- cron -- --nocapture
error: package ID specification `zeroclaw` did not match any packages

help: a package with a similar name exists: `zerocopy`

$ cargo test -p zeroclawlabs cron -- --nocapture
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 243 filtered out; finished in 0.00s
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 245 filtered out; finished in 0.00s
test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 151 filtered out; finished in 0.06s

$ cargo test
test result: ok. 244 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.36s
test result: ok. 250 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s
test result: ok. 207 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.26s
test result: ok. 159 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.38s
test result: ok. 0 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 0.00s
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s
Doc-tests zeroclaw
error: Option 'default-theme' given more than once
error: doctest failed, to rerun pass `--doc`
```

- **Beyond CI — what did you manually verify?** Verified the schema wording no longer says `Defaults to UTC`, one-shot timestamps without an explicit offset keep failing with a more actionable error, and `cron_add` / `cron_update` / `cron_list` preserve `next_run` while adding `next_run_utc`, `schedule_timezone`, `timezone_source`, and `next_run_local`.
- **If any command was intentionally skipped, why:** No command was intentionally skipped. Full workspace clippy was rerun from the workspace root and completed cleanly. Full `cargo test` was attempted after the rebase; the ordinary unit, integration, live-skipped, and system test binaries above passed, then the doc-test phase failed before running doctests because local `rustdoc` received duplicate `--default-theme=ayu` arguments. `cargo test --doc` reproduces the same local rustdoc flag issue.

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: `N/A`

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`Yes`)
- If `No` or `Yes` to either: Existing cron storage and `next_run` output remain compatible. CLI/help/schema wording and tool output are additive or clearer; existing users do not need a migration.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PRs: `git revert <sha>` is the plan unless otherwise noted.

Medium/high-risk PRs must fill:

- **Fast rollback command/path:** `git revert 60fb30a89`
- **Feature flags or config toggles:** `None`
- **Observable failure symptoms:** Cron tool schema generation failures, CLI cron help regressions, or cron tool JSON shape regressions around `next_run`, `next_run_utc`, `schedule_timezone`, `timezone_source`, and `next_run_local`.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): `N/A`
- Scope materially carried forward: `N/A`
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`No`)
- If `No`, why (inspiration-only, no direct code/design carry-over): `N/A`
