### PR TITLE
fix(provider): accept compatible typed content arrays

### DIFF
--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -732,6 +732,53 @@ fn strip_think_tags(s: &str) -> String {
     result.trim().to_string()
 }
 
+/// OpenAI Chat Completions may return assistant `message.content` as a string,
+/// null, or an array of typed parts. Normalize it before storing the internal
+/// response shape so compatible gateways that preserve typed parts still work,
+/// while unsupported top-level content shapes still fail deserialization.
+fn openai_assistant_content_plaintext(content: Option<OpenAiAssistantContent>) -> Option<String> {
+    match content? {
+        OpenAiAssistantContent::Text(s) => {
+            if s.is_empty() {
+                None
+            } else {
+                Some(s)
+            }
+        }
+        OpenAiAssistantContent::Parts(parts) => {
+            let mut text = String::new();
+            for part in parts {
+                if part.kind.as_deref() != Some("text") {
+                    continue;
+                }
+                let Some(part_text) = part.text.filter(|text| !text.is_empty()) else {
+                    continue;
+                };
+                if !text.is_empty() {
+                    text.push('\n');
+                }
+                text.push_str(&part_text);
+            }
+
+            if text.is_empty() { None } else { Some(text) }
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum OpenAiAssistantContent {
+    Text(String),
+    Parts(Vec<OpenAiAssistantContentPart>),
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiAssistantContentPart {
+    #[serde(rename = "type")]
+    kind: Option<String>,
+    text: Option<String>,
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(from = "RawResponseMessage")]
 struct ResponseMessage {
@@ -757,7 +804,7 @@ struct ResponseMessage {
 #[derive(Debug, Deserialize)]
 struct RawResponseMessage {
     #[serde(default)]
-    content: Option<String>,
+    content: Option<OpenAiAssistantContent>,
     #[serde(default)]
     reasoning_content: Option<String>,
     #[serde(default)]
@@ -772,7 +819,7 @@ impl From<RawResponseMessage> for ResponseMessage {
         // when the canonical name is absent or null.
         let reasoning_content = raw.reasoning_content.or(raw.reasoning);
         ResponseMessage {
-            content: raw.content,
+            content: openai_assistant_content_plaintext(raw.content),
             reasoning_content,
             tool_calls: raw.tool_calls,
         }
@@ -3089,6 +3136,34 @@ mod tests {
             resp.choices[0].message.content,
             Some("Hello from Venice!".to_string())
         );
+    }
+
+    #[test]
+    fn response_deserializes_content_as_openai_text_parts_array() {
+        let json =
+            r#"{"choices":[{"message":{"content":[{"type":"text","text":"Hello array"}]}}]}"#;
+        let resp: ApiChatResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            resp.choices[0].message.content.as_deref(),
+            Some("Hello array")
+        );
+    }
+
+    #[test]
+    fn response_deserializes_multiple_text_parts_with_newlines() {
+        let json = r#"{"choices":[{"message":{"content":[{"type":"text","text":"Hello"},{"type":"image_url","image_url":{"url":"https://example.com/image.png"}},{"type":"text","text":"array"}]}}]}"#;
+        let resp: ApiChatResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            resp.choices[0].message.content.as_deref(),
+            Some("Hello\narray")
+        );
+    }
+
+    #[test]
+    fn response_rejects_unsupported_top_level_content_shape() {
+        let json = r#"{"choices":[{"message":{"content":{"type":"text","text":"Hello object"}}}]}"#;
+        serde_json::from_str::<ApiChatResponse>(json)
+            .expect_err("object-shaped assistant content must remain an invalid payload");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Restores the #4149 compatible-provider response shape that accepts non-streaming Chat Completions assistant `message.content` as OpenAI typed text parts, not only a plain string.
  - Keeps the internal `ResponseMessage.content` as normalized plain text so the existing native-tool parser and reasoning fallback paths continue to work unchanged.
  - Uses a narrow accepted-content enum so unsupported top-level content shapes such as objects, numbers, and booleans still fail deserialization instead of becoming silent empty responses.
  - Adds behavior tests for a single typed text part, multiple typed text parts, and unsupported object-shaped top-level content.
- **Scope boundary:** This does not change streaming SSE parsing, provider request serialization, native tool-call ID handling, reasoning-content precedence, config, or public API surface.
- **Blast radius:** Limited to OpenAI-compatible provider non-streaming Chat Completions response parsing in `zeroclaw-providers`.
- **Linked issue(s):** Related #6074. Restores the remaining compatible-provider typed-content-array portion of merged #4149 / `6469a262`, lost in bulk revert `c3ff635`.
- **Labels:** `bug`, `risk: medium`, `size: XS`, `provider`, `provider:compatible`

## Validation Evidence (required)

- **Commands run and tail output:**

```text
cargo fmt --all -- --check
Result: passed.

git diff --check
Result: passed.

cargo test -p zeroclaw-providers response_deserializes_content_as_openai_text_parts_array -- --nocapture
Result: passed; 1 test passed.

cargo test -p zeroclaw-providers response_deserializes_multiple_text_parts_with_newlines -- --nocapture
Result: passed; 1 test passed.

cargo test -p zeroclaw-providers response_rejects_unsupported_top_level_content_shape -- --nocapture
Result: passed; 1 test passed.

cargo test -p zeroclaw-providers response_deserializes -- --nocapture
Result: passed; 20 selected provider response tests passed.

cargo test -p zeroclaw-providers response_message -- --nocapture
Result: passed; 4 selected ResponseMessage tests passed.

cargo test -p zeroclaw-providers reasoning_content -- --nocapture
Result: passed; 35 selected reasoning-content tests passed.

cargo clippy -p zeroclaw-providers --lib -- -D warnings
Result: passed.

cargo clippy --all-targets -- -D warnings
Result: passed.

cargo nextest run --locked --workspace --exclude zeroclaw-desktop
Result: failed after running 5614/8117 tests; three unrelated zeroclaw-runtime delegate background-task timeout tests failed before nextest stopped.

cargo nextest run -p zeroclaw-runtime delegate::tests
Result: passed; 60 runtime delegate tests passed, including the three tests that failed during the broad run.
```
- **Beyond CI — what did you manually verify?** Compared the current master implementation against #4149 and confirmed this PR only recovers the missing non-streaming compatible-provider typed-content-array response path. The diff does not change streaming SSE parsing, provider request serialization, native tool-call ID handling, or reasoning-content precedence; the focused response and reasoning tests listed above stayed green.
- **If any command was intentionally skipped, why:** Plain `cargo test` was not run directly because the repo's current full-test standard is the CI-shaped `cargo nextest run --locked --workspace --exclude zeroclaw-desktop` command. That local nextest run was attempted, but it stopped on unrelated `zeroclaw-runtime` delegate timeout failures after 5614/8117 tests. The failed runtime delegate neighborhood passed on focused rerun, and GitHub CI's `Test` job is green. I am treating the local nextest interruption as unrelated to this provider-only change; it is not counted as green full local nextest evidence.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: `N/A`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: `N/A`

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <merge-sha>`
- **Feature flags or config toggles:** `None`
- **Observable failure symptoms:** OpenAI-compatible non-streaming chat responses with typed assistant content arrays fail to parse, return empty assistant text, or unexpectedly reject compatible-provider responses.

## Supersede Attribution (required only when `Supersedes #` is used)

This PR does not use `Supersedes #` because #4149 was already merged. For #6074 recovery tracking, this section records the prior merged work restored here.

- Superseded/prior PRs + authors (`#<pr> by @<author>`, one per line): `#4149 by @locnh-ssid`
- Scope materially carried forward: Compatible-provider support for non-streaming Chat Completions assistant `message.content` as an array of typed text parts.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `Yes`
- If `No`, why (inspiration-only, no direct code/design carry-over): `N/A`
