### PR TITLE
fix(channels/telegram): wire transcription_provider alias for inbound voice

### DIFF
--- a/crates/zeroclaw-channels/src/telegram.rs
+++ b/crates/zeroclaw-channels/src/telegram.rs
@@ -528,6 +528,23 @@ impl TelegramChannel {
         }
         match super::transcription::TranscriptionManager::new(&config) {
             Ok(m) => {
+                // Wire the resolved STT backend alias here so the channel-internal
+                // voice path (`try_parse_voice_message` -> `manager.transcribe`)
+                // dispatches to a configured provider. The orchestrator only wires
+                // the alias for the MediaPipeline/attachment path, which inbound
+                // Telegram voice notes never traverse. Bind to the sole registered
+                // provider when exactly one is configured so the single-provider
+                // case dispatches without an agent context; multi-provider setups
+                // keep the alias empty and still require explicit
+                // `agent.<alias>.transcription_provider` routing through the
+                // orchestrator (mirrors `wati.rs` / `lark.rs` / `mattermost.rs`).
+                let names = m.available_providers();
+                let m = if names.len() == 1 {
+                    let only = names[0].to_string();
+                    m.with_agent_transcription_provider(only)
+                } else {
+                    m
+                };
                 self.transcription_manager = Some(std::sync::Arc::new(m));
                 self.transcription = Some(config);
             }
@@ -3858,6 +3875,54 @@ mod tests {
             mention_only,
         );
         assert_eq!(ch.name(), "telegram");
+    }
+
+    /// Regression for #6999 / #7000: the channel-internal voice path
+    /// (`try_parse_voice_message` -> `manager.transcribe`) must dispatch to a
+    /// configured STT backend. When exactly one provider is registered,
+    /// `with_transcription` binds it as the resolved alias so `transcribe()`
+    /// no longer fails with "Agent has no transcription_provider configured".
+    #[tokio::test]
+    async fn telegram_with_transcription_binds_sole_provider_alias() {
+        // SAFETY: test-only, single-threaded test runner.
+        unsafe { std::env::remove_var("GROQ_API_KEY") };
+
+        // Only the Groq key is set -> exactly one provider registers.
+        let config = zeroclaw_config::schema::TranscriptionConfig {
+            enabled: true,
+            api_key: Some("test-groq-key".to_string()),
+            ..zeroclaw_config::schema::TranscriptionConfig::default()
+        };
+
+        let ch = TelegramChannel::new(
+            "fake-token".into(),
+            "telegram_test_alias",
+            Arc::new(|| vec!["*".into()]),
+            false,
+        )
+        .with_transcription(config);
+
+        let manager = ch
+            .transcription_manager
+            .as_ref()
+            .expect("single configured provider must build a transcription manager");
+
+        // Alias is bound for the single-provider case. Stop before any network
+        // call by using an unsupported audio format, which `validate_audio`
+        // rejects first inside the provider's `transcribe`.
+        let err = manager
+            .transcribe(&[0u8; 16], "voice.aac")
+            .await
+            .expect_err("unsupported format must error before any network call");
+        let msg = err.to_string();
+        assert!(
+            !msg.contains("no transcription_provider configured"),
+            "alias must be bound for the single-provider case; got: {msg}"
+        );
+        assert!(
+            msg.contains("Unsupported audio format"),
+            "expected the bound provider to reach audio validation; got: {msg}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Telegram's `with_transcription()` built a `TranscriptionManager` but never called `with_agent_transcription_provider()`, leaving the resolved alias empty. The channel-internal voice path (`try_parse_voice_message` → `manager.transcribe()`) then bailed with `Agent has no transcription_provider configured` for **every** inbound voice note. This fix binds the alias only when exactly one STT backend is configured, matching the direct-ingest pattern already used by `wati.rs`, `lark.rs`, and `mattermost.rs`.
- **Scope boundary:** Only `crates/zeroclaw-channels/src/telegram.rs` `with_transcription()`. No changes to `TranscriptionManager`, the orchestrator, config schema, or any other channel.
- **Blast radius:** Inbound Telegram voice transcription only. No effect on text messages, attachments (MediaPipeline path already wired the alias), outbound TTS, or other channels.
- **Linked issue(s):** Fixes #6999
- **Labels:** `bug`, `channel`, `channel:telegram`, `risk: medium`, `size: XS`

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo build --release --no-default-features --features agent-runtime,gateway,embedded-web,acp-bridge,channel-telegram,rag-pdf
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` → exit 0 (no diff).
  - Release build with the deployed feature set → `Finished \`release\` profile [optimized] target(s) in 19m 35s` (compiles clean).
- **Beyond CI — what did you manually verify?** Built the binary with the fix, replaced the running daemon, and sent a real Telegram voice note: it is now downloaded, transcribed via the configured `[transcription.local_whisper]` backend, and delivered to the agent. Before the fix the identical config produced `Voice transcription failed / Agent has no transcription_provider configured` on every voice note.
- **If any command was intentionally skipped, why:** Full `cargo clippy --all-targets -- -D warnings` and `cargo test` were not run locally (each triggers a fresh ~20 min release-mode rebuild of the large `zeroclaw-channels` crate on this host); the change now follows the existing single-provider direct-ingest pattern used by `wati.rs`, `lark.rs`, and `mattermost.rs`, and the release build compiles clean. Relying on CI for the full clippy/test battery.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No (uses the already-configured transcription endpoint)
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- If `No` or `Yes` to either: No new config. Operators who already configured an STT backend under `[transcription.*]` now get working Telegram voice transcription with no action required.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <sha>`
- **Feature flags or config toggles:** None (set `[transcription].enabled = false` to disable voice transcription entirely)
- **Observable failure symptoms:** grep daemon logs for `Voice transcription failed` / `Agent has no transcription_provider configured`; transcription failures cause inbound Telegram voice notes to be dropped.
