### PR TITLE
chore(log-runtime): remove dead code - unused marker functions and empty() constructor

### DIFF
--- a/crates/zeroclaw-log/src/tool_io.rs
+++ b/crates/zeroclaw-log/src/tool_io.rs
@@ -21,16 +21,6 @@ pub struct ToolIoCapture {
     pub truncated: bool,
 }
 
-impl ToolIoCapture {
-    fn empty() -> Self {
-        Self {
-            text: String::new(),
-            original_bytes: 0,
-            truncated: false,
-        }
-    }
-}
-
 /// Capture redacted tool input.
 ///
 /// `redacted` is the input string AFTER the runtime has scanned it for
@@ -102,13 +92,6 @@ fn capture_with_policy(
             }
         }
     }
-}
-
-#[allow(dead_code)]
-fn empty_unused_marker() {
-    // Suppress unused-import false positives for `ToolIoCapture::empty`
-    // (kept around for future "explicit empty capture" call sites).
-    let _ = ToolIoCapture::empty();
 }
 
 #[cfg(test)]

--- a/crates/zeroclaw-runtime/src/sop/engine.rs
+++ b/crates/zeroclaw-runtime/src/sop/engine.rs
@@ -1144,17 +1144,6 @@ mod tests {
         }
     }
 
-    /// Get the first active run_id from the engine (for tests with a single run).
-    #[allow(dead_code)]
-    fn first_active_run_id(engine: &SopEngine) -> String {
-        engine
-            .active_runs()
-            .keys()
-            .next()
-            .expect("expected at least one active run")
-            .clone()
-    }
-
     // ── Trigger matching ────────────────────────────────
 
     #[test]


### PR DESCRIPTION
## Summary

Remove two dead-code functions behind #[allow(dead_code)] that have zero callers anywhere in the codebase.

## Changes

### 1. tool_io.rs
Remove empty_unused_marker() and the now-unused ToolIoCapture::empty() constructor. The marker existed solely to suppress an unused-import warning for empty() - both are removed.

### 2. sop/engine.rs
Remove first_active_run_id() which was marked as a test helper but has no callers in tests or production code.

## Verification
- No callers found via codebase search for both functions
- Pure deletions, no logic changes
- No breaking changes