### PR TITLE
fix(web): 0.8.0 ui fixes

### DIFF
--- a/web/src/components/layout/ReloadBanner.tsx
+++ b/web/src/components/layout/ReloadBanner.tsx
@@ -60,7 +60,7 @@ export default function ReloadBanner() {
 
   return (
     <div
-      className="px-4 py-3 border-b flex items-start gap-3"
+      className="px-4 py-3 border-b flex items-center gap-3"
       style={{
         background: 'rgba(245, 180, 0, 0.06)',
         borderColor: 'rgba(245, 180, 0, 0.25)',

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -431,6 +431,7 @@ const translations: Record<Locale, Record<string, string>> = {
     'dashboard.overview': 'Overview',
     'dashboard.system_info': 'System Information',
     'dashboard.quick_actions': 'Quick Actions',
+    'dashboard.add_memory': 'Add memory',
 
     // Agent / Chat
     'agent.title': 'Agent Chat',

--- a/web/src/pages/Cron.tsx
+++ b/web/src/pages/Cron.tsx
@@ -547,7 +547,7 @@ export default function Cron() {
       {/* Unified Add / Edit Modal */}
       {modalJob !== null && (
         <div className="fixed inset-0 modal-backdrop flex items-center justify-center z-50">
-          <div className="surface-panel p-6 w-full max-w-md mx-4 animate-fade-in-scale mt-15">
+          <div className="surface-panel p-6 w-full max-w-md mx-4 animate-fade-in-scale mt-15 max-h-9/10 overflow-auto">
             <div className="flex items-center justify-between mb-4">
               <h3 className="text-lg font-semibold" style={{ color: 'var(--pc-text-primary)' }}>
                 {isEditing ? t('cron.edit_modal_title') : t('cron.add_modal_title')}

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -1941,7 +1941,7 @@ function MemoriesTab() {
           title="Add a memory entry"
         >
           <Plus className="h-3 w-3" />
-          Add memory
+          {t('dashboard.add_memory')}
         </button>
 
         <div className="ml-auto flex items-center gap-2 flex-wrap">
@@ -2109,7 +2109,7 @@ function MemoriesTab() {
                 className="text-lg font-semibold"
                 style={{ color: 'var(--pc-text-primary)' }}
               >
-                Add memory
+                {t('dashboard.add_memory')}
               </h3>
               <button
                 type="button"

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -2029,7 +2029,7 @@ function MemoriesTab() {
           {visibleEntries.map((entry) => (
             <div
               key={entry.id}
-              className="flex items-start justify-between gap-3 py-3 px-4 rounded-xl"
+              className="flex items-center justify-between gap-3 py-3 px-4 rounded-xl"
               style={{ background: 'var(--pc-bg-elevated)' }}
             >
               <div className="flex-1 min-w-0">


### PR DESCRIPTION
@singlerider 

1) reload banner message align center
Before:
<img width="3456" height="1698" alt="image" src="https://github.com/user-attachments/assets/1b46a107-e7d7-4c93-b737-c066904a1eea" />

After:
<img width="3456" height="1693" alt="image" src="https://github.com/user-attachments/assets/f5afc3c3-a1d3-4313-af28-cc18f78b1fad" />

2) scheduled jobs
Before:
<img width="3038" height="1344" alt="image" src="https://github.com/user-attachments/assets/7f76d160-2a79-467b-a648-ca724b1ae183" />

After:
<img width="3456" height="1699" alt="image" src="https://github.com/user-attachments/assets/8ed8290b-423d-490e-bf98-2fc0ffebd399" />

3) Memory actions
Before:
<img width="3219" height="278" alt="image" src="https://github.com/user-attachments/assets/7e9e70f3-1d8a-429d-b930-6cb671ba2014" />

After:
<img width="2900" height="334" alt="image" src="https://github.com/user-attachments/assets/e3b6c190-827a-4d64-8038-5268d1a247d4" />
