### PR TITLE
fix(web): define missing CronSchedule discriminated union type

### DIFF
--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -54,6 +54,11 @@ export interface ToolSpec {
   parameters: any;
 }
 
+export type CronSchedule =
+  | { kind: "cron"; expr: string; tz?: string | null }
+  | { kind: "every"; every_ms: number }
+  | { kind: "at"; at: string };
+
 export interface CronDeliveryConfig {
   mode: string;
   channel?: string | null;


### PR DESCRIPTION
## Summary

- **Base branch:** `integration/v0.8.0`
- **What changed and why:**
  - `web/src/types/api.ts`: Added the `CronSchedule` discriminated union type that `CronJob.schedule` references but was never defined
  - Without this, `tsc` exits with `Cannot find name 'CronSchedule'`, which breaks the `web-builder` Docker build stage entirely
- **Scope boundary:** touches only `web/src/types/api.ts`; does not change any generated file, Rust code, or runtime behavior
- **Blast radius:** none — this is a type definition only; no runtime path affected
- **Linked issues:** Related #6398 (v0.8.0 integration — this bug was introduced in that branch)
- **Labels:** `type: fix`, `risk: low`, `size: XS`

## Validation Evidence (required)

Docker build `Dockerfile.local` passed end-to-end after this fix:

```
web-builder: tsc + Vite build — 2140 modules, built in 2.15s  ✓
zeroclaw-builder: cargo release build — 3m 03s               ✓
final image: 61.82 MB (distroless cc-debian13:nonroot)        ✓
```

Before the fix, Docker build failed at the `web-builder` stage:
```
src/types/api.ts:XX:XX - error TS2304: Cannot find name 'CronSchedule'.
```

- **Commands run:** `docker build -f Dockerfile.local -t zeroclaw:local .`
- **Beyond CI:** Verified the type shape matches `CronScheduleDecl` in `crates/zeroclaw-config/src/schema.rs` (serde `tag = "kind"`, variants `cron`/`every`/`at`)
- **Skipped:** `cargo fmt/clippy/test` — no Rust code changed

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No