### PR TITLE
feat(ui): sidebar update button + nodes dashboard

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -3735,10 +3735,22 @@ pub struct NodesConfig {
     /// Optional bearer token for node authentication.
     #[serde(default)]
     pub auth_token: Option<String>,
+    /// Seconds before a node is considered "stale" in the dashboard.
+    #[serde(default = "default_stale_after_secs")]
+    pub stale_after_secs: u64,
+    /// Seconds before a node is considered "offline" in the dashboard.
+    #[serde(default = "default_offline_after_secs")]
+    pub offline_after_secs: u64,
 }
 
 fn default_max_nodes() -> usize {
     16
+}
+fn default_stale_after_secs() -> u64 {
+    300
+}
+fn default_offline_after_secs() -> u64 {
+    1800
 }
 
 impl Default for NodesConfig {
@@ -3747,6 +3759,8 @@ impl Default for NodesConfig {
             enabled: false,
             max_nodes: default_max_nodes(),
             auth_token: None,
+            stale_after_secs: default_stale_after_secs(),
+            offline_after_secs: default_offline_after_secs(),
         }
     }
 }

--- a/crates/zeroclaw-gateway/src/lib.rs
+++ b/crates/zeroclaw-gateway/src/lib.rs
@@ -23,6 +23,7 @@ pub mod api_personality;
 #[cfg(feature = "plugins-wasm")]
 pub mod api_plugins;
 pub mod api_skills;
+pub mod api_update;
 #[cfg(feature = "webauthn")]
 pub mod api_webauthn;
 pub mod auth_rate_limit;
@@ -439,6 +440,8 @@ pub struct AppState {
     /// need to be rebuilt to apply it." The dashboard polls
     /// `/api/config/reload-status` and surfaces a reload banner when true.
     pub pending_reload: Arc<std::sync::atomic::AtomicBool>,
+    /// Single-flight guard for the update pipeline. Only one update can run at a time.
+    pub update_in_progress: Arc<std::sync::atomic::AtomicBool>,
 }
 
 /// Run the HTTP gateway using axum with proper HTTP/1.1 compliance.
@@ -1132,6 +1135,7 @@ pub async fn run_gateway(
     println!("  GET  {pfx}/api/*     — REST API (bearer token required)");
     println!("  GET  {pfx}/ws/chat   — WebSocket agent chat");
     if config.nodes.enabled {
+        println!("  GET  {pfx}/api/nodes — list connected nodes");
         println!("  GET  {pfx}/ws/nodes  — WebSocket node discovery");
     }
     println!("  GET  {pfx}/health    — health check");
@@ -1226,6 +1230,7 @@ pub async fn run_gateway(
         canvas_store,
         cancel_tokens: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         pending_reload: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        update_in_progress: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         #[cfg(feature = "webauthn")]
         webauthn: if config.security.webauthn.enabled {
             let secret_store = Arc::new(zeroclaw_runtime::security::SecretStore::new(
@@ -1393,6 +1398,14 @@ pub async fn run_gateway(
             "/api/doctor",
             get(api::handle_api_doctor).post(api::handle_api_doctor),
         )
+        .route(
+            "/api/update/check",
+            get(api_update::handle_api_update_check),
+        )
+        .route(
+            "/api/update/run",
+            post(api_update::handle_api_update_run),
+        )
         .route("/api/memory", get(api::handle_api_memory_list))
         .route("/api/memory", post(api::handle_api_memory_store))
         .route("/api/memory/{key}", delete(api::handle_api_memory_delete))
@@ -1480,7 +1493,8 @@ pub async fn run_gateway(
         .route("/ws/chat", get(ws::handle_ws_chat))
         // ── WebSocket canvas updates ──
         .route("/ws/canvas/{id}", get(canvas::handle_ws_canvas))
-        // ── WebSocket node discovery ──
+        // ── Node discovery ──
+        .route("/api/nodes", get(nodes::list_nodes))
         .route("/ws/nodes", get(nodes::handle_ws_nodes))
         // ── Static assets (web dashboard) ──
         .route("/_app/{*path}", get(static_files::handle_static))
@@ -3454,6 +3468,7 @@ mod tests {
             canvas_store: CanvasStore::new(),
             cancel_tokens: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             pending_reload: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            update_in_progress: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             #[cfg(feature = "webauthn")]
             webauthn: None,
         };
@@ -3524,6 +3539,7 @@ mod tests {
             canvas_store: CanvasStore::new(),
             cancel_tokens: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             pending_reload: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            update_in_progress: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             #[cfg(feature = "webauthn")]
             webauthn: None,
         };
@@ -4075,6 +4091,7 @@ mod tests {
             canvas_store: CanvasStore::new(),
             cancel_tokens: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             pending_reload: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            update_in_progress: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             #[cfg(feature = "webauthn")]
             webauthn: None,
         };
@@ -4158,6 +4175,7 @@ mod tests {
             canvas_store: CanvasStore::new(),
             cancel_tokens: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             pending_reload: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            update_in_progress: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             #[cfg(feature = "webauthn")]
             webauthn: None,
         };
@@ -4253,6 +4271,7 @@ mod tests {
             canvas_store: CanvasStore::new(),
             cancel_tokens: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             pending_reload: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            update_in_progress: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             #[cfg(feature = "webauthn")]
             webauthn: None,
         };
@@ -4320,6 +4339,7 @@ mod tests {
             canvas_store: CanvasStore::new(),
             cancel_tokens: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             pending_reload: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            update_in_progress: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             #[cfg(feature = "webauthn")]
             webauthn: None,
         };
@@ -4392,6 +4412,7 @@ mod tests {
             canvas_store: CanvasStore::new(),
             cancel_tokens: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             pending_reload: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            update_in_progress: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             #[cfg(feature = "webauthn")]
             webauthn: None,
         };
@@ -4469,6 +4490,7 @@ mod tests {
             canvas_store: CanvasStore::new(),
             cancel_tokens: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             pending_reload: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            update_in_progress: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             #[cfg(feature = "webauthn")]
             webauthn: None,
         };
@@ -4546,6 +4568,7 @@ mod tests {
             canvas_store: CanvasStore::new(),
             cancel_tokens: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             pending_reload: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            update_in_progress: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             #[cfg(feature = "webauthn")]
             webauthn: None,
         };
@@ -4650,6 +4673,7 @@ mod tests {
             nextcloud_talk: Some(channel),
             nextcloud_talk_webhook_secret: None,
             pending_reload: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            update_in_progress: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             wati: None,
             gmail_push: None,
             observer: Arc::new(zeroclaw_runtime::observability::NoopObserver),

--- a/crates/zeroclaw-gateway/src/nodes.rs
+++ b/crates/zeroclaw-gateway/src/nodes.rs
@@ -146,6 +146,39 @@ impl NodeRegistry {
     }
 }
 
+/// `GET /api/nodes` — list currently connected nodes with their capabilities.
+pub async fn list_nodes(State(state): State<AppState>, headers: HeaderMap) -> impl IntoResponse {
+    if let Err(e) = super::api::require_auth(&state, &headers) {
+        return e.into_response();
+    }
+
+    let nodes_guard = state.node_registry.nodes.read();
+    let nodes: Vec<serde_json::Value> = nodes_guard
+        .values()
+        .map(|info| {
+            serde_json::json!({
+                "node_id": info.node_id,
+                "capabilities": info.capabilities,
+                "capability_count": info.capabilities.len(),
+                "status": "online",
+            })
+        })
+        .collect();
+    let count = nodes.len();
+    drop(nodes_guard);
+
+    let nodes_cfg = state.config.read().nodes.clone();
+    axum::response::Json(serde_json::json!({
+        "nodes": nodes,
+        "count": count,
+        "policy": {
+            "stale_after_secs": nodes_cfg.stale_after_secs,
+            "offline_after_secs": nodes_cfg.offline_after_secs,
+        }
+    }))
+    .into_response()
+}
+
 /// Messages received from a node.
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]

--- a/crates/zeroclaw-runtime/src/lib.rs
+++ b/crates/zeroclaw-runtime/src/lib.rs
@@ -39,4 +39,5 @@ pub mod subagent;
 pub mod tools;
 pub mod trust;
 pub mod tunnel;
+pub mod updater;
 pub mod verifiable_intent;

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -6,14 +6,21 @@ import {
   LayoutDashboard,
   MessageSquare,
   Monitor,
+  Network,
   Puzzle,
   Settings,
   Stethoscope,
   Wrench,
+  ArrowUpCircle,
+  Loader2,
+  CheckCircle2,
+  AlertCircle,
 } from 'lucide-react';
 import { t } from '@/lib/i18n';
 import { useEffect, useState } from 'react';
 import { getStatus } from '@/lib/api';
+import { useUpdate } from '@/hooks/useUpdate';
+import type { UpdateState } from '@/hooks/useUpdate';
 
 interface NavItem {
   to: string;
@@ -27,6 +34,7 @@ const navItems: NavItem[] = [
   { to: '/tools', icon: Wrench, labelKey: 'nav.tools' },
   { to: '/cron', icon: Clock, labelKey: 'nav.cron' },
   { to: '/integrations', icon: Puzzle, labelKey: 'nav.integrations' },
+  { to: '/nodes', icon: Network, labelKey: 'nav.nodes' },
   { to: '/config', icon: Settings, labelKey: 'nav.config' },
   { to: '/logs', icon: Activity, labelKey: 'nav.logs' },
   { to: '/doctor', icon: Stethoscope, labelKey: 'nav.doctor' },
@@ -197,6 +205,7 @@ function SidebarLogo({ collapsed }: { collapsed: boolean }) {
 
 function SidebarFooter({ collapsed, layout }: { collapsed: boolean; layout: 'desktop' | 'mobile' }) {
   const [version, setVersion] = useState<string | null>(null);
+  const update = useUpdate();
 
   useEffect(() => {
     getStatus()
@@ -204,16 +213,77 @@ function SidebarFooter({ collapsed, layout }: { collapsed: boolean; layout: 'des
       .catch(() => { /* silently ignore */ });
   }, []);
 
+  const renderUpdateButton = () => {
+    if (collapsed) return null;
+
+    switch (update.state) {
+      case 'checking':
+        return (
+          <div className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-[11px]" style={{ color: 'var(--pc-text-muted)' }}>
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            Checking...
+          </div>
+        );
+      case 'available':
+        return (
+          <button
+            onClick={update.run}
+            className="w-full flex items-center justify-center gap-1.5 px-3 py-1.5 rounded-lg text-[11px] font-medium transition-colors cursor-pointer"
+            style={{ background: 'var(--pc-accent)', color: '#fff' }}
+            title={`Update to v${update.latestVersion}`}
+          >
+            <ArrowUpCircle className="h-3.5 w-3.5" />
+            Update to v{update.latestVersion}
+          </button>
+        );
+      case 'updating':
+        return (
+          <div className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-[11px]" style={{ color: 'var(--pc-text-muted)' }}>
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            <span className="truncate max-w-[140px]">{update.progressMsg}</span>
+          </div>
+        );
+      case 'complete':
+        return (
+          <div className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-[11px]" style={{ color: 'var(--color-status-success)' }}>
+            <CheckCircle2 className="h-3.5 w-3.5" />
+            Updated — restarting...
+          </div>
+        );
+      case 'error':
+        return (
+          <div className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-[11px] cursor-pointer" style={{ color: 'var(--color-status-error)' }} onClick={update.check}>
+            <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+            <span className="truncate max-w-30">{update.errorMsg}</span>
+            <span style={{ color: 'var(--pc-accent)' }} className="underline ml-0.5">Retry</span>
+          </div>
+        );
+      default:
+        return (
+          <button
+            onClick={update.check}
+            className="w-full flex items-center justify-center gap-1.5 px-3 py-1.5 rounded-lg text-[11px] font-medium transition-colors cursor-pointer"
+            style={{ background: 'var(--pc-accent-glow)', color: 'var(--pc-accent)', border: '1px solid var(--pc-accent-dim)' }}
+            title="Check for updates"
+          >
+            <ArrowUpCircle className="h-3.5 w-3.5" />
+            Check for updates
+          </button>
+        );
+    }
+  };
+
   if (layout === 'mobile') {
     return (
       <div
-        className="px-5 py-4 border-t text-[10px] uppercase tracking-wider"
-        style={{ borderColor: 'var(--pc-border)', color: 'var(--pc-text-faint)' }}
+        className="px-5 py-4 border-t space-y-2"
+        style={{ borderColor: 'var(--pc-border)' }}
       >
-        ZeroClaw Gateway
+        {renderUpdateButton()}
         {version && (
-          <div className="mt-0.5 normal-case tracking-normal" style={{ fontSize: '9px' }}>
-            v{version}
+          <div className="text-[12px] uppercase tracking-wider" style={{ color: 'var(--pc-text-faint)' }}>
+            ZeroClaw Gateway
+            <span className="ml-1 normal-case tracking-normal" style={{ fontSize: '11px' }}>v{version}</span>
           </div>
         )}
       </div>
@@ -224,19 +294,20 @@ function SidebarFooter({ collapsed, layout }: { collapsed: boolean; layout: 'des
       className="border-t shrink-0 whitespace-nowrap overflow-hidden transition-opacity duration-200"
       style={{
         borderColor: 'var(--pc-border)',
-        padding: collapsed ? '12px 0' : '16px 20px',
-        fontSize: '10px',
-        color: 'var(--pc-text-faint)',
-        textTransform: 'uppercase',
-        letterSpacing: '0.1em',
+        padding: collapsed ? '12px 0' : '12px 16px',
         opacity: collapsed ? 0 : 1,
-        textAlign: collapsed ? 'center' : 'left',
       }}
     >
-      {!collapsed && 'ZeroClaw Gateway'}
-      {!collapsed && version && (
-        <div style={{ marginTop: '2px', fontSize: '9px', textTransform: 'none', letterSpacing: 'normal' }}>
-          v{version}
+      {!collapsed && renderUpdateButton()}
+      {!collapsed && (
+        <div
+          className="mt-1.5 text-[12px] uppercase tracking-wider"
+          style={{ color: 'var(--pc-text-faint)', paddingLeft: '4px' }}
+        >
+          ZeroClaw Gateway
+          {version && (
+            <span className="ml-1 normal-case tracking-normal" style={{ fontSize: '11px' }}>v{version}</span>
+          )}
         </div>
       )}
     </div>

--- a/web/src/hooks/useUpdate.ts
+++ b/web/src/hooks/useUpdate.ts
@@ -1,0 +1,74 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useSSE } from './useSSE';
+import { checkForUpdate, runUpdate } from '@/lib/api';
+
+export type UpdateState = 'idle' | 'checking' | 'available' | 'up-to-date' | 'updating' | 'complete' | 'error';
+
+export interface UpdateInfo {
+  state: UpdateState;
+  latestVersion: string | null;
+  progressMsg: string;
+  errorMsg: string;
+  check: () => void;
+  run: () => void;
+}
+
+export function useUpdate(): UpdateInfo {
+  const [state, setState] = useState<UpdateState>('idle');
+  const [latestVersion, setLatestVersion] = useState<string | null>(null);
+  const [progressMsg, setProgressMsg] = useState('');
+  const [errorMsg, setErrorMsg] = useState('');
+
+  const { events } = useSSE({
+    filterTypes: ['update_progress', 'update_complete', 'update_failed'],
+    autoConnect: true,
+  });
+  const eventsRef = useRef(events);
+  eventsRef.current = events;
+
+  useEffect(() => {
+    const latest = events[events.length - 1];
+    if (!latest) return;
+    if (latest.type === 'update_progress') {
+      setState('updating');
+      setProgressMsg((latest as { message?: string }).message || 'Updating...');
+    } else if (latest.type === 'update_complete') {
+      setState('complete');
+      setProgressMsg('');
+    } else if (latest.type === 'update_failed') {
+      setState('error');
+      setErrorMsg((latest as { error?: string }).error || 'Update failed');
+    }
+  }, [events]);
+
+  const check = useCallback(async () => {
+    setState('checking');
+    try {
+      const result = await checkForUpdate();
+      if (result.is_newer) {
+        setLatestVersion(result.latest_version);
+        setState('available');
+      } else {
+        setState('up-to-date');
+      }
+    } catch {
+      setState('error');
+      setErrorMsg('Failed to check for updates');
+    }
+  }, []);
+
+  const run = useCallback(async () => {
+    try {
+      setState('updating');
+      setProgressMsg('Starting update...');
+      await runUpdate();
+    } catch (e) {
+      if (!(e instanceof Error && e.message.includes('409'))) {
+        setState('error');
+        setErrorMsg(e instanceof Error ? e.message : 'Failed to start update');
+      }
+    }
+  }, []);
+
+  return { state, latestVersion, progressMsg, errorMsg, check, run };
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -12,6 +12,9 @@ import type {
   Session,
   ChannelDetail,
   SessionMessagesResponse,
+  NodesResponse,
+  PairedDeviceInfo,
+  DevicesResponse,
 } from '../types/api';
 import { clearToken, getToken, setToken } from './auth';
 import { apiOrigin, basePath } from './basePath';
@@ -1403,4 +1406,48 @@ export function getCliTools(): Promise<CliTool[]> {
     const result = unwrapField(data, 'cli_tools');
     return Array.isArray(result) ? result : [];
   });
+}
+
+// ---------------------------------------------------------------------------
+// Nodes
+// ---------------------------------------------------------------------------
+
+export function getNodes(): Promise<NodesResponse> {
+  return apiFetch<NodesResponse>('/api/nodes');
+}
+
+// ---------------------------------------------------------------------------
+// Paired Devices
+// ---------------------------------------------------------------------------
+
+export function getPairedDevices(): Promise<PairedDeviceInfo[]> {
+  return apiFetch<DevicesResponse | PairedDeviceInfo[]>('/api/pairing/devices').then((data) => {
+    if (Array.isArray(data)) return data;
+    return data.devices ?? [];
+  });
+}
+
+export function revokePairedDevice(id: string): Promise<void> {
+  return apiFetch<void>(`/api/pairing/devices/${encodeURIComponent(id)}`, {
+    method: 'DELETE',
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Self-update
+// ---------------------------------------------------------------------------
+
+export interface UpdateCheckResponse {
+  current_version: string;
+  latest_version: string;
+  is_newer: boolean;
+  download_url: string | null;
+}
+
+export function checkForUpdate(): Promise<UpdateCheckResponse> {
+  return apiFetch<UpdateCheckResponse>('/api/update/check');
+}
+
+export function runUpdate(): Promise<{ status: string }> {
+  return apiFetch<{ status: string }>('/api/update/run', { method: 'POST' });
 }

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -413,6 +413,7 @@ const translations: Record<Locale, Record<string, string>> = {
     'nav.cost': 'Cost Tracker',
     'nav.logs': 'Logs',
     'nav.doctor': 'Doctor',
+    'nav.nodes': 'Nodes',
     'nav.canvas': 'Canvas',
     'nav.onboard': 'Onboard',
 

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -269,6 +269,7 @@ function healthBg(status: string): string {
 // were single-agent leftovers from pre-v0.8.0 and are gone: each agent now
 // picks its own model_provider and memory backend (shown per agent on the
 // agent cards above this grid).
+
 const STATUS_CARDS = [
   {
     icon: Clock,

--- a/web/src/pages/Nodes.tsx
+++ b/web/src/pages/Nodes.tsx
@@ -1,0 +1,294 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Network, Server, Cpu, RefreshCw, Trash2 } from 'lucide-react';
+import {
+  getNodes,
+  getPairedDevices,
+  revokePairedDevice,
+  type DaemonNode,
+  type NodePolicy,
+  type PairedDeviceInfo,
+} from '@/lib/api';
+
+interface UnifiedNode {
+  key: string;
+  kind: 'daemon' | 'client';
+  label: string;
+  shortKey: string;
+  icon: typeof Network;
+  typeLabel: string;
+  health: Health;
+  lastSeen?: string | null;
+  device?: PairedDeviceInfo;
+  daemon?: DaemonNode;
+  capabilities?: string[];
+}
+
+const POLL_INTERVAL_MS = 30_000;
+const DEFAULT_POLICY: NodePolicy = { stale_after_secs: 300, offline_after_secs: 1800 };
+
+type Health = 'online' | 'stale' | 'offline';
+
+function deviceHealth(lastSeenIso: string | null | undefined, policy: NodePolicy): Health {
+  if (!lastSeenIso) return 'offline';
+  try {
+    const diffSecs = (Date.now() - new Date(lastSeenIso).getTime()) / 1000;
+    if (diffSecs < policy.stale_after_secs) return 'online';
+    if (diffSecs < policy.offline_after_secs) return 'stale';
+    return 'offline';
+  } catch {
+    return 'offline';
+  }
+}
+
+function healthClasses(health: Health) {
+  switch (health) {
+    case 'online':
+      return { cls: 'bg-green-900/20 border-green-700/40 text-green-400', label: 'Online' };
+    case 'stale':
+      return { cls: 'bg-yellow-900/20 border-yellow-700/40 text-yellow-400', label: 'Stale' };
+    case 'offline':
+      return { cls: 'bg-red-900/20 border-red-700/40 text-red-400', label: 'Offline' };
+  }
+}
+
+function formatRelative(iso: string | null | undefined): string {
+  if (!iso) return 'Unknown';
+  try {
+    const diff = Date.now() - new Date(iso).getTime();
+    const seconds = Math.floor(diff / 1000);
+    if (seconds < 60) return 'just now';
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 60) return `${minutes}m ago`;
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return `${hours}h ago`;
+    const days = Math.floor(hours / 24);
+    return `${days}d ago`;
+  } catch {
+    return iso;
+  }
+}
+
+function shortId(id: string): string {
+  return id.length > 12 ? `${id.slice(0, 8)}...${id.slice(-4)}` : id;
+}
+
+export default function Nodes() {
+  const [devices, setDevices] = useState<PairedDeviceInfo[]>([]);
+  const [nodes, setNodes] = useState<DaemonNode[]>([]);
+  const [policy, setPolicy] = useState<NodePolicy>(DEFAULT_POLICY);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [revoking, setRevoking] = useState<string | null>(null);
+
+  const fetchAll = useCallback(async () => {
+    try {
+      const [deviceList, nodeRes] = await Promise.all([getPairedDevices(), getNodes()]);
+      setDevices(deviceList);
+      setNodes(nodeRes.nodes ?? []);
+      setPolicy(nodeRes.policy ?? DEFAULT_POLICY);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchAll();
+    const id = window.setInterval(fetchAll, POLL_INTERVAL_MS);
+    return () => window.clearInterval(id);
+  }, [fetchAll]);
+
+  const handleRevoke = useCallback(
+    async (id: string) => {
+      if (!window.confirm('Revoke this device? It will need to re-pair.')) return;
+      setRevoking(id);
+      try {
+        await revokePairedDevice(id);
+        await fetchAll();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        setRevoking(null);
+      }
+    },
+    [fetchAll],
+  );
+
+  const unified = unifyNodes(nodes, devices, policy);
+
+  if (loading && devices.length === 0 && nodes.length === 0) {
+    return (
+      <div className="min-h-[60vh] flex items-center justify-center">
+        <div className="h-8 w-8 animate-spin rounded-full border-2 border-t-transparent" style={{ borderColor: 'var(--pc-border)', borderTopColor: 'var(--pc-accent)' }} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Network className="h-5 w-5" style={{ color: 'var(--pc-accent)' }} />
+          <h2 className="text-sm font-semibold uppercase tracking-wider" style={{ color: 'var(--pc-text-primary)' }}>
+            Nodes ({unified.length})
+          </h2>
+        </div>
+        <button
+          onClick={() => fetchAll()}
+          className="inline-flex items-center gap-1.5 rounded-xl border px-3 py-1.5 text-xs font-medium transition-all"
+          style={{ borderColor: 'var(--pc-border)', color: 'var(--pc-text-muted)' }}
+        >
+          <RefreshCw className="h-3.5 w-3.5" /> Refresh
+        </button>
+      </div>
+
+      <p className="text-sm" style={{ color: 'var(--pc-text-muted)' }}>
+        Every ZeroClaw instance across your fleet, with live health.
+      </p>
+
+      {error && (
+        <div className="rounded-2xl border p-4 text-sm" style={{ background: 'rgba(239,68,68,0.08)', borderColor: 'rgba(239,68,68,0.2)', color: '#f87171' }}>
+          {error}
+        </div>
+      )}
+
+      {unified.length === 0 ? (
+        <div className="card p-8 text-center" style={{ color: 'var(--pc-text-muted)' }}>
+          <Network className="h-10 w-10 mx-auto mb-3 opacity-30" />
+          <p className="text-sm">No nodes connected yet.</p>
+          <p className="text-xs mt-1" style={{ color: 'var(--pc-text-faint)' }}>
+            Enable <code>[nodes] enabled = true</code> in config and connect nodes via WebSocket.
+          </p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+          {unified.map((node) => (
+            <NodeCard
+              key={node.key}
+              node={node}
+              revoking={!!node.device && revoking === node.device.id}
+              onRevoke={node.device ? () => handleRevoke(node.device!.id) : undefined}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function unifyNodes(
+  daemons: DaemonNode[],
+  devices: PairedDeviceInfo[],
+  policy: NodePolicy,
+): UnifiedNode[] {
+  const fromDaemons: UnifiedNode[] = daemons.map((d) => ({
+    key: `node:${d.node_id}`,
+    kind: 'daemon',
+    label: d.node_id,
+    shortKey: shortId(d.node_id),
+    icon: Cpu,
+    typeLabel: 'Daemon node',
+    health: 'online' as Health,
+    capabilities: d.capabilities.map((c) => c.name),
+    daemon: d,
+  }));
+
+  const fromDevices: UnifiedNode[] = devices.map((d) => ({
+    key: `device:${d.id}`,
+    kind: 'client',
+    label: d.token_fingerprint.slice(0, 12),
+    shortKey: shortId(d.id),
+    icon: Server,
+    typeLabel: 'Paired client',
+    health: deviceHealth(d.last_seen_at, policy),
+    lastSeen: d.last_seen_at,
+    device: d,
+  }));
+
+  return [
+    ...fromDaemons,
+    ...fromDevices.sort((a, b) => {
+      const order: Record<Health, number> = { online: 0, stale: 1, offline: 2 };
+      return order[a.health] - order[b.health];
+    }),
+  ];
+}
+
+interface NodeCardProps {
+  node: UnifiedNode;
+  revoking: boolean;
+  onRevoke?: () => void;
+}
+
+function NodeCard({ node, revoking, onRevoke }: NodeCardProps) {
+  const Icon = node.icon;
+  const pill = healthClasses(node.health);
+
+  return (
+    <div className="card p-5" style={{ opacity: revoking ? 0.5 : 1 }}>
+      <div className="flex items-start gap-3">
+        <div className="shrink-0 rounded-2xl p-2" style={{ background: 'rgba(var(--pc-accent-rgb), 0.08)', color: 'var(--pc-accent)' }}>
+          <Icon className="h-5 w-5" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <h4 className="truncate text-sm font-semibold" style={{ color: 'var(--pc-text-primary)' }}>
+            {node.label}
+          </h4>
+          <p className="truncate font-mono text-xs" style={{ color: 'var(--pc-text-faint)' }} title={node.key}>
+            {node.shortKey}
+          </p>
+        </div>
+        <span className={`shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-medium ${pill.cls}`}>
+          {pill.label}
+        </span>
+        {onRevoke && (
+          <button
+            onClick={onRevoke}
+            disabled={revoking}
+            className="shrink-0 rounded-xl p-1.5 transition-all disabled:opacity-50"
+            style={{ color: 'var(--color-status-error)' }}
+            title="Revoke"
+          >
+            <Trash2 className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+
+      <div className="mt-4 space-y-1.5 border-t pt-3 text-xs" style={{ borderColor: 'var(--pc-border)' }}>
+        <div className="flex justify-between">
+          <span style={{ color: 'var(--pc-text-muted)' }}>Type</span>
+          <span style={{ color: 'var(--pc-text-secondary)' }}>{node.typeLabel}</span>
+        </div>
+        {node.lastSeen && (
+          <div className="flex justify-between">
+            <span style={{ color: 'var(--pc-text-muted)' }}>Last seen</span>
+            <span style={{ color: 'var(--pc-text-secondary)' }}>{formatRelative(node.lastSeen)}</span>
+          </div>
+        )}
+        {node.capabilities && node.capabilities.length > 0 && (
+          <div className="pt-1">
+            <span style={{ color: 'var(--pc-text-muted)' }}>Capabilities ({node.capabilities.length})</span>
+            <div className="mt-1.5 flex flex-wrap gap-1">
+              {node.capabilities.slice(0, 4).map((cap) => (
+                <span
+                  key={cap}
+                  className="inline-flex items-center rounded-full border px-2 py-0.5 font-mono text-[10px]"
+                  style={{ borderColor: 'var(--pc-border)', color: 'var(--pc-text-muted)', background: 'var(--pc-bg-base)' }}
+                >
+                  {cap}
+                </span>
+              ))}
+              {node.capabilities.length > 4 && (
+                <span className="self-center text-[10px]" style={{ color: 'var(--pc-text-faint)' }}>
+                  +{node.capabilities.length - 4} more
+                </span>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/router/lazyPages.tsx
+++ b/web/src/router/lazyPages.tsx
@@ -7,6 +7,7 @@ export const AgentWorkspaceExplorer = lazy(() => import('../pages/AgentWorkspace
 export const Tools = lazy(() => import('../pages/Tools'));
 export const Cron = lazy(() => import('../pages/Cron'));
 export const Integrations = lazy(() => import('../pages/Integrations'));
+export const Nodes = lazy(() => import('../pages/Nodes'));
 export const Config = lazy(() => import('../pages/Config'));
 export const Logs = lazy(() => import('../pages/Logs'));
 export const Doctor = lazy(() => import('../pages/Doctor'));

--- a/web/src/router/router.tsx
+++ b/web/src/router/router.tsx
@@ -12,6 +12,7 @@ import {
   Doctor,
   Integrations,
   Logs,
+  Nodes,
   Onboard,
   Pairing,
   Tools,
@@ -40,6 +41,7 @@ export const Router = () => (
         <Route path="/tools" element={<Tools />} />
         <Route path="/cron" element={<Cron />} />
         <Route path="/integrations" element={<Integrations />} />
+        <Route path="/nodes" element={<Nodes />} />
         <Route path="/memory" element={<Navigate to="/?tab=memories" replace />} />
         <Route path="/config" element={<Config />} />
         <Route path="/config/:section" element={<Config />} />

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -268,3 +268,51 @@ export interface SessionMessagesResponse {
   messages: SessionMessageRow[];
   session_persistence: boolean;
 }
+
+// ── Nodes ────────────────────────────────────────────────────────────────
+
+export interface NodeCapability {
+  name: string;
+  description: string;
+  parameters: Record<string, unknown>;
+}
+
+export interface DaemonNode {
+  node_id: string;
+  capabilities: NodeCapability[];
+  capability_count: number;
+  status: string;
+}
+
+export interface NodePolicy {
+  stale_after_secs: number;
+  offline_after_secs: number;
+}
+
+export interface NodesResponse {
+  nodes: DaemonNode[];
+  count: number;
+  policy: NodePolicy;
+}
+
+export interface PairedDeviceInfo {
+  id: string;
+  token_fingerprint: string;
+  created_at: string | null;
+  last_seen_at: string | null;
+  paired_by: string | null;
+}
+
+export interface DevicesResponse {
+  devices: PairedDeviceInfo[];
+  policy?: NodePolicy;
+}
+
+// ── Self-update ─────────────────────────────────────────────────────
+
+export interface UpdateCheckResponse {
+  current_version: string;
+  latest_version: string;
+  is_newer: boolean;
+  download_url: string | null;
+}


### PR DESCRIPTION
## Summary
- Add self-update button to sidebar footer — checks GitHub latest stable release, shows update available badge, runs 6-phase update pipeline with SSE progress
- Extract shared `useUpdate` hook (`web/src/hooks/useUpdate.ts`) to eliminate duplicate state logic
- Add `/nodes` page with REST endpoint (`GET /api/nodes`) listing connected daemon nodes with stale/offline policy from config
- Add sidebar nav entry for Nodes, frontend types and API functions for nodes + paired devices
- Bump sidebar footer font sizes (ZeroClaw Gateway 10→12px, version 9→11px)

## Test plan
- [x] `cargo build --release` — compiles clean
- [x] `cargo test -p zeroclaw-gateway -- nodes` — 13 node tests pass
- [x] `GET /api/update/check` returns `{current_version, latest_version, is_newer}` from GitHub latest stable
- [x] `POST /api/update/run` returns `{status: "started"}` with SSE events
- [x] `GET /api/nodes` returns `{nodes, count, policy}` with stale/offline thresholds from config
- [x] Frontend builds clean (`npx vite build`)
- [x] Sidebar "Check for updates" button works end-to-end on running daemon

🤖 Generated with [Claude Code](https://claude.com/claude-code)