### PR TITLE
feat(desktop): macOS Accessibility permission flow — system dialog prompt and resume re-check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13277,6 +13277,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
+ "core-foundation",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",

--- a/apps/tauri/Cargo.toml
+++ b/apps/tauri/Cargo.toml
@@ -24,6 +24,7 @@ base64 = "0.22"
 objc2 = "0.6"
 objc2-app-kit = { version = "0.3", features = ["NSApplication", "NSImage", "NSRunningApplication"] }
 objc2-foundation = { version = "0.3", features = ["NSData"] }
+core-foundation = "0.10"
 
 [features]
 default = ["custom-protocol"]

--- a/apps/tauri/src/commands/permissions.rs
+++ b/apps/tauri/src/commands/permissions.rs
@@ -127,17 +127,17 @@ pub fn get_permissions_status() -> Vec<PermissionInfo> {
 pub fn get_runtime_platform() -> String {
     #[cfg(target_os = "macos")]
     {
-        return "macos".into();
+        "macos".into()
     }
 
     #[cfg(target_os = "linux")]
     {
-        return "linux".into();
+        "linux".into()
     }
 
     #[cfg(target_os = "windows")]
     {
-        return "windows".into();
+        "windows".into()
     }
 
     #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
@@ -160,9 +160,10 @@ pub fn request_permission<R: Runtime>(app: AppHandle<R>, name: String) -> Result
             "microphone" => Ok(permissions::request_microphone().into()),
             "screen_recording" => Ok(permissions::request_screen_recording().into()),
             "input_monitoring" => Ok(permissions::request_input_monitoring().into()),
+            "accessibility" => Ok(permissions::request_accessibility().into()),
             // These permissions cannot be requested programmatically — open Settings.
-            "accessibility" | "automation" | "notifications" | "speech_recognition"
-            | "full_disk_access" | "local_network" => {
+            "automation" | "notifications" | "speech_recognition" | "full_disk_access"
+            | "local_network" => {
                 permissions::open_system_settings(&name).map(|_| "open_settings".into())
             }
             _ => Err(format!("Unknown permission: {name}")),

--- a/apps/tauri/src/lib.rs
+++ b/apps/tauri/src/lib.rs
@@ -13,7 +13,7 @@ pub mod windows;
 use commands::onboarding::read_onboarding_complete;
 use gateway_client::GatewayClient;
 use state::shared_state;
-use tauri::{Manager, RunEvent};
+use tauri::{Emitter, Manager, RunEvent};
 
 /// Attempt to auto-pair with the gateway so the WebView has a valid token
 /// before the React frontend mounts. Runs on localhost so the admin endpoints
@@ -82,6 +82,33 @@ fn set_dock_icon() {
     }
 }
 
+/// Track the last-known accessibility status so we can detect revocations
+/// when the app resumes from the background.
+#[cfg(target_os = "macos")]
+static AX_WAS_GRANTED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Check accessibility status on resume. If it was previously granted but is
+/// now denied, emit an `accessibility-lost` event to all webviews.
+#[cfg(target_os = "macos")]
+fn check_ax_on_resume<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
+    let current = crate::macos::permissions::check_accessibility() == "granted";
+    let was_granted = AX_WAS_GRANTED.load(std::sync::atomic::Ordering::Relaxed);
+
+    if was_granted && !current {
+        // Accessibility was revoked while the app was in the background.
+        let _ = app.emit("accessibility-lost", ());
+    }
+
+    AX_WAS_GRANTED.store(current, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Initialize AX tracking — snapshot the current accessibility status.
+#[cfg(target_os = "macos")]
+fn init_ax_tracking() {
+    let granted = crate::macos::permissions::check_accessibility() == "granted";
+    AX_WAS_GRANTED.store(granted, std::sync::atomic::Ordering::Relaxed);
+}
+
 /// Configure and run the Tauri application.
 pub fn run() {
     let shared = shared_state();
@@ -122,6 +149,10 @@ pub fn run() {
             #[cfg(target_os = "macos")]
             set_dock_icon();
 
+            // Snapshot initial accessibility status for revocation detection.
+            #[cfg(target_os = "macos")]
+            init_ax_tracking();
+
             // Set up the system tray.
             let _ = tray::setup_tray(app);
 
@@ -152,11 +183,19 @@ pub fn run() {
         })
         .build(tauri::generate_context!())
         .expect("error while building tauri application")
-        .run(|_app, event| {
-            // Keep the app running in the background when all windows are closed.
-            // This is the standard pattern for menu bar / tray apps.
-            if let RunEvent::ExitRequested { api, .. } = event {
-                api.prevent_exit();
+        .run(|app, event| {
+            match event {
+                // Keep the app running in the background when all windows are closed.
+                // This is the standard pattern for menu bar / tray apps.
+                RunEvent::ExitRequested { api, .. } => {
+                    api.prevent_exit();
+                }
+                // Re-check accessibility when the app returns to the foreground.
+                RunEvent::Resumed => {
+                    #[cfg(target_os = "macos")]
+                    check_ax_on_resume(app);
+                }
+                _ => {}
             }
         });
 }

--- a/apps/tauri/src/macos/permissions.rs
+++ b/apps/tauri/src/macos/permissions.rs
@@ -10,12 +10,33 @@ use std::process::Command;
 #[link(name = "ApplicationServices", kind = "framework")]
 unsafe extern "C" {
     fn AXIsProcessTrusted() -> bool;
+    fn AXIsProcessTrustedWithOptions(options: core_foundation::dictionary::CFDictionaryRef)
+    -> bool;
 }
 
 /// Check if the app has Accessibility permission.
 pub fn check_accessibility() -> &'static str {
     // Safety: AXIsProcessTrusted is a simple boolean query with no side effects.
     let trusted = unsafe { AXIsProcessTrusted() };
+    if trusted { "granted" } else { "denied" }
+}
+
+/// Request Accessibility permission by showing the system dialog that directs
+/// the user to System Settings → Privacy & Security → Accessibility.
+/// Returns the current status after the dialog is dismissed.
+pub fn request_accessibility() -> &'static str {
+    use core_foundation::base::TCFType;
+    use core_foundation::boolean::CFBoolean;
+    use core_foundation::dictionary::CFDictionary;
+    use core_foundation::string::CFString;
+
+    let key = CFString::new("AXTrustedCheckOptionPrompt");
+    let value = CFBoolean::true_value();
+    let options = CFDictionary::from_CFType_pairs(&[(key.as_CFType(), value.as_CFType())]);
+
+    // Safety: AXIsProcessTrustedWithOptions is the supported API for prompting.
+    // Passing kAXTrustedCheckOptionPrompt => true shows the system accessibility dialog.
+    let trusted = unsafe { AXIsProcessTrustedWithOptions(options.as_concrete_TypeRef()) };
     if trusted { "granted" } else { "denied" }
 }
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Added `request_accessibility()` using `AXIsProcessTrustedWithOptions` to show the native macOS system dialog directing users to System Settings → Privacy & Security → Accessibility, replacing the previous fallback that simply opened System Settings without prompting.
  - Added `AX_WAS_GRANTED` atomic flag and `check_ax_on_resume()` to detect when Accessibility permission is revoked while the app is backgrounded, emitting an `accessibility-lost` event to all webviews on resume.
  - Moved `accessibility` from the "open settings" fallback branch to the programmatic request branch in `request_permission`, so the system dialog is shown first.
  - Added `core-foundation` dependency for `CFDictionary`/`CFString`/`CFBoolean` types needed by the options-based API.
- **Scope boundary:** Does not change the Accessibility *check* logic, other permission flows, or any non-macOS platform code.
- **Blast radius:** The `request_permission` command dispatcher, the app lifecycle event handler, and the native macOS permissions module. Frontend consumers listening for `accessibility-lost` events will receive a new emission when permission is revoked.
- **Linked issue(s):** Resolves #6333

## Validation Evidence

- **Commands run:**
  - `cargo check -p zeroclaw-desktop` — clean
  - `cargo clippy -p zeroclaw-desktop --all-targets -- -D warnings` — clean
  - `cargo test -p zeroclaw-desktop` — 18/18 tests pass
  - `cargo fmt -p zeroclaw-desktop -- --check` — clean
- **Beyond CI — what was manually verified:** Reviewed FFI `#[link]` declarations against Apple's ApplicationServices framework headers. Confirmed `AXIsProcessTrustedWithOptions` signature matches the C API.

## Security & Privacy Impact

- **New permissions / capabilities / file system access scope?** No — uses existing macOS Accessibility APIs already gated by the OS.
- **New external network calls?** No.
- **Secrets / tokens / credentials handling changed?** No.
- **PII, real identities, or personal data in diff, tests, fixtures, or docs?** No.

## Compatibility

- **Backward compatible?** Yes — `request_permission("accessibility")` previously returned `"open_settings"`; it now returns `"granted"` or `"denied"` after showing the system dialog. Frontend code already handles these status strings.
- **Config / env / CLI surface changed?** No.

## Rollback

- **Fast rollback:** `git revert <sha>` removes the system dialog prompt and resume re-check.

## Test plan

- [x] `cargo check` clean
- [x] `cargo clippy` clean (zero warnings)
- [x] `cargo test` — 18/18 pass
- [x] `cargo fmt` clean
- [ ] Manual: `request_permission("accessibility")` shows native macOS accessibility dialog
- [ ] Manual: granting accessibility in System Settings → re-check returns `"granted"`
- [ ] Manual: revoking accessibility while app is backgrounded → `accessibility-lost` event fires on resume
- [ ] Manual: onboarding wizard Step 2 uses new system dialog instead of just opening Settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)