### PR TITLE
fix(zerocode): refresh empty states after setup

### DIFF
--- a/apps/zerocode/locales/en/zerocode.ftl
+++ b/apps/zerocode/locales/en/zerocode.ftl
@@ -108,7 +108,7 @@ zc-dashboard-tab-health = Health
 zc-dashboard-tab-cost = Cost
 zc-dashboard-tab-cron = Cron
 
-zc-dashboard-memory-not-configured = Memory subsystem not configured
+zc-dashboard-memory-not-configured = Memory is not configured yet. Use Quickstart or Config to add a memory backend, or ignore this tab until you need persistent memory.
 zc-dashboard-search-action-apply = apply
 zc-dashboard-search-action-cancel = cancel
 zc-dashboard-search-prefix = search:
@@ -265,7 +265,7 @@ zc-quickstart-save-and-close = Save & close
 zc-chat-pane-chat = Chat
 zc-chat-pane-acp = ACP
 
-zc-chat-no-agents = No enabled agents. Configure an agent in the Config tab.
+zc-chat-no-agents = No enabled agents yet. Open Quickstart to create one, or use Config to add and enable an agent.
 zc-chat-error-fetch-agents = Failed to fetch agents: { $error }
 zc-chat-error-create-session = Failed to create session: { $error }
 

--- a/apps/zerocode/src/acp.rs
+++ b/apps/zerocode/src/acp.rs
@@ -22,6 +22,10 @@ impl Acp {
         self.inner.init().await
     }
 
+    pub(crate) async fn refresh_if_inactive(&mut self) {
+        self.inner.refresh_if_inactive().await;
+    }
+
     pub(crate) fn draw(&mut self, frame: &mut ratatui::Frame, area: Rect) {
         self.inner.draw(frame, area);
     }

--- a/apps/zerocode/src/app.rs
+++ b/apps/zerocode/src/app.rs
@@ -83,6 +83,27 @@ impl Mode {
     }
 }
 
+async fn switch_mode(
+    mode: &mut Mode,
+    next: Mode,
+    conn_state: &ConnectionState,
+    quickstart: &mut quickstart_pane::QuickstartPane,
+    acp_pane: &mut acp::Acp,
+    chat_pane: &mut chat::Chat,
+) {
+    if *mode == Mode::Quickstart && next != Mode::Quickstart {
+        quickstart.dismiss_beacon().await;
+    }
+    if !matches!(conn_state, ConnectionState::Disconnected { .. }) {
+        match next {
+            Mode::Acp => acp_pane.refresh_if_inactive().await,
+            Mode::Chat => chat_pane.refresh_if_inactive().await,
+            _ => {}
+        }
+    }
+    *mode = next;
+}
+
 // ── Top-level entry point ────────────────────────────────────────
 
 /// Run the TUI event loop. Returns `true` if the daemon disconnected
@@ -326,10 +347,15 @@ pub async fn run(
                     _ => None,
                 };
                 if let Some(next) = switch_to {
-                    if mode == Mode::Quickstart && next != Mode::Quickstart {
-                        quickstart.dismiss_beacon().await;
-                    }
-                    mode = next;
+                    switch_mode(
+                        &mut mode,
+                        next,
+                        &conn_state,
+                        &mut quickstart,
+                        &mut acp_pane,
+                        &mut chat_pane,
+                    )
+                    .await;
                     continue;
                 }
 
@@ -377,10 +403,15 @@ pub async fn run(
                         mouse::mode_bar_click(mouse.column, mouse.row, bar_area, &label_refs)
                     {
                         let next = MODES[(n - 1) as usize];
-                        if mode == Mode::Quickstart && next != Mode::Quickstart {
-                            quickstart.dismiss_beacon().await;
-                        }
-                        mode = next;
+                        switch_mode(
+                            &mut mode,
+                            next,
+                            &conn_state,
+                            &mut quickstart,
+                            &mut acp_pane,
+                            &mut chat_pane,
+                        )
+                        .await;
                         continue;
                     }
                 }

--- a/apps/zerocode/src/chat.rs
+++ b/apps/zerocode/src/chat.rs
@@ -92,6 +92,10 @@ pub(crate) struct Chat {
     pane_kind: PaneKind,
 }
 
+fn should_retry_on_entry(phase: &ChatPhase) -> bool {
+    matches!(phase, ChatPhase::Error(_))
+}
+
 impl Chat {
     pub(crate) fn new(rpc: Arc<RpcClient>, pane_kind: PaneKind) -> Self {
         let (git_branch_tx, git_branch_rx) = mpsc::channel(4);
@@ -174,6 +178,17 @@ impl Chat {
     /// user into the freshly-created agent's chat.
     pub(crate) async fn focus_agent(&mut self, agent_alias: &str) {
         self.pick_or_start_session(agent_alias).await;
+    }
+
+    /// Re-check stale setup errors when the user returns to a chat-style pane.
+    ///
+    /// Manual setup can happen in Config while Chat is parked on a stale
+    /// "no agents" error. Quickstart uses `focus_agent()` directly after
+    /// creation, but manual Config setup needs this small refresh hook.
+    pub(crate) async fn refresh_if_inactive(&mut self) {
+        if should_retry_on_entry(&self.phase) {
+            let _ = self.init().await;
+        }
     }
 
     /// Start the session, optionally with a caller-supplied `cwd`.
@@ -2952,6 +2967,52 @@ mod tests {
 
     fn state() -> ChatState {
         ChatState::new("sess-1".to_string(), "myagent".to_string())
+    }
+
+    #[tokio::test]
+    async fn chat_entry_refresh_reloads_agents_from_error_phase() {
+        let (tx, mut rx) = mpsc::channel::<String>(16);
+        let rpc = Arc::new(RpcOutbound::new(tx));
+        let client = Arc::new(RpcClient::with_rpc(Arc::clone(&rpc)));
+        let mut chat = Chat::new(client, PaneKind::Chat);
+        chat.phase = ChatPhase::Error("No enabled agents yet.".to_string());
+
+        let refresh = tokio::spawn(async move {
+            chat.refresh_if_inactive().await;
+            chat
+        });
+
+        let line = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+            .await
+            .expect("refresh should request the agent list")
+            .unwrap();
+        let request: serde_json::Value = serde_json::from_str(&line).unwrap();
+        assert_eq!(request["method"], method::AGENTS_STATUS);
+
+        let id = request["id"].as_str().unwrap().to_string();
+        rpc.dispatch_response(
+            &id,
+            Some(serde_json::json!({
+                "agents": [
+                    {"alias": "alpha", "enabled": true, "active_sessions": 0},
+                    {"alias": "beta", "enabled": true, "active_sessions": 0}
+                ]
+            })),
+            None,
+        );
+
+        let chat = tokio::time::timeout(Duration::from_secs(2), refresh)
+            .await
+            .expect("refresh should finish after agents/status response")
+            .unwrap();
+        let ChatPhase::PickAgent {
+            agents, loading, ..
+        } = chat.phase
+        else {
+            panic!("refresh should leave stale error state");
+        };
+        assert_eq!(agents, vec!["alpha".to_string(), "beta".to_string()]);
+        assert!(!loading);
     }
 
     #[tokio::test]

--- a/apps/zerocode/src/dashboard.rs
+++ b/apps/zerocode/src/dashboard.rs
@@ -951,7 +951,9 @@ impl<'a> Dashboard<'a> {
             let inner = block.inner(area);
             frame.render_widget(block, area);
             frame.render_widget(
-                Paragraph::new(Span::styled(err.clone(), theme::warn_style())),
+                Paragraph::new(err.as_str())
+                    .style(theme::warn_style())
+                    .wrap(Wrap { trim: true }),
                 inner,
             );
             return;


### PR DESCRIPTION
## Summary

- **Base branch:** `integration/zeroclaw-tui` (stacked on #6848; review target is this small delta against the integration branch, not #6848's merge-readiness against `master`)
- **What changed and why:**
  - Refreshes Chat and Code/ACP when returning from a stale no-agent setup error, so manual Config setup no longer leaves either pane parked on old empty-state text.
  - Updates the no-agent Chat copy to point new users toward Quickstart or Config instead of only Config.
  - Makes the Memories not-configured message explain that persistent memory is optional until configured, and wraps the longer text in the dashboard pane.
  - Adds a behavior-level regression test that proves the refresh path re-requests `agents/status` and leaves the stale error state when agents become available.
- **Scope boundary:** This does not change daemon, config, memory backend, provider, or session protocol behavior. It only changes Zerocode pane entry handling and empty-state display text on the TUI integration branch, and it does not attempt to resolve #6848's broader integration conflicts.
- **Blast radius:** Limited to `apps/zerocode` in the stacked TUI branch. The affected paths are pane switching, Chat/ACP initialization retry behavior, and dashboard empty-state rendering.
- **Linked issue(s):** Depends on #6848. Supersedes #6858.
- **Labels:** `bug`, `risk: medium`, `size: S`, `onboard: tui`

## Validation Evidence (required)

- **Commands run and tail output:**

```text
cargo fmt -p zerocode -- --check
result: passed

cargo test -p zerocode chat_entry_refresh_reloads_agents_from_error_phase -- --nocapture
result: passed; 1 passed in src/main.rs

cargo test -p zerocode -- --nocapture
result: passed; 168 passed, 0 failed

cargo clippy -p zerocode --all-targets -- -D warnings
result: passed

git diff --check
result: passed with no whitespace errors
```

- **Beyond CI — what did you manually verify?** Reviewed the final diff against the Chat, ACP wrapper, app mode-switch, dashboard memory rendering, and Fluent catalogue call sites. No live terminal smoke was run after this follow-up.
- **If any command was intentionally skipped, why:** CI-shaped workspace nextest and workspace-shaped clippy were not run locally because this PR is a small reviewable delta stacked on #6848, whose integration branch still has broader merge-readiness work. This does not block review of #7029's diff. Before this change is merged, retargeted to `master`, or folded into #6848, run the current stack-level CI-shaped test job and workspace-shaped clippy for the relevant branch state, or explicitly accept GitHub CI coverage for the stack.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: `N/A`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No upgrade steps. This only changes TUI display and pane-entry retry behavior.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert a49aa06af7a6608821230982b6f87d2e1aef5d02`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** TUI-only regressions such as Chat or Code repeatedly reloading on pane entry, no-agent setup guidance failing to update after Config creates/enables an agent, or the Memories tab showing awkward wrapped warning text.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors: #6858 by @Audacity88
- Scope materially carried forward: The stale first-run empty-state follow-up is rebuilt on the current `integration/zeroclaw-tui` branch. This PR carries forward the Chat no-agent refresh/copy and Memory not-configured guidance, then narrows the implementation around the current Quickstart/Config flow and adds ACP parity.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why: Same author; no third-party code or design was incorporated.
