### PR TITLE
docs(triage): define status label semantics

### DIFF
--- a/.claude/skills/github-issue-triage/SKILL.md
+++ b/.claude/skills/github-issue-triage/SKILL.md
@@ -18,7 +18,7 @@ Read these repository files at the start of every session — they are authorita
 
 Then read `references/triage-protocol.md` for the full mode-by-mode workflow.
 
-The protocol encodes operational details from RFC #5577 (governance, stale policy, label taxonomy) and RFC #5615 (contribution culture). If you need background context beyond what the protocol provides, fetch these RFCs (open issues in zeroclaw-labs/zeroclaw). The RFCs are authoritative where they conflict with this skill — but the protocol already reflects their current state, so routine sessions should not need to fetch them.
+The protocol encodes operational details from RFC #5577 (governance and stale thresholds), RFC #5615 (contribution culture), and later maintainer label-policy corrections. If you need background context beyond what the protocol provides, fetch those RFCs or the current maintainer label guide. RFC #5577 remains authoritative for stale timing; `docs/book/src/maintainers/labels.md` and `references/triage-protocol.md` carry the current operational label policy.
 
 ## Invocation
 
@@ -50,7 +50,7 @@ The protocol encodes operational details from RFC #5577 (governance, stale polic
 | Action | Authority | Condition |
 |---|---|---|
 | Apply labels | Act | Always |
-| Remove labels | Act | Only for labels the agent applied in this session, or `status:stale` when the author has re-engaged. Never remove `status:no-stale`, `priority:critical`, `status:blocked`, or `type:rfc` — these are protection labels. |
+| Remove labels | Act | Only for labels the agent applied in this session, or `status:stale` when the author has re-engaged. Never remove `status:no-stale`, `priority:p0`, or `type:rfc` autonomously. Do not remove `status:blocked` during routine triage; during a stale pass, first verify the recorded blocker and present any proposed `status:blocked` change to the user. |
 | Comment on an issue | Act | Always |
 | Close — fixed by merged PR | Act (single-issue: present first) | PR confirmed merged; issue explicitly referenced in PR |
 | Close — duplicate | Act (single-issue: present first) | Concrete shared identifier confirmed per §3 Pass 2; primary issue clearly identified |

--- a/.claude/skills/github-issue-triage/references/triage-protocol.md
+++ b/.claude/skills/github-issue-triage/references/triage-protocol.md
@@ -130,7 +130,7 @@ Process two groups:
 
 2. **Apply labels** — apply the appropriate primary label (`bug`, `feature`, `r:support`) plus any module/channel/provider labels derivable from the title or body (e.g., `channel:telegram`, `provider:ollama`). Apply risk tier if determinable.
 
-3. **Link open PRs** — search for open PRs that reference this issue number or describe the same fix. If found, apply `status:in-progress` and comment linking the PR so the reporter knows work is in progress.
+3. **Link open PRs** — search for open PRs that reference this issue number or describe the same fix. If found, apply `status:in-progress` and comment linking the PR so the reporter knows work is in progress. Do not add `status:no-stale` only because a PR exists; the stale pass excludes issues with open linked PRs.
 
 4. **Evaluate for community labels** — after classifying and labeling, ask:
    - Is this a bug or feature that is well-scoped, clearly documented, and accessible to a new contributor? → apply `good first issue`
@@ -273,7 +273,10 @@ Activity is defined as: a follow-up comment or update from the **original author
 - `priority:critical`
 - `type:rfc`
 - `status:no-stale`
+- an open linked PR
 - 10 or more 👍 reactions on the opening post (community has signaled relevance regardless of author silence)
+
+`status:in-progress` is a routing signal, not a permanent stale exemption by itself. During stale passes, verify that an open linked PR still exists. If the PR has closed without resolving the issue, remove or replace `status:in-progress` only after presenting the exact label change to the user.
 
 ### Stale enforcement steps
 
@@ -389,10 +392,11 @@ Derived from RFC #5577. Apply these consistently:
 ### Status
 
 - `status:stale` — original author has not engaged for 45+ days; pending closure
-- `status:blocked` — waiting on external blocker; exempt from stale
-- `status:in-progress` — linked open PR exists
+- `status:accepted` — RFC or work item accepted by the team; not stale-exempt by itself
+- `status:blocked` — waiting on external blocker; exempt from stale while the blocker is recorded
+- `status:in-progress` — linked open PR exists; verify live PR state before stale decisions
 - `status:wont-do` — architectural won't-fix; permanent decision, not a deferral
-- `status:no-stale` — explicitly exempt from stale automation; maintainer-applied
+- `status:no-stale` — explicitly exempt from stale automation; maintainer-applied with a recorded reason
 
 ### Module labels (apply when issue is scoped to a specific subsystem)
 

--- a/.claude/skills/github-issue-triage/references/triage-protocol.md
+++ b/.claude/skills/github-issue-triage/references/triage-protocol.md
@@ -24,7 +24,9 @@ If a required label is missing, create it before applying:
 
 ```bash
 gh label create "status:stale"       --color "E4E669" --repo zeroclaw-labs/zeroclaw
-gh label create "status:no-stale"    --color "E4E669" --repo zeroclaw-labs/zeroclaw
+gh label create "status:accepted"    --color "0E8A16" --repo zeroclaw-labs/zeroclaw
+gh label create "status:blocked"     --color "B60205" --repo zeroclaw-labs/zeroclaw
+gh label create "status:no-stale"    --color "0E8A16" --repo zeroclaw-labs/zeroclaw
 gh label create "status:wont-do"     --color "B60205" --repo zeroclaw-labs/zeroclaw
 gh label create "status:in-progress" --color "0075CA" --repo zeroclaw-labs/zeroclaw
 gh label create "duplicate"          --color "CFD3D7" --repo zeroclaw-labs/zeroclaw
@@ -258,9 +260,9 @@ Flag (do not close) issues that meet the stale entry condition per §4. Present 
 
 ## §4 Stale Mode
 
-**Purpose:** Enforce the RFC #5577 stale policy. Operate mechanically — policy thresholds are defined in the RFC and are not judgment calls.
+**Purpose:** Enforce the RFC #5577 stale policy. Operate mechanically — policy thresholds are defined in the RFC and are not judgment calls. Current maintainer operating rules add the exclusion checks below so the stale pass reflects live repository label policy.
 
-### Policy (from RFC #5577 §11)
+### Policy thresholds (from RFC #5577 §11)
 
 - Issues with **no activity for 45 days** → apply `status:stale` + comment asking if still relevant
 - Issues with **no activity for 15 days after `status:stale` was applied** (60 days total) → close with welcoming re-open invite
@@ -269,32 +271,49 @@ Activity is defined as: a follow-up comment or update from the **original author
 
 ### Exclusions — never apply stale to issues with any of
 
-- `status:blocked`
-- `priority:critical`
+- `status:blocked` with a recorded unresolved blocker
+- `priority:p0`
 - `type:rfc`
 - `status:no-stale`
 - an open linked PR
 - 10 or more 👍 reactions on the opening post (community has signaled relevance regardless of author silence)
 
+`status:blocked` protects an issue only while the blocker is recorded in a maintainer comment, issue body, or tracker entry and still appears unresolved. If the blocker is missing or resolved, present the exact `status:blocked` label change to the user before evaluating the issue for stale handling.
+
 `status:in-progress` is a routing signal, not a permanent stale exemption by itself. During stale passes, verify that an open linked PR still exists. If the PR has closed without resolving the issue, remove or replace `status:in-progress` only after presenting the exact label change to the user.
 
 ### Stale enforcement steps
 
-1. Fetch all open issues with `createdAt`, `author`, `comments`, and `reactions` fields.
+1. Fetch all open issues with `createdAt`, `author`, `labels`, `comments`, and `reactionGroups` fields.
 
-2. For each issue, compute **author-last-active**: the date of the most recent comment where `comment.author.login == issue.author.login`. If the author has never commented after opening, use `createdAt`. Maintainer comments, label changes, and PR links do not count.
+2. Fetch open PR metadata once for the stale pass and scan titles/bodies for issue references:
 
-3. For issues at 45–59 days since author-last-active (not already labeled `status:stale`):
+   ```bash
+   gh pr list --repo zeroclaw-labs/zeroclaw --state open --limit 300 \
+     --json number,title,body,url
+   ```
+
+   Use per-issue PR searches only when this batch result is inconclusive.
+
+3. For each issue, compute **author-last-active**: the date of the most recent comment where `comment.author.login == issue.author.login`. If the author has never commented after opening, use `createdAt`. Maintainer comments, label changes, and PR links do not count.
+
+4. Before proposing stale action, verify exclusions against current state:
+   - Check current labels for `priority:p0`, `type:rfc`, and `status:no-stale`.
+   - For `status:blocked`, fetch the issue body and relevant maintainer comments or tracker entry, then verify the recorded blocker and whether it is still unresolved. If not, present the label correction to the user first and do not treat the issue as exempt until the user approves the change.
+   - Check the open PR batch for issue references before relying on `status:in-progress` or stale eligibility. Fall back to a per-issue PR search only when the batch result is ambiguous.
+   - Check opening-post reactions for the 10-or-more 👍 threshold.
+
+5. For issues at 45–59 days since author-last-active (not already labeled `status:stale`):
    - Apply `status:stale`
    - Comment: acknowledge the issue is still valid, ask if it is still relevant or if the reporter has a workaround; mention that it will be closed in 15 days without a response but can always be reopened
 
-4. For issues already carrying `status:stale`, compute when the label was applied (check the label-application comment date or use `gh api` to check issue timeline events). Close only if **15+ days have passed since `status:stale` was applied** — not since author-last-active. The 15-day window is the reporter's guaranteed response time; do not shorten it.
+6. For issues already carrying `status:stale`, compute when the label was applied (check the label-application comment date or use `gh api` to check issue timeline events). Close only if **15+ days have passed since `status:stale` was applied** — not since author-last-active. The 15-day window is the reporter's guaranteed response time; do not shorten it.
    - Close with a comment: thank the reporter, explain the backlog hygiene reason, and include the phrase **"you can reopen this issue by commenting here, or open a new issue with updated context — either works"**
    - Reference a related open issue or feature if one exists
 
-5. **Reopened issues:** if an issue carrying `status:stale` has a comment from the original author posted *after* the stale label was applied, remove the `status:stale` label and skip it — the author has re-engaged. Similarly, if an issue was recently reopened (closed then reopened), remove `status:stale` and reset the clock from the reopen date.
+7. **Reopened issues:** if an issue carrying `status:stale` has a comment from the original author posted *after* the stale label was applied, remove the `status:stale` label and skip it — the author has re-engaged. Similarly, if an issue was recently reopened (closed then reopened), remove `status:stale` and reset the clock from the reopen date.
 
-6. Report the full list of actions to the user before executing. Confirm before proceeding.
+8. Report the full list of actions to the user before executing. Confirm before proceeding.
 
 ### Tone requirement for stale closures
 
@@ -371,7 +390,7 @@ Stale closures are especially sensitive — a reporter may have been waiting pat
 
 ## §7 Label Taxonomy
 
-Derived from RFC #5577. Apply these consistently:
+Derived from RFC #5577 and current maintainer label policy. Apply these consistently:
 
 ### Type
 
@@ -384,7 +403,7 @@ Derived from RFC #5577. Apply these consistently:
 
 ### Priority (apply when determinable)
 
-- `priority:critical` — security issue or complete workflow blocker
+- `priority:p0` — security issue or complete workflow blocker
 - `priority:high` — significant degraded experience
 - `priority:medium` — notable but has workaround
 - `priority:low` — minor issue or edge case
@@ -393,10 +412,10 @@ Derived from RFC #5577. Apply these consistently:
 
 - `status:stale` — original author has not engaged for 45+ days; pending closure
 - `status:accepted` — RFC or work item accepted by the team; not stale-exempt by itself
-- `status:blocked` — waiting on external blocker; exempt from stale while the blocker is recorded
+- `status:blocked` — waiting on external blocker; exempt from stale while the blocker is recorded and unresolved
 - `status:in-progress` — linked open PR exists; verify live PR state before stale decisions
 - `status:wont-do` — architectural won't-fix; permanent decision, not a deferral
-- `status:no-stale` — explicitly exempt from stale automation; maintainer-applied with a recorded reason
+- `status:no-stale` — explicitly exempt from stale automation for accepted or otherwise long-lived work that is not already protected by another exclusion; maintainer-applied with a recorded reason
 
 ### Module labels (apply when issue is scoped to a specific subsystem)
 
@@ -423,7 +442,7 @@ Before closing any issue, verify:
 - [ ] Comment is welcoming and specific to this issue
 - [ ] Comment tells the reporter explicitly how to reopen ("you can reopen this by commenting here")
 - [ ] Comment does not contain personal identifiers or real names
-- [ ] Issue is not in the exclusion list: `type:rfc`, open linked PR, `status:no-stale`, `priority:critical`, `status:blocked`
+- [ ] Issue is not in the exclusion list: `type:rfc`, open linked PR, `status:no-stale`, `priority:p0`, or `status:blocked` with a recorded unresolved blocker
 - [ ] Label has been applied matching the closure reason (e.g., `r:support`, `status:stale`)
 - [ ] Security issues have been redirected, not closed publicly
 

--- a/docs/book/src/foundations/fnd-003-governance.md
+++ b/docs/book/src/foundations/fnd-003-governance.md
@@ -20,6 +20,7 @@
 |---|---|---|
 | 1 | 2026-04-09 | Initial draft |
 | 2 | 2026-04-09 | Added §6.4 Architectural Compliance: Human Review, AI Support; added Discussion Question on AI automation of architecture reviews |
+| 3 | 2026-05-24 | Added #6808 operational-label-policy pointers; current label behavior lives in maintainer docs |
 
 ---
 
@@ -866,10 +867,16 @@ Use `#f1f5f9` (light gray) for all component labels to distinguish them visually
 
 ### `status:` — Where is this in the process?
 
+This table records governance intent and historical taxonomy shape. For current live label semantics and automation behavior, use the maintainer label guide as the operational reference; maintainer docs carry later label-policy corrections from #6808.
+
 | Label | Color | Use |
 |---|---|---|
 | `status:needs-triage` | `#f8fafc` White | Newly opened, not yet reviewed |
-| `status:blocked` | `#dc2626` Red | Waiting on something external |
+| `status:accepted` | `#0e8a16` Green | RFC or work item ratified; not stale-exempt by itself |
+| `status:blocked` | `#b60205` Red | Waiting on a recorded unresolved external dependency, maintainer decision, or linked prerequisite |
+| `status:in-progress` | `#0075ca` Blue | Open PR is actively targeting the issue; verify live PR state during stale passes |
+| `status:stale` | `#e4e669` Yellow | No original-author activity for the stale threshold window |
+| `status:no-stale` | `#0e8a16` Green | Explicit stale exemption with a recorded reason, for accepted or otherwise long-lived work not already protected by another exclusion |
 | `status:help-wanted` | `#059669` Green | Looking for a contributor |
 | `status:good-first-issue` | `#059669` Green | Suitable for new contributors |
 | `status:discussion` | `#a78bfa` Purple | Needs team discussion before work begins |
@@ -948,7 +955,7 @@ GitHub enforces CODEOWNERS automatically when the file exists and branch protect
 
 **Stale issue management (`.github/workflows/stale.yml`):**
 
-Issues with no activity for 45 days are labeled `status:stale` and a comment is posted asking if the issue is still relevant. Issues with no activity for 15 days after the stale label is applied are closed. This prevents the backlog from accumulating hundreds of issues that are months old and no longer relevant. Exclude `status:blocked`, `priority:critical`, and `type:rfc` from the stale process.
+Issues with no activity for 45 days are labeled `status:stale` and a comment is posted asking if the issue is still relevant. Issues with no activity for 15 days after the stale label is applied are closed. This prevents the backlog from accumulating hundreds of issues that are months old and no longer relevant. Exclude `priority:p0`, `type:rfc`, `status:no-stale`, issues with open linked PRs, and issues with `status:blocked` while a recorded blocker remains unresolved. The maintainer label guide and issue-triage protocol carry the current operational details.
 
 **PR size labeling (`.github/workflows/pr-size.yml`):**
 

--- a/docs/book/src/maintainers/labels.md
+++ b/docs/book/src/maintainers/labels.md
@@ -163,9 +163,9 @@ Track lifecycle state of RFCs and tracked work items. Applied manually.
 | Label | Description |
 |---|---|
 | `status:accepted` | RFC or work item ratified by the team. This does not exempt the issue from stale handling by itself. |
-| `status:blocked` | Work is valid but waiting on an external dependency, maintainer decision, or linked prerequisite. Exempt from stale while the blocker is recorded. |
+| `status:blocked` | Work is valid but waiting on an external dependency, maintainer decision, or linked prerequisite. Exempt from stale while the blocker is recorded and unresolved. Do not pair with `status:no-stale` for the same blocker. |
 | `status:in-progress` | An open PR is actively targeting this issue. Reconcile against live PR state during stale passes; the label is not a permanent exemption after the PR closes. |
-| `status:no-stale` | Explicit stale exemption for accepted or blocked work. Use only when a maintainer comment, issue body, or tracker entry records why the issue should stay open. |
+| `status:no-stale` | Explicit stale exemption for accepted or otherwise long-lived work that is not already protected by another stale exclusion. Use only when a maintainer comment, issue body, or tracker entry records why the issue should stay open. |
 
 ## Triage labels
 

--- a/docs/book/src/maintainers/labels.md
+++ b/docs/book/src/maintainers/labels.md
@@ -162,8 +162,10 @@ Track lifecycle state of RFCs and tracked work items. Applied manually.
 
 | Label | Description |
 |---|---|
-| `status:in-progress` | An open PR is actively targeting this issue |
-| `status:accepted` | RFC or work item ratified by the team |
+| `status:accepted` | RFC or work item ratified by the team. This does not exempt the issue from stale handling by itself. |
+| `status:blocked` | Work is valid but waiting on an external dependency, maintainer decision, or linked prerequisite. Exempt from stale while the blocker is recorded. |
+| `status:in-progress` | An open PR is actively targeting this issue. Reconcile against live PR state during stale passes; the label is not a permanent exemption after the PR closes. |
+| `status:no-stale` | Explicit stale exemption for accepted or blocked work. Use only when a maintainer comment, issue body, or tracker entry records why the issue should stay open. |
 
 ## Triage labels
 
@@ -177,7 +179,6 @@ Applied manually — the auto-response automation that used to handle these was 
 | `duplicate` | Duplicate of an existing issue |
 | `stale-candidate` | Dormant PR or issue; candidate for closing |
 | `superseded` | Replaced by a newer PR |
-| `status:no-stale` | Exempt from stale automation; accepted but blocked work |
 
 ## Maintenance triggers
 

--- a/docs/book/src/maintainers/pr-workflow.md
+++ b/docs/book/src/maintainers/pr-workflow.md
@@ -99,7 +99,7 @@ For AI-heavy PRs, reviewers focus on:
 
 - First maintainer triage target: **within 48 hours**.
 - Blocked PRs get one actionable checklist comment, not a series of partial reviews.
-- `status:no-stale` reserved for accepted-but-blocked work.
+- `status:no-stale` is reserved for accepted or blocked work with a recorded reason to stay open.
 
 For stacked work, require explicit `Depends on #...` so review order is deterministic.
 

--- a/docs/book/src/maintainers/pr-workflow.md
+++ b/docs/book/src/maintainers/pr-workflow.md
@@ -99,7 +99,7 @@ For AI-heavy PRs, reviewers focus on:
 
 - First maintainer triage target: **within 48 hours**.
 - Blocked PRs get one actionable checklist comment, not a series of partial reviews.
-- `status:no-stale` is reserved for accepted or blocked work with a recorded reason to stay open.
+- `status:no-stale` is reserved for accepted or otherwise long-lived work with a recorded reason to stay open when the issue is not already protected by another stale exclusion.
 
 For stacked work, require explicit `Depends on #...` so review order is deterministic.
 

--- a/docs/book/src/maintainers/reviewer-playbook.md
+++ b/docs/book/src/maintainers/reviewer-playbook.md
@@ -85,7 +85,10 @@ The same risk-routing principle applies to issues, but the labels and signals ar
 | `r:needs-repro` | Bug report missing a deterministic repro. Block deeper triage on this. |
 | `r:support` | Usage or help question better routed outside the bug backlog. |
 | `duplicate` / `invalid` | Non-actionable noise. Close with a polite pointer. |
-| `status:no-stale` | Accepted work waiting on an external blocker. Keeps the issue out of stale automation. |
+| `status:accepted` | The team has accepted the RFC or work item. Add `status:no-stale` only when the issue also needs stale protection. |
+| `status:blocked` | Valid work is waiting on an external dependency, maintainer decision, or linked prerequisite. Record the blocker. |
+| `status:in-progress` | An open PR is actively targeting the issue. Re-check live PR state before relying on it during stale passes. |
+| `status:no-stale` | Accepted or blocked work should stay open. Record the reason in a maintainer comment, issue body, or tracker entry. |
 
 If logs or payloads in the report contain personal identifiers or sensitive data, request redaction before deeper triage. The triage process must not propagate the exposure.
 
@@ -121,7 +124,7 @@ This keeps context loss low and avoids the next reviewer redoing the same fetche
 
 ## Weekly queue hygiene
 
-- Walk the stale queue. Apply `status:no-stale` only to accepted-but-blocked work.
+- Walk the stale queue. Apply `status:no-stale` only when accepted or blocked work has a recorded reason to stay open.
 - Prioritize `size: XS/S` bug and security PRs first.
 - Convert recurring support questions into docs improvements and auto-response guidance.
 

--- a/docs/book/src/maintainers/reviewer-playbook.md
+++ b/docs/book/src/maintainers/reviewer-playbook.md
@@ -86,9 +86,9 @@ The same risk-routing principle applies to issues, but the labels and signals ar
 | `r:support` | Usage or help question better routed outside the bug backlog. |
 | `duplicate` / `invalid` | Non-actionable noise. Close with a polite pointer. |
 | `status:accepted` | The team has accepted the RFC or work item. Add `status:no-stale` only when the issue also needs stale protection. |
-| `status:blocked` | Valid work is waiting on an external dependency, maintainer decision, or linked prerequisite. Record the blocker. |
+| `status:blocked` | Valid work is waiting on an external dependency, maintainer decision, or linked prerequisite. Record the blocker; this is stale protection only while that blocker remains unresolved. |
 | `status:in-progress` | An open PR is actively targeting the issue. Re-check live PR state before relying on it during stale passes. |
-| `status:no-stale` | Accepted or blocked work should stay open. Record the reason in a maintainer comment, issue body, or tracker entry. |
+| `status:no-stale` | Accepted or otherwise long-lived work should stay open and is not already protected by another stale exclusion. Record the reason in a maintainer comment, issue body, or tracker entry. |
 
 If logs or payloads in the report contain personal identifiers or sensitive data, request redaction before deeper triage. The triage process must not propagate the exposure.
 
@@ -124,7 +124,7 @@ This keeps context loss low and avoids the next reviewer redoing the same fetche
 
 ## Weekly queue hygiene
 
-- Walk the stale queue. Apply `status:no-stale` only when accepted or blocked work has a recorded reason to stay open.
+- Walk the stale queue. Apply `status:no-stale` only when accepted or otherwise long-lived work has a recorded reason to stay open and is not already protected by another stale exclusion.
 - Prioritize `size: XS/S` bug and security PRs first.
 - Convert recurring support questions into docs improvements and auto-response guidance.
 

--- a/docs/book/src/maintainers/skills.md
+++ b/docs/book/src/maintainers/skills.md
@@ -57,7 +57,7 @@ The `github-issue-triage` skill runs autonomous backlog sweeps within defined au
 - **Wont-fix pass** — close issues that won't be accepted, with a brief rationale
 - **Specific issue** — handle a single issue by number
 
-Labels and the stale policy are defined in [Reviewer playbook → Issue triage](./reviewer-playbook.md#issue-triage). The skill escalates ambiguity to the user before acting.
+Label definitions live in [Labels](./labels.md). Stale procedure lives in the issue-triage skill protocol, with reviewer-side context in [Reviewer playbook → Issue triage](./reviewer-playbook.md#issue-triage). The skill escalates ambiguity to the user before acting.
 
 PRs with merge conflicts receive `needs-author-action` only — no review, no diff comment — per `feedback_conflicts_label_only`.
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Documents maintainer semantics for `status:accepted`, `status:blocked`, `status:in-progress`, and `status:no-stale` in the maintainer label guide.
  - Clarifies that `status:accepted` is not stale protection by itself.
  - Clarifies that `status:blocked` is stale protection only while the blocker is recorded and unresolved.
  - Clarifies that `status:in-progress` is tied to a live open PR and must be rechecked during stale passes.
  - Aligns FND-003, maintainer docs, and the issue-triage skill protocol with the same status-label semantics, including current `priority:p0` stale protection.
- **Scope boundary:** This PR does not create, rename, migrate, delete, add, or remove any live GitHub labels. It does not change GitHub Actions stale automation or issue state. It does not resolve the separate terminal-resolution label split between `wontfix`, `status:wont-do`, and `status:wont-fix`.
- **Blast radius:** Governance/maintainer docs and the in-repo issue-triage skill guidance only.
- **Linked issue(s):** Related #6808. Follows #6855.
- **Labels:** `type: docs`, `risk: low`, `size: XS`, `docs`.

## Validation Evidence (required)

- **Commands run and tail output:**

```text
$ git diff --check

$ bash -lc 'DOCS_FILES=$(printf "%s\n" ".claude/skills/github-issue-triage/SKILL.md" ".claude/skills/github-issue-triage/references/triage-protocol.md" "docs/book/src/foundations/fnd-003-governance.md" "docs/book/src/maintainers/labels.md" "docs/book/src/maintainers/pr-workflow.md" "docs/book/src/maintainers/reviewer-playbook.md" "docs/book/src/maintainers/skills.md"); export DOCS_FILES; bash scripts/ci/docs_quality_gate.sh'
Linting docs files: .claude/skills/github-issue-triage/SKILL.md .claude/skills/github-issue-triage/references/triage-protocol.md docs/book/src/foundations/fnd-003-governance.md docs/book/src/maintainers/labels.md docs/book/src/maintainers/pr-workflow.md docs/book/src/maintainers/reviewer-playbook.md docs/book/src/maintainers/skills.md
markdownlint-cli2 v0.20.0 (markdownlint v0.40.0)
Finding: .claude/skills/github-issue-triage/SKILL.md .claude/skills/github-issue-triage/references/triage-protocol.md docs/book/src/foundations/fnd-003-governance.md docs/book/src/maintainers/labels.md docs/book/src/maintainers/pr-workflow.md docs/book/src/maintainers/reviewer-playbook.md docs/book/src/maintainers/skills.md !target/**
Linting: 7 file(s)
Existing markdown issues outside changed lines (non-blocking):
  - docs/book/src/foundations/fnd-003-governance.md has pre-existing MD001/MD012/MD022/MD026/MD034/MD036 issues outside changed lines.
No blocking markdown issues on changed lines.
```

- **Beyond CI — what did you manually verify?** Verified from the public diff and PR metadata that the PR is docs/skill guidance only, with no live label mutations, no GitHub Actions stale-automation changes, and no issue-state changes. Confirmed #6855 is merged. Confirmed #6808 is open and includes the maintainer request for @WareWolf-MoonWall's FND-003 review. Reviewed the status/stale-semantics wording across all touched files; deferred the separate terminal-resolution label split.
- **If any command was intentionally skipped, why:** Rust cargo validation was skipped because this is a docs-only and skill-guidance change.

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `Yes`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: Product/runtime behavior does not gain a network call. The issue-triage skill protocol now documents a GitHub PR metadata fetch during stale passes so maintainers can verify `status:in-progress` against open PR state.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: N/A

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PRs: revert the PR if the status-label wording proves wrong or conflicts with the final #6808 policy direction.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Scope materially carried forward: N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why (inspiration-only, no direct code/design carry-over): No superseded PR content was incorporated.
