### PR TITLE
feat(api): add ChannelMessage::new and SendMessage::reply_to constructors

### DIFF
--- a/crates/zeroclaw-api/src/channel.rs
+++ b/crates/zeroclaw-api/src/channel.rs
@@ -140,6 +140,54 @@ impl SendMessage {
     }
 }
 
+impl ChannelMessage {
+    /// Construct a `ChannelMessage` with all required fields set and all optional
+    /// fields zeroed. Prefer this over raw struct literals so that new optional
+    /// fields added to `ChannelMessage` in the future don't require mechanical
+    /// updates at every call site.
+    pub fn new(
+        id: impl Into<String>,
+        sender: impl Into<String>,
+        reply_target: impl Into<String>,
+        content: impl Into<String>,
+        channel: impl Into<String>,
+        timestamp: u64,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            sender: sender.into(),
+            reply_target: reply_target.into(),
+            content: content.into(),
+            channel: channel.into(),
+            timestamp,
+            ..Self::default()
+        }
+    }
+}
+
+impl SendMessage {
+    /// Build a reply `SendMessage` from an inbound `ChannelMessage`.
+    ///
+    /// Sets `recipient` from `msg.reply_target`, threads via `in_reply_to` and
+    /// `thread_ts`, and prepends `Re:` to the subject when the inbound message
+    /// carried one. Safe to call from any channel handler; the `in_reply_to`
+    /// field is silently ignored by channels that don't support it.
+    pub fn reply_to(msg: &ChannelMessage, content: impl Into<String>) -> Self {
+        let mut sm = Self::new(content, &msg.reply_target)
+            .in_thread(msg.thread_ts.clone())
+            .in_reply_to(Some(msg.id.clone()));
+        if let Some(ref subj) = msg.subject {
+            let reply_subject = if subj.to_ascii_lowercase().starts_with("re:") {
+                subj.clone()
+            } else {
+                format!("Re: {}", subj)
+            };
+            sm = sm.subject(reply_subject);
+        }
+        sm
+    }
+}
+
 /// Core channel trait — implement for any messaging platform.
 ///
 /// Every `Channel` is `Attributable`: the orchestrator's spawn site opens
@@ -418,19 +466,58 @@ mod tests {
     }
 
     fn msg_from(sender: &str) -> ChannelMessage {
-        ChannelMessage {
-            id: "1".into(),
-            sender: sender.into(),
-            reply_target: String::new(),
-            content: "hi".into(),
-            channel: "stub".into(),
-            channel_alias: None,
-            timestamp: 0,
-            thread_ts: None,
-            interruption_scope_id: None,
-            attachments: Vec::new(),
-            subject: None,
-        }
+        ChannelMessage::new("1", sender, "", "hi", "stub", 0)
+    }
+
+    #[test]
+    fn channel_message_new_zeros_optional_fields() {
+        let msg = ChannelMessage::new("id1", "alice", "room-1", "hello", "slack", 42);
+        assert_eq!(msg.id, "id1");
+        assert_eq!(msg.sender, "alice");
+        assert_eq!(msg.reply_target, "room-1");
+        assert_eq!(msg.content, "hello");
+        assert_eq!(msg.channel, "slack");
+        assert_eq!(msg.timestamp, 42);
+        assert!(msg.channel_alias.is_none());
+        assert!(msg.thread_ts.is_none());
+        assert!(msg.interruption_scope_id.is_none());
+        assert!(msg.attachments.is_empty());
+        assert!(msg.subject.is_none());
+    }
+
+    #[test]
+    fn send_message_reply_to_sets_threading_fields() {
+        let inbound = ChannelMessage {
+            id: "msg-001".into(),
+            reply_target: "user@example.com".into(),
+            thread_ts: Some("thread-1".into()),
+            subject: Some("Hello there".into()),
+            ..ChannelMessage::new("msg-001", "alice", "user@example.com", "", "email", 0)
+        };
+        let reply = SendMessage::reply_to(&inbound, "Got it");
+        assert_eq!(reply.recipient, "user@example.com");
+        assert_eq!(reply.in_reply_to.as_deref(), Some("msg-001"));
+        assert_eq!(reply.thread_ts.as_deref(), Some("thread-1"));
+        assert_eq!(reply.subject.as_deref(), Some("Re: Hello there"));
+        assert_eq!(reply.content, "Got it");
+    }
+
+    #[test]
+    fn send_message_reply_to_does_not_double_re_prefix() {
+        let inbound = ChannelMessage {
+            subject: Some("Re: Already prefixed".into()),
+            ..ChannelMessage::new("msg-002", "alice", "user@example.com", "", "email", 0)
+        };
+        let reply = SendMessage::reply_to(&inbound, "");
+        assert_eq!(reply.subject.as_deref(), Some("Re: Already prefixed"));
+    }
+
+    #[test]
+    fn send_message_reply_to_no_subject_omits_subject() {
+        let inbound = ChannelMessage::new("msg-003", "alice", "room-1", "ping", "slack", 0);
+        let reply = SendMessage::reply_to(&inbound, "pong");
+        assert!(reply.subject.is_none());
+        assert_eq!(reply.in_reply_to.as_deref(), Some("msg-003"));
     }
 
     #[test]

--- a/crates/zeroclaw-channels/src/email_channel.rs
+++ b/crates/zeroclaw-channels/src/email_channel.rs
@@ -596,17 +596,17 @@ impl EmailChannel {
             }
 
             let msg = ChannelMessage {
-                id: email.msg_id,
-                reply_target: email.sender.clone(),
-                sender: email.sender,
-                content: email.content,
-                channel: "email".to_string(),
                 channel_alias: Some(self.alias.clone()),
-                timestamp: email.timestamp,
-                thread_ts: None,
-                interruption_scope_id: None,
                 attachments: email.attachments,
                 subject: Some(email.subject),
+                ..ChannelMessage::new(
+                    email.msg_id,
+                    email.sender.clone(),
+                    email.sender,
+                    email.content,
+                    "email",
+                    email.timestamp,
+                )
             };
 
             if tx.send(msg).await.is_err() {

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -2477,21 +2477,6 @@ fn strip_think_tags_inline(s: &str) -> String {
     result.trim().to_string()
 }
 
-fn build_email_reply(msg: &ChannelMessage, content: impl Into<String>) -> SendMessage {
-    let mut sm = SendMessage::new(content, &msg.reply_target)
-        .in_thread(msg.thread_ts.clone())
-        .in_reply_to(Some(msg.id.clone()));
-    if let Some(ref subj) = msg.subject {
-        let reply_subject = if subj.to_ascii_lowercase().starts_with("re:") {
-            subj.clone()
-        } else {
-            format!("Re: {}", subj)
-        };
-        sm = sm.subject(reply_subject);
-    }
-    sm
-}
-
 fn starts_with_visible_tool_call_tag_example(response: &str) -> bool {
     let lower = response.trim_start().to_ascii_lowercase();
     let starts_with_tool_tag = lower.starts_with("<tool_call")
@@ -3381,7 +3366,7 @@ async fn process_channel_message_body(
                 route.model_provider
             );
             if let Some(channel) = target_channel.as_ref() {
-                let _ = channel.send(&build_email_reply(&msg, message)).await;
+                let _ = channel.send(&SendMessage::reply_to(&msg, message)).await;
             }
             return;
         }
@@ -4334,12 +4319,12 @@ async fn process_channel_message_body(
                             "Failed to finalize draft; sending as new message"
                         );
                         let _ = channel
-                            .send(&build_email_reply(&msg, &delivered_response))
+                            .send(&SendMessage::reply_to(&msg, &delivered_response))
                             .await;
                     }
                 } else if let Err(e) = channel
                     .send(
-                        &build_email_reply(&msg, &delivered_response)
+                        &SendMessage::reply_to(&msg, &delivered_response)
                             .with_cancellation(cancellation_token.clone()),
                     )
                     .await
@@ -17161,39 +17146,37 @@ Done."#;
 
     fn email_msg(id: &str, subject: Option<&str>) -> ChannelMessage {
         ChannelMessage {
-            id: id.into(),
-            sender: "user@example.com".into(),
-            reply_target: "user@example.com".into(),
-            content: "Hello".into(),
-            channel: "email".into(),
-            channel_alias: None,
-            timestamp: 0,
-            thread_ts: None,
-            interruption_scope_id: None,
-            attachments: vec![],
             subject: subject.map(Into::into),
+            ..ChannelMessage::new(
+                id,
+                "user@example.com",
+                "user@example.com",
+                "Hello",
+                "email",
+                0,
+            )
         }
     }
 
     #[test]
-    fn build_email_reply_sets_in_reply_to_and_re_subject() {
+    fn reply_to_sets_in_reply_to_and_re_subject() {
         let msg = email_msg("<abc123@mail.example>", Some("Weekly report"));
-        let sm = build_email_reply(&msg, "Here is the answer");
+        let sm = SendMessage::reply_to(&msg, "Here is the answer");
         assert_eq!(sm.in_reply_to.as_deref(), Some("<abc123@mail.example>"));
         assert_eq!(sm.subject.as_deref(), Some("Re: Weekly report"));
     }
 
     #[test]
-    fn build_email_reply_does_not_double_re_prefix() {
+    fn reply_to_does_not_double_re_prefix() {
         let msg = email_msg("<abc123@mail.example>", Some("Re: Weekly report"));
-        let sm = build_email_reply(&msg, "Here is the answer");
+        let sm = SendMessage::reply_to(&msg, "Here is the answer");
         assert_eq!(sm.subject.as_deref(), Some("Re: Weekly report"));
     }
 
     #[test]
-    fn build_email_reply_no_subject_still_sets_in_reply_to() {
+    fn reply_to_no_subject_still_sets_in_reply_to() {
         let msg = email_msg("<abc123@mail.example>", None);
-        let sm = build_email_reply(&msg, "Here is the answer");
+        let sm = SendMessage::reply_to(&msg, "Here is the answer");
         assert_eq!(sm.in_reply_to.as_deref(), Some("<abc123@mail.example>"));
         assert!(sm.subject.is_none());
     }

--- a/crates/zeroclaw-channels/src/wecom_ws.rs
+++ b/crates/zeroclaw-channels/src/wecom_ws.rs
@@ -678,17 +678,16 @@ impl WeComWsChannel {
             );
             let _ = tx
                 .send(ChannelMessage {
-                    id: parsed.msg_id.clone(),
-                    sender: parsed.sender_userid.clone(),
-                    reply_target: scopes.conversation_scope.clone(),
-                    content: "/new".to_string(),
-                    channel: "wecom_ws".to_string(),
                     channel_alias: Some(self.alias.clone()),
-                    timestamp: bytes_timestamp_now(),
                     thread_ts: Some(req_id),
-                    interruption_scope_id: None,
-                    attachments: Vec::new(),
-                    subject: None,
+                    ..ChannelMessage::new(
+                        parsed.msg_id.clone(),
+                        parsed.sender_userid.clone(),
+                        scopes.conversation_scope.clone(),
+                        "/new",
+                        "wecom_ws",
+                        bytes_timestamp_now(),
+                    )
                 })
                 .await;
             return;
@@ -703,17 +702,15 @@ impl WeComWsChannel {
                 .await;
             let _ = tx
                 .send(ChannelMessage {
-                    id: parsed.msg_id.clone(),
-                    sender: parsed.sender_userid.clone(),
-                    reply_target: scopes.conversation_scope.clone(),
-                    content: "/stop".to_string(),
-                    channel: "wecom_ws".to_string(),
                     channel_alias: Some(self.alias.clone()),
-                    timestamp: bytes_timestamp_now(),
-                    thread_ts: None,
-                    interruption_scope_id: None,
-                    attachments: Vec::new(),
-                    subject: None,
+                    ..ChannelMessage::new(
+                        parsed.msg_id.clone(),
+                        parsed.sender_userid.clone(),
+                        scopes.conversation_scope.clone(),
+                        "/stop",
+                        "wecom_ws",
+                        bytes_timestamp_now(),
+                    )
                 })
                 .await;
             return;
@@ -728,17 +725,16 @@ impl WeComWsChannel {
             );
             let _ = tx
                 .send(ChannelMessage {
-                    id: parsed.msg_id.clone(),
-                    sender: parsed.sender_userid.clone(),
-                    reply_target: scopes.conversation_scope.clone(),
-                    content: runtime_command,
-                    channel: "wecom_ws".to_string(),
                     channel_alias: Some(self.alias.clone()),
-                    timestamp: bytes_timestamp_now(),
                     thread_ts: Some(req_id),
-                    interruption_scope_id: None,
-                    attachments: Vec::new(),
-                    subject: None,
+                    ..ChannelMessage::new(
+                        parsed.msg_id.clone(),
+                        parsed.sender_userid.clone(),
+                        scopes.conversation_scope.clone(),
+                        runtime_command,
+                        "wecom_ws",
+                        bytes_timestamp_now(),
+                    )
                 })
                 .await;
             return;
@@ -813,17 +809,16 @@ impl WeComWsChannel {
 
             let _ = tx
                 .send(ChannelMessage {
-                    id: inbound.msg_id.clone(),
-                    sender: inbound.sender_userid.clone(),
-                    reply_target: scopes.conversation_scope.clone(),
-                    content: composed,
-                    channel: "wecom_ws".to_string(),
                     channel_alias: Some(channel_self.alias.clone()),
-                    timestamp: bytes_timestamp_now(),
                     thread_ts: Some(req_id),
-                    interruption_scope_id: None,
-                    attachments: Vec::new(),
-                    subject: None,
+                    ..ChannelMessage::new(
+                        inbound.msg_id.clone(),
+                        inbound.sender_userid.clone(),
+                        scopes.conversation_scope.clone(),
+                        composed,
+                        "wecom_ws",
+                        bytes_timestamp_now(),
+                    )
                 })
                 .await;
         });
@@ -3357,19 +3352,14 @@ mod tests {
         let channel = WeComWsChannel::new(&config, Path::new("/tmp")).unwrap();
 
         let (tx, mut rx) = mpsc::channel::<ChannelMessage>(1);
-        tx.send(ChannelMessage {
-            id: "prefill-clear".to_string(),
-            sender: "tester".to_string(),
-            reply_target: "user--zeroclaw_user".to_string(),
-            content: "prefill".to_string(),
-            channel: "wecom_ws".to_string(),
-            channel_alias: None,
-            timestamp: bytes_timestamp_now(),
-            thread_ts: None,
-            interruption_scope_id: None,
-            attachments: Vec::new(),
-            subject: None,
-        })
+        tx.send(ChannelMessage::new(
+            "prefill-clear",
+            "tester",
+            "user--zeroclaw_user",
+            "prefill",
+            "wecom_ws",
+            bytes_timestamp_now(),
+        ))
         .await
         .unwrap();
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Every raw `ChannelMessage { ... }` struct literal in the workspace is a latent compile break: when #6512 added `subject: Option<String>`, five unrelated `ChannelMessage` literals from #6680 (WeCom WS) broke during the rebase. `ChannelMessage::new(...)` centralizes the required fields and defaults the optional ones via `..Self::default()`, so a future optional field is a one-line change instead of a workspace-wide fix tax.
  - The reply-construction pattern (`in_reply_to`, `thread_ts`, `Re:` subject) was duplicated per channel; #6512 added a local `build_email_reply` in the orchestrator. This promotes it to `SendMessage::reply_to(msg, content)` so every channel shares one implementation.
- **Scope boundary:** Does NOT sweep the remaining ~50 raw literals across the workspace (follow-up once this lands); migrates only the 5 WeCom literals that broke in #6512 as proof-of-concept. No behavior change to any channel.
- **Blast radius:** `zeroclaw-api` (`channel.rs`), the orchestrator reply path, and the email + WeCom inbound construction. Additive constructors — existing raw literals keep compiling.
- **Linked issue(s):** Closes #6883.
- **Labels:** Current snapshot — `enhancement`, `size: M`, `risk: medium`, `channel`, `channel:email`, `channel:wecom`. (Pull-only access; cannot self-apply or correct labels — please adjust via the sidebar if needed.)

## Changes

**`crates/zeroclaw-api/src/channel.rs`**
- `ChannelMessage::new(id, sender, reply_target, content, channel, timestamp)` — sets required fields, zeros all optional ones via `..Self::default()`.
- `SendMessage::reply_to(msg, content)` — builds a reply from an inbound `ChannelMessage`: recipient from `reply_target`, `in_reply_to`/`thread_ts` threaded, `Re:` prepended when a subject is present (idempotent). Channels that don't support `in_reply_to` ignore it.

**`crates/zeroclaw-channels/src/orchestrator/mod.rs`** — removes the redundant `build_email_reply` wrapper (15 lines), replaces its 3 call sites with `SendMessage::reply_to`, updates the `email_msg` test helper, renames 3 tests.

**`crates/zeroclaw-channels/src/email_channel.rs`** — inbound construction migrated to `..ChannelMessage::new(...)`.

**`crates/zeroclaw-channels/src/wecom_ws.rs`** — 5 `ChannelMessage` literals migrated (the ones that broke during the #6512 rebase).

## Validation Evidence (required)

Local commands run on the branch head:

```bash
cargo fmt --all -- --check                                  # clean
cargo clippy --workspace --exclude zeroclaw-desktop \
  --all-targets --features ci-all -- -D warnings            # Finished, 0 warnings
```

- **Beyond CI — what I manually verified:** This is a pure-Rust refactor with no runtime config/network surface; correctness is carried by the unit tests below (the `reply_to` threading invariants and the `new()` optional-field defaults). The behavior-equivalence of the promoted `build_email_reply` is covered by the 3 pre-existing orchestrator tests, preserved under their new names.
- **New unit tests** (`zeroclaw-api`):
  - `channel_message_new_zeros_optional_fields` — all optional fields default to None/empty.
  - `send_message_reply_to_sets_threading_fields` — recipient, `in_reply_to`, `thread_ts`, `Re:` subject, content.
  - `send_message_reply_to_does_not_double_re_prefix` — idempotent on already-prefixed subjects.
  - `send_message_reply_to_no_subject_omits_subject` — subject stays None when inbound has none.
- **Intentionally skipped:** the full `cargo test` harness is not run on the local dev box (a Raspberry Pi 5 OOMs building the full test harness). The new tests compile under `cargo clippy --all-targets` locally and their assertions run in CI (currently green).

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No** — tests use synthetic ids/addresses (`test@example.com`-style placeholders).

## Compatibility (required)

- Backward compatible? **Yes** — `ChannelMessage::new` and `SendMessage::reply_to` are additive; existing raw struct literals compile unchanged.
- Config / env / CLI surface changed? **No.**
- Upgrade steps for existing users: none. `build_email_reply` was crate-private (`fn`, not `pub fn`), so removing it is not a breaking change.

## Rollback (required for `risk: medium`)

- **Fast rollback command/path:** `git revert <sha>`. No config, schema, or migration changes — the revert restores the raw literals and the local `build_email_reply` wrapper.
- **Feature flags or config toggles:** None (compile-time refactor only).
- **Observable failure symptoms:** would surface at compile time, not runtime. If a regression slipped past tests it would show as mis-threaded replies — grep the trace for outbound replies missing `in_reply_to`/`thread_ts` or a doubled/absent `Re:` subject.
