### PR TITLE
fix(config): materialize typed provider aliases from config set

### DIFF
--- a/crates/zeroclaw-config/src/helpers.rs
+++ b/crates/zeroclaw-config/src/helpers.rs
@@ -430,10 +430,12 @@ pub fn validate_alias_key(key: &str) -> Result<(), String> {
 ///
 /// Field segments derived from the schema are kebab-case; aliases are
 /// snake-only per [`validate_alias_key`]. For each known canonical
-/// path, segments are compared pairwise: equal verbatim, OR equal
-/// after swapping `_`/`-` only when the canonical segment contains a
-/// `-` (i.e. is a schema-derived field name, not an alias). Returns
-/// `raw` unchanged when no canonical path matches.
+/// path, segments are compared pairwise: equal verbatim, equal after
+/// swapping `-` → `_` when the canonical segment contains `-`, or
+/// equal after swapping `_` → `-` for the final field segment. The
+/// final-segment rule lets older CLI spelling like `api-key` resolve
+/// to schema-canonical `api_key` without rewriting map aliases such as
+/// `my_bot`. Returns `raw` unchanged when no canonical path matches.
 #[must_use]
 pub fn resolve_field_path(known_paths: &[String], raw: &str) -> String {
     let raw_segs: Vec<&str> = raw.split('.').collect();
@@ -442,10 +444,16 @@ pub fn resolve_field_path(known_paths: &[String], raw: &str) -> String {
         if known_segs.len() != raw_segs.len() {
             continue;
         }
+        let final_index = known_segs.len().saturating_sub(1);
         let all_match = known_segs
             .iter()
             .zip(raw_segs.iter())
-            .all(|(k, r)| k == r || (k.contains('-') && k.replace('-', "_") == **r));
+            .enumerate()
+            .all(|(idx, (k, r))| {
+                k == r
+                    || (k.contains('-') && k.replace('-', "_") == **r)
+                    || (idx == final_index && k.contains('_') && k.replace('_', "-") == **r)
+            });
         if all_match {
             return known.clone();
         }
@@ -669,6 +677,15 @@ mod tests {
         assert_eq!(
             resolve_field_path(&known, "providers.models.anthropic.my_bot.api-key"),
             "providers.models.anthropic.my_bot.api-key",
+        );
+    }
+
+    #[test]
+    fn resolve_field_path_canonicalizes_kebab_final_field_segments() {
+        let known = vec!["providers.models.deepseek.default.api_key".to_string()];
+        assert_eq!(
+            resolve_field_path(&known, "providers.models.deepseek.default.api-key"),
+            "providers.models.deepseek.default.api_key",
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2057,6 +2057,37 @@ fn model_path_provider_type(path: &str) -> Option<&'static str> {
         .map(|p| p.name)
 }
 
+fn map_key_for_prop_path<'a>(section_path: &str, prop_path: &'a str) -> Option<&'a str> {
+    let tail = prop_path.strip_prefix(section_path)?.strip_prefix('.')?;
+    let mut parts = tail.split('.');
+    let key = parts.next().filter(|key| !key.is_empty())?;
+    parts.next()?;
+    Some(key)
+}
+
+fn ensure_map_key_for_prop_path(config: &mut Config, prop_path: &str) -> Result<bool> {
+    let Some((section_path, key)) = Config::map_key_sections()
+        .into_iter()
+        .filter(|section| section.path.starts_with("providers.models."))
+        .filter(|section| section.kind == zeroclaw_config::traits::MapKeyKind::Map)
+        .filter_map(|section| {
+            let key = map_key_for_prop_path(section.path, prop_path)?;
+            Some((section.path, key))
+        })
+        .max_by_key(|(section_path, _)| section_path.len())
+    else {
+        return Ok(false);
+    };
+
+    let created = config
+        .create_map_key(section_path, key)
+        .map_err(anyhow::Error::msg)?;
+    if created {
+        config.mark_dirty(&format!("{section_path}.{key}"));
+    }
+    Ok(created)
+}
+
 #[cfg(feature = "agent-runtime")]
 fn trimmed_agent_name_for_templates(prior_name: Option<&str>) -> String {
     prior_name
@@ -3950,7 +3981,12 @@ async fn main() -> Result<()> {
                 crate::config::migration::ensure_disk_at_current_version(&config.config_path)?;
                 let known_paths: Vec<String> =
                     config.prop_fields().into_iter().map(|f| f.name).collect();
-                let path = zeroclaw_config::helpers::resolve_field_path(&known_paths, &path);
+                let mut path = zeroclaw_config::helpers::resolve_field_path(&known_paths, &path);
+                if ensure_map_key_for_prop_path(&mut config, &path)? {
+                    let known_paths: Vec<String> =
+                        config.prop_fields().into_iter().map(|f| f.name).collect();
+                    path = zeroclaw_config::helpers::resolve_field_path(&known_paths, &path);
+                }
                 if no_interactive {
                     let val = value.ok_or_else(|| {
                         ::zeroclaw_log::record!(
@@ -5732,6 +5768,72 @@ mod tests {
         });
 
         assert!((final_temperature - 1.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    #[cfg(feature = "agent-runtime")]
+    fn config_set_materializes_missing_typed_provider_alias() {
+        let mut config = Config::default();
+        let path = "providers.models.deepseek.default.model";
+
+        assert!(
+            config
+                .providers
+                .models
+                .find("deepseek", "default")
+                .is_none(),
+            "fresh config should not already contain the requested provider alias"
+        );
+
+        let created = ensure_map_key_for_prop_path(&mut config, path)
+            .expect("known typed provider path should be materialized");
+
+        assert!(created, "missing provider alias should be created");
+        config
+            .set_prop_persistent(path, "deepseek-chat")
+            .expect("materialized path should be writable");
+        assert_eq!(
+            config
+                .providers
+                .models
+                .find("deepseek", "default")
+                .and_then(|provider| provider.model.as_deref()),
+            Some("deepseek-chat")
+        );
+
+        let known_paths: Vec<String> = config.prop_fields().into_iter().map(|f| f.name).collect();
+        let api_key_path = zeroclaw_config::helpers::resolve_field_path(
+            &known_paths,
+            "providers.models.deepseek.default.api-key",
+        );
+        config
+            .set_prop_persistent(&api_key_path, "sk-test-placeholder")
+            .expect(
+                "kebab-case secret path should resolve to the materialized typed provider field",
+            );
+        assert_eq!(
+            config
+                .providers
+                .models
+                .find("deepseek", "default")
+                .and_then(|provider| provider.api_key.as_deref()),
+            Some("sk-test-placeholder")
+        );
+    }
+
+    #[test]
+    fn config_set_does_not_materialize_non_provider_map_keys() {
+        let mut config = Config::default();
+        let created = ensure_map_key_for_prop_path(
+            &mut config,
+            "cost.rates.providers.models.openai.gpt-4.1.input_per_mtok",
+        )
+        .expect("non-provider map paths should be ignored, not rejected");
+
+        assert!(
+            !created,
+            "auto-materialization must stay scoped to typed model provider aliases"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `integration/zeroclaw-tui` (stacked on #6848; review target is this small delta against the integration branch, not #6848's merge-readiness against `master`)
- **What changed and why:**
  - `zeroclaw config set providers.models.<family>.<alias>.<field>` now creates the missing typed provider alias before setting a nested field, so a fresh config can accept commands such as `providers.models.deepseek.default.model` without requiring users to hand-edit TOML first.
  - Final field spelling keeps the older CLI-friendly `api-key` form working by resolving it to the schema-canonical `api_key` field after the provider alias exists.
  - Auto-materialization is scoped to typed model provider aliases only, with a regression guard so unrelated map/resource-key paths are not split into bogus provider aliases.
- **Scope boundary:** This does not change provider credential resolution, provider runtime behavior, the config schema shape from #6848, or arbitrary dynamic map sections outside `providers.models.<family>.<alias>`.
- **Blast radius:** CLI `config set`, config field-path resolution, and typed model-provider config persistence.
- **Linked issue(s):** Depends on #6848. Follows on from #6053 / #6398 for typed-provider `config set` UX.
- **Labels:** `bug`, `risk: medium`, `size: S`, `config`, `core`

## Validation Evidence (required)

- **Commands run and tail output:**

```text
cargo test -p zeroclawlabs config_set_materializes_missing_typed_provider_alias -- --nocapture
result: passed; covered creating providers.models.deepseek.default before setting model and api_key

cargo test -p zeroclawlabs config_set_does_not_materialize_non_provider_map_keys -- --nocapture
result: passed; covered that cost/resource map paths are ignored by the provider-alias materializer

cargo test -p zeroclaw-config resolve_field_path_canonicalizes_kebab_final_field_segments -- --nocapture
result: passed; covered api-key resolving to the schema-canonical api_key final field

cargo check -p zeroclawlabs --no-default-features
result: passed; confirmed the config-set helper is available without agent-runtime

cargo fmt --all -- --check
result: passed

git diff --check -- src/main.rs crates/zeroclaw-config/src/helpers.rs
result: passed with no whitespace errors

cargo clippy --workspace --all-targets --features ci-all -- -D warnings
result: failed; inherited from #6848 test code outside this PR's diff: disallowed `tokio::spawn` in `crates/zeroclaw-providers/src/factory.rs:1284` and `crates/zeroclaw-tools/src/http_request.rs:1205`. This PR only changes `src/main.rs` and `crates/zeroclaw-config/src/helpers.rs`.

cargo nextest run --locked --workspace --exclude zeroclaw-desktop
result: passed; 8,481 tests passed, 10 skipped
```

- **Beyond CI — what did you manually verify?** I ran a scratch-config CLI smoke that set `providers.models.deepseek.default.model` and `providers.models.deepseek.default.api-key` on a fresh config. It created `[providers.models.deepseek.default]`, persisted `model = "deepseek-chat"`, and stored `api_key` through the existing encrypted-secret path.
- **If any command was intentionally skipped, why:** No planned local command remains skipped. Full workspace clippy was run and failed on inherited parent-branch lint outside this PR's diff; CI-equivalent nextest passed.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `Yes`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: This changes how `config set` reaches an existing secret field when the typed provider alias is missing. It does not introduce a new credential store or plaintext path; the scratch-config smoke verified the API key still flows through the existing encrypted config writer.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `Yes`
- If `No` or `Yes` to either: No upgrade steps are required; existing configs continue to load unchanged. The CLI now accepts a previously failing setup path for typed provider aliases, including older `api-key` input spelling for the final field.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** Revert this PR.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** `zeroclaw config set providers.models.<family>.<alias>.<field>` would either fail with `Unknown property ...` again, create an unexpected provider alias, or write a value under the wrong field spelling.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): Not applicable.
- Scope materially carried forward: Not applicable.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why (inspiration-only, no direct code/design carry-over): Not applicable; this is a direct follow-up to the current #6848 integration branch.
