### PR TITLE
fix(gateway): add structured onboarding repair items

### DIFF
--- a/crates/zeroclaw-gateway/src/api_onboard.rs
+++ b/crates/zeroclaw-gateway/src/api_onboard.rs
@@ -16,6 +16,7 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use zeroclaw_config::api_error::{ConfigApiCode, ConfigApiError};
+use zeroclaw_config::sections::Section;
 
 use super::AppState;
 use super::api::require_auth;
@@ -197,6 +198,21 @@ pub struct SectionsResponse {
 
 #[derive(Debug, Serialize)]
 #[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
+pub struct OnboardRepairItem {
+    /// Stable machine-readable reason. The web UI uses this for targeted
+    /// onboarding repair controls without parsing localized copy.
+    pub code: &'static str,
+    /// Human-readable repair instruction for the current non-localized UI.
+    pub message: String,
+    /// Onboarding section that contains the repair surface.
+    pub section: &'static str,
+    /// Optional config prefix the UI can open directly.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub focus: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
 pub struct OnboardStatusResponse {
     /// `true` when no agent is dispatchable yet. The dashboard uses this
     /// signal to redirect first-load visits from `/` to `/onboard`.
@@ -212,6 +228,9 @@ pub struct OnboardStatusResponse {
     /// Human-readable readiness failures. When onboarding cannot finish, the
     /// UI shows these directly so the operator knows exactly what is missing.
     pub missing: Vec<String>,
+    /// Structured repair checklist for half-configured installs. Mirrors
+    /// `missing` but keeps stable codes and targets for UI routing.
+    pub repair_items: Vec<OnboardRepairItem>,
 }
 
 /// Pure derivation of the onboard-status response from a config snapshot.
@@ -222,8 +241,12 @@ pub struct OnboardStatusResponse {
 /// that state.
 #[must_use]
 pub fn derive_onboard_status(cfg: &zeroclaw_config::schema::Config) -> OnboardStatusResponse {
-    let missing = onboard_missing_requirements(cfg);
-    let ready = missing.is_empty();
+    let repair_items = onboard_repair_items(cfg);
+    let missing: Vec<String> = repair_items
+        .iter()
+        .map(|item| item.message.clone())
+        .collect();
+    let ready = repair_items.is_empty();
     let has_partial_state = !cfg.onboard_state.completed_sections.is_empty()
         || cfg.providers.models.iter_entries().next().is_some()
         || !cfg.risk_profiles.is_empty()
@@ -241,87 +264,201 @@ pub fn derive_onboard_status(cfg: &zeroclaw_config::schema::Config) -> OnboardSt
         reason,
         has_partial_state,
         missing,
+        repair_items,
     }
 }
 
-fn onboard_missing_requirements(cfg: &zeroclaw_config::schema::Config) -> Vec<String> {
-    let mut missing = Vec::new();
+fn onboard_repair_items(cfg: &zeroclaw_config::schema::Config) -> Vec<OnboardRepairItem> {
+    let mut items = Vec::new();
     if cfg.providers.models.iter_entries().next().is_none() {
-        missing.push("Add a model provider.".to_string());
+        items.push(repair_item(
+            "model_provider_missing",
+            "Add a model provider.",
+            Section::ModelProviders,
+            None,
+        ));
     }
     if cfg.agents.is_empty() {
-        missing.push("Create an agent.".to_string());
-        return missing;
+        items.push(repair_item(
+            "agent_missing",
+            "Create an agent.",
+            Section::Agents,
+            None,
+        ));
+        return items;
     }
 
     let mut agent_aliases: Vec<&String> = cfg.agents.keys().collect();
     agent_aliases.sort();
-    let mut has_dispatchable_agent = false;
+    if agent_aliases
+        .iter()
+        .any(|alias| onboard_agent_is_dispatchable(cfg, alias, &cfg.agents[*alias]))
+    {
+        return Vec::new();
+    }
     for alias in agent_aliases {
-        let agent_missing = onboard_agent_missing_requirements(cfg, alias, &cfg.agents[alias]);
-        if agent_missing.is_empty() {
-            has_dispatchable_agent = true;
-            break;
-        }
-        missing.extend(agent_missing);
+        items.extend(onboard_agent_repair_items(cfg, alias, &cfg.agents[alias]));
     }
-    if has_dispatchable_agent {
-        missing.clear();
-    }
-    missing
+    items
 }
 
-fn onboard_agent_missing_requirements(
+fn onboard_agent_repair_items(
     cfg: &zeroclaw_config::schema::Config,
     alias: &str,
     agent: &zeroclaw_config::schema::AliasedAgentConfig,
-) -> Vec<String> {
-    let mut missing = Vec::new();
+) -> Vec<OnboardRepairItem> {
+    let agent_focus = Some(format!("agents.{alias}"));
+    let mut items = Vec::new();
     if !agent.enabled {
-        missing.push(format!("Enable agent `{alias}`."));
+        items.push(repair_item(
+            "agent_disabled",
+            format!("Enable agent `{alias}`."),
+            Section::Agents,
+            agent_focus.clone(),
+        ));
     }
 
     let model_ref = agent.model_provider.trim();
     if model_ref.is_empty() {
-        missing.push(format!("Set a model provider for agent `{alias}`."));
-    } else if let Some((family, _, provider)) = cfg.resolved_model_provider_for_agent(alias) {
+        items.push(repair_item(
+            "agent_model_provider_missing",
+            format!("Set a model provider for agent `{alias}`."),
+            Section::Agents,
+            agent_focus.clone(),
+        ));
+    } else if let Some((family, provider_alias, provider)) =
+        cfg.resolved_model_provider_for_agent(alias)
+    {
         let has_model = provider
             .model
             .as_deref()
             .map(str::trim)
             .is_some_and(|m| !m.is_empty());
+        let provider_focus = model_provider_focus(family, provider_alias);
         if !has_model {
-            missing.push(format!("Choose a model for model provider `{model_ref}`."));
+            items.push(repair_item(
+                "model_provider_model_missing",
+                format!("Choose a model for model provider `{model_ref}`."),
+                Section::ModelProviders,
+                provider_focus,
+            ));
         } else if !model_provider_alias_usable(provider, model_provider_family_is_local(family)) {
-            missing.push(format!(
-                "Set credential/auth for model provider `{model_ref}`."
+            items.push(repair_item(
+                "model_provider_auth_missing",
+                format!("Set credential/auth for model provider `{model_ref}`."),
+                Section::ModelProviders,
+                provider_focus,
             ));
         }
     } else {
-        missing.push(format!(
-            "Fix agent `{alias}` model provider `{model_ref}`; it does not resolve to a configured provider."
+        items.push(repair_item(
+            "agent_model_provider_unresolved",
+            format!(
+                "Fix agent `{alias}` model provider `{model_ref}`; it does not resolve to a configured provider."
+            ),
+            Section::Agents,
+            agent_focus.clone(),
         ));
     }
 
     let risk_ref = agent.risk_profile.trim();
     if risk_ref.is_empty() {
-        missing.push(format!("Set a risk profile for agent `{alias}`."));
+        items.push(repair_item(
+            "agent_risk_profile_missing",
+            format!("Set a risk profile for agent `{alias}`."),
+            Section::Agents,
+            agent_focus.clone(),
+        ));
     } else if !cfg.risk_profiles.contains_key(risk_ref) {
-        missing.push(format!(
-            "Fix agent `{alias}` risk profile `{risk_ref}`; it does not resolve to a configured profile."
+        items.push(repair_item(
+            "agent_risk_profile_unresolved",
+            format!(
+                "Fix agent `{alias}` risk profile `{risk_ref}`; it does not resolve to a configured profile."
+            ),
+            Section::Agents,
+            agent_focus.clone(),
         ));
     }
 
     let runtime_ref = agent.runtime_profile.trim();
     if runtime_ref.is_empty() {
-        missing.push(format!("Set a runtime profile for agent `{alias}`."));
+        items.push(repair_item(
+            "agent_runtime_profile_missing",
+            format!("Set a runtime profile for agent `{alias}`."),
+            Section::Agents,
+            agent_focus,
+        ));
     } else if !cfg.runtime_profiles.contains_key(runtime_ref) {
-        missing.push(format!(
-            "Fix agent `{alias}` runtime profile `{runtime_ref}`; it does not resolve to a configured profile."
+        items.push(repair_item(
+            "agent_runtime_profile_unresolved",
+            format!(
+                "Fix agent `{alias}` runtime profile `{runtime_ref}`; it does not resolve to a configured profile."
+            ),
+            Section::Agents,
+            agent_focus,
         ));
     }
 
-    missing
+    items
+}
+
+fn repair_item(
+    code: &'static str,
+    message: impl Into<String>,
+    section: Section,
+    focus: Option<String>,
+) -> OnboardRepairItem {
+    OnboardRepairItem {
+        code,
+        message: message.into(),
+        section: section.as_str(),
+        focus,
+    }
+}
+
+fn model_provider_focus(family: &str, alias: &str) -> Option<String> {
+    if alias.trim().is_empty() {
+        return None;
+    }
+    let section = Section::ModelProviders;
+    let config_family = typed_family_config_key(section, family);
+    let section_key = section.as_str();
+    Some(format!("{section_key}.{config_family}.{alias}"))
+}
+
+fn onboard_agent_is_dispatchable(
+    cfg: &zeroclaw_config::schema::Config,
+    alias: &str,
+    agent: &zeroclaw_config::schema::AliasedAgentConfig,
+) -> bool {
+    if !agent.enabled {
+        return false;
+    }
+    let model_ref = agent.model_provider.trim();
+    if model_ref.is_empty() {
+        return false;
+    }
+    let Some((family, _, provider)) = cfg.resolved_model_provider_for_agent(alias) else {
+        return false;
+    };
+    let has_model = provider
+        .model
+        .as_deref()
+        .map(str::trim)
+        .is_some_and(|m| !m.is_empty());
+    if !has_model || !model_provider_alias_usable(provider, model_provider_family_is_local(family))
+    {
+        return false;
+    }
+    let risk_ref = agent.risk_profile.trim();
+    if risk_ref.is_empty() || !cfg.risk_profiles.contains_key(risk_ref) {
+        return false;
+    }
+    let runtime_ref = agent.runtime_profile.trim();
+    if runtime_ref.is_empty() || !cfg.runtime_profiles.contains_key(runtime_ref) {
+        return false;
+    }
+    true
 }
 
 /// `GET /api/onboard/status` — boolean signal for the dashboard's
@@ -573,7 +710,7 @@ fn section_ready(cfg: &zeroclaw_config::schema::Config, key: &str, completed_mar
         Some(Section::Agents) => cfg
             .agents
             .iter()
-            .any(|(alias, agent)| onboard_agent_missing_requirements(cfg, alias, agent).is_empty()),
+            .any(|(alias, agent)| onboard_agent_is_dispatchable(cfg, alias, agent)),
         _ => completed_marker,
     }
 }
@@ -1603,6 +1740,50 @@ mod tests {
             "completed_sections marker without a dispatchable agent must NOT flip the redirect"
         );
         assert_eq!(resp.reason, "incomplete_agent");
+    }
+
+    #[test]
+    fn derive_onboard_status_returns_structured_repair_items_for_half_configured_agent() {
+        let mut cfg = zeroclaw_config::schema::Config::default();
+        cfg.create_map_key("providers.models.atomic-chat", "local")
+            .unwrap();
+        cfg.create_map_key("risk-profiles", "default").unwrap();
+        cfg.create_map_key("agents", "default").unwrap();
+        let agent = cfg.agents.get_mut("default").unwrap();
+        agent.enabled = true;
+        agent.model_provider = "atomic_chat.local".into();
+        agent.risk_profile = "default".into();
+
+        let resp = derive_onboard_status(&cfg);
+
+        assert!(resp.needs_onboarding);
+        assert_eq!(resp.reason, "incomplete_agent");
+        let provider_item = resp
+            .repair_items
+            .iter()
+            .find(|item| item.code == "model_provider_model_missing")
+            .expect("model repair item");
+        assert_eq!(provider_item.section, "providers.models");
+        assert_eq!(
+            provider_item.focus.as_deref(),
+            Some("providers.models.atomic-chat.local")
+        );
+        assert_eq!(
+            provider_item.message,
+            "Choose a model for model provider `atomic_chat.local`."
+        );
+        let runtime_item = resp
+            .repair_items
+            .iter()
+            .find(|item| item.code == "agent_runtime_profile_missing")
+            .expect("runtime repair item");
+        assert_eq!(runtime_item.section, "agents");
+        assert_eq!(runtime_item.focus.as_deref(), Some("agents.default"));
+        assert!(
+            resp.missing
+                .iter()
+                .any(|item| item == "Set a runtime profile for agent `default`.")
+        );
     }
 
     #[test]

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -950,6 +950,15 @@ export interface OnboardStatusResponse {
   has_partial_state: boolean;
   /** Human-readable readiness failures for the finish gate. */
   missing: string[];
+  /** Structured repair targets for half-configured onboarding state. */
+  repair_items: OnboardRepairItem[];
+}
+
+export interface OnboardRepairItem {
+  code: string;
+  message: string;
+  section: string;
+  focus?: string;
 }
 
 export function getOnboardStatus(): Promise<OnboardStatusResponse> {

--- a/web/src/pages/onboard/Onboard.tsx
+++ b/web/src/pages/onboard/Onboard.tsx
@@ -31,6 +31,7 @@ import {
   patchConfig,
   reloadDaemon,
   selectSectionItem,
+  type OnboardRepairItem,
   type PickerItem,
   type SectionInfo,
 } from '../../lib/api';
@@ -74,6 +75,7 @@ export default function Onboard() {
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [canFinish, setCanFinish] = useState(false);
   const [finishIssues, setFinishIssues] = useState<string[] | null>(null);
+  const [repairItems, setRepairItems] = useState<OnboardRepairItem[]>([]);
   const [issueTitle, setIssueTitle] = useState('Complete this step before continuing.');
   const [applyIssue, setApplyIssue] = useState<string | null>(null);
   const [editingProfile, setEditingProfile] = useState(false);
@@ -91,6 +93,7 @@ export default function Onboard() {
       const status = await getOnboardStatus();
       const readyToFinish = !status.needs_onboarding && firstRunRequiredSectionsReady(onboardingSections);
       setCanFinish(readyToFinish);
+      setRepairItems(status.repair_items ?? []);
       if (readyToFinish) setFinishIssues(null);
       const agents = await getMapKeys('agents').catch(() => null);
       const onlyAgent = agents?.keys.length === 1 ? agents.keys[0] : null;
@@ -374,6 +377,7 @@ export default function Onboard() {
       const wizardIssues = firstRunReadinessIssues(onboardingSections);
       const readyToFinish = !status.needs_onboarding && wizardIssues.length === 0;
       setCanFinish(readyToFinish);
+      setRepairItems(status.repair_items ?? []);
       if (!readyToFinish) {
         setIssueTitle('Finish needs a runnable agent first.');
         setFinishIssues(
@@ -398,6 +402,47 @@ export default function Onboard() {
     } finally {
       setFinishing(false);
     }
+  };
+
+  const openRepairItem = (item: OnboardRepairItem) => {
+    setFinishIssues(null);
+    setApplyIssue(null);
+    setPickedType(null);
+    setEditingProfile(false);
+    setActiveKey(item.section);
+
+    const focus = item.focus ?? '';
+    const parts = focus.split('.');
+    if (item.section === 'agents' && parts[0] === 'agents' && parts[1]) {
+      setSelectedAgentAlias(parts[1]);
+      setPicked({
+        item: { key: parts[1], label: parts[1] },
+        fieldsPrefix: focus,
+      });
+      return;
+    }
+
+    if (item.section === 'providers.models' && parts[0] === 'providers' && parts[1] === 'models') {
+      const providerType = parts[2];
+      const providerAlias = parts[3];
+      if (providerType && providerAlias) {
+        setPicked({
+          item: { key: providerType, label: providerType },
+          fieldsPrefix: focus,
+        });
+        return;
+      }
+    }
+
+    if ((item.section === 'risk-profiles' || item.section === 'runtime-profiles') && parts[1]) {
+      setPicked({
+        item: { key: parts[1], label: parts[1] },
+        fieldsPrefix: focus,
+      });
+      return;
+    }
+
+    setPicked(null);
   };
 
   if (loading) {
@@ -610,7 +655,9 @@ export default function Onboard() {
                 <FirstRunCompleteActions
                   canFinish={canFinish}
                   finishing={finishing}
+                  repairItems={repairItems}
                   onFinish={() => void finishOnboarding()}
+                  onOpenRepairItem={openRepairItem}
                   onAdvanced={() => {
                     setShowAdvanced(true);
                     if (advancedSections[0]) goToSection(advancedSections[0].key);
@@ -1006,12 +1053,16 @@ function isAgentFirstRunPath(prefix: string, path: string): boolean {
 function FirstRunCompleteActions({
   canFinish,
   finishing,
+  repairItems,
   onFinish,
+  onOpenRepairItem,
   onAdvanced,
 }: {
   canFinish: boolean;
   finishing: boolean;
+  repairItems: OnboardRepairItem[];
   onFinish: () => void;
+  onOpenRepairItem: (item: OnboardRepairItem) => void;
   onAdvanced: () => void;
 }) {
   return (
@@ -1056,7 +1107,48 @@ function FirstRunCompleteActions({
           Continue advanced setup
         </button>
       </div>
+      {!canFinish && repairItems.length > 0 && (
+        <RepairChecklist items={repairItems} onOpen={onOpenRepairItem} />
+      )}
     </div>
+  );
+}
+
+function RepairChecklist({
+  items,
+  onOpen,
+}: {
+  items: OnboardRepairItem[];
+  onOpen: (item: OnboardRepairItem) => void;
+}) {
+  return (
+    <ul className="flex flex-col gap-2">
+      {items.map((item) => (
+        <li
+          key={`${item.code}:${item.focus ?? item.section}:${item.message}`}
+          className="rounded-lg border px-3 py-2 flex items-center justify-between gap-3"
+          style={{
+            borderColor: 'var(--pc-border)',
+            background: 'var(--pc-bg-surface)',
+          }}
+        >
+          <div className="min-w-0">
+            <p style={{ color: 'var(--pc-text-primary)' }}>{item.message}</p>
+            <code className="text-xs" style={{ color: 'var(--pc-text-faint)' }}>
+              {item.focus ?? item.section}
+            </code>
+          </div>
+          <button
+            type="button"
+            onClick={() => onOpen(item)}
+            className="btn-secondary text-xs px-2.5 py-1.5 inline-flex items-center gap-1 flex-shrink-0"
+          >
+            Fix
+            <ChevronRight className="h-3 w-3" />
+          </button>
+        </li>
+      ))}
+    </ul>
   );
 }
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Adds structured onboarding repair items to `GET /api/onboard/status`, alongside the existing plain `missing` strings, so the dashboard can route users to the exact incomplete setup surface.
  - Reports repair targets for missing model providers, missing agents, disabled agents, unresolved agent model/risk/runtime profile references, and provider entries that still need a model or credential/auth.
  - Renders those repair items in the first-run onboarding finish area with a `Fix` action that opens the relevant agent or provider form.
  - Keeps the first-run completion gate tied to a runnable agent, rather than treating completed sections or partial config as enough to finish.
- **Scope boundary:** This PR does not redesign the onboarding order, add provider API-key shape validation, change channel setup, address tunnel picker behavior (#6815), or add second-agent onboarding flows. Those remain follow-up work.
- **Blast radius:** Gateway onboarding status responses now include a new `repair_items` array. Existing consumers can keep using `missing`; the web onboarding page consumes the structured array for repair routing.
- **Linked issue/PR(s):** Related #6398, Related #6815
- **Labels:** Current labels: `bug`, `gateway`, `onboard`, `risk: high`, `size: M`.

## Validation Evidence (required)

- **Commands run and tail output:**

```text
cargo fmt --all -- --check
Result: passed.

cargo test -p zeroclaw-gateway derive_onboard_status_returns_structured_repair_items_for_half_configured_agent -- --nocapture
Result: passed. 1 passed; 0 failed; 205 filtered out.

cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
Result: passed.

cargo nextest run --locked --workspace --exclude zeroclaw-desktop
Result: passed. 7858 passed; 10 skipped.

npm run build
Result: passed TypeScript and Vite production build. Existing large-chunk warnings only.

git diff --check
Result: passed.
```

- **Beyond CI — what did you manually verify?** Browser smoke tested the gateway-served onboarding UI with a scratch config. Pairing worked, first-run setup reached the agent step, breaking the agent model-provider assignment rendered a concrete repair item with `agents.default`, breaking the provider model rendered a concrete repair item with `providers.models.openai.default`, and clicking `Fix` opened the matching agent or provider repair surface.
- **If any command was intentionally skipped, why:** No required local validation was intentionally skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: N/A. The API response is additive; existing `missing` consumers are preserved.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert 1533e7dd9`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Onboarding finish/repair UI shows incorrect or missing repair items; `GET /api/onboard/status` returns wrong `repair_items` targets; clicking `Fix` opens the wrong onboarding section.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Scope materially carried forward: N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why (inspiration-only, no direct code/design carry-over): No superseded PR scope is incorporated.
