### PR TITLE
fix(tools): resolve image_info paths through policy

### DIFF
--- a/crates/zeroclaw-tools/src/image_info.rs
+++ b/crates/zeroclaw-tools/src/image_info.rs
@@ -1,7 +1,6 @@
 use async_trait::async_trait;
 use serde_json::json;
 use std::fmt::Write;
-use std::path::Path;
 use std::sync::Arc;
 use zeroclaw_api::tool::{Tool, ToolResult};
 use zeroclaw_config::policy::SecurityPolicy;
@@ -15,11 +14,9 @@ const MAX_IMAGE_BYTES: u64 = 5_242_880;
 /// (file size, format, dimensions from header bytes) and provides base64
 /// data for future multimodal model_provider support.
 pub struct ImageInfoTool {
-    // Held for API symmetry with other tools and to keep room for future
-    // tool-specific checks (e.g. post-canonicalization is_resolved_path_allowed).
-    // Pre-canonicalization path-allowlist enforcement now lives in the
-    // PathGuardedTool wrapper applied at registration time.
-    #[allow(dead_code)]
+    // Pre-canonicalization path-allowlist enforcement lives in the
+    // PathGuardedTool wrapper. The concrete tool still resolves raw tool
+    // paths and applies the read-side post-canonicalization boundary.
     security: Arc<SecurityPolicy>,
 }
 
@@ -167,21 +164,41 @@ impl Tool for ImageInfoTool {
             .and_then(serde_json::Value::as_bool)
             .unwrap_or(false);
 
-        let path = Path::new(path_str);
-
         // Path-allowlist checks are applied by the PathGuardedTool wrapper at
-        // registration time (see zeroclaw-runtime::tools::mod). Rate limiting
-        // for this tool is also wrapper-driven via RateLimitedTool.
+        // registration time (see zeroclaw-runtime::tools::mod). Successful
+        // reads consume budget through RateLimitedTool; post-wrapper
+        // canonicalize failures are charged here so missing-file probes are not
+        // free.
 
-        if !path.exists() {
+        let full_path = self.security.resolve_tool_path(path_str);
+        let resolved_path = match tokio::fs::canonicalize(&full_path).await {
+            Ok(path) => path,
+            Err(e) => {
+                let _ = self.security.record_action();
+                let error = if e.kind() == std::io::ErrorKind::NotFound {
+                    format!("File not found: {path_str}")
+                } else {
+                    format!("Failed to resolve file path: {e}")
+                };
+                return Ok(ToolResult {
+                    success: false,
+                    output: String::new(),
+                    error: Some(error),
+                });
+            }
+        };
+
+        if !self.security.is_resolved_path_readable(&resolved_path) {
             return Ok(ToolResult {
                 success: false,
                 output: String::new(),
-                error: Some(format!("File not found: {path_str}")),
+                error: Some(
+                    "Resolved image path is outside the allowed readable roots.".to_string(),
+                ),
             });
         }
 
-        let metadata = tokio::fs::metadata(path).await.map_err(|e| {
+        let metadata = tokio::fs::metadata(&resolved_path).await.map_err(|e| {
             ::zeroclaw_log::record!(
                 ERROR,
                 ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
@@ -207,7 +224,7 @@ impl Tool for ImageInfoTool {
             });
         }
 
-        let bytes = tokio::fs::read(path).await.map_err(|e| {
+        let bytes = tokio::fs::read(&resolved_path).await.map_err(|e| {
             ::zeroclaw_log::record!(
                 ERROR,
                 ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
@@ -256,8 +273,18 @@ impl Tool for ImageInfoTool {
 mod tests {
     use super::*;
     use crate::wrappers::{PathGuardedTool, RateLimitedTool};
+    use std::path::{Component, Path, PathBuf};
+    use tempfile::TempDir;
     use zeroclaw_config::autonomy::AutonomyLevel;
     use zeroclaw_config::policy::SecurityPolicy;
+
+    const MINIMAL_PNG: &[u8] = &[
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44,
+        0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x02, 0x00, 0x00, 0x00, 0x90,
+        0x77, 0x53, 0xDE, 0x00, 0x00, 0x00, 0x0C, 0x49, 0x44, 0x41, 0x54, 0x08, 0xD7, 0x63, 0xF8,
+        0xCF, 0xC0, 0x00, 0x00, 0x00, 0x02, 0x00, 0x01, 0xE2, 0x21, 0xBC, 0x33, 0x00, 0x00, 0x00,
+        0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
+    ];
 
     fn test_security() -> Arc<SecurityPolicy> {
         Arc::new(SecurityPolicy {
@@ -280,12 +307,28 @@ mod tests {
         })
     }
 
+    fn rootless_path(path: &Path) -> PathBuf {
+        let mut relative = PathBuf::new();
+        for component in path.components() {
+            match component {
+                Component::Prefix(_) | Component::RootDir | Component::CurDir => {}
+                Component::ParentDir => panic!("test path must not contain parent components"),
+                Component::Normal(part) => relative.push(part),
+            }
+        }
+        relative
+    }
+
     /// Wraps `ImageInfoTool` with the production `PathGuardedTool` +
     /// `RateLimitedTool` stack, mirroring the registration in
     /// `zeroclaw-runtime::tools::mod`.  Use this in tests that exercise
     /// path-allowlist or rate-limit behavior.
     fn wrapped_tool(workspace: std::path::PathBuf) -> Box<dyn Tool> {
         let security = workspace_security(workspace);
+        wrapped_tool_with_security(security)
+    }
+
+    fn wrapped_tool_with_security(security: Arc<SecurityPolicy>) -> Box<dyn Tool> {
         Box::new(RateLimitedTool::new(
             PathGuardedTool::new(ImageInfoTool::new(security.clone()), security.clone()),
             security,
@@ -475,29 +518,9 @@ mod tests {
 
     #[tokio::test]
     async fn execute_real_file() {
-        // Create a minimal valid PNG
-        let dir = std::env::temp_dir().join("zeroclaw_image_info_test");
-        let _ = tokio::fs::create_dir_all(&dir).await;
-        let png_path = dir.join("test.png");
-
-        // Minimal 1x1 red PNG (67 bytes)
-        let png_bytes: Vec<u8> = vec![
-            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, // signature
-            0x00, 0x00, 0x00, 0x0D, // IHDR length
-            0x49, 0x48, 0x44, 0x52, // IHDR
-            0x00, 0x00, 0x00, 0x01, // width: 1
-            0x00, 0x00, 0x00, 0x01, // height: 1
-            0x08, 0x02, 0x00, 0x00, 0x00, // bit depth, color type, etc.
-            0x90, 0x77, 0x53, 0xDE, // CRC
-            0x00, 0x00, 0x00, 0x0C, // IDAT length
-            0x49, 0x44, 0x41, 0x54, // IDAT
-            0x08, 0xD7, 0x63, 0xF8, 0xCF, 0xC0, 0x00, 0x00, 0x00, 0x02, 0x00, 0x01, 0xE2, 0x21,
-            0xBC, 0x33, // CRC
-            0x00, 0x00, 0x00, 0x00, // IEND length
-            0x49, 0x45, 0x4E, 0x44, // IEND
-            0xAE, 0x42, 0x60, 0x82, // CRC
-        ];
-        tokio::fs::write(&png_path, &png_bytes).await.unwrap();
+        let dir = TempDir::new().unwrap();
+        let png_path = dir.path().join("test.png");
+        tokio::fs::write(&png_path, MINIMAL_PNG).await.unwrap();
 
         let tool = ImageInfoTool::new(test_security());
         let result = tool
@@ -508,9 +531,6 @@ mod tests {
         assert!(result.output.contains("Format: png"));
         assert!(result.output.contains("Dimensions: 1x1"));
         assert!(!result.output.contains("data:"));
-
-        // Clean up
-        let _ = tokio::fs::remove_dir_all(&dir).await;
     }
 
     #[tokio::test]
@@ -568,20 +588,121 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn execute_with_base64() {
-        let dir = std::env::temp_dir().join("zeroclaw_image_info_b64");
-        let _ = tokio::fs::create_dir_all(&dir).await;
-        let png_path = dir.join("test_b64.png");
+    async fn wrapped_normalizes_workspace_prefixed_relative_path() {
+        let root = TempDir::new().unwrap();
+        let workspace = root.path().join("zeroclaw-data").join("workspace");
+        let images_dir = workspace.join("images");
+        tokio::fs::create_dir_all(&images_dir).await.unwrap();
 
-        // Minimal 1x1 PNG
-        let png_bytes: Vec<u8> = vec![
-            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48,
-            0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x02, 0x00, 0x00,
-            0x00, 0x90, 0x77, 0x53, 0xDE, 0x00, 0x00, 0x00, 0x0C, 0x49, 0x44, 0x41, 0x54, 0x08,
-            0xD7, 0x63, 0xF8, 0xCF, 0xC0, 0x00, 0x00, 0x00, 0x02, 0x00, 0x01, 0xE2, 0x21, 0xBC,
-            0x33, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
-        ];
-        tokio::fs::write(&png_path, &png_bytes).await.unwrap();
+        let png_path = images_dir.join("one.png");
+        tokio::fs::write(&png_path, MINIMAL_PNG).await.unwrap();
+
+        let workspace_prefixed = rootless_path(&workspace).join("images").join("one.png");
+        let tool = wrapped_tool(workspace);
+
+        let result = tool
+            .execute(json!({"path": workspace_prefixed.to_string_lossy()}))
+            .await
+            .unwrap();
+
+        assert!(
+            result.success,
+            "workspace-prefixed image path should resolve through security policy, error: {:?}",
+            result.error
+        );
+        assert!(result.output.contains("Format: png"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn wrapped_blocks_symlink_escape_after_resolution() {
+        use std::os::unix::fs::symlink;
+
+        let root = TempDir::new().unwrap();
+        let workspace = root.path().join("workspace");
+        let outside = root.path().join("outside");
+        tokio::fs::create_dir_all(&workspace).await.unwrap();
+        tokio::fs::create_dir_all(&outside).await.unwrap();
+        tokio::fs::write(outside.join("secret.png"), MINIMAL_PNG)
+            .await
+            .unwrap();
+        symlink(outside.join("secret.png"), workspace.join("link.png")).unwrap();
+
+        let tool = wrapped_tool(workspace);
+        let result = tool.execute(json!({"path": "link.png"})).await.unwrap();
+
+        assert!(!result.success, "symlink escape must be blocked");
+        let error = result.error.as_deref().unwrap_or("");
+        assert!(
+            error.contains("outside the allowed readable roots"),
+            "expected readable-roots error, got: {:?}",
+            error
+        );
+        assert!(
+            !error.contains(&outside.to_string_lossy().to_string()),
+            "policy error must not disclose resolved outside path, got: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn wrapped_blocks_write_only_allowed_root_read() {
+        let root = TempDir::new().unwrap();
+        let workspace = root.path().join("workspace");
+        let write_only = root.path().join("write-only");
+        tokio::fs::create_dir_all(&workspace).await.unwrap();
+        tokio::fs::create_dir_all(&write_only).await.unwrap();
+        let png_path = write_only.join("one.png");
+        tokio::fs::write(&png_path, MINIMAL_PNG).await.unwrap();
+
+        let security = Arc::new(SecurityPolicy {
+            autonomy: AutonomyLevel::Full,
+            workspace_dir: workspace,
+            workspace_only: true,
+            allowed_roots_write_only: vec![write_only],
+            ..SecurityPolicy::default()
+        });
+        let tool = wrapped_tool_with_security(security);
+        let result = tool
+            .execute(json!({"path": png_path.to_string_lossy()}))
+            .await
+            .unwrap();
+
+        assert!(!result.success, "write-only root must not be readable");
+        assert!(
+            result
+                .error
+                .as_deref()
+                .unwrap_or("")
+                .contains("outside the allowed readable roots"),
+            "expected readable-roots error, got: {:?}",
+            result.error
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_file_probe_consumes_action_budget() {
+        let root = TempDir::new().unwrap();
+        let security = Arc::new(SecurityPolicy {
+            autonomy: AutonomyLevel::Full,
+            workspace_dir: root.path().to_path_buf(),
+            workspace_only: true,
+            max_actions_per_hour: 1,
+            ..SecurityPolicy::default()
+        });
+        let tool = ImageInfoTool::new(security.clone());
+
+        assert!(!security.is_rate_limited());
+        let result = tool.execute(json!({"path": "missing.png"})).await.unwrap();
+
+        assert!(!result.success);
+        assert!(security.is_rate_limited());
+    }
+
+    #[tokio::test]
+    async fn execute_with_base64() {
+        let dir = TempDir::new().unwrap();
+        let png_path = dir.path().join("test_b64.png");
+        tokio::fs::write(&png_path, MINIMAL_PNG).await.unwrap();
 
         let tool = ImageInfoTool::new(test_security());
         let result = tool
@@ -590,7 +711,5 @@ mod tests {
             .unwrap();
         assert!(result.success);
         assert!(result.output.contains("data:image/png;base64,"));
-
-        let _ = tokio::fs::remove_dir_all(&dir).await;
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Re-recovers the `image_info` part of the old `371c59d1` path-resolution fix for #3774, tracked by #6074.
  - Keeps the existing `PathGuardedTool` wrapper as the first path-policy gate, then makes `ImageInfoTool` read from the same `SecurityPolicy::resolve_tool_path` result instead of reopening the raw input string.
  - Canonicalizes the resolved path and applies `SecurityPolicy::is_resolved_path_readable` before metadata or byte reads, matching the recovered read-side boundary used by adjacent file tools without disclosing the canonical outside path in policy errors.
  - Adds wrapped-tool regression tests for workspace-prefixed relative image paths, symlink escapes, write-only allowed roots, and missing-file probes consuming action budget.
- **Scope boundary:** Does not change path-policy configuration, allowed-root semantics, file write/edit behavior, image parsing, base64 output, or runtime tool registration.
- **Blast radius:** Limited to `image_info` file reads in `zeroclaw-tools`. The main risk is path-resolution behavior for image metadata requests.
- **Linked issue(s):** Related #6074. Related #3774.
- **Labels:** `bug`, `risk: high`, `size: S`, `tool`

## Validation Evidence (required)

- **Commands run and tail output:**

```text
time zc-cargo test -p zeroclaw-tools wrapped_normalizes_workspace_prefixed_relative_path --lib -- --nocapture
Before fix: failed. The wrapper accepted the workspace-prefixed relative path, but the inner tool reopened the wrong path and returned File not found.
After fix: passed. 1 passed, 0 failed.

time zc-cargo test -p zeroclaw-tools image_info --lib -- --nocapture
Passed. 27 passed, 0 failed.

time zc-cargo fmt --all -- --check
Passed.

git diff --check
Passed.

time zc-cargo clippy -p zeroclaw-tools --all-targets -- -D warnings
Passed.

time zc-cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
Passed in 8m33s.

time zc-cargo nextest run --locked --workspace --exclude zeroclaw-desktop
Initial run before rebasing onto #6962 was not green. It reached the test suite and failed on the unrelated #6813 timing test in zeroclaw-channels: orchestrator::tests::message_dispatch_processes_messages_in_parallel.

time zc-cargo nextest run --locked -p zeroclaw-channels message_dispatch_processes_messages_in_parallel
Same unrelated #6813 timing failure reproduced in isolation before rebasing onto #6962.

Separate check of PR #6962, which has since merged and closed #6813:
time zc-cargo nextest run --locked -p zeroclaw-channels message_dispatch_processes_messages_in_parallel
Passed. 1 passed, 0 failed.

After rebasing this branch onto current master containing #6962:
time zc-cargo nextest run --locked --workspace --exclude zeroclaw-desktop
Passed in 57m45s. 8110 tests run, 8110 passed, 1 leaky, 10 skipped.
```

- **Beyond CI — what did you manually verify?** Reviewed the current `file_write`, `file_edit`, `PathGuardedTool`, `PdfReadTool`, `SecurityPolicy::resolve_tool_path`, and `SecurityPolicy::is_resolved_path_readable` behavior against the lost `371c59d1` intent. Confirmed the missing behavior was specific to `image_info` opening a raw or only-normalized path after wrapper validation.
- **If any command was intentionally skipped, why:** No intended local command was skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: `N/A`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: `N/A`

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** Use GitHub's Revert button, or revert the landed commit for this PR.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** `image_info` returns unexpected file metadata for workspace-prefixed relative paths, or starts rejecting paths that adjacent guarded file tools accept through the same policy.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): No active PR is superseded. Original recovered commit: `371c59d1` by linyibin.
- Scope materially carried forward: User-visible path-resolution behavior for #3774 is carried forward; the old patch code is not copied.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why (inspiration-only, no direct code/design carry-over): This re-recovers the user-visible behavior tracked by #6074, but the implementation uses current `SecurityPolicy` helpers and does not copy old patch code or reuse the old implementation.
