### PR TITLE
fix(setup): align Windows minimal install with core-only build

### DIFF
--- a/docs/book/src/setup/windows.md
+++ b/docs/book/src/setup/windows.md
@@ -28,7 +28,9 @@ The script:
 1. Checks for `rustup`; downloads `rustup-init.exe` and installs stable toolchain if missing
 2. Builds (or downloads) the binary
 3. Installs to `%USERPROFILE%\.zeroclaw\bin\zeroclaw.exe`
-4. Runs `zeroclaw onboard` automatically
+4. Prints mode-specific next steps:
+   - `--prebuilt`, `--standard`, `--full`: run `zeroclaw onboard`
+   - `--minimal`: onboarding is unavailable; configure `%USERPROFILE%\.zeroclaw\config.toml` manually and use the reduced CLI path (`zeroclaw agent ...`)
 
 For source builds, `setup.bat` now prints the exact `cargo build ...` command it executes and reports the installed `zeroclaw.exe` size so command shape and artifact expectations stay visible.
 
@@ -124,7 +126,10 @@ zeroclaw service uninstall
 Remove the binary:
 
 ```cmd
-:: setup.bat / cargo install
+:: setup.bat
+del "%USERPROFILE%\.zeroclaw\bin\zeroclaw.exe"
+
+:: cargo install
 del "%USERPROFILE%\.cargo\bin\zeroclaw.exe"
 
 :: Scoop

--- a/docs/book/src/setup/windows.md
+++ b/docs/book/src/setup/windows.md
@@ -19,7 +19,7 @@ Flags:
 | Flag | Behaviour |
 |---|---|
 | `--prebuilt` | Download prebuilt binary from GitHub Releases (fastest — no Rust toolchain needed) |
-| `--minimal` | Build core only (no channels, no hardware) |
+| `--minimal` | Build core only (`--no-default-features`; no channels, no hardware) |
 | `--standard` | Build with common channels (Telegram, Discord, Slack, Matrix) |
 | `--full` | Build everything |
 
@@ -27,8 +27,10 @@ The script:
 
 1. Checks for `rustup`; downloads `rustup-init.exe` and installs stable toolchain if missing
 2. Builds (or downloads) the binary
-3. Installs to `%USERPROFILE%\.cargo\bin\zeroclaw.exe`
+3. Installs to `%USERPROFILE%\.zeroclaw\bin\zeroclaw.exe`
 4. Runs `zeroclaw onboard` automatically
+
+For source builds, `setup.bat` now prints the exact `cargo build ...` command it executes and reports the installed `zeroclaw.exe` size so command shape and artifact expectations stay visible.
 
 ### Option 2 — Scoop
 

--- a/setup.bat
+++ b/setup.bat
@@ -294,8 +294,14 @@ echo %BOLD%%GREEN%=========================================%RESET%
 echo.
 echo   Next steps:
 echo     1. Restart your terminal (for PATH changes)
+if /I "%MODE%"=="minimal" (
+echo     2. Minimal build excludes onboarding ^(zeroclaw onboard is unavailable^)
+echo     3. Configure model providers manually in %%USERPROFILE%%\.zeroclaw\config.toml
+echo     4. Use reduced CLI path: zeroclaw agent --message "Hello"
+) else (
 echo     2. Run: zeroclaw onboard
 echo     3. Configure your API key in %%USERPROFILE%%\.zeroclaw\config.toml
+)
 echo.
 echo   Alternative install via Scoop:
 echo     scoop bucket add zeroclaw https://github.com/zeroclaw-labs/scoop-zeroclaw

--- a/setup.bat
+++ b/setup.bat
@@ -128,7 +128,7 @@ if "%MODE%"=="full"     goto :build_full
 echo %BOLD%[2/5] Choose installation method:%RESET%
 echo.
 echo   1) Prebuilt binary   - Download pre-compiled release (fastest, ~2 min)
-echo   2) Minimal build     - Default features only (~15 min)
+echo   2) Minimal build     - Core only (^--no-default-features, ~15 min)
 echo   3) Standard build    - Default + Lark/Feishu + Matrix (~20 min)
 echo   4) Full build        - All features including hardware + browser (~30 min)
 echo.
@@ -189,8 +189,8 @@ goto verify
 
 :: ---- Minimal build ----
 :build_minimal
-set "FEATURES="
-set "BUILD_DESC=minimal (default features)"
+set "FEATURES=--no-default-features"
+set "BUILD_DESC=minimal (core only, no default features)"
 goto :do_build
 
 :: ---- Standard build ----
@@ -227,6 +227,7 @@ rustup target add %TARGET% >nul 2>&1
 echo   This may take 15-30 minutes on first build...
 echo.
 
+echo   Command: cargo build --release --locked %FEATURES% --target %TARGET%
 cargo build --release --locked %FEATURES% --target %TARGET%
 if %ERRORLEVEL% NEQ 0 (
     echo.
@@ -245,7 +246,15 @@ echo.
 echo %BOLD%[4/5] Installing binary...%RESET%
 mkdir "%USERPROFILE%\.zeroclaw\bin" 2>nul
 copy /Y "target\%TARGET%\release\zeroclaw.exe" "%USERPROFILE%\.zeroclaw\bin\zeroclaw.exe" >nul
-echo   %GREEN%OK%RESET% Installed to %USERPROFILE%\.zeroclaw\bin\zeroclaw.exe
+set "BIN_PATH=%USERPROFILE%\.zeroclaw\bin\zeroclaw.exe"
+for /f %%S in ('powershell -NoProfile -Command "[math]::Round(((Get-Item -LiteralPath ''%BIN_PATH%'').Length / 1MB), 2)"') do (
+    set "BINARY_MB=%%S"
+)
+if defined BINARY_MB (
+    echo   %GREEN%OK%RESET% Installed to %USERPROFILE%\.zeroclaw\bin\zeroclaw.exe ^(%BINARY_MB% MB^)
+) else (
+    echo   %GREEN%OK%RESET% Installed to %USERPROFILE%\.zeroclaw\bin\zeroclaw.exe ^(size unavailable^)
+)
 
 :: Add to PATH if not already there
 echo %PATH% | findstr /I /C:".zeroclaw\bin" >nul 2>&1
@@ -305,7 +314,7 @@ echo Usage: setup.bat [OPTIONS]
 echo.
 echo Options:
 echo   --prebuilt    Download pre-compiled binary (fastest)
-echo   --minimal     Build with default features only
+echo   --minimal     Build core only ^(--no-default-features^)
 echo   --standard    Build with Matrix + Lark/Feishu
 echo   --full        Build with all features
 echo   --help, -h    Show this help message


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - `setup.bat --minimal` now builds with `--no-default-features` instead of default features, so Windows behavior matches the documented "core only" contract and expected smaller artifact profile.
  - Updated Windows setup docs/help text to state the exact minimal command shape and avoid feature-set ambiguity.
  - `setup.bat` now prints the exact `cargo build` command and reports installed binary size (with explicit fallback) so artifact-size expectations are observable at install time.
  - Corrected Windows docs install path to `%USERPROFILE%\.zeroclaw\bin\zeroclaw.exe`, matching actual script behavior.
- **Scope boundary:** Does not change Linux/macOS installer behavior, Cargo feature definitions, runtime code paths, or release packaging.
- **Blast radius:** Windows source-install flow only (`setup.bat` users, especially `--minimal`); docs consumers for Windows install instructions.
- **Linked issue(s):** fixes #6836
- **Labels:** `bug`, `risk: medium`, `size: S`, `docs`

- **Key implementation snippet:**
  ```bat
  :build_minimal
  set "FEATURES=--no-default-features"
  set "BUILD_DESC=minimal (core only, no default features)"
  ```

## Validation Evidence (required)

Local validation is the signal CI cannot replace. Run the full battery and paste literal output (tails, failures, warnings -- not "all passed").

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

Docs-only changes: replace with markdown lint + link-integrity (`scripts/ci/docs_quality_gate.sh`). Bootstrap scripts: add `bash -n install.sh`.

- **Commands run and tail output:**
  - `cargo fmt --all -- --check`
    - `<exited with exit code 0>`
  - `cargo clippy --all-targets -- -D warnings`
    - `Finished 'dev' profile [unoptimized + debuginfo] target(s) in 1.12s`
    - `<exited with exit code 0>`
  - `cargo test`
    - `Finished 'test' profile [unoptimized + debuginfo] target(s) in 0.55s`
    - `Running unittests src/lib.rs (target/debug/deps/zeroclaw-...)`
    - `running 224 tests`
    - `<exited with exit code 0>`
- **Beyond CI -- what did you manually verify?** Verified `setup.bat` now emits `cargo build --release --locked --no-default-features --target ...` for `--minimal`; verified install summary now includes size output or explicit `(size unavailable)` fallback; verified docs reflect the new minimal behavior and actual install path.
- **If any command was intentionally skipped, why:** None.

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1-2 sentence explanation.

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? (`No`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: exact upgrade steps for existing users:
  - If you previously used `setup.bat --minimal` expecting default-feature behavior, switch to `setup.bat --standard` or `setup.bat --full`.
  - If you need specific non-default capability, build from source with explicit Cargo feature flags instead of `--minimal`.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PRs: `git revert <sha>` is the plan unless otherwise noted.

Medium/high-risk PRs must fill:

- **Fast rollback command/path:** After merge, run `git revert <squash-merge-sha-for-#6867>`.
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Windows minimal install unexpectedly lacks previously available runtime/channel behavior; setup output shows `--no-default-features` command shape and resulting artifact size diverges from expected local baselines.

---

**Labels** live in the GitHub label UI, not in the body. Maintainers and reviewers with label permissions set `risk:*`, `size:*`, and scope labels via the sidebar. If auto-labels need correction, add `risk: manual` and the intended label. Contributors without label permission can note the mismatch in a comment.

**Do not add bot/AI attribution footers** such as `Co-authored-by: Claude ...`
or `Created with Claude Code` to the PR body or commit-message tail. Human
co-author trailers are appropriate only for incorporated contributor work under
the supersede-attribution section and privacy contract.

**Privacy contract** (`docs/book/src/contributing/privacy.md`) is a merge gate. Never commit real identities, secrets, personal emails, or PII in diff, tests, fixtures, or docs.
