### PR TITLE
fix(runtime): replace unwrap() with expect() for background delegate result deserialization

### DIFF
--- a/crates/zeroclaw-runtime/src/tools/delegate.rs
+++ b/crates/zeroclaw-runtime/src/tools/delegate.rs
@@ -1837,7 +1837,8 @@ mod tests {
 
         loop {
             if let Ok(content) = std::fs::read_to_string(&result_path) {
-                let result: BackgroundDelegateResult = serde_json::from_str(&content).unwrap();
+                let result: BackgroundDelegateResult =
+                    serde_json::from_str(&content).expect("failed to deserialize background delegate result; JSON written by subprocess may be malformed");
                 if result.status != BackgroundTaskStatus::Running {
                     return result;
                 }


### PR DESCRIPTION
## Summary

Replace bare .unwrap() with .expect() carrying a diagnostic message when deserializing background delegate results, aiding debugging when subprocess output is malformed.

## Changes

- delegate.rs: wait_for_terminal_background_result - replace serde_json::from_str(&content).unwrap() with .expect() that explains the likely cause (malformed JSON from subprocess)

## Verification

- No logic changes, only panic message improvement

- Existing callers in test code unchanged