### PR TITLE
fix(channels-runtime): remove redundant Option wrapping and replace unwrap() with expect()

### DIFF
--- a/crates/zeroclaw-channels/src/telegram.rs
+++ b/crates/zeroclaw-channels/src/telegram.rs
@@ -926,7 +926,7 @@ impl TelegramChannel {
         let voice_chats = self.voice_chats.clone();
         let api_base = self.api_base.clone();
         let bot_token = self.bot_token.clone();
-        let tts_manager = self.tts_manager.clone().unwrap();
+        let tts_manager = self.tts_manager.clone().expect("TTS manager not configured");
 
         if immediate {
             // Finalize path: text is already the final answer — no debounce.

--- a/crates/zeroclaw-channels/src/whatsapp_web.rs
+++ b/crates/zeroclaw-channels/src/whatsapp_web.rs
@@ -988,7 +988,7 @@ impl Channel for WhatsAppWebChannel {
                 let client_clone = client.clone();
                 let to_clone = to.clone();
                 let recipient = message.recipient.clone();
-                let tts_manager = self.tts_manager.clone().unwrap();
+                let tts_manager = self.tts_manager.clone().expect("TTS manager not configured");
                 zeroclaw_spawn::spawn!(async move {
                     // Wait 10 seconds — long enough for the agent to finish its
                     // full tool chain and send the final answer.

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -1071,19 +1071,20 @@ pub fn all_tools_with_runtime(
     tool_arcs.push(Arc::new(reaction_tool));
 
     // Interactive ask_user tool — always registered; owns its own late-bound channel map.
-    let ask_user_handle: Option<PerToolChannelHandle> = Some(Arc::new(RwLock::new(HashMap::new())));
+    let ask_user_handle = Arc::new(RwLock::new(HashMap::new()));
     let ask_user_tool =
-        AskUserTool::new(security.clone(), ask_user_handle.as_ref().cloned().unwrap());
+        AskUserTool::new(security.clone(), ask_user_handle);
     tool_arcs.push(Arc::new(ask_user_tool));
 
     // Human escalation tool — always registered; owns its own late-bound channel map.
-    let escalate_handle: Option<PerToolChannelHandle> = Some(Arc::new(RwLock::new(HashMap::new())));
+    let escalate_handle = Arc::new(RwLock::new(HashMap::new()));
     let escalate_tool = EscalateToHumanTool::new(
         security.clone(),
         root_config.escalation.alert_channels.clone(),
-        escalate_handle.as_ref().cloned().unwrap(),
+        escalate_handle,
     );
     tool_arcs.push(Arc::new(escalate_tool));
+
 
     // Microsoft 365 Graph API integration
     if root_config.microsoft365.enabled {


### PR DESCRIPTION
## Summary

Remove redundant Option-wrapping and replace bare unwrap() with expect() in TTS manager access and tool channel handles.

## Changes

### 1. telegram.rs + whatsapp_web.rs
Replace tts_manager.clone().unwrap() with .expect("TTS manager not configured") for clearer diagnostics.

### 2. tools/mod.rs
Remove redundant Option<PerToolChannelHandle> wrapping for ask_user, escalate, and channel_send handles. Values were created with Some() then immediately unwrapped via .as_ref().cloned().unwrap() - replaced with direct Arc bindings.

## Verification
- No logic changes, only simplified code paths
- No breaking changes