### PR TITLE
fix(runtime): fall back before visible stream errors

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -1815,6 +1815,8 @@ impl Agent {
             let mut streamed_tool_calls: Vec<zeroclaw_providers::traits::ToolCall> = Vec::new();
             let mut streamed_usage: Option<zeroclaw_providers::traits::TokenUsage> = None;
             let mut got_stream = false;
+            let mut visible_streamed_output = false;
+            let mut stream_error: Option<String> = None;
             let mut pre_executed_call_ids: HashMap<String, VecDeque<String>> = HashMap::new();
             let mut was_cancelled = false;
 
@@ -1852,12 +1854,14 @@ impl Agent {
                                 let _ = event_tx
                                     .send(TurnEvent::Thinking { delta: reasoning })
                                     .await;
+                                visible_streamed_output = true;
                             }
                             if !chunk.delta.is_empty() {
                                 got_stream = true;
                                 streamed_text.push_str(&chunk.delta);
                                 let _ =
                                     event_tx.send(TurnEvent::Chunk { delta: chunk.delta }).await;
+                                visible_streamed_output = true;
                             }
                         }
                         zeroclaw_providers::traits::StreamEvent::ToolCall(tc) => {
@@ -1882,6 +1886,7 @@ impl Agent {
                                     args: serde_json::from_str(&args).unwrap_or_default(),
                                 })
                                 .await;
+                            visible_streamed_output = true;
                             // NOT pushed to streamed_tool_calls — already executed by proxy
                         }
                         zeroclaw_providers::traits::StreamEvent::PreExecutedToolResult {
@@ -1899,6 +1904,7 @@ impl Agent {
                                     output,
                                 })
                                 .await;
+                            visible_streamed_output = true;
                         }
                         zeroclaw_providers::traits::StreamEvent::Usage(usage) => {
                             streamed_usage = Some(usage);
@@ -1906,35 +1912,7 @@ impl Agent {
                         zeroclaw_providers::traits::StreamEvent::Final => break,
                     },
                     Err(error) => {
-                        if got_stream || !committed_response.is_empty() {
-                            if !streamed_text.is_empty() {
-                                let partial = Self::marked_partial_response(
-                                    &streamed_text,
-                                    "[stream interrupted]",
-                                );
-                                self.append_streamed_assistant_message_to_history(
-                                    partial,
-                                    &mut new_msgs,
-                                    &mut committed_response,
-                                );
-                            }
-                            let safe_error =
-                                zeroclaw_providers::sanitize_api_error(&error.to_string());
-                            self.observer.record_event(&ObserverEvent::LlmResponse {
-                                model_provider: self.model_provider_name.clone(),
-                                model: effective_model.clone(),
-                                duration: llm_started_at.elapsed(),
-                                success: false,
-                                error_message: Some(safe_error),
-                                input_tokens: None,
-                                output_tokens: None,
-                            });
-                            return Err(StreamedTurnError {
-                                error: anyhow::Error::msg(error.to_string()),
-                                committed_response,
-                                new_messages: new_msgs,
-                            });
-                        }
+                        stream_error = Some(error.to_string());
                         break;
                     }
                 }
@@ -1969,9 +1947,41 @@ impl Agent {
                 });
             }
 
-            // If streaming produced text, use it as the response and
-            // check for tool calls via the dispatcher.
-            let response = if got_stream {
+            if stream_error.is_some() && visible_streamed_output {
+                if !streamed_text.is_empty() {
+                    let partial =
+                        Self::marked_partial_response(&streamed_text, "[stream interrupted]");
+                    self.append_streamed_assistant_message_to_history(
+                        partial,
+                        &mut new_msgs,
+                        &mut committed_response,
+                    );
+                }
+                let safe_error = zeroclaw_providers::sanitize_api_error(
+                    stream_error.as_deref().unwrap_or_default(),
+                );
+                self.observer.record_event(&ObserverEvent::LlmResponse {
+                    model_provider: self.model_provider_name.clone(),
+                    model: effective_model.clone(),
+                    duration: llm_started_at.elapsed(),
+                    success: false,
+                    error_message: Some(safe_error),
+                    input_tokens: None,
+                    output_tokens: None,
+                });
+                return Err(StreamedTurnError {
+                    error: anyhow::Error::msg(stream_error.unwrap_or_default()),
+                    committed_response,
+                    new_messages: new_msgs,
+                });
+            }
+
+            // If streaming completed cleanly and produced text, use it as the
+            // response and check for tool calls via the dispatcher. If the
+            // stream errored before emitting visible output, fall back to
+            // non-streaming chat so provider error text does not become the
+            // final answer.
+            let response = if got_stream && stream_error.is_none() {
                 // Build a synthetic ChatResponse from streamed text.
                 // `streamed_reasoning` carries signed thinking blocks from
                 // providers that emit them via `StreamChunk.reasoning`
@@ -1988,6 +1998,18 @@ impl Agent {
                     },
                 }
             } else {
+                if let Some(error) = stream_error.as_ref() {
+                    ::zeroclaw_log::record!(
+                        WARN,
+                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+                            .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                            .with_attrs(::serde_json::json!({
+                                "model": effective_model.as_str(),
+                                "error": zeroclaw_providers::sanitize_api_error(error),
+                            })),
+                        "turn_streamed provider stream failed; falling back to non-streaming chat"
+                    );
+                }
                 // Fall back to non-streaming chat, with cancellation guard
                 let chat_fut = self.model_provider.chat(
                     ChatRequest {
@@ -2006,8 +2028,16 @@ impl Agent {
                     tokio::select! {
                         biased;
                         () = token.cancelled() => {
+                            let partial = if streamed_text.is_empty() {
+                                "[interrupted by user]".to_string()
+                            } else {
+                                Self::marked_partial_response(
+                                    &streamed_text,
+                                    "[interrupted by user]",
+                                )
+                            };
                             self.append_streamed_assistant_message_to_history(
-                                "[interrupted by user]".to_string(),
+                                partial,
                                 &mut new_msgs,
                                 &mut committed_response,
                             );
@@ -2044,6 +2074,17 @@ impl Agent {
                             input_tokens: None,
                             output_tokens: None,
                         });
+                        if got_stream && !streamed_text.is_empty() {
+                            let partial = Self::marked_partial_response(
+                                &streamed_text,
+                                "[stream interrupted]",
+                            );
+                            self.append_streamed_assistant_message_to_history(
+                                partial,
+                                &mut new_msgs,
+                                &mut committed_response,
+                            );
+                        }
                         return Err(StreamedTurnError {
                             error,
                             committed_response,
@@ -2483,7 +2524,9 @@ mod tests {
         seen_messages: Arc<Mutex<Vec<Vec<ChatMessage>>>>,
         call_count: AtomicUsize,
         fail_on_call: Option<usize>,
+        fail_chat_on_call: Option<usize>,
         fail_after_delta_on_call: Option<usize>,
+        delay_chat_on_call: Option<usize>,
     }
 
     #[async_trait]
@@ -2506,8 +2549,14 @@ mod tests {
         ) -> Result<zeroclaw_providers::ChatResponse> {
             let call = self.call_count.fetch_add(1, Ordering::SeqCst) + 1;
             self.seen_messages.lock().push(request.messages.to_vec());
+            if self.delay_chat_on_call == Some(call) {
+                tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+            }
             if self.fail_on_call == Some(call) {
                 anyhow::bail!("synthetic provider failure on call {call}");
+            }
+            if self.fail_chat_on_call == Some(call) {
+                anyhow::bail!("synthetic chat failure on call {call}");
             }
             if self.fail_after_delta_on_call == Some(call) {
                 anyhow::bail!("synthetic provider failure after delta on call {call}");
@@ -4711,7 +4760,9 @@ mod tests {
             seen_messages: seen_messages.clone(),
             call_count: AtomicUsize::new(0),
             fail_on_call: None,
+            fail_chat_on_call: None,
             fail_after_delta_on_call: None,
+            delay_chat_on_call: None,
         });
         let observer: Arc<dyn Observer> = Arc::from(crate::observability::NoopObserver {});
         let mut agent = Agent::builder()
@@ -4807,7 +4858,9 @@ mod tests {
             seen_messages: Arc::new(Mutex::new(Vec::new())),
             call_count: AtomicUsize::new(0),
             fail_on_call: Some(2),
+            fail_chat_on_call: Some(3),
             fail_after_delta_on_call: None,
+            delay_chat_on_call: None,
         });
         let observer: Arc<dyn Observer> = Arc::from(crate::observability::NoopObserver {});
         let mut agent = Agent::builder()
@@ -4861,7 +4914,73 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn turn_streamed_error_after_delta_returns_visible_partial_output() {
+    async fn turn_streamed_error_before_visible_output_falls_back_to_chat() {
+        let memory_cfg = zeroclaw_config::schema::MemoryConfig {
+            backend: "none".into(),
+            ..zeroclaw_config::schema::MemoryConfig::default()
+        };
+        let mem: Arc<dyn Memory> = Arc::from(
+            zeroclaw_memory::create_memory(&memory_cfg, std::path::Path::new("/tmp"), None)
+                .expect("memory creation should succeed with valid config"),
+        );
+
+        let seen_messages = Arc::new(Mutex::new(Vec::new()));
+        let model_provider = Box::new(StreamingSteeringModelProvider {
+            seen_messages: seen_messages.clone(),
+            call_count: AtomicUsize::new(0),
+            fail_on_call: Some(1),
+            fail_chat_on_call: None,
+            fail_after_delta_on_call: None,
+            delay_chat_on_call: None,
+        });
+        let observer: Arc<dyn Observer> = Arc::from(crate::observability::NoopObserver {});
+        let mut agent = Agent::builder()
+            .model_provider(model_provider)
+            .tools(vec![Box::new(MockTool)])
+            .memory(mem)
+            .observer(observer)
+            .tool_dispatcher(Box::new(NativeToolDispatcher))
+            .workspace_dir(std::path::PathBuf::from("/tmp"))
+            .build()
+            .expect("agent builder should succeed with valid config");
+
+        let (event_tx, _event_rx) = tokio::sync::mpsc::channel::<TurnEvent>(64);
+        let handle = tokio::spawn(async move {
+            agent
+                .turn_streamed_with_steering_state("first", event_tx, None, None)
+                .await
+        });
+
+        let outcome = handle
+            .await
+            .expect("turn task should finish")
+            .expect("pre-output stream failure should fall back to non-streaming chat");
+        assert_eq!(outcome.response, "final");
+        assert!(
+            outcome.new_messages.iter().any(|msg| {
+                matches!(msg, ConversationMessage::Chat(message) if message.role == "assistant" && message.content == "final")
+            }),
+            "new messages should carry the fallback assistant answer"
+        );
+        assert!(
+            !outcome.new_messages.iter().any(|msg| {
+                matches!(msg, ConversationMessage::Chat(message) if message.role == "assistant" && message.content.contains("[stream interrupted]"))
+            }),
+            "successful fallback should not persist interrupted stream text"
+        );
+
+        let seen = seen_messages.lock();
+        assert_eq!(seen.len(), 2);
+        assert!(
+            !seen[1]
+                .iter()
+                .any(|msg| { msg.role == "assistant" && msg.content.contains("draft") }),
+            "fallback chat must not receive the abandoned stream attempt as prior assistant text"
+        );
+    }
+
+    #[tokio::test]
+    async fn turn_streamed_error_after_delta_preserves_visible_partial() {
         let memory_cfg = zeroclaw_config::schema::MemoryConfig {
             backend: "none".into(),
             ..zeroclaw_config::schema::MemoryConfig::default()
@@ -4875,7 +4994,9 @@ mod tests {
             seen_messages: Arc::new(Mutex::new(Vec::new())),
             call_count: AtomicUsize::new(0),
             fail_on_call: None,
+            fail_chat_on_call: None,
             fail_after_delta_on_call: Some(1),
+            delay_chat_on_call: None,
         });
         let observer: Arc<dyn Observer> = Arc::from(crate::observability::NoopObserver {});
         let mut agent = Agent::builder()
@@ -4906,7 +5027,7 @@ mod tests {
         let err = handle
             .await
             .expect("turn task should finish")
-            .expect_err("provider stream failure should be returned");
+            .expect_err("post-output stream failure should return an error with partial output");
         assert!(
             err.error
                 .to_string()
@@ -4915,18 +5036,74 @@ mod tests {
             err.error
         );
         assert!(
-            err.committed_response.contains("draft"),
-            "visible streamed text should be committed after a provider stream error"
-        );
-        assert!(
             err.committed_response.contains("[stream interrupted]"),
-            "persisted partial text should mark that the stream did not complete"
+            "persisted partial text should mark that the visible stream was interrupted"
         );
         assert!(
             err.new_messages.iter().any(|msg| {
                 matches!(msg, ConversationMessage::Chat(message) if message.role == "assistant" && message.content.contains("draft"))
             }),
             "new messages should carry the visible assistant partial for gateway persistence"
+        );
+    }
+
+    #[tokio::test]
+    async fn turn_streamed_error_before_visible_output_fallback_can_be_cancelled() {
+        let memory_cfg = zeroclaw_config::schema::MemoryConfig {
+            backend: "none".into(),
+            ..zeroclaw_config::schema::MemoryConfig::default()
+        };
+        let mem: Arc<dyn Memory> = Arc::from(
+            zeroclaw_memory::create_memory(&memory_cfg, std::path::Path::new("/tmp"), None)
+                .expect("memory creation should succeed with valid config"),
+        );
+
+        let model_provider = Box::new(StreamingSteeringModelProvider {
+            seen_messages: Arc::new(Mutex::new(Vec::new())),
+            call_count: AtomicUsize::new(0),
+            fail_on_call: Some(1),
+            fail_chat_on_call: None,
+            fail_after_delta_on_call: None,
+            delay_chat_on_call: Some(2),
+        });
+        let observer: Arc<dyn Observer> = Arc::from(crate::observability::NoopObserver {});
+        let mut agent = Agent::builder()
+            .model_provider(model_provider)
+            .tools(vec![Box::new(MockTool)])
+            .memory(mem)
+            .observer(observer)
+            .tool_dispatcher(Box::new(NativeToolDispatcher))
+            .workspace_dir(std::path::PathBuf::from("/tmp"))
+            .build()
+            .expect("agent builder should succeed with valid config");
+
+        let (event_tx, _event_rx) = tokio::sync::mpsc::channel::<TurnEvent>(64);
+        let cancel_token = tokio_util::sync::CancellationToken::new();
+        let cancel_for_task = cancel_token.clone();
+        let handle = tokio::spawn(async move {
+            agent
+                .turn_streamed_with_steering_state("first", event_tx, Some(cancel_for_task), None)
+                .await
+        });
+
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        cancel_token.cancel();
+
+        let err = handle
+            .await
+            .expect("turn task should finish")
+            .expect_err("cancelled fallback should return cancellation");
+        assert!(
+            crate::agent::loop_::is_tool_loop_cancelled(&err.error),
+            "unexpected error: {}",
+            err.error
+        );
+        assert_eq!(err.committed_response, "[interrupted by user]");
+        assert!(
+            err.new_messages.iter().any(|msg| {
+                matches!(msg, ConversationMessage::Chat(message) if message.role == "assistant" && message.content == "[interrupted by user]")
+            }),
+            "pre-output fallback cancellation should include an interruption marker"
         );
     }
 
@@ -4945,7 +5122,9 @@ mod tests {
             seen_messages: Arc::new(Mutex::new(Vec::new())),
             call_count: AtomicUsize::new(0),
             fail_on_call: None,
+            fail_chat_on_call: None,
             fail_after_delta_on_call: None,
+            delay_chat_on_call: None,
         });
         let observer: Arc<dyn Observer> = Arc::from(crate::observability::NoopObserver {});
         let mut agent = Agent::builder()
@@ -4996,7 +5175,9 @@ mod tests {
             seen_messages: Arc::new(Mutex::new(Vec::new())),
             call_count: AtomicUsize::new(0),
             fail_on_call: None,
+            fail_chat_on_call: None,
             fail_after_delta_on_call: Some(1),
+            delay_chat_on_call: None,
         });
         let capturing = Arc::new(CapturingObserver::default());
         let observer: Arc<dyn Observer> = capturing.clone();
@@ -5092,7 +5273,9 @@ mod tests {
             seen_messages: Arc::new(Mutex::new(Vec::new())),
             call_count: AtomicUsize::new(0),
             fail_on_call: None,
+            fail_chat_on_call: None,
             fail_after_delta_on_call: None,
+            delay_chat_on_call: None,
         });
         let capturing = Arc::new(CapturingObserver::default());
         let observer: Arc<dyn Observer> = capturing.clone();


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Restores the #4675 stream-error recovery path for runtime streamed turns, but keeps it conservative: if a provider stream fails before anything visible reaches the client, `turn_streamed` retries through the existing non-streaming chat path instead of turning provider error text into the answer.
- **What changed and why:** If the provider stream fails after visible output has already reached the client, the runtime keeps the visible partial with `[stream interrupted]` instead of silently replacing it with a different fallback answer. That keeps the live append-only stream and persisted answer consistent.
- **What changed and why:** Adds or updates focused regressions for pre-visible fallback, cancellation during fallback, post-visible partial preservation, and LLM observer-event preservation.
- **Scope boundary:** Does not change normal successful streaming, the non-streaming `turn()` path, provider tool-spec handling, or gateway WebSocket framing.
- **Blast radius:** Limited to runtime streamed agent turns, including `Agent::turn_streamed` and `turn_streamed_with_steering_state`.
- **Linked issue(s):** Related #6074. Supersedes #4675 for the `b58d18d5` stream-error fallback slice.
- **Labels:** `bug`, `risk: high`, `size: S`, `runtime`, `agent`

## Validation Evidence (required)

- **Commands run and result summaries:**

```text
zc-cargo test -p zeroclaw-runtime --lib turn_streamed_with_steering_error_returns_committed_partial_output -- --nocapture
Result: passed. 1 selected existing regression test passed, 0 failed.

zc-cargo test -p zeroclaw-runtime --lib turn_streamed_error -- --nocapture
Result: passed. 3 selected tests matching the `turn_streamed_error` filter passed, 0 failed.
Coverage: pre-visible-output fallback, pre-visible-output fallback cancellation, and post-visible-output partial preservation.

zc-cargo fmt --all -- --check
Result: passed.

git diff --check
Result: passed.

zc-cargo clippy -p zeroclaw-runtime --lib -- -D warnings
Result: passed.

zc-cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
Result: passed.

zc-cargo nextest run --locked --workspace --exclude zeroclaw-desktop
Result: passed. 8108 tests run, 8108 passed, 1 leaky, 10 skipped.

After rebasing onto current master:

zc-cargo test -p zeroclaw-runtime --lib turn_streamed -- --nocapture
Result: passed. 11 selected `turn_streamed` tests passed, 0 failed.
Coverage: stream fallback behavior plus LLM observer-event preservation after the rebase.

zc-cargo fmt --all -- --check
Result: passed.

git diff --check origin/master...HEAD
Result: passed.

zc-cargo clippy -p zeroclaw-runtime --lib -- -D warnings
Result: passed.
```

- **Beyond CI — what did you manually verify?** Reviewed the affected runtime stream loop. The new behavior only uses fallback before any visible `Thinking`, `Chunk`, pre-executed tool call, or pre-executed tool result event is sent. Once visible output exists, the runtime preserves the partial response instead of making the final answer disagree with what the client already saw. The rebase resolution also preserves LLM observer events on streamed success, streamed failure, cancellation, fallback failure, and fallback success paths.
- **If any command was intentionally skipped, why:** Full local nextest and workspace-shaped clippy were not rerun after the current-master rebase because the rebase conflict was isolated to `Agent::turn_streamed` integration with observer events. The focused post-rebase suite covers that conflict directly; GitHub Actions is green on the rebased head, including Test, Security, Lint, platform builds, all-features/no-default/32-bit checks, benchmarks compile, and CI Required Gate.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `Yes`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: On provider stream failure before visible output, the runtime may make one fallback call through the existing non-streaming provider chat path. It reuses the same prepared messages, model, tool specs, provider client, and credential handling; no new destination, permission, or secret surface is introduced.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No user migration required. This only changes streamed-turn error handling.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <merge-sha>`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Streamed runtime turns may return provider streaming error text as the assistant answer, may fail to recover from pre-output stream errors, may omit LLM observer events on streamed-turn failures, or may persist a response that disagrees with visible streamed output.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line):
  - #4675 by @tylerjenningsw
- Scope materially carried forward: Restores the lost stream-error fallback behavior from #4675 for the current `Agent::turn_streamed` implementation, with a narrower post-visible-output rule to preserve append-only stream consistency.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `Yes`
- If `No`, why (inspiration-only, no direct code/design carry-over): `N/A`
