### PR TITLE
fix(slack): default strict_mention_in_thread to true

### DIFF
--- a/CHANGELOG-next.md
+++ b/CHANGELOG-next.md
@@ -119,6 +119,7 @@ ACP mode (the `zeroclaw acp` subprocess and the `zeroclaw-acp-bridge` editor bri
 |---|---|
 | Config / V3 | V2→V3 migration correctness: provider-globals fold lands on the right V3 paths, channel `enabled` restored, dotted `model_provider` aliases resolve in routes and channel paths, Feishu V2 block migrates to `lark.feishu`, JSON-patch errors emitted for CLI patch (#6617) |
 | Channels | Telegram tool calls; Matrix honors global `ack_reactions`; localized runtime command replies (#6550); media uploads routed into the owning agent's workspace |
+| Channels (Slack) | `strict_mention_in_thread` defaults to `true` so the bot no longer auto-engages in unrelated human threads in shared channels — Slack delivers every thread reply in joined channels regardless of whether the bot ever spoke in that thread, and the old `false` default treated any thread reply as an active conversation. Opt out per channel with `strict_mention_in_thread = false`. |
 | Providers | Skip unresolvable multimodal images (#6743); Ollama routed through `compatible.rs` at `/v1/chat/completions`; error source chain included in retry logs; GLM/compat fixes |
 | Gateway / Web | Boot degrades (not crashes) when an enabled agent has an unresolved `risk_profile`; CronSchedule union restored; reload-banner and cron-modal fixes; OpenAPI re-export cleanup |
 | Cron | Timezone preserved through the cron API (#6741, #6740); `cmd.exe` on Windows instead of hardcoded `sh` (#6713) |

--- a/crates/zeroclaw-channels/src/slack.rs
+++ b/crates/zeroclaw-channels/src/slack.rs
@@ -186,7 +186,7 @@ impl SlackChannel {
             peer_resolver,
             thread_replies: true,
             mention_only: false,
-            strict_mention_in_thread: false,
+            strict_mention_in_thread: true,
             group_reply_allowed_sender_ids: Vec::new(),
             user_display_name_cache: Mutex::new(HashMap::new()),
             workspace_dir: None,
@@ -248,8 +248,13 @@ impl SlackChannel {
     }
 
     /// When true (and `mention_only` is also true), require an @-mention
-    /// for messages inside a Slack thread too. Default: false (threads
-    /// bypass the mention requirement so follow-ups don't need @).
+    /// for messages inside a Slack thread too. Default: `true`.
+    ///
+    /// Slack delivers every thread reply event in channels the bot is a
+    /// member of, so the previous default (`false`) caused the bot to engage
+    /// in unrelated human threads. Set to `false` only when the bot is the
+    /// primary participant in its channels and you want thread follow-ups to
+    /// skip the `@`-mention requirement.
     pub fn with_strict_mention_in_thread(mut self, strict: bool) -> Self {
         self.strict_mention_in_thread = strict;
         self
@@ -4745,9 +4750,9 @@ mod tests {
             "slack_test_alias",
             Arc::new(Vec::new),
         );
-        assert!(!ch.strict_mention_in_thread);
-        let ch = ch.with_strict_mention_in_thread(true);
         assert!(ch.strict_mention_in_thread);
+        let ch = ch.with_strict_mention_in_thread(false);
+        assert!(!ch.strict_mention_in_thread);
     }
 
     #[test]

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -10488,12 +10488,16 @@ pub struct SlackConfig {
     #[serde(default)]
     pub mention_only: bool,
     /// When true (and `mention_only` is also true), messages inside a Slack
-    /// thread must also @-mention the bot to trigger a response. By default,
-    /// thread replies are allowed through without a mention so the bot can
-    /// keep a back-and-forth going without the user repeating @-mentions.
-    /// Set this to true in channels shared with human discussion where the
-    /// bot should stay silent unless explicitly addressed.
-    #[serde(default)]
+    /// thread must also @-mention the bot to trigger a response. Default: `true`.
+    ///
+    /// Slack delivers every thread reply event in any channel the bot is a
+    /// member of — regardless of whether the bot ever spoke in that specific
+    /// thread. The previous default (`false`) treated any thread reply as an
+    /// active conversation with the bot, which caused the bot to jump into
+    /// unrelated human threads in shared channels. Set this to `false` only if
+    /// the bot is the sole/primary participant in its channels and you want
+    /// thread follow-ups to skip the `@`-mention requirement.
+    #[serde(default = "default_strict_mention_in_thread")]
     pub strict_mention_in_thread: bool,
     /// Use the newer Slack `markdown` block type (12 000 char limit, richer formatting).
     /// Defaults to false (uses universally supported `section` blocks with `mrkdwn`).
@@ -10527,6 +10531,10 @@ pub struct SlackConfig {
 
 fn default_slack_draft_update_interval_ms() -> u64 {
     1200
+}
+
+fn default_strict_mention_in_thread() -> bool {
+    true
 }
 
 impl ChannelConfig for SlackConfig {
@@ -17801,6 +17809,22 @@ bot_token = "xoxb-tok"
 "#;
         let parsed: SlackConfig = toml::from_str(toml_str).unwrap();
         assert!(parsed.channel_ids.is_empty());
+    }
+
+    #[test]
+    async fn slack_config_strict_mention_in_thread_defaults_to_true() {
+        let toml_str = r#"
+bot_token = "xoxb-tok"
+"#;
+        let parsed: SlackConfig = toml::from_str(toml_str).unwrap();
+        assert!(parsed.strict_mention_in_thread);
+
+        let opt_out = r#"
+bot_token = "xoxb-tok"
+strict_mention_in_thread = false
+"#;
+        let parsed: SlackConfig = toml::from_str(opt_out).unwrap();
+        assert!(!parsed.strict_mention_in_thread);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Change the default of `[channels.slack.<alias>].strict_mention_in_thread` from `false` to `true` so the @-mention rule applies uniformly to top-level messages and thread replies.
- Update the `SlackChannel::new` in-code default and the builder docstring to match.
- Add a serde-default coverage test and a CHANGELOG-next entry.

## Why

Slack delivers every thread reply event in any channel the bot is a member of, regardless of whether the bot ever spoke in that specific thread. The previous default treated any inbound thread reply as an active engagement with the bot:

```rust
// crates/zeroclaw-channels/src/slack.rs (Socket Mode dispatch path)
let is_thread_reply = event.get(\"thread_ts\").and_then(|v| v.as_str()).is_some();
let require_mention = self.mention_only
    && is_group_message
    && !allow_sender_without_mention
    && (!is_thread_reply || self.strict_mention_in_thread);
```

With `strict_mention_in_thread = false`, the `(!is_thread_reply || false)` clause collapses to `false` for any reply, killing `require_mention` regardless of `mention_only`. In a shared channel where a human starts a fresh thread, the bot will process every reply as if it had been addressed — even though it was never mentioned in that thread. There is no per-thread engagement state in the channel; `active_assistant_thread` only powers the Slack Assistants API typing indicator.

The schema docstring already recommended `true` for channels shared with human discussion; this aligns the default with that advice. The `false` behavior remains available per channel as an opt-out for installations where the bot is the sole/primary participant and operators want thread follow-ups to skip the `@`-mention requirement.

## Compatibility

This is a small default change. Existing configs that explicitly set `strict_mention_in_thread = false` continue to work as before. Configs that omitted the field now require an `@`-mention in threads too — operators who want the old behavior can add `strict_mention_in_thread = false` per Slack channel.

## Test plan

- [x] `cargo test -p zeroclaw-channels --features channel-slack --lib slack::` — 96 passed
- [x] `cargo test -p zeroclaw-config --lib slack_config` — 7 passed (including new `slack_config_strict_mention_in_thread_defaults_to_true`)
- [x] `cargo check -p zeroclaw-channels --features channel-slack --tests`
- [ ] Manual verification: deploy a Slack bot to a channel shared with humans, start a fresh thread that does not mention the bot, post replies — bot should stay silent. Mentioning the bot once should still let it respond, and follow-up `@`-mentions remain required.