### PR TITLE
feat(tools): optional base64 encoding for file_read / file_write

### DIFF
--- a/crates/zeroclaw-runtime/src/tools/file_read.rs
+++ b/crates/zeroclaw-runtime/src/tools/file_read.rs
@@ -59,7 +59,7 @@ impl Tool for FileReadTool {
     }
 
     fn description(&self) -> &str {
-        "Read file contents with line numbers. Supports partial reading via offset and limit. Extracts text from PDF; other binary files are read with lossy UTF-8 conversion."
+        "Read file contents with line numbers. Supports partial reading via offset and limit. Extracts text from PDF; other binary files are read with lossy UTF-8 conversion. Set encoding=\"base64\" to return raw bytes base64-encoded (for binary files such as .xlsx/.docx); offset/limit are ignored in that mode."
     }
 
     fn parameters_schema(&self) -> serde_json::Value {
@@ -72,11 +72,16 @@ impl Tool for FileReadTool {
                 },
                 "offset": {
                     "type": "integer",
-                    "description": "Starting line number (1-based, default: 1)"
+                    "description": "Starting line number (1-based, default: 1). Ignored when encoding is 'base64'."
                 },
                 "limit": {
                     "type": "integer",
-                    "description": "Maximum number of lines to return (default: all)"
+                    "description": "Maximum number of lines to return (default: all). Ignored when encoding is 'base64'."
+                },
+                "encoding": {
+                    "type": "string",
+                    "enum": ["utf8", "base64"],
+                    "description": "Output encoding (default: 'utf8'). Use 'base64' to read binary files as base64-encoded bytes."
                 }
             },
             "required": ["path"]
@@ -166,6 +171,41 @@ impl Tool for FileReadTool {
                     error: Some(format!("Failed to read file metadata: {e}")),
                 });
             }
+        }
+
+        let encoding = args
+            .get("encoding")
+            .and_then(|v| v.as_str())
+            .unwrap_or("utf8");
+
+        if encoding == "base64" {
+            // Binary read: return raw bytes base64-encoded. Line numbering and
+            // offset/limit are text concepts and do not apply here.
+            let bytes = match tokio::fs::read(&resolved_path).await {
+                Ok(b) => b,
+                Err(e) => {
+                    return Ok(ToolResult {
+                        success: false,
+                        output: String::new(),
+                        error: Some(format!("Failed to read file: {e}")),
+                    });
+                }
+            };
+            use base64::Engine;
+            let encoded = base64::engine::general_purpose::STANDARD.encode(&bytes);
+            return Ok(ToolResult {
+                success: true,
+                output: encoded,
+                error: None,
+            });
+        } else if encoding != "utf8" {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!(
+                    "Unsupported encoding '{encoding}' (expected 'utf8' or 'base64')"
+                )),
+            });
         }
 
         match tokio::fs::read_to_string(&resolved_path).await {
@@ -427,6 +467,63 @@ mod tests {
         let tool = test_tool(std::env::temp_dir());
         let result = tool.execute(json!({})).await;
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn file_read_schema_has_encoding() {
+        let tool = test_tool(std::env::temp_dir());
+        let schema = tool.parameters_schema();
+        assert!(schema["properties"]["encoding"].is_object());
+    }
+
+    #[tokio::test]
+    async fn file_read_base64_returns_encoded_bytes() {
+        let dir = std::env::temp_dir().join("zeroclaw_test_file_read_base64");
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+
+        // Non-UTF-8 bytes — proves we return raw bytes, not lossy text.
+        let raw: Vec<u8> = vec![0x00, 0x80, 0xFF, 0xFE, b'P', b'K', 0x03, 0x04];
+        tokio::fs::write(dir.join("data.bin"), &raw).await.unwrap();
+
+        let tool = test_tool(dir.clone());
+        let result = tool
+            .execute(json!({"path": "data.bin", "encoding": "base64"}))
+            .await
+            .unwrap();
+        assert!(result.success, "error: {:?}", result.error);
+
+        use base64::Engine;
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(result.output.trim())
+            .expect("output must be valid base64");
+        assert_eq!(decoded, raw, "base64 read must round-trip exact bytes");
+
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+    }
+
+    #[tokio::test]
+    async fn file_read_unsupported_encoding_errors() {
+        let dir = std::env::temp_dir().join("zeroclaw_test_file_read_bad_encoding");
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+        tokio::fs::write(dir.join("f.txt"), "hi").await.unwrap();
+
+        let tool = test_tool(dir.clone());
+        let result = tool
+            .execute(json!({"path": "f.txt", "encoding": "hex"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(
+            result
+                .error
+                .as_deref()
+                .unwrap_or("")
+                .contains("Unsupported encoding")
+        );
+
+        let _ = tokio::fs::remove_dir_all(&dir).await;
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-tools/src/file_write.rs
+++ b/crates/zeroclaw-tools/src/file_write.rs
@@ -22,7 +22,7 @@ impl Tool for FileWriteTool {
     }
 
     fn description(&self) -> &str {
-        "Write contents to a file in the workspace"
+        "Write contents to a file in the workspace. Text by default; set encoding=\"base64\" to write binary files (e.g. .xlsx/.docx) by decoding base64 content into raw bytes."
     }
 
     fn parameters_schema(&self) -> serde_json::Value {
@@ -35,7 +35,12 @@ impl Tool for FileWriteTool {
                 },
                 "content": {
                     "type": "string",
-                    "description": "Content to write to the file"
+                    "description": "Content to write. UTF-8 text when encoding is 'utf8'; base64-encoded bytes when encoding is 'base64'."
+                },
+                "encoding": {
+                    "type": "string",
+                    "enum": ["utf8", "base64"],
+                    "description": "How to interpret 'content' before writing (default: 'utf8'). Use 'base64' for binary files."
                 }
             },
             "required": ["path", "content"]
@@ -68,6 +73,11 @@ impl Tool for FileWriteTool {
                 anyhow::Error::msg("Missing 'content' parameter")
             })?;
 
+        let encoding = args
+            .get("encoding")
+            .and_then(|v| v.as_str())
+            .unwrap_or("utf8");
+
         if !self.security.can_act() {
             return Ok(ToolResult {
                 success: false,
@@ -75,6 +85,36 @@ impl Tool for FileWriteTool {
                 error: Some("Action blocked: autonomy is read-only".into()),
             });
         }
+
+        // Validate the encoding and decode base64 BEFORE any write-side
+        // filesystem mutation (e.g. parent directory creation), so invalid
+        // input fails without touching the workspace. Path-sandbox checks
+        // below still run on the resolved target before the write.
+        let bytes = match encoding {
+            "utf8" => content.as_bytes().to_vec(),
+            "base64" => {
+                use base64::Engine;
+                match base64::engine::general_purpose::STANDARD.decode(content) {
+                    Ok(decoded) => decoded,
+                    Err(e) => {
+                        return Ok(ToolResult {
+                            success: false,
+                            output: String::new(),
+                            error: Some(format!("Invalid base64 content: {e}")),
+                        });
+                    }
+                }
+            }
+            other => {
+                return Ok(ToolResult {
+                    success: false,
+                    output: String::new(),
+                    error: Some(format!(
+                        "Unsupported encoding '{other}' (expected 'utf8' or 'base64')"
+                    )),
+                });
+            }
+        };
 
         // Rate limiting and path-allowlist checks are applied by the
         // RateLimitedTool + PathGuardedTool wrappers at registration time
@@ -151,10 +191,10 @@ impl Tool for FileWriteTool {
             });
         }
 
-        match tokio::fs::write(&resolved_target, content).await {
+        match tokio::fs::write(&resolved_target, &bytes).await {
             Ok(()) => Ok(ToolResult {
                 success: true,
-                output: format!("Written {} bytes to {path}", content.len()),
+                output: format!("Written {} bytes to {path}", bytes.len()),
                 error: None,
             }),
             Err(e) => Ok(ToolResult {
@@ -373,6 +413,169 @@ mod tests {
         let tool = test_tool(std::env::temp_dir());
         let result = tool.execute(json!({"path": "file.txt"})).await;
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn file_write_schema_has_encoding() {
+        let tool = test_tool(std::env::temp_dir());
+        let schema = tool.parameters_schema();
+        assert!(schema["properties"]["encoding"].is_object());
+    }
+
+    #[tokio::test]
+    async fn file_write_base64_writes_decoded_bytes() {
+        let dir = std::env::temp_dir().join("zeroclaw_test_file_write_base64");
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+
+        // Bytes that are NOT valid UTF-8 — proves we persist raw bytes, not text.
+        let raw: Vec<u8> = vec![0x00, 0x01, 0xFF, 0xFE, b'P', b'K', 0x03, 0x04];
+        use base64::Engine;
+        let encoded = base64::engine::general_purpose::STANDARD.encode(&raw);
+
+        let tool = test_tool(dir.clone());
+        let result = tool
+            .execute(json!({"path": "out.bin", "content": encoded, "encoding": "base64"}))
+            .await
+            .unwrap();
+        assert!(result.success, "error: {:?}", result.error);
+        assert!(result.output.contains(&format!("{} bytes", raw.len())));
+
+        let written = tokio::fs::read(dir.join("out.bin")).await.unwrap();
+        assert_eq!(written, raw, "base64 write must persist exact raw bytes");
+
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+    }
+
+    #[tokio::test]
+    async fn file_write_base64_invalid_content_errors() {
+        let dir = std::env::temp_dir().join("zeroclaw_test_file_write_base64_invalid");
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+
+        let tool = test_tool(dir.clone());
+        let result = tool
+            .execute(
+                json!({"path": "out.bin", "content": "not!valid!base64!", "encoding": "base64"}),
+            )
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(
+            result
+                .error
+                .as_deref()
+                .unwrap_or("")
+                .contains("Invalid base64")
+        );
+        assert!(
+            !dir.join("out.bin").exists(),
+            "no file must be written on decode failure"
+        );
+
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+    }
+
+    #[tokio::test]
+    async fn file_write_unsupported_encoding_errors() {
+        let dir = std::env::temp_dir().join("zeroclaw_test_file_write_bad_encoding");
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+
+        let tool = test_tool(dir.clone());
+        let result = tool
+            .execute(json!({"path": "out.txt", "content": "hi", "encoding": "hex"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(
+            result
+                .error
+                .as_deref()
+                .unwrap_or("")
+                .contains("Unsupported encoding")
+        );
+
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+    }
+
+    /// Rejected writes (invalid base64 / unsupported encoding) targeting a
+    /// missing nested parent must fail WITHOUT mutating the workspace — no
+    /// file and, crucially, no parent directory may be created.
+    #[tokio::test]
+    async fn file_write_rejected_encoding_does_not_create_parent_dirs() {
+        let dir = std::env::temp_dir().join("zeroclaw_test_file_write_no_dir_on_reject");
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+
+        let tool = test_tool(dir.clone());
+
+        // Invalid base64 into a missing nested parent.
+        let result = tool
+            .execute(json!({
+                "path": "nested/out.bin",
+                "content": "not!valid!base64!",
+                "encoding": "base64"
+            }))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(
+            result
+                .error
+                .as_deref()
+                .unwrap_or("")
+                .contains("Invalid base64")
+        );
+        assert!(
+            !dir.join("nested").exists(),
+            "rejected base64 write must not create the parent directory"
+        );
+        assert!(!dir.join("nested/out.bin").exists());
+
+        // Unsupported encoding into a (different) missing nested parent.
+        let result = tool
+            .execute(json!({
+                "path": "nested2/out.txt",
+                "content": "hi",
+                "encoding": "hex"
+            }))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(
+            result
+                .error
+                .as_deref()
+                .unwrap_or("")
+                .contains("Unsupported encoding")
+        );
+        assert!(
+            !dir.join("nested2").exists(),
+            "unsupported encoding must not create the parent directory"
+        );
+        assert!(!dir.join("nested2/out.txt").exists());
+
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+    }
+
+    #[tokio::test]
+    async fn file_write_base64_still_blocks_path_traversal() {
+        let dir = std::env::temp_dir().join("zeroclaw_test_file_write_base64_traversal");
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+
+        use base64::Engine;
+        let encoded = base64::engine::general_purpose::STANDARD.encode(b"bad");
+        let tool = wrapped_tool(dir.clone());
+        let result = tool
+            .execute(json!({"path": "../../etc/evil", "content": encoded, "encoding": "base64"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.as_ref().unwrap().contains("Path blocked"));
+
+        let _ = tokio::fs::remove_dir_all(&dir).await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Adds an optional `encoding` parameter (`"utf8"` default | `"base64"`) to the `file_read` and `file_write` tools.
  - Today the file tools are text/UTF-8 only — `file_write` writes the `content` string verbatim and `file_read` returns UTF-8 — so no binary format can be read or written (office docs `.xlsx`/`.docx` are ZIP+XML, images, archives, etc.). The plugin protocol even lists `file_read`/`file_write` as *“not yet implemented.”*
  - `"base64"` reads raw bytes and returns them base64-encoded, and decodes base64 `content` into raw bytes on write. This is the minimal general primitive that lets agents and pure (FS-less) plugins produce/consume real binary artifacts without an interpreter escape hatch (Python/Node via shell) or lossy text formats (CSV/HTML).
  - `file_write` validates the `encoding` and decodes base64 **before any filesystem mutation** (including parent-directory creation), so rejected input (invalid base64 / unsupported encoding) fails without touching the workspace. The existing path-sandbox checks still run on the resolved target before the write.
  - Default `"utf8"` preserves current behavior byte-for-byte.
- **Scope boundary:** No new tools, no new plugin host functions. Adds an opt-in binary read/write capability to the existing file tools, confined to the existing path-sandboxing, allowlist, symlink, and autonomy guards. Does not touch the client→daemon upload protocol.
- **Blast radius:** `file_read` (`zeroclaw-runtime`) and `file_write` (`zeroclaw-tools`) only. Any caller passing no `encoding` is unaffected.
- **Linked issue(s):** Related #6819 (file/attachment *upload* protocol — a different layer: client→daemon ingestion; this PR is about the agent-facing read/write tools operating on bytes already in the workspace).
- **Labels:** `enhancement`, `risk: high`, `size: S`, `runtime`, `tool`, `tool:file`.

## Validation Evidence (required)

Run on Windows (`x86_64-pc-windows-msvc`); scoped to the two changed crates.

`cargo fmt --all` — applied, no diff to changed files.

`cargo test -p zeroclaw-runtime --lib file_read`:

```
running 27 tests
test tools::file_read::tests::file_read_base64_returns_encoded_bytes ... ok
test tools::file_read::tests::file_read_schema_has_encoding ... ok
test tools::file_read::tests::file_read_unsupported_encoding_errors ... ok
...
test result: ok. 26 passed; 0 failed; 1 ignored; 0 measured; 1824 filtered out
```

`cargo test -p zeroclaw-tools --lib file_write` — base64 + write-ordering tests pass:

```
test file_write::tests::file_write_base64_writes_decoded_bytes ... ok
test file_write::tests::file_write_base64_invalid_content_errors ... ok
test file_write::tests::file_write_base64_still_blocks_path_traversal ... ok
test file_write::tests::file_write_unsupported_encoding_errors ... ok
test file_write::tests::file_write_rejected_encoding_does_not_create_parent_dirs ... ok
test file_write::tests::file_write_schema_has_encoding ... ok
```

- **Beyond CI — what did you manually verify?** base64 round-trips exact non-UTF-8 bytes on both read and write; invalid base64 and unsupported encoding values return clean error results (no panic, no partial write) **and create neither the target file nor a missing parent directory**; path-traversal is still blocked in base64 write mode.
- **Pre-existing failures observed (NOT introduced by this PR, not in changed files):** two `file_write` tests fail only on Windows because they hardcode Unix paths (`file_write_blocks_absolute_path` asserts a Unix-specific error string; `file_write_normalizes_workspace_prefixed_relative_path` calls `strip_prefix("/")`). `cargo clippy --all-targets -- -D warnings` fails on a pre-existing `unreachable_code`/`unused_variable` in `glob_search.rs` (unrelated file). Recommend a final `dev/ci.sh all` run on Linux CI.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **Yes — a new capability, not a new scope.** This adds an opt-in binary read/write capability to the existing `file_read`/`file_write` tools (`encoding: "base64"`). It does **not** broaden path permissions or workspace scope: all I/O remains confined to the existing file-tool path guards (sandbox, allowlist, symlink-escape refusal, read-only autonomy). Rejected base64 writes now fail before any filesystem mutation.
- New external network calls? **No.**
- Secrets / tokens / credentials handling changed? **No.**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No.** Tests use synthetic byte arrays.

## Compatibility (required)

- Backward compatible? **Yes.** `encoding` is optional and defaults to `"utf8"` (existing behavior).
- Config / env / CLI surface changed? **No.** Only the two tools' JSON parameter schemas gain an optional field.
- Upgrade steps: none.

## Rollback (required for risk: medium and high)

- **Fast rollback command/path:** `git revert <sha>` (single commit, two files).
- **Feature flags or config toggles:** None (opt-in per call via `encoding`).
- **Observable failure symptoms:** `file_read`/`file_write` returning `Invalid base64 content` or `Unsupported encoding` errors, or binary files written with wrong bytes.

