### PR TITLE
feat(gateway): preserve websocket steering transcript

### DIFF
--- a/crates/zeroclaw-gateway/src/ws.rs
+++ b/crates/zeroclaw-gateway/src/ws.rs
@@ -441,11 +441,18 @@ async fn handle_socket(
             if parsed["type"].as_str() == Some("message") {
                 let content = parsed["content"].as_str().unwrap_or("").to_string();
                 if !content.is_empty() {
-                    // Persist user message
-                    if let Some(ref backend) = state.session_backend {
-                        let user_msg = zeroclaw_providers::ChatMessage::user(&content);
-                        let _ = backend.append(&session_key, &user_msg);
-                    }
+                    let _session_guard = match state.session_queue.acquire(&session_key).await {
+                        Ok(guard) => guard,
+                        Err(e) => {
+                            let err = serde_json::json!({
+                                "type": "error",
+                                "message": e.to_string(),
+                                "code": session_queue_ws_error_code(&e)
+                            });
+                            let _ = sender.send(Message::Text(err.to_string().into())).await;
+                            return;
+                        }
+                    };
                     process_chat_message(
                         &state,
                         &mut agent,
@@ -580,18 +587,12 @@ async fn handle_socket(
                         let err = serde_json::json!({
                             "type": "error",
                             "message": e.to_string(),
-                            "code": "SESSION_BUSY"
+                            "code": session_queue_ws_error_code(&e)
                         });
                         let _ = sender.send(Message::Text(err.to_string().into())).await;
                         continue;
                     }
                 };
-
-                // Persist user message
-                if let Some(ref backend) = state.session_backend {
-                    let user_msg = zeroclaw_providers::ChatMessage::user(&content);
-                    let _ = backend.append(&session_key, &user_msg);
-                }
 
                 process_chat_message(
                     &state,
@@ -672,6 +673,39 @@ fn resolve_session_cwd(
     })
 }
 
+fn session_queue_ws_error_code(error: &crate::session_queue::SessionQueueError) -> &'static str {
+    match error {
+        crate::session_queue::SessionQueueError::QueueFull { .. } => "SESSION_QUEUE_FULL",
+        crate::session_queue::SessionQueueError::Timeout { .. } => "SESSION_QUEUE_TIMEOUT",
+    }
+}
+
+fn persist_conversation_messages(
+    backend: &dyn zeroclaw_infra::session_backend::SessionBackend,
+    session_key: &str,
+    messages: &[zeroclaw_providers::ConversationMessage],
+) {
+    for message in messages {
+        let zeroclaw_providers::ConversationMessage::Chat(message) = message else {
+            continue;
+        };
+        if message.role == "system" {
+            continue;
+        }
+        let _ = backend.append(session_key, message);
+    }
+}
+
+fn has_assistant_chat_message(messages: &[zeroclaw_providers::ConversationMessage]) -> bool {
+    messages.iter().any(|message| {
+        matches!(
+            message,
+            zeroclaw_providers::ConversationMessage::Chat(message)
+                if message.role == "assistant"
+        )
+    })
+}
+
 fn needs_onboarding_ws_error(
     config: &zeroclaw_config::schema::Config,
 ) -> Option<serde_json::Value> {
@@ -745,6 +779,7 @@ async fn process_chat_message(
 
     // Channel for streaming turn events from the agent.
     let (event_tx, mut event_rx) = tokio::sync::mpsc::channel::<TurnEvent>(64);
+    let (steering_tx, mut steering_rx) = tokio::sync::mpsc::channel::<String>(32);
 
     // Run the streamed turn concurrently: the agent produces events
     // while we forward them to the WebSocket below.  We cannot move
@@ -756,7 +791,12 @@ async fn process_chat_message(
     let turn_fut = async {
         zeroclaw_runtime::agent::loop_::scope_session_key(
             Some(session_key_owned),
-            agent.turn_streamed(&content_owned, event_tx, Some(cancel_token.clone())),
+            agent.turn_streamed_with_steering_state(
+                &content_owned,
+                event_tx,
+                Some(cancel_token.clone()),
+                Some(&mut steering_rx),
+            ),
         )
         .await
     };
@@ -765,15 +805,7 @@ async fn process_chat_message(
     // and we relay them over WebSocket. Track streamed chunks so we
     // can reconstruct partial content on cancellation.
     //
-    // WHY incremental persistence: If the process crashes during streaming,
-    // the assistant's response is lost — only the user message survives.
-    // We append a placeholder assistant message on the first chunk, then
-    // update_last periodically (every 500ms) so partial content survives.
-    // The final response overwrites this via update_last on completion.
     let mut accumulated_text = String::new();
-    let mut partial_saved = false;
-    let mut last_partial_save = std::time::Instant::now();
-    let partial_save_interval = std::time::Duration::from_millis(500);
 
     // Aggregate token usage across all LLM calls in this turn.
     // The agent emits TurnEvent::Usage once per LLM call when the provider
@@ -827,28 +859,64 @@ async fn process_chat_message(
                         _ => continue,
                     };
                     let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&text) else {
+                        let err = serde_json::json!({
+                            "type": "error",
+                            "message": "Invalid JSON. Send {\"type\":\"message\",\"content\":\"your text\"}",
+                            "code": "INVALID_JSON"
+                        });
+                        let _ = sender.send(Message::Text(err.to_string().into())).await;
                         continue;
                     };
-                    if parsed["type"].as_str() != Some("approval_response") {
-                        // Mid-turn `message` / other frames are ignored. The
-                        // outer `select!` will not see them either; we drop
-                        // them deliberately rather than queueing.
-                        continue;
-                    }
-                    let request_id = parsed["request_id"].as_str().unwrap_or("");
-                    let decision = match parsed["decision"].as_str().unwrap_or("") {
-                        "approve" => Some(ChannelApprovalResponse::Approve),
-                        "always" => Some(ChannelApprovalResponse::AlwaysApprove),
-                        "deny" => Some(ChannelApprovalResponse::Deny),
-                        _ => None,
-                    };
-                    if request_id.is_empty() || decision.is_none() {
-                        continue;
-                    }
-                    if let Some(tx) = pending_approvals.lock().remove(request_id) {
-                        let _ = tx.send(decision.expect("checked above"));
-                    } else {
-                        ::zeroclaw_log::record!(DEBUG, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(::serde_json::json!({"request_id": request_id})), "approval_response with no matching pending request (mid-turn)");
+                    match parsed["type"].as_str() {
+                        Some("approval_response") => {
+                            let request_id = parsed["request_id"].as_str().unwrap_or("");
+                            let decision = match parsed["decision"].as_str().unwrap_or("") {
+                                "approve" => Some(ChannelApprovalResponse::Approve),
+                                "always" => Some(ChannelApprovalResponse::AlwaysApprove),
+                                "deny" => Some(ChannelApprovalResponse::Deny),
+                                _ => None,
+                            };
+                            if request_id.is_empty() || decision.is_none() {
+                                continue;
+                            }
+                            if let Some(tx) = pending_approvals.lock().remove(request_id) {
+                                let _ = tx.send(decision.expect("checked above"));
+                            } else {
+                                ::zeroclaw_log::record!(DEBUG, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(::serde_json::json!({"request_id": request_id})), "approval_response with no matching pending request (mid-turn)");
+                            }
+                        }
+                        Some("message") => {
+                            let content = parsed["content"].as_str().unwrap_or("").to_string();
+                            if content.is_empty() {
+                                let err = serde_json::json!({
+                                    "type": "error",
+                                    "message": "Message content cannot be empty",
+                                    "code": "EMPTY_CONTENT"
+                                });
+                                let _ = sender.send(Message::Text(err.to_string().into())).await;
+                                continue;
+                            }
+                            match steering_tx.try_send(content) {
+                                Ok(()) => {}
+                                Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                                    let err = serde_json::json!({
+                                        "type": "error",
+                                        "message": "Steering queue is full for the running turn",
+                                        "code": "STEERING_QUEUE_FULL"
+                                    });
+                                    let _ = sender.send(Message::Text(err.to_string().into())).await;
+                                }
+                                Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                                    let err = serde_json::json!({
+                                        "type": "error",
+                                        "message": "Running turn is no longer accepting steering messages",
+                                        "code": "STEERING_CLOSED"
+                                    });
+                                    let _ = sender.send(Message::Text(err.to_string().into())).await;
+                                }
+                            }
+                        }
+                        _ => {}
                     }
                 }
                 approval = approval_event_rx.recv() => {
@@ -887,23 +955,6 @@ async fn process_chat_message(
                         }
                         TurnEvent::Chunk { ref delta } => {
                             accumulated_text.push_str(delta);
-                            // Incremental persistence: save partial content so it
-                            // survives a crash. First chunk appends, subsequent
-                            // chunks update in-place.
-                            if last_partial_save.elapsed() >= partial_save_interval {
-                                if let Some(ref backend) = state.session_backend {
-                                    let partial = zeroclaw_providers::ChatMessage::assistant(
-                                        &accumulated_text,
-                                    );
-                                    if partial_saved {
-                                        let _ = backend.update_last(session_key, &partial);
-                                    } else {
-                                        let _ = backend.append(session_key, &partial);
-                                        partial_saved = true;
-                                    }
-                                }
-                                last_partial_save = std::time::Instant::now();
-                            }
                             serde_json::json!({ "type": "chunk", "content": delta })
                         }
                         TurnEvent::Thinking { delta } => {
@@ -948,25 +999,38 @@ async fn process_chat_message(
     // Check if this turn was cancelled. `turn_streamed` propagates
     // `ToolLoopCancelled` through anyhow, so we detect it here.
     let was_cancelled = match &result {
-        Err(e) => zeroclaw_runtime::agent::loop_::is_tool_loop_cancelled(e),
+        Err(e) => zeroclaw_runtime::agent::loop_::is_tool_loop_cancelled(&e.error),
         Ok(_) => false,
     };
 
     if was_cancelled {
-        // Store partial content with interruption marker so the
-        // conversation stays coherent for subsequent turns.
-        let truncated = if accumulated_text.is_empty() {
-            "[interrupted by user]".to_string()
-        } else {
-            format!("{accumulated_text}\n\n[interrupted by user]")
-        };
-
         if let Some(ref backend) = state.session_backend {
-            let assistant_msg = zeroclaw_providers::ChatMessage::assistant(&truncated);
-            if partial_saved {
-                let _ = backend.update_last(session_key, &assistant_msg);
-            } else {
-                let _ = backend.append(session_key, &assistant_msg);
+            match &result {
+                Err(error) if !error.new_messages.is_empty() => {
+                    persist_conversation_messages(
+                        backend.as_ref(),
+                        session_key,
+                        &error.new_messages,
+                    );
+                    if !has_assistant_chat_message(&error.new_messages) {
+                        let truncated = if accumulated_text.is_empty() {
+                            "[interrupted by user]".to_string()
+                        } else {
+                            format!("{accumulated_text}\n\n[interrupted by user]")
+                        };
+                        let assistant_msg = zeroclaw_providers::ChatMessage::assistant(&truncated);
+                        let _ = backend.append(session_key, &assistant_msg);
+                    }
+                }
+                _ => {
+                    let truncated = if accumulated_text.is_empty() {
+                        "[interrupted by user]".to_string()
+                    } else {
+                        format!("{accumulated_text}\n\n[interrupted by user]")
+                    };
+                    let assistant_msg = zeroclaw_providers::ChatMessage::assistant(&truncated);
+                    let _ = backend.append(session_key, &assistant_msg);
+                }
             }
         }
 
@@ -1007,16 +1071,9 @@ async fn process_chat_message(
     }
 
     match result {
-        Ok((response, _)) => {
-            // Persist final assistant response. If we saved partial content
-            // during streaming, update it in-place; otherwise append fresh.
+        Ok(outcome) => {
             if let Some(ref backend) = state.session_backend {
-                let assistant_msg = zeroclaw_providers::ChatMessage::assistant(&response);
-                if partial_saved {
-                    let _ = backend.update_last(session_key, &assistant_msg);
-                } else {
-                    let _ = backend.append(session_key, &assistant_msg);
-                }
+                persist_conversation_messages(backend.as_ref(), session_key, &outcome.new_messages);
             }
 
             // Fire-and-forget memory consolidation so facts from WS sessions
@@ -1027,7 +1084,7 @@ async fn process_chat_message(
                 let model = state.model.clone();
                 let temperature = state.temperature;
                 let user_msg = content.to_string();
-                let assistant_resp = response.clone();
+                let assistant_resp = outcome.response.clone();
                 tokio::spawn(async move {
                     if let Err(e) = zeroclaw_memory::consolidation::consolidate_turn(
                         model_provider.as_ref(),
@@ -1052,11 +1109,6 @@ async fn process_chat_message(
                 });
             }
 
-            // Send chunk_reset so the client clears any accumulated draft
-            // before the authoritative done message.
-            let reset = serde_json::json!({ "type": "chunk_reset" });
-            let _ = sender.send(Message::Text(reset.to_string().into())).await;
-
             // Compute cost from accumulated tokens + configured pricing,
             // then write the cost record so /api/cost and costs.jsonl reflect
             // this turn. Done before the done frame so cost_usd can ride along.
@@ -1077,7 +1129,7 @@ async fn process_chat_message(
 
             let done = serde_json::json!({
                 "type": "done",
-                "full_response": response,
+                "full_response": outcome.response,
                 "input_tokens": total_input_tokens,
                 "output_tokens": total_output_tokens,
                 "tokens_used": total_tokens,
@@ -1120,6 +1172,12 @@ async fn process_chat_message(
             );
         }
         Err(e) => {
+            if let Some(ref backend) = state.session_backend
+                && !e.new_messages.is_empty()
+            {
+                persist_conversation_messages(backend.as_ref(), session_key, &e.new_messages);
+            }
+
             // Set session state to error
             if let Some(ref backend) = state.session_backend {
                 let _ = backend.set_session_state(session_key, "error", Some(&turn_id));
@@ -1129,10 +1187,10 @@ async fn process_chat_message(
                 ERROR,
                 ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
                     .with_outcome(::zeroclaw_log::EventOutcome::Failure)
-                    .with_attrs(::serde_json::json!({"error": format!("{}", e)})),
+                    .with_attrs(::serde_json::json!({"error": format!("{}", e.error)})),
                 "Agent turn failed"
             );
-            let sanitized = zeroclaw_providers::sanitize_api_error(&e.to_string());
+            let sanitized = zeroclaw_providers::sanitize_api_error(&e.error.to_string());
             let error_code = if sanitized.to_lowercase().contains("api key")
                 || sanitized.to_lowercase().contains("authentication")
                 || sanitized.to_lowercase().contains("unauthorized")
@@ -1491,6 +1549,25 @@ mod tests {
         assert!(
             clone_for_turn.is_cancelled(),
             "cloned token (held by turn_fut via agent.turn_streamed) must observe cancellation"
+        );
+    }
+
+    #[test]
+    fn session_queue_errors_map_to_explicit_websocket_codes() {
+        use crate::session_queue::SessionQueueError;
+
+        assert_eq!(
+            session_queue_ws_error_code(&SessionQueueError::QueueFull {
+                session_id: "gw_test".into(),
+                depth: 2,
+            }),
+            "SESSION_QUEUE_FULL"
+        );
+        assert_eq!(
+            session_queue_ws_error_code(&SessionQueueError::Timeout {
+                session_id: "gw_test".into(),
+            }),
+            "SESSION_QUEUE_TIMEOUT"
         );
     }
 }

--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -1873,7 +1873,7 @@ impl Agent {
                                 );
                             }
                             return Err(StreamedTurnError {
-                                error: anyhow::anyhow!(error.to_string()),
+                                error: anyhow::Error::msg(error.to_string()),
                                 committed_response,
                                 new_messages: new_msgs,
                             });
@@ -2103,10 +2103,10 @@ impl Agent {
         }
 
         Err(StreamedTurnError {
-            error: anyhow::anyhow!(
+            error: anyhow::Error::msg(format!(
                 "Agent exceeded maximum tool iterations ({})",
                 self.config.max_tool_iterations
-            ),
+            )),
             committed_response,
             new_messages: new_msgs,
         })

--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -79,6 +79,19 @@ pub struct Agent {
     channel_handles: AgentChannelHandles,
 }
 
+#[derive(Debug)]
+pub struct StreamedTurnSuccess {
+    pub response: String,
+    pub new_messages: Vec<ConversationMessage>,
+}
+
+#[derive(Debug)]
+pub struct StreamedTurnError {
+    pub error: anyhow::Error,
+    pub committed_response: String,
+    pub new_messages: Vec<ConversationMessage>,
+}
+
 /// Bundle of late-bound channel-map handles owned by an Agent. Cloning is
 /// cheap (Arc clones); the underlying maps are shared with the live tools.
 #[derive(Clone, Default)]
@@ -496,6 +509,121 @@ impl Agent {
 
     pub fn clear_history(&mut self) {
         self.history.clear();
+    }
+
+    fn encode_response_cache_transcript(messages: &[ChatMessage]) -> String {
+        let mut transcript = String::new();
+        for message in messages.iter().filter(|message| message.role != "system") {
+            transcript.push_str("role=");
+            transcript.push_str(&message.role.len().to_string());
+            transcript.push(':');
+            transcript.push_str(&message.role);
+            transcript.push_str(";content=");
+            transcript.push_str(&message.content.len().to_string());
+            transcript.push(':');
+            transcript.push_str(&message.content);
+            transcript.push('\n');
+        }
+        transcript
+    }
+
+    fn response_cache_key_for_messages(
+        &self,
+        messages: &[ChatMessage],
+        effective_model: &str,
+    ) -> Option<String> {
+        if self.temperature != 0.0 || self.response_cache.is_none() {
+            return None;
+        }
+
+        let system = messages
+            .iter()
+            .find(|message| message.role == "system")
+            .map(|message| message.content.as_str());
+        let transcript = Self::encode_response_cache_transcript(messages);
+
+        Some(zeroclaw_memory::response_cache::ResponseCache::cache_key(
+            effective_model,
+            system,
+            &transcript,
+        ))
+    }
+
+    fn drain_steering_messages(
+        steering_rx: &mut Option<&mut tokio::sync::mpsc::Receiver<String>>,
+    ) -> Vec<String> {
+        let Some(rx) = steering_rx.as_deref_mut() else {
+            return Vec::new();
+        };
+
+        let mut messages = Vec::new();
+        loop {
+            match rx.try_recv() {
+                Ok(message) => messages.push(message),
+                Err(tokio::sync::mpsc::error::TryRecvError::Empty) => break,
+                Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => break,
+            }
+        }
+        messages
+    }
+
+    async fn append_streamed_user_message_to_history(
+        &mut self,
+        user_message: &str,
+        new_msgs: &mut Vec<ConversationMessage>,
+    ) {
+        let context = self
+            .memory_loader
+            .load_context(
+                self.memory.as_ref(),
+                user_message,
+                self.memory_session_id.as_deref(),
+            )
+            .await
+            .unwrap_or_default();
+
+        if self.auto_save {
+            let _ = self
+                .memory
+                .store(
+                    "user_msg",
+                    user_message,
+                    MemoryCategory::Conversation,
+                    self.memory_session_id.as_deref(),
+                )
+                .await;
+        }
+
+        let now = chrono::Local::now().format("%Y-%m-%d %H:%M:%S %Z");
+        let enriched = if context.is_empty() {
+            format!("[{now}] {user_message}")
+        } else {
+            format!("{context}[{now}] {user_message}")
+        };
+
+        let user_msg = ConversationMessage::Chat(ChatMessage::user(enriched));
+        new_msgs.push(user_msg.clone());
+        self.history.push(user_msg);
+    }
+
+    fn marked_partial_response(partial: &str, marker: &str) -> String {
+        if partial.is_empty() {
+            marker.to_string()
+        } else {
+            format!("{partial}\n\n{marker}")
+        }
+    }
+
+    fn append_streamed_assistant_message_to_history(
+        &mut self,
+        content: String,
+        new_msgs: &mut Vec<ConversationMessage>,
+        committed_response: &mut String,
+    ) {
+        let assistant_msg = ConversationMessage::Chat(ChatMessage::assistant(content.clone()));
+        new_msgs.push(assistant_msg.clone());
+        self.history.push(assistant_msg);
+        committed_response.push_str(&content);
     }
 
     fn should_send_tool_specs(&self) -> bool {
@@ -1393,28 +1521,13 @@ impl Agent {
 
         for _ in 0..self.config.max_tool_iterations {
             let messages = self.tool_dispatcher.to_provider_messages(&self.history);
+            let prepared_messages = self.prepare_provider_messages(&messages).await?;
 
-            // Response cache: check before LLM call (only for deterministic, text-only prompts)
-            let cache_key = if self.temperature == 0.0 {
-                self.response_cache.as_ref().map(|_| {
-                    let last_user = messages
-                        .iter()
-                        .rfind(|m| m.role == "user")
-                        .map(|m| m.content.as_str())
-                        .unwrap_or("");
-                    let system = messages
-                        .iter()
-                        .find(|m| m.role == "system")
-                        .map(|m| m.content.as_str());
-                    zeroclaw_memory::response_cache::ResponseCache::cache_key(
-                        &effective_model,
-                        system,
-                        last_user,
-                    )
-                })
-            } else {
-                None
-            };
+            // Response cache: check before LLM call (only for deterministic, text-only prompts).
+            // The key must include the whole provider-visible transcript, not just the last user
+            // message, otherwise distinct conversations can collide when their final prompt matches.
+            let cache_key =
+                self.response_cache_key_for_messages(&prepared_messages, &effective_model);
 
             if let (Some(cache), Some(key)) = (&self.response_cache, &cache_key) {
                 if let Ok(Some(cached)) = cache.get(key) {
@@ -1433,8 +1546,6 @@ impl Agent {
                     cache_type: "response".into(),
                 });
             }
-
-            let prepared_messages = self.prepare_provider_messages(&messages).await?;
 
             let response = match self
                 .model_provider
@@ -1524,51 +1635,41 @@ impl Agent {
         event_tx: tokio::sync::mpsc::Sender<TurnEvent>,
         cancel_token: Option<tokio_util::sync::CancellationToken>,
     ) -> Result<(String, Vec<ConversationMessage>)> {
+        self.turn_streamed_with_steering_state(user_message, event_tx, cancel_token, None)
+            .await
+            .map(|outcome| (outcome.response, outcome.new_messages))
+            .map_err(|err| err.error)
+    }
+
+    pub async fn turn_streamed_with_steering_state(
+        &mut self,
+        user_message: &str,
+        event_tx: tokio::sync::mpsc::Sender<TurnEvent>,
+        cancel_token: Option<tokio_util::sync::CancellationToken>,
+        mut steering_rx: Option<&mut tokio::sync::mpsc::Receiver<String>>,
+    ) -> std::result::Result<StreamedTurnSuccess, StreamedTurnError> {
         // ── Preamble (identical to turn) ───────────────────────────────
         if self.history.is_empty() {
-            let system_prompt = self.build_system_prompt()?;
+            let system_prompt = self
+                .build_system_prompt()
+                .map_err(|error| StreamedTurnError {
+                    error,
+                    committed_response: String::new(),
+                    new_messages: Vec::new(),
+                })?;
             self.history
                 .push(ConversationMessage::Chat(ChatMessage::system(
                     system_prompt,
                 )));
         }
 
-        let context = self
-            .memory_loader
-            .load_context(
-                self.memory.as_ref(),
-                user_message,
-                self.memory_session_id.as_deref(),
-            )
-            .await
-            .unwrap_or_default();
-
-        if self.auto_save {
-            let _ = self
-                .memory
-                .store(
-                    "user_msg",
-                    user_message,
-                    MemoryCategory::Conversation,
-                    self.memory_session_id.as_deref(),
-                )
-                .await;
-        }
-
-        let now = chrono::Local::now().format("%Y-%m-%d %H:%M:%S %Z");
-        let enriched = if context.is_empty() {
-            format!("[{now}] {user_message}")
-        } else {
-            format!("{context}[{now}] {user_message}")
-        };
-
         let mut new_msgs: Vec<ConversationMessage> = Vec::new();
-        let user_msg = ConversationMessage::Chat(ChatMessage::user(enriched));
-        new_msgs.push(user_msg.clone());
-        self.history.push(user_msg);
+        self.append_streamed_user_message_to_history(user_message, &mut new_msgs)
+            .await;
 
         let effective_model = self.classify_model(user_message);
         let turn_started_at = std::time::Instant::now();
+        let mut committed_response = String::new();
 
         // ── Turn loop ──────────────────────────────────────────────────
         for _ in 0..self.config.max_tool_iterations {
@@ -1577,32 +1678,38 @@ impl Agent {
                 .as_ref()
                 .is_some_and(tokio_util::sync::CancellationToken::is_cancelled)
             {
-                return Err(crate::agent::loop_::ToolLoopCancelled.into());
+                self.append_streamed_assistant_message_to_history(
+                    "[interrupted by user]".to_string(),
+                    &mut new_msgs,
+                    &mut committed_response,
+                );
+                return Err(StreamedTurnError {
+                    error: crate::agent::loop_::ToolLoopCancelled.into(),
+                    committed_response,
+                    new_messages: new_msgs,
+                });
+            }
+
+            for steering_message in Self::drain_steering_messages(&mut steering_rx) {
+                self.append_streamed_user_message_to_history(&steering_message, &mut new_msgs)
+                    .await;
             }
 
             let messages = self.tool_dispatcher.to_provider_messages(&self.history);
-
-            // Response cache check (same as turn)
-            let cache_key = if self.temperature == 0.0 {
-                self.response_cache.as_ref().map(|_| {
-                    let last_user = messages
-                        .iter()
-                        .rfind(|m| m.role == "user")
-                        .map(|m| m.content.as_str())
-                        .unwrap_or("");
-                    let system = messages
-                        .iter()
-                        .find(|m| m.role == "system")
-                        .map(|m| m.content.as_str());
-                    zeroclaw_memory::response_cache::ResponseCache::cache_key(
-                        &effective_model,
-                        system,
-                        last_user,
-                    )
-                })
-            } else {
-                None
+            let prepared_messages = match self.prepare_provider_messages(&messages).await {
+                Ok(messages) => messages,
+                Err(error) => {
+                    return Err(StreamedTurnError {
+                        error,
+                        committed_response,
+                        new_messages: new_msgs,
+                    });
+                }
             };
+
+            // Response cache check (same as turn): include the full provider-visible transcript.
+            let cache_key =
+                self.response_cache_key_for_messages(&prepared_messages, &effective_model);
 
             if let (Some(cache), Some(key)) = (&self.response_cache, &cache_key) {
                 if let Ok(Some(cached)) = cache.get(key) {
@@ -1623,14 +1730,16 @@ impl Agent {
                         tokens_used: None,
                         cost_usd: None,
                     });
-                    return Ok((cached, new_msgs));
+                    committed_response.push_str(&cached);
+                    return Ok(StreamedTurnSuccess {
+                        response: committed_response,
+                        new_messages: new_msgs,
+                    });
                 }
                 self.observer.record_event(&ObserverEvent::CacheMiss {
                     cache_type: "response".into(),
                 });
             }
-
-            let prepared_messages = self.prepare_provider_messages(&messages).await?;
 
             // ── Streaming LLM call ────────────────────────────────────
             // Try streaming first; if the model_provider returns content we
@@ -1750,7 +1859,27 @@ impl Agent {
                         }
                         zeroclaw_providers::traits::StreamEvent::Final => break,
                     },
-                    Err(_) => break,
+                    Err(error) => {
+                        if got_stream || !committed_response.is_empty() {
+                            if !streamed_text.is_empty() {
+                                let partial = Self::marked_partial_response(
+                                    &streamed_text,
+                                    "[stream interrupted]",
+                                );
+                                self.append_streamed_assistant_message_to_history(
+                                    partial,
+                                    &mut new_msgs,
+                                    &mut committed_response,
+                                );
+                            }
+                            return Err(StreamedTurnError {
+                                error: anyhow::anyhow!(error.to_string()),
+                                committed_response,
+                                new_messages: new_msgs,
+                            });
+                        }
+                        break;
+                    }
                 }
             }
             // Drop the stream so we release the borrow on model_provider.
@@ -1760,16 +1889,18 @@ impl Agent {
             // the interruption marker appended. The caller (ws.rs) will
             // persist this truncated message and send an abort frame.
             if was_cancelled {
-                let partial = if streamed_text.is_empty() {
-                    "[interrupted by user]".to_string()
-                } else {
-                    format!("{streamed_text}\n\n[interrupted by user]")
-                };
-                self.history
-                    .push(ConversationMessage::Chat(ChatMessage::assistant(
-                        partial.clone(),
-                    )));
-                return Err(crate::agent::loop_::ToolLoopCancelled.into());
+                let partial =
+                    Self::marked_partial_response(&streamed_text, "[interrupted by user]");
+                self.append_streamed_assistant_message_to_history(
+                    partial,
+                    &mut new_msgs,
+                    &mut committed_response,
+                );
+                return Err(StreamedTurnError {
+                    error: crate::agent::loop_::ToolLoopCancelled.into(),
+                    committed_response,
+                    new_messages: new_msgs,
+                });
             }
 
             // If streaming produced text, use it as the response and
@@ -1809,7 +1940,16 @@ impl Agent {
                     tokio::select! {
                         biased;
                         () = token.cancelled() => {
-                            return Err(crate::agent::loop_::ToolLoopCancelled.into());
+                            self.append_streamed_assistant_message_to_history(
+                                "[interrupted by user]".to_string(),
+                                &mut new_msgs,
+                                &mut committed_response,
+                            );
+                            return Err(StreamedTurnError {
+                                error: crate::agent::loop_::ToolLoopCancelled.into(),
+                                committed_response,
+                                new_messages: new_msgs,
+                            });
                         }
                         result = chat_fut => result,
                     }
@@ -1818,7 +1958,13 @@ impl Agent {
                 };
                 match chat_result {
                     Ok(resp) => resp,
-                    Err(err) => return Err(err),
+                    Err(error) => {
+                        return Err(StreamedTurnError {
+                            error,
+                            committed_response,
+                            new_messages: new_msgs,
+                        });
+                    }
                 }
             };
 
@@ -1843,6 +1989,27 @@ impl Agent {
                 } else {
                     text
                 };
+
+                let steering_messages = Self::drain_steering_messages(&mut steering_rx);
+                if !steering_messages.is_empty() {
+                    if !final_text.is_empty() {
+                        let assistant_msg =
+                            ConversationMessage::Chat(ChatMessage::assistant(final_text.clone()));
+                        new_msgs.push(assistant_msg.clone());
+                        self.history.push(assistant_msg);
+                        committed_response.push_str(&final_text);
+                        self.trim_history();
+                    }
+
+                    for steering_message in steering_messages {
+                        self.append_streamed_user_message_to_history(
+                            &steering_message,
+                            &mut new_msgs,
+                        )
+                        .await;
+                    }
+                    continue;
+                }
 
                 // Store in response cache
                 if let (Some(cache), Some(key)) = (&self.response_cache, &cache_key) {
@@ -1871,6 +2038,7 @@ impl Agent {
                     .push(ConversationMessage::Chat(ChatMessage::assistant(
                         final_text.clone(),
                     )));
+                committed_response.push_str(&final_text);
                 self.trim_history();
                 self.observer.record_event(&ObserverEvent::TurnComplete);
                 self.observer.record_event(&ObserverEvent::AgentEnd {
@@ -1880,7 +2048,10 @@ impl Agent {
                     tokens_used: None,
                     cost_usd: None,
                 });
-                return Ok((final_text, new_msgs));
+                return Ok(StreamedTurnSuccess {
+                    response: committed_response,
+                    new_messages: new_msgs,
+                });
             }
 
             // Pre-assign stable IDs to tool calls that don't have one
@@ -1931,10 +2102,14 @@ impl Agent {
             self.trim_history();
         }
 
-        anyhow::bail!(
-            "Agent exceeded maximum tool iterations ({})",
-            self.config.max_tool_iterations
-        )
+        Err(StreamedTurnError {
+            error: anyhow::anyhow!(
+                "Agent exceeded maximum tool iterations ({})",
+                self.config.max_tool_iterations
+            ),
+            committed_response,
+            new_messages: new_msgs,
+        })
     }
 
     pub async fn run_single(&mut self, message: &str) -> Result<String> {
@@ -2151,6 +2326,170 @@ mod tests {
         }
         fn alias(&self) -> &str {
             "ModelCaptureModelProvider"
+        }
+    }
+
+    struct TranscriptCaptureModelProvider {
+        responses: Mutex<Vec<zeroclaw_providers::ChatResponse>>,
+        seen_messages: Arc<Mutex<Vec<Vec<ChatMessage>>>>,
+    }
+
+    #[async_trait]
+    impl ModelProvider for TranscriptCaptureModelProvider {
+        async fn chat_with_system(
+            &self,
+            _system_prompt: Option<&str>,
+            _message: &str,
+            _model: &str,
+            _temperature: Option<f64>,
+        ) -> Result<String> {
+            Ok("ok".into())
+        }
+
+        async fn chat(
+            &self,
+            request: ChatRequest<'_>,
+            _model: &str,
+            _temperature: Option<f64>,
+        ) -> Result<zeroclaw_providers::ChatResponse> {
+            self.seen_messages.lock().push(request.messages.to_vec());
+            let mut responses = self.responses.lock();
+            if responses.is_empty() {
+                return Ok(zeroclaw_providers::ChatResponse {
+                    text: Some("done".into()),
+                    tool_calls: vec![],
+                    usage: None,
+                    reasoning_content: None,
+                });
+            }
+            Ok(responses.remove(0))
+        }
+    }
+
+    impl ::zeroclaw_api::attribution::Attributable for TranscriptCaptureModelProvider {
+        fn role(&self) -> ::zeroclaw_api::attribution::Role {
+            ::zeroclaw_api::attribution::Role::Provider(
+                ::zeroclaw_api::attribution::ProviderKind::Model(
+                    ::zeroclaw_api::attribution::ModelProviderKind::Custom,
+                ),
+            )
+        }
+        fn alias(&self) -> &str {
+            "TranscriptCaptureModelProvider"
+        }
+    }
+
+    struct StreamingSteeringModelProvider {
+        seen_messages: Arc<Mutex<Vec<Vec<ChatMessage>>>>,
+        call_count: AtomicUsize,
+        fail_on_call: Option<usize>,
+        fail_after_delta_on_call: Option<usize>,
+    }
+
+    #[async_trait]
+    impl ModelProvider for StreamingSteeringModelProvider {
+        async fn chat_with_system(
+            &self,
+            _system_prompt: Option<&str>,
+            _message: &str,
+            _model: &str,
+            _temperature: Option<f64>,
+        ) -> Result<String> {
+            Ok("ok".into())
+        }
+
+        async fn chat(
+            &self,
+            request: ChatRequest<'_>,
+            _model: &str,
+            _temperature: Option<f64>,
+        ) -> Result<zeroclaw_providers::ChatResponse> {
+            let call = self.call_count.fetch_add(1, Ordering::SeqCst) + 1;
+            self.seen_messages.lock().push(request.messages.to_vec());
+            if self.fail_on_call == Some(call) {
+                anyhow::bail!("synthetic provider failure on call {call}");
+            }
+            if self.fail_after_delta_on_call == Some(call) {
+                anyhow::bail!("synthetic provider failure after delta on call {call}");
+            }
+            Ok(zeroclaw_providers::ChatResponse {
+                text: Some(if call == 1 { "draft" } else { "final" }.into()),
+                tool_calls: vec![],
+                usage: None,
+                reasoning_content: None,
+            })
+        }
+
+        fn supports_streaming(&self) -> bool {
+            true
+        }
+
+        fn stream_chat(
+            &self,
+            request: ChatRequest<'_>,
+            _model: &str,
+            _temperature: Option<f64>,
+            _options: zeroclaw_providers::traits::StreamOptions,
+        ) -> futures_util::stream::BoxStream<
+            'static,
+            zeroclaw_providers::traits::StreamResult<zeroclaw_providers::traits::StreamEvent>,
+        > {
+            use futures_util::StreamExt as _;
+
+            let call = self.call_count.fetch_add(1, Ordering::SeqCst) + 1;
+            self.seen_messages.lock().push(request.messages.to_vec());
+            let should_fail = self.fail_on_call == Some(call);
+            let should_fail_after_delta = self.fail_after_delta_on_call == Some(call);
+            let delta = if call == 1 { "draft" } else { "final" }.to_string();
+            futures_util::stream::unfold(0, move |step| {
+                let delta = delta.clone();
+                async move {
+                    match step {
+                        0 if should_fail => Some((
+                            Err(zeroclaw_providers::traits::StreamError::ModelProvider(
+                                "synthetic provider failure".into(),
+                            )),
+                            1,
+                        )),
+                        0 => Some((
+                            Ok(zeroclaw_providers::traits::StreamEvent::TextDelta(
+                                zeroclaw_providers::traits::StreamChunk {
+                                    delta,
+                                    is_final: false,
+                                    reasoning: None,
+                                    token_count: 0,
+                                },
+                            )),
+                            1,
+                        )),
+                        1 if should_fail_after_delta => Some((
+                            Err(zeroclaw_providers::traits::StreamError::ModelProvider(
+                                "synthetic provider failure after delta".into(),
+                            )),
+                            2,
+                        )),
+                        1 => {
+                            tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+                            Some((Ok(zeroclaw_providers::traits::StreamEvent::Final), 2))
+                        }
+                        _ => None,
+                    }
+                }
+            })
+            .boxed()
+        }
+    }
+
+    impl ::zeroclaw_api::attribution::Attributable for StreamingSteeringModelProvider {
+        fn role(&self) -> ::zeroclaw_api::attribution::Role {
+            ::zeroclaw_api::attribution::Role::Provider(
+                ::zeroclaw_api::attribution::ProviderKind::Model(
+                    ::zeroclaw_api::attribution::ModelProviderKind::Custom,
+                ),
+            )
+        }
+        fn alias(&self) -> &str {
+            "StreamingSteeringModelProvider"
         }
     }
 
@@ -4095,6 +4434,381 @@ mod tests {
                  AssistantToolCalls — duplicate narration push was not removed"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn response_cache_key_uses_full_provider_visible_transcript() {
+        let tmp = tempfile::tempdir().expect("temp response cache dir");
+        let cache = Arc::new(
+            zeroclaw_memory::response_cache::ResponseCache::new(tmp.path(), 60, 100)
+                .expect("response cache should initialize"),
+        );
+
+        let memory_cfg = zeroclaw_config::schema::MemoryConfig {
+            backend: "none".into(),
+            ..zeroclaw_config::schema::MemoryConfig::default()
+        };
+        let mem_a: Arc<dyn Memory> = Arc::from(
+            zeroclaw_memory::create_memory(&memory_cfg, std::path::Path::new("/tmp"), None)
+                .expect("memory creation should succeed with valid config"),
+        );
+        let mem_b: Arc<dyn Memory> = Arc::from(
+            zeroclaw_memory::create_memory(&memory_cfg, std::path::Path::new("/tmp"), None)
+                .expect("memory creation should succeed with valid config"),
+        );
+
+        let seen_a = Arc::new(Mutex::new(Vec::new()));
+        let seen_b = Arc::new(Mutex::new(Vec::new()));
+        let provider_a = Box::new(TranscriptCaptureModelProvider {
+            responses: Mutex::new(vec![zeroclaw_providers::ChatResponse {
+                text: Some("from prior transcript".into()),
+                tool_calls: vec![],
+                usage: None,
+                reasoning_content: None,
+            }]),
+            seen_messages: seen_a.clone(),
+        });
+        let provider_b = Box::new(TranscriptCaptureModelProvider {
+            responses: Mutex::new(vec![zeroclaw_providers::ChatResponse {
+                text: Some("from fresh transcript".into()),
+                tool_calls: vec![],
+                usage: None,
+                reasoning_content: None,
+            }]),
+            seen_messages: seen_b.clone(),
+        });
+
+        let observer: Arc<dyn Observer> = Arc::from(crate::observability::NoopObserver {});
+        let mut agent_a = Agent::builder()
+            .model_provider(provider_a)
+            .tools(vec![Box::new(MockTool)])
+            .memory(mem_a)
+            .observer(observer.clone())
+            .response_cache(Some(cache.clone()))
+            .tool_dispatcher(Box::new(NativeToolDispatcher))
+            .workspace_dir(std::path::PathBuf::from("/tmp"))
+            .model_name("test-model".into())
+            .temperature(0.0)
+            .build()
+            .expect("agent builder should succeed with valid config");
+        agent_a.seed_history(&[
+            ChatMessage::user("earlier turn"),
+            ChatMessage::assistant("earlier answer"),
+        ]);
+
+        let mut agent_b = Agent::builder()
+            .model_provider(provider_b)
+            .tools(vec![Box::new(MockTool)])
+            .memory(mem_b)
+            .observer(observer)
+            .response_cache(Some(cache))
+            .tool_dispatcher(Box::new(NativeToolDispatcher))
+            .workspace_dir(std::path::PathBuf::from("/tmp"))
+            .model_name("test-model".into())
+            .temperature(0.0)
+            .build()
+            .expect("agent builder should succeed with valid config");
+
+        assert_eq!(
+            agent_a.turn("same final prompt").await.unwrap(),
+            "from prior transcript"
+        );
+        assert_eq!(
+            agent_b.turn("same final prompt").await.unwrap(),
+            "from fresh transcript"
+        );
+        assert_eq!(seen_a.lock().len(), 1);
+        assert_eq!(
+            seen_b.lock().len(),
+            1,
+            "fresh transcript must not reuse a cache entry written for a different prior transcript"
+        );
+    }
+
+    #[tokio::test]
+    async fn turn_streamed_with_steering_commits_streamed_output_before_continuing() {
+        let memory_cfg = zeroclaw_config::schema::MemoryConfig {
+            backend: "none".into(),
+            ..zeroclaw_config::schema::MemoryConfig::default()
+        };
+        let mem: Arc<dyn Memory> = Arc::from(
+            zeroclaw_memory::create_memory(&memory_cfg, std::path::Path::new("/tmp"), None)
+                .expect("memory creation should succeed with valid config"),
+        );
+
+        let seen_messages = Arc::new(Mutex::new(Vec::new()));
+        let model_provider = Box::new(StreamingSteeringModelProvider {
+            seen_messages: seen_messages.clone(),
+            call_count: AtomicUsize::new(0),
+            fail_on_call: None,
+            fail_after_delta_on_call: None,
+        });
+        let observer: Arc<dyn Observer> = Arc::from(crate::observability::NoopObserver {});
+        let mut agent = Agent::builder()
+            .model_provider(model_provider)
+            .tools(vec![Box::new(MockTool)])
+            .memory(mem)
+            .observer(observer)
+            .tool_dispatcher(Box::new(NativeToolDispatcher))
+            .workspace_dir(std::path::PathBuf::from("/tmp"))
+            .build()
+            .expect("agent builder should succeed with valid config");
+
+        let (event_tx, mut event_rx) = tokio::sync::mpsc::channel::<TurnEvent>(64);
+        let (steering_tx, mut steering_rx) = tokio::sync::mpsc::channel::<String>(4);
+        let handle = tokio::spawn(async move {
+            agent
+                .turn_streamed_with_steering_state("first", event_tx, None, Some(&mut steering_rx))
+                .await
+        });
+
+        loop {
+            match event_rx.recv().await.expect("turn event should arrive") {
+                TurnEvent::Chunk { delta } if delta == "draft" => {
+                    steering_tx
+                        .send("second".into())
+                        .await
+                        .expect("steering message should enqueue");
+                    break;
+                }
+                _ => {}
+            }
+        }
+
+        let outcome = handle
+            .await
+            .expect("turn task should finish")
+            .expect("steered turn should succeed");
+        assert_eq!(outcome.response, "draftfinal");
+
+        let new_chat_messages: Vec<_> = outcome
+            .new_messages
+            .iter()
+            .filter_map(|msg| match msg {
+                ConversationMessage::Chat(message) => {
+                    Some((message.role.as_str(), message.content.as_str()))
+                }
+                _ => None,
+            })
+            .collect();
+        assert!(
+            new_chat_messages
+                .iter()
+                .any(|(role, content)| { *role == "assistant" && *content == "draft" }),
+            "already streamed output must be committed before the steering continuation"
+        );
+        assert!(
+            new_chat_messages
+                .iter()
+                .any(|(role, content)| { *role == "user" && content.contains("second") }),
+            "accepted steering must be retained as its own user turn"
+        );
+
+        let seen = seen_messages.lock();
+        assert_eq!(seen.len(), 2);
+        let second_call = &seen[1];
+        assert!(
+            second_call
+                .iter()
+                .any(|msg| msg.role == "assistant" && msg.content == "draft"),
+            "second provider call must see the committed streamed assistant text"
+        );
+        assert!(
+            second_call
+                .iter()
+                .filter(|msg| msg.role == "user")
+                .any(|msg| msg.content.contains("second")),
+            "second provider call must include the accepted steering user message"
+        );
+    }
+
+    #[tokio::test]
+    async fn turn_streamed_with_steering_error_returns_committed_partial_output() {
+        let memory_cfg = zeroclaw_config::schema::MemoryConfig {
+            backend: "none".into(),
+            ..zeroclaw_config::schema::MemoryConfig::default()
+        };
+        let mem: Arc<dyn Memory> = Arc::from(
+            zeroclaw_memory::create_memory(&memory_cfg, std::path::Path::new("/tmp"), None)
+                .expect("memory creation should succeed with valid config"),
+        );
+
+        let model_provider = Box::new(StreamingSteeringModelProvider {
+            seen_messages: Arc::new(Mutex::new(Vec::new())),
+            call_count: AtomicUsize::new(0),
+            fail_on_call: Some(2),
+            fail_after_delta_on_call: None,
+        });
+        let observer: Arc<dyn Observer> = Arc::from(crate::observability::NoopObserver {});
+        let mut agent = Agent::builder()
+            .model_provider(model_provider)
+            .tools(vec![Box::new(MockTool)])
+            .memory(mem)
+            .observer(observer)
+            .tool_dispatcher(Box::new(NativeToolDispatcher))
+            .workspace_dir(std::path::PathBuf::from("/tmp"))
+            .build()
+            .expect("agent builder should succeed with valid config");
+
+        let (event_tx, mut event_rx) = tokio::sync::mpsc::channel::<TurnEvent>(64);
+        let (steering_tx, mut steering_rx) = tokio::sync::mpsc::channel::<String>(4);
+        let handle = tokio::spawn(async move {
+            agent
+                .turn_streamed_with_steering_state("first", event_tx, None, Some(&mut steering_rx))
+                .await
+        });
+
+        loop {
+            match event_rx.recv().await.expect("turn event should arrive") {
+                TurnEvent::Chunk { delta } if delta == "draft" => {
+                    steering_tx
+                        .send("second".into())
+                        .await
+                        .expect("steering message should enqueue");
+                    break;
+                }
+                _ => {}
+            }
+        }
+
+        let err = handle
+            .await
+            .expect("turn task should finish")
+            .expect_err("second provider call should fail");
+        assert_eq!(err.committed_response, "draft");
+        assert!(
+            err.new_messages.iter().any(|msg| {
+                matches!(msg, ConversationMessage::Chat(message) if message.role == "assistant" && message.content == "draft")
+            }),
+            "committed partial assistant output should be returned for persistence after continuation failure"
+        );
+        assert!(
+            err.new_messages.iter().any(|msg| {
+                matches!(msg, ConversationMessage::Chat(message) if message.role == "user" && message.content.contains("second"))
+            }),
+            "accepted steering user message should still be returned after continuation failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn turn_streamed_error_after_delta_returns_visible_partial_output() {
+        let memory_cfg = zeroclaw_config::schema::MemoryConfig {
+            backend: "none".into(),
+            ..zeroclaw_config::schema::MemoryConfig::default()
+        };
+        let mem: Arc<dyn Memory> = Arc::from(
+            zeroclaw_memory::create_memory(&memory_cfg, std::path::Path::new("/tmp"), None)
+                .expect("memory creation should succeed with valid config"),
+        );
+
+        let model_provider = Box::new(StreamingSteeringModelProvider {
+            seen_messages: Arc::new(Mutex::new(Vec::new())),
+            call_count: AtomicUsize::new(0),
+            fail_on_call: None,
+            fail_after_delta_on_call: Some(1),
+        });
+        let observer: Arc<dyn Observer> = Arc::from(crate::observability::NoopObserver {});
+        let mut agent = Agent::builder()
+            .model_provider(model_provider)
+            .tools(vec![Box::new(MockTool)])
+            .memory(mem)
+            .observer(observer)
+            .tool_dispatcher(Box::new(NativeToolDispatcher))
+            .workspace_dir(std::path::PathBuf::from("/tmp"))
+            .build()
+            .expect("agent builder should succeed with valid config");
+
+        let (event_tx, mut event_rx) = tokio::sync::mpsc::channel::<TurnEvent>(64);
+        let handle = tokio::spawn(async move {
+            agent
+                .turn_streamed_with_steering_state("first", event_tx, None, None)
+                .await
+        });
+
+        assert!(
+            matches!(
+                event_rx.recv().await,
+                Some(TurnEvent::Chunk { delta }) if delta == "draft"
+            ),
+            "the client should see the streamed text before the provider error"
+        );
+
+        let err = handle
+            .await
+            .expect("turn task should finish")
+            .expect_err("provider stream failure should be returned");
+        assert!(
+            err.error
+                .to_string()
+                .contains("synthetic provider failure after delta"),
+            "unexpected error: {}",
+            err.error
+        );
+        assert!(
+            err.committed_response.contains("draft"),
+            "visible streamed text should be committed after a provider stream error"
+        );
+        assert!(
+            err.committed_response.contains("[stream interrupted]"),
+            "persisted partial text should mark that the stream did not complete"
+        );
+        assert!(
+            err.new_messages.iter().any(|msg| {
+                matches!(msg, ConversationMessage::Chat(message) if message.role == "assistant" && message.content.contains("draft"))
+            }),
+            "new messages should carry the visible assistant partial for gateway persistence"
+        );
+    }
+
+    #[tokio::test]
+    async fn turn_streamed_cancel_before_output_returns_interruption_message() {
+        let memory_cfg = zeroclaw_config::schema::MemoryConfig {
+            backend: "none".into(),
+            ..zeroclaw_config::schema::MemoryConfig::default()
+        };
+        let mem: Arc<dyn Memory> = Arc::from(
+            zeroclaw_memory::create_memory(&memory_cfg, std::path::Path::new("/tmp"), None)
+                .expect("memory creation should succeed with valid config"),
+        );
+
+        let model_provider = Box::new(StreamingSteeringModelProvider {
+            seen_messages: Arc::new(Mutex::new(Vec::new())),
+            call_count: AtomicUsize::new(0),
+            fail_on_call: None,
+            fail_after_delta_on_call: None,
+        });
+        let observer: Arc<dyn Observer> = Arc::from(crate::observability::NoopObserver {});
+        let mut agent = Agent::builder()
+            .model_provider(model_provider)
+            .tools(vec![Box::new(MockTool)])
+            .memory(mem)
+            .observer(observer)
+            .tool_dispatcher(Box::new(NativeToolDispatcher))
+            .workspace_dir(std::path::PathBuf::from("/tmp"))
+            .build()
+            .expect("agent builder should succeed with valid config");
+
+        let (event_tx, _event_rx) = tokio::sync::mpsc::channel::<TurnEvent>(64);
+        let cancel_token = tokio_util::sync::CancellationToken::new();
+        cancel_token.cancel();
+
+        let err = agent
+            .turn_streamed_with_steering_state("first", event_tx, Some(cancel_token), None)
+            .await
+            .expect_err("pre-cancelled turn should return cancellation");
+
+        assert!(
+            crate::agent::loop_::is_tool_loop_cancelled(&err.error),
+            "unexpected error: {}",
+            err.error
+        );
+        assert_eq!(err.committed_response, "[interrupted by user]");
+        assert!(
+            err.new_messages.iter().any(|msg| {
+                matches!(msg, ConversationMessage::Chat(message) if message.role == "assistant" && message.content == "[interrupted by user]")
+            }),
+            "cancelled turn should include an assistant interruption marker for persistence"
+        );
     }
 
     // ── Skill tool registration & excluded_tools filtering ──────────


### PR DESCRIPTION
## Summary

- **What changed and why:**
  - WebSocket `message` frames sent while a turn is already streaming now enter a bounded steering queue instead of being dropped.
  - The runtime commits already-streamed assistant text before continuing with an accepted steering message, so the next provider call sees the actual transcript order.
  - Cancellation and provider stream failures now return assistant interruption or partial-output messages for session persistence, including the no-output cancellation case.
  - Deterministic response-cache keys now use the prepared provider-visible transcript, not only the final user message, so different prior turns do not collide.
- **Scope boundary:** This does not migrate gateway session storage to full-fidelity `ConversationMessage` persistence; #6932 tracks that follow-up. It also does not add steering support to non-WebSocket channels, change auth, change provider selection, change config or CLI surface, or change the WebSocket client request payload shape. It does change WebSocket response behavior by accepting mid-turn `message` frames, returning explicit error codes for rejected frames, and omitting successful-turn `chunk_reset`. The deterministic response-cache keying fix is shared runtime behavior and can affect all agent turn paths that use the response cache.
- **Blast radius:** High-risk runtime/gateway path: streamed agent turns, WebSocket session persistence, cancellation handling, session-queue error reporting, and deterministic response caching.
- **Linked issue(s):** Closes #6661. Related #5161. Follow-up #6932.
- **Labels:** `enhancement`, `agent`, `gateway`, `runtime`, `risk: high`, `size: XL`

## Validation Evidence (required)

- **Commands run and result summaries:**

```text
cargo fmt --all -- --check
Result: passed after the final source patch.

git diff --check
Result: passed with no whitespace errors.

cargo test -p zeroclaw-runtime response_cache_key_uses_full_provider_visible_transcript -- --nocapture
Result: passed. Verifies same final prompt plus different prior transcript does not reuse the wrong cached answer.

cargo test -p zeroclaw-runtime turn_streamed_ -- --nocapture
Result: passed. Seven streamed-turn tests cover existing tool-spec/image/history-limit paths plus steering continuation, provider stream failure after a delta, and cancellation-before-output persistence.

cargo test -p zeroclaw-gateway session_queue_errors_map_to_explicit_websocket_codes -- --nocapture
Result: passed. Verifies queue-full and timeout cases map to distinct WebSocket error codes.

cargo clippy --all-targets -- -D warnings
Result: passed. Broad all-target clippy covered the gateway/runtime changes after the CI lint cleanup.

cargo nextest run --locked --workspace --exclude zeroclaw-desktop
Result: passed with 8005 tests passed and 10 skipped. This matches the current CI-shaped Test job for the non-desktop workspace.

node tmp/smoke-ws-steering.mjs
Result: passed. Live local gateway/WebSocket smoke used a temporary OpenAI-compatible SSE provider plus the real `/ws/chat` endpoint. It streamed an initial assistant chunk, accepted a mid-turn steering message, then continued the turn. The second provider call saw the committed assistant chunk before the steering user message, and the persisted gateway session transcript stored initial user, assistant partial, steering user, and final assistant in that order.
```

- **Beyond CI — what did you manually verify?** Reviewed the runtime streamed-turn control flow, gateway mid-turn frame handling, cancellation persistence path, cache-key construction, and session-history ordering against #6661. The live smoke also exercised the real WebSocket boundary and session persistence path.
- **If any command was intentionally skipped, why:** No known local validation gap remains.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: No new permission, network, credential, or PII surface. The security-relevant risk is behavioral: a user can now steer an in-flight WebSocket turn instead of having that frame silently dropped. The mitigation is a bounded in-memory queue, explicit queue-full/closed errors, and persistence only after the runtime accepts and orders the messages.

## Compatibility (required)

- Backward compatible? `No` for clients that depended on successful-turn `chunk_reset`; otherwise no migration is required.
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No config, environment, or CLI changes are required. WebSocket behavior changes are limited to accepted mid-turn `message` frames, explicit error codes for rejected frames, and no successful-turn `chunk_reset`. Clients should treat streamed chunks plus the final `done.full_response` as the authoritative result. For steered turns, `done.full_response` contains the full committed assistant output across all steering continuations, not only the final segment.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <merge-sha>`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** WebSocket steering messages are still ignored, accepted steering appears out of order in session history, cancellation leaves no assistant interruption marker, provider stream errors lose visible partial text, or response cache returns an answer from a different prior transcript. Check gateway WebSocket `error` frames, session transcript ordering, and runtime cache-hit behavior around repeated final prompts.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): #5161 by @casualjim.
- Scope materially carried forward: #5161's design and acceptance shape for additive WebSocket steering, committed streamed output, transcript ordering, explicit queue-admission errors, and provider-visible transcript cache keying. This PR is a fresh current-crate implementation with no direct code copied.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `Yes` — include `Co-authored-by: Ivan Porto Carrero <casualjim@users.noreply.github.com>` in the squash merge body.
- If `No`, why (inspiration-only, no direct code/design carry-over): N/A.
