### PR TITLE
fix(mdbook): stabilize gettext catalog diffs for docs sync

### DIFF
--- a/docs/book/src/developing/building-docs.md
+++ b/docs/book/src/developing/building-docs.md
@@ -52,6 +52,21 @@ Then the command counts fuzzy + untranslated entries. If there's a delta and `--
 
 Without `--provider`, `cargo mdbook sync` still runs extract + merge and reports how many strings need translation. Strings without a `msgstr` fall back to English at render time — partial translations are valid.
 
+`cargo mdbook sync` normalizes generated gettext catalogs with stable output rules (`msgcat --sort-output --no-wrap --add-location=file`). That keeps diffs focused on real source changes and avoids global line-number churn from small edits.
+
+Expected unavoidable churn:
+
+- Header metadata updates (for example `POT-Creation-Date` / `PO-Revision-Date`)
+- Reference updates when a string moves to a different source file
+- Actual source-string additions, removals, and edits
+
+Quick stability check after a small docs edit:
+
+```bash
+cargo mdbook sync
+git diff --numstat -- docs/book/po
+```
+
 ## Adding a new locale
 
 1. Edit `locales.toml` at the repo root — the **only** file you need to touch:

--- a/xtask/src/cmd/mdbook/sync.rs
+++ b/xtask/src/cmd/mdbook/sync.rs
@@ -17,6 +17,7 @@ pub fn run(
     require_tool("msginit", "apt install gettext / brew install gettext")?;
     require_tool("msgfmt", "apt install gettext / brew install gettext")?;
     require_tool("msgattrib", "apt install gettext / brew install gettext")?;
+    require_tool("msgcat", "apt install gettext / brew install gettext")?;
 
     let book = book_dir(&root);
     let po_dir = po_dir(&root);
@@ -46,6 +47,7 @@ pub fn run(
              cargo install mdbook-i18n-helpers --locked"
         );
     }
+    normalize_gettext_catalog(&pot)?;
 
     // Step 2+3: per-locale merge + AI fill
     let targets: Vec<String> = match locale {
@@ -85,6 +87,7 @@ pub fn run(
                     .arg(&po_file),
             )?;
         }
+        normalize_gettext_catalog(&po_file)?;
 
         if force {
             if let Some(p) = model_provider {
@@ -160,6 +163,20 @@ fn fill(
         cmd.arg("--force");
     }
     run_cmd(&mut cmd)
+}
+
+fn normalize_gettext_catalog(path: &Path) -> anyhow::Result<()> {
+    run_cmd(
+        Command::new("msgcat")
+            .args([
+                "--sort-output",
+                "--no-wrap",
+                "--add-location=file",
+                "--output-file",
+            ])
+            .arg(path)
+            .arg(path),
+    )
 }
 
 pub fn count_delta(po_file: &Path) -> anyhow::Result<u32> {


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Small English docs edits were triggering broad `.po` rewrites; this PR makes `cargo mdbook sync` normalize generated gettext output to keep diffs reviewable.
  - Added deterministic post-processing in `xtask` sync via `msgcat` (`--sort-output --no-wrap --add-location=file`) for both POT and per-locale PO files.
  - Added `msgcat` to required gettext tool checks so normalization fails fast when tooling is missing.
  - Updated docs guidance to define expected unavoidable churn (header metadata, source-file movement, true msgid changes) and a quick diff-check command for reviewers.
  - Result: routine prose-only docs PRs can avoid incidental translation-cache noise while still preserving real translation deltas.
- **Scope boundary:** Does not change translation model/provider behavior, AI fill logic, locale coverage, or release/CI translation policy.
- **Blast radius:** `cargo mdbook sync` output formatting in `docs/book/po/*`; contributors and maintainers who run docs translation sync locally.
- **Linked issue(s):** Closes #6697. Related #6694, Related #6696
- **Labels:** `type: docs`, `risk: low`, `size: XS`, `docs`

Example normalization step now enforced by sync:
```bash
msgcat --sort-output --no-wrap --add-location=file --output-file <catalog> <catalog>
```

## Validation Evidence (required)

- **Commands run and tail output:**
  ```bash
  cargo fmt --all -- --check
  # exited with code 0

  cargo clippy --all-targets -- -D warnings
  # Finished `dev` profile ... target(s) in 7m 41s
  # exited with code 0

  cargo test
  # exited with code 0
  ```
  ```bash
  cargo test -p xtask
  # test result: ok. 15 passed; 0 failed
  # exited with code 0

  cargo clippy -p xtask --all-targets -- -D warnings
  # Finished `dev` profile ...
  # exited with code 0
  ```
- **Beyond CI -- what did you manually verify?** Verified sync pipeline wiring and docs updates: normalization runs after extraction and merge/obsolete-strip, and docs now call out unavoidable churn boundaries plus a repeatable `git diff --numstat -- docs/book/po` check.
- **If any command was intentionally skipped, why:** Full local `cargo mdbook sync` churn repro was not rerun in this environment because `mdbook-xgettext`/gettext binaries were unavailable.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: `N/A`

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: exact upgrade steps for existing users: Ensure gettext provides `msgcat` on PATH when running `cargo mdbook sync`.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PRs: `git revert <sha>` is the plan unless otherwise noted.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): `N/A`
- Scope materially carried forward: `N/A`
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`No`)
- If `No`, why (inspiration-only, no direct code/design carry-over): No superseded PR scope was incorporated.
