### PR TITLE
fix(discord): keep gateway preflight 429 retryable

### DIFF
--- a/crates/zeroclaw-channels/src/discord.rs
+++ b/crates/zeroclaw-channels/src/discord.rs
@@ -212,6 +212,12 @@ impl DiscordChannel {
         anyhow::Error::new(DiscordListenerFatalError::new(message))
     }
 
+    fn validate_gateway_preflight_response(
+        response: reqwest::Response,
+    ) -> anyhow::Result<reqwest::Response> {
+        Ok(response.error_for_status()?)
+    }
+
     pub fn with_archive_memory(mut self, mem: std::sync::Arc<dyn zeroclaw_memory::Memory>) -> Self {
         self.archive_memory = Some(mem);
         self
@@ -1568,12 +1574,7 @@ impl Channel for DiscordChannel {
             .header("Authorization", format!("Bot {}", self.bot_token))
             .send()
             .await?;
-        if gw_resp.status().as_u16() == 429 {
-            return Err(Self::fatal_listener_error(
-                "discord gateway preflight rate-limited (429 Too Many Requests)",
-            ));
-        }
-        let gw_resp = gw_resp.error_for_status()?;
+        let gw_resp = Self::validate_gateway_preflight_response(gw_resp)?;
         let gw_resp: serde_json::Value = gw_resp.json().await?;
 
         if let Some(remaining) = gw_resp
@@ -2662,6 +2663,29 @@ mod tests {
         let token = "MTIzNDU2.fake.hmac";
         let id = DiscordChannel::bot_user_id_from_token(token);
         assert_eq!(id, Some("123456".to_string()));
+    }
+
+    #[test]
+    fn gateway_preflight_429_remains_retryable_http_error() {
+        let response = reqwest::Response::from(
+            axum::http::Response::builder()
+                .status(reqwest::StatusCode::TOO_MANY_REQUESTS)
+                .header(reqwest::header::RETRY_AFTER, "1")
+                .body(reqwest::Body::from(""))
+                .expect("test response should build"),
+        );
+
+        let error = DiscordChannel::validate_gateway_preflight_response(response)
+            .expect_err("429 should remain an HTTP error");
+        assert!(error.downcast_ref::<reqwest::Error>().is_some());
+        assert!(
+            error.downcast_ref::<DiscordListenerFatalError>().is_none(),
+            "gateway preflight 429 must not be wrapped as fatal"
+        );
+        assert!(
+            !zeroclaw_providers::reliable::is_non_retryable(&error),
+            "gateway preflight 429 should stay on the supervisor retry path"
+        );
     }
 
     #[test]

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -14914,16 +14914,14 @@ This is an example JSON object for profile settings."#;
 
     #[cfg(feature = "channel-discord")]
     #[tokio::test]
-    async fn supervised_listener_does_not_restart_on_fatal_discord_rate_limit() {
+    async fn supervised_listener_enters_retry_path_on_discord_gateway_rate_limit() {
         let calls = Arc::new(AtomicUsize::new(0));
         let channel_name = format!("discord-{}", uuid::Uuid::new_v4());
         let channel: Arc<dyn Channel> = Arc::new(FailOnceChannel {
             name: channel_name,
             calls: Arc::clone(&calls),
-            err: Mutex::new(Some(anyhow::Error::new(
-                crate::discord::DiscordListenerFatalError::new(
-                    "discord gateway preflight rate-limited (429 Too Many Requests)",
-                ),
+            err: Mutex::new(Some(anyhow::Error::msg(
+                "discord gateway preflight rate-limited (429 Too Many Requests)",
             ))),
         });
 
@@ -14937,12 +14935,15 @@ This is an example JSON object for profile settings."#;
         let component = &snapshot["components"][&component_name];
         assert_eq!(calls.load(Ordering::SeqCst), 1);
         assert_eq!(component["status"], "error");
-        assert_eq!(component["restart_count"].as_u64().unwrap_or(0), 0);
         assert!(
             component["last_error"]
                 .as_str()
                 .unwrap_or("")
                 .contains("429 Too Many Requests")
+        );
+        assert!(
+            component["restart_count"].as_u64().unwrap_or(0) >= 1,
+            "Discord gateway 429 should back off through the retry path instead of parking"
         );
 
         drop(rx);
@@ -15006,7 +15007,7 @@ This is an example JSON object for profile settings."#;
             calls: Arc::clone(&discord_calls),
             err: Mutex::new(Some(anyhow::Error::new(
                 crate::discord::DiscordListenerFatalError::new(
-                    "discord gateway preflight rate-limited (429 Too Many Requests)",
+                    "discord gateway closed with fatal code 4014: disallowed intent(s)",
                 ),
             ))),
         });
@@ -15062,7 +15063,7 @@ This is an example JSON object for profile settings."#;
             discord["last_error"]
                 .as_str()
                 .unwrap_or("")
-                .contains("429 Too Many Requests")
+                .contains("fatal code 4014")
         );
         assert_eq!(healthy["status"], "ok");
         assert!(


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Keep Discord `/gateway/bot` HTTP 429 responses as typed `reqwest` HTTP errors instead of wrapping them in `DiscordListenerFatalError`.
  - Let the existing channel supervisor retry/backoff path handle transient Discord gateway preflight rate limits.
  - Add a direct regression test for the Discord preflight 429 path so the error stays retryable and is not treated as fatal.
  - Update supervisor tests so 429 enters the retry path while truly fatal Discord listener errors still park the listener.
- **Scope boundary:** This PR does not add custom Discord `Retry-After` scheduling. It restores retryability through the existing supervisor backoff path.
- **Blast radius:** Discord channel listener startup and the shared channel supervisor retry/fatal classification boundary. Other channels should be unaffected.
- **Linked issue(s):**
  - Closes #6879
  - Related #6834
- **Labels:** `bug`, `risk: medium`, `size: XS`, `channel`, `channel:discord`

## Validation Evidence (required)

- **Commands run and tail output:**

```text
cargo test -p zeroclaw-channels gateway_preflight_429_remains_retryable_http_error --lib -- --nocapture
result: pass, 1 test

cargo test -p zeroclaw-channels supervised_listener_enters_retry_path_on_discord_gateway_rate_limit --lib -- --nocapture
result: pass, 1 test

cargo test -p zeroclaw-channels supervised_listener --lib -- --nocapture
result: pass, 5 tests

cargo test -p zeroclaw-channels fatal_discord --lib -- --nocapture
result: pass, 2 tests

cargo fmt --all -- --check
result: pass

cargo clippy -p zeroclaw-channels --all-targets -- -D warnings
result: pass

cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
result: pass

cargo nextest run --locked --workspace --exclude zeroclaw-desktop
result: pass, 8003 tests passed, 10 skipped

git diff --check
result: pass
```

- **Beyond CI — what did you manually verify?** I checked that the `/gateway/bot` preflight response now flows through `error_for_status()` so HTTP 429 remains a typed `reqwest::Error`, that the shared retry classifier does not classify it as non-retryable, and that `DiscordListenerFatalError` is still used for explicitly fatal Discord listener conditions.
- **If any command was intentionally skipped, why:** No live Discord smoke test was run because safely forcing a real Discord `/gateway/bot` 429 is not practical in local validation.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: N/A

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** Revert the PR merge commit.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Discord listener startup logs include `discord gateway preflight rate-limited (429 Too Many Requests)` followed by `channel listener hit non-retryable error; waiting for config change or shutdown`, or a transient Discord gateway preflight rate limit leaves the Discord listener parked until restart/config change.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A
