### PR TITLE
feat(runtime): apply runtime profiles to agent execution paths

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -4048,9 +4048,7 @@ async fn process_channel_message_body(
                         ctx.activated_tools.as_ref(),
                         Some(model_switch_callback.clone()),
                         &ctx.pacing,
-                        ctx.prompt_config
-                            .agent(ctx.agent_alias.as_str())
-                            .is_some_and(|agent| agent.strict_tool_parsing),
+                        ctx.agent_cfg.strict_tool_parsing,
                         ctx.max_tool_result_chars,
                         ctx.context_token_budget,
                         None, // shared_budget
@@ -7468,9 +7466,8 @@ pub async fn start_channels(
 
     for agent_alias in &enabled_agents {
         let agent = config
-            .agent(agent_alias)
-            .with_context(|| format!("agents.{agent_alias} is not configured"))?
-            .clone();
+            .effective_agent_config(agent_alias)
+            .with_context(|| format!("agents.{agent_alias} is not configured"))?;
         let risk_profile = config
             .risk_profile_for_agent(agent_alias)
             .with_context(|| {

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -3101,6 +3101,18 @@ impl Config {
         self.runtime_profiles.get(profile_alias)
     }
 
+    /// Resolve an aliased-agent config with its selected runtime profile
+    /// applied. This preserves `agent()` as the raw config lookup while
+    /// runtime call sites can consume one effective set of loop tunables.
+    #[must_use]
+    pub fn effective_agent_config(&self, agent_alias: &str) -> Option<AliasedAgentConfig> {
+        let mut agent = self.agents.get(agent_alias)?.clone();
+        if let Some(runtime_profile) = self.runtime_profiles.get(agent.runtime_profile.trim()) {
+            runtime_profile.apply_to_agent_config(&mut agent);
+        }
+        Some(agent)
+    }
+
     /// Resolve an agent's `model_provider` reference (`"<type>.<alias>"`) to
     /// its concrete `ModelProviderConfig` entry. Returns `None` when the
     /// agent doesn't exist, the reference is unparseable, or the
@@ -9010,6 +9022,8 @@ pub struct RuntimeProfileConfig {
     pub parallel_tools: Option<bool>,
     /// Tool dispatch strategy (e.g. `"auto"`). `None` inherits.
     pub tool_dispatcher: Option<String>,
+    /// When true, only native provider tool calls are executable. `None` inherits.
+    pub strict_tool_parsing: Option<bool>,
     /// Tools exempt from within-turn dedup check.
     pub tool_call_dedup_exempt: Vec<String>,
     /// Maximum characters for the assembled system prompt. `None` inherits.
@@ -9038,11 +9052,61 @@ impl Default for RuntimeProfileConfig {
             compact_context: None,
             parallel_tools: None,
             tool_dispatcher: None,
+            strict_tool_parsing: None,
             tool_call_dedup_exempt: Vec::new(),
             max_system_prompt_chars: None,
             context_aware_tools: None,
             max_tool_result_chars: None,
             keep_tool_context_turns: None,
+        }
+    }
+}
+
+impl RuntimeProfileConfig {
+    /// Apply runtime-profile tunables to an agent config clone.
+    ///
+    /// `max_tool_iterations = 0` and `None` option values inherit the agent
+    /// config. Explicit `Some(0)` values keep the corresponding agent-field
+    /// meaning. Dedup exemptions are additive because an empty profile list is
+    /// also the serde default, so it cannot mean "replace with empty."
+    pub fn apply_to_agent_config(&self, agent: &mut AliasedAgentConfig) {
+        if self.max_tool_iterations > 0 {
+            agent.max_tool_iterations = self.max_tool_iterations;
+        }
+        if let Some(max_history_messages) = self.max_history_messages {
+            agent.max_history_messages = max_history_messages;
+        }
+        if let Some(max_context_tokens) = self.max_context_tokens {
+            agent.max_context_tokens = max_context_tokens;
+        }
+        if let Some(compact_context) = self.compact_context {
+            agent.compact_context = compact_context;
+        }
+        if let Some(parallel_tools) = self.parallel_tools {
+            agent.parallel_tools = parallel_tools;
+        }
+        if let Some(tool_dispatcher) = &self.tool_dispatcher {
+            agent.tool_dispatcher = tool_dispatcher.clone();
+        }
+        if let Some(strict_tool_parsing) = self.strict_tool_parsing {
+            agent.strict_tool_parsing = strict_tool_parsing;
+        }
+        for tool in &self.tool_call_dedup_exempt {
+            if !agent.tool_call_dedup_exempt.contains(tool) {
+                agent.tool_call_dedup_exempt.push(tool.clone());
+            }
+        }
+        if let Some(max_system_prompt_chars) = self.max_system_prompt_chars {
+            agent.max_system_prompt_chars = max_system_prompt_chars;
+        }
+        if let Some(context_aware_tools) = self.context_aware_tools {
+            agent.context_aware_tools = context_aware_tools;
+        }
+        if let Some(max_tool_result_chars) = self.max_tool_result_chars {
+            agent.max_tool_result_chars = max_tool_result_chars;
+        }
+        if let Some(keep_tool_context_turns) = self.keep_tool_context_turns {
+            agent.keep_tool_context_turns = keep_tool_context_turns;
         }
     }
 }
@@ -16821,6 +16885,101 @@ strict_tool_parsing = true
         assert!(agent.parallel_tools);
         assert_eq!(agent.tool_dispatcher, "xml");
         assert!(agent.strict_tool_parsing);
+    }
+
+    #[test]
+    async fn runtime_profile_config_deserializes_runtime_tunables() {
+        let raw = r#"
+default_temperature = 0.7
+
+[runtime_profiles.local]
+compact_context = true
+max_tool_iterations = 3
+max_history_messages = 12
+max_context_tokens = 4096
+parallel_tools = true
+tool_dispatcher = "native"
+strict_tool_parsing = true
+tool_call_dedup_exempt = ["model_routing_config"]
+max_system_prompt_chars = 8000
+context_aware_tools = true
+max_tool_result_chars = 1000
+keep_tool_context_turns = 1
+"#;
+        let parsed = parse_test_config(raw);
+        let profile = parsed
+            .runtime_profiles
+            .get("local")
+            .expect("[runtime_profiles.local] parses into runtime_profiles map");
+        assert_eq!(profile.compact_context, Some(true));
+        assert_eq!(profile.max_tool_iterations, 3);
+        assert_eq!(profile.max_history_messages, Some(12));
+        assert_eq!(profile.max_context_tokens, Some(4096));
+        assert_eq!(profile.parallel_tools, Some(true));
+        assert_eq!(profile.tool_dispatcher.as_deref(), Some("native"));
+        assert_eq!(profile.strict_tool_parsing, Some(true));
+        assert_eq!(
+            profile.tool_call_dedup_exempt,
+            vec!["model_routing_config".to_string()]
+        );
+        assert_eq!(profile.max_system_prompt_chars, Some(8000));
+        assert_eq!(profile.context_aware_tools, Some(true));
+        assert_eq!(profile.max_tool_result_chars, Some(1000));
+        assert_eq!(profile.keep_tool_context_turns, Some(1));
+    }
+
+    #[test]
+    async fn effective_agent_config_applies_runtime_profile_tunables() {
+        let raw = r#"
+default_temperature = 0.7
+
+[agents.default]
+runtime_profile = "local"
+compact_context = false
+max_tool_iterations = 20
+max_history_messages = 80
+tool_call_dedup_exempt = ["agent_only"]
+
+[runtime_profiles.local]
+compact_context = true
+max_tool_iterations = 3
+max_history_messages = 12
+max_context_tokens = 4096
+parallel_tools = true
+tool_dispatcher = "native"
+strict_tool_parsing = true
+tool_call_dedup_exempt = ["profile_only", "agent_only"]
+max_system_prompt_chars = 8000
+context_aware_tools = true
+max_tool_result_chars = 1000
+keep_tool_context_turns = 1
+"#;
+        let parsed = parse_test_config(raw);
+        let raw_agent = parsed
+            .agent("default")
+            .expect("[agents.default] parses into agents map");
+        assert!(!raw_agent.compact_context);
+        assert_eq!(raw_agent.max_tool_iterations, 20);
+        assert!(!raw_agent.strict_tool_parsing);
+
+        let effective = parsed
+            .effective_agent_config("default")
+            .expect("effective agent config resolves");
+        assert!(effective.compact_context);
+        assert_eq!(effective.max_tool_iterations, 3);
+        assert_eq!(effective.max_history_messages, 12);
+        assert_eq!(effective.max_context_tokens, 4096);
+        assert!(effective.parallel_tools);
+        assert_eq!(effective.tool_dispatcher, "native");
+        assert!(effective.strict_tool_parsing);
+        assert_eq!(effective.max_system_prompt_chars, 8000);
+        assert!(effective.context_aware_tools);
+        assert_eq!(effective.max_tool_result_chars, 1000);
+        assert_eq!(effective.keep_tool_context_turns, 1);
+        assert_eq!(
+            effective.tool_call_dedup_exempt,
+            vec!["agent_only".to_string(), "profile_only".to_string()]
+        );
     }
 
     #[test]

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -1133,6 +1133,8 @@ pub async fn agent_turn(
     activated_tools: Option<&std::sync::Arc<std::sync::Mutex<crate::tools::ActivatedToolSet>>>,
     model_switch_callback: Option<ModelSwitchCallback>,
     strict_tool_parsing: bool,
+    max_tool_result_chars: usize,
+    context_token_budget: usize,
     channel: Option<&dyn Channel>,
 ) -> Result<String> {
     run_tool_call_loop(
@@ -1158,8 +1160,8 @@ pub async fn agent_turn(
         model_switch_callback,
         &zeroclaw_config::schema::PacingConfig::default(),
         strict_tool_parsing,
-        0,    // max_tool_result_chars: 0 = disabled (legacy callers)
-        0,    // context_token_budget: 0 = disabled (legacy callers)
+        max_tool_result_chars,
+        context_token_budget,
         None, // shared_budget: no shared budget for legacy callers
         channel,
         None, // receipt_generator
@@ -2905,9 +2907,8 @@ pub async fn run(
 ) -> Result<String> {
     use ::zeroclaw_log::Instrument;
     let agent = config
-        .agent(agent_alias)
-        .with_context(|| format!("agents.{agent_alias} is not configured"))?
-        .clone();
+        .effective_agent_config(agent_alias)
+        .with_context(|| format!("agents.{agent_alias} is not configured"))?;
     crate::agent::thinking::validate_thinking_config(&agent.thinking);
     let risk_profile = config
         .risk_profile_for_agent(agent_alias)
@@ -4271,9 +4272,8 @@ pub async fn process_message(
 ) -> Result<String> {
     use ::zeroclaw_log::Instrument;
     let agent = config
-        .agent(agent_alias)
-        .with_context(|| format!("agents.{agent_alias} is not configured"))?
-        .clone();
+        .effective_agent_config(agent_alias)
+        .with_context(|| format!("agents.{agent_alias} is not configured"))?;
     crate::agent::thinking::validate_thinking_config(&agent.thinking);
     let risk_profile = config
         .risk_profile_for_agent(agent_alias)
@@ -4776,6 +4776,8 @@ pub async fn process_message(
                     activated_handle_pm.as_ref(),
                     None,
                     agent.strict_tool_parsing,
+                    agent.max_tool_result_chars,
+                    agent.max_context_tokens,
                     None, // channel: process_message path has no channel ref
                 ),
             )
@@ -9806,6 +9808,8 @@ This is an example, not an invocation."#;
                 Some(&activated),
                 None,
                 false,
+                0,
+                0,
                 None, // channel
             )
             .await
@@ -9871,6 +9875,8 @@ This is an example, not an invocation."#;
                 Some(&activated),
                 None,
                 true,
+                0,
+                0,
                 None, // channel
             )
             .await
@@ -9884,6 +9890,89 @@ This is an example, not an invocation."#;
             assert!(
                 !result.contains("private reasoning"),
                 "strict parser should still strip think tags from final text, got: {result}"
+            );
+        });
+    }
+
+    #[test]
+    fn agent_turn_forwards_max_tool_result_chars_to_tool_loop() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime should initialize");
+
+        runtime.block_on(async {
+            let long_value = "x".repeat(200);
+            let first_response = format!(
+                r#"<tool_call>
+{{"name":"pixel__get_api_health","arguments":{{"value":"{long_value}"}}}}
+</tool_call>"#
+            );
+            let model_provider = ScriptedModelProvider {
+                responses: Arc::new(Mutex::new(VecDeque::from([
+                    ChatResponse {
+                        text: Some(first_response),
+                        tool_calls: Vec::new(),
+                        usage: None,
+                        reasoning_content: None,
+                    },
+                    ChatResponse {
+                        text: Some("done".to_string()),
+                        tool_calls: Vec::new(),
+                        usage: None,
+                        reasoning_content: None,
+                    },
+                ]))),
+                capabilities: ProviderCapabilities::default(),
+            };
+
+            let invocations = Arc::new(AtomicUsize::new(0));
+            let tools_registry: Vec<Box<dyn Tool>> = vec![Box::new(CountingTool::new(
+                "pixel__get_api_health",
+                Arc::clone(&invocations),
+            ))];
+            let mut history = vec![
+                ChatMessage::system("test-system"),
+                ChatMessage::user("produce a long tool result"),
+            ];
+            let observer = NoopObserver;
+
+            let result = agent_turn(
+                &model_provider,
+                &mut history,
+                &tools_registry,
+                &observer,
+                "mock-provider",
+                "mock-model",
+                Some(0.0),
+                true,
+                "daemon",
+                None,
+                &zeroclaw_config::schema::MultimodalConfig::default(),
+                4,
+                None,
+                &[],
+                &[],
+                None,
+                None,
+                false,
+                80,
+                0,
+                None, // channel
+            )
+            .await
+            .expect("wrapper path should complete");
+
+            assert!(result.ends_with("done"), "unexpected result: {result}");
+            assert_eq!(invocations.load(Ordering::SeqCst), 1);
+            let tool_results = history
+                .iter()
+                .find(|msg| msg.role == "user" && msg.content.starts_with("[Tool results]"))
+                .expect("tool result payload should be present");
+            assert!(
+                tool_results.content.contains("[... "),
+                "tool result should be truncated by forwarded max_tool_result_chars, got: {}",
+                tool_results.content
             );
         });
     }

--- a/crates/zeroclaw-runtime/src/tools/delegate.rs
+++ b/crates/zeroclaw-runtime/src/tools/delegate.rs
@@ -235,6 +235,18 @@ impl DelegateTool {
             .map(|cfg| cfg.agent_workspace_dir(agent_alias))
     }
 
+    fn effective_agent_config(&self, agent_alias: &str) -> Option<AliasedAgentConfig> {
+        if let Some(config) = self.root_config.as_ref() {
+            return config.effective_agent_config(agent_alias);
+        }
+
+        let mut agent = self.agents.get(agent_alias)?.clone();
+        if let Some(profile) = self.runtime_profiles.get(agent.runtime_profile.trim()) {
+            profile.apply_to_agent_config(&mut agent);
+        }
+        Some(agent)
+    }
+
     /// Attach a cancellation token for cascade control of background tasks.
     /// When the token is cancelled, all background sub-agents are aborted.
     pub fn with_cancellation_token(mut self, token: CancellationToken) -> Self {
@@ -686,7 +698,7 @@ impl DelegateTool {
             .unwrap_or("");
 
         // Look up agent config
-        let agent_config = match self.agents.get(agent_name) {
+        let agent_config = match self.effective_agent_config(agent_name) {
             Some(cfg) => cfg,
             None => {
                 let available: Vec<&str> =
@@ -776,7 +788,7 @@ impl DelegateTool {
             return self
                 .execute_agentic(
                     agent_name,
-                    agent_config,
+                    &agent_config,
                     &provider_type,
                     &model,
                     &*model_provider,
@@ -789,7 +801,7 @@ impl DelegateTool {
         // Build enriched system prompt for non-agentic sub-agent.
         let enriched_system_prompt = self.build_enriched_system_prompt(
             agent_name,
-            agent_config,
+            &agent_config,
             &model,
             &[],
             &self.workspace_dir,
@@ -854,8 +866,8 @@ impl DelegateTool {
         args: &serde_json::Value,
     ) -> anyhow::Result<ToolResult> {
         // Validate agent exists and check depth/security before spawning
-        let agent_config = match self.agents.get(agent_name) {
-            Some(cfg) => cfg.clone(),
+        let agent_config = match self.effective_agent_config(agent_name) {
+            Some(cfg) => cfg,
             None => {
                 let available: Vec<&str> =
                     self.agents.keys().map(|s: &String| s.as_str()).collect();
@@ -1592,7 +1604,11 @@ impl DelegateTool {
             });
         }
 
-        let max_iterations = self.resolve_max_iterations(&agent_config.runtime_profile);
+        let max_iterations = if agent_config.max_tool_iterations > 0 {
+            agent_config.max_tool_iterations
+        } else {
+            self.resolve_max_iterations(&agent_config.runtime_profile)
+        };
 
         // Build enriched system prompt with tools, skills, workspace, datetime context.
         let enriched_system_prompt = self.build_enriched_system_prompt(
@@ -1646,13 +1662,13 @@ impl DelegateTool {
                 None,
                 None,
                 &[],
-                &[],
+                &agent_config.tool_call_dedup_exempt,
                 None,
                 None,
                 &zeroclaw_config::schema::PacingConfig::default(),
                 agent_config.strict_tool_parsing,
-                0,    // max_tool_result_chars: inherit from parent config in future
-                0,    // context_token_budget: 0 = disabled for subagents
+                agent_config.max_tool_result_chars,
+                agent_config.max_context_tokens,
                 None, // shared_budget: TODO thread from parent in future
                 None, // channel: delegate subagents don't support approval
                 receipt_generator,
@@ -1756,7 +1772,7 @@ mod tests {
     use zeroclaw_config::schema::{
         DEFAULT_DELEGATE_AGENTIC_TIMEOUT_SECS, DEFAULT_DELEGATE_TIMEOUT_SECS,
     };
-    use zeroclaw_providers::{ChatRequest, ChatResponse, ToolCall};
+    use zeroclaw_providers::{ChatMessage, ChatRequest, ChatResponse, ToolCall};
 
     zeroclaw_api::mock_tool_attribution!(EchoTool, FakeMcpTool);
 
@@ -1902,6 +1918,71 @@ mod tests {
         }
         fn alias(&self) -> &str {
             "OneToolThenFinalModelProvider"
+        }
+    }
+
+    struct RecordingToolResultModelProvider {
+        requests: Arc<std::sync::Mutex<Vec<Vec<ChatMessage>>>>,
+        value: String,
+    }
+
+    #[async_trait]
+    impl ModelProvider for RecordingToolResultModelProvider {
+        async fn chat_with_system(
+            &self,
+            _system_prompt: Option<&str>,
+            _message: &str,
+            _model: &str,
+            _temperature: Option<f64>,
+        ) -> anyhow::Result<String> {
+            Ok("unused".to_string())
+        }
+
+        async fn chat(
+            &self,
+            request: ChatRequest<'_>,
+            _model: &str,
+            _temperature: Option<f64>,
+        ) -> anyhow::Result<ChatResponse> {
+            self.requests
+                .lock()
+                .expect("requests lock should be valid")
+                .push(request.messages.to_vec());
+            let has_tool_result = request.messages.iter().any(|message| {
+                message.role == "tool" || message.content.starts_with("[Tool results]")
+            });
+            if has_tool_result {
+                Ok(ChatResponse {
+                    text: Some("done".to_string()),
+                    tool_calls: Vec::new(),
+                    usage: None,
+                    reasoning_content: None,
+                })
+            } else {
+                Ok(ChatResponse {
+                    text: None,
+                    tool_calls: vec![ToolCall {
+                        id: "call_1".to_string(),
+                        name: "echo_tool".to_string(),
+                        arguments: format!(r#"{{"value":"{}"}}"#, self.value),
+                        extra_content: None,
+                    }],
+                    usage: None,
+                    reasoning_content: None,
+                })
+            }
+        }
+    }
+    impl ::zeroclaw_api::attribution::Attributable for RecordingToolResultModelProvider {
+        fn role(&self) -> ::zeroclaw_api::attribution::Role {
+            ::zeroclaw_api::attribution::Role::Provider(
+                ::zeroclaw_api::attribution::ProviderKind::Model(
+                    ::zeroclaw_api::attribution::ModelProviderKind::Custom,
+                ),
+            )
+        }
+        fn alias(&self) -> &str {
+            "RecordingToolResultModelProvider"
         }
     }
 
@@ -2077,6 +2158,40 @@ mod tests {
             },
         );
         profiles
+    }
+
+    #[test]
+    fn effective_agent_config_applies_attached_runtime_profile_without_root_config() {
+        let mut agents = HashMap::new();
+        agents.insert(
+            "agentic".to_string(),
+            AliasedAgentConfig {
+                runtime_profile: "agentic_test".to_string(),
+                max_tool_iterations: 20,
+                strict_tool_parsing: false,
+                ..agentic_agent_config()
+            },
+        );
+        let mut profiles = HashMap::new();
+        profiles.insert(
+            "agentic_test".to_string(),
+            RuntimeProfileConfig {
+                agentic: true,
+                max_tool_iterations: 2,
+                strict_tool_parsing: Some(true),
+                max_tool_result_chars: Some(1234),
+                ..Default::default()
+            },
+        );
+
+        let tool = DelegateTool::new(agents, None, test_security()).with_runtime_profiles(profiles);
+        let effective = tool
+            .effective_agent_config("agentic")
+            .expect("attached runtime profile resolves");
+
+        assert_eq!(effective.max_tool_iterations, 2);
+        assert!(effective.strict_tool_parsing);
+        assert_eq!(effective.max_tool_result_chars, 1234);
     }
 
     #[test]
@@ -2532,17 +2647,21 @@ mod tests {
 
     #[tokio::test]
     async fn execute_agentic_respects_max_iterations() {
-        let config = agentic_agent_config();
-        let tool = DelegateTool::new(HashMap::new(), None, test_security())
+        let mut agents = HashMap::new();
+        agents.insert("agentic".to_string(), agentic_agent_config());
+        let tool = DelegateTool::new(agents, None, test_security())
             .with_runtime_profiles(agentic_runtime_profiles(2))
             .with_risk_profiles(agentic_risk_profiles(vec!["echo_tool".to_string()]))
             .with_parent_tools(Arc::new(RwLock::new(vec![Arc::new(EchoTool)])));
+        let agent_config = tool
+            .effective_agent_config("agentic")
+            .expect("runtime profile applies to delegate agent");
 
         let model_provider = InfiniteToolCallModelProvider;
         let result = tool
             .execute_agentic(
                 "agentic",
-                &config,
+                &agent_config,
                 "openrouter",
                 "model-test",
                 &model_provider,
@@ -2559,6 +2678,70 @@ mod tests {
                 .as_deref()
                 .unwrap_or("")
                 .contains("maximum tool iterations (2)")
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_agentic_forwards_profile_applied_tool_result_limit() {
+        let mut agents = HashMap::new();
+        agents.insert("agentic".to_string(), agentic_agent_config());
+        let mut runtime_profiles = HashMap::new();
+        runtime_profiles.insert(
+            "agentic_test".to_string(),
+            RuntimeProfileConfig {
+                agentic: true,
+                max_tool_iterations: 4,
+                max_tool_result_chars: Some(80),
+                ..Default::default()
+            },
+        );
+        let tool = DelegateTool::new(agents, None, test_security())
+            .with_runtime_profiles(runtime_profiles)
+            .with_risk_profiles(agentic_risk_profiles(vec!["echo_tool".to_string()]))
+            .with_parent_tools(Arc::new(RwLock::new(vec![Arc::new(EchoTool)])));
+        let agent_config = tool
+            .effective_agent_config("agentic")
+            .expect("runtime profile applies to delegate agent");
+        let requests = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let model_provider = RecordingToolResultModelProvider {
+            requests: Arc::clone(&requests),
+            value: "x".repeat(200),
+        };
+
+        let result = tool
+            .execute_agentic(
+                "agentic",
+                &agent_config,
+                "openrouter",
+                "model-test",
+                &model_provider,
+                "run",
+                Some(0.2),
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            result.success,
+            "delegate sub-loop should complete: {result:?}"
+        );
+        let requests = requests.lock().expect("requests lock should be valid");
+        let replay = requests
+            .iter()
+            .find(|messages| {
+                messages.iter().any(|message| {
+                    message.role == "tool" || message.content.starts_with("[Tool results]")
+                })
+            })
+            .expect("second request should include the tool result");
+        let tool_result = replay
+            .iter()
+            .find(|message| message.role == "tool" || message.content.starts_with("[Tool results]"))
+            .expect("tool result message should be present");
+        assert!(
+            tool_result.content.contains("[... "),
+            "delegate tool result should honor profile-applied max_tool_result_chars, got: {}",
+            tool_result.content
         );
     }
 

--- a/docs/book/src/getting-started/multi-model-setup.md
+++ b/docs/book/src/getting-started/multi-model-setup.md
@@ -82,6 +82,13 @@ max_tool_iterations  = 50
 max_actions_per_hour = 200
 ```
 
+Runtime profiles apply to the agent runtime after an agent selects them with
+`runtime_profile = "<alias>"`. Use them for reusable loop and context tuning
+such as `max_tool_iterations`, `max_history_messages`,
+`max_context_tokens`, `compact_context`, `strict_tool_parsing`, and
+`max_tool_result_chars`. Keep model identity on `model_provider` and
+authorization or sandbox choices on `risk_profile`.
+
 Each channel binds to one agent at a time. To move a channel to a different agent, edit the `channels = [...]` list on the agent that should pick it up — `Config::validate()` makes sure references resolve at startup.
 
 ## Cross-vendor reliability — use OpenRouter


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Added runtime-profile support for agent loop/context tunables, including strict tool parsing, tool-result truncation, context budgets, dispatcher settings, and tool-call dedup exemptions.
  - Added a shared effective-agent resolver so runtime call sites can keep raw agent config as the source of truth while applying the selected runtime profile at use time.
  - Updated runtime `run()` / `process_message()`, channel orchestrator, and delegate execution paths to consume effective agent config instead of silently ignoring profile-level loop settings.
  - Forwarded profile-applied tool-result/context/dedup settings into the main tool loop and agentic delegate sub-loops, with focused regressions for the truncation path.
  - Documented that runtime profiles tune loop/context behavior while model identity, authorization, sandboxing, and credential behavior remain owned by their existing config surfaces.
- **Scope boundary:** This PR does not change model/provider selection, risk-profile authorization, sandbox policy, credential handling, or default runtime-profile selection.
- **Blast radius:** Agents that opt into `[runtime_profiles.<alias>]` can now have loop/context knobs applied in runtime, channel, and delegate paths. If the resolver is wrong, affected agents could get different tool iteration limits, context budgets, strict parser behavior, or tool-result truncation than configured; agents without a selected runtime profile should keep existing behavior.
- **Linked issue(s):** Related #5287.
- **Labels:** `enhancement`, `risk: high`, `size: M`, `config`, `runtime`, `agent`, `channel`, `tool:delegate`, `docs`.

## Validation Evidence (required)

- **Commands run and tail output:**

```text
cargo fmt --all -- --check
Result: passed after the branch was rebased onto current origin/master, and again after the delegate test-fixture fix.
Tail: command exited 0 with no formatting diff.

git diff --check
Result: passed after the branch was rebased onto current origin/master, and again after the delegate test-fixture fix.
Tail: command exited 0 with no whitespace errors.

cargo test -p zeroclaw-config runtime_profile -- --nocapture
Result: passed; 5 tests matched the runtime_profile filters.
Tail: test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured.

cargo test -p zeroclaw-runtime execute_agentic_respects_max_iterations -- --nocapture
Result: passed after fixing the delegate test fixture to use the runtime-profile-applied effective agent config.
Tail: test tools::delegate::tests::execute_agentic_respects_max_iterations ... ok; test result: ok. 1 passed; 0 failed.

GitHub Actions
Result: on the previous pushed head b73aeb0cd, Lint passed but Test failed in execute_agentic_respects_max_iterations. This draft now includes the local fix on head bb79614b. Fresh GitHub checks for bb79614b are green, including Lint, Test, Security, CI Required Gate, 32-bit/no-default/all-features checks, benchmarks compile, and Linux/macOS/Windows builds.
```

- **Beyond CI — what did you manually verify?** I traced the effective-agent config flow through config parsing, `process_message()`, the channel orchestrator, delegate dispatch, and agentic delegate sub-loops. After rebasing, I also checked that #6945's `classifier_provider` routing in the channel orchestrator still composes with this PR's effective-agent config path.
- **If any command was intentionally skipped, why:** Broad high-risk local readiness checks were not rerun locally after the final one-file test-fixture fix. We are accepting green GitHub Actions on head bb79614b for the broader readiness signal, including the CI Required Gate, Test, Lint, Security, feature checks, benchmarks compile, and platform builds.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: No security or privacy surface is intentionally expanded. The change applies existing runtime-profile configuration to existing agent execution paths; risk-profile authorization, sandboxing, model-provider credentials, and workspace boundaries remain on their current source-of-truth config surfaces.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `Yes`
- If `No` or `Yes` to either: `[runtime_profiles.<alias>]` now accepts optional loop/context tuning keys that mirror existing per-agent behavior. Existing configs continue to load, and absent runtime-profile keys inherit the agent config. Users can opt in by setting an agent's `runtime_profile` and placing loop/context tunables under that profile.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** Revert the merge commit for this PR.
- **Feature flags or config toggles:** None. Operators can stop using the affected runtime profile by clearing or changing an agent's `runtime_profile` entry.
- **Observable failure symptoms:** Agents using runtime profiles may show unexpected strict-parser behavior, tool iteration counts, context compaction, tool-result truncation, or delegate loop behavior. Look for agent-loop/tool-loop logs around tool dispatch and compare the effective behavior against the configured agent and runtime-profile values.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): Not used.
- Scope materially carried forward: Not applicable.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why (inspiration-only, no direct code/design carry-over): This is a new slice for #5287 and does not supersede another contributor PR.
