### PR TITLE
fix(ci): unblock pr-title workflow with inline regex check

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -15,7 +15,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run validator unit tests
         run: ./scripts/check-pr-title.test.sh
       - name: Check PR title

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,7 +1,7 @@
 name: Validate PR title
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - reopened
@@ -9,20 +9,16 @@ on:
       - synchronize
 
 permissions:
-  pull-requests: read
+  contents: read
 
 jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - name: Check Conventional Commits format
+      - uses: actions/checkout@v4
+      - name: Run validator unit tests
+        run: ./scripts/check-pr-title.test.sh
+      - name: Check PR title
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
-        run: |
-          pattern='^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)\([a-z0-9._/:-]+\)!?: .+'
-          if ! printf '%s' "$PR_TITLE" | grep -qE "$pattern"; then
-            echo "::error::PR title must follow Conventional Commits with a scope: 'type(scope): description'"
-            echo "Allowed types: build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test"
-            echo "Got: $PR_TITLE"
-            exit 1
-          fi
+        run: ./scripts/check-pr-title.sh "$PR_TITLE"

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -15,8 +15,14 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50  # v6.1.1
+      - name: Check Conventional Commits format
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          requireScope: true
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          pattern='^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)\([a-z0-9._/:-]+\)!?: .+'
+          if ! printf '%s' "$PR_TITLE" | grep -qE "$pattern"; then
+            echo "::error::PR title must follow Conventional Commits with a scope: 'type(scope): description'"
+            echo "Allowed types: build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test"
+            echo "Got: $PR_TITLE"
+            exit 1
+          fi

--- a/scripts/check-pr-title.sh
+++ b/scripts/check-pr-title.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Validate a PR title against Conventional Commits with required scope.
+# Usage: check-pr-title.sh "<title>"
+# Exits 0 on accept, 1 on reject.
+
+set -u
+
+title="${1-}"
+
+pattern='^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)\([a-z0-9._/:-]+\)!?: .+'
+
+if printf '%s' "$title" | grep -qE "$pattern"; then
+  exit 0
+fi
+
+echo "::error::PR title must follow Conventional Commits with a scope: 'type(scope): description'"
+echo "Allowed types: build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test"
+echo "Got: $title"
+exit 1

--- a/scripts/check-pr-title.test.sh
+++ b/scripts/check-pr-title.test.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Tests for scripts/check-pr-title.sh
+# Asserts pass/fail behavior against representative PR titles.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECKER="$SCRIPT_DIR/check-pr-title.sh"
+
+if [[ ! -x "$CHECKER" ]]; then
+  echo "FAIL: $CHECKER is missing or not executable"
+  exit 1
+fi
+
+pass=0
+fail=0
+failures=()
+
+assert_accept() {
+  local title="$1"
+  if "$CHECKER" "$title" >/dev/null 2>&1; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    failures+=("expected ACCEPT, got REJECT: $title")
+  fi
+}
+
+assert_reject() {
+  local title="$1"
+  if "$CHECKER" "$title" >/dev/null 2>&1; then
+    fail=$((fail + 1))
+    failures+=("expected REJECT, got ACCEPT: $title")
+  else
+    pass=$((pass + 1))
+  fi
+}
+
+# --- ACCEPT: valid conventional commits with scope ---
+assert_accept "fix(ci): unblock pr-title workflow"
+assert_accept "feat(channel:rocketchat): add Rocket.Chat channel"
+assert_accept "fix(providers/compatible): normalize image markers"
+assert_accept "refactor(config): decompose schema.rs into sub-modules"
+assert_accept "fix(scope)!: breaking change indicator"
+assert_accept "chore(deps): bump foo to 1.2.3"
+assert_accept "docs(security): point sandboxing example at default image"
+assert_accept "feat(channels/acp): persist ACP sessions"
+assert_accept "test(tools): cover Tavily search routing aliases"
+assert_accept "perf(memory): reduce allocations in hot path"
+assert_accept "build(docker): add arm64 target"
+assert_accept "style(rust): apply rustfmt"
+assert_accept "revert(api): roll back endpoint rename"
+assert_accept "fix(a): single-char scope"
+assert_accept "fix(channels.email): scope with dot"
+assert_accept "fix(scope_with_underscore): underscore in scope"
+assert_accept "fix(ci): description with (#1234) PR number suffix"
+assert_accept "feat(skills): 🎉 description with unicode emoji"
+assert_accept "fix(my-scope): scope with hyphen"
+assert_accept "fix(ci):  description with double space after colon"
+assert_accept "feat(providers/compatible/openai): deeply nested scope"
+
+# --- REJECT: invalid format ---
+assert_reject ""
+assert_reject "fix something"
+assert_reject "fix: no scope provided"
+assert_reject "v0.8.0: Multi-Agent Runtime and Schema V3"
+assert_reject "Fix(ci): capitalized type"
+assert_reject "FIX(ci): all caps type"
+assert_reject "wip(ci): wip is not an allowed type"
+assert_reject "fix(): empty scope"
+assert_reject "fix(ci):no space after colon"
+assert_reject "fix(ci) : space before colon"
+assert_reject "refactor!(api): bang in wrong place"
+assert_reject "fix(ci):"
+assert_reject "fix(ci): "
+assert_reject "  fix(ci): leading whitespace"
+assert_reject "fix(CI): uppercase scope"
+assert_reject "fix(ci with space): space in scope"
+assert_reject "feat(scope): "
+assert_reject "fix-something: dash in type"
+assert_reject "fix (ci): space between type and scope"
+assert_reject "(ci): missing type"
+assert_reject "fix(ci) description without colon"
+
+echo "passed: $pass"
+echo "failed: $fail"
+if (( fail > 0 )); then
+  echo
+  echo "Failures:"
+  for f in "${failures[@]}"; do
+    echo "  - $f"
+  done
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
    - what: replaced `amannn/action-semantic-pull-request` in `.github/workflows/pr-title.yml` with a local bash validator (`scripts/check-pr-title.sh`) plus a regression test harness (`scripts/check-pr-title.test.sh`) that runs ahead of the validator in CI.
    - why: the action is not on this repo's allowed-actions allowlist, so every run since #6396 merged has been `startup_failure` with 0 jobs — the check has never actually gated a PR (see #6751).
- **Scope boundary:** edits `.github/workflows/pr-title.yml` and adds two scripts under `scripts/`. No code, no other workflows.
- **Blast radius:** PR-title validation only. If the regex is wrong, PRs may be falsely rejected/accepted at title-edit time; no impact on builds, tests, or merges (this workflow is not in the required gate). The test harness (`scripts/check-pr-title.test.sh`) runs as the first CI step so a broken regex fails fast before it can mis-gate a PR.
- **Linked issue(s):** Closes #6751

## Validation Evidence

`scripts/check-pr-title.test.sh` covers 42 cases (accept + reject) including nested scopes, breaking-change indicator, unicode emoji, hyphens/dots/underscores in scopes, and a representative range of rejection cases (capitalized type, empty scope, missing colon, bang in wrong position). Local run: **42 passed, 0 failed.**

End-to-end verification will come from this PR's own `Validate PR title` run — the title `fix(ci): unblock pr-title workflow with inline regex check` is itself a positive test case.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? `Yes (narrower)` — `permissions:` changed from `pull-requests: read` to `contents: read` (needed for `actions/checkout`; no longer needs PR write context).
- New external network calls? `No` — removes one third-party action; the remaining dependency is `actions/checkout` (first-party, SHA-pinned to `de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2`, matching every other workflow in the repo per FND-004 §5.4).
- Secrets / tokens / credentials handling changed? `Yes (reduced)` — `GITHUB_TOKEN` env removed from the step; the inline validator does not need it.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

**Net positive:** trigger changed from `pull_request_target` → `pull_request`, so the workflow no longer runs in the base-repo context with elevated privileges. `PR_TITLE` is passed via env var (not interpolated into the `run:` shell text) and quoted inside the script, so titles with shell metacharacters are not an injection path.

## Compatibility

- Backward compatible? `Yes` — same workflow name, same triggers (sans `_target`), same semantics (`requireScope: true`-equivalent).
- Config / env / CLI surface changed? `No`

## Rollback

`git revert <squash sha>` (resolve post-merge) returns to the prior `amannn/action-semantic-pull-request` state. Since that workflow has never produced a real signal, revert risk is nil.

---

## Why a local validator over allowlisting the action

Considered: adding `amannn/action-semantic-pull-request@*` to the repo's selected-actions allowlist. Rejected because:

1. **Supply-chain risk under `pull_request_target`** — the original trigger ran in the base repo context with access to secrets. Switching to `pull_request` plus inline bash removes the entire third-party dependency for this workflow.
2. **The check is ~10 lines of bash.** Not worth an external dependency.
3. **Allowlist churn** — each new policy entry must be re-audited over time.
