### PR TITLE
fix(gateway/acp): wire shared CanvasStore into WS chat and ACP sessions

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/acp_server.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/acp_server.rs
@@ -32,6 +32,7 @@ use zeroclaw_api::model_provider::ConversationMessage;
 use zeroclaw_config::schema::Config;
 use zeroclaw_infra::acp_session_store::AcpSessionStore;
 use zeroclaw_runtime::agent::agent::{Agent, TurnEvent};
+use zeroclaw_runtime::tools::CanvasStore;
 
 use crate::acp_channel::AcpChannel;
 
@@ -304,6 +305,11 @@ pub struct AcpServer {
     /// against `max_sessions`.
     loading_sessions: Arc<tokio::sync::Mutex<HashSet<String>>>,
     store: Option<Arc<AcpSessionStore>>,
+    /// Shared canvas store from the gateway / daemon supervisor.  When set,
+    /// agents created by this server write canvas frames to the same store
+    /// that `/ws/canvas/:id` WebSocket subscribers read from.  `None` in
+    /// standalone `zeroclaw acp` mode where no gateway is running.
+    canvas_store: Option<CanvasStore>,
 }
 
 impl AcpServer {
@@ -354,7 +360,16 @@ impl AcpServer {
             cancel_tokens: Arc::new(std::sync::Mutex::new(HashMap::new())),
             loading_sessions: Arc::new(tokio::sync::Mutex::new(HashSet::new())),
             store,
+            canvas_store: None,
         }
+    }
+
+    /// Attach the shared gateway [`CanvasStore`] so that agents created by
+    /// this server write canvas frames to the same store that the
+    /// `/ws/canvas/:id` WebSocket endpoint serves.
+    pub fn with_canvas_store(mut self, canvas_store: CanvasStore) -> Self {
+        self.canvas_store = Some(canvas_store);
+        self
     }
 
     /// Run the ACP server, reading JSON-RPC requests from stdin and writing
@@ -685,6 +700,7 @@ impl AcpServer {
             &agent_alias,
             Some(std::path::Path::new(&workspace_dir)),
             false,
+            self.canvas_store.clone(),
         )
         .await
         .map_err(|e| RpcError {
@@ -834,6 +850,7 @@ impl AcpServer {
             &restore_alias,
             Some(&workspace_dir),
             false,
+            self.canvas_store.clone(),
         )
         .await
         .map_err(|e| RpcError {
@@ -982,6 +999,7 @@ impl AcpServer {
             &restore_alias,
             Some(&workspace_dir),
             false,
+            self.canvas_store.clone(),
         )
         .await
         .map_err(|e| RpcError {

--- a/crates/zeroclaw-gateway/src/acp.rs
+++ b/crates/zeroclaw-gateway/src/acp.rs
@@ -76,12 +76,17 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
             );
         })
         .ok();
+    let canvas_store = state.canvas_store.clone();
     let server = if let Some(store) = store {
-        Arc::new(AcpServer::new_with_writer_and_store(
-            config, acp_config, output_tx, store,
-        ))
+        Arc::new(
+            AcpServer::new_with_writer_and_store(config, acp_config, output_tx, store)
+                .with_canvas_store(canvas_store),
+        )
     } else {
-        Arc::new(AcpServer::new_with_writer(config, acp_config, output_tx))
+        Arc::new(
+            AcpServer::new_with_writer(config, acp_config, output_tx)
+                .with_canvas_store(canvas_store),
+        )
     };
 
     let server_task = tokio::spawn(Arc::clone(&server).run_messages(input_rx));

--- a/crates/zeroclaw-gateway/src/ws.rs
+++ b/crates/zeroclaw-gateway/src/ws.rs
@@ -381,6 +381,7 @@ async fn handle_socket(
             &agent_alias,
             Some(&session_cwd),
             true,
+            Some(state.canvas_store.clone()),
         )
         .await
         {

--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -604,17 +604,24 @@ impl Agent {
             session_cwd,
             initialize_mcp,
             false,
+            None,
         )
         .await
     }
 
     /// Build an Agent for direct ACP/WS sessions that have a client approval
     /// back-channel. This keeps shell approval on the runtime-controlled path.
+    ///
+    /// `canvas_store` should be the shared [`tools::CanvasStore`] from the
+    /// gateway / daemon supervisor so that canvas frames pushed by this agent
+    /// reach the `/ws/canvas/:id` WebSocket subscribers.  Pass `None` only in
+    /// standalone contexts (e.g. `zeroclaw acp`) where no gateway is running.
     pub async fn from_config_with_session_cwd_and_mcp_backchannel(
         config: &Config,
         agent_alias: &str,
         session_cwd: Option<&Path>,
         initialize_mcp: bool,
+        canvas_store: Option<tools::CanvasStore>,
     ) -> Result<Self> {
         Self::from_config_with_session_cwd_and_mcp_approval_mode(
             config,
@@ -622,6 +629,7 @@ impl Agent {
             session_cwd,
             initialize_mcp,
             true,
+            canvas_store,
         )
         .await
     }
@@ -632,6 +640,7 @@ impl Agent {
         session_cwd: Option<&Path>,
         initialize_mcp: bool,
         approval_backchannel: bool,
+        canvas_store: Option<tools::CanvasStore>,
     ) -> Result<Self> {
         let agent_cfg = config
             .agent(agent_alias)
@@ -743,7 +752,7 @@ impl Agent {
             &config.agents,
             agent_model_provider.and_then(|e| e.api_key.as_deref()),
             config,
-            None,
+            canvas_store,
             false,
         );
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `Agent::from_config_with_session_cwd_and_mcp_backchannel` was hard-coding `None` as `canvas_store` when calling `all_tools_with_runtime`, causing every web-UI WebSocket chat session and every ACP session to instantiate a private `CanvasStore::default()`. Frames pushed by the agent through the `canvas` tool were silently dropped because that private store is isolated from `AppState::canvas_store` -- the store that `/ws/canvas/:id` WebSocket subscribers read from.
  - #6221 (`61db5c8`) wired up the daemon-supervisor path (gateway <-> channels orchestrator) but left two paths unpatched: the WebSocket `/ws/chat` handler (`ws.rs`) and the ACP server (`acp_server.rs`).
  - `agent.rs`: added `canvas_store: Option<CanvasStore>` to `from_config_with_session_cwd_and_mcp_backchannel` (and the private `_approval_mode` variant); threads it through to `all_tools_with_runtime` instead of the hardcoded `None`.
  - `ws.rs`: passes `Some(state.canvas_store.clone())` so the WS chat agent shares the gateway `AppState` store.
  - `acp_server.rs`: adds `canvas_store: Option<CanvasStore>` field + `with_canvas_store(CanvasStore) -> Self` builder method; existing constructors default to `None` (no API break); all three `session/new` call sites pass `self.canvas_store.clone()`.
  - `acp.rs`: calls `.with_canvas_store(state.canvas_store.clone())` when building the ACP server for the gateway WebSocket `/acp` endpoint.
- **Scope boundary:** Does not change standalone `zeroclaw acp` behavior (still gets `None`/its own store, no gateway to subscribe to). Does not touch channels orchestrator wiring (already correct after #6221).
- **Blast radius:** High-risk runtime/gateway/channel-session wiring. The behavior change is intentionally limited to sharing the existing gateway `CanvasStore` with web UI chat and gateway-hosted ACP sessions; standalone ACP keeps the prior isolated-store behavior.
- **Linked issue(s):** Closes #6965
- **Labels:** `bug`, `risk: high`, `size: XS`, `agent`, `channel`, `gateway`, `runtime`

## Validation Evidence (required)

- **Commands run and tail output:**

```text
$ cargo fmt --all -- --check
(no output -- clean)

$ cargo clippy -p zeroclaw-runtime -p zeroclaw-gateway -p zeroclaw-channels -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 8m 18s

$ cargo test -p zeroclaw-runtime -p zeroclaw-gateway -p zeroclaw-channels
test result: ok. 1843 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 10.76s
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.32s
(doc-tests) test result: ok. 0 passed; 0 failed; 1 ignored
```

- **Beyond CI -- what did you manually verify?**
  - Confirmed `cargo build` for all three affected crates succeeds.
  - Verified the bug: `POST /api/canvas/default` (REST) updated the canvas page immediately; agent canvas tool call (via WS chat) did not -- confirming store isolation.
  - After the fix: canvas frames pushed through `/ws/chat` agent sessions now reach `/ws/canvas/:id` subscribers.
  - Standalone `zeroclaw acp` path (passes `None`) continues to compile and behave as before.
- **If any command was intentionally skipped, why:** Full workspace local test was not run to avoid a long CI-equivalent wait. This PR relies on the targeted local checks above plus GitHub's workspace-shaped CI (`Lint`, `Test`, build matrix, and `CI Required Gate`) for full-workspace coverage.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? Yes -- existing constructors on `AcpServer` retain their signatures; `from_config_with_session_cwd_and_mcp_backchannel` gains a new parameter but its only in-tree callers are updated in this PR.
- Config / env / CLI surface changed? No
- If `No` or `Yes` to either: N/A

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert 4c6cdeb1b`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** canvas frames from `/ws/chat` or gateway `/acp` sessions stop appearing on `/ws/canvas/:id` subscribers, while direct `POST /api/canvas/<id>` still updates the canvas; ACP or web-chat session startup errors would appear around the changed `Agent::from_config_with_session_cwd_and_mcp_backchannel` call sites.
