### PR TITLE
feat(web): declare minimum browser floor and add unsupported-browser fallback banner

### DIFF
--- a/docs/book/src/developing/web.md
+++ b/docs/book/src/developing/web.md
@@ -60,3 +60,13 @@ The gateway loads `web/dist/` from the filesystem at runtime via `static_files.r
 | `cargo`| <https://rustup.rs>                    |
 
 `cargo web` fails fast with an install hint if `npm` is missing.
+
+## Supported browsers (minimum)
+
+The dashboard targets evergreen browsers with support for both `color-mix()`
+and `structuredClone()`.
+
+- Chrome 111+
+- Edge 111+
+- Firefox 113+
+- Safari 16.2+

--- a/web/index.html
+++ b/web/index.html
@@ -21,7 +21,35 @@
     <title>ZeroClaw</title>
   </head>
   <body>
+    <div
+      id="unsupported-browser"
+      style="display:none;margin:2rem auto;max-width:720px;padding:1rem 1.25rem;border:1px solid #7f1d1d;border-radius:0.75rem;background:#1f1414;color:#fecaca;font-family:system-ui,-apple-system,'Segoe UI',sans-serif;line-height:1.5;"
+    >
+      Your browser is not supported for the ZeroClaw web dashboard. Please use
+      Chrome 111+, Edge 111+, Firefox 113+, or Safari 16.2+.
+    </div>
     <div id="root"></div>
+    <script>
+      (function () {
+        var supportsColorMix =
+          typeof CSS !== "undefined" &&
+          typeof CSS.supports === "function" &&
+          CSS.supports("color", "color-mix(in srgb, red 50%, blue)");
+        var supportsStructuredClone = typeof structuredClone === "function";
+        var root = document.getElementById("root");
+        var banner = document.getElementById("unsupported-browser");
+
+        if (!supportsColorMix || !supportsStructuredClone) {
+          document.documentElement.setAttribute("data-unsupported-browser", "1");
+          if (root) {
+            root.style.display = "none";
+          }
+          if (banner) {
+            banner.style.display = "block";
+          }
+        }
+      })();
+    </script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/web/package.json
+++ b/web/package.json
@@ -8,6 +8,12 @@
     "build": "tsc -b && vite build",
     "dev": "vite"
   },
+  "browserslist": [
+    "chrome >= 111",
+    "firefox >= 113",
+    "safari >= 16.2",
+    "edge >= 111"
+  ],
   "dependencies": {
     "@codemirror/lang-markdown": "^6.5.0",
     "@codemirror/language": "^6.12.3",

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -5,11 +5,16 @@ import App from './App';
 import { basePath } from './lib/basePath';
 import './index.css';
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    {/* basePath is injected by the Rust gateway at serve time for reverse-proxy prefix support. */}
-    <BrowserRouter basename={basePath || '/'}>
-      <App />
-    </BrowserRouter>
-  </React.StrictMode>
-);
+const unsupportedBrowser =
+  document.documentElement.getAttribute('data-unsupported-browser') === '1';
+
+if (!unsupportedBrowser) {
+  ReactDOM.createRoot(document.getElementById('root')!).render(
+    <React.StrictMode>
+      {/* basePath is injected by the Rust gateway at serve time for reverse-proxy prefix support. */}
+      <BrowserRouter basename={basePath || '/'}>
+        <App />
+      </BrowserRouter>
+    </React.StrictMode>
+  );
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig(({ command }) => ({
   },
   build: {
     outDir: "dist",
+    target: ["chrome111", "edge111", "firefox113", "safari16.2"],
   },
   server: {
     proxy: {


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - **Compatibility contract:** added `browserslist` in `web/package.json` (`chrome>=111`, `edge>=111`, `firefox>=113`, `safari>=16.2`) so the minimum supported floor is explicit and machine-readable.
  - **Build alignment:** set `build.target` in `web/vite.config.ts` to the same floor (`chrome111`, `edge111`, `firefox113`, `safari16.2`) so emitted JS/CSS matches declared support.
  - **Runtime UX guardrail:** added an inline pre-mount gate in `web/index.html` that checks both `CSS.supports('color', 'color-mix(...)')` and `structuredClone`; unsupported browsers get a visible message instead of a blank/misrendered app.
  - **User-facing docs:** documented minimum browser versions in `docs/book/src/developing/web.md` so requirements are discoverable before launch.
  - **Gate behavior snippet:**
    ```html
    <script>
      const supportsColorMix = CSS?.supports?.("color", "color-mix(in srgb, red 50%, blue)");
      const supportsStructuredClone = typeof structuredClone === "function";
      if (!supportsColorMix || !supportsStructuredClone) { /* show banner, hide root */ }
    </script>
    ```
- **Scope boundary:** no polyfill layer, no backend/gateway changes, no CSS refactor away from `color-mix`, no support expansion beyond evergreen floors.
- **Blast radius:** limited to `web/` bootstrapping and build config; affects only dashboard rendering behavior on unsupported browsers.
- **Linked issue(s):** Closes #6921
- **Labels:** `enhancement`, `docs`, `web`, `risk: medium`, `size: XS`

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check`  
    - exit code `0`
  - `cargo clippy --all-targets -- -D warnings`  
    - exit code `101` (pre-existing, unrelated):
      ```text
      error: this loop could be written as a `while let` loop
      --> crates/zeroclaw-channels/src/wecom_ws.rs:2352:5
      = note: `-D clippy::while-let-loop` implied by `-D warnings`
      error: could not compile `zeroclaw-channels` (lib) due to 1 previous error
      ```
  - `cargo test`  
    - exit code `0`
  - Additional targeted validation:
    - `cargo web check` → success
    - `cargo web build` → success (`vite build` completed; `dist/index.html` emitted)
- **Beyond CI — what did you manually verify?**  
  - Verified unsupported path now blocks app mount and displays explicit browser support message.
  - Verified supported path continues normal mount/build behavior.
  - Did not emulate legacy browser matrix end-to-end in real devices.
- **If any command was intentionally skipped, why:**  
  - None.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation:  
  - N/A

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: exact upgrade steps for existing users:  
  - Users on browsers below the documented floor now receive a clear unsupported-browser banner instead of undefined rendering behavior.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PRs: `git revert <sha>` is the plan unless otherwise noted.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line):  
  - None
- Scope materially carried forward:  
  - N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`No`)
- If `No`, why (inspiration-only, no direct code/design carry-over):  
  - No superseded PR content was incorporated.

---

**Labels** live in the GitHub label UI, not in the body. Maintainers and reviewers with label permissions set `risk:*`, `size:*`, and scope labels via the sidebar. If auto-labels need correction, add `risk: manual` and the intended label. Contributors without label permission can note the mismatch in a comment.

**Do not add bot/AI attribution footers** such as `Co-authored-by: Claude ...`
or `Created with Claude Code` to the PR body or commit-message tail. Human
co-author trailers are appropriate only for incorporated contributor work under
the supersede-attribution section and privacy contract.

**Privacy contract** (`docs/book/src/contributing/privacy.md`) is a merge gate. Never commit real identities, secrets, personal emails, or PII in diff, tests, fixtures, or docs.
