### PR TITLE
fix(ollama): keep structured tools prompt-guided

### DIFF
--- a/crates/zeroclaw-providers/src/ollama.rs
+++ b/crates/zeroclaw-providers/src/ollama.rs
@@ -1,6 +1,7 @@
 use crate::multimodal;
 use crate::traits::{
     ChatMessage, ChatResponse, ModelProvider, ProviderCapabilities, TokenUsage, ToolCall,
+    ToolsPayload,
 };
 use async_trait::async_trait;
 use reqwest::Client;
@@ -570,6 +571,89 @@ impl OllamaModelProvider {
             .collect()
     }
 
+    fn with_prompt_guided_tool_instructions(
+        &self,
+        messages: &[ChatMessage],
+        tools: Option<&[zeroclaw_api::tool::ToolSpec]>,
+    ) -> anyhow::Result<Vec<ChatMessage>> {
+        let Some(tools) = tools.filter(|items| !items.is_empty()) else {
+            return Ok(messages.to_vec());
+        };
+
+        let ToolsPayload::PromptGuided { instructions } = self.convert_tools(tools) else {
+            anyhow::bail!(
+                "Ollama returned non-prompt-guided tools payload while native tools are disabled"
+            );
+        };
+        let mut modified_messages = messages.to_vec();
+
+        if let Some(system_message) = modified_messages.iter_mut().find(|m| m.role == "system") {
+            if !system_message.content.is_empty() {
+                system_message.content.push_str("\n\n");
+            }
+            system_message.content.push_str(&instructions);
+        } else {
+            modified_messages.insert(0, ChatMessage::system(instructions));
+        }
+
+        Ok(modified_messages)
+    }
+
+    fn response_to_chat_response(&self, response: ApiChatResponse, model: &str) -> ChatResponse {
+        let usage = if response.prompt_eval_count.is_some() || response.eval_count.is_some() {
+            Some(TokenUsage {
+                input_tokens: response.prompt_eval_count,
+                output_tokens: response.eval_count,
+                cached_input_tokens: None,
+            })
+        } else {
+            None
+        };
+
+        if !response.message.tool_calls.is_empty() {
+            let tool_calls: Vec<ToolCall> = response
+                .message
+                .tool_calls
+                .iter()
+                .map(|tc| {
+                    let (name, args) = self.extract_tool_name_and_args(tc);
+                    ToolCall {
+                        id: tc
+                            .id
+                            .clone()
+                            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string()),
+                        name,
+                        arguments: serde_json::to_string(&args)
+                            .unwrap_or_else(|_| "{}".to_string()),
+                        extra_content: None,
+                    }
+                })
+                .collect();
+            let text = Self::normalize_response_text(response.message.content);
+            return ChatResponse {
+                text,
+                tool_calls,
+                usage,
+                reasoning_content: None,
+            };
+        }
+
+        let text = Self::effective_content(
+            &response.message.content,
+            response.message.thinking.as_deref(),
+        )
+        .unwrap_or_else(|| {
+            Self::fallback_text_for_empty_content(model, response.message.thinking.as_deref())
+        });
+
+        ChatResponse {
+            text: Some(text),
+            tool_calls: vec![],
+            usage,
+            reasoning_content: None,
+        }
+    }
+
     /// Send a single HTTP request to Ollama and parse the response.
     async fn send_request_inner(
         &self,
@@ -945,67 +1029,7 @@ impl ModelProvider for OllamaModelProvider {
             )
             .await?;
 
-        let usage = if response.prompt_eval_count.is_some() || response.eval_count.is_some() {
-            Some(TokenUsage {
-                input_tokens: response.prompt_eval_count,
-                output_tokens: response.eval_count,
-                cached_input_tokens: None,
-            })
-        } else {
-            None
-        };
-
-        // Native tool calls returned by the model.
-        if !response.message.tool_calls.is_empty() {
-            let tool_calls: Vec<ToolCall> = response
-                .message
-                .tool_calls
-                .iter()
-                .map(|tc| {
-                    let (name, args) = self.extract_tool_name_and_args(tc);
-                    ToolCall {
-                        id: tc
-                            .id
-                            .clone()
-                            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string()),
-                        name,
-                        arguments: serde_json::to_string(&args)
-                            .unwrap_or_else(|_| "{}".to_string()),
-                        extra_content: None,
-                    }
-                })
-                .collect();
-            let text = Self::normalize_response_text(response.message.content);
-            return Ok(ChatResponse {
-                text,
-                tool_calls,
-                usage,
-                reasoning_content: None,
-            });
-        }
-
-        // No native tool calls — use the effective content (content with
-        // `<think>` tags stripped, falling back to thinking field).
-        // The loop_.rs `parse_tool_calls` will extract any XML-style tool
-        // calls from the text, so preserve `<tool_call>` tags here.
-        let effective = Self::effective_content(
-            &response.message.content,
-            response.message.thinking.as_deref(),
-        );
-        let text = if let Some(content) = effective {
-            content
-        } else {
-            Self::fallback_text_for_empty_content(
-                &normalized_model,
-                response.message.thinking.as_deref(),
-            )
-        };
-        Ok(ChatResponse {
-            text: Some(text),
-            tool_calls: vec![],
-            usage,
-            reasoning_content: None,
-        })
+        Ok(self.response_to_chat_response(response, &normalized_model))
     }
 
     fn supports_native_tools(&self) -> bool {
@@ -1024,40 +1048,22 @@ impl ModelProvider for OllamaModelProvider {
         model: &str,
         temperature: Option<f64>,
     ) -> anyhow::Result<ChatResponse> {
-        // Convert ToolSpec to OpenAI-compatible JSON and delegate to chat_with_tools.
-        if let Some(specs) = request.tools
-            && !specs.is_empty()
-        {
-            let tools: Vec<serde_json::Value> = specs
-                .iter()
-                .map(|s| {
-                    let params =
-                        zeroclaw_api::schema::SchemaCleanr::clean_for_openai(s.parameters.clone());
-                    serde_json::json!({
-                        "type": "function",
-                        "function": {
-                            "name": s.name,
-                            "description": s.description,
-                            "parameters": params
-                        }
-                    })
-                })
-                .collect();
-            return self
-                .chat_with_tools(request.messages, &tools, model, temperature)
-                .await;
-        }
-
-        // No tools — fall back to plain text chat.
-        let text = self
-            .chat_with_history(request.messages, model, temperature)
+        let temperature = temperature.unwrap_or(self.default_temperature());
+        let (normalized_model, should_auth) = self.resolve_request_details(model)?;
+        let messages =
+            self.with_prompt_guided_tool_instructions(request.messages, request.tools)?;
+        let api_messages = self.convert_messages(&messages);
+        let response = self
+            .send_request(
+                api_messages,
+                &normalized_model,
+                temperature,
+                should_auth,
+                None,
+            )
             .await?;
-        Ok(ChatResponse {
-            text: Some(text),
-            tool_calls: vec![],
-            usage: None,
-            reasoning_content: None,
-        })
+
+        Ok(self.response_to_chat_response(response, &normalized_model))
     }
 
     async fn list_models(&self) -> anyhow::Result<Vec<String>> {
@@ -1104,6 +1110,7 @@ impl ::zeroclaw_api::attribution::Attributable for OllamaModelProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Arc, Mutex};
 
     #[test]
     fn default_url() {
@@ -1229,6 +1236,117 @@ mod tests {
         let p = OllamaModelProvider::new("test", None, Some("ollama-key"));
         let (_model, should_auth) = p.resolve_request_details("llama3").unwrap();
         assert!(!should_auth);
+    }
+
+    #[tokio::test]
+    async fn chat_with_tool_specs_omits_native_tools_payload() {
+        use axum::{Json, Router, extract::State, routing::post};
+        use tokio::net::TcpListener;
+        use zeroclaw_api::model_provider::ChatRequest;
+        use zeroclaw_api::tool::ToolSpec;
+
+        type CapturedBody = Arc<Mutex<Option<serde_json::Value>>>;
+
+        async fn capture_request(
+            State(captured): State<CapturedBody>,
+            Json(body): Json<serde_json::Value>,
+        ) -> Json<serde_json::Value> {
+            *captured.lock().expect("capture mutex poisoned") = Some(body);
+            Json(serde_json::json!({
+                "message": {
+                    "role": "assistant",
+                    "content": "done"
+                },
+                "prompt_eval_count": 10,
+                "eval_count": 3
+            }))
+        }
+
+        let captured: CapturedBody = Arc::new(Mutex::new(None));
+        let app = Router::new()
+            .route("/api/chat", post(capture_request))
+            .with_state(captured.clone());
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test listener should bind");
+        let addr = listener.local_addr().expect("listener should have address");
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("test server should run");
+        });
+
+        let provider = OllamaModelProvider::new("test", Some(&format!("http://{addr}")), None);
+        let messages = vec![
+            ChatMessage::system("You are helpful."),
+            ChatMessage::user("read a file"),
+        ];
+        let tools = vec![ToolSpec {
+            name: "file_read".to_string(),
+            description: "Read a file".to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string"}
+                },
+                "required": ["path"]
+            }),
+        }];
+
+        let response = provider
+            .chat(
+                ChatRequest {
+                    messages: &messages,
+                    tools: Some(&tools),
+                    thinking: None,
+                },
+                "llama3",
+                Some(0.2),
+            )
+            .await
+            .expect("ollama chat request should succeed");
+
+        server.abort();
+
+        assert_eq!(response.text.as_deref(), Some("done"));
+        assert_eq!(
+            response.usage.as_ref().and_then(|usage| usage.input_tokens),
+            Some(10)
+        );
+        assert_eq!(
+            response
+                .usage
+                .as_ref()
+                .and_then(|usage| usage.output_tokens),
+            Some(3)
+        );
+        let body = captured
+            .lock()
+            .expect("capture mutex poisoned")
+            .take()
+            .expect("request body should be captured");
+        assert!(
+            body.get("tools").is_none(),
+            "Ollama chat() must not serialize native tools while supports_native_tools() is false: {body}"
+        );
+        let request_messages = body
+            .get("messages")
+            .and_then(serde_json::Value::as_array)
+            .expect("request messages should be serialized");
+        assert!(
+            request_messages.iter().any(|message| {
+                message.get("role").and_then(serde_json::Value::as_str) == Some("system")
+                    && message
+                        .get("content")
+                        .and_then(serde_json::Value::as_str)
+                        .is_some_and(|content| {
+                            content.contains("## Tool Use Protocol")
+                                && content.contains("file_read")
+                                && content.contains("\"path\"")
+                        })
+            }),
+            "prompt-guided tool instructions should be generated from ToolSpec: {body}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Ollama advertises `supports_native_tools() == false`, but the structured `chat()` path still converted `ToolSpec` values into a native `/api/chat.tools` payload whenever tools were present.
  - That made tool-using prompts depend on model-side native Ollama tool support, which can fail for models like the ones reported in #5962 instead of using ZeroClaw's prompt-guided tool protocol.
  - This PR keeps structured Ollama tool requests on the prompt-guided path: it injects the existing tool protocol instructions into the chat messages and sends `/api/chat` without a native `tools` array.
  - The response parsing shared by `chat()` and `chat_with_tools()` now preserves returned text, native tool calls if Ollama still returns them, reasoning fallback behavior, and Ollama token usage counts.
  - A regression test captures the outgoing request body and verifies the request omits `tools`, includes the prompt-guided `file_read` schema, and preserves response usage.
- **Scope boundary:** This does not change retry policy, session recovery, Ollama transport/auth routing, live model capability detection, or the explicit `chat_with_tools()` native JSON path. It only aligns the structured provider `chat()` path with Ollama's advertised non-native-tools contract.
- **Blast radius:** Ollama provider structured chat requests that include tool specs. Other providers and non-tool Ollama chat requests are not intended to change.
- **Linked issue(s):** Closes #5962. Supersedes #6029.
- **Labels:** `bug`, `risk: medium`, `size: M`, `provider`, `provider:ollama`.

## Validation Evidence (required)

- **Commands run and public-safe result digest:**

```text
cargo fmt --all -- --check
Result: passed.

git diff --check origin/master...HEAD
Result: passed.

cargo test -p zeroclaw-providers chat_with_tool_specs_omits_native_tools_payload -- --nocapture
Result: passed. 1 passed; 0 failed; 896 filtered.

cargo clippy -p zeroclaw-providers --all-targets -- -D warnings
Result: passed.

Temporary combined validation stack: current master + #7091 + this PR
git diff --check origin/master...HEAD
Result: passed.

cargo fmt --all -- --check
Result: passed.

scripts/zc-cargo-broad clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
Result: passed.

scripts/zc-cargo-broad --lane nextest nextest run --locked --workspace --exclude zeroclaw-desktop
Result: passed. 7444 tests passed; 10 skipped.
```

- **Beyond CI — what did you manually verify?** The regression test verifies the request body sent to `/api/chat`: no top-level native `tools` key is present, the injected system instructions include the prompt-guided tool protocol, the `file_read` tool name, and the `path` schema field, and the returned Ollama usage counters are preserved in `ChatResponse.usage`. I also merged this PR locally with #7091 over current `master` and ran the repo-shaped broad clippy and nextest gates on that combined stack.
- **If any command was intentionally skipped, why:** I did not run live Ollama against the reporter's Windows models. The focused provider regression verifies the corrected request shape directly, and the combined local broad validation plus green GitHub Quality Gate cover the broader Rust test/lint surface.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: N/A

The new test uses a local loopback HTTP server only. The production change removes a native tool payload from the structured Ollama request path; it does not add a new network destination, credential path, filesystem operation, or autonomous capability.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No user migration is required.

The user-visible behavior change is that structured Ollama tool requests now follow the existing prompt-guided tool contract instead of sending native Ollama tool arrays from a provider that advertises native tools as unsupported.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert 6e0c2f9e9`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Ollama tool-using prompts may again send native tool payloads from the structured chat path and fail with provider 500 responses such as `{"error":"EOF"}` on models that do not support Ollama native tool arrays.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): #6029 by @TeoConnexioh
- Scope materially carried forward: #6029 identified the same Ollama provider contract gap: structured tool requests were reaching Ollama as native tool payloads even though the provider advertises prompt-guided tools. This PR carries that direction forward from current `master`, keeps the fix in the structured `chat()` path, adds request-body regression coverage, preserves response usage, and keeps the explicit native JSON helper path scoped separately.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why (inspiration-only, no direct code/design carry-over): No direct code was copied from #6029. The public attribution is the `Supersedes #6029` relationship and this section.
