### PR TITLE
fix(onboard): validate provider catalog aliases

### DIFF
--- a/crates/zeroclaw-gateway/src/api_onboard.rs
+++ b/crates/zeroclaw-gateway/src/api_onboard.rs
@@ -116,6 +116,8 @@ async fn catalog_models_for_config(
                 .as_deref()
                 .map(str::trim)
                 .is_some_and(|uri| !uri.is_empty());
+        let alias_catalog_must_match_alias =
+            has_alias_endpoint || !model_provider_family_has_public_catalog(model_provider);
         match zeroclaw_providers::create_model_provider_for_alias(
             cfg,
             model_provider,
@@ -127,10 +129,7 @@ async fn catalog_models_for_config(
                 Ok(models) => Some((models, true)),
                 Err(e) => {
                     record_catalog_models_error(model_provider, Some(alias), &e);
-                    if local
-                        && (has_alias_endpoint
-                            || !model_provider_family_has_public_catalog(model_provider))
-                    {
+                    if alias_catalog_must_match_alias {
                         return ModelsResponse {
                             model_provider: model_provider.to_string(),
                             models: Vec::new(),
@@ -143,10 +142,7 @@ async fn catalog_models_for_config(
             },
             Err(e) => {
                 record_catalog_models_error(model_provider, Some(alias), &e);
-                if local
-                    && (has_alias_endpoint
-                        || !model_provider_family_has_public_catalog(model_provider))
-                {
+                if alias_catalog_must_match_alias {
                     return ModelsResponse {
                         model_provider: model_provider.to_string(),
                         models: Vec::new(),
@@ -1770,6 +1766,26 @@ mod tests {
         let resp = catalog_models_for_config(&cfg, "ollama", Some("default")).await;
 
         assert!(resp.local);
+        assert!(!resp.live);
+        assert!(resp.models.is_empty());
+    }
+
+    #[tokio::test]
+    async fn catalog_models_marks_unreachable_hosted_alias_endpoint_not_live() {
+        let mut cfg = zeroclaw_config::schema::Config::default();
+        cfg.create_map_key("providers.models.moonshot", "default")
+            .unwrap();
+        cfg.set_prop_persistent("providers.models.moonshot.default.api-key", "sk-test")
+            .unwrap();
+        cfg.set_prop_persistent(
+            "providers.models.moonshot.default.uri",
+            "http://127.0.0.1:1",
+        )
+        .unwrap();
+
+        let resp = catalog_models_for_config(&cfg, "moonshot", Some("default")).await;
+
+        assert!(!resp.local);
         assert!(!resp.live);
         assert!(resp.models.is_empty());
     }

--- a/crates/zeroclaw-gateway/src/api_onboard.rs
+++ b/crates/zeroclaw-gateway/src/api_onboard.rs
@@ -65,6 +65,11 @@ pub struct ModelsQuery {
     /// `provider` alias matches the query-string name the web dashboard uses.
     #[serde(alias = "provider")]
     pub model_provider: String,
+    /// Optional configured alias under `providers.models.<provider>.<alias>`.
+    /// When present, the catalog endpoint validates that alias's own URI/auth
+    /// instead of only checking the provider family's default endpoint.
+    #[serde(default)]
+    pub alias: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -79,6 +84,135 @@ pub struct ModelsResponse {
     /// served (or if this model_provider has no remote catalog and the empty list
     /// is the genuine answer).
     pub live: bool,
+}
+
+async fn catalog_models_for_config(
+    cfg: &zeroclaw_config::schema::Config,
+    model_provider: &str,
+    alias: Option<&str>,
+) -> ModelsResponse {
+    let alias = alias.map(str::trim).filter(|alias| !alias.is_empty());
+    let local = model_provider_family_is_local(model_provider);
+
+    let provider_path = if let Some(alias) = alias {
+        let Some(entry) = cfg.providers.models.find(model_provider, alias) else {
+            return ModelsResponse {
+                model_provider: model_provider.to_string(),
+                models: Vec::new(),
+                local,
+                live: false,
+            };
+        };
+        let api_key = entry.api_key.as_deref();
+        let options =
+            zeroclaw_providers::provider_runtime_options_for_alias(cfg, model_provider, alias);
+        let has_alias_endpoint = entry
+            .uri
+            .as_deref()
+            .map(str::trim)
+            .is_some_and(|uri| !uri.is_empty())
+            || options
+                .provider_api_url
+                .as_deref()
+                .map(str::trim)
+                .is_some_and(|uri| !uri.is_empty());
+        match zeroclaw_providers::create_model_provider_for_alias(
+            cfg,
+            model_provider,
+            alias,
+            api_key,
+            &options,
+        ) {
+            Ok(provider) => match provider.list_models().await {
+                Ok(models) => Some((models, true)),
+                Err(e) => {
+                    record_catalog_models_error(model_provider, Some(alias), &e);
+                    if local
+                        && (has_alias_endpoint
+                            || !model_provider_family_has_public_catalog(model_provider))
+                    {
+                        return ModelsResponse {
+                            model_provider: model_provider.to_string(),
+                            models: Vec::new(),
+                            local,
+                            live: false,
+                        };
+                    }
+                    None
+                }
+            },
+            Err(e) => {
+                record_catalog_models_error(model_provider, Some(alias), &e);
+                if local
+                    && (has_alias_endpoint
+                        || !model_provider_family_has_public_catalog(model_provider))
+                {
+                    return ModelsResponse {
+                        model_provider: model_provider.to_string(),
+                        models: Vec::new(),
+                        local,
+                        live: false,
+                    };
+                }
+                None
+            }
+        }
+    } else {
+        match zeroclaw_providers::create_model_provider(model_provider, None) {
+            Ok(provider) => match provider.list_models().await {
+                Ok(models) => Some((models, true)),
+                Err(e) => {
+                    record_catalog_models_error(model_provider, None, &e);
+                    None
+                }
+            },
+            Err(e) => {
+                record_catalog_models_error(model_provider, None, &e);
+                None
+            }
+        }
+    };
+
+    let (models, live) = match provider_path {
+        Some((models, live)) => (models, live),
+        None => match zeroclaw_providers::catalog::list_models_for_family(model_provider).await {
+            Ok(models) => (models, true),
+            Err(e) => {
+                record_catalog_models_error(model_provider, alias, &e);
+                (Vec::new(), false)
+            }
+        },
+    };
+
+    ModelsResponse {
+        model_provider: model_provider.to_string(),
+        models,
+        local,
+        live,
+    }
+}
+
+fn model_provider_family_has_public_catalog(family: &str) -> bool {
+    match zeroclaw_providers::catalog::catalog_source_for(family) {
+        Some((models_dev_key, openrouter_vendor_prefix)) => {
+            models_dev_key.is_some() || openrouter_vendor_prefix.is_some()
+        }
+        None => false,
+    }
+}
+
+fn record_catalog_models_error(model_provider: &str, alias: Option<&str>, error: &anyhow::Error) {
+    ::zeroclaw_log::record!(
+        DEBUG,
+        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(
+            ::serde_json::json!({
+                "model_provider": model_provider,
+                "alias": alias,
+                "error": format!("{}", error),
+            })
+        ),
+        "model catalog fetch failed"
+    );
 }
 
 /// `GET /api/onboard/catalog/models?model_provider=<name>` — fetch the model list
@@ -98,43 +232,9 @@ pub async fn handle_catalog_models(
     if let Err(e) = require_auth(&state, &headers) {
         return e.into_response();
     }
-    let _ = state;
-    let local = model_provider_family_is_local(&q.model_provider);
-
-    // Try provider construction + list_models first (covers credentialed
-    // /models endpoints). Fall back to the family catalog table when
-    // construction or list_models fails — this is the path that covers
-    // onboard mode where the operator hasn't supplied a credential
-    // and the provider has typed required fields (Azure resource,
-    // Bedrock region, …) that haven't been populated yet.
-    let provider_path = match zeroclaw_providers::create_model_provider(&q.model_provider, None) {
-        Ok(h) => match h.list_models().await {
-            Ok(ms) if !ms.is_empty() => Some(ms),
-            _ => None,
-        },
-        Err(_) => None,
-    };
-
-    let (models, live) = match provider_path {
-        Some(ms) => (ms, true),
-        None => {
-            match zeroclaw_providers::catalog::list_models_for_family(&q.model_provider).await {
-                Ok(ms) => (ms, true),
-                Err(e) => {
-                    ::zeroclaw_log::record!(DEBUG, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(::serde_json::json!({"model_provider": q.model_provider, "error": format!("{}", e)})), "model catalog fetch failed");
-                    (Vec::new(), false)
-                }
-            }
-        }
-    };
-
-    axum::Json(ModelsResponse {
-        model_provider: q.model_provider,
-        models,
-        local,
-        live,
-    })
-    .into_response()
+    let cfg = state.config.read().clone();
+    axum::Json(catalog_models_for_config(&cfg, &q.model_provider, q.alias.as_deref()).await)
+        .into_response()
 }
 
 fn error_response(err: ConfigApiError) -> Response {
@@ -1633,6 +1733,102 @@ mod tests {
             section_ready(&cfg, "memory", true),
             "Memory should show checked after the user has advanced through that section"
         );
+    }
+
+    #[tokio::test]
+    async fn catalog_models_uses_alias_local_uri() {
+        let base_url =
+            spawn_openai_compatible_models_server(r#"{"data":[{"id":"llama3.2:latest"}]}"#).await;
+        let cfg = ollama_alias_config(&base_url);
+
+        let resp = catalog_models_for_config(&cfg, "ollama", Some("default")).await;
+
+        assert!(resp.local);
+        assert!(resp.live);
+        assert_eq!(resp.models, vec!["llama3.2:latest"]);
+    }
+
+    #[tokio::test]
+    async fn catalog_models_keeps_live_empty_alias_catalog() {
+        let base_url = spawn_openai_compatible_models_server(r#"{"data":[]}"#).await;
+        let cfg = ollama_alias_config(&base_url);
+
+        let resp = catalog_models_for_config(&cfg, "ollama", Some("default")).await;
+
+        assert!(resp.local);
+        assert!(
+            resp.live,
+            "reachable local endpoint with no models is still live"
+        );
+        assert!(resp.models.is_empty());
+    }
+
+    #[tokio::test]
+    async fn catalog_models_marks_unreachable_local_alias_not_live() {
+        let cfg = ollama_alias_config("http://127.0.0.1:1");
+
+        let resp = catalog_models_for_config(&cfg, "ollama", Some("default")).await;
+
+        assert!(resp.local);
+        assert!(!resp.live);
+        assert!(resp.models.is_empty());
+    }
+
+    #[tokio::test]
+    async fn catalog_models_missing_alias_does_not_probe_default_endpoint() {
+        let base_url =
+            spawn_openai_compatible_models_server(r#"{"data":[{"id":"llama3.2:latest"}]}"#).await;
+        let cfg = ollama_alias_config(&base_url);
+
+        let resp = catalog_models_for_config(&cfg, "ollama", Some("missing")).await;
+
+        assert!(resp.local);
+        assert!(!resp.live);
+        assert!(resp.models.is_empty());
+    }
+
+    fn ollama_alias_config(base_url: &str) -> zeroclaw_config::schema::Config {
+        let mut cfg = zeroclaw_config::schema::Config::default();
+        cfg.create_map_key("providers.models.ollama", "default")
+            .unwrap();
+        cfg.set_prop_persistent("providers.models.ollama.default.uri", base_url)
+            .unwrap();
+        cfg
+    }
+
+    async fn spawn_openai_compatible_models_server(body: &'static str) -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    break;
+                };
+                tokio::spawn(async move {
+                    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+                    let mut buf = [0_u8; 1024];
+                    let n = stream.read(&mut buf).await.unwrap_or(0);
+                    let request = String::from_utf8_lossy(&buf[..n]);
+                    let response = if request.starts_with("GET /v1/models ") {
+                        format!(
+                            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{}",
+                            body.len(),
+                            body,
+                        )
+                    } else {
+                        let body = r#"{"error":"unexpected path"}"#;
+                        format!(
+                            "HTTP/1.1 404 Not Found\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{}",
+                            body.len(),
+                            body,
+                        )
+                    };
+                    let _ = stream.write_all(response.as_bytes()).await;
+                });
+            }
+        });
+        format!("http://{addr}")
     }
 
     fn empty_cfg() -> zeroclaw_config::schema::Config {

--- a/web/src/components/onboard/FieldForm.tsx
+++ b/web/src/components/onboard/FieldForm.tsx
@@ -315,7 +315,7 @@ function isOptionalArray(typeHint: string): boolean {
   return compact.startsWith('Option<Vec<') || compact.startsWith('Option<HashSet<');
 }
 
-// Per-provider catalog cache. Cleared via clearFieldFormCatalogCaches() on
+// Per-provider+alias catalog cache. Cleared via clearFieldFormCatalogCaches() on
 // nav so a new model alias added under (say) `anthropic` shows up the next
 // time the user opens an agent form without a hard refresh.
 let modelsCache: Record<string, { models: string[]; live: boolean; local: boolean }> = {};
@@ -989,22 +989,23 @@ function FieldRow({ entry, value, onChange, comment, onCommentChange, error, onD
 
   useEffect(() => {
     if (!isProviderModelField) return;
-    const provider = entry.path.split('.')[2];
-    if (!provider) return;
-    const cached = modelsCache[provider];
+    const [, , provider, alias] = entry.path.split('.');
+    if (!provider || !alias) return;
+    const cacheKey = `${provider}.${alias}`;
+    const cached = modelsCache[cacheKey];
     if (cached) {
       setProviderModels(cached.models);
       setModelsFetchFailed(!cached.live && cached.models.length === 0);
       return;
     }
-    void getCatalogModels(provider)
+    void getCatalogModels(provider, alias)
       .then((r) => {
-        modelsCache[provider] = { models: r.models, live: r.live, local: r.local };
+        modelsCache[cacheKey] = { models: r.models, live: r.live, local: r.local };
         setProviderModels(r.models);
         setModelsFetchFailed(!r.live && r.models.length === 0);
       })
       .catch(() => {
-        modelsCache[provider] = {
+        modelsCache[cacheKey] = {
           models: [],
           live: false,
           local: isLocalModelProviderName(provider),

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -893,9 +893,11 @@ export interface ModelsResponse {
   live: boolean;
 }
 
-export function getCatalogModels(provider: string): Promise<ModelsResponse> {
+export function getCatalogModels(provider: string, alias?: string): Promise<ModelsResponse> {
+  const params = new URLSearchParams({ provider });
+  if (alias) params.set('alias', alias);
   return apiFetch<ModelsResponse>(
-    `/api/onboard/catalog/models?provider=${encodeURIComponent(provider)}`,
+    `/api/onboard/catalog/models?${params.toString()}`,
   );
 }
 

--- a/web/src/pages/onboard/Onboard.tsx
+++ b/web/src/pages/onboard/Onboard.tsx
@@ -372,13 +372,15 @@ export default function Onboard() {
       const onboardingSections = resp.sections.filter((s) => s.is_onboarding);
       setSections(onboardingSections);
       const wizardIssues = firstRunReadinessIssues(onboardingSections);
-      const readyToFinish = !status.needs_onboarding && wizardIssues.length === 0;
+      const providerIssues = await configuredLocalModelProviderStepIssues();
+      const readyToFinish =
+        !status.needs_onboarding && wizardIssues.length === 0 && providerIssues.length === 0;
       setCanFinish(readyToFinish);
       if (!readyToFinish) {
         setIssueTitle('Finish needs a runnable agent first.');
         setFinishIssues(
-          status.missing.length > 0 || wizardIssues.length > 0
-            ? [...status.missing, ...wizardIssues]
+          status.missing.length > 0 || wizardIssues.length > 0 || providerIssues.length > 0
+            ? [...status.missing, ...wizardIssues, ...providerIssues]
             : ['Complete the required setup steps before finishing onboarding.'],
         );
         return;
@@ -806,9 +808,9 @@ function providerTypeForFieldsPrefix(fieldsPrefix: string): string | null {
   return parts[0] === 'providers' && parts[1] === 'models' && parts[2] ? parts[2] : null;
 }
 
-async function hasCustomProviderEndpoint(fieldsPrefix: string): Promise<boolean> {
-  const uri = await getProp(`${fieldsPrefix}.uri`).catch(() => null);
-  return hasTextValue(uri?.value);
+function providerAliasForFieldsPrefix(fieldsPrefix: string): string | null {
+  const parts = fieldsPrefix.split('.');
+  return parts[0] === 'providers' && parts[1] === 'models' && parts[3] ? parts[3] : null;
 }
 
 async function configuredLocalModelProviderStepIssues(): Promise<string[]> {
@@ -846,9 +848,11 @@ async function modelProviderStepIssues(picked: { item: PickerItem; fieldsPrefix:
 
   if (catalogProviderType) {
     try {
-      const catalog = await getCatalogModels(catalogProviderType);
+      const catalog = await getCatalogModels(
+        catalogProviderType,
+        providerAliasForFieldsPrefix(picked.fieldsPrefix) ?? undefined,
+      );
       if (catalog.local) {
-        if (await hasCustomProviderEndpoint(picked.fieldsPrefix)) return [];
         if (!catalog.live) {
           return [
             `Start or configure the local provider for \`${providerRef}\` so ZeroClaw can list its installed models.`,


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Resolves `/api/onboard/catalog/models` through the configured provider alias, so onboarding validates the endpoint the user actually selected instead of probing a provider-family default.
  - Keeps reachable local catalogs live even when they return an empty model list, while treating missing aliases and unreachable provider aliases with configured endpoints as not live.
  - Passes provider aliases from the onboarding field editor into catalog lookups, including the provider readiness check used before `Finish`.
  - Reuses the same provider-readiness check for `Finish` that the step flow uses, so restored or partially completed onboarding state cannot bypass the selected-provider gate.
- **Scope boundary:** This does not add hosted-provider API key shape validation or make a real authenticated request to prove arbitrary credentials. It only makes catalog/model readiness alias-aware and fail-closed for missing aliases plus configured alias endpoints that cannot be reached.
- **Blast radius:** Onboarding model-provider setup, the gateway onboarding catalog endpoint, and the web UI field form/provider-readiness flow.
- **Linked issue(s):** None.
- **Labels:** `bug`, `risk: high`, `size: M`, `gateway`, `web`.

## Validation Evidence (required)

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` — passed.
  - `cargo test -p zeroclaw-gateway catalog_models -- --nocapture` — passed; 5 catalog model tests passed, including missing-alias, reachable-empty local catalog, unreachable local alias, and unreachable hosted alias endpoint coverage.
  - `cargo clippy -p zeroclaw-gateway --all-targets -- -D warnings` — passed.
  - `cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings` — passed.
  - `cargo nextest run --locked --workspace --exclude zeroclaw-desktop` — passed; 8004 tests passed, 10 skipped.
  - `npm run build` — passed; Vite reported existing large-chunk warnings.
  - `git diff --check` — passed.
- **Beyond CI — what did you manually verify?** Checked the branch diff against the onboarding flow that triggered this fix: alias-aware catalog lookup, missing-alias fail-closed behavior, reachable-empty catalog behavior, configured endpoint fail-closed behavior, and `Finish` readiness reuse.
- **If any command was intentionally skipped, why:** None.

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No` new class of call. The existing onboarding catalog probe now resolves configured provider aliases instead of using a provider-family default.
- Secrets / tokens / credentials handling changed? `No` schema or storage change. Existing provider config, including any configured API key, flows through the existing provider factory path.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: The alias-aware probe can now reach the configured provider alias the user selected. That is the intended onboarding readiness check, and missing aliases or unreachable configured alias endpoints fail closed rather than falling back to an unrelated default.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No` config/env/CLI change. The gateway onboarding catalog endpoint accepts an optional `alias` query parameter; existing provider-only calls continue to work.
- If `No` or `Yes` to either: exact upgrade steps for existing users: No upgrade steps. Existing onboarding configs keep their current aliases; the UI now checks the selected alias more accurately.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert aa84d307f adaa4ada2`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Onboarding provider cards or `Finish` may report provider readiness incorrectly, especially for missing aliases, configured alias endpoints that are unreachable, or reachable local catalogs with no currently listed models.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Scope materially carried forward: N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why (inspiration-only, no direct code/design carry-over): N/A
