### PR TITLE
fix(config): avoid char-boundary panic in attached short-option parsing

### DIFF
--- a/crates/zeroclaw-config/src/policy.rs
+++ b/crates/zeroclaw-config/src/policy.rs
@@ -1094,7 +1094,9 @@ fn attached_short_option_value(token: &str) -> Option<&str> {
     if body.starts_with('-') || body.len() < 2 {
         return None;
     }
-    let value = body[1..].trim_start_matches('=').trim();
+    let mut chars = body.chars();
+    chars.next();
+    let value = chars.as_str().trim_start_matches('=').trim();
     if value.is_empty() { None } else { Some(value) }
 }
 
@@ -5502,5 +5504,22 @@ mod tests {
         let t = PerSenderTracker::new();
         // Key "ghost" has never been recorded — should not be exhausted at max=1
         assert!(!t.is_exhausted("ghost", 1));
+    }
+
+    #[test]
+    fn attached_short_option_value_handles_multibyte_token() {
+        // A multibyte char immediately after the dash must not panic on a
+        // byte-index slice. Regression for a char-boundary abort.
+        assert_eq!(
+            attached_short_option_value("-é/etc/passwd"),
+            Some("/etc/passwd")
+        );
+        assert_eq!(attached_short_option_value("-—"), None);
+        assert_eq!(
+            attached_short_option_value("-f/etc/passwd"),
+            Some("/etc/passwd")
+        );
+        assert_eq!(attached_short_option_value("-f"), None);
+        assert_eq!(attached_short_option_value("--long"), None);
     }
 }


### PR DESCRIPTION
> **DO NOT MERGE - AUTHOR WILL MERGE WHEN READY. REVIEWS STILL REQUESTED**

## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `attached_short_option_value()` in `zeroclaw-config`'s command policy parser
    sliced the option token at byte index 1 (`body[1..]`) while only guarding on
    byte length (`body.len() < 2`). When the character immediately after the
    leading `-` is a multibyte UTF-8 codepoint, byte index 1 falls inside that
    codepoint and the slice panics with `start byte index 1 is not a char
    boundary`.
  - The release profile sets `panic = "abort"`, so that panic on a
    `tokio-rt-worker` thread took the whole daemon down with SIGABRT rather than
    failing the single task. Replaced the byte slice with a char-boundary-safe
    skip of the first character (`chars.next()` + `chars.as_str()`), preserving
    identical behavior for all ASCII tokens.
  - Added a regression test covering a multibyte token, a bare multibyte option,
    and the existing ASCII cases.
- **Scope boundary:** Only `attached_short_option_value` and its new test. No
  change to redirection parsing, path classification, or policy decisions. ASCII
  token handling is byte-for-byte identical.
- **Blast radius:** Command security policy parsing only. The fix narrows a
  panic path to a normal `Option` return; it cannot widen what tokens are
  accepted as attached values (the slice content is unchanged for valid UTF-8).
- **Linked issue(s):** Related #7123 (broader UTF-8 char-boundary sweep across
  different files; not a dependency of this PR).
- **Labels:** `bug`, `size: XS`, `risk: medium`, `config`.

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy -p zeroclaw-config --all-targets -- -D warnings
cargo test -p zeroclaw-config --lib
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` → clean, exit 0.
  - `cargo clippy -p zeroclaw-config --all-targets -- -D warnings` →
    `Finished dev profile ... ` exit 0, no warnings.
  - `cargo test -p zeroclaw-config --lib` →
    `test result: ok. 717 passed; 0 failed; 0 ignored`.
  - Targeted: `policy::tests::attached_short_option_value_handles_multibyte_token ... ok`.
- **Beyond CI — what did you manually verify?** Reproduced the original crash
  signature from a daemon coredump (`tokio-rt-worker` panic at
  `policy.rs:1097`, "start byte index 1 is not a char boundary; it is inside a
  3-byte char"). Confirmed the new test asserts `-é/etc/passwd → /etc/passwd`
  (the previously-panicking input) and `-— → None`. Did NOT run the full
  workspace `cargo test` — change is contained to one crate with no cross-crate
  surface.
- **If any command was intentionally skipped, why:** Clippy and test were
  scoped to `zeroclaw-config` rather than the full workspace. The edit is a
  single private function with no public-API or cross-crate surface change, so
  no other crate compiles differently; CI runs the full battery.

### Integration test checklist (`integration/zerocode-test`)

Validated as part of the aggregated integration branch. The items below are this PR's slice of that sign-off; `[x]` = verified (unit and/or live), `[~]` = code-verified pending live, `[ ]` = live-pending.

#### 7. Attached short-option char-boundary panic (#7154) — Tier 2

Commit `8bbc5a098`.

- [x] Attached short option with a multibyte char after the flag → no panic, parses — PASS: `attached_short_option_value_handles_multibyte_token` (`-é/etc/passwd`→`/etc/passwd`, `-—`→None). Was a char-boundary slice panic on `body[1..]`, fixed via char-iterator skip.
- [x] `-p value` and `-pvalue` still parse — PASS (same test: `-f/etc/passwd`→`/etc/passwd`, `-f`→None, `--long`→None).


## Original Crash Evidence

Captured from a local daemon coredump (paths sanitized). `coredumpctl`:

```
PID: <pid> (zeroclaw)
Signal: 6 (ABRT)
Command Line: zeroclaw daemon --ephemeral --config-dir <config-dir>
Message: Process <pid> (zeroclaw) of user <uid> dumped core.
```

Panic payload recovered from the core image:

```
thread 'tokio-rt-worker' panicked at crates/zeroclaw-config/src/policy.rs:1097:21:
start byte index 1 is not a char boundary; it is inside a 3-byte char
```

The release profile sets `panic = "abort"`, so this worker-thread panic
terminated the process with SIGABRT (signal 6) instead of unwinding a single
task.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: N/A. The fix converts a
  process-killing abort into a normal `Option` return: any command whose token
  list reaches the policy parser with a `-<multibyte>` token previously aborted
  the daemon. This is a small availability hardening; it does not change which
  commands are permitted.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: exact upgrade steps for existing users: None.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <sha>`. The change is one private
  helper plus its test, no schema/config/CLI surface, so a revert is safe and
  self-contained. Reverting restores the previous `body[1..]` slice (and its
  panic-on-multibyte behavior); only do so if the fix itself regresses ASCII
  short-option parsing.
- **Feature flags or config toggles:** None. The parser helper is always on the
  command-policy path and is not gated.
- **Observable failure symptoms:** A regression reappears as a daemon SIGABRT
  (signal 6) from a `tokio-rt-worker` thread; grep logs / coredumps for
  `start byte index 1 is not a char boundary` at `crates/zeroclaw-config/src/policy.rs`.
  The daemon process exits rather than failing a single task (release profile is
  `panic = "abort"`), so the operator-visible signal is the whole daemon
  restarting/cycling, not a logged task error.
