### PR TITLE
docs+test: refresh stale MiniMax endpoint and model

### DIFF
--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -3561,7 +3561,7 @@ mod tests {
     fn minimax_provider_supports_native_tool_calling_with_system_merge() {
         let p = OpenAiCompatibleProvider::new(
             "MiniMax",
-            "https://api.minimax.chat/v1",
+            "https://api.minimaxi.com/v1",
             Some("k"),
             AuthStyle::Bearer,
         )
@@ -3592,7 +3592,7 @@ mod tests {
         ];
         let p = OpenAiCompatibleProvider::new_merge_system_into_user(
             "MiniMax",
-            "https://api.minimax.chat/v1",
+            "https://api.minimaxi.com/v1",
             Some("k"),
             AuthStyle::Bearer,
         );
@@ -3638,7 +3638,7 @@ mod tests {
         ];
         let p = OpenAiCompatibleProvider::new_merge_system_into_user(
             "MiniMax",
-            "https://api.minimax.chat/v1",
+            "https://api.minimaxi.com/v1",
             Some("k"),
             AuthStyle::Bearer,
         );
@@ -3661,7 +3661,7 @@ mod tests {
         ];
         let p = OpenAiCompatibleProvider::new_merge_system_into_user(
             "MiniMax",
-            "https://api.minimax.chat/v1",
+            "https://api.minimaxi.com/v1",
             Some("k"),
             AuthStyle::Bearer,
         );
@@ -4838,7 +4838,7 @@ mod tests {
         ];
         let p = OpenAiCompatibleProvider::new_merge_system_into_user(
             "MiniMax",
-            "https://api.minimax.chat/v1",
+            "https://api.minimaxi.com/v1",
             Some("k"),
             AuthStyle::Bearer,
         );
@@ -4878,7 +4878,7 @@ mod tests {
         ];
         let p = OpenAiCompatibleProvider::new_merge_system_into_user(
             "MiniMax",
-            "https://api.minimax.chat/v1",
+            "https://api.minimaxi.com/v1",
             Some("k"),
             AuthStyle::Bearer,
         );

--- a/docs/book/src/providers/catalog.md
+++ b/docs/book/src/providers/catalog.md
@@ -152,7 +152,7 @@ Verified endpoints:
 | DeepSeek | `https://api.deepseek.com` | `deepseek-chat`, `deepseek-reasoner` |
 | Moonshot | `https://api.moonshot.cn/v1` | `moonshot-v1-32k` |
 | Z.AI / GLM | `https://open.bigmodel.cn/api/paas` | `glm-4-plus` |
-| MiniMax | `https://api.minimax.chat` | `abab6.5s-chat` |
+| MiniMax | `https://api.minimaxi.com/v1` | `MiniMax-M2.7` |
 | Qianfan | `https://qianfan.baidubce.com/v2` | per model |
 | Venice | `https://api.venice.ai/api` | per model |
 | Vercel AI Gateway | `https://gateway.ai.vercel.app` | per model |


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - `docs/book/src/providers/catalog.md` — the MiniMax row pointed at the legacy `api.minimax.chat` endpoint and `abab6.5s-chat` model. Both were stale by 2026 (MiniMax moved off `.chat` and `abab*` well before the M2 line). Updated to `https://api.minimaxi.com/v1` + `MiniMax-M2.7`.
  - `crates/zeroclaw-providers/src/compatible.rs` — six tests hard-coded the same legacy `https://api.minimax.chat/v1` string as input to `OpenAiCompatibleProvider::new` / `new_merge_system_into_user`. Refreshed to `https://api.minimaxi.com/v1` so test fixtures match the catalog and the production constants in `lib.rs:55-58` (`MINIMAX_CN_BASE_URL = "https://api.minimaxi.com/v1"`).
- **Scope boundary:** Catalog row + 6 test-fixture URL strings. **No production code paths touched** — the runtime provider already uses the correct URL via `MINIMAX_INTL_BASE_URL` / `MINIMAX_CN_BASE_URL` constants. The 6 test strings are mocked inputs that never hit the network; this commit is cosmetic consistency only.
- **Blast radius:** None at runtime. Catalog readers get the current endpoint/model. Test code uses a consistent URL string across the file.
- **Linked issue(s):** None.
- **Labels:** `type: docs`, `risk: low`, `size: XS`

## Validation Evidence (required)

```bash
bash scripts/ci/docs_quality_gate.sh
```

- **Commands run and tail output:**

  ```
  Linting docs files: docs/book/src/providers/catalog.md
  markdownlint-cli2 v0.20.0 (markdownlint v0.40.0)
  Finding: docs/book/src/providers/catalog.md !target/**
  Linting: 1 file(s)
  Summary: 0 error(s)
  ```

- **Beyond CI — what did you manually verify?**
  - Catalog change: cross-checked against the in-repo test `compatible.rs::chat_completions_url_minimax` (line 3115) which already uses `https://api.minimaxi.com/v1`, and against production constant `MINIMAX_CN_BASE_URL` in `lib.rs:56`.
  - Live API sanity: `POST https://api.minimaxi.com/v1/chat/completions` with `{"model":"MiniMax-M2.7", ...}` returned `HTTP 200` and a valid chat completion payload.
  - Test-URL change: pure string replacement; no network calls in those tests (they construct mocked providers and inspect generated payloads only). The diff is `s/api.minimax.chat/api.minimaxi.com/` in 6 places, all inside `#[cfg(test)] mod tests`.
- **If any command was intentionally skipped, why:**
  - `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` — **skipped locally** because this dev machine doesn't have a Rust toolchain installed (`rustc not found`, `cargo not found`). Risk is bounded: the source change is 6 string literals inside `#[cfg(test)]` blocks with no behavioral surface — `fmt` and `clippy` cannot care about the bytes of a URL literal, and `cargo test` will exercise the same code paths in CI with the new URL. Happy to push a follow-up if any CI lane fails.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Existing users with `https://api.minimax.chat` configs continue to work if the legacy endpoint still serves (it may not); the catalog now points new users at the supported endpoint.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PR: `git revert <sha>` is the plan unless otherwise noted.