### PR TITLE
fix(channel): restore legacy channel startup fallback when agent channel bindings are empty

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -6874,6 +6874,66 @@ pub async fn doctor_channels(config: Config) -> Result<()> {
     Ok(())
 }
 
+fn build_owner_by_channel_key(
+    config: &Config,
+    enabled_agents: &[String],
+    collected_channel_keys: &[String],
+) -> HashMap<String, String> {
+    // Owner map: `<channel_type>.<alias>` (and bare `<channel_type>` for
+    // backward-compat with cron callers / singleton channels) → agent_alias.
+    // Built from each enabled agent's `agents.<alias>.channels` list — the
+    // schema treats this as the source of truth for channel ownership.
+    let mut owner_by_channel_key: HashMap<String, String> = HashMap::new();
+    for alias_str in enabled_agents {
+        let Some(agent_cfg) = config.agents.get(alias_str) else {
+            debug_assert!(
+                false,
+                "enabled agent alias missing from config.agents: {}",
+                alias_str
+            );
+            continue;
+        };
+        for ch in &agent_cfg.channels {
+            let ch_str: &str = ch.as_ref();
+            owner_by_channel_key.insert(ch_str.to_string(), alias_str.clone());
+            if let Some((bare, _)) = ch_str.split_once('.') {
+                owner_by_channel_key
+                    .entry(bare.to_string())
+                    .or_insert_with(|| alias_str.clone());
+            }
+        }
+    }
+
+    // Legacy fallback mode: when no enabled agent declares channel bindings,
+    // channel collection accepts all enabled channels. Those channels must
+    // also be routable, so bind collected channel keys to the runtime-active
+    // agent selection.
+    // `owner_by_channel_key.is_empty()` means every enabled agent had an
+    // empty `agents.<alias>.channels` list; this is the same "legacy mode"
+    // signal used by `collect_configured_channels` to accept all enabled
+    // channel blocks.
+    if owner_by_channel_key.is_empty() && !collected_channel_keys.is_empty() {
+        let fallback_owner = config
+            .resolved_runtime_agent_alias()
+            .filter(|alias| enabled_agents.iter().any(|enabled| enabled == *alias))
+            .map(ToString::to_string)
+            .or_else(|| enabled_agents.first().cloned());
+
+        if let Some(owner_alias) = fallback_owner {
+            for channel_key in collected_channel_keys {
+                owner_by_channel_key.insert(channel_key.clone(), owner_alias.clone());
+                if let Some((bare, _)) = channel_key.split_once('.') {
+                    owner_by_channel_key
+                        .entry(bare.to_string())
+                        .or_insert_with(|| owner_alias.clone());
+                }
+            }
+        }
+    }
+
+    owner_by_channel_key
+}
+
 /// Start all configured channels and route messages to the agent
 #[allow(clippy::too_many_lines)]
 pub async fn start_channels(
@@ -6982,6 +7042,7 @@ pub async fn start_channels(
     // Subsequent iterations reuse `channels_by_name_shared` to populate
     // their tool handles and to seed their `ChannelRuntimeContext`.
     let mut channels_by_name_shared: Option<Arc<HashMap<String, Arc<dyn Channel>>>> = None;
+    let mut collected_channel_keys: Vec<String> = Vec::new();
     let mut max_in_flight_messages: Option<usize> = None;
     let mut listener_handles: Vec<tokio::task::JoinHandle<()>> = Vec::new();
     let mut rx_holder: Option<tokio::sync::mpsc::Receiver<zeroclaw_api::channel::ChannelMessage>> =
@@ -7410,6 +7471,7 @@ pub async fn start_channels(
                 .iter()
                 .map(|cc| composite_channel_key(cc.channel.name(), cc.alias.as_deref()))
                 .collect();
+            collected_channel_keys = channel_labels.clone();
             println!("  📡 Channels: {}", channel_labels.join(", "));
             println!("  🤖 Agents:   {}", enabled_agents.join(", "));
             println!();
@@ -7665,25 +7727,8 @@ pub async fn start_channels(
         agent_ctxs.insert(agent_alias.clone(), runtime_ctx);
     }
 
-    // Owner map: `<channel_type>.<alias>` (and bare `<channel_type>` for
-    // backward-compat with cron callers / singleton channels) → agent_alias.
-    // Built from each enabled agent's `agents.<alias>.channels` list — the
-    // schema treats this as the source of truth for channel ownership.
-    let mut owner_by_channel_key: HashMap<String, String> = HashMap::new();
-    for (alias_str, agent_cfg) in &config.agents {
-        if !agent_cfg.enabled {
-            continue;
-        }
-        for ch in &agent_cfg.channels {
-            let ch_str: &str = ch.as_ref();
-            owner_by_channel_key.insert(ch_str.to_string(), alias_str.clone());
-            if let Some((bare, _)) = ch_str.split_once('.') {
-                owner_by_channel_key
-                    .entry(bare.to_string())
-                    .or_insert_with(|| alias_str.clone());
-            }
-        }
-    }
+    let owner_by_channel_key =
+        build_owner_by_channel_key(&config, &enabled_agents, &collected_channel_keys);
 
     // Hydrate persisted session histories into the owning agent's
     // `conversation_histories` LRU. Sessions whose channel has no enabled
@@ -8441,6 +8486,32 @@ mod tests {
         let msg = channel_message("notion", None);
         let resolved = router.resolve(&msg).expect("notion resolves");
         assert!(Arc::ptr_eq(&resolved, &notion_agent_ctx));
+    }
+
+    #[test]
+    fn agent_router_multi_resolves_fallback_loaded_channel_to_legacy_agent() {
+        let mut config = Config::default();
+        config.agents.clear();
+        config.agents.insert(
+            "legacy".to_string(),
+            zeroclaw_config::schema::AliasedAgentConfig {
+                enabled: true,
+                channels: vec![],
+                ..Default::default()
+            },
+        );
+        let enabled_agents = vec!["legacy".to_string()];
+        let collected_channel_keys = vec!["mattermost.default".to_string()];
+        let owners = build_owner_by_channel_key(&config, &enabled_agents, &collected_channel_keys);
+
+        let legacy_ctx = router_test_ctx();
+        let mut by_agent: HashMap<String, Arc<ChannelRuntimeContext>> = HashMap::new();
+        by_agent.insert("legacy".to_string(), Arc::clone(&legacy_ctx));
+        let router = AgentRouter::multi(by_agent, owners);
+
+        let msg = channel_message("mattermost", Some("default"));
+        let resolved = router.resolve(&msg).expect("fallback owner resolves");
+        assert!(Arc::ptr_eq(&resolved, &legacy_ctx));
     }
 
     #[test]

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -7200,7 +7200,8 @@ fn build_owner_by_channel_key(
     // Legacy fallback mode: when no enabled agent declares channel bindings,
     // channel collection accepts all enabled channels. Those channels must
     // also be routable, so bind collected channel keys to the runtime-active
-    // agent selection.
+    // agent selection (explicit `"default"` alias when present, else
+    // lexicographically-smallest enabled alias).
     // `owner_by_channel_key.is_empty()` means every enabled agent had an
     // empty `agents.<alias>.channels` list; this is the same "legacy mode"
     // signal used by `collect_configured_channels` to accept all enabled
@@ -8819,6 +8820,38 @@ mod tests {
         let msg = channel_message("mattermost", Some("default"));
         let resolved = router.resolve(&msg).expect("fallback owner resolves");
         assert!(Arc::ptr_eq(&resolved, &legacy_ctx));
+    }
+
+    #[test]
+    fn build_owner_by_channel_key_legacy_fallback_is_deterministic_without_default() {
+        let mut config = Config::default();
+        config.agents.clear();
+        config.agents.insert(
+            "zeta".to_string(),
+            zeroclaw_config::schema::AliasedAgentConfig {
+                enabled: true,
+                channels: vec![],
+                ..Default::default()
+            },
+        );
+        config.agents.insert(
+            "alpha".to_string(),
+            zeroclaw_config::schema::AliasedAgentConfig {
+                enabled: true,
+                channels: vec![],
+                ..Default::default()
+            },
+        );
+
+        let enabled_agents = vec!["alpha".to_string(), "zeta".to_string()];
+        let collected_channel_keys = vec!["mattermost.default".to_string()];
+        let owners = build_owner_by_channel_key(&config, &enabled_agents, &collected_channel_keys);
+
+        assert_eq!(
+            owners.get("mattermost.default").map(String::as_str),
+            Some("alpha")
+        );
+        assert_eq!(owners.get("mattermost").map(String::as_str), Some("alpha"));
     }
 
     #[test]

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -5638,6 +5638,23 @@ fn find_channel_for_message<'a>(
         .and_then(|(base, _)| channels.get(base))
 }
 
+/// Active `<type>.<alias>` channel references from enabled agents.
+///
+/// An empty set means no enabled agent declared channel bindings, so
+/// collection falls back to legacy behavior and accepts all enabled channels.
+struct ActiveChannelAliases {
+    /// Set of `<type>.<alias>` channel references from enabled agents.
+    aliases: HashSet<String>,
+}
+
+impl ActiveChannelAliases {
+    /// Returns true when `channel_ref` is explicitly bound, or when there are
+    /// no explicit bindings and legacy "accept all enabled channels" mode applies.
+    fn contains(&self, channel_ref: &str) -> bool {
+        self.aliases.is_empty() || self.aliases.contains(channel_ref)
+    }
+}
+
 fn collect_configured_channels(
     config_arc: &Arc<RwLock<Config>>,
     matrix_skip_context: &str,
@@ -5653,12 +5670,14 @@ fn collect_configured_channels(
     // outlive the function capture `config_arc.clone()`.
     let config = config_arc.read();
 
-    let active_channel_aliases: std::collections::HashSet<String> = config
-        .agents
-        .values()
-        .filter(|a| a.enabled)
-        .flat_map(|a| a.channels.iter().map(|c| c.as_str().to_string()))
-        .collect();
+    let active_channel_aliases = ActiveChannelAliases {
+        aliases: config
+            .agents
+            .values()
+            .filter(|a| a.enabled)
+            .flat_map(|a| a.channels.iter().map(|c| c.as_str().to_string()))
+            .collect(),
+    };
 
     #[cfg(feature = "channel-telegram")]
     for (alias, tg) in &config.channels.telegram {
@@ -14131,6 +14150,49 @@ This is an example JSON object for profile settings."#;
             channels
                 .iter()
                 .any(|entry| entry.channel.name() == "mattermost")
+        );
+    }
+
+    #[cfg(feature = "channel-mattermost")]
+    #[test]
+    fn collect_configured_channels_falls_back_when_agent_bindings_missing() {
+        let mut config = Config::default();
+        config.channels.mattermost.insert(
+            "default".to_string(),
+            zeroclaw_config::schema::MattermostConfig {
+                enabled: true,
+                url: "https://mattermost.example.com".to_string(),
+                bot_token: Some("test-token".to_string()),
+                login_id: None,
+                password: None,
+                channel_ids: vec!["channel-1".to_string()],
+                team_ids: vec![],
+                discover_dms: None,
+                thread_replies: Some(true),
+                mention_only: Some(false),
+                interrupt_on_new_message: false,
+                proxy_url: None,
+                excluded_tools: vec![],
+            },
+        );
+        config.agents.clear();
+        config.agents.insert(
+            "legacy".to_string(),
+            zeroclaw_config::schema::AliasedAgentConfig {
+                enabled: true,
+                channels: vec![],
+                ..Default::default()
+            },
+        );
+
+        let config_arc = Arc::new(RwLock::new(config));
+        let channels = collect_configured_channels(&config_arc, "test", &[]);
+
+        assert!(
+            channels
+                .iter()
+                .any(|entry| entry.display_name == "Mattermost"),
+            "enabled channels should still load when no enabled agent declares channel bindings"
         );
     }
 

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -3236,8 +3236,9 @@ impl Config {
     /// Resolve the runtime-active agent alias the orchestrator binds
     /// channels to. Mirrors the same selection logic as
     /// `start_channels()` in zeroclaw-channels: prefer the migration-
-    /// synthesized `"default"` agent, fall back to the first enabled
-    /// agent. Returns `None` only when no agent is configured at all.
+    /// synthesized `"default"` agent, otherwise fall back to the
+    /// lexicographically-smallest enabled alias. Returns `None` only
+    /// when no enabled agent is configured.
     ///
     /// Used by per-agent infrastructure (TtsManager, TranscriptionManager)
     /// to pick which agent's `tts_provider` / `transcription_provider`
@@ -3249,13 +3250,14 @@ impl Config {
         self.agents
             .keys()
             .find(|k| k.as_str() == "default")
+            .map(String::as_str)
             .or_else(|| {
                 self.agents
                     .iter()
-                    .find(|(_, a)| a.enabled)
-                    .map(|(alias, _)| alias)
+                    .filter(|(_, a)| a.enabled)
+                    .map(|(alias, _)| alias.as_str())
+                    .min()
             })
-            .map(String::as_str)
     }
 
     /// Resolve the active storage backend for the memory subsystem.


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - v0.8 could start with zero collected channels when enabled agents had empty `agents.<alias>.channels`, causing the channel supervisor to loop with `No channels configured` despite valid channel blocks (common in pre-v0.8 configs used in containers).
  - Added `ActiveChannelAliases` semantics: if the enabled-agent binding set is empty, treat as legacy mode and accept all enabled configured channels; otherwise keep strict `<type>.<alias>` binding.
  - Added regression coverage in orchestrator tests for legacy fallback collection, fallback channel ownership/routing, and deterministic fallback owner selection.
  - **Key logic introduced:**
    ```rust
    impl ActiveChannelAliases {
        fn contains(&self, channel_ref: &str) -> bool {
            self.aliases.is_empty() || self.aliases.contains(channel_ref)
        }
    }
    ```
  - Also changes fallback channel ownership/routing and the shared `Config::resolved_runtime_agent_alias()` helper.
- **Scope boundary:** No changes to config schema shape, migration rules, daemon supervision policy, or channel implementations beyond legacy channel collection gating, fallback ownership/routing, and deterministic runtime-agent alias selection.
- **Blast radius:** Channel collection and owner routing at runtime startup; impacts all channel types routed through `collect_configured_channels`, especially legacy/partially-migrated deployments with enabled channel blocks but no `agents.<alias>.channels` bindings.
- **Linked issue(s):** Closes #6888
- **Labels:** `bug`, `size: S`, `risk: medium`, `channel`, `config`

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check`
    - `exited with exit code 0`
  - `cargo clippy --all-targets -- -D warnings`
    - `Checking zeroclaw-channels v0.8.0-beta-1 ...`
    - `Checking zeroclaw-gateway v0.8.0-beta-1 ...`
    - `Checking zeroclawlabs v0.8.0-beta-1 ...`
    - `Finished 'dev' profile ... target(s) in 17.93s`
  - `cargo test`
    - `Compiling zeroclaw-channels v0.8.0-beta-1 ...`
    - `Compiling zeroclaw-gateway v0.8.0-beta-1 ...`
    - `Compiling zeroclawlabs v0.8.0-beta-1 ...`
    - `Finished 'test' profile ...`
    - `exited with exit code 0`
- **Beyond CI — what did you manually verify?** Verified fallback behavior via regression tests: enabled channel config is collected when enabled agents exist but none declare channel bindings, fallback-loaded channels resolve to an owner for inbound routing, and the multi-agent/no-bindings/no-`default` case chooses a deterministic runtime owner. Did not manually run Podman in this patch cycle.
- **If any command was intentionally skipped, why:** None.

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: exact upgrade steps for existing users:
  - No upgrade action required; behavior is now tolerant of legacy configs lacking explicit `agents.<alias>.channels` bindings.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PRs: `git revert <sha>` is the plan unless otherwise noted.

Medium/high-risk PRs must fill:

- **Fast rollback command/path:** `git revert <merge_commit_sha>`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Unexpected channel fan-in (loading enabled channels not explicitly bound) or startup logs deviating from expected channel set; watch channel startup logs around `collect_configured_channels` and daemon channel component health.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Scope materially carried forward: N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`No`)
- If `No`, why (inspiration-only, no direct code/design carry-over): No supersede relationship in this PR.

