### PR TITLE
fix(web_fetch): honor private DNS host allowlist

### DIFF
--- a/crates/zeroclaw-tools/src/web_fetch.rs
+++ b/crates/zeroclaw-tools/src/web_fetch.rs
@@ -467,6 +467,24 @@ fn validate_target_url(
     allowed_private_hosts: &[String],
     tool_name: &str,
 ) -> anyhow::Result<String> {
+    validate_target_url_with_dns_check(
+        raw_url,
+        allowed_domains,
+        blocked_domains,
+        allowed_private_hosts,
+        tool_name,
+        validate_resolved_host_is_public,
+    )
+}
+
+fn validate_target_url_with_dns_check(
+    raw_url: &str,
+    allowed_domains: &[String],
+    blocked_domains: &[String],
+    allowed_private_hosts: &[String],
+    tool_name: &str,
+    validate_dns: impl FnOnce(&str) -> anyhow::Result<()>,
+) -> anyhow::Result<String> {
     let url = raw_url.trim();
 
     if url.is_empty() {
@@ -495,10 +513,11 @@ fn validate_target_url(
         anyhow::bail!("Host '{host}' is in {tool_name}.blocked_domains");
     }
 
+    let host_is_private_or_local = is_private_or_local_host(&host);
     let private_host_allowed =
-        is_private_or_local_host(&host) && host_matches_allowlist(&host, allowed_private_hosts);
+        host_matches_private_allowlist(&host, allowed_private_hosts, host_is_private_or_local);
 
-    if is_private_or_local_host(&host) && !private_host_allowed {
+    if host_is_private_or_local && !private_host_allowed {
         anyhow::bail!(
             "Blocked local/private host: {host}. \
              To allow this host, add it to {tool_name}.allowed_private_hosts in config.toml"
@@ -511,7 +530,7 @@ fn validate_target_url(
             ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
                 .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
                 .with_attrs(::serde_json::json!({"tool_name": tool_name, "host": host})),
-            ": allowing private/local host '' via allowed_private_hosts"
+            "web_fetch: allowing host via allowed_private_hosts"
         );
     }
 
@@ -520,7 +539,7 @@ fn validate_target_url(
     }
 
     if !private_host_allowed {
-        validate_resolved_host_is_public(&host)?;
+        validate_dns(&host)?;
     }
 
     Ok(url.to_string())
@@ -643,6 +662,23 @@ fn host_matches_allowlist(host: &str, allowed_domains: &[String]) -> bool {
             || host
                 .strip_suffix(domain)
                 .is_some_and(|prefix| prefix.ends_with('.'))
+    })
+}
+
+fn host_matches_private_allowlist(
+    host: &str,
+    allowed_private_hosts: &[String],
+    host_is_private_or_local: bool,
+) -> bool {
+    allowed_private_hosts.iter().any(|domain| {
+        if domain == "*" {
+            host_is_private_or_local
+        } else {
+            host == domain
+                || host
+                    .strip_suffix(domain)
+                    .is_some_and(|prefix| prefix.ends_with('.'))
+        }
     })
 }
 
@@ -1545,6 +1581,99 @@ mod tests {
     fn allowed_private_host_bypasses_ssrf_block() {
         let tool = test_tool_with_private_hosts(vec!["*"], vec![], vec!["192.168.1.5"]);
         assert!(tool.validate_url("https://192.168.1.5/api").is_ok());
+    }
+
+    #[test]
+    fn allowed_private_domain_skips_dns_public_check() {
+        let allowed_domains = vec!["*".to_string()];
+        let blocked_domains = vec![];
+        let allowed_private_hosts = vec!["local.internal".to_string()];
+
+        let result = validate_target_url_with_dns_check(
+            "https://local.internal/api",
+            &allowed_domains,
+            &blocked_domains,
+            &allowed_private_hosts,
+            "web_fetch",
+            |_| {
+                panic!("DNS public-host validation should be skipped");
+            },
+        );
+
+        assert!(
+            result.is_ok(),
+            "allowlisted private domain was rejected: {result:?}"
+        );
+    }
+
+    #[test]
+    fn unallowed_domain_resolving_private_ip_still_blocked() {
+        let allowed_domains = vec!["*".to_string()];
+        let blocked_domains = vec![];
+        let allowed_private_hosts = vec![];
+
+        let err = validate_target_url_with_dns_check(
+            "https://local.internal/api",
+            &allowed_domains,
+            &blocked_domains,
+            &allowed_private_hosts,
+            "web_fetch",
+            |host| {
+                validate_resolved_ips_are_public(
+                    host,
+                    &[std::net::IpAddr::V4(std::net::Ipv4Addr::new(
+                        192, 168, 1, 5,
+                    ))],
+                )
+            },
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(
+            err.contains("non-global address"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn private_allowlist_wildcard_does_not_allow_public_domain_miss() {
+        let allowed_domains = vec!["example.com".to_string()];
+        let blocked_domains = vec![];
+        let allowed_private_hosts = vec!["*".to_string()];
+
+        let err = validate_target_url_with_dns_check(
+            "https://not-example.com/api",
+            &allowed_domains,
+            &blocked_domains,
+            &allowed_private_hosts,
+            "web_fetch",
+            |_| anyhow::Ok(()),
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(err.contains("allowed_domains"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn blocklist_overrides_allowed_private_domain() {
+        let allowed_domains = vec!["*".to_string()];
+        let blocked_domains = vec!["local.internal".to_string()];
+        let allowed_private_hosts = vec!["local.internal".to_string()];
+
+        let err = validate_target_url_with_dns_check(
+            "https://local.internal/api",
+            &allowed_domains,
+            &blocked_domains,
+            &allowed_private_hosts,
+            "web_fetch",
+            |_| anyhow::bail!("blocklist should run before DNS validation"),
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(err.contains("blocked_domains"), "unexpected error: {err}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Let explicit `web_fetch.allowed_private_hosts` entries bypass DNS public-IP validation for matching domain names, so local/private services reached through DNS names can be fetched when the user has explicitly allowed that host.
  - Keep the SSRF boundary for unlisted DNS names: hosts not in `allowed_private_hosts` still run through resolved-IP validation and are blocked when DNS resolves to private or otherwise non-global addresses.
  - Preserve `blocked_domains` precedence over the private-host allowlist.
  - Preserve the old wildcard safety shape: `allowed_private_hosts = ["*"]` still covers syntactically private/local hosts, but does not become a universal bypass for ordinary public-looking domain names.
- **Scope boundary:** This PR is limited to `web_fetch` URL validation. It does not change `http_request`.
- **Blast radius:** `web_fetch` users with explicit private-host allowlist entries can now fetch DNS-backed local/private domains. Unlisted domains, blocked domains, and ordinary public-domain allowlist checks remain guarded.
- **Linked issue(s):** Related #5122. Supersedes #5136 and #5164.
- **Labels:** `bug`, `risk: high`, `security`, `tool`, `tool: web_fetch`, `domain:web-fetch`, `tool:web`, `size: S`

## Validation Evidence (required)

- **Commands run and tail output:**

```text
PASS cargo test -p zeroclaw-tools web_fetch::tests:: -- --nocapture
57 web_fetch tests passed after the wildcard and blocklist regressions were added.

PASS cargo fmt --all -- --check

PASS cargo clippy -p zeroclaw-tools --all-targets -- -D warnings

PASS cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
Finished dev profile in 37m 09s. This captured pass covered the `web_fetch.rs` diff before the later #6962 test-only merge; the post-#6962 CI-shaped nextest pass below verifies the refreshed test gate.

PASS cargo nextest run --locked --workspace --exclude zeroclaw-desktop
8110 tests run: 8110 passed, 10 skipped.

PASS cargo nextest run --locked -p zeroclaw-tools
1185 tests run: 1185 passed, 0 skipped.
```

- **Beyond CI — what did you manually verify?** I traced the validation order so `blocked_domains` still wins before any private-host allow, explicit private-host entries skip only the DNS public-IP check, unlisted DNS names resolving to private IPs still fail, and wildcard private-host allowlist entries do not broaden into a public-domain bypass.
- **If any command was intentionally skipped, why:** Full workspace plain `cargo test` was not run separately because the repository's CI-shaped full test gate is `cargo nextest run --locked --workspace --exclude zeroclaw-desktop`. Targeted `cargo test` coverage for `web_fetch::tests::` was run separately.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `Yes` — this enables the existing `web_fetch.allowed_private_hosts` capability for DNS-backed private/local domains. No new config key or file system scope is added.
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: The behavior intentionally changes an existing security gate: explicitly allowlisted `web_fetch.allowed_private_hosts` domains can now bypass resolved-IP private-address blocking. The mitigation is that the bypass requires an exact or subdomain match in the private-host allowlist, `blocked_domains` still overrides it, unlisted DNS names still run through resolved-IP validation, and `*` remains limited to syntactically private/local hosts.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `Yes`
- If `No` or `Yes` to either: No new config key is required. This fixes the behavior of the existing `web_fetch.allowed_private_hosts` list for DNS-backed private/local domains; users who need this behavior can add the domain they already trust to `web_fetch.allowed_private_hosts`.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** Revert the merge commit for this PR.
- **Feature flags or config toggles:** Remove the affected host from `web_fetch.allowed_private_hosts`, or add it to `web_fetch.blocked_domains` to force a local/config rollback for a specific hostname.
- **Observable failure symptoms:** Unexpected `web_fetch` access to an explicitly allowlisted private DNS name, or log/error changes around `Blocked resolved host with non-global address` and `web_fetch: allowing host via allowed_private_hosts`.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors:
  - #5136 by @ArchBirdie
  - #5164 by @c7ozkan
- Scope materially carried forward: The issue diagnosis and intended behavior are carried forward: domain names explicitly listed in `web_fetch.allowed_private_hosts` should not be blocked only because DNS resolves them to private IPs. The implementation here was rebuilt against the current `crates/zeroclaw-tools/src/web_fetch.rs` path and adds additional wildcard/blocklist regressions.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why: Inspiration-only. No direct code was copied from the superseded PRs into this branch.
