### PR TITLE
feat(hardware): add smartroom named-device tools (set_device / read_device) + peripheral wiring support

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -7765,6 +7765,23 @@ pub async fn start_channels(
         );
         let mut built_tools = all_tools_result_ch.tools;
         let delegate_handle_ch = all_tools_result_ch.delegate_handle;
+
+        // Wire peripheral tools (gpio_read/gpio_write etc.) so channel-driven
+        // sessions (Telegram, Discord, etc.) can actuate hardware when
+        // [peripherals] is configured. Mirrors the agent loop wiring.
+        // The helper is safe to call unconditionally (returns empty when
+        // no peripherals are wired).
+        let peripheral_tools =
+            zeroclaw_runtime::agent::loop_::load_peripheral_tools(config.peripherals.clone()).await;
+        if !peripheral_tools.is_empty() {
+            ::zeroclaw_log::record!(
+                INFO,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_attrs(::serde_json::json!({"count": peripheral_tools.len()})),
+                "Peripheral tools added (channels orchestrator)"
+            );
+            built_tools.extend(peripheral_tools);
+        }
         let reaction_handle_ch = all_tools_result_ch.reaction_handle;
         let ask_user_handle_ch = all_tools_result_ch.ask_user_handle;
         let poll_handle_ch = all_tools_result_ch.poll_handle;

--- a/crates/zeroclaw-hardware/src/peripherals/mod.rs
+++ b/crates/zeroclaw-hardware/src/peripherals/mod.rs
@@ -17,6 +17,8 @@ pub mod capabilities_tool;
 #[cfg(feature = "hardware")]
 pub mod nucleo_flash;
 #[cfg(feature = "hardware")]
+pub mod smartroom;
+#[cfg(feature = "hardware")]
 pub mod uno_q_bridge;
 #[cfg(feature = "hardware")]
 pub mod uno_q_setup;
@@ -133,6 +135,23 @@ pub async fn create_peripheral_tools(config: &PeripheralsConfig) -> Result<Vec<B
                         &format!("Arduino upload tool added (port: {})", path)
                     );
                 }
+
+                // Smart-room named device tools (ESP32 / ESP32 simulator).
+                // Lets the model use device names instead of guessing pin numbers.
+                if board.board == "esp32" || board.board == "esp32-sim" {
+                    let transport = p.transport();
+                    tools.push(Box::new(smartroom::SetDeviceTool {
+                        transport: transport.clone(),
+                    }));
+                    tools.push(Box::new(smartroom::ReadDeviceTool { transport }));
+                    ::zeroclaw_log::record!(
+                        INFO,
+                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                            .with_attrs(::serde_json::json!({"board": board.board})),
+                        "Smart-room device tools added (set_device, read_device)"
+                    );
+                }
+
                 ::zeroclaw_log::record!(
                     INFO,
                     ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)

--- a/crates/zeroclaw-hardware/src/peripherals/serial.rs
+++ b/crates/zeroclaw-hardware/src/peripherals/serial.rs
@@ -77,7 +77,7 @@ pub struct SerialTransport {
 const SERIAL_TIMEOUT_SECS: u64 = 5;
 
 impl SerialTransport {
-    async fn request(&self, cmd: &str, args: Value) -> anyhow::Result<ToolResult> {
+    pub(crate) async fn request(&self, cmd: &str, args: Value) -> anyhow::Result<ToolResult> {
         let mut port = self.port.lock().await;
         let resp = tokio::time::timeout(
             std::time::Duration::from_secs(SERIAL_TIMEOUT_SECS),

--- a/crates/zeroclaw-hardware/src/peripherals/smartroom.rs
+++ b/crates/zeroclaw-hardware/src/peripherals/smartroom.rs
@@ -16,7 +16,14 @@ use zeroclaw_api::attribution::{Attributable, Role};
 use zeroclaw_api::tool::{Tool, ToolResult};
 
 /// Pin mapping for the smart-room demo board.
-/// Output devices use gpio_write; the motion sensor uses gpio_read.
+///
+/// This mapping is intentionally hardcoded for the specific ESP32 demo board
+/// used in the hackathon vignette. If the physical wiring on a board changes,
+/// both this table and the firmware must be kept in sync.
+///
+/// For dynamic discovery of named devices, prefer the `pin_devices` map
+/// returned by the `hardware_capabilities` tool (see the companion PR that
+/// surfaces this field).
 fn output_pin(device: &str) -> Option<u8> {
     match device {
         "reading_lamp" | "lamp" | "reading lamp" => Some(12),

--- a/crates/zeroclaw-hardware/src/peripherals/smartroom.rs
+++ b/crates/zeroclaw-hardware/src/peripherals/smartroom.rs
@@ -1,0 +1,170 @@
+//! High-level smart-room device tools for ESP32 boards.
+//!
+//! Provides `set_device` and `read_device` tools that let the LLM
+//! reason in terms of named devices (e.g. "reading_lamp", "fan")
+//! instead of raw pin numbers. This eliminates the common failure mode
+//! where the model guesses the wrong pin based on training priors.
+//!
+//! These tools are automatically registered when a board with
+//! `board = "esp32"` or `board = "esp32-sim"` is configured.
+
+use super::serial::SerialTransport;
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use std::sync::Arc;
+use zeroclaw_api::attribution::{Attributable, Role};
+use zeroclaw_api::tool::{Tool, ToolResult};
+
+/// Pin mapping for the smart-room demo board.
+/// Output devices use gpio_write; the motion sensor uses gpio_read.
+fn output_pin(device: &str) -> Option<u8> {
+    match device {
+        "reading_lamp" | "lamp" | "reading lamp" => Some(12),
+        "overhead_light" | "overhead" | "ceiling" | "ceiling_light" => Some(13),
+        "heater" | "space_heater" => Some(14),
+        "fan" | "status_led" | "fan_led" => Some(2),
+        _ => None,
+    }
+}
+
+fn input_pin(device: &str) -> Option<u8> {
+    match device {
+        "motion_sensor" | "motion" | "presence" | "pir" => Some(5),
+        _ => None,
+    }
+}
+
+/// Tool: set a smart-room device on or off by name.
+pub struct SetDeviceTool {
+    pub transport: Arc<SerialTransport>,
+}
+
+#[async_trait]
+impl Tool for SetDeviceTool {
+    fn name(&self) -> &str {
+        "set_device"
+    }
+
+    fn description(&self) -> &str {
+        "Turn a smart-room device on or off by NAME. The hardware pin wiring \
+         is handled internally — you do NOT pick pin numbers. \
+         Available devices: reading_lamp, overhead_light, heater, fan. \
+         For the motion sensor use `read_device` instead. \
+         IMPORTANT: ALWAYS call this tool when the user asks to change device \
+         state — do NOT skip the call just because conversation history suggests \
+         the device is already in the desired state."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "device": {
+                    "type": "string",
+                    "enum": ["reading_lamp", "overhead_light", "heater", "fan"],
+                    "description": "Device name. reading_lamp = warm lamp by the chair; overhead_light = bright ceiling; heater = space heater; fan = cooling fan with status LED."
+                },
+                "state": {
+                    "type": "string",
+                    "enum": ["on", "off"],
+                    "description": "on = energize, off = de-energize"
+                }
+            },
+            "required": ["device", "state"]
+        })
+    }
+
+    async fn execute(&self, args: Value) -> anyhow::Result<ToolResult> {
+        let device = args
+            .get("device")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow::Error::msg("missing device"))?;
+
+        let state = args
+            .get("state")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow::Error::msg("missing state"))?;
+
+        let pin = output_pin(device)
+            .ok_or_else(|| anyhow::Error::msg(format!("unknown output device: {}", device)))?;
+
+        let value = match state {
+            "on" => 1,
+            "off" => 0,
+            _ => anyhow::bail!("state must be 'on' or 'off'"),
+        };
+
+        let result = self
+            .transport
+            .request("gpio_write", json!({ "pin": pin, "value": value }))
+            .await?;
+
+        Ok(result)
+    }
+}
+
+/// Tool: read a smart-room input device (currently only motion_sensor).
+pub struct ReadDeviceTool {
+    pub transport: Arc<SerialTransport>,
+}
+
+#[async_trait]
+impl Tool for ReadDeviceTool {
+    fn name(&self) -> &str {
+        "read_device"
+    }
+
+    fn description(&self) -> &str {
+        "Read the current state of a smart-room input device by NAME. \
+         Currently only the motion_sensor is supported as an input device."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "device": {
+                    "type": "string",
+                    "enum": ["motion_sensor"],
+                    "description": "Input device name. Only motion_sensor is supported."
+                }
+            },
+            "required": ["device"]
+        })
+    }
+
+    async fn execute(&self, args: Value) -> anyhow::Result<ToolResult> {
+        let device = args
+            .get("device")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow::Error::msg("missing device"))?;
+
+        let pin =
+            input_pin(device).ok_or_else(|| anyhow::Error::msg(format!("unknown input device: {}", device)))?;
+
+        let result = self
+            .transport
+            .request("gpio_read", json!({ "pin": pin }))
+            .await?;
+
+        Ok(result)
+    }
+}
+
+impl Attributable for SetDeviceTool {
+    fn role(&self) -> Role {
+        Role::Tool(zeroclaw_api::attribution::ToolKind::Plugin)
+    }
+    fn alias(&self) -> &str {
+        "set_device"
+    }
+}
+
+impl Attributable for ReadDeviceTool {
+    fn role(&self) -> Role {
+        Role::Tool(zeroclaw_api::attribution::ToolKind::Plugin)
+    }
+    fn alias(&self) -> &str {
+        "read_device"
+    }
+}

--- a/crates/zeroclaw-hardware/src/peripherals/smartroom.rs
+++ b/crates/zeroclaw-hardware/src/peripherals/smartroom.rs
@@ -139,8 +139,8 @@ impl Tool for ReadDeviceTool {
             .and_then(|v| v.as_str())
             .ok_or_else(|| anyhow::Error::msg("missing device"))?;
 
-        let pin =
-            input_pin(device).ok_or_else(|| anyhow::Error::msg(format!("unknown input device: {}", device)))?;
+        let pin = input_pin(device)
+            .ok_or_else(|| anyhow::Error::msg(format!("unknown input device: {}", device)))?;
 
         let result = self
             .transport

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -30,6 +30,19 @@ pub fn register_peripheral_tools_fn(f: PeripheralToolsFn) {
     let _ = PERIPHERAL_TOOLS_FN.set(f);
 }
 
+/// Public helper for other crates (e.g. channels orchestrator) to load
+/// peripheral tools through the registered factory. Returns empty vec
+/// when nothing is registered (hardware feature off or not yet wired).
+pub async fn load_peripheral_tools(
+    config: zeroclaw_config::schema::PeripheralsConfig,
+) -> Vec<Box<dyn Tool>> {
+    if let Some(f) = PERIPHERAL_TOOLS_FN.get() {
+        f(config).await.unwrap_or_default()
+    } else {
+        Vec::new()
+    }
+}
+
 /// Channel map factory type — builds `channel_key → Arc<dyn Channel>` map.
 /// Injected by the binary so `zeroclaw-runtime` doesn't depend on
 /// `zeroclaw-channels`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1703,6 +1703,15 @@ async fn main() -> Result<()> {
                 Box::new(zeroclaw_channels::cli::CliChannel::new("cli"))
             }));
 
+            // Wire peripheral tools (gpio_read/gpio_write etc.) for `zeroclaw agent`.
+            // Mirrors the registration done for the daemon command.
+            #[cfg(feature = "hardware")]
+            zeroclaw_runtime::agent::loop_::register_peripheral_tools_fn(Box::new(|config| {
+                Box::pin(async move {
+                    zeroclaw_hardware::peripherals::create_peripheral_tools(&config).await
+                })
+            }));
+
             // Register channel map factory for late-bound tool handle population.
             zeroclaw_runtime::agent::loop_::register_channel_map_fn(Box::new({
                 let config_clone = config.clone();


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Added a public `load_peripheral_tools()` helper in `zeroclaw-runtime`.
  - Wired peripheral tool registration in the `zeroclaw agent` command, where it previously differed from daemon startup.
  - Wired peripheral tools into the channels orchestrator so Telegram, Discord, and other channel-driven sessions can use hardware tools when `[peripherals]` is configured.
  - Added `smartroom.rs` with `set_device` and `read_device` tools that let the model control devices by name, such as `reading_lamp` and `fan`, instead of guessing raw pin numbers.
  - Automatically registers the smartroom tools for boards named `esp32` or `esp32-sim`.
- **Scope boundary:** This PR delivers the peripheral tools wiring plus the first small piece of the adapted demo work: named-device smartroom tools. It does **not** include the full `esp32_sim` example, demo harness, `dev-sim` feature, or the `pin_devices` capabilities change from the original bundle.
- **Blast radius:** Small and isolated to configurations that use hardware peripherals.
- **Linked issue(s):** Extracted from #6148.
- **Labels:** `enhancement`, `size: S`, `risk: high`, `core`, `agent`, `channel`, `runtime`

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --features "agent-runtime,hardware" -- -D warnings
cargo test --features "agent-runtime,hardware"
```

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? Yes. Agents and channel sessions with `[peripherals]` configured can now see hardware tools in the paths this PR wires.
- New external network calls? No.
- Secrets / tokens / credentials handling changed? No.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No.
- If any `Yes`, describe the risk and mitigation: The new capability is limited to explicit `[peripherals]` configuration and uses the existing peripheral tool factory. `load_peripheral_tools()` returns an empty tool set when the factory is absent or returns an error, so peripheral initialization failure does not crash agent or channel startup.

## Compatibility (required)

- Backward compatible? Yes.
- Config / env / CLI surface changed? No new config or CLI flags. Existing `[peripherals]` config now affects the `zeroclaw agent` command and channel-driven sessions as intended.
- If `No` or `Yes` to either: Existing users without `[peripherals]` configured are unaffected. Users with configured peripherals may now see hardware tools in agent and channel sessions; this is the intended behavior.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** Revert this PR.
- **Feature flags or config toggles:** Remove or disable the `[peripherals]` section to avoid registering hardware tools.
- **Observable failure symptoms:** Agent or channel sessions unexpectedly expose or call peripheral tools; hardware sessions log peripheral tool loading or serial connection warnings around startup.
