### PR TITLE
docs(channels): add feature-availability notes for lean default bundle

### DIFF
--- a/docs/book/src/channels/social.md
+++ b/docs/book/src/channels/social.md
@@ -2,6 +2,8 @@
 
 Broadcast / social-feed integrations. These differ from chat channels in two ways: messages are typically public, and the agent often acts as a poster rather than a bidirectional responder.
 
+> **Build note:** Social channels are **not included** in the lean default build. To use them, build with `--features channels-full` (all channels) or the specific feature flag (e.g. `--features channel-twitter`). Prebuilt binaries do not include these channels by default. See [Channels → Overview](./overview.md) for the full build-options table.
+
 ## Bluesky (AT Protocol)
 
 ```toml
@@ -61,7 +63,7 @@ subreddit = "rust"                        # optional: filter to a single subredd
 ```
 
 - **Auth:** OAuth 2.0 with a refresh token. Generate one with a script-type Reddit app and the `password` or `code` flow, then save the refresh token here for persistent access.
-- **Inbound:** new posts and comments in the configured subreddit (or all subreddits the bot has access to when `subreddit` is unset), plus replies to the agent's own posts.
+- **Inbound:** new posts and comments in the configured subreddit (or all subreddis the bot has access to when `subreddit` is unset), plus replies to the agent's own posts.
 - **Outbound:** posts, comments, private messages.
 
 ---

--- a/docs/book/src/channels/social.md
+++ b/docs/book/src/channels/social.md
@@ -63,7 +63,7 @@ subreddit = "rust"                        # optional: filter to a single subredd
 ```
 
 - **Auth:** OAuth 2.0 with a refresh token. Generate one with a script-type Reddit app and the `password` or `code` flow, then save the refresh token here for persistent access.
-- **Inbound:** new posts and comments in the configured subreddit (or all subreddis the bot has access to when `subreddit` is unset), plus replies to the agent's own posts.
+- **Inbound:** new posts and comments in the configured subreddit (or all subreddits the bot has access to when `subreddit` is unset), plus replies to the agent's own posts.
 - **Outbound:** posts, comments, private messages.
 
 ---

--- a/docs/book/src/setup/windows.md
+++ b/docs/book/src/setup/windows.md
@@ -20,8 +20,8 @@ Flags:
 |---|---|
 | `--prebuilt` | Download prebuilt binary from GitHub Releases (fastest — no Rust toolchain needed) |
 | `--minimal` | Build core only (`--no-default-features`; no channels, no hardware) |
-| `--standard` | Build with common channels (Telegram, Discord, Slack, Matrix) |
-| `--full` | Build everything |
+| `--standard` | Build with lean default channels (ACP server, webhook, email, Telegram) |
+| `--full` | Build with all channels (`channels-full`) |
 
 The script:
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Adds a feature-availability callout to `docs/book/src/channels/social.md` noting that social channels (Twitter/X, Bluesky, Nostr, Reddit) are not included in the lean default build and require `channels-full` or a specific `channel-*` feature flag.
  - Fixes stale `--standard` and `--full` descriptions in `docs/book/src/setup/windows.md` — post-#6904, `--standard` builds the lean default (ACP server, webhook, email, Telegram), not "common channels (Telegram, Discord, Slack, Matrix)".
  - `docs/book/src/channels/overview.md` was already updated by #6904 with the lean default explanation and build-options examples — no changes needed there.
- **Scope boundary:** Documentation only. No code changes, no feature flag changes, no config changes.
- **Blast radius:** Two docs files read by operators setting up social channels or using `setup.bat` on Windows.
- **Linked issue(s):**
  - Closes #7069
  - Related #6904
- **Labels:** `docs`, `size: XS`, `risk: low`

## Validation Evidence (required)

```text
# Verified the content renders correctly (checked locally against mdBook)
# No code to compile or test
```

- **Commands run and tail output:** Docs-only change. Verified the markdown is well-formed and the callout blockquote renders correctly in mdBook.
- **Beyond CI — what did you manually verify?** Cross-referenced the lean default bundle definition from #6904 (ACP server, webhook, email, Telegram) against the updated descriptions to ensure accuracy.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No.**
- New external network calls? **No.**
- Secrets / tokens / credentials handling changed? **No.**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No.**

## Compatibility (required)

- Backward compatible? **Yes.** Documentation-only change.
- Config / env / CLI surface changed? **No.**
