### PR TITLE
fix(tauri): remove manual MANIFEST linker flags to fix CVT1100/LNK1123 on Windows

### DIFF
--- a/apps/tauri/build.rs
+++ b/apps/tauri/build.rs
@@ -1,17 +1,12 @@
 fn main() {
     #[cfg(target_os = "windows")]
     {
-        let manifest = std::path::PathBuf::from(
-            std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR must be set"),
-        )
-        .join("windows")
-        .join("app.manifest");
-
-        println!("cargo:rustc-link-arg-bins=/MANIFEST:EMBED");
-        println!(
-            "cargo:rustc-link-arg-bins=/MANIFESTINPUT:{}",
-            manifest.display()
+        let attrs = tauri_build::Attributes::new().windows_attributes(
+            tauri_build::WindowsAttributes::new()
+                .app_manifest(include_str!("windows/app.manifest")),
         );
+        tauri_build::try_build(attrs).expect("failed to run tauri_build");
+        return;
     }
 
     tauri_build::build();


### PR DESCRIPTION
## Summary

- **Base branch:** \`master\` (all contributions)
- **What changed and why:**
  - \`apps/tauri/build.rs\` was emitting \`/MANIFEST:EMBED\` and \`/MANIFESTINPUT\` as raw \`cargo:rustc-link-arg-bins\` linker flags
  - \`tauri_build::build()\` independently compiles a \`.rc\` resource that also embeds a MANIFEST resource; MSVC sees two \`MANIFEST\` resources (type MANIFEST, name 1, language 0x0409) and aborts with CVT1100 → LNK1123, blocking all Windows desktop release builds
  - Fixed by routing the custom manifest through \`tauri_build::WindowsAttributes::new().app_manifest(include_str!("windows/app.manifest"))\` passed via \`tauri_build::try_build(attrs)\`, giving \`tauri-build\` sole ownership of manifest embedding and eliminating the duplicate resource
- **Scope boundary:** Only \`apps/tauri/build.rs\` is changed. No runtime code, no non-Windows paths, no config files altered.
- **Blast radius:** Affects only the Windows Tauri desktop build pipeline. Non-Windows builds fall through to the unchanged \`tauri_build::build()\` call.
- **Linked issue(s):** Closes #6964
- **Labels:** \`bug\`, \`risk: low\`, \`size: XS\`

## Validation Evidence (required)

All CI jobs passed on head \`fec5676429a9202473c2c3a5ae5a72d6cecc8d32\` (run [#26551833182](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/26551833182)):

```
Lint:                           success   6m38s
Check (32-bit):                 success   1m40s
Check (no default features):    success   1m19s
Check (all features):           success   5m06s
Security:                       success   2m19s
Test:                           success   8m30s
Benchmarks Compile:             success   9m37s
Build x86_64-unknown-linux-gnu: success   7m16s
Build aarch64-apple-darwin:     success   6m24s
Build x86_64-pc-windows-msvc:  success   8m22s   ← confirms CVT1100/LNK1123 eliminated
CI Required Gate:               success   2s
```

- **Commands run and tail output:** CI Lint job ran \`cargo fmt --all -- --check\` and \`cargo clippy --all-targets -- -D warnings\` — both passed. Test job ran \`cargo test\` — passed. \`Build x86_64-pc-windows-msvc\` passing confirms the duplicate-manifest error no longer occurs at link time.
- **Beyond CI — what did you manually verify?** The \`return;\` after \`try_build\` on the Windows path was verified to prevent fallthrough to \`tauri_build::build()\`. The non-Windows path is structurally unchanged.
- **If any command was intentionally skipped, why:** Full \`release:build:desktop:windows\` installer artifact job is not triggered on PRs by policy; \`Build x86_64-pc-windows-msvc\` CI success is the appropriate gate for this compile-time fix.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No

## Compatibility (required)

- Backward compatible? Yes — this is a build-script change only; the produced binary's runtime behavior is identical.
- Config / env / CLI surface changed? No

## Rollback (required for \`risk: medium\` and \`risk: high\`)

Low-risk PR. \`git revert fec567642\` is the rollback plan.

Closes #6964