### PR TITLE
fix(matrix): preserve self-anchored root sessions

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -488,7 +488,15 @@ pub fn conversation_history_key(msg: &zeroclaw_api::channel::ChannelMessage) -> 
     // Sanitize so the runtime HashMap key matches `SessionStore::list_sessions`
     // after a restart; otherwise hydration loads sessions under the on-disk
     // (sanitized) name while lookup keeps producing the un-sanitized form.
-    let raw = match &msg.thread_ts {
+    let thread_scope = match msg.thread_ts.as_deref() {
+        // Matrix root events can be self-anchored when `reply_in_thread`
+        // is enabled so outbound replies open a thread. That anchor is a
+        // delivery detail, not a conversation-history boundary; otherwise
+        // every top-level Matrix message becomes a fresh session.
+        Some(tid) if is_matrix_channel_name(&msg.channel) && tid == msg.id => None,
+        other => other,
+    };
+    let raw = match thread_scope {
         Some(tid) => format!("{channel_scope}_{}_{tid}_{}", msg.reply_target, msg.sender),
         None => format!("{channel_scope}_{}_{}", msg.reply_target, msg.sender),
     };
@@ -13387,6 +13395,36 @@ BTC is currently around $65,000 based on latest tool output."#
             id: "$second:server".into(),
             content: "send it again".into(),
             timestamp: 2,
+            ..first.clone()
+        };
+
+        let key = conversation_history_key(&first);
+        assert_eq!(key, conversation_history_key(&second));
+        assert!(!key.contains("$first:server"));
+        assert!(!key.contains("$second:server"));
+    }
+
+    #[test]
+    fn matrix_self_anchored_root_history_key_omits_event_id() {
+        let first = zeroclaw_api::channel::ChannelMessage {
+            id: "$first:server".into(),
+            sender: "@alice:server".into(),
+            reply_target: "!room:server".into(),
+            content: "call me boss".into(),
+            channel: "matrix".into(),
+            channel_alias: None,
+            timestamp: 1,
+            thread_ts: Some("$first:server".into()),
+            interruption_scope_id: Some("$first:server".into()),
+            attachments: vec![],
+            subject: None,
+        };
+        let second = zeroclaw_api::channel::ChannelMessage {
+            id: "$second:server".into(),
+            content: "hello".into(),
+            timestamp: 2,
+            thread_ts: Some("$second:server".into()),
+            interruption_scope_id: Some("$second:server".into()),
             ..first.clone()
         };
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Treat Matrix messages whose `thread_ts` equals their own event id as root-scoped for conversation history.
  - Preserve real Matrix thread replies by continuing to key them on the thread root id.
  - Add regression coverage for two top-level self-anchored Matrix messages from the same sender and room sharing one history key.
- **Scope boundary:** Does not change Matrix send/reply APIs, outbound threading behavior, storage schemas, config, CLI, or non-Matrix channel history keys.
- **Blast radius:** Matrix channel conversation-history keying only. The affected behavior is session continuity for Matrix top-level events that carry a self-anchor id.
- **Linked issue(s):** Related #6524; follow-up to #6525.
- **Labels:** Current GitHub labels: `bug`, `size: XS`, `risk: medium`, `channel`, `channel:matrix`.

## Validation Evidence (required)

Local validation is the signal CI cannot replace. Run the full battery and paste literal output (tails, failures, warnings — not "all passed").

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- **Commands run and tail output:**

```bash
$ cargo fmt --all -- --check
# exit 0; no output

$ git diff --check
# exit 0; no output

$ cargo clippy --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.40s

$ cargo test -p zeroclaw-channels matrix_ --lib -- --nocapture
running 5 tests
test orchestrator::tests::followup_thread_id_does_not_open_matrix_thread_for_root_message ... ok
test orchestrator::tests::matrix_root_conversation_history_key_omits_event_id ... ok
test orchestrator::tests::matrix_thread_conversation_history_key_uses_thread_root ... ok
test orchestrator::tests::matrix_self_anchored_root_history_key_omits_event_id ... ok
test orchestrator::tests::sender_session_ids_match_migrated_matrix_sender_rows ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 1146 filtered out; finished in 0.01s

$ cargo test
     Running tests/test_system.rs (target/debug/deps/system-e7d4ad239846b569)

running 9 tests
test system::multi_agent_e2e::peer_group_routes_messages_only_within_resolved_peer_set ... ok
test system::multi_agent_e2e::peer_group_dotted_channel_refs_remain_alias_scoped_for_dispatch ... ok
test system::multi_agent_e2e::legacy_install_upgrades_cleanly_with_backup ... ok
test system::full_stack::system_tool_execution_flow ... ok
test system::full_stack::system_simple_text_response ... ok
test system::full_stack::system_parallel_tool_execution ... ok
test system::full_stack::system_multi_turn_conversation ... ok
test system::full_stack::system_tool_arguments_passed_correctly ... ok
test system::multi_agent_e2e::two_sqlite_agents_on_one_install_have_isolated_memory ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.08s

   Doc-tests zeroclaw

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

- **Beyond CI — what did you manually verify?** Added a regression test for self-anchored Matrix root events (`thread_ts == id`) and verified they do not include per-event ids in the history key. Existing Matrix coverage still verifies that real threaded replies use the thread root id.
- **If any command was intentionally skipped, why:** None.

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? (`Yes/No`) No.
- New external network calls? (`Yes/No`) No.
- Secrets / tokens / credentials handling changed? (`Yes/No`) No.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`Yes/No`) No.
- If any `Yes`, describe the risk and mitigation: Not applicable.

## Compatibility (required)

- Backward compatible? (`Yes/No`) Yes.
- Config / env / CLI surface changed? (`Yes/No`) No.
- If `No` or `Yes` to either: No upgrade steps; existing Matrix sessions and configuration are unchanged.

## Rollback (required for `risk: medium` and `risk: high`)

Medium/high-risk PRs must fill:

- **Fast rollback command/path:** `git revert 75ba807efed3990a018d774fa2cca9fb89d86552`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Matrix top-level messages that carry self-anchor event ids would split into separate sessions again; real Matrix thread replies should continue using the thread root id.

## Supersede Attribution (required only when `Supersedes #` is used)

Not applicable; this PR does not supersede another PR and does not carry code from another contributor.
