### PR TITLE
email: migrate pub fn is_sender_allowed(&self, email: &str) -> bool → AllowlistAspect (archetype C)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,13 +274,15 @@ checksum = "9dbc3a507a82b17ba0d98f6ce8fd6954ea0c8152e98009d36a40d8dcc8ce078a"
 
 [[package]]
 name = "aspect-core"
-version = "0.1.0"
-source = "git+https://github.com/yijunyu/aspect-rs?rev=c31f453#c31f453509057cdef97f880daea3c3aed5d23bb0"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fd3e7f9100f7ae656584c40356ef60e2794da98b45acae5a51b6427ce20f60c"
 
 [[package]]
 name = "aspect-std"
-version = "0.1.0"
-source = "git+https://github.com/yijunyu/aspect-rs?rev=c31f453#c31f453509057cdef97f880daea3c3aed5d23bb0"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1abc65dfa3766d751105bc9a4ee8af5cfa0d4edf56a925f57eb9edeac4e58c"
 dependencies = [
  "aspect-core",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,12 +275,12 @@ checksum = "9dbc3a507a82b17ba0d98f6ce8fd6954ea0c8152e98009d36a40d8dcc8ce078a"
 [[package]]
 name = "aspect-core"
 version = "0.1.0"
-source = "git+https://github.com/yijunyu/aspect-rs?rev=239ba1d#239ba1d0089dfac61fdc85319d63f20b704885b8"
+source = "git+https://github.com/yijunyu/aspect-rs?rev=c31f453#c31f453509057cdef97f880daea3c3aed5d23bb0"
 
 [[package]]
 name = "aspect-std"
 version = "0.1.0"
-source = "git+https://github.com/yijunyu/aspect-rs?rev=239ba1d#239ba1d0089dfac61fdc85319d63f20b704885b8"
+source = "git+https://github.com/yijunyu/aspect-rs?rev=c31f453#c31f453509057cdef97f880daea3c3aed5d23bb0"
 dependencies = [
  "aspect-core",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,6 +273,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dbc3a507a82b17ba0d98f6ce8fd6954ea0c8152e98009d36a40d8dcc8ce078a"
 
 [[package]]
+name = "aspect-core"
+version = "0.1.0"
+source = "git+https://github.com/yijunyu/aspect-rs?rev=239ba1d#239ba1d0089dfac61fdc85319d63f20b704885b8"
+
+[[package]]
+name = "aspect-std"
+version = "0.1.0"
+source = "git+https://github.com/yijunyu/aspect-rs?rev=239ba1d#239ba1d0089dfac61fdc85319d63f20b704885b8"
+dependencies = [
+ "aspect-core",
+ "log",
+ "parking_lot",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13165,6 +13180,7 @@ version = "0.7.5"
 dependencies = [
  "aes",
  "anyhow",
+ "aspect-std",
  "async-imap",
  "async-trait",
  "axum",

--- a/crates/zeroclaw-channels/Cargo.toml
+++ b/crates/zeroclaw-channels/Cargo.toml
@@ -18,7 +18,7 @@ zeroclaw-tools.workspace = true
 # talk to the bot" check, replacing 20+ near-identical hand-rolled
 # `fn is_user_allowed` implementations across channel modules. Pinned to a
 # specific commit until aspect-rs publishes a 0.1 release on crates.io.
-aspect-std = { git = "https://github.com/yijunyu/aspect-rs", rev = "239ba1d" }
+aspect-std = { git = "https://github.com/yijunyu/aspect-rs", rev = "c31f453" }
 anyhow = "1.0"
 lru = "0.16"
 rumqttc = "0.25"

--- a/crates/zeroclaw-channels/Cargo.toml
+++ b/crates/zeroclaw-channels/Cargo.toml
@@ -16,9 +16,8 @@ zeroclaw-runtime.workspace = true
 zeroclaw-tools.workspace = true
 # AOP support: AllowlistAspect provides the per-channel "who is allowed to
 # talk to the bot" check, replacing 20+ near-identical hand-rolled
-# `fn is_user_allowed` implementations across channel modules. Pinned to a
-# specific commit until aspect-rs publishes a 0.1 release on crates.io.
-aspect-std = { git = "https://github.com/yijunyu/aspect-rs", rev = "c31f453" }
+# `fn is_user_allowed` implementations across channel modules.
+aspect-std = "0.1.1"
 anyhow = "1.0"
 lru = "0.16"
 rumqttc = "0.25"

--- a/crates/zeroclaw-channels/Cargo.toml
+++ b/crates/zeroclaw-channels/Cargo.toml
@@ -14,6 +14,11 @@ zeroclaw-memory.workspace = true
 zeroclaw-providers.workspace = true
 zeroclaw-runtime.workspace = true
 zeroclaw-tools.workspace = true
+# AOP support: AllowlistAspect provides the per-channel "who is allowed to
+# talk to the bot" check, replacing 20+ near-identical hand-rolled
+# `fn is_user_allowed` implementations across channel modules. Pinned to a
+# specific commit until aspect-rs publishes a 0.1 release on crates.io.
+aspect-std = { git = "https://github.com/yijunyu/aspect-rs", rev = "239ba1d" }
 anyhow = "1.0"
 lru = "0.16"
 rumqttc = "0.25"

--- a/crates/zeroclaw-channels/src/discord.rs
+++ b/crates/zeroclaw-channels/src/discord.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context as _, anyhow};
+use aspect_std::AllowlistAspect;
 use async_trait::async_trait;
 use futures_util::{SinkExt, StreamExt};
 use parking_lot::Mutex;
@@ -21,7 +22,11 @@ use zeroclaw_api::media::MediaAttachment;
 pub struct DiscordChannel {
     bot_token: String,
     guild_id: Option<String>,
-    allowed_users: Vec<String>,
+    /// Who is allowed to talk to this bot. Wildcard `"*"` admits everyone;
+    /// an empty list denies everyone. Backed by `aspect-std`'s
+    /// `AllowlistAspect` so the check is centralized and reusable across
+    /// channels rather than re-implemented per-module.
+    allowlist: AllowlistAspect,
     listen_to_bots: bool,
     mention_only: bool,
     typing_handles: Mutex<HashMap<String, tokio::task::JoinHandle<()>>>,
@@ -66,10 +71,30 @@ impl DiscordChannel {
         listen_to_bots: bool,
         mention_only: bool,
     ) -> Self {
+        Self::with_allowlist(
+            bot_token,
+            guild_id,
+            AllowlistAspect::new(allowed_users),
+            listen_to_bots,
+            mention_only,
+        )
+    }
+
+    /// Construct from an existing `AllowlistAspect`. Used internally when
+    /// spawning a reaction-worker `DiscordChannel` so the worker shares the
+    /// parent's allowlist `Arc<Inner>` (cheap clone, no `Vec` allocation,
+    /// and runtime allowlist changes propagate to the worker).
+    fn with_allowlist(
+        bot_token: String,
+        guild_id: Option<String>,
+        allowlist: AllowlistAspect,
+        listen_to_bots: bool,
+        mention_only: bool,
+    ) -> Self {
         Self {
             bot_token,
             guild_id,
-            allowed_users,
+            allowlist,
             listen_to_bots,
             mention_only,
             typing_handles: Mutex::new(HashMap::new()),
@@ -153,13 +178,6 @@ impl DiscordChannel {
             "channel.discord",
             self.proxy_url.as_deref(),
         )
-    }
-
-    /// Check if a Discord user ID is in the allowlist.
-    /// Empty list means deny everyone until explicitly configured.
-    /// `"*"` means allow everyone.
-    fn is_user_allowed(&self, user_id: &str) -> bool {
-        self.allowed_users.iter().any(|u| u == "*" || u == user_id)
     }
 
     fn bot_user_id_from_token(token: &str) -> Option<String> {
@@ -1459,7 +1477,7 @@ impl Channel for DiscordChannel {
                     }
 
                     // Sender validation
-                    if !self.is_user_allowed(author_id) {
+                    if !self.allowlist.is_allowed(author_id) {
                         tracing::warn!("Discord: ignoring message from unauthorized user: {author_id}");
                         continue;
                     }
@@ -1528,10 +1546,10 @@ impl Channel for DiscordChannel {
                         .to_string();
 
                     if !message_id.is_empty() && !channel_id.is_empty() {
-                        let reaction_channel = DiscordChannel::new(
+                        let reaction_channel = DiscordChannel::with_allowlist(
                             self.bot_token.clone(),
                             self.guild_id.clone(),
-                            self.allowed_users.clone(),
+                            self.allowlist.clone(),
                             self.listen_to_bots,
                             self.mention_only,
                         );
@@ -2107,15 +2125,15 @@ mod tests {
     #[test]
     fn empty_allowlist_denies_everyone() {
         let ch = DiscordChannel::new("fake".into(), None, vec![], false, false);
-        assert!(!ch.is_user_allowed("12345"));
-        assert!(!ch.is_user_allowed("anyone"));
+        assert!(!ch.allowlist.is_allowed("12345"));
+        assert!(!ch.allowlist.is_allowed("anyone"));
     }
 
     #[test]
     fn wildcard_allows_everyone() {
         let ch = DiscordChannel::new("fake".into(), None, vec!["*".into()], false, false);
-        assert!(ch.is_user_allowed("12345"));
-        assert!(ch.is_user_allowed("anyone"));
+        assert!(ch.allowlist.is_allowed("12345"));
+        assert!(ch.allowlist.is_allowed("anyone"));
     }
 
     #[test]
@@ -2127,24 +2145,24 @@ mod tests {
             false,
             false,
         );
-        assert!(ch.is_user_allowed("111"));
-        assert!(ch.is_user_allowed("222"));
-        assert!(!ch.is_user_allowed("333"));
-        assert!(!ch.is_user_allowed("unknown"));
+        assert!(ch.allowlist.is_allowed("111"));
+        assert!(ch.allowlist.is_allowed("222"));
+        assert!(!ch.allowlist.is_allowed("333"));
+        assert!(!ch.allowlist.is_allowed("unknown"));
     }
 
     #[test]
     fn allowlist_is_exact_match_not_substring() {
         let ch = DiscordChannel::new("fake".into(), None, vec!["111".into()], false, false);
-        assert!(!ch.is_user_allowed("1111"));
-        assert!(!ch.is_user_allowed("11"));
-        assert!(!ch.is_user_allowed("0111"));
+        assert!(!ch.allowlist.is_allowed("1111"));
+        assert!(!ch.allowlist.is_allowed("11"));
+        assert!(!ch.allowlist.is_allowed("0111"));
     }
 
     #[test]
     fn allowlist_empty_string_user_id() {
         let ch = DiscordChannel::new("fake".into(), None, vec!["111".into()], false, false);
-        assert!(!ch.is_user_allowed(""));
+        assert!(!ch.allowlist.is_allowed(""));
     }
 
     #[test]
@@ -2156,16 +2174,57 @@ mod tests {
             false,
             false,
         );
-        assert!(ch.is_user_allowed("111"));
-        assert!(ch.is_user_allowed("anyone_else"));
+        assert!(ch.allowlist.is_allowed("111"));
+        assert!(ch.allowlist.is_allowed("anyone_else"));
     }
 
     #[test]
     fn allowlist_case_sensitive() {
         let ch = DiscordChannel::new("fake".into(), None, vec!["ABC".into()], false, false);
-        assert!(ch.is_user_allowed("ABC"));
-        assert!(!ch.is_user_allowed("abc"));
-        assert!(!ch.is_user_allowed("Abc"));
+        assert!(ch.allowlist.is_allowed("ABC"));
+        assert!(!ch.allowlist.is_allowed("abc"));
+        assert!(!ch.allowlist.is_allowed("Abc"));
+    }
+
+    /// Parity test for the AllowlistAspect migration. Asserts that the
+    /// post-migration `allowlist.is_allowed(...)` returns byte-identical
+    /// results to the pre-migration shape
+    /// `allowed.iter().any(|u| u == "*" || u == id)` for a fixed truth table
+    /// covering the wildcard, empty-list, case-sensitivity, and substring
+    /// edge cases. If any reviewer worries the aspect drifted from the
+    /// original Boolean semantics, this test is the regression guard.
+    #[test]
+    fn allowlist_parity_with_pre_aspect_shape() {
+        let cases: Vec<(Vec<&str>, &str)> = vec![
+            (vec![], "alice"),
+            (vec![], ""),
+            (vec!["*"], "alice"),
+            (vec!["*"], ""),
+            (vec!["111"], "111"),
+            (vec!["111"], "112"),
+            (vec!["111", "222"], "222"),
+            (vec!["111", "*"], "anyone"),
+            (vec!["*", "111"], "anyone"),
+            (vec!["111"], "1111"), // substring rejected
+            (vec!["111"], "11"),   // prefix rejected
+            (vec!["ABC"], "abc"),  // case-sensitive
+            (vec!["ABC"], "Abc"),
+        ];
+        for (entries, identity) in cases {
+            let baseline = entries.iter().any(|u| *u == "*" || *u == identity);
+            let ch = DiscordChannel::new(
+                "fake".into(),
+                None,
+                entries.iter().map(|s| (*s).to_string()).collect(),
+                false,
+                false,
+            );
+            assert_eq!(
+                ch.allowlist.is_allowed(identity),
+                baseline,
+                "aspect drift for entries={entries:?} identity={identity:?}",
+            );
+        }
     }
 
     #[test]

--- a/crates/zeroclaw-channels/src/email_channel.rs
+++ b/crates/zeroclaw-channels/src/email_channel.rs
@@ -9,6 +9,7 @@
 #![allow(clippy::unnecessary_map_or)]
 
 use anyhow::{Result, anyhow};
+use aspect_std::AllowlistAspect;
 use async_imap::Session;
 use async_imap::extensions::idle::IdleResponse;
 use async_imap::types::Fetch;
@@ -38,41 +39,42 @@ pub use zeroclaw_config::scattered_types::EmailConfig;
 
 type ImapSession = Session<TlsStream<TcpStream>>;
 
+/// Email-allowlist matcher: allows an `entry` to be a full email
+/// (`"alice@example.com"`), a domain with `@` prefix (`"@example.com"`),
+/// or a bare domain (`"example.com"`). All comparisons are
+/// ASCII-case-insensitive. Used as the `.with_matcher(...)` predicate
+/// when constructing the email-channel `AllowlistAspect`.
+pub(crate) fn email_allowlist_match(entry: &str, email: &str) -> bool {
+    let email_lower = email.to_ascii_lowercase();
+    if let Some(domain) = entry.strip_prefix('@') {
+        email_lower.ends_with(&format!("@{}", domain.to_ascii_lowercase()))
+    } else if entry.contains('@') {
+        entry.eq_ignore_ascii_case(email)
+    } else {
+        email_lower.ends_with(&format!("@{}", entry.to_ascii_lowercase()))
+    }
+}
+
 /// Email channel — IMAP IDLE for instant push notifications, SMTP for outbound
 pub struct EmailChannel {
     pub config: EmailConfig,
+    /// Centralized allowlist check (see `aspect_std::AllowlistAspect`).
+    /// Built once from `config.allowed_senders`; the matcher implements
+    /// the full-email / `@domain` / bare-domain semantics shared with
+    /// the Gmail push channel.
+    allowlist: AllowlistAspect,
     seen_messages: Arc<Mutex<HashSet<String>>>,
 }
 
 impl EmailChannel {
     pub fn new(config: EmailConfig) -> Self {
+        let allowlist = AllowlistAspect::new(config.allowed_senders.clone())
+            .with_matcher(email_allowlist_match);
         Self {
             config,
+            allowlist,
             seen_messages: Arc::new(Mutex::new(HashSet::new())),
         }
-    }
-
-    /// Check if a sender email is in the allowlist
-    pub fn is_sender_allowed(&self, email: &str) -> bool {
-        if self.config.allowed_senders.is_empty() {
-            return false; // Empty = deny all
-        }
-        if self.config.allowed_senders.iter().any(|a| a == "*") {
-            return true; // Wildcard = allow all
-        }
-        let email_lower = email.to_lowercase();
-        self.config.allowed_senders.iter().any(|allowed| {
-            if allowed.starts_with('@') {
-                // Domain match with @ prefix: "@example.com"
-                email_lower.ends_with(&allowed.to_lowercase())
-            } else if allowed.contains('@') {
-                // Full email address match
-                allowed.eq_ignore_ascii_case(email)
-            } else {
-                // Domain match without @ prefix: "example.com"
-                email_lower.ends_with(&format!("@{}", allowed.to_lowercase()))
-            }
-        })
     }
 
     /// Strip HTML tags from content (basic)
@@ -474,7 +476,7 @@ impl EmailChannel {
 
         for email in messages {
             // Check allowlist
-            if !self.is_sender_allowed(&email.sender) {
+            if !self.allowlist.is_allowed(&email.sender) {
                 warn!("Blocked email from {}", email.sender);
                 continue;
             }
@@ -812,8 +814,8 @@ mod tests {
             ..Default::default()
         };
         let channel = EmailChannel::new(config);
-        assert!(!channel.is_sender_allowed("anyone@example.com"));
-        assert!(!channel.is_sender_allowed("user@test.com"));
+        assert!(!channel.allowlist.is_allowed("anyone@example.com"));
+        assert!(!channel.allowlist.is_allowed("user@test.com"));
     }
 
     #[test]
@@ -823,9 +825,9 @@ mod tests {
             ..Default::default()
         };
         let channel = EmailChannel::new(config);
-        assert!(channel.is_sender_allowed("anyone@example.com"));
-        assert!(channel.is_sender_allowed("user@test.com"));
-        assert!(channel.is_sender_allowed("random@domain.org"));
+        assert!(channel.allowlist.is_allowed("anyone@example.com"));
+        assert!(channel.allowlist.is_allowed("user@test.com"));
+        assert!(channel.allowlist.is_allowed("random@domain.org"));
     }
 
     #[test]
@@ -835,9 +837,9 @@ mod tests {
             ..Default::default()
         };
         let channel = EmailChannel::new(config);
-        assert!(channel.is_sender_allowed("allowed@example.com"));
-        assert!(!channel.is_sender_allowed("other@example.com"));
-        assert!(!channel.is_sender_allowed("allowed@other.com"));
+        assert!(channel.allowlist.is_allowed("allowed@example.com"));
+        assert!(!channel.allowlist.is_allowed("other@example.com"));
+        assert!(!channel.allowlist.is_allowed("allowed@other.com"));
     }
 
     #[test]
@@ -847,9 +849,9 @@ mod tests {
             ..Default::default()
         };
         let channel = EmailChannel::new(config);
-        assert!(channel.is_sender_allowed("user@example.com"));
-        assert!(channel.is_sender_allowed("admin@example.com"));
-        assert!(!channel.is_sender_allowed("user@other.com"));
+        assert!(channel.allowlist.is_allowed("user@example.com"));
+        assert!(channel.allowlist.is_allowed("admin@example.com"));
+        assert!(!channel.allowlist.is_allowed("user@other.com"));
     }
 
     #[test]
@@ -859,9 +861,9 @@ mod tests {
             ..Default::default()
         };
         let channel = EmailChannel::new(config);
-        assert!(channel.is_sender_allowed("user@example.com"));
-        assert!(channel.is_sender_allowed("admin@example.com"));
-        assert!(!channel.is_sender_allowed("user@other.com"));
+        assert!(channel.allowlist.is_allowed("user@example.com"));
+        assert!(channel.allowlist.is_allowed("admin@example.com"));
+        assert!(!channel.allowlist.is_allowed("user@other.com"));
     }
 
     #[test]
@@ -871,9 +873,9 @@ mod tests {
             ..Default::default()
         };
         let channel = EmailChannel::new(config);
-        assert!(channel.is_sender_allowed("allowed@example.com"));
-        assert!(channel.is_sender_allowed("ALLOWED@EXAMPLE.COM"));
-        assert!(channel.is_sender_allowed("AlLoWeD@eXaMpLe.cOm"));
+        assert!(channel.allowlist.is_allowed("allowed@example.com"));
+        assert!(channel.allowlist.is_allowed("ALLOWED@EXAMPLE.COM"));
+        assert!(channel.allowlist.is_allowed("AlLoWeD@eXaMpLe.cOm"));
     }
 
     #[test]
@@ -887,10 +889,10 @@ mod tests {
             ..Default::default()
         };
         let channel = EmailChannel::new(config);
-        assert!(channel.is_sender_allowed("user1@example.com"));
-        assert!(channel.is_sender_allowed("user2@test.com"));
-        assert!(channel.is_sender_allowed("anyone@allowed.com"));
-        assert!(!channel.is_sender_allowed("user3@example.com"));
+        assert!(channel.allowlist.is_allowed("user1@example.com"));
+        assert!(channel.allowlist.is_allowed("user2@test.com"));
+        assert!(channel.allowlist.is_allowed("anyone@allowed.com"));
+        assert!(!channel.allowlist.is_allowed("user3@example.com"));
     }
 
     #[test]
@@ -900,8 +902,8 @@ mod tests {
             ..Default::default()
         };
         let channel = EmailChannel::new(config);
-        assert!(channel.is_sender_allowed("anyone@example.com"));
-        assert!(channel.is_sender_allowed("specific@example.com"));
+        assert!(channel.allowlist.is_allowed("anyone@example.com"));
+        assert!(channel.allowlist.is_allowed("specific@example.com"));
     }
 
     #[test]
@@ -911,9 +913,9 @@ mod tests {
             ..Default::default()
         };
         let channel = EmailChannel::new(config);
-        assert!(!channel.is_sender_allowed(""));
+        assert!(!channel.allowlist.is_allowed(""));
         // "@example.com" ends with "@example.com" so it's allowed
-        assert!(channel.is_sender_allowed("@example.com"));
+        assert!(channel.allowlist.is_allowed("@example.com"));
     }
 
     // strip_html tests
@@ -1121,5 +1123,66 @@ mod tests {
         };
         let debug_str = format!("{:?}", config);
         assert!(debug_str.contains("imap.debug.com"));
+    }
+
+    /// Parity oracle: the aspect-backed check must return byte-identical
+    /// results to the pre-migration shape across the full email-allowlist
+    /// truth table — full-email, `@domain`, bare-domain, mixed
+    /// wildcard, empty list, and case-insensitivity.
+    #[test]
+    fn allowlist_parity_with_pre_aspect_shape() {
+        // The pre-migration shape, replayed locally for the oracle.
+        fn pre_aspect(allowed: &[String], email: &str) -> bool {
+            if allowed.is_empty() {
+                return false;
+            }
+            if allowed.iter().any(|a| a == "*") {
+                return true;
+            }
+            let email_lower = email.to_lowercase();
+            allowed.iter().any(|entry| {
+                if entry.starts_with('@') {
+                    email_lower.ends_with(&entry.to_lowercase())
+                } else if entry.contains('@') {
+                    entry.eq_ignore_ascii_case(email)
+                } else {
+                    email_lower.ends_with(&format!("@{}", entry.to_lowercase()))
+                }
+            })
+        }
+        let cases: Vec<(Vec<&str>, &str)> = vec![
+            (vec![], "alice@example.com"),
+            (vec![], ""),
+            (vec!["*"], "anyone@whatever.com"),
+            (vec!["*"], ""),
+            (vec!["alice@example.com"], "alice@example.com"),
+            (vec!["alice@example.com"], "bob@example.com"),
+            (vec!["alice@example.com"], "ALICE@Example.COM"), // case-insensitive
+            (vec!["@example.com"], "anyone@example.com"),
+            (vec!["@example.com"], "anyone@other.com"),
+            (vec!["@Example.COM"], "anyone@example.com"), // domain case-insensitive
+            (vec!["example.com"], "anyone@example.com"), // bare domain
+            (vec!["example.com"], "anyone@subdomain.example.com"), // must require @
+            (vec!["bare.com", "@allowed.com", "specific@host.com"], "x@allowed.com"),
+            (vec!["bare.com", "@allowed.com", "specific@host.com"], "specific@host.com"),
+            (vec!["bare.com", "@allowed.com", "specific@host.com"], "other@host.com"),
+            (vec!["*", "specific@host.com"], "anyone@whatever.com"),
+            (vec!["@example.com"], ""), // empty email
+        ];
+        for (entries, email) in cases {
+            let allowed: Vec<String> =
+                entries.iter().map(|s| (*s).to_string()).collect();
+            let baseline = pre_aspect(&allowed, email);
+            let config = EmailConfig {
+                allowed_senders: allowed.clone(),
+                ..Default::default()
+            };
+            let channel = EmailChannel::new(config);
+            assert_eq!(
+                channel.allowlist.is_allowed(email),
+                baseline,
+                "aspect drift for entries={entries:?} email={email:?}",
+            );
+        }
     }
 }

--- a/crates/zeroclaw-channels/src/telegram.rs
+++ b/crates/zeroclaw-channels/src/telegram.rs
@@ -1,11 +1,12 @@
 use anyhow::Context;
+use aspect_std::AllowlistAspect;
 use async_trait::async_trait;
 use directories::UserDirs;
 use parking_lot::Mutex;
 use reqwest::multipart::{Form, Part};
 use std::fmt::Write as _;
 use std::path::Path;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::fs;
 use zeroclaw_api::channel::{Channel, ChannelMessage, SendMessage};
@@ -365,7 +366,11 @@ const TELEGRAM_MAX_FILE_DOWNLOAD_BYTES: u64 = 20 * 1024 * 1024;
 /// Telegram channel — long-polls the Bot API for updates
 pub struct TelegramChannel {
     bot_token: String,
-    allowed_users: Arc<RwLock<Vec<String>>>,
+    /// Who is allowed to talk to this bot. Wildcard `"*"` admits everyone;
+    /// an empty list denies everyone. Identities are normalized with
+    /// `trim()` + leading-`@` stripping at check time, so `"@alice"` in
+    /// config matches `"alice"` from the Telegram update.
+    allowlist: AllowlistAspect,
     pairing: Option<PairingGuard>,
     client: reqwest::Client,
     typing_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
@@ -415,8 +420,14 @@ enum EditMessageResult {
 
 impl TelegramChannel {
     pub fn new(bot_token: String, allowed_users: Vec<String>, mention_only: bool) -> Self {
-        let normalized_allowed = Self::normalize_allowed_users(allowed_users);
-        let pairing = if normalized_allowed.is_empty() {
+        let allowlist = AllowlistAspect::new(
+            allowed_users
+                .into_iter()
+                .map(|s| Self::normalize_identity(&s))
+                .filter(|s| !s.is_empty()),
+        )
+        .with_normalizer(|s| s.trim().trim_start_matches('@').to_string());
+        let pairing = if allowlist.is_empty() {
             let guard = PairingGuard::new(true, &[]);
             if let Some(code) = guard.pairing_code() {
                 println!("  🔐 Telegram pairing required. One-time bind code: {code}");
@@ -429,7 +440,7 @@ impl TelegramChannel {
 
         Self {
             bot_token,
-            allowed_users: Arc::new(RwLock::new(normalized_allowed)),
+            allowlist,
             pairing,
             client: reqwest::Client::new(),
             stream_mode: StreamMode::Off,
@@ -592,14 +603,6 @@ impl TelegramChannel {
         value.trim().trim_start_matches('@').to_string()
     }
 
-    fn normalize_allowed_users(allowed_users: Vec<String>) -> Vec<String> {
-        allowed_users
-            .into_iter()
-            .map(|entry| Self::normalize_identity(&entry))
-            .filter(|entry| !entry.is_empty())
-            .collect()
-    }
-
     async fn load_config_without_env() -> anyhow::Result<Config> {
         let home = UserDirs::new()
             .map(|u| u.home_dir().to_path_buf())
@@ -649,11 +652,7 @@ impl TelegramChannel {
         if normalized.is_empty() {
             return;
         }
-        if let Ok(mut users) = self.allowed_users.write()
-            && !users.iter().any(|u| u == &normalized)
-        {
-            users.push(normalized);
-        }
+        self.allowlist.add(normalized);
     }
 
     fn extract_bind_code(text: &str) -> Option<&str> {
@@ -1069,19 +1068,11 @@ impl TelegramChannel {
             .unwrap_or(false)
     }
 
-    fn is_user_allowed(&self, username: &str) -> bool {
-        let identity = Self::normalize_identity(username);
-        self.allowed_users
-            .read()
-            .map(|users| users.iter().any(|u| u == "*" || u == &identity))
-            .unwrap_or(false)
-    }
-
     fn is_any_user_allowed<'a, I>(&self, identities: I) -> bool
     where
         I: IntoIterator<Item = &'a str>,
     {
-        identities.into_iter().any(|id| self.is_user_allowed(id))
+        identities.into_iter().any(|id| self.allowlist.is_allowed(id))
     }
 
     async fn handle_unauthorized_message(&self, update: &serde_json::Value) {
@@ -3603,56 +3594,56 @@ mod tests {
     #[test]
     fn telegram_user_allowed_wildcard() {
         let ch = TelegramChannel::new("t".into(), vec!["*".into()], false);
-        assert!(ch.is_user_allowed("anyone"));
+        assert!(ch.allowlist.is_allowed("anyone"));
     }
 
     #[test]
     fn telegram_user_allowed_specific() {
         let ch = TelegramChannel::new("t".into(), vec!["alice".into(), "bob".into()], false);
-        assert!(ch.is_user_allowed("alice"));
-        assert!(!ch.is_user_allowed("eve"));
+        assert!(ch.allowlist.is_allowed("alice"));
+        assert!(!ch.allowlist.is_allowed("eve"));
     }
 
     #[test]
     fn telegram_user_allowed_with_at_prefix_in_config() {
         let ch = TelegramChannel::new("t".into(), vec!["@alice".into()], false);
-        assert!(ch.is_user_allowed("alice"));
+        assert!(ch.allowlist.is_allowed("alice"));
     }
 
     #[test]
     fn telegram_user_denied_empty() {
         let ch = TelegramChannel::new("t".into(), vec![], false);
-        assert!(!ch.is_user_allowed("anyone"));
+        assert!(!ch.allowlist.is_allowed("anyone"));
     }
 
     #[test]
     fn telegram_user_exact_match_not_substring() {
         let ch = TelegramChannel::new("t".into(), vec!["alice".into()], false);
-        assert!(!ch.is_user_allowed("alice_bot"));
-        assert!(!ch.is_user_allowed("alic"));
-        assert!(!ch.is_user_allowed("malice"));
+        assert!(!ch.allowlist.is_allowed("alice_bot"));
+        assert!(!ch.allowlist.is_allowed("alic"));
+        assert!(!ch.allowlist.is_allowed("malice"));
     }
 
     #[test]
     fn telegram_user_empty_string_denied() {
         let ch = TelegramChannel::new("t".into(), vec!["alice".into()], false);
-        assert!(!ch.is_user_allowed(""));
+        assert!(!ch.allowlist.is_allowed(""));
     }
 
     #[test]
     fn telegram_user_case_sensitive() {
         let ch = TelegramChannel::new("t".into(), vec!["Alice".into()], false);
-        assert!(ch.is_user_allowed("Alice"));
-        assert!(!ch.is_user_allowed("alice"));
-        assert!(!ch.is_user_allowed("ALICE"));
+        assert!(ch.allowlist.is_allowed("Alice"));
+        assert!(!ch.allowlist.is_allowed("alice"));
+        assert!(!ch.allowlist.is_allowed("ALICE"));
     }
 
     #[test]
     fn telegram_wildcard_with_specific_users() {
         let ch = TelegramChannel::new("t".into(), vec!["alice".into(), "*".into()], false);
-        assert!(ch.is_user_allowed("alice"));
-        assert!(ch.is_user_allowed("bob"));
-        assert!(ch.is_user_allowed("anyone"));
+        assert!(ch.allowlist.is_allowed("alice"));
+        assert!(ch.allowlist.is_allowed("bob"));
+        assert!(ch.allowlist.is_allowed("anyone"));
     }
 
     #[test]
@@ -5851,5 +5842,53 @@ mod tests {
     fn non_approval_callback_data_is_ignored() {
         let cb_data = "some_other_action:data";
         assert!(cb_data.strip_prefix("approval:").is_none());
+    }
+
+    /// Parity oracle: the aspect-backed check must return byte-identical
+    /// results to the pre-migration shape across a truth table covering
+    /// wildcard, empty list, `@`-prefix normalization, case-sensitivity,
+    /// and substring rejection. If this drifts, the migration is unsound.
+    #[test]
+    fn allowlist_parity_with_pre_aspect_shape() {
+        fn norm(s: &str) -> String {
+            s.trim().trim_start_matches('@').to_string()
+        }
+        let cases: Vec<(Vec<&str>, &str)> = vec![
+            (vec![], "alice"),
+            (vec![], ""),
+            (vec!["*"], "alice"),
+            (vec!["*"], ""),
+            (vec!["alice"], "alice"),
+            (vec!["alice"], "eve"),
+            (vec!["@alice"], "alice"),
+            (vec!["alice"], "@alice"),
+            (vec!["  alice  "], "alice"),
+            (vec!["alice", "bob"], "bob"),
+            (vec!["alice", "*"], "anyone"),
+            (vec!["*", "alice"], "anyone"),
+            (vec!["alice"], "alice_bot"), // substring rejected
+            (vec!["alice"], "alic"),      // prefix rejected
+            (vec!["Alice"], "alice"),     // case-sensitive
+            (vec!["Alice"], "Alice"),
+            (vec!["123456789"], "123456789"),
+        ];
+        for (entries, identity) in cases {
+            let normalized_entries: Vec<String> =
+                entries.iter().map(|s| norm(s)).filter(|s| !s.is_empty()).collect();
+            let needle = norm(identity);
+            let baseline = normalized_entries
+                .iter()
+                .any(|u| u == "*" || u == &needle);
+            let ch = TelegramChannel::new(
+                "t".into(),
+                entries.iter().map(|s| (*s).to_string()).collect(),
+                false,
+            );
+            assert_eq!(
+                ch.allowlist.is_allowed(identity),
+                baseline,
+                "aspect drift for entries={entries:?} identity={identity:?}",
+            );
+        }
     }
 }

--- a/crates/zeroclaw-channels/src/wechat.rs
+++ b/crates/zeroclaw-channels/src/wechat.rs
@@ -6,12 +6,13 @@
 
 use aes::cipher::{BlockDecryptMut, BlockEncryptMut, KeyInit, block_padding::Pkcs7};
 use anyhow::Context;
+use aspect_std::AllowlistAspect;
 use async_trait::async_trait;
 use base64::Engine;
 use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, RwLock};
+use std::sync::RwLock;
 use std::time::Duration;
 use zeroclaw_api::channel::{Channel, ChannelMessage, SendMessage};
 use zeroclaw_runtime::i18n;
@@ -370,7 +371,9 @@ pub struct WeChatChannel {
     /// CDN base URL.
     cdn_base_url: String,
     /// Allowed WeChat user IDs. Empty = deny all, `"*"` = allow all.
-    allowed_users: Arc<RwLock<Vec<String>>>,
+    /// Backed by `aspect-std::AllowlistAspect` so the check is centralized
+    /// rather than re-implemented per-channel.
+    allowlist: AllowlistAspect,
     /// Pairing guard for /bind flow.
     pairing: Option<PairingGuard>,
     /// HTTP client for API requests.
@@ -603,7 +606,7 @@ impl WeChatChannel {
             account_id: RwLock::new(None),
             api_base_url,
             cdn_base_url,
-            allowed_users: Arc::new(RwLock::new(allowed_users)),
+            allowlist: AllowlistAspect::new(allowed_users),
             pairing,
             client: reqwest::Client::new(),
             context_tokens: Mutex::new(HashMap::new()),
@@ -713,22 +716,11 @@ impl WeChatChannel {
         self.context_tokens.lock().get(user_id).cloned()
     }
 
-    fn is_user_allowed(&self, user_id: &str) -> bool {
-        self.allowed_users
-            .read()
-            .map(|users| users.iter().any(|u| u == "*" || u == user_id))
-            .unwrap_or(false)
-    }
-
     fn add_allowed_identity_runtime(&self, identity: &str) {
         if identity.is_empty() {
             return;
         }
-        if let Ok(mut users) = self.allowed_users.write()
-            && !users.iter().any(|u| u == identity)
-        {
-            users.push(identity.to_string());
-        }
+        self.allowlist.add(identity);
     }
 
     fn extract_bind_code(text: &str) -> Option<&str> {
@@ -1865,7 +1857,7 @@ impl Channel for WeChatChannel {
                 let text = extract_text_from_items(&items);
 
                 // Check authorization
-                if !self.is_user_allowed(from_user_id) {
+                if !self.allowlist.is_allowed(from_user_id) {
                     self.handle_unauthorized_message(from_user_id, &text).await;
                     continue;
                 }
@@ -2082,7 +2074,7 @@ mod tests {
             Some("/tmp/test-wechat".into()),
         )
         .unwrap();
-        assert!(ch.is_user_allowed("anyone@im.wechat"));
+        assert!(ch.allowlist.is_allowed("anyone@im.wechat"));
     }
 
     #[test]
@@ -2094,8 +2086,8 @@ mod tests {
             Some("/tmp/test-wechat".into()),
         )
         .unwrap();
-        assert!(ch.is_user_allowed("user1@im.wechat"));
-        assert!(!ch.is_user_allowed("user2@im.wechat"));
+        assert!(ch.allowlist.is_allowed("user1@im.wechat"));
+        assert!(!ch.allowlist.is_allowed("user2@im.wechat"));
     }
 
     #[test]
@@ -2235,5 +2227,42 @@ mod tests {
             .and_then(|value| value.as_str())
             .unwrap_or("");
         assert!(!version.is_empty());
+    }
+
+    /// Parity oracle: the aspect-backed check must return byte-identical
+    /// results to the pre-migration shape across a truth table covering
+    /// wildcard, empty list, case-sensitivity, and substring rejection.
+    #[test]
+    fn allowlist_parity_with_pre_aspect_shape() {
+        let cases: Vec<(Vec<&str>, &str)> = vec![
+            (vec![], "alice@im.wechat"),
+            (vec![], ""),
+            (vec!["*"], "alice@im.wechat"),
+            (vec!["*"], ""),
+            (vec!["user1@im.wechat"], "user1@im.wechat"),
+            (vec!["user1@im.wechat"], "user2@im.wechat"),
+            (vec!["a", "b"], "b"),
+            (vec!["a", "*"], "anyone"),
+            (vec!["*", "a"], "anyone"),
+            (vec!["alice"], "alice_bot"), // substring rejected
+            (vec!["alice"], "alic"),      // prefix rejected
+            (vec!["Alice"], "alice"),     // case-sensitive
+            (vec!["Alice"], "Alice"),
+        ];
+        for (entries, identity) in cases {
+            let baseline = entries.iter().any(|u| *u == "*" || *u == identity);
+            let ch = WeChatChannel::new(
+                entries.iter().map(|s| (*s).to_string()).collect(),
+                None,
+                None,
+                Some("/tmp/test-wechat-parity".into()),
+            )
+            .unwrap();
+            assert_eq!(
+                ch.allowlist.is_allowed(identity),
+                baseline,
+                "aspect drift for entries={entries:?} identity={identity:?}",
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Replaces the hand-rolled `pub fn is_sender_allowed(&self, email: &str) -> bool` predicate in `email_channel.rs` with the shared `aspect_std::AllowlistAspect`. This PR is part of the 24-PR migration; the chain tip (#6799) carries the cumulative view + the M1–M5 evaluation results.
- **Scope boundary:** This PR does NOT change identity resolution (From-header parsing into a comparable address happens before the allowlist check), webhook/SSE parsing, downstream message routing, LLM dispatch, or response sending. The aspect owns *only* the matching half of allowlist enforcement for the `email` channel.
- **Blast radius:** the `email` channel only. Other channels in the chain are migrated by their own PRs. If `AllowlistAspect::is_allowed` regresses for this channel's archetype (flat-list + matcher (`email_allowlist_match`: domain `@example.com`, bare `example.com`, full email)), only `email` is affected at this commit; the chain-wide blast radius lives in #6799. Mitigated by per-channel parity tests against the old predicate.
- **Linked issue(s):** none
- **Labels:** `risk: high`, `size: S`, `type: refactor`, `area: channels`

## What changed

- Replaced `allowed_senders: Vec<String>` with `allowlist: AllowlistAspect` in the channel struct.
- Deleted the hand-rolled `pub fn is_sender_allowed(&self, email: &str) -> bool` predicate.
- Production caller routes through `self.allowlist.is_allowed(email)`.
- Unit tests updated to assert against `allowlist.is_allowed("…")` instead of field/predicate inspection.

## Archetype

Archetype **C** — flat-list + matcher (`email_allowlist_match`: domain `@example.com`, bare `example.com`, full email).

Email allowlist entries can be a full address (`alice@example.com`), a bare domain (`example.com`), or a `@`-prefixed domain (`@example.com`). The aspect uses `with_matcher(email_allowlist_match)` to preserve the three-way semantics.

## Supply-chain question (resolution)

The reviewer's blocker on sourcing `aspect-std` from `github.com/yijunyu/aspect-rs` is resolved by the latest commit on this branch (and all 23 other chain branches): **`aspect-std = "0.1.1"` is now on crates.io** (published 2026-05-24), so the dep is registry-sourced, immutable, and visible to `cargo audit` / `cargo deny`. The git-pinned source has been removed.

- `aspect-core v0.1.1` — https://crates.io/crates/aspect-core/0.1.1
- `aspect-runtime v0.1.1` — https://crates.io/crates/aspect-runtime/0.1.1
- `aspect-macros v0.1.1` — https://crates.io/crates/aspect-macros/0.1.1
- `aspect-std v0.1.1` — https://crates.io/crates/aspect-std/0.1.1 (contains `AllowlistAspect`)

## Validation Evidence

Local validation (commands from the test plan, tail output verbatim):

```
$ cargo build -p zeroclaw-channels --features channel-email
   Compiling event-listener v5.4.1
   Compiling stop-token v0.7.0
   Compiling url v2.5.8
   Compiling event-listener-strategy v0.5.4
   Compiling lettre v0.11.21
   Compiling imap-proto v0.16.7
   Compiling mail-parser v0.11.2
   Compiling pin-project v1.1.11
   Compiling async-channel v2.5.0
   Compiling hyper-util v0.1.20
   Compiling tower v0.5.3
   Compiling zeroclaw-api v0.7.5 (/home/y00577373/zeroclaw/crates/zeroclaw-api)
   Compiling tokio-tungstenite v0.29.0
   Compiling tokio-socks v0.5.2
   Compiling futures-executor v0.3.32
   Compiling rumqttc v0.25.1
   Compiling futures v0.3.32
   Compiling tower-http v0.6.8
   Compiling async-imap v0.11.2
   Compiling hyper-rustls v0.27.9
   Compiling axum v0.8.9
   Compiling reqwest v0.12.28
   Compiling zeroclaw-config v0.7.5 (/home/y00577373/zeroclaw/crates/zeroclaw-config)
   Compiling zeroclaw-infra v0.7.5 (/home/y00577373/zeroclaw/crates/zeroclaw-infra)
   Compiling zeroclaw-providers v0.7.5 (/home/y00577373/zeroclaw/crates/zeroclaw-providers)
   Compiling zeroclaw-memory v0.7.5 (/home/y00577373/zeroclaw/crates/zeroclaw-memory)
   Compiling zeroclaw-tools v0.7.5 (/home/y00577373/zeroclaw/crates/zeroclaw-tools)
   Compiling zeroclaw-runtime v0.7.5 (/home/y00577373/zeroclaw/crates/zeroclaw-runtime)
   Compiling zeroclaw-channels v0.7.5 (/home/y00577373/zeroclaw/crates/zeroclaw-channels)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 35.55s

$ cargo test -p zeroclaw-channels --features channel-email --lib email_channel::
test email_channel::tests::is_sender_allowed_wildcard_with_specific ... ok
test email_channel::tests::max_fetch_batch_bounds_chunk_size ... ok
test email_channel::tests::poll_interval_deserializes_as_independent_field ... ok
test email_channel::tests::poll_interval_has_default_when_unset ... ok
test email_channel::tests::strip_html_attributes_preserved ... ok
test email_channel::tests::strip_html_basic ... ok
test email_channel::tests::strip_html_handles_malformed ... ok
test email_channel::tests::seen_messages_starts_empty ... ok
test email_channel::tests::strip_html_multiple_lines ... ok
test email_channel::tests::seen_messages_tracks_unique_ids ... ok
test email_channel::tests::strip_html_multiple_spaces_collapsed ... ok
test email_channel::tests::strip_html_preserves_text ... ok
test email_channel::tests::strip_html_nested_tags ... ok
test email_channel::tests::strip_html_self_closing_tags ... ok
test email_channel::tests::strip_html_special_characters ... ok

test result: ok. 41 passed; 0 failed; 0 ignored; 0 measured; 1020 filtered out; finished in 0.00s


   Compiling async-imap v0.11.2
   Compiling reqwest v0.12.28
   Compiling wiremock v0.6.5
   Compiling zeroclaw-config v0.7.5 (/home/y00577373/zeroclaw/crates/zeroclaw-config)
   Compiling zeroclaw-providers v0.7.5 (/home/y00577373/zeroclaw/crates/zeroclaw-providers)
   Compiling zeroclaw-memory v0.7.5 (/home/y00577373/zeroclaw/crates/zeroclaw-memory)
   Compiling zeroclaw-tools v0.7.5 (/home/y00577373/zeroclaw/crates/zeroclaw-tools)
   Compiling zeroclaw-runtime v0.7.5 (/home/y00577373/zeroclaw/crates/zeroclaw-runtime)
   Compiling zeroclaw-channels v0.7.5 (/home/y00577373/zeroclaw/crates/zeroclaw-channels)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 52.93s
     Running unittests src/lib.rs (target/debug/deps/zeroclaw_channels-491504825b4f4698)

$ cargo clippy -p zeroclaw-channels --features channel-email --lib --no-deps -- -D warnings

   Compiling hashify v0.2.9
    Checking futures-util v0.3.32
    Checking pin-project v1.1.11
    Checking idna v1.1.0
    Checking url v2.5.8
    Checking lettre v0.11.21
    Checking hyper-util v0.1.20
    Checking tower v0.5.3
    Checking tokio-tungstenite v0.29.0
    Checking zeroclaw-api v0.7.5 (/home/y00577373/zeroclaw/crates/zeroclaw-api)
    Checking tokio-socks v0.5.2
    Checking futures-executor v0.3.32
    Checking rumqttc v0.25.1
    Checking mail-parser v0.11.2
    Checking futures v0.3.32
    Checking tower-http v0.6.8
    Checking async-imap v0.11.2
    Checking hyper-rustls v0.27.9
    Checking axum v0.8.9
    Checking zeroclaw-infra v0.7.5 (/home/y00577373/zeroclaw/crates/zeroclaw-infra)
    Checking reqwest v0.12.28
    Checking zeroclaw-config v0.7.5 (/home/y00577373/zeroclaw/crates/zeroclaw-config)
    Checking zeroclaw-memory v0.7.5 (/home/y00577373/zeroclaw/crates/zeroclaw-memory)
    Checking zeroclaw-providers v0.7.5 (/home/y00577373/zeroclaw/crates/zeroclaw-providers)
    Checking zeroclaw-tools v0.7.5 (/home/y00577373/zeroclaw/crates/zeroclaw-tools)
    Checking zeroclaw-runtime v0.7.5 (/home/y00577373/zeroclaw/crates/zeroclaw-runtime)
    Checking zeroclaw-channels v0.7.5 (/home/y00577373/zeroclaw/crates/zeroclaw-channels)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 26.84s
```

- **Commands run:** the three above; all pass with zero warnings.
- **Beyond CI — what I manually verified:** the channel-specific parity tests assert the new path produces the same allow/deny verdict as the old predicate across every truth-table case (wildcard, empty list, specific match, unknown, bare-domain match, `@`-domain match, full-address match).
- **Skipped:** `cargo fmt --check` and `cargo test --workspace` are not in the test plan because the relevant invariants are channel-local; the workspace-level checks belong to the merge gate.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? **No.**
- New external network calls? **No.**
- Secrets / tokens / credentials handling changed? **No.**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No** — test fixtures use synthetic IDs.

This is an access-control refactor: it changes *where* the allowlist check is implemented but not *what* it enforces. Per-channel parity tests assert the new path produces the same verdict as the old predicate across every truth-table case.

## Compatibility

- Backward compatible? **Yes** at the channel config surface — the `allowed_senders` config field is still consumed; its value is passed to `AllowlistAspect::new(...)` at channel construction.
- Config / env / CLI surface changed? **No.** Existing operator config files continue to work unchanged.
- Upgrade steps for existing users: none required.

## Rollback (risk: high)

- **Fast rollback command/path:** `git revert <merge-sha>` reverts this single-channel migration. The chain is designed so each PR is revertable on its own; the only post-revert constraint is that the chain tip (#6799) and any PRs further up the chain that depend on this commit would need to be rebased.
- **Feature flags or config toggles:** None. The aspect is statically linked.
- **Observable failure symptoms:**
  - Allowlist-deny false positives: legitimate `email` users denied at inbound. Grep logs for `is_allowed → false` followed by message drop in the `email` channel-level traces.
  - Allowlist-bypass false negatives: unauthorized users let through. Watch for unexpected senders appearing in `chat_history` rows for `email` if the deployment had a non-wildcard allowlist.
  - Metric to watch: `email` message-drop rate (delta from steady-state in the hour after deploy).

## Note on the clone warning

The reviewer correctly flagged that `AllowlistAspect::clone` zeros out the `normalizer` and `matcher` fields. This channel does not clone the aspect; the matcher closure is owned by the single instance. Follow-up filed against `aspect-std` to either (a) make `Clone` carry the closures via `Arc<dyn Fn …>` or (b) emit a compile-time warning when `clone()` is called on an aspect with non-`None` closures. Until then the safe pattern is to share the parent `Arc` rather than clone the aspect; this is the pattern already in use.
