### PR TITLE
fix(deploy): update service template and deploy script for v0.8.0

### DIFF
--- a/scripts/deploy-rpi.sh
+++ b/scripts/deploy-rpi.sh
@@ -180,7 +180,10 @@ fi
 SERVICE_DEST="/etc/systemd/system/zeroclaw.service"
 echo ""
 echo "==> Installing systemd service (requires sudo on the Pi)"
-${SCP_CMD} ${SCP_OPTS} "scripts/zeroclaw.service" "${RPI_USER}@${RPI_HOST}:/tmp/zeroclaw.service"
+# Substitute @@RPI_USER@@ placeholder with the actual deploy user.
+sed "s|@@RPI_USER@@|${RPI_USER}|g" scripts/zeroclaw.service > /tmp/zeroclaw.service.rendered
+${SCP_CMD} ${SCP_OPTS} /tmp/zeroclaw.service.rendered "${RPI_USER}@${RPI_HOST}:/tmp/zeroclaw.service"
+rm -f /tmp/zeroclaw.service.rendered
 # shellcheck disable=SC2029
 ${SSH_CMD} ${SSH_OPTS} "${RPI_USER}@${RPI_HOST}" \
   "sudo mv /tmp/zeroclaw.service ${SERVICE_DEST} && \

--- a/scripts/zeroclaw.service
+++ b/scripts/zeroclaw.service
@@ -6,17 +6,19 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-User=pi
-SupplementaryGroups=gpio spi i2c
-WorkingDirectory=/home/pi/zeroclaw
-ExecStart=/home/pi/zeroclaw/zeroclaw gateway --host 0.0.0.0 --port 8080
+User=@@RPI_USER@@
+SupplementaryGroups=gpio spidev i2c
+WorkingDirectory=/home/@@RPI_USER@@/zeroclaw
+ExecStart=/home/@@RPI_USER@@/zeroclaw/zeroclaw gateway start
 Restart=on-failure
 RestartSec=5
-EnvironmentFile=/home/pi/zeroclaw/.env
+EnvironmentFile=/home/@@RPI_USER@@/zeroclaw/.env
 Environment=RUST_LOG=info
+Environment=ZEROCLAW_gateway__allow_public_bind=true
+Environment=ZEROCLAW_gateway__port=8080
 
 # Expand ~ in config path
-Environment=HOME=/home/pi
+Environment=HOME=/home/@@RPI_USER@@
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

- **Base branch:** `integration/v0.8.0`
- **What changed and why:**
  1. CLI flags removed — `gateway --host 0.0.0.0 --port 8080` no longer exists in v0.8.0. ExecStart updated to `gateway start`; host/port injected via env vars in the unit file.
  2. Wrong supplementary group — `spi` renamed to `spidev` in recent RPi OS kernels.
  3. Hardcoded `pi` user — replaced with `@@RPI_USER@@` placeholder substituted by deploy-rpi.sh via sed at deploy time.
- **Scope boundary:** scripts/zeroclaw.service and scripts/deploy-rpi.sh only
- **Blast radius:** anyone running deploy-rpi.sh on v0.8.0
- **Linked issues:** Related #6398
- **Labels:** `type: fix`, `risk: low`, `size: XS`

## Validation Evidence (required)

Validated on a live Radxa deployment (v0.8.0 binary): service reached `active (running)` after applying these changes.

- **Skipped:** cargo fmt/clippy/test — no Rust code changed

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data? No

## Compatibility (required)

- Backward compatible? Yes for deploy script invocation.
- Config / env / CLI surface changed? Yes — ExecStart changed; existing boards need re-deploy or manual edit.
- Upgrade: re-run deploy-rpi.sh or manually update /etc/systemd/system/zeroclaw.service to use `gateway start` + add ZEROCLAW_gateway__allow_public_bind=true and ZEROCLAW_gateway__port=8080.