### PR TITLE
fix(agent): resolve runtime profile budgets when constructing security policy

### DIFF
--- a/crates/zeroclaw-config/src/policy.rs
+++ b/crates/zeroclaw-config/src/policy.rs
@@ -2697,6 +2697,45 @@ mod tests {
         );
     }
 
+    #[test]
+    fn from_profiles_with_runtime_profile_propagates_budget_caps() {
+        use crate::schema::RuntimeProfileConfig;
+        use std::path::Path;
+
+        let risk = crate::schema::RiskProfileConfig {
+            level: AutonomyLevel::Supervised,
+            ..crate::schema::RiskProfileConfig::default()
+        };
+        let runtime = RuntimeProfileConfig {
+            max_actions_per_hour: 99,
+            max_cost_per_day_cents: 1234,
+            shell_timeout_secs: 300,
+            ..RuntimeProfileConfig::default()
+        };
+
+        let policy = SecurityPolicy::from_profiles(&risk, Some(&runtime), Path::new("/ws"));
+
+        assert_eq!(policy.max_actions_per_hour, 99);
+        assert_eq!(policy.max_cost_per_day_cents, 1234);
+        assert_eq!(policy.shell_timeout_secs, 300);
+    }
+
+    #[test]
+    fn from_profiles_without_runtime_profile_uses_defaults() {
+        use std::path::Path;
+
+        let risk = crate::schema::RiskProfileConfig {
+            level: AutonomyLevel::Supervised,
+            ..crate::schema::RiskProfileConfig::default()
+        };
+
+        let policy = SecurityPolicy::from_profiles(&risk, None, Path::new("/ws"));
+
+        assert_eq!(policy.max_actions_per_hour, 20);
+        assert_eq!(policy.max_cost_per_day_cents, 500);
+        assert_eq!(policy.shell_timeout_secs, 60);
+    }
+
     fn unix_forbidden_path_policy() -> SecurityPolicy {
         SecurityPolicy {
             workspace_dir: PathBuf::from("/workspace"),

--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -667,9 +667,11 @@ impl Agent {
         if let Err(e) = zeroclaw_config::schema::ensure_bootstrap_files(&agent_workspace).await {
             ::zeroclaw_log::record!(WARN, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_outcome(::zeroclaw_log::EventOutcome::Unknown).with_attrs(::serde_json::json!({"agent": agent_alias, "workspace": agent_workspace.display().to_string(), "e": e.to_string()})), "Failed to ensure per-agent bootstrap files (continuing with whatever exists): ");
         }
+        let runtime_profile = config.runtime_profile_for_agent(agent_alias);
         let security = Arc::new({
-            let mut policy = SecurityPolicy::from_risk_profile(
+            let mut policy = SecurityPolicy::from_profiles(
                 risk_profile,
+                runtime_profile,
                 session_cwd.unwrap_or(&agent_workspace),
             );
             // When a per-session cwd overrides the sandbox root, ensure
@@ -4316,6 +4318,103 @@ mod tests {
             has_assistant,
             "new_msgs must include the assistant reply even after trim; got: {new_msgs:?}"
         );
+    }
+
+    /// Regression: Agent::from_config must propagate the runtime profile's
+    /// budget caps into the constructed Agent's security_summary.  The
+    /// existing from_profiles tests cover SecurityPolicy-level propagation,
+    /// but they pass even if Agent::from_config still calls
+    /// from_risk_profile (skipping runtime budgets).  This test exercises
+    /// the full from_config → SecurityPolicy::from_profiles path so that
+    /// reverting the runtime_profile resolution in agent.rs is caught.
+    #[tokio::test]
+    async fn from_config_runtime_profile_propagates_budget_caps() {
+        use axum::{Json, Router, routing::post};
+        use tempfile::TempDir;
+        use tokio::net::TcpListener;
+
+        let app = Router::new().route(
+            "/chat/completions",
+            post(|Json(_body): Json<serde_json::Value>| async move {
+                Json(serde_json::json!({
+                    "choices": [{
+                        "message": {
+                            "content": "ok"
+                        }
+                    }]
+                }))
+            }),
+        );
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let mock_addr = listener.local_addr().unwrap();
+        let server_handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let tmp = TempDir::new().expect("temp dir");
+        let workspace_dir = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace_dir).unwrap();
+
+        let mut config = zeroclaw_config::schema::Config {
+            data_dir: workspace_dir,
+            config_path: tmp.path().join("config.toml"),
+            ..Default::default()
+        };
+        {
+            let entry = config
+                .providers
+                .models
+                .ensure("custom", "default")
+                .expect("custom model_provider type slot");
+            entry.api_key = Some("test-key".to_string());
+            entry.model = Some("test-model".to_string());
+            entry.uri = Some(format!("http://{mock_addr}"));
+        }
+        config.memory.backend = "none".to_string();
+        config.memory.auto_save = false;
+
+        config.risk_profiles.insert(
+            "test-profile".to_string(),
+            zeroclaw_config::schema::RiskProfileConfig::default(),
+        );
+
+        // Runtime profile with a non-default max_actions_per_hour.
+        config.runtime_profiles.insert(
+            "test-runtime".to_string(),
+            zeroclaw_config::schema::RuntimeProfileConfig {
+                max_actions_per_hour: 99,
+                ..zeroclaw_config::schema::RuntimeProfileConfig::default()
+            },
+        );
+
+        let provider_alias = config
+            .first_model_provider_type()
+            .expect("model_provider configured above")
+            .to_string();
+        let agent_cfg = zeroclaw_config::schema::AliasedAgentConfig {
+            model_provider: format!("{provider_alias}.default").into(),
+            risk_profile: "test-profile".to_string(),
+            runtime_profile: "test-runtime".to_string(),
+            ..zeroclaw_config::schema::AliasedAgentConfig::default()
+        };
+        config.agents.insert("test-agent".to_string(), agent_cfg);
+
+        let agent = Agent::from_config(&config, "test-agent")
+            .await
+            .expect("agent from config");
+
+        let summary = agent
+            .security_summary
+            .as_deref()
+            .expect("security_summary should be populated by from_config");
+
+        assert!(
+            summary.contains("99"),
+            "expected security_summary to contain runtime max_actions_per_hour=99; got: {summary}"
+        );
+
+        server_handle.abort();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `Agent::new()` called `SecurityPolicy::from_risk_profile()`, which always fell back to default budget caps (`max_actions_per_hour=20`), ignoring the `runtime_profile` configured in `config.toml`. Changed to `from_profiles()` and pass the resolved runtime profile so budget limits from `runtime_profiles` take effect.
  - Added two unit tests: one verifying runtime profile budget fields propagate to `SecurityPolicy`, another confirming fallback defaults when no profile is given.
- **Scope boundary:** Authorization semantics (autonomy level, allowlists, sandbox) remain driven by risk profile only. No config format or CLI changes. No logging added.
- **Blast radius:** Only affects the `SecurityPolicy` construction path in `Agent::new()`. `from_risk_profile()` remains backward-compatible (delegates to `from_profiles(_, None, _)`).
- **Linked issue(s):** Related `06013f2`
- **Labels:** `bug`, `risk: high`, `size: XS`, `agent`, `config`, `runtime`

## Validation Evidence

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test -p zeroclaw-config
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` — clean.
  - `cargo clippy --all-targets -- -D warnings` — 1 pre-existing failure in `crates/zeroclaw-channels/src/wecom_ws.rs:2352` (`while_let_loop`), unrelated.
  - `cargo test -p zeroclaw-config` — 639 passed, 18 failed (all pre-existing Windows path assertion issues). Both new tests pass.
- **Beyond CI — what did you manually verify?** Action limit prompt now correctly obeys the config value.
- **If any command was intentionally skipped, why:** N/A

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility

- Backward compatible? **Yes** — `from_risk_profile()` still delegates to `from_profiles(_, None, _)`.
- Config / env / CLI surface changed? **No**
- If `No` or `Yes` to either: N/A

## Rollback

`git revert 8d4573f`.

## Supersede Attribution

N/A
