### PR TITLE
Draft:fix(agent): use per-agent provider runtime options instead of first model provider

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -846,7 +846,7 @@ impl Agent {
         };
 
         let provider_runtime_options =
-            zeroclaw_providers::provider_runtime_options_from_config(config);
+            zeroclaw_providers::provider_runtime_options_for_agent(config, agent_alias);
 
         let model_provider: Box<dyn ModelProvider> =
             zeroclaw_providers::create_routed_model_provider_with_options(

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -3158,7 +3158,7 @@ pub async fn run(
         }
 
         let provider_runtime_options =
-            zeroclaw_providers::provider_runtime_options_from_config(&config);
+            zeroclaw_providers::provider_runtime_options_for_agent(&config, agent_alias);
 
         let mut model_provider: Box<dyn ModelProvider> =
             zeroclaw_providers::create_routed_model_provider_with_options(
@@ -4383,7 +4383,7 @@ pub async fn process_message(
             ),
         };
         let provider_runtime_options =
-            zeroclaw_providers::provider_runtime_options_from_config(&config);
+            zeroclaw_providers::provider_runtime_options_for_agent(&config, agent_alias);
         let model_provider: Box<dyn ModelProvider> =
             zeroclaw_providers::create_routed_model_provider_with_options(
                 &config,

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -533,7 +533,7 @@ pub fn all_tools_with_runtime(
             .and_then(|e| e.model.clone())
             .unwrap_or_else(|| "openai/gpt-4o-mini".to_string());
         let llm_task_runtime_options =
-            zeroclaw_providers::provider_runtime_options_from_config(root_config);
+            zeroclaw_providers::provider_runtime_options_for_agent(root_config, agent_alias);
         tool_arcs.push(Arc::new(LlmTaskTool::new(
             security.clone(),
             llm_task_provider,
@@ -1057,7 +1057,7 @@ pub fn all_tools_with_runtime(
         (!trimmed_value.is_empty()).then(|| trimmed_value.to_owned())
     });
     let provider_runtime_options =
-        zeroclaw_providers::provider_runtime_options_from_config(root_config);
+        zeroclaw_providers::provider_runtime_options_for_agent(root_config, agent_alias);
 
     let delegate_handle: Option<DelegateParentToolsHandle> = if agents.is_empty() {
         None


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `provider_runtime_options_from_config()` returns the first model provider's options in config file order, not the agent's actual provider. When multiple providers have different `max_tokens` values, the wrong one gets sent to the API (e.g. `max_tokens=262144` from `custom.longcat2` sent to a model with limit 65536).
  - Replaced all 4 call sites with `provider_runtime_options_for_agent(config, agent_alias)` which resolves options for the specific agent's provider.
  - Call sites: `agent.rs` (Agent::new), `loop_.rs` (run + process_message), `tools/mod.rs` (LlmTaskTool + DelegateTool).
- **Scope boundary:** Does not touch gateway warmup path (`gateway/src/lib.rs`) which intentionally uses `provider_runtime_options_from_config` for boot-time seed logging via `first_model_provider()`. Does not address channel context `provider_runtime_options` not updating on config hot-reload (`maybe_apply_runtime_config_update`).
- **Blast radius:** Any agent or tool that constructs a `ModelProvider` with runtime options. In practice this affects all agent model API calls — wrong `max_tokens` or other provider-level overrides would now be correctly scoped.
- **Linked issue(s):** Related user-reported error: `max_tokens range is [1, 65536]` when switching agent models.
- **Labels:** `type: bug`, `risk: low`, `size: XS`, `scope: agent`

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` — no output (clean).
  - `cargo clippy --all-targets -- -D warnings` — no warnings or errors.
  - `cargo test` — (passed, some unrelated test failures).
- **Beyond CI — what did you manually verified?** Verified that `provider_runtime_options_for_agent` correctly resolves the agent's provider by tracing the call chain through `resolve_model_provider_and_model`. Confirmed the old function `provider_runtime_options_from_config` iterates providers in TOML file order and returns the first match without considering the agent alias.
- **If any command was intentionally skipped, why:** 

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No upgrade steps needed. Existing configs with multiple providers will now behave correctly; previously the first provider's options were silently applied to all agents.

## Rollback (required for `risk: medium` and `risk: high`)

