### PR TITLE
fix(wechat): replace 10 unwrap() calls with expect() in markdown rege…

### DIFF
--- a/crates/zeroclaw-channels/src/wechat.rs
+++ b/crates/zeroclaw-channels/src/wechat.rs
@@ -526,15 +526,16 @@ fn build_base_info() -> serde_json::Value {
 
 fn markdown_to_plain_text(text: &str) -> String {
     // TODO: Cache these Regex values instead of compiling them on every send path.
-    let code_block_re = regex::Regex::new(r"```[^\n]*\n?([\s\S]*?)```").unwrap();
-    let image_re = regex::Regex::new(r"!\[[^\]]*\]\([^)]*\)").unwrap();
-    let link_re = regex::Regex::new(r"\[([^\]]+)\]\([^)]*\)").unwrap();
-    let heading_re = regex::Regex::new(r"(?m)^\s{0,3}#{1,6}\s+").unwrap();
-    let blockquote_re = regex::Regex::new(r"(?m)^>\s?").unwrap();
-    let bullet_re = regex::Regex::new(r"(?m)^\s*[-*+]\s+").unwrap();
-    let emphasis_re = regex::Regex::new(r"(\*\*|__|~~|`|\*)").unwrap();
-    let table_separator_re = regex::Regex::new(r"^\|[\s:|-]+\|$").unwrap();
-    let table_row_re = regex::Regex::new(r"^\|(.+)\|$").unwrap();
+    let code_block_re =
+        regex::Regex::new(r"```[^\n]*\n?([\s\S]*?)```").expect("code_block_re must compile");
+    let image_re = regex::Regex::new(r"!\[[^\]]*\]\([^)]*\)").expect("image_re must compile");
+    let link_re = regex::Regex::new(r"\[([^\]]+)\]\([^)]*\)").expect("link_re must compile");
+    let heading_re = regex::Regex::new(r"(?m)^\s{0,3}#{1,6}\s+").expect("heading_re must compile");
+    let blockquote_re = regex::Regex::new(r"(?m)^>\s?").expect("blockquote_re must compile");
+    let bullet_re = regex::Regex::new(r"(?m)^\s*[-*+]\s+").expect("bullet_re must compile");
+    let emphasis_re = regex::Regex::new(r"(\*\*|__|~~|`|\*)").expect("emphasis_re must compile");
+    let table_separator_re = regex::Regex::new(r"^\|[\s:|-]+\|$").expect("table_separator_re must compile");
+    let table_row_re = regex::Regex::new(r"^\|(.+)\|$").expect("table_row_re must compile");
 
     let mut result = code_block_re.replace_all(text, "$1").into_owned();
     result = image_re.replace_all(&result, "").into_owned();
@@ -602,7 +603,7 @@ fn build_headers(token: Option<&str>) -> reqwest::header::HeaderMap {
     let mut headers = reqwest::header::HeaderMap::new();
     headers.insert("Content-Type", "application/json".parse().unwrap());
     headers.insert("AuthorizationType", "ilink_bot_token".parse().unwrap());
-    headers.insert("X-WECHAT-UIN", random_wechat_uin().parse().unwrap());
+    headers.insert("X-WECHAT-UIN", random_wechat_uin().parse().expect("X-WECHAT-UIN header value must be valid"));
     if let Some(t) = token
         && !t.is_empty()
         && let Ok(val) = format!("Bearer {t}").parse()


### PR DESCRIPTION
…x and header parsing

- markdown_to_plain_text: replace 9 .unwrap() calls on static regex compilation with .expect() naming each regex variable.

- build_headers: replace .unwrap() on dynamic X-WECHAT-UIN header parse with .expect() carrying a diagnostic message.

## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:** (2–5 bullets — the diff shows *what*, you explain *why*)
- **Scope boundary:** (what this PR explicitly does NOT change)
- **Blast radius:** (what other subsystems or consumers could be affected)
- **Linked issue(s):** Use plain text outside backticks. Use `Closes #`,
  `Fixes #`, or `Resolves #` only for issues this PR fully resolves. Use
  `Related #`, `Depends on #`, or `Supersedes #` for non-closing relationships.
- **Labels:** Snapshot the current GitHub labels after labels are applied, for
  example `type: docs`, `risk: low`, `size: S`, `docs`.

## Validation Evidence (required)

Local validation is the signal CI cannot replace. Run the full battery and paste literal output (tails, failures, warnings — not "all passed").

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

Docs-only changes: replace with markdown lint + link-integrity (`scripts/ci/docs_quality_gate.sh`). Bootstrap scripts: add `bash -n install.sh`.

- **Commands run and tail output:**
- **Beyond CI — what did you manually verify?** (scenarios, edge cases, what you did NOT verify)
- **If any command was intentionally skipped, why:**

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? (`Yes/No`)
- New external network calls? (`Yes/No`)
- Secrets / tokens / credentials handling changed? (`Yes/No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`Yes/No`)
- If any `Yes`, describe the risk and mitigation:

## Compatibility (required)

- Backward compatible? (`Yes/No`)
- Config / env / CLI surface changed? (`Yes/No`)
- If `No` or `Yes` to either: exact upgrade steps for existing users:

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PRs: `git revert <sha>` is the plan unless otherwise noted.

Medium/high-risk PRs must fill:

- **Fast rollback command/path:**
- **Feature flags or config toggles:** (or `None`)
- **Observable failure symptoms:** (what to grep logs for, which metric moves, which alert fires)

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line):
- Scope materially carried forward:
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`Yes/No`)
- If `No`, why (inspiration-only, no direct code/design carry-over):

---

**Labels** live in the GitHub label UI, not in the body. Maintainers and reviewers with label permissions set `risk:*`, `size:*`, and scope labels via the sidebar. If auto-labels need correction, add `risk: manual` and the intended label. Contributors without label permission can note the mismatch in a comment.

**Do not add bot/AI attribution footers** such as `Co-authored-by: Claude ...`
or `Created with Claude Code` to the PR body or commit-message tail. Human
co-author trailers are appropriate only for incorporated contributor work under
the supersede-attribution section and privacy contract.

**Privacy contract** (`docs/book/src/contributing/privacy.md`) is a merge gate. Never commit real identities, secrets, personal emails, or PII in diff, tests, fixtures, or docs.
