### PR TITLE
fix(providers): restore Kimi Code vision capability

### DIFF
--- a/crates/zeroclaw-providers/src/factory.rs
+++ b/crates/zeroclaw-providers/src/factory.rs
@@ -150,6 +150,23 @@ pub fn apply_compat_options(
     Box::new(p)
 }
 
+pub(crate) fn build_kimi_code_compat(
+    alias: &str,
+    key: Option<&str>,
+    base_url: &str,
+) -> OpenAiCompatibleModelProvider {
+    OpenAiCompatibleModelProvider::new_with_user_agent_and_vision(
+        alias,
+        "Kimi Code",
+        base_url,
+        key,
+        AuthStyle::Bearer,
+        "KimiCLI/0.77",
+        true,
+    )
+    .with_models_dev_key("moonshotai")
+}
+
 /// Dispatch family construction by routing `(family, alias)` to the typed
 /// slot's `FamilyProviderFactory` impl. Generated from
 /// `for_each_model_provider_slot!` so the family list lives in exactly one
@@ -229,15 +246,16 @@ use zeroclaw_config::schema::{
     HunyuanModelProviderConfig, HyperbolicModelProviderConfig, KiloCliModelProviderConfig,
     LeptonModelProviderConfig, LitellmModelProviderConfig, LlamacppModelProviderConfig,
     LmstudioModelProviderConfig, MinimaxModelProviderConfig, MistralModelProviderConfig,
-    MoonshotModelProviderConfig, NebiusModelProviderConfig, NovitaModelProviderConfig,
-    NscaleModelProviderConfig, NvidiaModelProviderConfig, OllamaModelProviderConfig,
-    OpenAIModelProviderConfig, OpenRouterModelProviderConfig, OpencodeModelProviderConfig,
-    OsaurusModelProviderConfig, OvhModelProviderConfig, PerplexityModelProviderConfig,
-    QianfanModelProviderConfig, QwenModelProviderConfig, RekaModelProviderConfig,
-    SambanovaModelProviderConfig, SglangModelProviderConfig, SiliconflowModelProviderConfig,
-    StepfunModelProviderConfig, SyntheticModelProviderConfig, TelnyxModelProviderConfig,
-    TogetherModelProviderConfig, VeniceModelProviderConfig, VercelModelProviderConfig,
-    VllmModelProviderConfig, XaiModelProviderConfig, YiModelProviderConfig, ZaiModelProviderConfig,
+    MoonshotEndpoint, MoonshotModelProviderConfig, NebiusModelProviderConfig,
+    NovitaModelProviderConfig, NscaleModelProviderConfig, NvidiaModelProviderConfig,
+    OllamaModelProviderConfig, OpenAIModelProviderConfig, OpenRouterModelProviderConfig,
+    OpencodeModelProviderConfig, OsaurusModelProviderConfig, OvhModelProviderConfig,
+    PerplexityModelProviderConfig, QianfanModelProviderConfig, QwenModelProviderConfig,
+    RekaModelProviderConfig, SambanovaModelProviderConfig, SglangModelProviderConfig,
+    SiliconflowModelProviderConfig, StepfunModelProviderConfig, SyntheticModelProviderConfig,
+    TelnyxModelProviderConfig, TogetherModelProviderConfig, VeniceModelProviderConfig,
+    VercelModelProviderConfig, VllmModelProviderConfig, XaiModelProviderConfig,
+    YiModelProviderConfig, ZaiModelProviderConfig,
 };
 
 // ── Pure-compat families ───────────────────────────────────────────────
@@ -464,6 +482,20 @@ impl CompatFamilySpec for MoonshotModelProviderConfig {
     const DEFAULT_URL: &'static str = crate::MOONSHOT_INTL_BASE_URL;
     const AUTH: AuthStyle = AuthStyle::Bearer;
     const MODELS_DEV_KEY: Option<&'static str> = Some("moonshotai");
+
+    fn build_compat(
+        &self,
+        alias: &str,
+        key: Option<&str>,
+        api_url: Option<&str>,
+    ) -> OpenAiCompatibleModelProvider {
+        let base_url = api_url.unwrap_or(Self::DEFAULT_URL);
+        if self.endpoint == MoonshotEndpoint::Code || base_url == crate::moonshot_code_base_url() {
+            return build_kimi_code_compat(alias, key, base_url);
+        }
+
+        self.build_compat_base(alias, key, api_url)
+    }
 }
 
 // ── Compat families with build_compat overrides ────────────────────────

--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -1132,6 +1132,16 @@ fn split_v2_colon_url(name: &str) -> (&str, Option<&str>) {
     (name, None)
 }
 
+pub(crate) fn moonshot_code_base_url() -> &'static str {
+    <zeroclaw_config::schema::MoonshotEndpoint as zeroclaw_config::schema::ModelEndpoint>::uri(
+        &zeroclaw_config::schema::MoonshotEndpoint::Code,
+    )
+}
+
+fn is_legacy_kimi_code_alias(name: &str) -> bool {
+    matches!(name, "kimi-code" | "kimi_coding" | "kimi_for_coding")
+}
+
 /// Factory: create model_provider with optional base URL and runtime options.
 #[allow(clippy::too_many_lines)]
 fn create_model_provider_inner(
@@ -1160,6 +1170,7 @@ fn create_model_provider_inner(
         }
     }
     let (split_name, split_url) = split_v2_colon_url(raw_name);
+    let legacy_kimi_code = is_legacy_kimi_code_alias(split_name);
     let api_url = api_url.or(split_url);
     let name = canonicalize_v2_model_provider_name(split_name);
 
@@ -1226,6 +1237,17 @@ fn create_model_provider_inner(
                     .map(str::trim)
                     .filter(|v| !v.is_empty())
             });
+
+    if legacy_kimi_code {
+        let base_url = match resolved_url {
+            Some(url) => url,
+            None => moonshot_code_base_url(),
+        };
+        return Ok(factory::apply_compat_options(
+            factory::build_kimi_code_compat(alias, key, base_url),
+            options,
+        ));
+    }
 
     factory::dispatch_family_factory(config, name, alias, key, resolved_url, options)
 }
@@ -2070,7 +2092,65 @@ mod tests {
     }
 
     #[test]
-    fn factory_kimi_code() {}
+    fn factory_kimi_code_supports_vision() {
+        for alias in ["kimi-code", "kimi_coding", "kimi_for_coding"] {
+            let provider = create_model_provider(alias, Some("key"))
+                .expect("legacy kimi-code alias should build");
+            assert!(
+                provider.supports_vision(),
+                "alias `{alias}` should report vision capability"
+            );
+            assert_eq!(
+                moonshot_code_base_url(),
+                "https://api.moonshot.cn/coder/v1",
+                "alias `{alias}` should resolve to the Moonshot code endpoint"
+            );
+        }
+    }
+
+    #[test]
+    fn factory_kimi_code_preserves_semantics_with_url_overrides() {
+        let custom_url = "https://proxy.example.test/v1";
+
+        let provider = create_model_provider_with_url("kimi-code", Some("key"), Some(custom_url))
+            .expect("legacy kimi-code alias with custom URL should build");
+        assert!(provider.supports_vision());
+
+        let provider = create_model_provider_with_options(
+            "kimi-code",
+            Some("key"),
+            &ModelProviderRuntimeOptions {
+                provider_api_url: Some(custom_url.to_string()),
+                ..ModelProviderRuntimeOptions::default()
+            },
+        )
+        .expect("legacy kimi-code alias with options URL should build");
+        assert!(provider.supports_vision());
+    }
+
+    #[test]
+    fn moonshot_code_endpoint_supports_vision() {
+        use zeroclaw_config::schema::{Config, MoonshotEndpoint, MoonshotModelProviderConfig};
+
+        let mut config = Config::default();
+        config.providers.models.moonshot.insert(
+            "code".to_string(),
+            MoonshotModelProviderConfig {
+                endpoint: MoonshotEndpoint::Code,
+                ..MoonshotModelProviderConfig::default()
+            },
+        );
+        let options = provider_runtime_options_for_alias(&config, "moonshot", "code");
+        assert_eq!(
+            options.provider_api_url.as_deref(),
+            Some(moonshot_code_base_url())
+        );
+
+        let provider =
+            create_model_provider_for_alias(&config, "moonshot", "code", Some("key"), &options)
+                .expect("moonshot code endpoint should build");
+        assert!(provider.supports_vision());
+    }
 
     #[test]
     fn factory_synthetic() {


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Restores vision capability for the Kimi Code provider path that was lost in bulk revert `c3ff635` and is tracked by #6074.
  - Keeps the current V3 provider architecture: legacy `kimi-code`, `kimi_coding`, and `kimi_for_coding` names still canonicalize to the `moonshot` family, but now resolve to the Moonshot code endpoint before dispatch.
  - Preserves Kimi Code semantics separately from the default endpoint URL, so custom/proxy URL overrides still get the Kimi Code user agent and vision capability.
  - Makes typed `model_providers.moonshot.<alias>` entries with `endpoint = "code"` build as `Kimi Code` with the Kimi CLI user agent and vision enabled.
  - Replaces the empty `factory_kimi_code` test with coverage for the legacy aliases and adds a typed `moonshot.code` endpoint regression.
- **Scope boundary:** This PR does not change Moonshot CN/intl behavior, model selection, auth handling, config migration, or any non-Moonshot providers.
- **Blast radius:** Limited to `zeroclaw-providers` factory construction for Moonshot/Kimi-compatible providers. The affected runtime behavior is provider capability reporting and the base endpoint used for legacy Kimi Code names.
- **Linked issue(s):** Related #6074. Supersedes #4108.
- **Labels:** `bug`, `provider`, `risk: medium`, `size: S`

## Validation Evidence (required)

- **Commands run and result summary:**

```text
cargo fmt --all -- --check
Result: passed.

cargo test -p zeroclaw-providers kimi_code -- --nocapture
Result: passed. Covers legacy kimi-code / kimi_coding / kimi_for_coding aliases, including custom URL and provider_api_url override semantics.

cargo test -p zeroclaw-providers moonshot_code_endpoint_supports_vision -- --nocapture
Result: passed. Covers the typed moonshot.code endpoint path.

cargo test -p zeroclaw-providers moonshot -- --nocapture
Result: passed. Covers the existing Moonshot factory test plus the new typed code-endpoint regression.

git diff --check -- crates/zeroclaw-providers/src/lib.rs crates/zeroclaw-providers/src/factory.rs
Result: passed.

cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
Result: passed.

cargo nextest run --locked --workspace --exclude zeroclaw-desktop
Result: passed: 7756 passed, 10 skipped.
```

- **Beyond CI — what did you manually verify?** I compared the superseded #4108 behavior against current `master`. The old direct `kimi-code` factory arm no longer exists; current config migration represents it as `model_providers.moonshot.<alias>` with `endpoint = "code"`, so the recovery belongs in the Moonshot factory path rather than a new flat provider arm. I also checked the custom URL/proxy path so legacy Kimi Code names keep Kimi Code behavior even when the endpoint is overridden.
- **If any command was intentionally skipped, why:** No medium-risk local validation commands were intentionally skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: Not applicable.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No upgrade steps required. Existing legacy Kimi Code names regain the intended endpoint/capability behavior; existing `moonshot.code` config entries now report vision support.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <merge-commit-sha>`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Kimi Code requests using image input would fail or be routed away if the provider no longer reports vision support. Legacy `kimi-code` names would also stop using the code endpoint if the endpoint helper regressed.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors: `#4108 by @g0ne150`
- Scope materially carried forward: Yes. This PR restores the same intended capability from #4108, adapted to the current V3 Moonshot/Kimi provider architecture.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `Yes`
- If `No`, why: Not applicable.
