### PR TITLE
ci(actions): split format gate from lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,26 @@ env:
   CARGO_INCREMENTAL: 0
 
 jobs:
-  # ── Stage 1: Lint (fast gate — fails early before burning compute) ────────
+  # ── Fast serial gate: fail formatting errors before burning compute ───────
+
+  fmt:
+    name: Format
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+        with:
+          toolchain: 1.93.0
+          components: rustfmt
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+  # ── Post-format required quality gate ─────────────────────────────────────
 
   lint:
     name: Lint
+    needs: [fmt]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -29,7 +45,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           toolchain: 1.93.0
-          components: rustfmt, clippy
+          components: clippy
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           cache-on-failure: true
@@ -38,8 +54,6 @@ jobs:
         run: sudo apt-get update -qq && sudo apt-get install -y libudev-dev
       - name: Ensure web/dist placeholder exists
         run: mkdir -p web/dist && touch web/dist/.gitkeep
-      - name: Check formatting
-        run: cargo fmt --all -- --check
       - name: Clippy
         run: >
           cargo clippy
@@ -53,11 +67,11 @@ jobs:
       - name: Fluent coverage guard (no bare user-facing strings)
         run: cargo test --test architecture user_facing_strings_route_through_fluent
 
-  # ── Stage 2: Build + Check (parallel, gated on lint) ─────────────────────
+  # ── Post-format build + check fan-out ─────────────────────────────────────
 
   build:
     name: Build ${{ matrix.target }}
-    needs: [lint]
+    needs: [fmt]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 40
     strategy:
@@ -96,7 +110,7 @@ jobs:
 
   check:
     name: Check (${{ matrix.name }})
-    needs: [lint]
+    needs: [fmt]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
@@ -128,7 +142,7 @@ jobs:
 
   check-32bit:
     name: Check (32-bit)
-    needs: [lint]
+    needs: [fmt]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -150,7 +164,7 @@ jobs:
 
   bench:
     name: Benchmarks Compile
-    needs: [lint]
+    needs: [fmt]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -167,11 +181,11 @@ jobs:
       - name: Verify benchmarks compile
         run: cargo bench --no-run --locked
 
-  # ── Stage 3: Test (gated on lint) ────────────────────────────────────────
+  # ── Post-format tests ─────────────────────────────────────────────────────
 
   test:
     name: Test
-    needs: [lint]
+    needs: [fmt]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -195,11 +209,11 @@ jobs:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
 
-  # ── Stage 4: Security (parallel with test, gated on lint) ────────────────
+  # ── Post-format security checks ───────────────────────────────────────────
 
   security:
     name: Security
-    needs: [lint]
+    needs: [fmt]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -216,14 +230,14 @@ jobs:
       - name: Check licenses, sources, and advisories
         run: cargo deny check
 
-  # ── Stage 5: Required gate ────────────────────────────────────────────────
+  # ── Required gate ─────────────────────────────────────────────────────────
   # Branch protection requires only this single job — internal structure
   # can change without touching branch protection settings.
 
   gate:
     name: CI Required Gate
     if: always()
-    needs: [lint, build, check, check-32bit, bench, test, security]
+    needs: [fmt, lint, build, check, check-32bit, bench, test, security]
     runs-on: ubuntu-latest
     steps:
       - name: Check results

--- a/docs/book/src/foundations/fnd-004-engineering-infrastructure.md
+++ b/docs/book/src/foundations/fnd-004-engineering-infrastructure.md
@@ -106,32 +106,34 @@ The existing workflows do pin actions to full commit SHAs, which is correct secu
 
 The two parallel workflows should be consolidated into a single, well-structured pipeline. The distinction between "Quality Gate" and "CI" is not meaningful to contributors — both are checks a PR must pass. The consolidation creates one place to find check results, one place to update when behaviour changes, and one place to document what each check is doing and why.
 
-The consolidated pipeline follows a staged structure where fast, cheap checks run first and gate slower, more expensive ones:
+The consolidated pipeline follows a staged structure where a very cheap formatting check runs first, then Rust-heavy jobs fan out in parallel. Lint remains required, but it should not unnecessarily hold the build and test cache warm-up hostage when the goal is to shorten the green critical path:
 
 ```
-Stage 1: Format + Lint (2–5 min)
+Stage 1: Format (cheap serial gate)
   └── cargo fmt --check
+
+Post-format quality gate (parallel, required)
   └── cargo clippy --workspace --all-targets -- -D warnings
   └── Docs quality gate
 
-Stage 2: Build + Check (parallel, 5–15 min)
+Post-format Build + Check (parallel, 5–15 min)
   └── Build matrix (Linux x86_64, macOS ARM, Windows)
   └── cargo check --features ci-all
   └── cargo check --no-default-features (kernel profile)
   └── cargo check --target i686 (32-bit)
 
-Stage 3: Test (10–30 min, gated on Stage 1)
+Post-format Test (parallel, 10–30 min)
   └── cargo nextest run --workspace
 
-Stage 4: Security (parallel with Stage 3)
+Post-format Security (parallel)
   └── cargo deny check (licenses, sources, advisories)
   └── Advisory triage gate (see §4)
 
-Stage 5: Required Gate
+Required Gate
   └── Composite status — branch protection requires only this job
 ```
 
-Stages 2, 3, and 4 run in parallel after Stage 1 passes. This means a formatting error fails fast without burning compute on a build that will be thrown away. The Required Gate job aggregates all results so branch protection needs to track only one job name — a pattern already present in both current workflows.
+The post-format jobs run in parallel after formatting passes. This means a formatting error fails fast without burning compute on a build that will be thrown away, while clippy, build, test, and security can make progress together on cleanly formatted PRs. The Required Gate job aggregates all results so branch protection needs to track only one job name — a pattern already present in both current workflows.
 
 ### 3.2 Workspace-Aware Clippy
 

--- a/docs/book/src/maintainers/ci-and-actions.md
+++ b/docs/book/src/maintainers/ci-and-actions.md
@@ -8,7 +8,8 @@ Every workflow lives in `.github/workflows/`. The sections below group them by t
 
 Fires on every PR targeting `master`. Composite job with multiple matrix legs:
 
-- **lint** — `cargo fmt --check`, `cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings`
+- **fmt** — `cargo fmt --all -- --check`
+- **lint** — `cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings`
 - **build** — matrix: `x86_64-unknown-linux-gnu`, `aarch64-apple-darwin`, `x86_64-pc-windows-msvc`
 - **check** — all features + no-default-features
 - **check-32bit** — `i686-unknown-linux-gnu` with no default features
@@ -16,7 +17,7 @@ Fires on every PR targeting `master`. Composite job with multiple matrix legs:
 - **test** — `cargo nextest run --locked --workspace --exclude zeroclaw-desktop` on Linux
 - **security** — `cargo deny check`
 
-`CI Required Gate` is the composite job branch protection pins. A PR cannot merge until this is green.
+`fmt` runs first as the cheap serial gate. The Rust-heavy jobs fan out after formatting passes, and `CI Required Gate` aggregates every result. Branch protection pins the composite gate job. A PR cannot merge until this is green.
 
 ### Daily Advisory Scan (`daily-audit.yml`)
 
@@ -72,7 +73,7 @@ Each fires on `workflow_dispatch` with a version input. They are also invoked fr
 
 ## Build cache behavior
 
-Every job in `ci.yml` uses `Swatinem/rust-cache@v2`. Three behaviors are worth knowing when triaging cache-related flakes:
+Most Rust-heavy jobs in `ci.yml` use `Swatinem/rust-cache@v2`. The lightweight `fmt` job and the Windows build leg do not. These behaviors are worth knowing when triaging cache-related flakes:
 
 - **Cache writes are master-only.** `save-if` is conditioned on `github.ref == 'refs/heads/master'`, so PR runs read the master-seeded cache but never update it. PR branches can't pollute the shared cache with branch-specific artifacts.
 - **Cache saves on failure.** `cache-on-failure: true` is set on every job, so a partial run still seeds the next attempt warm.
@@ -84,7 +85,7 @@ Every job in `ci.yml` uses `Swatinem/rust-cache@v2`. Three behaviors are worth k
 
 | Symptom | First thing to check |
 |---|---|
-| `CI Required Gate` red | Start with `lint` (fmt/clippy is the most common cause), then `test`, then `build` |
+| `CI Required Gate` red | Start with `fmt`, then `lint`, then `test`, then `build` |
 | Release `validate` failed | `Cargo.toml` version doesn't match the workflow input, or the tag already exists |
 | Release build leg failed | The specific target's job log. Android is `experimental` and runs with `continue-on-error` |
 | Environment gate timed out | Re-run only the timed-out job from the workflow run page |


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Split the Quality Gate workflow's formatting check into a new cheap `fmt` job.
  - Kept clippy and the existing architecture guards in `lint`, but made `lint` run after `fmt` instead of owning the first-stage gate.
  - Let build, check, 32-bit check, benchmarks compile, test, and security jobs start after formatting passes instead of waiting for full workspace clippy.
  - Kept `CI Required Gate` dependent on every required job, so clippy, architecture guards, tests, security, and platform builds still block the PR.
  - Updated the foundation and maintainer CI docs so the documented pipeline matches the new post-format fan-out.
- **Scope boundary:** This PR does not change Cargo caching, Windows cache behavior, build profiles, path-aware short-circuits, branch protection, or runner provider configuration. Those stay tracked in #7108.
- **Blast radius:** `.github/workflows/ci.yml` plus CI documentation. The workflow should spend more runner minutes when formatting passes but clippy later fails, but it should reduce wall-clock time for normal PRs where formatting is clean.
- **Linked issue(s):** Related #7108
- **Labels:** `enhancement`, `type: ci`, `risk: high`, `size: XS`, `ci`, `docs`

## Validation Evidence (required)

- **Commands run and tail output:**

```text
ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "yaml ok"'
result: passed; output: yaml ok

git diff --check
result: passed; no whitespace errors

rg -n "needs: \[lint\]" .github/workflows/ci.yml
result: passed; no remaining downstream jobs depend directly on lint

rg -n "uses: [^@]+@(v[0-9]+|main|master|latest)(\\s|$)" .github/workflows/ci.yml
result: passed; no mutable action refs found

git diff --stat
result: passed; three files changed, 43 insertions and 26 deletions
```

- **Beyond CI — what did you manually verify?** I traced the workflow graph after the edit: `fmt` is the only cheap prerequisite for the expensive jobs, `lint` still runs clippy and the existing architecture guards, and `CI Required Gate` still depends on `fmt`, `lint`, build, check, 32-bit check, benchmarks compile, test, and security. I also checked that the patch adds no new GitHub Actions and leaves all `uses:` references SHA-pinned with version comments.
- **If any command was intentionally skipped, why:** I did not run the full GitHub Actions workflow locally. The meaningful execution check for this workflow-only change is the PR's own GitHub Actions run. `actionlint` was not available locally, so I used YAML parsing and structural scans instead.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: `N/A`

This keeps the workflow on `pull_request` with repository `contents: read` permissions. It does not add new actions, secrets, write tokens, or untrusted-context interpolation.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: `N/A`

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** Revert this PR to return the Quality Gate workflow to the previous lint-first dependency graph.
- **Feature flags or config toggles:** `None`
- **Observable failure symptoms:** GitHub Actions graph shows build/test/security jobs starting too early, skipped required jobs, or `CI Required Gate` not failing when a required job fails.

## Supersede Attribution (required only when `Supersedes #` is used)

`N/A`
