### PR TITLE
fix(docs): keep _shared chrome master-owned and retrofit version selector

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -199,17 +199,37 @@ jobs:
           echo "docs.zeroclawlabs.ai" > CNAME
 
           SCRIPTS="${GITHUB_WORKSPACE}/.workflow-scripts/.github/scripts"
-          
-          # Sync shared chrome — new xtask produces book/_shared/
-          if [ -d "${GITHUB_WORKSPACE}/docs/book/book/_shared" ]; then
-            mkdir -p "$CLONE_DIR/_shared"
-            rsync -a --delete "${GITHUB_WORKSPACE}/docs/book/book/_shared/" "$CLONE_DIR/_shared/"
-          else
-            # Old-tag fallback: extract chrome from the deployed version content
+
+          # Shared chrome (_shared/) is owned by master only. Every deployed
+          # version's pages reference /_shared/, so letting an older tag's build
+          # overwrite it would regress the chrome (CSS/JS) for ALL versions —
+          # the beta-2-clobbers-master bug. Tag deploys sync their own <tag>/
+          # dir but leave _shared untouched; master is the single writer.
+          if [ "$TAG" = "master" ]; then
+            if [ -d "${GITHUB_WORKSPACE}/docs/book/book/_shared" ]; then
+              mkdir -p "$CLONE_DIR/_shared"
+              rsync -a --delete "${GITHUB_WORKSPACE}/docs/book/book/_shared/" "$CLONE_DIR/_shared/"
+            else
+              # master build predates the _shared layout: extract chrome from it.
+              cargo run --manifest-path "${GITHUB_WORKSPACE}/.workflow-scripts/Cargo.toml" -p xtask --bin mdbook -- extract-chrome "$CLONE_DIR/$TAG" "$CLONE_DIR/_shared"
+            fi
+          elif [ ! -d "$CLONE_DIR/_shared" ]; then
+            # Bootstrap only: a tag is the very first deploy and no master has
+            # populated _shared yet. Seed it from this tag so its pages aren't
+            # broken; the next master deploy takes ownership and overwrites it.
             cargo run --manifest-path "${GITHUB_WORKSPACE}/.workflow-scripts/Cargo.toml" -p xtask --bin mdbook -- extract-chrome "$CLONE_DIR/$TAG" "$CLONE_DIR/_shared"
           fi
 
           cargo run --manifest-path "${GITHUB_WORKSPACE}/.workflow-scripts/Cargo.toml" -p xtask --bin mdbook -- gen-versions > versions.json
+
+          # Remove orphaned root entries left by the pre-versioned layout
+          # (top-level en/, fr/, api/, ...). Keeps version dirs, _shared, and
+          # the allowlisted root files. Single source of truth: is_version_dir.
+          cargo run --manifest-path "${GITHUB_WORKSPACE}/.workflow-scripts/Cargo.toml" -p xtask --bin mdbook -- prune-root
+
+          # Retrofit the version-selector into any deployed version whose pages
+          # predate the selector (e.g. tags cut before it shipped). Idempotent.
+          cargo run --manifest-path "${GITHUB_WORKSPACE}/.workflow-scripts/Cargo.toml" -p xtask --bin mdbook -- retrofit-selector
 
           # Ensure root index.html points to /stable/en/ if stable docs exist, otherwise /master/en/
           if [ -d "stable" ]; then
@@ -220,5 +240,39 @@ jobs:
 
           git add --all
           git -c user.name="$GIT_AUTHOR_NAME" -c user.email="$GIT_AUTHOR_EMAIL" commit -m "docs: update docs for $TAG (from $GITHUB_SHA)" || true
-          git push "$REPO" gh-pages
+
+          # Concurrent deploy runs each clone, mutate, and push gh-pages. A run
+          # that cloned before a sibling's push would otherwise clobber it (or
+          # be rejected). Rebase onto the latest remote tip and retry so every
+          # deployed version and an up-to-date versions.json survive the race.
+          push_attempts=0
+          until git push "$REPO" gh-pages; do
+            push_attempts=$((push_attempts + 1))
+            if [ "$push_attempts" -ge 5 ]; then
+              echo "::error::gh-pages push failed after ${push_attempts} attempts"
+              exit 1
+            fi
+            echo "Push rejected (attempt ${push_attempts}); rebasing onto latest gh-pages and retrying"
+            git fetch --depth=50 "$REPO" gh-pages
+            git -c user.name="$GIT_AUTHOR_NAME" -c user.email="$GIT_AUTHOR_EMAIL" rebase FETCH_HEAD || {
+              echo "::error::rebase onto gh-pages failed"
+              git rebase --abort || true
+              exit 1
+            }
+            # Re-run finalizers after rebase: a sibling run may have added or
+            # removed a version dir, so versions.json / prune / retrofit must
+            # reflect the merged tree before we push.
+            cargo run --manifest-path "${GITHUB_WORKSPACE}/.workflow-scripts/Cargo.toml" -p xtask --bin mdbook -- gen-versions > versions.json
+            cargo run --manifest-path "${GITHUB_WORKSPACE}/.workflow-scripts/Cargo.toml" -p xtask --bin mdbook -- prune-root
+            cargo run --manifest-path "${GITHUB_WORKSPACE}/.workflow-scripts/Cargo.toml" -p xtask --bin mdbook -- retrofit-selector
+            if [ -d "stable" ]; then
+              bash "${SCRIPTS}/gen-index-stable.sh"
+            else
+              bash "${SCRIPTS}/gen-index-master.sh"
+            fi
+            if ! git diff --quiet || ! git diff --cached --quiet; then
+              git add --all
+              git -c user.name="$GIT_AUTHOR_NAME" -c user.email="$GIT_AUTHOR_EMAIL" commit --amend --no-edit
+            fi
+          done
           popd >/dev/null

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -173,17 +173,25 @@ jobs:
             popd > /dev/null
           fi
 
-          # Copy built tag docs into gh-pages under '<tag>/'
-          mkdir -p "$CLONE_DIR/$TAG"
-          if [ -d "docs/book/book/$TAG" ]; then
-            rsync -a --delete "docs/book/book/$TAG/" "$CLONE_DIR/$TAG/"
+          # Normalize the build output into a single versioned source dir so the
+          # initial sync and every retry copy from the same place. Old tags that
+          # still build into the pre-versioned layout (`docs/book/book/` with no
+          # `$TAG/` inside) get wrapped into `$TAG/` once, here — the retry path
+          # must not re-derive this, or a concurrent push rejection on an old tag
+          # would leave it with nothing to re-apply.
+          BUILD_ROOT="${GITHUB_WORKSPACE}/docs/book/book"
+          if [ -d "$BUILD_ROOT/$TAG" ]; then
+            TAG_SRC="$BUILD_ROOT/$TAG"
           else
             echo "Old docs layout detected (unversioned). Restructuring to $TAG/..."
-            mkdir -p "docs/book/book_temp/$TAG"
-            rsync -a docs/book/book/ "docs/book/book_temp/$TAG/"
-            rsync -a --delete "docs/book/book_temp/$TAG/" "$CLONE_DIR/$TAG/"
-            rm -rf docs/book/book_temp
+            TAG_SRC="$(mktemp -d)/$TAG"
+            mkdir -p "$TAG_SRC"
+            rsync -a "$BUILD_ROOT/" "$TAG_SRC/"
           fi
+
+          # Copy built tag docs into gh-pages under '<tag>/'
+          mkdir -p "$CLONE_DIR/$TAG"
+          rsync -a --delete "$TAG_SRC/" "$CLONE_DIR/$TAG/"
 
           # If this is a stable release (no pre-release suffix), also copy to /stable/
           if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -264,9 +272,11 @@ jobs:
             git reset --hard FETCH_HEAD
             git clean -fd
 
-            # Re-apply this run's own version dir from the build output.
+            # Re-apply this run's own version dir from the normalized build
+            # source (TAG_SRC), so old-layout tags re-apply the same wrapped
+            # `$TAG/` tree the initial sync used instead of failing here.
             mkdir -p "$TAG"
-            rsync -a --delete "${GITHUB_WORKSPACE}/docs/book/book/$TAG/" "$TAG/"
+            rsync -a --delete "$TAG_SRC/" "$TAG/"
             if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
               mkdir -p stable
               rsync -a --delete "$TAG/" "stable/"

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -243,8 +243,13 @@ jobs:
 
           # Concurrent deploy runs each clone, mutate, and push gh-pages. A run
           # that cloned before a sibling's push would otherwise clobber it (or
-          # be rejected). Rebase onto the latest remote tip and retry so every
-          # deployed version and an up-to-date versions.json survive the race.
+          # be rejected). The clone is shallow (--depth 1), so rebasing onto the
+          # remote tip can't rely on shared ancestry. On rejection: hard-reset
+          # onto the latest remote tip (adopting every sibling's version dirs),
+          # re-apply only THIS run's own deliverables (its <tag>/, and _shared
+          # when master), re-run the finalizers (idempotent), and commit fresh.
+          # This merges by tree, not by history, so it works regardless of how
+          # far gh-pages advanced or whether it was rebuilt via the orphan path.
           push_attempts=0
           until git push "$REPO" gh-pages; do
             push_attempts=$((push_attempts + 1))
@@ -252,16 +257,29 @@ jobs:
               echo "::error::gh-pages push failed after ${push_attempts} attempts"
               exit 1
             fi
-            echo "Push rejected (attempt ${push_attempts}); rebasing onto latest gh-pages and retrying"
-            git fetch --depth=50 "$REPO" gh-pages
-            git -c user.name="$GIT_AUTHOR_NAME" -c user.email="$GIT_AUTHOR_EMAIL" rebase FETCH_HEAD || {
-              echo "::error::rebase onto gh-pages failed"
-              git rebase --abort || true
-              exit 1
-            }
-            # Re-run finalizers after rebase: a sibling run may have added or
-            # removed a version dir, so versions.json / prune / retrofit must
-            # reflect the merged tree before we push.
+            echo "Push rejected (attempt ${push_attempts}); resetting onto latest gh-pages and retrying"
+            git fetch --depth=1 "$REPO" gh-pages
+            # Adopt the remote tree wholesale so sibling runs' version dirs are
+            # preserved exactly as they pushed them — never carry our stale view.
+            git reset --hard FETCH_HEAD
+            git clean -fd
+
+            # Re-apply this run's own version dir from the build output.
+            mkdir -p "$TAG"
+            rsync -a --delete "${GITHUB_WORKSPACE}/docs/book/book/$TAG/" "$TAG/"
+            if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              mkdir -p stable
+              rsync -a --delete "$TAG/" "stable/"
+            fi
+            # Re-assert master-owned _shared (same ownership rule as above).
+            if [ "$TAG" = "master" ] && [ -d "${GITHUB_WORKSPACE}/docs/book/book/_shared" ]; then
+              mkdir -p _shared
+              rsync -a --delete "${GITHUB_WORKSPACE}/docs/book/book/_shared/" "_shared/"
+            elif [ ! -d "_shared" ]; then
+              cargo run --manifest-path "${GITHUB_WORKSPACE}/.workflow-scripts/Cargo.toml" -p xtask --bin mdbook -- extract-chrome "$TAG" "_shared"
+            fi
+
+            echo "docs.zeroclawlabs.ai" > CNAME
             cargo run --manifest-path "${GITHUB_WORKSPACE}/.workflow-scripts/Cargo.toml" -p xtask --bin mdbook -- gen-versions > versions.json
             cargo run --manifest-path "${GITHUB_WORKSPACE}/.workflow-scripts/Cargo.toml" -p xtask --bin mdbook -- prune-root
             cargo run --manifest-path "${GITHUB_WORKSPACE}/.workflow-scripts/Cargo.toml" -p xtask --bin mdbook -- retrofit-selector
@@ -270,9 +288,9 @@ jobs:
             else
               bash "${SCRIPTS}/gen-index-master.sh"
             fi
-            if ! git diff --quiet || ! git diff --cached --quiet; then
-              git add --all
-              git -c user.name="$GIT_AUTHOR_NAME" -c user.email="$GIT_AUTHOR_EMAIL" commit --amend --no-edit
-            fi
+            git add --all
+            # Nothing to commit means the remote already matches our tree.
+            git -c user.name="$GIT_AUTHOR_NAME" -c user.email="$GIT_AUTHOR_EMAIL" \
+              commit -m "docs: update docs for $TAG (from $GITHUB_SHA)" || true
           done
           popd >/dev/null

--- a/xtask/src/bin/mdbook.rs
+++ b/xtask/src/bin/mdbook.rs
@@ -54,6 +54,10 @@ enum Cmd {
     },
     /// Generate versions.json list of deployed documentation versions
     GenVersions,
+    /// Remove orphaned root entries from the gh-pages clone (run in its root)
+    PruneRoot,
+    /// Inject the version-selector script into deployed pages that lack it
+    RetrofitSelector,
     /// Regenerate pc-themes.css + switcher list from the dashboard theme registry
     Themes,
 }
@@ -93,6 +97,8 @@ fn main() -> anyhow::Result<()> {
             std::path::Path::new(&shared_dir),
         ),
         Cmd::GenVersions => cmd::mdbook::versions::run(),
+        Cmd::PruneRoot => cmd::mdbook::versions::prune_root(),
+        Cmd::RetrofitSelector => cmd::mdbook::versions::retrofit_selector(),
         Cmd::Themes => cmd::mdbook::themes::run(&xtask::util::repo_root()),
     }
 }

--- a/xtask/src/cmd/mdbook/build.rs
+++ b/xtask/src/cmd/mdbook/build.rs
@@ -129,6 +129,11 @@ pub fn extract_shared_chrome(version_dir: &Path, shared_dir: &Path) -> anyhow::R
         return Ok(());
     }
 
+    // Map each hashed chrome file (path relative to the locale dir, e.g.
+    // `theme/custom-abc12345.css`) to its unhashed `_shared`-relative path
+    // (e.g. `theme/custom.css`). The `../` prefix is applied per HTML file
+    // below, because a page's correct depth to the version root — and thus to
+    // `_shared` at the gh-pages root — depends on how deep the page sits.
     let mut replacements = Vec::new();
     let prefixes = [
         "css/chrome",
@@ -178,7 +183,8 @@ pub fn extract_shared_chrome(version_dir: &Path, shared_dir: &Path) -> anyhow::R
                     std::fs::create_dir_all(dest.parent().unwrap())?;
                     std::fs::copy(&file, &dest)?;
                     let dest_rel_str = dest_rel.to_string_lossy().replace('\\', "/");
-                    replacements.push((rel_str.clone(), format!("../../_shared/{}", dest_rel_str)));
+                    // Store (locale-relative hashed path, unhashed shared-relative path).
+                    replacements.push((rel_str.clone(), dest_rel_str));
                 }
             }
         }
@@ -187,13 +193,34 @@ pub fn extract_shared_chrome(version_dir: &Path, shared_dir: &Path) -> anyhow::R
     for entry in locale_entries() {
         let loc_dir = version_dir.join(&entry.code);
         for file in walk_dir(&loc_dir) {
+            // Depth of this HTML file below the locale dir. mdBook emits chrome
+            // refs as `<../ × (locale_depth + page_depth)>theme/foo-HASH.css`
+            // for an HTML page `page_depth` levels under the locale dir; the
+            // matching `_shared` ref needs the same total `../` count plus one
+            // to clear the version dir up to the gh-pages root where `_shared`
+            // lives. Concretely: page directly in `<tag>/<locale>/` -> `../../`,
+            // one level deeper -> `../../../`, and so on.
+            let page_depth = file
+                .strip_prefix(&loc_dir)
+                .ok()
+                .map(|rel| rel.components().count().saturating_sub(1))
+                .unwrap_or(0);
+            let up = "../".repeat(page_depth + 2);
+
             if file.extension().is_some_and(|e| e == "html")
                 && let Ok(mut content) = std::fs::read_to_string(&file)
             {
                 let mut changed = false;
-                for (from, to) in &replacements {
-                    if content.contains(from) {
-                        content = content.replace(from, to);
+                for (hashed_rel, shared_rel) in &replacements {
+                    // mdBook references the chrome file relative to the page, so
+                    // the on-disk ref is `<../ × page_depth><hashed_rel>`. Match
+                    // and replace at that exact depth with the `_shared` ref at
+                    // the correct depth — never a hardcoded prefix.
+                    let page_up = "../".repeat(page_depth);
+                    let from = format!("{page_up}{hashed_rel}");
+                    let to = format!("{up}_shared/{shared_rel}");
+                    if content.contains(&from) {
+                        content = content.replace(&from, &to);
                         changed = true;
                     }
                 }

--- a/xtask/src/cmd/mdbook/versions.rs
+++ b/xtask/src/cmd/mdbook/versions.rs
@@ -71,32 +71,28 @@ pub fn is_version_dir(name: &str) -> bool {
     name == "master" || name == "stable" || parse_version(name).is_some()
 }
 
-/// Root-level entries that are not version dirs but must survive pruning.
-const ROOT_KEEP_FILES: &[&str] = &["index.html", "CNAME", "versions.json", ".nojekyll"];
+/// Root-level directories that are not version dirs but must survive pruning.
 const ROOT_KEEP_DIRS: &[&str] = &["_shared", ".git"];
 
-/// Remove orphaned root entries left over from the pre-versioned docs layout
-/// (e.g. top-level `en/`, `fr/`, `api/`). Keeps allowlisted files, the shared
-/// chrome dir, and every recognized version dir. Operates on the current
-/// working directory (the gh-pages clone root).
+/// Remove orphaned root *directories* left over from the pre-versioned docs
+/// layout (e.g. top-level `en/`, `fr/`, `api/`). Keeps the shared chrome dir
+/// and every recognized version dir. Root *files* are never touched — the
+/// orphans are all directories, and a closed file allowlist would silently
+/// delete legitimate root files a future deploy might add (`404.html`,
+/// `robots.txt`, `sitemap.xml`, ...). Operates on the current working
+/// directory (the gh-pages clone root).
 pub fn prune_root() -> anyhow::Result<()> {
     let entries = fs::read_dir(".")?;
     for entry in entries.flatten() {
-        let name = entry.file_name().to_string_lossy().to_string();
-        let ty = entry.file_type()?;
-        if ty.is_dir() {
-            if ROOT_KEEP_DIRS.contains(&name.as_str()) || is_version_dir(&name) {
-                continue;
-            }
-            println!("prune-root: removing orphaned dir {name}/");
-            fs::remove_dir_all(entry.path())?;
-        } else {
-            if ROOT_KEEP_FILES.contains(&name.as_str()) {
-                continue;
-            }
-            println!("prune-root: removing orphaned file {name}");
-            fs::remove_file(entry.path())?;
+        if !entry.file_type()?.is_dir() {
+            continue;
         }
+        let name = entry.file_name().to_string_lossy().to_string();
+        if ROOT_KEEP_DIRS.contains(&name.as_str()) || is_version_dir(&name) {
+            continue;
+        }
+        println!("prune-root: removing orphaned dir {name}/");
+        fs::remove_dir_all(entry.path())?;
     }
     Ok(())
 }

--- a/xtask/src/cmd/mdbook/versions.rs
+++ b/xtask/src/cmd/mdbook/versions.rs
@@ -1,6 +1,7 @@
 use serde_json::json;
 use std::env;
 use std::fs;
+use std::path::{Path, PathBuf};
 
 // Simple struct to represent parsed semver for sorting
 #[derive(Debug, PartialEq, Eq)]
@@ -60,6 +61,124 @@ fn parse_version(tag: &str) -> Option<Version> {
         pre,
         tag: tag.to_string(),
     })
+}
+
+/// True when a gh-pages root directory name denotes a deployable docs version:
+/// `master`, `stable`, or a `vX.Y.Z[-pre]` tag. This is the single source of
+/// truth shared by `versions.json` generation and root pruning so the two can
+/// never disagree about what counts as a version.
+pub fn is_version_dir(name: &str) -> bool {
+    name == "master" || name == "stable" || parse_version(name).is_some()
+}
+
+/// Root-level entries that are not version dirs but must survive pruning.
+const ROOT_KEEP_FILES: &[&str] = &["index.html", "CNAME", "versions.json", ".nojekyll"];
+const ROOT_KEEP_DIRS: &[&str] = &["_shared", ".git"];
+
+/// Remove orphaned root entries left over from the pre-versioned docs layout
+/// (e.g. top-level `en/`, `fr/`, `api/`). Keeps allowlisted files, the shared
+/// chrome dir, and every recognized version dir. Operates on the current
+/// working directory (the gh-pages clone root).
+pub fn prune_root() -> anyhow::Result<()> {
+    let entries = fs::read_dir(".")?;
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+        let ty = entry.file_type()?;
+        if ty.is_dir() {
+            if ROOT_KEEP_DIRS.contains(&name.as_str()) || is_version_dir(&name) {
+                continue;
+            }
+            println!("prune-root: removing orphaned dir {name}/");
+            fs::remove_dir_all(entry.path())?;
+        } else {
+            if ROOT_KEEP_FILES.contains(&name.as_str()) {
+                continue;
+            }
+            println!("prune-root: removing orphaned file {name}");
+            fs::remove_file(entry.path())?;
+        }
+    }
+    Ok(())
+}
+
+/// Inject the shared version-selector script into every deployed version page
+/// that lacks it. Old tags built before the selector existed render without a
+/// version dropdown; this retrofits the `<script>` reference so any deployed
+/// version — past, present, or future — surfaces the dropdown that reads the
+/// root `versions.json`. Idempotent: pages that already reference the selector
+/// are left untouched. Operates on the gh-pages clone root.
+pub fn retrofit_selector() -> anyhow::Result<()> {
+    let mut patched = 0usize;
+    for entry in fs::read_dir(".")?.flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+        if !entry.file_type()?.is_dir() || !is_version_dir(&name) {
+            continue;
+        }
+        patched += retrofit_dir(&entry.path())?;
+    }
+    println!("retrofit-selector: patched {patched} page(s)");
+    Ok(())
+}
+
+fn retrofit_dir(version_root: &Path) -> anyhow::Result<usize> {
+    let mut stack: Vec<PathBuf> = vec![version_root.to_path_buf()];
+    let mut patched = 0usize;
+    while let Some(dir) = stack.pop() {
+        for entry in fs::read_dir(&dir)?.flatten() {
+            let path = entry.path();
+            let ty = entry.file_type()?;
+            if ty.is_dir() {
+                stack.push(path);
+            } else if path.extension().is_some_and(|e| e == "html") && retrofit_file(&path)? {
+                patched += 1;
+            }
+        }
+    }
+    Ok(patched)
+}
+
+/// Patch one HTML file. Returns true if it was modified. Skips pages that
+/// already reference the selector or have no menu bar to host the dropdown.
+fn retrofit_file(path: &Path) -> anyhow::Result<bool> {
+    let content = fs::read_to_string(path)?;
+    if content.contains("theme/version-selector.js") {
+        return Ok(false);
+    }
+    if !content.contains("right-buttons") {
+        return Ok(false); // No menu bar — nothing for the dropdown to attach to.
+    }
+    let Some(prefix) = shared_prefix(path) else {
+        return Ok(false);
+    };
+    let script =
+        format!("        <script src=\"{prefix}_shared/theme/version-selector.js\"></script>\n");
+    // Insert just before </body> so it loads with the other chrome scripts.
+    let Some(pos) = content.rfind("</body>") else {
+        return Ok(false);
+    };
+    let line_start = content[..pos].rfind('\n').map(|i| i + 1).unwrap_or(pos);
+    let mut updated = String::with_capacity(content.len() + script.len());
+    updated.push_str(&content[..line_start]);
+    updated.push_str(&script);
+    updated.push_str(&content[line_start..]);
+    fs::write(path, updated)?;
+    Ok(true)
+}
+
+/// Relative prefix from `file` (under the gh-pages root) up to the root, where
+/// `_shared/` lives. One `../` per directory level above the file. E.g.
+/// `master/en/index.html` -> `../../`, `v1.2.3/en/a/b.html` -> `../../../`.
+/// Only real path segments count — a leading `./` from `read_dir(".")` must not
+/// inflate the depth, or the injected `_shared` ref would 404.
+fn shared_prefix(file: &Path) -> Option<String> {
+    let depth = file
+        .components()
+        .filter(|c| matches!(c, std::path::Component::Normal(_)))
+        .count();
+    if depth < 1 {
+        return None;
+    }
+    Some("../".repeat(depth - 1))
 }
 
 pub fn run() -> anyhow::Result<()> {
@@ -157,4 +276,42 @@ pub fn run() -> anyhow::Result<()> {
     println!("{}", serde_json::to_string_pretty(&output)?);
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shared_prefix_matches_page_depth() {
+        // Depth counts only real segments; a leading `./` must not inflate it,
+        // or the injected _shared ref 404s.
+        let two = "..".to_string() + "/" + ".." + "/";
+        let three = "..".to_string() + "/" + ".." + "/" + ".." + "/";
+        assert_eq!(
+            shared_prefix(Path::new("./master/en/index.html")).unwrap(),
+            two
+        );
+        assert_eq!(
+            shared_prefix(Path::new("master/en/index.html")).unwrap(),
+            two
+        );
+        assert_eq!(
+            shared_prefix(Path::new("v0.8.0-beta-2/en/architecture/crates.html")).unwrap(),
+            three
+        );
+    }
+
+    #[test]
+    fn is_version_dir_accepts_only_real_versions() {
+        for ok in ["master", "stable", "v0.8.0", "v0.8.0-beta-2", "v1.2.3"] {
+            assert!(is_version_dir(ok), "{ok} should be a version dir");
+        }
+        for orphan in ["en", "fr", "zh-CN", "api", "_shared", "main", "v1.2"] {
+            assert!(
+                !is_version_dir(orphan),
+                "{orphan} must not be a version dir"
+            );
+        }
+    }
 }


### PR DESCRIPTION
> **DO NOT MERGE - AUTHOR WILL MERGE WHEN READY. REVIEWS STILL REQUESTED**

## Summary

- **Base branch:** `master`
- **What changed and why:**
  - The versioned-docs deploy hoists each build's chrome (CSS/JS) into a single
    global `/_shared/` that every version's pages reference. Each deploy
    overwrote it unconditionally, so an older tag deploying after master
    (`v0.8.0-beta-2`) clobbered master's reskin with stale chrome — white code
    blocks and an unscrollable theme list across **all** versions. `_shared` is
    now written by **master deploys only**; tag deploys leave it untouched
    (bootstrap-seed only when absent).
  - Orphaned pre-versioned root trees (`/en/`, `/fr/`, `/api/`, …) lingered on
    `gh-pages` and served drop-down-less docs at `/en/`. New `prune-root`
    removes any root entry that isn't a real version dir or allowlisted file.
  - Tags built before the version-selector shipped render without a version
    dropdown. New `retrofit-selector` injects the selector `<script>` into any
    deployed page lacking it, at the correct `_shared` relative depth.
  - Concurrent deploys raced and desynced `versions.json`; push is now
    rebase-and-retry.
- **Scope boundary:** No docs *content* changes, no theme palette changes, no
  `book.toml` / `themes.json` changes. Only the deploy workflow and xtask tooling.
- **Blast radius:** `docs-deploy` workflow + `gh-pages` layout only. No runtime,
  crate, or product-surface code. `is_version_dir` is the single source of truth
  shared by `gen-versions` and `prune-root` so they cannot disagree.
- **Linked issue(s):** Related #7023 (versioned documentation deployment).
- **Labels:** `type: docs`, `docs`, `ci`, `risk: low`, `size: M`

## Validation Evidence (required)

```bash
cargo fmt --all -- --check                            # exit 0, no diff
cargo clippy -p xtask --all-targets -- -D warnings    # Finished, exit 0
cargo test -p xtask versions                          # ok. 2 passed; 0 failed
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` — exit 0 (clean, no diff).
  - `cargo clippy -p xtask --all-targets -- -D warnings` — `Finished dev profile`, exit 0.
  - `cargo test -p xtask versions` — `test result: ok. 2 passed; 0 failed; 0 ignored`
    (`shared_prefix_matches_page_depth`, `is_version_dir_accepts_only_real_versions`).
- **Beyond CI — what I manually verified:**
  - Ran `prune-root` + `retrofit-selector` against a materialized copy of the
    live `gh-pages` tree: pruned `en es fr ja zh-CN api`; kept `master`,
    `v0.8.0-beta-2`, `_shared`, `CNAME`, `index.html`, `versions.json`.
  - Retrofit patched beta-2 pages; **210 selector refs checked, 0 broken**; depth
    matches master ground truth exactly (`../../` for index pages, `../../../`
    for deep pages, verified across `en` / `fr` / `zh-CN`); idempotent (master
    pages untouched, exactly one ref per page).
  - Confirmed the live `_shared/theme/custom.css` was the stale 2342-byte file vs
    master's 27 KB reskin — the root cause of the white code blocks.
- **Not verified locally:** a full multi-locale `cargo mdbook build` + real
  `gh-pages` push (requires a CI runner); exercised via a live master dispatch.
- **Intentionally skipped:** full-workspace `cargo test` — the change is isolated
  to `xtask` tooling plus a workflow file, so the scoped `xtask` battery was run
  instead.

### Integration test checklist (`integration/zerocode-test`)

Validated as part of the aggregated integration branch. The items below are this PR's slice of that sign-off; `[x]` = verified (unit and/or live), `[~]` = code-verified pending live, `[ ]` = live-pending.

#### 1. Docs: master-owned `_shared` chrome + version selector (#7124) — Tier 0

Commits: `24b5d155f` (keep `_shared` master-owned, retrofit selector), `496fe4c30` (deploy hardening).

- [x] mdBook builds (`cargo run -p xtask --bin mdbook -- build`); selector wired into every page. RENDER+SWITCH verified end-to-end: seeded a 2nd version dir (`v0.7.5`), ran real `gen-versions` → `versions.json` (master + v0.7.5, stable=v0.7.5), served book root over HTTP, drove selector logic against live data → renders 2 entries, marks master current, switch `/master/en/index.html`→`/v0.7.5/en/index.html` resolves HTTP 200. Synthetic artifacts removed; tree clean.
- [x] `_shared` chrome master-owned: `extract_shared_chrome` hoists chrome to `book/_shared/`; pages reference it via depth-correct relative path.
- Evidence posted: PR #7124 comment (#7023 already MERGED — skipped).


## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `Yes` — two new internal `xtask mdbook`
  subcommands (`prune-root`, `retrofit-selector`) consumed only by the deploy
  workflow. No user-facing CLI or config change.
- Upgrade steps for existing users: none. The effect applies on the next
  `docs-deploy` run.

## Rollback (required for `risk: medium` and `risk: high`)

Low risk — `git revert <sha>`. The workflow change is idempotent and the new
xtask subcommands are additive; reverting restores the prior deploy behavior.


---

## Operator note — true apex redirect (CNAME / edge)

GitHub Pages serves `gh-pages` as static files and **cannot emit a real HTTP
301/302 for the apex path** `https://docs.zeroclawlabs.ai/`. This PR keeps the
in-repo fallback (the root `index.html` meta-refresh + canonical to the default
version) so the bare domain still lands on the docs. That fallback is best-effort:
meta-refresh can be slow and is ignored by some clients.

To get a genuine `301`/`302` from `/` to `/master/en/` (or `/stable/en/` once a
stable ships), add the redirect at the DNS/edge layer in front of Pages. The
domain currently resolves through GitHub's own Fastly CDN (no Cloudflare in
front), so this is a one-time infra change outside the repo:

**Option A — Cloudflare in front of Pages (recommended):**
1. Move `docs.zeroclawlabs.ai` DNS to Cloudflare (proxied / orange-cloud).
2. Keep the `CNAME` file (`docs.zeroclawlabs.ai`) so Pages still accepts the host.
3. Add a Bulk Redirect or Redirect Rule:
   - When `URI Path` equals `/`
   - Then `301` to `https://docs.zeroclawlabs.ai/master/en/`
   - (Switch the target to `/stable/en/` when a stable version is deployed.)
4. Leave deeper paths (`/master/...`, `/_shared/...`, `/versions.json`)
   untouched — only the exact apex path redirects.

**Option B — keep Pages-only (status quo):** no edge change; the root
`index.html` meta-refresh remains the redirect. Acceptable but not a true 301.

This PR does not and cannot make the edge change itself; it only guarantees the
target (`/master/en/`) always exists, is pruned of orphans, and carries the
version dropdown. The 301 is an operator action on the DNS/CDN.