### PR TITLE
fix(tests): replace wall-clock timing assert in parallel-dispatch test with deterministic overlap check

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -12007,6 +12007,54 @@ BTC is currently around $65,000 based on latest tool output."#
         }
     }
 
+    /// Model provider used by `message_dispatch_processes_messages_in_parallel`
+    /// to observe concurrent in-flight calls directly instead of inferring
+    /// parallelism from wall-clock elapsed time.
+    ///
+    /// Each `chat_with_system` invocation increments `in_flight` on entry,
+    /// records the running peak into `peak_in_flight`, then decrements on
+    /// exit. After the dispatch loop returns, the test asserts
+    /// `peak_in_flight >= 2`, which directly proves two messages were being
+    /// processed at the same time. This replaces the original
+    /// `elapsed < 700ms` assertion (issue #6813), which flaked on slow
+    /// runners because it depended on machine speed rather than on
+    /// observable concurrency.
+    struct ConcurrencyTrackingProvider {
+        delay: Duration,
+        in_flight: Arc<AtomicUsize>,
+        peak_in_flight: Arc<AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl ModelProvider for ConcurrencyTrackingProvider {
+        async fn chat_with_system(
+            &self,
+            _system_prompt: Option<&str>,
+            message: &str,
+            _model: &str,
+            _temperature: Option<f64>,
+        ) -> anyhow::Result<String> {
+            let current = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+            self.peak_in_flight.fetch_max(current, Ordering::SeqCst);
+            tokio::time::sleep(self.delay).await;
+            self.in_flight.fetch_sub(1, Ordering::SeqCst);
+            Ok(format!("echo: {message}"))
+        }
+    }
+
+    impl ::zeroclaw_api::attribution::Attributable for ConcurrencyTrackingProvider {
+        fn role(&self) -> ::zeroclaw_api::attribution::Role {
+            ::zeroclaw_api::attribution::Role::Provider(
+                ::zeroclaw_api::attribution::ProviderKind::Model(
+                    ::zeroclaw_api::attribution::ModelProviderKind::Custom,
+                ),
+            )
+        }
+        fn alias(&self) -> &str {
+            "ConcurrencyTrackingProvider"
+        }
+    }
+
     #[tokio::test]
     async fn message_dispatch_processes_messages_in_parallel() {
         let channel_impl = Arc::new(RecordingChannel::default());
@@ -12015,10 +12063,15 @@ BTC is currently around $65,000 based on latest tool output."#
         let mut channels_by_name = HashMap::new();
         channels_by_name.insert(channel.name().to_string(), channel);
 
+        let in_flight = Arc::new(AtomicUsize::new(0));
+        let peak_in_flight = Arc::new(AtomicUsize::new(0));
+
         let runtime_ctx = Arc::new(ChannelRuntimeContext {
             channels_by_name: Arc::new(channels_by_name),
-            model_provider: Arc::new(SlowModelProvider {
+            model_provider: Arc::new(ConcurrencyTrackingProvider {
                 delay: Duration::from_millis(250),
+                in_flight: in_flight.clone(),
+                peak_in_flight: peak_in_flight.clone(),
             }),
             default_model_provider: Arc::new("test-provider".to_string()),
             agent_alias: Arc::new("test-agent".to_string()),
@@ -12114,14 +12167,23 @@ BTC is currently around $65,000 based on latest tool output."#
         .unwrap();
         drop(tx);
 
-        let started = Instant::now();
         run_message_dispatch_loop(rx, AgentRouter::single(runtime_ctx), 2).await;
-        let elapsed = started.elapsed();
 
+        // Deterministic concurrency check: the dispatcher should have processed
+        // both messages in parallel, so the peak number of simultaneously
+        // in-flight model calls must reach at least 2. This observes parallelism
+        // directly rather than inferring it from wall-clock elapsed time, which
+        // flaked on slow runners (issue #6813).
+        let peak = peak_in_flight.load(Ordering::SeqCst);
         assert!(
-            elapsed < Duration::from_millis(700),
-            "expected parallel dispatch with precheck (<700ms), got {:?}",
-            elapsed
+            peak >= 2,
+            "expected at least 2 concurrent in-flight dispatches, got peak {}",
+            peak
+        );
+        assert_eq!(
+            in_flight.load(Ordering::SeqCst),
+            0,
+            "all in-flight dispatches should have completed",
         );
 
         let sent_messages = channel_impl.sent_messages.lock().await;


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - The `message_dispatch_processes_messages_in_parallel` test asserted total wall-clock duration was below a threshold to prove channels dispatched concurrently.
  - On slower runners, and after the #6812 Groq scanner change, that timing threshold could fail even when dispatch was still parallel.
  - This replaces the elapsed-time assertion with a test-only `ConcurrencyTrackingProvider` that records peak in-flight model calls.
- **Scope boundary:**
  - Test-only change in `crates/zeroclaw-channels/src/orchestrator/mod.rs`.
  - No production channel dispatch behavior changes.
- **Blast radius:**
  - The affected regression coverage should be less flaky while still proving overlapping dispatch.
  - If dispatch regresses back to serial processing, `peak_in_flight >= 2` should fail.
- **Linked issue(s):** Closes #6813.
- **Labels:** bug, size: XS, risk: low, channel, tests

## Validation Evidence

- **Commands run and tail output:**
  - `cargo test -p zeroclaw-channels orchestrator::tests::message_dispatch_processes_messages_in_parallel` — 3 consecutive runs all passed deterministically (1 passed each run, about 0.53s).
  - `cargo clippy -p zeroclaw-channels --tests -- -D warnings` — clean (exit 0).
  - `cargo fmt --check -p zeroclaw-channels` — clean (exit 0).
- **Beyond CI — what did you manually verify?**
  - Verified the new test checks peak concurrent in-flight provider calls directly rather than relying on elapsed wall-clock time.
  - Verified the final `in_flight == 0` assertion confirms the test provider drained after dispatch returned.
- **If any command was intentionally skipped, why:**
  - Full workspace validation was left to GitHub CI for this low-risk, test-only PR.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? No.
- New external network calls? No.
- Secrets / tokens / credentials handling changed? No.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No.
- If any `Yes`, describe the risk and mitigation: N/A.

## Compatibility

- Backward compatible? Yes.
- Config / env / CLI surface changed? No.
- If `No` or `Yes` to either: exact upgrade steps for existing users: N/A.

## Rollback

Low-risk PR: `git revert <sha>` is the plan.

## Files

- `crates/zeroclaw-channels/src/orchestrator/mod.rs` — single test function modified, with a new test-only `ConcurrencyTrackingProvider` added next to it.
