### PR TITLE
feat(memory): introduce MemoryStrategy trait and DefaultMemoryStrategy

### DIFF
--- a/crates/zeroclaw-api/src/memory_traits.rs
+++ b/crates/zeroclaw-api/src/memory_traits.rs
@@ -428,6 +428,27 @@ pub trait Memory: Send + Sync + crate::attribution::Attributable {
     }
 }
 
+/// High-level memory lifecycle policy.
+/// Implemented by strategy objects that wrap one or more `Memory` backends.
+#[async_trait]
+pub trait MemoryStrategy: Send + Sync {
+    /// Load and format relevant memory context for a conversation turn.
+    async fn load_context(&self, query: &str, session_id: Option<&str>) -> anyhow::Result<String>;
+
+    /// Consolidate a conversation turn into long-term memory.
+    async fn consolidate_turn(
+        &self,
+        user_message: &str,
+        assistant_response: &str,
+        provider: &dyn crate::model_provider::ModelProvider,
+        model: &str,
+        temperature: Option<f64>,
+    ) -> anyhow::Result<()>;
+
+    /// Run memory governance (cleanup, archiving, background consolidation).
+    async fn run_governance(&self) -> anyhow::Result<()>;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/zeroclaw-runtime/src/agent/memory_strategy.rs
+++ b/crates/zeroclaw-runtime/src/agent/memory_strategy.rs
@@ -1,0 +1,83 @@
+use std::sync::Arc;
+use zeroclaw_api::memory_traits::{Memory, MemoryStrategy};
+use zeroclaw_api::model_provider::ModelProvider;
+
+use crate::agent::memory_loader::{DefaultMemoryLoader, MemoryLoader};
+
+/// Default memory strategy that delegates to existing implementations.
+///
+/// Phase 1: This is a thin wrapper. It does not duplicate logic;
+/// it calls `DefaultMemoryLoader`, `consolidation::consolidate_turn`,
+/// and `hygiene::run_if_due` directly, preserving current behavior
+/// byte-for-byte.
+pub struct DefaultMemoryStrategy {
+    memory: Arc<dyn Memory>,
+    limit: usize,
+    min_relevance_score: f64,
+    memory_config: zeroclaw_config::schema::MemoryConfig,
+    workspace_dir: std::path::PathBuf,
+}
+
+impl DefaultMemoryStrategy {
+    pub fn new(
+        memory: Arc<dyn Memory>,
+        memory_config: zeroclaw_config::schema::MemoryConfig,
+        workspace_dir: impl Into<std::path::PathBuf>,
+    ) -> Self {
+        Self {
+            memory,
+            limit: 5,
+            min_relevance_score: memory_config.min_relevance_score,
+            memory_config,
+            workspace_dir: workspace_dir.into(),
+        }
+    }
+
+    /// Convenience constructor that takes the live `MemoryConfig` so
+    /// `run_governance` uses the operator's actual settings (archive
+    /// windows, hygiene toggle, etc.) rather than hardcoded defaults.
+    pub fn with_config(
+        memory: Arc<dyn Memory>,
+        memory_config: zeroclaw_config::schema::MemoryConfig,
+        workspace_dir: impl Into<std::path::PathBuf>,
+    ) -> Self {
+        Self::new(memory, memory_config, workspace_dir)
+    }
+}
+
+#[async_trait::async_trait]
+impl MemoryStrategy for DefaultMemoryStrategy {
+    async fn load_context(&self, query: &str, session_id: Option<&str>) -> anyhow::Result<String> {
+        let loader = DefaultMemoryLoader::new(self.limit, self.min_relevance_score);
+        loader
+            .load_context(self.memory.as_ref(), query, session_id)
+            .await
+    }
+
+    async fn consolidate_turn(
+        &self,
+        user_message: &str,
+        assistant_response: &str,
+        provider: &dyn ModelProvider,
+        model: &str,
+        temperature: Option<f64>,
+    ) -> anyhow::Result<()> {
+        zeroclaw_memory::consolidation::consolidate_turn(
+            provider,
+            model,
+            temperature,
+            self.memory.as_ref(),
+            user_message,
+            assistant_response,
+        )
+        .await
+    }
+
+    async fn run_governance(&self) -> anyhow::Result<()> {
+        // Delegate to the existing hygiene routine.
+        // Phase 1: `hygiene::run_if_due` returns `Result<()>`.
+        // A structured report will be wired in a follow-up when hygiene
+        // exposes per-action counters.
+        zeroclaw_memory::hygiene::run_if_due(&self.memory_config, &self.workspace_dir)
+    }
+}

--- a/crates/zeroclaw-runtime/src/agent/mod.rs
+++ b/crates/zeroclaw-runtime/src/agent/mod.rs
@@ -11,6 +11,7 @@ pub mod history_pruner;
 pub mod loop_;
 pub mod loop_detector;
 pub mod memory_loader;
+pub mod memory_strategy;
 pub mod personality;
 pub mod personality_templates;
 pub mod prompt;


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Add `MemoryStrategy` to `zeroclaw-api` so high-level memory lifecycle policy can be separated from the low-level `Memory` storage trait.
  - Add `DefaultMemoryStrategy` in `zeroclaw-runtime` as a thin delegation wrapper around the existing `DefaultMemoryLoader`, `consolidation::consolidate_turn`, and `hygiene::run_if_due` paths.
- **Scope boundary:** This first slice does not migrate `Agent`, gateway, channels, or test helpers to the new strategy. It does not change consolidation trigger paths, unify `build_context()`, remove `MemoryLoader`, add provenance tagging, add feedback APIs, add cross-backend strategy, or implement dreaming.
- **Blast radius:** Public API surface for the new `MemoryStrategy` trait plus a runtime wrapper/export. No default runtime call path is changed in this PR.
- **Linked issue(s):** Related #6850
- **Labels:** `enhancement`, `risk: high`, `size: S`, `agent`, `memory`, `runtime`

## Validation Evidence

Author-reported validation:

```bash
cargo fmt --all -- --check   # passed
cargo clippy --all-targets -- -D warnings   # passed, zero warnings
cargo test -p zeroclaw-api -p zeroclaw-runtime -p zeroclaw-gateway -p zeroclaw-channels   # 1839 passed; 0 failed
cargo test --test integration   # 159 passed; 0 failed
```

GitHub Actions are green on the current head, including Lint, Test, Security, platform builds, and CI Required Gate.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)

This PR introduces a trait boundary and wrapper module only. It does not add persistence fields, network calls, credential handling, or new runtime permissions.

## Compatibility

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)

The current diff does not remove `MemoryLoader`, does not change `AgentBuilder`, and does not migrate existing runtime entry points. Existing users and internal call sites continue using the current memory paths until follow-up PRs opt into the strategy boundary.

## Rollback

- **Fast rollback command/path:** Revert the squash commit for PR #6907. That removes the new `MemoryStrategy` trait, `DefaultMemoryStrategy` wrapper, and runtime module export.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Compile errors in crates or downstream consumers that import the new strategy surface, or unexpected behavior in follow-up branches that start migrating memory entry points onto this strategy. This first slice does not change the default runtime call path or storage schema.
