### PR TITLE
feat(tools): filter deferred MCP tools by access policy

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -3077,16 +3077,28 @@ pub async fn run(
                                 registry.server_count()
                             )
                         );
-                        deferred_section =
-                            crate::tools::build_deferred_tools_section(&deferred_set);
+                        // Build access policy from SecurityPolicy so blocked
+                        // MCP tools never surface anywhere in context.
+                        let mcp_policy =
+                            zeroclaw_tools::tool_search::ToolAccessPolicy::from_security(
+                                security.allowed_tools.as_deref(),
+                                security.excluded_tools.as_deref(),
+                                allowed_tools.as_deref(),
+                            );
+                        deferred_section = crate::tools::build_deferred_tools_section_filtered(
+                            &deferred_set,
+                            mcp_policy.as_ref(),
+                        );
                         let activated = std::sync::Arc::new(std::sync::Mutex::new(
                             crate::tools::ActivatedToolSet::new(),
                         ));
                         activated_handle = Some(std::sync::Arc::clone(&activated));
-                        tools_registry.push(Box::new(crate::tools::ToolSearchTool::new(
-                            deferred_set,
-                            activated,
-                        )));
+                        let mut tool_search =
+                            crate::tools::ToolSearchTool::new(deferred_set, activated);
+                        if let Some(policy) = mcp_policy {
+                            tool_search = tool_search.with_access_policy(policy);
+                        }
+                        tools_registry.push(Box::new(tool_search));
                     } else {
                         // Eager path: register all MCP tools directly
                         let names = registry.tool_names();
@@ -4346,16 +4358,26 @@ pub async fn process_message(
                                 registry.server_count()
                             )
                         );
-                        deferred_section =
-                            crate::tools::build_deferred_tools_section(&deferred_set);
+                        let mcp_policy_pm =
+                            zeroclaw_tools::tool_search::ToolAccessPolicy::from_security(
+                                security.allowed_tools.as_deref(),
+                                security.excluded_tools.as_deref(),
+                                None, // no caller-supplied allowlist in channel path
+                            );
+                        deferred_section = crate::tools::build_deferred_tools_section_filtered(
+                            &deferred_set,
+                            mcp_policy_pm.as_ref(),
+                        );
                         let activated = std::sync::Arc::new(std::sync::Mutex::new(
                             crate::tools::ActivatedToolSet::new(),
                         ));
                         activated_handle_pm = Some(std::sync::Arc::clone(&activated));
-                        tools_registry.push(Box::new(crate::tools::ToolSearchTool::new(
-                            deferred_set,
-                            activated,
-                        )));
+                        let mut tool_search_pm =
+                            crate::tools::ToolSearchTool::new(deferred_set, activated);
+                        if let Some(policy) = mcp_policy_pm {
+                            tool_search_pm = tool_search_pm.with_access_policy(policy);
+                        }
+                        tools_registry.push(Box::new(tool_search_pm));
                     } else {
                         let names = registry.tool_names();
                         let mut registered = 0usize;

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -81,6 +81,7 @@ pub use zeroclaw_tools::llm_task::LlmTaskTool;
 pub use zeroclaw_tools::mcp_client::McpRegistry;
 pub use zeroclaw_tools::mcp_deferred::{
     ActivatedToolSet, DeferredMcpToolSet, build_deferred_tools_section,
+    build_deferred_tools_section_filtered,
 };
 pub use zeroclaw_tools::mcp_tool::McpToolWrapper;
 pub use zeroclaw_tools::memory_export::MemoryExportTool;

--- a/crates/zeroclaw-tools/src/mcp_deferred.rs
+++ b/crates/zeroclaw-tools/src/mcp_deferred.rs
@@ -232,6 +232,13 @@ impl Default for ActivatedToolSet {
 /// consuming context window on full schemas. Includes an instruction
 /// block that tells the LLM to call `tool_search` to activate them.
 pub fn build_deferred_tools_section(deferred: &DeferredMcpToolSet) -> String {
+    build_deferred_tools_section_filtered(deferred, None)
+}
+
+pub fn build_deferred_tools_section_filtered(
+    deferred: &DeferredMcpToolSet,
+    policy: Option<&crate::tool_search::ToolAccessPolicy>,
+) -> String {
     if deferred.is_empty() {
         return String::new();
     }
@@ -245,13 +252,23 @@ pub fn build_deferred_tools_section(deferred: &DeferredMcpToolSet) -> String {
          become callable for the rest of the conversation.\n\n",
     );
     out.push_str("<available-deferred-tools>\n");
+    let mut count = 0;
     for stub in &deferred.stubs {
+        if let Some(p) = policy
+            && !p.is_tool_allowed(&stub.prefixed_name)
+        {
+            continue;
+        }
         out.push_str(&stub.prefixed_name);
         out.push_str(" - ");
         out.push_str(&stub.description);
         out.push('\n');
+        count += 1;
     }
     out.push_str("</available-deferred-tools>\n");
+    if count == 0 {
+        return String::new();
+    }
     out
 }
 

--- a/crates/zeroclaw-tools/src/tool_search.rs
+++ b/crates/zeroclaw-tools/src/tool_search.rs
@@ -16,10 +16,64 @@ use zeroclaw_api::tool::{Tool, ToolResult};
 /// Default maximum number of search results.
 const DEFAULT_MAX_RESULTS: usize = 5;
 
+/// Tool-level access policy applied at discovery time.
+///
+/// When set on `ToolSearchTool`, deferred tools that fail this check are
+/// never surfaced to the LLM and never activated — keeping them out of
+/// the context window entirely.
+#[derive(Clone, Default)]
+pub struct ToolAccessPolicy {
+    pub allowed: Option<Vec<String>>,
+    pub denied: Option<Vec<String>>,
+}
+
+impl ToolAccessPolicy {
+    /// Construct from a `SecurityPolicy`'s tool fields and an optional
+    /// caller-supplied allowlist. Used by both `run()` and
+    /// `process_message()` to keep policy construction in sync.
+    pub fn from_security(
+        allowed_tools: Option<&[String]>,
+        excluded_tools: Option<&[String]>,
+        caller_allowed: Option<&[String]>,
+    ) -> Option<Self> {
+        let mut policy = Self::default();
+        if let Some(list) = allowed_tools {
+            let mut merged = list.to_vec();
+            if let Some(caller) = caller_allowed {
+                merged.retain(|t| caller.iter().any(|c| c == t));
+            }
+            policy.allowed = Some(merged);
+        } else if let Some(caller) = caller_allowed {
+            policy.allowed = Some(caller.to_vec());
+        }
+        if let Some(list) = excluded_tools {
+            policy.denied = Some(list.to_vec());
+        }
+        if policy.allowed.is_some() || policy.denied.is_some() {
+            Some(policy)
+        } else {
+            None
+        }
+    }
+
+    pub fn is_tool_allowed(&self, name: &str) -> bool {
+        let in_allow = self
+            .allowed
+            .as_ref()
+            .is_none_or(|list| list.iter().any(|t| t == name));
+        let in_deny = self
+            .denied
+            .as_ref()
+            .is_some_and(|list| list.iter().any(|t| t == name));
+        in_allow && !in_deny
+    }
+}
+
 /// Built-in tool that fetches full schemas for deferred MCP tools.
 pub struct ToolSearchTool {
     deferred: DeferredMcpToolSet,
     activated: Arc<Mutex<ActivatedToolSet>>,
+    access_policy: Option<ToolAccessPolicy>,
 }
 
 impl ToolSearchTool {
@@ -27,7 +81,19 @@ impl ToolSearchTool {
         Self {
             deferred,
             activated,
+            access_policy: None,
         }
+    }
+
+    pub fn with_access_policy(mut self, policy: ToolAccessPolicy) -> Self {
+        self.access_policy = Some(policy);
+        self
+    }
+
+    fn is_allowed(&self, tool_name: &str) -> bool {
+        self.access_policy
+            .as_ref()
+            .is_none_or(|p| p.is_tool_allowed(tool_name))
     }
 }
 
@@ -88,8 +154,15 @@ impl Tool for ToolSearchTool {
             return self.select_tools(&names);
         }
 
-        // Keyword search mode
-        let results = self.deferred.search(query, max_results);
+        // Keyword search mode.
+        // When a policy is active, fetch all matches so denied tools don't
+        // consume result slots. The max_results cap is applied after filtering.
+        let search_limit = if self.access_policy.is_some() {
+            usize::MAX
+        } else {
+            max_results
+        };
+        let results = self.deferred.search(query, search_limit);
         if results.is_empty() {
             return Ok(ToolResult {
                 success: true,
@@ -98,12 +171,27 @@ impl Tool for ToolSearchTool {
             });
         }
 
-        // Activate and return full specs
+        // Activate and return full specs (policy-filtered, then capped)
         let mut output = String::from("<functions>\n");
         let mut activated_count = 0;
+        let mut returned_count = 0;
         let mut guard = self.activated.lock().unwrap();
 
         for stub in &results {
+            if returned_count >= max_results {
+                break;
+            }
+            if !self.is_allowed(&stub.prefixed_name) {
+                ::zeroclaw_log::record!(
+                    DEBUG,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note),
+                    &format!(
+                        "tool_search: '{}' matched query but denied by access policy",
+                        stub.prefixed_name
+                    )
+                );
+                continue;
+            }
             if let Some(spec) = self.deferred.tool_spec(&stub.prefixed_name) {
                 if !guard.is_activated(&stub.prefixed_name)
                     && let Some(tool) = self.deferred.activate(&stub.prefixed_name)
@@ -118,6 +206,7 @@ impl Tool for ToolSearchTool {
                     spec.description.replace('"', "\\\""),
                     spec.parameters
                 );
+                returned_count += 1;
             }
         }
 
@@ -150,6 +239,15 @@ impl ToolSearchTool {
 
         for name in names {
             if name.is_empty() {
+                continue;
+            }
+            if !self.is_allowed(name) {
+                ::zeroclaw_log::record!(
+                    DEBUG,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note),
+                    &format!("tool_search select: '{}' denied by access policy", name)
+                );
+                not_found.push(*name);
                 continue;
             }
             match self.deferred.tool_spec(name) {
@@ -372,5 +470,119 @@ mod tests {
             .unwrap();
 
         assert_eq!(activated.lock().unwrap().tool_specs().len(), 1);
+    }
+
+    #[test]
+    fn policy_none_is_unrestricted() {
+        let p = ToolAccessPolicy::default();
+        assert!(p.is_tool_allowed("shell"));
+        assert!(p.is_tool_allowed("anything"));
+    }
+
+    #[test]
+    fn policy_allowlist_admits_only_listed() {
+        let p = ToolAccessPolicy {
+            allowed: Some(vec!["shell".into(), "file_read".into()]),
+            denied: None,
+        };
+        assert!(p.is_tool_allowed("shell"));
+        assert!(!p.is_tool_allowed("file_write"));
+    }
+
+    #[test]
+    fn policy_denylist_rejects_listed() {
+        let p = ToolAccessPolicy {
+            allowed: None,
+            denied: Some(vec!["shell".into()]),
+        };
+        assert!(!p.is_tool_allowed("shell"));
+        assert!(p.is_tool_allowed("file_read"));
+    }
+
+    #[test]
+    fn policy_deny_overrides_allow() {
+        let p = ToolAccessPolicy {
+            allowed: Some(vec!["shell".into(), "file_read".into()]),
+            denied: Some(vec!["shell".into()]),
+        };
+        assert!(!p.is_tool_allowed("shell"));
+        assert!(p.is_tool_allowed("file_read"));
+    }
+
+    #[tokio::test]
+    async fn policy_filters_keyword_search_results() {
+        let activated = Arc::new(Mutex::new(ActivatedToolSet::new()));
+        let stubs = vec![
+            make_stub("srv__allowed_tool", "An allowed tool"),
+            make_stub("srv__blocked_tool", "A blocked tool"),
+        ];
+        let policy = ToolAccessPolicy {
+            allowed: None,
+            denied: Some(vec!["srv__blocked_tool".into()]),
+        };
+        let tool = ToolSearchTool::new(make_deferred_set(stubs).await, Arc::clone(&activated))
+            .with_access_policy(policy);
+
+        let result = tool
+            .execute(serde_json::json!({"query": "tool"}))
+            .await
+            .unwrap();
+        assert!(result.success);
+        assert!(result.output.contains("srv__allowed_tool"));
+        assert!(!result.output.contains("srv__blocked_tool"));
+        assert!(!activated.lock().unwrap().is_activated("srv__blocked_tool"));
+    }
+
+    #[tokio::test]
+    async fn policy_denied_tool_does_not_consume_max_results_slot() {
+        let activated = Arc::new(Mutex::new(ActivatedToolSet::new()));
+        // "denied_tool" ranks higher (more keyword matches) but is blocked.
+        // "allowed_tool" ranks lower but should still be returned with max_results=1.
+        let stubs = vec![
+            make_stub("srv__denied_tool", "tool for searching files"),
+            make_stub("srv__allowed_tool", "tool for files"),
+        ];
+        let policy = ToolAccessPolicy {
+            allowed: None,
+            denied: Some(vec!["srv__denied_tool".into()]),
+        };
+        let tool = ToolSearchTool::new(make_deferred_set(stubs).await, Arc::clone(&activated))
+            .with_access_policy(policy);
+
+        let result = tool
+            .execute(serde_json::json!({"query": "searching files", "max_results": 1}))
+            .await
+            .unwrap();
+        assert!(result.success);
+        // The allowed tool should be returned even though max_results=1
+        // and the denied tool ranked higher.
+        assert!(result.output.contains("srv__allowed_tool"));
+        assert!(!result.output.contains("srv__denied_tool"));
+        assert!(activated.lock().unwrap().is_activated("srv__allowed_tool"));
+    }
+
+    #[tokio::test]
+    async fn policy_filters_select_results() {
+        let activated = Arc::new(Mutex::new(ActivatedToolSet::new()));
+        let stubs = vec![
+            make_stub("srv__ok", "OK tool"),
+            make_stub("srv__nope", "Blocked tool"),
+        ];
+        let policy = ToolAccessPolicy {
+            allowed: Some(vec!["srv__ok".into()]),
+            denied: None,
+        };
+        let tool = ToolSearchTool::new(make_deferred_set(stubs).await, Arc::clone(&activated))
+            .with_access_policy(policy);
+
+        let result = tool
+            .execute(serde_json::json!({"query": "select:srv__ok,srv__nope"}))
+            .await
+            .unwrap();
+        assert!(result.success);
+        assert!(result.output.contains("srv__ok"));
+        assert!(!result.output.contains("\"name\": \"srv__nope\""));
+        assert!(result.output.contains("Not found"));
+        assert!(!activated.lock().unwrap().is_activated("srv__nope"));
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** MCP deferred tools bypassed `apply_policy_tool_filter()` because they load on-demand via `tool_search` and their stubs were listed unconditionally in the deferred system-prompt section. Tools blocked by `SecurityPolicy.allowed_tools` / `excluded_tools` stayed visible to the model and activatable. This PR filters them **at discovery time** so a blocked deferred MCP tool never reaches the LLM context — not in the deferred prompt section, not in `tool_search` keyword results, and not via `select:` activation. It also closes a gap where `process_message()` (the channel path) did not enforce `allowed_tools` for deferred MCP tools.
- **Scope boundary:** Does NOT add execution-dispatch enforcement, an agent-level `denied_tools` config, or any new CLI/config-file surface — it reuses the existing `SecurityPolicy` tool fields. Built-in (non-MCP) tool specs and `tool_descs` are unchanged; they were already filtered by `apply_policy_tool_filter` / `retain_registered_tool_descriptions`.
- **Blast radius:** Agent loop tool wiring (`run()` + `process_message()`), `tool_search` discovery, and the deferred MCP prompt section. Only deployments that set `allowed_tools`/`excluded_tools` change behavior; default deployments are unaffected because `ToolAccessPolicy::from_security()` returns `None` (no filtering) when neither field is set.

- **Linked issue(s):** Related #6914. This PR implements the **deferred-MCP discovery / prompt / search** slice of the tool-scope contract. The broader allow/deny work in #6914 — execution-dispatch enforcement, an agent-level denied-tools counterpart, and CLI/config-file surface — remains open, so this intentionally does **not** auto-close the tracking issue.
- **Labels:** `enhancement`, `size: M`, `risk: high`, `agent`, `runtime`, `security`, `tool`, `tool:mcp`.

## What changed

| File | Change |
|------|--------|
| `crates/zeroclaw-tools/src/tool_search.rs` | Add `ToolAccessPolicy` struct + `from_security()` + `with_access_policy()` on `ToolSearchTool`; filter in both keyword and `select:` paths |
| `crates/zeroclaw-tools/src/mcp_deferred.rs` | Add `build_deferred_tools_section_filtered()` — skips blocked stubs from the system prompt |
| `crates/zeroclaw-runtime/src/agent/loop_.rs` | Construct policy from `SecurityPolicy` and pass to both `ToolSearchTool` + deferred-section builder at the `run()` and `process_message()` sites |
| `crates/zeroclaw-runtime/src/tools/mod.rs` | Re-export `build_deferred_tools_section_filtered` |

4 files changed, +267 / −15.

All five surfaces a blocked tool could leak through are covered: built-in specs (existing `apply_policy_tool_filter`), `tool_descs` text (existing `retain_registered_tool_descriptions`), deferred prompt section (NEW filter), `tool_search` keyword results (NEW policy), and per-iteration activation (never activated because `tool_search` rejects them).

## Validation Evidence (required)

- **Commands run and tail output:**
  - **CI on `36e9522` (parent of the current head — tree is byte-identical; the current head `bbdaec9` differs only in the commit message):** full battery green — Lint (`cargo fmt --all -- --check` + `cargo clippy --all-targets -- -D warnings`), Test (`cargo test`), Check (all-features / no-default-features / 32-bit), Build (x86_64-linux, aarch64-darwin, x86_64-windows), Security (cargo-audit), Benchmarks Compile. Run: https://github.com/zeroclaw-labs/zeroclaw/actions/runs/26422829410
  - **Local (worktree on this commit, changed crate):**
    ```
    $ cargo fmt --all -- --check
    (clean; exit 0)

    $ cargo test -p zeroclaw-tools
    test result: ok. 1188 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.45s
       Doc-tests zeroclaw_tools
    test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out
    ```
    This package contains the security-critical logic and its tests: the 4 `ToolAccessPolicy` unit tests + 2 `tool_search` policy-integration tests. The key regression is covered directly — a denied higher-ranked match with `max_results: 1` no longer starves an allowed lower-ranked tool (keyword search now filters *before* applying the cap), and a denied `select:<name>` returns model-safe "not found".
- **Beyond CI — what did you manually verify?** Traced each of the five context surfaces above and confirmed a denied tool is dropped at every one. Confirmed the keyword path fetches the full match set (`usize::MAX`) and applies `max_results` only after policy filtering, so a denied high-rank match cannot consume an allowed tool's result slot. Confirmed default deployments are unchanged (`from_security()` → `None`).
- **If any command was intentionally skipped, why:** The full-workspace `cargo test`, `cargo clippy --all-targets -- -D warnings`, and the three-platform builds were **not** re-run locally for this revision — they ran in CI on `36e9522` (green, linked above) and the commit-message-only amend to `bbdaec9` leaves the tree byte-identical. Local re-run was scoped to the changed crate (`zeroclaw-tools`) to avoid a cold workspace recompile; CI is the authoritative signal for the heavy suite.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No** — this *narrows* the capability surface (removes blocked MCP tools from the model's reach). No new permissions or FS access.
- New external network calls? **No.**
- Secrets / tokens / credentials handling changed? **No.**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No** — test fixtures use synthetic tool names (`shell`, `file_read`, `file_write`).
- If any `Yes`, describe the risk and mitigation: N/A. This is a security-positive change: it enforces least-privilege for deferred MCP tools across all context surfaces, including the previously-unenforced `process_message()` channel path.

## Compatibility (required)

- Backward compatible? **Yes** for default deployments — when neither `allowed_tools` nor `excluded_tools` is set, `from_security()` returns `None` and discovery behavior is byte-for-byte unchanged. For deployments that already set those fields, deferred MCP tools that *should* have been blocked are now correctly hidden/blocked across `tool_search` and the prompt — this is the intended fix, not a regression.
- Config / env / CLI surface changed? **No** — reuses the existing `SecurityPolicy.allowed_tools` / `excluded_tools`; no new keys or flags.
- If `No` or `Yes` to either: exact upgrade steps for existing users: None required. Operators already using `allowed_tools`/`excluded_tools` will simply see deferred MCP tools honored consistently after upgrade; no config migration.

## Rollback (required for `risk: high`)

- **Fast rollback command/path:** `git revert bbdaec9` — single, self-contained commit; no migrations, schema, or persisted state.
- **Feature flags or config toggles:** None. The behavior is gated entirely by the existing `SecurityPolicy` fields; clearing `allowed_tools` and `excluded_tools` disables the filtering without a revert, but that also removes the least-privilege boundary, so `git revert` is preferred.
- **Observable failure symptoms:** A misconfigured policy would manifest as legitimate **allowed** MCP tools disappearing from `tool_search` results / the deferred prompt section, or `select:<name>` returning "not found" for an allowed tool. Grep the agent DEBUG log for `denied by access policy` — emitted on every policy rejection with the tool name — to see exactly which tools the policy is dropping and why.
