### PR TITLE
fix(email): ignore blank SMTP credential overrides

### DIFF
--- a/crates/zeroclaw-channels/src/email_channel.rs
+++ b/crates/zeroclaw-channels/src/email_channel.rs
@@ -619,16 +619,10 @@ impl EmailChannel {
     }
 
     fn smtp_credentials(&self) -> Credentials {
-        let user = self
-            .config
-            .smtp_username
-            .as_deref()
+        let user = smtp_credential_override(self.config.smtp_username.as_deref())
             .unwrap_or(&self.config.username)
             .to_owned();
-        let pass = self
-            .config
-            .smtp_password
-            .as_deref()
+        let pass = smtp_credential_override(self.config.smtp_password.as_deref())
             .unwrap_or(&self.config.password)
             .to_owned();
         Credentials::new(user, pass)
@@ -687,6 +681,11 @@ fn markdown_to_html(md: &str) -> String {
     html::push_html(&mut html_output, parser);
     html_output
 }
+
+fn smtp_credential_override(value: Option<&str>) -> Option<&str> {
+    value.filter(|value| !value.trim().is_empty())
+}
+
 #[async_trait]
 
 impl Channel for EmailChannel {
@@ -1449,6 +1448,40 @@ mod tests {
         let channel = EmailChannel::new(config, "email_test_alias", empty_resolver());
         let creds = channel.smtp_credentials();
         let expected = Credentials::new("smtp@example.com".to_string(), "smtp_pass".to_string());
+        assert_eq!(creds, expected);
+    }
+
+    #[test]
+    fn smtp_credentials_ignore_blank_dedicated_fields() {
+        let config = EmailConfig {
+            username: "shared@example.com".to_string(),
+            password: "shared_pass".to_string(),
+            smtp_username: Some("   ".to_string()),
+            smtp_password: Some("".to_string()),
+            ..Default::default()
+        };
+        let channel = EmailChannel::new(config, "email_test_alias", empty_resolver());
+        let creds = channel.smtp_credentials();
+        let expected =
+            Credentials::new("shared@example.com".to_string(), "shared_pass".to_string());
+        assert_eq!(creds, expected);
+    }
+
+    #[test]
+    fn smtp_credentials_preserve_nonblank_dedicated_fields() {
+        let config = EmailConfig {
+            username: "shared@example.com".to_string(),
+            password: "shared_pass".to_string(),
+            smtp_username: Some("  smtp@example.com  ".to_string()),
+            smtp_password: Some("  smtp_pass  ".to_string()),
+            ..Default::default()
+        };
+        let channel = EmailChannel::new(config, "email_test_alias", empty_resolver());
+        let creds = channel.smtp_credentials();
+        let expected = Credentials::new(
+            "  smtp@example.com  ".to_string(),
+            "  smtp_pass  ".to_string(),
+        );
         assert_eq!(creds, expected);
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** SMTP credential selection now treats blank `smtp_username` / `smtp_password` values as unset, so blank generated or manually edited overrides fall back to the shared email `username` / `password`.
- **What changed and why:** Nonblank SMTP-specific credentials are still preserved exactly, including leading or trailing spaces, so the fallback check does not mutate real credential values.
- **What changed and why:** Added focused email-channel regression coverage for absent overrides, dedicated overrides, blank overrides, and nonblank credential preservation.
- **Scope boundary:** This PR only changes local SMTP credential selection in the email channel. It does not change IMAP login, email parsing, SMTP transport construction, config schema fields, onboarding UI, or docs.
- **Blast radius:** Limited to email channel outbound SMTP authentication when `smtp_username` or `smtp_password` is present. Other channels and provider credential flows are not touched.
- **Linked issue(s):** Closes #6881.
- **Labels:** `bug`, `risk: medium`, `size: XS`, `channel`, `channel:email`, `config`

## Validation Evidence (required)

- **Commands run and tail output:**

```text
cargo test -p zeroclaw-channels --features channel-email smtp_credentials -- --nocapture
Result: passed. 5 passed; 0 failed; 1224 filtered out.

cargo fmt --all -- --check
Result: passed.

git diff --check
Result: passed.

cargo clippy -p zeroclaw-channels --features channel-email --all-targets -- -D warnings
Result: passed.

cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
Result: passed.

cargo nextest run --locked --workspace --exclude zeroclaw-desktop
Result: passed. 8108 tests passed; 10 skipped.
```

- **Beyond CI — what did you manually verify?** Verified the credential-selection diff directly: blank or whitespace-only SMTP overrides fall back to the shared email credentials, while nonblank SMTP credentials are passed through unchanged.
- **If any command was intentionally skipped, why:** No live SMTP server smoke was run. The changed behavior is pure local credential selection and is covered by focused unit tests, broad clippy, and CI-shaped nextest; a live SMTP auth smoke would require configured credentials and external service access.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`Yes`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: This changes which configured email credential string is selected for SMTP auth when SMTP-specific override fields are blank. The mitigation is narrow: blank overrides now fall back to the already-configured shared email credentials, and nonblank credential strings are preserved exactly instead of being trimmed or normalized.

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: Existing configs do not need migration. Users who leave `smtp_username` or `smtp_password` unset or blank keep the shared credential behavior; users with nonblank SMTP-specific credentials keep the dedicated SMTP behavior.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** Revert this PR to restore the previous `smtp_username.as_deref().unwrap_or(...)` and `smtp_password.as_deref().unwrap_or(...)` behavior in `crates/zeroclaw-channels/src/email_channel.rs`.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Email outbound replies fail SMTP authentication for configs that rely on blank SMTP-specific fields falling back to shared credentials; look for email channel send/auth failures around SMTP login.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Scope materially carried forward: N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`No`)
- If `No`, why (inspiration-only, no direct code/design carry-over): No superseded PR or contributor code is carried forward.
