### PR TITLE
fix(channels-tools): improve expect() diagnostic messages with actionable context

### DIFF
--- a/crates/zeroclaw-channels/src/gmail_push.rs
+++ b/crates/zeroclaw-channels/src/gmail_push.rs
@@ -196,7 +196,9 @@ impl GmailPushChannel {
         let http = Client::builder()
             .timeout(Duration::from_secs(30))
             .build()
-            .expect("failed to build HTTP client");
+            .expect(
+                "failed to build HTTP client for Gmail push channel — check TLS/cert configuration",
+            );
         Self {
             config,
             alias: alias.into(),

--- a/crates/zeroclaw-tools/src/browser_delegate.rs
+++ b/crates/zeroclaw-tools/src/browser_delegate.rs
@@ -71,7 +71,8 @@ impl BrowserDelegateTool {
     /// Prevents policy bypass by embedding blocked URLs in the `task` text,
     /// which is forwarded verbatim to the browser CLI subprocess.
     fn validate_task_urls(&self, task: &str) -> anyhow::Result<()> {
-        let url_re = Regex::new(r#"https?://[^\s\)\]\},\"'`<>]+"#).expect("valid regex");
+        let url_re = Regex::new(r#"https?://[^\s\)\]\},\"'`<>]+"#)
+            .expect("failed to compile URL extraction regex for browser-delegate task validation");
         for m in url_re.find_iter(task) {
             self.validate_url(m.as_str())?;
         }

--- a/crates/zeroclaw-tools/src/content_search.rs
+++ b/crates/zeroclaw-tools/src/content_search.rs
@@ -590,14 +590,16 @@ fn parse_content_line(line: &str) -> Option<(&str, bool)> {
     static CONTEXT_RE: OnceLock<regex::Regex> = OnceLock::new();
 
     let match_re = MATCH_RE.get_or_init(|| {
-        regex::Regex::new(r"^(?P<path>.+?):\d+:").expect("match line regex must be valid")
+        regex::Regex::new(r"^(?P<path>.+?):\d+:")
+            .expect("failed to compile ripgrep match-line regex for content_search")
     });
     if let Some(caps) = match_re.captures(line) {
         return caps.name("path").map(|m| (m.as_str(), true));
     }
 
     let context_re = CONTEXT_RE.get_or_init(|| {
-        regex::Regex::new(r"^(?P<path>.+?)-\d+-").expect("context line regex must be valid")
+        regex::Regex::new(r"^(?P<path>.+?)-\d+-")
+            .expect("failed to compile ripgrep context-line regex for content_search")
     });
     if let Some(caps) = context_re.captures(line) {
         return caps.name("path").map(|m| (m.as_str(), false));
@@ -610,7 +612,8 @@ fn parse_content_line(line: &str) -> Option<(&str, bool)> {
 fn parse_count_line(line: &str) -> Option<(&str, usize)> {
     static COUNT_RE: OnceLock<regex::Regex> = OnceLock::new();
     let count_re = COUNT_RE.get_or_init(|| {
-        regex::Regex::new(r"^(?P<path>.+?):(?P<count>\d+)\s*$").expect("count line regex valid")
+        regex::Regex::new(r"^(?P<path>.+?):(?P<count>\d+)\s*$")
+            .expect("failed to compile ripgrep count-line regex for content_search")
     });
 
     let caps = count_re.captures(line)?;


### PR DESCRIPTION
## Summary

Add component-specific context to .expect() messages in gmail_push, browser_delegate, and content_search to aid debugging when invariants are violated at runtime.

## Changes

### 1. gmail_push.rs
Add channel name and TLS troubleshooting hint to HTTP client build failure message.

### 2. browser_delegate.rs
Replace generic 'valid regex' with descriptive message naming the regex purpose and feature.

### 3. content_search.rs
Add 'ripgrep' backend label and consistent 'failed to compile ... for content_search' format to all three output-parsing regex .expect() calls.

## Verification
- No logic changes, string-only modifications
- No breaking changes, no new dependencies
- All messages follow consistent format