### PR TITLE
fix(providers): omit temperature for kimi-k2 models in compatible.rs (#7022)

### DIFF
--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -633,11 +633,20 @@ impl OpenAiCompatibleModelProvider {
     }
 }
 
+/// Kimi K2.5/K2.6 models enforce fixed temperatures per mode (1.0 thinking,
+/// 0.6 instant) and reject any other value with HTTP 400. Omit `temperature`
+/// for kimi-k2.* models so the backend chooses the correct mode default.
+/// Substring match covers k2.5, k2.6, and future k2.x variants.
+fn compatible_model_omits_temperature(model: &str) -> bool {
+    model.contains("kimi-k2")
+}
+
 #[derive(Debug, Serialize)]
 struct ApiChatRequest {
     model: String,
     messages: Vec<Message>,
-    temperature: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    temperature: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     stream: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -936,7 +945,8 @@ struct Function {
 struct NativeChatRequest {
     model: String,
     messages: Vec<NativeMessage>,
-    temperature: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    temperature: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     stream: Option<bool>,
     /// Mirrors `ApiChatRequest::stream_options`. Without this, tool-enabled
@@ -1690,7 +1700,7 @@ impl OpenAiCompatibleModelProvider {
         effective_messages: &[ChatMessage],
         tools: Option<Vec<serde_json::Value>>,
         model: &str,
-        temperature: f64,
+        temperature: Option<f64>,
         allow_user_image_parts: bool,
     ) -> NativeChatRequest {
         let has_tool_entries = tools.as_ref().is_some_and(|tools| !tools.is_empty());
@@ -2184,7 +2194,11 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
         model: &str,
         temperature: Option<f64>,
     ) -> anyhow::Result<String> {
-        let temperature = temperature.unwrap_or(self.default_temperature());
+        let temperature = if temperature.is_none() && compatible_model_omits_temperature(model) {
+            None
+        } else {
+            Some(temperature.unwrap_or(self.default_temperature()))
+        };
         let credential = self.credential.as_deref();
 
         // Normalize image markers (e.g. local file paths from channel
@@ -2297,7 +2311,11 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
         model: &str,
         temperature: Option<f64>,
     ) -> anyhow::Result<String> {
-        let temperature = temperature.unwrap_or(self.default_temperature());
+        let temperature = if temperature.is_none() && compatible_model_omits_temperature(model) {
+            None
+        } else {
+            Some(temperature.unwrap_or(self.default_temperature()))
+        };
         let credential = self.credential.as_deref();
 
         let normalized = Self::normalize_messages_for_upstream(messages).await?;
@@ -2379,7 +2397,11 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
         model: &str,
         temperature: Option<f64>,
     ) -> anyhow::Result<ProviderChatResponse> {
-        let temperature = temperature.unwrap_or(self.default_temperature());
+        let temperature = if temperature.is_none() && compatible_model_omits_temperature(model) {
+            None
+        } else {
+            Some(temperature.unwrap_or(self.default_temperature()))
+        };
         let credential = self.credential.as_deref();
 
         let normalized = Self::normalize_messages_for_upstream(messages).await?;
@@ -2420,9 +2442,7 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
                         self.name
                     )
                 );
-                let text = self
-                    .chat_with_history(messages, model, Some(temperature))
-                    .await?;
+                let text = self.chat_with_history(messages, model, temperature).await?;
                 return Ok(ProviderChatResponse {
                     text: Some(text),
                     tool_calls: vec![],
@@ -2489,7 +2509,11 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
         model: &str,
         temperature: Option<f64>,
     ) -> anyhow::Result<ProviderChatResponse> {
-        let temperature = temperature.unwrap_or(self.default_temperature());
+        let temperature = if temperature.is_none() && compatible_model_omits_temperature(model) {
+            None
+        } else {
+            Some(temperature.unwrap_or(self.default_temperature()))
+        };
         let credential = self.credential.as_deref();
 
         let normalized = Self::normalize_messages_for_upstream(request.messages).await?;
@@ -2534,7 +2558,7 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
                 let fallback_messages =
                     Self::with_prompt_guided_tool_instructions(request.messages, request.tools);
                 let text = self
-                    .chat_with_history(&fallback_messages, model, Some(temperature))
+                    .chat_with_history(&fallback_messages, model, temperature)
                     .await?;
                 return Ok(ProviderChatResponse {
                     text: Some(text),
@@ -2598,7 +2622,11 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
             return stream::once(async { Ok(StreamEvent::Final) }).boxed();
         }
 
-        let temperature = temperature.unwrap_or(self.default_temperature());
+        let temperature = if temperature.is_none() && compatible_model_omits_temperature(model) {
+            None
+        } else {
+            Some(temperature.unwrap_or(self.default_temperature()))
+        };
         let provider = self.clone();
         let messages_owned: Vec<ChatMessage> = request.messages.to_vec();
         let tools_owned: Option<Vec<zeroclaw_api::tool::ToolSpec>> =
@@ -2746,7 +2774,11 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
         temperature: Option<f64>,
         options: StreamOptions,
     ) -> stream::BoxStream<'static, StreamResult<StreamChunk>> {
-        let temperature = temperature.unwrap_or(self.default_temperature());
+        let temperature = if temperature.is_none() && compatible_model_omits_temperature(model) {
+            None
+        } else {
+            Some(temperature.unwrap_or(self.default_temperature()))
+        };
         let provider = self.clone();
         let system_prompt_owned: Option<String> = system_prompt.map(str::to_string);
         let message_owned = message.to_string();
@@ -2883,7 +2915,11 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
         temperature: Option<f64>,
         options: StreamOptions,
     ) -> stream::BoxStream<'static, StreamResult<StreamChunk>> {
-        let temperature = temperature.unwrap_or(self.default_temperature());
+        let temperature = if temperature.is_none() && compatible_model_omits_temperature(model) {
+            None
+        } else {
+            Some(temperature.unwrap_or(self.default_temperature()))
+        };
         let provider = self.clone();
         let messages_owned: Vec<ChatMessage> = messages.to_vec();
         let model = model.to_string();
@@ -3067,7 +3103,7 @@ mod tests {
                 tool_calls: None,
                 reasoning_content: None,
             }],
-            temperature: 0.7,
+            temperature: Some(0.7),
             stream: Some(true),
             stream_options: Some(StreamOptionsBody {
                 include_usage: true,
@@ -3098,7 +3134,7 @@ mod tests {
         let req = NativeChatRequest {
             model: "gpt-4o".to_string(),
             messages: vec![],
-            temperature: 0.7,
+            temperature: Some(0.7),
             stream: Some(false),
             stream_options: None,
             reasoning_effort: None,
@@ -3142,7 +3178,7 @@ mod tests {
                     content: MessageContent::Text("hello".to_string()),
                 },
             ],
-            temperature: 0.4,
+            temperature: Some(0.4),
             stream: Some(false),
             stream_options: None,
             reasoning_effort: None,
@@ -3718,7 +3754,7 @@ mod tests {
         let req = NativeChatRequest {
             model: "mistral-large-latest".to_string(),
             messages: provider.convert_messages_for_native(&messages, true),
-            temperature: 0.7,
+            temperature: Some(0.7),
             stream: Some(false),
             stream_options: None,
             reasoning_effort: None,
@@ -4230,7 +4266,7 @@ mod tests {
                 role: "user".to_string(),
                 content: MessageContent::Text("What is the weather?".to_string()),
             }],
-            temperature: 0.7,
+            temperature: Some(0.7),
             stream: Some(false),
             stream_options: None,
             reasoning_effort: None,
@@ -4254,7 +4290,7 @@ mod tests {
                 role: "user".to_string(),
                 content: MessageContent::Text("List /tmp".to_string()),
             }],
-            temperature: 0.7,
+            temperature: Some(0.7),
             stream: Some(false),
             stream_options: None,
             reasoning_effort: None,
@@ -4289,7 +4325,7 @@ mod tests {
                 role: "user".to_string(),
                 content: MessageContent::Text("List /tmp".to_string()),
             }],
-            temperature: 0.7,
+            temperature: Some(0.7),
             stream: Some(false),
             stream_options: None,
             reasoning_effort: None,
@@ -4465,7 +4501,7 @@ mod tests {
             &messages,
             Some(tools),
             "deepseek-v4-flash",
-            0.7,
+            Some(0.7),
             true,
         );
         let value = serde_json::to_value(&request).unwrap();
@@ -5396,5 +5432,22 @@ mod tests {
             vec!["user", "assistant"]
         );
         assert_eq!(stripped[1].content, "Here are the results");
+    }
+
+    #[test]
+    fn compatible_model_omits_temperature_matches_kimi_k2() {
+        assert!(compatible_model_omits_temperature("kimi-k2.5"));
+        assert!(compatible_model_omits_temperature("kimi-k2.6"));
+        assert!(compatible_model_omits_temperature("kimi-k2.7"));
+        assert!(compatible_model_omits_temperature("kimi-k2"));
+    }
+
+    #[test]
+    fn compatible_model_omits_temperature_skips_other_models() {
+        assert!(!compatible_model_omits_temperature("kimi-k1"));
+        assert!(!compatible_model_omits_temperature("kimi-latest"));
+        assert!(!compatible_model_omits_temperature("gpt-4o"));
+        assert!(!compatible_model_omits_temperature("claude-sonnet-4-6"));
+        assert!(!compatible_model_omits_temperature("llama-3.1-70b"));
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** `OpenAiCompatibleModelProvider` always sends `temperature: 0.7` (from `BASELINE_TEMPERATURE`), which breaks Moonshot `kimi-k2.5` and `kimi-k2.6` — they enforce fixed temperatures per mode (1.0 thinking, 0.6 instant) and reject any other value with HTTP 400. Fix follows the `anthropic_model_omits_temperature` / `bedrock_model_omits_temperature` precedent: add `compatible_model_omits_temperature(model)` helper, change both request structs to `Option<f64>` with `skip_serializing_if`, update 7 call sites to omit only when user did not configure temperature AND model requires omission; explicit user config passes through.
- **Scope boundary:** Only `compatible.rs` temperature handling for `kimi-k2.*` models. No changes to config schema, other providers, or top_p/penalty handling.
- **Blast radius:** All `OpenAiCompatibleModelProvider` callers (Kimi, OpenRouter-compatible, etc.). Non-kimi models unaffected — same behavior as before.
- **Linked issue(s):** Fixes #7022

## Validation Evidence (required)

```bash
$ cargo fmt --all -- --check
ok (all files formatted correctly)

$ cargo clippy --all-targets -- -D warnings
ok (no issues found)

$ cargo test --package zeroclaw-providers
ok 890 passed, 1 ignored

$ cargo test --package zeroclaw-providers compatible_model_omits_temperature
ok 2 passed
```

- **Beyond CI:** Manually verified diff — 7 call sites updated identically, 2 internal fallback calls cleaned up, 7 test struct literals updated, 2 new tests added matching anthropic/bedrock pattern.
- **Skipped commands:** None.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No

## Compatibility (required)

- Backward compatible? Yes — only omits temperature for models that currently fail with 400. Non-kimi models unchanged.
- Config / env / CLI surface changed? No

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <sha>` — single-file change in `compatible.rs`, no config migration.
- **Feature flags or config toggles:** None — behavioral change only.
- **Observable failure symptoms:** Kimi K2.5/K2.6 users will see 400 `invalid temperature` errors again; other providers unaffected.

## Files Changed

| File | What | Lines |
|------|------|-------|
| `crates/zeroclaw-providers/src/compatible.rs` | Helper function + 2 struct fields + 7 call sites + 2 internal calls + 7 test literals + 2 new tests | +75 / -22 |