### PR TITLE
fix(channels): include Twitter/X channel in default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -261,10 +261,11 @@ agent-runtime = [
 ]
 
 # Lean channel bundle included in `default`. These channels cover local/editor
-# ACP, gateway/webhook ingress, and common first-run external chat/email paths.
+# ACP, gateway/webhook ingress, common first-run external chat/email paths,
+# and a basic social/broadcast channel (Twitter/X).
 default-channels = [
     "channel-acp-server", "channel-webhook",
-    "channel-email", "channel-telegram",
+    "channel-email", "channel-telegram", "channel-twitter",
 ]
 
 # Historical broad channel bundle. Use this for builds that should preserve the

--- a/crates/zeroclaw-channels/Cargo.toml
+++ b/crates/zeroclaw-channels/Cargo.toml
@@ -160,6 +160,7 @@ default-channels = [
   "channel-acp-server",
   "channel-email",
   "channel-telegram",
+  "channel-twitter",
   "channel-webhook",
 ]
 channels-full = [


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Added `channel-twitter` to the `default-channels` feature bundle in both the root `Cargo.toml` and `crates/zeroclaw-channels/Cargo.toml`.
  - The Twitter/X channel implementation (`crates/zeroclaw-channels/src/twitter.rs`, 541 lines) is already complete and documented in `docs/book/src/channels/social.md`, but the `channel-twitter` feature was only available via the `channels-full` bundle — not in the default feature set used by the release CI pipeline (`RELEASE_CARGO_FEATURES`).
  - This caused the pre-built binary to omit Twitter/X entirely from `zeroclaw channel list` and `zeroclaw config list`, despite the docs describing it as supported.
- **Scope boundary:** Only feature-flag membership changes. No source code in `twitter.rs` or any other channel was modified.
- **Blast radius:** All default builds (pre-built binaries, `cargo install`, local `cargo build`) will now compile with the Twitter channel enabled. No behavioral change for existing users who already build with `channels-full`.
- **Linked issue(s):** Closes #7069
- **Labels:** bug, channel, risk: low, size: XS

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
# (no output — clean)

cargo clippy --all-targets -- -D warnings
# Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 38s — clean, no warnings

cargo test
# 159 passed; 0 failed; 0 ignored; 0 measured (unit + integration)
# 9 passed; 0 failed (system)
# 7 ignored (live — requires credentials)
```

- **Commands run and tail output:** All three commands above passed clean. `cargo test` output: `test result: ok. 159 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out`
- **Beyond CI — what did you manually verify?** Confirmed `channel-twitter = []` has zero optional dependencies, so this is a pure cfg-gate addition with no compile-time or binary-size cost. Ran `cargo test -p zeroclaw-channels --features channel-twitter` specifically to confirm the channel crate tests pass with the feature enabled.
- **If any command was intentionally skipped, why:** None skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No** — only enables already-existing code path
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **Yes** — `zeroclaw channel list` and `zeroclaw config list` will now show Twitter/X, and `[channels.twitter]` sections in `config.toml` will be recognized. Existing configs without a `[channels.twitter]` section are unaffected.
- Upgrade steps: None required. Twitter/X channel is disabled by default (`enabled = false`) until the user explicitly configures it.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PR: `git revert <sha>` is the plan.