### PR TITLE
feat(channel/mattermost): add optional WebSocket listener mode

### DIFF
--- a/crates/zeroclaw-channels/src/mattermost.rs
+++ b/crates/zeroclaw-channels/src/mattermost.rs
@@ -1,11 +1,14 @@
 use anyhow::{Context, Result, bail};
 use async_trait::async_trait;
+use futures_util::{SinkExt, StreamExt};
 use parking_lot::Mutex;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::OnceCell;
+use tokio_tungstenite::tungstenite::Message as WsMessage;
 use zeroclaw_api::channel::{Channel, ChannelMessage, SendMessage};
+pub use zeroclaw_config::schema::MattermostListenMode;
 
 const MAX_MATTERMOST_AUDIO_BYTES: u64 = 25 * 1024 * 1024;
 /// Cadence at which auto-discovery re-runs to pick up newly-created DMs
@@ -14,6 +17,22 @@ const DISCOVERY_REFRESH: Duration = Duration::from_secs(60);
 /// Poll interval per discovery iteration. Matches the previous single-channel
 /// cadence so operators see no change in latency.
 const POLL_INTERVAL: Duration = Duration::from_secs(3);
+
+/// Application-level ping interval for the Mattermost WebSocket protocol.
+const WS_PING_INTERVAL: Duration = Duration::from_secs(30);
+/// Read timeout for the initial "hello" frame after WebSocket connect.
+const WS_HELLO_TIMEOUT: Duration = Duration::from_secs(30);
+/// Read timeout for the active WebSocket session. If no frame arrives
+/// within this window the peer is considered unresponsive and the
+/// listener exits into the reconnect path. Set to 3× ping interval so
+/// the server can miss two pings before we declare it dead.
+const WS_READ_TIMEOUT: Duration = Duration::from_secs(90);
+/// Initial backoff (seconds) for WebSocket reconnect attempts.
+const WS_RECONNECT_INITIAL_BACKOFF_SECS: u64 = 3;
+/// Maximum backoff (seconds) for WebSocket reconnect attempts.
+const WS_RECONNECT_MAX_BACKOFF_SECS: u64 = 120;
+/// Maximum jitter (ms) added to each reconnect delay.
+const WS_RECONNECT_MAX_JITTER_MS: u64 = 500;
 
 /// One channel the bot will poll. `is_direct` flags DM (`type=D`) and group DM
 /// (`type=G`) channels so the receive path can bypass `mention_only` for them.
@@ -104,6 +123,8 @@ pub struct MattermostChannel {
     proxy_url: Option<String>,
     transcription: Option<zeroclaw_config::schema::TranscriptionConfig>,
     transcription_manager: Option<Arc<super::transcription::TranscriptionManager>>,
+    /// How this channel receives inbound messages. Defaults to `Polling`.
+    listen_mode: MattermostListenMode,
 }
 
 impl MattermostChannel {
@@ -138,6 +159,7 @@ impl MattermostChannel {
             proxy_url: None,
             transcription: None,
             transcription_manager: None,
+            listen_mode: MattermostListenMode::default(),
         }
     }
 
@@ -370,6 +392,12 @@ impl MattermostChannel {
         self
     }
 
+    /// Set the listen mode. Defaults to `Polling` when not called.
+    pub fn with_listen_mode(mut self, listen_mode: MattermostListenMode) -> Self {
+        self.listen_mode = listen_mode;
+        self
+    }
+
     fn http_client(&self) -> reqwest::Client {
         zeroclaw_config::schema::build_channel_proxy_client_with_timeouts(
             "channel.mattermost",
@@ -377,6 +405,28 @@ impl MattermostChannel {
             30,
             10,
         )
+    }
+
+    /// Derive the WebSocket URL from the REST base URL.
+    fn ws_url(&self) -> String {
+        self.base_url
+            .replacen("https://", "wss://", 1)
+            .replacen("http://", "ws://", 1)
+            + "/api/v4/websocket"
+    }
+
+    /// Compute an exponential backoff delay with jitter for WebSocket reconnect.
+    fn ws_reconnect_delay(attempt: u32) -> Duration {
+        let jitter_ms = if WS_RECONNECT_MAX_JITTER_MS > 0 {
+            rand::random::<u64>() % (WS_RECONNECT_MAX_JITTER_MS + 1)
+        } else {
+            0
+        };
+        let multiplier = 1u64.checked_shl(attempt).unwrap_or(u64::MAX);
+        let backoff_secs = WS_RECONNECT_INITIAL_BACKOFF_SECS
+            .saturating_mul(multiplier)
+            .min(WS_RECONNECT_MAX_BACKOFF_SECS);
+        Duration::from_secs(backoff_secs) + Duration::from_millis(jitter_ms)
     }
 
     /// Check if a user ID is in the allowlist.
@@ -643,97 +693,9 @@ impl Channel for MattermostChannel {
     }
 
     async fn listen(&self, tx: tokio::sync::mpsc::Sender<ChannelMessage>) -> Result<()> {
-        // Resolve auth up front so misconfiguration fails fast at listen-time.
-        let initial_token = self.token().await?.to_string();
-        let (bot_user_id, bot_username) = self.get_bot_identity().await;
-
-        let auto_discover = self.scoped_channel_ids().is_none();
-        let mut target_channels = self.list_target_channels().await?;
-        let mut last_discovery = Instant::now();
-        let mut last_create_at_by_channel: HashMap<String, i64> = HashMap::new();
-
-        ::zeroclaw_log::record!(
-            INFO,
-            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(
-                ::serde_json::json!({
-                    "alias": self.alias,
-                    "channel_count": target_channels.len(),
-                    "auto_discover": auto_discover,
-                    "team_ids": self.team_ids,
-                    "discover_dms": self.discover_dms,
-                })
-            ),
-            "Mattermost channel listening"
-        );
-
-        loop {
-            tokio::time::sleep(POLL_INTERVAL).await;
-
-            if auto_discover && last_discovery.elapsed() >= DISCOVERY_REFRESH {
-                match self.list_target_channels().await {
-                    Ok(refreshed) => {
-                        if refreshed != target_channels {
-                            ::zeroclaw_log::record!(
-                                INFO,
-                                ::zeroclaw_log::Event::new(
-                                    module_path!(),
-                                    ::zeroclaw_log::Action::Note,
-                                )
-                                .with_attrs(::serde_json::json!({
-                                    "alias": self.alias,
-                                    "before": target_channels.len(),
-                                    "after": refreshed.len(),
-                                })),
-                                "Mattermost auto-discovery refreshed channel list"
-                            );
-                            target_channels = refreshed;
-                        }
-                    }
-                    Err(e) => {
-                        ::zeroclaw_log::record!(
-                            WARN,
-                            ::zeroclaw_log::Event::new(
-                                module_path!(),
-                                ::zeroclaw_log::Action::Note,
-                            )
-                            .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                            .with_attrs(::serde_json::json!({
-                                "alias": self.alias,
-                                "error": format!("{}", e),
-                            })),
-                            "Mattermost auto-discovery refresh failed; keeping previous channel list"
-                        );
-                    }
-                }
-                last_discovery = Instant::now();
-            }
-
-            if target_channels.is_empty() {
-                continue;
-            }
-
-            #[allow(clippy::cast_possible_truncation)]
-            let bootstrap_ms = (std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_millis()) as i64;
-
-            for target in target_channels.clone() {
-                if self
-                    .poll_channel(
-                        &target,
-                        &initial_token,
-                        &bot_user_id,
-                        &bot_username,
-                        bootstrap_ms,
-                        &mut last_create_at_by_channel,
-                        &tx,
-                    )
-                    .await
-                {
-                    return Ok(());
-                }
-            }
+        match self.listen_mode {
+            MattermostListenMode::Polling => self.listen_polling(tx).await,
+            MattermostListenMode::Websocket => self.listen_websocket(tx).await,
         }
     }
 
@@ -810,6 +772,657 @@ impl Channel for MattermostChannel {
     }
 }
 
+impl MattermostChannel {
+    async fn listen_polling(&self, tx: tokio::sync::mpsc::Sender<ChannelMessage>) -> Result<()> {
+        // Resolve auth up front so misconfiguration fails fast at listen-time.
+        let initial_token = self.token().await?.to_string();
+        let (bot_user_id, bot_username) = self.get_bot_identity().await;
+
+        let auto_discover = self.scoped_channel_ids().is_none();
+        let mut target_channels = self.list_target_channels().await?;
+        let mut last_discovery = Instant::now();
+        let mut last_create_at_by_channel: HashMap<String, i64> = HashMap::new();
+
+        ::zeroclaw_log::record!(
+            INFO,
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(
+                ::serde_json::json!({
+                    "alias": self.alias,
+                    "channel_count": target_channels.len(),
+                    "auto_discover": auto_discover,
+                    "team_ids": self.team_ids,
+                    "discover_dms": self.discover_dms,
+                })
+            ),
+            "Mattermost channel listening (polling)"
+        );
+
+        loop {
+            tokio::time::sleep(POLL_INTERVAL).await;
+
+            if auto_discover && last_discovery.elapsed() >= DISCOVERY_REFRESH {
+                match self.list_target_channels().await {
+                    Ok(refreshed) => {
+                        if refreshed != target_channels {
+                            ::zeroclaw_log::record!(
+                                INFO,
+                                ::zeroclaw_log::Event::new(
+                                    module_path!(),
+                                    ::zeroclaw_log::Action::Note,
+                                )
+                                .with_attrs(::serde_json::json!({
+                                    "alias": self.alias,
+                                    "before": target_channels.len(),
+                                    "after": refreshed.len(),
+                                })),
+                                "Mattermost auto-discovery refreshed channel list"
+                            );
+                            target_channels = refreshed;
+                        }
+                    }
+                    Err(e) => {
+                        ::zeroclaw_log::record!(
+                            WARN,
+                            ::zeroclaw_log::Event::new(
+                                module_path!(),
+                                ::zeroclaw_log::Action::Note,
+                            )
+                            .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                            .with_attrs(::serde_json::json!({
+                                "alias": self.alias,
+                                "error": format!("{}", e),
+                            })),
+                            "Mattermost auto-discovery refresh failed; keeping previous channel list"
+                        );
+                    }
+                }
+                last_discovery = Instant::now();
+            }
+
+            if target_channels.is_empty() {
+                continue;
+            }
+
+            #[allow(clippy::cast_possible_truncation)]
+            let bootstrap_ms = (std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis()) as i64;
+
+            for target in target_channels.clone() {
+                if self
+                    .poll_channel(
+                        &target,
+                        &initial_token,
+                        &bot_user_id,
+                        &bot_username,
+                        bootstrap_ms,
+                        &mut last_create_at_by_channel,
+                        &tx,
+                    )
+                    .await
+                {
+                    return Ok(());
+                }
+            }
+        }
+    }
+
+    async fn listen_websocket(&self, tx: tokio::sync::mpsc::Sender<ChannelMessage>) -> Result<()> {
+        let token = self.token().await?.to_string();
+        let (bot_user_id, bot_username) = self.get_bot_identity().await;
+
+        let auto_discover = self.scoped_channel_ids().is_none();
+        let mut target_channels = self.list_target_channels().await?;
+
+        let build_map = |chs: &[TargetChannel]| -> HashMap<String, bool> {
+            chs.iter().map(|t| (t.id.clone(), t.is_direct)).collect()
+        };
+        let mut channel_direct_map: HashMap<String, bool> = build_map(&target_channels);
+        let mut last_discovery = Instant::now();
+
+        ::zeroclaw_log::record!(
+            INFO,
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(
+                ::serde_json::json!({
+                    "alias": self.alias,
+                    "channel_count": target_channels.len(),
+                    "auto_discover": auto_discover,
+                    "mode": "websocket",
+                })
+            ),
+            "Mattermost WebSocket listening"
+        );
+
+        let mut reconnect_attempt: u32 = 0;
+        let mut seq: i64 = 1;
+
+        loop {
+            // Periodic channel re-discovery
+            if auto_discover && last_discovery.elapsed() >= DISCOVERY_REFRESH {
+                match self.list_target_channels().await {
+                    Ok(refreshed) => {
+                        if refreshed != target_channels {
+                            ::zeroclaw_log::record!(
+                                INFO,
+                                ::zeroclaw_log::Event::new(
+                                    module_path!(),
+                                    ::zeroclaw_log::Action::Note,
+                                )
+                                .with_attrs(::serde_json::json!({
+                                    "alias": self.alias,
+                                    "before": target_channels.len(),
+                                    "after": refreshed.len(),
+                                })),
+                                "Mattermost WS auto-discovery refreshed channel list"
+                            );
+                            target_channels = refreshed;
+                            channel_direct_map = build_map(&target_channels);
+                        }
+                    }
+                    Err(e) => {
+                        ::zeroclaw_log::record!(
+                            WARN,
+                            ::zeroclaw_log::Event::new(
+                                module_path!(),
+                                ::zeroclaw_log::Action::Note,
+                            )
+                            .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                            .with_attrs(::serde_json::json!({
+                                "alias": self.alias,
+                                "error": format!("{}", e),
+                            })),
+                            "Mattermost WS discovery refresh failed; keeping previous"
+                        );
+                    }
+                }
+                last_discovery = Instant::now();
+            }
+
+            let ws_url = self.ws_url();
+            let (ws_stream, _) = match zeroclaw_config::schema::ws_connect_with_proxy(
+                &ws_url,
+                "channel.mattermost",
+                self.proxy_url.as_deref(),
+            )
+            .await
+            {
+                Ok(c) => {
+                    reconnect_attempt = 0;
+                    c
+                }
+                Err(e) => {
+                    let wait = Self::ws_reconnect_delay(reconnect_attempt);
+                    ::zeroclaw_log::record!(
+                        WARN,
+                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                            .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                            .with_attrs(::serde_json::json!({
+                                "alias": self.alias,
+                                "ws_url": &ws_url,
+                                "error": format!("{}", e),
+                                "retry_secs": wait.as_secs(),
+                                "attempt": reconnect_attempt,
+                            })),
+                        "Mattermost WS connect failed, retrying"
+                    );
+                    reconnect_attempt = reconnect_attempt.saturating_add(1);
+                    tokio::time::sleep(wait).await;
+                    continue;
+                }
+            };
+
+            ::zeroclaw_log::record!(
+                INFO,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_attrs(::serde_json::json!({
+                        "alias": self.alias,
+                        "ws_url": &ws_url,
+                    })),
+                "Mattermost WebSocket connected"
+            );
+
+            let (mut write, mut read) = ws_stream.split();
+
+            // Read the "hello" challenge frame with a deadline so an
+            // unresponsive server does not stall the listener forever.
+            let hello_text = match tokio::time::timeout(WS_HELLO_TIMEOUT, read.next()).await {
+                Ok(Some(Ok(WsMessage::Text(t)))) => t,
+                Ok(Some(Ok(WsMessage::Close(frame)))) => {
+                    let code = frame.as_ref().map(|f| u16::from(f.code));
+                    let reason = frame.as_ref().map(|f| f.reason.as_ref()).unwrap_or("");
+                    ::zeroclaw_log::record!(
+                        WARN,
+                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note,)
+                            .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                            .with_attrs(::serde_json::json!({
+                                "alias": self.alias,
+                                "ws_url": &ws_url,
+                                "code": code,
+                                "reason": reason,
+                            })),
+                        "Mattermost WS closed before hello, reconnecting"
+                    );
+                    let wait = Self::ws_reconnect_delay(reconnect_attempt);
+                    reconnect_attempt = reconnect_attempt.saturating_add(1);
+                    tokio::time::sleep(wait).await;
+                    continue;
+                }
+                Ok(None) => {
+                    ::zeroclaw_log::record!(
+                        WARN,
+                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note,)
+                            .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                            .with_attrs(::serde_json::json!({
+                                "alias": self.alias,
+                            })),
+                        "Mattermost WS stream ended before hello, reconnecting"
+                    );
+                    let wait = Self::ws_reconnect_delay(reconnect_attempt);
+                    reconnect_attempt = reconnect_attempt.saturating_add(1);
+                    tokio::time::sleep(wait).await;
+                    continue;
+                }
+                Ok(Some(Err(e))) => {
+                    ::zeroclaw_log::record!(
+                        WARN,
+                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note,)
+                            .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                            .with_attrs(::serde_json::json!({
+                                "alias": self.alias,
+                                "error": format!("{}", e),
+                            })),
+                        "Mattermost WS read error before hello, reconnecting"
+                    );
+                    let wait = Self::ws_reconnect_delay(reconnect_attempt);
+                    reconnect_attempt = reconnect_attempt.saturating_add(1);
+                    tokio::time::sleep(wait).await;
+                    continue;
+                }
+                Ok(_) => {
+                    ::zeroclaw_log::record!(
+                        WARN,
+                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note,)
+                            .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                            .with_attrs(::serde_json::json!({
+                                "alias": self.alias,
+                            })),
+                        "Mattermost WS unexpected frame before hello, reconnecting"
+                    );
+                    continue;
+                }
+                Err(_elapsed) => {
+                    ::zeroclaw_log::record!(
+                        WARN,
+                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note,)
+                            .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                            .with_attrs(::serde_json::json!({
+                                "alias": self.alias,
+                                "timeout_secs": WS_HELLO_TIMEOUT.as_secs(),
+                            })),
+                        "Mattermost WS hello timeout, reconnecting"
+                    );
+                    let wait = Self::ws_reconnect_delay(reconnect_attempt);
+                    reconnect_attempt = reconnect_attempt.saturating_add(1);
+                    tokio::time::sleep(wait).await;
+                    continue;
+                }
+            };
+
+            let hello: serde_json::Value = match serde_json::from_str(hello_text.as_ref()) {
+                Ok(v) => v,
+                Err(e) => {
+                    ::zeroclaw_log::record!(
+                        WARN,
+                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note,)
+                            .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                            .with_attrs(::serde_json::json!({
+                                "alias": self.alias,
+                                "error": format!("{}", e),
+                            })),
+                        "Mattermost WS hello parse failed, reconnecting"
+                    );
+                    continue;
+                }
+            };
+
+            if hello.get("event") != Some(&serde_json::json!("hello")) {
+                ::zeroclaw_log::record!(
+                    WARN,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                        .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                        .with_attrs(::serde_json::json!({
+                            "alias": self.alias,
+                            "event": hello.get("event"),
+                        })),
+                    "Mattermost WS unexpected first event (expected hello), reconnecting"
+                );
+                continue;
+            }
+
+            let server_version = hello
+                .get("data")
+                .and_then(|d| d.get("server_version"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown");
+            ::zeroclaw_log::record!(
+                INFO,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_attrs(::serde_json::json!({
+                        "alias": self.alias,
+                        "server_version": server_version,
+                    })),
+                "Mattermost WS received hello, authenticating"
+            );
+
+            // Send authentication challenge response
+            let auth_msg = serde_json::json!({
+                "seq": seq,
+                "action": "authentication_challenge",
+                "data": { "token": token }
+            });
+            if write
+                .send(WsMessage::Text(auth_msg.to_string().into()))
+                .await
+                .is_err()
+            {
+                ::zeroclaw_log::record!(
+                    WARN,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                        .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                        .with_attrs(::serde_json::json!({
+                            "alias": self.alias,
+                        })),
+                    "Mattermost WS auth send failed, reconnecting"
+                );
+                continue;
+            }
+            seq = seq.wrapping_add(1);
+
+            // Spawn heartbeat pinger
+            let (ping_tx, mut ping_rx) = tokio::sync::mpsc::channel::<()>(1);
+            let ping_handle = zeroclaw_spawn::spawn!(async move {
+                let mut interval = tokio::time::interval(WS_PING_INTERVAL);
+                loop {
+                    interval.tick().await;
+                    if ping_tx.send(()).await.is_err() {
+                        break;
+                    }
+                }
+            });
+
+            // Channel discovery refresh interval inside the active WS session.
+            // Solves the parity gap with polling mode: once connected, a long-lived
+            // healthy socket must still pick up new DMs/channels.
+            let mut discovery_interval = tokio::time::interval(DISCOVERY_REFRESH);
+            discovery_interval.reset(); // skip immediate first tick (already ran above)
+
+            // Inner event loop. Tracks last-frame time so a silent peer
+            // is detected and the listener exits into the reconnect path.
+            let mut last_frame = tokio::time::Instant::now();
+            'inner: loop {
+                let read_deadline = last_frame + WS_READ_TIMEOUT;
+                tokio::select! {
+                    _ = discovery_interval.tick() => {
+                        if auto_discover {
+                            match self.list_target_channels().await {
+                                Ok(refreshed) => {
+                                    if refreshed != target_channels {
+                                        ::zeroclaw_log::record!(
+                                            INFO,
+                                            ::zeroclaw_log::Event::new(
+                                                module_path!(),
+                                                ::zeroclaw_log::Action::Note,
+                                            )
+                                            .with_attrs(::serde_json::json!({
+                                                "alias": self.alias,
+                                                "before": target_channels.len(),
+                                                "after": refreshed.len(),
+                                            })),
+                                            "Mattermost WS in-session auto-discovery refreshed"
+                                        );
+                                        target_channels = refreshed;
+                                        channel_direct_map = build_map(&target_channels);
+                                    }
+                                }
+                                Err(e) => {
+                                    ::zeroclaw_log::record!(
+                                        WARN,
+                                        ::zeroclaw_log::Event::new(
+                                            module_path!(),
+                                            ::zeroclaw_log::Action::Note,
+                                        )
+                                        .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                                        .with_attrs(::serde_json::json!({
+                                            "alias": self.alias,
+                                            "error": format!("{}", e),
+                                        })),
+                                        "Mattermost WS in-session discovery refresh failed"
+                                    );
+                                }
+                            }
+                        }
+                    }
+                    _ = ping_rx.recv() => {
+                        let ping = serde_json::json!({"seq": seq, "action": "ping"});
+                        if write
+                            .send(WsMessage::Text(ping.to_string().into()))
+                            .await
+                            .is_err()
+                        {
+                            ::zeroclaw_log::record!(
+                                WARN,
+                                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note,)
+                                    .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                                    .with_attrs(::serde_json::json!({
+                                        "alias": self.alias,
+                                    })),
+                                "Mattermost WS ping send failed, reconnecting"
+                            );
+                            break 'inner;
+                        }
+                        seq = seq.wrapping_add(1);
+                    }
+                    frame = tokio::time::timeout(WS_READ_TIMEOUT, read.next()) => {
+                        let raw = match frame {
+                            Ok(msg) => {
+                                last_frame = tokio::time::Instant::now();
+                                msg
+                            }
+                            Err(_elapsed) => {
+                                ::zeroclaw_log::record!(
+                                    WARN,
+                                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note,)
+                                        .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                                        .with_attrs(::serde_json::json!({
+                                            "alias": self.alias,
+                                            "timeout_secs": WS_READ_TIMEOUT.as_secs(),
+                                        })),
+                                    "Mattermost WS read timeout, reconnecting"
+                                );
+                                break 'inner;
+                            }
+                        };
+                        let text = match raw {
+                            Some(Ok(WsMessage::Text(t))) => t,
+                            Some(Ok(WsMessage::Ping(payload))) => {
+                                let _ = write.send(WsMessage::Pong(payload)).await;
+                                continue;
+                            }
+                            Some(Ok(WsMessage::Close(frame))) => {
+                                let code = frame.as_ref().map(|f| u16::from(f.code));
+                                let reason = frame.as_ref().map(|f| f.reason.as_ref()).unwrap_or("");
+                                ::zeroclaw_log::record!(
+                                    WARN,
+                                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note,)
+                                        .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                                        .with_attrs(::serde_json::json!({
+                                            "alias": self.alias,
+                                            "code": code,
+                                            "reason": reason,
+                                        })),
+                                    "Mattermost WS closed, reconnecting"
+                                );
+                                break 'inner;
+                            }
+                            None => {
+                                ::zeroclaw_log::record!(
+                                    WARN,
+                                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note,)
+                                        .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                                        .with_attrs(::serde_json::json!({
+                                            "alias": self.alias,
+                                        })),
+                                    "Mattermost WS stream ended, reconnecting"
+                                );
+                                break 'inner;
+                            }
+                            Some(Err(e)) => {
+                                ::zeroclaw_log::record!(
+                                    WARN,
+                                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note,)
+                                        .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                                        .with_attrs(::serde_json::json!({
+                                            "alias": self.alias,
+                                            "error": format!("{}", e),
+                                        })),
+                                    "Mattermost WS read error, reconnecting"
+                                );
+                                break 'inner;
+                            }
+                            _ => continue,
+                        };
+
+                        let event: serde_json::Value = match serde_json::from_str(text.as_ref()) {
+                            Ok(v) => v,
+                            Err(_) => continue,
+                        };
+
+                        let event_type = event
+                            .get("event")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("");
+
+                        match event_type {
+                            "posted" => {
+                                let post_json = event
+                                    .get("data")
+                                    .and_then(|d| d.get("post"));
+                                // The "post" field in the WebSocket event is a JSON
+                                // string that must be parsed. Use as_str() because
+                                // Value::to_string() re-serializes as a quoted JSON
+                                // string literal, which from_str would parse back as
+                                // a Value::String rather than the post object.
+                                let post_str = match post_json.and_then(|v| v.as_str().map(|s| s.to_owned())) {
+                                    Some(s) => s,
+                                    None => continue,
+                                };
+                                let post: serde_json::Value = match serde_json::from_str(&post_str) {
+                                    Ok(v) => v,
+                                    Err(_) => continue,
+                                };
+
+                                let channel_id = post
+                                    .get("channel_id")
+                                    .and_then(|v| v.as_str())
+                                    .unwrap_or("");
+
+                                if !channel_direct_map.contains_key(channel_id) {
+                                    continue;
+                                }
+
+                                let is_direct = channel_direct_map
+                                    .get(channel_id)
+                                    .copied()
+                                    .unwrap_or(false);
+
+                                let effective_text = if post
+                                    .get("message")
+                                    .and_then(|m| m.as_str())
+                                    .unwrap_or("")
+                                    .trim()
+                                    .is_empty()
+                                    && post_has_audio_attachment(&post)
+                                {
+                                    self.try_transcribe_audio_attachment(&post).await
+                                } else {
+                                    None
+                                };
+
+                                if let Some(channel_msg) = self.parse_mattermost_post(
+                                    &post,
+                                    &bot_user_id,
+                                    &bot_username,
+                                    0, // no cursor needed for live events
+                                    channel_id,
+                                    effective_text.as_deref(),
+                                    is_direct,
+                                ) && tx.send(channel_msg).await.is_err()
+                                {
+                                    ping_handle.abort();
+                                    return Ok(());
+                                }
+                            }
+                            "hello" => {
+                                if let Some(conn_id) = event
+                                    .get("data")
+                                    .and_then(|d| d.get("connection_id"))
+                                    .and_then(|v| v.as_str())
+                                {
+                                    ::zeroclaw_log::record!(
+                                        INFO,
+                                        ::zeroclaw_log::Event::new(
+                                            module_path!(),
+                                            ::zeroclaw_log::Action::Note,
+                                        )
+                                        .with_attrs(::serde_json::json!({
+                                            "alias": self.alias,
+                                            "connection_id": conn_id,
+                                        })),
+                                        "Mattermost WS authenticated"
+                                    );
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                    _ = tokio::time::sleep_until(read_deadline) => {
+                        ::zeroclaw_log::record!(
+                            WARN,
+                            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note,)
+                                .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                                .with_attrs(::serde_json::json!({
+                                    "alias": self.alias,
+                                    "timeout_secs": WS_READ_TIMEOUT.as_secs(),
+                                })),
+                            "Mattermost WS idle timeout (no frame received), reconnecting"
+                        );
+                        break 'inner;
+                    }
+                }
+            } // end 'inner
+
+            ping_handle.abort();
+
+            let wait = Self::ws_reconnect_delay(reconnect_attempt);
+            ::zeroclaw_log::record!(
+                INFO,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_attrs(::serde_json::json!({
+                        "alias": self.alias,
+                        "retry_secs": wait.as_secs(),
+                        "attempt": reconnect_attempt,
+                    })),
+                "Mattermost WS reconnecting after disconnect"
+            );
+            reconnect_attempt = reconnect_attempt.saturating_add(1);
+            tokio::time::sleep(wait).await;
+        }
+    }
+}
+
+// listen_polling and listen_websocket helpers moved out of the Channel
+// trait impl so they can be tested and reviewed in isolation.
 impl MattermostChannel {
     /// Poll one target channel for new posts since its cursor, dispatch each
     /// post through `parse_mattermost_post`, and update the cursor in place.
@@ -2633,5 +3246,285 @@ mod tests {
             assert_eq!(by_id.get("explicit_pub"), Some(&false));
             assert_eq!(targets.len(), 2);
         }
+    }
+
+    #[test]
+    fn test_ws_url_conversion() {
+        let ch = MattermostChannel::new(
+            "https://mm.example.com".into(),
+            Some("token".into()),
+            None,
+            None,
+            vec![],
+            "test",
+            Arc::new(Vec::new),
+            false,
+            false,
+        );
+        assert_eq!(ch.ws_url(), "wss://mm.example.com/api/v4/websocket");
+
+        let ch2 = MattermostChannel::new(
+            "http://localhost:8065".into(),
+            Some("token".into()),
+            None,
+            None,
+            vec![],
+            "test",
+            Arc::new(Vec::new),
+            false,
+            false,
+        );
+        assert_eq!(ch2.ws_url(), "ws://localhost:8065/api/v4/websocket");
+
+        // server URL with path prefix should preserve it
+        let ch3 = MattermostChannel::new(
+            "https://mm.example.com/subpath".into(),
+            Some("token".into()),
+            None,
+            None,
+            vec![],
+            "test",
+            Arc::new(Vec::new),
+            false,
+            false,
+        );
+        assert_eq!(
+            ch3.ws_url(),
+            "wss://mm.example.com/subpath/api/v4/websocket"
+        );
+    }
+
+    #[test]
+    fn test_listen_mode_default_is_polling() {
+        assert_eq!(
+            MattermostListenMode::default(),
+            MattermostListenMode::Polling
+        );
+    }
+
+    #[test]
+    fn test_listen_mode_serde() {
+        // serialize
+        assert_eq!(
+            serde_json::to_string(&MattermostListenMode::Polling).unwrap(),
+            "\"polling\""
+        );
+        assert_eq!(
+            serde_json::to_string(&MattermostListenMode::Websocket).unwrap(),
+            "\"websocket\""
+        );
+
+        // deserialize
+        let polling: MattermostListenMode = serde_json::from_str("\"polling\"").unwrap();
+        assert_eq!(polling, MattermostListenMode::Polling);
+
+        let websocket: MattermostListenMode = serde_json::from_str("\"websocket\"").unwrap();
+        assert_eq!(websocket, MattermostListenMode::Websocket);
+
+        // deserialize unknown variant -> error
+        assert!(serde_json::from_str::<MattermostListenMode>("\"unknown\"").is_err());
+    }
+
+    #[test]
+    fn test_ws_reconnect_delay_bounds() {
+        // attempt 0: should be ~3s
+        let d = MattermostChannel::ws_reconnect_delay(0);
+        assert!(d >= Duration::from_secs(3));
+        assert!(d < Duration::from_secs(4)); // + jitter < 1s
+
+        // attempt 10 should be capped at ~120s
+        let d = MattermostChannel::ws_reconnect_delay(10);
+        assert!(d <= Duration::from_secs(121)); // 120s + jitter < 1s
+        assert!(d >= Duration::from_secs(120));
+
+        // large attempt should not overflow
+        let d = MattermostChannel::ws_reconnect_delay(u32::MAX);
+        assert!(d <= Duration::from_secs(121));
+    }
+
+    #[test]
+    fn test_ws_event_posted_parsing() {
+        let post = json!({
+            "id": "post123",
+            "user_id": "user456",
+            "message": "hello world",
+            "create_at": 1717000000000i64,
+            "root_id": "",
+            "channel_id": "chan789",
+            "type": ""
+        });
+
+        let ch = MattermostChannel::new(
+            "https://mm.example.com".into(),
+            Some("token".into()),
+            None,
+            None,
+            vec![],
+            "test",
+            Arc::new(|| vec!["user456".into()]),
+            false,
+            false,
+        );
+
+        let msg = ch
+            .parse_mattermost_post(&post, "bot_user", "bot_username", 0, "chan789", None, false)
+            .expect("should parse posted event post");
+
+        assert_eq!(msg.id, "mattermost_post123");
+        assert_eq!(msg.sender, "user456");
+        assert_eq!(msg.content, "hello world");
+    }
+
+    #[test]
+    fn test_ws_posted_envelope_post_is_json_string() {
+        // Mattermost sends data.post as a JSON-encoded string, not a nested
+        // object. This test exercises the extraction path the WebSocket listener
+        // uses: Value::String → as_str() → from_str. The old to_string() path
+        // would re-serialize as a quoted literal and silently drop the event.
+        let post_obj = json!({
+            "id": "post789",
+            "user_id": "user999",
+            "message": "ws message",
+            "create_at": 1717000000000i64,
+            "root_id": "",
+            "channel_id": "chan111",
+            "type": ""
+        });
+        let post_str = serde_json::to_string(&post_obj).unwrap();
+
+        let envelope = json!({
+            "event": "posted",
+            "data": {
+                "post": post_str
+            }
+        });
+
+        // Extract post the same way the fixed WebSocket listener does
+        let post_json = envelope.get("data").and_then(|d| d.get("post"));
+        let extracted_str = post_json
+            .and_then(|v| v.as_str().map(|s| s.to_owned()))
+            .expect("post field should be a JSON string");
+        let post: serde_json::Value =
+            serde_json::from_str(&extracted_str).expect("should parse the inner JSON string");
+
+        let ch = MattermostChannel::new(
+            "https://mm.example.com".into(),
+            Some("token".into()),
+            None,
+            None,
+            vec![],
+            "test",
+            Arc::new(|| vec!["user999".into()]),
+            false,
+            false,
+        );
+
+        let msg = ch
+            .parse_mattermost_post(&post, "bot_user", "bot_username", 0, "chan111", None, false)
+            .expect("should parse posted event post from envelope");
+
+        assert_eq!(msg.id, "mattermost_post789");
+        assert_eq!(msg.sender, "user999");
+        assert_eq!(msg.content, "ws message");
+    }
+
+    #[test]
+    fn test_ws_ping_message_format() {
+        // Verify the application-level ping frame the heartbeat pinger sends.
+        let seq = 1i64;
+        let ping = serde_json::json!({"seq": seq, "action": "ping"});
+        assert_eq!(ping["seq"], serde_json::json!(1i64));
+        assert_eq!(ping["action"], serde_json::json!("ping"));
+
+        // Round-trip: the message is a Text frame whose content is the JSON
+        // string. The Mattermost server expects this exact shape.
+        let text = ping.to_string();
+        let roundtripped: serde_json::Value =
+            serde_json::from_str(&text).expect("ping json must round-trip");
+        assert_eq!(roundtripped["action"], serde_json::json!("ping"));
+        assert!(roundtripped["seq"].is_i64());
+    }
+
+    #[test]
+    fn test_ws_auth_challenge_format() {
+        // Verify the authentication_challenge frame sent after hello.
+        let token = "test_bot_token";
+        let seq = 1i64;
+        let auth = serde_json::json!({
+            "seq": seq,
+            "action": "authentication_challenge",
+            "data": { "token": token }
+        });
+        assert_eq!(auth["seq"], serde_json::json!(1i64));
+        assert_eq!(
+            auth["action"],
+            serde_json::json!("authentication_challenge")
+        );
+        assert_eq!(auth["data"]["token"], serde_json::json!("test_bot_token"));
+
+        let text = auth.to_string();
+        let roundtripped: serde_json::Value =
+            serde_json::from_str(&text).expect("auth json must round-trip");
+        assert_eq!(
+            roundtripped["data"]["token"],
+            serde_json::json!("test_bot_token")
+        );
+    }
+
+    #[test]
+    fn test_ws_reconnect_delay_monotonic() {
+        // Backoff must increase across attempts. Because the delay includes
+        // up to 500ms jitter, adjacent attempts can overlap, but the
+        // minimum of attempt n+5 must exceed the maximum of attempt n.
+        let d0_max = MattermostChannel::ws_reconnect_delay(0);
+        // attempt 0: 3s base + jitter, so 3s ≤ d0_max < 4s
+        assert!(d0_max >= Duration::from_secs(3));
+        assert!(d0_max < Duration::from_secs(4));
+
+        let d5_min = MattermostChannel::ws_reconnect_delay(5);
+        // attempt 5: 96s base + jitter, so d5_min ≥ 96s
+        // This is far above d0_max, confirming meaningful backoff growth.
+        assert!(d5_min >= Duration::from_secs(96));
+
+        // The cap at 120s base is enforced: max ≤ 120s + jitter < 121s
+        let d_large = MattermostChannel::ws_reconnect_delay(u32::MAX);
+        assert!(d_large <= Duration::from_secs(121));
+        assert!(d_large >= Duration::from_secs(120));
+    }
+
+    #[test]
+    fn test_ws_timeout_constants() {
+        // WS_READ_TIMEOUT must be strictly greater than WS_PING_INTERVAL
+        // so a single missed ping does not trigger a false positive.
+        assert!(
+            WS_READ_TIMEOUT > WS_PING_INTERVAL,
+            "WS_READ_TIMEOUT ({:?}) must exceed WS_PING_INTERVAL ({:?})",
+            WS_READ_TIMEOUT,
+            WS_PING_INTERVAL
+        );
+        // WS_READ_TIMEOUT should be at least 3× ping interval so the
+        // server can miss two pings before the listener reconnects.
+        assert!(
+            WS_READ_TIMEOUT >= WS_PING_INTERVAL.mul_f64(3.0),
+            "WS_READ_TIMEOUT ({:?}) must be ≥ 3× WS_PING_INTERVAL ({:?})",
+            WS_READ_TIMEOUT,
+            WS_PING_INTERVAL
+        );
+        // Hello timeout must not exceed the read timeout.
+        assert!(WS_HELLO_TIMEOUT <= WS_READ_TIMEOUT);
+    }
+
+    #[tokio::test]
+    async fn test_ws_read_timeout_detects_silent_peer() {
+        // Simulate the pattern used in the inner event loop: wrap a read
+        // future in tokio::time::timeout with WS_READ_TIMEOUT. A pending
+        // future that never resolves must trigger the timeout.
+        let never: std::future::Pending<()> = std::future::pending();
+        let short_timeout = Duration::from_millis(50);
+        let result = tokio::time::timeout(short_timeout, never).await;
+        assert!(
+            result.is_err(),
+            "timeout must fire when the inner future never resolves"
+        );
     }
 }

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -49,7 +49,7 @@ pub use crate::line::LineChannel;
 #[cfg(feature = "channel-linq")]
 pub use crate::linq::LinqChannel;
 #[cfg(feature = "channel-mattermost")]
-pub use crate::mattermost::MattermostChannel;
+pub use crate::mattermost::{MattermostChannel, MattermostListenMode};
 #[cfg(feature = "channel-mochat")]
 pub use crate::mochat::MochatChannel;
 #[cfg(feature = "channel-nextcloud")]
@@ -6136,7 +6136,8 @@ fn build_channel_by_id(
                     mm.mention_only.unwrap_or(false),
                 )
                 .with_team_ids(mm.team_ids.clone())
-                .with_discover_dms(mm.discover_dms.unwrap_or(true)),
+                .with_discover_dms(mm.discover_dms.unwrap_or(true))
+                .with_listen_mode(mm.listen_mode),
             ))
         }
         #[cfg(not(feature = "channel-mattermost"))]
@@ -7257,7 +7258,8 @@ fn collect_configured_channels(
                     .with_team_ids(mm.team_ids.clone())
                     .with_discover_dms(mm.discover_dms.unwrap_or(true))
                     .with_proxy_url(mm.proxy_url.clone())
-                    .with_transcription(config.transcription.clone()),
+                    .with_transcription(config.transcription.clone())
+                    .with_listen_mode(mm.listen_mode),
                 ),
                 mm,
             ),
@@ -18363,6 +18365,7 @@ This is an example JSON object for profile settings."#;
                 mention_only: Some(false),
                 interrupt_on_new_message: false,
                 proxy_url: None,
+                listen_mode: MattermostListenMode::default(),
                 excluded_tools: vec![],
                 reply_min_interval_secs: 0,
                 reply_queue_depth_max: 0,
@@ -18411,6 +18414,7 @@ This is an example JSON object for profile settings."#;
                 mention_only: Some(false),
                 interrupt_on_new_message: false,
                 proxy_url: None,
+                listen_mode: MattermostListenMode::default(),
                 excluded_tools: vec![],
                 reply_min_interval_secs: 0,
                 reply_queue_depth_max: 0,

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -12385,6 +12385,21 @@ fn resolve_slack_token(configured: Option<&str>, kind: &str) -> Option<String> {
     None
 }
 
+/// How the Mattermost channel receives inbound messages.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default, zeroclaw_macros::ConfigEnum,
+)]
+#[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
+#[serde(rename_all = "lowercase")]
+pub enum MattermostListenMode {
+    /// Poll REST API every 3 seconds. The default — all existing configs
+    /// continue to work without changes.
+    #[default]
+    Polling,
+    /// Connect to `/api/v4/websocket` for near-real-time event delivery.
+    Websocket,
+}
+
 /// Mattermost bot channel configuration.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, Configurable)]
 #[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
@@ -12466,6 +12481,13 @@ pub struct MattermostConfig {
     #[tab(Advanced)]
     #[serde(default)]
     pub proxy_url: Option<String>,
+
+    /// Listen mode: `"polling"` (REST API every 3s, default) or `"websocket"`
+    /// (persistent WebSocket connection to `/api/v4/websocket` for near-real-time
+    /// event delivery). WebSocket mode reduces server load and delivers events
+    /// faster but requires a WebSocket-capable Mattermost server (v4.0+).
+    #[serde(default)]
+    pub listen_mode: MattermostListenMode,
 
     /// Tools excluded from this channel's tool spec. When set, these tools
     /// are not exposed to the model when responding via this channel.

--- a/crates/zeroclaw-runtime/src/daemon/mod.rs
+++ b/crates/zeroclaw-runtime/src/daemon/mod.rs
@@ -1411,6 +1411,7 @@ fn has_supervised_channels(config: &Config) -> bool {
 mod tests {
     use super::*;
     use tempfile::TempDir;
+    use zeroclaw_config::schema::MattermostListenMode;
 
     fn test_config(tmp: &TempDir) -> Config {
         let config = Config {
@@ -1658,6 +1659,7 @@ mod tests {
                 mention_only: Some(false),
                 interrupt_on_new_message: false,
                 proxy_url: None,
+                listen_mode: MattermostListenMode::default(),
                 excluded_tools: vec![],
                 reply_min_interval_secs: 0,
                 reply_queue_depth_max: 0,

--- a/docs/book/src/channels/mattermost.md
+++ b/docs/book/src/channels/mattermost.md
@@ -1,6 +1,6 @@
 # Mattermost
 
-REST v4 polling client. Self-hosted, on-prem, or sovereign-cloud Mattermost servers all work the same way: the bot polls the channels it can read every 3 seconds for new posts, and reply posts go out via `POST /api/v4/posts`.
+REST v4 polling and WebSocket client. By default the bot polls channels every 3 seconds for new posts; set `listen_mode = "websocket"` for near-real-time event delivery over a persistent WebSocket connection. Reply posts always go out via `POST /api/v4/posts` regardless of listen mode.
 
 ## Who can talk to the agent
 
@@ -39,6 +39,25 @@ There are two scoping modes.
 2. **Explicit** (when `channel_ids` is a non-empty list of IDs other than `*`). On startup the bot calls `GET /api/v4/channels/{id}` for each entry to learn its `type` (so it knows which are DMs for the `mention_only` bypass), then polls exactly those channels forever. No periodic re-discovery.
 
 In both modes each channel has its own `since` cursor: the bot tracks the highest `create_at` it has processed per channel and passes that as `since=<ms>` on the next `GET /api/v4/channels/{id}/posts` call. Cursors do not leak across channels, so a slow-moving channel doesn't suppress posts on a busy one.
+
+## WebSocket mode
+
+Set `listen_mode = "websocket"` to switch from REST polling to a persistent WebSocket connection (`wss://<server>/api/v4/websocket`). The WebSocket mode:
+
+- Delivers new posts in near-real-time (no 3-second poll delay).
+- Reduces HTTP load on the Mattermost server (one connection vs. N polls/3s).
+- Reconnects automatically with exponential backoff (3s initial, 120s max, with jitter).
+- Requires Mattermost v4.0+ (the `/api/v4/websocket` endpoint).
+
+Channel discovery, `mention_only`, `thread_replies`, audio transcription, and peer-group authorization work identically in both modes.
+
+**Trade-offs:**
+
+- WebSocket mode must maintain a persistent TCP+TLS connection.
+- During a reconnect window, messages posted to a channel may be missed (Mattermost has no WebSocket replay mechanism, unlike polling which catches up via `since=` cursors).
+- Polling mode is more resilient to transient network interruptions at the cost of constant HTTP traffic.
+
+To roll back, set `listen_mode = "polling"` (or remove the field; polling is the default).
 
 ## Direct messages
 


### PR DESCRIPTION
## Summary

Closes #7082.

- **Base branch:** `master`
- **What changed and why:**
  - Add opt-in WebSocket listener mode to Mattermost channel for near-real-time event delivery, replacing the default 3-second polling
  - Implement two-loop architecture (outer reconnect with exponential backoff, inner event processing) with ping/pong heartbeat
  - Add read timeout detection for silent/half-open peer connections so the listener exits into reconnect instead of hanging
  - All existing post-processing (mention_only, thread_replies, peer authorization, transcription) works identically
- **Scope boundary:** Only `posted` events in MVP; `post_edited`/`post_deleted` can follow later. Polling remains the default.
- **Blast radius:** Mattermost channel, config schema (additive field), orchestrator (pass-through), runtime daemon fixture, docs
- **Labels:** `type: feat`, `risk: medium`, `size: M`, `channel/mattermost`, `config`, `docs`

### Implementation

**Config schema** (`crates/zeroclaw-config/src/schema.rs`):
- New `MattermostListenMode` enum: `Polling` (default) / `Websocket`
- New `listen_mode` field on `MattermostConfig` — `#[serde(default)]` ensures backward compatibility

**Channel implementation** (`crates/zeroclaw-channels/src/mattermost.rs`):
- `listen()` dispatches to `listen_polling()` or `listen_websocket()` based on `listen_mode`
- `listen_websocket()` implements a two-loop architecture:
  - **Outer loop**: reconnect with exponential backoff (3s→120s, jitter)
  - **Inner loop**: `tokio::select!` over heartbeat (30s ping), WebSocket frames, channel discovery refresh (60s), and idle timeout detection
- WebSocket protocol: connect → receive `hello` (with 30s timeout) → reply `authentication_challenge` → process `posted` events
- Ping/pong: `tokio::spawn` heartbeat every 30s; server `Ping` frames get automatic `Pong` replies; client sends JSON `{"seq":N,"action":"ping"}`
- Timeout detection: `WS_HELLO_TIMEOUT` (30s) on initial hello read; `WS_READ_TIMEOUT` (90s, 3× ping interval) on active frame reads with `last_frame` tracking that persists across select iterations — a silent/half-open peer is detected and triggers reconnect
- Channel re-discovery refreshes every 60s both in the outer reconnect loop and inside the active WebSocket session loop

**Orchestrator** (`crates/zeroclaw-channels/src/orchestrator/mod.rs`):
- Two construction sites pass `.with_listen_mode(mm.listen_mode)`

**Docs** (`docs/book/src/channels/mattermost.md`):
- New `listen_mode` field in config table and field reference
- New "WebSocket mode" section explaining trade-offs

**Tests**: 11 unit tests covering:
- URL conversion, serde round-trip, and default value
- Reconnect backoff bounds and monotonic growth
- Posted event parsing and WebSocket envelope extraction
- Ping/auth frame format validation
- Timeout constants and silent-peer detection (`test_ws_timeout_constants`, `test_ws_read_timeout_detects_silent_peer`)

### Changes since review

- Fixed `posted` event parsing: use `as_str()` instead of `to_string()` for inner JSON string extraction
- Added in-session channel discovery refresh via a third `tokio::select!` branch
- Added regression test for WebSocket envelope → post extraction path
- Added focused tests for ping/pong/reconnect evidence
- **Added timeout detection**: `WS_HELLO_TIMEOUT` (30s) wraps the initial hello read; `WS_READ_TIMEOUT` (90s) wraps active frame reads with `last_frame` tracking so a silent peer is detected regardless of other select branch activity
- **Added timeout tests**: `test_ws_timeout_constants` validates timeout constant relationships; `test_ws_read_timeout_detects_silent_peer` validates the timeout mechanism fires on a never-resolving future
- **Removed bot/AI attribution** from commit message per PR template requirements
- Refreshed against current `master`

## Validation Evidence

```bash
$ cargo fmt --all -- --check
# OK

$ cargo clippy --all-targets -- -D warnings
# OK, no warnings

$ cargo test -p zeroclaw-channels --lib --features channel-mattermost
# 1009 passed, 3 failed (3 failures are pre-existing discord i18n issues, unrelated)
```

- **Commands run and tail output:** see above
- **Beyond CI — what was manually verified:** All WebSocket-specific tests pass locally. `test_ws_timeout_constants` confirms `WS_READ_TIMEOUT ≥ 3× WS_PING_INTERVAL`. `test_ws_read_timeout_detects_silent_peer` confirms `tokio::time::timeout` correctly fires on a pending future.
- **If any command was intentionally skipped, why:** Live WebSocket testing against a Mattermost instance was not possible (no Mattermost server available, Docker provisioning blocked by registry access). Server-initiated Ping → client Pong (tungstenite protocol-level), timeout detection under real network disruption, and full reconnect cycle remain for live validation.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **Yes** — WebSocket connection to the Mattermost server (same host as existing REST API calls, WSS when base URL uses https://)
- Secrets / tokens / credentials handling changed? **No** — reuses the same bot session token sent once in the `authentication_challenge` frame after TLS handshake
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility

- Backward compatible? **Yes** — `listen_mode` defaults to `"polling"`, existing configs without this field work unchanged
- Config / env / CLI surface changed? **Yes** — new optional `listen_mode` field on Mattermost channel config
- If `No` or `Yes` to either: exact upgrade steps for existing users: No action needed. To opt into WebSocket mode, set `listen_mode = "websocket"` and restart.

## Rollback

- **Fast rollback command/path:** Set `listen_mode = "polling"` (or remove the field) and restart the daemon. `git revert <sha>` also works.
- **Feature flags or config toggles:** `listen_mode` field itself is the toggle
- **Observable failure symptoms:** Log messages containing "Mattermost WS" at WARN level (connect/read/timeout/close), daemon reverts to reconnect loop or exits if tx channel closes