### PR TITLE
feat(config/channels): static output_modality preference on peer groups

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -5116,14 +5116,20 @@ fn build_channel_by_id(
                 Arc::new(move || cfg_arc.read().channel_external_peers("telegram", &alias))
             };
             Ok(Arc::new(
-                TelegramChannel::new(tg.bot_token.clone(), alias, peer_resolver, tg.mention_only)
-                    .with_persistence(config_arc.clone())
-                    .with_ack_reactions(ack)
-                    .with_streaming(tg.stream_mode, tg.draft_update_interval_ms)
-                    .with_transcription(config.transcription.clone())
-                    .with_tts(&config)
-                    .with_workspace_dir(config.data_dir.clone())
-                    .with_approval_timeout_secs(tg.approval_timeout_secs),
+                TelegramChannel::new(
+                    tg.bot_token.clone(),
+                    alias.clone(),
+                    peer_resolver,
+                    tg.mention_only,
+                )
+                .with_persistence(config_arc.clone())
+                .with_ack_reactions(ack)
+                .with_streaming(tg.stream_mode, tg.draft_update_interval_ms)
+                .with_transcription(config.transcription.clone())
+                .with_tts(&config)
+                .with_voice_peer_prefs(&config, "telegram", alias)
+                .with_workspace_dir(config.data_dir.clone())
+                .with_approval_timeout_secs(tg.approval_timeout_secs),
             ))
         }
         #[cfg(not(feature = "channel-telegram"))]
@@ -5929,6 +5935,7 @@ fn collect_configured_channels(
                 .with_streaming(tg.stream_mode, tg.draft_update_interval_ms)
                 .with_transcription(config.transcription.clone())
                 .with_tts(&config)
+                .with_voice_peer_prefs(&config, "telegram", alias)
                 .with_workspace_dir(config.channel_workspace_dir(&format!("telegram.{alias}")))
                 .with_proxy_url(tg.proxy_url.clone())
                 .with_tool_command_specs(tool_specs.to_vec())

--- a/crates/zeroclaw-channels/src/telegram.rs
+++ b/crates/zeroclaw-channels/src/telegram.rs
@@ -622,6 +622,35 @@ impl TelegramChannel {
     }
 
     /// Wire the shared Config handle so `persist_allowed_identity` can
+    /// Pre-seed voice-chat mode from peer-group static preferences.
+    ///
+    /// Iterates `[peer_groups.*]` entries that reference this channel and
+    /// carry `output_modality = "voice"`, then inserts every `external_peers`
+    /// entry into the `voice_chats` set so TTS fires unconditionally for
+    /// those peers — including cron/proactive messages that have no inbound
+    /// voice note to mirror.
+    pub fn with_voice_peer_prefs(
+        self,
+        config: &zeroclaw_config::schema::Config,
+        channel_type: &str,
+        alias: impl AsRef<str>,
+    ) -> Self {
+        use zeroclaw_config::multi_agent::OutputModality;
+        let alias = alias.as_ref();
+        let dotted = format!("{channel_type}.{alias}");
+        if let Ok(mut vc) = self.voice_chats.lock() {
+            for group in config.peer_groups.values() {
+                let matches = group.channel == channel_type || group.channel == dotted;
+                if matches && group.output_modality == OutputModality::Voice {
+                    for peer in &group.external_peers {
+                        vc.insert(peer.to_string());
+                    }
+                }
+            }
+        }
+        self
+    }
+
     /// write a paired user into `peer_groups` and save. The long-running
     /// daemon sets this from the orchestrator; tests and one-shot
     /// callers leave it unset (pairing works at runtime, doesn't persist).
@@ -3847,6 +3876,63 @@ Ensure only one `zeroclaw` process is using this bot token."
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn with_voice_peer_prefs_seeds_voice_chats_for_matching_groups_only() {
+        use zeroclaw_config::multi_agent::{OutputModality, PeerGroupConfig, PeerUsername};
+
+        let mut config = zeroclaw_config::schema::Config::default();
+        // Voice group on this channel type — should be seeded.
+        config.peer_groups.insert(
+            "voicers".to_string(),
+            PeerGroupConfig {
+                channel: "telegram".to_string(),
+                external_peers: vec![PeerUsername::new("@alice"), PeerUsername::new("@bob")],
+                output_modality: OutputModality::Voice,
+                ..Default::default()
+            },
+        );
+        // Voice group on a different channel — must NOT leak into telegram.
+        config.peer_groups.insert(
+            "other".to_string(),
+            PeerGroupConfig {
+                channel: "signal".to_string(),
+                external_peers: vec![PeerUsername::new("@carol")],
+                output_modality: OutputModality::Voice,
+                ..Default::default()
+            },
+        );
+        // Mirror group on this channel — not a voice preference, skip.
+        config.peer_groups.insert(
+            "mirrorers".to_string(),
+            PeerGroupConfig {
+                channel: "telegram".to_string(),
+                external_peers: vec![PeerUsername::new("@dave")],
+                output_modality: OutputModality::Mirror,
+                ..Default::default()
+            },
+        );
+
+        let ch = TelegramChannel::new(
+            "fake-token".into(),
+            "default",
+            Arc::new(|| vec!["*".into()]),
+            false,
+        )
+        .with_voice_peer_prefs(&config, "telegram", "default");
+
+        let vc = ch.voice_chats.lock().unwrap();
+        assert!(vc.contains("@alice"), "voice peer should be seeded");
+        assert!(vc.contains("@bob"), "voice peer should be seeded");
+        assert!(
+            !vc.contains("@carol"),
+            "peers on another channel must not be seeded"
+        );
+        assert!(
+            !vc.contains("@dave"),
+            "mirror-modality peers must not be seeded"
+        );
+    }
 
     #[test]
     fn telegram_channel_name() {

--- a/crates/zeroclaw-channels/src/telegram.rs
+++ b/crates/zeroclaw-channels/src/telegram.rs
@@ -393,6 +393,10 @@ pub struct TelegramChannel {
     ack_reactions: bool,
     tts_manager: Option<Arc<super::tts::TtsManager>>,
     voice_chats: Arc<std::sync::Mutex<std::collections::HashSet<String>>>,
+    /// Peers that always receive voice replies, sourced from peer-group
+    /// `output_modality = "voice"` config. Populated once at startup by
+    /// `with_voice_peer_prefs`; never mutated by session events.
+    static_voice_peers: Arc<std::sync::Mutex<std::collections::HashSet<String>>>,
     pending_voice:
         Arc<std::sync::Mutex<std::collections::HashMap<String, (String, std::time::Instant)>>>,
     /// Per-channel proxy URL override.
@@ -462,6 +466,7 @@ impl TelegramChannel {
             ack_reactions: true,
             tts_manager: None,
             voice_chats: Arc::new(std::sync::Mutex::new(std::collections::HashSet::new())),
+            static_voice_peers: Arc::new(std::sync::Mutex::new(std::collections::HashSet::new())),
             pending_voice: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             proxy_url: None,
             tool_command_specs: Vec::new(),
@@ -621,14 +626,15 @@ impl TelegramChannel {
         value.trim().trim_start_matches('@').to_string()
     }
 
-    /// Wire the shared Config handle so `persist_allowed_identity` can
-    /// Pre-seed voice-chat mode from peer-group static preferences.
+    /// Pre-seed static voice preferences from peer-group config.
     ///
     /// Iterates `[peer_groups.*]` entries that reference this channel and
-    /// carry `output_modality = "voice"`, then inserts every `external_peers`
-    /// entry into the `voice_chats` set so TTS fires unconditionally for
-    /// those peers — including cron/proactive messages that have no inbound
-    /// voice note to mirror.
+    /// carry `output_modality = "voice"`, then records every `external_peers`
+    /// entry in `static_voice_peers`. These peers always receive TTS replies —
+    /// including cron/proactive messages with no inbound voice note to mirror.
+    ///
+    /// Unlike the session `voice_chats` set, `static_voice_peers` is never
+    /// cleared by voice-send or text-message events.
     pub fn with_voice_peer_prefs(
         self,
         config: &zeroclaw_config::schema::Config,
@@ -638,12 +644,12 @@ impl TelegramChannel {
         use zeroclaw_config::multi_agent::OutputModality;
         let alias = alias.as_ref();
         let dotted = format!("{channel_type}.{alias}");
-        if let Ok(mut vc) = self.voice_chats.lock() {
+        if let Ok(mut sp) = self.static_voice_peers.lock() {
             for group in config.peer_groups.values() {
                 let matches = group.channel == channel_type || group.channel == dotted;
                 if matches && group.output_modality == OutputModality::Voice {
                     for peer in &group.external_peers {
-                        vc.insert(peer.to_string());
+                        sp.insert(peer.to_string());
                     }
                 }
             }
@@ -857,14 +863,24 @@ impl TelegramChannel {
     /// When `immediate` is `true` (called from `finalize_draft`), the 10-second
     /// debounce is skipped and `synthesize_and_send_voice` is called directly,
     /// since the text is already the final response.
-    fn try_queue_voice_reply(&self, recipient: &str, content: &str, immediate: bool) {
-        let is_voice_chat = self
-            .voice_chats
+    /// Returns true if this recipient should receive a TTS voice reply —
+    /// either because they triggered a voice-note session (`voice_chats`) or
+    /// because their peer group has `output_modality = "voice"` in config
+    /// (`static_voice_peers`).
+    fn is_voice_chat(&self, recipient: &str) -> bool {
+        self.voice_chats
             .lock()
             .map(|vs| vs.contains(recipient))
-            .unwrap_or(false);
+            .unwrap_or(false)
+            || self
+                .static_voice_peers
+                .lock()
+                .map(|sp| sp.contains(recipient))
+                .unwrap_or(false)
+    }
 
-        if !is_voice_chat || self.tts_manager.is_none() {
+    fn try_queue_voice_reply(&self, recipient: &str, content: &str, immediate: bool) {
+        if !self.is_voice_chat(recipient) || self.tts_manager.is_none() {
             return;
         }
 
@@ -3878,7 +3894,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn with_voice_peer_prefs_seeds_voice_chats_for_matching_groups_only() {
+    fn with_voice_peer_prefs_seeds_static_voice_peers_for_matching_groups_only() {
         use zeroclaw_config::multi_agent::{OutputModality, PeerGroupConfig, PeerUsername};
 
         let mut config = zeroclaw_config::schema::Config::default();
@@ -3921,16 +3937,58 @@ mod tests {
         )
         .with_voice_peer_prefs(&config, "telegram", "default");
 
-        let vc = ch.voice_chats.lock().unwrap();
-        assert!(vc.contains("@alice"), "voice peer should be seeded");
-        assert!(vc.contains("@bob"), "voice peer should be seeded");
+        // Peers go into static_voice_peers, not into the session voice_chats set.
+        let sp = ch.static_voice_peers.lock().unwrap();
+        assert!(sp.contains("@alice"), "voice peer should be in static set");
+        assert!(sp.contains("@bob"), "voice peer should be in static set");
         assert!(
-            !vc.contains("@carol"),
+            !sp.contains("@carol"),
             "peers on another channel must not be seeded"
         );
         assert!(
-            !vc.contains("@dave"),
+            !sp.contains("@dave"),
             "mirror-modality peers must not be seeded"
+        );
+        drop(sp);
+
+        let vc = ch.voice_chats.lock().unwrap();
+        assert!(
+            !vc.contains("@alice"),
+            "static peers must not pollute the session voice_chats set"
+        );
+    }
+
+    #[test]
+    fn static_voice_peers_survive_session_voice_chats_removal() {
+        use zeroclaw_config::multi_agent::{OutputModality, PeerGroupConfig, PeerUsername};
+
+        let mut config = zeroclaw_config::schema::Config::default();
+        config.peer_groups.insert(
+            "voicers".to_string(),
+            PeerGroupConfig {
+                channel: "telegram".to_string(),
+                external_peers: vec![PeerUsername::new("@alice")],
+                output_modality: OutputModality::Voice,
+                ..Default::default()
+            },
+        );
+
+        let ch = TelegramChannel::new(
+            "fake-token".into(),
+            "default",
+            Arc::new(|| vec!["*".into()]),
+            false,
+        )
+        .with_voice_peer_prefs(&config, "telegram", "default");
+
+        // Simulate a voice-send removing @alice from voice_chats (even though
+        // she was never in it — this proves static peers are checked separately).
+        ch.voice_chats.lock().unwrap().remove("@alice");
+
+        // is_voice_chat must still return true via static_voice_peers.
+        assert!(
+            ch.is_voice_chat("@alice"),
+            "static voice peer must remain active after voice_chats removal"
         );
     }
 

--- a/crates/zeroclaw-config/src/multi_agent.rs
+++ b/crates/zeroclaw-config/src/multi_agent.rs
@@ -122,6 +122,25 @@ pub struct AgentMemoryConfig {
     pub backend: MemoryBackendKind,
 }
 
+/// Preferred output modality for a peer group.
+///
+/// Controls how the agent delivers replies to peers in this group when no
+/// stronger per-turn signal is present. `Mirror` (default) preserves the
+/// existing input-driven behaviour: voice in → voice out, text in → text out.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum OutputModality {
+    /// Always reply in kind — voice note if user sent voice, text otherwise.
+    #[default]
+    Mirror,
+    /// Always deliver via TTS as a voice note, regardless of input modality.
+    /// Applies to proactive messages (cron, announces) as well as replies.
+    Voice,
+    /// Always deliver as text, even if user sent a voice note.
+    Text,
+}
+
 /// `[peer_groups.<name>]` — mutual-opt-in peer group on a channel type.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, Configurable)]
 #[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
@@ -138,6 +157,11 @@ pub struct PeerGroupConfig {
     pub external_peers: Vec<PeerUsername>,
     /// Per-group blocklist; subtracts from the resolved peer set.
     pub ignore: Vec<PeerUsername>,
+    /// Preferred output modality for all peers in this group.
+    /// Defaults to `mirror` (input-driven). Set to `voice` to have the
+    /// agent always reply and deliver proactive messages (cron, announces)
+    /// as TTS voice notes on channels that support audio output.
+    pub output_modality: OutputModality,
 }
 
 #[cfg(test)]
@@ -290,5 +314,40 @@ ignore = ["@known_spammer"]
         assert!(cfg.agents.is_empty());
         assert!(cfg.external_peers.is_empty());
         assert!(cfg.ignore.is_empty());
+        // Default modality preserves the existing input-driven behavior.
+        assert_eq!(cfg.output_modality, OutputModality::Mirror);
+    }
+
+    #[test]
+    fn output_modality_serializes_snake_case() {
+        let cases = [
+            (OutputModality::Mirror, "\"mirror\""),
+            (OutputModality::Voice, "\"voice\""),
+            (OutputModality::Text, "\"text\""),
+        ];
+        for (modality, expected) in cases {
+            let json = serde_json::to_string(&modality).unwrap();
+            assert_eq!(json, expected, "modality={modality:?}");
+            let back: OutputModality = serde_json::from_str(&json).unwrap();
+            assert_eq!(back, modality);
+        }
+    }
+
+    #[test]
+    fn peer_group_output_modality_parses_voice_and_defaults_to_mirror() {
+        let with_voice: PeerGroupConfig = toml::from_str(
+            r#"
+channel = "telegram"
+external_peers = ["@alice"]
+output_modality = "voice"
+"#,
+        )
+        .unwrap();
+        assert_eq!(with_voice.output_modality, OutputModality::Voice);
+        assert_eq!(with_voice.external_peers[0].as_str(), "@alice");
+
+        // Omitting the field falls back to mirror (current behavior).
+        let defaulted: PeerGroupConfig = toml::from_str(r#"channel = "telegram""#).unwrap();
+        assert_eq!(defaulted.output_modality, OutputModality::Mirror);
     }
 }

--- a/crates/zeroclaw-config/src/traits.rs
+++ b/crates/zeroclaw-config/src/traits.rs
@@ -105,6 +105,9 @@ impl HasPropKind for crate::multi_agent::AccessMode {
 impl HasPropKind for crate::multi_agent::MemoryBackendKind {
     const PROP_KIND: PropKind = PropKind::Enum;
 }
+impl HasPropKind for crate::multi_agent::OutputModality {
+    const PROP_KIND: PropKind = PropKind::Enum;
+}
 impl HasPropKind for Vec<crate::multi_agent::AgentAlias> {
     const PROP_KIND: PropKind = PropKind::StringArray;
 }

--- a/tests/system/multi_agent_e2e.rs
+++ b/tests/system/multi_agent_e2e.rs
@@ -244,6 +244,7 @@ async fn peer_group_routes_messages_only_within_resolved_peer_set() {
             agents: vec![AgentAlias::from("alpha"), AgentAlias::from("beta")],
             external_peers: vec![PeerUsername::from("operator")],
             ignore: vec![],
+            ..Default::default()
         },
     );
 
@@ -339,6 +340,7 @@ async fn peer_group_dotted_channel_refs_remain_alias_scoped_for_dispatch() {
             agents: vec![AgentAlias::from("alpha"), AgentAlias::from("beta")],
             external_peers: vec![],
             ignore: vec![],
+            ..Default::default()
         },
     );
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Output modality and channel routing are currently decided only at runtime by the in-memory `voice_chats` set, which is populated solely when an inbound voice note arrives. There's no way to say "this peer always gets voice" — so proactive/cron messages can't be delivered as voice notes. This adds a static, config-time preference: an `output_modality` field (`mirror` | `voice` | `text`) on `[peer_groups.*]`, and `TelegramChannel::with_voice_peer_prefs()` which records matching peers in `static_voice_peers` so TTS fires unconditionally for those peers without consuming session `voice_chats` state.
- **Scope boundary:** Config field + Telegram seeding only. No per-turn override tool, no cross-channel routing, no change to the existing input-mirroring path.
- **Blast radius:** Telegram voice delivery for peers in groups that opt into `output_modality = "voice"`. Default (`mirror`) is exactly today's behavior.
- **Linked issue(s):** Related #6969 — this is Layer 1 of the proposed output-routing model.
- **Labels:** `enhancement`, `risk: medium`, `size: S`, `config`, `channel`, `tests`, `channel:telegram`

## Validation Evidence (required)

```
cargo fmt --all -- --check          # clean
cargo clippy --release --all-targets   # 0 warnings (on the integration branch)
cargo build --bin zeroclaw --release   # Finished
```

- **Beyond CI — manually verified:** running on my fork, a peer group with `output_modality = "voice"` causes the agent to deliver replies as voice notes without an inbound voice note to mirror.
- **Tests:** `OutputModality` snake_case serde round-trip; `PeerGroupConfig` parsing `output_modality = "voice"` and defaulting to `mirror` when omitted; `with_voice_peer_prefs` seeds only matching voice groups on the right channel (peers on other channels and mirror-mode groups are not seeded).
- **Intentionally skipped:** full `cargo test` not run locally (Pi 5 OOMs on the suite build); tests compile under `clippy --tests` and run in CI.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No** — uses the already-configured TTS provider; only changes when a voice note is sent.
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No** — tests use placeholder `@alice`/`@bob` handles.

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **Yes** — one new *optional* key `output_modality` on `[peer_groups.<name>]`, defaulting to `mirror`.
- Upgrade steps: none. Omitting the field preserves current behavior.

## Rollback (required for `risk: medium`)

- **Fast rollback command/path:** remove `output_modality` from the affected `[peer_groups.*]` entries (reverts to `mirror`), or `git revert <sha>`.
- **Feature flags or config toggles:** the field itself (unset / `mirror` = old behavior).
- **Observable failure symptoms:** unexpected voice notes sent to a peer group, or TTS errors in the trace for those peers.
