### PR TITLE
fix(plugins): align install and discovery paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -325,7 +325,11 @@ peripheral-rpi = ["dep:zeroclaw-hardware", "zeroclaw-hardware/peripheral-rpi"]
 sandbox-landlock = ["zeroclaw-runtime/sandbox-landlock"]
 sandbox-bubblewrap = ["zeroclaw-runtime/sandbox-bubblewrap"]
 browser-native = ["zeroclaw-tools/browser-native"]
-plugins-wasm = ["dep:zeroclaw-plugins", "zeroclaw-runtime/plugins-wasm"]
+plugins-wasm = [
+    "dep:zeroclaw-plugins",
+    "zeroclaw-runtime/plugins-wasm",
+    "zeroclaw-gateway/plugins-wasm",
+]
 probe = ["dep:zeroclaw-hardware", "zeroclaw-hardware/probe"]
 rag-pdf = ["zeroclaw-tools/rag-pdf", "zeroclaw-runtime/rag-pdf"]
 webauthn = ["zeroclaw-runtime/webauthn", "zeroclaw-gateway?/webauthn"]

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -3792,6 +3792,9 @@ impl PluginsConfig {
     /// Explicit `plugins.plugins_dir` values always win. For omitted/default
     /// configs, discovery first uses the new default config-dir location, then
     /// falls back to the legacy workspace location if it contains plugins.
+    ///
+    /// This performs filesystem `read_dir` I/O to detect populated plugin
+    /// directories.
     pub fn resolved_plugins_discovery_dir(
         &self,
         config_path: &Path,
@@ -3829,6 +3832,9 @@ impl PluginsConfig {
 
 impl Config {
     /// Resolve the plugin discovery directory for this loaded config.
+    ///
+    /// This performs filesystem `read_dir` I/O to preserve legacy discovery
+    /// fallback behavior.
     pub fn resolved_plugins_discovery_dir(&self) -> PathBuf {
         self.plugins
             .resolved_plugins_discovery_dir(&self.config_path, &self.workspace_dir)

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -3765,6 +3765,16 @@ impl Default for PluginsConfig {
     }
 }
 
+impl PluginsConfig {
+    /// Resolve the configured plugin installation/discovery directory.
+    ///
+    /// CLI plugin management and runtime plugin discovery both use this helper
+    /// so `plugins.plugins_dir` remains the single source of truth.
+    pub fn resolved_plugins_dir(&self) -> PathBuf {
+        expand_tilde_path(&self.plugins_dir)
+    }
+}
+
 /// Content strategy configuration for LinkedIn auto-posting (`[linkedin.content]`).
 ///
 /// The agent reads this via the `linkedin get_content_strategy` action to know
@@ -12200,6 +12210,19 @@ mod tests {
                 "Tilde should be expanded when HOME is set"
             );
         }
+    }
+
+    #[test]
+    async fn plugins_config_resolves_plugins_dir_with_shared_tilde_expansion() {
+        let config = PluginsConfig {
+            plugins_dir: "~/.zeroclaw/plugins".to_string(),
+            ..PluginsConfig::default()
+        };
+
+        assert_eq!(
+            config.resolved_plugins_dir(),
+            expand_tilde_path("~/.zeroclaw/plugins")
+        );
     }
 
     // ── Defaults ─────────────────────────────────────────────

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -3749,6 +3749,17 @@ fn default_plugins_dir() -> String {
     default_path_under_config_dir("plugins")
 }
 
+fn has_plugin_entries(dir: &Path) -> bool {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return false;
+    };
+
+    entries.flatten().any(|entry| {
+        let path = entry.path();
+        path.is_dir() && path.join("manifest.toml").is_file()
+    })
+}
+
 fn default_max_plugins() -> usize {
     50
 }
@@ -3766,12 +3777,61 @@ impl Default for PluginsConfig {
 }
 
 impl PluginsConfig {
-    /// Resolve the configured plugin installation/discovery directory.
+    /// Resolve the configured plugin installation directory.
     ///
-    /// CLI plugin management and runtime plugin discovery both use this helper
-    /// so `plugins.plugins_dir` remains the single source of truth.
+    /// CLI plugin install/remove commands use this helper so writes always go
+    /// to the configured `plugins.plugins_dir`.
     pub fn resolved_plugins_dir(&self) -> PathBuf {
         expand_tilde_path(&self.plugins_dir)
+    }
+
+    /// Resolve the plugin discovery directory, preserving the pre-#6254
+    /// `workspace_dir/plugins` location when the configured default directory
+    /// has no installed plugins yet.
+    ///
+    /// Explicit `plugins.plugins_dir` values always win. For omitted/default
+    /// configs, discovery first uses the new default config-dir location, then
+    /// falls back to the legacy workspace location if it contains plugins.
+    pub fn resolved_plugins_discovery_dir(
+        &self,
+        config_path: &Path,
+        workspace_dir: &Path,
+    ) -> PathBuf {
+        let configured_dir = self.resolved_plugins_dir();
+        let legacy_dir = workspace_dir.join("plugins");
+
+        if !self.uses_default_plugins_dir(config_path) {
+            return configured_dir;
+        }
+
+        if has_plugin_entries(&configured_dir) {
+            return configured_dir;
+        }
+
+        if has_plugin_entries(&legacy_dir) {
+            return legacy_dir;
+        }
+
+        configured_dir
+    }
+
+    fn uses_default_plugins_dir(&self, config_path: &Path) -> bool {
+        let configured_dir = expand_tilde_path(&self.plugins_dir);
+        if configured_dir == expand_tilde_path(&default_plugins_dir()) {
+            return true;
+        }
+
+        config_path
+            .parent()
+            .is_some_and(|config_dir| configured_dir == config_dir.join("plugins"))
+    }
+}
+
+impl Config {
+    /// Resolve the plugin discovery directory for this loaded config.
+    pub fn resolved_plugins_discovery_dir(&self) -> PathBuf {
+        self.plugins
+            .resolved_plugins_discovery_dir(&self.config_path, &self.workspace_dir)
     }
 }
 
@@ -12222,6 +12282,120 @@ mod tests {
         assert_eq!(
             config.resolved_plugins_dir(),
             expand_tilde_path("~/.zeroclaw/plugins")
+        );
+    }
+
+    #[test]
+    async fn plugins_config_discovery_uses_explicit_plugins_dir() {
+        let tmp = TempDir::new().unwrap();
+        let configured = tmp.path().join("configured-plugins");
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(workspace.join("plugins").join("legacy-plugin")).unwrap();
+        std::fs::write(
+            workspace
+                .join("plugins")
+                .join("legacy-plugin")
+                .join("manifest.toml"),
+            "name = \"legacy-plugin\"\nversion = \"0.1.0\"\ncapabilities = [\"tool\"]\nwasm_path = \"plugin.wasm\"\n",
+        )
+        .unwrap();
+
+        let config = PluginsConfig {
+            plugins_dir: configured.to_string_lossy().into_owned(),
+            ..PluginsConfig::default()
+        };
+
+        assert_eq!(config.resolved_plugins_dir(), configured);
+        let config_path = tmp.path().join("config.toml");
+        assert_eq!(
+            config.resolved_plugins_discovery_dir(&config_path, &workspace),
+            configured
+        );
+    }
+
+    #[test]
+    async fn plugins_config_discovery_falls_back_to_legacy_workspace_plugins() {
+        let tmp = TempDir::new().unwrap();
+        let config_dir = tmp.path().join("config");
+        let configured = config_dir.join("plugins");
+        let workspace = config_dir.join("workspace");
+        let legacy_plugin = workspace.join("plugins").join("legacy-plugin");
+        std::fs::create_dir_all(&legacy_plugin).unwrap();
+        std::fs::write(
+            legacy_plugin.join("manifest.toml"),
+            "name = \"legacy-plugin\"\nversion = \"0.1.0\"\ncapabilities = [\"tool\"]\nwasm_path = \"plugin.wasm\"\n",
+        )
+        .unwrap();
+
+        let config = PluginsConfig {
+            plugins_dir: configured.to_string_lossy().into_owned(),
+            ..PluginsConfig::default()
+        };
+
+        assert_eq!(config.resolved_plugins_dir(), configured);
+        let config_path = config_dir.join("config.toml");
+        assert_eq!(
+            config.resolved_plugins_discovery_dir(&config_path, &workspace),
+            workspace.join("plugins")
+        );
+    }
+
+    #[test]
+    async fn plugins_config_discovery_falls_back_for_custom_workspace_name() {
+        let tmp = TempDir::new().unwrap();
+        let config_dir = tmp.path().join("config");
+        let configured = config_dir.join("plugins");
+        let workspace = tmp.path().join("project-a");
+        let legacy_plugin = workspace.join("plugins").join("legacy-plugin");
+        std::fs::create_dir_all(&legacy_plugin).unwrap();
+        std::fs::write(
+            legacy_plugin.join("manifest.toml"),
+            "name = \"legacy-plugin\"\nversion = \"0.1.0\"\ncapabilities = [\"tool\"]\nwasm_path = \"plugin.wasm\"\n",
+        )
+        .unwrap();
+
+        let config = PluginsConfig {
+            plugins_dir: configured.to_string_lossy().into_owned(),
+            ..PluginsConfig::default()
+        };
+
+        assert_eq!(
+            config.resolved_plugins_discovery_dir(&config_dir.join("config.toml"), &workspace),
+            workspace.join("plugins")
+        );
+    }
+
+    #[test]
+    async fn plugins_config_discovery_prefers_default_plugins_dir_when_populated() {
+        let tmp = TempDir::new().unwrap();
+        let config_dir = tmp.path().join("config");
+        let configured = config_dir.join("plugins");
+        let workspace = config_dir.join("workspace");
+        let configured_plugin = configured.join("configured-plugin");
+        let legacy_plugin = workspace.join("plugins").join("legacy-plugin");
+        std::fs::create_dir_all(&configured_plugin).unwrap();
+        std::fs::create_dir_all(&legacy_plugin).unwrap();
+        std::fs::write(
+            configured_plugin.join("manifest.toml"),
+            "name = \"configured-plugin\"\nversion = \"0.1.0\"\ncapabilities = [\"tool\"]\nwasm_path = \"plugin.wasm\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            legacy_plugin.join("manifest.toml"),
+            "name = \"legacy-plugin\"\nversion = \"0.1.0\"\ncapabilities = [\"tool\"]\nwasm_path = \"plugin.wasm\"\n",
+        )
+        .unwrap();
+
+        let config = PluginsConfig {
+            plugins_dir: configured.to_string_lossy().into_owned(),
+            ..PluginsConfig::default()
+        };
+
+        assert_eq!(config.resolved_plugins_dir(), configured);
+        let config_path = config_dir.join("config.toml");
+        assert_eq!(
+            config.resolved_plugins_discovery_dir(&config_path, &workspace),
+            configured
         );
     }
 

--- a/crates/zeroclaw-gateway/src/api_plugins.rs
+++ b/crates/zeroclaw-gateway/src/api_plugins.rs
@@ -115,12 +115,11 @@ pub mod plugin_routes {
             let workspace = config_dir.join("workspace");
             write_tool_plugin(&workspace.join("plugins"), "legacy-plugin");
 
-            unsafe { std::env::set_var("ZEROCLAW_CONFIG_DIR", &config_dir) };
             let plugins = PluginsConfig {
                 enabled: true,
+                plugins_dir: config_dir.join("plugins").to_string_lossy().into_owned(),
                 ..PluginsConfig::default()
             };
-            unsafe { std::env::remove_var("ZEROCLAW_CONFIG_DIR") };
 
             let config = Config {
                 workspace_dir: workspace.clone(),

--- a/crates/zeroclaw-gateway/src/api_plugins.rs
+++ b/crates/zeroclaw-gateway/src/api_plugins.rs
@@ -27,51 +27,112 @@ pub mod plugin_routes {
             }
         }
 
-        let config = state.config.lock();
-        let plugins_enabled = config.plugins.enabled;
-        let plugins_dir = config.plugins.plugins_dir.clone();
-        drop(config);
+        let (plugins_enabled, configured_plugins_dir, resolved_plugins_dir) = {
+            let config = state.config.lock();
+            (
+                config.plugins.enabled,
+                config.plugins.plugins_dir.clone(),
+                config.resolved_plugins_discovery_dir(),
+            )
+        };
 
         let plugins: Vec<serde_json::Value> = if plugins_enabled {
-            let plugin_path = if plugins_dir.starts_with("~/") {
-                directories::UserDirs::new()
-                    .map(|u| u.home_dir().join(&plugins_dir[2..]))
-                    .unwrap_or_else(|| std::path::PathBuf::from(&plugins_dir))
-            } else {
-                std::path::PathBuf::from(&plugins_dir)
-            };
-
-            if plugin_path.exists() {
-                match zeroclaw_plugins::host::PluginHost::new(
-                    plugin_path.parent().unwrap_or(&plugin_path),
-                ) {
-                    Ok(host) => host
-                        .list_plugins()
-                        .into_iter()
-                        .map(|p| {
-                            serde_json::json!({
-                                "name": p.name,
-                                "version": p.version,
-                                "description": p.description,
-                                "capabilities": p.capabilities,
-                                "loaded": p.loaded,
-                            })
-                        })
-                        .collect(),
-                    Err(_) => vec![],
-                }
-            } else {
-                vec![]
-            }
+            list_plugins_from_dir(&resolved_plugins_dir)
         } else {
             vec![]
         };
 
         Json(serde_json::json!({
             "plugins_enabled": plugins_enabled,
-            "plugins_dir": plugins_dir,
+            "plugins_dir": configured_plugins_dir,
             "plugins": plugins,
         }))
         .into_response()
+    }
+
+    pub(crate) fn list_plugins_from_dir(plugins_dir: &std::path::Path) -> Vec<serde_json::Value> {
+        if !plugins_dir.exists() {
+            return vec![];
+        }
+
+        match zeroclaw_plugins::host::PluginHost::from_plugins_dir(plugins_dir) {
+            Ok(host) => host.list_plugins().into_iter().map(plugin_json).collect(),
+            Err(_) => vec![],
+        }
+    }
+
+    fn plugin_json(p: zeroclaw_plugins::PluginInfo) -> serde_json::Value {
+        serde_json::json!({
+            "name": p.name,
+            "version": p.version,
+            "description": p.description,
+            "capabilities": p.capabilities,
+            "loaded": p.loaded,
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn resolved_plugins_discovery_dir_for_gateway(
+        config: &zeroclaw_config::schema::Config,
+    ) -> std::path::PathBuf {
+        config.resolved_plugins_discovery_dir()
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use tempfile::TempDir;
+        use zeroclaw_config::schema::{Config, PluginsConfig};
+
+        fn write_tool_plugin(plugins_dir: &std::path::Path, name: &str) {
+            let plugin_dir = plugins_dir.join(name);
+            std::fs::create_dir_all(&plugin_dir).unwrap();
+            std::fs::write(
+                plugin_dir.join("manifest.toml"),
+                format!(
+                    "name = \"{name}\"\nversion = \"0.1.0\"\ncapabilities = [\"tool\"]\nwasm_path = \"plugin.wasm\"\n"
+                ),
+            )
+            .unwrap();
+        }
+
+        #[test]
+        fn gateway_plugin_listing_uses_exact_resolved_plugins_dir() {
+            let tmp = TempDir::new().unwrap();
+            let configured = tmp.path().join("configured-plugins");
+            write_tool_plugin(&configured, "gateway-plugin");
+
+            let plugins = list_plugins_from_dir(&configured);
+
+            assert_eq!(plugins.len(), 1);
+            assert_eq!(plugins[0]["name"], "gateway-plugin");
+        }
+
+        #[test]
+        fn gateway_plugin_path_resolution_uses_config_helper_with_legacy_fallback() {
+            let tmp = TempDir::new().unwrap();
+            let config_dir = tmp.path().join("config");
+            let workspace = config_dir.join("workspace");
+            write_tool_plugin(&workspace.join("plugins"), "legacy-plugin");
+
+            unsafe { std::env::set_var("ZEROCLAW_CONFIG_DIR", &config_dir) };
+            let plugins = PluginsConfig {
+                enabled: true,
+                ..PluginsConfig::default()
+            };
+            unsafe { std::env::remove_var("ZEROCLAW_CONFIG_DIR") };
+
+            let config = Config {
+                workspace_dir: workspace.clone(),
+                config_path: config_dir.join("config.toml"),
+                plugins,
+                ..Config::default()
+            };
+
+            assert_eq!(
+                resolved_plugins_discovery_dir_for_gateway(&config),
+                workspace.join("plugins")
+            );
+        }
     }
 }

--- a/crates/zeroclaw-plugins/src/host.rs
+++ b/crates/zeroclaw-plugins/src/host.rs
@@ -527,6 +527,36 @@ permissions = []
     }
 
     #[test]
+    fn test_install_and_list_use_same_exact_plugins_dir() {
+        let dir = tempdir().unwrap();
+        let source_dir = dir.path().join("source");
+        let install_dir = dir.path().join("configured-plugins");
+        std::fs::create_dir_all(&source_dir).unwrap();
+        std::fs::write(
+            source_dir.join("manifest.toml"),
+            r#"
+name = "installed-plugin"
+version = "0.1.0"
+description = "Installed into configured directory"
+wasm_path = "plugin.wasm"
+capabilities = ["tool"]
+permissions = []
+"#,
+        )
+        .unwrap();
+        std::fs::write(source_dir.join("plugin.wasm"), b"not-real-wasm").unwrap();
+
+        let mut install_host = PluginHost::from_plugins_dir(&install_dir).unwrap();
+        install_host.install(source_dir.to_str().unwrap()).unwrap();
+
+        let list_host = PluginHost::from_plugins_dir(&install_dir).unwrap();
+        assert_eq!(list_host.plugins_dir(), install_dir);
+        let plugins = list_host.list_plugins();
+        assert_eq!(plugins.len(), 1);
+        assert_eq!(plugins[0].name, "installed-plugin");
+    }
+
+    #[test]
     fn test_discover_with_manifest() {
         let dir = tempdir().unwrap();
         let plugin_dir = dir.path().join("plugins").join("test-plugin");

--- a/crates/zeroclaw-plugins/src/host.rs
+++ b/crates/zeroclaw-plugins/src/host.rs
@@ -32,6 +32,11 @@ impl PluginHost {
         Self::with_security(workspace_dir, SignatureMode::Disabled, Vec::new())
     }
 
+    /// Create a new plugin host using an already-resolved plugin directory.
+    pub fn from_plugins_dir(plugins_dir: &Path) -> Result<Self, PluginError> {
+        Self::from_plugins_dir_with_security(plugins_dir, SignatureMode::Disabled, Vec::new())
+    }
+
     /// Create a new plugin host with signature verification settings.
     pub fn with_security(
         workspace_dir: &Path,
@@ -39,6 +44,17 @@ impl PluginHost {
         trusted_publisher_keys: Vec<String>,
     ) -> Result<Self, PluginError> {
         let plugins_dir = workspace_dir.join("plugins");
+        Self::from_plugins_dir_with_security(&plugins_dir, signature_mode, trusted_publisher_keys)
+    }
+
+    /// Create a new plugin host from an already-resolved plugin directory with
+    /// signature verification settings.
+    pub fn from_plugins_dir_with_security(
+        plugins_dir: &Path,
+        signature_mode: SignatureMode,
+        trusted_publisher_keys: Vec<String>,
+    ) -> Result<Self, PluginError> {
+        let plugins_dir = plugins_dir.to_path_buf();
         if !plugins_dir.exists() {
             std::fs::create_dir_all(&plugins_dir)?;
         }
@@ -482,6 +498,32 @@ mod tests {
         let dir = tempdir().unwrap();
         let host = PluginHost::new(dir.path()).unwrap();
         assert!(host.list_plugins().is_empty());
+    }
+
+    #[test]
+    fn test_from_plugins_dir_uses_exact_directory() {
+        let dir = tempdir().unwrap();
+        let plugins_dir = dir.path().join("custom-plugins");
+        let plugin_dir = plugins_dir.join("exact-dir");
+        std::fs::create_dir_all(&plugin_dir).unwrap();
+        std::fs::write(
+            plugin_dir.join("manifest.toml"),
+            r#"
+name = "exact-dir"
+version = "0.1.0"
+description = "Loaded from an exact plugin directory"
+wasm_path = "plugin.wasm"
+capabilities = ["tool"]
+permissions = []
+"#,
+        )
+        .unwrap();
+
+        let host = PluginHost::from_plugins_dir(&plugins_dir).unwrap();
+        assert_eq!(host.plugins_dir(), plugins_dir);
+        let plugins = host.list_plugins();
+        assert_eq!(plugins.len(), 1);
+        assert_eq!(plugins[0].name, "exact-dir");
     }
 
     #[test]

--- a/crates/zeroclaw-plugins/src/host.rs
+++ b/crates/zeroclaw-plugins/src/host.rs
@@ -251,13 +251,13 @@ impl PluginHost {
 
     /// Remove a plugin by name.
     pub fn remove(&mut self, name: &str) -> Result<(), PluginError> {
-        if self.loaded.remove(name).is_none() {
-            return Err(PluginError::NotFound(name.to_string()));
-        }
+        let plugin = self
+            .loaded
+            .remove(name)
+            .ok_or_else(|| PluginError::NotFound(name.to_string()))?;
 
-        let plugin_dir = self.plugins_dir.join(name);
-        if plugin_dir.exists() {
-            std::fs::remove_dir_all(plugin_dir)?;
+        if plugin.plugin_dir.exists() {
+            std::fs::remove_dir_all(plugin.plugin_dir)?;
         }
 
         Ok(())

--- a/crates/zeroclaw-runtime/src/skills/mod.rs
+++ b/crates/zeroclaw-runtime/src/skills/mod.rs
@@ -1809,19 +1809,15 @@ pub fn load_plugin_skills_from_config(config: &zeroclaw_config::schema::Config) 
         return Vec::new();
     }
 
-    let plugins_dir = expand_plugins_dir(&config.plugins.plugins_dir);
-    let parent = match plugins_dir.parent() {
-        Some(p) => p.to_path_buf(),
-        None => return Vec::new(),
-    };
+    let plugins_dir = config.plugins.resolved_plugins_dir();
 
     let signature_mode = zeroclaw_plugins::host::PluginHost::parse_signature_mode(
         &config.plugins.security.signature_mode,
     );
     let trusted_keys = config.plugins.security.trusted_publisher_keys.clone();
 
-    let host = match zeroclaw_plugins::host::PluginHost::with_security(
-        &parent,
+    let host = match zeroclaw_plugins::host::PluginHost::from_plugins_dir_with_security(
+        &plugins_dir,
         signature_mode,
         trusted_keys,
     ) {
@@ -1840,16 +1836,6 @@ pub fn load_plugin_skills_from_config(config: &zeroclaw_config::schema::Config) 
         }
     }
     skills
-}
-
-#[cfg(feature = "plugins-wasm")]
-fn expand_plugins_dir(plugins_dir: &str) -> PathBuf {
-    if let Some(rest) = plugins_dir.strip_prefix("~/")
-        && let Some(dirs) = UserDirs::new()
-    {
-        return dirs.home_dir().join(rest);
-    }
-    PathBuf::from(plugins_dir)
 }
 
 #[cfg(feature = "plugins-wasm")]

--- a/crates/zeroclaw-runtime/src/skills/mod.rs
+++ b/crates/zeroclaw-runtime/src/skills/mod.rs
@@ -1809,7 +1809,7 @@ pub fn load_plugin_skills_from_config(config: &zeroclaw_config::schema::Config) 
         return Vec::new();
     }
 
-    let plugins_dir = config.plugins.resolved_plugins_dir();
+    let plugins_dir = config.resolved_plugins_discovery_dir();
 
     let signature_mode = zeroclaw_plugins::host::PluginHost::parse_signature_mode(
         &config.plugins.security.signature_mode,
@@ -2408,5 +2408,75 @@ description = "fine"
             !names.contains(&"bad-open"),
             "bad open-skill must be skipped, not silently accepted; got: {names:?}"
         );
+    }
+}
+
+#[cfg(all(test, feature = "plugins-wasm"))]
+mod plugin_skill_discovery_tests {
+    use super::*;
+    use tempfile::TempDir;
+    use zeroclaw_config::schema::{Config, PluginsConfig};
+
+    fn write_skill_plugin(plugins_dir: &Path, plugin_name: &str, skill_name: &str) {
+        let plugin_dir = plugins_dir.join(plugin_name);
+        let skill_dir = plugin_dir.join("skills").join(skill_name);
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            plugin_dir.join("manifest.toml"),
+            format!("name = \"{plugin_name}\"\nversion = \"0.1.0\"\ncapabilities = [\"skill\"]\n"),
+        )
+        .unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            format!("---\nname: {skill_name}\ndescription: test skill\n---\n\nBody\n"),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn runtime_plugin_skill_discovery_uses_configured_plugins_dir() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("workspace");
+        let plugins_dir = tmp.path().join("configured-plugins");
+        write_skill_plugin(&plugins_dir, "configured-plugin", "configured-skill");
+
+        let config = Config {
+            workspace_dir: workspace,
+            config_path: tmp.path().join("config.toml"),
+            plugins: PluginsConfig {
+                enabled: true,
+                plugins_dir: plugins_dir.to_string_lossy().into_owned(),
+                ..PluginsConfig::default()
+            },
+            ..Config::default()
+        };
+
+        let skills = load_plugin_skills_from_config(&config);
+        let names: Vec<_> = skills.iter().map(|skill| skill.name.as_str()).collect();
+        assert_eq!(names, vec!["plugin:configured-plugin/configured-skill"]);
+    }
+
+    #[test]
+    fn runtime_plugin_skill_discovery_falls_back_to_legacy_workspace_plugins() {
+        let tmp = TempDir::new().unwrap();
+        let config_dir = tmp.path().join("config");
+        let workspace = tmp.path().join("workspace");
+        write_skill_plugin(&workspace.join("plugins"), "legacy-plugin", "legacy-skill");
+
+        let plugins = PluginsConfig {
+            enabled: true,
+            ..PluginsConfig::default()
+        };
+
+        let config = Config {
+            workspace_dir: workspace,
+            config_path: config_dir.join("config.toml"),
+            plugins,
+            ..Config::default()
+        };
+
+        let skills = load_plugin_skills_from_config(&config);
+        let names: Vec<_> = skills.iter().map(|skill| skill.name.as_str()).collect();
+        assert_eq!(names, vec!["plugin:legacy-plugin/legacy-skill"]);
     }
 }

--- a/crates/zeroclaw-runtime/src/skills/mod.rs
+++ b/crates/zeroclaw-runtime/src/skills/mod.rs
@@ -2465,6 +2465,7 @@ mod plugin_skill_discovery_tests {
 
         let plugins = PluginsConfig {
             enabled: true,
+            plugins_dir: config_dir.join("plugins").to_string_lossy().into_owned(),
             ..PluginsConfig::default()
         };
 

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -1019,20 +1019,10 @@ pub fn all_tools_with_runtime(
     // ── WASM plugin tools (requires plugins-wasm feature) ──
     #[cfg(feature = "plugins-wasm")]
     {
-        let plugin_dir = config.plugins.plugins_dir.clone();
-        let plugin_path = if plugin_dir.starts_with("~/") {
-            let home = directories::UserDirs::new()
-                .map(|u| u.home_dir().to_path_buf())
-                .unwrap_or_else(|| std::path::PathBuf::from("."));
-            home.join(plugin_dir.strip_prefix("~/").unwrap())
-        } else {
-            std::path::PathBuf::from(&plugin_dir)
-        };
+        let plugin_path = config.plugins.resolved_plugins_dir();
 
         if plugin_path.exists() && config.plugins.enabled {
-            match zeroclaw_plugins::host::PluginHost::new(
-                plugin_path.parent().unwrap_or(&plugin_path),
-            ) {
+            match zeroclaw_plugins::host::PluginHost::from_plugins_dir(&plugin_path) {
                 Ok(host) => {
                     let details = host.tool_plugin_details();
                     let count = details.len();

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -1019,7 +1019,7 @@ pub fn all_tools_with_runtime(
     // ── WASM plugin tools (requires plugins-wasm feature) ──
     #[cfg(feature = "plugins-wasm")]
     {
-        let plugin_path = config.plugins.resolved_plugins_dir();
+        let plugin_path = config.resolved_plugins_discovery_dir();
 
         if plugin_path.exists() && config.plugins.enabled {
             match zeroclaw_plugins::host::PluginHost::from_plugins_dir(&plugin_path) {
@@ -1066,7 +1066,7 @@ pub fn all_tools_with_runtime(
 mod tests {
     use super::*;
     use tempfile::TempDir;
-    use zeroclaw_config::schema::{BrowserConfig, Config, MemoryConfig};
+    use zeroclaw_config::schema::{BrowserConfig, Config, MemoryConfig, PluginsConfig};
 
     fn test_config(tmp: &TempDir) -> Config {
         Config {
@@ -1167,6 +1167,54 @@ mod tests {
         assert!(names.contains(&"model_routing_config"));
         assert!(names.contains(&"pushover"));
         assert!(names.contains(&"proxy_config"));
+    }
+
+    #[cfg(feature = "plugins-wasm")]
+    #[test]
+    fn all_tools_discovers_plugins_from_configured_plugins_dir() {
+        let tmp = TempDir::new().unwrap();
+        let plugins_dir = tmp.path().join("configured-plugins");
+        let plugin_dir = plugins_dir.join("configured-tool");
+        std::fs::create_dir_all(&plugin_dir).unwrap();
+        std::fs::write(
+            plugin_dir.join("manifest.toml"),
+            r#"
+name = "configured-tool"
+version = "0.1.0"
+description = "configured plugin tool"
+wasm_path = "plugin.wasm"
+capabilities = ["tool"]
+permissions = []
+"#,
+        )
+        .unwrap();
+
+        let security = Arc::new(SecurityPolicy::default());
+        let mem: Arc<dyn Memory> = Arc::new(zeroclaw_memory::NoneMemory::new());
+        let mut cfg = test_config(&tmp);
+        cfg.plugins = PluginsConfig {
+            enabled: true,
+            plugins_dir: plugins_dir.to_string_lossy().into_owned(),
+            ..PluginsConfig::default()
+        };
+
+        let (tools, _, _, _, _, _) = all_tools(
+            Arc::new(cfg.clone()),
+            &security,
+            mem,
+            None,
+            None,
+            &BrowserConfig::default(),
+            &zeroclaw_config::schema::HttpRequestConfig::default(),
+            &zeroclaw_config::schema::WebFetchConfig::default(),
+            tmp.path(),
+            &HashMap::new(),
+            None,
+            &cfg,
+            None,
+        );
+        let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+        assert!(names.contains(&"configured-tool"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3026,7 +3026,7 @@ async fn main() -> Result<()> {
         #[cfg(feature = "plugins-wasm")]
         Commands::Plugin { plugin_command } => match plugin_command {
             PluginCommands::List => {
-                let plugins_dir = config.plugins.resolved_plugins_dir();
+                let plugins_dir = config.resolved_plugins_discovery_dir();
                 let host = zeroclaw::plugins::host::PluginHost::from_plugins_dir(&plugins_dir)?;
                 let plugins = host.list_plugins();
                 if plugins.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3052,14 +3052,14 @@ async fn main() -> Result<()> {
                 Ok(())
             }
             PluginCommands::Remove { name } => {
-                let plugins_dir = config.plugins.resolved_plugins_dir();
+                let plugins_dir = config.resolved_plugins_discovery_dir();
                 let mut host = zeroclaw::plugins::host::PluginHost::from_plugins_dir(&plugins_dir)?;
                 host.remove(&name)?;
                 println!("Plugin '{name}' removed.");
                 Ok(())
             }
             PluginCommands::Info { name } => {
-                let plugins_dir = config.plugins.resolved_plugins_dir();
+                let plugins_dir = config.resolved_plugins_discovery_dir();
                 let host = zeroclaw::plugins::host::PluginHost::from_plugins_dir(&plugins_dir)?;
                 match host.get_plugin(&name) {
                     Some(info) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3026,7 +3026,8 @@ async fn main() -> Result<()> {
         #[cfg(feature = "plugins-wasm")]
         Commands::Plugin { plugin_command } => match plugin_command {
             PluginCommands::List => {
-                let host = zeroclaw::plugins::host::PluginHost::new(&config.workspace_dir)?;
+                let plugins_dir = config.plugins.resolved_plugins_dir();
+                let host = zeroclaw::plugins::host::PluginHost::from_plugins_dir(&plugins_dir)?;
                 let plugins = host.list_plugins();
                 if plugins.is_empty() {
                     println!("No plugins installed.");
@@ -3044,19 +3045,22 @@ async fn main() -> Result<()> {
                 Ok(())
             }
             PluginCommands::Install { source } => {
-                let mut host = zeroclaw::plugins::host::PluginHost::new(&config.workspace_dir)?;
+                let plugins_dir = config.plugins.resolved_plugins_dir();
+                let mut host = zeroclaw::plugins::host::PluginHost::from_plugins_dir(&plugins_dir)?;
                 host.install(&source)?;
                 println!("Plugin installed from {source}");
                 Ok(())
             }
             PluginCommands::Remove { name } => {
-                let mut host = zeroclaw::plugins::host::PluginHost::new(&config.workspace_dir)?;
+                let plugins_dir = config.plugins.resolved_plugins_dir();
+                let mut host = zeroclaw::plugins::host::PluginHost::from_plugins_dir(&plugins_dir)?;
                 host.remove(&name)?;
                 println!("Plugin '{name}' removed.");
                 Ok(())
             }
             PluginCommands::Info { name } => {
-                let host = zeroclaw::plugins::host::PluginHost::new(&config.workspace_dir)?;
+                let plugins_dir = config.plugins.resolved_plugins_dir();
+                let host = zeroclaw::plugins::host::PluginHost::from_plugins_dir(&plugins_dir)?;
                 match host.get_plugin(&name) {
                     Some(info) => {
                         println!("Plugin: {} v{}", info.name, info.version);

--- a/src/main.rs
+++ b/src/main.rs
@@ -3045,6 +3045,8 @@ async fn main() -> Result<()> {
                 Ok(())
             }
             PluginCommands::Install { source } => {
+                // Installs are writes, so they always target the configured
+                // plugins dir instead of migrating legacy discovery results.
                 let plugins_dir = config.plugins.resolved_plugins_dir();
                 let mut host = zeroclaw::plugins::host::PluginHost::from_plugins_dir(&plugins_dir)?;
                 host.install(&source)?;
@@ -3052,6 +3054,8 @@ async fn main() -> Result<()> {
                 Ok(())
             }
             PluginCommands::Remove { name } => {
+                // Removes follow discovery so users can delete plugins that
+                // still live in the pre-config-dir workspace fallback.
                 let plugins_dir = config.resolved_plugins_discovery_dir();
                 let mut host = zeroclaw::plugins::host::PluginHost::from_plugins_dir(&plugins_dir)?;
                 host.remove(&name)?;

--- a/tests/component/mod.rs
+++ b/tests/component/mod.rs
@@ -6,6 +6,7 @@ mod dockerignore_test;
 mod gateway;
 mod gemini_capabilities;
 mod otel_dependency_feature_regression;
+mod plugin_cli;
 mod provider_resolution;
 mod provider_schema;
 mod reply_target_field_regression;

--- a/tests/component/plugin_cli.rs
+++ b/tests/component/plugin_cli.rs
@@ -1,0 +1,77 @@
+use std::process::Command;
+
+fn zeroclaw_bin() -> String {
+    std::env::var("CARGO_BIN_EXE_zeroclaw").unwrap_or_else(|_| "target/debug/zeroclaw".to_string())
+}
+
+fn write_tool_plugin(plugin_dir: &std::path::Path, name: &str) {
+    std::fs::create_dir_all(plugin_dir).unwrap();
+    std::fs::write(
+        plugin_dir.join("manifest.toml"),
+        format!(
+            "name = \"{name}\"\nversion = \"0.1.0\"\ndescription = \"CLI plugin\"\nwasm_path = \"plugin.wasm\"\ncapabilities = [\"tool\"]\npermissions = []\n"
+        ),
+    )
+    .unwrap();
+    std::fs::write(plugin_dir.join("plugin.wasm"), b"not-real-wasm").unwrap();
+}
+
+#[test]
+#[cfg(feature = "plugins-wasm")]
+fn plugin_install_and_list_use_configured_plugins_dir() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let config_dir = tmp.path().join("config");
+    let configured_plugins_dir = tmp.path().join("configured-plugins");
+    let source_plugin = tmp.path().join("source-plugin");
+    write_tool_plugin(&source_plugin, "cli-installed");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    std::fs::write(
+        config_dir.join("config.toml"),
+        format!(
+            "[plugins]\nenabled = true\nplugins_dir = \"{}\"\n",
+            configured_plugins_dir.display()
+        ),
+    )
+    .unwrap();
+
+    let install = Command::new(zeroclaw_bin())
+        .arg("--config-dir")
+        .arg(&config_dir)
+        .arg("plugin")
+        .arg("install")
+        .arg(&source_plugin)
+        .output()
+        .expect("run plugin install");
+    assert!(
+        install.status.success(),
+        "install failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&install.stdout),
+        String::from_utf8_lossy(&install.stderr)
+    );
+    assert!(
+        configured_plugins_dir
+            .join("cli-installed")
+            .join("manifest.toml")
+            .is_file(),
+        "plugin install should write to configured plugins.plugins_dir"
+    );
+
+    let list = Command::new(zeroclaw_bin())
+        .arg("--config-dir")
+        .arg(&config_dir)
+        .arg("plugin")
+        .arg("list")
+        .output()
+        .expect("run plugin list");
+    assert!(
+        list.status.success(),
+        "list failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&list.stdout),
+        String::from_utf8_lossy(&list.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&list.stdout);
+    assert!(
+        stdout.contains("cli-installed"),
+        "plugin list should read from configured plugins.plugins_dir, got:\n{stdout}"
+    );
+}

--- a/tests/component/plugin_cli.rs
+++ b/tests/component/plugin_cli.rs
@@ -75,3 +75,75 @@ fn plugin_install_and_list_use_configured_plugins_dir() {
         "plugin list should read from configured plugins.plugins_dir, got:\n{stdout}"
     );
 }
+
+#[test]
+#[cfg(feature = "plugins-wasm")]
+fn plugin_info_and_remove_use_legacy_discovery_fallback() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let config_dir = tmp.path().join("config");
+    let legacy_plugin = config_dir
+        .join("workspace")
+        .join("plugins")
+        .join("legacy-cli-plugin");
+    write_tool_plugin(&legacy_plugin, "legacy-cli-plugin");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    std::fs::write(config_dir.join("config.toml"), "").unwrap();
+
+    let info = Command::new(zeroclaw_bin())
+        .arg("--config-dir")
+        .arg(&config_dir)
+        .arg("plugin")
+        .arg("info")
+        .arg("legacy-cli-plugin")
+        .output()
+        .expect("run plugin info");
+    assert!(
+        info.status.success(),
+        "info failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&info.stdout),
+        String::from_utf8_lossy(&info.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&info.stdout);
+    assert!(
+        stdout.contains("Plugin: legacy-cli-plugin v0.1.0"),
+        "plugin info should read from legacy workspace plugins fallback, got:\n{stdout}"
+    );
+
+    let remove = Command::new(zeroclaw_bin())
+        .arg("--config-dir")
+        .arg(&config_dir)
+        .arg("plugin")
+        .arg("remove")
+        .arg("legacy-cli-plugin")
+        .output()
+        .expect("run plugin remove");
+    assert!(
+        remove.status.success(),
+        "remove failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&remove.stdout),
+        String::from_utf8_lossy(&remove.stderr)
+    );
+    assert!(
+        !legacy_plugin.exists(),
+        "plugin remove should delete the legacy fallback plugin directory"
+    );
+
+    let list = Command::new(zeroclaw_bin())
+        .arg("--config-dir")
+        .arg(&config_dir)
+        .arg("plugin")
+        .arg("list")
+        .output()
+        .expect("run plugin list after remove");
+    assert!(
+        list.status.success(),
+        "list after remove failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&list.stdout),
+        String::from_utf8_lossy(&list.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&list.stdout);
+    assert!(
+        stdout.contains("No plugins installed."),
+        "plugin list should not show removed legacy plugin, got:\n{stdout}"
+    );
+}


### PR DESCRIPTION
Closes #6254.

## Base
- Base branch: `master`
- Head branch: `issue-6254-plugin-install-discovery-path`

## Scope
- Align plugin install/list/info/remove path handling around configured `plugins.plugins_dir`.
- Preserve legacy `workspace/plugins` discovery fallback when the default config-dir plugin directory is empty.
- Route gateway, runtime tool discovery, and runtime plugin skill discovery through the same config helper.
- Add coverage for configured plugin dirs, legacy fallback discovery, CLI install/list/info/remove, and exact plugin host directories.
- Address reviewer warnings by avoiding new test env var mutation and documenting discovery helper filesystem I/O.

## Blast Radius
- Plugin config path resolution.
- CLI plugin management commands.
- Gateway plugin listing response.
- Runtime plugin tool and skill discovery when `plugins-wasm` is enabled.
- No database, network, auth, channel delivery, or provider behavior changes.

## Labels
- Existing labels observed: `bug`, `size: M`, `risk: high`, `dependencies`, `core`, `config`, `gateway`, `runtime`, `skills`, `tests`.

## Validation
- `cargo fmt --check`
  - Tail: completed successfully.
- `git diff --check origin/master...HEAD`
  - Tail: completed successfully.
- `cargo test -p zeroclaw-config plugins_config_discovery --lib`
  - Tail: `test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 639 filtered out`.
- `cargo test --test component plugin_ --features plugins-wasm`
  - Tail: `test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 207 filtered out`.
- `cargo test -p zeroclaw-plugins remove_plugin --lib`
  - Tail: `test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 40 filtered out`.
- `cargo test -p zeroclaw-gateway plugin --features plugins-wasm --lib`
  - Tail: `test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 190 filtered out`.
- `cargo test -p zeroclaw-runtime plugin_skill_discovery --features plugins-wasm --lib`
  - Tail: `test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 1703 filtered out`.
- `cargo test -p zeroclaw-runtime all_tools_discovers_plugins_from_configured_plugins_dir --features plugins-wasm --lib`
  - Tail: `test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1704 filtered out`.
- `cargo test -p zeroclaw-runtime plugin_tool --features plugins-wasm --lib`
  - Tail: `test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1705 filtered out`.

## Security
- No new network calls, credential handling, signature policy changes, or permission expansion.
- Discovery still only reads local plugin directories and manifests through existing plugin host loading.

## Privacy
- No new telemetry, logging, user data collection, or external transmission.
- Tests use temporary local directories and synthetic plugin manifests.

## Compatibility
- Explicit `plugins.plugins_dir` remains authoritative.
- Default configs prefer the config-dir plugin location when populated.
- Legacy `workspace/plugins` remains discoverable for list/info/remove when the default config-dir location is empty.
- If both default/configured and legacy locations contain plugins, the default/configured location wins; directories are not merged.
- Install writes to the configured plugin directory, while remove follows discovery so legacy installs can be removed without migration.

## Rollback
- Revert this PR to restore the prior plugin path behavior.
- No data migration is required; plugin directories remain on disk in their existing locations.
