### PR TITLE
fix(providers): preserve full reqwest error chains in transport/log diagnostics

### DIFF
--- a/crates/zeroclaw-providers/src/anthropic.rs
+++ b/crates/zeroclaw-providers/src/anthropic.rs
@@ -1191,7 +1191,9 @@ impl ModelProvider for AnthropicModelProvider {
             let response = match req.send().await {
                 Ok(r) => r,
                 Err(e) => {
-                    let _ = tx.send(Err(StreamError::Http(e.to_string()))).await;
+                    let _ = tx
+                        .send(Err(StreamError::Http(super::format_error_chain(&e))))
+                        .await;
                     return;
                 }
             };

--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -450,7 +450,9 @@ impl OpenAiCompatibleModelProvider {
                     WARN,
                     ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
                         .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                        .with_attrs(::serde_json::json!({"error": format!("{}", error)})),
+                        .with_attrs(
+                            ::serde_json::json!({"error": super::format_error_chain(&error)})
+                        ),
                     "Failed to build proxied timeout client with custom headers: "
                 );
                 Client::new()
@@ -513,7 +515,9 @@ impl OpenAiCompatibleModelProvider {
                     WARN,
                     ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
                         .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                        .with_attrs(::serde_json::json!({"error": format!("{}", error)})),
+                        .with_attrs(
+                            ::serde_json::json!({"error": super::format_error_chain(&error)})
+                        ),
                     "Failed to build proxied streaming client with custom headers: "
                 );
                 Client::new()
@@ -528,7 +532,7 @@ impl OpenAiCompatibleModelProvider {
                 WARN,
                 ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
                     .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                    .with_attrs(::serde_json::json!({"error": format!("{}", error)})),
+                    .with_attrs(::serde_json::json!({"error": super::format_error_chain(&error)})),
                 "Failed to build proxied streaming client: "
             );
             Client::new()
@@ -1270,7 +1274,9 @@ fn sse_bytes_to_chunks(
         match response.error_for_status_ref() {
             Ok(_) => {}
             Err(e) => {
-                let _ = tx.send(Err(StreamError::Http(e.to_string()))).await;
+                let _ = tx
+                    .send(Err(StreamError::Http(super::format_error_chain(&e))))
+                    .await;
                 return;
             }
         }
@@ -1332,7 +1338,9 @@ fn sse_bytes_to_chunks(
                     }
                 }
                 Err(e) => {
-                    let _ = tx.send(Err(StreamError::Http(e.to_string()))).await;
+                    let _ = tx
+                        .send(Err(StreamError::Http(super::format_error_chain(&e))))
+                        .await;
                     return;
                 }
             }
@@ -1371,7 +1379,9 @@ fn sse_bytes_to_events_for_contract(
         match response.error_for_status_ref() {
             Ok(_) => {}
             Err(e) => {
-                let _ = tx.send(Err(StreamError::Http(e.to_string()))).await;
+                let _ = tx
+                    .send(Err(StreamError::Http(super::format_error_chain(&e))))
+                    .await;
                 return;
             }
         }
@@ -1498,7 +1508,9 @@ fn sse_bytes_to_events_for_contract(
                     }
                 }
                 Err(e) => {
-                    let _ = tx.send(Err(StreamError::Http(e.to_string()))).await;
+                    let _ = tx
+                        .send(Err(StreamError::Http(super::format_error_chain(&e))))
+                        .await;
                     return;
                 }
             }
@@ -1994,7 +2006,7 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
                                 "model_provider": &self.name,
                                 "url": &url,
                                 "phase": "model_list_request",
-                                "error": format!("{}", e),
+                                "error": super::format_error_chain(&e),
                             })),
                         "compatible: model list request failed"
                     );
@@ -2015,7 +2027,7 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
                         .with_attrs(::serde_json::json!({
                             "model_provider": &self.name,
                             "phase": "model_list_parse",
-                            "error": format!("{}", e),
+                            "error": super::format_error_chain(&e),
                         })),
                     "compatible: model list returned invalid JSON"
                 );
@@ -2582,7 +2594,9 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
             let response = match req_builder.send().await {
                 Ok(r) => r,
                 Err(e) => {
-                    let _ = tx.send(Err(StreamError::Http(e.to_string()))).await;
+                    let _ = tx
+                        .send(Err(StreamError::Http(super::format_error_chain(&e))))
+                        .await;
                     return;
                 }
             };
@@ -2719,7 +2733,9 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
             let response = match req_builder.send().await {
                 Ok(r) => r,
                 Err(e) => {
-                    let _ = tx.send(Err(StreamError::Http(e.to_string()))).await;
+                    let _ = tx
+                        .send(Err(StreamError::Http(super::format_error_chain(&e))))
+                        .await;
                     return;
                 }
             };
@@ -2821,7 +2837,9 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
             let response = match req_builder.send().await {
                 Ok(r) => r,
                 Err(e) => {
-                    let _ = tx.send(Err(StreamError::Http(e.to_string()))).await;
+                    let _ = tx
+                        .send(Err(StreamError::Http(super::format_error_chain(&e))))
+                        .await;
                     return;
                 }
             };

--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -857,6 +857,18 @@ pub fn sanitize_api_error(input: &str) -> String {
     format!("{}...", &scrubbed[..end])
 }
 
+/// Format an error including its full source chain and sanitize the result.
+pub fn format_error_chain(error: &(dyn std::error::Error + 'static)) -> String {
+    let mut formatted = String::new();
+    let _ = std::fmt::Write::write_fmt(&mut formatted, format_args!("{error}"));
+    let mut current = error.source();
+    while let Some(source) = current {
+        let _ = std::fmt::Write::write_fmt(&mut formatted, format_args!(": {source}"));
+        current = source.source();
+    }
+    sanitize_api_error(&formatted)
+}
+
 /// Build a sanitized model_provider error from a failed HTTP response.
 pub async fn api_error(model_provider: &str, response: reqwest::Response) -> anyhow::Error {
     let status = response.status();

--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -2704,6 +2704,45 @@ mod tests {
     // ── API error sanitization ───────────────────────────────
 
     #[test]
+    fn format_error_chain_includes_sources_and_sanitizes_output() {
+        #[derive(Debug)]
+        struct ChainError {
+            message: &'static str,
+            source: Option<Box<dyn std::error::Error + 'static>>,
+        }
+
+        impl std::fmt::Display for ChainError {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "{}", self.message)
+            }
+        }
+
+        impl std::error::Error for ChainError {
+            fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+                self.source.as_deref()
+            }
+        }
+
+        let error = ChainError {
+            message: "outer context",
+            source: Some(Box::new(ChainError {
+                message: "middle context",
+                source: Some(Box::new(ChainError {
+                    message: "inner source leaked sk-1234567890abcdef",
+                    source: None,
+                })),
+            })),
+        };
+
+        let result = format_error_chain(&error);
+
+        assert!(result.contains("outer context"));
+        assert!(result.contains("middle context"));
+        assert!(result.contains("inner source leaked [REDACTED]"));
+        assert!(!result.contains("sk-1234567890abcdef"));
+    }
+
+    #[test]
     fn sanitize_scrubs_sk_prefix() {
         let input = "request failed: sk-1234567890abcdef";
         let out = sanitize_api_error(input);

--- a/crates/zeroclaw-providers/src/openrouter.rs
+++ b/crates/zeroclaw-providers/src/openrouter.rs
@@ -408,7 +408,7 @@ impl OpenRouterModelProvider {
         response: reqwest::Response,
     ) -> anyhow::Result<String> {
         response.text().await.map_err(|error| {
-            let sanitized = super::sanitize_api_error(&format!("{}", error));
+            let sanitized = super::format_error_chain(&error);
             ::zeroclaw_log::record!(
                 ERROR,
                 ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
@@ -849,7 +849,9 @@ impl ModelProvider for OpenRouterModelProvider {
             {
                 Ok(r) => r,
                 Err(e) => {
-                    let _ = tx.send(Err(StreamError::Http(e.to_string()))).await;
+                    let _ = tx
+                        .send(Err(StreamError::Http(super::format_error_chain(&e))))
+                        .await;
                     return;
                 }
             };


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Provider transport failures were collapsing `reqwest::Error` to top-level text, hiding root causes (timeout vs DNS vs TLS vs connection refused) in one-line diagnostics.
  - Added shared formatter `format_error_chain(...)` in `zeroclaw-providers/src/lib.rs` to traverse `Error::source()` and sanitize the full chain once.
  - Rewired affected call sites in `compatible.rs`, `openrouter.rs`, and `anthropic.rs` to use the shared formatter for `StreamError::Http` and structured `"error"` attrs.
  - Kept error sanitization in the path to preserve existing secret-redaction behavior while increasing transport detail.
- **Scope boundary:** Does not change request logic, retry/backoff, HTTP status handling, provider auth, or logging schema shape; only the error message content for reqwest transport failures.
- **Blast radius:** `zeroclaw-providers` diagnostics paths for OpenAI-compatible, OpenRouter, and Anthropic streaming/list-model transport failures; downstream impact is improved log/message text.
- **Linked issue(s):** Closes #6889
- **Labels:** `type: bug`, `priority:p2`, `area:provider`, `area:observability`, `risk: medium`, `size: S`

- **Change sketch:**
  - `lib.rs`
    - Added `format_error_chain(error: &(dyn std::error::Error + 'static)) -> String`
  - `compatible.rs`
    - Replaced `e.to_string()` / `format!("{}", e)` at listed transport/log points with `super::format_error_chain(&e)` (and `&error` variants)
  - `openrouter.rs`
    - Switched transport/body-read error formatting to shared chain formatter
  - `anthropic.rs`
    - Switched streaming transport error formatting to shared chain formatter

```rust
// before
Err(StreamError::Http(e.to_string()))

// after
Err(StreamError::Http(super::format_error_chain(&e)))
```

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check`  
    - pass after formatting updates.
  - `cargo clippy --all-targets -- -D warnings`  
    - failed on pre-existing unrelated lint in `crates/zeroclaw-channels/src/wecom_ws.rs:2352` (`clippy::while_let_loop`).
  - `cargo test`  
    - pass.
- **Beyond CI — what did you manually verify?** Reviewed all issue-listed call sites and confirmed they now route through full-chain formatting + sanitization; did not run live unreachable-endpoint repro against external services in this pass.
- **If any command was intentionally skipped, why:** None.

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: N/A.

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: exact upgrade steps for existing users: No upgrade steps required.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert 6f13871 dbd411e`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** If regression occurs, provider transport lines lose chain detail and revert to top-level summaries; grep for `StreamError::Http(` outputs/log attrs lacking nested `: ...` cause context.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line):
- Scope materially carried forward:
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`No`)
- If `No`, why (inspiration-only, no direct code/design carry-over):

---

**Labels** live in the GitHub label UI, not in the body. Maintainers and reviewers with label permissions set `risk:*`, `size:*`, and scope labels via the sidebar. If auto-labels need correction, add `risk: manual` and the intended label. Contributors without label permission can note the mismatch in a comment.

**Do not add bot/AI attribution footers** such as `Co-authored-by: Claude ...`
or `Created with Claude Code` to the PR body or commit-message tail. Human
co-author trailers are appropriate only for incorporated contributor work under
the supersede-attribution section and privacy contract.

**Privacy contract** (`docs/book/src/contributing/privacy.md`) is a merge gate. Never commit real identities, secrets, personal emails, or PII in diff, tests, fixtures, or docs.