### PR TITLE
fix(update): verify self-update downloads against SHA256SUMS

### DIFF
--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -1,6 +1,7 @@
 //! `zeroclaw update` — self-update pipeline with rollback.
 
 use anyhow::{Context, Result, bail};
+use sha2::{Digest, Sha256};
 use std::path::Path;
 
 const GITHUB_RELEASES_LATEST_URL: &str =
@@ -13,6 +14,7 @@ pub struct UpdateInfo {
     pub current_version: String,
     pub latest_version: String,
     pub download_url: Option<String>,
+    pub sha256sums_url: Option<String>,
     pub is_newer: bool,
 }
 
@@ -57,12 +59,14 @@ pub async fn check(target_version: Option<&str>) -> Result<UpdateInfo> {
         .to_string();
 
     let download_url = find_asset_url(&release);
+    let sha256sums_url = find_sha256sums_url(&release);
     let is_newer = version_is_newer(&current, &tag);
 
     Ok(UpdateInfo {
         current_version: current,
         latest_version: tag,
         download_url,
+        sha256sums_url,
         is_newer,
     })
 }
@@ -104,7 +108,12 @@ pub async fn run(target_version: Option<&str>) -> Result<()> {
     );
     let temp_dir = tempfile::tempdir().context("failed to create temp dir")?;
     let download_path = temp_dir.path().join("zeroclaw_new");
-    download_binary(&download_url, &download_path).await?;
+    download_binary(
+        &download_url,
+        update_info.sha256sums_url.as_deref(),
+        &download_path,
+    )
+    .await?;
 
     // Phase 3: Backup
     ::zeroclaw_log::record!(
@@ -193,6 +202,42 @@ fn find_asset_url(release: &serde_json::Value) -> Option<String> {
     })
 }
 
+fn find_sha256sums_url(release: &serde_json::Value) -> Option<String> {
+    let assets = release["assets"].as_array()?;
+    assets
+        .iter()
+        .find_map(|asset| sha256sums_url_for_asset(asset, is_exact_sha256sums_asset))
+        .or_else(|| {
+            assets
+                .iter()
+                .find_map(|asset| sha256sums_url_for_asset(asset, is_sha256sums_asset))
+        })
+}
+
+fn sha256sums_url_for_asset(
+    asset: &serde_json::Value,
+    predicate: impl Fn(&str) -> bool,
+) -> Option<String> {
+    let name = asset["name"].as_str()?;
+    if !predicate(name) {
+        return None;
+    }
+    let url = asset["browser_download_url"].as_str()?.trim();
+    (!url.is_empty()).then(|| url.to_string())
+}
+
+fn is_exact_sha256sums_asset(name: &str) -> bool {
+    name.eq_ignore_ascii_case("sha256sums")
+}
+
+fn is_sha256sums_asset(name: &str) -> bool {
+    is_exact_sha256sums_asset(name)
+        || name.eq_ignore_ascii_case("sha256sums.txt")
+        || name
+            .rsplit_once('.')
+            .is_some_and(|(_, ext)| ext.eq_ignore_ascii_case("sha256sums"))
+}
+
 fn is_installable_release_asset(name: &str, target: &str) -> bool {
     name == format!("zeroclaw-{target}.tar.gz") || name == format!("zeroclaw-{target}.tgz")
 }
@@ -230,7 +275,7 @@ fn version_is_newer(current: &str, candidate: &str) -> bool {
     cand > cur
 }
 
-async fn download_binary(url: &str, dest: &Path) -> Result<()> {
+async fn download_binary(url: &str, sha256sums_url: Option<&str>, dest: &Path) -> Result<()> {
     let client = reqwest::Client::builder()
         .user_agent(format!("zeroclaw/{}", env!("CARGO_PKG_VERSION")))
         .timeout(std::time::Duration::from_secs(300))
@@ -246,6 +291,17 @@ async fn download_binary(url: &str, dest: &Path) -> Result<()> {
     }
 
     let bytes = resp.bytes().await.context("failed to read download body")?;
+
+    if let Some(sums_url) = sha256sums_url {
+        verify_download_checksum(&bytes, url, sums_url, &client).await?;
+    } else {
+        ::zeroclaw_log::record!(
+            WARN,
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                .with_outcome(::zeroclaw_log::EventOutcome::Unknown),
+            "No SHA256SUMS asset found; skipping update download checksum verification"
+        );
+    }
 
     // Release assets are .tar.gz archives containing a single `zeroclaw` binary.
     // Extract the binary from the archive instead of writing the raw tarball.
@@ -266,6 +322,91 @@ async fn download_binary(url: &str, dest: &Path) -> Result<()> {
     }
 
     Ok(())
+}
+
+async fn verify_download_checksum(
+    bytes: &[u8],
+    asset_url: &str,
+    sha256sums_url: &str,
+    client: &reqwest::Client,
+) -> Result<()> {
+    let asset_name = asset_name_from_url(asset_url)
+        .context("cannot derive release asset filename from download URL")?;
+
+    let sums_resp = client
+        .get(sha256sums_url)
+        .send()
+        .await
+        .context("failed to fetch SHA256SUMS")?;
+    if !sums_resp.status().is_success() {
+        bail!("SHA256SUMS fetch returned {}", sums_resp.status());
+    }
+
+    let sums_text = sums_resp
+        .text()
+        .await
+        .context("failed to read SHA256SUMS body")?;
+    verify_checksum_bytes(bytes, &asset_name, &sums_text)?;
+
+    ::zeroclaw_log::record!(
+        INFO,
+        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+            .with_outcome(::zeroclaw_log::EventOutcome::Success)
+            .with_attrs(::serde_json::json!({"asset": asset_name})),
+        "Update download checksum verified"
+    );
+    Ok(())
+}
+
+fn verify_checksum_bytes(bytes: &[u8], asset_name: &str, sums_text: &str) -> Result<()> {
+    let expected_hex = expected_sha256_for_asset(sums_text, asset_name)?;
+    let actual_hex = hex::encode(Sha256::digest(bytes));
+
+    if !actual_hex.eq_ignore_ascii_case(expected_hex) {
+        bail!(
+            "checksum mismatch for '{asset_name}': expected {expected_hex}, got {actual_hex}. \
+             The downloaded update may be corrupted or tampered with."
+        );
+    }
+
+    Ok(())
+}
+
+fn asset_name_from_url(url: &str) -> Option<String> {
+    reqwest::Url::parse(url)
+        .ok()?
+        .path_segments()?
+        .next_back()
+        .filter(|name| !name.is_empty())
+        .map(str::to_string)
+}
+
+fn expected_sha256_for_asset<'a>(sums_text: &'a str, asset_name: &str) -> Result<&'a str> {
+    for line in sums_text.lines() {
+        let mut parts = line.split_whitespace();
+        let Some(digest) = parts.next() else {
+            continue;
+        };
+        let Some(name) = parts.next() else {
+            continue;
+        };
+        let name = name.trim_start_matches('*');
+        if name == asset_name {
+            if parts.next().is_some() {
+                bail!("invalid SHA256SUMS entry for '{asset_name}'");
+            }
+            if !is_sha256_hex(digest) {
+                bail!("invalid SHA256SUMS entry for '{asset_name}'");
+            }
+            return Ok(digest);
+        }
+    }
+
+    bail!("asset '{asset_name}' not found in SHA256SUMS")
+}
+
+fn is_sha256_hex(value: &str) -> bool {
+    value.len() == 64 && value.bytes().all(|b| b.is_ascii_hexdigit())
 }
 
 /// Extract the `zeroclaw` binary from a `.tar.gz` archive.
@@ -590,6 +731,245 @@ mod tests {
     fn find_asset_url_returns_none_for_missing_assets() {
         let release = serde_json::json!({});
         assert!(find_asset_url(&release).is_none());
+    }
+
+    #[test]
+    fn find_sha256sums_url_accepts_common_names() {
+        for name in ["SHA256SUMS", "sha256sums.txt", "checksums.sha256sums"] {
+            let release = make_release(&[name]);
+            assert_eq!(
+                find_sha256sums_url(&release),
+                Some(format!("https://example.com/{name}"))
+            );
+        }
+    }
+
+    #[test]
+    fn find_sha256sums_url_is_case_insensitive() {
+        let release = make_release(&["Sha256Sums"]);
+        assert_eq!(
+            find_sha256sums_url(&release),
+            Some("https://example.com/Sha256Sums".to_string())
+        );
+    }
+
+    #[test]
+    fn find_sha256sums_url_skips_missing_or_unusable_url() {
+        let release = serde_json::json!({
+            "assets": [
+                {
+                    "name": "zeroclaw-x86_64-unknown-linux-gnu.tar.gz",
+                    "browser_download_url": "https://example.com/asset"
+                },
+                {
+                    "name": "SHA256SUMS",
+                    "browser_download_url": ""
+                },
+                {
+                    "name": "sha256sums.txt",
+                    "browser_download_url": null
+                },
+                {
+                    "name": "checksums.sha256sums",
+                    "browser_download_url": "https://example.com/checksums.sha256sums"
+                }
+            ]
+        });
+
+        assert_eq!(
+            find_sha256sums_url(&release),
+            Some("https://example.com/checksums.sha256sums".to_string())
+        );
+    }
+
+    #[test]
+    fn find_sha256sums_url_prefers_canonical_asset() {
+        let release = serde_json::json!({
+            "assets": [
+                {
+                    "name": "checksums.sha256sums",
+                    "browser_download_url": "https://example.com/checksums.sha256sums"
+                },
+                {
+                    "name": "SHA256SUMS",
+                    "browser_download_url": "https://example.com/SHA256SUMS"
+                }
+            ]
+        });
+
+        assert_eq!(
+            find_sha256sums_url(&release),
+            Some("https://example.com/SHA256SUMS".to_string())
+        );
+    }
+
+    #[test]
+    fn expected_sha256_for_asset_matches_text_and_binary_mode_entries() {
+        let digest = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+        let sums = format!(
+            "{digest}  zeroclaw-aarch64-apple-darwin.tar.gz\n\
+             {digest} *zeroclaw-x86_64-unknown-linux-gnu.tar.gz\n"
+        );
+
+        assert_eq!(
+            expected_sha256_for_asset(&sums, "zeroclaw-aarch64-apple-darwin.tar.gz").unwrap(),
+            digest
+        );
+        assert_eq!(
+            expected_sha256_for_asset(&sums, "zeroclaw-x86_64-unknown-linux-gnu.tar.gz").unwrap(),
+            digest
+        );
+    }
+
+    #[test]
+    fn expected_sha256_for_asset_rejects_missing_or_malformed_entry() {
+        let err = expected_sha256_for_asset(
+            "not-a-hex-digest  zeroclaw-x86_64-unknown-linux-gnu.tar.gz\n",
+            "zeroclaw-x86_64-unknown-linux-gnu.tar.gz",
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("invalid SHA256SUMS entry"));
+
+        let err = expected_sha256_for_asset(
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  other.tar.gz\n",
+            "zeroclaw-x86_64-unknown-linux-gnu.tar.gz",
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("not found"));
+
+        let err = expected_sha256_for_asset(
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  zeroclaw-x86_64-unknown-linux-gnu.tar.gz extra\n",
+            "zeroclaw-x86_64-unknown-linux-gnu.tar.gz",
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("invalid SHA256SUMS entry"));
+    }
+
+    #[test]
+    fn verify_checksum_bytes_accepts_matching_digest_and_rejects_mismatch() {
+        let asset_name = "zeroclaw-x86_64-unknown-linux-gnu.tar.gz";
+        let digest = hex::encode(Sha256::digest(b"downloaded bytes"));
+        let sums = format!("{digest}  {asset_name}\n");
+
+        verify_checksum_bytes(b"downloaded bytes", asset_name, &sums).unwrap();
+
+        let err = verify_checksum_bytes(b"tampered bytes", asset_name, &sums)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("checksum mismatch"));
+    }
+
+    #[test]
+    fn asset_name_from_url_uses_last_path_component() {
+        assert_eq!(
+            asset_name_from_url(
+                "https://github.com/zeroclaw-labs/zeroclaw/releases/download/v0.8.0/zeroclaw-aarch64-apple-darwin.tar.gz"
+            ),
+            Some("zeroclaw-aarch64-apple-darwin.tar.gz".to_string())
+        );
+        assert_eq!(
+            asset_name_from_url(
+                "https://github.com/zeroclaw-labs/zeroclaw/releases/download/v0.8.0/zeroclaw-aarch64-apple-darwin.tar.gz?download=1#asset"
+            ),
+            Some("zeroclaw-aarch64-apple-darwin.tar.gz".to_string())
+        );
+        assert_eq!(asset_name_from_url("https://example.com/releases/"), None);
+    }
+
+    #[tokio::test]
+    async fn download_binary_verifies_checksum_before_writing() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let asset = b"downloaded bytes";
+        let digest = hex::encode(Sha256::digest(asset));
+        let sums = format!("{digest}  zeroclaw-test.bin\n");
+
+        Mock::given(method("GET"))
+            .and(path("/zeroclaw-test.bin"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(asset))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/SHA256SUMS"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(sums))
+            .mount(&server)
+            .await;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = tmp.path().join("zeroclaw_new");
+        download_binary(
+            &format!("{}/zeroclaw-test.bin", server.uri()),
+            Some(&format!("{}/SHA256SUMS", server.uri())),
+            &dest,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(std::fs::read(dest).unwrap(), asset);
+    }
+
+    #[tokio::test]
+    async fn download_binary_rejects_checksum_mismatch_without_writing() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let asset = b"downloaded bytes";
+        let digest = hex::encode(Sha256::digest(b"different bytes"));
+        let sums = format!("{digest}  zeroclaw-test.bin\n");
+
+        Mock::given(method("GET"))
+            .and(path("/zeroclaw-test.bin"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(asset))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/SHA256SUMS"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(sums))
+            .mount(&server)
+            .await;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = tmp.path().join("zeroclaw_new");
+        let err = download_binary(
+            &format!("{}/zeroclaw-test.bin", server.uri()),
+            Some(&format!("{}/SHA256SUMS", server.uri())),
+            &dest,
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+
+        assert!(err.contains("checksum mismatch"));
+        assert!(!dest.exists());
+    }
+
+    #[tokio::test]
+    async fn download_binary_preserves_missing_checksum_fallback() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let asset = b"downloaded bytes";
+
+        Mock::given(method("GET"))
+            .and(path("/zeroclaw-test.bin"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(asset))
+            .mount(&server)
+            .await;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = tmp.path().join("zeroclaw_new");
+        download_binary(&format!("{}/zeroclaw-test.bin", server.uri()), None, &dest)
+            .await
+            .unwrap();
+
+        assert_eq!(std::fs::read(dest).unwrap(), asset);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Restores `zeroclaw update` discovery of a release `SHA256SUMS` asset.
  - Verifies the downloaded update bytes against the matching SHA-256 digest before extracting or writing the new binary.
  - Keeps the previous fallback behavior from #4434: if a release has no `SHA256SUMS` asset, the update path warns and continues instead of failing closed.
  - Adds behavior coverage for the real download path so checksum match, checksum mismatch, and missing-checksum fallback are all exercised.
- **Scope boundary:** This does not change `install.sh`, release publishing, dashboard self-update UX, or the existing binary architecture/smoke validation stages.
- **Blast radius:** Limited to `zeroclaw update` self-update downloads in the root CLI. The installer path already verifies prebuilt downloads separately.
- **Linked issue(s):** Related #6074. Recovers the `c96bd63e` / #4434 checksum slice.
- **Labels:** `bug`, `risk: high`, `size: M`, `core`

## Validation Evidence (required)

- **Commands run and tail output:**

  ```text
  git diff --check
  Result: passed.

  zc-cargo fmt --all -- --check
  Result: passed.

  zc-cargo test -p zeroclawlabs --bin zeroclaw sha256 -- --nocapture
  Result: passed. 5 tests passed, 0 failed, 247 filtered.

  zc-cargo test -p zeroclawlabs --bin zeroclaw commands::update::tests -- --nocapture
  Result: passed. 31 tests passed, 0 failed, 226 filtered.

  zc-cargo clippy -p zeroclawlabs --bin zeroclaw -- -D warnings
  Result: passed.

  zc-cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
  Result: passed.

  zc-cargo nextest run --locked --workspace --exclude zeroclaw-desktop
  Result: passed. 7979 tests passed, 10 skipped.
  ```

- **Beyond CI — what did you manually verify?** Compared this recovery against the original #4434 behavior and current release packaging. Current release publishing emits a top-level `SHA256SUMS` asset, and `install.sh` already verifies that same asset for initial prebuilt installs. This PR restores the missing equivalent check for the self-update path.
- **If any command was intentionally skipped, why:** None.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `Yes`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: `zeroclaw update` now performs one additional release-asset fetch for `SHA256SUMS` when that asset is present. The fetched file is public release metadata and is used only to verify the downloaded update bytes before extraction/write.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: `N/A`

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <merge-sha>`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** `zeroclaw update` fails during download with `failed to fetch SHA256SUMS`, `asset '<name>' not found in SHA256SUMS`, `invalid SHA256SUMS entry`, or `checksum mismatch` before any binary swap occurs.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): #4434 by @spacelobster88
- Scope materially carried forward: `SHA256SUMS` release-asset discovery, digest lookup by downloaded asset filename, byte-level SHA-256 verification before extraction/write, and warn-and-continue behavior when no checksum asset exists.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `Yes`
- If `No`, why (inspiration-only, no direct code/design carry-over): `N/A`
