### PR TITLE
fix(channels/tts): bind TTS manager to the channel-owning agent

### DIFF
--- a/crates/zeroclaw-channels/src/telegram.rs
+++ b/crates/zeroclaw-channels/src/telegram.rs
@@ -551,7 +551,13 @@ impl TelegramChannel {
     /// or when the manager fails to construct (logged at warn).
     pub fn with_tts(mut self, config: &zeroclaw_config::schema::Config) -> Self {
         if config.tts.enabled {
-            match super::tts::TtsManager::from_config(config) {
+            // Bind the TTS manager to the agent that owns THIS channel so the
+            // voice reply uses that agent's `tts_provider`. Without this the
+            // shared manager resolves the lexicographically-smallest enabled
+            // agent, which silently breaks TTS when that agent has no
+            // `tts_provider` set (e.g. a background/delegate agent).
+            let owner = config.agent_for_channel(&format!("telegram.{}", self.alias));
+            match super::tts::TtsManager::from_config_for_agent(config, owner) {
                 Ok(m) => self.tts_manager = Some(Arc::new(m)),
                 Err(e) => ::zeroclaw_log::record!(
                     WARN,

--- a/crates/zeroclaw-channels/src/tts.rs
+++ b/crates/zeroclaw-channels/src/tts.rs
@@ -583,6 +583,19 @@ impl TtsManager {
     /// so when no agent-bound resolution is available the manager refuses
     /// to silently pick a provider (`synthesize` fails loud).
     pub fn from_config(config: &Config) -> Result<Self> {
+        Self::from_config_for_agent(config, None)
+    }
+
+    /// Build a `TtsManager` bound to a specific agent's `tts_provider`.
+    ///
+    /// `agent_alias` is the channel-owning agent (resolve via
+    /// [`Config::agent_for_channel`]). When `None`, falls back to the
+    /// runtime-active agent ([`Config::resolved_runtime_agent_alias`]) for
+    /// callers that cannot determine the owning agent. Binding to the
+    /// owning agent is what lets a channel owned by e.g. `primary` use
+    /// `primary`'s `tts_provider` instead of whichever enabled agent
+    /// happens to sort first.
+    pub fn from_config_for_agent(config: &Config, agent_alias: Option<&str>) -> Result<Self> {
         let mut tts_providers: HashMap<String, Box<dyn TtsProvider>> = HashMap::new();
         let mut voice_by_alias: HashMap<String, String> = HashMap::new();
 
@@ -633,12 +646,12 @@ impl TtsManager {
             config.tts.max_text_length
         };
 
-        // Per-agent join: the runtime-active agent's `tts_provider` is the
-        // resolved alias for this manager instance. Empty (or no resolved
+        // Per-agent join: bind to the channel-owning agent's `tts_provider`
+        // when known, else the runtime-active agent. Empty (or no resolved
         // agent) = no TTS; `synthesize` fails loud rather than silently
         // pick a provider.
-        let agent_tts_provider = config
-            .resolved_runtime_agent_alias()
+        let agent_tts_provider = agent_alias
+            .or_else(|| config.resolved_runtime_agent_alias())
             .and_then(|alias| config.agents.get(alias))
             .map(|a| a.tts_provider.as_str().to_string())
             .unwrap_or_default();
@@ -842,6 +855,47 @@ mod tests {
         let cfg = config_with_edge_alias();
         let manager = TtsManager::from_config(&cfg).unwrap();
         assert_eq!(manager.available_providers(), vec!["edge.default"]);
+    }
+
+    /// Regression for #7001: a channel-owning agent's `tts_provider` must win
+    /// over a lexicographically-earlier enabled agent that has none. Binding
+    /// the manager to the owner (`from_config_for_agent(cfg, Some("primary"))`)
+    /// resolves `primary`'s provider, not the first-sorting agent's empty one.
+    #[test]
+    fn tts_manager_binds_owning_agent_provider() {
+        // Reuse the edge.default provider registration, but install two agents:
+        // `primary` (the channel owner, has the provider) and a
+        // lexicographically-earlier `background` agent with no `tts_provider`.
+        let mut cfg = config_with_edge_alias();
+        cfg.agents.clear();
+        cfg.agents.insert(
+            "primary".into(),
+            zeroclaw_config::schema::AliasedAgentConfig {
+                tts_provider: "edge.default".into(),
+                ..Default::default()
+            },
+        );
+        cfg.agents.insert(
+            "background".into(),
+            zeroclaw_config::schema::AliasedAgentConfig {
+                ..Default::default()
+            },
+        );
+
+        // Owner-bound resolution picks primary's provider...
+        let owner_bound = TtsManager::from_config_for_agent(&cfg, Some("primary")).unwrap();
+        assert_eq!(
+            owner_bound.agent_tts_provider, "edge.default",
+            "owner-bound manager must resolve the channel owner's tts_provider"
+        );
+
+        // ...while binding to the provider-less first-sorting agent stays empty,
+        // proving the binding is per-agent and not a global/first-sorting pick.
+        let background_bound = TtsManager::from_config_for_agent(&cfg, Some("background")).unwrap();
+        assert!(
+            background_bound.agent_tts_provider.is_empty(),
+            "an agent with no tts_provider must not inherit another agent's provider"
+        );
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-channels/src/whatsapp_web.rs
+++ b/crates/zeroclaw-channels/src/whatsapp_web.rs
@@ -219,7 +219,13 @@ impl WhatsAppWebChannel {
     #[cfg(feature = "whatsapp-web")]
     pub fn with_tts(mut self, config: &zeroclaw_config::schema::Config) -> Self {
         if config.tts.enabled {
-            match super::tts::TtsManager::from_config(config) {
+            // Bind the TTS manager to the agent that owns THIS channel so the
+            // voice reply uses that agent's `tts_provider`. Without this the
+            // shared manager resolves the lexicographically-smallest enabled
+            // agent, which silently breaks TTS when that agent has no
+            // `tts_provider` set (e.g. a background/delegate agent).
+            let owner = config.agent_for_channel(&format!("whatsapp.{}", self.alias));
+            match super::tts::TtsManager::from_config_for_agent(config, owner) {
                 Ok(m) => self.tts_manager = Some(Arc::new(m)),
                 Err(e) => ::zeroclaw_log::record!(
                     WARN,


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** `TtsManager::from_config` resolved the manager's `agent_tts_provider` via `Config::resolved_runtime_agent_alias()` (agent named `default`, else lexicographically-smallest enabled agent) instead of the agent that owns the channel. In a multi-agent config where the channel owner isn't first — e.g. `primary` behind a `background_agent` that has no `tts_provider` — the manager bound to an empty provider and every voice reply failed with `Agent has no tts_provider configured`, despite the owning agent being configured correctly.
- Adds `TtsManager::from_config_for_agent(config, agent_alias)`. Both voice-reply channels now resolve the channel owner and bind through it: Telegram's `with_tts` via `Config::agent_for_channel("telegram.<alias>")` and WhatsApp Web's `with_tts` via `Config::agent_for_channel("whatsapp.<alias>")`. `from_config` delegates with `None` (unchanged back-compat fallback to the runtime-active agent).
- **Scope boundary:** TTS owner resolution for the two voice-reply channels (Telegram + WhatsApp Web). No change to `resolved_runtime_agent_alias`, the STT/transcription path, the provider registration loop, or config schema.
- **Blast radius:** TTS voice replies on Telegram and WhatsApp Web. `from_config` callers are unaffected (delegates to `None`). Single-agent and `default`-named-agent setups resolve identically; only multi-agent setups where the owning agent wasn't being selected change — and they change to the correct agent.
- **Linked issue(s):** Fixes #7001
- **Labels:** `bug`, `channel`, `channel:telegram`, `channel:whatsapp`, `risk: medium`, `size: XS`

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo test -p zeroclaw-channels --features channel-telegram tts_manager_binds_owning_agent_provider
cargo build --release --no-default-features --features agent-runtime,gateway,embedded-web,acp-bridge,channel-telegram,rag-pdf
cargo build -p zeroclaw-channels --features whatsapp-web   # WhatsApp Web path compile-check
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` → exit 0 (no diff).
  - Regression test `tts_manager_binds_owning_agent_provider` → pass.
  - Release build with the deployed feature set → compiles clean. WhatsApp Web `with_tts` change compile-checked under `--features whatsapp-web`.
- **Beyond CI — what did you manually verify?** Reproduced the failure on a live two-agent config (`primary` owns `telegram.default` with `tts_provider = "edge.default"`; `background_agent` enabled, sorts first, no `tts_provider`): voice replies failed with `Agent has no tts_provider configured` at `telegram.rs` (manager bound to `background_agent`). Confirmed the resolution flips to `primary` with this change. Corroborated independently: temporarily copying `tts_provider = "edge.default"` onto `background_agent` (making the wrongly-resolved agent valid) also restored TTS — which is exactly the broken resolution this PR fixes at the source.
- **If any command was intentionally skipped, why:** Full `cargo clippy --all-targets -- -D warnings` / whole-suite `cargo test` not run locally (each triggers a ~14 min release rebuild of `zeroclaw-channels` on this host); change is small, lint-clean, and compiles. Relying on CI for the full battery.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- If `No` or `Yes` to either: No new config. `from_config` keeps its existing behavior (delegates with `None`). Single-agent and `default`-named-agent setups resolve identically; only multi-agent setups where the owning agent wasn't being selected change — and they change to the correct agent.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <sha>`
- **Feature flags or config toggles:** None (workaround without the fix: set `tts_provider` on the first-sorting enabled agent)
- **Observable failure symptoms:** grep daemon logs for `TTS voice reply failed` / `Agent has no tts_provider configured`.
