### PR TITLE
feat(gateway): report honest channel readiness

### DIFF
--- a/crates/zeroclaw-gateway/src/api.rs
+++ b/crates/zeroclaw-gateway/src/api.rs
@@ -8,7 +8,7 @@ use axum::{
     http::{HeaderMap, StatusCode, header},
     response::{IntoResponse, Json},
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 // ── Bearer token auth extractor ─────────────────────────────────
 
@@ -1128,6 +1128,7 @@ pub async fn handle_api_channels(
     }
 
     let config = state.config.read().clone();
+    let health = zeroclaw_runtime::health::snapshot();
     // One entry per `[channels.<type>.<alias>]` block (v0.8.0). Owning
     // agent comes from the agents.<alias>.channels reverse lookup.
     let channels: Vec<serde_json::Value> = config
@@ -1135,21 +1136,187 @@ pub async fn handle_api_channels(
         .into_iter()
         .map(|info| {
             let composite = format!("{}.{}", info.channel_type, info.alias);
+            let readiness = channel_readiness(&config, &info, &health, &state);
+            let (status, health_status) = channel_readiness_summary(&readiness);
             serde_json::json!({
                 "name": composite,
                 "type": info.channel_type,
                 "alias": info.alias,
                 "owning_agent": info.owning_agent,
                 "enabled": info.enabled,
-                "status": "active",
+                "status": status,
                 "message_count": 0,
                 "last_message_at": null,
-                "health": "healthy",
+                "health": health_status,
+                "readiness": readiness,
             })
         })
         .collect();
 
     Json(serde_json::json!({ "channels": channels })).into_response()
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum ChannelReadinessState {
+    Ready,
+    Missing,
+    Unknown,
+}
+
+const CHANNEL_LISTENER_HEALTH_MAX_AGE_SECS: i64 = 30;
+
+#[derive(Debug, Clone, Serialize)]
+struct ChannelReadiness {
+    enabled: ChannelReadinessState,
+    bound_to_agent: ChannelReadinessState,
+    authenticated: ChannelReadinessState,
+    listening: ChannelReadinessState,
+    requirements: Vec<String>,
+    notes: Vec<String>,
+}
+
+fn channel_readiness(
+    config: &zeroclaw_config::schema::Config,
+    info: &zeroclaw_config::schema::ChannelAliasInfo,
+    health: &zeroclaw_runtime::health::HealthSnapshot,
+    state: &AppState,
+) -> ChannelReadiness {
+    let mut readiness = ChannelReadiness {
+        enabled: if info.enabled {
+            ChannelReadinessState::Ready
+        } else {
+            ChannelReadinessState::Missing
+        },
+        bound_to_agent: if info.owning_agent.is_some() {
+            ChannelReadinessState::Ready
+        } else {
+            ChannelReadinessState::Missing
+        },
+        authenticated: ChannelReadinessState::Unknown,
+        listening: ChannelReadinessState::Unknown,
+        requirements: Vec::new(),
+        notes: Vec::new(),
+    };
+
+    if readiness.enabled == ChannelReadinessState::Missing {
+        readiness
+            .requirements
+            .push("Enable this channel alias.".to_string());
+    }
+    if readiness.bound_to_agent == ChannelReadinessState::Missing {
+        readiness
+            .requirements
+            .push("Bind this channel to an enabled agent.".to_string());
+    }
+
+    if readiness.enabled == ChannelReadinessState::Ready
+        && readiness.bound_to_agent == ChannelReadinessState::Ready
+    {
+        if info.channel_type == "webhook" {
+            apply_webhook_readiness(config, &info.alias, health, state, &mut readiness);
+        } else {
+            readiness.notes.push(format!(
+                "Live readiness is not checked for `{}` channels yet.",
+                info.channel_type
+            ));
+        }
+    }
+
+    readiness
+}
+
+fn channel_readiness_summary(readiness: &ChannelReadiness) -> (&'static str, &'static str) {
+    if readiness.enabled == ChannelReadinessState::Missing
+        || readiness.bound_to_agent == ChannelReadinessState::Missing
+    {
+        return ("inactive", "degraded");
+    }
+
+    if readiness.authenticated == ChannelReadinessState::Unknown
+        && readiness.listening == ChannelReadinessState::Unknown
+    {
+        return ("unknown", "degraded");
+    }
+
+    if readiness.authenticated == ChannelReadinessState::Ready
+        && readiness.listening == ChannelReadinessState::Ready
+    {
+        ("active", "healthy")
+    } else {
+        ("error", "down")
+    }
+}
+
+fn apply_webhook_readiness(
+    config: &zeroclaw_config::schema::Config,
+    alias: &str,
+    health: &zeroclaw_runtime::health::HealthSnapshot,
+    state: &AppState,
+    readiness: &mut ChannelReadiness,
+) {
+    let Some(webhook) = config.channels.webhook.get(alias) else {
+        readiness.authenticated = ChannelReadinessState::Missing;
+        readiness.listening = ChannelReadinessState::Missing;
+        readiness
+            .requirements
+            .push("Webhook config block is missing.".to_string());
+        return;
+    };
+
+    if state.pairing.require_pairing() && !state.pairing.is_paired() {
+        readiness.authenticated = ChannelReadinessState::Missing;
+        readiness
+            .requirements
+            .push("Pair the gateway before using the webhook endpoint.".to_string());
+    } else {
+        readiness.authenticated = ChannelReadinessState::Ready;
+    }
+
+    let component = format!("channel:webhook.{alias}");
+    let component_health = health.components.get(&component);
+    let component_status = component_health.map(|component| component.status.as_str());
+    let supervised_listener_ok = component_health.is_some_and(component_health_ok_and_fresh);
+    let listen_path = normalized_webhook_path(webhook.listen_path.as_deref());
+
+    if supervised_listener_ok {
+        readiness.listening = ChannelReadinessState::Ready;
+    } else if component_status == Some("error") {
+        readiness.listening = ChannelReadinessState::Missing;
+        readiness.requirements.push(format!(
+            "Resolve the listener error for `webhook.{alias}` before using this channel."
+        ));
+    } else {
+        readiness.listening = ChannelReadinessState::Missing;
+        readiness.requirements.push(format!(
+            "Start a channel listener for `webhook.{alias}` on port {}{}.",
+            webhook.port, listen_path
+        ));
+    }
+}
+
+fn component_health_ok_and_fresh(component: &zeroclaw_runtime::health::ComponentHealth) -> bool {
+    if component.status != "ok" {
+        return false;
+    }
+
+    let Ok(updated_at) = chrono::DateTime::parse_from_rfc3339(&component.updated_at) else {
+        return false;
+    };
+    let age = chrono::Utc::now().signed_duration_since(updated_at.with_timezone(&chrono::Utc));
+    age >= chrono::Duration::zero()
+        && age <= chrono::Duration::seconds(CHANNEL_LISTENER_HEALTH_MAX_AGE_SECS)
+}
+
+fn normalized_webhook_path(path: Option<&str>) -> String {
+    let trimmed = path.unwrap_or("/webhook").trim();
+    if trimmed.is_empty() {
+        "/webhook".to_string()
+    } else if trimmed.starts_with('/') {
+        trimmed.to_string()
+    } else {
+        format!("/{trimmed}")
+    }
 }
 
 /// GET /api/health — component health snapshot
@@ -1853,6 +2020,236 @@ mod tests {
             .expect("test-agent configured by with_test_agent")
             .cron_jobs
             .push(job_id.to_string());
+    }
+
+    fn config_with_webhook(
+        alias: &str,
+        enabled: bool,
+        bound: bool,
+        port: u16,
+        listen_path: Option<&str>,
+    ) -> zeroclaw_config::schema::Config {
+        let mut config = zeroclaw_config::schema::Config::default();
+        config.gateway.port = 42617;
+        config.gateway.require_pairing = false;
+        config.channels.webhook.insert(
+            alias.to_string(),
+            zeroclaw_config::schema::WebhookConfig {
+                enabled,
+                port,
+                listen_path: listen_path.map(ToString::to_string),
+                ..Default::default()
+            },
+        );
+        if bound {
+            config.agents.insert(
+                "rowan".to_string(),
+                zeroclaw_config::schema::AliasedAgentConfig {
+                    channels: vec![zeroclaw_config::providers::ChannelRef::new(format!(
+                        "webhook.{alias}"
+                    ))],
+                    ..Default::default()
+                },
+            );
+        }
+        config
+    }
+
+    fn config_with_telegram(alias: &str) -> zeroclaw_config::schema::Config {
+        let mut config = zeroclaw_config::schema::Config::default();
+        config.channels.telegram.insert(
+            alias.to_string(),
+            zeroclaw_config::schema::TelegramConfig {
+                enabled: true,
+                bot_token: "test-token".to_string(),
+                ..Default::default()
+            },
+        );
+        config.agents.insert(
+            "rowan".to_string(),
+            zeroclaw_config::schema::AliasedAgentConfig {
+                channels: vec![zeroclaw_config::providers::ChannelRef::new(format!(
+                    "telegram.{alias}"
+                ))],
+                ..Default::default()
+            },
+        );
+        config
+    }
+
+    fn first_channel_info(
+        config: &zeroclaw_config::schema::Config,
+    ) -> zeroclaw_config::schema::ChannelAliasInfo {
+        config
+            .channels_by_alias()
+            .into_iter()
+            .next()
+            .expect("channel alias should be present")
+    }
+
+    #[test]
+    fn channel_readiness_webhook_does_not_call_gateway_route_healthy_without_listener() {
+        let config = config_with_webhook("default", true, true, 42617, Some("/webhook"));
+        let state = test_state(config.clone());
+        let health = zeroclaw_runtime::health::snapshot();
+        let info = first_channel_info(&config);
+        let readiness = channel_readiness(&config, &info, &health, &state);
+
+        assert_eq!(readiness.authenticated, ChannelReadinessState::Ready);
+        assert_eq!(readiness.listening, ChannelReadinessState::Missing);
+        assert_eq!(channel_readiness_summary(&readiness), ("error", "down"));
+        assert!(
+            readiness
+                .requirements
+                .iter()
+                .any(|item| item.contains("Start a channel listener"))
+        );
+    }
+
+    #[test]
+    fn channel_readiness_webhook_does_not_call_custom_path_healthy_without_listener() {
+        let config = config_with_webhook("custom_path", true, true, 42632, Some("/eyrie"));
+        let state = test_state(config.clone());
+        let health = zeroclaw_runtime::health::snapshot();
+        let info = first_channel_info(&config);
+        let readiness = channel_readiness(&config, &info, &health, &state);
+
+        assert_eq!(readiness.authenticated, ChannelReadinessState::Ready);
+        assert_eq!(readiness.listening, ChannelReadinessState::Missing);
+        assert_eq!(channel_readiness_summary(&readiness), ("error", "down"));
+        assert!(
+            readiness
+                .requirements
+                .iter()
+                .any(|item| item.contains("Start a channel listener"))
+        );
+    }
+
+    #[test]
+    fn channel_readiness_webhook_uses_supervised_listener_health_for_custom_path() {
+        let config = config_with_webhook("supervised", true, true, 42632, Some("/eyrie"));
+        zeroclaw_runtime::health::mark_component_ok("channel:webhook.supervised");
+        let state = test_state(config.clone());
+        let health = zeroclaw_runtime::health::snapshot();
+        let info = first_channel_info(&config);
+        let readiness = channel_readiness(&config, &info, &health, &state);
+
+        assert_eq!(readiness.listening, ChannelReadinessState::Ready);
+        assert_eq!(channel_readiness_summary(&readiness), ("active", "healthy"));
+    }
+
+    #[test]
+    fn channel_readiness_webhook_rejects_stale_listener_health() {
+        let config = config_with_webhook("stale", true, true, 42632, Some("/eyrie"));
+        let component = "channel:webhook.stale".to_string();
+        let old = (chrono::Utc::now()
+            - chrono::Duration::seconds(CHANNEL_LISTENER_HEALTH_MAX_AGE_SECS + 5))
+        .to_rfc3339();
+        let health = zeroclaw_runtime::health::HealthSnapshot {
+            pid: std::process::id(),
+            updated_at: chrono::Utc::now().to_rfc3339(),
+            uptime_seconds: 1,
+            components: std::collections::BTreeMap::from([(
+                component,
+                zeroclaw_runtime::health::ComponentHealth {
+                    status: "ok".to_string(),
+                    updated_at: old,
+                    last_ok: None,
+                    last_error: None,
+                    restart_count: 0,
+                },
+            )]),
+        };
+        let state = test_state(config.clone());
+        let info = first_channel_info(&config);
+        let readiness = channel_readiness(&config, &info, &health, &state);
+
+        assert_eq!(readiness.listening, ChannelReadinessState::Missing);
+        assert_eq!(channel_readiness_summary(&readiness), ("error", "down"));
+    }
+
+    #[test]
+    fn channel_readiness_webhook_uses_live_pairing_guard_for_auth() {
+        let config = config_with_webhook("paired", true, true, 42632, Some("/eyrie"));
+        zeroclaw_runtime::health::mark_component_ok("channel:webhook.paired");
+        let mut state = test_state(config.clone());
+        state.pairing = Arc::new(PairingGuard::new(true, &[]));
+        let health = zeroclaw_runtime::health::snapshot();
+        let info = first_channel_info(&config);
+        let readiness = channel_readiness(&config, &info, &health, &state);
+
+        assert_eq!(readiness.authenticated, ChannelReadinessState::Missing);
+        assert_eq!(readiness.listening, ChannelReadinessState::Ready);
+        assert_eq!(channel_readiness_summary(&readiness), ("error", "down"));
+    }
+
+    #[test]
+    fn channel_readiness_unchecked_channel_types_are_unknown_not_down() {
+        let config = config_with_telegram("ops");
+        let state = test_state(config.clone());
+        let health = zeroclaw_runtime::health::snapshot();
+        let info = first_channel_info(&config);
+        let readiness = channel_readiness(&config, &info, &health, &state);
+
+        assert_eq!(readiness.enabled, ChannelReadinessState::Ready);
+        assert_eq!(readiness.bound_to_agent, ChannelReadinessState::Ready);
+        assert_eq!(readiness.authenticated, ChannelReadinessState::Unknown);
+        assert_eq!(readiness.listening, ChannelReadinessState::Unknown);
+        assert_eq!(
+            channel_readiness_summary(&readiness),
+            ("unknown", "degraded")
+        );
+        assert!(readiness.requirements.is_empty());
+        assert!(
+            readiness
+                .notes
+                .iter()
+                .any(|item| item.contains("not checked"))
+        );
+    }
+
+    #[test]
+    fn channel_readiness_orphan_channel_reports_missing_agent_binding_without_broken_health() {
+        let config = config_with_webhook("orphan", true, false, 42617, Some("/webhook"));
+        let state = test_state(config.clone());
+        let health = zeroclaw_runtime::health::snapshot();
+        let info = first_channel_info(&config);
+        let readiness = channel_readiness(&config, &info, &health, &state);
+
+        assert_eq!(readiness.bound_to_agent, ChannelReadinessState::Missing);
+        assert_eq!(readiness.listening, ChannelReadinessState::Unknown);
+        assert_eq!(
+            channel_readiness_summary(&readiness),
+            ("inactive", "degraded")
+        );
+        assert!(
+            readiness
+                .requirements
+                .iter()
+                .any(|item| item.contains("Bind this channel"))
+        );
+    }
+
+    #[tokio::test]
+    async fn api_channels_serializes_readiness_without_duplicate_summary_fields() {
+        let config = config_with_telegram("ops");
+        let state = test_state(config);
+
+        let response = handle_api_channels(State(state), HeaderMap::new())
+            .await
+            .into_response();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let json = response_json(response).await;
+        let channel = &json["channels"][0];
+        assert_eq!(channel["name"], "telegram.ops");
+        assert_eq!(channel["status"], "unknown");
+        assert_eq!(channel["health"], "degraded");
+        assert_eq!(channel["readiness"]["enabled"], "ready");
+        assert_eq!(channel["readiness"]["authenticated"], "unknown");
+        assert!(channel["readiness"].get("configured").is_none());
+        assert!(channel["readiness"].get("status").is_none());
+        assert!(channel["readiness"].get("health").is_none());
     }
 
     fn test_state_with_session_backend(

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -29,6 +29,7 @@ import type {
   CostSummary,
   Session,
   ChannelDetail,
+  ChannelReadinessState,
   SessionMessageRow,
   ProcessStats,
 } from '@/types/api';
@@ -264,6 +265,38 @@ function healthBg(status: string): string {
       return 'rgba(255, 68, 102, 0.05)';
   }
 }
+
+function readinessColor(state: ChannelReadinessState): string {
+  switch (state) {
+    case 'ready':
+      return 'var(--color-status-success)';
+    case 'missing':
+      return 'var(--color-status-error)';
+    case 'unknown':
+      return 'var(--pc-text-muted)';
+  }
+}
+
+function readinessLabel(state: ChannelReadinessState): string {
+  switch (state) {
+    case 'ready':
+      return 'ready';
+    case 'missing':
+      return 'missing';
+    case 'unknown':
+      return 'not checked';
+  }
+}
+
+const CHANNEL_READINESS_ROWS: Array<[
+  string,
+  'enabled' | 'bound_to_agent' | 'authenticated' | 'listening',
+]> = [
+  ['Enabled', 'enabled'],
+  ['Agent', 'bound_to_agent'],
+  ['Authenticated', 'authenticated'],
+  ['Listening', 'listening'],
+];
 
 // Genuinely process-global tiles only. Provider/Model and Memory Backend
 // were single-agent leftovers from pre-v0.8.0 and are gone: each agent now
@@ -1263,13 +1296,7 @@ function ChannelsTab() {
             <EntityEnabledToggle
               prefix={`channels.${channel.type}.${channel.alias}`}
               enabled={channel.enabled}
-              onChange={(next) =>
-                setChannels((prev) =>
-                  prev.map((c) =>
-                    c.name === channel.name ? { ...c, enabled: next } : c,
-                  ),
-                )
-              }
+              onChange={() => loadChannels()}
             />
           </div>
 
@@ -1281,12 +1308,53 @@ function ChannelsTab() {
             className="pt-3 border-t space-y-2"
             style={{ borderColor: "var(--pc-border)" }}
           >
+            {channel.readiness ? (
+              <>
+                {CHANNEL_READINESS_ROWS.map(([label, key]) => {
+                  const value = channel.readiness?.[key];
+                  return value ? (
+                    <div key={key} className="flex justify-between gap-3 text-xs">
+                      <span style={{ color: "var(--pc-text-muted)" }}>{label}</span>
+                      <span style={{ color: readinessColor(value) }}>
+                        {readinessLabel(value)}
+                      </span>
+                    </div>
+                  ) : null;
+                })}
+              </>
+            ) : null}
             <div className="flex justify-between text-xs">
               <span style={{ color: "var(--pc-text-muted)" }}>{t("dashboard.health")}</span>
               <span style={{ color: healthColor(channel.health) }}>
                 {channel.health}
               </span>
             </div>
+            {channel.readiness?.requirements?.length ? (
+              <div className="pt-2 space-y-1">
+                {channel.readiness.requirements.map((requirement) => (
+                  <p
+                    key={requirement}
+                    className="text-xs leading-snug"
+                    style={{ color: "var(--color-status-warning)" }}
+                  >
+                    {requirement}
+                  </p>
+                ))}
+              </div>
+            ) : null}
+            {channel.readiness?.notes?.length ? (
+              <div className="pt-2 space-y-1">
+                {channel.readiness.notes.map((note) => (
+                  <p
+                    key={note}
+                    className="text-xs leading-snug"
+                    style={{ color: "var(--pc-text-muted)" }}
+                  >
+                    {note}
+                  </p>
+                ))}
+              </div>
+            ) : null}
           </div>
         </div>
       ))}

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -185,6 +185,17 @@ export interface Session {
   channel_id: string | null;
 }
 
+export type ChannelReadinessState = 'ready' | 'missing' | 'unknown';
+
+export interface ChannelReadiness {
+  enabled: ChannelReadinessState;
+  bound_to_agent: ChannelReadinessState;
+  authenticated: ChannelReadinessState;
+  listening: ChannelReadinessState;
+  requirements: string[];
+  notes: string[];
+}
+
 export interface ChannelDetail {
   /** Composite `<type>.<alias>` identifier (v0.8.0). */
   name: string;
@@ -196,10 +207,11 @@ export interface ChannelDetail {
    * when the block is orphaned. */
   owning_agent: string | null;
   enabled: boolean;
-  status: 'active' | 'inactive' | 'error';
+  status: 'active' | 'inactive' | 'error' | 'unknown';
   message_count: number;
   last_message_at: string | null;
   health: 'healthy' | 'degraded' | 'down';
+  readiness?: ChannelReadiness;
 }
 
 export interface SSEEvent {


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Adds a structured `readiness` object to `/api/channels` so the gateway can distinguish channel alias existence from enabled config, agent binding, authentication, and listener health.
  - Makes webhook channel readiness depend on supervised `channel:webhook.<alias>` health instead of treating the generic gateway `/webhook` route as proof that a webhook channel listener is running.
  - Rejects stale webhook listener health so old `ok` snapshots do not make the dashboard report a stopped listener as healthy.
  - Updates dashboard channel cards to show readiness rows plus concrete requirements and notes.
- **Scope boundary:** This does not start channel listeners, validate third-party channel credentials, or add live readiness checks for non-webhook channel types. Unsupported channel types now report `unknown` / `not checked` instead of pretending they are healthy or broken.
- **Blast radius:** `/api/channels` response shape and dashboard channel cards. Existing top-level channel fields remain present, but `status` and `health` now summarize readiness instead of always returning `active` / `healthy`.
- **Linked issue(s):** Related #6398.
- **Labels:** `enhancement`, `risk: high`, `size: M`, `gateway`, `gateway:core`, `channel`.

## Validation Evidence (required)

- **Commands run and tail output:**

```text
cargo fmt --all -- --check
Result: passed

git diff --check
Result: passed

npm run build
Result: passed
Note: Vite reported the existing large-chunk warning.

cargo test -p zeroclaw-gateway api_channels_serializes_readiness_without_duplicate_summary_fields --lib -- --nocapture
Result: passed, 1 test passed, 0 failed

cargo test -p zeroclaw-gateway channel_readiness --lib -- --nocapture
Result: passed, 7 tests passed, 0 failed

cargo clippy --workspace --exclude zeroclaw-desktop --all-targets -- -D warnings
Result: passed in 1h12m34.21s

cargo nextest run --locked --workspace --exclude zeroclaw-desktop
Result: passed, 8114 tests passed, 10 skipped, 2m23.91s
```

- **Beyond CI — what did you manually verify?** I reviewed the `/api/channels` serialization contract, the webhook readiness decision tree, stale health handling, live pairing guard behavior, orphan channel behavior, and dashboard rendering of readiness rows/requirements. I did not perform a live webhook listener smoke in this slice.
- **If any command was intentionally skipped, why:** I did not run `./dev/ci.sh all`, plain `cargo test`, desktop validation, or a live webhook delivery smoke in this slice. Instead, I ran the repository's CI-shaped `nextest` command excluding `zeroclaw-desktop`, workspace clippy excluding `zeroclaw-desktop`, focused gateway readiness tests, `npm run build`, formatting, and diff checks. This PR verifies readiness decision logic and dashboard rendering; it does not prove live third-party webhook delivery.

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? `No` for strict `/api/channels` consumers that depend on the old `status` / `health` semantics; mostly additive for tolerant JSON consumers.
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: Existing `/api/channels` consumers still receive the existing top-level fields, with an added `readiness` object. Consumers that assumed every configured channel is always `active` / `healthy` may see more accurate `unknown`, `inactive`, or `error` summaries and should prefer the structured readiness fields.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert eae6465fdc62c32a8f28282555cd31ee1567f948`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Dashboard channel cards show incorrect readiness rows or requirements, `/api/channels` reports an unexpected `status` / `health`, or webhook aliases stay `missing` even while a supervised `channel:webhook.<alias>` component is fresh and healthy.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Scope materially carried forward: N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why (inspiration-only, no direct code/design carry-over): No superseded PR is being carried forward.
