### PR TITLE
docs(triage): define contributor pickup semantics

### DIFF
--- a/.claude/skills/github-issue-triage/references/triage-protocol.md
+++ b/.claude/skills/github-issue-triage/references/triage-protocol.md
@@ -130,14 +130,15 @@ Process two groups:
    - Security issue (vulnerability — redirect immediately, see §2a)
    - Spam or noise — flag to user, do not close autonomously
 
-2. **Apply labels** — apply the appropriate primary label (`bug`, `feature`, `r:support`) plus any module/channel/provider labels derivable from the title or body (e.g., `channel:telegram`, `provider:ollama`). Apply risk tier if determinable.
+2. **Apply labels** — apply the appropriate primary label (`bug`, `feature`, `r:support`) plus any module/channel/provider labels derivable from the title or body (e.g., `channel:telegram`, `provider:ollama`). Apply issue risk tier if determinable. Issue risk is the likely fix blast radius from the report, not a prediction that the eventual PR will carry the same risk label.
 
 3. **Link open PRs** — search for open PRs that reference this issue number or describe the same fix. If found, apply `status:in-progress` and comment linking the PR so the reporter knows work is in progress. Do not add `status:no-stale` only because a PR exists; the stale pass excludes issues with open linked PRs.
 
 4. **Evaluate for community labels** — after classifying and labeling, ask:
-   - Is this a bug or feature that is well-scoped, clearly documented, and accessible to a new contributor? → apply `good first issue`
-   - Is this something maintainers actively want external help on but haven't prioritized internally? → apply `help wanted`
+   - Is this a bug or feature that is XS/S, self-contained, clearly documented, linked to the relevant code or docs, and has a named mentor or contact? → apply `good first issue`
+   - Is this actionable, unblocked, and something maintainers actively want external help on and can review? → apply `help wanted`
    Do not apply these speculatively — only when the issue genuinely fits.
+   Do not apply `help wanted` to issues that are merely valid, accepted, or unowned. Skip pickup labels when the issue is blocked, missing acceptance criteria, or waiting on a policy decision. For likely high-risk work, apply `help wanted` only when a maintainer explicitly asks for outside help on that exact scope.
 
 5. **Assess repro quality (bug reports only)** — check for:
    - Concrete steps to reproduce
@@ -408,6 +409,14 @@ Derived from RFC #5577 and current maintainer label policy. Apply these consiste
 - `priority:medium` — notable but has workaround
 - `priority:low` — minor issue or edge case
 
+### Risk (apply when determinable)
+
+- `risk: low` — likely docs, tests, or isolated low-blast-radius fix
+- `risk: medium` — likely behavioral code change without boundary or security impact
+- `risk: high` — likely security, runtime, gateway, tool-execution, workflow, or other high-blast-radius change
+
+For issues, risk labels estimate likely fix blast radius from the report. Reassess the label when an actual PR exists; PR risk is based on the diff under review.
+
 ### Status
 
 - `status:stale` — original author has not engaged for 45+ days; pending closure
@@ -428,8 +437,8 @@ Derived from RFC #5577 and current maintainer label policy. Apply these consiste
 
 ### Community
 
-- `good first issue` — well-scoped, documented, beginner-accessible
-- `help wanted` — maintainers welcome external contribution
+- `good first issue` — XS/S, self-contained, documented, linked, and mentored beginner-accessible work
+- `help wanted` — actionable, unblocked external contribution wanted; not a generic valid/unowned marker
 
 ---
 

--- a/docs/book/src/foundations/fnd-003-governance.md
+++ b/docs/book/src/foundations/fnd-003-governance.md
@@ -1,7 +1,7 @@
 # FND-003: Team Organization, Project Governance, and Contribution Pipeline
-### Starting v0.7.0 · Type: Governance · Rev. 2
+### Starting v0.7.0 · Type: Governance · Rev. 4
 
-> **Canonical reference** · Ratified by the team · Rev. 2
+> **Canonical reference** · Ratified by the team · Rev. 4
 > Discussion thread and full revision history: [#5577](https://github.com/zeroclaw-labs/zeroclaw/issues/5577)
 
 
@@ -21,6 +21,7 @@
 | 1 | 2026-04-09 | Initial draft |
 | 2 | 2026-04-09 | Added §6.4 Architectural Compliance: Human Review, AI Support; added Discussion Question on AI automation of architecture reviews |
 | 3 | 2026-05-24 | Added #6808 operational-label-policy pointers; current label behavior lives in maintainer docs |
+| 4 | 2026-05-24 | Added #6808 community-pickup and issue-risk/PR-risk operational pointers |
 
 ---
 
@@ -179,7 +180,7 @@ GitHub allows up to six pinned issues per repository. Use them for high-signal, 
 1. The current active RFC under discussion
 2. The most wanted community feature (highest-voted Discussion)
 3. The next release milestone tracking issue
-4. The good-first-issue index (an issue that links to all current `good-first-issue` items)
+4. The good first issue index (an issue that links to all current `good first issue` items)
 
 Pinned issues are a promise to the community: these are the things that matter most right now. Update them when priorities shift.
 
@@ -692,7 +693,7 @@ body:
 ```yaml
 name: Good First Issue (Core Team only)
 description: Tag an issue as a good entry point for new contributors
-labels: ["good-first-issue", "status:needs-triage"]
+labels: ["good first issue"]
 body:
   - type: markdown
     attributes:
@@ -883,6 +884,8 @@ This table records governance intent and historical taxonomy shape. For current 
 | `status:wont-fix` | `#9ca3af` Gray | Explicitly decided not to pursue |
 | `status:duplicate` | `#9ca3af` Gray | Duplicate of another issue |
 
+The live community-pickup labels are the unprefixed `good first issue` and `help wanted`; the `status:*` pickup rows above are historical taxonomy. Current operational risk labels also distinguish issue risk (likely fix blast radius from the report) from PR risk (the actual diff under review). See the [maintainer label guide](../maintainers/labels.md) for the live policy.
+
 ### `rfc:` — RFC-specific status
 
 `rfc:accepted` · `rfc:rejected` · `rfc:revision-requested`
@@ -945,9 +948,9 @@ Configure these in the Project's built-in automation settings:
 
 ### 11.2 GitHub Actions Workflows
 
-**Auto-label by changed files (`.github/workflows/label-by-path.yml`):**
+**Auto-label by changed files:**
 
-Automatically add component and risk labels to PRs based on which files were changed. A PR touching `src/security/` gets `component:security` and `risk:high`. A PR touching `docs/` gets `type:docs` and `risk:low`. This eliminates the requirement for PR authors to remember to label their own PRs and gives reviewers immediate context.
+The active path labeler applies scope labels to PRs based on changed files. Risk and size labels are currently maintainer-applied; the maintainer label guide is the live source for label names, automation status, and risk semantics.
 
 **Auto-request CODEOWNERS review (built into CODEOWNERS — no Action needed):**
 
@@ -1020,12 +1023,12 @@ Establish the full workflow and populate the backlog from the accepted RFCs.
 As the plugin system becomes usable, external contributors will start arriving. The contribution infrastructure must be ready.
 
 - [ ] Implement the PR size labeling workflow
-- [ ] Create the first batch of `good-first-issue` items (minimum 5) for the plugin SDK work
-- [ ] Add the `Good First Issue Index` as a pinned issue with links to current good-first-issues
+- [ ] Create the first batch of `good first issue` items (minimum 5) for the plugin SDK work
+- [ ] Add the `Good First Issue Index` as a pinned issue with links to current good first issues
 - [ ] Establish the idea promotion threshold and promote the first Discussion idea to an issue
 - [ ] Document the Core Team expansion process — criteria for inviting new Core Team members
 
-**Success signal:** At least one external contributor (not on the current team) submits a PR via a good-first-issue. The Discussions Ideas category has active community participation.
+**Success signal:** At least one external contributor (not on the current team) submits a PR via a good first issue. The Discussions Ideas category has active community participation.
 
 ---
 
@@ -1073,7 +1076,7 @@ By v1.0.0, the governance model should be self-sustaining — the team should no
 - **CODEOWNERS syntax reference** — https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners — The full syntax for CODEOWNERS files.
 - **"Producing Open Source Software"** — Karl Fogel — The definitive book on running an open source project. Free online at https://producingoss.com. Chapters on governance, contributor management, and communication are directly applicable.
 - **"An Introduction to Open Source Governance Models"** — The Apache Software Foundation's governance documentation is a good model for how a mature open source project formalizes authority and decision-making: https://www.apache.org/foundation/governance/
-- **Vale prose linter** — https://vale.sh — Referenced in the documentation RFC; integrates with the `good-first-issue` documentation improvement workflow.
+- **Vale prose linter** — [Vale](https://vale.sh) — Referenced in the documentation RFC; integrates with the `good first issue` documentation improvement workflow.
 
 ---
 

--- a/docs/book/src/maintainers/labels.md
+++ b/docs/book/src/maintainers/labels.md
@@ -181,7 +181,7 @@ Based on effective changed line count, normalized for docs-only and lockfile-hea
 
 ## Risk labels
 
-Heuristic combining touched paths and change size. Currently applied **manually**.
+For PRs, risk labels describe the actual diff under review: touched paths, behavior change, security boundary exposure, and rollback difficulty. For issues, risk labels describe the likely fix blast radius based on the report, help triage reviewer depth and contributor fit, and may change once a concrete PR shows the actual implementation path. Currently applied **manually**.
 
 | Label | Meaning |
 |---|---|
@@ -229,6 +229,17 @@ Applied manually — the auto-response automation that used to handle these was 
 | `duplicate` | Duplicate of an existing issue |
 | `stale-candidate` | Dormant PR or issue; candidate for closing |
 | `superseded` | Replaced by a newer PR |
+
+## Community pickup labels
+
+Applied manually when maintainers want outside contribution.
+
+| Label | Purpose |
+|---|---|
+| `good first issue` | Small, self-contained, well-documented XS/S work that is safe for a new contributor and has acceptance criteria, relevant code or docs links, and a named mentor or contact |
+| `help wanted` | Actionable, unblocked work that maintainers want external help on and can review, usually low or medium likely issue risk |
+
+Do not use `help wanted` as a generic marker for "valid but unstaffed." If an issue is blocked, architecture-dependent, missing acceptance criteria, likely high-risk, or waiting on a policy decision, leave it without pickup labels until the blocker is resolved or a maintainer writes the missing scope.
 
 ## Maintenance triggers
 

--- a/docs/book/src/maintainers/reviewer-playbook.md
+++ b/docs/book/src/maintainers/reviewer-playbook.md
@@ -80,6 +80,8 @@ Vague comments create avoidable round trips. If you find yourself writing "this 
 
 The same risk-routing principle applies to issues, but the labels and signals are different.
 
+Issue `risk:*` labels describe likely fix blast radius from the report. PR `risk:*` labels describe the actual diff under review. Reassess risk when an issue becomes a PR instead of carrying the issue label forward automatically.
+
 ### Triage labels
 
 | Label | When to use |
@@ -91,6 +93,8 @@ The same risk-routing principle applies to issues, but the labels and signals ar
 | `status:blocked` | Valid work is waiting on an external dependency, maintainer decision, or linked prerequisite. Record the blocker; this is stale protection only while that blocker remains unresolved. |
 | `status:in-progress` | An open PR is actively targeting the issue. Re-check live PR state before relying on it during stale passes. |
 | `status:no-stale` | Accepted or otherwise long-lived work should stay open and is not already protected by another stale exclusion. Record the reason in a maintainer comment, issue body, or tracker entry. |
+| `good first issue` | XS/S, self-contained, documented work with clear acceptance criteria, relevant code or docs links, a named mentor or contact, and low onboarding risk. |
+| `help wanted` | Actionable, unblocked work maintainers want external help on and can review. Do not use it as a generic valid/unowned marker. |
 
 If logs or payloads in the report contain personal identifiers or sensitive data, request redaction before deeper triage. The triage process must not propagate the exposure.
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **Stacked review note:** This PR was originally reviewed as the incremental diff on top of #6899. #6899 has now landed, and this PR is being retargeted to `master` as the contributor-pickup and issue-risk/PR-risk semantics slice.
- **What changed and why:**
  - Documents that issue `risk:*` labels estimate likely fix blast radius, while PR `risk:*` labels describe the actual diff under review.
  - Defines `help wanted` as actionable, unblocked external contribution wanted, not a generic valid/unowned marker.
  - Tightens `good first issue` semantics around XS/S, self-contained, documented, linked, and mentored work.
  - Updates FND-003 operational pointers for current unprefixed community-pickup labels and current manual risk/size labeling behavior.
- **Scope boundary:** This PR does not create, rename, migrate, delete, add, or remove any live GitHub labels. It does not change GitHub Actions automation, issue state, stale policy, or the separate terminal-resolution label split.
- **Blast radius:** Governance/maintainer docs and the in-repo issue-triage skill guidance only.
- **Linked issue(s):** Related #6808. Follows #6899.
- **Labels:** `type: docs`, `risk: low`, `size: XS`, `docs`.

## Validation Evidence (required)

- **Commands run and tail output:**

```text
$ git diff --check

$ bash -lc 'DOCS_FILES=$(printf "%s\n" ".claude/skills/github-issue-triage/references/triage-protocol.md" "docs/book/src/foundations/fnd-003-governance.md" "docs/book/src/maintainers/labels.md" "docs/book/src/maintainers/reviewer-playbook.md"); export DOCS_FILES; bash scripts/ci/docs_quality_gate.sh'
Linting docs files: .claude/skills/github-issue-triage/references/triage-protocol.md docs/book/src/foundations/fnd-003-governance.md docs/book/src/maintainers/labels.md docs/book/src/maintainers/reviewer-playbook.md
Existing markdown issues outside changed lines (non-blocking):
  - docs/book/src/foundations/fnd-003-governance.md has pre-existing MD001/MD012/MD022/MD026/MD034/MD036 issues outside changed lines.
No blocking markdown issues on changed lines.
```

- **Beyond CI — what did you manually verify?** Verified the diff is docs/skill guidance only, with no live label mutations, no GitHub Actions changes, and no issue-state changes. Checked that the community-pickup wording stays aligned across the maintainer label guide, reviewer playbook, FND-003, and the issue-triage skill protocol. Confirmed the remaining `status:*` pickup rows in FND-003 are explicitly framed as historical taxonomy, while the live labels are `good first issue` and `help wanted`.
- **If any command was intentionally skipped, why:** Rust cargo validation was skipped because this is a docs-only and skill-guidance change.

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: N/A

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PRs: revert the PR if the community-pickup or issue-risk wording conflicts with the final #6808 policy direction.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Scope materially carried forward: N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why (inspiration-only, no direct code/design carry-over): No superseded PR content was incorporated.
