### PR TITLE
docs(providers): correct Codex-subscription credential source in catalog

### DIFF
--- a/docs/book/src/providers/catalog.md
+++ b/docs/book/src/providers/catalog.md
@@ -39,7 +39,7 @@ wire_api               = "responses"
 requires_openai_auth   = true
 ```
 
-OpenAI Codex subscription auth lives on the `openai` slot. Set `wire_api = "responses"` to route through `POST /v1/responses` and `requires_openai_auth = true` to pull credentials from `OPENAI_API_KEY` / `~/.codex/auth.json` instead of an `api_key` field on the entry.
+OpenAI Codex subscription auth lives on the `openai` slot. Set `wire_api = "responses"` to route through `POST /v1/responses` and `requires_openai_auth = true` to pull credentials from the OAuth profile imported from `~/.codex/auth.json` instead of an `api_key` field on the entry. The subscription path does not read `OPENAI_API_KEY` — that variable applies only to the metered `openai` API-key mode.
 
 ### Ollama — slot `ollama`
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** `catalog.md` said the OpenAI Codex subscription slot pulls credentials from `OPENAI_API_KEY` / `~/.codex/auth.json`. The subscription path (`requires_openai_auth = true` + `wire_api = "responses"`) loads the OAuth profile imported from `~/.codex/auth.json` and does **not** read `OPENAI_API_KEY` — that variable only applies to the metered `openai` API-key mode. Corrected the sentence so operators have the right mental model.
- **Scope boundary:** Docs-only, one sentence in `catalog.md`. No code, config, or behavior change.
- **Blast radius:** None at runtime. Single existing doc line.
- **Linked issue(s):** Related to the OpenAI Codex subscription provider docs (raised in review of #7116).
- **Labels:** `type: docs`, `risk: low`, `size: XS`, `docs`

## Validation Evidence (required)

```bash
$ grep -n OPENAI_API_KEY crates/zeroclaw-providers/src/openai_codex.rs
# (no output — the Codex path contains no OPENAI_API_KEY reference)
$ bash scripts/ci/docs_quality_gate.sh   # full lint runs in CI on the changed file
```

- **Commands run and tail output:** Verified `crates/zeroclaw-providers/src/openai_codex.rs` has zero `OPENAI_API_KEY` references; auth loads via `get_profile("openai-codex", …)` (line ~1142). markdownlint runs in CI.
- **Beyond CI — what did you manually verify?** The corrected text matches the actual credential-load path (OAuth profile, not env var) and the related OpenAI Codex subscription docs work in #7116.
- **If any command was intentionally skipped, why:** `cargo fmt`/`clippy`/`test` — no Rust changed.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No** (corrects a doc description only)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- If any `Yes`, describe the risk and mitigation: n/a

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- Upgrade steps for existing users: None — docs-only.

## Rollback

Low-risk: `git revert <sha>`.
