### PR TITLE
fix(cron): add dingtalk to cron delivery channel schemas

### DIFF
--- a/crates/zeroclaw-runtime/src/tools/cron_add.rs
+++ b/crates/zeroclaw-runtime/src/tools/cron_add.rs
@@ -176,7 +176,7 @@ impl Tool for CronAddTool {
                         },
                         "channel": {
                             "type": "string",
-                            "enum": ["telegram", "discord", "slack", "mattermost", "matrix", "qq", "webhook", "lark", "feishu"],
+                            "enum": ["telegram", "discord", "slack", "mattermost", "matrix", "qq", "webhook", "lark", "feishu", "dingtalk"],
                             "description": "Channel type to deliver output to"
                         },
                         "to": {
@@ -951,6 +951,24 @@ mod tests {
                 .unwrap_or_default();
 
         assert!(values.iter().any(|value| value == "matrix"));
+    }
+
+    #[tokio::test]
+    async fn delivery_schema_includes_dingtalk_channel() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = test_config(&tmp).await;
+        let tool = CronAddTool::new(cfg.clone(), test_security(&cfg), TEST_AGENT);
+
+        let values =
+            tool.parameters_schema()["properties"]["delivery"]["properties"]["channel"]["enum"]
+                .as_array()
+                .cloned()
+                .unwrap_or_default();
+
+        assert!(
+            values.iter().any(|value| value == "dingtalk"),
+            "delivery.channel enum must include dingtalk"
+        );
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-runtime/src/tools/cron_update.rs
+++ b/crates/zeroclaw-runtime/src/tools/cron_update.rs
@@ -164,7 +164,7 @@ impl Tool for CronUpdateTool {
                                 },
                                 "channel": {
                                     "type": "string",
-                                    "enum": ["telegram", "discord", "slack", "mattermost", "matrix", "qq", "webhook", "lark", "feishu"],
+                                    "enum": ["telegram", "discord", "slack", "mattermost", "matrix", "qq", "webhook", "lark", "feishu", "dingtalk"],
                                     "description": "Channel type to deliver output to"
                                 },
                                 "to": {
@@ -644,6 +644,7 @@ mod tests {
             "matrix",
             "qq",
             "webhook",
+            "dingtalk",
         ] {
             assert!(channel_strs.contains(ch), "delivery.channel missing: {ch}");
         }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Added `dingtalk` to the `delivery.channel` enum in both `cron_add` and `cron_update` tool schemas
  - DingTalk channel support exists in the codebase but was omitted from the cron tool schemas, making the tool contract inconsistent with configured channel types
  - Added a regression test `delivery_schema_includes_dingtalk_channel` in `cron_add.rs`
  - Added `dingtalk` to the test assertion list in `cron_update.rs`
- **Scope boundary:** Only adds `dingtalk` string to existing channel enums and tests. Does not change any runtime logic, channel implementation, or validation behavior.
- **Blast radius:** None. This is a schema-only change — the enums are descriptive labels for agent-facing tool contracts, not validation gate logic.
- **Linked issue(s):** Closes #7088
- **Labels:** `bug`, `risk: low`, `size: XS`, `cron`

## Validation Evidence (required)

```bash
cargo test -p zeroclaw-runtime -- delivery_schema_includes_dingtalk
cargo test -p zeroclaw-runtime -- cron_update_schema_includes_all_channels
```

- **Commands run and tail output:** Unable to run locally due to environment disk constraints. The change is trivially verifiable: it adds a single string literal (`"dingtalk"`) to three locations — two enum arrays and one test assertion list — following the exact same pattern as existing channels like `lark`, `feishu`, and `webhook`.
- **Beyond CI — what did you manually verify?** Confirmed via source inspection that DingTalk channel support exists in the codebase and that `dingtalk` was the only channel missing from the cron delivery enums.
- **If any command was intentionally skipped, why:** Local `cargo test` skipped due to environment disk space constraints. CI will verify.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PR: `git revert <sha>` is the plan.