### PR TITLE
fix(providers): siliconflow DEFAULT_URL .cn → .com (international endpoint)

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -1669,7 +1669,7 @@ pub enum SiliconflowEndpoint {
 impl ModelEndpoint for SiliconflowEndpoint {
     fn uri(&self) -> &'static str {
         match self {
-            Self::Default => "https://api.siliconflow.cn/v1",
+            Self::Default => "https://api.siliconflow.com/v1",
         }
     }
 }

--- a/crates/zeroclaw-providers/src/factory.rs
+++ b/crates/zeroclaw-providers/src/factory.rs
@@ -352,7 +352,7 @@ impl CompatFamilySpec for AstraiModelProviderConfig {
 }
 impl CompatFamilySpec for SiliconflowModelProviderConfig {
     const DISPLAY: &'static str = "SiliconFlow";
-    const DEFAULT_URL: &'static str = "https://api.siliconflow.cn/v1";
+    const DEFAULT_URL: &'static str = "https://api.siliconflow.com/v1";
     const AUTH: AuthStyle = AuthStyle::Bearer;
     const MODELS_DEV_KEY: Option<&'static str> = Some("siliconflow");
 }


### PR DESCRIPTION
## Problem

`SiliconflowModelProviderConfig::DEFAULT_URL` is hardcoded to `https://api.siliconflow.cn/v1` (China endpoint), but most SiliconFlow API keys are issued on the international site `api.siliconflow.com`. The two endpoints accept different key tiers and reject each other's keys.

Operators using an international `.com` key hit a `non_retryable` 401:

```
SiliconFlow API error (401 Unauthorized): "Api key is invalid"
```

with no clear remediation. The `providers.models.siliconflow.*.base_url` config field is not honored by `CompatFamilySpec` providers (separate fix needed there), so users cannot work around it.

## Verification

Same key, both endpoints:

```
$ curl -sS -o /dev/null -w "%{http_code}" -X POST \
    -H "Authorization: Bearer sk-..." \
    -H "Content-Type: application/json" \
    https://api.siliconflow.com/v1/chat/completions \
    -d '{"model":"Qwen/Qwen3-Coder-30B-A3B-Instruct",...}'
200

$ curl ... https://api.siliconflow.cn/v1/chat/completions ...
401 — "Api key is invalid"
```

## Change

Two single-line changes:

1. `crates/zeroclaw-providers/src/factory.rs:355` — `SiliconflowModelProviderConfig::DEFAULT_URL`
2. `crates/zeroclaw-config/src/schema.rs:1672` — `SiliconflowEndpoint::Default`

Both flip `.cn` → `.com`. China traffic routes via SiliconFlow's CDN — switching the default doesn't break .cn-tier users (their key works on both endpoints; international keys only work on `.com`).

## Test plan

- [x] Confirmed `.com` accepts both .com and .cn keys (SiliconFlow CDN routes appropriately)
- [x] Confirmed `.cn` rejects .com keys with HTTP 401
- [x] No tests in this repo reference `siliconflow.cn` by URL

## Closes

zeroclaw native `siliconflow` provider on master is unusable for international key holders. This restores international access without breaking .cn users.