### PR TITLE
fix(runtime): avoid invalid GLM history after pruning

### DIFF
--- a/crates/zeroclaw-providers/src/factory.rs
+++ b/crates/zeroclaw-providers/src/factory.rs
@@ -1208,6 +1208,92 @@ mod tests {
         assert!(!provider.capabilities().native_tool_calling);
     }
 
+    #[tokio::test]
+    async fn zai_and_glm_factory_path_honors_api_url_override() {
+        use axum::{Json, Router, extract::State, http::Uri, routing::post};
+        use serde_json::{Value, json};
+        use std::sync::{Arc, Mutex};
+
+        type Capture = Arc<Mutex<Vec<String>>>;
+
+        async fn capture_chat_request(
+            State(capture): State<Capture>,
+            uri: Uri,
+            Json(_body): Json<Value>,
+        ) -> Json<Value> {
+            capture
+                .lock()
+                .expect("capture lock poisoned")
+                .push(uri.path().to_string());
+            Json(json!({
+                "choices": [{"message": {"content": "ok"}}]
+            }))
+        }
+
+        let capture: Capture = Arc::new(Mutex::new(Vec::new()));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test server");
+        let addr = listener.local_addr().expect("test server addr");
+        let app = Router::new()
+            .route(
+                "/zai/api/paas/v4/chat/completions",
+                post(capture_chat_request),
+            )
+            .route(
+                "/glm/api/paas/v4/chat/completions",
+                post(capture_chat_request),
+            )
+            .with_state(capture.clone());
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("serve test server");
+        });
+
+        let base_url = format!("http://{addr}");
+        let zai_url = format!("{base_url}/zai/api/paas/v4");
+        let zai = ZaiModelProviderConfig::default()
+            .create_provider(
+                "cn",
+                Some("id.secret"),
+                Some(&zai_url),
+                &ModelProviderRuntimeOptions::default(),
+            )
+            .expect("zai provider should build");
+        assert_eq!(
+            zai.chat_with_system(None, "hello", "glm-5-turbo", Some(0.7))
+                .await
+                .expect("zai chat should use overridden URL"),
+            "ok"
+        );
+
+        let glm_url = format!("{base_url}/glm/api/paas/v4");
+        let glm = GlmModelProviderConfig::default()
+            .create_provider(
+                "global",
+                Some("id.secret"),
+                Some(&glm_url),
+                &ModelProviderRuntimeOptions::default(),
+            )
+            .expect("glm provider should build");
+        assert!(glm.capabilities().vision);
+        assert_eq!(
+            glm.chat_with_system(None, "hello", "glm-4.5", Some(0.7))
+                .await
+                .expect("glm chat should use overridden URL"),
+            "ok"
+        );
+
+        let paths = capture.lock().expect("capture lock poisoned").clone();
+        assert_eq!(
+            paths,
+            vec![
+                "/zai/api/paas/v4/chat/completions".to_string(),
+                "/glm/api/paas/v4/chat/completions".to_string(),
+            ]
+        );
+        server.abort();
+    }
+
     #[test]
     fn ollama_factory_uses_no_credential_when_key_absent() {
         let provider = build_ollama_compat_provider(

--- a/crates/zeroclaw-runtime/src/agent/history_pruner.rs
+++ b/crates/zeroclaw-runtime/src/agent/history_pruner.rs
@@ -65,6 +65,29 @@ pub struct PrunedOrphans {
     pub orphan_tool_call_ids: Vec<String>,
 }
 
+fn is_tool_exchange_summary(content: &str) -> bool {
+    content.starts_with("[Tool exchange:") && content.contains("results collapsed]")
+}
+
+fn assistant_tool_calls_have_immediate_results(
+    messages: &[ChatMessage],
+    assistant_idx: usize,
+    tool_call_ids: &[String],
+) -> bool {
+    if tool_call_ids.is_empty() {
+        return false;
+    }
+
+    tool_call_ids.iter().all(|expected| {
+        messages
+            .iter()
+            .skip(assistant_idx + 1)
+            .take_while(|msg| msg.role == "tool")
+            .filter_map(|msg| extract_tool_call_id(&msg.content))
+            .any(|actual| actual == *expected)
+    })
+}
+
 impl PrunedOrphans {
     pub fn is_empty(&self) -> bool {
         self.removed == 0
@@ -84,13 +107,17 @@ pub fn remove_orphaned_tool_messages(messages: &mut Vec<ChatMessage>) -> PrunedO
     // them, destroying structured tool_use blocks and orphaning the results.
     let mut i = 0;
     while i < messages.len() {
-        if messages[i].role == "assistant"
-            && extract_assistant_tool_call_ids(&messages[i].content).is_some()
+        let assistant_tool_call_ids = if messages[i].role == "assistant" {
+            extract_assistant_tool_call_ids(&messages[i].content)
+        } else {
+            None
+        };
+        if let Some(doomed_ids) = assistant_tool_call_ids
             && i > 0
             && messages[i - 1].role == "assistant"
+            && (!is_tool_exchange_summary(&messages[i - 1].content)
+                || !assistant_tool_calls_have_immediate_results(messages, i, &doomed_ids))
         {
-            let doomed_ids =
-                extract_assistant_tool_call_ids(&messages[i].content).unwrap_or_default();
             outcome
                 .orphan_tool_call_ids
                 .extend(doomed_ids.iter().cloned());
@@ -302,8 +329,45 @@ pub fn prune_history(messages: &mut Vec<ChatMessage>, config: &HistoryPrunerConf
         }
     }
 
-    // Phase 3 – remove orphaned tool messages left behind by phases 1-2.
+    // Phase 3 – merge consecutive synthetic tool-exchange summaries. GLM/Z.AI
+    // reject adjacent assistant messages, but these summaries are safe to
+    // combine because they are both pruner-generated placeholders.
+    let mut i = 0;
+    while i + 1 < messages.len() {
+        if messages[i].role == "assistant"
+            && messages[i + 1].role == "assistant"
+            && is_tool_exchange_summary(&messages[i].content)
+            && is_tool_exchange_summary(&messages[i + 1].content)
+        {
+            let next = messages.remove(i + 1);
+            messages[i].content = format!("{}\n\n{}", messages[i].content, next.content);
+            dropped_messages += 1;
+        } else {
+            i += 1;
+        }
+    }
+
+    // Phase 4 – remove orphaned tool messages left behind by phases 1-3.
     dropped_messages += remove_orphaned_tool_messages(messages).removed;
+
+    // Phase 5 – separate any remaining adjacent assistant messages. These can
+    // happen when a protected assistant(tool_calls) group follows a collapsed
+    // summary. Insert a tiny user boundary rather than dropping protected data.
+    let mut i = 1;
+    while i < messages.len() {
+        if messages[i - 1].role == "assistant" && messages[i].role == "assistant" {
+            messages.insert(
+                i,
+                ChatMessage {
+                    role: "user".to_string(),
+                    content: "[context continues]".to_string(),
+                },
+            );
+            i += 2;
+        } else {
+            i += 1;
+        }
+    }
 
     PruneStats {
         messages_before,
@@ -608,6 +672,198 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn prune_merges_consecutive_collapsed_assistant_messages() {
+        let mut messages = vec![
+            msg("system", "sys"),
+            msg(
+                "assistant",
+                r#"{"content":null,"tool_calls":[{"id":"t1","name":"shell","arguments":"{}"}]}"#,
+            ),
+            msg("tool", r#"{"tool_call_id":"t1","content":"first"}"#),
+            msg(
+                "assistant",
+                r#"{"content":null,"tool_calls":[{"id":"t2","name":"web","arguments":"{}"}]}"#,
+            ),
+            msg("tool", r#"{"tool_call_id":"t2","content":"second"}"#),
+            msg("user", "recent"),
+            msg("assistant", "done"),
+        ];
+
+        let config = HistoryPrunerConfig {
+            enabled: true,
+            max_tokens: 100_000,
+            keep_recent: 2,
+            collapse_tool_results: true,
+        };
+        let stats = prune_history(&mut messages, &config);
+
+        assert_eq!(stats.collapsed_pairs, 2);
+        assert_eq!(messages.len(), 4);
+        assert_eq!(messages[1].role, "assistant");
+        assert!(messages[1].content.contains("1 tool call(s)"));
+        assert_eq!(messages.iter().filter(|m| m.role == "assistant").count(), 2);
+        assert!(
+            messages
+                .windows(2)
+                .all(|pair| !(pair[0].role == "assistant" && pair[1].role == "assistant")),
+            "pruned roles should not contain adjacent assistants: {:?}",
+            messages.iter().map(|m| m.role.as_str()).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn prune_preserves_straddled_tool_group_after_collapsed_summary() {
+        let mut messages = vec![
+            msg("system", "sys"),
+            msg(
+                "assistant",
+                r#"{"content":null,"tool_calls":[{"id":"old","name":"shell","arguments":"{}"}]}"#,
+            ),
+            msg("tool", r#"{"tool_call_id":"old","content":"old result"}"#),
+            msg(
+                "assistant",
+                r#"{"content":null,"tool_calls":[{"id":"live","name":"shell","arguments":"{}"}]}"#,
+            ),
+            msg("tool", r#"{"tool_call_id":"live","content":"live result"}"#),
+            msg("user", "follow up"),
+        ];
+
+        let config = HistoryPrunerConfig {
+            enabled: true,
+            max_tokens: 100_000,
+            keep_recent: 3,
+            collapse_tool_results: true,
+        };
+        let stats = prune_history(&mut messages, &config);
+
+        assert_eq!(stats.collapsed_pairs, 1);
+        assert!(
+            messages
+                .iter()
+                .any(|m| m.role == "assistant" && m.content.contains("\"id\":\"live\"")),
+            "protected assistant tool call should survive: {messages:?}"
+        );
+        assert!(
+            messages
+                .iter()
+                .any(|m| m.role == "tool" && m.content.contains("\"tool_call_id\":\"live\"")),
+            "matching protected tool result should survive: {messages:?}"
+        );
+        assert!(
+            messages
+                .iter()
+                .any(|m| m.role == "user" && m.content == "[context continues]"),
+            "Phase 5 should separate collapsed summary from live assistant"
+        );
+        assert!(
+            messages
+                .windows(2)
+                .all(|pair| !(pair[0].role == "assistant" && pair[1].role == "assistant")),
+            "pruned roles should not contain adjacent assistants: {:?}",
+            messages.iter().map(|m| m.role.as_str()).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn prune_removes_dangling_tool_call_after_collapsed_summary() {
+        let mut messages = vec![
+            msg("system", "sys"),
+            msg(
+                "assistant",
+                "[Tool exchange: 1 tool call(s) — results collapsed]",
+            ),
+            msg(
+                "assistant",
+                r#"{"content":null,"tool_calls":[{"id":"dangling","name":"shell","arguments":"{}"}]}"#,
+            ),
+            msg("user", "follow up"),
+        ];
+
+        let config = HistoryPrunerConfig {
+            enabled: true,
+            max_tokens: 100_000,
+            keep_recent: 2,
+            collapse_tool_results: true,
+        };
+        let stats = prune_history(&mut messages, &config);
+
+        assert_eq!(stats.dropped_messages, 1);
+        assert!(
+            !messages
+                .iter()
+                .any(|m| m.content.contains("\"id\":\"dangling\"")),
+            "dangling assistant tool call should not survive: {messages:?}"
+        );
+        assert_eq!(
+            messages.iter().map(|m| m.role.as_str()).collect::<Vec<_>>(),
+            vec!["system", "assistant", "user"]
+        );
+    }
+
+    #[test]
+    fn prune_does_not_merge_json_tool_call_assistants_as_summaries() {
+        let mut messages = vec![
+            msg("system", "sys"),
+            msg(
+                "assistant",
+                r#"{"content":null,"tool_calls":[{"id":"live1","name":"shell","arguments":"{}"}]}"#,
+            ),
+            msg("tool", r#"{"tool_call_id":"live1","content":"first"}"#),
+            msg(
+                "assistant",
+                r#"{"content":null,"tool_calls":[{"id":"live2","name":"web","arguments":"{}"}]}"#,
+            ),
+            msg("tool", r#"{"tool_call_id":"live2","content":"second"}"#),
+        ];
+
+        let config = HistoryPrunerConfig {
+            enabled: true,
+            max_tokens: 100_000,
+            keep_recent: 4,
+            collapse_tool_results: true,
+        };
+        let stats = prune_history(&mut messages, &config);
+
+        assert_eq!(stats.collapsed_pairs, 0);
+        assert!(
+            messages
+                .iter()
+                .any(|m| m.content.contains("\"id\":\"live1\"")),
+            "first protected tool call should remain structured"
+        );
+        assert!(
+            messages
+                .iter()
+                .any(|m| m.content.contains("\"id\":\"live2\"")),
+            "second protected tool call should remain structured"
+        );
+    }
+
+    #[test]
+    fn prune_inserts_separator_when_tight_budget_leaves_protected_assistants() {
+        let mut messages = vec![
+            msg("system", "sys"),
+            msg("assistant", "protected assistant one"),
+            msg("assistant", "protected assistant two"),
+        ];
+
+        let config = HistoryPrunerConfig {
+            enabled: true,
+            max_tokens: 1,
+            keep_recent: 2,
+            collapse_tool_results: false,
+        };
+        let stats = prune_history(&mut messages, &config);
+
+        assert_eq!(stats.dropped_messages, 0);
+        assert_eq!(
+            messages.iter().map(|m| m.role.as_str()).collect::<Vec<_>>(),
+            vec!["system", "assistant", "user", "assistant"]
+        );
+        assert_eq!(messages[2].content, "[context continues]");
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Fixes the GLM/Z.AI-invalid message shape that can appear after preemptive history pruning by merging consecutive synthetic tool-exchange summaries, preserving protected assistant/tool groups only when their immediate tool results still exist, and inserting a small user boundary when a valid protected assistant turn would otherwise sit next to a collapsed assistant summary.
- **Regression coverage:** Adds tests for the collapsed-summary straddle case, the dangling assistant tool-call case, JSON tool-call assistants that must not be treated as summaries, and tight-budget protected assistant adjacency.
- **Provider coverage:** Adds a provider factory-path regression that verifies Z.AI and GLM `api_url` overrides are used for the actual chat request path.
- **Scope boundary:** Does not change provider defaults, model selection, pruning budgets, or config schema. It also does not carry forward the unrelated `deny.toml` cleanup from the closed reference PR.
- **Blast radius:** Runtime history pruning can affect any provider after context trimming. The primary target is strict OpenAI-compatible GLM/Z.AI endpoints that reject adjacent assistant messages or dangling assistant tool calls. The provider-side change is test-only.
- **Linked issue(s):** Closes #5636. Supersedes #6515.
- **Labels:** `bug`, `risk: high`, `size: M`, `agent`, `provider`, `runtime`

## Validation Evidence (required)

- **Commands run and tail output:**

```text
cargo fmt --all -- --check
Result: passed.

git diff --check
Result: passed.

cargo test -p zeroclaw-runtime history_pruner -- --nocapture
Result: passed. 27 history_pruner tests passed; 1843 filtered out.

cargo test -p zeroclaw-providers zai_and_glm_factory_path_honors_api_url_override -- --nocapture
Result: passed after rerunning with local test-server socket access. 1 provider factory-path regression passed; it verifies Z.AI and GLM api_url overrides are honored by the actual chat request path.

cargo clippy --all-targets -- -D warnings
Result: broad local clippy intentionally not rerun before ready; green GitHub CI Lint, Test, Security, and CI Required Gate cover the broad readiness check.
```

- **Beyond CI — what did you manually verify?** Diff inspection confirmed the new pruning path is scoped to synthetic tool-exchange summaries, dangling assistant tool-call cleanup, and adjacent-assistant separation. The focused runtime/provider cargo checks now cover the changed behavior and provider factory-path regression.
- **If any command was intentionally skipped, why:** Workspace-shaped local clippy/full-test validation was not rerun locally before ready because the focused runtime/provider regressions passed locally and GitHub CI is green across Lint, Test, Security, and CI Required Gate.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: `N/A`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No user upgrade steps. Existing configs and provider aliases keep the same surface.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** Revert the merge commit for this PR.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** GLM/Z.AI users may continue to see upstream `1214` / invalid `messages` errors after context trimming, or providers may reject malformed assistant/tool-call history after pruning.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): #6515 by @DjaPy
- Scope materially carried forward: The problem framing and desired behavior from #6515 are carried forward, but this is a fresh current-master implementation scoped to the runtime history-pruner repair plus provider factory-path regression coverage.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why (inspiration-only, no direct code/design carry-over): This reimplements the fix against current master and credits the superseded PR in this section rather than adding a commit trailer.
