### PR TITLE
fix(channels): redact Discord delivery failure targets

### DIFF
--- a/crates/zeroclaw-channels/src/discord.rs
+++ b/crates/zeroclaw-channels/src/discord.rs
@@ -16,6 +16,7 @@ use zeroclaw_api::channel::{
     Channel, ChannelApprovalRequest, ChannelApprovalResponse, ChannelMessage, SendMessage,
 };
 use zeroclaw_api::media::MediaAttachment;
+use zeroclaw_runtime::i18n;
 
 /// Discord channel — connects via Gateway WebSocket for real-time messages
 pub struct DiscordChannel {
@@ -901,11 +902,7 @@ fn validate_marker_target(
 fn classify_outgoing_attachments(
     attachments: &[DiscordAttachment],
     workspace_dir: Option<&Path>,
-) -> (
-    Vec<PathBuf>,
-    Vec<String>,
-    Vec<(String, DiscordMarkerFailure)>,
-) {
+) -> (Vec<PathBuf>, Vec<String>, Vec<DiscordMarkerFailure>) {
     let mut local_files = Vec::new();
     let mut remote_urls = Vec::new();
     let mut failures = Vec::new();
@@ -920,7 +917,7 @@ fn classify_outgoing_attachments(
                     DiscordMarkerFailure::NotFound => "not found",
                 };
                 ::zeroclaw_log::record!(WARN, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_outcome(::zeroclaw_log::EventOutcome::Unknown).with_attrs(::serde_json::json!({"kind": attachment.kind.marker_name(), "target": attachment.target, "reason": kind_label, "error": format!("{}", e)})), "dropping unresolved outbound attachment marker");
-                failures.push((attachment.target.clone(), e.kind()));
+                failures.push(e.kind());
             }
         }
     }
@@ -928,23 +925,23 @@ fn classify_outgoing_attachments(
     (local_files, remote_urls, failures)
 }
 
-/// Build the Matrix-style "(note: I couldn't deliver ...)" tail appended
-/// to the bot's reply when at least one marker was dropped. Returns
-/// `None` when the failure list is empty so callers can keep the body
-/// untouched.
-fn delivery_failure_note(failures: &[(String, DiscordMarkerFailure)]) -> Option<String> {
+/// Build the count-only delivery failure tail appended to the bot's reply
+/// when at least one marker was dropped. Returns `None` when the failure
+/// list is empty so callers can keep the body untouched.
+fn delivery_failure_note(failures: &[DiscordMarkerFailure]) -> Option<String> {
     if failures.is_empty() {
         return None;
     }
-    let targets: Vec<&str> = failures.iter().map(|(t, _)| t.as_str()).collect();
-    Some(if targets.len() == 1 {
-        format!("(note: I couldn't deliver the file at {}.)", targets[0])
+    let count = failures.len().to_string();
+    let key = if failures.len() == 1 {
+        "channel-discord-delivery-failure-note-one"
     } else {
-        format!(
-            "(note: I couldn't deliver these files: {}.)",
-            targets.join(", ")
-        )
-    })
+        "channel-discord-delivery-failure-note-many"
+    };
+    Some(i18n::get_required_cli_string_with_args(
+        key,
+        &[("count", count.as_str())],
+    ))
 }
 
 /// Compose the final reply body with the delivery-failure note appended.
@@ -962,17 +959,17 @@ fn compose_body_with_failure_note(content: &str, note: Option<&str>) -> String {
 /// kinds of marker failures occurred. 🚫 signals a trust-boundary refusal,
 /// ⚠️ signals a post-validation delivery failure. Both can fire on the
 /// same message when a batch mixes refusals and not-found targets.
-fn decide_failure_reactions(failures: &[(String, DiscordMarkerFailure)]) -> Vec<&'static str> {
+fn decide_failure_reactions(failures: &[DiscordMarkerFailure]) -> Vec<&'static str> {
     let mut out = Vec::new();
     if failures
         .iter()
-        .any(|(_, k)| matches!(k, DiscordMarkerFailure::Refused))
+        .any(|k| matches!(k, DiscordMarkerFailure::Refused))
     {
         out.push("🚫");
     }
     if failures
         .iter()
-        .any(|(_, k)| matches!(k, DiscordMarkerFailure::NotFound))
+        .any(|k| matches!(k, DiscordMarkerFailure::NotFound))
     {
         out.push("⚠️");
     }
@@ -3541,7 +3538,7 @@ mod tests {
         assert!(locals.is_empty());
         assert!(remotes.is_empty());
         assert_eq!(failures.len(), 1);
-        assert_eq!(failures[0].1, DiscordMarkerFailure::NotFound);
+        assert_eq!(failures[0], DiscordMarkerFailure::NotFound);
     }
 
     #[test]
@@ -3564,7 +3561,7 @@ mod tests {
         );
         assert!(remotes.is_empty());
         assert_eq!(failures.len(), 1);
-        assert_eq!(failures[0].1, DiscordMarkerFailure::Refused);
+        assert_eq!(failures[0], DiscordMarkerFailure::Refused);
     }
 
     #[test]
@@ -3580,7 +3577,7 @@ mod tests {
         assert!(locals.is_empty(), "relative paths must be refused");
         assert!(remotes.is_empty());
         assert_eq!(failures.len(), 1);
-        assert_eq!(failures[0].1, DiscordMarkerFailure::Refused);
+        assert_eq!(failures[0], DiscordMarkerFailure::Refused);
     }
 
     #[test]
@@ -3606,7 +3603,7 @@ mod tests {
         assert!(locals.is_empty());
         assert!(remotes.is_empty());
         assert_eq!(failures.len(), 3);
-        for (_, kind) in &failures {
+        for kind in &failures {
             assert_eq!(*kind, DiscordMarkerFailure::Refused);
         }
     }
@@ -3625,7 +3622,7 @@ mod tests {
         );
         assert!(remotes.is_empty());
         assert_eq!(failures.len(), 1);
-        assert_eq!(failures[0].1, DiscordMarkerFailure::Refused);
+        assert_eq!(failures[0], DiscordMarkerFailure::Refused);
     }
 
     #[test]
@@ -3663,28 +3660,43 @@ mod tests {
 
     #[test]
     fn delivery_failure_note_singular_for_one_failure() {
-        let note = delivery_failure_note(&[(
-            "/workspace/missing.png".to_string(),
-            DiscordMarkerFailure::NotFound,
-        )])
-        .expect("one failure should produce a note");
-        assert_eq!(
-            note,
-            "(note: I couldn't deliver the file at /workspace/missing.png.)"
+        let note = delivery_failure_note(&[DiscordMarkerFailure::NotFound])
+            .expect("one failure should produce a note");
+        assert_eq!(note, "(note: I couldn't deliver 1 file.)");
+        assert!(
+            !note.contains("/workspace/missing.png"),
+            "user-facing failure note must not echo local marker targets"
         );
     }
 
     #[test]
-    fn delivery_failure_note_plural_lists_targets_in_order() {
+    fn delivery_failure_note_plural_redacts_targets() {
         let note = delivery_failure_note(&[
-            ("a.png".to_string(), DiscordMarkerFailure::Refused),
-            ("b.pdf".to_string(), DiscordMarkerFailure::NotFound),
-            ("c.mp4".to_string(), DiscordMarkerFailure::Refused),
+            DiscordMarkerFailure::Refused,
+            DiscordMarkerFailure::NotFound,
+            DiscordMarkerFailure::Refused,
         ])
         .expect("multiple failures should produce a note");
-        assert_eq!(
-            note,
-            "(note: I couldn't deliver these files: a.png, b.pdf, c.mp4.)"
+        assert_eq!(note, "(note: I couldn't deliver 3 files.)");
+        assert!(
+            !note.contains("a.png") && !note.contains("b.pdf") && !note.contains("c.mp4"),
+            "user-facing failure note must not echo failed marker targets"
+        );
+    }
+
+    #[test]
+    fn composed_delivery_failure_note_redacts_parsed_marker_target() {
+        let content = "Done\n[IMAGE: /workspace/missing.png]";
+        let (cleaned_content, parsed_attachments) = parse_attachment_markers(content);
+        let (_locals, _remotes, failures) =
+            classify_outgoing_attachments(&parsed_attachments, None);
+        let note = delivery_failure_note(&failures);
+        let composed = compose_body_with_failure_note(&cleaned_content, note.as_deref());
+
+        assert_eq!(composed, "Done\n\n(note: I couldn't deliver 1 file.)");
+        assert!(
+            !composed.contains("/workspace/missing.png"),
+            "composed outbound body must not echo failed marker targets"
         );
     }
 
@@ -3720,23 +3732,23 @@ mod tests {
     #[test]
     fn decide_failure_reactions_emits_refused_only() {
         let r = decide_failure_reactions(&[
-            ("a".to_string(), DiscordMarkerFailure::Refused),
-            ("b".to_string(), DiscordMarkerFailure::Refused),
+            DiscordMarkerFailure::Refused,
+            DiscordMarkerFailure::Refused,
         ]);
         assert_eq!(r, vec!["🚫"]);
     }
 
     #[test]
     fn decide_failure_reactions_emits_not_found_only() {
-        let r = decide_failure_reactions(&[("a".to_string(), DiscordMarkerFailure::NotFound)]);
+        let r = decide_failure_reactions(&[DiscordMarkerFailure::NotFound]);
         assert_eq!(r, vec!["\u{26A0}\u{FE0F}"]);
     }
 
     #[test]
     fn decide_failure_reactions_emits_both_when_mixed() {
         let r = decide_failure_reactions(&[
-            ("a".to_string(), DiscordMarkerFailure::Refused),
-            ("b".to_string(), DiscordMarkerFailure::NotFound),
+            DiscordMarkerFailure::Refused,
+            DiscordMarkerFailure::NotFound,
         ]);
         assert_eq!(r, vec!["🚫", "\u{26A0}\u{FE0F}"]);
     }

--- a/crates/zeroclaw-runtime/locales/en/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/en/cli.ftl
@@ -383,6 +383,8 @@ channel-wecom-ws-dm-access-denied =
     Your userid: {$userid}
 
     Ask an administrator to add your userid to {$allowed_users_path}.
+channel-discord-delivery-failure-note-one = (note: I couldn't deliver {$count} file.)
+channel-discord-delivery-failure-note-many = (note: I couldn't deliver {$count} files.)
 
 # Onboarding — OpenAI auth picker
 onboard-openai-auth-note =


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Redacts Discord outbound attachment delivery failure notes so they report only the failed file count instead of echoing raw marker targets.
  - Drops raw marker targets from the returned failure classification state after the existing validation warning log, so the user-facing note and reaction path only receive failure kinds.
  - Moves the new Discord delivery failure note text into the Fluent CLI catalog.
  - Adds a parsed-marker composition test that proves a failed local marker target is not echoed into the outbound Discord body.
- **Scope boundary:** This does not change marker parsing, local file validation rules, Discord upload behavior, remote URL inlining, reaction selection semantics, Matrix failure-note wording, or live Discord API behavior.
- **Blast radius:** Discord outbound messages that contain invalid or refused attachment markers. The visible behavior changes only the appended failure note text; callers still get the same refusal and not-found reactions.
- **Linked issue(s):** None.
- **Labels:** `bug`, `risk: medium`, `size: S`, `channel`, `channel: discord`, `domain:channels`

## Validation Evidence

- **Commands run and tail output:**

```text
git diff --check
Result: pass

cargo fmt --all -- --check
Result: pass

cargo test -p zeroclaw-channels delivery_failure_note --lib -- --nocapture
running 4 tests
test discord::tests::delivery_failure_note_is_none_when_no_failures ... ok
test discord::tests::delivery_failure_note_plural_redacts_targets ... ok
test discord::tests::composed_delivery_failure_note_redacts_parsed_marker_target ... ok
test discord::tests::delivery_failure_note_singular_for_one_failure ... ok
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 1171 filtered out

cargo test -p zeroclaw-channels classify_outgoing_attachments --lib -- --nocapture
running 7 tests
test discord::tests::classify_outgoing_attachments_drops_missing_absolute_paths ... ok
test discord::tests::classify_outgoing_attachments_keeps_workspace_locals_and_http ... ok
test discord::tests::classify_outgoing_attachments_passes_http_without_workspace ... ok
test discord::tests::classify_outgoing_attachments_drops_relative_paths ... ok
test discord::tests::classify_outgoing_attachments_refuses_local_without_workspace ... ok
test discord::tests::classify_outgoing_attachments_drops_paths_outside_workspace ... ok
test discord::tests::classify_outgoing_attachments_drops_disallowed_schemes ... ok
test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 1168 filtered out

cargo clippy -p zeroclaw-channels --lib -- -D warnings
Result: pass

cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
Result: pass

cargo nextest run --locked --workspace --exclude zeroclaw-desktop
Summary [339.865s] 8246 tests run: 8246 passed, 10 skipped

GitHub Actions: Quality Gate / Test
Result: pass

GitHub Actions: Quality Gate / CI Required Gate
Result: pass
```

- **Beyond CI — what did you manually verify?** The focused tests cover the delivery-note helper, the attachment classifier, and a parsed-marker composition path. The diff also shows the validation warning still records marker-target context before the returned failure state is reduced to failure kinds, so the user-facing note no longer carries the raw marker target.
- **If any command was intentionally skipped, why:** No local validation commands were intentionally skipped.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: Not applicable. This narrows a privacy leak by preventing local marker targets from being echoed back into Discord messages.

## Compatibility

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: Not applicable.

## Rollback

- **Fast rollback command/path:** `git revert e1d016e1c`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Discord replies with dropped attachment markers would show the wrong appended note text, missing warning reactions, or missing diagnostic warnings for refused/not-found markers.

## Supersede Attribution

- Superseded PRs + authors: Not applicable.
- Scope materially carried forward: Not applicable.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why: No superseded contributor work was carried forward.
