### PR TITLE
fix(providers): route system streaming through RouterModelProvider

### DIFF
--- a/crates/zeroclaw-providers/src/router.rs
+++ b/crates/zeroclaw-providers/src/router.rs
@@ -308,6 +308,25 @@ impl ModelProvider for RouterModelProvider {
             .any(|(_, model_provider)| model_provider.supports_streaming_tool_events())
     }
 
+    fn stream_chat_with_system(
+        &self,
+        system_prompt: Option<&str>,
+        message: &str,
+        model: &str,
+        temperature: Option<f64>,
+        options: StreamOptions,
+    ) -> BoxStream<'static, StreamResult<StreamChunk>> {
+        let (provider_idx, resolved_model) = self.resolve(model);
+        let (_, model_provider) = &self.model_providers[provider_idx];
+        model_provider.stream_chat_with_system(
+            system_prompt,
+            message,
+            &resolved_model,
+            temperature,
+            options,
+        )
+    }
+
     fn stream_chat_with_history(
         &self,
         messages: &[ChatMessage],
@@ -505,6 +524,16 @@ mod tests {
                 response,
             }
         }
+
+        fn stream_response(&self, model: &str) -> BoxStream<'static, StreamResult<StreamChunk>> {
+            self.stream_calls.fetch_add(1, Ordering::SeqCst);
+            *self.last_stream_model.lock() = model.to_string();
+            let chunks = vec![
+                Ok(StreamChunk::delta(self.response)),
+                Ok(StreamChunk::final_chunk()),
+            ];
+            futures_util::stream::iter(chunks).boxed()
+        }
     }
 
     #[async_trait]
@@ -523,6 +552,17 @@ mod tests {
             true
         }
 
+        fn stream_chat_with_system(
+            &self,
+            _system_prompt: Option<&str>,
+            _message: &str,
+            model: &str,
+            _temperature: Option<f64>,
+            _options: StreamOptions,
+        ) -> BoxStream<'static, StreamResult<StreamChunk>> {
+            self.stream_response(model)
+        }
+
         fn stream_chat_with_history(
             &self,
             _messages: &[ChatMessage],
@@ -530,13 +570,7 @@ mod tests {
             _temperature: Option<f64>,
             _options: StreamOptions,
         ) -> BoxStream<'static, StreamResult<StreamChunk>> {
-            self.stream_calls.fetch_add(1, Ordering::SeqCst);
-            *self.last_stream_model.lock() = model.to_string();
-            let chunks = vec![
-                Ok(StreamChunk::delta(self.response)),
-                Ok(StreamChunk::final_chunk()),
-            ];
-            futures_util::stream::iter(chunks).boxed()
+            self.stream_response(model)
         }
     }
     impl ::zeroclaw_api::attribution::Attributable for StreamingMockModelProvider {
@@ -1154,6 +1188,50 @@ mod tests {
         );
 
         assert!(router.supports_streaming());
+    }
+
+    #[tokio::test]
+    async fn stream_chat_with_system_routes_hint_to_correct_provider_and_model() {
+        let streaming = Arc::new(StreamingMockModelProvider::new("streamed system response"));
+        let router = RouterModelProvider::new(
+            "test",
+            vec![
+                (
+                    "default".into(),
+                    Box::new(MockModelProvider::new("default")) as Box<dyn ModelProvider>,
+                ),
+                (
+                    "streaming".into(),
+                    Box::new(Arc::clone(&streaming)) as Box<dyn ModelProvider>,
+                ),
+            ],
+            vec![(
+                "reasoning".into(),
+                Route {
+                    provider_name: "streaming".into(),
+                    model: "claude-opus".into(),
+                },
+            )],
+            "model".into(),
+        );
+
+        let mut stream = router.stream_chat_with_system(
+            Some("system"),
+            "hello",
+            "hint:reasoning",
+            Some(0.0),
+            StreamOptions::new(true),
+        );
+
+        let mut collected = String::new();
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.expect("stream chunk should be ok");
+            collected.push_str(&chunk.delta);
+        }
+
+        assert_eq!(collected, "streamed system response");
+        assert_eq!(streaming.stream_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(*streaming.last_stream_model.lock(), "claude-opus");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Restores the missing `RouterModelProvider::stream_chat_with_system` override that was still absent after the #6074 recovery audit for `f12c1761`.
  - Resolves router model hints before delegating system-prompt streaming to the selected underlying provider, matching the router's existing non-streaming and streaming-history dispatch paths.
  - Adds a focused regression proving `hint:reasoning` reaches the configured streaming provider with the resolved model.
  - Keeps the scope narrow because current master already covers router `supports_streaming`, `stream_chat_with_history`, and structured `stream_chat`.
- **Scope boundary:** This does not change provider selection rules, router capability reporting, runtime streaming, web UI streaming, config shape, or any provider implementation outside the router wrapper.
- **Blast radius:** Limited to `zeroclaw-providers` router dispatch for direct `stream_chat_with_system` callers. Existing runtime/web streaming paths use `stream_chat` and are unchanged.
- **Linked issue(s):** Related #6074. Supersedes #4533 for the remaining RouterProvider system-streaming delegation slice.
- **Labels:** `bug`, `risk: medium`, `size: S`, `provider`

## Validation Evidence (required)

- **Commands run and tail output:**
  - `cargo test -p zeroclaw-providers stream_chat_with_system_routes_hint_to_correct_provider_and_model --lib -- --nocapture` — passed; 1 test passed.
  - `cargo test -p zeroclaw-providers router::tests::stream_chat --lib -- --nocapture` — passed after the final test-helper cleanup; 5 router/openrouter streaming tests passed, including system-prompt, history, and structured stream routing.
  - `cargo fmt --all -- --check` — passed.
  - `git diff --check` — passed.
  - `cargo clippy -p zeroclaw-providers --all-targets -- -D warnings` — passed.
  - `cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings` — passed.
  - `cargo nextest run --locked --workspace --exclude zeroclaw-desktop` — passed; 8009 tests passed, 10 skipped.
- **Beyond CI — what did you manually verify?** Compared the reverted `f12c1761` / #4533 patch against current `RouterModelProvider`. Current master already had router delegation for `supports_streaming`, `stream_chat_with_history`, and structured `stream_chat`; this patch restores the remaining direct `stream_chat_with_system` trait surface. I did not run live provider or web UI streaming because this PR does not change the runtime/web `stream_chat` path.
- **If any command was intentionally skipped, why:** None.

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: `N/A`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: `N/A`

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <merge-sha>`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Routed direct system-prompt streaming calls could again return an empty/default stream or fail to reach the configured routed provider/model.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line):
  - #4533 by @rareba
- Scope materially carried forward: Restores the RouterProvider streaming-delegation behavior for `stream_chat_with_system` in the current `RouterModelProvider` crate structure. Current master had already recovered the other router streaming surfaces from #4533.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `Yes`
- If `No`, why (inspiration-only, no direct code/design carry-over): `N/A`
