### PR TITLE
feat(memory): extend hygiene to prune daily and core DB rows

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -9433,7 +9433,7 @@ pub struct MemoryConfig {
     /// Delete daily memory rows older than this many days from the DB. Age is measured by `updated_at` (last write time). 0 = keep forever.
     #[serde(default = "default_zero_retention")]
     pub daily_retention_days: u32,
-    /// Delete core memory rows older than this many days from the DB. Age is measured by `created_at` (first-write time), not `updated_at`, so frequently-recalled memories are not protected from pruning — only rewrites refresh the clock. Set this to a generously large window for durable core memories. 0 = keep forever.
+    /// Delete core memory rows older than this many days from the DB. Age is measured by `created_at` (first-write time). Neither recall nor ordinary rewrites refresh `created_at` under the current SQLite upsert, so core retention is an absolute age limit from first write. Set this to a generously large window for durable core memories, or keep 0 = keep forever.
     #[serde(default = "default_zero_retention")]
     pub core_retention_days: u32,
     /// Source of embedding vectors for semantic search. `none` = keyword-only retrieval (no API calls, no vector cost); `openai` = OpenAI's embedding API; `custom:URL` = any OpenAI-compatible embedding endpoint (LiteLLM, local gateway, etc.).

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -9427,9 +9427,15 @@ pub struct MemoryConfig {
     /// Delete archived files permanently after this many days. Set high if you need long-term history; set low for privacy / disk-space reasons.
     #[serde(default = "default_purge_after_days")]
     pub purge_after_days: u32,
-    /// For the sqlite backend only — drop conversation rows older than this many days to keep the DB lean. Doesn't touch core memories or notes.
+    /// Delete conversation rows older than this many days from the DB (sqlite backend only). Age is measured by `updated_at` (last write time). 0 = keep forever.
     #[serde(default = "default_conversation_retention_days")]
     pub conversation_retention_days: u32,
+    /// Delete daily memory rows older than this many days from the DB. Age is measured by `updated_at` (last write time). 0 = keep forever.
+    #[serde(default = "default_zero_retention")]
+    pub daily_retention_days: u32,
+    /// Delete core memory rows older than this many days from the DB. Age is measured by `created_at` (first-write time), not `updated_at`, so frequently-recalled memories are not protected from pruning — only rewrites refresh the clock. Set this to a generously large window for durable core memories. 0 = keep forever.
+    #[serde(default = "default_zero_retention")]
+    pub core_retention_days: u32,
     /// Source of embedding vectors for semantic search. `none` = keyword-only retrieval (no API calls, no vector cost); `openai` = OpenAI's embedding API; `custom:URL` = any OpenAI-compatible embedding endpoint (LiteLLM, local gateway, etc.).
     #[serde(default = "default_embedding_provider")]
     pub embedding_provider: String,
@@ -9588,6 +9594,9 @@ fn default_purge_after_days() -> u32 {
 fn default_conversation_retention_days() -> u32 {
     30
 }
+fn default_zero_retention() -> u32 {
+    0
+}
 fn default_embedding_model() -> String {
     "text-embedding-3-small".into()
 }
@@ -9629,6 +9638,8 @@ impl Default for MemoryConfig {
             archive_after_days: default_archive_after_days(),
             purge_after_days: default_purge_after_days(),
             conversation_retention_days: default_conversation_retention_days(),
+            daily_retention_days: default_zero_retention(),
+            core_retention_days: default_zero_retention(),
             embedding_provider: default_embedding_provider(),
             embedding_model: default_embedding_model(),
             embedding_dimensions: default_embedding_dims(),

--- a/crates/zeroclaw-memory/src/hygiene.rs
+++ b/crates/zeroclaw-memory/src/hygiene.rs
@@ -18,6 +18,8 @@ struct HygieneReport {
     purged_memory_archives: u64,
     purged_session_archives: u64,
     pruned_conversation_rows: u64,
+    pruned_daily_rows: u64,
+    pruned_core_rows: u64,
 }
 
 impl HygieneReport {
@@ -27,6 +29,8 @@ impl HygieneReport {
             + self.purged_memory_archives
             + self.purged_session_archives
             + self.pruned_conversation_rows
+            + self.pruned_daily_rows
+            + self.pruned_core_rows
     }
 }
 
@@ -54,6 +58,14 @@ pub fn run_if_due(config: &MemoryConfig, workspace_dir: &Path) -> Result<()> {
         &crate::traits::MemoryCategory::Conversation,
         config.conversation_retention_days,
     );
+    let daily_retention = enforcer.retention_days_for_category(
+        &crate::traits::MemoryCategory::Daily,
+        config.daily_retention_days,
+    );
+    let core_retention = enforcer.retention_days_for_category(
+        &crate::traits::MemoryCategory::Core,
+        config.core_retention_days,
+    );
 
     let report = HygieneReport {
         archived_memory_files: archive_daily_memory_files(
@@ -63,7 +75,14 @@ pub fn run_if_due(config: &MemoryConfig, workspace_dir: &Path) -> Result<()> {
         archived_session_files: archive_session_files(workspace_dir, config.archive_after_days)?,
         purged_memory_archives: purge_memory_archives(workspace_dir, config.purge_after_days)?,
         purged_session_archives: purge_session_archives(workspace_dir, config.purge_after_days)?,
-        pruned_conversation_rows: prune_conversation_rows(workspace_dir, conversation_retention)?,
+        pruned_conversation_rows: prune_category_rows(
+            workspace_dir,
+            conversation_retention,
+            "conversation",
+            false,
+        )?,
+        pruned_daily_rows: prune_category_rows(workspace_dir, daily_retention, "daily", false)?,
+        pruned_core_rows: prune_category_rows(workspace_dir, core_retention, "core", true)?,
     };
 
     // Prune audit entries if audit is enabled.
@@ -85,12 +104,14 @@ pub fn run_if_due(config: &MemoryConfig, workspace_dir: &Path) -> Result<()> {
             INFO,
             ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note),
             &format!(
-                "memory hygiene complete: archived_memory={} archived_sessions={} purged_memory={} purged_sessions={} pruned_conversation_rows={}",
+                "memory hygiene complete: archived_memory={} archived_sessions={} purged_memory={} purged_sessions={} pruned_conversation={} pruned_daily={} pruned_core={}",
                 report.archived_memory_files,
                 report.archived_session_files,
                 report.purged_memory_archives,
                 report.purged_session_archives,
-                report.pruned_conversation_rows
+                report.pruned_conversation_rows,
+                report.pruned_daily_rows,
+                report.pruned_core_rows,
             )
         );
     }
@@ -316,7 +337,12 @@ fn purge_session_archives(workspace_dir: &Path, purge_after_days: u32) -> Result
     Ok(removed)
 }
 
-fn prune_conversation_rows(workspace_dir: &Path, retention_days: u32) -> Result<u64> {
+fn prune_category_rows(
+    workspace_dir: &Path,
+    retention_days: u32,
+    category: &str,
+    use_created_at: bool,
+) -> Result<u64> {
     if retention_days == 0 {
         return Ok(0);
     }
@@ -331,10 +357,20 @@ fn prune_conversation_rows(workspace_dir: &Path, retention_days: u32) -> Result<
     conn.execute_batch("PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL;")?;
     let cutoff = (Local::now() - Duration::days(i64::from(retention_days))).to_rfc3339();
 
-    let affected = conn.execute(
-        "DELETE FROM memories WHERE category = 'conversation' AND updated_at < ?1",
-        params![cutoff],
-    )?;
+    // Core memories use created_at so that frequently-recalled-but-never-rewritten
+    // entries are not pruned based on a stale updated_at (which only advances on write).
+    // Conversation and daily rows use updated_at — those categories are write-heavy and
+    // the distinction is immaterial.
+    let timestamp_col = if use_created_at {
+        "created_at"
+    } else {
+        "updated_at"
+    };
+    let sql = format!(
+        "DELETE FROM memories WHERE category = ?1 AND {} < ?2",
+        timestamp_col
+    );
+    let affected = conn.execute(&sql, params![category, cutoff])?;
 
     Ok(u64::try_from(affected).unwrap_or(0))
 }
@@ -373,8 +409,16 @@ fn prune_audit_entries(workspace_dir: &Path, retention_days: u32) -> Result<()> 
 
 fn memory_date_from_filename(filename: &str) -> Option<NaiveDate> {
     let stem = filename.strip_suffix(".md")?;
+    // Split on '_' first (handles YYYY-MM-DD_suffix.md).
     let date_part = stem.split('_').next().unwrap_or(stem);
-    NaiveDate::parse_from_str(date_part, "%Y-%m-%d").ok()
+    // If the date part has more than 10 chars (e.g. 2026-03-28-1442),
+    // take only the YYYY-MM-DD prefix.
+    let date_str = if date_part.len() > 10 {
+        date_part.get(..10)?
+    } else {
+        date_part
+    };
+    NaiveDate::parse_from_str(date_str, "%Y-%m-%d").ok()
 }
 
 fn date_prefix(filename: &str) -> Option<NaiveDate> {
@@ -597,5 +641,157 @@ mod tests {
             mem2.get("core_keep").await.unwrap().is_some(),
             "core memory should remain"
         );
+    }
+
+    #[tokio::test]
+    async fn prunes_old_daily_rows_in_sqlite_backend() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path();
+
+        let mem = SqliteMemory::new("sqlite", workspace).unwrap();
+        mem.store("daily_old", "stale", MemoryCategory::Daily, None)
+            .await
+            .unwrap();
+        mem.store("daily_recent", "fresh", MemoryCategory::Daily, None)
+            .await
+            .unwrap();
+        drop(mem);
+
+        let db_path = workspace.join("memory").join("brain.db");
+        let conn = Connection::open(&db_path).unwrap();
+        let old_cutoff = (Local::now() - Duration::days(60)).to_rfc3339();
+        conn.execute(
+            "UPDATE memories SET created_at = ?1, updated_at = ?1 WHERE key = 'daily_old'",
+            params![old_cutoff],
+        )
+        .unwrap();
+        drop(conn);
+
+        let mut cfg = default_cfg();
+        cfg.archive_after_days = 0;
+        cfg.purge_after_days = 0;
+        cfg.daily_retention_days = 30;
+
+        run_if_due(&cfg, workspace).unwrap();
+
+        let mem2 = SqliteMemory::new("sqlite", workspace).unwrap();
+        assert!(
+            mem2.get("daily_old").await.unwrap().is_none(),
+            "old daily rows should be pruned"
+        );
+        assert!(
+            mem2.get("daily_recent").await.unwrap().is_some(),
+            "recent daily rows should remain"
+        );
+    }
+
+    #[tokio::test]
+    async fn zero_retention_disables_daily_pruning() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path();
+
+        let mem = SqliteMemory::new("sqlite", workspace).unwrap();
+        mem.store("daily_old", "stale", MemoryCategory::Daily, None)
+            .await
+            .unwrap();
+        drop(mem);
+
+        let db_path = workspace.join("memory").join("brain.db");
+        let conn = Connection::open(&db_path).unwrap();
+        let old_cutoff = (Local::now() - Duration::days(60)).to_rfc3339();
+        conn.execute(
+            "UPDATE memories SET created_at = ?1, updated_at = ?1 WHERE key = 'daily_old'",
+            params![old_cutoff],
+        )
+        .unwrap();
+        drop(conn);
+
+        let mut cfg = default_cfg();
+        cfg.daily_retention_days = 0; // default: keep forever
+
+        run_if_due(&cfg, workspace).unwrap();
+
+        let mem2 = SqliteMemory::new("sqlite", workspace).unwrap();
+        assert!(
+            mem2.get("daily_old").await.unwrap().is_some(),
+            "daily rows should be kept when retention_days = 0"
+        );
+    }
+
+    #[tokio::test]
+    async fn prunes_old_core_rows_when_configured() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path();
+
+        let mem = SqliteMemory::new("sqlite", workspace).unwrap();
+        mem.store("core_old", "obsolete", MemoryCategory::Core, None)
+            .await
+            .unwrap();
+        mem.store(
+            "core_updated",
+            "touched recently",
+            MemoryCategory::Core,
+            None,
+        )
+        .await
+        .unwrap();
+        drop(mem);
+
+        let db_path = workspace.join("memory").join("brain.db");
+        let conn = Connection::open(&db_path).unwrap();
+        let old_cutoff = (Local::now() - Duration::days(120)).to_rfc3339();
+        let recent = (Local::now() - Duration::days(1)).to_rfc3339();
+        // core_old: both timestamps are old → should be pruned
+        conn.execute(
+            "UPDATE memories SET created_at = ?1, updated_at = ?1 WHERE key = 'core_old'",
+            params![old_cutoff],
+        )
+        .unwrap();
+        // core_updated: created_at is old but updated_at is recent → still pruned
+        // because core pruning keys on created_at, not updated_at
+        conn.execute(
+            "UPDATE memories SET created_at = ?1, updated_at = ?2 WHERE key = 'core_updated'",
+            params![old_cutoff, recent],
+        )
+        .unwrap();
+        drop(conn);
+
+        let mut cfg = default_cfg();
+        cfg.archive_after_days = 0;
+        cfg.purge_after_days = 0;
+        cfg.core_retention_days = 90;
+
+        run_if_due(&cfg, workspace).unwrap();
+
+        let mem2 = SqliteMemory::new("sqlite", workspace).unwrap();
+        assert!(
+            mem2.get("core_old").await.unwrap().is_none(),
+            "old core rows should be pruned when retention is configured"
+        );
+        assert!(
+            mem2.get("core_updated").await.unwrap().is_none(),
+            "core rows with old created_at should be pruned even if updated_at is recent"
+        );
+    }
+
+    #[test]
+    fn date_from_filename_handles_hyphen_suffix() {
+        let d = memory_date_from_filename("2026-03-28-1442.md");
+        assert!(d.is_some(), "YYYY-MM-DD-HHMM.md should be parsed");
+        assert_eq!(d.unwrap(), NaiveDate::from_ymd_opt(2026, 3, 28).unwrap());
+    }
+
+    #[test]
+    fn date_from_filename_handles_underscore_suffix() {
+        let d = memory_date_from_filename("2026-03-28_session_notes.md");
+        assert!(d.is_some(), "YYYY-MM-DD_suffix.md should be parsed");
+        assert_eq!(d.unwrap(), NaiveDate::from_ymd_opt(2026, 3, 28).unwrap());
+    }
+
+    #[test]
+    fn date_from_filename_plain_date() {
+        let d = memory_date_from_filename("2026-03-28.md");
+        assert!(d.is_some(), "YYYY-MM-DD.md should be parsed");
+        assert_eq!(d.unwrap(), NaiveDate::from_ymd_opt(2026, 3, 28).unwrap());
     }
 }

--- a/crates/zeroclaw-memory/src/hygiene.rs
+++ b/crates/zeroclaw-memory/src/hygiene.rs
@@ -357,8 +357,10 @@ fn prune_category_rows(
     conn.execute_batch("PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL;")?;
     let cutoff = (Local::now() - Duration::days(i64::from(retention_days))).to_rfc3339();
 
-    // Core memories use created_at so that frequently-recalled-but-never-rewritten
-    // entries are not pruned based on a stale updated_at (which only advances on write).
+    // Core memories use created_at (first-write time). Neither recall nor ordinary
+    // rewrites refresh created_at under the current SQLite upsert, so core retention
+    // is an absolute age limit from first write. Operators should set a large window
+    // or keep core_retention_days = 0 for durable core memory.
     // Conversation and daily rows use updated_at — those categories are write-heavy and
     // the distinction is immaterial.
     let timestamp_col = if use_created_at {


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - The memory hygiene system (`hygiene.rs`) only pruned `conversation` rows from `brain.db`. `core` and `daily` rows grew unbounded — a long-running deployment reported 700 rows (560 daily, 139 core) over ~2 months with zero pruning.
  - Added `daily_retention_days` and `core_retention_days` config fields (default `0` = keep forever, opt-in). Generalized `prune_conversation_rows()` into `prune_category_rows()` with a parameterized `category = ?1` query.
  - Core pruning keys on `created_at` (first-write time), not `updated_at`. Neither recall nor ordinary rewrites refresh `created_at` under the current SQLite upsert, so core retention is an absolute age limit from first write. Operators should keep `core_retention_days = 0` for durable core memory or set a generously large window.
  - Fixed `memory_date_from_filename()` to accept `YYYY-MM-DD-HHMM.md` filenames from older capture flows.
  - `HygieneReport` gained `pruned_daily_rows` and `pruned_core_rows` counters, surfaced in logs and `memory_hygiene_state.json`.
  - Per-category overrides via `[memory.policy.retention_days_by_category]` work for all three categories.
- **Scope boundary:** This PR only touches the hygiene pruning pass and its config schema. It does NOT change the SQLite read/write paths, the recall/retrieval pipeline, the memory tool, or any other subsystem.
- **Blast radius:** If `daily_retention_days` or `core_retention_days` is misconfigured to a too-small value, operators could lose daily or core memory rows. The default `0 = keep forever` prevents this for existing installs. The hygiene pass runs every 12 hours — misconfiguration is visible within that window.
- **Linked issue:** Closes #7056.
- **Labels:** `enhancement`, `size: S`, `risk: high`, `config`, `memory`, `memory:hygiene`, `memory:sqlite`

## Validation Evidence (required)

```bash
# Format check
$ cargo fmt --check -p zeroclaw-memory -p zeroclaw-config
(clean, no diff)

# Clippy
$ cargo clippy -p zeroclaw-memory -p zeroclaw-config -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 28s
(no warnings)

# Hygiene tests (11 tests)
$ cargo test -p zeroclaw-memory --lib hygiene

running 11 tests
test hygiene::tests::date_from_filename_handles_hyphen_suffix ... ok
test hygiene::tests::date_from_filename_handles_underscore_suffix ... ok
test hygiene::tests::date_from_filename_plain_date ... ok
test hygiene::tests::archives_old_daily_memory_files ... ok
test hygiene::tests::archives_old_session_files ... ok
test hygiene::tests::skips_second_run_within_cadence_window ... ok
test hygiene::tests::purges_old_memory_archives ... ok
test hygiene::tests::prunes_old_core_rows_when_configured ... ok
test hygiene::tests::prunes_old_conversation_rows_in_sqlite_backend ... ok
test hygiene::tests::prunes_old_daily_rows_in_sqlite_backend ... ok
test hygiene::tests::zero_retention_disables_daily_pruning ... ok

test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 301 filtered out

# Policy tests (5 tests)
$ cargo test -p zeroclaw-memory --lib policy

running 5 tests
test policy::tests::category_quota_enforced ... ok
test policy::tests::namespace_quota_enforced ... ok
test policy::tests::default_policy_allows_everything ... ok
test policy::tests::read_only_namespace_blocks_writes ... ok
test policy::tests::per_category_retention_overrides_default ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 307 filtered out
```

- **Beyond CI — what did you manually verify?**
  - Verified the `created_at`-vs-`updated_at` distinction: the `prunes_old_core_rows_when_configured` test explicitly sets `created_at` to old and `updated_at` to recent for a core row, confirming it is still pruned (core keys on `created_at`).
  - Verified `zero_retention_disables_daily_pruning` confirms default-`0` keeps existing daily rows.
  - Did NOT manually verify in a long-running deployment with real accumulated core/daily rows — the unit tests simulate old rows by backdating timestamps.
- **If any command was intentionally skipped, why:** None skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility (required)

- Backward compatible? **Yes** — default `0 = keep forever` preserves existing behavior. No existing rows are touched unless the operator explicitly sets a retention value.
- Config / env / CLI surface changed? **Yes** — two new optional config fields: `daily_retention_days` and `core_retention_days`. Both default to `0` (keep forever).
- If `No` or `Yes` to either: exact upgrade steps for existing users:
  - **No action required for existing installs.** The new fields default to `0`, which matches the previous hardcoded behavior (daily/core rows were never pruned).
  - Operators who want pruning should add to their config:
    ```toml
    [memory]
    daily_retention_days = 30   # prune daily rows older than 30 days
    core_retention_days = 90    # prune core rows older than 90 days (by created_at)
    ```
  - Core retention uses `created_at` (first-write time), not `updated_at`. Set a generously large window — recall does not refresh the clock.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <merge-sha>`. Reverting restores the previous behavior where only conversation rows are pruned. Daily/core rows stop being pruned immediately on next hygiene pass.
- **Feature flags or config toggles:** Set `daily_retention_days = 0` and `core_retention_days = 0` in `[memory]` config and restart. This disables pruning without a code rollback.
- **Observable failure symptoms:**
  - **Log grep:** `grep pruned_daily memory_hygiene_state.json` or watch for `pruned_daily=N` / `pruned_core=N` in the "memory hygiene complete" log line. If N is unexpectedly large, retention is too aggressive.
  - **Metric:** `memory/mem_total` dropping faster than expected.
  - **Alert:** Memory recall returning fewer results than expected for daily or core categories.
  - **State file:** `workspace/state/memory_hygiene_state.json` records the last report including `pruned_daily_rows` and `pruned_core_rows`.

## Supersede Attribution

Not applicable — no superseded PRs.
