### PR TITLE
docs(maintainers): define issue ownership path

### DIFF
--- a/.claude/skills/github-issue-triage/references/triage-protocol.md
+++ b/.claude/skills/github-issue-triage/references/triage-protocol.md
@@ -284,6 +284,8 @@ Activity is defined as: a follow-up comment or update from the **original author
 
 `status:in-progress` is a routing signal, not a permanent stale exemption by itself. During stale passes, verify that an open linked PR still exists. If the PR has closed without resolving the issue, remove or replace `status:in-progress` only after presenting the exact label change to the user.
 
+Target policy: `status:no-stale` protects an issue only when the reason and active owner or steward path are visible through the contributor-visible sources defined in the maintainer Project board contract. Assignees count as active owners. Public issue fields count only when they are visible to normal issue readers; organization-only or private issue and Project fields do not satisfy the contributor-visible requirement. Labels can identify the likely area, but they are not an owner source by themselves. Until the stale-exemption audit and repair packet lands, missing reason or owner evidence is an audit finding and proposed correction, not an automatic stale-closure trigger.
+
 ### Stale enforcement steps
 
 1. Fetch all open issues with `createdAt`, `author`, `labels`, `comments`, and `reactionGroups` fields.
@@ -301,6 +303,7 @@ Activity is defined as: a follow-up comment or update from the **original author
 
 4. Before proposing stale action, verify exclusions against current state:
    - Check current labels for `priority:p0`, `type:rfc`, and `status:no-stale`.
+   - For `status:no-stale`, inspect the cited visible source first: assignee, issue body/comment, Public issue field, public Project field, or linked public tracker entry. Record whether both the reason and active owner or steward path are present. If the issue does not cite a visible source or the source is ambiguous, add it to the stale-exemption audit findings and present the proposed correction to the user; reserve exhaustive source gathering for the stale-exemption audit/repair packet.
    - For `status:blocked`, fetch the issue body and relevant maintainer comments or tracker entry, then verify the recorded blocker and whether it is still unresolved. If not, present the label correction to the user first and do not treat the issue as exempt until the user approves the change.
    - Check the open PR batch for issue references before relying on `status:in-progress` or stale eligibility. Fall back to a per-issue PR search only when the batch result is ambiguous.
    - Check opening-post reactions for the 10-or-more 👍 threshold.
@@ -423,7 +426,7 @@ For issues, risk labels estimate likely fix blast radius from the report. Reasse
 - `status:accepted` — RFC or work item accepted by the team; not stale-exempt by itself
 - `status:blocked` — waiting on external blocker; exempt from stale while the blocker is recorded and unresolved
 - `status:in-progress` — linked open PR exists; verify live PR state before stale decisions
-- `status:no-stale` — explicitly exempt from stale automation for accepted or otherwise long-lived work that is not already protected by another exclusion; maintainer-applied with a recorded reason
+- `status:no-stale` — explicitly exempt from stale automation for accepted or otherwise long-lived work that is not already protected by another exclusion; target policy requires a recorded reason and contributor-visible active owner or steward path, with existing gaps handled by the stale-exemption audit packet
 
 ### Resolution
 

--- a/docs/book/src/foundations/fnd-003-governance.md
+++ b/docs/book/src/foundations/fnd-003-governance.md
@@ -224,13 +224,13 @@ Use this split:
 | Surface | Owns | Does not own |
 |---|---|---|
 | Labels | durable classification: type, scope, risk, size, contributor tier, stale/triage policy | per-push review state, active CI status, personal task lists |
-| Project board | planning state: readiness, active owner, roadmap grouping, dependency/blocker state, stale-exemption reason when a field exists | authoritative PR review queue, mergeability, required checks |
+| Project board | planning state: readiness, active owner or steward path, roadmap grouping, dependency/blocker state, stale-exemption reason when a field exists | authoritative PR review queue, mergeability, required checks |
 | Native PR state | review decision, required checks, branch freshness, conflicts, mergeability, draft/ready state | long-term roadmap ownership |
 | Issues/RFCs | durable discussion record, acceptance state, user need, linked implementation trail | live replacement for maintainer docs after policy promotion |
 
 PR lanes, contributor-pickup labels, stale-exemption labels, and label migration are durable governance concepts, but their exact operational criteria live in maintainer docs. FND-003 owns the split: labels classify durable work, project boards plan work, native PR state owns live review and merge state, and issues/RFCs preserve decisions. The [Maintainer PR workflow](../maintainers/pr-workflow.md#pr-lanes) owns PR lane definitions, the [Labels guide](../maintainers/labels.md) owns exact label meanings and cleanup rules, and the [Reviewer playbook](../maintainers/reviewer-playbook.md#issue-triage) owns how reviewers apply those signals during triage and review. Treat live label migration as a separate maintainer-approved cleanup, not ordinary PR review.
 
-Stale exemptions are governance exceptions, not permanent label shields. The target policy is that `status:no-stale` is valid only when the lane's operational source records both why the issue is exempt and who owns it. The maintainer docs define where those facts live and how stale automation or stale sweeps enforce the rule.
+Stale exemptions are governance exceptions, not permanent label shields. The target policy is that `status:no-stale` is valid only when the lane's operational source records both why the issue is exempt and who owns the next movement. The maintainer docs define where those facts live and how stale automation or stale sweeps enforce the rule.
 
 ---
 
@@ -912,7 +912,7 @@ This table records governance intent and historical taxonomy shape. For current 
 | `status:blocked` | `#b60205` Red | Waiting on a recorded unresolved external dependency, maintainer decision, or linked prerequisite |
 | `status:in-progress` | `#0075ca` Blue | Open PR is actively targeting the issue; verify live PR state during stale passes |
 | `status:stale` | `#e4e669` Yellow | No original-author activity for the stale threshold window |
-| `status:no-stale` | `#0e8a16` Green | Explicit stale exemption for accepted or otherwise long-lived work; target policy requires a recorded reason and active owner in the operational source |
+| `status:no-stale` | `#0e8a16` Green | Explicit stale exemption for accepted or otherwise long-lived work; target policy requires a recorded reason and active owner or steward path in the operational source |
 | `status:help-wanted` | `#059669` Green | Looking for a contributor |
 | `status:good-first-issue` | `#059669` Green | Suitable for new contributors |
 | `status:discussion` | `#a78bfa` Purple | Needs team discussion before work begins |
@@ -993,7 +993,7 @@ GitHub enforces CODEOWNERS automatically when the file exists and branch protect
 
 **Stale issue management (`.github/workflows/stale.yml`):**
 
-Issues with no activity for 45 days are labeled `status:stale` and a comment is posted asking if the issue is still relevant. Issues with no activity for 15 days after the stale label is applied are closed. This prevents the backlog from accumulating hundreds of issues that are months old and no longer relevant. Exclude `priority:p0`, `type:rfc`, issues with open linked PRs, and issues with `status:blocked` while a recorded blocker remains unresolved. The intended `status:no-stale` follow-up is to exclude it only while the operational source records both the stale-exemption reason and the active owner. The maintainer label guide and issue-triage protocol carry the current operational details.
+Issues with no activity for 45 days are labeled `status:stale` and a comment is posted asking if the issue is still relevant. Issues with no activity for 15 days after the stale label is applied are closed. This prevents the backlog from accumulating hundreds of issues that are months old and no longer relevant. Exclude `priority:p0`, `type:rfc`, issues with open linked PRs, and issues with `status:blocked` while a recorded blocker remains unresolved. The intended `status:no-stale` follow-up is to exclude it only while the operational source records both the stale-exemption reason and a contributor-visible active owner or steward path. The maintainer label guide and issue-triage protocol carry the current operational details.
 
 **PR size labeling (`.github/workflows/pr-size.yml`):**
 

--- a/docs/book/src/maintainers/labels.md
+++ b/docs/book/src/maintainers/labels.md
@@ -21,10 +21,14 @@ answer fast-moving review and merge questions.
 Keep the split based on update frequency:
 
 - Labels own durable classification: work type, scope/component, review risk, measured PR size, and stale exemption.
-- Project board fields are appropriate for issue planning stage, active owner, dependency state, and roadmap grouping when those fields are actively maintained.
+- Project board fields are appropriate for issue planning stage, active owner or steward path, dependency state, stale-exemption reason, and roadmap grouping when those fields are actively maintained.
 - Native GitHub PR state owns fast-changing review state: review decision, required checks, mergeability, conflicts, and stale approvals.
 
 The board should reduce maintainer work. If a field would need manual upkeep after every PR push or review, prefer labels, milestones, or native GitHub state instead.
+
+Labels can suggest likely ownership, but they are not ownership. A `channel:*`, `provider:*`, `tool:*`, `security:*`, or `docs` label identifies the surface that probably needs attention. Contributor-visible owner-source rules live in the [Project board contract](./pr-workflow.md#project-board-contract).
+
+Use assignees for active work. Use area stewardship for routing responsibility when nobody is implementing yet. The [Project board contract](./pr-workflow.md#issue-ownership-path) defines the accepted owner sources and routing outcomes.
 
 ## Canonical spelling
 
@@ -215,7 +219,7 @@ Track lifecycle state of RFCs and tracked work items. Applied manually unless a 
 | `status:blocked` | Work is valid but waiting on an external dependency, maintainer decision, or linked prerequisite. Exempt from stale while the blocker is recorded and unresolved. Do not pair with `status:no-stale` for the same blocker. |
 | `status:in-progress` | An open PR is actively targeting this issue. Reconcile against live PR state during stale passes; the label is not a permanent exemption after the PR closes. |
 | `status:stale` | No author activity for the stale window; may close if not refreshed |
-| `status:no-stale` | Explicit stale exemption for accepted or otherwise long-lived work that is not already protected by another stale exclusion. Use only when a maintainer comment, issue body, or tracker entry records why the issue should stay open. |
+| `status:no-stale` | Explicit stale exemption for accepted or otherwise long-lived work that is not already protected by another stale exclusion. Target policy: use only when the [Project board contract](./pr-workflow.md#issue-ownership-path) has a contributor-visible stale-exemption reason and owner path. Existing exemptions missing those facts should be audited and repaired before stale sweeps stop honoring them. |
 
 ## Resolution labels
 

--- a/docs/book/src/maintainers/pr-workflow.md
+++ b/docs/book/src/maintainers/pr-workflow.md
@@ -33,6 +33,36 @@ Do not mirror native PR review state into manual board lanes. GitHub PR state ow
 
 This keeps the board useful without asking maintainers to update it after every push, review, or CI run.
 
+### Issue ownership path
+
+Issues need an ownership path before they can safely stay accepted, in progress, or stale-exempt for long periods. PRs have CODEOWNERS and requested reviewers; issues need an equivalent routing contract for the next triage decision.
+
+Use these meanings consistently:
+
+| Signal | Means | Does not mean |
+|---|---|---|
+| Assignee | Someone is actively implementing, investigating, or shepherding the immediate work. | Permanent area ownership or passive responsibility for every related issue. |
+| Area steward | A maintainer or documented steward surface owns the next routing decision: clarify, accept, close, defer, or identify the next implementation path. | Automatic implementation ownership. |
+| Project active owner | The board-visible person or steward source currently responsible for the next movement. | A replacement for live PR review state. |
+| Labels | Durable classification and likely area routing. | Ownership by themselves. |
+
+Area stewardship is the issue-side analogue to CODEOWNERS, but it is not implemented through CODEOWNERS. If GitHub issue fields are enabled and visible to the public on the issue page, prefer a Public issue field for `Area steward` or `Owner path`. Organization-only or private issue and Project fields do not satisfy contributor-visible ownership. Otherwise, the contributor-visible source can be a maintained steward table, a public Project field, an issue-visible maintainer comment, or a public tracker entry linked from the issue.
+
+Identifying the next implementation path does not mean the steward must personally implement the issue or guarantee staffing. It means they make the next step explicit: assign an active owner, make the issue contributor-ready, route it to a tracker or milestone, schedule it for maintainer triage, or close/defer it with a recorded rationale.
+
+Stewardship is decision ownership, not indefinite delivery ownership. A stewarded issue should not sit in an "owned" limbo; the next visible update should record one of the outcomes above or name the decision needed.
+
+Scheduling an issue for maintainer triage is valid only when the issue records what decision is needed, where that decision will be tracked, and when it will be revisited. After that triage pass, replace the triage routing with an active owner, contributor-ready scope, tracker or milestone route, blocked/deferred state, or closure rationale.
+
+For accepted or protected issues, prefer one of these visible owner sources before adding or keeping `status:no-stale`:
+
+- an assignee doing active work;
+- a Public issue field, issue comment, or body section naming the steward path;
+- a public Project active-owner or area-steward field;
+- a linked public tracker entry that names the steward or owner source.
+
+If none of those exists, the issue can still stay open while triage continues, but it should not rely on `status:no-stale` as a permanent shield. Until the stale-exemption audit lands, missing reason or owner evidence is an audit finding and proposed correction, not an automatic stale-closure trigger.
+
 ## PR lanes
 
 PR lanes are routing expectations, not another required label family. Use them to decide how much review depth, sequencing, and maintainer attention a PR needs. CODEOWNERS, native GitHub review state, CI, labels, linked issues, and explicit relationship keywords still carry the actual routing data.
@@ -125,7 +155,7 @@ For AI-heavy PRs, reviewers focus on:
 
 - First maintainer triage target: **within 48 hours**.
 - Blocked PRs get one actionable checklist comment, not a series of partial reviews.
-- `status:no-stale` is reserved for accepted or otherwise long-lived work with a recorded reason to stay open when the issue is not already protected by another stale exclusion.
+- `status:no-stale` is reserved for accepted or otherwise long-lived work with a recorded stale-exemption reason and contributor-visible active owner or steward path when the issue is not already protected by another stale exclusion. Existing exemptions missing those facts are audit findings until the stale-exemption repair packet lands.
 
 For stacked work, require explicit `Depends on #...` so review order is deterministic.
 

--- a/docs/book/src/maintainers/project-board-contract.json
+++ b/docs/book/src/maintainers/project-board-contract.json
@@ -15,12 +15,12 @@
     "maintenance": "manual_or_future_automation",
     "examples": [
       "issue_readiness",
-      "active_owner",
+      "owner_path",
       "roadmap_group",
       "dependency_state",
       "stale_exemption_reason"
     ],
-    "guidance": "Use for slower planning questions such as readiness, ownership, roadmap grouping, dependencies, and explicit stale-exemption rationale."
+    "guidance": "Use for slower planning questions such as readiness, owner path, roadmap grouping, dependencies, and explicit stale-exemption rationale. The owner path may be an active assignee or a steward path."
   },
   "derived_github_pr_signals": {
     "owner": "github_pr",
@@ -54,7 +54,7 @@
       "status",
       "stale_exemption"
     ],
-    "guidance": "Use labels for portable classification across issues and PRs."
+    "guidance": "Use labels for portable classification across issues and PRs. Labels can suggest the likely area, but they are not an owner source by themselves."
   },
   "non_goals": [
     "active GitHub Project integration",

--- a/docs/book/src/maintainers/reviewer-playbook.md
+++ b/docs/book/src/maintainers/reviewer-playbook.md
@@ -91,9 +91,11 @@ Issue `risk:*` labels describe likely fix blast radius from the report. PR `risk
 | `status:accepted` | The team has accepted the RFC or work item. Add `status:no-stale` only when the issue also needs stale protection. |
 | `status:blocked` | Valid work is waiting on an external dependency, maintainer decision, or linked prerequisite. Record the blocker; this is stale protection only while that blocker remains unresolved. |
 | `status:in-progress` | An open PR is actively targeting the issue. Re-check live PR state before relying on it during stale passes. |
-| `status:no-stale` | Accepted or otherwise long-lived work should stay open and is not already protected by another stale exclusion. Record the reason in a maintainer comment, issue body, or tracker entry. |
+| `status:no-stale` | Accepted or otherwise long-lived work should stay open and is not already protected by another stale exclusion. Record the reason and active owner or steward path using the contributor-visible owner sources in the [Project board contract](./pr-workflow.md#issue-ownership-path). |
 | `good first issue` | XS/S, self-contained, documented work with clear acceptance criteria, relevant code or docs links, a named mentor or contact, and low onboarding risk. |
 | `help wanted` | Actionable, unblocked work maintainers want external help on and can review. Do not use it as a generic valid/unowned marker. |
+
+Assignee means active work. Area steward means responsibility for the next issue-routing decision when no implementer is active. The [Project board contract](./pr-workflow.md#issue-ownership-path) defines the accepted owner sources and routing outcomes. Labels can identify the likely area, but labels alone are not an owner source.
 
 ### Resolution labels
 
@@ -137,7 +139,7 @@ This keeps context loss low and avoids the next reviewer redoing the same fetche
 
 ## Weekly queue hygiene
 
-- Walk the stale queue. Apply `status:no-stale` only when accepted or otherwise long-lived work has a recorded reason to stay open and is not already protected by another stale exclusion.
+- Walk the stale queue. Apply `status:no-stale` only when accepted or otherwise long-lived work has a recorded reason to stay open, a visible active owner or steward path, and no other stale exclusion already applies. Until the stale-exemption audit lands, treat existing `status:no-stale` issues missing those facts as audit findings rather than automatic stale candidates.
 - Prioritize `size: XS/S` bug and security PRs first.
 - Convert recurring support questions into docs improvements and auto-response guidance.
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Defines an issue ownership path in the maintainer PR workflow so accepted, in-progress, and stale-exempt issues have a visible next-movement owner or steward source.
  - Distinguishes active assignees from area stewards: assignees mean active work, while stewards own the next routing decision and do not automatically become implementers.
  - Requires `status:no-stale` to have a contributor-visible stale-exemption reason and active owner or steward path, while treating current gaps as audit findings until the later repair/enforcement packet lands.
  - Updates the labels guide, reviewer playbook, FND-003 governance text, Project board contract JSON, and issue-triage skill reference to point at the same owner-path contract instead of duplicating competing rules.
- **Scope boundary:** This PR does not mutate live labels, Project fields, issue state, stale automation, or named steward assignments. It also does not run the later stale-exemption audit or repair packet.
- **Blast radius:** Maintainer workflow docs, governance reference text, the Project board contract JSON, and the issue-triage skill reference. Runtime code, configuration, CI, and user-facing CLI behavior are unchanged.
- **Linked issue(s):** Related #6808
- **Labels:** `type: docs`, `risk: low`, `size: XS`, `docs`

## Validation Evidence (required)

- **Commands run and tail output:**

```text
git diff --check origin/master...HEAD
<no output; exit 0>

ruby -e 'require "json"; JSON.parse(File.read("docs/book/src/maintainers/project-board-contract.json")); puts "project-board-contract json ok"'
project-board-contract json ok

DOCS_FILES=".claude/skills/github-issue-triage/references/triage-protocol.md
docs/book/src/foundations/fnd-003-governance.md
docs/book/src/maintainers/labels.md
docs/book/src/maintainers/pr-workflow.md
docs/book/src/maintainers/reviewer-playbook.md" scripts/ci/docs_quality_gate.sh
Existing markdown issues outside changed lines (non-blocking):
  - docs/book/src/foundations/fnd-003-governance.md:1 MD022/blanks-around-headings Headings should be surrounded by blank lines [Expected: 1; Actual: 0; Below] [Context: "# FND-003: Team Organization, Project Governance, and Contribution Pipeline"]
  - docs/book/src/foundations/fnd-003-governance.md:8 MD012/no-multiple-blanks Multiple consecutive blank lines [Expected: 1; Actual: 2]
  - docs/book/src/foundations/fnd-003-governance.md:17 MD012/no-multiple-blanks Multiple consecutive blank lines [Expected: 1; Actual: 2]
  - docs/book/src/foundations/fnd-003-governance.md:182 MD036/no-emphasis-as-heading Emphasis used instead of a heading [Context: "View 1: Roadmap"]
  - docs/book/src/foundations/fnd-003-governance.md:188 MD036/no-emphasis-as-heading Emphasis used instead of a heading [Context: "View 2: Board"]
  - docs/book/src/foundations/fnd-003-governance.md:195 MD036/no-emphasis-as-heading Emphasis used instead of a heading [Context: "View 3: Backlog"]
  - docs/book/src/foundations/fnd-003-governance.md:202 MD036/no-emphasis-as-heading Emphasis used instead of a heading [Context: "View 4: My Work"]
  - docs/book/src/foundations/fnd-003-governance.md:936:21 MD026/no-trailing-punctuation Trailing punctuation in heading [Punctuation: ':']
  - docs/book/src/foundations/fnd-003-governance.md:947:30 MD026/no-trailing-punctuation Trailing punctuation in heading [Punctuation: ':']
  - docs/book/src/foundations/fnd-003-governance.md:954:17 MD026/no-trailing-punctuation Trailing punctuation in heading [Punctuation: ':']
  - docs/book/src/foundations/fnd-003-governance.md:1108:39 MD034/no-bare-urls Bare URL used [Context: "https://docs.github.com/en/iss..."]
  - docs/book/src/foundations/fnd-003-governance.md:1109:42 MD034/no-bare-urls Bare URL used [Context: "https://docs.github.com/en/dis..."]
  - docs/book/src/foundations/fnd-003-governance.md:1110:37 MD034/no-bare-urls Bare URL used [Context: "https://docs.github.com/en/rep..."]
  - docs/book/src/foundations/fnd-003-governance.md:1111:125 MD034/no-bare-urls Bare URL used [Context: "https://producingoss.com"]
  - docs/book/src/foundations/fnd-003-governance.md:1112:213 MD034/no-bare-urls Bare URL used [Context: "https://www.apache.org/foundat..."]
No blocking markdown issues on changed lines.

DOCS_FILES=".claude/skills/github-issue-triage/references/triage-protocol.md
docs/book/src/foundations/fnd-003-governance.md
docs/book/src/maintainers/labels.md
docs/book/src/maintainers/pr-workflow.md
docs/book/src/maintainers/reviewer-playbook.md" scripts/ci/docs_links_gate.sh
Collected 1 added link(s) from 5 docs file(s).
Checking added links with lychee (offline mode)...
📝 Summary
---------------------
🔍 Total............0
🔗 Unique...........0
✅ Successful.......0
⏳ Timeouts.........0
🔀 Redirected.......0
👻 Excluded.........0
❓ Unknown..........0
🚫 Errors...........0
⛔ Unsupported......0
```

- **Beyond CI — what did you manually verify?** Read the changed maintainer docs, FND-003 section, Project board contract JSON, and issue-triage skill reference side by side to confirm the detailed owner-source rule lives in `pr-workflow.md`, supporting docs link back to it, labels are not treated as owner sources, Public/contributor-visible fields are required for stale-exemption evidence, and existing `status:no-stale` gaps are routed to the later audit/repair packet instead of becoming automatic stale closures.
- **If any command was intentionally skipped, why:** Rust format, clippy, and tests were skipped because this is docs and workflow-reference only; no Rust source, build scripts, config, or runtime behavior changed.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: None.

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: No upgrade steps. This is a maintainer documentation and workflow-reference update only.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PRs: `git revert 97d76bac9084c7aea19935301b8360c638b1683c` is the rollback plan.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Scope materially carried forward: N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`No`)
- If `No`, why (inspiration-only, no direct code/design carry-over): No superseded PR scope or contributor-authored patch was carried forward.
