### PR TITLE
fix(channels): deliver WhatsApp replies for LID JIDs and empty sanitization

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -2517,6 +2517,34 @@ fn sanitize_channel_response(response: &str, tools: &[Box<dyn Tool>]) -> String 
     }
 }
 
+/// Shown when the agent turn completes but no visible text remains after sanitization.
+const EMPTY_CHANNEL_REPLY_FALLBACK: &str =
+    "I couldn't produce a visible reply for that message. Please try again.";
+
+/// Ensure channel outbound text is never empty so users don't see typing with no message.
+fn ensure_nonempty_channel_reply(
+    delivered_response: String,
+    outbound_response: &str,
+    channel: &str,
+    reply_target: &str,
+) -> String {
+    if !delivered_response.trim().is_empty() {
+        return delivered_response;
+    }
+    ::zeroclaw_log::record!(
+        WARN,
+        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+            .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+            .with_attrs(::serde_json::json!({
+                "channel": channel,
+                "reply_target": reply_target,
+                "outbound_len": outbound_response.len(),
+            })),
+        "channel_reply_empty; substituting fallback"
+    );
+    EMPTY_CHANNEL_REPLY_FALLBACK.to_string()
+}
+
 /// Remove leading lines that narrate tool usage (e.g. "Let me check the weather for you.").
 ///
 /// Only strips lines from the very beginning of the message that match common
@@ -4081,6 +4109,12 @@ async fn process_channel_message_body(
             } else {
                 sanitized_response
             };
+            delivered_response = ensure_nonempty_channel_reply(
+                delivered_response,
+                &outbound_response,
+                &msg.channel,
+                &msg.reply_target,
+            );
 
             // Append a footer when the response was served by a different model_provider family.
             // Intra-family fallbacks (e.g. minimax → minimax-cn) are suppressed.
@@ -8524,6 +8558,28 @@ mod tests {
             strip_tool_summary_prefix(input),
             "The command output is 42."
         );
+    }
+
+    #[test]
+    fn ensure_nonempty_channel_reply_substitutes_fallback_when_empty() {
+        let result = ensure_nonempty_channel_reply(
+            String::new(),
+            "   ",
+            "whatsapp",
+            "15551234567@s.whatsapp.net",
+        );
+        assert_eq!(result, EMPTY_CHANNEL_REPLY_FALLBACK);
+    }
+
+    #[test]
+    fn ensure_nonempty_channel_reply_preserves_nonempty_text() {
+        let result = ensure_nonempty_channel_reply(
+            "Hello".to_string(),
+            "Hello",
+            "whatsapp",
+            "15551234567@s.whatsapp.net",
+        );
+        assert_eq!(result, "Hello");
     }
 
     #[test]

--- a/crates/zeroclaw-channels/src/whatsapp_web.rs
+++ b/crates/zeroclaw-channels/src/whatsapp_web.rs
@@ -357,6 +357,61 @@ impl WhatsAppWebChannel {
         candidates
     }
 
+    /// True when the address is a WhatsApp LID JID (not deliverable for outbound).
+    #[cfg(feature = "whatsapp-web")]
+    fn is_lid_jid_string(jid: &str) -> bool {
+        jid.trim()
+            .rsplit_once('@')
+            .is_some_and(|(_, domain)| domain.eq_ignore_ascii_case("lid"))
+    }
+
+    /// Map an undeliverable LID chat JID to `digits@s.whatsapp.net` when phone
+    /// candidates are known. Returns `(target, converted)`.
+    #[cfg(feature = "whatsapp-web")]
+    fn resolve_deliverable_reply_target(chat: &str, phone_candidates: &[String]) -> (String, bool) {
+        if !Self::is_lid_jid_string(chat) {
+            return (chat.to_string(), false);
+        }
+        for candidate in phone_candidates {
+            let digits: String = candidate.chars().filter(|c| c.is_ascii_digit()).collect();
+            if !digits.is_empty() {
+                return (format!("{digits}@s.whatsapp.net"), true);
+            }
+        }
+        (chat.to_string(), false)
+    }
+
+    /// Resolve an outbound recipient, converting LID JIDs via the live client cache.
+    #[cfg(feature = "whatsapp-web")]
+    async fn resolve_outbound_recipient(client: &wa_rs::Client, recipient: &str) -> Result<String> {
+        let trimmed = recipient.trim();
+        if !Self::is_lid_jid_string(trimmed) {
+            return Ok(trimmed.to_string());
+        }
+        let lid_user = trimmed.split('@').next().unwrap_or(trimmed);
+        if let Some(phone) = client.get_phone_number_from_lid(lid_user).await
+            && let Some(token) = Self::normalize_phone_token(&phone)
+        {
+            let digits: String = token.chars().filter(|c| c.is_ascii_digit()).collect();
+            if !digits.is_empty() {
+                let resolved = format!("{digits}@s.whatsapp.net");
+                ::zeroclaw_log::record!(
+                    INFO,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                        .with_attrs(::serde_json::json!({
+                            "from": trimmed,
+                            "to": resolved,
+                        })),
+                    "outbound LID→phone recipient"
+                );
+                return Ok(resolved);
+            }
+        }
+        anyhow::bail!(
+            "Cannot deliver to LID JID `{trimmed}`: phone resolution failed (LID JIDs cannot receive messages)"
+        )
+    }
+
     /// Normalize phone number to E.164 format
     #[cfg(feature = "whatsapp-web")]
     fn normalize_phone(&self, phone: &str) -> String {
@@ -805,7 +860,9 @@ impl Channel for WhatsAppWebChannel {
             }
         }
 
-        let to = self.recipient_to_jid(&message.recipient)?;
+        let deliverable_recipient =
+            Self::resolve_outbound_recipient(&client, &message.recipient).await?;
+        let to = self.recipient_to_jid(&deliverable_recipient)?;
 
         // Voice chat mode: send text normally AND queue a voice note of the
         // final answer. Only substantive messages (not tool outputs) are queued.
@@ -1085,16 +1142,13 @@ impl Channel for WhatsAppWebChannel {
                                         }
                                         // self_chat_mode=true: always process, skip further policy checks.
                                         //
-                                        // When the chat JID is LID-based, replies
-                                        // won't be delivered. Convert to a phone
-                                        // JID so the reply shows up in the self-chat.
                                         if info.source.chat.is_lid() {
-                                            let phone_digits = normalized
-                                                .as_ref()
-                                                .map(|n| n.chars().filter(|c| c.is_ascii_digit()).collect::<String>())
-                                                .filter(|d| !d.is_empty());
-                                            if let Some(digits) = phone_digits {
-                                                reply_target = format!("{digits}@s.whatsapp.net");
+                                            let (resolved, converted) = Self::resolve_deliverable_reply_target(
+                                                &chat,
+                                                &sender_candidates,
+                                            );
+                                            if converted {
+                                                reply_target = resolved;
                                                 ::zeroclaw_log::record!(DEBUG, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(::serde_json::json!({"reply_target": reply_target})), "self-chat LID→phone reply target");
                                             }
                                         }
@@ -1161,6 +1215,53 @@ impl Channel for WhatsAppWebChannel {
                                 }
 
                                 let normalized = normalized.unwrap_or_else(|| sender.clone());
+
+                                // LID chat JIDs cannot receive outbound messages (typing may
+                                // still work). Resolve to phone JID for all non-group DMs.
+                                if !is_group && Self::is_lid_jid_string(&reply_target) {
+                                    let mut lid_candidates = sender_candidates.clone();
+                                    if let Some(chat_user) =
+                                        reply_target.split('@').next().filter(|u| !u.is_empty())
+                                        && let Some(phone) =
+                                            client.get_phone_number_from_lid(chat_user).await
+                                        && let Some(token) = Self::normalize_phone_token(&phone)
+                                        && !lid_candidates.iter().any(|c| c == &token)
+                                    {
+                                        lid_candidates.push(token);
+                                    }
+                                    let (resolved, converted) =
+                                        Self::resolve_deliverable_reply_target(
+                                            &reply_target,
+                                            &lid_candidates,
+                                        );
+                                    if converted {
+                                        reply_target = resolved;
+                                        ::zeroclaw_log::record!(
+                                            INFO,
+                                            ::zeroclaw_log::Event::new(
+                                                module_path!(),
+                                                ::zeroclaw_log::Action::Note
+                                            )
+                                            .with_attrs(::serde_json::json!({
+                                                "reply_target": reply_target,
+                                            })),
+                                            "DM LID→phone reply target"
+                                        );
+                                    } else {
+                                        ::zeroclaw_log::record!(
+                                            WARN,
+                                            ::zeroclaw_log::Event::new(
+                                                module_path!(),
+                                                ::zeroclaw_log::Action::Note
+                                            )
+                                            .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                                            .with_attrs(::serde_json::json!({
+                                                "reply_target": reply_target,
+                                            })),
+                                            "undeliverable LID reply_target; outbound may fail"
+                                        );
+                                    }
+                                }
 
                                 // Attempt voice note transcription (ptt = push-to-talk = voice note).
                                 // When `transcribe_non_ptt_audio` is enabled in the transcription
@@ -1257,8 +1358,8 @@ impl Channel for WhatsAppWebChannel {
                                         channel_alias: Some((*alias).clone()),
                                         sender: normalized.clone(),
                                         // Reply to the originating chat JID (DM or group).
-                                        // For self-chat with LID JIDs, this is the
-                                        // resolved phone JID (see above).
+                                        // For DMs with LID JIDs, this is the resolved
+                                        // phone JID (see LID→phone resolution above).
                                         reply_target,
                                         content,
                                         timestamp: chrono::Utc::now().timestamp() as u64,
@@ -1481,7 +1582,8 @@ impl Channel for WhatsAppWebChannel {
             }
         }
 
-        let to = self.recipient_to_jid(recipient)?;
+        let deliverable_recipient = Self::resolve_outbound_recipient(&client, recipient).await?;
+        let to = self.recipient_to_jid(&deliverable_recipient)?;
         client.chatstate().send_composing(&to).await.map_err(|e| {
             ::zeroclaw_log::record!(
                 ERROR,
@@ -1520,7 +1622,8 @@ impl Channel for WhatsAppWebChannel {
             }
         }
 
-        let to = self.recipient_to_jid(recipient)?;
+        let deliverable_recipient = Self::resolve_outbound_recipient(&client, recipient).await?;
+        let to = self.recipient_to_jid(&deliverable_recipient)?;
         client.chatstate().send_paused(&to).await.map_err(|e| {
             ::zeroclaw_log::record!(
                 ERROR,
@@ -1806,6 +1909,46 @@ mod tests {
         let candidates =
             WhatsAppWebChannel::sender_phone_candidates(&sender, None, Some("15551234567"));
         assert!(candidates.contains(&"+15551234567".to_string()));
+    }
+
+    #[test]
+    #[cfg(feature = "whatsapp-web")]
+    fn is_lid_jid_string_detects_lid_domain() {
+        assert!(WhatsAppWebChannel::is_lid_jid_string("76188559093817@lid"));
+        assert!(!WhatsAppWebChannel::is_lid_jid_string(
+            "15551234567@s.whatsapp.net"
+        ));
+        assert!(!WhatsAppWebChannel::is_lid_jid_string("+15551234567"));
+    }
+
+    #[test]
+    #[cfg(feature = "whatsapp-web")]
+    fn resolve_deliverable_reply_target_converts_lid_with_phone_candidate() {
+        let (target, converted) = WhatsAppWebChannel::resolve_deliverable_reply_target(
+            "76188559093817@lid",
+            &["+15551234567".to_string()],
+        );
+        assert!(converted);
+        assert_eq!(target, "15551234567@s.whatsapp.net");
+    }
+
+    #[test]
+    #[cfg(feature = "whatsapp-web")]
+    fn resolve_deliverable_reply_target_leaves_phone_jid_unchanged() {
+        let chat = "15551234567@s.whatsapp.net";
+        let (target, converted) =
+            WhatsAppWebChannel::resolve_deliverable_reply_target(chat, &["+15551234567".into()]);
+        assert!(!converted);
+        assert_eq!(target, chat);
+    }
+
+    #[test]
+    #[cfg(feature = "whatsapp-web")]
+    fn resolve_deliverable_reply_target_warns_via_unchanged_lid_when_no_candidates() {
+        let chat = "76188559093817@lid";
+        let (target, converted) = WhatsAppWebChannel::resolve_deliverable_reply_target(chat, &[]);
+        assert!(!converted);
+        assert_eq!(target, chat);
     }
 
     // ── lid_rejection_diagnostic: scoped LID warning ────


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Resolve WhatsApp Web LID JIDs (`*@lid`) to deliverable phone JIDs (`digits@s.whatsapp.net`) on inbound DM/self-chat `reply_target` and on outbound send/typing/paused paths, using sender candidates and `get_phone_number_from_lid`.
  - Fail outbound explicitly when LID→phone resolution is impossible, instead of silently targeting an undeliverable JID.
  - Substitute a short fallback message when the channel orchestrator would otherwise send an empty reply after sanitization (avoids typing with no visible message).
- **Scope boundary:** Does not change WhatsApp Cloud API, other channels, or config schema.
- **Blast radius:** `zeroclaw-channels` orchestrator (all channels get empty-reply fallback); WhatsApp Web paths require `whatsapp-web` feature.
- **Linked issue(s):** None filed — community fix for undelivered WhatsApp Web replies and empty channel responses.
- **Labels:** `channel:whatsapp`, `risk: medium`, `size: S` (requested; adjust in sidebar if needed)

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy -p zeroclaw-channels --all-targets --features whatsapp-web -- -D warnings
cargo test -p zeroclaw-channels --features whatsapp-web
```

- **Commands run and tail output:**

```
$ cargo fmt --all -- --check
(no diff — exit 0)

$ cargo clippy -p zeroclaw-channels --all-targets --features whatsapp-web -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.67s

$ cargo test -p zeroclaw-channels --features whatsapp-web
test result: ok. 1137 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.00s
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.05s
```

- **Beyond CI — what did you manually verify?** Not run: live WhatsApp Web session with a LID-based DM contact. Recommended manual checks: DM from LID contact receives reply; self-chat with LID JID; agent turn that sanitizes to empty text shows fallback.
- **If any command was intentionally skipped, why:** Full-workspace `cargo test` / `cargo clippy --all-targets` not run locally; change is confined to `zeroclaw-channels` and validated with `whatsapp-web` feature enabled.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- If `No` or `Yes` to either: exact upgrade steps for existing users: N/A

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert f4e0fd771` (or merge revert of this PR)
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Logs `undeliverable LID reply_target`, `Cannot deliver to LID JID`, or `channel_reply_empty`; users see fallback text instead of silence when sanitization empties the reply.

Made with [Cursor](https://cursor.com)