### PR TITLE
fix(web_fetch): unwrap zero-limit regression test tools

### DIFF
--- a/crates/zeroclaw-tools/src/web_fetch.rs
+++ b/crates/zeroclaw-tools/src/web_fetch.rs
@@ -1114,7 +1114,8 @@ mod tests {
             30,
             FirecrawlConfig::default(),
             vec![],
-        );
+        )
+        .unwrap();
         let long_text = "x".repeat(10_000);
         let result = tool.truncate_response(&long_text);
         assert_eq!(result.len(), 10_000, "zero limit must not truncate");
@@ -1161,7 +1162,8 @@ mod tests {
                 ..FirecrawlConfig::default()
             },
             vec![],
-        );
+        )
+        .unwrap();
 
         // Bypass SSRF-guarded execute() — call standard_fetch directly so
         // wiremock on 127.0.0.1 is reachable.


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Unwraps the two `WebFetchTool::new(...)` calls added in the #6884 zero-limit regression tests.
  - Aligns those tests with the now-fallible `WebFetchTool::new(...)` constructor after #5450.
  - Restores the `zeroclaw-tools` test-target compile path that failed in PR #7014's Quality Gate / Lint job.
  - Keeps the #6884 behavior coverage intact for both direct truncation and the streamed `standard_fetch` path.
- **Scope boundary:** This PR only fixes test construction in `web_fetch.rs`; it does not change production `web_fetch` behavior, configuration, networking, Firecrawl fallback logic, or runtime tool registration.
- **Blast radius:** Test-only change in `zeroclaw-tools`. The affected surface is CI/local lint and test compilation for `web_fetch` regressions.
- **Linked issue(s):** Related #6884; Related #5450; Related #7014 (CI unblock).
- **Labels:** `bug`, `risk: high`, `size: XS`, `tool`, `tool:web`

## Validation Evidence (required)

- **Commands run and tail output:**

```text
scripts/zc-cargo fmt --all -- --check
Result: passed in 10.24s.

scripts/zc-cargo clippy -p zeroclaw-tools --all-targets -- -D warnings
Result: passed in 1m26.35s.

scripts/zc-cargo test -p zeroclaw-tools zero_limit -- --nocapture
Result: passed in 3m48.69s. The streamed zero-limit regression test passed: 1 passed, 1224 filtered out.

scripts/zc-cargo test -p zeroclaw-tools truncate_response_zero_means_unlimited -- --nocapture
Result: passed in 0.76s. The web_fetch direct truncate test and sibling http_request test passed: 2 passed, 1223 filtered out.

git diff --check
Result: passed with no output.
```

- **Beyond CI — what did you manually verify?** Confirmed the failed PR #7014 lint log was a `zeroclaw-tools` test-target compile error caused by calling `WebFetchTool` methods on `Result<WebFetchTool, anyhow::Error>`. This PR fixes that base integration regression in the `web_fetch` zero-limit tests without changing production `web_fetch` behavior.
- **If any command was intentionally skipped, why:** Full workspace clippy and CI-shaped full tests were not run locally because this is a two-call-site test-only compile fix. The focused crate clippy command matches the failing CI lint shape for the touched crate, and the current GitHub checks for this PR are passing.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: None.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No upgrade steps required.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** Revert this PR.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** If reverted while #6884 is on `master`, `cargo clippy -p zeroclaw-tools --all-targets -- -D warnings` and the GitHub Quality Gate / Lint job fail with `no method named ... found for enum std::result::Result` in `crates/zeroclaw-tools/src/web_fetch.rs`.
