### PR TITLE
fix(policy): allow multiline heredocs in SecurityPolicy command splitting

### DIFF
--- a/crates/zeroclaw-config/src/policy.rs
+++ b/crates/zeroclaw-config/src/policy.rs
@@ -667,11 +667,21 @@ enum QuoteState {
 ///
 /// Characters inside single or double quotes are treated as literals, so
 /// `sqlite3 db "SELECT 1; SELECT 2;"` remains a single segment.
+///
+/// Heredoc bodies (`<<WORD ... WORD`) are kept as part of the same segment
+/// as the command that opens them; newlines inside the body do not split.
 fn split_unquoted_segments(command: &str) -> Vec<String> {
     let mut segments = Vec::new();
     let mut current = String::new();
     let mut quote = QuoteState::None;
     let mut escaped = false;
+    // Heredoc state: Some(delim) while inside a heredoc body.
+    let mut heredoc_delimiter: Option<String> = None;
+    // Accumulates the current line while inside a heredoc body, for terminator detection.
+    let mut heredoc_line_buf = String::new();
+    // True while reading the delimiter word that follows `<<`.
+    let mut reading_heredoc_word = false;
+    let mut heredoc_word_buf = String::new();
     let mut chars = command.chars().peekable();
 
     let push_segment = |segments: &mut Vec<String>, current: &mut String| {
@@ -710,11 +720,58 @@ fn split_unquoted_segments(command: &str) -> Vec<String> {
                 if escaped {
                     escaped = false;
                     current.push(ch);
+                    if heredoc_delimiter.is_some() {
+                        heredoc_line_buf.push(ch);
+                    }
                     continue;
                 }
                 if ch == '\\' {
                     escaped = true;
                     current.push(ch);
+                    if heredoc_delimiter.is_some() {
+                        heredoc_line_buf.push(ch);
+                    }
+                    continue;
+                }
+
+                // Reading the delimiter word that follows `<<`.
+                if reading_heredoc_word {
+                    if ch == '\n' {
+                        // Finalise the delimiter and enter the heredoc body.
+                        let raw = heredoc_word_buf.trim().trim_start_matches('-');
+                        let delim = raw
+                            .trim_matches(|c| c == '\'' || c == '"' || c == '\\')
+                            .to_string();
+                        if !delim.is_empty() {
+                            heredoc_delimiter = Some(delim);
+                        }
+                        heredoc_word_buf.clear();
+                        reading_heredoc_word = false;
+                        // The newline after `<<WORD` belongs to the same segment.
+                        current.push(ch);
+                    } else {
+                        heredoc_word_buf.push(ch);
+                        current.push(ch);
+                    }
+                    continue;
+                }
+
+                // Inside a heredoc body: don't split on newlines.
+                if let Some(ref delim) = heredoc_delimiter.clone() {
+                    if ch == '\n' {
+                        if heredoc_line_buf.trim() == delim.as_str() {
+                            // Terminator line reached — end of heredoc body.
+                            heredoc_delimiter = None;
+                            heredoc_line_buf.clear();
+                            push_segment(&mut segments, &mut current);
+                        } else {
+                            heredoc_line_buf.clear();
+                            current.push(ch);
+                        }
+                    } else {
+                        heredoc_line_buf.push(ch);
+                        current.push(ch);
+                    }
                     continue;
                 }
 
@@ -740,6 +797,18 @@ fn split_unquoted_segments(command: &str) -> Vec<String> {
                             push_segment(&mut segments, &mut current);
                         } else {
                             current.push(ch);
+                        }
+                    }
+                    '<' => {
+                        current.push(ch);
+                        // Detect `<<` (heredoc) but not `<<<` (here-string).
+                        if chars.peek() == Some(&'<') {
+                            let second = chars.next().unwrap();
+                            current.push(second);
+                            if chars.peek() != Some(&'<') {
+                                reading_heredoc_word = true;
+                            }
+                            // `<<<` falls through with no heredoc tracking.
                         }
                     }
                     _ => current.push(ch),
@@ -3524,6 +3593,22 @@ mod tests {
         assert!(!p.is_command_allowed("cat < /etc/passwd"));
         // Output redirects to files still blocked
         assert!(!p.is_command_allowed("echo secret > output.txt"));
+    }
+
+    #[test]
+    fn multiline_heredoc_allowed() {
+        let p = default_policy();
+        // Multiline heredoc body must not be split into separate segments that
+        // fail the allowlist check on the body lines.
+        assert!(p.is_command_allowed("cat <<EOF\nhello world\nEOF"));
+        assert!(p.is_command_allowed("cat <<'EOF'\nhello world\nEOF"));
+        assert!(p.is_command_allowed("cat << EOF\nhello world\nEOF"));
+        // Quoted delimiter variant
+        assert!(p.is_command_allowed("cat <<\"EOF\"\nhello world\nEOF"));
+        // Heredoc followed by an allowed command is still two valid segments
+        assert!(p.is_command_allowed("cat <<EOF\nhello\nEOF\necho done"));
+        // Heredoc followed by a disallowed command must be blocked
+        assert!(!p.is_command_allowed("cat <<EOF\nhello\nEOF\nrm -rf /"));
     }
 
     #[test]

--- a/crates/zeroclaw-config/src/policy.rs
+++ b/crates/zeroclaw-config/src/policy.rs
@@ -757,9 +757,9 @@ fn split_unquoted_segments(command: &str) -> Vec<String> {
                 }
 
                 // Inside a heredoc body: don't split on newlines.
-                if let Some(ref delim) = heredoc_delimiter.clone() {
+                if let Some(delim) = heredoc_delimiter.as_deref() {
                     if ch == '\n' {
-                        if heredoc_line_buf.trim() == delim.as_str() {
+                        if heredoc_line_buf.trim() == delim {
                             // Terminator line reached — end of heredoc body.
                             heredoc_delimiter = None;
                             heredoc_line_buf.clear();
@@ -3609,6 +3609,8 @@ mod tests {
         assert!(p.is_command_allowed("cat <<EOF\nhello\nEOF\necho done"));
         // Heredoc followed by a disallowed command must be blocked
         assert!(!p.is_command_allowed("cat <<EOF\nhello\nEOF\nrm -rf /"));
+        // Unterminated heredoc — entire input stays as one segment (safe: cat is allowed).
+        assert!(p.is_command_allowed("cat <<EOF\nhello world"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:** `split_unquoted_segments` in `policy.rs` split on every bare newline, so a multiline heredoc (`cat <<EOF\nhello\nEOF`) would be tokenised as three separate segments — the body lines failing the allowlist check even though the command itself was permitted. Added heredoc-body tracking that keeps the entire heredoc (open through terminator) as a single segment, matching shell semantics.
- **Scope boundary:** Only affects `split_unquoted_segments` and its downstream caller `is_command_allowed`. No change to allowlist entries, policy schema, config parsing, or any channel/runtime path.
- **Blast radius:** Any caller of `SecurityPolicy::is_command_allowed` that previously passed multiline commands containing heredocs. Those commands were being incorrectly blocked; they will now be correctly evaluated against the allowlist.
- **Linked issue(s):** Fixes #6771
- **Labels:** `type: bug`, `risk: low`, `size: S`

## Validation Evidence (required)

- **Commands run and tail output:**

  ```
  cargo fmt --all -- --check
  # → (no output, clean)

  cargo clippy --all-targets -- -D warnings
  # → Finished `dev` profile [unoptimized + debuginfo] target(s) in 51.82s
  # → (no warnings)

  cargo test -p zeroclaw-config
  # → test policy::tests::heredoc_and_herestring_allowed ... ok
  # → test policy::tests::multiline_heredoc_allowed ... ok
  # → test result: ok. 652 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.06s
  # → test result: ok. 88 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s
  ```

- **Beyond CI — what did you manually verify?** Confirmed that `multiline_heredoc_allowed` (new test) and `heredoc_and_herestring_allowed` (pre-existing regression guard) both pass. Verified `<<<` here-strings are not incorrectly entered into heredoc tracking. Did not test with tab-stripped `<<-WORD` heredocs in a live shell execution context; the delimiter-stripping logic handles the `-` prefix but integration with a real agent tool loop was not exercised.
- **If any command was intentionally skipped, why:** Full workspace `cargo test` not run; scope is isolated to `zeroclaw-config`/policy.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility (required)

- Backward compatible? **Yes** — multiline heredoc commands that were incorrectly blocked are now correctly allowed; no previously-allowed command is newly blocked.
- Config / env / CLI surface changed? **No**

## Rollback (required for `risk: medium` and `risk: high`)

`git revert 516584388` is the plan unless otherwise noted.