### PR TITLE
feat(config): generalize #[secret] via SecretField trait

### DIFF
--- a/crates/zeroclaw-config/src/migration.rs
+++ b/crates/zeroclaw-config/src/migration.rs
@@ -174,34 +174,22 @@ pub fn generate(target_version: u32, opts: &GenerateOptions<'_>) -> Result<Strin
 }
 
 /// Set of TOML terminal key names whose string leaves are treated as
-/// secrets by [`encrypt_secret_strings`]. Derived once from the typed
-/// schema by migrating the comprehensive V1 fixture and collecting the
-/// terminal segment of every `prop_fields()` entry with `is_secret =
-/// true`. The set is schema-driven — adding a new `#[secret]`
-/// annotation anywhere in the schema automatically extends encryption
-/// coverage with no companion edit in this module.
+/// secrets by [`encrypt_secret_strings`]. Sourced from
+/// `Config::secret_field_terminals()`, the macro-emitted static
+/// enumeration of every `#[secret]` field reachable from the schema.
+/// The set is schema-driven — adding a new `#[secret]` annotation
+/// anywhere in the schema automatically extends encryption coverage
+/// with no companion edit in this module.
+///
+/// `secret_field_terminals()` (vs. the older `prop_fields().filter(is_secret)`
+/// approach) covers compound shapes like `HashMap<String, String>`
+/// — `prop_fields()` intentionally skips non-Vec compound types, which
+/// would silently drop e.g. `mcp.servers[*].headers` from the allowlist.
 fn secret_key_names() -> &'static std::collections::HashSet<&'static str> {
     use std::collections::HashSet;
     use std::sync::OnceLock;
     static CACHE: OnceLock<HashSet<&'static str>> = OnceLock::new();
-    CACHE.get_or_init(|| {
-        let cfg = migrate_to_current(V1_FIXTURE)
-            .expect("V1 fixture migrates cleanly — this is also asserted in tests");
-        cfg.prop_fields()
-            .into_iter()
-            .filter(|f| f.is_secret)
-            .filter_map(|f| {
-                // The macro emits names in kebab form
-                // (`channels.matrix.access-token`); TOML keys at
-                // runtime use the raw field ident (snake). Take the
-                // terminal segment, snake-ify, then leak to satisfy
-                // the &'static str lifetime needed by the cached set.
-                let terminal = f.name.rsplit('.').next()?.to_string();
-                let snake = terminal.replace('-', "_");
-                Some(Box::leak(snake.into_boxed_str()) as &'static str)
-            })
-            .collect()
-    })
+    CACHE.get_or_init(|| Config::secret_field_terminals().into_iter().collect())
 }
 
 /// Walk a TOML tree and encrypt every string leaf whose terminal key
@@ -251,6 +239,13 @@ fn encrypt_walk(
 /// a table containing strings — using the given store. Non-string leaves
 /// (numbers, bools) are left alone; the operator presumably annotated a
 /// non-secret field with a secret-shaped name and we don't second-guess.
+///
+/// When the slot is a Table (e.g. `headers = { Authorization = "Bearer
+/// ...", X-Tenant = "..." }`), every leaf in the subtree is encrypted —
+/// the parent key matched the secret allowlist, so every value below it
+/// inherits the secret marker. This is the contract for `HashMap<String,
+/// String>`-shaped `#[secret]` fields where individual keys are
+/// user-supplied and can't be checked against a static allowlist.
 fn encrypt_in_place(value: &mut toml::Value, store: &crate::secrets::SecretStore) -> Result<()> {
     match value {
         toml::Value::String(s)
@@ -265,9 +260,8 @@ fn encrypt_in_place(value: &mut toml::Value, store: &crate::secrets::SecretStore
             }
         }
         toml::Value::Table(table) => {
-            let names = secret_key_names();
             for (_, child) in table.iter_mut() {
-                encrypt_walk(child, store, names)?;
+                encrypt_in_place(child, store)?;
             }
         }
         _ => {}

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -3641,8 +3641,11 @@ pub struct McpServerConfig {
     /// Optional environment variables for stdio transport.
     #[serde(default)]
     pub env: HashMap<String, String>,
-    /// Optional HTTP headers for HTTP/SSE transports.
+    /// Optional HTTP headers for HTTP/SSE transports. Treated as secret —
+    /// the values commonly carry Bearer tokens for the upstream MCP server.
     #[serde(default)]
+    #[secret]
+    #[cfg_attr(feature = "schema-export", schemars(extend("x-secret" = true)))]
     pub headers: HashMap<String, String>,
     /// Optional per-call timeout in seconds (hard capped in validation).
     #[serde(default)]
@@ -10569,6 +10572,8 @@ pub struct WebhookConfig {
     pub send_method: Option<String>,
     /// Optional `Authorization` header value for outbound requests.
     #[serde(default)]
+    #[secret]
+    #[cfg_attr(feature = "schema-export", schemars(extend("x-secret" = true)))]
     pub auth_header: Option<String>,
     /// Optional shared secret for webhook signature verification (HMAC-SHA256).
     #[secret]
@@ -17011,6 +17016,33 @@ default_temperature = 0.7
             },
         );
 
+        // Webhook channel: auth_header carries a Bearer token; must be
+        // encrypted alongside the existing webhook `secret` field.
+        config.channels.webhook.insert(
+            "primary".into(),
+            WebhookConfig {
+                enabled: true,
+                port: 8080,
+                auth_header: Some("Bearer webhook-cred".into()),
+                secret: Some("webhook-shared-secret".into()),
+                ..Default::default()
+            },
+        );
+
+        // MCP server: HTTP headers map carries an Authorization Bearer
+        // token; the new `#[secret]` on `HashMap<String, String>` must
+        // encrypt every value (and only every value — keys stay plain).
+        config.mcp.servers.push(McpServerConfig {
+            name: "primary".into(),
+            transport: McpTransport::Sse,
+            url: Some("https://mcp.example.invalid/sse".into()),
+            headers: HashMap::from([
+                ("Authorization".to_string(), "Bearer mcp-cred".to_string()),
+                ("X-Tenant".to_string(), "tenant-42".to_string()),
+            ]),
+            ..Default::default()
+        });
+
         config.save().await.unwrap();
 
         let contents = tokio::fs::read_to_string(config.config_path.clone())
@@ -17110,6 +17142,42 @@ default_temperature = 0.7
                 .unwrap(),
             "feishu-verify"
         );
+
+        // Webhook auth_header — newly tagged `#[secret]`.
+        let webhook = stored.channels.webhook.get("primary").unwrap();
+        let webhook_auth = webhook.auth_header.as_deref().unwrap();
+        assert!(
+            crate::secrets::SecretStore::is_encrypted(webhook_auth),
+            "webhook auth_header must be encrypted on save"
+        );
+        assert_eq!(store.decrypt(webhook_auth).unwrap(), "Bearer webhook-cred");
+        // The pre-existing webhook `secret` field stays encrypted too —
+        // sanity check that the refactor didn't regress it.
+        let webhook_secret = webhook.secret.as_deref().unwrap();
+        assert!(crate::secrets::SecretStore::is_encrypted(webhook_secret));
+        assert_eq!(
+            store.decrypt(webhook_secret).unwrap(),
+            "webhook-shared-secret"
+        );
+
+        // MCP server headers — every value must be encrypted; the keys
+        // stay plaintext (TOML table headers are not secret).
+        let mcp_server = stored
+            .mcp
+            .servers
+            .iter()
+            .find(|s| s.name == "primary")
+            .expect("mcp server `primary` round-trips through save");
+        for (key, value) in &mcp_server.headers {
+            assert!(
+                crate::secrets::SecretStore::is_encrypted(value),
+                "mcp.servers.primary.headers.{key} must be encrypted on save"
+            );
+        }
+        let auth = mcp_server.headers.get("Authorization").unwrap();
+        let tenant = mcp_server.headers.get("X-Tenant").unwrap();
+        assert_eq!(store.decrypt(auth).unwrap(), "Bearer mcp-cred");
+        assert_eq!(store.decrypt(tenant).unwrap(), "tenant-42");
 
         let _ = fs::remove_dir_all(&dir).await;
     }

--- a/crates/zeroclaw-config/src/traits.rs
+++ b/crates/zeroclaw-config/src/traits.rs
@@ -222,34 +222,271 @@ impl<T: MaskSecrets> MaskSecrets for std::collections::HashMap<String, T> {
     }
 }
 
+impl<T: MaskSecrets> MaskSecrets for Vec<T> {
+    fn mask_secrets(&mut self) {
+        for v in self.iter_mut() {
+            v.mask_secrets();
+        }
+    }
+    fn restore_secrets_from(&mut self, current: &Self) {
+        for (v, cur) in self.iter_mut().zip(current.iter()) {
+            v.restore_secrets_from(cur);
+        }
+    }
+}
+
 pub const MASKED_SECRET: &str = "***MASKED***";
 
 pub fn is_masked_secret(value: &str) -> bool {
     value == MASKED_SECRET
 }
 
-pub fn mask_optional_secret(value: &mut Option<String>) {
-    if value.is_some() {
-        *value = Some(MASKED_SECRET.to_string());
+/// Per-field secret operations the `Configurable` derive emits for every
+/// `#[secret]` field. Generalizes mask / restore / encrypt / decrypt / is_set
+/// across the supported shapes — `String`, `Option<String>`, `Vec<String>`,
+/// `HashMap<String, String>`, and `Option<HashMap<String, String>>` — so adding
+/// a new shape is a single trait impl rather than a fourth branch in the macro.
+///
+/// `encrypt_in_place` and `decrypt_in_place` are idempotent: encrypting an
+/// already-`enc2:`-prefixed value or decrypting a plaintext value is a no-op,
+/// detected via [`crate::security::SecretStore::is_encrypted`]. The `field`
+/// argument is the dotted config-path (e.g. `mcp.servers`); the impls suffix
+/// per-element coordinates (`[<idx>]` for `Vec`, `.<key>` for `HashMap`) so
+/// error messages point at the exact failed entry.
+pub trait SecretField {
+    /// Replace each non-empty inner string with [`MASKED_SECRET`].
+    fn mask(&mut self);
+
+    /// Restore inner strings that currently equal [`MASKED_SECRET`] from the
+    /// matching position in `current`. The dashboard write path relies on this
+    /// so re-posting an already-displayed masked value doesn't overwrite the
+    /// real secret in config.
+    fn restore_from(&mut self, current: &Self);
+
+    /// Encrypt every non-empty, not-already-encrypted inner string.
+    fn encrypt_in_place(
+        &mut self,
+        store: &crate::security::SecretStore,
+        field: &str,
+    ) -> anyhow::Result<()>;
+
+    /// Inverse of [`Self::encrypt_in_place`].
+    fn decrypt_in_place(
+        &mut self,
+        store: &crate::security::SecretStore,
+        field: &str,
+    ) -> anyhow::Result<()>;
+
+    /// Whether the field carries at least one non-empty inner string. Reported
+    /// back through [`SecretFieldInfo::is_set`].
+    fn is_set(&self) -> bool;
+}
+
+impl SecretField for String {
+    fn mask(&mut self) {
+        if !self.is_empty() {
+            *self = MASKED_SECRET.to_string();
+        }
+    }
+
+    fn restore_from(&mut self, current: &Self) {
+        if is_masked_secret(self) {
+            self.clone_from(current);
+        }
+    }
+
+    fn encrypt_in_place(
+        &mut self,
+        store: &crate::security::SecretStore,
+        field: &str,
+    ) -> anyhow::Result<()> {
+        use anyhow::Context;
+        if !self.is_empty() && !crate::security::SecretStore::is_encrypted(self) {
+            *self = store
+                .encrypt(self)
+                .with_context(|| format!("Failed to encrypt {field}"))?;
+        }
+        Ok(())
+    }
+
+    fn decrypt_in_place(
+        &mut self,
+        store: &crate::security::SecretStore,
+        field: &str,
+    ) -> anyhow::Result<()> {
+        use anyhow::Context;
+        if crate::security::SecretStore::is_encrypted(self) {
+            *self = store
+                .decrypt(self)
+                .with_context(|| format!("Failed to decrypt {field}"))?;
+        }
+        Ok(())
+    }
+
+    fn is_set(&self) -> bool {
+        !self.is_empty()
     }
 }
 
-pub fn mask_required_secret(value: &mut String) {
-    if !value.is_empty() {
-        *value = MASKED_SECRET.to_string();
+impl SecretField for Option<String> {
+    fn mask(&mut self) {
+        if let Some(inner) = self {
+            inner.mask();
+        }
+    }
+
+    fn restore_from(&mut self, current: &Self) {
+        if let (Some(inner), Some(cur)) = (self.as_mut(), current.as_ref()) {
+            inner.restore_from(cur);
+        }
+    }
+
+    fn encrypt_in_place(
+        &mut self,
+        store: &crate::security::SecretStore,
+        field: &str,
+    ) -> anyhow::Result<()> {
+        match self {
+            Some(inner) => inner.encrypt_in_place(store, field),
+            None => Ok(()),
+        }
+    }
+
+    fn decrypt_in_place(
+        &mut self,
+        store: &crate::security::SecretStore,
+        field: &str,
+    ) -> anyhow::Result<()> {
+        match self {
+            Some(inner) => inner.decrypt_in_place(store, field),
+            None => Ok(()),
+        }
+    }
+
+    fn is_set(&self) -> bool {
+        self.as_ref().is_some_and(|v| !v.is_empty())
     }
 }
 
-#[allow(clippy::ref_option)]
-pub fn restore_optional_secret(value: &mut Option<String>, current: &Option<String>) {
-    if value.as_deref().is_some_and(is_masked_secret) {
-        *value = current.clone();
+impl SecretField for Vec<String> {
+    fn mask(&mut self) {
+        for element in self.iter_mut() {
+            element.mask();
+        }
+    }
+
+    fn restore_from(&mut self, current: &Self) {
+        for (element, cur) in self.iter_mut().zip(current.iter()) {
+            element.restore_from(cur);
+        }
+    }
+
+    fn encrypt_in_place(
+        &mut self,
+        store: &crate::security::SecretStore,
+        field: &str,
+    ) -> anyhow::Result<()> {
+        for (idx, element) in self.iter_mut().enumerate() {
+            element.encrypt_in_place(store, &format!("{field}[{idx}]"))?;
+        }
+        Ok(())
+    }
+
+    fn decrypt_in_place(
+        &mut self,
+        store: &crate::security::SecretStore,
+        field: &str,
+    ) -> anyhow::Result<()> {
+        for (idx, element) in self.iter_mut().enumerate() {
+            element.decrypt_in_place(store, &format!("{field}[{idx}]"))?;
+        }
+        Ok(())
+    }
+
+    fn is_set(&self) -> bool {
+        !self.is_empty()
     }
 }
 
-pub fn restore_required_secret(value: &mut String, current: &str) {
-    if is_masked_secret(value) {
-        *value = current.to_string();
+impl SecretField for std::collections::HashMap<String, String> {
+    fn mask(&mut self) {
+        for value in self.values_mut() {
+            value.mask();
+        }
+    }
+
+    fn restore_from(&mut self, current: &Self) {
+        for (key, value) in self.iter_mut() {
+            if let Some(cur) = current.get(key) {
+                value.restore_from(cur);
+            }
+        }
+    }
+
+    fn encrypt_in_place(
+        &mut self,
+        store: &crate::security::SecretStore,
+        field: &str,
+    ) -> anyhow::Result<()> {
+        for (key, value) in self.iter_mut() {
+            value.encrypt_in_place(store, &format!("{field}.{key}"))?;
+        }
+        Ok(())
+    }
+
+    fn decrypt_in_place(
+        &mut self,
+        store: &crate::security::SecretStore,
+        field: &str,
+    ) -> anyhow::Result<()> {
+        for (key, value) in self.iter_mut() {
+            value.decrypt_in_place(store, &format!("{field}.{key}"))?;
+        }
+        Ok(())
+    }
+
+    fn is_set(&self) -> bool {
+        !self.is_empty()
+    }
+}
+
+impl SecretField for Option<std::collections::HashMap<String, String>> {
+    fn mask(&mut self) {
+        if let Some(inner) = self {
+            inner.mask();
+        }
+    }
+
+    fn restore_from(&mut self, current: &Self) {
+        if let (Some(inner), Some(cur)) = (self.as_mut(), current.as_ref()) {
+            inner.restore_from(cur);
+        }
+    }
+
+    fn encrypt_in_place(
+        &mut self,
+        store: &crate::security::SecretStore,
+        field: &str,
+    ) -> anyhow::Result<()> {
+        match self {
+            Some(inner) => inner.encrypt_in_place(store, field),
+            None => Ok(()),
+        }
+    }
+
+    fn decrypt_in_place(
+        &mut self,
+        store: &crate::security::SecretStore,
+        field: &str,
+    ) -> anyhow::Result<()> {
+        match self {
+            Some(inner) => inner.decrypt_in_place(store, field),
+            None => Ok(()),
+        }
+    }
+
+    fn is_set(&self) -> bool {
+        self.as_ref().is_some_and(|m| !m.is_empty())
     }
 }
 
@@ -441,4 +678,176 @@ pub trait OnboardUi: Send {
     fn note(&mut self, msg: &str);
     fn status(&mut self, msg: &str);
     fn warn(&mut self, msg: &str);
+}
+
+#[cfg(test)]
+mod secret_field_tests {
+    use super::{MASKED_SECRET, SecretField};
+    use crate::security::SecretStore;
+    use std::collections::HashMap;
+    use tempfile::TempDir;
+
+    fn store() -> (TempDir, SecretStore) {
+        let tmp = TempDir::new().unwrap();
+        let store = SecretStore::new(tmp.path(), true);
+        (tmp, store)
+    }
+
+    #[test]
+    fn string_roundtrip_and_idempotent() {
+        let (_tmp, store) = store();
+        let mut s = String::from("sk-abc");
+        s.encrypt_in_place(&store, "test.s").unwrap();
+        assert!(SecretStore::is_encrypted(&s));
+        let enc1 = s.clone();
+        // idempotent: encrypting again must not double-wrap
+        s.encrypt_in_place(&store, "test.s").unwrap();
+        assert_eq!(s, enc1);
+        s.decrypt_in_place(&store, "test.s").unwrap();
+        assert_eq!(s, "sk-abc");
+    }
+
+    #[test]
+    fn string_empty_stays_empty() {
+        let (_tmp, store) = store();
+        let mut s = String::new();
+        s.encrypt_in_place(&store, "test.s").unwrap();
+        assert_eq!(s, "");
+        assert!(!s.is_set());
+    }
+
+    #[test]
+    fn string_mask_and_restore() {
+        let mut s = String::from("Bearer xyz");
+        let cur = String::from("Bearer xyz");
+        s.mask();
+        assert_eq!(s, MASKED_SECRET);
+        s.restore_from(&cur);
+        assert_eq!(s, "Bearer xyz");
+    }
+
+    #[test]
+    fn option_string_none_is_noop() {
+        let (_tmp, store) = store();
+        let mut v: Option<String> = None;
+        v.encrypt_in_place(&store, "test.o").unwrap();
+        v.decrypt_in_place(&store, "test.o").unwrap();
+        v.mask();
+        assert_eq!(v, None);
+        assert!(!v.is_set());
+    }
+
+    #[test]
+    fn option_string_some_roundtrip() {
+        let (_tmp, store) = store();
+        let mut v: Option<String> = Some("Bearer xyz".into());
+        v.encrypt_in_place(&store, "test.o").unwrap();
+        assert!(SecretStore::is_encrypted(v.as_ref().unwrap()));
+        v.decrypt_in_place(&store, "test.o").unwrap();
+        assert_eq!(v.as_deref(), Some("Bearer xyz"));
+        assert!(v.is_set());
+    }
+
+    #[test]
+    fn vec_string_roundtrip_per_element() {
+        let (_tmp, store) = store();
+        let mut v: Vec<String> = vec!["one".into(), "".into(), "two".into()];
+        v.encrypt_in_place(&store, "test.v").unwrap();
+        assert!(SecretStore::is_encrypted(&v[0]));
+        assert_eq!(v[1], "", "empty element must stay empty");
+        assert!(SecretStore::is_encrypted(&v[2]));
+        v.decrypt_in_place(&store, "test.v").unwrap();
+        assert_eq!(v, vec!["one", "", "two"]);
+    }
+
+    #[test]
+    fn hashmap_string_string_roundtrip_per_value() {
+        let (_tmp, store) = store();
+        let mut h: HashMap<String, String> = HashMap::from([
+            ("Authorization".into(), "Bearer sk-abc".into()),
+            ("X-Trace".into(), "req-123".into()),
+        ]);
+        h.encrypt_in_place(&store, "mcp.servers.foo.headers")
+            .unwrap();
+        for v in h.values() {
+            assert!(SecretStore::is_encrypted(v));
+        }
+        h.decrypt_in_place(&store, "mcp.servers.foo.headers")
+            .unwrap();
+        assert_eq!(
+            h.get("Authorization").map(String::as_str),
+            Some("Bearer sk-abc")
+        );
+        assert_eq!(h.get("X-Trace").map(String::as_str), Some("req-123"));
+        assert!(h.is_set());
+    }
+
+    #[test]
+    fn hashmap_string_string_mask_and_restore() {
+        let mut h: HashMap<String, String> =
+            HashMap::from([("Authorization".into(), "Bearer xyz".into())]);
+        let cur = h.clone();
+        h.mask();
+        assert_eq!(
+            h.get("Authorization").map(String::as_str),
+            Some(MASKED_SECRET)
+        );
+        h.restore_from(&cur);
+        assert_eq!(
+            h.get("Authorization").map(String::as_str),
+            Some("Bearer xyz")
+        );
+    }
+
+    #[test]
+    fn option_hashmap_none_is_noop() {
+        let (_tmp, store) = store();
+        let mut v: Option<HashMap<String, String>> = None;
+        v.encrypt_in_place(&store, "test.oh").unwrap();
+        v.decrypt_in_place(&store, "test.oh").unwrap();
+        v.mask();
+        assert!(v.is_none());
+        assert!(!v.is_set());
+    }
+
+    #[test]
+    fn option_hashmap_some_roundtrip() {
+        let (_tmp, store) = store();
+        let mut v: Option<HashMap<String, String>> =
+            Some(HashMap::from([("k".into(), "secret".into())]));
+        v.encrypt_in_place(&store, "test.oh").unwrap();
+        assert!(SecretStore::is_encrypted(
+            v.as_ref().unwrap().get("k").unwrap()
+        ));
+        v.decrypt_in_place(&store, "test.oh").unwrap();
+        assert_eq!(
+            v.as_ref().unwrap().get("k").map(String::as_str),
+            Some("secret")
+        );
+        assert!(v.is_set());
+    }
+
+    #[test]
+    fn hashmap_empty_is_not_set() {
+        let h: HashMap<String, String> = HashMap::new();
+        assert!(!h.is_set());
+        let oh: Option<HashMap<String, String>> = Some(HashMap::new());
+        assert!(!oh.is_set());
+    }
+
+    #[test]
+    fn encrypt_decrypt_failure_message_includes_field_path() {
+        let tmp = TempDir::new().unwrap();
+        let bad_store = SecretStore::new(tmp.path(), true);
+        // Construct a malformed enc2 string that will fail to decrypt.
+        let mut s = String::from("enc2:not-valid-hex");
+        let err = s
+            .decrypt_in_place(&bad_store, "mcp.servers.foo.headers.Authorization")
+            .expect_err("malformed ciphertext must fail");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("mcp.servers.foo.headers.Authorization"),
+            "error must include field path; got: {msg}"
+        );
+    }
 }

--- a/crates/zeroclaw-config/src/traits.rs
+++ b/crates/zeroclaw-config/src/traits.rs
@@ -446,7 +446,7 @@ impl SecretField for std::collections::HashMap<String, String> {
     }
 
     fn is_set(&self) -> bool {
-        !self.is_empty()
+        self.values().any(|v| !v.is_empty())
     }
 }
 
@@ -486,7 +486,8 @@ impl SecretField for Option<std::collections::HashMap<String, String>> {
     }
 
     fn is_set(&self) -> bool {
-        self.as_ref().is_some_and(|m| !m.is_empty())
+        self.as_ref()
+            .is_some_and(|m| m.values().any(|v| !v.is_empty()))
     }
 }
 
@@ -833,6 +834,30 @@ mod secret_field_tests {
         assert!(!h.is_set());
         let oh: Option<HashMap<String, String>> = Some(HashMap::new());
         assert!(!oh.is_set());
+    }
+
+    #[test]
+    fn hashmap_with_only_empty_values_is_not_set() {
+        // The trait contract for `is_set` is "at least one non-empty inner
+        // string". A map carrying placeholder keys with empty values has no
+        // secret material to encrypt or mask, so it must report not-set —
+        // otherwise the dashboard would render `***MASKED***` over a blank
+        // header row.
+        let h: HashMap<String, String> = HashMap::from([
+            ("Authorization".into(), String::new()),
+            ("X-Trace".into(), String::new()),
+        ]);
+        assert!(!h.is_set());
+
+        let oh: Option<HashMap<String, String>> =
+            Some(HashMap::from([("Authorization".into(), String::new())]));
+        assert!(!oh.is_set());
+
+        let mixed: HashMap<String, String> = HashMap::from([
+            ("Authorization".into(), "Bearer xyz".into()),
+            ("X-Trace".into(), String::new()),
+        ]);
+        assert!(mixed.is_set(), "any non-empty value makes the map set");
     }
 
     #[test]

--- a/crates/zeroclaw-config/tests/migration.rs
+++ b/crates/zeroclaw-config/tests/migration.rs
@@ -11,7 +11,7 @@
 
 use zeroclaw_config::autonomy::AutonomyLevel;
 use zeroclaw_config::migration::{
-    CURRENT_SCHEMA_VERSION, GenerateOptions, MigrateReport, detect_version,
+    CURRENT_SCHEMA_VERSION, GenerateOptions, MigrateReport, detect_version, encrypt_secret_strings,
     ensure_disk_at_current_version, generate, migrate_file, migrate_file_in_place,
     migrate_to_current,
 };
@@ -2533,6 +2533,87 @@ fn encryption_covers_every_schema_secret_field() {
          the generated config — the field exists in prop_fields() but its \
          string leaf survived as plaintext:\n\n{}",
         missed.join("\n")
+    );
+}
+
+#[test]
+fn encryption_covers_compound_map_secret_field() {
+    // Map-shaped `#[secret]` fields (e.g. `mcp.servers[*].headers:
+    // HashMap<String, String>`) don't surface through `prop_fields()`
+    // — the derive intentionally skips non-Vec compound types. The
+    // raw-TOML encrypt walker must therefore source its allowlist
+    // from `secret_field_terminals()` (compile-time enumeration of
+    // every `#[secret]` field at every depth), so map-shaped values
+    // get the same encrypt-on-save coverage as scalar ones.
+    //
+    // This regression encodes that: a TOML config containing an MCP
+    // headers table with bearer credentials must have every value
+    // encrypted by the raw walker, while keys stay plaintext and
+    // sibling non-secret strings (`url`, `name`) stay plaintext too.
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let store = SecretStore::new(tmp.path(), true);
+
+    let raw_toml = r#"
+schema_version = 3
+
+[[mcp.servers]]
+name = "primary"
+transport = "sse"
+url = "https://mcp.example.invalid/sse"
+command = ""
+
+[mcp.servers.headers]
+Authorization = "Bearer mcp-cred"
+X-Tenant = "tenant-42"
+"#;
+
+    let mut value: toml::Value = toml::from_str(raw_toml).expect("toml parses");
+    encrypt_secret_strings(&mut value, &store).expect("encrypt walker succeeds");
+
+    let server = value
+        .get("mcp")
+        .and_then(|v| v.get("servers"))
+        .and_then(toml::Value::as_array)
+        .and_then(|arr| arr.first())
+        .expect("mcp.servers[0] table");
+    let headers = server
+        .get("headers")
+        .and_then(toml::Value::as_table)
+        .expect("mcp.servers[0].headers table");
+
+    for (key, val) in headers {
+        let s = val
+            .as_str()
+            .unwrap_or_else(|| panic!("headers.{key} is not a string"));
+        assert!(
+            s.starts_with("enc2:"),
+            "mcp.servers[0].headers.{key} must be enc2-prefixed; got: {s}"
+        );
+    }
+    let auth = headers
+        .get("Authorization")
+        .and_then(toml::Value::as_str)
+        .expect("Authorization value");
+    let tenant = headers
+        .get("X-Tenant")
+        .and_then(toml::Value::as_str)
+        .expect("X-Tenant value");
+    assert_eq!(
+        store.decrypt(auth).expect("decrypt auth"),
+        "Bearer mcp-cred",
+    );
+    assert_eq!(store.decrypt(tenant).expect("decrypt tenant"), "tenant-42",);
+
+    // Sibling non-secret strings remain plaintext — the walker only
+    // descends through allowlisted keys, not every string in the tree.
+    assert_eq!(
+        server.get("url").and_then(toml::Value::as_str),
+        Some("https://mcp.example.invalid/sse"),
+    );
+    assert_eq!(
+        server.get("name").and_then(toml::Value::as_str),
+        Some("primary"),
     );
 }
 

--- a/crates/zeroclaw-macros/src/lib.rs
+++ b/crates/zeroclaw-macros/src/lib.rs
@@ -215,6 +215,17 @@ pub fn derive_configurable(input: TokenStream) -> TokenStream {
     // section's role in this Config, which is what the operator needs.
     let mut nested_section_help_arms: Vec<proc_macro2::TokenStream> = Vec::new();
 
+    // Static enumeration of every `#[secret]` field's terminal name
+    // reachable from this Configurable type. Direct `#[secret]` fields
+    // push their own snake-case ident; `#[nested]` fields push a
+    // recursive call into the inner type's `secret_field_terminals()`.
+    // The migration crate's raw-TOML encrypt walker uses this allowlist
+    // so map-shaped `#[secret]` fields (e.g. `mcp.servers[*].headers`)
+    // get the same coverage as scalar ones — `prop_fields()` skips
+    // compound types and is not a safe source for that allowlist.
+    let mut secret_terminal_pushes: Vec<proc_macro2::TokenStream> = Vec::new();
+    let mut secret_terminal_recurse: Vec<proc_macro2::TokenStream> = Vec::new();
+
     for field in fields {
         let field_ident = field.ident.as_ref().expect("Named field must have ident");
         let is_secret = has_attr(field, "secret");
@@ -262,6 +273,14 @@ pub fn derive_configurable(input: TokenStream) -> TokenStream {
                     is_set: crate::traits::SecretField::is_set(&self.#field_ident),
                 }
             });
+            // Static terminal name (snake_case, matches the raw TOML key).
+            // Pushed regardless of shape so compound `#[secret]` fields
+            // like `HashMap<String, String>` reach the migration encrypt
+            // walker — they don't surface through `prop_fields()`.
+            let terminal_name = field_ident.to_string();
+            secret_terminal_pushes.push(quote! {
+                out.push(#terminal_name);
+            });
             encrypt_ops.push(quote! {
                 crate::traits::SecretField::encrypt_in_place(
                     &mut self.#field_ident,
@@ -278,12 +297,17 @@ pub fn derive_configurable(input: TokenStream) -> TokenStream {
             });
 
             // Only string-shaped fields wire into `set_secret` — the
-            // container shapes have no single-string set semantics.
+            // container shapes have no single-string set semantics. Look
+            // through `Option<...>` when checking shape so an annotation
+            // like `Option<HashMap<String, String>> #[secret]` doesn't fall
+            // through to a `self.field = Some(value: String)` arm that
+            // wouldn't type-check.
             let is_option = is_option_type(&field.ty);
-            let is_vec_string = extract_vec_inner(&field.ty)
+            let shape_ty = extract_option_inner(&field.ty).unwrap_or(&field.ty);
+            let is_vec_string = extract_vec_inner(shape_ty)
                 .map(|inner| inner.to_token_stream().to_string() == "String")
                 .unwrap_or(false);
-            let is_hashmap_string_string = extract_hashmap_value_type(&field.ty)
+            let is_hashmap_string_string = extract_hashmap_value_type(shape_ty)
                 .map(|inner| inner.to_token_stream().to_string() == "String")
                 .unwrap_or(false);
             if !is_vec_string && !is_hashmap_string_string {
@@ -438,6 +462,9 @@ pub fn derive_configurable(input: TokenStream) -> TokenStream {
                                 fields.extend(inner.secret_fields());
                             }
                         }
+                    });
+                    secret_terminal_recurse.push(quote! {
+                        out.extend(<#inner_ty>::secret_field_terminals());
                     });
                     nested_set.push(quote! {
                         for inner_map in self.#field_ident.values_mut() {
@@ -776,6 +803,9 @@ pub fn derive_configurable(input: TokenStream) -> TokenStream {
                         for inner in self.#field_ident.values() {
                             fields.extend(inner.secret_fields());
                         }
+                    });
+                    secret_terminal_recurse.push(quote! {
+                        out.extend(<#value_ty>::secret_field_terminals());
                     });
                     nested_set.push(quote! {
                         for inner in self.#field_ident.values_mut() {
@@ -1119,6 +1149,10 @@ pub fn derive_configurable(input: TokenStream) -> TokenStream {
                         }
                     });
 
+                    secret_terminal_recurse.push(quote! {
+                        out.extend(<#inner_ty_tokens>::secret_field_terminals());
+                    });
+
                     // Recurse: pull the inner type's map_key_sections + create_map_key.
                     map_key_recurse.push(quote! {
                         out.extend(<#inner_ty_tokens>::map_key_sections());
@@ -1156,6 +1190,9 @@ pub fn derive_configurable(input: TokenStream) -> TokenStream {
                     for inner in self.#field_ident.iter() {
                         fields.extend(inner.secret_fields());
                     }
+                });
+                secret_terminal_recurse.push(quote! {
+                    out.extend(<#vec_inner_ty>::secret_field_terminals());
                 });
                 nested_set.push(quote! {
                     for inner in self.#field_ident.iter_mut() {
@@ -1246,6 +1283,10 @@ pub fn derive_configurable(input: TokenStream) -> TokenStream {
                 }
                 nested_collect.push(quote! {
                     fields.extend(self.#field_ident.secret_fields());
+                });
+                let plain_field_ty = &field.ty;
+                secret_terminal_recurse.push(quote! {
+                    out.extend(<#plain_field_ty>::secret_field_terminals());
                 });
                 nested_set.push(quote! {
                     if let Ok(()) = self.#field_ident.set_secret(name, value.clone()) {
@@ -1687,6 +1728,24 @@ pub fn derive_configurable(input: TokenStream) -> TokenStream {
                 let mut fields = vec![#(#secret_field_entries),*];
                 #(#nested_collect)*
                 fields
+            }
+
+            /// Static enumeration of every `#[secret]` field's terminal name
+            /// (snake_case, matching the on-disk TOML key) reachable from
+            /// this type via `#[nested]` traversal. Unlike `secret_fields()`,
+            /// this requires no instance — the per-struct codegen literals
+            /// are joined at call time with recursive calls into the inner
+            /// types' own `secret_field_terminals()`.
+            ///
+            /// Used by the migration crate's raw-TOML encrypt walker as the
+            /// secret-key allowlist. `prop_fields()`-derived allowlists skip
+            /// compound (non-Vec) `#[secret]` fields, so this method is the
+            /// authoritative source.
+            pub fn secret_field_terminals() -> Vec<&'static str> {
+                let mut out: Vec<&'static str> = Vec::new();
+                #(#secret_terminal_pushes)*
+                #(#secret_terminal_recurse)*
+                out
             }
 
             /// Encrypt all secret fields in place using the provided store.

--- a/crates/zeroclaw-macros/src/lib.rs
+++ b/crates/zeroclaw-macros/src/lib.rs
@@ -225,6 +225,17 @@ pub fn derive_configurable(input: TokenStream) -> TokenStream {
         let is_resource_key = has_attr(field, "resource_key");
 
         // ── Secret handling ──
+        //
+        // mask / restore / encrypt / decrypt / is_set are dispatched through
+        // `crate::traits::SecretField`. Each supported shape (`String`,
+        // `Option<String>`, `Vec<String>`, `HashMap<String, String>`,
+        // `Option<HashMap<String, String>>`) lives as a trait impl in
+        // `crates/zeroclaw-config/src/traits.rs` — adding a new shape is a
+        // single impl block, not a new branch here.
+        //
+        // `set_secret(name, value)` only makes sense for string-shaped fields
+        // (the public API takes `String`), so only `String` and `Option<String>`
+        // push to `set_arms`. Container shapes are read-only through that path.
         if is_secret {
             let field_name_kebab = snake_to_kebab(&field_ident.to_string());
             let full_name = if prefix.is_empty() {
@@ -232,119 +243,59 @@ pub fn derive_configurable(input: TokenStream) -> TokenStream {
             } else {
                 format!("{}.{}", prefix, field_name_kebab)
             };
+            let full_name_lit = &full_name;
+            let category_lit = &category;
 
+            mask_ops.push(quote! {
+                crate::traits::SecretField::mask(&mut self.#field_ident);
+            });
+            restore_ops.push(quote! {
+                crate::traits::SecretField::restore_from(
+                    &mut self.#field_ident,
+                    &current.#field_ident,
+                );
+            });
+            secret_field_entries.push(quote! {
+                crate::config::SecretFieldInfo {
+                    name: #full_name_lit,
+                    category: #category_lit,
+                    is_set: crate::traits::SecretField::is_set(&self.#field_ident),
+                }
+            });
+            encrypt_ops.push(quote! {
+                crate::traits::SecretField::encrypt_in_place(
+                    &mut self.#field_ident,
+                    store,
+                    #full_name_lit,
+                )?;
+            });
+            decrypt_ops.push(quote! {
+                crate::traits::SecretField::decrypt_in_place(
+                    &mut self.#field_ident,
+                    store,
+                    #full_name_lit,
+                )?;
+            });
+
+            // Only string-shaped fields wire into `set_secret` — the
+            // container shapes have no single-string set semantics.
             let is_option = is_option_type(&field.ty);
             let is_vec_string = extract_vec_inner(&field.ty)
                 .map(|inner| inner.to_token_stream().to_string() == "String")
                 .unwrap_or(false);
-            let full_name_lit = &full_name;
-            let category_lit = &category;
-
-            if is_vec_string {
-                // Vec<String> with #[secret]: mask each element
-                mask_ops.push(quote! {
-                    for element in &mut self.#field_ident {
-                        crate::traits::mask_required_secret(element);
-                    }
-                });
-                restore_ops.push(quote! {
-                    for (element, cur) in self.#field_ident.iter_mut().zip(current.#field_ident.iter()) {
-                        crate::traits::restore_required_secret(element, cur);
-                    }
-                });
-
-                // Vec<String> with #[secret]: iterate elements for encrypt/decrypt
-                secret_field_entries.push(quote! {
-                    crate::config::SecretFieldInfo {
-                        name: #full_name_lit,
-                        category: #category_lit,
-                        is_set: !self.#field_ident.is_empty(),
-                    }
-                });
-                encrypt_ops.push(quote! {
-                    for element in &mut self.#field_ident {
-                        if !element.is_empty() && !crate::security::SecretStore::is_encrypted(element) {
-                            *element = store.encrypt(element)
-                                .with_context(|| format!("Failed to encrypt {}[]", #full_name_lit))?;
-                        }
-                    }
-                });
-                decrypt_ops.push(quote! {
-                    for element in &mut self.#field_ident {
-                        if crate::security::SecretStore::is_encrypted(element) {
-                            *element = store.decrypt(element)
-                                .with_context(|| format!("Failed to decrypt {}[]", #full_name_lit))?;
-                        }
-                    }
-                });
-            } else if is_option {
-                mask_ops.push(quote! {
-                    crate::traits::mask_optional_secret(&mut self.#field_ident);
-                });
-                restore_ops.push(quote! {
-                    crate::traits::restore_optional_secret(&mut self.#field_ident, &current.#field_ident);
-                });
-
-                secret_field_entries.push(quote! {
-                    crate::config::SecretFieldInfo {
-                        name: #full_name_lit,
-                        category: #category_lit,
-                        is_set: self.#field_ident.as_ref().is_some_and(|v| !v.is_empty()),
-                    }
-                });
-                set_arms.push(quote! {
-                    #full_name_lit => { self.#field_ident = Some(value); Ok(()) }
-                });
-                encrypt_ops.push(quote! {
-                    if let Some(raw) = &self.#field_ident {
-                        if !crate::security::SecretStore::is_encrypted(raw) {
-                            self.#field_ident = Some(
-                                store.encrypt(raw)
-                                    .with_context(|| format!("Failed to encrypt {}", #full_name_lit))?
-                            );
-                        }
-                    }
-                });
-                decrypt_ops.push(quote! {
-                    if let Some(raw) = &self.#field_ident {
-                        if crate::security::SecretStore::is_encrypted(raw) {
-                            self.#field_ident = Some(
-                                store.decrypt(raw)
-                                    .with_context(|| format!("Failed to decrypt {}", #full_name_lit))?
-                            );
-                        }
-                    }
-                });
-            } else {
-                mask_ops.push(quote! {
-                    crate::traits::mask_required_secret(&mut self.#field_ident);
-                });
-                restore_ops.push(quote! {
-                    crate::traits::restore_required_secret(&mut self.#field_ident, &current.#field_ident);
-                });
-
-                secret_field_entries.push(quote! {
-                    crate::config::SecretFieldInfo {
-                        name: #full_name_lit,
-                        category: #category_lit,
-                        is_set: !self.#field_ident.is_empty(),
-                    }
-                });
-                set_arms.push(quote! {
-                    #full_name_lit => { self.#field_ident = value; Ok(()) }
-                });
-                encrypt_ops.push(quote! {
-                    if !self.#field_ident.is_empty() && !crate::security::SecretStore::is_encrypted(&self.#field_ident) {
-                        self.#field_ident = store.encrypt(&self.#field_ident)
-                            .with_context(|| format!("Failed to encrypt {}", #full_name_lit))?;
-                    }
-                });
-                decrypt_ops.push(quote! {
-                    if crate::security::SecretStore::is_encrypted(&self.#field_ident) {
-                        self.#field_ident = store.decrypt(&self.#field_ident)
-                            .with_context(|| format!("Failed to decrypt {}", #full_name_lit))?;
-                    }
-                });
+            let is_hashmap_string_string = extract_hashmap_value_type(&field.ty)
+                .map(|inner| inner.to_token_stream().to_string() == "String")
+                .unwrap_or(false);
+            if !is_vec_string && !is_hashmap_string_string {
+                if is_option {
+                    set_arms.push(quote! {
+                        #full_name_lit => { self.#field_ident = Some(value); Ok(()) }
+                    });
+                } else {
+                    set_arms.push(quote! {
+                        #full_name_lit => { self.#field_ident = value; Ok(()) }
+                    });
+                }
             }
         }
 
@@ -1184,18 +1135,55 @@ pub fn derive_configurable(input: TokenStream) -> TokenStream {
             } else if let Some(vec_inner_ty) = extract_vec_inner(&field.ty) {
                 // ── Nested Vec<T> ──
                 // Vec doesn't implement Configurable, so we cannot delegate
-                // get_prop / set_prop / secret_fields / prop_fields /
-                // init_defaults to the field directly. The list-section
-                // emission below handles `+ Add` and per-entry creation;
-                // per-prop access to elements happens through the schema's
-                // natural-key routing once entries are inserted.
+                // get_prop / set_prop / prop_fields / init_defaults to the
+                // field directly — those address an element by name and a
+                // Vec carries no name index. The list-section emission below
+                // handles `+ Add` and per-entry creation; per-prop access to
+                // elements happens through the schema's natural-key routing
+                // once entries are inserted.
                 //
-                // Intentionally NO push to nested_collect / nested_set /
-                // nested_encrypt / nested_decrypt / nested_prop_fields /
-                // nested_get_prop / nested_set_prop / nested_prop_is_secret
-                // / init_defaults_ops / map_key_recurse / create_map_key_recurse
-                // for Vec<T> + #[nested] — all those call methods Vec doesn't
-                // have.
+                // Bulk-walk operations (encrypt / decrypt / mask / restore /
+                // secret_fields / set_secret), however, only need to iterate
+                // the Vec and dispatch on each element's own `T` method —
+                // they don't address by name. So those DO push here, mirroring
+                // the single-level `HashMap<String, T>` traversal above.
+                //
+                // Intentionally NO push to nested_prop_fields / nested_get_prop /
+                // nested_set_prop / nested_prop_is_secret / init_defaults_ops /
+                // map_key_recurse / create_map_key_recurse for Vec<T> + #[nested]
+                // — all those call methods Vec doesn't have.
+                nested_collect.push(quote! {
+                    for inner in self.#field_ident.iter() {
+                        fields.extend(inner.secret_fields());
+                    }
+                });
+                nested_set.push(quote! {
+                    for inner in self.#field_ident.iter_mut() {
+                        if let Ok(()) = inner.set_secret(name, value.clone()) {
+                            return Ok(());
+                        }
+                    }
+                });
+                nested_encrypt.push(quote! {
+                    for inner in self.#field_ident.iter_mut() {
+                        inner.encrypt_secrets(store)?;
+                    }
+                });
+                nested_decrypt.push(quote! {
+                    for inner in self.#field_ident.iter_mut() {
+                        inner.decrypt_secrets(store)?;
+                    }
+                });
+                mask_ops.push(quote! {
+                    crate::traits::MaskSecrets::mask_secrets(&mut self.#field_ident);
+                });
+                restore_ops.push(quote! {
+                    crate::traits::MaskSecrets::restore_secrets_from(
+                        &mut self.#field_ident,
+                        &current.#field_ident,
+                    );
+                });
+
                 let vec_inner_name = vec_inner_ty.to_token_stream().to_string();
                 let field_doc = extract_doc(&field.attrs);
                 let vec_field_name_lit = snake_to_kebab(&field_ident.to_string());
@@ -1703,7 +1691,6 @@ pub fn derive_configurable(input: TokenStream) -> TokenStream {
 
             /// Encrypt all secret fields in place using the provided store.
             pub fn encrypt_secrets(&mut self, store: &crate::security::SecretStore) -> anyhow::Result<()> {
-                use anyhow::Context;
                 #(#encrypt_ops)*
                 #(#nested_encrypt)*
                 Ok(())
@@ -1711,7 +1698,6 @@ pub fn derive_configurable(input: TokenStream) -> TokenStream {
 
             /// Decrypt all secret fields in place using the provided store.
             pub fn decrypt_secrets(&mut self, store: &crate::security::SecretStore) -> anyhow::Result<()> {
-                use anyhow::Context;
                 #(#decrypt_ops)*
                 #(#nested_decrypt)*
                 Ok(())


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - The `Configurable` derive's secret handling had three near-duplicate per-shape branches (`String`, `Option<String>`, `Vec<String>`) inlined in the macro for mask / restore / encrypt / decrypt / is_set. Adding a fourth supported shape — `HashMap<String, String>`, needed so MCP headers carrying Bearer tokens get the same encrypt-on-save lifecycle as everything else — would have meant a fourth branch. Instead, push the per-shape logic behind a `SecretField` trait so adding the next shape is a trait impl, not a macro patch.
  - Tag `WebhookConfig.auth_header` (`Option<String>`) and `McpServerConfig.headers` (`HashMap<String, String>`) with `#[secret]` + the matching `x-secret` schemars hint. These are the two upstream-applicable fields from the phase-2 secret-encryption work.
  - Fix a latent macro skip: `Vec<T>` with `#[nested]` (`mcp.servers`) wasn't propagating `encrypt_secrets` / `decrypt_secrets` / `secret_fields` / `mask` / `restore` to its children. Bug was dormant because no field inside an mcp.servers child carried `#[secret]` — surfaces immediately once `headers` is tagged.
- **Scope boundary:** Does NOT tag `ModelProviderConfig.extra_headers` or `ObservabilityConfig.otel_headers` (same `HashMap<String, String>` shape, same threat model — the new trait makes those a one-line follow-up). Does NOT change wire formats, secret-store crypto, or the `MaskSecrets` trait surface beyond adding a `Vec<T: MaskSecrets>` blanket impl that mirrors the existing `HashMap<String, T>` one.
- **Blast radius:** The derive's secret-arm output changes shape for every struct that uses `#[secret]`. The trait dispatches preserve the existing semantics (idempotent `enc2:` short-circuit, `MASKED_SECRET` for masking) and round-trip tests for every previously-tagged field still pass. Gateway / dashboard masking code (`mask_secrets()` on `Config`) is unaffected; that already went through the per-struct `MaskSecrets` derived methods.
- **Linked issue(s):** None.

## Validation Evidence

```
$ cargo fmt --all -- --check
(no output — clean)

$ cargo clippy --all-targets -- -D warnings
    Finished \`dev\` profile [unoptimized + debuginfo] target(s) in 1m 35s
(no warnings, no errors)

$ cargo test -p zeroclaw-config --lib
test result: ok. 675 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.29s

$ cargo test --workspace --lib --tests
(every crate reports \"test result: ok\"; no FAILED lines)
```

- **Beyond CI — what did you manually verify?** Targeted `config_save_encrypts_nested_credentials` first, watched it fail on the latent `Vec<T>` `#[nested]` skip when `McpServerConfig.headers` was tagged, then re-ran after the macro fix to confirm every map value round-trips through encrypt → save → reload → decrypt. New trait unit tests in `crates/zeroclaw-config/src/traits.rs` cover each impl (empty / set / mask / restore / idempotent re-encrypt / error-message-includes-field-path).
- **Not verified:** dashboard/web-UI behavior for the newly-secret MCP `headers` field — the masking propagates through the unchanged `MaskSecrets` trait, but I haven't loaded the dashboard. Doctest harness was skipped: a pre-existing `.cargo/config.toml` × scratch-worktree-layout collision passes `--default-theme=ayu` twice in this checkout. Doctests run fine from the canonical worktree.
- **Intentionally skipped:** None of the CI commands.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **Yes** — two previously-plaintext config fields (`channels.webhook.<alias>.auth_header`, `mcp.servers[*].headers`) now flow through the `SecretStore` encrypt-on-save / decrypt-on-load lifecycle. Pre-existing plaintext values in existing configs are passed through unchanged on load (`SecretStore::decrypt` already has a plaintext passthrough); on the next save they're encrypted into `enc2:<hex>`. Mask flow (`***MASKED***` in dashboard read paths) extends to the new shapes via the new trait impls.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No** — test fixtures use `Bearer mcp-cred`, `Bearer webhook-cred`, `tenant-42`.

## Compatibility

- Backward compatible? **Yes**
  - Existing `enc2:`-encrypted values continue to decrypt identically (no algorithm change).
  - Existing plaintext values continue to round-trip (passthrough on load, encrypted on next save).
  - Existing structs derive the same `secret_fields()` / `encrypt_secrets()` / `decrypt_secrets()` / `mask_secrets()` API; the body is generated from the trait now, but the surface is unchanged.
- Config / env / CLI surface changed? **No** — TOML keys and shapes are unchanged.
- No upgrade steps required.

## Rollback

- **Fast rollback command/path:** `git revert <merge-sha>`. The two newly-tagged fields fall back to plaintext storage; legacy `enc2:` values written under this change remain decryptable (the secret store didn't change).
- **Feature flags or config toggles:** None. Operators who explicitly want plaintext can already set `secrets.encrypt = false`.
- **Observable failure symptoms:** Encrypt/decrypt failures now log the dotted field path (e.g. `Failed to decrypt mcp.servers.foo.headers.Authorization`), so grep `Failed to decrypt` or `Failed to encrypt` in `journalctl` / Docker logs. Mask flow regressions would show `***MASKED***` reaching the agent runtime — grep `MASKED_SECRET` in runtime logs.
