### PR TITLE
fix(runtime): deliver only final assistant turn's content to channels

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -2100,8 +2100,12 @@ pub async fn run_tool_call_loop(
             return Ok(accumulated_display_text);
         }
 
-        // Accumulate text from this iteration (tool calls present, loop continues).
-        accumulated_display_text.push_str(&display_text);
+        // Do NOT accumulate intermediate-turn display_text into the final
+        // channel response: intermediate text is the model's narration
+        // between tool calls (chain-of-thought leakage on thinking-mode
+        // models like GLM-4.5+, DeepSeek-R1, QwQ). Streaming users still
+        // see it via tx.send(StreamDelta::Text(...)) below. Channel layer
+        // delivers only the final assistant turn's content.
 
         // Native tool-call model_providers can return assistant text separately from
         // the structured call payload; relay it to draft-capable channels.


### PR DESCRIPTION
Models with interleaved thinking (like GLM-5) emit content alongside tool_calls on intermediate turns. run_tool_call_loop was appending that text into accumulated_display_text on every iteration, then returning the whole buffer as the agent's deliverable response. Chain-of-thought leaks into channel messages even when the model's final no-tool-calls turn is a clean one-liner.

This stops accumulating intermediate-turn display_text. Only the final turn populates accumulated_display_text. Streaming consumers still receive intermediate text live via the existing tx.send(StreamDelta::Text(...)) path immediately below, so that behavior is unchanged.

Behavior change:
- stream_mode = "off": channel reply used to be the concat of every turn's content. Now it's just the final turn's content.
- stream_mode = "partial" / "multi_message": live updates during the run are unchanged. The final delivered message (or finalized draft) now contains only the final turn's content rather than the accumulated narration.

if some of us prefer the existing behavior then maybe we should have a config setting to switch accumulated display with channels on or off.

Ran cargo test locally. Everything passed.


---

## Maintainer note

Related to #6510.

Same root cause: `accumulated_display_text` in `run_tool_call_loop` accumulates intermediate-turn narration into the final delivered output. Same file (`crates/zeroclaw-runtime/src/agent/loop_.rs`), same mechanism.

**Scope difference — does not auto-close #6510.** The issue asks for an opt-in flag on `delivery.mode = "announce"` so existing consumers that rely on accumulated narration can keep it. This PR changes the default unconditionally and (per the PR description) only floats the config flag as a future possibility. If we land this as-is, that's a behaviour change for anyone whose cron output happens to depend on intermediate narration being concatenated, and the `[Feature]` opt-in shape #6510 requested still isn't delivered.

Two paths forward:
1. Land this PR as the new default and close #6510 with a note that the opt-in flag was deemed unnecessary because the new default is what most users want, **or**
2. Extend this PR to add the config flag (`delivery.only_final_message: bool` default `true`) so the change is opt-out for the few who want the old behaviour.

Flagging for review discussion. Leaving #6510 open until that's decided.

— @singlerider, 2026-05-28
