### PR TITLE
fix(cli): suppress INFO logs in agent interactive mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1301,9 +1301,12 @@ async fn main() -> Result<()> {
     }
 
     // Initialize logging - respects RUST_LOG env var, defaults to INFO.
-    // For the ACP command, we default to WARN to avoid INFO logs corrupting the stdio protocol.
+    // For the ACP command and agent interactive mode, we default to WARN to avoid
+    // INFO logs corrupting the stdio protocol or interleaving with conversation output.
     // We also always redirect logs to stderr so stdout remains clean for data.
-    let default_log_level = if matches!(cli.command, Commands::Acp { .. }) {
+    let default_log_level = if matches!(cli.command, Commands::Acp { .. })
+        || matches!(cli.command, Commands::Agent { message: None, .. })
+    {
         "warn"
     } else {
         // matrix_sdk crates are suppressed to warn because they are extremely


### PR DESCRIPTION
## Summary

- **What changed and why:**
  - In interactive TTY mode (`zeroclaw agent` without `-m/--message`), INFO-level structured log lines were interleaved with user conversation text, making chat messages hard to read
  - This change defaults agent interactive mode to WARN log level, matching the existing ACP command behavior
  - Users can still opt-in to verbose logging via `RUST_LOG=info`
- **Scope boundary:**
  - Single-message mode (`zeroclaw agent -m "..."`) retains INFO logging for debugging purposes
  - No changes to other commands (daemon, gateway, etc.)
- **Blast radius:**
  - Agent interactive mode: INFO logs suppressed by default; WARN+ still visible
  - All other commands unchanged
- **Linked issue(s):** Closes #6944
- **Labels:** bug, size: XS, risk: low, core

## Validation Evidence

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check`: (pending CI)
  - `cargo clippy --all-targets -- -D warnings`: (pending CI)
  - `cargo test`: (pending CI)
- **Beyond CI — what did you manually verify?**
  - Code logic review: verified the `message: None` pattern correctly identifies interactive mode
  - Pattern consistency: matches existing `Commands::Acp` handling in same code location
- **If any command was intentionally skipped, why:**
  - Rust toolchain not available in current environment; validation deferred to CI

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No

## Compatibility

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- If `No` or `Yes` to either: exact upgrade steps for existing users: N/A

## Rollback

Low-risk PR: `git revert <sha>` is the plan.
