### PR TITLE
fix(runtime): apply SecurityPolicy tool filter in process_message()

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -145,6 +145,37 @@ pub fn apply_policy_tool_filter(
     });
 }
 
+/// Apply the SecurityPolicy built-in tool filter on the channel/daemon
+/// (`process_message`) path.
+///
+/// Extracted as a named seam so the production filtering of the eager
+/// built-in registry is regression-testable without driving the full agent
+/// loop (see `process_message_policy_filters_eager_builtins`). The channel
+/// path has no caller-supplied allowlist, so only the agent's own
+/// `SecurityPolicy` (`allowed_tools` + `excluded_tools`) gates here; the
+/// `run()` path additionally composes a caller-supplied `allowed_tools` gate.
+pub(crate) fn filter_channel_builtin_tools(
+    tools_registry: &mut Vec<Box<dyn Tool>>,
+    security: &zeroclaw_config::policy::SecurityPolicy,
+) {
+    let before_filter = tools_registry.len();
+    apply_policy_tool_filter(tools_registry, Some(security), None);
+    if tools_registry.len() != before_filter {
+        ::zeroclaw_log::record!(
+            INFO,
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(
+                ::serde_json::json!({
+                    "before": before_filter,
+                    "retained": tools_registry.len(),
+                    "policy_allowed": security.allowed_tools.as_ref().map(|v| v.len()),
+                    "policy_excluded": security.excluded_tools.as_ref().map(|v| v.len()),
+                })
+            ),
+            "Applied capability-based tool access filter (process_message)"
+        );
+    }
+}
+
 /// Returns the subset of `tool_specs` that should be sent to the LLM for this turn.
 ///
 /// Rules (mirrors NullClaw `filterToolSpecsForTurn`):
@@ -4380,10 +4411,18 @@ pub async fn process_message(
         };
         tools_registry.extend(peripheral_tools);
 
+        // ── Capability-based tool access control ─────────────────────
+        // Mirror the `run()` path: apply the SecurityPolicy filter
+        // (allowed_tools + excluded_tools) so daemon-provisioned agents get
+        // the same restriction as CLI-invoked agents. Extracted into
+        // `filter_channel_builtin_tools` so the production path is
+        // regression-tested (see process_message_policy_filters_eager_builtins).
+        filter_channel_builtin_tools(&mut tools_registry, security.as_ref());
+
         // ── Wire MCP tools (non-fatal) — process_message path ────────
         // NOTE: Same ordering contract as the CLI path above — MCP tools must be
-        // injected after filter_primary_agent_tools_or_fail (or equivalent built-in
-        // tool allow/deny filtering) to avoid MCP tools being silently dropped.
+        // injected after the policy tool filter to avoid MCP tools being
+        // silently dropped by a restrictive allowlist.
         let mut deferred_section = String::new();
         let mut activated_handle_pm: Option<
             std::sync::Arc<std::sync::Mutex<crate::tools::ActivatedToolSet>>,
@@ -11676,6 +11715,120 @@ Let me check the result."#;
             Some("openai"),
             "bare family name would bypass the alias-aware factory path and drop \
              requires_openai_auth from the config, routing to the wrong provider"
+        );
+    }
+
+    // ── process_message() path regression (#6959) ─────────────────
+    //
+    // The bug was not that `apply_policy_tool_filter` filtered wrong; it
+    // was that the daemon/channel `process_message` path never called it,
+    // so a restrictive SecurityPolicy did not apply when the same agent was
+    // reached through a channel. This drives the exact seam that path now
+    // calls (`filter_channel_builtin_tools`) against the *real* eager
+    // built-in registry produced by `all_tools`, and proves an agent
+    // allowlisted to `file_read` does not get raw `shell` / `file_write`.
+    #[test]
+    fn process_message_policy_filters_eager_builtins() {
+        use std::sync::Arc;
+
+        let config = zeroclaw_config::schema::Config::default();
+        let security = Arc::new(TestPolicy {
+            workspace_dir: std::env::temp_dir(),
+            ..TestPolicy::default()
+        });
+        let risk = zeroclaw_config::schema::RiskProfileConfig::default();
+        let mem: Arc<dyn zeroclaw_memory::Memory> =
+            Arc::new(zeroclaw_memory::NoneMemory::new("test"));
+
+        let (mut registry, ..) = crate::tools::all_tools(
+            Arc::new(config.clone()),
+            &security,
+            &risk,
+            "test",
+            mem,
+            None,
+            None,
+            &config.browser,
+            &config.http_request,
+            &config.web_fetch,
+            &security.workspace_dir,
+            &config.agents,
+            None,
+            &config,
+            None,
+            false,
+        );
+
+        // Sanity: the unrestricted channel registry exposes the dangerous
+        // eager built-ins a restrictive policy is expected to remove.
+        let unrestricted = tool_names(&registry);
+        assert!(
+            unrestricted.contains(&"file_read"),
+            "expected file_read in unrestricted registry, got {unrestricted:?}"
+        );
+        assert!(
+            unrestricted.contains(&"shell"),
+            "expected shell in unrestricted registry, got {unrestricted:?}"
+        );
+        assert!(
+            unrestricted.contains(&"file_write"),
+            "expected file_write in unrestricted registry, got {unrestricted:?}"
+        );
+
+        // Allowlist the agent to `file_read` only, then run the exact filter
+        // `process_message` applies.
+        let policy = TestPolicy {
+            allowed_tools: Some(vec!["file_read".into()]),
+            ..TestPolicy::default()
+        };
+        super::filter_channel_builtin_tools(&mut registry, &policy);
+
+        let filtered = tool_names(&registry);
+        assert!(
+            filtered.contains(&"file_read"),
+            "allowlisted tool must survive on process_message path, got {filtered:?}"
+        );
+        assert!(
+            !filtered.contains(&"shell"),
+            "shell must be filtered out on process_message path, got {filtered:?}"
+        );
+        assert!(
+            !filtered.contains(&"file_write"),
+            "file_write must be filtered out on process_message path, got {filtered:?}"
+        );
+
+        // Denylist variant: an exclusion drops only the named tool.
+        let (mut registry2, ..) = crate::tools::all_tools(
+            Arc::new(config.clone()),
+            &security,
+            &risk,
+            "test",
+            Arc::new(zeroclaw_memory::NoneMemory::new("test")),
+            None,
+            None,
+            &config.browser,
+            &config.http_request,
+            &config.web_fetch,
+            &security.workspace_dir,
+            &config.agents,
+            None,
+            &config,
+            None,
+            false,
+        );
+        let deny = TestPolicy {
+            excluded_tools: Some(vec!["shell".into()]),
+            ..TestPolicy::default()
+        };
+        super::filter_channel_builtin_tools(&mut registry2, &deny);
+        let after_deny = tool_names(&registry2);
+        assert!(
+            !after_deny.contains(&"shell"),
+            "excluded shell must be removed on process_message path, got {after_deny:?}"
+        );
+        assert!(
+            after_deny.contains(&"file_read"),
+            "non-excluded file_read must remain, got {after_deny:?}"
         );
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** `process_message()` — the daemon/webhook/channel entrypoint — never called `apply_policy_tool_filter()`, so eager built-in tools were sent to the LLM **unfiltered regardless of `SecurityPolicy`**. A channel-invoked agent therefore had a wider tool surface than the *same* agent on the CLI `run()` path (#6959). This applies the filter on the `process_message()` path, extracted into a named seam `filter_channel_builtin_tools`, after peripheral tools are extended and before MCP wiring — mirroring `run()`'s ordering.
- **Scope boundary:** Does **not** add eager-MCP filtering, and does **not** add a channel caller-supplied allowlist — `run()` composes a caller `allowed_tools` gate, but the channel path has no equivalent source, so it passes `None` (only the agent's own `SecurityPolicy` gates here). `run()` itself is **unchanged** (its inline filter is left as-is to avoid churn/conflict with in-flight #6920).
- **Blast radius:** `process_message()` tool-registry assembly only. The `run()` path is untouched. Default deployments (no `allowed_tools`/`excluded_tools`) are unaffected — the filter retains every tool when the policy admits everything.
- **Linked issue(s):** Related #6959. The issue is broader than this slice (it also asks for filtering after **all** eager sources incl. eager MCP, and mentions the full request payload); eager-MCP and the channel caller-filter remain open, so this intentionally does **not** auto-close it.
- **Labels:** `bug`, `size: XS`, `risk: high`, `agent`, `runtime`, `security`, `tool`. (Auto-size may bump after the added regression test.)

## Validation Evidence (required)

- **Commands run and tail output** (local, worktree on this commit, scoped to the changed crate):
  ```
  $ cargo fmt --all -- --check
  (clean; exit 0)

  $ cargo clippy -p zeroclaw-runtime --lib --all-targets -- -D warnings
      Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 06s   (no warnings)

  $ cargo test -p zeroclaw-runtime --lib
  test agent::loop_::tests::process_message_policy_filters_eager_builtins ... ok
  test result: ok. 1851 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out
  ```
- **Beyond CI — what did you manually verify?** The new `process_message_policy_filters_eager_builtins` builds the **real** eager built-in registry via `all_tools(...)` (not a synthetic vec), asserts the unrestricted registry exposes `shell`/`file_write`/`file_read`, then runs the exact seam `process_message()` calls and asserts an agent allowlisted to `file_read` no longer exposes `shell`/`file_write`; a denylist case proves only the excluded tool is dropped. This targets the actual production-path bug (the missing call), not `apply_policy_tool_filter` in isolation (already unit-tested).
- **If any command was intentionally skipped, why:** Did not drive `process_message()` end-to-end — it requires a mock model provider + channel scaffolding that does not exist in-crate; per the reviewer's guidance the registry-assembly+filter seam is the testable boundary. Full-workspace `cargo test` and multi-platform builds are left to CI on push; local runs were scoped to `zeroclaw-runtime` (the only changed crate).

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No** — this *narrows* the channel path's capability surface to match `run()`.
- New external network calls? **No.**
- Secrets / tokens / credentials handling changed? **No.**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No** (synthetic tool names only).
- If any `Yes`, describe the risk and mitigation: N/A. Security-positive: closes a policy-bypass where channel/daemon-invoked agents ignored `allowed_tools`/`excluded_tools` for eager built-in tools.

## Compatibility (required)

- Backward compatible? **Yes** — with no `allowed_tools`/`excluded_tools` set, the filter retains every tool (`is_tool_allowed` → true), so default behavior is unchanged. Deployments that set those fields now get them enforced on the channel path — the intended fix.
- Config / env / CLI surface changed? **No** — reuses the existing `SecurityPolicy` fields.
- If `No` or `Yes` to either: exact upgrade steps for existing users: None required.

## Rollback (required for `risk: high`)

- **Fast rollback command/path:** `git revert 2c5f88f19` — single self-contained commit; no migrations or state.
- **Feature flags or config toggles:** None. Behavior is gated by the existing `SecurityPolicy` fields; clearing `allowed_tools`/`excluded_tools` disables filtering but also removes the boundary, so revert is preferred.
- **Observable failure symptoms:** If the filter were mis-scoped, legitimate allowed tools would vanish for channel-invoked agents. Grep INFO logs for `Applied capability-based tool access filter (process_message)` — it records `before`/`retained` counts; an unexpected drop (or `retained` far below `before`) on the channel path indicates a policy/config problem.
