### PR TITLE
feat(tools): add result mode to execute_pipeline

### DIFF
--- a/crates/zeroclaw-tools/src/pipeline.rs
+++ b/crates/zeroclaw-tools/src/pipeline.rs
@@ -42,6 +42,22 @@ pub struct PipelineRequest {
     pub steps: Vec<PipelineStep>,
     #[serde(default)]
     pub parallel: bool,
+    /// What to include in the tool output. Defaults to every step's result.
+    #[serde(default)]
+    pub result: PipelineResultMode,
+}
+
+/// Controls what `execute_pipeline` returns to the caller.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PipelineResultMode {
+    /// Return every step's result as a JSON array (default; backward compatible).
+    #[default]
+    All,
+    /// Return only the final step's raw output. Use when earlier steps produce
+    /// large intermediate blobs (e.g. base64) that must not flow back into the
+    /// model context.
+    Last,
 }
 
 /// Result of a single pipeline step.
@@ -217,7 +233,9 @@ impl Tool for PipelineTool {
     fn description(&self) -> &str {
         "Execute a multi-step tool pipeline in a single call. Steps run sequentially by default \
          with result interpolation (use {{step[N].result}} to reference prior outputs), \
-         or in parallel when 'parallel: true' is set."
+         or in parallel when 'parallel: true' is set. Set 'result: \"last\"' to return only the \
+         final step's output (recommended when an earlier step yields a large blob, e.g. base64, \
+         that should not flow back into the context); the default 'all' returns every step's result."
     }
 
     fn parameters_schema(&self) -> serde_json::Value {
@@ -246,6 +264,12 @@ impl Tool for PipelineTool {
                     "type": "boolean",
                     "description": "Run steps in parallel (no interpolation). Default: false",
                     "default": false
+                },
+                "result": {
+                    "type": "string",
+                    "enum": ["all", "last"],
+                    "description": "What to return: 'all' (default) = every step's result as JSON; 'last' = only the final step's raw output. Use 'last' to keep large intermediate blobs (e.g. base64) out of the context.",
+                    "default": "all"
                 }
             },
             "required": ["steps"]
@@ -281,8 +305,14 @@ impl Tool for PipelineTool {
 
         match results {
             Ok(step_results) => {
-                let output = serde_json::to_string_pretty(&step_results)
-                    .unwrap_or_else(|_| "Pipeline completed".to_string());
+                let output = match request.result {
+                    PipelineResultMode::Last => step_results
+                        .last()
+                        .map(|s| s.output.clone())
+                        .unwrap_or_default(),
+                    PipelineResultMode::All => serde_json::to_string_pretty(&step_results)
+                        .unwrap_or_else(|_| "Pipeline completed".to_string()),
+                };
                 Ok(ToolResult {
                     success: true,
                     output,
@@ -525,6 +555,7 @@ mod tests {
                 },
             ],
             parallel: false,
+            result: PipelineResultMode::default(),
         };
 
         let err = tool.validate(&request).unwrap_err();
@@ -546,6 +577,7 @@ mod tests {
                 args: serde_json::json!({}),
             }],
             parallel: false,
+            result: PipelineResultMode::default(),
         };
 
         let err = tool.validate(&request).unwrap_err();
@@ -573,6 +605,7 @@ mod tests {
                 },
             ],
             parallel: false,
+            result: PipelineResultMode::default(),
         };
 
         assert!(tool.validate(&request).is_ok());
@@ -590,6 +623,7 @@ mod tests {
         let request = PipelineRequest {
             steps: vec![],
             parallel: false,
+            result: PipelineResultMode::default(),
         };
 
         assert!(tool.validate(&request).is_ok());
@@ -621,5 +655,82 @@ mod tests {
     #[test]
     fn resolve_out_of_range_index() {
         assert_eq!(resolve_template("step[5].result", &[]), None);
+    }
+
+    // ── Result mode ────────────────────────────────────────
+
+    struct EchoTool {
+        name: String,
+        output: String,
+    }
+
+    zeroclaw_api::mock_tool_attribution!(EchoTool);
+
+    #[async_trait::async_trait]
+    impl Tool for EchoTool {
+        fn name(&self) -> &str {
+            &self.name
+        }
+        fn description(&self) -> &str {
+            "echo"
+        }
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object"})
+        }
+        async fn execute(&self, _args: serde_json::Value) -> Result<ToolResult> {
+            Ok(ToolResult {
+                success: true,
+                output: self.output.clone(),
+                error: None,
+            })
+        }
+    }
+
+    fn echo_pipeline() -> PipelineTool {
+        let config = PipelineConfig {
+            enabled: true,
+            max_steps: 20,
+            allowed_tools: vec!["a".to_string(), "b".to_string()],
+        };
+        let tools: Vec<Arc<dyn Tool>> = vec![
+            Arc::new(EchoTool {
+                name: "a".into(),
+                output: "FIRST_BIG_BLOB".into(),
+            }),
+            Arc::new(EchoTool {
+                name: "b".into(),
+                output: "final answer".into(),
+            }),
+        ];
+        PipelineTool::new(config, tools)
+    }
+
+    #[tokio::test]
+    async fn result_last_returns_only_final_output() {
+        let args = serde_json::json!({
+            "steps": [
+                {"tool": "a", "args": {}},
+                {"tool": "b", "args": {}}
+            ],
+            "result": "last"
+        });
+        let res = echo_pipeline().execute(args).await.unwrap();
+        assert!(res.success);
+        assert_eq!(res.output, "final answer");
+        assert!(!res.output.contains("FIRST_BIG_BLOB"));
+    }
+
+    #[tokio::test]
+    async fn result_all_is_default_and_includes_every_step() {
+        let args = serde_json::json!({
+            "steps": [
+                {"tool": "a", "args": {}},
+                {"tool": "b", "args": {}}
+            ]
+        });
+        let res = echo_pipeline().execute(args).await.unwrap();
+        assert!(res.success);
+        assert!(res.output.contains("FIRST_BIG_BLOB"));
+        assert!(res.output.contains("final answer"));
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Adds an optional `result` field (`all` | `last`) to the `execute_pipeline` tool. By default `execute_pipeline` serializes *every* step's result into the tool output; when an early step produces a large blob (e.g. base64 bytes from `file_read`), that blob flows back into the model context even though only the final step's output is wanted. `result: "last"` returns only the final step's raw output, keeping intermediate blobs out of context.
- **Scope boundary:** Only `execute_pipeline` output shaping. No change to step execution, interpolation, parallel mode, the allowlist, or any other tool.
- **Blast radius:** `crates/zeroclaw-tools/src/pipeline.rs` only. Default behavior is unchanged (`result` defaults to `all`), so existing callers are unaffected.
- **Linked issue(s):** None.
- **Labels:** `enhancement`, `risk: low`, `size: S`, `tool`.

## Validation Evidence (required)

```bash
cargo fmt -p zeroclaw-tools -- --check      # clean (exit 0)
cargo test -p zeroclaw-tools --lib pipeline # 16 passed; 0 failed
cargo clippy -p zeroclaw-tools --all-targets -- -D warnings
```

`cargo test` tail:

```
running 16 tests
...
test pipeline::tests::result_all_is_default_and_includes_every_step ... ok
test pipeline::tests::result_last_returns_only_final_output ... ok
test result: ok. 16 passed; 0 failed; 0 ignored; 0 measured; 1180 filtered out
```

- **Commands run and tail output:** `fmt` clean; the two new tests (`result_last_returns_only_final_output`, `result_all_is_default_and_includes_every_step`) plus all existing pipeline tests pass.
- **Beyond CI — what I manually verified:** End-to-end on a live agent reading a `.docx` via `execute_pipeline` (`file_read` base64 → `office_read`) with `result: "last"`: only the extracted text returned to the model, base64 no longer entered the context.
- **clippy note:** `clippy --all-targets -- -D warnings` reports two failures, both pre-existing and unrelated to this PR, in `crates/zeroclaw-tools/src/glob_search.rs` (an `unreachable statement` and `unused variable` in a test, lines 418/424; appear only on Windows where the test's early `return;` is taken). This diff touches only `pipeline.rs`, which is clippy-clean.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility (required)

- Backward compatible? **Yes** — `result` is optional (`#[serde(default)]`) and defaults to `all`, the prior behavior. Existing pipelines need no changes.
- Config / env / CLI surface changed? **No** — only the `execute_pipeline` tool's JSON arg schema gains an optional `result` field.

## Rollback (required for `risk: medium` and `risk: high`)

Low risk: `git revert <sha>`.
