### PR TITLE
fix(channels): honor webhook Retry-After dates

### DIFF
--- a/crates/zeroclaw-channels/src/webhook.rs
+++ b/crates/zeroclaw-channels/src/webhook.rs
@@ -1,5 +1,6 @@
 use anyhow::{Result, bail};
 use async_trait::async_trait;
+use chrono::{DateTime, NaiveDateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use zeroclaw_api::channel::{Channel, ChannelMessage, SendMessage};
@@ -214,9 +215,13 @@ fn apply_jitter(delay_ms: u64) -> u64 {
     jittered
 }
 
-/// Parse a `Retry-After` header value. Supports integer seconds and
-/// decimal seconds (truncated to whole seconds). HTTP-date form is not supported.
+/// Parse a `Retry-After` header value. Supports integer seconds, decimal
+/// seconds (truncated to whole seconds), and HTTP-date values.
 fn parse_retry_after_ms(value: &str) -> Option<u64> {
+    parse_retry_after_ms_at(value, Utc::now())
+}
+
+fn parse_retry_after_ms_at(value: &str, now: DateTime<Utc>) -> Option<u64> {
     let trimmed = value.trim();
     if trimmed.is_empty() {
         return None;
@@ -228,7 +233,30 @@ fn parse_retry_after_ms(value: &str) -> Option<u64> {
         .split_once('.')
         .map(|(whole, _)| whole)
         .unwrap_or(trimmed);
-    whole.parse::<u64>().ok().map(|s| s.saturating_mul(1000))
+    if let Ok(seconds) = whole.parse::<u64>() {
+        return Some(seconds.saturating_mul(1000));
+    }
+
+    parse_retry_after_http_date(trimmed).map(|date| {
+        let delay_ms = date.signed_duration_since(now).num_milliseconds();
+        if delay_ms <= 0 {
+            0
+        } else {
+            u64::try_from(delay_ms).unwrap_or(u64::MAX)
+        }
+    })
+}
+
+fn parse_retry_after_http_date(value: &str) -> Option<DateTime<Utc>> {
+    if let Ok(date) = NaiveDateTime::parse_from_str(value, "%a, %d %b %Y %H:%M:%S GMT") {
+        return Some(DateTime::from_naive_utc_and_offset(date, Utc));
+    }
+    if let Ok(date) = NaiveDateTime::parse_from_str(value, "%A, %d-%b-%y %H:%M:%S GMT") {
+        return Some(DateTime::from_naive_utc_and_offset(date, Utc));
+    }
+    NaiveDateTime::parse_from_str(value, "%a %b %e %H:%M:%S %Y")
+        .ok()
+        .map(|date| DateTime::from_naive_utc_and_offset(date, Utc))
 }
 
 /// Outcome of a single send attempt.
@@ -666,6 +694,43 @@ mod tests {
     }
 
     #[test]
+    fn parse_retry_after_http_date() {
+        let now = DateTime::parse_from_rfc2822("Sun, 06 Nov 1994 08:49:37 GMT")
+            .unwrap()
+            .with_timezone(&Utc);
+        assert_eq!(
+            parse_retry_after_ms_at("Sun, 06 Nov 1994 08:49:39 GMT", now),
+            Some(2_000)
+        );
+    }
+
+    #[test]
+    fn parse_retry_after_obsolete_http_dates() {
+        let now = DateTime::parse_from_rfc2822("Sun, 06 Nov 1994 08:49:37 GMT")
+            .unwrap()
+            .with_timezone(&Utc);
+        assert_eq!(
+            parse_retry_after_ms_at("Sunday, 06-Nov-94 08:49:39 GMT", now),
+            Some(2_000)
+        );
+        assert_eq!(
+            parse_retry_after_ms_at("Sun Nov  6 08:49:39 1994", now),
+            Some(2_000)
+        );
+    }
+
+    #[test]
+    fn parse_retry_after_past_http_date_as_zero() {
+        let now = DateTime::parse_from_rfc2822("Sun, 06 Nov 1994 08:49:39 GMT")
+            .unwrap()
+            .with_timezone(&Utc);
+        assert_eq!(
+            parse_retry_after_ms_at("Sun, 06 Nov 1994 08:49:37 GMT", now),
+            Some(0)
+        );
+    }
+
+    #[test]
     fn parse_retry_after_rejects_non_numeric() {
         assert_eq!(parse_retry_after_ms("later"), None);
     }
@@ -885,6 +950,53 @@ mod tests {
         assert!(
             elapsed >= Duration::from_millis(900),
             "expected to wait ~1s for Retry-After, elapsed = {:?}",
+            elapsed
+        );
+    }
+
+    #[tokio::test]
+    async fn send_honors_retry_after_http_date_header() {
+        use std::time::Instant;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+        let retry_at = (Utc::now() + chrono::Duration::seconds(60))
+            .format("%a, %d %b %Y %H:%M:%S GMT")
+            .to_string();
+        Mock::given(method("POST"))
+            .and(path("/cb"))
+            .respond_with(ResponseTemplate::new(429).insert_header("Retry-After", retry_at))
+            .up_to_n_times(1)
+            .expect(1)
+            .mount(&mock)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/cb"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        let ch = WebhookChannel::new(
+            "test-hook".into(),
+            8080,
+            None,
+            Some(format!("{}/cb", mock.uri())),
+            None,
+            None,
+            None,
+            Some(2),
+            Some(10),
+            Some(150),
+        );
+
+        let start = Instant::now();
+        ch.send(&test_message()).await.unwrap();
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed >= Duration::from_millis(100),
+            "expected to wait for date-form Retry-After, elapsed = {:?}",
             elapsed
         );
     }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Webhook outbound retry handling now parses HTTP-date `Retry-After` header values instead of only numeric seconds.
  - Past date-form headers clamp to a zero-millisecond retry delay, matching the already-accepted zero-second numeric behavior.
  - Regression coverage now includes numeric, decimal, IMF-fixdate, RFC850, and asctime `Retry-After` values, plus a wiremock send-path test for a date-form `Retry-After` on a `429`.
- **Scope boundary:** This PR only changes webhook `Retry-After` parsing and tests. It does not change retry budgets, jitter behavior, config keys, other channels, or public API shape.
- **Blast radius:** Limited to the webhook channel's outbound retry behavior when a server returns `429` or `503` with `Retry-After`. Numeric `Retry-After` values continue to behave as before.
- **Linked issue(s):** N/A
- **Labels:** `bug`, `risk: medium`, `size: S`, `channel`, `channel:webhook`

## Validation Evidence (required)

- **Commands run and tail output:**

```text
cargo fmt --all -- --check
Result: OK.

cargo test -p zeroclaw-channels parse_retry_after -- --nocapture
Result: OK. 12 passed; 0 failed; 0 ignored; 0 measured; 1165 filtered out.

cargo test -p zeroclaw-channels send_honors_retry_after_http_date_header -- --nocapture
Result: OK on final local rerun. 1 passed; 0 failed; 0 ignored; 0 measured; 1176 filtered out.

cargo clippy -p zeroclaw-channels --all-targets -- -D warnings
Result: OK. Finished `dev` profile.

cargo nextest run --locked --workspace --exclude zeroclaw-desktop
Result: OK. 8195 tests run: 8195 passed; 10 skipped.

git diff --check
Result: OK. No whitespace errors.
```

- **Beyond CI — what did you manually verify?** I confirmed the original focused parser test failed before the fix, then verified the parser accepts integer seconds, decimal seconds, the three HTTP-date forms, and past-date clamping. I also ran the webhook send-path regression against wiremock so the parsed date-form header reaches the retry branch before the successful retry.
- **If any command was intentionally skipped, why:** Full workspace plain `cargo test` was not run separately because ZeroClaw's CI-shaped local test gate is `cargo nextest run --locked --workspace --exclude zeroclaw-desktop`, which passed locally for this PR.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: `N/A`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No user action required. Existing numeric `Retry-After` behavior is preserved; date-form headers now follow the HTTP contract instead of falling back to local exponential backoff.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** Revert this PR to restore numeric-only webhook `Retry-After` parsing.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Webhook outbound retries may wait too long, retry too quickly, or fail delayed delivery after a `429` / `503` response with `Retry-After`. Look for webhook retry log lines such as `server requested retry after` and repeated `Webhook send failed` messages.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): `N/A`
- Scope materially carried forward: `N/A`
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why (inspiration-only, no direct code/design carry-over): No superseded PR or contributor code is incorporated.
