### PR TITLE
docs(triage): define terminal resolution labels

### DIFF
--- a/.claude/skills/github-issue-triage/references/triage-protocol.md
+++ b/.claude/skills/github-issue-triage/references/triage-protocol.md
@@ -27,9 +27,10 @@ gh label create "status:stale"       --color "E4E669" --repo zeroclaw-labs/zeroc
 gh label create "status:accepted"    --color "0E8A16" --repo zeroclaw-labs/zeroclaw
 gh label create "status:blocked"     --color "B60205" --repo zeroclaw-labs/zeroclaw
 gh label create "status:no-stale"    --color "0E8A16" --repo zeroclaw-labs/zeroclaw
-gh label create "status:wont-do"     --color "B60205" --repo zeroclaw-labs/zeroclaw
 gh label create "status:in-progress" --color "0075CA" --repo zeroclaw-labs/zeroclaw
+gh label create "wontfix"            --color "B60205" --repo zeroclaw-labs/zeroclaw
 gh label create "duplicate"          --color "CFD3D7" --repo zeroclaw-labs/zeroclaw
+gh label create "invalid"            --color "CFD3D7" --repo zeroclaw-labs/zeroclaw
 ```
 
 Only create labels that are actually needed in the current run.
@@ -400,7 +401,6 @@ Derived from RFC #5577 and current maintainer label policy. Apply these consiste
 - `type:rfc` — architectural proposal issue
 - `r:needs-repro` — bug report missing reproduction evidence
 - `r:support` — usage/configuration question, not a bug
-- `duplicate` — applied to the issue being closed in favour of a primary
 
 ### Priority (apply when determinable)
 
@@ -423,8 +423,13 @@ For issues, risk labels estimate likely fix blast radius from the report. Reasse
 - `status:accepted` — RFC or work item accepted by the team; not stale-exempt by itself
 - `status:blocked` — waiting on external blocker; exempt from stale while the blocker is recorded and unresolved
 - `status:in-progress` — linked open PR exists; verify live PR state before stale decisions
-- `status:wont-do` — architectural won't-fix; permanent decision, not a deferral
 - `status:no-stale` — explicitly exempt from stale automation for accepted or otherwise long-lived work that is not already protected by another exclusion; maintainer-applied with a recorded reason
+
+### Resolution
+
+- `wontfix` — valid request or report the project is explicitly choosing not to pursue; leave a rationale
+- `invalid` — not actionable as a bug, feature request, support item, RFC, or tracked project work
+- `duplicate` — applied to the issue being closed in favour of a primary
 
 ### Module labels (apply when issue is scoped to a specific subsystem)
 

--- a/docs/book/src/foundations/fnd-003-governance.md
+++ b/docs/book/src/foundations/fnd-003-governance.md
@@ -122,6 +122,8 @@ Plus one terminal state that can be reached from anywhere:
 🚫 Won't Do  ← explicit decision not to pursue; never silently closed
 ```
 
+The board-level `Won't Do` state is a durable closure decision. Current closure-label spelling and replacement-process rules live in the [maintainer label guide](../maintainers/labels.md#resolution-labels) and [superseding guide](../maintainers/superseding.md).
+
 ### 3.2 The Gate Questions
 
 Every transition has a gate question. The question must be answered "yes" before the item moves forward. This is the project board made operational — the Vision → Architecture → Design → Implementation → Testing → Documentation hierarchy becomes a checklist at each stage.
@@ -914,10 +916,10 @@ This table records governance intent and historical taxonomy shape. For current 
 | `status:help-wanted` | `#059669` Green | Looking for a contributor |
 | `status:good-first-issue` | `#059669` Green | Suitable for new contributors |
 | `status:discussion` | `#a78bfa` Purple | Needs team discussion before work begins |
-| `status:wont-fix` | `#9ca3af` Gray | Explicitly decided not to pursue |
-| `status:duplicate` | `#9ca3af` Gray | Duplicate of another issue |
 
 The live community-pickup labels are the unprefixed `good first issue` and `help wanted`; the `status:*` pickup rows above are historical taxonomy. Current operational risk labels also distinguish issue risk (likely fix blast radius from the report) from PR risk (the actual diff under review). See the [maintainer label guide](../maintainers/labels.md) for the live policy.
+
+Terminal closure labels are operational policy, not part of the historical `status:*` taxonomy in this foundation document. Use the [maintainer label guide](../maintainers/labels.md#resolution-labels) for current resolution labels and the [superseding guide](../maintainers/superseding.md) for replacement-process rules.
 
 ### `rfc:` — RFC-specific status
 

--- a/docs/book/src/maintainers/labels.md
+++ b/docs/book/src/maintainers/labels.md
@@ -217,6 +217,20 @@ Track lifecycle state of RFCs and tracked work items. Applied manually unless a 
 | `status:stale` | No author activity for the stale window; may close if not refreshed |
 | `status:no-stale` | Explicit stale exemption for accepted or otherwise long-lived work that is not already protected by another stale exclusion. Use only when a maintainer comment, issue body, or tracker entry records why the issue should stay open. |
 
+## Resolution labels
+
+Resolution labels explain why an issue or PR is being closed or removed from the active queue. They are terminal outcomes, not lifecycle status labels, and should include enough comment context for a future maintainer to understand the decision.
+
+| Label | Purpose |
+|---|---|
+| `wontfix` | Valid request or report that the project is explicitly choosing not to pursue. Use a brief rationale; do not silently close. |
+| `invalid` | Not actionable as a bug, feature request, support item, RFC, or tracked project work. Explain the mismatch or missing requirement. |
+| `duplicate` | Same underlying issue as another tracked issue or PR. Link the canonical target before closing or redirecting discussion. |
+
+Do not create or apply proposed terminal labels such as `status:wont-do` or `status:wont-fix` until a maintainer-approved label migration packet defines the exact rename, alias, or deletion plan. The current live label for the board-level "Won't Do" concept is `wontfix`.
+
+Superseding is a replacement process, not currently a live label. Use [Superseding PRs](./superseding.md) for replacement rules and attribution requirements until a later approved migration packet creates or maps a superseding label.
+
 ## Triage labels
 
 Applied manually — the auto-response automation that used to handle these was removed during CI simplification.
@@ -225,10 +239,7 @@ Applied manually — the auto-response automation that used to handle these was 
 |---|---|
 | `r:needs-repro` | Incomplete bug report; request a deterministic repro |
 | `r:support` | Usage / help item better handled outside the bug backlog |
-| `invalid` | Not a valid bug or feature request |
-| `duplicate` | Duplicate of an existing issue |
 | `stale-candidate` | Dormant PR or issue; candidate for closing |
-| `superseded` | Replaced by a newer PR |
 
 ## Community pickup labels
 

--- a/docs/book/src/maintainers/reviewer-playbook.md
+++ b/docs/book/src/maintainers/reviewer-playbook.md
@@ -88,13 +88,20 @@ Issue `risk:*` labels describe likely fix blast radius from the report. PR `risk
 |---|---|
 | `r:needs-repro` | Bug report missing a deterministic repro. Block deeper triage on this. |
 | `r:support` | Usage or help question better routed outside the bug backlog. |
-| `duplicate` / `invalid` | Non-actionable noise. Close with a polite pointer. |
 | `status:accepted` | The team has accepted the RFC or work item. Add `status:no-stale` only when the issue also needs stale protection. |
 | `status:blocked` | Valid work is waiting on an external dependency, maintainer decision, or linked prerequisite. Record the blocker; this is stale protection only while that blocker remains unresolved. |
 | `status:in-progress` | An open PR is actively targeting the issue. Re-check live PR state before relying on it during stale passes. |
 | `status:no-stale` | Accepted or otherwise long-lived work should stay open and is not already protected by another stale exclusion. Record the reason in a maintainer comment, issue body, or tracker entry. |
 | `good first issue` | XS/S, self-contained, documented work with clear acceptance criteria, relevant code or docs links, a named mentor or contact, and low onboarding risk. |
 | `help wanted` | Actionable, unblocked work maintainers want external help on and can review. Do not use it as a generic valid/unowned marker. |
+
+### Resolution labels
+
+Use resolution labels only when closing or removing an item from the active queue. They explain the terminal outcome; they do not replace `status:*` lifecycle labels on work that should stay open. The [labels guide](./labels.md#resolution-labels) is the source of truth for current resolution-label definitions and migration holdbacks.
+
+For duplicates, link the canonical target before closing or redirecting discussion. For invalid reports, explain what makes the report unactionable or where it should go instead. For work we are explicitly choosing not to pursue, use the board-level `Won't Do` / live `wontfix` path and leave a brief rationale.
+
+For replaced PRs or issue paths, use [Superseding PRs](./superseding.md) and preserve contributor attribution when relevant.
 
 If logs or payloads in the report contain personal identifiers or sensitive data, request redaction before deeper triage. The triage process must not propagate the exposure.
 
@@ -103,7 +110,7 @@ If logs or payloads in the report contain personal identifiers or sensitive data
 When review demand exceeds capacity:
 
 1. Keep active bug and security PRs (`size: XS/S`) at the top of the queue.
-2. Ask overlapping PRs to consolidate; close older ones as `superseded` after the author acknowledges. See [Superseding PRs](./superseding.md) for the attribution rules.
+2. Ask overlapping PRs to consolidate; close older ones with a superseded or replaced rationale after the author acknowledges. See [Superseding PRs](./superseding.md) for the attribution rules.
 3. Mark dormant PRs as `stale-candidate` before stale closure window starts.
 4. Require rebase + fresh validation evidence before reopening anything that's been stale-closed.
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Adds a canonical resolution-label section to the maintainer label guide for `wontfix`, `invalid`, and `duplicate`.
  - Moves `invalid` and `duplicate` out of triage-label guidance so closure labels are not mixed with active issue-routing labels.
  - Removes standalone `superseded` triage-label guidance and routes replacement cases through the superseding guide instead.
  - Keeps FND-003 at durable governance level by pointing terminal closure policy to the maintainer label guide and superseding guide instead of restating live label spellings.
  - Updates the issue-triage protocol so agents no longer create or apply the non-live `status:wont-do` label.
- **Scope boundary:** Does not add, delete, rename, or migrate live GitHub labels. Does not change stale automation, project board fields, issue state, or PR state.
- **Blast radius:** Docs and maintainer workflow guidance only. Affects how maintainers and triage agents describe terminal closure outcomes.
- **Linked issue(s):** Related #6808. #6919 has landed; this PR now carries only the terminal-resolution follow-up diff.
- **Labels:** `docs`, `type: docs`, `risk: low`, `size: XS`

## Validation Evidence (required)

- **Commands run and tail output:**

```text
git diff --check origin/master...HEAD
pass

scripts/ci/docs_links_gate.sh
pass; collected 2 added links from 4 docs files; offline link check reported 0 errors.

scripts/ci/docs_quality_gate.sh
pass; existing FND-003 markdown issues outside changed lines are non-blocking; no blocking markdown issues on changed lines.
```

- **Beyond CI — what did you manually verify?** Reviewed the changed hunks for `status:wont-do` / `status:wont-fix` references and kept terminal-resolution definitions canonical in the maintainer label guide. After #6919 landed, rebased this branch onto `origin/master` so the PR diff contains only the terminal-resolution follow-up.
- **If any command was intentionally skipped, why:** Rust cargo checks skipped; this is a docs-only maintainer workflow change.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: N/A.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No user upgrade steps; docs-only maintainer guidance update.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PR. Rollback is `git revert <merge-sha>`.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A.
