### PR TITLE
feat(tts): transcode to OGG/Opus for voice notes (Telegram + WhatsApp)

### DIFF
--- a/crates/zeroclaw-channels/src/telegram.rs
+++ b/crates/zeroclaw-channels/src/telegram.rs
@@ -997,7 +997,7 @@ impl TelegramChannel {
         text: &str,
         tts_manager: &crate::tts::TtsManager,
     ) -> anyhow::Result<()> {
-        let audio_bytes = tts_manager.synthesize(text).await?;
+        let audio_bytes = tts_manager.synthesize_opus(text).await?;
         let audio_len = audio_bytes.len();
         ::zeroclaw_log::record!(
             INFO,
@@ -1019,7 +1019,7 @@ impl TelegramChannel {
                 "voice",
                 reqwest::multipart::Part::bytes(audio_bytes)
                     .file_name("voice.ogg")
-                    .mime_str("audio/ogg")?,
+                    .mime_str("audio/ogg; codecs=opus")?,
             );
 
         if let Some(tid) = thread_id {

--- a/crates/zeroclaw-channels/src/tts.rs
+++ b/crates/zeroclaw-channels/src/tts.rs
@@ -30,6 +30,11 @@ pub trait TtsProvider: Send + Sync + ::zeroclaw_api::attribution::Attributable {
     /// Synthesize `text` using the given `voice`, returning raw audio bytes.
     async fn synthesize(&self, text: &str, voice: &str) -> Result<Vec<u8>>;
 
+    /// The audio container/codec of the bytes returned by `synthesize`
+    /// (e.g. `"opus"`, `"wav"`, `"mp3"`). Used by `TtsManager::synthesize_opus`
+    /// to decide whether transcoding is necessary — only `"opus"` skips it.
+    fn output_format(&self) -> &str;
+
     /// Voices supported by this model_provider.
     fn supported_voices(&self) -> Vec<String>;
 
@@ -103,6 +108,10 @@ impl OpenAiTtsProvider {
 impl TtsProvider for OpenAiTtsProvider {
     fn name(&self) -> &str {
         "openai"
+    }
+
+    fn output_format(&self) -> &str {
+        &self.response_format
     }
 
     async fn synthesize(&self, text: &str, voice: &str) -> Result<Vec<u8>> {
@@ -205,6 +214,9 @@ impl ElevenLabsTtsProvider {
 
 #[async_trait::async_trait]
 impl TtsProvider for ElevenLabsTtsProvider {
+    fn output_format(&self) -> &str {
+        "mp3"
+    }
     fn name(&self) -> &str {
         "elevenlabs"
     }
@@ -312,6 +324,10 @@ impl GoogleTtsProvider {
 
 #[async_trait::async_trait]
 impl TtsProvider for GoogleTtsProvider {
+    fn output_format(&self) -> &str {
+        "mp3"
+    }
+
     fn name(&self) -> &str {
         "google"
     }
@@ -426,6 +442,10 @@ impl EdgeTtsProvider {
 
 #[async_trait::async_trait]
 impl TtsProvider for EdgeTtsProvider {
+    fn output_format(&self) -> &str {
+        "mp3"
+    }
+
     fn name(&self) -> &str {
         "edge"
     }
@@ -518,6 +538,10 @@ impl PiperTtsProvider {
 
 #[async_trait::async_trait]
 impl TtsProvider for PiperTtsProvider {
+    fn output_format(&self) -> &str {
+        "wav"
+    }
+
     fn name(&self) -> &str {
         "piper"
     }
@@ -570,6 +594,69 @@ impl TtsProvider for PiperTtsProvider {
 }
 
 // ── TtsManager ───────────────────────────────────────────────────
+
+/// Transcode raw audio bytes to OGG/Opus via an `ffmpeg` subprocess.
+///
+/// Pipes `audio` into ffmpeg's stdin and reads OGG/Opus from stdout.
+/// stdin and stdout are driven concurrently to avoid buffer-deadlocks on
+/// large inputs. Requires `ffmpeg` with `libopus` support installed.
+async fn transcode_to_opus(audio: Vec<u8>) -> Result<Vec<u8>> {
+    use std::process::Stdio;
+    use tokio::io::AsyncWriteExt;
+
+    let mut child = tokio::process::Command::new("ffmpeg")
+        .args([
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-i",
+            "pipe:0",
+            "-f",
+            "ogg",
+            "-acodec",
+            "libopus",
+            "-b:a",
+            "32k",
+            "-vbr",
+            "on",
+            "pipe:1",
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .context(
+            "failed to spawn ffmpeg — ensure ffmpeg with libopus support is installed \
+             (e.g. `sudo dnf install ffmpeg` / `sudo apt install ffmpeg`)",
+        )?;
+
+    let mut stdin = child.stdin.take().expect("stdin configured above");
+
+    // Drive stdin and wait concurrently: if ffmpeg fills its stdout pipe
+    // before we finish writing stdin, sequential operation would deadlock.
+    let (write_result, output) = tokio::join!(
+        async move {
+            stdin.write_all(&audio).await?;
+            stdin.shutdown().await
+        },
+        child.wait_with_output()
+    );
+
+    write_result.context("failed to write audio to ffmpeg stdin")?;
+    let output = output.context("ffmpeg process error")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("ffmpeg transcode to opus failed: {stderr}");
+    }
+
+    anyhow::ensure!(
+        !output.stdout.is_empty(),
+        "ffmpeg produced empty output — check that libopus is available"
+    );
+
+    Ok(output.stdout)
+}
 
 /// Central manager for per-agent TTS synthesis.
 ///
@@ -667,6 +754,25 @@ impl TtsManager {
             default_voice: config.tts.default_voice.clone(),
             max_text_length,
         })
+    }
+
+    /// Synthesize `text` and return OGG/Opus audio suitable for Telegram
+    /// `sendVoice` and WhatsApp PTT voice notes. If the active provider
+    /// already outputs Opus (e.g. OpenAI with `response_format = "opus"`),
+    /// the bytes pass through unchanged; otherwise they are transcoded via an
+    /// `ffmpeg` subprocess. Requires `ffmpeg` with `libopus` support installed.
+    pub async fn synthesize_opus(&self, text: &str) -> Result<Vec<u8>> {
+        let audio = self.synthesize(text).await?;
+        let provider_alias = self.agent_tts_provider.as_str();
+        let format = self
+            .tts_providers
+            .get(provider_alias)
+            .map(|p| p.output_format())
+            .unwrap_or("unknown");
+        if format == "opus" {
+            return Ok(audio);
+        }
+        transcode_to_opus(audio).await
     }
 
     /// Synthesize text using the runtime-active agent's resolved

--- a/crates/zeroclaw-channels/src/whatsapp_web.rs
+++ b/crates/zeroclaw-channels/src/whatsapp_web.rs
@@ -614,7 +614,7 @@ impl WhatsAppWebChannel {
         text: &str,
         tts_manager: &super::tts::TtsManager,
     ) -> Result<()> {
-        let audio_bytes = tts_manager.synthesize(text).await?;
+        let audio_bytes = tts_manager.synthesize_opus(text).await?;
         let audio_len = audio_bytes.len();
         ::zeroclaw_log::record!(
             INFO,
@@ -652,7 +652,7 @@ impl WhatsAppWebChannel {
             )
         );
 
-        // Estimate duration: Opus at ~32kbps → bytes / 4000 ≈ seconds
+        // Estimate duration from file size: Opus at ~32 kbps → bytes / 4000 ≈ seconds
         #[allow(clippy::cast_possible_truncation)]
         let estimated_seconds = std::cmp::max(1, (upload.file_length / 4000) as u32);
 


### PR DESCRIPTION
## Summary

- **What changed and why:** Adds `TtsManager::synthesize_opus()` which transcodes any TTS output to OGG/Opus via an `ffmpeg` subprocess before delivery. Telegram's `synthesize_and_send_voice` and WhatsApp's `synthesize_voice_static` now call this instead of `synthesize()`, so every voice reply arrives as a real PTT/voice-note bubble regardless of which TTS provider is active.
- **Why needed:** Groq Orpheus and several other providers return WAV or MP3. Telegram `sendVoice` only renders a voice bubble for OGG/Opus; anything else arrives as a plain audio attachment. WhatsApp was also lying — uploading WAV bytes while claiming `mimetype = "audio/ogg; codecs=opus"`, producing corrupted voice notes and a wrong duration estimate.
- **Scope boundary:** Does not change provider selection, routing, or config schema. OpenAI with `response_format = "opus"` (the default) passes through unchanged — no ffmpeg call.
- **Blast radius:** Telegram and WhatsApp voice-reply paths only. Channels that do not call `synthesize_opus()` are unaffected.
- **Linked issue:** Related #7020 (RFC output_modality context)
- **Labels:** `enhancement`, `risk: medium`, `size: S`, `channel`, `channel:telegram`, `channel:whatsapp`

## Validation Evidence (required)

```bash
cargo fmt --all -- --check    # clean
cargo clippy -p zeroclaw-channels --tests -j2 -- -D warnings    # clean
```

Full workspace lint/test: CI gate.

- **Commands run and tail output:** `cargo clippy -p zeroclaw-channels --tests -j2 -- -D warnings` -> `Finished dev profile in 10.89s`, no warnings or errors.
- **Beyond CI — what did you manually verify?** Deployed to Raspberry Pi 5 (aarch64, ffmpeg 7.1.3 with libopus). Sent a Telegram voice message -> agent replied with both a text message and a **voice bubble** (waveform rendered in client, not a plain audio file). Confirms the `ffmpeg` pipe:0 -> pipe:1 transcode path fires correctly for Groq Orpheus WAV output, producing an OGG/Opus voice bubble.
- **If any command was intentionally skipped, why:** `cargo test` skipped locally per repo policy for Pi builds (CI covers this; `--no-verify` push).

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No new ZeroClaw file access. Non-Opus voice replies invoke a host `ffmpeg` binary through stdin/stdout pipes; no temp files are created.
- New external network calls? No.
- Secrets / tokens / credentials handling changed? No.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No.

## Compatibility (required)

- Backward compatible? Yes — providers that already return Opus (OpenAI default) pass through unchanged. Providers returning other formats are transcoded transparently.
- Config / env / CLI surface changed? No.
- Prerequisite: `ffmpeg` with `libopus` must be installed on the host. Standard on Raspberry Pi OS and most Linux distros; not enforced at startup — missing `ffmpeg` surfaces as a runtime error on first voice reply attempt.

## Rollback (required for `risk: medium` and `risk: high`)

Revert the merge/squash commit for this PR to restore `synthesize()` calls in Telegram and WhatsApp and remove `synthesize_opus()` / `transcode_to_opus()` / `output_format()`. Voice replies revert to WAV-over-sendAudio (plain attachment) on Groq Orpheus, and WhatsApp reverts to the lying MIME type.

