### PR TITLE
feat(hardware): add dev-sim feature with /tmp/zc-sim-* serial allowlist

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -328,6 +328,10 @@ observability-prometheus = [
 observability-otel = ["zeroclaw-runtime/observability-otel"]
 hardware = ["dep:zeroclaw-hardware", "zeroclaw-hardware/hardware"]
 peripheral-rpi = ["dep:zeroclaw-hardware", "zeroclaw-hardware/peripheral-rpi"]
+# Forwards `zeroclaw-hardware/dev-sim`: extends the serial allow-list with
+# `/tmp/zc-sim-*` for hardware-free simulation. Off by default; opt-in for the
+# simulator and demo.
+dev-sim = ["dep:zeroclaw-hardware", "zeroclaw-hardware/dev-sim"]
 sandbox-landlock = ["zeroclaw-runtime/sandbox-landlock"]
 sandbox-bubblewrap = ["zeroclaw-runtime/sandbox-bubblewrap"]
 browser-native = ["zeroclaw-tools/browser-native"]

--- a/crates/zeroclaw-hardware/Cargo.toml
+++ b/crates/zeroclaw-hardware/Cargo.toml
@@ -41,3 +41,6 @@ default = []
 hardware = ["dep:nusb", "dep:tokio-serial", "dep:dialoguer", "dep:console"]
 peripheral-rpi = ["rppal"]
 probe = ["dep:probe-rs"]
+# Extends the serial peripheral allow-list with `/tmp/zc-sim-*` for hardware-free
+# local testing (paired with the `esp32_sim` example). Off by default; opt-in.
+dev-sim = []

--- a/crates/zeroclaw-hardware/Cargo.toml
+++ b/crates/zeroclaw-hardware/Cargo.toml
@@ -43,4 +43,7 @@ peripheral-rpi = ["rppal"]
 probe = ["dep:probe-rs"]
 # Extends the serial peripheral allow-list with `/tmp/zc-sim-*` for hardware-free
 # local testing (paired with the `esp32_sim` example). Off by default; opt-in.
+#
+# Note: this feature is normally used together with the `hardware` feature
+# (i.e. `--features "hardware,dev-sim"`).
 dev-sim = []

--- a/crates/zeroclaw-hardware/src/peripherals/serial.rs
+++ b/crates/zeroclaw-hardware/src/peripherals/serial.rs
@@ -29,6 +29,10 @@ const ALLOWED_PATH_PREFIXES: &[&str] = &[
     "/dev/tty.usbserial",
     "/dev/cu.usbserial", // Arduino Uno (FTDI), clones
     "COM",               // Windows
+    // Opt-in via `dev-sim` cargo feature: enables hardware-free simulation
+    // by allowing paths created by the `esp32_sim` example (socat / pty pair).
+    #[cfg(feature = "dev-sim")]
+    "/tmp/zc-sim-",
 ];
 
 fn is_path_allowed(path: &str) -> bool {
@@ -143,9 +147,14 @@ impl SerialPeripheral {
         })?;
 
         if !is_path_allowed(path) {
+            #[cfg(feature = "dev-sim")]
+            let hint = ", /tmp/zc-sim-*";
+            #[cfg(not(feature = "dev-sim"))]
+            let hint = "";
             anyhow::bail!(
-                "Serial path not allowed: {}. Allowed: /dev/ttyACM*, /dev/ttyUSB*, /dev/tty.usbmodem*, /dev/cu.usbmodem*",
-                path
+                "Serial path not allowed: {}. Allowed: /dev/ttyACM*, /dev/ttyUSB*, /dev/tty.usbmodem*, /dev/cu.usbmodem*{}",
+                path,
+                hint
             );
         }
 


### PR DESCRIPTION
**Extracted from #6148** (hackathon ESP32 demo bundle, split per AGENTS.md one-concern rule as requested in the review by @theonlyhennygod and @Audacity88).

## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Added a new opt-in `dev-sim` Cargo feature.
  - When enabled, the serial peripheral allow-list is extended with `/tmp/zc-sim-*` paths for the ESP32 simulator and similar hardware-free testing.
  - Updated the serial-path rejection message to surface the simulator paths as a hint when the feature is active.
- **Scope boundary:** This PR only adds the `dev-sim` feature and allow-list extension. It does **not** include the `esp32_sim` example, the demo harness, smartroom tools, or any other pieces from the original bundle.
- **Blast radius:** Small and defensive. The feature is off-by-default and only affects builds compiled with `dev-sim`.
- **Linked issue(s):** Extracted from #6148
- **Labels:** `enhancement`, `size: XS`, `risk: medium`, `dependencies`

## Validation Evidence (required)

```bash
# 1. Formatting
cargo fmt --all -- --check
Result: ✅ Passed (clean, exit code 0)

# 2. Clippy (strict)
cargo clippy --all-targets --features "agent-runtime,hardware,dev-sim" -- -D warnings
Result: ✅ Passed (no warnings or errors)

# 3. Tests with the feature
cargo test --features "agent-runtime,hardware,dev-sim" --test '*'
Result: ✅ Passed (relevant tests green)

# 4. Slim build check
cargo check --no-default-features --features "agent-runtime,hardware,dev-sim"
Result: ✅ Passed (compiles cleanly)
```

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `Yes` — builds compiled with `dev-sim` allow serial paths under `/tmp/zc-sim-*` so hardware-free simulator ptys can be used.
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Risk and mitigation: the new paths are compile-time gated behind the opt-in `dev-sim` feature. Production builds without the feature keep the existing serial allow-list.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `Yes` — this adds a new opt-in Cargo feature.
- Upgrade steps for existing users: none. Existing builds are unchanged unless users explicitly compile with `dev-sim`.

## Rollback

- Remove the `dev-sim` feature flag, stop compiling with `--features dev-sim`, or revert this PR.
