### PR TITLE
fix(security): conditionally bind /lib64 and /lib in bubblewrap sandbox

### DIFF
--- a/crates/zeroclaw-runtime/src/security/bubblewrap.rs
+++ b/crates/zeroclaw-runtime/src/security/bubblewrap.rs
@@ -64,6 +64,17 @@ impl Sandbox for BubblewrapSandbox {
             "--unshare-all",
             "--die-with-parent",
         ]);
+        // Conditionally bind dynamic-loader library directories that may exist
+        // on the host.  On Fedora / RHEL systems the ELF interpreter and shared
+        // libraries live in /lib64; on some older or non-merged-usr distros they
+        // live in /lib.  Without these paths inside the sandbox, any dynamically
+        // linked executable (including `cargo`) will fail to start even when its
+        // binary is reachable.
+        for lib_dir in &["/lib64", "/lib"] {
+            if std::path::Path::new(lib_dir).exists() {
+                bwrap_cmd.args(["--ro-bind", lib_dir, lib_dir]);
+            }
+        }
         bwrap_cmd.arg(&program);
         bwrap_cmd.args(&args);
 
@@ -163,6 +174,39 @@ mod tests {
             args.contains(&"/tmp".to_string()),
             "original args must be preserved"
         );
+    }
+
+    #[test]
+    fn bubblewrap_wrap_command_conditionally_binds_lib_dirs() {
+        // /lib64 and /lib must be bind-mounted (with --ro-bind src dst) when
+        // they exist on the host so that dynamically linked binaries (e.g.
+        // `cargo`) can find the ELF interpreter and shared libraries inside the
+        // sandbox.
+        let sandbox = BubblewrapSandbox;
+        let mut cmd = Command::new("echo");
+        sandbox.wrap_command(&mut cmd).unwrap();
+
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|s| s.to_string_lossy().to_string())
+            .collect();
+
+        for lib_dir in &["/lib64", "/lib"] {
+            if std::path::Path::new(lib_dir).exists() {
+                // Verify the triplet `--ro-bind <dir> <dir>` is present and in
+                // the correct order; a bare path without the flag would be silently
+                // ignored by bwrap and leave the sandbox broken.
+                let has_ro_bind_triplet = args
+                    .windows(3)
+                    .any(|w| w[0] == "--ro-bind" && w[1] == *lib_dir && w[2] == *lib_dir);
+                assert!(
+                    has_ro_bind_triplet,
+                    "{lib_dir} exists on host but --ro-bind {lib_dir} {lib_dir} \
+                     is missing from bwrap args — dynamically linked binaries \
+                     will fail inside the sandbox"
+                );
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
On Fedora/RHEL and other non-merged-usr distros, the ELF dynamic linker and shared libraries live in `/lib64`. The bubblewrap sandbox mount recipe omitted this path, so any dynamically linked binary inside the sandbox (including `cargo`, which is in the autonomy allowlist) exited immediately, causing the availability probe to fail and fall back to application-layer security.

## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Added a runtime-conditional loop in `BubblewrapSandbox::wrap_command` that emits `--ro-bind /lib64 /lib64` and `--ro-bind /lib /lib` only when those paths exist on the host. Without these mounts, `bwrap` launches binaries that immediately abort with a missing-interpreter error, making the sandbox appear unavailable.
  - Check is `Path::exists()` at wrap time — no new state, no config field; resolves from the host filesystem on demand.
- **Scope boundary:** Does not change sandbox policy, network isolation, writable paths, or any other bind-mount. Does not affect Landlock, Firejail, Docker, or Seatbelt backends.
- **Blast radius:** `BubblewrapSandbox::wrap_command` only. On merged-usr Debian/Ubuntu where `/lib64` doesn't exist as a standalone path, behaviour is identical to before.
- **Linked issue(s):** Related #5126, Related #5127, Closes #6878
- **Labels:** `bug`, `size: XS`, `risk: high`, `runtime`, `security`

## Validation Evidence (required)

```text
cargo fmt --all -- --check
# exit 0

cargo clippy -p zeroclaw-runtime -- -D warnings
# Finished `dev` profile — exit 0, no warnings

cargo test -p zeroclaw-runtime --features sandbox-bubblewrap -- bubblewrap
# running 6 tests
# test security::bubblewrap::tests::bubblewrap_is_available_only_if_installed ... ok
# test security::bubblewrap::tests::bubblewrap_sandbox_name ... ok
# test security::bubblewrap::tests::bubblewrap_wrap_command_binds_required_paths ... ok
# test security::bubblewrap::tests::bubblewrap_wrap_command_conditionally_binds_lib_dirs ... ok
# test security::bubblewrap::tests::bubblewrap_wrap_command_includes_isolation_flags ... ok
# test security::bubblewrap::tests::bubblewrap_wrap_command_preserves_original_command ... ok
# test result: ok. 6 passed; 0 failed; 0 ignored
```

- **Commands run and tail output:** Above — all 6 bubblewrap unit tests pass; fmt and clippy clean.
- **Beyond CI — what did you manually verify?** Verified that `Path::exists()` follows symlinks (so a `/lib64 -> /usr/lib/x86_64-linux-gnu` symlink on a merged-usr system would still bind correctly if the symlink exists). Did NOT verify on a live Fedora 43 host or against a real `bwrap` invocation in CI — the test environment does not have `bwrap` installed.
- **If any command was intentionally skipped, why:** Full workspace `cargo test` not run; only the affected crate with the relevant feature flag was exercised to keep iteration fast. CI runs the full suite.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **Yes** — adds read-only bind-mounts for `/lib64` and `/lib` when present. These are system library directories with no writable or secret content; exposure is the same as the existing `/usr` bind. The mounts are gated on host path existence and are read-only (`--ro-bind`).
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility (required)

- Backward compatible? **Yes** — on systems where `/lib64` and `/lib` don't exist as standalone paths (merged-usr Debian/Ubuntu) the mount list is unchanged.
- Config / env / CLI surface changed? **No**

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <squash sha>`
- **Feature flags or config toggles:** None — users who need to revert can also set `security.sandbox.backend = "none"` or another backend in config.
- **Observable failure symptoms:** `WARN zeroclaw_runtime::security::detect: Bubblewrap requested but not available, falling back to application-layer` in startup logs; sandbox name reported as `"none"` rather than `"bubblewrap"`.
