### PR TITLE
lark: migrate fn is_user_allowed(&self, open_id: &str) -> bool → AllowlistAspect (archetype A)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,13 +274,15 @@ checksum = "9dbc3a507a82b17ba0d98f6ce8fd6954ea0c8152e98009d36a40d8dcc8ce078a"
 
 [[package]]
 name = "aspect-core"
-version = "0.1.0"
-source = "git+https://github.com/yijunyu/aspect-rs?rev=c31f453#c31f453509057cdef97f880daea3c3aed5d23bb0"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fd3e7f9100f7ae656584c40356ef60e2794da98b45acae5a51b6427ce20f60c"
 
 [[package]]
 name = "aspect-std"
-version = "0.1.0"
-source = "git+https://github.com/yijunyu/aspect-rs?rev=c31f453#c31f453509057cdef97f880daea3c3aed5d23bb0"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1abc65dfa3766d751105bc9a4ee8af5cfa0d4edf56a925f57eb9edeac4e58c"
 dependencies = [
  "aspect-core",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,12 +275,12 @@ checksum = "9dbc3a507a82b17ba0d98f6ce8fd6954ea0c8152e98009d36a40d8dcc8ce078a"
 [[package]]
 name = "aspect-core"
 version = "0.1.0"
-source = "git+https://github.com/yijunyu/aspect-rs?rev=239ba1d#239ba1d0089dfac61fdc85319d63f20b704885b8"
+source = "git+https://github.com/yijunyu/aspect-rs?rev=c31f453#c31f453509057cdef97f880daea3c3aed5d23bb0"
 
 [[package]]
 name = "aspect-std"
 version = "0.1.0"
-source = "git+https://github.com/yijunyu/aspect-rs?rev=239ba1d#239ba1d0089dfac61fdc85319d63f20b704885b8"
+source = "git+https://github.com/yijunyu/aspect-rs?rev=c31f453#c31f453509057cdef97f880daea3c3aed5d23bb0"
 dependencies = [
  "aspect-core",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,6 +273,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dbc3a507a82b17ba0d98f6ce8fd6954ea0c8152e98009d36a40d8dcc8ce078a"
 
 [[package]]
+name = "aspect-core"
+version = "0.1.0"
+source = "git+https://github.com/yijunyu/aspect-rs?rev=239ba1d#239ba1d0089dfac61fdc85319d63f20b704885b8"
+
+[[package]]
+name = "aspect-std"
+version = "0.1.0"
+source = "git+https://github.com/yijunyu/aspect-rs?rev=239ba1d#239ba1d0089dfac61fdc85319d63f20b704885b8"
+dependencies = [
+ "aspect-core",
+ "log",
+ "parking_lot",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13165,6 +13180,7 @@ version = "0.7.5"
 dependencies = [
  "aes",
  "anyhow",
+ "aspect-std",
  "async-imap",
  "async-trait",
  "axum",

--- a/crates/zeroclaw-channels/Cargo.toml
+++ b/crates/zeroclaw-channels/Cargo.toml
@@ -18,7 +18,7 @@ zeroclaw-tools.workspace = true
 # talk to the bot" check, replacing 20+ near-identical hand-rolled
 # `fn is_user_allowed` implementations across channel modules. Pinned to a
 # specific commit until aspect-rs publishes a 0.1 release on crates.io.
-aspect-std = { git = "https://github.com/yijunyu/aspect-rs", rev = "239ba1d" }
+aspect-std = { git = "https://github.com/yijunyu/aspect-rs", rev = "c31f453" }
 anyhow = "1.0"
 lru = "0.16"
 rumqttc = "0.25"

--- a/crates/zeroclaw-channels/Cargo.toml
+++ b/crates/zeroclaw-channels/Cargo.toml
@@ -16,9 +16,8 @@ zeroclaw-runtime.workspace = true
 zeroclaw-tools.workspace = true
 # AOP support: AllowlistAspect provides the per-channel "who is allowed to
 # talk to the bot" check, replacing 20+ near-identical hand-rolled
-# `fn is_user_allowed` implementations across channel modules. Pinned to a
-# specific commit until aspect-rs publishes a 0.1 release on crates.io.
-aspect-std = { git = "https://github.com/yijunyu/aspect-rs", rev = "c31f453" }
+# `fn is_user_allowed` implementations across channel modules.
+aspect-std = "0.1.1"
 anyhow = "1.0"
 lru = "0.16"
 rumqttc = "0.25"

--- a/crates/zeroclaw-channels/Cargo.toml
+++ b/crates/zeroclaw-channels/Cargo.toml
@@ -14,6 +14,11 @@ zeroclaw-memory.workspace = true
 zeroclaw-providers.workspace = true
 zeroclaw-runtime.workspace = true
 zeroclaw-tools.workspace = true
+# AOP support: AllowlistAspect provides the per-channel "who is allowed to
+# talk to the bot" check, replacing 20+ near-identical hand-rolled
+# `fn is_user_allowed` implementations across channel modules. Pinned to a
+# specific commit until aspect-rs publishes a 0.1 release on crates.io.
+aspect-std = { git = "https://github.com/yijunyu/aspect-rs", rev = "239ba1d" }
 anyhow = "1.0"
 lru = "0.16"
 rumqttc = "0.25"

--- a/crates/zeroclaw-channels/src/dingtalk.rs
+++ b/crates/zeroclaw-channels/src/dingtalk.rs
@@ -1,3 +1,4 @@
+use aspect_std::AllowlistAspect;
 use async_trait::async_trait;
 use futures_util::{SinkExt, StreamExt};
 use std::collections::HashMap;
@@ -14,7 +15,7 @@ const DINGTALK_BOT_CALLBACK_TOPIC: &str = "/v1.0/im/bot/messages/get";
 pub struct DingTalkChannel {
     client_id: String,
     client_secret: String,
-    allowed_users: Vec<String>,
+    allowlist: AllowlistAspect,
     /// Per-chat session webhooks for sending replies (chatID -> webhook URL).
     /// DingTalk provides a unique webhook URL with each incoming message.
     session_webhooks: Arc<RwLock<HashMap<String, String>>>,
@@ -34,7 +35,7 @@ impl DingTalkChannel {
         Self {
             client_id,
             client_secret,
-            allowed_users,
+            allowlist: AllowlistAspect::new(allowed_users),
             session_webhooks: Arc::new(RwLock::new(HashMap::new())),
             proxy_url: None,
         }
@@ -51,10 +52,6 @@ impl DingTalkChannel {
             "channel.dingtalk",
             self.proxy_url.as_deref(),
         )
-    }
-
-    fn is_user_allowed(&self, user_id: &str) -> bool {
-        self.allowed_users.iter().any(|u| u == "*" || u == user_id)
     }
 
     fn parse_stream_data(frame: &serde_json::Value) -> Option<serde_json::Value> {
@@ -244,7 +241,7 @@ impl Channel for DingTalkChannel {
                         .and_then(|s| s.as_str())
                         .unwrap_or("unknown");
 
-                    if !self.is_user_allowed(sender_id) {
+                    if !self.allowlist.is_allowed(sender_id) {
                         tracing::warn!(
                             "DingTalk: ignoring message from unauthorized user: {sender_id}"
                         );
@@ -326,20 +323,20 @@ mod tests {
     #[test]
     fn test_user_allowed_wildcard() {
         let ch = DingTalkChannel::new("id".into(), "secret".into(), vec!["*".into()]);
-        assert!(ch.is_user_allowed("anyone"));
+        assert!(ch.allowlist.is_allowed("anyone"));
     }
 
     #[test]
     fn test_user_allowed_specific() {
         let ch = DingTalkChannel::new("id".into(), "secret".into(), vec!["user123".into()]);
-        assert!(ch.is_user_allowed("user123"));
-        assert!(!ch.is_user_allowed("other"));
+        assert!(ch.allowlist.is_allowed("user123"));
+        assert!(!ch.allowlist.is_allowed("other"));
     }
 
     #[test]
     fn test_user_denied_empty() {
         let ch = DingTalkChannel::new("id".into(), "secret".into(), vec![]);
-        assert!(!ch.is_user_allowed("anyone"));
+        assert!(!ch.allowlist.is_allowed("anyone"));
     }
 
     #[test]

--- a/crates/zeroclaw-channels/src/discord.rs
+++ b/crates/zeroclaw-channels/src/discord.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context as _, anyhow};
+use aspect_std::AllowlistAspect;
 use async_trait::async_trait;
 use futures_util::{SinkExt, StreamExt};
 use parking_lot::Mutex;
@@ -21,7 +22,11 @@ use zeroclaw_api::media::MediaAttachment;
 pub struct DiscordChannel {
     bot_token: String,
     guild_id: Option<String>,
-    allowed_users: Vec<String>,
+    /// Who is allowed to talk to this bot. Wildcard `"*"` admits everyone;
+    /// an empty list denies everyone. Backed by `aspect-std`'s
+    /// `AllowlistAspect` so the check is centralized and reusable across
+    /// channels rather than re-implemented per-module.
+    allowlist: AllowlistAspect,
     listen_to_bots: bool,
     mention_only: bool,
     typing_handles: Mutex<HashMap<String, tokio::task::JoinHandle<()>>>,
@@ -66,10 +71,30 @@ impl DiscordChannel {
         listen_to_bots: bool,
         mention_only: bool,
     ) -> Self {
+        Self::with_allowlist(
+            bot_token,
+            guild_id,
+            AllowlistAspect::new(allowed_users),
+            listen_to_bots,
+            mention_only,
+        )
+    }
+
+    /// Construct from an existing `AllowlistAspect`. Used internally when
+    /// spawning a reaction-worker `DiscordChannel` so the worker shares the
+    /// parent's allowlist `Arc<Inner>` (cheap clone, no `Vec` allocation,
+    /// and runtime allowlist changes propagate to the worker).
+    fn with_allowlist(
+        bot_token: String,
+        guild_id: Option<String>,
+        allowlist: AllowlistAspect,
+        listen_to_bots: bool,
+        mention_only: bool,
+    ) -> Self {
         Self {
             bot_token,
             guild_id,
-            allowed_users,
+            allowlist,
             listen_to_bots,
             mention_only,
             typing_handles: Mutex::new(HashMap::new()),
@@ -153,13 +178,6 @@ impl DiscordChannel {
             "channel.discord",
             self.proxy_url.as_deref(),
         )
-    }
-
-    /// Check if a Discord user ID is in the allowlist.
-    /// Empty list means deny everyone until explicitly configured.
-    /// `"*"` means allow everyone.
-    fn is_user_allowed(&self, user_id: &str) -> bool {
-        self.allowed_users.iter().any(|u| u == "*" || u == user_id)
     }
 
     fn bot_user_id_from_token(token: &str) -> Option<String> {
@@ -1459,7 +1477,7 @@ impl Channel for DiscordChannel {
                     }
 
                     // Sender validation
-                    if !self.is_user_allowed(author_id) {
+                    if !self.allowlist.is_allowed(author_id) {
                         tracing::warn!("Discord: ignoring message from unauthorized user: {author_id}");
                         continue;
                     }
@@ -1528,10 +1546,10 @@ impl Channel for DiscordChannel {
                         .to_string();
 
                     if !message_id.is_empty() && !channel_id.is_empty() {
-                        let reaction_channel = DiscordChannel::new(
+                        let reaction_channel = DiscordChannel::with_allowlist(
                             self.bot_token.clone(),
                             self.guild_id.clone(),
-                            self.allowed_users.clone(),
+                            self.allowlist.clone(),
                             self.listen_to_bots,
                             self.mention_only,
                         );
@@ -2107,15 +2125,15 @@ mod tests {
     #[test]
     fn empty_allowlist_denies_everyone() {
         let ch = DiscordChannel::new("fake".into(), None, vec![], false, false);
-        assert!(!ch.is_user_allowed("12345"));
-        assert!(!ch.is_user_allowed("anyone"));
+        assert!(!ch.allowlist.is_allowed("12345"));
+        assert!(!ch.allowlist.is_allowed("anyone"));
     }
 
     #[test]
     fn wildcard_allows_everyone() {
         let ch = DiscordChannel::new("fake".into(), None, vec!["*".into()], false, false);
-        assert!(ch.is_user_allowed("12345"));
-        assert!(ch.is_user_allowed("anyone"));
+        assert!(ch.allowlist.is_allowed("12345"));
+        assert!(ch.allowlist.is_allowed("anyone"));
     }
 
     #[test]
@@ -2127,24 +2145,24 @@ mod tests {
             false,
             false,
         );
-        assert!(ch.is_user_allowed("111"));
-        assert!(ch.is_user_allowed("222"));
-        assert!(!ch.is_user_allowed("333"));
-        assert!(!ch.is_user_allowed("unknown"));
+        assert!(ch.allowlist.is_allowed("111"));
+        assert!(ch.allowlist.is_allowed("222"));
+        assert!(!ch.allowlist.is_allowed("333"));
+        assert!(!ch.allowlist.is_allowed("unknown"));
     }
 
     #[test]
     fn allowlist_is_exact_match_not_substring() {
         let ch = DiscordChannel::new("fake".into(), None, vec!["111".into()], false, false);
-        assert!(!ch.is_user_allowed("1111"));
-        assert!(!ch.is_user_allowed("11"));
-        assert!(!ch.is_user_allowed("0111"));
+        assert!(!ch.allowlist.is_allowed("1111"));
+        assert!(!ch.allowlist.is_allowed("11"));
+        assert!(!ch.allowlist.is_allowed("0111"));
     }
 
     #[test]
     fn allowlist_empty_string_user_id() {
         let ch = DiscordChannel::new("fake".into(), None, vec!["111".into()], false, false);
-        assert!(!ch.is_user_allowed(""));
+        assert!(!ch.allowlist.is_allowed(""));
     }
 
     #[test]
@@ -2156,16 +2174,57 @@ mod tests {
             false,
             false,
         );
-        assert!(ch.is_user_allowed("111"));
-        assert!(ch.is_user_allowed("anyone_else"));
+        assert!(ch.allowlist.is_allowed("111"));
+        assert!(ch.allowlist.is_allowed("anyone_else"));
     }
 
     #[test]
     fn allowlist_case_sensitive() {
         let ch = DiscordChannel::new("fake".into(), None, vec!["ABC".into()], false, false);
-        assert!(ch.is_user_allowed("ABC"));
-        assert!(!ch.is_user_allowed("abc"));
-        assert!(!ch.is_user_allowed("Abc"));
+        assert!(ch.allowlist.is_allowed("ABC"));
+        assert!(!ch.allowlist.is_allowed("abc"));
+        assert!(!ch.allowlist.is_allowed("Abc"));
+    }
+
+    /// Parity test for the AllowlistAspect migration. Asserts that the
+    /// post-migration `allowlist.is_allowed(...)` returns byte-identical
+    /// results to the pre-migration shape
+    /// `allowed.iter().any(|u| u == "*" || u == id)` for a fixed truth table
+    /// covering the wildcard, empty-list, case-sensitivity, and substring
+    /// edge cases. If any reviewer worries the aspect drifted from the
+    /// original Boolean semantics, this test is the regression guard.
+    #[test]
+    fn allowlist_parity_with_pre_aspect_shape() {
+        let cases: Vec<(Vec<&str>, &str)> = vec![
+            (vec![], "alice"),
+            (vec![], ""),
+            (vec!["*"], "alice"),
+            (vec!["*"], ""),
+            (vec!["111"], "111"),
+            (vec!["111"], "112"),
+            (vec!["111", "222"], "222"),
+            (vec!["111", "*"], "anyone"),
+            (vec!["*", "111"], "anyone"),
+            (vec!["111"], "1111"), // substring rejected
+            (vec!["111"], "11"),   // prefix rejected
+            (vec!["ABC"], "abc"),  // case-sensitive
+            (vec!["ABC"], "Abc"),
+        ];
+        for (entries, identity) in cases {
+            let baseline = entries.iter().any(|u| *u == "*" || *u == identity);
+            let ch = DiscordChannel::new(
+                "fake".into(),
+                None,
+                entries.iter().map(|s| (*s).to_string()).collect(),
+                false,
+                false,
+            );
+            assert_eq!(
+                ch.allowlist.is_allowed(identity),
+                baseline,
+                "aspect drift for entries={entries:?} identity={identity:?}",
+            );
+        }
     }
 
     #[test]

--- a/crates/zeroclaw-channels/src/email_channel.rs
+++ b/crates/zeroclaw-channels/src/email_channel.rs
@@ -9,6 +9,7 @@
 #![allow(clippy::unnecessary_map_or)]
 
 use anyhow::{Result, anyhow};
+use aspect_std::AllowlistAspect;
 use async_imap::Session;
 use async_imap::extensions::idle::IdleResponse;
 use async_imap::types::Fetch;
@@ -38,41 +39,42 @@ pub use zeroclaw_config::scattered_types::EmailConfig;
 
 type ImapSession = Session<TlsStream<TcpStream>>;
 
+/// Email-allowlist matcher: allows an `entry` to be a full email
+/// (`"alice@example.com"`), a domain with `@` prefix (`"@example.com"`),
+/// or a bare domain (`"example.com"`). All comparisons are
+/// ASCII-case-insensitive. Used as the `.with_matcher(...)` predicate
+/// when constructing the email-channel `AllowlistAspect`.
+pub(crate) fn email_allowlist_match(entry: &str, email: &str) -> bool {
+    let email_lower = email.to_ascii_lowercase();
+    if let Some(domain) = entry.strip_prefix('@') {
+        email_lower.ends_with(&format!("@{}", domain.to_ascii_lowercase()))
+    } else if entry.contains('@') {
+        entry.eq_ignore_ascii_case(email)
+    } else {
+        email_lower.ends_with(&format!("@{}", entry.to_ascii_lowercase()))
+    }
+}
+
 /// Email channel — IMAP IDLE for instant push notifications, SMTP for outbound
 pub struct EmailChannel {
     pub config: EmailConfig,
+    /// Centralized allowlist check (see `aspect_std::AllowlistAspect`).
+    /// Built once from `config.allowed_senders`; the matcher implements
+    /// the full-email / `@domain` / bare-domain semantics shared with
+    /// the Gmail push channel.
+    allowlist: AllowlistAspect,
     seen_messages: Arc<Mutex<HashSet<String>>>,
 }
 
 impl EmailChannel {
     pub fn new(config: EmailConfig) -> Self {
+        let allowlist = AllowlistAspect::new(config.allowed_senders.clone())
+            .with_matcher(email_allowlist_match);
         Self {
             config,
+            allowlist,
             seen_messages: Arc::new(Mutex::new(HashSet::new())),
         }
-    }
-
-    /// Check if a sender email is in the allowlist
-    pub fn is_sender_allowed(&self, email: &str) -> bool {
-        if self.config.allowed_senders.is_empty() {
-            return false; // Empty = deny all
-        }
-        if self.config.allowed_senders.iter().any(|a| a == "*") {
-            return true; // Wildcard = allow all
-        }
-        let email_lower = email.to_lowercase();
-        self.config.allowed_senders.iter().any(|allowed| {
-            if allowed.starts_with('@') {
-                // Domain match with @ prefix: "@example.com"
-                email_lower.ends_with(&allowed.to_lowercase())
-            } else if allowed.contains('@') {
-                // Full email address match
-                allowed.eq_ignore_ascii_case(email)
-            } else {
-                // Domain match without @ prefix: "example.com"
-                email_lower.ends_with(&format!("@{}", allowed.to_lowercase()))
-            }
-        })
     }
 
     /// Strip HTML tags from content (basic)
@@ -474,7 +476,7 @@ impl EmailChannel {
 
         for email in messages {
             // Check allowlist
-            if !self.is_sender_allowed(&email.sender) {
+            if !self.allowlist.is_allowed(&email.sender) {
                 warn!("Blocked email from {}", email.sender);
                 continue;
             }
@@ -812,8 +814,8 @@ mod tests {
             ..Default::default()
         };
         let channel = EmailChannel::new(config);
-        assert!(!channel.is_sender_allowed("anyone@example.com"));
-        assert!(!channel.is_sender_allowed("user@test.com"));
+        assert!(!channel.allowlist.is_allowed("anyone@example.com"));
+        assert!(!channel.allowlist.is_allowed("user@test.com"));
     }
 
     #[test]
@@ -823,9 +825,9 @@ mod tests {
             ..Default::default()
         };
         let channel = EmailChannel::new(config);
-        assert!(channel.is_sender_allowed("anyone@example.com"));
-        assert!(channel.is_sender_allowed("user@test.com"));
-        assert!(channel.is_sender_allowed("random@domain.org"));
+        assert!(channel.allowlist.is_allowed("anyone@example.com"));
+        assert!(channel.allowlist.is_allowed("user@test.com"));
+        assert!(channel.allowlist.is_allowed("random@domain.org"));
     }
 
     #[test]
@@ -835,9 +837,9 @@ mod tests {
             ..Default::default()
         };
         let channel = EmailChannel::new(config);
-        assert!(channel.is_sender_allowed("allowed@example.com"));
-        assert!(!channel.is_sender_allowed("other@example.com"));
-        assert!(!channel.is_sender_allowed("allowed@other.com"));
+        assert!(channel.allowlist.is_allowed("allowed@example.com"));
+        assert!(!channel.allowlist.is_allowed("other@example.com"));
+        assert!(!channel.allowlist.is_allowed("allowed@other.com"));
     }
 
     #[test]
@@ -847,9 +849,9 @@ mod tests {
             ..Default::default()
         };
         let channel = EmailChannel::new(config);
-        assert!(channel.is_sender_allowed("user@example.com"));
-        assert!(channel.is_sender_allowed("admin@example.com"));
-        assert!(!channel.is_sender_allowed("user@other.com"));
+        assert!(channel.allowlist.is_allowed("user@example.com"));
+        assert!(channel.allowlist.is_allowed("admin@example.com"));
+        assert!(!channel.allowlist.is_allowed("user@other.com"));
     }
 
     #[test]
@@ -859,9 +861,9 @@ mod tests {
             ..Default::default()
         };
         let channel = EmailChannel::new(config);
-        assert!(channel.is_sender_allowed("user@example.com"));
-        assert!(channel.is_sender_allowed("admin@example.com"));
-        assert!(!channel.is_sender_allowed("user@other.com"));
+        assert!(channel.allowlist.is_allowed("user@example.com"));
+        assert!(channel.allowlist.is_allowed("admin@example.com"));
+        assert!(!channel.allowlist.is_allowed("user@other.com"));
     }
 
     #[test]
@@ -871,9 +873,9 @@ mod tests {
             ..Default::default()
         };
         let channel = EmailChannel::new(config);
-        assert!(channel.is_sender_allowed("allowed@example.com"));
-        assert!(channel.is_sender_allowed("ALLOWED@EXAMPLE.COM"));
-        assert!(channel.is_sender_allowed("AlLoWeD@eXaMpLe.cOm"));
+        assert!(channel.allowlist.is_allowed("allowed@example.com"));
+        assert!(channel.allowlist.is_allowed("ALLOWED@EXAMPLE.COM"));
+        assert!(channel.allowlist.is_allowed("AlLoWeD@eXaMpLe.cOm"));
     }
 
     #[test]
@@ -887,10 +889,10 @@ mod tests {
             ..Default::default()
         };
         let channel = EmailChannel::new(config);
-        assert!(channel.is_sender_allowed("user1@example.com"));
-        assert!(channel.is_sender_allowed("user2@test.com"));
-        assert!(channel.is_sender_allowed("anyone@allowed.com"));
-        assert!(!channel.is_sender_allowed("user3@example.com"));
+        assert!(channel.allowlist.is_allowed("user1@example.com"));
+        assert!(channel.allowlist.is_allowed("user2@test.com"));
+        assert!(channel.allowlist.is_allowed("anyone@allowed.com"));
+        assert!(!channel.allowlist.is_allowed("user3@example.com"));
     }
 
     #[test]
@@ -900,8 +902,8 @@ mod tests {
             ..Default::default()
         };
         let channel = EmailChannel::new(config);
-        assert!(channel.is_sender_allowed("anyone@example.com"));
-        assert!(channel.is_sender_allowed("specific@example.com"));
+        assert!(channel.allowlist.is_allowed("anyone@example.com"));
+        assert!(channel.allowlist.is_allowed("specific@example.com"));
     }
 
     #[test]
@@ -911,9 +913,9 @@ mod tests {
             ..Default::default()
         };
         let channel = EmailChannel::new(config);
-        assert!(!channel.is_sender_allowed(""));
+        assert!(!channel.allowlist.is_allowed(""));
         // "@example.com" ends with "@example.com" so it's allowed
-        assert!(channel.is_sender_allowed("@example.com"));
+        assert!(channel.allowlist.is_allowed("@example.com"));
     }
 
     // strip_html tests
@@ -1121,5 +1123,66 @@ mod tests {
         };
         let debug_str = format!("{:?}", config);
         assert!(debug_str.contains("imap.debug.com"));
+    }
+
+    /// Parity oracle: the aspect-backed check must return byte-identical
+    /// results to the pre-migration shape across the full email-allowlist
+    /// truth table — full-email, `@domain`, bare-domain, mixed
+    /// wildcard, empty list, and case-insensitivity.
+    #[test]
+    fn allowlist_parity_with_pre_aspect_shape() {
+        // The pre-migration shape, replayed locally for the oracle.
+        fn pre_aspect(allowed: &[String], email: &str) -> bool {
+            if allowed.is_empty() {
+                return false;
+            }
+            if allowed.iter().any(|a| a == "*") {
+                return true;
+            }
+            let email_lower = email.to_lowercase();
+            allowed.iter().any(|entry| {
+                if entry.starts_with('@') {
+                    email_lower.ends_with(&entry.to_lowercase())
+                } else if entry.contains('@') {
+                    entry.eq_ignore_ascii_case(email)
+                } else {
+                    email_lower.ends_with(&format!("@{}", entry.to_lowercase()))
+                }
+            })
+        }
+        let cases: Vec<(Vec<&str>, &str)> = vec![
+            (vec![], "alice@example.com"),
+            (vec![], ""),
+            (vec!["*"], "anyone@whatever.com"),
+            (vec!["*"], ""),
+            (vec!["alice@example.com"], "alice@example.com"),
+            (vec!["alice@example.com"], "bob@example.com"),
+            (vec!["alice@example.com"], "ALICE@Example.COM"), // case-insensitive
+            (vec!["@example.com"], "anyone@example.com"),
+            (vec!["@example.com"], "anyone@other.com"),
+            (vec!["@Example.COM"], "anyone@example.com"), // domain case-insensitive
+            (vec!["example.com"], "anyone@example.com"), // bare domain
+            (vec!["example.com"], "anyone@subdomain.example.com"), // must require @
+            (vec!["bare.com", "@allowed.com", "specific@host.com"], "x@allowed.com"),
+            (vec!["bare.com", "@allowed.com", "specific@host.com"], "specific@host.com"),
+            (vec!["bare.com", "@allowed.com", "specific@host.com"], "other@host.com"),
+            (vec!["*", "specific@host.com"], "anyone@whatever.com"),
+            (vec!["@example.com"], ""), // empty email
+        ];
+        for (entries, email) in cases {
+            let allowed: Vec<String> =
+                entries.iter().map(|s| (*s).to_string()).collect();
+            let baseline = pre_aspect(&allowed, email);
+            let config = EmailConfig {
+                allowed_senders: allowed.clone(),
+                ..Default::default()
+            };
+            let channel = EmailChannel::new(config);
+            assert_eq!(
+                channel.allowlist.is_allowed(email),
+                baseline,
+                "aspect drift for entries={entries:?} email={email:?}",
+            );
+        }
     }
 }

--- a/crates/zeroclaw-channels/src/gmail_push.rs
+++ b/crates/zeroclaw-channels/src/gmail_push.rs
@@ -18,9 +18,12 @@
 //! and renews it before the 7-day expiry.
 
 use anyhow::{Result, anyhow};
+use aspect_std::AllowlistAspect;
 use async_trait::async_trait;
 use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
 use reqwest::Client;
+
+use crate::email_channel::email_allowlist_match;
 use serde::{Deserialize, Serialize};
 use std::fmt::Write as _;
 use std::sync::Arc;
@@ -171,6 +174,11 @@ pub struct WatchResponse {
 /// subscription and periodically renews it.
 pub struct GmailPushChannel {
     pub config: GmailPushConfig,
+    /// Centralized allowlist check (see `aspect_std::AllowlistAspect`).
+    /// Shares the `email_allowlist_match` predicate with `EmailChannel`
+    /// — the entry semantics are identical (full-email / `@domain` /
+    /// bare-domain, ASCII-case-insensitive).
+    allowlist: AllowlistAspect,
     http: Client,
     last_history_id: Arc<Mutex<u64>>,
     /// Sender half injected by the gateway to forward webhook-received messages.
@@ -183,8 +191,11 @@ impl GmailPushChannel {
             .timeout(Duration::from_secs(30))
             .build()
             .expect("failed to build HTTP client");
+        let allowlist = AllowlistAspect::new(config.allowed_senders.clone())
+            .with_matcher(email_allowlist_match);
         Self {
             config,
+            allowlist,
             http,
             last_history_id: Arc::new(Mutex::new(0)),
             tx: Arc::new(Mutex::new(None)),
@@ -331,26 +342,6 @@ impl GmailPushChannel {
         Ok(resp.json().await?)
     }
 
-    /// Check if a sender email is in the allowlist.
-    pub fn is_sender_allowed(&self, email: &str) -> bool {
-        if self.config.allowed_senders.is_empty() {
-            return false;
-        }
-        if self.config.allowed_senders.iter().any(|a| a == "*") {
-            return true;
-        }
-        let email_lower = email.to_lowercase();
-        self.config.allowed_senders.iter().any(|allowed| {
-            if allowed.starts_with('@') {
-                email_lower.ends_with(&allowed.to_lowercase())
-            } else if allowed.contains('@') {
-                allowed.eq_ignore_ascii_case(email)
-            } else {
-                email_lower.ends_with(&format!("@{}", allowed.to_lowercase()))
-            }
-        })
-    }
-
     /// Process a Pub/Sub push notification and dispatch new messages to the agent.
     pub async fn handle_notification(&self, envelope: &PubSubEnvelope) -> Result<()> {
         let notification = parse_notification(&envelope.message)?;
@@ -407,7 +398,7 @@ impl GmailPushChannel {
                     let sender = extract_header(&gmail_msg, "From").unwrap_or_default();
                     let sender_email = extract_email_from_header(&sender);
 
-                    if !self.is_sender_allowed(&sender_email) {
+                    if !self.allowlist.is_allowed(&sender_email) {
                         warn!("Gmail push: blocked message from {}", sender_email);
                         continue;
                     }
@@ -951,7 +942,7 @@ mod tests {
     #[test]
     fn sender_allowed_empty_denies() {
         let ch = GmailPushChannel::new(GmailPushConfig::default());
-        assert!(!ch.is_sender_allowed("anyone@example.com"));
+        assert!(!ch.allowlist.is_allowed("anyone@example.com"));
     }
 
     #[test]
@@ -960,7 +951,7 @@ mod tests {
             allowed_senders: vec!["*".into()],
             ..Default::default()
         });
-        assert!(ch.is_sender_allowed("anyone@example.com"));
+        assert!(ch.allowlist.is_allowed("anyone@example.com"));
     }
 
     #[test]
@@ -969,8 +960,8 @@ mod tests {
             allowed_senders: vec!["user@example.com".into()],
             ..Default::default()
         });
-        assert!(ch.is_sender_allowed("user@example.com"));
-        assert!(!ch.is_sender_allowed("other@example.com"));
+        assert!(ch.allowlist.is_allowed("user@example.com"));
+        assert!(!ch.allowlist.is_allowed("other@example.com"));
     }
 
     #[test]
@@ -979,9 +970,9 @@ mod tests {
             allowed_senders: vec!["@example.com".into()],
             ..Default::default()
         });
-        assert!(ch.is_sender_allowed("user@example.com"));
-        assert!(ch.is_sender_allowed("admin@example.com"));
-        assert!(!ch.is_sender_allowed("user@other.com"));
+        assert!(ch.allowlist.is_allowed("user@example.com"));
+        assert!(ch.allowlist.is_allowed("admin@example.com"));
+        assert!(!ch.allowlist.is_allowed("user@other.com"));
     }
 
     #[test]
@@ -990,8 +981,8 @@ mod tests {
             allowed_senders: vec!["example.com".into()],
             ..Default::default()
         });
-        assert!(ch.is_sender_allowed("user@example.com"));
-        assert!(!ch.is_sender_allowed("user@other.com"));
+        assert!(ch.allowlist.is_allowed("user@example.com"));
+        assert!(!ch.allowlist.is_allowed("user@other.com"));
     }
 
     // ── Strip HTML ───────────────────────────────────────────────
@@ -1085,5 +1076,65 @@ mod tests {
             size: 12,
         };
         assert_eq!(decode_body(Some(&body)), Some("test content".to_string()));
+    }
+
+    /// Parity oracle: the aspect-backed check must return byte-identical
+    /// results to the pre-migration shape across the full
+    /// email-allowlist truth table. Mirrors the email_channel parity
+    /// test exactly — both channels share the same matcher predicate.
+    #[test]
+    fn allowlist_parity_with_pre_aspect_shape() {
+        fn pre_aspect(allowed: &[String], email: &str) -> bool {
+            if allowed.is_empty() {
+                return false;
+            }
+            if allowed.iter().any(|a| a == "*") {
+                return true;
+            }
+            let email_lower = email.to_lowercase();
+            allowed.iter().any(|entry| {
+                if entry.starts_with('@') {
+                    email_lower.ends_with(&entry.to_lowercase())
+                } else if entry.contains('@') {
+                    entry.eq_ignore_ascii_case(email)
+                } else {
+                    email_lower.ends_with(&format!("@{}", entry.to_lowercase()))
+                }
+            })
+        }
+        let cases: Vec<(Vec<&str>, &str)> = vec![
+            (vec![], "alice@example.com"),
+            (vec![], ""),
+            (vec!["*"], "anyone@whatever.com"),
+            (vec!["*"], ""),
+            (vec!["alice@example.com"], "alice@example.com"),
+            (vec!["alice@example.com"], "bob@example.com"),
+            (vec!["alice@example.com"], "ALICE@Example.COM"),
+            (vec!["@example.com"], "anyone@example.com"),
+            (vec!["@example.com"], "anyone@other.com"),
+            (vec!["@Example.COM"], "anyone@example.com"),
+            (vec!["example.com"], "anyone@example.com"),
+            (vec!["example.com"], "anyone@subdomain.example.com"),
+            (vec!["bare.com", "@allowed.com", "specific@host.com"], "x@allowed.com"),
+            (vec!["bare.com", "@allowed.com", "specific@host.com"], "specific@host.com"),
+            (vec!["bare.com", "@allowed.com", "specific@host.com"], "other@host.com"),
+            (vec!["*", "specific@host.com"], "anyone@whatever.com"),
+            (vec!["@example.com"], ""),
+        ];
+        for (entries, email) in cases {
+            let allowed: Vec<String> =
+                entries.iter().map(|s| (*s).to_string()).collect();
+            let baseline = pre_aspect(&allowed, email);
+            let config = GmailPushConfig {
+                allowed_senders: allowed.clone(),
+                ..Default::default()
+            };
+            let ch = GmailPushChannel::new(config);
+            assert_eq!(
+                ch.allowlist.is_allowed(email),
+                baseline,
+                "aspect drift for entries={entries:?} email={email:?}",
+            );
+        }
     }
 }

--- a/crates/zeroclaw-channels/src/irc.rs
+++ b/crates/zeroclaw-channels/src/irc.rs
@@ -1,3 +1,4 @@
+use aspect_std::AllowlistAspect;
 use async_trait::async_trait;
 use portable_atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -26,7 +27,9 @@ pub struct IrcChannel {
     nickname: String,
     username: String,
     channels: Vec<String>,
-    allowed_users: Vec<String>,
+    /// AllowlistAspect with ASCII-lowercase normalizer for case-insensitive
+    /// nick comparison. Initialized from `IrcChannelConfig.allowed_users`.
+    allowlist: AllowlistAspect,
     server_password: Option<String>,
     nickserv_password: Option<String>,
     sasl_password: Option<String>,
@@ -240,13 +243,15 @@ pub struct IrcChannelConfig {
 impl IrcChannel {
     pub fn new(cfg: IrcChannelConfig) -> Self {
         let username = cfg.username.unwrap_or_else(|| cfg.nickname.clone());
+        let allowlist =
+            AllowlistAspect::new(cfg.allowed_users).with_normalizer(|s| s.to_ascii_lowercase());
         Self {
             server: cfg.server,
             port: cfg.port,
             nickname: cfg.nickname,
             username,
             channels: cfg.channels,
-            allowed_users: cfg.allowed_users,
+            allowlist,
             server_password: cfg.server_password,
             nickserv_password: cfg.nickserv_password,
             sasl_password: cfg.sasl_password,
@@ -254,15 +259,6 @@ impl IrcChannel {
             mention_only: cfg.mention_only,
             writer: Arc::new(Mutex::new(None)),
         }
-    }
-
-    fn is_user_allowed(&self, nick: &str) -> bool {
-        if self.allowed_users.iter().any(|u| u == "*") {
-            return true;
-        }
-        self.allowed_users
-            .iter()
-            .any(|u| u.eq_ignore_ascii_case(nick))
     }
 
     fn is_mentioned(my_nick: &str, text: &str) -> bool {
@@ -549,7 +545,7 @@ impl Channel for IrcChannel {
                         continue;
                     }
 
-                    if !self.is_user_allowed(sender_nick) {
+                    if !self.allowlist.is_allowed(sender_nick) {
                         continue;
                     }
 
@@ -815,8 +811,8 @@ mod tests {
     fn wildcard_allows_anyone() {
         let ch = make_channel();
         // Default make_channel has wildcard
-        assert!(ch.is_user_allowed("anyone"));
-        assert!(ch.is_user_allowed("stranger"));
+        assert!(ch.allowlist.is_allowed("anyone"));
+        assert!(ch.allowlist.is_allowed("stranger"));
     }
 
     #[test]
@@ -834,9 +830,9 @@ mod tests {
             verify_tls: true,
             mention_only: false,
         });
-        assert!(ch.is_user_allowed("alice"));
-        assert!(ch.is_user_allowed("bob"));
-        assert!(!ch.is_user_allowed("eve"));
+        assert!(ch.allowlist.is_allowed("alice"));
+        assert!(ch.allowlist.is_allowed("bob"));
+        assert!(!ch.allowlist.is_allowed("eve"));
     }
 
     #[test]
@@ -854,9 +850,9 @@ mod tests {
             verify_tls: true,
             mention_only: false,
         });
-        assert!(ch.is_user_allowed("alice"));
-        assert!(ch.is_user_allowed("ALICE"));
-        assert!(ch.is_user_allowed("Alice"));
+        assert!(ch.allowlist.is_allowed("alice"));
+        assert!(ch.allowlist.is_allowed("ALICE"));
+        assert!(ch.allowlist.is_allowed("Alice"));
     }
 
     #[test]
@@ -874,7 +870,7 @@ mod tests {
             verify_tls: true,
             mention_only: false,
         });
-        assert!(!ch.is_user_allowed("anyone"));
+        assert!(!ch.allowlist.is_allowed("anyone"));
     }
 
     // ── Mention only ────────────────────────────────────────
@@ -977,7 +973,8 @@ mod tests {
         assert_eq!(ch.nickname, "zcbot");
         assert_eq!(ch.username, "zeroclaw");
         assert_eq!(ch.channels, vec!["#test"]);
-        assert_eq!(ch.allowed_users, vec!["alice"]);
+        assert!(ch.allowlist.is_allowed("alice"));
+        assert!(!ch.allowlist.is_allowed("eve"));
         assert_eq!(ch.server_password.as_deref(), Some("serverpass"));
         assert_eq!(ch.nickserv_password.as_deref(), Some("nspass"));
         assert_eq!(ch.sasl_password.as_deref(), Some("saslpass"));
@@ -1068,5 +1065,52 @@ nickname = "bot"
             verify_tls: true,
             mention_only: false,
         })
+    }
+
+    // ── M1 parity: AllowlistAspect must accept exactly the same set of
+    // (entries, nick) pairs that the pre-aspect is_user_allowed body did.
+    // The pre-aspect shape: wildcard "*" short-circuit, otherwise
+    // case-insensitive equality against any entry.
+    #[test]
+    fn allowlist_parity_with_pre_aspect_shape() {
+        fn pre_aspect(entries: &[String], nick: &str) -> bool {
+            if entries.iter().any(|u| u == "*") {
+                return true;
+            }
+            entries.iter().any(|u| u.eq_ignore_ascii_case(nick))
+        }
+
+        let cases: Vec<(Vec<&str>, &str)> = vec![
+            (vec![], "alice"),
+            (vec![], ""),
+            (vec!["*"], "alice"),
+            (vec!["*"], ""),
+            (vec!["alice"], "alice"),
+            (vec!["alice"], "eve"),
+            (vec!["Alice"], "alice"),
+            (vec!["alice"], "ALICE"),
+            (vec!["ALICE"], "Alice"),
+            (vec!["alice", "bob"], "bob"),
+            (vec!["alice", "*"], "eve"),
+            (vec!["*", "alice"], "anyone"),
+            (vec!["alice"], "alice_"),    // suffix rejected
+            (vec!["alice"], "_alice"),    // prefix rejected
+            (vec!["alice_bot"], "alice"), // substring rejected
+            (vec!["123"], "123"),
+            (vec!["a", "b", "c"], "C"),   // case-insensitive multi-entry
+        ];
+
+        for (entries, nick) in cases {
+            let entries_owned: Vec<String> =
+                entries.iter().map(|s| (*s).to_string()).collect();
+            let baseline = pre_aspect(&entries_owned, nick);
+            let aspect = AllowlistAspect::new(entries_owned.clone())
+                .with_normalizer(|s| s.to_ascii_lowercase());
+            assert_eq!(
+                aspect.is_allowed(nick),
+                baseline,
+                "aspect drift for entries={entries:?} nick={nick:?}",
+            );
+        }
     }
 }

--- a/crates/zeroclaw-channels/src/lark.rs
+++ b/crates/zeroclaw-channels/src/lark.rs
@@ -1,3 +1,4 @@
+use aspect_std::AllowlistAspect;
 use async_trait::async_trait;
 use base64::Engine as _;
 use futures_util::{SinkExt, StreamExt};
@@ -386,7 +387,7 @@ pub struct LarkChannel {
     app_secret: String,
     verification_token: String,
     port: Option<u16>,
-    allowed_users: Vec<String>,
+    allowlist: AllowlistAspect,
     /// Bot open_id resolved at runtime via `/bot/v3/info`.
     resolved_bot_open_id: Arc<StdRwLock<Option<String>>>,
     mention_only: bool,
@@ -440,7 +441,7 @@ impl LarkChannel {
             app_secret,
             verification_token,
             port,
-            allowed_users,
+            allowlist: AllowlistAspect::new(allowed_users),
             resolved_bot_open_id: Arc::new(StdRwLock::new(None)),
             mention_only,
             platform,
@@ -894,7 +895,7 @@ impl LarkChannel {
                     if recv.sender.sender_type == "app" || recv.sender.sender_type == "bot" { continue; }
 
                     let sender_open_id = recv.sender.sender_id.open_id.as_deref().unwrap_or("");
-                    if !self.is_user_allowed(sender_open_id) {
+                    if !self.allowlist.is_allowed(sender_open_id) {
                         tracing::warn!("Lark WS: ignoring {sender_open_id} (not in allowed_users)");
                         continue;
                     }
@@ -1037,11 +1038,6 @@ impl LarkChannel {
             }
         }
         Ok(())
-    }
-
-    /// Check if a user open_id is allowed
-    fn is_user_allowed(&self, open_id: &str) -> bool {
-        self.allowed_users.iter().any(|u| u == "*" || u == open_id)
     }
 
     /// Get or refresh tenant access token
@@ -1488,7 +1484,7 @@ impl LarkChannel {
             .pointer("/event/sender/sender_id/open_id")
             .and_then(|v| v.as_str())
             .unwrap_or("");
-        if !self.is_user_allowed(open_id) {
+        if !self.allowlist.is_allowed(open_id) {
             tracing::warn!("Lark: ignoring audio from unauthorized user: {open_id}");
             return vec![];
         }
@@ -1612,7 +1608,7 @@ impl LarkChannel {
         }
 
         // Check allowlist
-        if !self.is_user_allowed(open_id) {
+        if !self.allowlist.is_allowed(open_id) {
             tracing::warn!("Lark: ignoring message from unauthorized user: {open_id}");
             return messages;
         }
@@ -2609,8 +2605,8 @@ mod tests {
     #[test]
     fn lark_user_allowed_exact() {
         let ch = make_channel();
-        assert!(ch.is_user_allowed("ou_testuser123"));
-        assert!(!ch.is_user_allowed("ou_other"));
+        assert!(ch.allowlist.is_allowed("ou_testuser123"));
+        assert!(!ch.allowlist.is_allowed("ou_other"));
     }
 
     #[test]
@@ -2623,7 +2619,7 @@ mod tests {
             vec!["*".into()],
             true,
         );
-        assert!(ch.is_user_allowed("ou_anyone"));
+        assert!(ch.allowlist.is_allowed("ou_anyone"));
     }
 
     #[test]
@@ -2636,7 +2632,7 @@ mod tests {
             vec![],
             true,
         );
-        assert!(!ch.is_user_allowed("ou_anyone"));
+        assert!(!ch.allowlist.is_allowed("ou_anyone"));
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-channels/src/matrix.rs
+++ b/crates/zeroclaw-channels/src/matrix.rs
@@ -27,6 +27,7 @@ use std::{
 };
 
 use anyhow::{Context as _, Result, anyhow, bail};
+use aspect_std::AllowlistAspect;
 use async_trait::async_trait;
 use tokio::sync::{Mutex as TokioMutex, RwLock as TokioRwLock, mpsc, oneshot};
 
@@ -182,20 +183,19 @@ mod mention {
 
 // ─── allowlist ─────────────────────────────────────────────────────────────
 mod allowlist {
+    use super::AllowlistAspect;
+
+    /// Build the user-allowlist aspect from the raw config strings.
+    ///
     /// Matrix user IDs are spec-lowercase for the localpart, but some
     /// homeservers accept capitalised forms in the auth layer. An operator
     /// who configured `allowed_users = ["@Bot:Example.org"]` would silently
     /// see no messages on a strict byte match — the channel filters to
     /// `@bot:example.org`. ASCII case-insensitive match is the conservative
-    /// reading.
-    pub(super) fn user_allowed(allowed_users: &[String], sender: &str) -> bool {
-        if allowed_users.is_empty() {
-            return false;
-        }
-        if allowed_users.iter().any(|u| u == "*") {
-            return true;
-        }
-        allowed_users.iter().any(|u| u.eq_ignore_ascii_case(sender))
+    /// reading, expressed here by lowering both sides via
+    /// `with_normalizer`.
+    pub(super) fn user_allowlist(allowed_users: Vec<String>) -> AllowlistAspect {
+        AllowlistAspect::new(allowed_users).with_normalizer(|s| s.to_ascii_lowercase())
     }
 
     pub(super) fn room_allowed_static(allowed_rooms: &[String], room_id: &str) -> bool {
@@ -1241,6 +1241,9 @@ mod inbound {
     #[derive(Clone)]
     pub(super) struct HandlerCtx {
         pub config: Arc<MatrixConfig>,
+        /// User allowlist built once from `config.allowed_users` so per-event
+        /// dispatch does not re-parse the raw `Vec<String>`.
+        pub user_allowlist: super::AllowlistAspect,
         pub transcription: Option<Arc<TranscriptionConfig>>,
         pub workspace_dir: Option<Arc<std::path::PathBuf>>,
         pub tx: mpsc::Sender<ChannelMessage>,
@@ -1365,7 +1368,7 @@ mod inbound {
             }
         }
 
-        if !allowlist::user_allowed(&ctx.config.allowed_users, sender) {
+        if !ctx.user_allowlist.is_allowed(sender) {
             debug!("matrix: drop message from non-allowed sender {sender}");
             return Ok(());
         }
@@ -2732,6 +2735,7 @@ impl Channel for MatrixChannel {
             .ok_or_else(|| anyhow!("matrix: client has no user_id after login"))?
             .to_owned();
         let ctx = inbound::HandlerCtx {
+            user_allowlist: allowlist::user_allowlist(self.config.allowed_users.clone()),
             config: self.config.clone(),
             transcription: self.transcription.clone(),
             workspace_dir: self.workspace_dir.clone(),
@@ -3282,40 +3286,39 @@ mod tests {
     }
 
     mod allowlist {
-        use super::super::allowlist::{room_allowed_static, user_allowed};
+        use super::super::AllowlistAspect;
+        use super::super::allowlist::{room_allowed_static, user_allowlist};
+
+        fn make(entries: &[&str]) -> AllowlistAspect {
+            user_allowlist(entries.iter().map(|s| (*s).to_string()).collect())
+        }
 
         #[test]
         fn empty_user_list_denies_all() {
-            assert!(!user_allowed(&[], "@a:b"));
+            assert!(!make(&[]).is_allowed("@a:b"));
         }
 
         #[test]
         fn star_user_list_allows_all() {
-            assert!(user_allowed(&["*".to_string()], "@a:b"));
+            assert!(make(&["*"]).is_allowed("@a:b"));
         }
 
         #[test]
         fn user_in_list_allowed() {
-            assert!(user_allowed(&["@a:b".to_string()], "@a:b"));
+            assert!(make(&["@a:b"]).is_allowed("@a:b"));
         }
 
         #[test]
         fn user_not_in_list_denied() {
-            assert!(!user_allowed(&["@a:b".to_string()], "@c:d"));
+            assert!(!make(&["@a:b"]).is_allowed("@c:d"));
         }
 
         #[test]
         fn user_in_list_case_insensitive() {
             // Operator-configured case shouldn't matter — Matrix MXIDs are
             // spec-lowercase but tolerated in mixed case by some servers.
-            assert!(user_allowed(
-                &["@Bot:Example.org".to_string()],
-                "@bot:example.org"
-            ));
-            assert!(user_allowed(
-                &["@bot:example.org".to_string()],
-                "@Bot:EXAMPLE.org"
-            ));
+            assert!(make(&["@Bot:Example.org"]).is_allowed("@bot:example.org"));
+            assert!(make(&["@bot:example.org"]).is_allowed("@Bot:EXAMPLE.org"));
         }
 
         #[test]
@@ -3337,6 +3340,52 @@ mod tests {
                 &["!ok:server".to_string()],
                 "!nope:server"
             ));
+        }
+
+        // ── M1 parity: AllowlistAspect must accept exactly the same set of
+        // (entries, sender) pairs that the pre-aspect user_allowed shape did.
+        #[test]
+        fn allowlist_parity_with_pre_aspect_shape() {
+            fn pre_aspect(entries: &[String], sender: &str) -> bool {
+                if entries.is_empty() {
+                    return false;
+                }
+                if entries.iter().any(|u| u == "*") {
+                    return true;
+                }
+                entries.iter().any(|u| u.eq_ignore_ascii_case(sender))
+            }
+
+            let cases: Vec<(Vec<&str>, &str)> = vec![
+                (vec![], "@a:b"),
+                (vec![], ""),
+                (vec!["*"], "@a:b"),
+                (vec!["*"], ""),
+                (vec!["@a:b"], "@a:b"),
+                (vec!["@a:b"], "@c:d"),
+                (vec!["@Bot:Example.org"], "@bot:example.org"),
+                (vec!["@bot:example.org"], "@Bot:EXAMPLE.org"),
+                (vec!["@A:B"], "@a:b"),
+                (vec!["@a:b", "@c:d"], "@c:d"),
+                (vec!["@a:b", "*"], "@zz:zz"),
+                (vec!["*", "@a:b"], "@anyone:srv"),
+                (vec!["@bot:example.org"], "@bot:example.org_"), // suffix
+                (vec!["@bot:example.org"], "_@bot:example.org"), // prefix
+                (vec!["@bot:example.org_"], "@bot:example.org"), // substring rejected
+                (vec!["@a:b"], ""),
+                (vec!["@a:b", "@c:d", "@e:f"], "@E:F"),
+            ];
+            for (entries, sender) in cases {
+                let entries_owned: Vec<String> =
+                    entries.iter().map(|s| (*s).to_string()).collect();
+                let baseline = pre_aspect(&entries_owned, sender);
+                let aspect = make(&entries);
+                assert_eq!(
+                    aspect.is_allowed(sender),
+                    baseline,
+                    "aspect drift for entries={entries:?} sender={sender:?}",
+                );
+            }
         }
     }
 

--- a/crates/zeroclaw-channels/src/mattermost.rs
+++ b/crates/zeroclaw-channels/src/mattermost.rs
@@ -1,4 +1,5 @@
 use anyhow::{Result, bail};
+use aspect_std::AllowlistAspect;
 use async_trait::async_trait;
 use parking_lot::Mutex;
 use std::sync::Arc;
@@ -12,7 +13,9 @@ pub struct MattermostChannel {
     base_url: String, // e.g., https://mm.example.com
     bot_token: String,
     channel_id: Option<String>,
-    allowed_users: Vec<String>,
+    /// Allowlist of permitted sender user_ids, built once from
+    /// `allowed_users`. Empty list = deny-all; `"*"` = allow-all.
+    allowlist: AllowlistAspect,
     /// When true (default), replies thread on the original post's root_id.
     /// When false, replies go to the channel root.
     thread_replies: bool,
@@ -41,7 +44,7 @@ impl MattermostChannel {
             base_url,
             bot_token,
             channel_id,
-            allowed_users,
+            allowlist: AllowlistAspect::new(allowed_users),
             thread_replies,
             mention_only,
             typing_handle: Mutex::new(None),
@@ -85,12 +88,6 @@ impl MattermostChannel {
             30,
             10,
         )
-    }
-
-    /// Check if a user ID is in the allowlist.
-    /// Empty list means deny everyone. "*" means allow everyone.
-    fn is_user_allowed(&self, user_id: &str) -> bool {
-        self.allowed_users.iter().any(|u| u == "*" || u == user_id)
     }
 
     /// Get the bot's own user ID and username so we can ignore our own messages
@@ -432,7 +429,7 @@ impl MattermostChannel {
             text
         };
 
-        if !self.is_user_allowed(user_id) {
+        if !self.allowlist.is_allowed(user_id) {
             tracing::warn!("Mattermost: ignoring message from unauthorized user: {user_id}");
             return None;
         }
@@ -660,7 +657,7 @@ mod tests {
     #[test]
     fn mattermost_allowlist_wildcard() {
         let ch = make_channel(vec!["*".into()], false);
-        assert!(ch.is_user_allowed("any-id"));
+        assert!(ch.allowlist.is_allowed("any-id"));
     }
 
     #[test]

--- a/crates/zeroclaw-channels/src/nostr.rs
+++ b/crates/zeroclaw-channels/src/nostr.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use aspect_std::AllowlistAspect;
 use async_trait::async_trait;
 use nostr_sdk::prelude::*;
 use std::collections::HashMap;
@@ -13,38 +14,27 @@ enum NostrProtocol {
     Nip17,
 }
 
-/// Whether to allow all senders (wildcard) or only specific public keys.
-#[derive(Debug, Clone)]
-enum AllowList {
-    /// "*" — accept messages from any pubkey.
-    Any,
-    /// Accept only from these specific pubkeys.
-    Set(Vec<PublicKey>),
-}
-
-impl AllowList {
-    /// Parse the raw config strings into a typed allow list.
-    /// Empty list means deny-all. A single `"*"` means allow-all.
-    fn parse(raw: &[String]) -> Result<Self> {
-        if raw.is_empty() {
-            return Ok(Self::Set(Vec::new())); // deny-all
-        }
-        if raw.iter().any(|p| p == "*") {
-            return Ok(Self::Any);
-        }
-        let mut keys = Vec::with_capacity(raw.len());
-        for s in raw {
-            keys.push(PublicKey::parse(s).with_context(|| format!("Invalid allowed pubkey: {s}"))?);
-        }
-        Ok(Self::Set(keys))
+/// Canonicalize the configured pubkey allow list into the hex strings the
+/// AllowlistAspect compares against. Empty list = deny-all; a single
+/// `"*"` is preserved verbatim and short-circuits the aspect's wildcard
+/// path. Every other entry is validated via `PublicKey::parse` (which
+/// accepts both bech32 npub and hex forms) and stored as canonical
+/// 64-char lowercase hex so it matches `event.pubkey.to_hex()` at the
+/// call site.
+fn canonicalize_allowed_pubkeys(raw: &[String]) -> Result<Vec<String>> {
+    if raw.is_empty() {
+        return Ok(Vec::new());
     }
-
-    fn is_allowed(&self, pubkey: &PublicKey) -> bool {
-        match self {
-            Self::Any => true,
-            Self::Set(keys) => keys.iter().any(|k| k == pubkey),
-        }
+    if raw.iter().any(|p| p == "*") {
+        return Ok(vec!["*".to_string()]);
     }
+    let mut hex_keys = Vec::with_capacity(raw.len());
+    for s in raw {
+        let pk =
+            PublicKey::parse(s).with_context(|| format!("Invalid allowed pubkey: {s}"))?;
+        hex_keys.push(pk.to_hex());
+    }
+    Ok(hex_keys)
 }
 
 /// Nostr channel supporting NIP-04 (legacy) and NIP-17 (gift-wrapped) private messages.
@@ -52,7 +42,10 @@ impl AllowList {
 pub struct NostrChannel {
     client: Client,
     public_key: PublicKey,
-    allowed: AllowList,
+    /// Allowlist of permitted sender pubkeys, stored as canonical
+    /// lowercase hex. Call sites pass `event.pubkey.to_hex()` to
+    /// `is_allowed`. Built once via `AllowlistAspect::new`.
+    allowlist: AllowlistAspect,
     /// Tracks last-seen protocol per sender pubkey so replies match.
     sender_protocols: Arc<RwLock<HashMap<PublicKey, NostrProtocol>>>,
 }
@@ -68,7 +61,7 @@ impl NostrChannel {
     ) -> Result<Self> {
         let keys = Keys::parse(private_key).context("Invalid Nostr private key")?;
         let public_key = keys.public_key();
-        let allowed = AllowList::parse(allowed_pubkeys)?;
+        let allowlist = AllowlistAspect::new(canonicalize_allowed_pubkeys(allowed_pubkeys)?);
 
         let client = Client::builder().signer(keys).build();
         for relay in &relays {
@@ -82,7 +75,7 @@ impl NostrChannel {
         Ok(Self {
             client,
             public_key,
-            allowed,
+            allowlist,
             sender_protocols: Arc::new(RwLock::new(HashMap::new())),
         })
     }
@@ -180,7 +173,7 @@ impl Channel for NostrChannel {
                             if event.created_at < listen_start {
                                 continue;
                             }
-                            if !self.allowed.is_allowed(&event.pubkey) {
+                            if !self.allowlist.is_allowed(&event.pubkey.to_hex()) {
                                 tracing::warn!(
                                     "Nostr: ignoring NIP-04 message from unauthorized pubkey: {}",
                                     event.pubkey.to_hex()
@@ -217,7 +210,7 @@ impl Channel for NostrChannel {
                                         continue;
                                     }
                                     let sender = rumor.pubkey;
-                                    if !self.allowed.is_allowed(&sender) {
+                                    if !self.allowlist.is_allowed(&sender.to_hex()) {
                                         tracing::warn!(
                                             "Nostr: ignoring NIP-17 message from unauthorized pubkey: {}",
                                             sender.to_hex()
@@ -286,18 +279,22 @@ impl Channel for NostrChannel {
 mod tests {
     use super::*;
 
+    fn make_aspect(raw: &[String]) -> AllowlistAspect {
+        AllowlistAspect::new(canonicalize_allowed_pubkeys(raw).unwrap())
+    }
+
     #[test]
     fn allow_list_empty_denies_all() {
-        let al = AllowList::parse(&[]).unwrap();
+        let al = make_aspect(&[]);
         let pk = Keys::generate().public_key();
-        assert!(!al.is_allowed(&pk));
+        assert!(!al.is_allowed(&pk.to_hex()));
     }
 
     #[test]
     fn allow_list_wildcard_allows_all() {
-        let al = AllowList::parse(&["*".to_string()]).unwrap();
+        let al = make_aspect(&["*".to_string()]);
         let pk = Keys::generate().public_key();
-        assert!(al.is_allowed(&pk));
+        assert!(al.is_allowed(&pk.to_hex()));
     }
 
     #[test]
@@ -305,16 +302,29 @@ mod tests {
         let k1 = Keys::generate();
         let k2 = Keys::generate();
         let k3 = Keys::generate();
-        let al = AllowList::parse(&[k1.public_key().to_hex(), k2.public_key().to_hex()]).unwrap();
-        assert!(al.is_allowed(&k1.public_key()));
-        assert!(al.is_allowed(&k2.public_key()));
-        assert!(!al.is_allowed(&k3.public_key()));
+        let al = make_aspect(&[k1.public_key().to_hex(), k2.public_key().to_hex()]);
+        assert!(al.is_allowed(&k1.public_key().to_hex()));
+        assert!(al.is_allowed(&k2.public_key().to_hex()));
+        assert!(!al.is_allowed(&k3.public_key().to_hex()));
     }
 
     #[test]
     fn allow_list_rejects_invalid_key() {
-        let result = AllowList::parse(&["not-a-valid-pubkey".to_string()]);
+        let result = canonicalize_allowed_pubkeys(&["not-a-valid-pubkey".to_string()]);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn allow_list_canonicalizes_npub_to_hex() {
+        // bech32 npub form must match the hex form (and vice versa).
+        let k = Keys::generate();
+        let pk = k.public_key();
+        let npub = pk.to_bech32().unwrap();
+        let al = make_aspect(std::slice::from_ref(&npub));
+        assert!(
+            al.is_allowed(&pk.to_hex()),
+            "aspect must canonicalize npub entries to hex so call-site to_hex() matches",
+        );
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-channels/src/qq.rs
+++ b/crates/zeroclaw-channels/src/qq.rs
@@ -1,3 +1,4 @@
+use aspect_std::AllowlistAspect;
 use async_trait::async_trait;
 use base64::Engine as _;
 use futures_util::{SinkExt, StreamExt};
@@ -280,7 +281,7 @@ const AUTH_RETRY_MAX_BACKOFF_MS: u64 = 8_000;
 pub struct QQChannel {
     app_id: String,
     app_secret: String,
-    allowed_users: Vec<String>,
+    allowlist: AllowlistAspect,
     /// Cached access token + expiry timestamp.
     token_cache: Arc<RwLock<Option<(String, u64)>>>,
     /// Message deduplication set.
@@ -305,7 +306,7 @@ impl QQChannel {
         Self {
             app_id,
             app_secret,
-            allowed_users,
+            allowlist: AllowlistAspect::new(allowed_users),
             token_cache: Arc::new(RwLock::new(None)),
             dedup: Arc::new(RwLock::new(HashSet::new())),
             workspace_dir: None,
@@ -331,10 +332,6 @@ impl QQChannel {
 
     fn http_client(&self) -> reqwest::Client {
         zeroclaw_config::schema::build_channel_proxy_client("channel.qq", self.proxy_url.as_deref())
-    }
-
-    fn is_user_allowed(&self, user_id: &str) -> bool {
-        self.allowed_users.iter().any(|u| u == "*" || u == user_id)
     }
 
     /// Fetch an access token from QQ's OAuth2 endpoint.
@@ -1276,7 +1273,7 @@ impl Channel for QQChannel {
                             // For QQ, user_openid is the identifier
                             let user_openid = d.get("author").and_then(|a| a.get("user_openid")).and_then(|u| u.as_str()).unwrap_or(author_id);
 
-                            if !self.is_user_allowed(user_openid) {
+                            if !self.allowlist.is_allowed(user_openid) {
                                 tracing::warn!("QQ: ignoring C2C message from unauthorized user: {user_openid}");
                                 continue;
                             }
@@ -1316,7 +1313,7 @@ impl Channel for QQChannel {
 
                             let author_id = d.get("author").and_then(|a| a.get("member_openid")).and_then(|m| m.as_str()).unwrap_or("unknown");
 
-                            if !self.is_user_allowed(author_id) {
+                            if !self.allowlist.is_allowed(author_id) {
                                 tracing::warn!("QQ: ignoring group message from unauthorized user: {author_id}");
                                 continue;
                             }
@@ -1431,20 +1428,20 @@ mod tests {
     #[test]
     fn test_user_allowed_wildcard() {
         let ch = QQChannel::new("id".into(), "secret".into(), vec!["*".into()]);
-        assert!(ch.is_user_allowed("anyone"));
+        assert!(ch.allowlist.is_allowed("anyone"));
     }
 
     #[test]
     fn test_user_allowed_specific() {
         let ch = QQChannel::new("id".into(), "secret".into(), vec!["user123".into()]);
-        assert!(ch.is_user_allowed("user123"));
-        assert!(!ch.is_user_allowed("other"));
+        assert!(ch.allowlist.is_allowed("user123"));
+        assert!(!ch.allowlist.is_allowed("other"));
     }
 
     #[test]
     fn test_user_denied_empty() {
         let ch = make_channel();
-        assert!(!ch.is_user_allowed("anyone"));
+        assert!(!ch.allowlist.is_allowed("anyone"));
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-channels/src/slack.rs
+++ b/crates/zeroclaw-channels/src/slack.rs
@@ -1,4 +1,5 @@
 use anyhow::Context;
+use aspect_std::AllowlistAspect;
 use async_trait::async_trait;
 use base64::Engine as _;
 use chrono::Utc;
@@ -27,7 +28,7 @@ pub struct SlackChannel {
     bot_token: String,
     app_token: Option<String>,
     channel_ids: Vec<String>,
-    allowed_users: Vec<String>,
+    allowlist: AllowlistAspect,
     thread_replies: bool,
     mention_only: bool,
     strict_mention_in_thread: bool,
@@ -171,7 +172,7 @@ impl SlackChannel {
             bot_token,
             app_token,
             channel_ids,
-            allowed_users,
+            allowlist: AllowlistAspect::new(allowed_users),
             thread_replies: true,
             mention_only: false,
             strict_mention_in_thread: false,
@@ -504,13 +505,6 @@ impl SlackChannel {
         }
 
         Ok(())
-    }
-
-    /// Check if a Slack user ID is in the allowlist.
-    /// Empty list means deny everyone until explicitly configured.
-    /// `"*"` means allow everyone.
-    fn is_user_allowed(&self, user_id: &str) -> bool {
-        self.allowed_users.iter().any(|u| u == "*" || u == user_id)
     }
 
     fn is_group_sender_trigger_enabled(&self, user_id: &str) -> bool {
@@ -2767,7 +2761,7 @@ impl SlackChannel {
                                 .get("user")
                                 .and_then(|v| v.as_str())
                                 .unwrap_or_default();
-                            if !user.is_empty() && self.is_user_allowed(user) {
+                            if !user.is_empty() && self.allowlist.is_allowed(user) {
                                 let item = event.get("item");
                                 let item_channel = item
                                     .and_then(|i| i.get("channel"))
@@ -2841,7 +2835,7 @@ impl SlackChannel {
                 if user.is_empty() || user == bot_user_id {
                     continue;
                 }
-                if !self.is_user_allowed(user) {
+                if !self.allowlist.is_allowed(user) {
                     tracing::warn!("Slack: ignoring message from unauthorized user: {user}");
                     continue;
                 }
@@ -3859,7 +3853,7 @@ impl Channel for SlackChannel {
                         }
 
                         // Sender validation
-                        if !self.is_user_allowed(user) {
+                        if !self.allowlist.is_allowed(user) {
                             tracing::warn!(
                                 "Slack: ignoring message from unauthorized user: {user}"
                             );
@@ -3963,7 +3957,7 @@ impl Channel for SlackChannel {
                     if user.is_empty() || user == bot_user_id {
                         continue;
                     }
-                    if !self.is_user_allowed(user) {
+                    if !self.allowlist.is_allowed(user) {
                         continue;
                     }
 
@@ -4318,14 +4312,14 @@ mod tests {
     #[test]
     fn empty_allowlist_denies_everyone() {
         let ch = SlackChannel::new("xoxb-fake".into(), None, vec![], vec![]);
-        assert!(!ch.is_user_allowed("U12345"));
-        assert!(!ch.is_user_allowed("anyone"));
+        assert!(!ch.allowlist.is_allowed("U12345"));
+        assert!(!ch.allowlist.is_allowed("anyone"));
     }
 
     #[test]
     fn wildcard_allows_everyone() {
         let ch = SlackChannel::new("xoxb-fake".into(), None, vec![], vec!["*".into()]);
-        assert!(ch.is_user_allowed("U12345"));
+        assert!(ch.allowlist.is_allowed("U12345"));
     }
 
     #[test]
@@ -4726,29 +4720,29 @@ mod tests {
             vec![],
             vec!["U111".into(), "U222".into()],
         );
-        assert!(ch.is_user_allowed("U111"));
-        assert!(ch.is_user_allowed("U222"));
-        assert!(!ch.is_user_allowed("U333"));
+        assert!(ch.allowlist.is_allowed("U111"));
+        assert!(ch.allowlist.is_allowed("U222"));
+        assert!(!ch.allowlist.is_allowed("U333"));
     }
 
     #[test]
     fn allowlist_exact_match_not_substring() {
         let ch = SlackChannel::new("xoxb-fake".into(), None, vec![], vec!["U111".into()]);
-        assert!(!ch.is_user_allowed("U1111"));
-        assert!(!ch.is_user_allowed("U11"));
+        assert!(!ch.allowlist.is_allowed("U1111"));
+        assert!(!ch.allowlist.is_allowed("U11"));
     }
 
     #[test]
     fn allowlist_empty_user_id() {
         let ch = SlackChannel::new("xoxb-fake".into(), None, vec![], vec!["U111".into()]);
-        assert!(!ch.is_user_allowed(""));
+        assert!(!ch.allowlist.is_allowed(""));
     }
 
     #[test]
     fn allowlist_case_sensitive() {
         let ch = SlackChannel::new("xoxb-fake".into(), None, vec![], vec!["U111".into()]);
-        assert!(ch.is_user_allowed("U111"));
-        assert!(!ch.is_user_allowed("u111"));
+        assert!(ch.allowlist.is_allowed("U111"));
+        assert!(!ch.allowlist.is_allowed("u111"));
     }
 
     #[test]
@@ -4759,8 +4753,8 @@ mod tests {
             vec![],
             vec!["U111".into(), "*".into()],
         );
-        assert!(ch.is_user_allowed("U111"));
-        assert!(ch.is_user_allowed("anyone"));
+        assert!(ch.allowlist.is_allowed("U111"));
+        assert!(ch.allowlist.is_allowed("anyone"));
     }
 
     // ── Message ID edge cases ─────────────────────────────────────

--- a/crates/zeroclaw-channels/src/telegram.rs
+++ b/crates/zeroclaw-channels/src/telegram.rs
@@ -1,11 +1,12 @@
 use anyhow::Context;
+use aspect_std::AllowlistAspect;
 use async_trait::async_trait;
 use directories::UserDirs;
 use parking_lot::Mutex;
 use reqwest::multipart::{Form, Part};
 use std::fmt::Write as _;
 use std::path::Path;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::fs;
 use zeroclaw_api::channel::{Channel, ChannelMessage, SendMessage};
@@ -365,7 +366,11 @@ const TELEGRAM_MAX_FILE_DOWNLOAD_BYTES: u64 = 20 * 1024 * 1024;
 /// Telegram channel — long-polls the Bot API for updates
 pub struct TelegramChannel {
     bot_token: String,
-    allowed_users: Arc<RwLock<Vec<String>>>,
+    /// Who is allowed to talk to this bot. Wildcard `"*"` admits everyone;
+    /// an empty list denies everyone. Identities are normalized with
+    /// `trim()` + leading-`@` stripping at check time, so `"@alice"` in
+    /// config matches `"alice"` from the Telegram update.
+    allowlist: AllowlistAspect,
     pairing: Option<PairingGuard>,
     client: reqwest::Client,
     typing_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
@@ -415,8 +420,14 @@ enum EditMessageResult {
 
 impl TelegramChannel {
     pub fn new(bot_token: String, allowed_users: Vec<String>, mention_only: bool) -> Self {
-        let normalized_allowed = Self::normalize_allowed_users(allowed_users);
-        let pairing = if normalized_allowed.is_empty() {
+        let allowlist = AllowlistAspect::new(
+            allowed_users
+                .into_iter()
+                .map(|s| Self::normalize_identity(&s))
+                .filter(|s| !s.is_empty()),
+        )
+        .with_normalizer(|s| s.trim().trim_start_matches('@').to_string());
+        let pairing = if allowlist.is_empty() {
             let guard = PairingGuard::new(true, &[]);
             if let Some(code) = guard.pairing_code() {
                 println!("  🔐 Telegram pairing required. One-time bind code: {code}");
@@ -429,7 +440,7 @@ impl TelegramChannel {
 
         Self {
             bot_token,
-            allowed_users: Arc::new(RwLock::new(normalized_allowed)),
+            allowlist,
             pairing,
             client: reqwest::Client::new(),
             stream_mode: StreamMode::Off,
@@ -592,14 +603,6 @@ impl TelegramChannel {
         value.trim().trim_start_matches('@').to_string()
     }
 
-    fn normalize_allowed_users(allowed_users: Vec<String>) -> Vec<String> {
-        allowed_users
-            .into_iter()
-            .map(|entry| Self::normalize_identity(&entry))
-            .filter(|entry| !entry.is_empty())
-            .collect()
-    }
-
     async fn load_config_without_env() -> anyhow::Result<Config> {
         let home = UserDirs::new()
             .map(|u| u.home_dir().to_path_buf())
@@ -649,11 +652,7 @@ impl TelegramChannel {
         if normalized.is_empty() {
             return;
         }
-        if let Ok(mut users) = self.allowed_users.write()
-            && !users.iter().any(|u| u == &normalized)
-        {
-            users.push(normalized);
-        }
+        self.allowlist.add(normalized);
     }
 
     fn extract_bind_code(text: &str) -> Option<&str> {
@@ -1069,19 +1068,11 @@ impl TelegramChannel {
             .unwrap_or(false)
     }
 
-    fn is_user_allowed(&self, username: &str) -> bool {
-        let identity = Self::normalize_identity(username);
-        self.allowed_users
-            .read()
-            .map(|users| users.iter().any(|u| u == "*" || u == &identity))
-            .unwrap_or(false)
-    }
-
     fn is_any_user_allowed<'a, I>(&self, identities: I) -> bool
     where
         I: IntoIterator<Item = &'a str>,
     {
-        identities.into_iter().any(|id| self.is_user_allowed(id))
+        identities.into_iter().any(|id| self.allowlist.is_allowed(id))
     }
 
     async fn handle_unauthorized_message(&self, update: &serde_json::Value) {
@@ -3603,56 +3594,56 @@ mod tests {
     #[test]
     fn telegram_user_allowed_wildcard() {
         let ch = TelegramChannel::new("t".into(), vec!["*".into()], false);
-        assert!(ch.is_user_allowed("anyone"));
+        assert!(ch.allowlist.is_allowed("anyone"));
     }
 
     #[test]
     fn telegram_user_allowed_specific() {
         let ch = TelegramChannel::new("t".into(), vec!["alice".into(), "bob".into()], false);
-        assert!(ch.is_user_allowed("alice"));
-        assert!(!ch.is_user_allowed("eve"));
+        assert!(ch.allowlist.is_allowed("alice"));
+        assert!(!ch.allowlist.is_allowed("eve"));
     }
 
     #[test]
     fn telegram_user_allowed_with_at_prefix_in_config() {
         let ch = TelegramChannel::new("t".into(), vec!["@alice".into()], false);
-        assert!(ch.is_user_allowed("alice"));
+        assert!(ch.allowlist.is_allowed("alice"));
     }
 
     #[test]
     fn telegram_user_denied_empty() {
         let ch = TelegramChannel::new("t".into(), vec![], false);
-        assert!(!ch.is_user_allowed("anyone"));
+        assert!(!ch.allowlist.is_allowed("anyone"));
     }
 
     #[test]
     fn telegram_user_exact_match_not_substring() {
         let ch = TelegramChannel::new("t".into(), vec!["alice".into()], false);
-        assert!(!ch.is_user_allowed("alice_bot"));
-        assert!(!ch.is_user_allowed("alic"));
-        assert!(!ch.is_user_allowed("malice"));
+        assert!(!ch.allowlist.is_allowed("alice_bot"));
+        assert!(!ch.allowlist.is_allowed("alic"));
+        assert!(!ch.allowlist.is_allowed("malice"));
     }
 
     #[test]
     fn telegram_user_empty_string_denied() {
         let ch = TelegramChannel::new("t".into(), vec!["alice".into()], false);
-        assert!(!ch.is_user_allowed(""));
+        assert!(!ch.allowlist.is_allowed(""));
     }
 
     #[test]
     fn telegram_user_case_sensitive() {
         let ch = TelegramChannel::new("t".into(), vec!["Alice".into()], false);
-        assert!(ch.is_user_allowed("Alice"));
-        assert!(!ch.is_user_allowed("alice"));
-        assert!(!ch.is_user_allowed("ALICE"));
+        assert!(ch.allowlist.is_allowed("Alice"));
+        assert!(!ch.allowlist.is_allowed("alice"));
+        assert!(!ch.allowlist.is_allowed("ALICE"));
     }
 
     #[test]
     fn telegram_wildcard_with_specific_users() {
         let ch = TelegramChannel::new("t".into(), vec!["alice".into(), "*".into()], false);
-        assert!(ch.is_user_allowed("alice"));
-        assert!(ch.is_user_allowed("bob"));
-        assert!(ch.is_user_allowed("anyone"));
+        assert!(ch.allowlist.is_allowed("alice"));
+        assert!(ch.allowlist.is_allowed("bob"));
+        assert!(ch.allowlist.is_allowed("anyone"));
     }
 
     #[test]
@@ -5851,5 +5842,53 @@ mod tests {
     fn non_approval_callback_data_is_ignored() {
         let cb_data = "some_other_action:data";
         assert!(cb_data.strip_prefix("approval:").is_none());
+    }
+
+    /// Parity oracle: the aspect-backed check must return byte-identical
+    /// results to the pre-migration shape across a truth table covering
+    /// wildcard, empty list, `@`-prefix normalization, case-sensitivity,
+    /// and substring rejection. If this drifts, the migration is unsound.
+    #[test]
+    fn allowlist_parity_with_pre_aspect_shape() {
+        fn norm(s: &str) -> String {
+            s.trim().trim_start_matches('@').to_string()
+        }
+        let cases: Vec<(Vec<&str>, &str)> = vec![
+            (vec![], "alice"),
+            (vec![], ""),
+            (vec!["*"], "alice"),
+            (vec!["*"], ""),
+            (vec!["alice"], "alice"),
+            (vec!["alice"], "eve"),
+            (vec!["@alice"], "alice"),
+            (vec!["alice"], "@alice"),
+            (vec!["  alice  "], "alice"),
+            (vec!["alice", "bob"], "bob"),
+            (vec!["alice", "*"], "anyone"),
+            (vec!["*", "alice"], "anyone"),
+            (vec!["alice"], "alice_bot"), // substring rejected
+            (vec!["alice"], "alic"),      // prefix rejected
+            (vec!["Alice"], "alice"),     // case-sensitive
+            (vec!["Alice"], "Alice"),
+            (vec!["123456789"], "123456789"),
+        ];
+        for (entries, identity) in cases {
+            let normalized_entries: Vec<String> =
+                entries.iter().map(|s| norm(s)).filter(|s| !s.is_empty()).collect();
+            let needle = norm(identity);
+            let baseline = normalized_entries
+                .iter()
+                .any(|u| u == "*" || u == &needle);
+            let ch = TelegramChannel::new(
+                "t".into(),
+                entries.iter().map(|s| (*s).to_string()).collect(),
+                false,
+            );
+            assert_eq!(
+                ch.allowlist.is_allowed(identity),
+                baseline,
+                "aspect drift for entries={entries:?} identity={identity:?}",
+            );
+        }
     }
 }

--- a/crates/zeroclaw-channels/src/twitter.rs
+++ b/crates/zeroclaw-channels/src/twitter.rs
@@ -1,3 +1,4 @@
+use aspect_std::AllowlistAspect;
 use async_trait::async_trait;
 use serde_json::json;
 use std::collections::HashSet;
@@ -12,7 +13,7 @@ const TWITTER_API_BASE: &str = "https://api.x.com/2";
 /// for sending tweets/DMs and filtered stream for receiving mentions.
 pub struct TwitterChannel {
     bearer_token: String,
-    allowed_users: Vec<String>,
+    allowlist: AllowlistAspect,
     /// Message deduplication set.
     dedup: Arc<RwLock<HashSet<String>>>,
 }
@@ -24,17 +25,13 @@ impl TwitterChannel {
     pub fn new(bearer_token: String, allowed_users: Vec<String>) -> Self {
         Self {
             bearer_token,
-            allowed_users,
+            allowlist: AllowlistAspect::new(allowed_users),
             dedup: Arc::new(RwLock::new(HashSet::new())),
         }
     }
 
     fn http_client(&self) -> reqwest::Client {
         zeroclaw_config::schema::build_runtime_proxy_client("channel.twitter")
-    }
-
-    fn is_user_allowed(&self, user_id: &str) -> bool {
-        self.allowed_users.iter().any(|u| u == "*" || u == user_id)
     }
 
     /// Check and insert tweet ID for deduplication.
@@ -257,7 +254,8 @@ impl Channel for TwitterChannel {
                                 .cloned()
                                 .unwrap_or_else(|| author_id.to_string());
 
-                            if !self.is_user_allowed(&username) && !self.is_user_allowed(author_id)
+                            if !self.allowlist.is_allowed(&username)
+                                && !self.allowlist.is_allowed(author_id)
                             {
                                 tracing::debug!(
                                     "Twitter: ignoring mention from unauthorized user: {username}"
@@ -390,20 +388,20 @@ mod tests {
     #[test]
     fn test_user_allowed_wildcard() {
         let ch = TwitterChannel::new("token".into(), vec!["*".into()]);
-        assert!(ch.is_user_allowed("anyone"));
+        assert!(ch.allowlist.is_allowed("anyone"));
     }
 
     #[test]
     fn test_user_allowed_specific() {
         let ch = TwitterChannel::new("token".into(), vec!["user123".into()]);
-        assert!(ch.is_user_allowed("user123"));
-        assert!(!ch.is_user_allowed("other"));
+        assert!(ch.allowlist.is_allowed("user123"));
+        assert!(!ch.allowlist.is_allowed("other"));
     }
 
     #[test]
     fn test_user_denied_empty() {
         let ch = TwitterChannel::new("token".into(), vec![]);
-        assert!(!ch.is_user_allowed("anyone"));
+        assert!(!ch.allowlist.is_allowed("anyone"));
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-channels/src/wechat.rs
+++ b/crates/zeroclaw-channels/src/wechat.rs
@@ -6,12 +6,13 @@
 
 use aes::cipher::{BlockDecryptMut, BlockEncryptMut, KeyInit, block_padding::Pkcs7};
 use anyhow::Context;
+use aspect_std::AllowlistAspect;
 use async_trait::async_trait;
 use base64::Engine;
 use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, RwLock};
+use std::sync::RwLock;
 use std::time::Duration;
 use zeroclaw_api::channel::{Channel, ChannelMessage, SendMessage};
 use zeroclaw_runtime::i18n;
@@ -370,7 +371,9 @@ pub struct WeChatChannel {
     /// CDN base URL.
     cdn_base_url: String,
     /// Allowed WeChat user IDs. Empty = deny all, `"*"` = allow all.
-    allowed_users: Arc<RwLock<Vec<String>>>,
+    /// Backed by `aspect-std::AllowlistAspect` so the check is centralized
+    /// rather than re-implemented per-channel.
+    allowlist: AllowlistAspect,
     /// Pairing guard for /bind flow.
     pairing: Option<PairingGuard>,
     /// HTTP client for API requests.
@@ -603,7 +606,7 @@ impl WeChatChannel {
             account_id: RwLock::new(None),
             api_base_url,
             cdn_base_url,
-            allowed_users: Arc::new(RwLock::new(allowed_users)),
+            allowlist: AllowlistAspect::new(allowed_users),
             pairing,
             client: reqwest::Client::new(),
             context_tokens: Mutex::new(HashMap::new()),
@@ -713,22 +716,11 @@ impl WeChatChannel {
         self.context_tokens.lock().get(user_id).cloned()
     }
 
-    fn is_user_allowed(&self, user_id: &str) -> bool {
-        self.allowed_users
-            .read()
-            .map(|users| users.iter().any(|u| u == "*" || u == user_id))
-            .unwrap_or(false)
-    }
-
     fn add_allowed_identity_runtime(&self, identity: &str) {
         if identity.is_empty() {
             return;
         }
-        if let Ok(mut users) = self.allowed_users.write()
-            && !users.iter().any(|u| u == identity)
-        {
-            users.push(identity.to_string());
-        }
+        self.allowlist.add(identity);
     }
 
     fn extract_bind_code(text: &str) -> Option<&str> {
@@ -1865,7 +1857,7 @@ impl Channel for WeChatChannel {
                 let text = extract_text_from_items(&items);
 
                 // Check authorization
-                if !self.is_user_allowed(from_user_id) {
+                if !self.allowlist.is_allowed(from_user_id) {
                     self.handle_unauthorized_message(from_user_id, &text).await;
                     continue;
                 }
@@ -2082,7 +2074,7 @@ mod tests {
             Some("/tmp/test-wechat".into()),
         )
         .unwrap();
-        assert!(ch.is_user_allowed("anyone@im.wechat"));
+        assert!(ch.allowlist.is_allowed("anyone@im.wechat"));
     }
 
     #[test]
@@ -2094,8 +2086,8 @@ mod tests {
             Some("/tmp/test-wechat".into()),
         )
         .unwrap();
-        assert!(ch.is_user_allowed("user1@im.wechat"));
-        assert!(!ch.is_user_allowed("user2@im.wechat"));
+        assert!(ch.allowlist.is_allowed("user1@im.wechat"));
+        assert!(!ch.allowlist.is_allowed("user2@im.wechat"));
     }
 
     #[test]
@@ -2235,5 +2227,42 @@ mod tests {
             .and_then(|value| value.as_str())
             .unwrap_or("");
         assert!(!version.is_empty());
+    }
+
+    /// Parity oracle: the aspect-backed check must return byte-identical
+    /// results to the pre-migration shape across a truth table covering
+    /// wildcard, empty list, case-sensitivity, and substring rejection.
+    #[test]
+    fn allowlist_parity_with_pre_aspect_shape() {
+        let cases: Vec<(Vec<&str>, &str)> = vec![
+            (vec![], "alice@im.wechat"),
+            (vec![], ""),
+            (vec!["*"], "alice@im.wechat"),
+            (vec!["*"], ""),
+            (vec!["user1@im.wechat"], "user1@im.wechat"),
+            (vec!["user1@im.wechat"], "user2@im.wechat"),
+            (vec!["a", "b"], "b"),
+            (vec!["a", "*"], "anyone"),
+            (vec!["*", "a"], "anyone"),
+            (vec!["alice"], "alice_bot"), // substring rejected
+            (vec!["alice"], "alic"),      // prefix rejected
+            (vec!["Alice"], "alice"),     // case-sensitive
+            (vec!["Alice"], "Alice"),
+        ];
+        for (entries, identity) in cases {
+            let baseline = entries.iter().any(|u| *u == "*" || *u == identity);
+            let ch = WeChatChannel::new(
+                entries.iter().map(|s| (*s).to_string()).collect(),
+                None,
+                None,
+                Some("/tmp/test-wechat-parity".into()),
+            )
+            .unwrap();
+            assert_eq!(
+                ch.allowlist.is_allowed(identity),
+                baseline,
+                "aspect drift for entries={entries:?} identity={identity:?}",
+            );
+        }
     }
 }

--- a/crates/zeroclaw-channels/src/wecom.rs
+++ b/crates/zeroclaw-channels/src/wecom.rs
@@ -1,3 +1,4 @@
+use aspect_std::AllowlistAspect;
 use async_trait::async_trait;
 use zeroclaw_api::channel::{Channel, ChannelMessage, SendMessage};
 
@@ -7,15 +8,15 @@ use zeroclaw_api::channel::{Channel, ChannelMessage, SendMessage};
 /// through a configurable callback URL that WeCom posts to.
 pub struct WeComChannel {
     webhook_key: String,
-    #[allow(dead_code)] // used by is_user_allowed which is WIP
-    allowed_users: Vec<String>,
+    #[allow(dead_code)] // used by allowlist which is WIP
+    allowlist: AllowlistAspect,
 }
 
 impl WeComChannel {
     pub fn new(webhook_key: String, allowed_users: Vec<String>) -> Self {
         Self {
             webhook_key,
-            allowed_users,
+            allowlist: AllowlistAspect::new(allowed_users),
         }
     }
 
@@ -28,11 +29,6 @@ impl WeComChannel {
             "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key={}",
             self.webhook_key
         )
-    }
-
-    #[cfg(test)]
-    fn is_user_allowed(&self, user_id: &str) -> bool {
-        self.allowed_users.iter().any(|u| u == "*" || u == user_id)
     }
 }
 
@@ -131,20 +127,20 @@ mod tests {
     #[test]
     fn test_user_allowed_wildcard() {
         let ch = WeComChannel::new("key".into(), vec!["*".into()]);
-        assert!(ch.is_user_allowed("anyone"));
+        assert!(ch.allowlist.is_allowed("anyone"));
     }
 
     #[test]
     fn test_user_allowed_specific() {
         let ch = WeComChannel::new("key".into(), vec!["user123".into()]);
-        assert!(ch.is_user_allowed("user123"));
-        assert!(!ch.is_user_allowed("other"));
+        assert!(ch.allowlist.is_allowed("user123"));
+        assert!(!ch.allowlist.is_allowed("other"));
     }
 
     #[test]
     fn test_user_denied_empty() {
         let ch = WeComChannel::new("key".into(), vec![]);
-        assert!(!ch.is_user_allowed("anyone"));
+        assert!(!ch.allowlist.is_allowed("anyone"));
     }
 
     #[test]

--- a/crates/zeroclaw-channels/src/whatsapp_web.rs
+++ b/crates/zeroclaw-channels/src/whatsapp_web.rs
@@ -30,6 +30,8 @@
 
 use super::whatsapp_storage::RusqliteStore;
 use anyhow::{Result, anyhow};
+#[cfg(feature = "whatsapp-web")]
+use aspect_std::AllowlistAspect;
 use async_trait::async_trait;
 use parking_lot::Mutex;
 use std::path::Path;
@@ -39,6 +41,22 @@ use wa_rs_proto::whatsapp::device_props::PlatformType;
 use zeroclaw_api::channel::{Channel, ChannelMessage, SendMessage};
 #[cfg(not(feature = "whatsapp-web"))]
 use zeroclaw_runtime::i18n;
+
+/// Two-way E.164 normalize-and-compare predicate used by the
+/// allowlist aspect for WhatsApp Web. Mirrors the pre-aspect
+/// semantics: if either the entry or the phone fails to normalize to
+/// `+<digits>`, the match is rejected; otherwise the canonical forms
+/// are compared for byte equality.
+#[cfg(feature = "whatsapp-web")]
+pub(crate) fn whatsapp_phone_match(entry: &str, phone: &str) -> bool {
+    match (
+        WhatsAppWebChannel::normalize_phone_token(entry),
+        WhatsAppWebChannel::normalize_phone_token(phone),
+    ) {
+        (Some(a), Some(b)) => a == b,
+        _ => false,
+    }
+}
 
 /// WhatsApp Web channel using wa-rs with custom rusqlite storage
 ///
@@ -62,8 +80,11 @@ pub struct WhatsAppWebChannel {
     pair_phone: Option<String>,
     /// Custom pair code (optional)
     pair_code: Option<String>,
-    /// Allowed phone numbers (E.164 format) or "*" for all
-    allowed_numbers: Vec<String>,
+    /// Allowed phone numbers (E.164 format) or "*" for all.
+    /// Configured via `allowed_numbers`; the AllowlistAspect installs
+    /// `whatsapp_phone_match` as a matcher so both entries and
+    /// inputs are normalized to canonical E.164 before comparison.
+    allowlist: AllowlistAspect,
     /// When true, only respond to messages that @-mention the bot in groups
     mention_only: bool,
     /// Bot phone number (digits only), resolved from pair_phone or device identity at runtime
@@ -142,11 +163,13 @@ impl WhatsAppWebChannel {
             );
         }
 
+        let allowlist = AllowlistAspect::new(allowed_numbers).with_matcher(whatsapp_phone_match);
+
         Self {
             session_path,
             pair_phone,
             pair_code,
-            allowed_numbers,
+            allowlist,
             mention_only,
             bot_phone: Arc::new(Mutex::new(bot_phone)),
             mode,
@@ -220,35 +243,11 @@ impl WhatsAppWebChannel {
         self
     }
 
-    /// Check if a phone number is allowed (E.164 format: +1234567890)
-    #[cfg(feature = "whatsapp-web")]
-    fn is_number_allowed(&self, phone: &str) -> bool {
-        Self::is_number_allowed_for_list(&self.allowed_numbers, phone)
-    }
-
-    /// Check whether a phone number is allowed against a provided allowlist.
-    #[cfg(feature = "whatsapp-web")]
-    fn is_number_allowed_for_list(allowed_numbers: &[String], phone: &str) -> bool {
-        if allowed_numbers.iter().any(|entry| entry.trim() == "*") {
-            return true;
-        }
-
-        let Some(phone_norm) = Self::normalize_phone_token(phone) else {
-            return false;
-        };
-
-        allowed_numbers.iter().any(|entry| {
-            Self::normalize_phone_token(entry)
-                .as_deref()
-                .is_some_and(|allowed_norm| allowed_norm == phone_norm)
-        })
-    }
-
     /// Normalize a phone-like token to canonical E.164 (`+<digits>`).
     ///
     /// Accepts raw numbers, `+` numbers, and JIDs (uses the user part before `@`).
     #[cfg(feature = "whatsapp-web")]
-    fn normalize_phone_token(value: &str) -> Option<String> {
+    pub(crate) fn normalize_phone_token(value: &str) -> Option<String> {
         let trimmed = value.trim();
         if trimmed.is_empty() {
             return None;
@@ -983,7 +982,7 @@ impl Channel for WhatsAppWebChannel {
         // Validate recipient allowlist only for direct phone-number targets.
         if !Self::is_jid(&message.recipient) {
             let normalized = self.normalize_phone(&message.recipient);
-            if !self.is_number_allowed(&normalized) {
+            if !self.allowlist.is_allowed(&normalized) {
                 tracing::warn!(
                     "WhatsApp Web: recipient {} not in allowed list",
                     message.recipient
@@ -1148,7 +1147,7 @@ impl Channel for WhatsAppWebChannel {
 
             // Build the bot
             let tx_clone = tx.clone();
-            let allowed_numbers = self.allowed_numbers.clone();
+            let allowlist = self.allowlist.clone();
             let logout_tx_clone = logout_tx.clone();
             let retry_count_clone = retry_count.clone();
             let session_revoked_clone = session_revoked.clone();
@@ -1175,7 +1174,7 @@ impl Channel for WhatsAppWebChannel {
                 )
                 .on_event(move |event, client| {
                     let tx_inner = tx_clone.clone();
-                    let allowed_numbers = allowed_numbers.clone();
+                    let allowlist = allowlist.clone();
                     let logout_tx = logout_tx_clone.clone();
                     let retry_count = retry_count_clone.clone();
                     let session_revoked = session_revoked_clone.clone();
@@ -1210,9 +1209,7 @@ impl Channel for WhatsAppWebChannel {
 
                                 let normalized = sender_candidates
                                     .iter()
-                                    .find(|candidate| {
-                                        Self::is_number_allowed_for_list(&allowed_numbers, candidate)
-                                    })
+                                    .find(|candidate| allowlist.is_allowed(candidate))
                                     .cloned();
 
                                 let is_group = info.source.is_group;
@@ -1668,7 +1665,7 @@ impl Channel for WhatsAppWebChannel {
 
         if !Self::is_jid(recipient) {
             let normalized = self.normalize_phone(recipient);
-            if !self.is_number_allowed(&normalized) {
+            if !self.allowlist.is_allowed(&normalized) {
                 tracing::warn!(
                     "WhatsApp Web: typing target {} not in allowed list",
                     recipient
@@ -1696,7 +1693,7 @@ impl Channel for WhatsAppWebChannel {
 
         if !Self::is_jid(recipient) {
             let normalized = self.normalize_phone(recipient);
-            if !self.is_number_allowed(&normalized) {
+            if !self.allowlist.is_allowed(&normalized) {
                 tracing::warn!(
                     "WhatsApp Web: typing target {} not in allowed list",
                     recipient
@@ -1816,8 +1813,8 @@ mod tests {
     #[cfg(feature = "whatsapp-web")]
     fn whatsapp_web_number_allowed_exact() {
         let ch = make_channel();
-        assert!(ch.is_number_allowed("+1234567890"));
-        assert!(!ch.is_number_allowed("+9876543210"));
+        assert!(ch.allowlist.is_allowed("+1234567890"));
+        assert!(!ch.allowlist.is_allowed("+9876543210"));
     }
 
     #[test]
@@ -1834,8 +1831,8 @@ mod tests {
             zeroclaw_config::schema::WhatsAppChatPolicy::default(),
             false,
         );
-        assert!(ch.is_number_allowed("+1234567890"));
-        assert!(ch.is_number_allowed("+9999999999"));
+        assert!(ch.allowlist.is_allowed("+1234567890"));
+        assert!(ch.allowlist.is_allowed("+9999999999"));
     }
 
     #[test]
@@ -1853,7 +1850,7 @@ mod tests {
             false,
         );
         // Empty allowlist means "deny all" (matches channel-wide allowlist policy).
-        assert!(!ch.is_number_allowed("+1234567890"));
+        assert!(!ch.allowlist.is_allowed("+1234567890"));
     }
 
     #[test]
@@ -1892,11 +1889,18 @@ mod tests {
     #[test]
     #[cfg(feature = "whatsapp-web")]
     fn whatsapp_web_allowlist_matches_normalized_format() {
-        let allowed = vec!["+15551234567".to_string()];
-        assert!(WhatsAppWebChannel::is_number_allowed_for_list(
-            &allowed,
-            "+1 (555) 123-4567"
-        ));
+        let ch = WhatsAppWebChannel::new(
+            "/tmp/test.db".into(),
+            None,
+            None,
+            vec!["+15551234567".to_string()],
+            false,
+            zeroclaw_config::schema::WhatsAppWebMode::default(),
+            zeroclaw_config::schema::WhatsAppChatPolicy::default(),
+            zeroclaw_config::schema::WhatsAppChatPolicy::default(),
+            false,
+        );
+        assert!(ch.allowlist.is_allowed("+1 (555) 123-4567"));
     }
 
     #[test]
@@ -2487,5 +2491,62 @@ mod tests {
         assert!(!fromme_outside_self_chat_is_operator_trigger(
             false, &dm, &group, ""
         ));
+    }
+
+    // ── M1 parity: AllowlistAspect must accept exactly the same set of
+    // (entries, phone) pairs that the pre-aspect
+    // is_number_allowed_for_list shape did. Reference implementation is
+    // inlined below; both implementations are exercised against the
+    // same truth table.
+    #[test]
+    #[cfg(feature = "whatsapp-web")]
+    fn allowlist_parity_with_pre_aspect_shape() {
+        fn pre_aspect(entries: &[String], phone: &str) -> bool {
+            if entries.iter().any(|entry| entry.trim() == "*") {
+                return true;
+            }
+            let Some(phone_norm) = WhatsAppWebChannel::normalize_phone_token(phone) else {
+                return false;
+            };
+            entries.iter().any(|entry| {
+                WhatsAppWebChannel::normalize_phone_token(entry)
+                    .as_deref()
+                    .is_some_and(|allowed_norm| allowed_norm == phone_norm)
+            })
+        }
+
+        let cases: Vec<(Vec<&str>, &str)> = vec![
+            (vec![], "+1234567890"),                          // empty deny
+            (vec![], ""),                                     // empty + invalid input
+            (vec!["*"], "+1234567890"),                       // wildcard
+            (vec!["*"], ""),                                  // wildcard + invalid input
+            (vec!["+1234567890"], "+1234567890"),             // exact E.164 match
+            (vec!["+1234567890"], "+9876543210"),             // E.164 mismatch
+            (vec!["1234567890"], "+1234567890"),              // entry missing '+'
+            (vec!["+1234567890"], "1234567890"),              // phone missing '+'
+            (vec!["+1 (555) 123-4567"], "+15551234567"),      // formatted entry
+            (vec!["+15551234567"], "+1 (555) 123-4567"),      // formatted phone
+            (vec!["+15551234567"], "15551234567@s.whatsapp.net"), // JID phone
+            (vec!["15551234567@s.whatsapp.net"], "+15551234567"), // JID entry
+            (vec!["+1234567890", "+9999999999"], "+9999999999"), // multi-entry hit
+            (vec!["+1234567890", "*"], "anything"),           // wildcard among real entries (deny: not E.164, but wildcard wins)
+            (vec!["garbage"], "+1234567890"),                 // entry with no digits
+            (vec!["+1234567890"], "garbage"),                 // phone with no digits
+            (vec!["garbage"], "trash"),                       // both unnormalizable
+        ];
+
+        for (entries, phone) in cases {
+            let entries_owned: Vec<String> =
+                entries.iter().map(|s| (*s).to_string()).collect();
+            let baseline = pre_aspect(&entries_owned, phone);
+
+            let aspect =
+                AllowlistAspect::new(entries_owned.clone()).with_matcher(whatsapp_phone_match);
+            assert_eq!(
+                aspect.is_allowed(phone),
+                baseline,
+                "aspect drift for entries={entries:?} phone={phone:?}",
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Replaces the hand-rolled `fn is_user_allowed(&self, open_id: &str) -> bool` predicate in `lark.rs` with the shared `aspect_std::AllowlistAspect`. This PR is part of the 24-PR migration; the chain tip (#6799) carries the cumulative view + the M1–M5 evaluation results.
- **Scope boundary:** This PR does NOT change identity resolution (Lark open_ids are opaque platform IDs), webhook/SSE parsing, downstream message routing, LLM dispatch, or response sending. The aspect owns *only* the matching half of allowlist enforcement for the `lark` channel.
- **Blast radius:** the `lark` channel only. Other channels in the chain are migrated by their own PRs. If `AllowlistAspect::is_allowed` regresses for this channel's archetype (flat-list + `*` byte-equality), only `lark` is affected at this commit; the chain-wide blast radius lives in #6799. Mitigated by per-channel parity tests against the old predicate.
- **Linked issue(s):** none
- **Labels:** `risk: medium`, `size: S`, `type: refactor`, `area: channels`

## What changed

- Replaced `allowed_users: Vec<String>` with `allowlist: AllowlistAspect` in the channel struct.
- Deleted the hand-rolled `fn is_user_allowed(&self, open_id: &str) -> bool` predicate.
- Production caller routes through `self.allowlist.is_allowed(open_id)`.
- Unit tests updated to assert against `allowlist.is_allowed("…")` instead of field/predicate inspection.

## Archetype

Archetype **A** — flat-list + `*` byte-equality.

A flat `Vec<String>` of allowed Lark open_id values with `*` as wildcard.

## Supply-chain question (resolution)

The reviewer's blocker on sourcing `aspect-std` from `github.com/yijunyu/aspect-rs` is resolved by the latest commit on this branch (and all 23 other chain branches): **`aspect-std = "0.1.1"` is now on crates.io** (published 2026-05-24), so the dep is registry-sourced, immutable, and visible to `cargo audit` / `cargo deny`. The git-pinned source has been removed.

- `aspect-core v0.1.1` — https://crates.io/crates/aspect-core/0.1.1
- `aspect-runtime v0.1.1` — https://crates.io/crates/aspect-runtime/0.1.1
- `aspect-macros v0.1.1` — https://crates.io/crates/aspect-macros/0.1.1
- `aspect-std v0.1.1` — https://crates.io/crates/aspect-std/0.1.1 (contains `AllowlistAspect`)

## Validation Evidence

Local validation (commands from the test plan, tail output verbatim):

```
$ cargo build -p zeroclaw-channels --features channel-lark

   Compiling prost v0.14.3
   Compiling zeroclaw-channels v0.7.5 (/home/y00577373/zeroclaw/crates/zeroclaw-channels)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 37.41s

$ cargo test -p zeroclaw-channels --features channel-lark --lib lark::
test lark::tests::split_markdown_chunks_handles_no_newlines ... ok
test lark::tests::split_markdown_chunks_single_chunk_for_small_content ... ok
test lark::tests::split_markdown_chunks_splits_on_newline_boundaries ... ok
test lark::tests::lark_audio_routes_through_transcription_manager ... ok
test lark::tests::lark_audio_token_refresh_on_invalid_token_response ... ok

test result: ok. 75 passed; 0 failed; 0 ignored; 0 measured; 991 filtered out; finished in 0.01s


   Compiling zeroclaw-channels v0.7.5 (/home/y00577373/zeroclaw/crates/zeroclaw-channels)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 52.71s
     Running unittests src/lib.rs (target/debug/deps/zeroclaw_channels-83c41bce69625f3a)

$ cargo clippy -p zeroclaw-channels --features channel-lark --lib --no-deps -- -D warnings

    Checking prost v0.14.3
    Checking zeroclaw-channels v0.7.5 (/home/y00577373/zeroclaw/crates/zeroclaw-channels)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 22.82s
```

- **Commands run:** the three above; all pass with zero warnings.
- **Beyond CI — what I manually verified:** the channel-specific parity tests assert the new path produces the same allow/deny verdict as the old predicate across every truth-table case (wildcard, empty list, specific match, unknown, case sensitivity, substring rejection).
- **Skipped:** `cargo fmt --check` and `cargo test --workspace` are not in the test plan because the relevant invariants are channel-local; the workspace-level checks belong to the merge gate.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? **No.**
- New external network calls? **No.**
- Secrets / tokens / credentials handling changed? **No.**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No** — test fixtures use synthetic IDs.

This is an access-control refactor: it changes *where* the allowlist check is implemented but not *what* it enforces. Per-channel parity tests assert the new path produces the same verdict as the old predicate across every truth-table case.

## Compatibility

- Backward compatible? **Yes** at the channel config surface — the `allowed_users` config field is still consumed; its value is passed to `AllowlistAspect::new(...)` at channel construction.
- Config / env / CLI surface changed? **No.** Existing operator config files continue to work unchanged.
- Upgrade steps for existing users: none required.

## Rollback (risk: medium)

- **Fast rollback command/path:** `git revert <merge-sha>` reverts this single-channel migration. The chain is designed so each PR is revertable on its own; the only post-revert constraint is that the chain tip (#6799) and any PRs further up the chain that depend on this commit would need to be rebased.
- **Feature flags or config toggles:** None. The aspect is statically linked.
- **Observable failure symptoms:**
  - Allowlist-deny false positives: legitimate `lark` users denied at inbound. Grep logs for `is_allowed → false` followed by message drop in the `lark` channel-level traces.
  - Allowlist-bypass false negatives: unauthorized users let through. Watch for unexpected senders appearing in `chat_history` rows for `lark` if the deployment had a non-wildcard allowlist.
  - Metric to watch: `lark` message-drop rate (delta from steady-state in the hour after deploy).

## Note on the clone warning

The reviewer correctly flagged that `AllowlistAspect::clone` zeros out the `normalizer` and `matcher` fields. This channel does not clone the aspect; no closures are at risk. Follow-up filed against `aspect-std` to either (a) make `Clone` carry the closures via `Arc<dyn Fn …>` or (b) emit a compile-time warning when `clone()` is called on an aspect with non-`None` closures. Until then the safe pattern is to share the parent `Arc` rather than clone the aspect; this is the pattern already in use.
