### PR TITLE
fix(cron): persist manual delivery failures as degraded

### DIFF
--- a/crates/zeroclaw-gateway/src/api.rs
+++ b/crates/zeroclaw-gateway/src/api.rs
@@ -520,47 +520,23 @@ pub async fn handle_api_cron_run(
         zeroclaw_runtime::cron::scheduler::execute_job_now(&config, &job).await;
     let finished_at = chrono::Utc::now();
     let duration_ms = (finished_at - started_at).num_milliseconds();
+    let outcome = zeroclaw_runtime::cron::scheduler::deliver_and_classify_run_result(
+        &config,
+        &job,
+        success,
+        output,
+        zeroclaw_runtime::cron::scheduler::CronDeliveryContext::GatewayManual,
+    )
+    .await;
+    success = outcome.success;
 
-    if job.delivery.mode.eq_ignore_ascii_case("announce")
-        && let (Some(channel), Some(target)) =
-            (job.delivery.channel.as_deref(), job.delivery.to.as_deref())
-        && let Err(e) = zeroclaw_runtime::cron::scheduler::deliver_announcement(
-            &config,
-            channel,
-            target,
-            job.delivery.thread_id.as_deref(),
-            &output,
-        )
-        .await
-    {
-        if job.delivery.best_effort {
-            ::zeroclaw_log::record!(
-                WARN,
-                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                    .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                    .with_attrs(::serde_json::json!({"job_id": job.id, "error": format!("{}", e)})),
-                "manual cron trigger delivery failed (best_effort)"
-            );
-        } else {
-            ::zeroclaw_log::record!(
-                WARN,
-                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                    .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                    .with_attrs(::serde_json::json!({"job_id": job.id, "error": format!("{}", e)})),
-                "manual cron trigger delivery failed"
-            );
-            success = false;
-        }
-    }
-
-    let status = if success { "ok" } else { "error" };
     if let Err(e) = zeroclaw_runtime::cron::record_run(
         &config,
         &job.id,
         started_at,
         finished_at,
-        status,
-        Some(&output),
+        &outcome.status,
+        Some(&outcome.output),
         duration_ms,
     ) {
         ::zeroclaw_log::record!(
@@ -571,9 +547,13 @@ pub async fn handle_api_cron_run(
             "manual cron trigger: failed to persist run history"
         );
     }
-    if let Err(e) =
-        zeroclaw_runtime::cron::record_last_run(&config, &job.id, finished_at, success, &output)
-    {
+    if let Err(e) = zeroclaw_runtime::cron::record_last_run_with_status(
+        &config,
+        &job.id,
+        finished_at,
+        &outcome.status,
+        &outcome.output,
+    ) {
         ::zeroclaw_log::record!(
             WARN,
             ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
@@ -589,16 +569,16 @@ pub async fn handle_api_cron_run(
         "type": "cron_result",
         "job_id": job.id,
         "success": success,
-        "output": output,
+        "output": &outcome.output,
         "manual": true,
         "timestamp": finished_at.to_rfc3339(),
     }));
 
     Json(serde_json::json!({
-        "status": status,
+        "status": &outcome.status,
         "job_id": job.id,
         "success": success,
-        "output": output,
+        "output": &outcome.output,
         "duration_ms": duration_ms,
         "started_at": started_at.to_rfc3339(),
         "finished_at": finished_at.to_rfc3339(),
@@ -1864,6 +1844,17 @@ mod tests {
         serde_json::from_slice(&body).expect("valid json response")
     }
 
+    fn link_job_to_test_agent(state: &AppState, job_id: &str) {
+        state
+            .config
+            .write()
+            .agents
+            .get_mut("test-agent")
+            .expect("test-agent configured by with_test_agent")
+            .cron_jobs
+            .push(job_id.to_string());
+    }
+
     fn test_state_with_session_backend(
         config: zeroclaw_config::schema::Config,
         backend: Arc<dyn SessionBackend>,
@@ -2545,18 +2536,8 @@ mod tests {
         .expect("job added");
 
         // Imperative jobs get UUID ids; the scheduler resolves owning
-        // agent by reverse-lookup against `agent.cron_jobs`. Wire the
-        // freshly-created job's id into test-agent so execute_job_now
-        // can find its owner. (Carrying agent on the DB row is a
-        // follow-up.)
-        state
-            .config
-            .write()
-            .agents
-            .get_mut("test-agent")
-            .expect("test-agent configured by with_test_agent")
-            .cron_jobs
-            .push(job.id.clone());
+        // agent by reverse-lookup against `agent.cron_jobs`.
+        link_job_to_test_agent(&state, &job.id);
 
         let response =
             handle_api_cron_run(State(state.clone()), HeaderMap::new(), Path(job.id.clone()))
@@ -2579,6 +2560,88 @@ mod tests {
             .expect("runs listed");
         assert_eq!(runs.len(), 1);
         assert_eq!(runs[0].status, "ok");
+    }
+
+    #[tokio::test]
+    async fn cron_api_run_records_best_effort_delivery_failure_as_degraded() {
+        zeroclaw_runtime::cron::scheduler::register_delivery_fn(Box::new(
+            |_config, channel, _target, _thread_id, _output| {
+                Box::pin(async move {
+                    if channel == "fail-delivery" {
+                        anyhow::bail!("synthetic delivery failure");
+                    }
+                    Ok(())
+                })
+            },
+        ));
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let config = zeroclaw_config::schema::Config {
+            data_dir: tmp.path().join("data"),
+            config_path: tmp.path().join("config.toml"),
+            ..zeroclaw_config::schema::Config::default()
+        };
+        std::fs::create_dir_all(&config.data_dir).unwrap();
+        let state = test_state(with_test_agent(config));
+
+        let job = zeroclaw_runtime::cron::add_shell_job_with_approval(
+            &state.config.read().clone(),
+            "test-agent",
+            None,
+            zeroclaw_runtime::cron::Schedule::Cron {
+                expr: "*/5 * * * *".to_string(),
+                tz: None,
+            },
+            "echo hello-from-manual-trigger",
+            Some(zeroclaw_runtime::cron::DeliveryConfig {
+                mode: "announce".into(),
+                channel: Some("fail-delivery".into()),
+                to: Some("123456".into()),
+                thread_id: None,
+                best_effort: true,
+            }),
+            true,
+        )
+        .expect("job added");
+        link_job_to_test_agent(&state, &job.id);
+
+        let response =
+            handle_api_cron_run(State(state.clone()), HeaderMap::new(), Path(job.id.clone()))
+                .await
+                .into_response();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let json = response_json(response).await;
+        assert_eq!(json["status"], "degraded");
+        assert_eq!(json["success"], true);
+        assert!(
+            json["output"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("delivery failed:")
+        );
+
+        let config = state.config.read().clone();
+        let updated = zeroclaw_runtime::cron::get_job(&config, &job.id).expect("updated job");
+        assert_eq!(updated.last_status.as_deref(), Some("degraded"));
+        assert!(
+            updated
+                .last_output
+                .as_deref()
+                .unwrap_or_default()
+                .contains("delivery failed:")
+        );
+
+        let runs = zeroclaw_runtime::cron::list_runs(&config, &job.id, 10).expect("runs listed");
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].status, "degraded");
+        assert!(
+            runs[0]
+                .output
+                .as_deref()
+                .unwrap_or_default()
+                .contains("delivery failed:")
+        );
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-runtime/src/cron/scheduler.rs
+++ b/crates/zeroclaw-runtime/src/cron/scheduler.rs
@@ -24,6 +24,100 @@ const SCHEDULER_COMPONENT: &str = "scheduler";
 /// to connected dashboard/SSE clients.
 pub type EventBroadcast = Option<tokio::sync::broadcast::Sender<serde_json::Value>>;
 
+#[derive(Clone, Copy)]
+pub enum CronDeliveryContext {
+    Scheduled,
+    ToolManual,
+    GatewayManual,
+}
+
+impl CronDeliveryContext {
+    fn failure_message(self, best_effort: bool) -> &'static str {
+        match (self, best_effort) {
+            (Self::Scheduled, true) => "Cron delivery failed (best_effort)",
+            (Self::Scheduled, false) => "Cron delivery failed",
+            (Self::ToolManual, true) => "cron_run delivery failed (best_effort)",
+            (Self::ToolManual, false) => "cron_run delivery failed",
+            (Self::GatewayManual, true) => "manual cron trigger delivery failed (best_effort)",
+            (Self::GatewayManual, false) => "manual cron trigger delivery failed",
+        }
+    }
+}
+
+pub struct CronDeliveryOutcome {
+    pub success: bool,
+    pub status: String,
+    pub output: String,
+}
+
+pub async fn deliver_and_classify_run_result(
+    config: &Config,
+    job: &CronJob,
+    mut success: bool,
+    mut output: String,
+    context: CronDeliveryContext,
+) -> CronDeliveryOutcome {
+    let mut status = if success { "ok" } else { "error" }.to_string();
+
+    if let Err(e) = deliver_if_configured(config, job, &output).await {
+        // Cron add-time accepts dangling delivery refs (the job's channel
+        // may not be provisioned yet); the loudly-logged warn here is
+        // the scheduler-side half of that contract. Manual trigger paths
+        // share this classifier so status history cannot drift again.
+        let channel = job.delivery.channel.as_deref().unwrap_or("");
+        let target = job.delivery.to.as_deref().unwrap_or("");
+        let delivery_error = e.to_string();
+
+        if job.delivery.best_effort {
+            ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                    .with_attrs(::serde_json::json!({
+                        "job_id": job.id,
+                        "agent_alias": job.agent_alias,
+                        "channel": channel,
+                        "target": target,
+                        "error": delivery_error
+                    })),
+                context.failure_message(true)
+            );
+            if success {
+                status = "degraded".to_string();
+            }
+        } else {
+            success = false;
+            ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                    .with_attrs(::serde_json::json!({
+                        "job_id": job.id,
+                        "agent_alias": job.agent_alias,
+                        "channel": channel,
+                        "target": target,
+                        "error": delivery_error
+                    })),
+                context.failure_message(false)
+            );
+            status = "error".to_string();
+        }
+
+        if output.trim().is_empty() {
+            output = format!("delivery failed: {delivery_error}");
+        } else {
+            output.push_str("\n\ndelivery failed: ");
+            output.push_str(&delivery_error);
+        }
+    }
+
+    CronDeliveryOutcome {
+        success,
+        status,
+        output,
+    }
+}
+
 pub async fn run(config: Config, event_tx: EventBroadcast) -> Result<()> {
     let poll_secs = config.reliability.scheduler_poll_secs.max(MIN_POLL_SECONDS);
     let mut interval = time::interval(Duration::from_secs(poll_secs));
@@ -520,43 +614,22 @@ async fn run_agent_job(
 async fn persist_job_result(
     config: &Config,
     job: &CronJob,
-    mut success: bool,
+    success: bool,
     output: &str,
     started_at: DateTime<Utc>,
     finished_at: DateTime<Utc>,
 ) -> bool {
     let duration_ms = (finished_at - started_at).num_milliseconds();
-    let mut persisted_status = if success { "ok" } else { "error" }.to_string();
-    let mut persisted_output = output.to_string();
+    let outcome = deliver_and_classify_run_result(
+        config,
+        job,
+        success,
+        output.to_string(),
+        CronDeliveryContext::Scheduled,
+    )
+    .await;
 
-    if let Err(e) = deliver_if_configured(config, job, output).await {
-        // Cron add-time accepts dangling delivery refs (the job's channel
-        // may not be provisioned yet); the loudly-logged warn here is
-        // the scheduler-side half of that contract — operators see the
-        // exact channel composite, target, and job id every time a
-        // dangling delivery fires.
-        let channel = job.delivery.channel.as_deref().unwrap_or("");
-        let target = job.delivery.to.as_deref().unwrap_or("");
-        if job.delivery.best_effort {
-            ::zeroclaw_log::record!(WARN, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_outcome(::zeroclaw_log::EventOutcome::Unknown).with_attrs(::serde_json::json!({"job_id": job.id, "agent_alias": job.agent_alias, "channel": channel, "target": target, "error": format!("{}", e)})), "Cron delivery failed (best_effort)");
-            if success {
-                persisted_status = "degraded".to_string();
-            }
-        } else {
-            success = false;
-            ::zeroclaw_log::record!(WARN, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_outcome(::zeroclaw_log::EventOutcome::Unknown).with_attrs(::serde_json::json!({"job_id": job.id, "agent_alias": job.agent_alias, "channel": channel, "target": target, "error": format!("{}", e)})), "Cron delivery failed");
-            persisted_status = "error".to_string();
-        }
-
-        if persisted_output.trim().is_empty() {
-            persisted_output = format!("delivery failed: {e}");
-        } else {
-            persisted_output.push_str("\n\ndelivery failed: ");
-            persisted_output.push_str(&e.to_string());
-        }
-    }
-
-    let action = if is_one_shot_auto_delete(job) && success {
+    let action = if is_one_shot_auto_delete(job) && outcome.success {
         RunCompletionAction::Delete
     } else if matches!(job.schedule, Schedule::At { .. }) {
         RunCompletionAction::Disable
@@ -571,8 +644,8 @@ async fn persist_job_result(
         started_at,
         finished_at,
         job_state_at,
-        &persisted_status,
-        Some(&persisted_output),
+        &outcome.status,
+        Some(&outcome.output),
         duration_ms,
         action,
     ) {
@@ -593,8 +666,8 @@ async fn persist_job_result(
                 config,
                 job,
                 job_state_at,
-                &persisted_status,
-                Some(&persisted_output),
+                &outcome.status,
+                Some(&outcome.output),
                 RunCompletionAction::Disable,
             ) {
                 ::zeroclaw_log::record!(
@@ -612,8 +685,8 @@ async fn persist_job_result(
                 config,
                 job,
                 job_state_at,
-                &persisted_status,
-                Some(&persisted_output),
+                &outcome.status,
+                Some(&outcome.output),
                 action,
             ) {
                 ::zeroclaw_log::record!(
@@ -627,7 +700,7 @@ async fn persist_job_result(
         }
     }
 
-    success
+    outcome.success
 }
 
 fn is_one_shot_auto_delete(job: &CronJob) -> bool {
@@ -1743,6 +1816,43 @@ mod tests {
         let runs = cron::list_runs(&config, &job.id, 10).unwrap();
         assert_eq!(runs.len(), 1);
         assert_eq!(runs[0].status, "degraded");
+    }
+
+    #[tokio::test]
+    async fn delivery_failure_classification_preserves_empty_output_evidence() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(&tmp).await;
+        register_delivery_fn(Box::new(
+            |_config, channel, _target, _thread_id, _output| {
+                Box::pin(async move {
+                    if channel == "fail-delivery" {
+                        anyhow::bail!("synthetic delivery failure");
+                    }
+                    Ok(())
+                })
+            },
+        ));
+        let mut job = cron::add_job(&config, "test-agent", "*/5 * * * *", "echo ok").unwrap();
+        job.delivery = DeliveryConfig {
+            mode: "announce".into(),
+            channel: Some("fail-delivery".into()),
+            to: Some("123456".into()),
+            thread_id: None,
+            best_effort: true,
+        };
+
+        let outcome = deliver_and_classify_run_result(
+            &config,
+            &job,
+            true,
+            String::new(),
+            CronDeliveryContext::Scheduled,
+        )
+        .await;
+
+        assert!(outcome.success);
+        assert_eq!(outcome.status, "degraded");
+        assert!(outcome.output.starts_with("delivery failed:"));
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-runtime/src/tools/cron_run.rs
+++ b/crates/zeroclaw-runtime/src/tools/cron_run.rs
@@ -119,80 +119,40 @@ impl Tool for CronRunTool {
             Box::pin(cron::scheduler::execute_job_now(&self.config, &job)).await;
         let finished_at = Utc::now();
         let duration_ms = (finished_at - started_at).num_milliseconds();
-        let mut persisted_status = if success { "ok" } else { "error" }.to_string();
-        let mut persisted_output = output.to_string();
-
-        if job.delivery.mode.eq_ignore_ascii_case("announce")
-            && let (Some(channel), Some(target)) =
-                (job.delivery.channel.as_deref(), job.delivery.to.as_deref())
-            && let Err(e) = cron::scheduler::deliver_announcement(
-                &self.config,
-                channel,
-                target,
-                job.delivery.thread_id.as_deref(),
-                &output,
-            )
-            .await
-        {
-            if job.delivery.best_effort {
-                ::zeroclaw_log::record!(
-                    WARN,
-                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                        .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                        .with_attrs(
-                            ::serde_json::json!({"job_id": job.id, "error": format!("{}", e)})
-                        ),
-                    "cron_run delivery failed (best_effort)"
-                );
-                if success {
-                    persisted_status = "degraded".to_string();
-                }
-            } else {
-                ::zeroclaw_log::record!(
-                    WARN,
-                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                        .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                        .with_attrs(
-                            ::serde_json::json!({"job_id": job.id, "error": format!("{}", e)})
-                        ),
-                    "cron_run delivery failed"
-                );
-                success = false;
-                persisted_status = "error".to_string();
-            }
-
-            if persisted_output.trim().is_empty() {
-                persisted_output = format!("delivery failed: {e}");
-            } else {
-                persisted_output.push_str("\n\ndelivery failed: ");
-                persisted_output.push_str(&e.to_string());
-            }
-        }
+        let outcome = cron::scheduler::deliver_and_classify_run_result(
+            &self.config,
+            &job,
+            success,
+            output,
+            cron::scheduler::CronDeliveryContext::ToolManual,
+        )
+        .await;
+        success = outcome.success;
 
         let _ = cron::record_run(
             &self.config,
             &job.id,
             started_at,
             finished_at,
-            &persisted_status,
-            Some(&persisted_output),
+            &outcome.status,
+            Some(&outcome.output),
             duration_ms,
         );
         let _ = cron::record_last_run_with_status(
             &self.config,
             &job.id,
             finished_at,
-            &persisted_status,
-            &persisted_output,
+            &outcome.status,
+            &outcome.output,
         );
 
         Ok(ToolResult {
             success,
             output: serde_json::to_string_pretty(&json!({
                 "job_id": job.id,
-                "status": persisted_status,
+                "status": outcome.status,
                 "duration_ms": duration_ms,
-                "output": persisted_output
+                "output": outcome.output
             }))?,
             error: if success {
                 None

--- a/crates/zeroclaw-runtime/src/tools/cron_run.rs
+++ b/crates/zeroclaw-runtime/src/tools/cron_run.rs
@@ -119,6 +119,8 @@ impl Tool for CronRunTool {
             Box::pin(cron::scheduler::execute_job_now(&self.config, &job)).await;
         let finished_at = Utc::now();
         let duration_ms = (finished_at - started_at).num_milliseconds();
+        let mut persisted_status = if success { "ok" } else { "error" }.to_string();
+        let mut persisted_output = output.to_string();
 
         if job.delivery.mode.eq_ignore_ascii_case("announce")
             && let (Some(channel), Some(target)) =
@@ -142,6 +144,9 @@ impl Tool for CronRunTool {
                         ),
                     "cron_run delivery failed (best_effort)"
                 );
+                if success {
+                    persisted_status = "degraded".to_string();
+                }
             } else {
                 ::zeroclaw_log::record!(
                     WARN,
@@ -153,29 +158,41 @@ impl Tool for CronRunTool {
                     "cron_run delivery failed"
                 );
                 success = false;
+                persisted_status = "error".to_string();
+            }
+
+            if persisted_output.trim().is_empty() {
+                persisted_output = format!("delivery failed: {e}");
+            } else {
+                persisted_output.push_str("\n\ndelivery failed: ");
+                persisted_output.push_str(&e.to_string());
             }
         }
-
-        let status = if success { "ok" } else { "error" };
 
         let _ = cron::record_run(
             &self.config,
             &job.id,
             started_at,
             finished_at,
-            status,
-            Some(&output),
+            &persisted_status,
+            Some(&persisted_output),
             duration_ms,
         );
-        let _ = cron::record_last_run(&self.config, &job.id, finished_at, success, &output);
+        let _ = cron::record_last_run_with_status(
+            &self.config,
+            &job.id,
+            finished_at,
+            &persisted_status,
+            &persisted_output,
+        );
 
         Ok(ToolResult {
             success,
             output: serde_json::to_string_pretty(&json!({
                 "job_id": job.id,
-                "status": status,
+                "status": persisted_status,
                 "duration_ms": duration_ms,
-                "output": output
+                "output": persisted_output
             }))?,
             error: if success {
                 None
@@ -265,6 +282,88 @@ mod tests {
 
         let runs = cron::list_runs(&cfg, &job.id, 10).unwrap();
         assert_eq!(runs.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn best_effort_delivery_failure_records_degraded_history() {
+        cron::scheduler::register_delivery_fn(Box::new(
+            |_config, channel, _target, _thread_id, _output| {
+                Box::pin(async move {
+                    if channel == "fail-delivery" {
+                        anyhow::bail!("synthetic delivery failure");
+                    }
+                    Ok(())
+                })
+            },
+        ));
+
+        let tmp = TempDir::new().unwrap();
+        let mut config = Config {
+            data_dir: tmp.path().join("data"),
+            config_path: tmp.path().join("config.toml"),
+            ..Config::default()
+        };
+        seed_test_agent(&mut config);
+        tokio::fs::create_dir_all(&config.data_dir).await.unwrap();
+        let job = cron::add_shell_job_with_approval(
+            &config,
+            TEST_AGENT,
+            None,
+            cron::Schedule::Cron {
+                expr: "*/5 * * * *".into(),
+                tz: None,
+            },
+            "echo run-now",
+            Some(cron::DeliveryConfig {
+                mode: "announce".into(),
+                channel: Some("fail-delivery".into()),
+                to: Some("123456".into()),
+                thread_id: None,
+                best_effort: true,
+            }),
+            true,
+        )
+        .unwrap();
+        config
+            .agents
+            .get_mut(TEST_AGENT)
+            .unwrap()
+            .cron_jobs
+            .push(job.id.clone());
+        let cfg = Arc::new(config);
+        let tool = CronRunTool::new(cfg.clone(), test_security(&cfg));
+
+        let result = tool.execute(json!({ "job_id": job.id })).await.unwrap();
+        assert!(result.success, "{:?}", result.error);
+        let response: serde_json::Value = serde_json::from_str(&result.output).unwrap();
+        assert_eq!(response["status"], "degraded");
+        assert!(
+            response["output"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("delivery failed:")
+        );
+
+        let updated = cron::get_job(&cfg, &job.id).unwrap();
+        assert_eq!(updated.last_status.as_deref(), Some("degraded"));
+        assert!(
+            updated
+                .last_output
+                .as_deref()
+                .unwrap_or_default()
+                .contains("delivery failed:")
+        );
+
+        let runs = cron::list_runs(&cfg, &job.id, 10).unwrap();
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].status, "degraded");
+        assert!(
+            runs[0]
+                .output
+                .as_deref()
+                .unwrap_or_default()
+                .contains("delivery failed:")
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Updated cron delivery persistence so best-effort delivery failures record a degraded run status instead of `ok` for both manual forced-run entrypoints.
  - Moved the delivery-status classification into a shared scheduler helper used by scheduled cron, tool `cron_run`, and the dashboard/API manual cron trigger.
  - Kept best-effort execution success semantics intact while distinguishing delivered success from delivery-degraded success in stored history, `last_status`, tool JSON, and API JSON.
  - Appended the delivery failure message to stored run output so manual run history keeps the same operator-visible evidence as scheduled cron.
  - Added runtime and gateway regression tests covering the shared classifier, tool `cron_run`, and `POST /api/cron/{id}/run`.
- **Scope boundary:** This PR changes cron run status/output classification and persistence after delivery failure. It does not change job execution, channel delivery implementations, delivery retry policy, cron job creation/validation, config shape, or database schema.
- **Blast radius:** Runtime cron scheduler persistence, the `cron_run` tool response/history path, and the gateway manual run endpoint/event payload for `POST /api/cron/{id}/run`.
- **Linked issue(s):** Closes #6632. Related #6026.
- **Labels:** `bug`, `risk: high`, `size: M`, `cron`, `gateway`, `runtime`, `tool: cron_run`.

## Validation Evidence (required)

- **Commands run and tail output:**

```text
cargo fmt --all -- --check
Result: passed on PR head 9b0d5f092288d094230b6efdd327e3858eb5f5ca.

cargo test -p zeroclaw-runtime delivery_failure_classification_preserves_empty_output_evidence --lib -- --nocapture
Result: passed; 1 passed, 1842 filtered.

cargo test -p zeroclaw-gateway cron_api_run_records_best_effort_delivery_failure_as_degraded --lib -- --nocapture
Result: passed; 1 passed, 205 filtered.

cargo test -p zeroclaw-runtime best_effort_delivery_failure_records_degraded_history --lib -- --nocapture
Result: passed; 1 passed, 1842 filtered.

cargo test -p zeroclaw-runtime cron_run --lib -- --nocapture
Result: passed; 8 passed, 1835 filtered.

cargo test -p zeroclaw-gateway cron_api_run --lib -- --nocapture
Result: passed; 3 passed, 203 filtered.

cargo clippy -p zeroclaw-runtime -p zeroclaw-gateway --all-targets -- -D warnings
Result: passed.

cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
Result: passed earlier on PR head e7bcdd2fa2f131aeea244f895147774a7db8d229 before the gateway/API follow-up commit.

cargo nextest run --locked --workspace --exclude zeroclaw-desktop
Result: passed earlier on PR head e7bcdd2fa2f131aeea244f895147774a7db8d229 before the gateway/API follow-up commit; 7958 passed, 10 skipped.
```

- **Beyond CI — what did you manually verify?** Compared the scheduled cron delivery-failure persistence path, tool `cron_run`, and gateway manual run path. Verified they now share the same delivery-status classifier: best-effort delivery failures keep execution success true, persist `degraded` in run history and `last_status`, and store `delivery failed:` evidence for operator visibility.
- **If any command was intentionally skipped, why:** Current-head validation focused on the changed runtime/gateway behavior after the follow-up commit. The earlier workspace clippy and CI-shaped nextest runs are included for broader pre-follow-up coverage; GitHub CI is expected to provide current-head full-repository coverage after this update.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: N/A.

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: Existing users do not need upgrade steps. Manual cron run responses and stored history become more accurate for best-effort delivery failures, but no config, env, CLI, or database schema changes are required.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** Revert the commits in this PR to restore the previous manual cron status persistence behavior.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Manual cron history, `cron_run` JSON output, or `POST /api/cron/{id}/run` JSON output would unexpectedly report `error`, report `ok`, or omit `delivery failed:` for best-effort delivery failures. Operators can inspect cron run history and `last_status` for affected jobs.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A.
- Scope materially carried forward: N/A.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`No`)
- If `No`, why (inspiration-only, no direct code/design carry-over): No superseded PR or external contributor code is incorporated.
