### PR TITLE
docs(channels): document Signal and WhatsApp setup

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -50,6 +50,8 @@
 - [Mattermost](./channels/mattermost.md)
 - [LINE](./channels/line.md)
 - [Nextcloud Talk](./channels/nextcloud-talk.md)
+- [Signal](./channels/signal.md)
+- [WhatsApp](./channels/whatsapp.md)
 - [Other chat platforms](./channels/chat-others.md)
 - [Social (Bluesky, Nostr, Twitter, Reddit)](./channels/social.md)
 - [Email](./channels/email.md)

--- a/docs/book/src/channels/chat-others.md
+++ b/docs/book/src/channels/chat-others.md
@@ -47,17 +47,6 @@ use_long_polling = true            # default — no webhook needed
 - Long polling is the default; no public URL required. Switch to webhook mode by setting `webhook_url` (then expose the gateway).
 - Streaming draft edits are supported but capped by Telegram's rate limit. Tune `draft_update_interval_ms` if you see "Too Many Requests".
 
-## Signal
-
-```toml
-[channels.signal]
-enabled = true
-phone_number = "+14155550123"
-signal_cli_rest_url = "http://localhost:8080"   # signal-cli-rest-api service
-```
-
-Signal integration requires running the [signal-cli-rest-api](https://github.com/bbernhard/signal-cli-rest-api) container locally — Signal has no official bot API, so we tunnel through `signal-cli`.
-
 ## iMessage (macOS only)
 
 ```toml
@@ -204,5 +193,7 @@ Channels with more intricate setup (OAuth flows, end-to-end encryption, multi-de
 - [Mattermost](./mattermost.md)
 - [LINE](./line.md)
 - [Nextcloud Talk](./nextcloud-talk.md)
+- [Signal](./signal.md)
+- [WhatsApp](./whatsapp.md)
 
 If you run into configuration friction on any channel above, file an issue with the repro and we'll consider promoting it to a dedicated guide.

--- a/docs/book/src/channels/overview.md
+++ b/docs/book/src/channels/overview.md
@@ -16,7 +16,10 @@ Real-time messaging where the agent can hold a conversation, get notified of new
 | Mattermost | `channel-mattermost` | [Mattermost](./mattermost.md) |
 | LINE | `channel-line` | [LINE](./line.md) |
 | Nextcloud Talk | `channel-nextcloud-talk` | [Nextcloud Talk](./nextcloud-talk.md) |
-| Discord, Slack, Telegram, Signal, iMessage, WeCom Bot Webhook, WeCom AI Bot Long Connection, WeChat personal iLink Bot, DingTalk, Lark, QQ, IRC, Mochat, Notion | per channel | [Other chat platforms](./chat-others.md) |
+| Signal | `channel-signal` | [Signal](./signal.md) |
+| WhatsApp Cloud API | `channel-whatsapp-cloud` | [WhatsApp](./whatsapp.md) |
+| WhatsApp Web | `whatsapp-web` | [WhatsApp](./whatsapp.md) |
+| Discord, Slack, Telegram, iMessage, WeCom Bot Webhook, WeCom AI Bot Long Connection, WeChat personal iLink Bot, DingTalk, Lark, QQ, IRC, Mochat, Notion | per channel | [Other chat platforms](./chat-others.md) |
 
 ### Social & broadcast
 
@@ -64,17 +67,21 @@ See [Webhooks](./webhook.md) and [ACP](./acp.md).
 
 ## Configuration
 
-Every channel is configured under `[channels.<name>]`:
+Modern channel instances are configured under `[channels.<type>.<alias>]`, with `default` as the common first alias:
 
 ```toml
-[channels.discord]
+[channels.discord.default]
 enabled = true
 bot_token = "..."
 allowed_users = ["123456789012345678"]
 reply_to_mentions_only = false
+
+[agents.assistant]
+enabled = true
+channels = ["discord.default"]
 ```
 
-Channel-specific options live under the same block. Common keys across channels:
+The `channels` entry binds the channel alias to the agent that should answer it. Some older per-channel guides still show legacy flat examples; prefer the alias shape above for new config. Channel-specific options live under the same block. Common keys across channels:
 
 | Key | What it does |
 |---|---|
@@ -87,7 +94,7 @@ Channel-specific options live under the same block. Common keys across channels:
 
 ## Pairing
 
-Most channels require **pairing** — a one-time handshake that binds an incoming message source to the agent's policy. `zeroclaw onboard channels` walks you through pairing each channel you configure; use `zeroclaw channel add` and `zeroclaw channel bind-telegram` (for Telegram specifically) to pair additional identities later. Without pairing, the channel rejects everything.
+Most channels require **pairing** — a one-time handshake that binds an incoming message source to the agent's policy. `zeroclaw onboard channels` walks you through pairing each channel you configure; use `zeroclaw channel bind-telegram` for Telegram-specific identities and the channel-specific guide for channels such as WhatsApp or Signal. Without pairing, the channel rejects everything.
 
 The rationale: an agent with a public Telegram bot token and no pairing is a publicly-accessible shell. Pairing is the gate.
 

--- a/docs/book/src/channels/signal.md
+++ b/docs/book/src/channels/signal.md
@@ -1,0 +1,78 @@
+# Signal
+
+ZeroClaw's Signal channel talks to a running `signal-cli` HTTP daemon. Signal does not provide an official bot API, so ZeroClaw connects to `signal-cli` over local HTTP and lets `signal-cli` own the Signal account, device keys, and message transport.
+
+Use this channel when you already operate a Signal account with `signal-cli`, or when you can run the daemon next to ZeroClaw. If you only have the Signal desktop or mobile app installed, that is not enough by itself; ZeroClaw needs the HTTP daemon endpoint.
+
+## Prerequisites
+
+- A Signal account linked or registered in `signal-cli`.
+- A running `signal-cli` HTTP daemon, for example `signal-cli daemon --http 127.0.0.1:8686`.
+- A ZeroClaw build with the `channel-signal` feature enabled.
+
+Keep the daemon bound to localhost unless you have put it behind your own authenticated network boundary. The daemon can send and receive as the linked Signal account.
+
+## Configure the channel
+
+The easiest path is the channels onboarding flow:
+
+```bash
+zeroclaw onboard channels
+```
+
+For manual config, create or update a Signal channel block:
+
+```toml
+[channels.signal.default]
+enabled = true
+http_url = "http://127.0.0.1:8686"
+account = "<your-signal-e164-number>"
+
+[agents.assistant]
+enabled = true
+channels = ["signal.default"]
+```
+
+`http_url` is the base URL of the `signal-cli` daemon. `account` is the account identifier `signal-cli` uses for the linked Signal account, usually the E.164 phone number you registered with Signal.
+
+The `channels` entry binds the channel alias to the agent that should answer it. Use your real agent alias instead of `assistant`.
+
+## Restrict who can talk to the agent
+
+Inbound peer authorization lives in `peer_groups`. A group can target every Signal alias with `channel = "signal"` or one alias with `channel = "signal.default"`.
+
+```toml
+[peer_groups.signal_ops]
+channel = "signal.default"
+agents = []
+external_peers = ["<allowed-signal-sender>"]
+ignore = []
+```
+
+Signal sender identifiers may be E.164 phone numbers or UUID/source identifiers depending on what `signal-cli` reports for the event. Use the identifier shape from your daemon logs or event payloads.
+
+You can also narrow traffic at the channel level:
+
+```toml
+[channels.signal.default]
+dm_only = true
+ignore_attachments = true
+ignore_stories = true
+```
+
+`dm_only = true` ignores groups. `group_ids = ["<signal-group-id>"]` accepts only listed groups while still accepting DMs. `ignore_attachments` and `ignore_stories` reduce message types that are forwarded to the agent.
+
+## Start and check
+
+Start the daemon first, then start ZeroClaw channels:
+
+```bash
+signal-cli daemon --http 127.0.0.1:8686
+zeroclaw channel start
+```
+
+Use `zeroclaw channel doctor` to confirm ZeroClaw can load the configured channel. If the channel fails at runtime, check that `http_url` points at the daemon, the account is registered in `signal-cli`, and the build includes `channel-signal`.
+
+## Common confusion
+
+The `signal-cli` project is primarily known as a CLI, but ZeroClaw needs its HTTP daemon mode. If you installed only the command-line binary and never started the daemon, ZeroClaw has nothing to connect to.

--- a/docs/book/src/channels/whatsapp.md
+++ b/docs/book/src/channels/whatsapp.md
@@ -1,0 +1,102 @@
+# WhatsApp
+
+ZeroClaw supports two WhatsApp backends under the same `channels.whatsapp` config family:
+
+| Mode | Use it when | Required selector |
+|---|---|---|
+| WhatsApp Cloud API | You have a Meta Business app and WhatsApp Business phone number ID | `phone_number_id` |
+| WhatsApp Web | You want to link a regular WhatsApp account through the Web protocol | `session_path` |
+
+Do not configure both selectors in the same channel unless you intentionally want Cloud API mode to win for backward compatibility.
+
+## Cloud API mode
+
+Cloud API mode is the Meta Business Platform integration. It requires a Meta Business account, a WhatsApp Business app, a phone number ID, a verify token, and an access token. It is the right mode for business deployments that receive messages through Meta webhooks.
+
+```toml
+[channels.whatsapp.default]
+enabled = true
+phone_number_id = "<meta-phone-number-id>"
+verify_token = "<webhook-verify-token>"
+access_token = "<meta-access-token>"
+# app_secret = "<meta-app-secret>" # recommended for webhook signature verification
+```
+
+The gateway must be reachable by Meta for inbound webhooks. Use `zeroclaw onboard tunnel` or your own reverse proxy to expose the webhook endpoint when developing locally.
+
+## Web mode
+
+WhatsApp Web mode links a regular WhatsApp account through the optional Web backend. It does not need a Meta Business account. It does need a ZeroClaw build with the `whatsapp-web` feature enabled and a persistent session database path.
+
+```toml
+[channels.whatsapp.default]
+enabled = true
+session_path = "~/.zeroclaw/state/whatsapp-web/session.db"
+mode = "personal"
+dm_policy = "allowlist"
+group_policy = "allowlist"
+mention_only = true
+
+[agents.assistant]
+enabled = true
+channels = ["whatsapp.default"]
+```
+
+On first start, the Web backend pairs the account using QR or pair-code linking. `pair_phone` can seed pair-code linking, but leave it unset if you want QR pairing:
+
+```toml
+[channels.whatsapp.default]
+pair_phone = "<country-code-and-number-without-plus>"
+```
+
+Keep `session_path` on persistent storage. Removing it forces a fresh device link.
+
+The `channels` entry binds the channel alias to the agent that should answer it. Use your real agent alias instead of `assistant`.
+
+## Personal and business behavior
+
+For Web mode, `mode = "personal"` applies separate DM, group, and self-chat policies:
+
+| Field | Values | Effect |
+|---|---|---|
+| `dm_policy` | `allowlist`, `ignore`, `all` | Controls direct messages |
+| `group_policy` | `allowlist`, `ignore`, `all` | Controls group chats |
+| `self_chat_mode` | `true`, `false` | Controls the user's self-chat |
+| `mention_only` | `true`, `false` | Requires group messages to mention the bot |
+
+The default `mode = "business"` does not apply the personal DM/group policy split. For peer-gated regular-account deployments, use `mode = "personal"` with `dm_policy = "allowlist"` and `group_policy = "allowlist"`.
+
+## Restrict who can talk to the agent
+
+Inbound peer authorization lives in `peer_groups`. A group can target every WhatsApp alias with `channel = "whatsapp"` or one alias with `channel = "whatsapp.default"`.
+
+```toml
+[peer_groups.whatsapp_ops]
+channel = "whatsapp.default"
+agents = []
+external_peers = ["<allowed-whatsapp-peer>"]
+ignore = []
+```
+
+Use the peer identifier shape that the active backend reports. Cloud API usually reports sender phone identifiers from the webhook payload. Web mode may report chat or JID-shaped identifiers. Keep examples and fixtures neutral; do not commit real phone numbers, account IDs, or chat IDs.
+
+## Configuring from the CLI
+
+Prefer onboarding or `zeroclaw config set` for WhatsApp:
+
+```bash
+zeroclaw onboard channels
+zeroclaw config set channels.whatsapp.default.session-path ~/.zeroclaw/state/whatsapp-web/session.db
+```
+
+`zeroclaw channel add <type> <CONFIG>` is not the recommended setup path for WhatsApp. It takes a JSON object at the CLI layer, but current channel setup is routed through onboarding and config editing so secret handling, pairing, and peer authorization stay explicit.
+
+## Start and check
+
+After configuring one mode, start the channel runner:
+
+```bash
+zeroclaw channel start
+```
+
+Use `zeroclaw channel doctor` for a first check. For Web mode, also confirm the binary was built with `whatsapp-web`; for Cloud API mode, confirm the webhook tunnel and Meta verify token agree.


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Added a dedicated Signal channel guide that names the current `signal-cli daemon --http` requirement and documents the `channels.signal.default` config shape, agent binding, peer authorization, and group filters.
  - Added a dedicated WhatsApp guide that separates Cloud API mode from WhatsApp Web mode, including selector fields, agent binding, Web-mode policies, pairing notes, and peer authorization.
  - Promoted Signal and WhatsApp from the catch-all chat page into the channel overview and mdBook summary, and refreshed the overview's generic channel config example to use the current alias shape.
- **Scope boundary:** Documentation only. This PR does not change runtime behavior, onboarding prompts, config schema, pairing, or channel authorization logic.
- **Blast radius:** mdBook channel docs and navigation only.
- **Linked issue(s):** Closes #6315.
- **Labels:** `docs`, `type: docs`, `risk: low`, `size: S`.

## Validation Evidence (required)

- **Commands run and tail output:**

  ```bash
  git diff --check origin/master...HEAD
  ```

  Passed with no output.

  ```bash
  scripts/ci/docs_quality_gate.sh
  ```

  Passed. The gate reported existing `SUMMARY.md` MD025 findings outside changed lines as non-blocking and ended with:

  ```text
  No blocking markdown issues on changed lines.
  ```

  ```bash
  mdbook build -d /private/tmp/zc-6315-mdbook
  ```

  Passed. The build completed with existing warnings in generated/reference docs and wrote the HTML book:

  ```text
  INFO HTML book written to `/private/tmp/zc-6315-mdbook`
  ```

- **Beyond CI — what did you manually verify?** Compared the new docs against the current `SignalConfig`, `WhatsAppConfig`, channel alias table shape, and Signal channel implementation. Also scanned the edited docs to make sure the old `signal_cli_rest_url`, `signal-cli-rest-api`, and stale Signal `phone_number` example were removed from the touched channel docs.
- **If any command was intentionally skipped, why:** Full `cargo mdbook build` was not used for this low-risk docs-only change because it also regenerates CLI/config refs and rustdoc API output. The targeted mdBook build and docs quality gate cover the touched Markdown/navigation surface.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: N/A. Examples use neutral placeholders for phone numbers, tokens, peer IDs, and session paths.

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: N/A. This PR documents existing config fields and setup modes only.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PRs: `git revert 5f213e463` is the rollback plan.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A.
