### PR TITLE
fix(web_fetch): treat max_response_size=0 as unlimited

### DIFF
--- a/crates/zeroclaw-tools/src/web_fetch.rs
+++ b/crates/zeroclaw-tools/src/web_fetch.rs
@@ -1087,25 +1087,81 @@ mod tests {
         );
     }
 
-    #[test]
-    fn read_response_text_limited_zero_means_unlimited() {
-        // When max_response_size == 0, read_response_text_limited must not
-        // stop streaming after 1 byte (the old saturating_add(1) bug that
-        // caused short output and triggered spurious Firecrawl fallback).
+    /// Drives the actual streamed-read path (standard_fetch +
+    /// read_response_text_limited) via wiremock to lock in the
+    /// max_response_size=0 behaviour. Audacity88 review (PR #6884)
+    /// flagged the direct-helper test as insufficient because it
+    /// did not exercise the saturating_add(1) cap that previously
+    /// stopped streaming after 1 byte and triggered spurious
+    /// Firecrawl fallback.
+    #[tokio::test]
+    async fn standard_fetch_with_zero_limit_returns_full_body_and_skips_firecrawl_fallback() {
+        use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let addr = server.address();
+
+        // Body must exceed FIRECRAWL_MIN_BODY_LEN (100 bytes) so any
+        // truncation to <100 bytes would (incorrectly) trigger fallback.
+        let body = "a".repeat(500);
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(body.clone()))
+            .mount(&server)
+            .await;
+
         let tool = WebFetchTool::new(
-            Arc::new(SecurityPolicy::default()),
-            vec!["example.com".into()],
+            Arc::new(SecurityPolicy {
+                autonomy: AutonomyLevel::Supervised,
+                ..SecurityPolicy::default()
+            }),
+            vec!["*".into()],
             vec![],
-            0, // unlimited
+            0, // max_response_size = unlimited
             30,
-            FirecrawlConfig::default(),
+            FirecrawlConfig {
+                enabled: true,
+                ..FirecrawlConfig::default()
+            },
             vec![],
         );
-        // Build a body well above FIRECRAWL_MIN_BODY_LEN (100 bytes).
-        let body = "a".repeat(500);
-        let result = tool.truncate_response(&body);
-        assert_eq!(result.len(), 500, "zero limit must return full body");
-        assert!(!result.contains("[Response truncated"), "must not truncate");
+
+        // Bypass SSRF-guarded execute() — call standard_fetch directly so
+        // wiremock on 127.0.0.1 is reachable.
+        let url = format!("http://{}:{}/", addr.ip(), addr.port());
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(5))
+            .build()
+            .expect("reqwest client");
+        let standard_result = tool.standard_fetch(&client, &url).await;
+
+        // (a) standard result IS the full body — proves streamed read did
+        // not stop after 1 byte under the zero-limit path.
+        assert!(
+            standard_result.success,
+            "standard_fetch must succeed, got error={:?}",
+            standard_result.error
+        );
+        assert_eq!(
+            standard_result.output.len(),
+            body.len(),
+            "streamed body length under zero-limit must equal full body"
+        );
+        assert_eq!(
+            standard_result.output, body,
+            "streamed body content must equal full body"
+        );
+        assert!(
+            !standard_result.output.contains("[Response truncated"),
+            "must not append truncation marker under zero limit"
+        );
+
+        // (b) result does NOT trip should_fallback_to_firecrawl — proves
+        // the regression (1-byte short body) is locked out.
+        assert!(
+            !tool.should_fallback_to_firecrawl(&standard_result),
+            "500-byte body under zero limit must not trigger Firecrawl fallback"
+        );
     }
 
     #[test]

--- a/crates/zeroclaw-tools/src/web_fetch.rs
+++ b/crates/zeroclaw-tools/src/web_fetch.rs
@@ -1081,7 +1081,10 @@ mod tests {
         let long_text = "x".repeat(10_000);
         let result = tool.truncate_response(&long_text);
         assert_eq!(result.len(), 10_000, "zero limit must not truncate");
-        assert!(!result.contains("[Response truncated"), "must not append truncation marker");
+        assert!(
+            !result.contains("[Response truncated"),
+            "must not append truncation marker"
+        );
     }
 
     #[test]

--- a/crates/zeroclaw-tools/src/web_fetch.rs
+++ b/crates/zeroclaw-tools/src/web_fetch.rs
@@ -1066,6 +1066,46 @@ mod tests {
     }
 
     #[test]
+    fn truncate_response_zero_means_unlimited() {
+        // max_response_size == 0 must be treated as unlimited — no truncation
+        // marker, full text returned regardless of length.
+        let tool = WebFetchTool::new(
+            Arc::new(SecurityPolicy::default()),
+            vec!["example.com".into()],
+            vec![],
+            0, // unlimited
+            30,
+            FirecrawlConfig::default(),
+            vec![],
+        );
+        let long_text = "x".repeat(10_000);
+        let result = tool.truncate_response(&long_text);
+        assert_eq!(result.len(), 10_000, "zero limit must not truncate");
+        assert!(!result.contains("[Response truncated"), "must not append truncation marker");
+    }
+
+    #[test]
+    fn read_response_text_limited_zero_means_unlimited() {
+        // When max_response_size == 0, read_response_text_limited must not
+        // stop streaming after 1 byte (the old saturating_add(1) bug that
+        // caused short output and triggered spurious Firecrawl fallback).
+        let tool = WebFetchTool::new(
+            Arc::new(SecurityPolicy::default()),
+            vec!["example.com".into()],
+            vec![],
+            0, // unlimited
+            30,
+            FirecrawlConfig::default(),
+            vec![],
+        );
+        // Build a body well above FIRECRAWL_MIN_BODY_LEN (100 bytes).
+        let body = "a".repeat(500);
+        let result = tool.truncate_response(&body);
+        assert_eq!(result.len(), 500, "zero limit must return full body");
+        assert!(!result.contains("[Response truncated"), "must not truncate");
+    }
+
+    #[test]
     fn truncate_over_limit() {
         let tool = WebFetchTool::new(
             Arc::new(SecurityPolicy::default()),

--- a/crates/zeroclaw-tools/src/web_fetch.rs
+++ b/crates/zeroclaw-tools/src/web_fetch.rs
@@ -62,6 +62,15 @@ impl WebFetchTool {
     }
 
     fn truncate_response(&self, text: &str) -> String {
+        // max_response_size == 0 means "unlimited" (matches the
+        // http_request tool's documented semantics + tests at
+        // crates/zeroclaw-tools/src/http_request.rs:151). Without this
+        // branch, the unsigned-arithmetic path below would truncate
+        // every response to zero bytes, then append the truncation
+        // marker — useless content + spurious Firecrawl fallback.
+        if self.max_response_size == 0 {
+            return text.to_string();
+        }
         if text.len() > self.max_response_size {
             let mut truncated = text
                 .chars()
@@ -79,7 +88,16 @@ impl WebFetchTool {
         response: reqwest::Response,
     ) -> anyhow::Result<String> {
         let mut bytes_stream = response.bytes_stream();
-        let hard_cap = self.max_response_size.saturating_add(1);
+        // max_response_size == 0 → unlimited. Without this branch, the
+        // existing saturating_add(1) made hard_cap = 1 byte, so the
+        // entire stream was truncated after one byte. Use usize::MAX as
+        // the effective hard_cap when unlimited so append_chunk_with_cap
+        // never stops early on size grounds.
+        let hard_cap = if self.max_response_size == 0 {
+            usize::MAX
+        } else {
+            self.max_response_size.saturating_add(1)
+        };
         let mut bytes = Vec::new();
 
         while let Some(chunk_result) = bytes_stream.next().await {


### PR DESCRIPTION
## Problem

`WebFetchTool::read_response_text_limited` computed `hard_cap = self.max_response_size.saturating_add(1)` at `crates/zeroclaw-tools/src/web_fetch.rs:82`, so a configured `max_response_size` of 0 read only 1 byte and truncated every response. `truncate_response` had matching behavior.

This diverges from `http_request`, which already documents + tests the `0 = unlimited` contract at `crates/zeroclaw-tools/src/http_request.rs:151` (per PR #1320 merged 2026-02-21 — same fix needed here for the sibling tool).

Users configuring `max_response_size = 0` for `web_fetch` got unusable single-byte content AND triggered spurious Firecrawl fallback because the body looked smaller than `FIRECRAWL_MIN_BODY_LEN`.

## Fix

Both `truncate_response` and `read_response_text_limited` now branch on `max_response_size == 0` to skip size enforcement entirely. `read_response_text_limited` uses `usize::MAX` as the effective `hard_cap` so `append_chunk_with_cap` never stops early on size grounds; `truncate_response` returns the input text unchanged.

`cargo check -p zeroclaw-tools` passes.

## Discovery

Codex audit of `zeroclaw-contrib` 2026-05-23 via project-wide repository scan.