### PR TITLE
fix(platform): use raw_arg for Windows shell commands to preserve double quotes

### DIFF
--- a/crates/zeroclaw-config/src/platform/native.rs
+++ b/crates/zeroclaw-config/src/platform/native.rs
@@ -54,12 +54,17 @@ impl RuntimeAdapter for NativeRuntime {
 
         #[cfg(target_os = "windows")]
         {
+            use std::os::windows::process::CommandExt;
             const CREATE_NO_WINDOW: u32 = 0x08000000;
 
             let mut process = tokio::process::Command::new("cmd.exe");
+            // Use raw_arg so the command string is passed verbatim to cmd.exe,
+            // bypassing Rust's CommandLineToArgvW escaping which would mangle
+            // embedded double quotes with backslash escapes that cmd doesn't
+            // understand (see #7083).
             process
-                .arg("/C")
-                .arg(command)
+                .raw_arg("/C")
+                .raw_arg(format!("\"{command}\""))
                 .current_dir(workspace_dir)
                 .creation_flags(CREATE_NO_WINDOW);
             Ok(process)
@@ -110,5 +115,160 @@ mod tests {
             .unwrap();
         let debug = format!("{command:?}");
         assert!(debug.contains("echo hello"));
+    }
+
+    /// On Windows, `std::process::Command` applies `CommandLineToArgvW`
+    /// escaping to each `.arg()`, which mangles embedded double quotes
+    /// with backslash escapes that `cmd.exe` does not understand.
+    /// `raw_arg` must pass the command verbatim so that quoted paths
+    /// and arguments survive intact (see #7083).
+    #[test]
+    fn shell_command_preserves_double_quotes() {
+        let cwd = std::env::temp_dir();
+        let command = NativeRuntime::new()
+            .build_shell_command(r#"dir "C:\Users\test\Desktop" /b"#, &cwd)
+            .unwrap();
+        let debug = format!("{command:?}");
+
+        // The command string must contain the core command text.
+        assert!(
+            debug.contains("dir"),
+            "debug output must contain the command, got: {debug}"
+        );
+        assert!(
+            debug.contains("Desktop"),
+            "debug output must contain the path, got: {debug}"
+        );
+
+        // On Windows, raw_arg must NOT produce backslash-escaped quotes
+        // (the core issue in #7083).
+        #[cfg(target_os = "windows")]
+        {
+            assert!(
+                debug.contains(r#""C:\Users\test\Desktop""#),
+                "Windows: double-quoted path must appear verbatim, got: {debug}"
+            );
+            assert!(
+                !debug.contains(r#"\\\""#) && !debug.contains(r#"\""#),
+                "Windows: must not contain backslash-escaped quotes, got: {debug}"
+            );
+        }
+    }
+
+    /// A command with mixed quoted and unquoted segments must pass
+    /// through without mangling any part of the command line.
+    #[test]
+    fn shell_command_preserves_mixed_quoted_unquoted() {
+        let cwd = std::env::temp_dir();
+        let command = NativeRuntime::new()
+            .build_shell_command(
+                r#"dir "C:\path with spaces" /b 2>nul || echo "directory missing""#,
+                &cwd,
+            )
+            .unwrap();
+        let debug = format!("{command:?}");
+
+        // The core command text and operators must be present.
+        assert!(debug.contains("dir"), "missing dir command, got: {debug}");
+        assert!(debug.contains("path with spaces"), "missing path, got: {debug}");
+        assert!(
+            debug.contains("2>nul"),
+            "redirect operator must be present, got: {debug}"
+        );
+        assert!(
+            debug.contains("||"),
+            "pipe operator must be present, got: {debug}"
+        );
+        assert!(
+            debug.contains("directory missing"),
+            "missing echo message, got: {debug}"
+        );
+
+        // On Windows, raw_arg must preserve quotes verbatim.
+        #[cfg(target_os = "windows")]
+        {
+            assert!(
+                debug.contains(r#""C:\path with spaces""#),
+                "Windows: quoted path must appear verbatim, got: {debug}"
+            );
+            assert!(
+                debug.contains(r#""directory missing""#),
+                "Windows: quoted echo message must appear verbatim, got: {debug}"
+            );
+        }
+    }
+
+    /// On Windows, actually invoke `cmd /C` with a quoted `echo`
+    /// argument to confirm the fix works end-to-end. Skipped on
+    /// non-Windows hosts since there's no `cmd.exe`.
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn windows_echo_quoted_argument_succeeds() {
+        let cwd = std::env::temp_dir();
+        let output = NativeRuntime::new()
+            .build_shell_command(r#"echo "hello world""#, &cwd)
+            .unwrap()
+            .output()
+            .expect("cmd /C echo should execute");
+
+        assert!(output.status.success(), "cmd must exit 0");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains("hello world"),
+            "quoted echo output mismatch, got: {stdout}"
+        );
+    }
+
+    /// On Windows, verify `dir` with a quoted path works (previous
+    /// behavior: "The filename, directory name, or volume label
+    /// syntax is incorrect").
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn windows_dir_quoted_path_succeeds() {
+        let cwd = std::env::temp_dir();
+        let output = NativeRuntime::new()
+            .build_shell_command(r#"dir "C:\Windows" /b"#, &cwd)
+            .unwrap()
+            .output()
+            .expect("cmd /C dir should execute");
+
+        assert!(output.status.success(), "cmd must exit 0");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains("explorer.exe") || stdout.contains("System32"),
+            "dir should list C:\\Windows contents, got: {stdout}"
+        );
+    }
+
+    /// Verify a command with entirely unquoted arguments still works
+    /// (regression check for the raw_arg conversion).
+    #[test]
+    fn shell_command_no_quotes_still_works() {
+        let cwd = std::env::temp_dir();
+        let command = NativeRuntime::new()
+            .build_shell_command("echo hello_world", &cwd)
+            .unwrap();
+        let debug = format!("{command:?}");
+        assert!(debug.contains("echo hello_world"));
+    }
+
+    /// Verify `echo %VAR%` expansion syntax is preserved verbatim
+    /// and not mangled by escaping.
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn windows_echo_percent_expansion_preserved() {
+        let cwd = std::env::temp_dir();
+        let output = NativeRuntime::new()
+            .build_shell_command("echo %USERPROFILE%", &cwd)
+            .unwrap()
+            .output()
+            .expect("cmd /C echo should execute");
+
+        assert!(output.status.success(), "cmd must exit 0");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains(":\\"),
+            "%%USERPROFILE%% should expand to a path, got: {stdout}"
+        );
     }
 }

--- a/crates/zeroclaw-config/src/platform/native.rs
+++ b/crates/zeroclaw-config/src/platform/native.rs
@@ -170,7 +170,10 @@ mod tests {
 
         // The core command text and operators must be present.
         assert!(debug.contains("dir"), "missing dir command, got: {debug}");
-        assert!(debug.contains("path with spaces"), "missing path, got: {debug}");
+        assert!(
+            debug.contains("path with spaces"),
+            "missing path, got: {debug}"
+        );
         assert!(
             debug.contains("2>nul"),
             "redirect operator must be present, got: {debug}"


### PR DESCRIPTION
## Summary

Closes #7083.

### Purpose

On Windows, any agent shell command containing double quotes — which models emit constantly to quote paths, arguments, and strings — fails with `The filename, directory name, or volume label syntax is incorrect.` This blocks virtually all real-world shell tool usage on Windows, since models routinely produce commands like `dir "C:\path with spaces" /b`.

### Root cause

`build_shell_command()` (Windows branch in `crates/zeroclaw-config/src/platform/native.rs:55-66`) passes the command string to `cmd.exe` via `.arg()`. Rust's `std::process::Command` applies `CommandLineToArgvW` escaping to each `.arg()` — embedded `"` characters become `\"` backslash-escapes. But `cmd.exe` does **not** understand this escaping: it treats `\"` as literal characters, producing a malformed command line that the target program (`dir`, `echo`, etc.) cannot parse.

Example: `dir "C:\Users\u\Desktop" /b` becomes:
```
cmd.exe /C "dir \"C:\Users\u\Desktop\" /b"
```
cmd strips the outer quotes but the inner `\"` passes through to `dir` → `"The filename, directory name, or volume label syntax is incorrect."`

### Fix

Use `raw_arg()` from `std::os::windows::process::CommandExt` instead of `.arg()`, which passes arguments verbatim to the child process with **zero** escaping. The command is wrapped in one pair of quotes (standard `cmd /C` convention: cmd strips them and runs the inner text as-is):

```rust
process
    .raw_arg("/C")
    .raw_arg(format!("\"{command}\""))
```

This preserves all embedded double quotes, redirect operators (`2>nul`), pipe operators (`||`), and `%VAR%` expansions exactly as the model emits them.

### Files changed

| File | Change |
|---|---|
| `crates/zeroclaw-config/src/platform/native.rs` | +139/-2 — `raw_arg` fix + 6 new tests |

### Tests added

| Test | Scope | What it verifies |
|---|---|---|
| `shell_command_preserves_double_quotes` | Cross-platform | Debug output contains literal `"C:\Users\test\Desktop"`, no `\"` escapes |
| `shell_command_preserves_mixed_quoted_unquoted` | Cross-platform | Mixed quoted/unquoted args, redirects, pipes survive intact |
| `shell_command_no_quotes_still_works` | Cross-platform | Regression: unquoted commands still pass through correctly |
| `windows_echo_quoted_argument_succeeds` | Windows only | `echo "hello world"` executes and outputs correctly |
| `windows_dir_quoted_path_succeeds` | Windows only | `dir "C:\Windows" /b` executes and lists directory contents |
| `windows_echo_percent_expansion_preserved` | Windows only | `echo %USERPROFILE%` expands to a real path |

### Expected outcome

- Shell tool commands containing double quotes work correctly on Windows
- Commands without quotes continue to work (no regression)
- `%VAR%` expansions, redirects, and pipes are preserved verbatim
- Non-Windows platforms are unaffected (unchanged code path)

## Test plan

- [ ] On a Windows host: `cargo test -p zeroclaw-config --lib platform::native` — all tests pass
- [ ] Manual: run `dir "C:\path with spaces" /b` via the shell tool — succeeds without "syntax incorrect" errors
- [ ] Manual: run `echo "hello world"` via the shell tool — outputs `hello world`
