### PR TITLE
fix(channels): restore date-only channel prompt context

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -206,6 +206,8 @@ const MAX_CHANNEL_HISTORY: usize = 50;
 /// Messages shorter than this (e.g. "ok", "thanks") are not stored,
 /// reducing noise in memory recall.
 const AUTOSAVE_MIN_MESSAGE_CHARS: usize = 20;
+const CURRENT_DATE_HEADING: &str = "## Current Date\n\n";
+const LEGACY_CURRENT_DATE_TIME_HEADING: &str = "## Current Date & Time\n\n";
 
 // System prompt functions live in `zeroclaw_runtime::agent::system_prompt`.
 #[allow(unused_imports)]
@@ -737,24 +739,7 @@ fn build_channel_system_prompt(
 ) -> String {
     let mut prompt = base_prompt.to_string();
 
-    // Refresh the stale datetime in the cached system prompt
-    {
-        let now = chrono::Local::now();
-        let fresh = format!(
-            "## Current Date & Time\n\n{} ({})\n",
-            now.format("%Y-%m-%d %H:%M:%S"),
-            now.format("%Z"),
-        );
-        if let Some(start) = prompt.find("## Current Date & Time\n\n") {
-            // Find the end of this section (next "## " heading or end of string)
-            let rest = &prompt[start + 24..]; // skip past "## Current Date & Time\n\n"
-            let section_end = rest
-                .find("\n## ")
-                .map(|i| start + 24 + i)
-                .unwrap_or(prompt.len());
-            prompt.replace_range(start..section_end, fresh.trim_end());
-        }
-    }
+    refresh_channel_prompt_date_section(&mut prompt);
 
     if let Some(instructions) = channel_delivery_instructions(channel_name) {
         if prompt.is_empty() {
@@ -812,6 +797,44 @@ fn build_channel_system_prompt(
     }
 
     prompt
+}
+
+fn current_date_section() -> String {
+    let now = chrono::Local::now();
+    format!(
+        "{CURRENT_DATE_HEADING}{} ({})",
+        now.format("%Y-%m-%d"),
+        now.format("%:z")
+    )
+}
+
+fn refresh_channel_prompt_date_section(prompt: &mut String) {
+    let runtime_start = prompt
+        .find("\n## Runtime")
+        .map(|i| i + 1)
+        .unwrap_or(prompt.len());
+
+    if let Some((start, heading_len)) = find_latest_date_heading_before(prompt, runtime_start) {
+        let content_start = start + heading_len;
+        let section_end = prompt[content_start..]
+            .find("\n## ")
+            .map(|i| content_start + i)
+            .unwrap_or(prompt.len());
+        prompt.replace_range(start..section_end, &current_date_section());
+    }
+}
+
+fn find_latest_date_heading_before(prompt: &str, before: usize) -> Option<(usize, usize)> {
+    let prefix = &prompt[..before];
+    [CURRENT_DATE_HEADING, LEGACY_CURRENT_DATE_TIME_HEADING]
+        .iter()
+        .filter_map(|heading| prefix.rfind(heading).map(|start| (start, heading.len())))
+        .max_by_key(|(start, _)| *start)
+}
+
+fn timestamp_channel_user_content(content: &str) -> String {
+    let now = chrono::Local::now();
+    format!("[{}] {}", now.format("%Y-%m-%d %H:%M:%S %Z"), content)
 }
 
 fn normalize_cached_channel_turns(turns: Vec<ChatMessage>) -> Vec<ChatMessage> {
@@ -3402,12 +3425,18 @@ async fn process_channel_message_body(
             .is_some_and(|turns| !turns.is_empty())
     };
 
-    // Preserve user turn before the LLM call so interrupted requests keep context.
-    append_sender_turn(ctx.as_ref(), &history_key, ChatMessage::user(&msg.content));
+    // Preserve the dated user turn before the LLM call so interrupted requests
+    // keep the same temporal context as CLI turns.
+    let timestamped_content = timestamp_channel_user_content(&msg.content);
+    append_sender_turn(
+        ctx.as_ref(),
+        &history_key,
+        ChatMessage::user(&timestamped_content),
+    );
 
     // Build history from per-sender conversation cache.
     let prior_turns_raw = if force_fresh_session {
-        vec![ChatMessage::user(&msg.content)]
+        vec![ChatMessage::user(&timestamped_content)]
     } else {
         ctx.conversation_histories
             .lock()
@@ -4475,7 +4504,7 @@ async fn process_channel_message_body(
                 );
                 let should_rollback_user_turn = should_rollback_failed_user_turn(&e);
                 let rolled_back = should_rollback_user_turn
-                    && rollback_orphan_user_turn(ctx.as_ref(), &history_key, &msg.content);
+                    && rollback_orphan_user_turn(ctx.as_ref(), &history_key, &timestamped_content);
 
                 if !rolled_back {
                     // Close the orphan user turn so subsequent messages don't
@@ -9387,6 +9416,20 @@ mod tests {
     }
 
     #[test]
+    fn timestamp_channel_user_content_adds_wall_clock_prefix() {
+        let stamped = timestamp_channel_user_content("hello");
+
+        assert!(
+            stamped.starts_with('['),
+            "timestamped content should start with a bracketed timestamp: {stamped}"
+        );
+        assert!(
+            stamped.contains("] hello"),
+            "timestamped content should preserve the user message after the timestamp: {stamped}"
+        );
+    }
+
+    #[test]
     fn rollback_orphan_user_turn_removes_only_latest_matching_user_turn() {
         let sender = "telegram_u3".to_string();
         let mut histories =
@@ -12724,9 +12767,10 @@ BTC is currently around $65,000 based on latest tool output."#
             prompt.contains("## Project Context"),
             "missing Project Context"
         );
+        assert!(prompt.contains("## Current Date"), "missing Date section");
         assert!(
-            prompt.contains("## Current Date & Time"),
-            "missing Date/Time"
+            !prompt.contains("## Current Date & Time"),
+            "prompt should use date-only context"
         );
         assert!(prompt.contains("## Runtime"), "missing Runtime section");
     }
@@ -13846,8 +13890,10 @@ BTC is currently around $65,000 based on latest tool output."#
         assert_eq!(calls[1][1].0, "user");
         assert_eq!(calls[1][2].0, "assistant");
         assert_eq!(calls[1][3].0, "user");
+        assert!(calls[1][1].1.starts_with('['));
         assert!(calls[1][1].1.contains("hello"));
         assert!(calls[1][2].1.contains("response-1"));
+        assert!(calls[1][3].1.starts_with('['));
         assert!(calls[1][3].1.contains("follow up"));
     }
 
@@ -14177,7 +14223,12 @@ BTC is currently around $65,000 based on latest tool output."#
         assert!(calls[0][0].1.contains(MEMORY_CONTEXT_OPEN));
         assert!(calls[0][0].1.contains("Age is 45"));
         assert_eq!(calls[0][1].0, "user");
-        assert_eq!(calls[0][1].1, "hello");
+        assert!(calls[0][1].1.starts_with('['));
+        assert!(
+            calls[0][1].1.contains("] hello"),
+            "current channel user turn should be timestamped: {}",
+            calls[0][1].1
+        );
 
         let histories = runtime_ctx
             .conversation_histories
@@ -14187,7 +14238,12 @@ BTC is currently around $65,000 based on latest tool output."#
             .peek("test-channel_chat-ctx_alice")
             .expect("history should be stored for sender");
         assert_eq!(turns[0].role, "user");
-        assert_eq!(turns[0].content, "hello");
+        assert!(turns[0].content.starts_with('['));
+        assert!(
+            turns[0].content.contains("] hello"),
+            "stored channel user turn should be timestamped: {}",
+            turns[0].content
+        );
         assert!(!turns[0].content.contains(MEMORY_CONTEXT_OPEN));
     }
 
@@ -15350,7 +15406,11 @@ This is an example JSON object for profile settings."#;
             .expect("history should exist for sender");
         assert_eq!(turns.len(), 2);
         assert_eq!(turns[0].role, "user");
-        assert_eq!(turns[0].content, "What is WAL?");
+        assert!(
+            turns[0].content.contains("] What is WAL?"),
+            "follow-up user turn should be timestamped: {}",
+            turns[0].content
+        );
         assert_eq!(turns[1].role, "assistant");
         assert_eq!(turns[1].content, "ok");
         assert!(
@@ -15490,7 +15550,11 @@ This is an example JSON object for profile settings."#;
             .expect("history should exist for sender");
         assert_eq!(turns.len(), 2);
         assert_eq!(turns[0].role, "user");
-        assert_eq!(turns[0].content, "What is WAL?");
+        assert!(
+            turns[0].content.contains("] What is WAL?"),
+            "follow-up user turn should be timestamped: {}",
+            turns[0].content
+        );
         assert_eq!(turns[1].role, "assistant");
         assert_eq!(turns[1].content, "ok");
         assert!(
@@ -16935,6 +16999,64 @@ Done."#;
         assert!(prompt_a.contains("sender=user_aaa"));
         assert!(prompt_b.contains("sender=user_bbb"));
         assert_ne!(prompt_a, prompt_b);
+    }
+
+    #[test]
+    fn build_channel_system_prompt_refreshes_legacy_datetime_section_to_date_only() {
+        let prompt = build_channel_system_prompt(
+            "Base.\n\n## Current Date\n\nProject note, not generated date context.\n\n## Current Date & Time\n\n2026-01-01 01:02:03 (UTC)\n\n## Runtime\n\nHost: old\n",
+            "mattermost",
+            "ch:thread",
+            "user_aaa",
+            "msg-1",
+            None,
+        );
+
+        assert!(prompt.contains("## Current Date\n\n"));
+        assert!(prompt.contains("Project note, not generated date context."));
+        assert!(!prompt.contains("## Current Date & Time"));
+        assert!(!prompt.contains("01:02:03"));
+        let generated_section = prompt
+            .split("## Runtime")
+            .next()
+            .expect("prompt should contain runtime section before generated date assertion");
+        let date_line = generated_section
+            .rsplit("## Current Date\n\n")
+            .next()
+            .and_then(|rest| rest.lines().next())
+            .expect("current date section should have a date line");
+        assert_eq!(
+            &date_line[..10],
+            &chrono::Local::now().format("%Y-%m-%d").to_string()
+        );
+        assert!(
+            date_line[10..].starts_with(" ("),
+            "date line should contain only date plus UTC offset: {date_line}"
+        );
+    }
+
+    #[test]
+    fn build_channel_system_prompt_refreshes_current_date_section() {
+        let prompt = build_channel_system_prompt(
+            "Base.\n\n## Current Date\n\n2026-01-01 (+00:00)\n\n## Runtime\n\nHost: old\n",
+            "mattermost",
+            "ch:thread",
+            "user_aaa",
+            "msg-1",
+            None,
+        );
+
+        assert!(prompt.contains("## Current Date\n\n"));
+        assert!(!prompt.contains("2026-01-01 (+00:00)"));
+        let date_line = prompt
+            .split("## Current Date\n\n")
+            .nth(1)
+            .and_then(|rest| rest.lines().next())
+            .expect("current date section should have a date line");
+        assert_eq!(
+            &date_line[..10],
+            &chrono::Local::now().format("%Y-%m-%d").to_string()
+        );
     }
 
     #[test]

--- a/crates/zeroclaw-runtime/src/agent/prompt.rs
+++ b/crates/zeroclaw-runtime/src/agent/prompt.rs
@@ -4,7 +4,7 @@ use crate::security::AutonomyLevel;
 use crate::skills::Skill;
 use crate::tools::Tool;
 use anyhow::Result;
-use chrono::{Datelike, Local, Timelike};
+use chrono::{Datelike, Local};
 use std::fmt::Write;
 use std::path::Path;
 use zeroclaw_config::schema::IdentityConfig;
@@ -279,16 +279,13 @@ impl PromptSection for DateTimeSection {
         let now = Local::now();
         // Force Gregorian year to avoid confusion with local calendars (e.g. Buddhist calendar).
         let (year, month, day) = (now.year(), now.month(), now.day());
-        let (hour, minute, second) = (now.hour(), now.minute(), now.second());
-        let tz = now.format("%Z");
 
         Ok(format!(
-            "## CRITICAL CONTEXT: CURRENT DATE & TIME\n\n\
-             The following is the ABSOLUTE TRUTH regarding the current date and time. \
+            "## CRITICAL CONTEXT: CURRENT DATE\n\n\
+             The following is the ABSOLUTE TRUTH regarding the current date. \
              Use this for all relative time calculations (e.g. \"last 7 days\").\n\n\
              Date: {year:04}-{month:02}-{day:02}\n\
-             Time: {hour:02}:{minute:02}:{second:02} ({tz})\n\
-             ISO 8601: {year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}{}",
+             UTC offset: {}",
             now.format("%:z")
         ))
     }
@@ -560,7 +557,7 @@ mod tests {
     }
 
     #[test]
-    fn datetime_section_includes_timestamp_and_timezone() {
+    fn datetime_section_includes_date_and_offset_without_wall_clock_time() {
         let tools: Vec<Box<dyn Tool>> = vec![];
         let ctx = PromptContext {
             workspace_dir: Path::new("/tmp"),
@@ -578,12 +575,15 @@ mod tests {
         };
 
         let rendered = DateTimeSection.build(&ctx).unwrap();
-        assert!(rendered.starts_with("## CRITICAL CONTEXT: CURRENT DATE & TIME\n\n"));
+        assert!(rendered.starts_with("## CRITICAL CONTEXT: CURRENT DATE\n\n"));
+        assert!(!rendered.contains("CURRENT DATE & TIME"));
 
-        let payload = rendered.trim_start_matches("## CRITICAL CONTEXT: CURRENT DATE & TIME\n\n");
+        let payload = rendered.trim_start_matches("## CRITICAL CONTEXT: CURRENT DATE\n\n");
         assert!(payload.chars().any(|c| c.is_ascii_digit()));
         assert!(payload.contains("Date:"));
-        assert!(payload.contains("Time:"));
+        assert!(payload.contains("UTC offset:"));
+        assert!(!payload.contains("Time:"));
+        assert!(!payload.contains("ISO 8601:"));
     }
 
     #[test]

--- a/crates/zeroclaw-runtime/src/agent/system_prompt.rs
+++ b/crates/zeroclaw-runtime/src/agent/system_prompt.rs
@@ -43,7 +43,7 @@ fn load_openclaw_bootstrap_files(
 /// 3. Skills — full skill instructions and tool metadata
 /// 4. Workspace — working directory
 /// 5. Bootstrap files — AGENTS, SOUL, TOOLS, IDENTITY, USER, BOOTSTRAP, MEMORY
-/// 6. Date & Time — timezone for cache stability
+/// 6. Date — timezone offset for cache stability
 /// 7. Runtime — host, OS, model
 ///
 /// When `identity_config` is set to AIEOS format, the bootstrap files section
@@ -291,13 +291,13 @@ pub fn build_system_prompt_with_mode_and_autonomy(
         load_openclaw_bootstrap_files(&mut prompt, workspace_dir, max_chars);
     }
 
-    // ── 6. Date & Time ──────────────────────────────────────────
+    // ── 6. Date ─────────────────────────────────────────────────
     let now = chrono::Local::now();
     let _ = writeln!(
         prompt,
-        "## Current Date & Time\n\n{} ({})\n",
-        now.format("%Y-%m-%d %H:%M:%S"),
-        now.format("%Z")
+        "## Current Date\n\n{} ({})\n",
+        now.format("%Y-%m-%d"),
+        now.format("%:z")
     );
 
     // ── 7. Runtime ──────────────────────────────────────────────

--- a/crates/zeroclaw-runtime/src/tools/delegate.rs
+++ b/crates/zeroclaw-runtime/src/tools/delegate.rs
@@ -2828,7 +2828,7 @@ mod tests {
     }
 
     #[test]
-    fn enriched_prompt_includes_tools_workspace_datetime() {
+    fn enriched_prompt_includes_tools_workspace_date() {
         let config = AliasedAgentConfig {
             model_provider: "openrouter.test".into(),
             ..Default::default()
@@ -2859,9 +2859,12 @@ mod tests {
             "should contain workspace path"
         );
         assert!(
-            prompt.contains("## CRITICAL CONTEXT: CURRENT DATE & TIME"),
-            "should contain datetime section"
+            prompt.contains("## CRITICAL CONTEXT: CURRENT DATE"),
+            "should contain date section"
         );
+        assert!(!prompt.contains("CURRENT DATE & TIME"));
+        assert!(!prompt.contains("Time:"));
+        assert!(!prompt.contains("ISO 8601:"));
         // Identity files come from the target sub-agent's per-agent
         // workspace dir. The test's install_root is unset, so no
         // identity files exist for the dummy alias — the prompt still


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Restores the missing #3271 channel recovery slice from the #6074 bulk-revert audit.
  - Changes runtime prompt date context from wall-clock date/time to date plus UTC offset, so cached prompts do not churn every second.
  - Refreshes cached channel prompts that still contain either the legacy `## Current Date & Time` section or the current `## Current Date` section.
  - Timestamps channel-originated user turns before storage, replay, provider send, and rollback, matching the existing direct agent path's time-aware user-turn shape.
- **Scope boundary:** This does not change provider selection, channel registration, channel transport clients, config/env/CLI surface, or non-channel tool execution.
- **Blast radius:** Runtime prompt assembly and shared channel message orchestration. Channel models will now see timestamp-prefixed user content in the channel path, and cached channel prompts use date-only current-date context.
- **Linked issue(s):** Related #6074. Supersedes #3271.
- **Labels:** `bug`, `risk: high`, `size: S`, `agent`, `channel`, `runtime`

## Validation Evidence (required)

- **Commands run and tail output:**

```text
cargo fmt --all -- --check
Result: passed.

cargo test -p zeroclaw-runtime datetime_section_includes_date_and_offset_without_wall_clock_time -- --nocapture
Result: passed. 1 test passed.

cargo test -p zeroclaw-channels build_channel_system_prompt -- --nocapture
Result: passed. 8 tests passed.

cargo test -p zeroclaw-channels timestamp_channel_user_content -- --nocapture
Result: passed. 1 test passed.

cargo test -p zeroclaw-channels process_channel_message -- --nocapture
Result: passed. 23 tests passed.

cargo test -p zeroclaw-channels e2e_failed -- --nocapture
Result: passed. 2 tests passed.

cargo test -p zeroclaw-channels build_channel_system_prompt_refreshes -- --nocapture
Result: passed. 2 tests passed.

cargo test -p zeroclaw-runtime enriched_prompt_includes_tools_workspace_date -- --nocapture
Result: passed. 1 test passed.

cargo clippy -p zeroclaw-runtime -p zeroclaw-channels --all-targets -- -D warnings
Result: passed.

cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
Result: passed.

cargo nextest run --locked --workspace --exclude zeroclaw-desktop
Result: passed. 8002 tests passed, 10 skipped.

git diff --check
Result: passed.
```

- **Beyond CI — what did you manually verify?** I verified the recovered behavior against the channel orchestrator boundary. The `process_channel_message` regressions send real `ChannelMessage` values through the shared orchestrator path and assert that provider-facing user turns and persisted sender history are timestamped. The rollback regressions also exercise failed channel turns and confirm failed multimodal/non-retryable turns do not poison follow-up text history. I did not run a live Telegram/Discord/Slack/Mattermost backend smoke; for this generic shared-orchestrator recovery slice, the near-live orchestrator coverage is the accepted channel smoke evidence.
- **If any command was intentionally skipped, why:** No required local readiness command was skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: `N/A`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No user migration is required. Existing channel configs keep working; the changed behavior is the internal prompt/history text shape used for channel-originated turns.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <merge-sha>`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Channel conversations lose current-date awareness, channel prompt caches churn because wall-clock time returns to the system prompt, or channel follow-up history contains duplicate/missing user turns after failed multimodal or non-retryable messages.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): #3271 by @whtiehack
- Scope materially carried forward: Date-only prompt context, channel cached prompt date refresh, timestamped channel-originated user turns, and rollback handling for timestamped failed channel turns.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `Yes`
- If `No`, why (inspiration-only, no direct code/design carry-over): `N/A`
