### PR TITLE
feat: add Jina AI as web_search provider

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -5964,7 +5964,7 @@ pub struct WebSearchConfig {
     /// Enable `web_search_tool` for web searches
     #[serde(default)]
     pub enabled: bool,
-    /// Search provider: "duckduckgo" (free), "brave" (requires API key), "tavily" (requires API key), or "searxng" (self-hosted)
+    /// Search provider: "duckduckgo" (free), "brave" (requires API key), "tavily" (requires API key), "searxng" (self-hosted), or "jina" (requires API key)
     #[serde(default = "default_web_search_provider")]
     pub search_provider: String,
     /// Brave Search API key (required if search_provider is "brave")
@@ -5977,6 +5977,11 @@ pub struct WebSearchConfig {
     #[secret]
     #[cfg_attr(feature = "schema-export", schemars(extend("x-secret" = true)))]
     pub tavily_api_key: Option<String>,
+    /// Jina AI API key (required if search_provider is "jina")
+    #[serde(default)]
+    #[secret]
+    #[cfg_attr(feature = "schema-export", schemars(extend("x-secret" = true)))]
+    pub jina_api_key: Option<String>,
     /// SearXNG instance URL (required if search_provider is `"searxng"`), e.g. `"https://searx.example.com"`.
     #[serde(default)]
     pub searxng_instance_url: Option<String>,
@@ -6007,6 +6012,7 @@ impl Default for WebSearchConfig {
             search_provider: default_web_search_provider(),
             brave_api_key: None,
             tavily_api_key: None,
+            jina_api_key: None,
             searxng_instance_url: None,
             max_results: default_web_search_max_results(),
             timeout_secs: default_web_search_timeout_secs(),

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -651,6 +651,7 @@ pub fn all_tools_with_runtime(
             root_config.web_search.search_provider.clone(),
             root_config.web_search.brave_api_key.clone(),
             root_config.web_search.tavily_api_key.clone(),
+            root_config.web_search.jina_api_key.clone(),
             root_config.web_search.searxng_instance_url.clone(),
             root_config.web_search.max_results,
             root_config.web_search.timeout_secs,

--- a/crates/zeroclaw-tools/src/web_search_provider_routing.rs
+++ b/crates/zeroclaw-tools/src/web_search_provider_routing.rs
@@ -4,6 +4,7 @@ pub enum WebSearchProviderRoute {
     Brave,
     SearXNG,
     Tavily,
+    Jina,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -17,6 +18,7 @@ pub const DEFAULT_WEB_SEARCH_PROVIDER: &str = "duckduckgo";
 const BRAVE_PROVIDER: &str = "brave";
 const SEARXNG_PROVIDER: &str = "searxng";
 const TAVILY_PROVIDER: &str = "tavily";
+const JINA_PROVIDER: &str = "jina";
 
 pub fn resolve_web_search_provider(raw_model_provider: &str) -> WebSearchProviderResolution {
     let normalized = raw_model_provider.trim().to_ascii_lowercase();
@@ -43,8 +45,13 @@ pub fn resolve_web_search_provider(raw_model_provider: &str) -> WebSearchProvide
             canonical_provider: TAVILY_PROVIDER,
             used_fallback: false,
         },
+        "jina" | "jina-ai" | "jina_ai" => WebSearchProviderResolution {
+            route: WebSearchProviderRoute::Jina,
+            canonical_provider: JINA_PROVIDER,
+            used_fallback: false,
+        },
         // Warns for unknown model_providers, falls back to default.
-        // Known non-default model_providers: Brave, SearXNG, Tavily.
+        // Known non-default model_providers: Brave, SearXNG, Tavily, Jina.
         _ => WebSearchProviderResolution {
             route: WebSearchProviderRoute::DuckDuckGo,
             canonical_provider: DEFAULT_WEB_SEARCH_PROVIDER,
@@ -97,6 +104,17 @@ mod tests {
             let resolved = resolve_web_search_provider(alias);
             assert_eq!(resolved.route, WebSearchProviderRoute::Tavily);
             assert_eq!(resolved.canonical_provider, TAVILY_PROVIDER);
+            assert!(!resolved.used_fallback);
+        }
+    }
+
+    #[test]
+    fn resolve_aliases_to_jina() {
+        let jina_aliases = ["jina", "jina-ai", "jina_ai"];
+        for alias in jina_aliases {
+            let resolved = resolve_web_search_provider(alias);
+            assert_eq!(resolved.route, WebSearchProviderRoute::Jina);
+            assert_eq!(resolved.canonical_provider, JINA_PROVIDER);
             assert!(!resolved.used_fallback);
         }
     }

--- a/crates/zeroclaw-tools/src/web_search_tool.rs
+++ b/crates/zeroclaw-tools/src/web_search_tool.rs
@@ -8,7 +8,8 @@ use zeroclaw_api::tool::{Tool, ToolResult};
 
 /// Web search tool for searching the internet.
 /// Supports multiple model_providers: DuckDuckGo (free), Brave (requires API key),
-/// Tavily (requires API key), SearXNG (self-hosted, requires instance URL).
+/// Tavily (requires API key), SearXNG (self-hosted, requires instance URL),
+/// Jina AI (requires API key).
 ///
 /// API keys are resolved lazily at execution time: if the boot-time key
 /// is missing or still encrypted, the tool re-reads `config.toml`, decrypts the
@@ -21,6 +22,8 @@ pub struct WebSearchTool {
     boot_brave_api_key: Option<String>,
     /// Boot-time Tavily key snapshot.
     boot_tavily_api_key: Option<String>,
+    /// Boot-time Jina AI key snapshot.
+    boot_jina_api_key: Option<String>,
     /// SearXNG instance base URL (e.g. `"https://searx.example.com"`).
     searxng_instance_url: Option<String>,
     max_results: usize,
@@ -35,6 +38,7 @@ impl WebSearchTool {
     pub fn new(
         model_provider: String,
         brave_api_key: Option<String>,
+        jina_api_key: Option<String>,
         max_results: usize,
         timeout_secs: u64,
     ) -> Self {
@@ -42,6 +46,7 @@ impl WebSearchTool {
             model_provider: model_provider.trim().to_lowercase(),
             boot_brave_api_key: brave_api_key,
             boot_tavily_api_key: None,
+            boot_jina_api_key: jina_api_key,
             searxng_instance_url: None,
             max_results: max_results.clamp(1, 10),
             timeout_secs: timeout_secs.max(1),
@@ -60,6 +65,7 @@ impl WebSearchTool {
         model_provider: String,
         brave_api_key: Option<String>,
         tavily_api_key: Option<String>,
+        jina_api_key: Option<String>,
         searxng_instance_url: Option<String>,
         max_results: usize,
         timeout_secs: u64,
@@ -70,6 +76,7 @@ impl WebSearchTool {
             model_provider: model_provider.trim().to_lowercase(),
             boot_brave_api_key: brave_api_key,
             boot_tavily_api_key: tavily_api_key,
+            boot_jina_api_key: jina_api_key,
             searxng_instance_url,
             max_results: max_results.clamp(1, 10),
             timeout_secs: timeout_secs.max(1),
@@ -468,6 +475,155 @@ impl WebSearchTool {
         Ok(lines.join("\n"))
     }
 
+    /// Resolve the Jina AI API key from the boot-time snapshot, falling back
+    /// to a fresh config read + decryption when the boot-time value is absent.
+    fn resolve_jina_api_key(&self) -> anyhow::Result<String> {
+        if let Some(ref key) = self.boot_jina_api_key
+            && !key.is_empty()
+            && !zeroclaw_config::secrets::SecretStore::is_encrypted(key)
+        {
+            return Ok(key.clone());
+        }
+        self.reload_jina_api_key()
+    }
+
+    /// Re-read `config.toml` and decrypt `[web_search] jina_api_key`.
+    fn reload_jina_api_key(&self) -> anyhow::Result<String> {
+        let contents = std::fs::read_to_string(&self.config_path).map_err(|e| {
+            ::zeroclaw_log::record!(
+                ERROR,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                    .with_attrs(::serde_json::json!({
+                        "path": self.config_path.display().to_string(),
+                        "search_provider": "jina",
+                        "error": format!("{}", e),
+                    })),
+                "web_search: failed to read config for Jina AI API key"
+            );
+            anyhow::Error::msg(format!(
+                "Failed to read config file {} for Jina AI API key: {e}",
+                self.config_path.display()
+            ))
+        })?;
+
+        let config: zeroclaw_config::schema::Config = toml::from_str(&contents).map_err(|e| {
+            ::zeroclaw_log::record!(
+                ERROR,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                    .with_attrs(::serde_json::json!({
+                        "path": self.config_path.display().to_string(),
+                        "search_provider": "jina",
+                        "error": format!("{}", e),
+                    })),
+                "web_search: failed to parse config for Jina AI API key"
+            );
+            anyhow::Error::msg(format!(
+                "Failed to parse config file {} for Jina AI API key: {e}",
+                self.config_path.display()
+            ))
+        })?;
+
+        let raw_key = config
+            .web_search
+            .jina_api_key
+            .filter(|k| !k.is_empty())
+            .ok_or_else(|| {
+                ::zeroclaw_log::record!(
+                    ERROR,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Reject)
+                        .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                        .with_attrs(::serde_json::json!({"search_provider": "jina"})),
+                    "web_search: Jina AI API key not configured"
+                );
+                anyhow::Error::msg("Jina AI API key not configured")
+            })?;
+
+        if zeroclaw_config::secrets::SecretStore::is_encrypted(&raw_key) {
+            let zeroclaw_dir = self.config_path.parent().unwrap_or_else(|| Path::new("."));
+            let store =
+                zeroclaw_config::secrets::SecretStore::new(zeroclaw_dir, self.secrets_encrypt);
+            let plaintext = store.decrypt(&raw_key)?;
+            if plaintext.is_empty() {
+                anyhow::bail!("Jina AI API key not configured (decrypted value is empty)");
+            }
+            Ok(plaintext)
+        } else {
+            Ok(raw_key)
+        }
+    }
+
+    async fn search_jina(&self, query: &str) -> anyhow::Result<String> {
+        let api_key = self.resolve_jina_api_key()?;
+
+        let encoded_query = urlencoding::encode(query);
+        let search_url = format!("https://s.jina.ai/?q={}", encoded_query);
+
+        let builder = reqwest::Client::builder()
+            .timeout(Duration::from_secs(self.timeout_secs))
+            .user_agent("ZeroClaw/1.0 (https://zeroclaw.ai)");
+        let builder =
+            zeroclaw_config::schema::apply_runtime_proxy_to_builder(builder, "tool.web_search");
+        let client = builder.build()?;
+
+        let response = client
+            .get(&search_url)
+            .header("Authorization", format!("Bearer {}", api_key))
+            .header("Accept", "application/json")
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            anyhow::bail!("Jina AI search failed with status: {}", response.status());
+        }
+
+        let json: serde_json::Value = response.json().await?;
+        self.parse_jina_results(&json, query)
+    }
+
+    fn parse_jina_results(&self, json: &serde_json::Value, query: &str) -> anyhow::Result<String> {
+        let results = json
+            .get("results")
+            .and_then(|r| r.as_array())
+            .ok_or_else(|| {
+                ::zeroclaw_log::record!(
+                    ERROR,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+                        .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                        .with_attrs(::serde_json::json!({"search_provider": "jina"})),
+                    "web_search: invalid Jina AI response"
+                );
+                anyhow::Error::msg("Invalid Jina AI API response")
+            })?;
+
+        if results.is_empty() {
+            return Ok(format!("No results found for: {}", query));
+        }
+
+        let mut lines = vec![format!("Search results for: {} (via Jina AI)", query)];
+
+        for (i, result) in results.iter().take(self.max_results).enumerate() {
+            let title = result
+                .get("title")
+                .and_then(|t| t.as_str())
+                .unwrap_or("No title");
+            let url = result.get("url").and_then(|u| u.as_str()).unwrap_or("");
+            let description = result
+                .get("description")
+                .and_then(|d| d.as_str())
+                .unwrap_or("");
+
+            lines.push(format!("{}. {}", i + 1, title));
+            lines.push(format!("   {}", url));
+            if !description.is_empty() {
+                lines.push(format!("   {}", description));
+            }
+        }
+
+        Ok(lines.join("\n"))
+    }
+
     fn parse_brave_results(&self, json: &serde_json::Value, query: &str) -> anyhow::Result<String> {
         let results = json
             .get("web")
@@ -752,6 +908,7 @@ impl Tool for WebSearchTool {
             WebSearchProviderRoute::Brave => self.search_brave(query).await?,
             WebSearchProviderRoute::Tavily => self.search_tavily(query).await?,
             WebSearchProviderRoute::SearXNG => self.search_searxng(query).await?,
+            WebSearchProviderRoute::Jina => self.search_jina(query).await?,
         };
 
         Ok(ToolResult {
@@ -768,19 +925,19 @@ mod tests {
 
     #[test]
     fn test_tool_name() {
-        let tool = WebSearchTool::new("duckduckgo".to_string(), None, 5, 15);
+        let tool = WebSearchTool::new("duckduckgo".to_string(), None, None, 5, 15);
         assert_eq!(tool.name(), "web_search_tool");
     }
 
     #[test]
     fn test_tool_description() {
-        let tool = WebSearchTool::new("duckduckgo".to_string(), None, 5, 15);
+        let tool = WebSearchTool::new("duckduckgo".to_string(), None, None, 5, 15);
         assert!(tool.description().contains("Search the web"));
     }
 
     #[test]
     fn test_parameters_schema() {
-        let tool = WebSearchTool::new("duckduckgo".to_string(), None, 5, 15);
+        let tool = WebSearchTool::new("duckduckgo".to_string(), None, None, 5, 15);
         let schema = tool.parameters_schema();
         assert_eq!(schema["type"], "object");
         assert!(schema["properties"]["query"].is_object());
@@ -794,7 +951,7 @@ mod tests {
 
     #[test]
     fn test_parse_duckduckgo_results_empty() {
-        let tool = WebSearchTool::new("duckduckgo".to_string(), None, 5, 15);
+        let tool = WebSearchTool::new("duckduckgo".to_string(), None, None, 5, 15);
         let result = tool
             .parse_duckduckgo_results("<html>No results here</html>", "test")
             .unwrap();
@@ -803,7 +960,7 @@ mod tests {
 
     #[test]
     fn test_parse_duckduckgo_results_with_data() {
-        let tool = WebSearchTool::new("duckduckgo".to_string(), None, 5, 15);
+        let tool = WebSearchTool::new("duckduckgo".to_string(), None, None, 5, 15);
         let html = r#"
             <a class="result__a" href="https://example.com">Example Title</a>
             <a class="result__snippet">This is a description</a>
@@ -815,7 +972,7 @@ mod tests {
 
     #[test]
     fn test_parse_duckduckgo_results_decodes_redirect_url() {
-        let tool = WebSearchTool::new("duckduckgo".to_string(), None, 5, 15);
+        let tool = WebSearchTool::new("duckduckgo".to_string(), None, None, 5, 15);
         let html = r#"
             <a class="result__a" href="https://duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fpath%3Fa%3D1&amp;rut=test">Example Title</a>
             <a class="result__snippet">This is a description</a>
@@ -880,7 +1037,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let tool = WebSearchTool::new("duckduckgo".to_string(), None, 5, 15);
+        let tool = WebSearchTool::new("duckduckgo".to_string(), None, None, 5, 15);
         let err = tool
             .search_duckduckgo_at(&format!("{}/html/", server.uri()), "test")
             .await
@@ -911,7 +1068,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let tool = WebSearchTool::new("duckduckgo".to_string(), None, 5, 15);
+        let tool = WebSearchTool::new("duckduckgo".to_string(), None, None, 5, 15);
         let err = tool
             .search_duckduckgo_at(&format!("{}/html/", server.uri()), "test")
             .await
@@ -936,7 +1093,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let tool = WebSearchTool::new("duckduckgo".to_string(), None, 5, 15);
+        let tool = WebSearchTool::new("duckduckgo".to_string(), None, None, 5, 15);
         let err = tool
             .search_duckduckgo_at(&format!("{}/html/", server.uri()), "test")
             .await
@@ -965,7 +1122,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let tool = WebSearchTool::new("duckduckgo".to_string(), None, 5, 15);
+        let tool = WebSearchTool::new("duckduckgo".to_string(), None, None, 5, 15);
         let err = tool
             .search_duckduckgo_at(&format!("{}/html/", server.uri()), "test")
             .await
@@ -990,7 +1147,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let tool = WebSearchTool::new("duckduckgo".to_string(), None, 5, 15);
+        let tool = WebSearchTool::new("duckduckgo".to_string(), None, None, 5, 15);
         let result = tool
             .search_duckduckgo_at(&format!("{}/html/", server.uri()), "test")
             .await
@@ -1001,7 +1158,7 @@ mod tests {
 
     #[test]
     fn test_constructor_clamps_web_search_limits() {
-        let tool = WebSearchTool::new("duckduckgo".to_string(), None, 0, 0);
+        let tool = WebSearchTool::new("duckduckgo".to_string(), None, None, 0, 0);
         let html = r#"
             <a class="result__a" href="https://example.com">Example Title</a>
             <a class="result__snippet">This is a description</a>
@@ -1012,21 +1169,21 @@ mod tests {
 
     #[tokio::test]
     async fn test_execute_missing_query() {
-        let tool = WebSearchTool::new("duckduckgo".to_string(), None, 5, 15);
+        let tool = WebSearchTool::new("duckduckgo".to_string(), None, None, 5, 15);
         let result = tool.execute(json!({})).await;
         assert!(result.is_err());
     }
 
     #[tokio::test]
     async fn test_execute_empty_query() {
-        let tool = WebSearchTool::new("duckduckgo".to_string(), None, 5, 15);
+        let tool = WebSearchTool::new("duckduckgo".to_string(), None, None, 5, 15);
         let result = tool.execute(json!({"query": ""})).await;
         assert!(result.is_err());
     }
 
     #[tokio::test]
     async fn test_execute_brave_without_api_key() {
-        let tool = WebSearchTool::new("brave".to_string(), None, 5, 15);
+        let tool = WebSearchTool::new("brave".to_string(), None, None, 5, 15);
         let result = tool.execute(json!({"query": "test"})).await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("API key"));
@@ -1037,6 +1194,7 @@ mod tests {
         let tool = WebSearchTool::new(
             "brave".to_string(),
             Some("sk-plaintext-key".to_string()),
+            None,
             5,
             15,
         );
@@ -1057,6 +1215,7 @@ mod tests {
         // No boot key -- forces reload from config
         let tool = WebSearchTool::new_with_config(
             "brave".to_string(),
+            None,
             None,
             None,
             None,
@@ -1088,6 +1247,7 @@ mod tests {
             Some(encrypted),
             None,
             None,
+            None,
             5,
             15,
             config_path,
@@ -1108,6 +1268,7 @@ mod tests {
             None,
             None,
             None,
+            None,
             5,
             15,
             config_path,
@@ -1125,7 +1286,7 @@ mod tests {
 
     #[test]
     fn test_parse_tavily_results_empty() {
-        let tool = WebSearchTool::new("tavily".to_string(), None, 5, 15);
+        let tool = WebSearchTool::new("tavily".to_string(), None, None, 5, 15);
         let json = serde_json::json!({"results": []});
         let result = tool.parse_tavily_results(&json, "test").unwrap();
         assert!(result.contains("No results found"));
@@ -1133,7 +1294,7 @@ mod tests {
 
     #[test]
     fn test_parse_tavily_results_with_data() {
-        let tool = WebSearchTool::new("tavily".to_string(), None, 5, 15);
+        let tool = WebSearchTool::new("tavily".to_string(), None, None, 5, 15);
         let json = serde_json::json!({
             "query": "test",
             "results": [
@@ -1159,7 +1320,7 @@ mod tests {
 
     #[test]
     fn test_parse_tavily_results_invalid_response() {
-        let tool = WebSearchTool::new("tavily".to_string(), None, 5, 15);
+        let tool = WebSearchTool::new("tavily".to_string(), None, None, 5, 15);
         let json = serde_json::json!({"error": "bad api key"});
         let result = tool.parse_tavily_results(&json, "test");
         assert!(result.is_err());
@@ -1184,6 +1345,7 @@ mod tests {
             None,
             None,
             None,
+            None,
             5,
             15,
             config_path,
@@ -1203,6 +1365,7 @@ mod tests {
     fn test_resolve_tavily_api_key_uses_boot_key() {
         let tool = WebSearchTool::new_with_config(
             "tavily".to_string(),
+            None,
             None,
             Some("tvly-boot-key".to_string()),
             None,
@@ -1231,6 +1394,7 @@ mod tests {
             None,
             None,
             None,
+            None,
             5,
             15,
             config_path,
@@ -1256,6 +1420,7 @@ mod tests {
         // Boot key is the encrypted blob -- should trigger reload + decrypt
         let tool = WebSearchTool::new_with_config(
             "tavily".to_string(),
+            None,
             None,
             Some(encrypted),
             None,
@@ -1294,6 +1459,7 @@ mod tests {
 
         let tool = WebSearchTool::new_with_config(
             "tavily".to_string(),
+            None,
             None,
             Some("tvly-test-key".to_string()),
             None,
@@ -1345,7 +1511,7 @@ mod tests {
 
     #[test]
     fn test_parse_searxng_results_empty() {
-        let tool = WebSearchTool::new("searxng".to_string(), None, 5, 15);
+        let tool = WebSearchTool::new("searxng".to_string(), None, None, 5, 15);
         let json = serde_json::json!({"results": []});
         let result = tool.parse_searxng_results(&json, "test").unwrap();
         assert!(result.contains("No results found"));
@@ -1353,7 +1519,7 @@ mod tests {
 
     #[test]
     fn test_parse_searxng_results_with_data() {
-        let tool = WebSearchTool::new("searxng".to_string(), None, 5, 15);
+        let tool = WebSearchTool::new("searxng".to_string(), None, None, 5, 15);
         let json = serde_json::json!({
             "results": [
                 {
@@ -1377,7 +1543,7 @@ mod tests {
 
     #[test]
     fn test_parse_searxng_results_invalid_response() {
-        let tool = WebSearchTool::new("searxng".to_string(), None, 5, 15);
+        let tool = WebSearchTool::new("searxng".to_string(), None, None, 5, 15);
         let json = serde_json::json!({"error": "bad request"});
         let result = tool.parse_searxng_results(&json, "test");
         assert!(result.is_err());
@@ -1395,6 +1561,7 @@ mod tests {
             model_provider: "searxng".into(),
             boot_brave_api_key: None,
             boot_tavily_api_key: None,
+            boot_jina_api_key: None,
             searxng_instance_url: Some("https://searx.example.com".to_string()),
             max_results: 5,
             timeout_secs: 15,
@@ -1420,6 +1587,7 @@ mod tests {
             None,
             None,
             None,
+            None,
             5,
             15,
             config_path,
@@ -1442,6 +1610,7 @@ mod tests {
             None,
             None,
             None,
+            None,
             5,
             15,
             config_path.clone(),
@@ -1461,5 +1630,122 @@ mod tests {
         // Now should succeed with the updated key
         let key = tool.resolve_brave_api_key().unwrap();
         assert_eq!(key, "runtime-updated-key");
+    }
+
+    #[test]
+    fn test_resolve_jina_api_key_uses_boot_key() {
+        let tool = WebSearchTool::new_with_config(
+            "jina".to_string(),
+            None,
+            None,
+            Some("jina-boot-key".to_string()),
+            None,
+            5,
+            15,
+            PathBuf::new(),
+            false,
+        );
+        let key = tool.resolve_jina_api_key().unwrap();
+        assert_eq!(key, "jina-boot-key");
+    }
+
+    #[test]
+    fn test_resolve_jina_api_key_reloads_from_config() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            "[web_search]\njina_api_key = \"jina-fresh-from-disk\"\n",
+        )
+        .unwrap();
+
+        // No boot key — forces reload from config
+        let tool = WebSearchTool::new_with_config(
+            "jina".to_string(),
+            None,
+            None,
+            None,
+            None,
+            5,
+            15,
+            config_path,
+            false,
+        );
+        let key = tool.resolve_jina_api_key().unwrap();
+        assert_eq!(key, "jina-fresh-from-disk");
+    }
+
+    #[test]
+    fn test_parse_jina_results_empty() {
+        let tool = WebSearchTool::new("jina".to_string(), None, None, 5, 15);
+        let json = serde_json::json!({"results": []});
+        let result = tool.parse_jina_results(&json, "test").unwrap();
+        assert!(result.contains("No results found"));
+    }
+
+    #[test]
+    fn test_parse_jina_results_with_data() {
+        let tool = WebSearchTool::new("jina".to_string(), None, None, 5, 15);
+        let json = serde_json::json!({
+            "results": [
+                {
+                    "title": "Jina AI",
+                    "url": "https://jina.ai/",
+                    "description": "Best-in-class embeddings, rerankers, web reader, deepsearch"
+                },
+                {
+                    "title": "Jina AI on GitHub",
+                    "url": "https://github.com/jina-ai",
+                    "description": "Open-source AI infrastructure"
+                }
+            ]
+        });
+        let result = tool.parse_jina_results(&json, "test").unwrap();
+        assert!(result.contains("Jina AI"));
+        assert!(result.contains("https://jina.ai/"));
+        assert!(result.contains("via Jina AI"));
+    }
+
+    #[test]
+    fn test_parse_jina_results_invalid_response() {
+        let tool = WebSearchTool::new("jina".to_string(), None, None, 5, 15);
+        let json = serde_json::json!({"error": "bad api key"});
+        let result = tool.parse_jina_results(&json, "test");
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Invalid Jina AI API response")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_execute_jina_without_api_key() {
+        // No boot key + no config field → resolve_jina_api_key must error
+        // before any network call is attempted.
+        let tmp = tempfile::tempdir().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(&config_path, "[web_search]\n").unwrap();
+
+        let tool = WebSearchTool::new_with_config(
+            "jina".to_string(),
+            None,
+            None,
+            None,
+            None,
+            5,
+            15,
+            config_path,
+            false,
+        );
+        let result = tool.execute(json!({"query": "test"})).await;
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Jina AI API key not configured")
+        );
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Added Jina AI as a new web search provider in `crates/zeroclaw-tools/src/web_search_provider_routing.rs`
  - Added `jina_api_key` config field in `crates/zeroclaw-config/src/schema.rs`
  - Implemented `search_jina()` and `parse_jina_results()` in `crates/zeroclaw-tools/src/web_search_tool.rs`
  - Added comprehensive tests for Jina AI provider including API key resolution, response parsing, and error handling
  - Jina AI offers a generous free tier (10M requests/month, no credit card required) with results optimized for LLM context
- **Scope boundary:** This PR does not modify the web reader functionality (https://r.jina.ai/) which is mentioned as out of scope in the issue
- **Blast radius:** Low. This is an additive change that adds a new optional provider. Existing providers (DuckDuckGo, Brave, Tavily, SearXNG) are unaffected.
- **Linked issue(s):** Closes #6827
- **Labels:** type: feature, risk: low, size: S

## Validation Evidence (required)

Commands run:
```bash
# Note: cargo not available in this environment, validation would be:
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test -p zeroclaw-tools -- --nocapture
cargo test -p zeroclaw-config
```

- **Commands run and tail output:** N/A (cargo not available in current environment)
- **Beyond CI — what did you manually verify?**
  - Verified the routing logic correctly maps "jina", "jina-ai", "jina_ai" to WebSearchProviderRoute::Jina
  - Verified the implementation follows the same pattern as existing providers (Brave, Tavily)
  - Verified API key resolution follows lazy-load pattern with boot-time snapshot and config reload fallback
  - Verified JSON response parsing handles empty results and invalid responses correctly
- **What I did NOT verify:**
  - Actual network call to Jina AI API (requires valid API key)
  - End-to-end integration with zeroclaw runtime

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? No
- New external network calls? Yes - adds HTTPS call to `https://s.jina.ai/` when Jina AI provider is configured
- Secrets / tokens / credentials handling changed? Yes - adds `jina_api_key` config field with secret encryption support (same pattern as `tavily_api_key` and `brave_api_key`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No

## Compatibility

- Backward compatible? Yes
- Config / env / CLI surface changed? Yes - new optional `jina_api_key` config field in `[web_search]` section

Upgrade steps for existing users:
```toml
[web_search]
provider = "jina"  # Optional, defaults to "duckduckgo"
jina_api_key = "your-jina-api-key"  # Optional, only required when provider is "jina"
```

## Rollback

Low-risk PRs: `git revert <sha>` is the plan unless otherwise noted.