### PR TITLE
fix(security): detect Groq API keys in leak scanner

### DIFF
--- a/crates/zeroclaw-runtime/src/security/leak_detector.rs
+++ b/crates/zeroclaw-runtime/src/security/leak_detector.rs
@@ -102,6 +102,8 @@ impl LeakDetector {
                     Regex::new(r"sk-ant-[a-zA-Z0-9-_]{32,}").unwrap(),
                     "Anthropic API key",
                 ),
+                // Groq
+                (Regex::new(r"gsk_[a-zA-Z0-9]{20,}").unwrap(), "Groq API key"),
                 // Google
                 (
                     Regex::new(r"AIza[a-zA-Z0-9_-]{35}").unwrap(),
@@ -410,6 +412,21 @@ mod tests {
                 assert!(patterns.iter().any(|p| p.contains("AWS")));
             }
             LeakResult::Clean => panic!("Should detect AWS key"),
+        }
+    }
+
+    #[test]
+    fn detects_groq_api_keys() {
+        let detector = LeakDetector::new();
+        let content = "Groq key: gsk_abcdefghijklmnopqrstuvwxyz123456";
+        let result = detector.scan(content);
+        match result {
+            LeakResult::Detected { patterns, redacted } => {
+                assert!(patterns.iter().any(|p| p.contains("Groq")));
+                assert!(redacted.contains("[REDACTED"));
+                assert!(!redacted.contains("gsk_abcdefghijklmnopqrstuvwxyz123456"));
+            }
+            LeakResult::Clean => panic!("Should detect Groq API key"),
         }
     }
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Recover the Groq leak-detector pattern from `ce6dd7ca` / #4688 after the `c3ff635` bulk revert.
  - Detect and redact Groq API keys with the `gsk_` prefix.
  - Add focused regression coverage for the Groq key pattern.
- **Scope boundary:** This PR only restores Groq key detection in the output leak scanner. It does not change config loading, provider authentication, transcription behavior, or the web config editor.
- **Blast radius:** Limited to `zeroclaw-runtime` leak scanning. The only expected behavior change is that Groq-looking credentials are reported and redacted like other known API-key formats.
- **Linked issue(s):** Related #6074. Related #4672. Supersedes #4688.
- **Labels:** `bug`, `runtime`, `security`, `risk: high`, `size: XS`.

## Validation Evidence (required)

- **Commands run and tail output:**

```text
scripts/zc-cargo fmt --all -- --check
Result: passed.

scripts/zc-cargo test -p zeroclaw-runtime detects_groq_api_keys -- --nocapture
Result: passed.
Relevant output:
test security::leak_detector::tests::detects_groq_api_keys ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 1831 filtered out

scripts/zc-cargo clippy -p zeroclaw-runtime --all-targets -- -D warnings
Result: passed.
Relevant output:
Finished dev profile [unoptimized + debuginfo] target(s) in 1m 22s

scripts/zc-cargo nextest run --locked --workspace --exclude zeroclaw-desktop
Result: failed before completion on an unrelated timing-sensitive channel test.
Relevant output:
FAIL zeroclaw-channels orchestrator::tests::message_dispatch_processes_messages_in_parallel
expected parallel dispatch with precheck (<700ms), got 857.208917ms
Summary: 812/7830 tests run: 811 passed, 1 failed, 10 skipped

scripts/zc-cargo nextest run --locked -p zeroclaw-channels message_dispatch_processes_messages_in_parallel
Result: failed the same unrelated timing-sensitive channel test in isolation.
Relevant output:
expected parallel dispatch with precheck (<700ms), got 814.4015ms

scripts/zc-cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
Result: passed.
Relevant output:
Finished dev profile [unoptimized + debuginfo] target(s) in 11m 03s
```

- **Beyond CI — what did you manually verify?** Compared the reverted #4688 diff against current `master`. The schema-derived secret masking now covers the old transcription config masking portion, but the Groq `gsk_...` leak-detector pattern was still absent before this patch.
- **If any command was intentionally skipped, why:** No command was intentionally skipped. CI-shaped full tests are not green locally because an unrelated `zeroclaw-channels` timing-threshold test fails both in the full run and in isolation; the focused runtime regression and workspace clippy are green. The unrelated timing-test failure is tracked separately in #6813.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `Yes`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: This strengthens credential handling by recognizing Groq `gsk_` API keys in the leak detector. It does not store, send, or expose secrets; matching values are redacted in the same path as the existing provider key patterns.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No upgrade steps required.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** Revert the landed PR commit.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** False-positive leak warnings mentioning `Groq API key` for benign `gsk_`-prefixed text.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors: #4688 by @rareba.
- Scope materially carried forward: The Groq `gsk_` leak-detector pattern and focused detection behavior.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `Yes`
- If `No`, why: Not applicable.
