### PR TITLE
fix(shell): prevent interactive subprocesses from hijacking the terminal

### DIFF
--- a/crates/zeroclaw-runtime/src/tools/shell.rs
+++ b/crates/zeroclaw-runtime/src/tools/shell.rs
@@ -335,6 +335,7 @@ impl Tool for ShellTool {
         // `output()` pipes stdio implicitly; `spawn()` does not.
         cmd.stdout(std::process::Stdio::piped());
         cmd.stderr(std::process::Stdio::piped());
+        cmd.stdin(std::process::Stdio::null());
 
         let mut child = match cmd.spawn() {
             Ok(c) => c,
@@ -496,6 +497,24 @@ mod tests {
                 .contains(&json!("command"))
         );
         assert!(schema["properties"]["approved"].is_object());
+    }
+
+    #[tokio::test]
+    async fn shell_stdin_is_eof_not_the_terminal() {
+        let security = Arc::new(SecurityPolicy {
+            autonomy: AutonomyLevel::Supervised,
+            workspace_dir: std::env::temp_dir(),
+            allowed_commands: vec!["cat".into()],
+            ..SecurityPolicy::default()
+        });
+        let tool = ShellTool::new(security, test_runtime());
+        let fut = tool.execute(json!({"command": "cat"}));
+        let res = tokio::time::timeout(std::time::Duration::from_secs(10), fut).await;
+        assert!(
+            res.is_ok(),
+            "a stdin-reading command hung — stdin is not null and may reach the terminal"
+        );
+        assert!(res.unwrap().expect("cat should return a result").success);
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-tools/src/git_operations.rs
+++ b/crates/zeroclaw-tools/src/git_operations.rs
@@ -209,6 +209,8 @@ impl GitOperationsTool {
         let output = tokio::process::Command::new("git")
             .args(args)
             .current_dir(working_dir)
+            .env("GIT_TERMINAL_PROMPT", "0")
+            .stdin(std::process::Stdio::null())
             .output()
             .await?;
 
@@ -1255,6 +1257,28 @@ mod tests {
         // Branch listing is read-only; it must not require write access
         assert!(!tool.requires_write_access("branch"));
         assert!(tool.is_read_only("branch"));
+    }
+
+    #[tokio::test]
+    async fn git_credential_op_fails_fast_without_terminal_prompt() {
+        let tmp = TempDir::new().unwrap();
+        git_init_no_sign(tmp.path(), &[]);
+        let tool = test_tool(tmp.path());
+
+        let fetch = tool.run_git_command(
+            &["fetch", "https://127.0.0.1:1/private/repo.git"],
+            tmp.path(),
+        );
+        let res = tokio::time::timeout(std::time::Duration::from_secs(10), fetch).await;
+
+        assert!(
+            res.is_ok(),
+            "git fetch hung — it likely prompted for credentials on the terminal"
+        );
+        assert!(
+            res.unwrap().is_err(),
+            "fetch to an unreachable private remote should fail, not succeed"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
> **DO NOT MERGE - AUTHOR WILL MERGE WHEN READY. REVIEWS STILL REQUESTED**

## Summary

- **Base branch:** `master`
- **What changed and why:** Stops interactive-required subprocesses from hijacking the controlling terminal — which, in a TUI deployment, is the terminal a zerocode session owns. Observed symptom: a `git` credential prompt (`Username for 'https://github.com'`) from one process appeared inside a different zerocode input box.
  - **shell tool** (`crates/zeroclaw-runtime/src/tools/shell.rs`): spawned commands inherited stdin from the parent. Set stdin to `/dev/null` so any command that reads stdin (or an interactive prompt) gets immediate EOF and fails instead of blocking on or drawing from the terminal.
  - **git operations** (`crates/zeroclaw-tools/src/git_operations.rs`): git ignores a non-terminal stdin for credentials by design and falls back to `/dev/tty`. Set `GIT_TERMINAL_PROMPT=0` (git's own documented non-interactive contract) plus a null stdin on the single production git spawn helper, so credential ops fail with `terminal prompts disabled` rather than prompting.
- **Scope boundary:** Does NOT add any hardcoded list of "interactive tools" or per-tool env tables — the shell fix is tool-agnostic (null stdin), and the git fix uses git's single documented flag. Does NOT change command parsing, the sandbox, autonomy gating, or env passthrough. Does NOT detach the child into a new session (`setsid`); see Blast radius.
- **Blast radius:** Process spawning in the shell tool and the git tool. A command that explicitly opens `/dev/tty` (rather than reading stdin) could still find a controlling terminal if the daemon has one; fully severing that requires a new session, which interacts with the existing `ChildGroupGuard` process-group reaping and is intentionally left out of this fix. The reported vector (git) is fully covered by `GIT_TERMINAL_PROMPT=0`.
- **Linked issue(s):** None (standalone fix surfaced during TUI work).
- **Labels:** `bug` (see sidebar).

## Validation Evidence (required)

The diff touches only `zeroclaw-tools` and `zeroclaw-runtime`, so clippy and tests were scoped to those crates; `cargo fmt --all -- --check` was run across the whole workspace.

```bash
cargo fmt --all -- --check
cargo clippy -p zeroclaw-tools -p zeroclaw-runtime --all-targets -- -D warnings
cargo test -p zeroclaw-tools git
cargo test -p zeroclaw-runtime tools::shell
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` → exit 0, no diff.
  - `cargo clippy -p zeroclaw-tools --all-targets -- -D warnings` → `Finished` (no warnings).
  - `cargo clippy -p zeroclaw-runtime --all-targets -- -D warnings` → `Finished` (no warnings).
  - `cargo test -p zeroclaw-tools git` → `test result: ok. 33 passed; 0 failed`.
  - `cargo test -p zeroclaw-runtime tools::shell` → `test result: ok. 40 passed; 0 failed`.
  - New tests: `git_credential_op_fails_fast_without_terminal_prompt` (timeout-guarded fetch to an unreachable private remote returns fast) and `shell_stdin_is_eof_not_the_terminal` (a stdin-reading command gets EOF instead of hanging). Both complete in <0.05s.
- **Beyond CI — what did you manually verify?** Confirmed git's behavior directly: with `GIT_TERMINAL_PROMPT=0`, `git ls-remote` to a private GitHub URL fails immediately with `fatal: could not read Username for 'https://github.com': terminal prompts disabled` instead of prompting. Confirmed via git's own manual that `GIT_TERMINAL_PROMPT` is the documented switch for this, and that git prompts on the terminal independent of stdin.
- **If any command was intentionally skipped, why:** Full-workspace clippy/test scoped to the two touched crates; no other crate is affected by the diff.

### Integration test checklist (`integration/zerocode-test`)

Validated as part of the aggregated integration branch. The items below are this PR's slice of that sign-off; `[x]` = verified (unit and/or live), `[~]` = code-verified pending live, `[ ]` = live-pending.

#### 12. Shell/git terminal hijack prevention (#7120) — Tier 4

Commits `edbf9e1d0` (null stdin), `0604c0068` (git prompt disable).

- [x] Spawned command that reads stdin (`read`, ssh/sudo prompt) → fails fast with null stdin, no hang (`edbf9e1d0`) — PASS (unit, timeout-guarded). `shell_stdin_is_eof_not_the_terminal` (shell.rs:502) spawns `cat` (reads stdin) under a 10s timeout; with `stdin(Stdio::null())` at spawn (shell.rs:338) it gets immediate EOF, returns fast and succeeds. If stdin reached the terminal the test would hang and fail. Contract: interactive-required commands fail, never prompt or steal keystrokes from the TUI.
- [x] Git credential op with no creds → fails fast, no TTY prompt leak/hang (`0604c0068`) — PASS (unit, timeout-guarded). `git_credential_op_fails_fast_without_terminal_prompt` (git_operations.rs:1262) fetches `https://127.0.0.1:1/private/repo.git` under a 10s timeout; the production helper sets `GIT_TERMINAL_PROMPT=0` + null stdin (git_operations.rs:212-213) so git cannot fall back to /dev/tty — it returns fast (not hung) AND errors. Both tests green.


## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `Yes` — git credential prompting is now disabled in the tool path, so operations that would have prompted for a username/password now fail fast instead. No credential is stored, logged, or transmitted; the change strictly removes an interactive prompt path.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: no upgrade steps. Behavioral note: a git operation against a remote that requires credentials and has none cached will now fail with a clear `terminal prompts disabled` error instead of hanging — configure a credential helper or cached credentials for such remotes.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk: `git revert <sha>` for either commit independently. No feature flags or config toggles involved.