### PR TITLE
docs(review): update milestone fallback owner

### DIFF
--- a/.claude/skills/github-pr-review-session/SKILL.md
+++ b/.claude/skills/github-pr-review-session/SKILL.md
@@ -161,7 +161,7 @@ the handoff.
    |---|---|
    | PR fits a milestone (any type) | Assign that milestone → go to step 5 |
    | No scope match + break-fix or docs | Assign the **earliest open milestone** by version order → go to step 5 |
-   | No scope match + feature | Tag @JordanTheJet → go to step 6 |
+   | No scope match + feature | Ask the milestone owner: default @singlerider; use @JordanTheJet for hardware, edge-deployment, or project-lead scope → go to step 6 |
 
    "Earliest open milestone" means the lowest semver among all currently open
    milestones (e.g. v0.7.6 before v0.7.7 before v0.8.0). Sort by the version
@@ -204,13 +204,16 @@ the handoff.
         --body-file tmp/tracking-<milestone-title>.md
       ```
 
-6. **Jordan trapdoor — feature with no scope match:**
+6. **Milestone-owner fallback — feature with no scope match:**
 
-   Post a comment on the PR tagging @JordanTheJet for milestone alignment:
+   Post a comment on the PR tagging @singlerider for milestone alignment:
    ```bash
    gh pr comment <number> --repo zeroclaw-labs/zeroclaw \
-     --body "@JordanTheJet — milestone alignment needed: this PR does not clearly fit within the scope boundary of any open milestone. Please advise on placement or deferral."
+     --body "@singlerider — milestone alignment needed: this PR does not clearly fit within the scope boundary of any open milestone. Please advise on placement or deferral."
    ```
+
+   Use @JordanTheJet instead when the unclear milestone placement is primarily
+   about hardware, edge deployments, or project-lead scope.
 
    Note this in `tmp/handoff.md` so the next session knows alignment is
    pending.
@@ -222,7 +225,7 @@ After every posted review, update `tmp/handoff.md`:
 - Mark the PR with the verdict posted, the commit reviewed (`head.sha`), and
   what remains open (if anything).
 - Record the milestone alignment action taken (milestone set, tracking issue
-  updated, @JordanTheJet tagged, or skipped with reason).
+  updated, milestone owner tagged, or skipped with reason).
 - If the PR queue changed (e.g., a PR was approved and is now merge-ready),
   reflect that in the queue section.
 - Keep the handoff accurate enough that a new session starting cold can pick
@@ -279,9 +282,10 @@ These norms are documented in
    documented no-milestone type (`chore:`/`deps:` prefix or deps-only diff).
    Note the skip reason in the handoff when bypassing. Break-fix (`fix:`
    prefix or `bug` label) and docs (`docs:` prefix) PRs with no scope match
-   are assigned the earliest open milestone by version order — do not tag
-   @JordanTheJet for those. @JordanTheJet is only the fallback for feature
-   PRs with no scope match.
+   are assigned the earliest open milestone by version order. For feature PRs
+   with no scope match, ask @singlerider for milestone placement by default;
+   use @JordanTheJet only when the unclear placement is primarily about
+   hardware, edge deployments, or project-lead scope.
 8. **Always update `tmp/handoff.md` after posting.** The handoff is useless if
    it's not current. Include the milestone alignment outcome.
 9. **Never merge.** Never push to contributor branches.

--- a/.claude/skills/github-pr-review-session/SKILL.md
+++ b/.claude/skills/github-pr-review-session/SKILL.md
@@ -161,7 +161,7 @@ the handoff.
    |---|---|
    | PR fits a milestone (any type) | Assign that milestone → go to step 5 |
    | No scope match + break-fix or docs | Assign the **earliest open milestone** by version order → go to step 5 |
-   | No scope match + feature | Ask the milestone owner: default @singlerider; use @JordanTheJet for hardware, edge-deployment, or project-lead scope → go to step 6 |
+   | No scope match + feature | Ask the milestone owners: default @singlerider and @theonlyhennygod; use @JordanTheJet for hardware, edge-deployment, or project-lead scope → go to step 6 |
 
    "Earliest open milestone" means the lowest semver among all currently open
    milestones (e.g. v0.7.6 before v0.7.7 before v0.8.0). Sort by the version
@@ -206,10 +206,11 @@ the handoff.
 
 6. **Milestone-owner fallback — feature with no scope match:**
 
-   Post a comment on the PR tagging @singlerider for milestone alignment:
+   Post a comment on the PR tagging @singlerider and @theonlyhennygod for
+   milestone alignment:
    ```bash
    gh pr comment <number> --repo zeroclaw-labs/zeroclaw \
-     --body "@singlerider — milestone alignment needed: this PR does not clearly fit within the scope boundary of any open milestone. Please advise on placement or deferral."
+     --body "@singlerider @theonlyhennygod — milestone alignment needed: this PR does not clearly fit within the scope boundary of any open milestone. Please advise on placement or deferral."
    ```
 
    Use @JordanTheJet instead when the unclear milestone placement is primarily
@@ -283,9 +284,9 @@ These norms are documented in
    Note the skip reason in the handoff when bypassing. Break-fix (`fix:`
    prefix or `bug` label) and docs (`docs:` prefix) PRs with no scope match
    are assigned the earliest open milestone by version order. For feature PRs
-   with no scope match, ask @singlerider for milestone placement by default;
-   use @JordanTheJet only when the unclear placement is primarily about
-   hardware, edge deployments, or project-lead scope.
+   with no scope match, ask @singlerider and @theonlyhennygod for milestone
+   placement by default; use @JordanTheJet only when the unclear placement is
+   primarily about hardware, edge deployments, or project-lead scope.
 8. **Always update `tmp/handoff.md` after posting.** The handoff is useless if
    it's not current. Include the milestone alignment outcome.
 9. **Never merge.** Never push to contributor branches.


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Renames the PR review skill's person-specific "Jordan trapdoor" to a role-based milestone-owner fallback.
  - Makes `@singlerider` and `@theonlyhennygod` the default escalation for feature PRs that do not clearly fit any open milestone.
  - Keeps `@JordanTheJet` as the fallback when the unclear placement is about hardware, edge deployments, or project-lead scope.
- **Scope boundary:** This only updates the local PR review skill instructions. It does not change public maintainer docs, labels, milestones, issue state, or any runtime behavior.
- **Blast radius:** PR reviewers using the `.claude` review skill will route unclear feature milestone questions to the current practical milestone owners by default.
- **Linked issue(s):** None.
- **Labels:** Proposed: `type: docs`, `risk: low`, `size: XS`.

## Validation Evidence (required)

- **Commands run and tail output:**

  ```bash
  git diff --check
  ```

  No output; passed.

  ```bash
  DOCS_FILES=.claude/skills/github-pr-review-session/SKILL.md bash scripts/ci/docs_quality_gate.sh
  ```

  ```text
  markdownlint-cli2 v0.20.0 (markdownlint v0.40.0)
  Finding: .claude/skills/github-pr-review-session/SKILL.md !target/**
  Linting: 1 file(s)
  Summary: 0 error(s)
  ```

- **Beyond CI — what did you manually verify?** Checked the changed skill text to confirm break-fix/docs/other PRs still avoid fallback pings, unclear feature PRs now default to `@singlerider` and `@theonlyhennygod`, and `@JordanTheJet` remains reserved for hardware, edge-deployment, or project-lead scope questions.
- **If any command was intentionally skipped, why:** Rust validation was skipped because this is a one-file workflow-skill Markdown change with no code or generated docs changes.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No user upgrade steps required.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PR: `git revert <sha>` is sufficient.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors: N/A
- Scope materially carried forward: N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why: No superseded contributor work is incorporated.
