### PR TITLE
fix(web): validate local provider models during onboarding

### DIFF
--- a/web/src/pages/onboard/Onboard.tsx
+++ b/web/src/pages/onboard/Onboard.tsx
@@ -22,9 +22,11 @@ import { useNavigate } from 'react-router-dom';
 import { AlertTriangle, Check, ChevronRight } from 'lucide-react';
 import {
   ApiError,
+  getCatalogModels,
   getMapKeys,
   getOnboardStatus,
   getProp,
+  getSectionPicker,
   getSections,
   patchConfig,
   reloadDaemon,
@@ -282,10 +284,10 @@ export default function Onboard() {
       if (!picked && !activeSection.ready) {
         return blockAdvance(['Choose a model provider, then set its required model and credential/auth.']);
       }
-      if (picked) {
-        const providerIssues = await modelProviderStepIssues(picked);
-        if (providerIssues.length > 0) return blockAdvance(providerIssues);
-      }
+      const providerIssues = picked
+        ? await modelProviderStepIssues(picked)
+        : await configuredLocalModelProviderStepIssues();
+      if (providerIssues.length > 0) return blockAdvance(providerIssues);
     }
 
     if (activeSection.key === 'storage' && !picked && !activeSection.ready) {
@@ -799,14 +801,81 @@ function providerRefForFieldsPrefix(fieldsPrefix: string): string | null {
   return providerType && providerAlias ? `${canonicalProviderRefSegment(providerType)}.${providerAlias}` : null;
 }
 
+function providerTypeForFieldsPrefix(fieldsPrefix: string): string | null {
+  const parts = fieldsPrefix.split('.');
+  return parts[0] === 'providers' && parts[1] === 'models' && parts[2] ? parts[2] : null;
+}
+
+async function hasCustomProviderEndpoint(fieldsPrefix: string): Promise<boolean> {
+  const uri = await getProp(`${fieldsPrefix}.uri`).catch(() => null);
+  return hasTextValue(uri?.value);
+}
+
+async function configuredLocalModelProviderStepIssues(): Promise<string[]> {
+  const picker = await getSectionPicker('providers.models').catch(() => null);
+  if (!picker) return [];
+
+  const issues: string[] = [];
+  for (const item of picker.items) {
+    const catalogProviderType = canonicalProviderRefSegment(item.key);
+    const catalog = await getCatalogModels(catalogProviderType).catch(() => null);
+    if (!(catalog?.local ?? isLocalModelProvider(catalogProviderType))) continue;
+
+    const mapPath = `providers.models.${typedMapPathSegment('providers.models', item.key)}`;
+    const aliases = await getMapKeys(mapPath).catch(() => null);
+    if (!aliases) continue;
+    for (const alias of aliases.keys) {
+      const fieldsPrefix = `${mapPath}.${alias}`;
+      const model = await getProp(`${fieldsPrefix}.model`).catch(() => null);
+      if (!hasTextValue(model?.value)) continue;
+      issues.push(...await modelProviderStepIssues({ item, fieldsPrefix }));
+    }
+  }
+  return issues;
+}
+
 async function modelProviderStepIssues(picked: { item: PickerItem; fieldsPrefix: string }): Promise<string[]> {
   const providerRef = providerRefForFieldsPrefix(picked.fieldsPrefix) ?? picked.item.label;
+  const providerType = providerTypeForFieldsPrefix(picked.fieldsPrefix);
+  const catalogProviderType = providerType ? canonicalProviderRefSegment(providerType) : null;
   const model = await getProp(`${picked.fieldsPrefix}.model`).catch(() => null);
-  if (!hasTextValue(model?.value)) {
+  const modelName = hasTextValue(model?.value) ? String(model?.value).trim() : '';
+  if (!modelName) {
     return [`Choose a model for model provider \`${providerRef}\`.`];
   }
 
-  if (isLocalPickerItem(picked.item)) return [];
+  if (catalogProviderType) {
+    try {
+      const catalog = await getCatalogModels(catalogProviderType);
+      if (catalog.local) {
+        if (await hasCustomProviderEndpoint(picked.fieldsPrefix)) return [];
+        if (!catalog.live) {
+          return [
+            `Start or configure the local provider for \`${providerRef}\` so ZeroClaw can list its installed models.`,
+          ];
+        }
+        if (catalog.models.length === 0) {
+          return [
+            `No installed models were found for local provider \`${providerRef}\`. Install a model or configure the provider endpoint first.`,
+          ];
+        }
+        if (!catalog.models.includes(modelName)) {
+          return [
+            `Model \`${modelName}\` was not found on local provider \`${providerRef}\`. Pick an installed model or install it first.`,
+          ];
+        }
+        return [];
+      }
+    } catch {
+      if (!isLocalModelProvider(catalogProviderType)) {
+        // Fall through to hosted credential checks below.
+      } else {
+        return [
+          `Start or configure the local provider for \`${providerRef}\` so ZeroClaw can list its installed models.`,
+        ];
+      }
+    }
+  }
 
   const apiKey = await getProp(`${picked.fieldsPrefix}.api-key`).catch(() => null);
   const openAiAuth = await getProp(`${picked.fieldsPrefix}.requires-openai-auth`).catch(() => null);
@@ -822,10 +891,6 @@ function isTruthyValue(value: unknown): boolean {
   if (typeof value === 'boolean') return value;
   if (typeof value === 'string') return value.trim().toLowerCase() === 'true';
   return false;
-}
-
-function isLocalPickerItem(item: PickerItem): boolean {
-  return item.description?.toLowerCase().includes('local') ?? false;
 }
 
 function canonicalProviderRefSegment(providerType: string): string {


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Validates configured local model providers against the live backend catalog before onboarding advances.
  - Blocks local-provider setup when the provider is not reachable, has no installed models, or the selected model is not in the live catalog.
  - Re-checks saved/reloaded local provider config even when the user is back on the provider list and no provider card is actively selected.
  - Canonicalizes provider family names before catalog lookup so kebab-case UI/config paths still resolve to snake-case catalog providers.
- **Scope boundary:** This does not add hosted provider API-key shape/auth validation, alias-aware custom URI validation, or new backend validation APIs.
- **Blast radius:** Web onboarding model-provider validation only; runtime provider dispatch and stored config schema are unchanged.
- **Linked issue(s):** Related #6398
- **Labels:** Proposed: `risk: low`, `size: S`, `onboard`, `provider`

## Validation Evidence (required)

- **Commands run and tail output:**

```bash
git diff --check HEAD~1..HEAD
```

Passed with no output.

```bash
npm run build
```

Tail:

```text
dist/assets/Onboard-DOjbWV62.js                  32.36 kB │ gzip:   9.19 kB
dist/assets/AgentChat-TuoV17Gw.js                34.59 kB │ gzip:   9.94 kB
dist/assets/SectionPicker-DfyMiUpB.js            39.36 kB │ gzip:  10.97 kB
dist/assets/Dashboard-DGyO6mG5.js                54.67 kB │ gzip:  12.35 kB
dist/assets/index-DwYNO6wa.js                   156.63 kB │ gzip:  47.42 kB
dist/assets/index-Z7tjWbDo.js                   759.40 kB │ gzip: 193.49 kB
dist/assets/Config-Bk9qCtwn.js                  841.72 kB │ gzip: 277.93 kB

(!) Some chunks are larger than 500 kB after minification. Consider:
- Using dynamic import() to code-split the application
- Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/configuration-options/#output-manualchunks
- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
✓ built in 8.66s
```

- **Beyond CI — what did you manually verify?** Used the in-app Browser against `http://127.0.0.1:5174/onboard`, proxied to the scratch gateway on port `42633`. Created and saved an `ollama.default` provider with model `llama3.2`, returned to the provider list so no provider detail page was selected, clicked `Next`, and confirmed onboarding blocked with:

```text
Start or configure the local provider for `ollama.default` so ZeroClaw can list its installed models.
```

This covers the saved/reloaded provider-list path, not only the active provider detail page.

- **If any command was intentionally skipped, why:** Rust cargo gates were skipped because this PR only changes `web/src/pages/onboard/Onboard.tsx`. Full CI-shaped validation was skipped in favor of focused web validation for this small onboarding fix.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: Existing configs continue to load. The onboarding UI now blocks invalid local-provider model choices earlier instead of allowing a later chat/runtime failure.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PRs: `git revert ce0304daa` is the rollback plan unless the commit SHA changes before merge.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Scope materially carried forward: N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`No`)
- If `No`, why (inspiration-only, no direct code/design carry-over): No superseded PR or incorporated contributor work.
