### PR TITLE
fix(runtime): sanitize compressor media markers before truncation

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/context_compressor.rs
+++ b/crates/zeroclaw-runtime/src/agent/context_compressor.rs
@@ -318,12 +318,16 @@ impl ContextCompressor {
             return Ok(false);
         }
 
+        let summary_model = self.config.summary_model.as_deref().unwrap_or(model);
+        let preserve_media_markers =
+            self.config.summary_model.is_none() && model_provider.supports_vision();
+
         // Build transcript from the middle section
         let middle = &history[start..end];
         let transcript = build_summarizer_transcript(
             middle,
             self.config.source_max_chars,
-            model_provider.supports_vision(),
+            preserve_media_markers,
         );
 
         if transcript.is_empty() {
@@ -331,7 +335,6 @@ impl ContextCompressor {
         }
 
         let message_count = end - start;
-        let summary_model = self.config.summary_model.as_deref().unwrap_or(model);
 
         let identifier_note = if self.config.identifier_policy == "strict" {
             "\nIMPORTANT: Preserve all identifiers exactly as they appear."
@@ -515,30 +518,25 @@ fn repair_tool_pairs(messages: &mut Vec<ChatMessage>) {
 // Helpers
 // ---------------------------------------------------------------------------
 
-fn build_transcript(messages: &[ChatMessage], max_chars: usize) -> String {
+fn build_full_transcript(messages: &[ChatMessage]) -> String {
     let mut transcript = String::new();
     for msg in messages {
         let role = msg.role.to_uppercase();
         let _ = writeln!(transcript, "{role}: {}", msg.content.trim());
     }
-
-    if transcript.len() > max_chars {
-        truncate_chars(&transcript, max_chars)
-    } else {
-        transcript
-    }
+    transcript
 }
 
 fn build_summarizer_transcript(
     messages: &[ChatMessage],
     max_chars: usize,
-    supports_vision: bool,
+    preserve_media_markers: bool,
 ) -> String {
-    let transcript = build_transcript(messages, max_chars);
-    if supports_vision {
+    let transcript = build_full_transcript(messages);
+    if preserve_media_markers {
         // Vision-capable summarizer can read media markers; preserve them so
         // visual content is reflected in the summary (per #6189 contract).
-        return transcript;
+        return truncate_owned_if_needed(transcript, max_chars);
     }
 
     // Non-vision summarizer cannot consume media markers. Strip ALL inbound
@@ -546,7 +544,15 @@ fn build_summarizer_transcript(
     // AUDIO — case-insensitive) instead of just `[IMAGE:...]`, otherwise a
     // local filesystem path can leak into the auxiliary `chat_with_system`
     // payload and the upstream API rejects it as a malformed `image_url.url`.
-    multimodal::strip_media_markers(&transcript)
+    truncate_owned_if_needed(multimodal::strip_media_markers(&transcript), max_chars)
+}
+
+fn truncate_owned_if_needed(s: String, max: usize) -> String {
+    if s.len() > max {
+        truncate_chars(&s, max)
+    } else {
+        s
+    }
 }
 
 fn truncate_chars(s: &str, max: usize) -> String {
@@ -772,7 +778,7 @@ mod tests {
     #[test]
     fn test_build_transcript() {
         let messages = vec![msg("user", "hello"), msg("assistant", "hi there")];
-        let t = build_transcript(&messages, 10_000);
+        let t = build_full_transcript(&messages);
         assert!(t.contains("USER: hello"));
         assert!(t.contains("ASSISTANT: hi there"));
     }
@@ -815,9 +821,36 @@ mod tests {
     }
 
     #[test]
+    fn test_build_summarizer_transcript_strips_media_markers_before_truncation() {
+        let long_path = format!(
+            "/private/tmp/zeroclaw/signal_inbound/{}",
+            "nested-directory/".repeat(12)
+        );
+        let messages = vec![msg(
+            "user",
+            &format!("Please summarize [IMAGE:{long_path}photo.png] after text"),
+        )];
+
+        let transcript = build_summarizer_transcript(&messages, 64, false);
+
+        assert!(
+            !transcript.contains("[IMAGE:"),
+            "non-vision transcript should not retain a split image marker: {transcript}"
+        );
+        assert!(
+            !transcript.contains("/private/tmp"),
+            "non-vision transcript should not leak local path fragments: {transcript}"
+        );
+        assert!(
+            transcript.contains("[media attachment]"),
+            "non-vision transcript should preserve an attachment placeholder: {transcript}"
+        );
+    }
+
+    #[test]
     fn test_build_transcript_truncates() {
         let messages = vec![msg("user", &"x".repeat(1000))];
-        let t = build_transcript(&messages, 100);
+        let t = truncate_owned_if_needed(build_full_transcript(&messages), 100);
         assert!(t.len() <= 103); // 100 + "..."
     }
 
@@ -909,6 +942,39 @@ mod tests {
         let prompt = seen.last().expect("summarizer should be invoked");
         assert!(!prompt.contains("[IMAGE:"));
         assert!(!prompt.contains("/tmp/example.png"));
+    }
+
+    #[tokio::test]
+    async fn compress_if_needed_strips_image_markers_when_summary_model_overrides() {
+        let config = ContextCompressionConfig {
+            protect_first_n: 1,
+            protect_last_n: 1,
+            threshold_ratio: 0.01,
+            summary_model: Some("text-summary-model".to_string()),
+            ..Default::default()
+        };
+        let compressor = ContextCompressor::new(config, 64);
+        let model_provider = CaptureSummarizerModelProvider {
+            supports_vision: true,
+            seen_messages: Mutex::new(Vec::new()),
+        };
+        let mut history = vec![
+            msg("system", "sys"),
+            msg("user", "Earlier question [IMAGE:/tmp/summary-override.png]"),
+            msg("assistant", "Earlier answer"),
+            msg("user", "Newest question"),
+        ];
+
+        let result = compressor
+            .compress_if_needed(&mut history, &model_provider, "default-vision-model", None)
+            .await
+            .expect("compression should succeed");
+
+        assert!(result.compressed);
+        let seen = model_provider.seen_messages.lock();
+        let prompt = seen.last().expect("summarizer should be invoked");
+        assert!(!prompt.contains("[IMAGE:"));
+        assert!(!prompt.contains("/tmp/summary-override.png"));
     }
 
     // ── fast_trim_tool_results tests ────────────────────────────────


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:** Context compression now strips media markers before applying the summarizer transcript source limit when the summarizer target should not receive raw media markers. This prevents truncation from splitting a marker such as `[IMAGE:<local-path>]` and leaving a local path fragment in the auxiliary summarizer prompt. Summary-model overrides are treated conservatively because the configured summary model can differ from the active/default provider capability. Focused regressions cover both the split-marker truncation case and the summary-model override prompt boundary.
- **Scope boundary:** This PR does not change provider-bound media handling, channel attachment parsing, vision-capable summarizer behavior when no `summary_model` override is configured, context-compression thresholds, or the summary text format.
- **Blast radius:** `zeroclaw-runtime` context compression only. The affected path is the auxiliary summarizer prompt used while compacting old conversation history.
- **Linked issue(s):** None.
- **Labels:** `bug`, `runtime`, `risk: high`, `size: S`, `agent`.

## Validation Evidence (required)

- **Commands run and tail output:**

```text
$ cargo test -p zeroclaw-runtime test_build_summarizer_transcript_strips_media_markers_before_truncation --lib -- --nocapture
test agent::context_compressor::tests::test_build_summarizer_transcript_strips_media_markers_before_truncation ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1841 filtered out; finished in 0.02s

$ cargo test -p zeroclaw-runtime context_compressor --lib -- --nocapture
test agent::context_compressor::tests::test_build_summarizer_transcript_strips_media_markers_before_truncation ... ok
test agent::context_compressor::tests::compress_if_needed_strips_image_markers_when_summary_model_overrides ... ok
test result: ok. 33 passed; 0 failed; 0 ignored; 0 measured; 1810 filtered out; finished in 0.23s

$ cargo fmt --all -- --check
passed

$ git diff --check
passed

$ cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
passed

$ cargo nextest run --locked --workspace --exclude zeroclaw-desktop
failed outside this PR's runtime context-compressor path:
zeroclaw-channels orchestrator::tests::message_dispatch_processes_messages_in_parallel exceeded its timing threshold during the full run.
The run had 827 passed, 1 failed, and 10 skipped before fail-fast cancelled the remaining tests.

$ cargo nextest run --locked -p zeroclaw-channels message_dispatch_processes_messages_in_parallel
PASS zeroclaw-channels orchestrator::tests::message_dispatch_processes_messages_in_parallel
test result: ok. 1 passed; 0 failed; 1097 skipped; finished in 0.561s
```

- **Beyond CI — what did you manually verify?** I compared the prior dataflow against the new helper split and confirmed that non-vision summarizer input is now sanitized before `source_max_chars` truncation. I also checked the summary-model override path: when `summary_model` is set, raw media markers are stripped before the captured `chat_with_system` prompt even if the default provider reports vision support. As an extra provider-boundary smoke, I ran a local OpenAI-compatible mock server, drove the compressor through the real HTTP provider path, and confirmed the captured summarizer request used the `summary_model` override, contained `[media attachment]`, and did not contain the raw `[IMAGE:]` marker or the local-path canary.
- **If any command was intentionally skipped, why:** Full nextest was attempted but did not complete because fail-fast stopped after one load-sensitive timing failure in `zeroclaw-channels`; the failing test passed in isolation. We are accepting this as a local validation caveat because GitHub's full Quality Gate passed at the same head, including `Test` and `CI Required Gate`.

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: This is a privacy hardening fix. It reduces the chance that local attachment paths are forwarded to an auxiliary summarizer model after transcript truncation splits a media marker.

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: No user action is required. Existing context-compression configuration keeps working; `summary_model` overrides now choose the privacy-preserving marker-stripping path.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert a7b95073d`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Context summaries may lose media-marker detail for summary-model overrides, or tests under `agent::context_compressor::tests::*summary_model*` / `*media_markers*` may fail. If the patch is wrong, look for context-compression summaries that replace media markers with `[media attachment]` where visual detail was expected.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): Not applicable.
- Scope materially carried forward: Not applicable.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`No`)
- If `No`, why (inspiration-only, no direct code/design carry-over): No superseded PR or external contributor code is incorporated.
