### PR TITLE
docs(readme): use stable Discord vanity invite

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <a href="LICENSE-APACHE"><img src="https://img.shields.io/badge/license-MIT%20OR%20Apache%202.0-blue.svg" alt="License" /></a>
   <a href="https://www.rust-lang.org"><img src="https://img.shields.io/badge/rust-edition%202024-orange?logo=rust" alt="Rust Edition 2024" /></a>
   <a href="https://github.com/zeroclaw-labs/zeroclaw/graphs/contributors"><img src="https://img.shields.io/github/contributors/zeroclaw-labs/zeroclaw?color=green" alt="Contributors" /></a>
-  <a href="https://discord.com/invite/wDshRVqRjx"><img src="https://img.shields.io/badge/Discord-join-5865F2?style=flat&logo=discord&logoColor=white" alt="Discord" /></a>
+  <a href="https://discord.gg/zeroclaw"><img src="https://img.shields.io/badge/Discord-join-5865F2?style=flat&logo=discord&logoColor=white" alt="Discord" /></a>
 </p>
 
 <p align="center">
@@ -22,7 +22,7 @@
   <a href="docs/book/src/philosophy.md">Philosophy</a> ·
   <a href="docs/book/src/getting-started/quick-start.md">Quick start</a> ·
   <a href="docs/book/src/architecture/overview.md">Architecture</a> ·
-  <a href="https://discord.com/invite/wDshRVqRjx">Discord</a>
+  <a href="https://discord.gg/zeroclaw">Discord</a>
 </p>
 
 ---
@@ -134,7 +134,7 @@ Full detail with Mermaid diagrams: [Architecture overview](docs/book/src/archite
 
 ## Contributing
 
-Start with [how to contribute](docs/book/src/contributing/how-to.md). Larger changes go through the [RFC process](docs/book/src/contributing/rfcs.md). Real-time chat lives on [Discord](https://discord.com/invite/wDshRVqRjx) (the best way to reach the team); durable work tracking is on [GitHub issues](https://github.com/zeroclaw-labs/zeroclaw/issues).
+Start with [how to contribute](docs/book/src/contributing/how-to.md). Larger changes go through the [RFC process](docs/book/src/contributing/rfcs.md). Real-time chat lives on [Discord](https://discord.gg/zeroclaw) (the best way to reach the team); durable work tracking is on [GitHub issues](https://github.com/zeroclaw-labs/zeroclaw/issues).
 
 Good places to start:
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Replaced the expired/broken README Discord invite code with the ZeroClaw vanity invite.
  - Updated all three README Discord entry points so the badge, nav link, and contributing section agree.
  - Uses `https://discord.gg/zeroclaw`, which resolves to the ZeroClaw guild and has no invite expiration.
- **Scope boundary:** README link update only; this does not change Discord server settings, onboarding, or docs book content.
- **Blast radius:** Public README readers who click the Discord link.
- **Linked issue(s):** Closes #7037.
- **Labels:** `bug`, `type: docs`, `risk: low`, `size: XS`, `docs`.

## Validation Evidence (required)

- **Commands run and tail output:**
  - `git diff --check` — passed.
  - `BASE_SHA=origin/master DOCS_FILES=README.md scripts/ci/docs_links_gate.sh` — passed; no added Markdown links detected in changed lines.
  - `BASE_SHA=origin/master DOCS_FILES=README.md scripts/ci/docs_quality_gate.sh` — passed; markdownlint reported 0 errors for `README.md`.
- **Beyond CI — what did you manually verify?**
  - Verified `https://discord.gg/zeroclaw` redirects to `https://discord.com/invite/zeroclaw`.
  - Verified Discord's public invite API resolves invite code `zeroclaw` to the ZeroClaw guild with `expires_at: null`.
- **If any command was intentionally skipped, why:** No Rust or cargo validation was run because this is a README-only link change.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: None.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No upgrade steps needed.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PR: revert the README link change if the vanity invite stops working.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): None.
- Scope materially carried forward: None.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why (inspiration-only, no direct code/design carry-over): No superseded contributor work was incorporated.
