### PR TITLE
fix(config-tools-channels): replace unwrap() with expect() and cache regex

### DIFF
--- a/crates/zeroclaw-channels/src/telegram.rs
+++ b/crates/zeroclaw-channels/src/telegram.rs
@@ -2225,7 +2225,10 @@ Allowlist Telegram username (without '@') or numeric user ID.",
                     continue;
                 }
                 // Default: escape HTML entities
-                let ch = line[i..].chars().next().unwrap();
+                let ch = line[i..]
+                    .chars()
+                    .next()
+                    .expect("line slice must be non-empty after i < bytes.len()");
                 match ch {
                     '<' => line_out.push_str("&lt;"),
                     '>' => line_out.push_str("&gt;"),

--- a/crates/zeroclaw-config/src/helpers.rs
+++ b/crates/zeroclaw-config/src/helpers.rs
@@ -397,8 +397,8 @@ pub fn validate_alias_key(key: &str) -> Result<(), String> {
             key.len()
         ));
     }
-    let first = key.chars().next().unwrap();
-    let last = key.chars().next_back().unwrap();
+    let first = key.chars().next().expect("alias must not be empty");
+    let last = key.chars().next_back().expect("alias must not be empty");
     if !matches!(first, 'a'..='z' | '0'..='9') {
         return Err(format!(
             "alias '{key}' must start with a lowercase letter or digit"

--- a/crates/zeroclaw-tools/src/web_search_tool.rs
+++ b/crates/zeroclaw-tools/src/web_search_tool.rs
@@ -844,8 +844,9 @@ fn contains_ascii_case_insensitive(haystack: &str, needle: &str) -> bool {
 }
 
 fn strip_tags(content: &str) -> String {
-    let re = Regex::new(r"<[^>]+>").unwrap();
-    re.replace_all(content, "").to_string()
+    static RE: std::sync::LazyLock<Regex> =
+        std::sync::LazyLock::new(|| Regex::new(r"<[^>]+>").expect("strip_tags regex must compile"));
+    RE.replace_all(content, "").to_string()
 }
 
 #[async_trait]


### PR DESCRIPTION
## Summary

Three targeted fixes: replace bare unwrap() with expect(), cache regex compilation, and harden char indexing.

## Changes

### 1. helpers.rs - alias validation
Replace two chars().next().unwrap() calls with expect() after the empty check guard, making the assumption explicit.

### 2. web_search_tool.rs - strip_tags regex
Convert strip_tags regex from per-call Regex::new().unwrap() to a LazyLock static, avoiding repeated compilation on every search result.

### 3. telegram.rs - escape_html char access
Replace chars().next().unwrap() with expect() documenting the loop invariant that guarantees non-empty slices.

## Verification
- No logic changes
- No breaking changes