### PR TITLE
feat(tts): configurable uri and response_format for openai provider

### DIFF
--- a/crates/zeroclaw-channels/src/tts.rs
+++ b/crates/zeroclaw-channels/src/tts.rs
@@ -45,6 +45,13 @@ pub struct OpenAiTtsProvider {
     api_key: String,
     model: String,
     speed: f64,
+    /// Full endpoint URL. Defaults to the OpenAI production endpoint; can be
+    /// overridden via `[providers.tts.openai.<alias>].uri` to point at any
+    /// OpenAI-compatible TTS backend (Groq, Azure, self-hosted proxies).
+    base_url: String,
+    /// Audio response format. Defaults to `"opus"`; override to `"wav"` for
+    /// Orpheus-class models or `"mp3"` for broader compatibility.
+    response_format: String,
     client: reqwest::Client,
 }
 
@@ -74,6 +81,16 @@ impl OpenAiTtsProvider {
                 .filter(|m| !m.trim().is_empty())
                 .unwrap_or_else(|| "tts-1".to_string()),
             speed: config.speed.unwrap_or(1.0),
+            base_url: config
+                .uri
+                .clone()
+                .filter(|u| !u.trim().is_empty())
+                .unwrap_or_else(|| "https://api.openai.com/v1/audio/speech".to_string()),
+            response_format: config
+                .response_format
+                .clone()
+                .filter(|f| !f.trim().is_empty())
+                .unwrap_or_else(|| "opus".to_string()),
             client: reqwest::Client::builder()
                 .timeout(TTS_HTTP_TIMEOUT)
                 .build()
@@ -94,12 +111,12 @@ impl TtsProvider for OpenAiTtsProvider {
             "input": text,
             "voice": voice,
             "speed": self.speed,
-            "response_format": "opus",
+            "response_format": self.response_format,
         });
 
         let resp = self
             .client
-            .post("https://api.openai.com/v1/audio/speech")
+            .post(&self.base_url)
             .bearer_auth(&self.api_key)
             .json(&body)
             .send()

--- a/crates/zeroclaw-channels/src/tts.rs
+++ b/crates/zeroclaw-channels/src/tts.rs
@@ -959,4 +959,86 @@ mod tests {
         let manager = TtsManager::from_config(&cfg).unwrap();
         assert_eq!(manager.max_text_length, DEFAULT_MAX_TEXT_LENGTH);
     }
+
+    #[tokio::test]
+    async fn synthesize_posts_to_configured_uri_with_response_format() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/audio/speech"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"FAKE_WAV".to_vec()))
+            .mount(&server)
+            .await;
+
+        let cfg = TtsProviderConfig {
+            api_key: Some("sk-test".to_string()),
+            uri: Some(format!("{}/v1/audio/speech", server.uri())),
+            response_format: Some("wav".to_string()),
+            ..TtsProviderConfig::default()
+        };
+        let provider = OpenAiTtsProvider::new("test", &cfg).unwrap();
+
+        let audio = provider.synthesize("hello world", "hannah").await.unwrap();
+        assert_eq!(
+            audio, b"FAKE_WAV",
+            "synthesize should return the bytes served by the configured endpoint"
+        );
+
+        let reqs = server.received_requests().await.unwrap();
+        assert_eq!(
+            reqs.len(),
+            1,
+            "exactly one POST should reach the configured uri"
+        );
+        let body: serde_json::Value = serde_json::from_slice(&reqs[0].body).unwrap();
+        assert_eq!(
+            body["response_format"], "wav",
+            "configured response_format must reach the outgoing request body"
+        );
+        assert_eq!(body["input"], "hello world");
+        assert_eq!(body["voice"], "hannah");
+        assert_eq!(body["model"], "tts-1");
+    }
+
+    #[tokio::test]
+    async fn synthesize_defaults_response_format_to_opus_when_unset() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/audio/speech"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"AUDIO".to_vec()))
+            .mount(&server)
+            .await;
+
+        // uri points at the mock so we can inspect the body; response_format left unset.
+        let cfg = TtsProviderConfig {
+            api_key: Some("sk-test".to_string()),
+            uri: Some(format!("{}/v1/audio/speech", server.uri())),
+            ..TtsProviderConfig::default()
+        };
+        let provider = OpenAiTtsProvider::new("test", &cfg).unwrap();
+        provider.synthesize("hi", "alloy").await.unwrap();
+
+        let reqs = server.received_requests().await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&reqs[0].body).unwrap();
+        assert_eq!(
+            body["response_format"], "opus",
+            "unset response_format must default to opus in the outgoing request"
+        );
+    }
+
+    #[test]
+    fn openai_defaults_to_production_endpoint_when_uri_unset() {
+        let cfg = TtsProviderConfig {
+            api_key: Some("sk-test".to_string()),
+            ..TtsProviderConfig::default()
+        };
+        let provider = OpenAiTtsProvider::new("test", &cfg).unwrap();
+        assert_eq!(provider.base_url, "https://api.openai.com/v1/audio/speech");
+        assert_eq!(provider.response_format, "opus");
+    }
 }

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -3830,8 +3830,15 @@ pub struct TtsProviderConfig {
     pub language_code: Option<String>,
     /// Path to backend binary (edge-tts subprocess; piper local server).
     pub binary_path: Option<String>,
-    /// Endpoint URI for HTTP-based backends (piper local server). Renamed
-    /// from `api_url` for parity with `ModelProviderConfig.uri`.
+    /// Audio response format sent to the TTS backend (e.g. `"opus"`, `"mp3"`,
+    /// `"wav"`). Defaults to `"opus"` for the OpenAI family. Override to
+    /// `"wav"` for Orpheus-class models (e.g. `canopylabs/orpheus-v1-english`
+    /// on Groq) or `"mp3"` for broader compatibility.
+    pub response_format: Option<String>,
+    /// Endpoint URI for HTTP-based backends. Overrides the family default
+    /// when pointing at a compatible third-party API (Groq, Azure, self-hosted
+    /// proxies). Set to the **full** URL — there is no separate path-suffix
+    /// field. Renamed from `api_url` for parity with `ModelProviderConfig.uri`.
     #[serde(alias = "api_url")]
     pub uri: Option<String>,
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** `OpenAiTtsProvider` hardcoded its endpoint (`https://api.openai.com/v1/audio/speech`) and audio format (`opus`), so any OpenAI-compatible TTS backend (Groq, Azure, self-hosted) needed a shim proxy just to redirect the URL and swap the format. This now reads the existing `uri` field on `TtsProviderConfig` and the newly added `response_format` field for the OpenAI provider.
- **Scope boundary:** Only `OpenAiTtsProvider`. ElevenLabs and Google embed the voice ID in the URL path, which makes a `uri` override ambiguous - left as a follow-up.
- **Blast radius:** TTS request path for OpenAI-type providers only. Unset config = current behavior, so existing setups are unaffected.
- **Linked issue(s):** Related #6954 is unrelated; this PR stands alone.
- **Labels:** `enhancement`, `size: S`, `risk: medium`, `channel`, `config`

## Changes

- `crates/zeroclaw-config/src/schema.rs` - add `response_format: Option<String>` to `TtsProviderConfig` with a doc comment on defaults/override cases.
- `crates/zeroclaw-channels/src/tts.rs` - `OpenAiTtsProvider` now reads `config.uri` (-> `base_url`) and `config.response_format`, both falling back to the existing hardcoded defaults when unset. **No behavior change for existing configs.**
- Tests - added `wiremock` coverage for the request boundary (see below).

Example - Groq Orpheus, no proxy:

```toml
[providers.tts.openai.groq]
uri             = "https://api.groq.com/openai/v1/audio/speech"
api_key         = "gsk_..."
model           = "canopylabs/orpheus-v1-english"
response_format = "wav"   # Orpheus needs wav; default stays opus
```

## Validation Evidence (required)

Local commands and results (run on the rebased branch):

```text
cargo fmt --all -- --check        # clean
cargo clippy --release --all-targets   # Finished, 0 warnings
cargo build --bin zeroclaw --release   # Finished `release` in 7m58s
```

- **Beyond CI - what I manually verified:** Deployed the built binary and exercised the live path end to end on Telegram - a Groq Orpheus (`response_format = "wav"`) reply was synthesized (518 KB) and delivered, confirming the configured `uri` and format reach the real provider call. Incoming voice transcription also verified in the same round-trip.
- **New regression tests** (`crates/zeroclaw-channels/src/tts.rs`): a `wiremock` server asserts `synthesize()` POSTs to the configured `uri` with the configured `response_format` in the JSON body; a second test proves an unset `response_format` still sends `opus`; a unit test pins the default endpoint to the OpenAI URL when `uri` is unset.
- **Intentionally skipped:** the full `cargo test` suite is not run on the local dev box (a Raspberry Pi 5 OOMs on the full harness build). The new tests compile under `cargo clippy --tests` locally and their assertions run in CI.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **Yes** - an operator can now point TTS synthesis at any configured third-party `uri`. This is opt-in: with no `uri` set, requests go only to the existing OpenAI endpoint as before. The API key is still required and is sent as a bearer token to whatever endpoint the operator configures, so operators should only set a `uri` they trust with that key.
- Secrets / tokens / credentials handling changed? **No** - same `api_key` field and bearer-auth path; only the destination URL is configurable.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No** - tests use a local mock server and a placeholder `sk-test` key.

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **Yes** - two new *optional* keys on `[providers.tts.openai.<alias>]`: `uri` and `response_format`. Both default to current behavior.
- Upgrade steps for existing users: none. Existing configs keep hitting the OpenAI endpoint with `opus`.

## Rollback (required for `risk: medium`)

- **Fast rollback command/path:** remove or empty the `uri` and `response_format` keys on the affected `[providers.tts.openai.<alias>]` entry - the provider falls back to the OpenAI endpoint and `opus`. Code-level: `git revert <sha>`.
- **Feature flags or config toggles:** the two config keys are themselves the toggle (unset = old behavior).
- **Observable failure symptoms:** TTS synthesis errors in the trace from the configured endpoint (`OpenAI TTS API error (...)`), or voice replies failing to send; grep the runtime trace for `tts` / the provider error message.
