### PR TITLE
fix(providers): preserve Ollama cloud suffix for private remotes

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -13091,7 +13091,7 @@ fn prune_default_values(actual: &mut toml::Table, defaults: &toml::Table) {
     }
 }
 
-fn is_local_ollama_endpoint(api_url: Option<&str>) -> bool {
+pub fn is_local_ollama_endpoint(api_url: Option<&str>) -> bool {
     let Some(raw) = api_url.map(str::trim).filter(|value| !value.is_empty()) else {
         return true;
     };
@@ -13100,6 +13100,17 @@ fn is_local_ollama_endpoint(api_url: Option<&str>) -> bool {
         .ok()
         .and_then(|url| url.host_str().map(|host| host.to_ascii_lowercase()))
         .is_some_and(|host| matches!(host.as_str(), "localhost" | "127.0.0.1" | "::1" | "0.0.0.0"))
+}
+
+pub fn is_official_ollama_cloud_endpoint(api_url: Option<&str>) -> bool {
+    let Some(raw) = api_url.map(str::trim).filter(|value| !value.is_empty()) else {
+        return false;
+    };
+
+    reqwest::Url::parse(raw)
+        .ok()
+        .and_then(|url| url.host_str().map(|host| host.to_ascii_lowercase()))
+        .is_some_and(|host| matches!(host.as_str(), "ollama.com" | "api.ollama.com"))
 }
 
 fn has_ollama_cloud_credential(config_api_key: Option<&str>) -> bool {
@@ -14005,7 +14016,9 @@ impl Config {
                     "default_model uses ':cloud' with model_provider 'ollama', but uri is local or unset. Set uri to a remote Ollama endpoint (for example https://ollama.com)."
                 );
             }
-            if !has_ollama_cloud_credential(entry.api_key.as_deref()) {
+            if is_official_ollama_cloud_endpoint(entry.uri.as_deref())
+                && !has_ollama_cloud_credential(entry.api_key.as_deref())
+            {
                 anyhow::bail!(
                     "default_model uses ':cloud' with model_provider 'ollama', but no API key is configured. Set api_key on [providers.models.ollama.<alias>] (or via the schema-mirror grammar: ZEROCLAW_providers__models__ollama__<alias>__api_key=<value>)."
                 );
@@ -18233,6 +18246,50 @@ model = "primary-model"
 
         let result = config.validate();
         assert!(result.is_ok(), "expected validation to pass: {result:?}");
+    }
+
+    #[test]
+    async fn validate_ollama_cloud_model_accepts_private_remote_without_api_key() {
+        let _env_guard = env_override_lock().await;
+        let mut config = Config::default();
+        config.providers.models.ollama.insert(
+            "default".to_string(),
+            OllamaModelProviderConfig {
+                base: ModelProviderConfig {
+                    model: Some("glm-5:cloud".to_string()),
+                    uri: Some("http://100.126.1.2:11434".to_string()),
+                    api_key: None,
+                    ..Default::default()
+                },
+                ..OllamaModelProviderConfig::default()
+            },
+        );
+
+        let result = config.validate();
+        assert!(result.is_ok(), "expected validation to pass: {result:?}");
+    }
+
+    #[test]
+    async fn validate_ollama_cloud_model_rejects_official_remote_without_api_key() {
+        let _env_guard = env_override_lock().await;
+        let mut config = Config::default();
+        config.providers.models.ollama.insert(
+            "default".to_string(),
+            OllamaModelProviderConfig {
+                base: ModelProviderConfig {
+                    model: Some("glm-5:cloud".to_string()),
+                    uri: Some("https://api.ollama.com".to_string()),
+                    api_key: None,
+                    ..Default::default()
+                },
+                ..OllamaModelProviderConfig::default()
+            },
+        );
+
+        let error = config.validate().expect_err("expected validation to fail");
+        assert!(error.to_string().contains(
+            "default_model uses ':cloud' with model_provider 'ollama', but no API key is configured"
+        ));
     }
 
     #[test]

--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -65,6 +65,13 @@ pub struct OpenAiCompatibleModelProvider {
     /// non-string `default` quirks crash the tool-call parser). The check
     /// runs at tool conversion time against the runtime model id.
     local_model_tool_sanitize: bool,
+    model_request_policy: ModelRequestPolicy,
+}
+
+#[derive(Clone, Copy)]
+enum ModelRequestPolicy {
+    Default,
+    OllamaCloud,
 }
 
 /// How the model_provider expects the API key to be sent.
@@ -279,6 +286,7 @@ impl OpenAiCompatibleModelProvider {
             models_dev_key: None,
             openrouter_vendor_prefix: None,
             local_model_tool_sanitize: false,
+            model_request_policy: ModelRequestPolicy::Default,
         }
     }
     /// Opt this provider into per-model conservative tool-schema sanitization.
@@ -289,6 +297,11 @@ impl OpenAiCompatibleModelProvider {
     /// happily serves llama, qwen, etc. without sanitization.
     pub fn with_local_model_tool_sanitize(mut self) -> Self {
         self.local_model_tool_sanitize = true;
+        self
+    }
+
+    pub fn with_ollama_cloud_model_routing(mut self) -> Self {
+        self.model_request_policy = ModelRequestPolicy::OllamaCloud;
         self
     }
 
@@ -616,6 +629,41 @@ impl OpenAiCompatibleModelProvider {
         let is_likely_codex_supported = id.contains("codex") && id.starts_with("gpt-");
 
         (is_openai_reasoning_model || is_likely_codex_supported).then(|| effort.clone())
+    }
+
+    pub(crate) fn resolve_model_request<'a>(
+        &'a self,
+        model: &str,
+    ) -> anyhow::Result<(String, Option<&'a str>)> {
+        let credential = self.credential.as_deref();
+        if !matches!(self.model_request_policy, ModelRequestPolicy::OllamaCloud) {
+            return Ok((model.to_string(), credential));
+        }
+
+        let requests_cloud = model.ends_with(":cloud");
+        if requests_cloud && zeroclaw_config::schema::is_local_ollama_endpoint(Some(&self.base_url))
+        {
+            anyhow::bail!(
+                "Model '{}' requested cloud routing, but Ollama endpoint is local. Configure api_url with a remote Ollama endpoint.",
+                model
+            );
+        }
+
+        let official_cloud =
+            zeroclaw_config::schema::is_official_ollama_cloud_endpoint(Some(&self.base_url));
+        if requests_cloud && official_cloud && credential.is_none() {
+            anyhow::bail!(
+                "Model '{}' requested cloud routing, but no API key is configured. Set api_key on [providers.models.ollama.<alias>].",
+                model
+            );
+        }
+
+        let request_model = if requests_cloud && official_cloud {
+            model.strip_suffix(":cloud").unwrap_or(model).to_string()
+        } else {
+            model.to_string()
+        };
+        Ok((request_model, credential))
     }
 }
 
@@ -1978,11 +2026,15 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
 
     async fn list_models(&self) -> anyhow::Result<Vec<String>> {
         // When a credential is present, hit the model_provider's native /models endpoint
-        // (OpenAI-compatible: GET {base_url}/models).
-        if let Some(credential) = self.credential.as_deref() {
+        // (OpenAI-compatible: GET {base_url}/models). Keyless Ollama remotes
+        // expose the same endpoint and should not fall back to static catalogs.
+        if self.credential.is_some()
+            || matches!(self.model_request_policy, ModelRequestPolicy::OllamaCloud)
+        {
+            let credential = self.credential.as_deref();
             let url = format!("{}/models", self.base_url);
             let response = self
-                .apply_auth_header(self.http_client().get(&url), Some(credential))
+                .apply_auth_header(self.http_client().get(&url), credential)
                 .send()
                 .await
                 .map_err(|e| {
@@ -2053,7 +2105,7 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
         temperature: Option<f64>,
     ) -> anyhow::Result<String> {
         let temperature = temperature.unwrap_or(self.default_temperature());
-        let credential = self.credential.as_deref();
+        let (request_model, credential) = self.resolve_model_request(model)?;
 
         // Normalize image markers (e.g. local file paths from channel
         // attachments) into base64 data URIs before this message reaches the
@@ -2095,7 +2147,7 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
         }
 
         let request = ApiChatRequest {
-            model: model.to_string(),
+            model: request_model,
             messages,
             temperature,
             stream: Some(false),
@@ -2166,7 +2218,7 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
         temperature: Option<f64>,
     ) -> anyhow::Result<String> {
         let temperature = temperature.unwrap_or(self.default_temperature());
-        let credential = self.credential.as_deref();
+        let (request_model, credential) = self.resolve_model_request(model)?;
 
         let normalized = Self::normalize_messages_for_upstream(messages).await?;
         let merge = self.effective_merge_system(model);
@@ -2182,7 +2234,7 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
             .collect();
 
         let request = ApiChatRequest {
-            model: model.to_string(),
+            model: request_model,
             messages: api_messages,
             temperature,
             stream: Some(false),
@@ -2248,7 +2300,7 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
         temperature: Option<f64>,
     ) -> anyhow::Result<ProviderChatResponse> {
         let temperature = temperature.unwrap_or(self.default_temperature());
-        let credential = self.credential.as_deref();
+        let (request_model, credential) = self.resolve_model_request(model)?;
 
         let normalized = Self::normalize_messages_for_upstream(messages).await?;
         let merge = self.effective_merge_system(model);
@@ -2263,7 +2315,7 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
             .collect();
 
         let request = ApiChatRequest {
-            model: model.to_string(),
+            model: request_model,
             messages: api_messages,
             temperature,
             stream: Some(false),
@@ -2370,7 +2422,7 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
         temperature: Option<f64>,
     ) -> anyhow::Result<ProviderChatResponse> {
         let temperature = temperature.unwrap_or(self.default_temperature());
-        let credential = self.credential.as_deref();
+        let (request_model, credential) = self.resolve_model_request(model)?;
 
         let normalized = Self::normalize_messages_for_upstream(request.messages).await?;
         let merge = self.effective_merge_system(model);
@@ -2381,7 +2433,7 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
 
         let tools = self.convert_tool_specs_for_model(request.tools, model);
         let native_request = NativeChatRequest {
-            model: model.to_string(),
+            model: request_model,
             messages: self.convert_messages_for_native(&effective_messages, !merge),
             temperature,
             stream: Some(false),
@@ -2505,6 +2557,15 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
             };
 
             let merge = provider.effective_merge_system(&model);
+            let (request_model, credential) = match provider.resolve_model_request(&model) {
+                Ok(details) => details,
+                Err(err) => {
+                    let _ = tx
+                        .send(Err(StreamError::ModelProvider(err.to_string())))
+                        .await;
+                    return;
+                }
+            };
             let has_tools = tools_owned.as_ref().is_some_and(|tools| !tools.is_empty());
             let effective_messages = Self::flatten_system_messages(&normalized, merge);
             let effective_messages = provider.strip_native_tool_messages(&effective_messages);
@@ -2512,7 +2573,7 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
 
             let payload_result = if has_tools {
                 serde_json::to_value(NativeChatRequest {
-                    model: model.clone(),
+                    model: request_model.clone(),
                     messages: provider.convert_messages_for_native(&effective_messages, !merge),
                     temperature,
                     reasoning_effort: provider.reasoning_effort_for_model(&model),
@@ -2542,7 +2603,7 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
                     .collect();
 
                 serde_json::to_value(ApiChatRequest {
-                    model: model.clone(),
+                    model: request_model.clone(),
                     messages,
                     temperature,
                     reasoning_effort: provider.reasoning_effort_for_model(&model),
@@ -2572,11 +2633,10 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
             let url = provider.chat_completions_url();
             let client = provider.streaming_http_client();
             let auth_header = provider.auth_header.clone();
-            let credential = provider.credential.clone();
             let targets_mistral_tool_call_contract = provider.targets_mistral_tool_call_contract();
 
             let mut req_builder = client.post(&url).json(&payload);
-            req_builder = apply_auth_to_request(req_builder, &auth_header, credential.as_deref());
+            req_builder = apply_auth_to_request(req_builder, &auth_header, credential);
             req_builder = req_builder.header("Accept", "text/event-stream");
 
             let response = match req_builder.send().await {
@@ -2663,6 +2723,15 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
             let normalized_message_content = normalized_user.content;
 
             let merge = provider.effective_merge_system(&model);
+            let (request_model, credential) = match provider.resolve_model_request(&model) {
+                Ok(details) => details,
+                Err(err) => {
+                    let _ = tx
+                        .send(Err(StreamError::ModelProvider(err.to_string())))
+                        .await;
+                    return;
+                }
+            };
             let mut messages = Vec::new();
             if merge {
                 let content = match system_prompt_owned.as_deref() {
@@ -2687,7 +2756,7 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
             }
 
             let request = ApiChatRequest {
-                model: model.clone(),
+                model: request_model,
                 messages,
                 temperature,
                 stream: Some(options_enabled),
@@ -2704,13 +2773,12 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
             let url = provider.chat_completions_url();
             let client = provider.streaming_http_client();
             let auth_header = provider.auth_header.clone();
-            let credential = provider.credential.clone();
 
             // Build request with auth
             let mut req_builder = client.post(&url).json(&request);
 
             // Apply auth header
-            req_builder = apply_auth_to_request(req_builder, &auth_header, credential.as_deref());
+            req_builder = apply_auth_to_request(req_builder, &auth_header, credential);
 
             // Set accept header for streaming
             req_builder = req_builder.header("Accept", "text/event-stream");
@@ -2784,6 +2852,15 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
             };
 
             let merge = provider.effective_merge_system(&model);
+            let (request_model, credential) = match provider.resolve_model_request(&model) {
+                Ok(details) => details,
+                Err(err) => {
+                    let _ = tx
+                        .send(Err(StreamError::ModelProvider(err.to_string())))
+                        .await;
+                    return;
+                }
+            };
             let effective_messages = Self::flatten_system_messages(&normalized, merge);
             let effective_messages = provider.strip_native_tool_messages(&effective_messages);
             let api_messages: Vec<Message> = effective_messages
@@ -2795,7 +2872,7 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
                 .collect();
 
             let request = ApiChatRequest {
-                model: model.clone(),
+                model: request_model,
                 messages: api_messages,
                 temperature,
                 stream: Some(options_enabled),
@@ -2812,10 +2889,9 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
             let url = provider.chat_completions_url();
             let client = provider.streaming_http_client();
             let auth_header = provider.auth_header.clone();
-            let credential = provider.credential.clone();
 
             let mut req_builder = client.post(&url).json(&request);
-            req_builder = apply_auth_to_request(req_builder, &auth_header, credential.as_deref());
+            req_builder = apply_auth_to_request(req_builder, &auth_header, credential);
             req_builder = req_builder.header("Accept", "text/event-stream");
 
             let response = match req_builder.send().await {
@@ -2914,6 +2990,47 @@ mod tests {
     fn strips_trailing_slash() {
         let p = make_model_provider("test", "https://example.com/", None);
         assert_eq!(p.base_url, "https://example.com");
+    }
+
+    #[test]
+    fn ollama_cloud_routing_strips_model_for_official_endpoint() {
+        let p = make_model_provider("Ollama", "https://api.ollama.com/v1", Some("ollama-key"))
+            .with_ollama_cloud_model_routing();
+        let (model, credential) = p.resolve_model_request("qwen3:cloud").unwrap();
+        assert_eq!(model, "qwen3");
+        assert_eq!(credential, Some("ollama-key"));
+    }
+
+    #[test]
+    fn ollama_cloud_routing_preserves_private_remote_without_api_key() {
+        let p = make_model_provider("Ollama", "http://100.126.1.2:11434/v1", None)
+            .with_ollama_cloud_model_routing();
+        let (model, credential) = p.resolve_model_request("qwen3:cloud").unwrap();
+        assert_eq!(model, "qwen3:cloud");
+        assert_eq!(credential, None);
+    }
+
+    #[test]
+    fn ollama_cloud_routing_preserves_private_remote_with_api_key() {
+        let p = make_model_provider("Ollama", "http://100.126.1.2:11434/v1", Some("private-key"))
+            .with_ollama_cloud_model_routing();
+        let (model, credential) = p.resolve_model_request("qwen3:cloud").unwrap();
+        assert_eq!(model, "qwen3:cloud");
+        assert_eq!(credential, Some("private-key"));
+    }
+
+    #[test]
+    fn ollama_cloud_routing_rejects_official_endpoint_without_api_key() {
+        let p = make_model_provider("Ollama", "https://ollama.com/v1", None)
+            .with_ollama_cloud_model_routing();
+        let error = p
+            .resolve_model_request("qwen3:cloud")
+            .expect_err("official Ollama Cloud should require a key");
+        assert!(
+            error
+                .to_string()
+                .contains("requested cloud routing, but no API key is configured")
+        );
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-providers/src/factory.rs
+++ b/crates/zeroclaw-providers/src/factory.rs
@@ -718,6 +718,49 @@ impl FamilyProviderFactory for OpenAIModelProviderConfig {
     }
 }
 
+fn normalize_ollama_compat_base_url(api_url: Option<&str>) -> String {
+    let raw = api_url
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("http://localhost:11434/v1");
+
+    let Ok(mut url) = reqwest::Url::parse(raw) else {
+        return raw.trim_end_matches('/').to_string();
+    };
+
+    let path = url.path().trim_end_matches('/');
+    if path.is_empty() || matches!(path, "/" | "/api" | "/api/chat") {
+        url.set_path("/v1");
+        return url.to_string().trim_end_matches('/').to_string();
+    }
+
+    raw.trim_end_matches('/').to_string()
+}
+
+fn build_ollama_compat_provider(
+    alias: &str,
+    key: Option<&str>,
+    api_url: Option<&str>,
+    opts: &ModelProviderRuntimeOptions,
+) -> OpenAiCompatibleModelProvider {
+    let base_url = normalize_ollama_compat_base_url(api_url);
+    let ollama_key = key.map(str::trim).filter(|value| !value.is_empty());
+    let mut p = OpenAiCompatibleModelProvider::new_with_vision(
+        alias,
+        "Ollama",
+        &base_url,
+        ollama_key,
+        AuthStyle::Bearer,
+        true,
+    )
+    .with_local_model_tool_sanitize()
+    .with_ollama_cloud_model_routing();
+    if opts.merge_system_into_user {
+        p = p.with_merge_system_into_user();
+    }
+    p
+}
+
 impl FamilyProviderFactory for OllamaModelProviderConfig {
     fn create_provider(
         &self,
@@ -726,24 +769,10 @@ impl FamilyProviderFactory for OllamaModelProviderConfig {
         api_url: Option<&str>,
         opts: &ModelProviderRuntimeOptions,
     ) -> Result<Box<dyn ModelProvider>> {
-        let base_url = api_url.unwrap_or("http://localhost:11434/v1");
-        let ollama_key = key
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .unwrap_or("ollama");
-        let mut p = OpenAiCompatibleModelProvider::new_with_vision(
-            alias,
-            "Ollama",
-            base_url,
-            Some(ollama_key),
-            AuthStyle::Bearer,
-            true,
-        )
-        .with_local_model_tool_sanitize();
-        if opts.merge_system_into_user {
-            p = p.with_merge_system_into_user();
-        }
-        Ok(apply_compat_options(p, opts))
+        Ok(apply_compat_options(
+            build_ollama_compat_provider(alias, key, api_url, opts),
+            opts,
+        ))
     }
 }
 
@@ -1142,5 +1171,40 @@ impl FamilyProviderFactory for CustomModelProviderConfig {
             p = p.with_merge_system_into_user();
         }
         Ok(apply_compat_options(p, opts))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ollama_compat_provider_preserves_private_cloud_model_without_key() {
+        let provider = build_ollama_compat_provider(
+            "default",
+            None,
+            Some("http://100.126.1.2:11434"),
+            &ModelProviderRuntimeOptions::default(),
+        );
+
+        assert_eq!(provider.base_url, "http://100.126.1.2:11434/v1");
+        let (model, credential) = provider.resolve_model_request("qwen3:cloud").unwrap();
+        assert_eq!(model, "qwen3:cloud");
+        assert_eq!(credential, None);
+    }
+
+    #[test]
+    fn ollama_compat_provider_strips_official_cloud_model_with_key() {
+        let provider = build_ollama_compat_provider(
+            "default",
+            Some("ollama-key"),
+            Some("https://api.ollama.com/api"),
+            &ModelProviderRuntimeOptions::default(),
+        );
+
+        assert_eq!(provider.base_url, "https://api.ollama.com/v1");
+        let (model, credential) = provider.resolve_model_request("qwen3:cloud").unwrap();
+        assert_eq!(model, "qwen3");
+        assert_eq!(credential, Some("ollama-key"));
     }
 }

--- a/crates/zeroclaw-providers/src/ollama.rs
+++ b/crates/zeroclaw-providers/src/ollama.rs
@@ -257,6 +257,10 @@ impl OllamaModelProvider {
             .is_some_and(|host| matches!(host.as_str(), "localhost" | "127.0.0.1" | "::1"))
     }
 
+    fn is_official_cloud_endpoint(&self) -> bool {
+        zeroclaw_config::schema::is_official_ollama_cloud_endpoint(Some(&self.base_url))
+    }
+
     fn http_client(&self) -> Client {
         zeroclaw_config::schema::build_runtime_proxy_client_with_timeouts(
             "model_provider.ollama",
@@ -267,7 +271,11 @@ impl OllamaModelProvider {
 
     fn resolve_request_details(&self, model: &str) -> anyhow::Result<(String, bool)> {
         let requests_cloud = model.ends_with(":cloud");
-        let normalized_model = model.strip_suffix(":cloud").unwrap_or(model).to_string();
+        let normalized_model = if requests_cloud && self.is_official_cloud_endpoint() {
+            model.strip_suffix(":cloud").unwrap_or(model).to_string()
+        } else {
+            model.to_string()
+        };
 
         if requests_cloud && self.is_local_endpoint() {
             anyhow::bail!(
@@ -276,7 +284,7 @@ impl OllamaModelProvider {
             );
         }
 
-        if requests_cloud && self.api_key.is_none() {
+        if requests_cloud && self.is_official_cloud_endpoint() && self.api_key.is_none() {
             anyhow::bail!(
                 "Model '{}' requested cloud routing, but no API key is configured. Set OLLAMA_API_KEY or config api_key.",
                 model
@@ -1152,6 +1160,23 @@ mod tests {
                 .to_string()
                 .contains("requested cloud routing, but no API key is configured")
         );
+    }
+
+    #[test]
+    fn cloud_suffix_preserved_for_private_remote_without_api_key() {
+        let p = OllamaModelProvider::new("test", Some("http://100.126.1.2:11434"), None);
+        let (model, should_auth) = p.resolve_request_details("qwen3:cloud").unwrap();
+        assert_eq!(model, "qwen3:cloud");
+        assert!(!should_auth);
+    }
+
+    #[test]
+    fn cloud_suffix_preserved_for_private_remote_with_api_key() {
+        let p =
+            OllamaModelProvider::new("test", Some("http://100.126.1.2:11434"), Some("ollama-key"));
+        let (model, should_auth) = p.resolve_request_details("qwen3:cloud").unwrap();
+        assert_eq!(model, "qwen3:cloud");
+        assert!(should_auth);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Preserves literal `:cloud` model names for non-official remote Ollama endpoints, so private or proxied Ollama servers can request models that are actually named with the suffix.
  - Keeps the existing official Ollama Cloud shorthand behavior for `ollama.com` and `api.ollama.com`: `qwen3:cloud` still resolves to `qwen3` and still requires an API key there.
  - Keeps local endpoint validation unchanged: local `:cloud` requests are still rejected instead of being treated as remote cloud models.
  - Aligns config validation, configured OpenAI-compatible Ollama requests, native Ollama helper behavior, and model-listing auth so private remote aliases without API keys do not get blocked or sent with a dummy Authorization header.
  - Adds focused regression tests for config validation, compatible request routing, factory opt-in behavior, and the native helper path.
- **Scope boundary:** This does not change non-Ollama providers, provider selection, reliability fallback policy, or local `:cloud` rejection.
- **Blast radius:** Limited to Ollama config validation and Ollama request/model-list preparation.
- **Linked issue(s):** Related #6074. Reapplies #4173. Supersedes #6277.
- **Labels:** `bug`, `config`, `provider`, `provider:compatible`, `provider:ollama`, `risk: medium`, `size: M`

## Validation Evidence (required)

- **Commands run and tail output:**

```text
cargo fmt --all -- --check
Result: passed.

cargo test -p zeroclaw-config validate_ollama_cloud_model -- --nocapture
Result: passed. 4 tests passed; 651 tests filtered out.

cargo test -p zeroclaw-providers ollama_ -- --nocapture
Result: passed. 12 tests passed; 842 tests filtered out.

cargo test -p zeroclaw-providers cloud_suffix -- --nocapture
Result: passed. 5 tests passed; 849 tests filtered out.

cargo clippy -p zeroclaw-config --all-targets -- -D warnings
Result: passed.

cargo clippy -p zeroclaw-providers --all-targets -- -D warnings
Result: passed.

git diff --check
Result: passed.
```

- **Beyond CI — what did you manually verify?** Traced the configured Ollama path from config validation through `OllamaModelProviderConfig::create_provider()` into `OpenAiCompatibleModelProvider`, then checked the native helper path separately. Verified that only `ollama.com` and `api.ollama.com` strip `:cloud` and require a key, private remote endpoints preserve `qwen3:cloud`, keyless private remotes do not get a dummy Authorization header, and local `:cloud` rejection remains covered.
- **If any command was intentionally skipped, why:** Full CI-shaped local tests and workspace-shaped clippy were not run for this draft. This is a focused config/provider patch with touched-crate fmt/test/clippy coverage; because it is `risk: medium`, the PR should stay draft until broader local validation is either run or explicitly accepted.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `Yes`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: The API-key guard is narrowed to official Ollama Cloud endpoints only. Private remote Ollama endpoints no longer require a key solely because the model name ends in `:cloud`; when no key is configured, those requests and model-list calls omit Authorization instead of sending a dummy value. Private remotes still attach Authorization when an API key is configured.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: `N/A`

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <merge-sha>`
- **Feature flags or config toggles:** `None`
- **Observable failure symptoms:** Ollama requests to official cloud endpoints stop stripping `:cloud`, private/proxied remote Ollama requests again fail with "model '<name>' not found" after the suffix is stripped, or local `:cloud` validation behavior changes.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line):
  - #6277 by @jeffjhunter
- Scope materially carried forward:
  - The official-host split and private remote `:cloud` preservation from #4173 and #6277.
  - Config/factory/compatible-provider coverage added during #6277 recovery.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `Yes`
- If `No`, why (inspiration-only, no direct code/design carry-over): `N/A`
