### PR TITLE
fix(runtime): preserve provider aliases for Codex OAuth

### DIFF
--- a/crates/zeroclaw-channels/src/wecom_ws.rs
+++ b/crates/zeroclaw-channels/src/wecom_ws.rs
@@ -2349,14 +2349,10 @@ fn split_stream_content_and_overflow(input: &str) -> (String, Option<String>) {
 fn strip_trailing_provider_sentinels(input: &str) -> String {
     let mut trimmed = input.trim_end();
 
-    loop {
-        let Some(sentinel) = WECOM_PROVIDER_TRAILING_SENTINELS
-            .iter()
-            .find(|sentinel| trimmed.ends_with(**sentinel))
-        else {
-            break;
-        };
-
+    while let Some(sentinel) = WECOM_PROVIDER_TRAILING_SENTINELS
+        .iter()
+        .find(|sentinel| trimmed.ends_with(**sentinel))
+    {
         trimmed = trimmed[..trimmed.len() - sentinel.len()].trim_end();
     }
 

--- a/crates/zeroclaw-gateway/src/lib.rs
+++ b/crates/zeroclaw-gateway/src/lib.rs
@@ -487,14 +487,24 @@ pub async fn run_gateway(
     let display_addr = format!("{host}:{actual_port}");
 
     let fallback = config.first_model_provider();
-    let model_provider_name = config.first_model_provider_type().unwrap_or("openrouter");
+    let model_provider_name = config
+        .first_model_provider_alias()
+        .unwrap_or_else(|| "openrouter".to_string());
+    let provider_runtime_options_base =
+        zeroclaw_providers::provider_runtime_options_from_config(&config);
+    let provider_runtime_options = zeroclaw_providers::options_for_provider_ref(
+        &config,
+        &model_provider_name,
+        &provider_runtime_options_base,
+    );
     let model_provider: Arc<dyn ModelProvider> = Arc::from(
-        zeroclaw_providers::create_resilient_model_provider_with_options(
-            model_provider_name,
+        zeroclaw_providers::create_resilient_model_provider_from_ref(
+            &config,
+            &model_provider_name,
             fallback.and_then(|e| e.api_key.as_deref()),
             fallback.and_then(|e| e.uri.as_deref()),
             &config.reliability,
-            &zeroclaw_providers::provider_runtime_options_from_config(&config),
+            &provider_runtime_options,
         )?,
     );
     // Model resolution (1) the first-model_provider's `model`,

--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -683,7 +683,7 @@ impl Agent {
             policy
         });
 
-        let (provider_name, _provider_alias, agent_model_provider) =
+        let (provider_name, provider_alias, agent_model_provider) =
             match config.resolved_model_provider_for_agent(agent_alias) {
                 Some(resolved) => (resolved.0, resolved.1, Some(resolved.2)),
                 None => {
@@ -845,13 +845,17 @@ impl Agent {
             ),
         };
 
-        let provider_runtime_options =
-            zeroclaw_providers::provider_runtime_options_from_config(config);
+        let provider_ref = format!("{provider_name}.{provider_alias}");
+        let provider_runtime_options = zeroclaw_providers::provider_runtime_options_for_alias(
+            config,
+            provider_name,
+            provider_alias,
+        );
 
         let model_provider: Box<dyn ModelProvider> =
             zeroclaw_providers::create_routed_model_provider_with_options(
                 config,
-                provider_name,
+                &provider_ref,
                 agent_model_provider.and_then(|e| e.api_key.as_deref()),
                 agent_model_provider.and_then(|e| e.uri.as_deref()),
                 &config.reliability,
@@ -2004,9 +2008,8 @@ pub async fn run(
     let mut agent = Agent::from_config(&effective_config, agent_alias).await?;
 
     let provider_name = effective_config
-        .first_model_provider_type()
-        .unwrap_or("openrouter")
-        .to_string();
+        .first_model_provider_alias()
+        .unwrap_or_else(|| "openrouter.default".to_string());
     // `Agent::from_config` above has already errored if no model could be resolved,
     // so this telemetry line should always find one. We keep `resolve_default_model`
     // as a cheap secondary lookup and emit "<unresolved>" only if nothing matches —
@@ -3110,6 +3113,57 @@ mod tests {
         );
 
         server_handle.abort();
+    }
+
+    #[tokio::test]
+    async fn from_config_accepts_openai_alias_with_requires_openai_auth() {
+        use tempfile::TempDir;
+        use zeroclaw_config::schema::{
+            AliasedAgentConfig, Config, ModelProviderConfig, OpenAIModelProviderConfig,
+            RiskProfileConfig, WireApi,
+        };
+
+        let tmp = TempDir::new().expect("temp dir");
+        let workspace_dir = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace_dir).expect("workspace dir");
+
+        let mut config = Config {
+            data_dir: workspace_dir,
+            config_path: tmp.path().join("config.toml"),
+            ..Default::default()
+        };
+        config.memory.backend = "none".to_string();
+        config.memory.auto_save = false;
+        config
+            .risk_profiles
+            .insert("test-profile".to_string(), RiskProfileConfig::default());
+        config.providers.models.openai.insert(
+            "codex".to_string(),
+            OpenAIModelProviderConfig {
+                base: ModelProviderConfig {
+                    model: Some("gpt-5.4".to_string()),
+                    requires_openai_auth: true,
+                    wire_api: Some(WireApi::Responses),
+                    ..ModelProviderConfig::default()
+                },
+            },
+        );
+        config.agents.insert(
+            "test-agent".to_string(),
+            AliasedAgentConfig {
+                model_provider: "openai.codex".into(),
+                risk_profile: "test-profile".to_string(),
+                ..AliasedAgentConfig::default()
+            },
+        );
+
+        let result = Agent::from_config(&config, "test-agent").await;
+
+        assert!(
+            result.is_ok(),
+            "openai alias with requires_openai_auth should construct via Codex OAuth path: {}",
+            result.err().unwrap()
+        );
     }
 
     #[test]

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -3133,10 +3133,12 @@ pub async fn run(
         }
 
         // ── Resolve model_provider ─────────────────────────────────────────
-        let agent_provider_type = agent_provider_resolved.as_ref().map(|(ty, _, _)| *ty);
+        let agent_provider_ref = agent_provider_resolved
+            .as_ref()
+            .map(|(ty, alias, _)| format!("{ty}.{alias}"));
         let mut provider_name = provider_override
             .as_deref()
-            .or(agent_provider_type)
+            .or(agent_provider_ref.as_deref())
             .ok_or_else(|| {
                 ::zeroclaw_log::record!(
                     ERROR,
@@ -3174,8 +3176,13 @@ pub async fn run(
             span.record("model", model_name.as_str());
         }
 
-        let provider_runtime_options =
+        let provider_runtime_options_base =
             zeroclaw_providers::provider_runtime_options_from_config(&config);
+        let provider_runtime_options = zeroclaw_providers::options_for_provider_ref(
+            &config,
+            &provider_name,
+            &provider_runtime_options_base,
+        );
 
         let mut model_provider: Box<dyn ModelProvider> =
             zeroclaw_providers::create_routed_model_provider_with_options(
@@ -3620,7 +3627,11 @@ pub async fn run(
                                     &config.reliability,
                                     &config.model_routes,
                                     &new_model,
-                                    &provider_runtime_options,
+                                    &zeroclaw_providers::options_for_provider_ref(
+                                        &config,
+                                        &new_model_provider,
+                                        &provider_runtime_options_base,
+                                    ),
                                 )?;
 
                             provider_name = new_model_provider;
@@ -4013,7 +4024,11 @@ pub async fn run(
                                         &config.reliability,
                                         &config.model_routes,
                                         &new_model,
-                                        &provider_runtime_options,
+                                        &zeroclaw_providers::options_for_provider_ref(
+                                            &config,
+                                            &new_model_provider,
+                                            &provider_runtime_options_base,
+                                        ),
                                     )?;
 
                                 provider_name = new_model_provider;
@@ -4238,7 +4253,7 @@ pub async fn process_message(
         let runtime: Arc<dyn platform::RuntimeAdapter> =
             Arc::from(platform::create_runtime(&config.runtime)?);
         let security = Arc::new(SecurityPolicy::for_agent(&config, agent_alias)?);
-        let (provider_name, _provider_alias, agent_model_provider) = match config
+        let (provider_name, provider_alias, agent_model_provider) = match config
             .resolved_model_provider_for_agent(agent_alias)
         {
             Some(resolved) => (resolved.0, resolved.1.to_string(), Some(resolved.2.clone())),
@@ -4412,12 +4427,15 @@ pub async fn process_message(
              `model` set. Configure [model_providers.{provider_name}.<alias>] model = \"...\"."
             ),
         };
-        let provider_runtime_options =
-            zeroclaw_providers::provider_runtime_options_from_config(&config);
+        let provider_runtime_options = zeroclaw_providers::provider_runtime_options_for_alias(
+            &config,
+            provider_name,
+            provider_alias.as_str(),
+        );
         let model_provider: Box<dyn ModelProvider> =
             zeroclaw_providers::create_routed_model_provider_with_options(
                 &config,
-                provider_name,
+                &format!("{provider_name}.{provider_alias}"),
                 agent_model_provider
                     .as_ref()
                     .and_then(|e| e.api_key.as_deref()),


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Preserve the resolved dotted provider reference in `Agent::from_config` so a configured OpenAI alias keeps its alias-scoped runtime settings during provider construction.
  - Keep the agent loop on that dotted provider reference for the initial provider build and later provider rebuilds instead of collapsing to bare `openai`.
  - Seed gateway boot/default provider construction from the same dotted alias reference so config-driven runtime and gateway paths both honor `requires_openai_auth = true` on `[providers.models.openai.<alias>]`.
  - Add a regression test covering `openai.<alias>` with `requires_openai_auth = true`.
- **Cause:** The runtime resolved the configured alias early, but later provider reconstruction paths reused only the bare provider family name. That discarded alias-scoped settings, so the documented alias-based Codex configuration path behaved like plain OpenAI API-key mode instead of the configured OAuth-backed provider.
- **Scope boundary:** Does not change the OAuth login flow, auth-profile persistence, legacy `openai-codex` override behavior, or non-OpenAI provider families.
- **Blast radius:** `zeroclaw-runtime` agent initialization and loop provider rebuilds, plus gateway boot/default provider seeding for config-driven model-provider selection.
- **Linked issue(s):** Fixes #6923
- **Labels:** `agent`, `channel`, `channel:wecom`, `gateway`, `runtime`

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- **Commands run and tail output:**

```text
$ cargo fmt --all -- --check
(no output; exited 0)

$ cargo clippy --all-targets -- -D warnings
    Checking zeroclaw-gateway v0.8.0-beta-1 (/Users/vrurg/src/rust/zeroclaw/crates/zeroclaw-gateway)
    Checking zeroclawlabs v0.8.0-beta-1 (/Users/vrurg/src/rust/zeroclaw)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 44.91s

$ cargo test
test result: ok. 159 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.59s

test result: ok. 0 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 0.00s

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.05s

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

- **Beyond CI — what I manually verified:** Verified the runtime cause against the documented alias-based configuration path and added a regression test for `openai.<alias>` with `requires_openai_auth = true`.

  Live validation in a Web chat session passed where previously was failing with `All model_providers/models failed.` error.
- **If any command was intentionally skipped, why:** None

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `Yes`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Risk and mitigation: This change preserves the already-selected typed provider alias so runtime paths keep using the configured Codex OAuth mode instead of incorrectly falling back to `OPENAI_API_KEY`. It does not add new secret storage, broader token access, or new credential surfaces.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Upgrade steps for existing users: None. Existing `[providers.models.openai.<alias>]` entries that set `requires_openai_auth = true` should start behaving consistently in runtime and gateway paths after upgrading.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert 295badc7 f438d501`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Runtime or gateway turns still fail with `OpenAI API key not set. Set OPENAI_API_KEY or edit config.toml.` for agents configured to use a typed OpenAI alias with Codex OAuth, or logs show the provider collapsing to bare `openai` instead of the configured dotted alias in config-driven execution paths.
