### PR TITLE
fix(channels/media-pipeline): inline image data for vision

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/media_pipeline.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/media_pipeline.rs
@@ -12,6 +12,7 @@
 //!
 //! The pipeline is **opt-in** via `[media_pipeline] enabled = true` in config.
 
+use base64::{Engine as _, engine::general_purpose::STANDARD};
 use zeroclaw_config::schema::MediaPipelineConfig;
 
 use super::super::transcription::TranscriptionManager;
@@ -124,13 +125,14 @@ impl<'a> MediaPipeline<'a> {
     ///
     /// When vision is available, the image will be passed through to the
     /// model_provider as an `[IMAGE:]` marker and described by the model in the
-    /// normal flow. Here we only add a placeholder annotation so the agent
-    /// knows an image is present.
+    /// normal flow.
     fn process_image(&self, attachment: &MediaAttachment) -> String {
         if self.vision_available {
+            let mime = attachment.mime_type.as_deref().unwrap_or("image/jpeg");
+            let b64 = STANDARD.encode(&attachment.data);
             format!(
-                "[Image: {} attached, will be processed by vision model]",
-                attachment.file_name
+                "[Image: {} attached, will be processed by vision model]\n[IMAGE:data:{};base64,{}]",
+                attachment.file_name, mime, b64
             )
         } else {
             format!("[Image: {} attached]", attachment.file_name)
@@ -266,6 +268,10 @@ mod tests {
             result.contains("[Image: photo.jpg attached, will be processed by vision model]"),
             "expected vision annotation, got: {result}"
         );
+        assert!(
+            result.contains("[IMAGE:data:image/jpeg;base64,"),
+            "expected image data marker, got: {result}"
+        );
         assert!(result.contains("check this"));
     }
 
@@ -278,6 +284,10 @@ mod tests {
         assert!(
             result.contains("[Image: photo.jpg attached]"),
             "expected basic image annotation, got: {result}"
+        );
+        assert!(
+            !result.contains("[IMAGE:data:"),
+            "non-vision path must not inline image data, got: {result}"
         );
     }
 


### PR DESCRIPTION
## Summary

**Base branch:** `master`

**What changed / why:**

Fixes the media pipeline vision path so image attachments are surfaced using the existing inline multimodal marker format.

When vision is available, `MediaPipeline::process_image` now keeps the human-readable annotation and appends `[IMAGE:data:<mime>;base64,<data>]`, allowing downstream provider code to extract the actual image bytes instead of receiving only a text placeholder.

**Scope boundary:**

Only `MediaPipeline::process_image` is changed. This does not change provider routing, multimodal provider parsing, channel download behavior, audio transcription, or video handling.

**Blast radius:**

Medium. This affects opt-in `[media_pipeline] describe_images = true` behavior when the active model provider reports vision support. The non-vision image annotation path is unchanged except for a test asserting it does not inline image data.

**Linked issues:**

Fixes #7033
Refs #6841

## Validation Evidence

```bash
cargo fmt --all -- --check
cargo test -p zeroclaw-channels media_pipeline::tests::image_annotation -- --nocapture
cargo clippy -p zeroclaw-channels --all-targets -- -D warnings
```

Focused test result: 2 passed, 0 failed, 1178 filtered out.

## Security & Privacy

No secrets, tokens, file paths, or personal data are added. Tests use synthetic attachment bytes and placeholder file names.

## Compatibility

The non-vision path continues to emit only `[Image: <file> attached]`. The vision path still includes the existing text annotation and adds the standard `[IMAGE:data:...]` marker already parsed by providers.

## Rollback

Revert this commit to restore the previous placeholder-only media pipeline image annotation behavior.

## Supersede Attribution

No superseded PR. This is a narrow media-pipeline data-marker fix and does not claim to fully resolve the broader provider-routing issue tracked in #6841.
