### PR TITLE
feat(desktop): input monitoring permission flow — resume re-check and revocation detection

### DIFF
--- a/apps/tauri/src/commands/permissions.rs
+++ b/apps/tauri/src/commands/permissions.rs
@@ -127,17 +127,17 @@ pub fn get_permissions_status() -> Vec<PermissionInfo> {
 pub fn get_runtime_platform() -> String {
     #[cfg(target_os = "macos")]
     {
-        return "macos".into();
+        "macos".into()
     }
 
     #[cfg(target_os = "linux")]
     {
-        return "linux".into();
+        "linux".into()
     }
 
     #[cfg(target_os = "windows")]
     {
-        return "windows".into();
+        "windows".into()
     }
 
     #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]

--- a/apps/tauri/src/lib.rs
+++ b/apps/tauri/src/lib.rs
@@ -13,7 +13,7 @@ pub mod windows;
 use commands::onboarding::read_onboarding_complete;
 use gateway_client::GatewayClient;
 use state::shared_state;
-use tauri::{Manager, RunEvent};
+use tauri::{Emitter, Manager, RunEvent};
 
 /// Attempt to auto-pair with the gateway so the WebView has a valid token
 /// before the React frontend mounts. Runs on localhost so the admin endpoints
@@ -82,6 +82,32 @@ fn set_dock_icon() {
     }
 }
 
+/// Track the last-known input monitoring status so we can detect revocations
+/// when the app resumes from the background.
+#[cfg(target_os = "macos")]
+static INPUT_WAS_GRANTED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Check input monitoring status on resume. If it was previously granted but
+/// is now denied, emit an `input-monitoring-lost` event to all webviews.
+#[cfg(target_os = "macos")]
+fn check_input_on_resume<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
+    let current = crate::macos::permissions::check_input_monitoring() == "granted";
+    let was_granted = INPUT_WAS_GRANTED.load(std::sync::atomic::Ordering::Relaxed);
+
+    if was_granted && !current {
+        let _ = app.emit("input-monitoring-lost", ());
+    }
+
+    INPUT_WAS_GRANTED.store(current, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Initialize input monitoring tracking — snapshot the current status.
+#[cfg(target_os = "macos")]
+fn init_input_tracking() {
+    let granted = crate::macos::permissions::check_input_monitoring() == "granted";
+    INPUT_WAS_GRANTED.store(granted, std::sync::atomic::Ordering::Relaxed);
+}
+
 /// Configure and run the Tauri application.
 pub fn run() {
     let shared = shared_state();
@@ -122,6 +148,10 @@ pub fn run() {
             #[cfg(target_os = "macos")]
             set_dock_icon();
 
+            // Snapshot initial input monitoring status for revocation detection.
+            #[cfg(target_os = "macos")]
+            init_input_tracking();
+
             // Set up the system tray.
             let _ = tray::setup_tray(app);
 
@@ -152,11 +182,19 @@ pub fn run() {
         })
         .build(tauri::generate_context!())
         .expect("error while building tauri application")
-        .run(|_app, event| {
-            // Keep the app running in the background when all windows are closed.
-            // This is the standard pattern for menu bar / tray apps.
-            if let RunEvent::ExitRequested { api, .. } = event {
-                api.prevent_exit();
+        .run(|app, event| {
+            match event {
+                // Keep the app running in the background when all windows are closed.
+                // This is the standard pattern for menu bar / tray apps.
+                RunEvent::ExitRequested { api, .. } => {
+                    api.prevent_exit();
+                }
+                // Re-check input monitoring when the app returns to the foreground.
+                RunEvent::Resumed => {
+                    #[cfg(target_os = "macos")]
+                    check_input_on_resume(app);
+                }
+                _ => {}
             }
         });
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Added `INPUT_WAS_GRANTED` atomic flag to track last-known input monitoring permission status.
  - Added `check_input_on_resume()` to re-check input monitoring on `RunEvent::Resumed` and emit `input-monitoring-lost` event to all webviews if permission was revoked while the app was backgrounded.
  - Added `init_input_tracking()` to snapshot initial input monitoring status on app launch.
  - `request_input_monitoring()` already triggers the native IOKit system dialog — no changes needed there.
- **Scope boundary:** Does not change the IOKit FFI bindings, the onboarding wizard, or other permission flows. No new dependencies.
- **Blast radius:** App lifecycle handler in `lib.rs` only. The `input-monitoring-lost` event is new — frontend consumers can listen for it to show re-grant prompts.
- **Linked issue(s):** Resolves #6482

## Validation Evidence

- **Commands run:**
  - `cargo check -p zeroclaw-desktop` — clean
  - `cargo clippy -p zeroclaw-desktop --all-targets -- -D warnings` — clean
  - `cargo test -p zeroclaw-desktop` — 18/18 tests pass
  - `cargo fmt -p zeroclaw-desktop -- --check` — clean

## Security & Privacy Impact

- **New permissions / capabilities / file system access scope?** No — uses existing IOKit input monitoring check API.
- **New external network calls?** No.
- **Secrets / tokens / credentials handling changed?** No.
- **PII, real identities, or personal data in diff, tests, fixtures, or docs?** No.

## Compatibility

- **Backward compatible?** Yes — purely additive. Existing commands unchanged.
- **Config / env / CLI surface changed?** No.

## Rollback

- **Fast rollback:** `git revert <sha>` removes the resume re-check.

## Test plan

- [x] `cargo check` clean
- [x] `cargo clippy` clean (zero warnings)
- [x] `cargo test` — 18/18 pass
- [x] `cargo fmt` clean
- [ ] Manual: revoking Input Monitoring in System Settings while app is backgrounded → `input-monitoring-lost` event fires on resume
- [ ] Manual: `request_permission("input_monitoring")` triggers IOKit system dialog
- [ ] Manual: global hotkeys detect permission loss and show re-grant prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)