### PR TITLE
fix(provider): preserve reasoning_content in native tool requests

### DIFF
--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -1638,6 +1638,33 @@ impl OpenAiCompatibleModelProvider {
         model.is_empty() || lower.contains("gemma-4") || lower.contains("gemma4")
     }
 
+    fn build_native_tool_chat_request(
+        &self,
+        effective_messages: &[ChatMessage],
+        tools: Option<Vec<serde_json::Value>>,
+        model: &str,
+        temperature: f64,
+        allow_user_image_parts: bool,
+    ) -> NativeChatRequest {
+        let has_tool_entries = tools.as_ref().is_some_and(|tools| !tools.is_empty());
+        let tool_choice = tools.as_ref().map(|_| "auto".to_string());
+
+        NativeChatRequest {
+            model: model.to_string(),
+            messages: self.convert_messages_for_native(effective_messages, allow_user_image_parts),
+            temperature,
+            stream: Some(false),
+            // Non-streaming path; `usage` is on the final response body, not
+            // gated on `stream_options.include_usage`.
+            stream_options: None,
+            reasoning_effort: self.reasoning_effort_for_model(model),
+            tool_stream: self.tool_stream_for_tools(has_tool_entries),
+            tools,
+            tool_choice,
+            max_tokens: self.max_tokens,
+        }
+    }
+
     /// Normalize local file paths and remote URLs inside `[IMAGE:…]` markers
     /// to base64 data URIs before any message reaches the upstream provider.
     ///
@@ -2279,35 +2306,23 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
         let normalized = Self::normalize_messages_for_upstream(messages).await?;
         let merge = self.effective_merge_system(model);
         let effective_messages = Self::flatten_system_messages(&normalized, merge);
-        let effective_messages = self.strip_native_tool_messages(&effective_messages);
-        let api_messages: Vec<Message> = effective_messages
-            .iter()
-            .map(|m| Message {
-                role: m.role.clone(),
-                content: Self::to_message_content(&m.role, &m.content, !merge),
-            })
-            .collect();
-
-        let request = ApiChatRequest {
-            model: model.to_string(),
-            messages: api_messages,
-            temperature,
-            stream: Some(false),
-            stream_options: None,
-            reasoning_effort: self.reasoning_effort_for_model(model),
-            tool_stream: self.tool_stream_for_tools(!tools.is_empty()),
-            tools: if tools.is_empty() {
-                None
-            } else {
-                Some(tools.to_vec())
-            },
-            tool_choice: if tools.is_empty() {
-                None
-            } else {
-                Some("auto".to_string())
-            },
-            max_tokens: self.max_tokens,
+        let effective_messages = if self.native_tool_calling {
+            effective_messages
+        } else {
+            self.strip_native_tool_messages(&effective_messages)
         };
+        let tools = if tools.is_empty() {
+            None
+        } else {
+            Some(tools.to_vec())
+        };
+        let request = self.build_native_tool_chat_request(
+            &effective_messages,
+            tools,
+            model,
+            temperature,
+            !merge,
+        );
 
         let url = self.chat_completions_url();
         let response = match self
@@ -2401,26 +2416,22 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
         let normalized = Self::normalize_messages_for_upstream(request.messages).await?;
         let merge = self.effective_merge_system(model);
         let effective_messages = Self::flatten_system_messages(&normalized, merge);
-        let effective_messages = self.strip_native_tool_messages(&effective_messages);
+        let effective_messages = if self.native_tool_calling {
+            effective_messages
+        } else {
+            self.strip_native_tool_messages(&effective_messages)
+        };
 
         // When wire_api = "responses", route all turns through the responses API.
 
         let tools = self.convert_tool_specs_for_model(request.tools, model);
-        let native_request = NativeChatRequest {
-            model: model.to_string(),
-            messages: self.convert_messages_for_native(&effective_messages, !merge),
-            temperature,
-            stream: Some(false),
-            // Non-streaming path; `usage` is on the final response body, not
-            // gated on `stream_options.include_usage`.
-            stream_options: None,
-            reasoning_effort: self.reasoning_effort_for_model(model),
-            tool_stream: self
-                .tool_stream_for_tools(tools.as_ref().is_some_and(|tools| !tools.is_empty())),
-            tool_choice: tools.as_ref().map(|_| "auto".to_string()),
+        let native_request = self.build_native_tool_chat_request(
+            &effective_messages,
             tools,
-            max_tokens: self.max_tokens,
-        };
+            model,
+            temperature,
+            !merge,
+        );
 
         let url = self.chat_completions_url();
         let response = match self
@@ -4315,6 +4326,55 @@ mod tests {
             !err_msg.contains("API key not set"),
             "should not get credential error, got: {err_msg}"
         );
+    }
+
+    #[test]
+    fn chat_with_tools_request_preserves_reasoning_content_in_history() {
+        let p = make_model_provider("DeepSeek", "https://api.deepseek.example/v1", None);
+        let history_json = serde_json::json!({
+            "content": "I will inspect the workspace.",
+            "tool_calls": [{
+                "id": "call_1",
+                "name": "shell",
+                "arguments": "{\"cmd\":\"ls\"}"
+            }],
+            "reasoning_content": "Need to inspect the current files before answering."
+        });
+        let messages = vec![
+            ChatMessage::assistant(history_json.to_string()),
+            ChatMessage::tool(r#"{"tool_call_id":"call_1","content":"src\nCargo.toml"}"#),
+            ChatMessage::user("continue"),
+        ];
+        let tools = vec![serde_json::json!({
+            "type": "function",
+            "function": {
+                "name": "shell",
+                "description": "Run a shell command",
+                "parameters": {}
+            }
+        })];
+
+        let request = p.build_native_tool_chat_request(
+            &messages,
+            Some(tools),
+            "deepseek-v4-flash",
+            0.7,
+            true,
+        );
+        let value = serde_json::to_value(&request).unwrap();
+        let first_message = &value["messages"][0];
+
+        assert_eq!(first_message["role"], "assistant");
+        assert_eq!(
+            first_message["reasoning_content"],
+            "Need to inspect the current files before answering."
+        );
+        assert!(
+            first_message["tool_calls"].is_array(),
+            "assistant tool-call history must stay native in chat_with_tools requests"
+        );
+        assert_eq!(value["tools"][0]["function"]["name"], "shell");
+        assert_eq!(value["tool_choice"], "auto");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Routes compatible-provider native tool requests through `NativeChatRequest` instead of the older role/content-only `ApiChatRequest` shape.
  - Reuses the native message conversion path so assistant tool-call history preserves `reasoning_content` when the next request is sent.
  - Shares the non-streaming native request builder between `chat()` and `chat_with_tools()` so request fields do not drift between the two paths.
  - Adds a regression test for assistant tool-call history that includes `reasoning_content`.
- **Scope boundary:** This PR only fixes the compatible-provider native tool request replay path. It does not change streaming capture, plain-text assistant replay, context compression, provider routing, gateway websocket behavior, or DeepSeek-specific provider configuration.
- **Blast radius:** Compatible-provider `chat_with_tools()` requests now use the same native request shape as `chat()`, which already used `NativeChatRequest`. The change affects request serialization for the native non-streaming `chat()` / `chat_with_tools()` path, but keeps the existing tool fields, `tool_choice`, `tool_stream`, `reasoning_effort`, `max_tokens`, and fallback behavior.
- **Linked issue(s):** Related #6059
- **Labels:** `bug`, `risk: medium`, `size: S`, `provider`, `provider:compatible`, `provider:deepseek`

## Validation Evidence (required)

- **Commands run and tail output:**

```text
cargo fmt --all -- --check
result: passed

git diff --check
result: passed

cargo test -p zeroclaw-providers chat_with_tools_request_preserves_reasoning_content_in_history -- --nocapture
result: passed
running 1 test
test compatible::tests::chat_with_tools_request_preserves_reasoning_content_in_history ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 872 filtered out

cargo clippy --all-targets -- -D warnings
result: passed
```

- **Beyond CI — what did you manually verify?** I compared the old `chat_with_tools()` request construction against the existing native `chat()` path and the issue's latest gateway repro. The updated path preserves the assistant `reasoning_content` field and native `tool_calls` when serializing the next request, while keeping the tool list and `tool_choice: auto` in the outgoing payload.
- **If any command was intentionally skipped, why:** Local CI-shaped full tests were not run on this machine. For this narrow one-file provider serialization fix, I’m relying on the green GitHub Actions Test job for broad test coverage, alongside the focused local regression and workspace-shaped clippy evidence above.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: `N/A`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No user action required.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** Revert this PR.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Compatible providers with native tool calls may reject multi-turn thinking-mode requests again with errors like `reasoning_content in the thinking mode must be passed back to the API`, especially after an assistant tool-call response is replayed through the gateway/tool loop.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): `N/A`
- Scope materially carried forward: `N/A`
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why (inspiration-only, no direct code/design carry-over): This PR is a narrow new fix for the latest native-tool request path identified on #6059. Related PRs #6284 and #6285 cover sibling replay/compression paths and are not superseded here.
