### PR TITLE
fix(config): resilient daemon config load with security-critical gating

### DIFF
--- a/crates/zeroclaw-config/src/migration.rs
+++ b/crates/zeroclaw-config/src/migration.rs
@@ -269,14 +269,9 @@ fn encrypt_in_place(value: &mut toml::Value, store: &crate::secrets::SecretStore
     Ok(())
 }
 
-/// High-level: arbitrary versioned TOML → fully validated V3 `Config`.
-/// Runs migration if needed, then deserializes into the current `Config` type.
-///
-/// **Strict.** Any deserialization defect is returned as an error. This is the
-/// contract repair tooling depends on (`zeroclaw config migrate`,
-/// `model_routing_config`): they need to know precisely what is wrong. The
-/// daemon load path uses [`migrate_to_current_resilient`] instead, which never
-/// fails so the operator can always reach a repair surface.
+/// Versioned TOML → validated V3 `Config`, strict: any defect errors.
+/// Used by repair tooling (`zeroclaw config migrate`, `model_routing_config`)
+/// that needs the precise failure. Daemon load uses the resilient path.
 pub fn migrate_to_current(input: &str) -> Result<Config> {
     let final_value = migrate_value(input)?;
     final_value
@@ -284,60 +279,35 @@ pub fn migrate_to_current(input: &str) -> Result<Config> {
         .context("migrated config failed to deserialize as current schema")
 }
 
-/// Daemon load path: arbitrary versioned TOML → a usable `Config`, **always**.
-///
-/// The daemon must start no matter what so the config can be repaired through
-/// the gateway, CLI, or dashboard. This function therefore degrades instead of
-/// failing; see [`migrate_to_current_salvaged`] for the salvage contract and
-/// the security-section caveat. This thin wrapper discards the salvage report
-/// for callers that only need the `Config`.
+/// Daemon load path: versioned TOML → usable `Config`, never failing.
+/// Thin wrapper over [`migrate_to_current_salvaged`] that drops the report.
 pub fn migrate_to_current_resilient(input: &str) -> Config {
     migrate_to_current_salvaged(input).config
 }
 
-/// Top-level config keys whose silent loss could *weaken* the running
-/// security posture. "Secure by default" cuts both ways: if one of these
-/// sections is malformed, reverting it to its serde `Default` may grant a
-/// broader posture than the operator intended (e.g. a dropped `[security]`
-/// table loses hardening; a dropped `risk_profiles`/`peer_groups` loses
-/// authorization scoping). Salvage still drops them so the daemon can boot —
-/// but it logs at ERROR (not WARN) and reports them in
-/// [`ResilientLoad::dropped_security`] so the caller can refuse network
-/// exposure until the operator repairs the file.
+/// Top-level keys whose silent loss could *weaken* security posture: dropping
+/// a malformed one to its `Default` may grant a broader posture than intended.
+/// Salvage still drops them (so the daemon boots) but logs ERROR and reports
+/// them in [`ResilientLoad::dropped_security`] for exposure gating.
 pub const SECURITY_CRITICAL_KEYS: &[&str] = &["security", "risk_profiles", "peer_groups"];
 
 /// Result of a resilient (never-failing) config load.
 #[derive(Debug, Clone, Default)]
 pub struct ResilientLoad {
-    /// The loaded config — always present, carrying every section that
-    /// parsed and `Default` for every section that had to be dropped.
+    /// Loaded config: every section that parsed, `Default` for any dropped.
     pub config: Config,
-    /// Dotted paths of non-security sections/aliases dropped during salvage
-    /// (logged at WARN). Empty on a clean load.
+    /// Non-security paths dropped during salvage (logged WARN).
     pub dropped: Vec<String>,
-    /// Top-level [`SECURITY_CRITICAL_KEYS`] sections that had to be dropped
-    /// to their `Default` (logged at ERROR). Non-empty means the running
-    /// posture may be weaker than intended; the caller should refuse
-    /// exposure until repaired.
+    /// [`SECURITY_CRITICAL_KEYS`] sections dropped to `Default` (logged ERROR).
+    /// Non-empty means the running posture may be weaker than intended.
     pub dropped_security: Vec<String>,
 }
 
-/// Daemon load path with a full salvage report. Degrades instead of failing:
-///
-/// 1. Strict deserialize (identical to [`migrate_to_current`]) — the common
-///    case, zero behavior change for valid configs.
-/// 2. If that fails, drop each invalid `[channels.<type>.<alias>]`, each
-///    invalid `[channels.<type>]` whole-type block (e.g. a scalar where a
-///    table is required), and each invalid top-level section — substituting
-///    the section's `Default`. Non-security drops log at WARN; security-
-///    critical drops ([`SECURITY_CRITICAL_KEYS`]) log at ERROR and surface in
-///    [`ResilientLoad::dropped_security`].
-/// 3. If even the migration/parse stage fails (not valid TOML, or an
-///    unsupported future schema), fall back to `Config::default()` so the
-///    process still boots. The original error is logged at ERROR.
-///
-/// `Config::validate()` is intentionally NOT run here — a config that fails
-/// validation must still load so it can be fixed.
+/// Daemon load path with a salvage report. Degrades instead of failing:
+/// strict deserialize first; else drop each invalid channel alias, channel
+/// type, and top-level section (substituting `Default`); else fall back to
+/// `Config::default()`. Security-critical drops log ERROR and surface in
+/// `dropped_security`. `Config::validate()` is intentionally not run.
 pub fn migrate_to_current_salvaged(input: &str) -> ResilientLoad {
     let value = match migrate_value(input) {
         Ok(value) => value,
@@ -361,8 +331,7 @@ pub fn migrate_to_current_salvaged(input: &str) -> ResilientLoad {
 }
 
 /// Parse + migrate to the current schema version as a `toml::Value`, without
-/// the final typed deserialize. Shared by the strict and resilient entry
-/// points so the version-detection and chain logic lives in one place.
+/// the final typed deserialize. Shared by the strict and resilient entries.
 fn migrate_value(input: &str) -> Result<toml::Value> {
     let value: toml::Value = toml::from_str(input).context("failed to parse config TOML")?;
     let from = detect_version(&value)?;
@@ -388,12 +357,8 @@ fn migrate_value(input: &str) -> Result<toml::Value> {
 }
 
 /// Deserialize a migrated `toml::Value` into `Config`, never failing.
-///
-/// Strict first; on failure, salvage broken `[channels.<type>.<alias>]`
-/// entries and broken `[channels.<type>]` whole-type blocks, then drop any
-/// remaining top-level section that blocks the load (substituting its
-/// `Default`). The returned `Config` always carries every section that
-/// parsed, so the operator only loses the specific broken blocks.
+/// Strict first; on failure prune broken channel aliases, channel types, then
+/// top-level sections (each → `Default`), so only the broken blocks are lost.
 fn deserialize_resilient(value: toml::Value) -> ResilientLoad {
     if let Ok(config) = value.clone().try_into::<Config>() {
         return ResilientLoad {
@@ -466,20 +431,10 @@ fn deserialize_resilient(value: toml::Value) -> ResilientLoad {
     }
 }
 
-/// Drop any top-level `[section]` that blocks the config from deserializing,
-/// substituting the section's `Default` via serde. A section is dropped when it
-/// is the offender; valid sections are never touched. Two complementary probes
-/// catch every reachable case:
-///
-/// 1. **Joint:** if removing a single key makes the whole config valid, that
-///    key was the sole offender — drop it and finish.
-/// 2. **Isolated:** otherwise drop every key that fails to deserialize *in
-///    isolation* (its own section, wrapped alone, will not parse). This catches
-///    multiple independent offenders in one pass — e.g. two unrelated malformed
-///    sections — which the joint probe alone cannot, since neither one's
-///    removal validates the config while the other remains broken.
-///
-/// Removed paths are appended to `dropped`.
+/// Drop top-level `[section]`s that block deserialization (each → `Default`).
+/// Two probes: drop a single key if its removal validates the whole config;
+/// else drop every key that fails to deserialize in isolation (catches
+/// multiple independent offenders the joint probe can't). Appends to `dropped`.
 fn prune_bad_top_level_sections(value: &mut toml::Value, dropped: &mut Vec<String>) {
     if value.as_table().is_none() {
         return;
@@ -521,21 +476,15 @@ fn prune_bad_top_level_sections(value: &mut toml::Value, dropped: &mut Vec<Strin
     }
 }
 
-/// True when a single top-level `[section]` cannot deserialize into `Config`
-/// when it is the only key present. Wraps `{ <key> = <section> }` and runs it
-/// through the strict deserializer, isolating the failure to this one section
-/// so independent offenders are each judged on their own.
+/// True when top-level `[<key>]`, wrapped alone, fails to deserialize.
 fn top_level_section_is_invalid(key: &str, section: &toml::Value) -> bool {
     let mut root = toml::value::Table::new();
     root.insert(key.to_string(), section.clone());
     toml::Value::Table(root).try_into::<Config>().is_err()
 }
 
-/// Drop every `[channels.<type>.<alias>]` entry that cannot deserialize into
-/// its concrete channel config type. Each alias is checked in isolation via
-/// [`channel_alias_is_invalid`]; valid aliases sharing a `[channels]` section
-/// with a broken sibling are preserved. Dropped paths
-/// (`channels.<type>.<alias>`) are appended to `dropped`.
+/// Drop each `[channels.<type>.<alias>]` that fails to deserialize, checked in
+/// isolation so valid siblings survive. Appends `channels.<type>.<alias>`.
 fn prune_bad_channel_aliases(value: &mut toml::Value, dropped: &mut Vec<String>) {
     let Some(channels) = value
         .as_table_mut()
@@ -561,12 +510,9 @@ fn prune_bad_channel_aliases(value: &mut toml::Value, dropped: &mut Vec<String>)
     }
 }
 
-/// Drop every `[channels.<type>]` whole-type block that still blocks the load
-/// after alias-level pruning — e.g. a scalar written where an alias table is
-/// required (`email = "oops"`), or a type whose remaining shape is invalid.
-/// Critically this drops ONLY the offending channel type, never the entire
-/// `[channels]` section, so valid sibling channel types survive. Dropped paths
-/// (`channels.<type>`) are appended to `dropped`.
+/// Drop each `[channels.<type>]` block still blocking the load after alias
+/// pruning (e.g. a scalar where a table is required). Drops only the offending
+/// type, never the whole `[channels]` section. Appends `channels.<type>`.
 fn prune_bad_channel_types(value: &mut toml::Value, dropped: &mut Vec<String>) {
     let Some(channel_types) = value
         .as_table()
@@ -602,8 +548,7 @@ fn prune_bad_channel_types(value: &mut toml::Value, dropped: &mut Vec<String>) {
     }
 }
 
-/// True when the `[channels]` section of `value` deserializes cleanly,
-/// isolating channel-section validity from defects elsewhere in the config.
+/// True when `value`'s `[channels]` section deserializes cleanly in isolation.
 fn channels_section_is_valid(value: &toml::Value) -> bool {
     let Some(channels) = value
         .as_table()
@@ -617,11 +562,7 @@ fn channels_section_is_valid(value: &toml::Value) -> bool {
     toml::Value::Table(root).try_into::<Config>().is_ok()
 }
 
-/// True when a single `[channels.<type>.<alias>]` table cannot deserialize
-/// into its concrete channel config type. Wraps the alias under a minimal
-/// `{ channels = { <type> = { probe = <alias> } } }` document and runs it
-/// through the strict `Config` deserializer, isolating the failure to this
-/// one alias.
+/// True when `[channels.<type>.<alias>]`, wrapped alone, fails to deserialize.
 fn channel_alias_is_invalid(chan_type: &str, alias_value: &toml::Value) -> bool {
     let mut inner = toml::value::Table::new();
     inner.insert("probe".to_string(), alias_value.clone());

--- a/crates/zeroclaw-config/src/migration.rs
+++ b/crates/zeroclaw-config/src/migration.rs
@@ -419,7 +419,9 @@ fn deserialize_resilient(value: toml::Value) -> ResilientLoad {
             &format!(
                 "SECURITY-CRITICAL config section `{path}` is invalid and was reset to \
                  its default so the daemon can boot; the running posture may be WEAKER \
-                 than intended — repair `{path}` and reload before trusting this instance"
+                 than intended — repair `{path}` and reload before trusting this instance. \
+                 Run `zeroclaw config migrate` to see the precise parse error, or fix it \
+                 via the gateway config editor at `/api/config`"
             )
         );
     }
@@ -446,6 +448,8 @@ fn prune_bad_top_level_sections(value: &mut toml::Value, dropped: &mut Vec<Strin
     let keys: Vec<String> = value
         .as_table()
         .expect("root is a table")
+        // toml::Value tables preserve insertion order, so drops are reported
+        // in TOML declaration order — predictable for operators reading logs.
         .keys()
         .cloned()
         .collect();
@@ -1157,6 +1161,34 @@ enabled = "also-not-a-bool"
             load.dropped.iter().any(|p| p == "backup"),
             "second offender must be dropped, got {:?}",
             load.dropped
+        );
+    }
+
+    #[test]
+    fn multiple_bad_sections_one_security_critical() {
+        let raw = r#"
+schema_version = 3
+
+[security]
+audit = "should-be-a-table-not-a-string"
+
+[heartbeat]
+enabled = "not-a-bool"
+"#;
+        let load = migrate_to_current_salvaged(raw);
+        assert!(
+            load.dropped_security.iter().any(|p| p == "security"),
+            "malformed [security] must be classified security-critical, got {:?}",
+            load.dropped_security
+        );
+        assert!(
+            load.dropped.iter().any(|p| p == "heartbeat"),
+            "malformed [heartbeat] must be a plain drop, got {:?}",
+            load.dropped
+        );
+        assert!(
+            !load.dropped.iter().any(|p| p == "security"),
+            "security drop must not also appear in the plain dropped list"
         );
     }
 

--- a/crates/zeroclaw-config/src/migration.rs
+++ b/crates/zeroclaw-config/src/migration.rs
@@ -288,20 +288,57 @@ pub fn migrate_to_current(input: &str) -> Result<Config> {
 ///
 /// The daemon must start no matter what so the config can be repaired through
 /// the gateway, CLI, or dashboard. This function therefore degrades instead of
-/// failing:
+/// failing; see [`migrate_to_current_salvaged`] for the salvage contract and
+/// the security-section caveat. This thin wrapper discards the salvage report
+/// for callers that only need the `Config`.
+pub fn migrate_to_current_resilient(input: &str) -> Config {
+    migrate_to_current_salvaged(input).config
+}
+
+/// Top-level config keys whose silent loss could *weaken* the running
+/// security posture. "Secure by default" cuts both ways: if one of these
+/// sections is malformed, reverting it to its serde `Default` may grant a
+/// broader posture than the operator intended (e.g. a dropped `[security]`
+/// table loses hardening; a dropped `risk_profiles`/`peer_groups` loses
+/// authorization scoping). Salvage still drops them so the daemon can boot —
+/// but it logs at ERROR (not WARN) and reports them in
+/// [`ResilientLoad::dropped_security`] so the caller can refuse network
+/// exposure until the operator repairs the file.
+pub const SECURITY_CRITICAL_KEYS: &[&str] = &["security", "risk_profiles", "peer_groups"];
+
+/// Result of a resilient (never-failing) config load.
+#[derive(Debug, Clone, Default)]
+pub struct ResilientLoad {
+    /// The loaded config — always present, carrying every section that
+    /// parsed and `Default` for every section that had to be dropped.
+    pub config: Config,
+    /// Dotted paths of non-security sections/aliases dropped during salvage
+    /// (logged at WARN). Empty on a clean load.
+    pub dropped: Vec<String>,
+    /// Top-level [`SECURITY_CRITICAL_KEYS`] sections that had to be dropped
+    /// to their `Default` (logged at ERROR). Non-empty means the running
+    /// posture may be weaker than intended; the caller should refuse
+    /// exposure until repaired.
+    pub dropped_security: Vec<String>,
+}
+
+/// Daemon load path with a full salvage report. Degrades instead of failing:
 ///
 /// 1. Strict deserialize (identical to [`migrate_to_current`]) — the common
 ///    case, zero behavior change for valid configs.
-/// 2. If that fails, drop each invalid `[channels.<type>.<alias>]` and each
-///    invalid top-level section, substituting the section's `Default`. Every
-///    drop is logged at WARN with the offending path.
+/// 2. If that fails, drop each invalid `[channels.<type>.<alias>]`, each
+///    invalid `[channels.<type>]` whole-type block (e.g. a scalar where a
+///    table is required), and each invalid top-level section — substituting
+///    the section's `Default`. Non-security drops log at WARN; security-
+///    critical drops ([`SECURITY_CRITICAL_KEYS`]) log at ERROR and surface in
+///    [`ResilientLoad::dropped_security`].
 /// 3. If even the migration/parse stage fails (not valid TOML, or an
 ///    unsupported future schema), fall back to `Config::default()` so the
 ///    process still boots. The original error is logged at ERROR.
 ///
 /// `Config::validate()` is intentionally NOT run here — a config that fails
 /// validation must still load so it can be fixed.
-pub fn migrate_to_current_resilient(input: &str) -> Config {
+pub fn migrate_to_current_salvaged(input: &str) -> ResilientLoad {
     let value = match migrate_value(input) {
         Ok(value) => value,
         Err(err) => {
@@ -313,7 +350,11 @@ pub fn migrate_to_current_resilient(input: &str) -> Config {
                 "config could not be parsed or migrated; starting on defaults so it \
                  can be repaired (gateway /api/config, `zeroclaw config migrate`)"
             );
-            return Config::default();
+            return ResilientLoad {
+                config: Config::default(),
+                dropped: Vec::new(),
+                dropped_security: Vec::new(),
+            };
         }
     };
     deserialize_resilient(value)
@@ -349,18 +390,23 @@ fn migrate_value(input: &str) -> Result<toml::Value> {
 /// Deserialize a migrated `toml::Value` into `Config`, never failing.
 ///
 /// Strict first; on failure, salvage broken `[channels.<type>.<alias>]`
-/// entries, then drop any remaining top-level section that blocks the load
-/// (substituting its `Default`). Every drop is logged at WARN. The returned
-/// `Config` always carries every section that parsed, so the operator only
-/// loses the specific broken blocks — which the repair surfaces can then fix.
-fn deserialize_resilient(value: toml::Value) -> Config {
+/// entries and broken `[channels.<type>]` whole-type blocks, then drop any
+/// remaining top-level section that blocks the load (substituting its
+/// `Default`). The returned `Config` always carries every section that
+/// parsed, so the operator only loses the specific broken blocks.
+fn deserialize_resilient(value: toml::Value) -> ResilientLoad {
     if let Ok(config) = value.clone().try_into::<Config>() {
-        return config;
+        return ResilientLoad {
+            config,
+            dropped: Vec::new(),
+            dropped_security: Vec::new(),
+        };
     }
 
     let mut salvaged = value;
     let mut dropped: Vec<String> = Vec::new();
     prune_bad_channel_aliases(&mut salvaged, &mut dropped);
+    prune_bad_channel_types(&mut salvaged, &mut dropped);
     prune_bad_top_level_sections(&mut salvaged, &mut dropped);
 
     let config = salvaged.try_into::<Config>().unwrap_or_else(|err| {
@@ -377,7 +423,17 @@ fn deserialize_resilient(value: toml::Value) -> Config {
         Config::default()
     });
 
-    for path in &dropped {
+    let mut dropped_security: Vec<String> = Vec::new();
+    let mut dropped_plain: Vec<String> = Vec::new();
+    for path in dropped {
+        if SECURITY_CRITICAL_KEYS.contains(&path.as_str()) {
+            dropped_security.push(path);
+        } else {
+            dropped_plain.push(path);
+        }
+    }
+
+    for path in &dropped_plain {
         ::zeroclaw_log::record!(
             WARN,
             ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
@@ -389,47 +445,96 @@ fn deserialize_resilient(value: toml::Value) -> Config {
             )
         );
     }
+    for path in &dropped_security {
+        ::zeroclaw_log::record!(
+            ERROR,
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+                .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                .with_attrs(::serde_json::json!({ "dropped_security_config": path })),
+            &format!(
+                "SECURITY-CRITICAL config section `{path}` is invalid and was reset to \
+                 its default so the daemon can boot; the running posture may be WEAKER \
+                 than intended — repair `{path}` and reload before trusting this instance"
+            )
+        );
+    }
 
-    config
+    ResilientLoad {
+        config,
+        dropped: dropped_plain,
+        dropped_security,
+    }
 }
 
-/// Drop any top-level `[section]` whose removal is required for the config to
-/// deserialize, substituting the section's `Default` via serde. Each candidate
-/// is tested by removing it from a clone and re-deserializing; a section is
-/// dropped only when its removal is what fixes the load, so valid sections are
-/// never touched. Removed paths are appended to `dropped`.
+/// Drop any top-level `[section]` that blocks the config from deserializing,
+/// substituting the section's `Default` via serde. A section is dropped when it
+/// is the offender; valid sections are never touched. Two complementary probes
+/// catch every reachable case:
+///
+/// 1. **Joint:** if removing a single key makes the whole config valid, that
+///    key was the sole offender — drop it and finish.
+/// 2. **Isolated:** otherwise drop every key that fails to deserialize *in
+///    isolation* (its own section, wrapped alone, will not parse). This catches
+///    multiple independent offenders in one pass — e.g. two unrelated malformed
+///    sections — which the joint probe alone cannot, since neither one's
+///    removal validates the config while the other remains broken.
+///
+/// Removed paths are appended to `dropped`.
 fn prune_bad_top_level_sections(value: &mut toml::Value, dropped: &mut Vec<String>) {
-    let Some(root) = value.as_table_mut() else {
+    if value.as_table().is_none() {
         return;
-    };
-    let keys: Vec<String> = root.keys().cloned().collect();
-    for key in keys {
-        if value.clone().try_into::<Config>().is_ok() {
-            break;
-        }
+    }
+    if value.clone().try_into::<Config>().is_ok() {
+        return;
+    }
+
+    let keys: Vec<String> = value
+        .as_table()
+        .expect("root is a table")
+        .keys()
+        .cloned()
+        .collect();
+    for key in &keys {
         let root = value.as_table_mut().expect("root is a table");
-        let Some(removed) = root.remove(&key) else {
+        let Some(removed) = root.remove(key) else {
             continue;
         };
         if value.clone().try_into::<Config>().is_ok() {
-            // Removing this key fixed (or advanced) the load — it was the
-            // offender. Leave it dropped; serde fills the section default.
+            dropped.push(key.clone());
+            return;
+        }
+        value
+            .as_table_mut()
+            .expect("root is a table")
+            .insert(key.clone(), removed);
+    }
+
+    for key in keys {
+        let still_present = value.as_table().and_then(|root| root.get(&key)).cloned();
+        let Some(section) = still_present else {
+            continue;
+        };
+        if top_level_section_is_invalid(&key, &section) {
+            value.as_table_mut().expect("root is a table").remove(&key);
             dropped.push(key);
-        } else {
-            // Removing it did not help; restore and keep probing. The real
-            // offender is a different key (handled on a later iteration).
-            value
-                .as_table_mut()
-                .expect("root is a table")
-                .insert(key, removed);
         }
     }
 }
 
-/// Remove every `[channels.<type>.<alias>]` entry that cannot deserialize
-/// into its concrete channel config type. Each alias is checked in isolation
-/// via [`channel_alias_is_invalid`]; valid aliases sharing a `[channels]`
-/// section with a broken sibling are preserved. Dropped paths
+/// True when a single top-level `[section]` cannot deserialize into `Config`
+/// when it is the only key present. Wraps `{ <key> = <section> }` and runs it
+/// through the strict deserializer, isolating the failure to this one section
+/// so independent offenders are each judged on their own.
+fn top_level_section_is_invalid(key: &str, section: &toml::Value) -> bool {
+    let mut root = toml::value::Table::new();
+    root.insert(key.to_string(), section.clone());
+    toml::Value::Table(root).try_into::<Config>().is_err()
+}
+
+/// Drop every `[channels.<type>.<alias>]` entry that cannot deserialize into
+/// its concrete channel config type. Each alias is checked in isolation via
+/// [`channel_alias_is_invalid`]; valid aliases sharing a `[channels]` section
+/// with a broken sibling are preserved. Dropped paths
 /// (`channels.<type>.<alias>`) are appended to `dropped`.
 fn prune_bad_channel_aliases(value: &mut toml::Value, dropped: &mut Vec<String>) {
     let Some(channels) = value
@@ -454,6 +559,62 @@ fn prune_bad_channel_aliases(value: &mut toml::Value, dropped: &mut Vec<String>)
             dropped.push(format!("channels.{chan_type}.{alias}"));
         }
     }
+}
+
+/// Drop every `[channels.<type>]` whole-type block that still blocks the load
+/// after alias-level pruning — e.g. a scalar written where an alias table is
+/// required (`email = "oops"`), or a type whose remaining shape is invalid.
+/// Critically this drops ONLY the offending channel type, never the entire
+/// `[channels]` section, so valid sibling channel types survive. Dropped paths
+/// (`channels.<type>`) are appended to `dropped`.
+fn prune_bad_channel_types(value: &mut toml::Value, dropped: &mut Vec<String>) {
+    let Some(channel_types) = value
+        .as_table()
+        .and_then(|root| root.get("channels"))
+        .and_then(toml::Value::as_table)
+        .map(|chans| chans.keys().cloned().collect::<Vec<_>>())
+    else {
+        return;
+    };
+
+    for chan_type in channel_types {
+        if channels_section_is_valid(value) {
+            return;
+        }
+        let Some(removed) = value
+            .as_table_mut()
+            .and_then(|root| root.get_mut("channels"))
+            .and_then(toml::Value::as_table_mut)
+            .and_then(|chans| chans.remove(&chan_type))
+        else {
+            continue;
+        };
+        if channels_section_is_valid(value) {
+            dropped.push(format!("channels.{chan_type}"));
+        } else {
+            value
+                .as_table_mut()
+                .and_then(|root| root.get_mut("channels"))
+                .and_then(toml::Value::as_table_mut)
+                .expect("channels is a table")
+                .insert(chan_type, removed);
+        }
+    }
+}
+
+/// True when the `[channels]` section of `value` deserializes cleanly,
+/// isolating channel-section validity from defects elsewhere in the config.
+fn channels_section_is_valid(value: &toml::Value) -> bool {
+    let Some(channels) = value
+        .as_table()
+        .and_then(|root| root.get("channels"))
+        .cloned()
+    else {
+        return true;
+    };
+    let mut root = toml::value::Table::new();
+    root.insert("channels".to_string(), channels);
+    toml::Value::Table(root).try_into::<Config>().is_ok()
 }
 
 /// True when a single `[channels.<type>.<alias>]` table cannot deserialize
@@ -969,6 +1130,92 @@ from_address = "a@example.com"
         assert!(
             migrate_to_current(raw).is_err(),
             "strict path must surface the defect for repair tooling"
+        );
+    }
+
+    #[test]
+    fn broken_security_section_is_reported_as_degraded() {
+        let raw = r#"
+schema_version = 3
+
+[security]
+audit = "should-be-a-table-not-a-string"
+"#;
+        let load = migrate_to_current_salvaged(raw);
+        assert!(
+            load.dropped_security.iter().any(|p| p == "security"),
+            "malformed [security] must be reported as a security-critical drop"
+        );
+        assert!(
+            load.dropped.is_empty(),
+            "security drop must not also appear in the plain dropped list"
+        );
+    }
+
+    #[test]
+    fn broken_non_security_section_is_plain_drop_not_security() {
+        let raw = r#"
+schema_version = 3
+
+[heartbeat]
+enabled = "not-a-bool"
+"#;
+        let load = migrate_to_current_salvaged(raw);
+        assert!(
+            load.dropped.iter().any(|p| p == "heartbeat"),
+            "malformed [heartbeat] must be a plain drop"
+        );
+        assert!(
+            load.dropped_security.is_empty(),
+            "a non-security section must never be flagged security-critical"
+        );
+    }
+
+    #[test]
+    fn broken_channel_type_block_is_dropped_not_fatal() {
+        let raw = r#"
+schema_version = 3
+
+[channels]
+email = "oops-this-should-be-a-table"
+
+[channels.telegram.main]
+enabled = true
+bot_token = "t"
+"#;
+        let load = migrate_to_current_salvaged(raw);
+        assert!(
+            load.dropped.iter().any(|p| p == "channels.email"),
+            "the broken whole-type block must be dropped, got {:?}",
+            load.dropped
+        );
+        assert!(
+            load.config.channels.telegram.contains_key("main"),
+            "valid sibling channel type must survive a broken-type drop"
+        );
+    }
+
+    #[test]
+    fn multiple_independent_bad_sections_all_dropped() {
+        let raw = r#"
+schema_version = 3
+
+[heartbeat]
+enabled = "not-a-bool"
+
+[backup]
+enabled = "also-not-a-bool"
+"#;
+        let load = migrate_to_current_salvaged(raw);
+        assert!(
+            load.dropped.iter().any(|p| p == "heartbeat"),
+            "first offender must be dropped, got {:?}",
+            load.dropped
+        );
+        assert!(
+            load.dropped.iter().any(|p| p == "backup"),
+            "second offender must be dropped, got {:?}",
+            load.dropped
         );
     }
 

--- a/crates/zeroclaw-config/src/migration.rs
+++ b/crates/zeroclaw-config/src/migration.rs
@@ -291,6 +291,14 @@ pub fn migrate_to_current_resilient(input: &str) -> Config {
 /// them in [`ResilientLoad::dropped_security`] for exposure gating.
 pub const SECURITY_CRITICAL_KEYS: &[&str] = &["security", "risk_profiles", "peer_groups"];
 
+/// Sentinel `dropped_security` entry used when the *whole* config is replaced
+/// by `Config::default()` (unparseable TOML, unsupported future schema, broken
+/// migration chain, or a root that cannot be salvaged section-by-section). In
+/// that case every security-critical section is lost at once, so the posture is
+/// degraded and the serving gate must refuse to start without an explicit
+/// operator override — exactly as it does for a single dropped section.
+pub const WHOLE_CONFIG_SENTINEL: &str = "<entire-config>";
+
 /// Result of a resilient (never-failing) config load.
 #[derive(Debug, Clone, Default)]
 pub struct ResilientLoad {
@@ -323,7 +331,10 @@ pub fn migrate_to_current_salvaged(input: &str) -> ResilientLoad {
             return ResilientLoad {
                 config: Config::default(),
                 dropped: Vec::new(),
-                dropped_security: Vec::new(),
+                // Whole-config loss degrades the security posture: every
+                // security-critical section is gone, so mark it so the serving
+                // gate refuses to start without an explicit override.
+                dropped_security: vec![WHOLE_CONFIG_SENTINEL.to_string()],
             };
         }
     };
@@ -374,9 +385,11 @@ fn deserialize_resilient(value: toml::Value) -> ResilientLoad {
     prune_bad_channel_types(&mut salvaged, &mut dropped);
     prune_bad_top_level_sections(&mut salvaged, &mut dropped);
 
+    let mut whole_config_lost = false;
     let config = salvaged.try_into::<Config>().unwrap_or_else(|err| {
         // Nothing in the root table is individually salvageable (e.g. a
         // non-table root). Boot on defaults so repair surfaces are reachable.
+        whole_config_lost = true;
         ::zeroclaw_log::record!(
             ERROR,
             ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
@@ -390,6 +403,11 @@ fn deserialize_resilient(value: toml::Value) -> ResilientLoad {
 
     let mut dropped_security: Vec<String> = Vec::new();
     let mut dropped_plain: Vec<String> = Vec::new();
+    // A whole-config default loses every security-critical section at once, so
+    // mark it degraded even though no individual section was named in `dropped`.
+    if whole_config_lost {
+        dropped_security.push(WHOLE_CONFIG_SENTINEL.to_string());
+    }
     for path in dropped {
         if SECURITY_CRITICAL_KEYS.contains(&path.as_str()) {
             dropped_security.push(path);
@@ -1057,6 +1075,47 @@ enabled = "not-a-bool"
         let raw = format!("schema_version = {}\n", CURRENT_SCHEMA_VERSION + 100);
         let cfg = migrate_to_current_resilient(&raw);
         assert_eq!(cfg.schema_version, Config::default().schema_version);
+    }
+
+    #[test]
+    fn unparseable_config_marks_whole_config_degraded() {
+        // Whole-config loss loses every security-critical section at once, so it
+        // must mark the posture degraded — otherwise the serving gate has no
+        // signal and boots a defaulted security posture silently.
+        let load = migrate_to_current_salvaged("this is not valid TOML {{{");
+        assert!(
+            load.dropped_security
+                .iter()
+                .any(|p| p == WHOLE_CONFIG_SENTINEL),
+            "unparseable config must degrade security posture, got {:?}",
+            load.dropped_security
+        );
+    }
+
+    #[test]
+    fn future_schema_version_marks_whole_config_degraded() {
+        let raw = format!("schema_version = {}\n", CURRENT_SCHEMA_VERSION + 100);
+        let load = migrate_to_current_salvaged(&raw);
+        assert!(
+            load.dropped_security
+                .iter()
+                .any(|p| p == WHOLE_CONFIG_SENTINEL),
+            "unsupported future schema must degrade security posture, got {:?}",
+            load.dropped_security
+        );
+    }
+
+    #[test]
+    fn unsalvageable_root_marks_whole_config_degraded() {
+        // A root that is not a table cannot be salvaged section-by-section; the
+        // final deserialize fallback defaults the whole config and must mark it.
+        let raw = "schema_version = 3\nthis_is_a_bare_top_level = \"value\"\n[\n";
+        let load = migrate_to_current_salvaged(raw);
+        assert!(
+            !load.dropped_security.is_empty(),
+            "an unsalvageable root must degrade security posture, got {:?}",
+            load.dropped_security
+        );
     }
 
     #[test]

--- a/crates/zeroclaw-config/src/migration.rs
+++ b/crates/zeroclaw-config/src/migration.rs
@@ -271,11 +271,62 @@ fn encrypt_in_place(value: &mut toml::Value, store: &crate::secrets::SecretStore
 
 /// High-level: arbitrary versioned TOML → fully validated V3 `Config`.
 /// Runs migration if needed, then deserializes into the current `Config` type.
+///
+/// **Strict.** Any deserialization defect is returned as an error. This is the
+/// contract repair tooling depends on (`zeroclaw config migrate`,
+/// `model_routing_config`): they need to know precisely what is wrong. The
+/// daemon load path uses [`migrate_to_current_resilient`] instead, which never
+/// fails so the operator can always reach a repair surface.
 pub fn migrate_to_current(input: &str) -> Result<Config> {
+    let final_value = migrate_value(input)?;
+    final_value
+        .try_into()
+        .context("migrated config failed to deserialize as current schema")
+}
+
+/// Daemon load path: arbitrary versioned TOML → a usable `Config`, **always**.
+///
+/// The daemon must start no matter what so the config can be repaired through
+/// the gateway, CLI, or dashboard. This function therefore degrades instead of
+/// failing:
+///
+/// 1. Strict deserialize (identical to [`migrate_to_current`]) — the common
+///    case, zero behavior change for valid configs.
+/// 2. If that fails, drop each invalid `[channels.<type>.<alias>]` and each
+///    invalid top-level section, substituting the section's `Default`. Every
+///    drop is logged at WARN with the offending path.
+/// 3. If even the migration/parse stage fails (not valid TOML, or an
+///    unsupported future schema), fall back to `Config::default()` so the
+///    process still boots. The original error is logged at ERROR.
+///
+/// `Config::validate()` is intentionally NOT run here — a config that fails
+/// validation must still load so it can be fixed.
+pub fn migrate_to_current_resilient(input: &str) -> Config {
+    let value = match migrate_value(input) {
+        Ok(value) => value,
+        Err(err) => {
+            ::zeroclaw_log::record!(
+                ERROR,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                    .with_attrs(::serde_json::json!({ "error": format!("{err:#}") })),
+                "config could not be parsed or migrated; starting on defaults so it \
+                 can be repaired (gateway /api/config, `zeroclaw config migrate`)"
+            );
+            return Config::default();
+        }
+    };
+    deserialize_resilient(value)
+}
+
+/// Parse + migrate to the current schema version as a `toml::Value`, without
+/// the final typed deserialize. Shared by the strict and resilient entry
+/// points so the version-detection and chain logic lives in one place.
+fn migrate_value(input: &str) -> Result<toml::Value> {
     let value: toml::Value = toml::from_str(input).context("failed to parse config TOML")?;
     let from = detect_version(&value)?;
-    let final_value = if from == CURRENT_SCHEMA_VERSION {
-        value
+    if from == CURRENT_SCHEMA_VERSION {
+        Ok(value)
     } else if from > CURRENT_SCHEMA_VERSION {
         ::zeroclaw_log::record!(
             ERROR,
@@ -289,13 +340,135 @@ pub fn migrate_to_current(input: &str) -> Result<Config> {
         );
         anyhow::bail!(
             "config schema_version {from} is newer than this binary supports ({CURRENT_SCHEMA_VERSION})"
-        );
+        )
     } else {
-        run_chain(value, from)?
+        run_chain(value, from)
+    }
+}
+
+/// Deserialize a migrated `toml::Value` into `Config`, never failing.
+///
+/// Strict first; on failure, salvage broken `[channels.<type>.<alias>]`
+/// entries, then drop any remaining top-level section that blocks the load
+/// (substituting its `Default`). Every drop is logged at WARN. The returned
+/// `Config` always carries every section that parsed, so the operator only
+/// loses the specific broken blocks — which the repair surfaces can then fix.
+fn deserialize_resilient(value: toml::Value) -> Config {
+    if let Ok(config) = value.clone().try_into::<Config>() {
+        return config;
+    }
+
+    let mut salvaged = value;
+    let mut dropped: Vec<String> = Vec::new();
+    prune_bad_channel_aliases(&mut salvaged, &mut dropped);
+    prune_bad_top_level_sections(&mut salvaged, &mut dropped);
+
+    let config = salvaged.try_into::<Config>().unwrap_or_else(|err| {
+        // Nothing in the root table is individually salvageable (e.g. a
+        // non-table root). Boot on defaults so repair surfaces are reachable.
+        ::zeroclaw_log::record!(
+            ERROR,
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+                .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                .with_attrs(::serde_json::json!({ "error": format!("{err:#}") })),
+            "config could not be salvaged section-by-section; starting on defaults \
+             so it can be repaired"
+        );
+        Config::default()
+    });
+
+    for path in &dropped {
+        ::zeroclaw_log::record!(
+            WARN,
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                .with_attrs(::serde_json::json!({ "dropped_config": path })),
+            &format!(
+                "config section `{path}` is invalid and was skipped so the daemon can \
+                 start; fix the block and reload to re-enable it"
+            )
+        );
+    }
+
+    config
+}
+
+/// Drop any top-level `[section]` whose removal is required for the config to
+/// deserialize, substituting the section's `Default` via serde. Each candidate
+/// is tested by removing it from a clone and re-deserializing; a section is
+/// dropped only when its removal is what fixes the load, so valid sections are
+/// never touched. Removed paths are appended to `dropped`.
+fn prune_bad_top_level_sections(value: &mut toml::Value, dropped: &mut Vec<String>) {
+    let Some(root) = value.as_table_mut() else {
+        return;
     };
-    final_value
-        .try_into()
-        .context("migrated config failed to deserialize as current schema")
+    let keys: Vec<String> = root.keys().cloned().collect();
+    for key in keys {
+        if value.clone().try_into::<Config>().is_ok() {
+            break;
+        }
+        let root = value.as_table_mut().expect("root is a table");
+        let Some(removed) = root.remove(&key) else {
+            continue;
+        };
+        if value.clone().try_into::<Config>().is_ok() {
+            // Removing this key fixed (or advanced) the load — it was the
+            // offender. Leave it dropped; serde fills the section default.
+            dropped.push(key);
+        } else {
+            // Removing it did not help; restore and keep probing. The real
+            // offender is a different key (handled on a later iteration).
+            value
+                .as_table_mut()
+                .expect("root is a table")
+                .insert(key, removed);
+        }
+    }
+}
+
+/// Remove every `[channels.<type>.<alias>]` entry that cannot deserialize
+/// into its concrete channel config type. Each alias is checked in isolation
+/// via [`channel_alias_is_invalid`]; valid aliases sharing a `[channels]`
+/// section with a broken sibling are preserved. Dropped paths
+/// (`channels.<type>.<alias>`) are appended to `dropped`.
+fn prune_bad_channel_aliases(value: &mut toml::Value, dropped: &mut Vec<String>) {
+    let Some(channels) = value
+        .as_table_mut()
+        .and_then(|root| root.get_mut("channels"))
+        .and_then(toml::Value::as_table_mut)
+    else {
+        return;
+    };
+
+    for (chan_type, aliases) in channels.iter_mut() {
+        let Some(alias_table) = aliases.as_table_mut() else {
+            continue;
+        };
+        let invalid: Vec<String> = alias_table
+            .iter()
+            .filter(|(_, v)| channel_alias_is_invalid(chan_type, v))
+            .map(|(k, _)| k.clone())
+            .collect();
+        for alias in invalid {
+            alias_table.remove(&alias);
+            dropped.push(format!("channels.{chan_type}.{alias}"));
+        }
+    }
+}
+
+/// True when a single `[channels.<type>.<alias>]` table cannot deserialize
+/// into its concrete channel config type. Wraps the alias under a minimal
+/// `{ channels = { <type> = { probe = <alias> } } }` document and runs it
+/// through the strict `Config` deserializer, isolating the failure to this
+/// one alias.
+fn channel_alias_is_invalid(chan_type: &str, alias_value: &toml::Value) -> bool {
+    let mut inner = toml::value::Table::new();
+    inner.insert("probe".to_string(), alias_value.clone());
+    let mut type_table = toml::value::Table::new();
+    type_table.insert(chan_type.to_string(), toml::Value::Table(inner));
+    let mut channels = toml::value::Table::new();
+    channels.insert("channels".to_string(), toml::Value::Table(type_table));
+    toml::Value::Table(channels).try_into::<Config>().is_err()
 }
 
 /// File-API wrapper: read disk config, migrate, write `<file>.backup`
@@ -694,8 +867,112 @@ mod tests {
         assert!(detect_version(&v).is_err());
     }
 
-    // ── migrate_file_in_place atomic-write semantics ──
+    // ── resilient daemon load: starts no matter what, so config can be repaired ──
 
+    #[test]
+    fn broken_channel_alias_is_dropped_not_fatal() {
+        // Email alias missing required `imap_host` must not abort the load.
+        let raw = r#"
+schema_version = 3
+
+[channels.email.fakeemail]
+enabled = true
+smtp_host = "smtp.example.com"
+username = "u"
+password = "p"
+from_address = "a@example.com"
+"#;
+        let cfg = migrate_to_current_resilient(raw);
+        assert!(
+            !cfg.channels.email.contains_key("fakeemail"),
+            "invalid alias must be pruned"
+        );
+    }
+
+    #[test]
+    fn valid_alias_survives_broken_sibling() {
+        let raw = r#"
+schema_version = 3
+
+[channels.email.broken]
+enabled = true
+smtp_host = "smtp.example.com"
+username = "u"
+password = "p"
+from_address = "a@example.com"
+
+[channels.email.good]
+enabled = true
+imap_host = "imap.example.com"
+smtp_host = "smtp.example.com"
+username = "u"
+password = "p"
+from_address = "a@example.com"
+"#;
+        let cfg = migrate_to_current_resilient(raw);
+        assert!(
+            cfg.channels.email.contains_key("good"),
+            "valid sibling must be kept"
+        );
+        assert!(
+            !cfg.channels.email.contains_key("broken"),
+            "invalid sibling must be pruned"
+        );
+    }
+
+    #[test]
+    fn broken_non_channel_section_falls_back_to_default() {
+        // A type mismatch outside the channel maps must NOT abort the daemon:
+        // the section is dropped to its default so the operator can repair it.
+        let raw = r#"
+schema_version = 3
+
+[heartbeat]
+enabled = "not-a-bool"
+"#;
+        let cfg = migrate_to_current_resilient(raw);
+        // `[heartbeat]` reverted to its serde default; load did not panic.
+        assert!(!cfg.heartbeat.enabled);
+        assert_eq!(cfg.heartbeat.interval_minutes, 30);
+    }
+
+    #[test]
+    fn unparseable_config_falls_back_to_defaults() {
+        // Not even valid TOML — the daemon still boots on defaults so the
+        // operator can reach a repair surface and overwrite the file.
+        let cfg = migrate_to_current_resilient("this is not valid TOML {{{");
+        assert_eq!(cfg.schema_version, Config::default().schema_version);
+    }
+
+    #[test]
+    fn future_schema_version_falls_back_to_defaults() {
+        // A schema newer than this binary can't be migrated, but the daemon
+        // must still start rather than refuse to boot.
+        let raw = format!("schema_version = {}\n", CURRENT_SCHEMA_VERSION + 100);
+        let cfg = migrate_to_current_resilient(&raw);
+        assert_eq!(cfg.schema_version, Config::default().schema_version);
+    }
+
+    #[test]
+    fn strict_path_still_errors_for_tooling() {
+        // `migrate_to_current` stays strict — repair tooling needs the error.
+        let raw = r#"
+schema_version = 3
+
+[channels.email.fakeemail]
+enabled = true
+smtp_host = "smtp.example.com"
+username = "u"
+password = "p"
+from_address = "a@example.com"
+"#;
+        assert!(
+            migrate_to_current(raw).is_err(),
+            "strict path must surface the defect for repair tooling"
+        );
+    }
+
+    // ── migrate_file_in_place atomic-write semantics ──
     fn setup_temp_config_dir() -> tempfile::TempDir {
         tempfile::TempDir::new().expect("temp dir")
     }

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -20039,6 +20039,56 @@ default_model = "persisted-profile"
     }
 
     #[test]
+    #[allow(clippy::large_futures)]
+    async fn load_or_init_assigns_degraded_security_for_malformed_section() {
+        let _env_guard = env_override_lock().await;
+        let temp_home =
+            std::env::temp_dir().join(format!("zeroclaw_test_home_{}", uuid::Uuid::new_v4()));
+        let workspace_dir = temp_home.join("profile-a");
+        let config_path = workspace_dir.join("config.toml");
+
+        fs::create_dir_all(&workspace_dir).await.unwrap();
+        // `[security] audit` must be a table; a scalar forces the security
+        // section to drop to its default on the resilient daemon path.
+        fs::write(
+            &config_path,
+            r#"schema_version = 3
+audit = "should-be-a-table-not-a-string"
+
+[security]
+audit = "should-be-a-table-not-a-string"
+"#,
+        )
+        .await
+        .unwrap();
+
+        let original_home = std::env::var("HOME").ok();
+        // SAFETY: test-only, single-threaded test runner.
+        unsafe { std::env::set_var("HOME", &temp_home) };
+        // SAFETY: test-only, single-threaded test runner.
+        unsafe { std::env::set_var("ZEROCLAW_WORKSPACE", &workspace_dir) };
+
+        let config = Box::pin(Config::load_or_init()).await.unwrap();
+
+        assert!(
+            config.degraded_security.iter().any(|s| s == "security"),
+            "load_or_init must surface a dropped [security] section on degraded_security, got {:?}",
+            config.degraded_security
+        );
+
+        // SAFETY: test-only, single-threaded test runner.
+        unsafe { std::env::remove_var("ZEROCLAW_WORKSPACE") };
+        if let Some(home) = original_home {
+            // SAFETY: test-only, single-threaded test runner.
+            unsafe { std::env::set_var("HOME", home) };
+        } else {
+            // SAFETY: test-only, single-threaded test runner.
+            unsafe { std::env::remove_var("HOME") };
+        }
+        let _ = fs::remove_dir_all(temp_home).await;
+    }
+
+    #[test]
     async fn validate_rejects_out_of_range_temperature() {
         let mut config = Config::default();
         config.providers.models.openrouter.insert(

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -20089,6 +20089,49 @@ audit = "should-be-a-table-not-a-string"
     }
 
     #[test]
+    #[allow(clippy::large_futures)]
+    async fn load_or_init_marks_whole_config_degraded_for_unparseable_file() {
+        let _env_guard = env_override_lock().await;
+        let temp_home =
+            std::env::temp_dir().join(format!("zeroclaw_test_home_{}", uuid::Uuid::new_v4()));
+        let workspace_dir = temp_home.join("profile-a");
+        let config_path = workspace_dir.join("config.toml");
+
+        fs::create_dir_all(&workspace_dir).await.unwrap();
+        // Not valid TOML at all: the whole config defaults, so every
+        // security-critical section is lost at once. load_or_init must surface
+        // that on degraded_security so the serving gate refuses to start.
+        fs::write(&config_path, "this is not valid TOML {{{")
+            .await
+            .unwrap();
+
+        let original_home = std::env::var("HOME").ok();
+        // SAFETY: test-only, single-threaded test runner.
+        unsafe { std::env::set_var("HOME", &temp_home) };
+        // SAFETY: test-only, single-threaded test runner.
+        unsafe { std::env::set_var("ZEROCLAW_WORKSPACE", &workspace_dir) };
+
+        let config = Box::pin(Config::load_or_init()).await.unwrap();
+
+        assert!(
+            !config.degraded_security.is_empty(),
+            "load_or_init must surface a whole-config loss on degraded_security, got {:?}",
+            config.degraded_security
+        );
+
+        // SAFETY: test-only, single-threaded test runner.
+        unsafe { std::env::remove_var("ZEROCLAW_WORKSPACE") };
+        if let Some(home) = original_home {
+            // SAFETY: test-only, single-threaded test runner.
+            unsafe { std::env::set_var("HOME", home) };
+        } else {
+            // SAFETY: test-only, single-threaded test runner.
+            unsafe { std::env::remove_var("HOME") };
+        }
+        let _ = fs::remove_dir_all(temp_home).await;
+    }
+
+    #[test]
     async fn validate_rejects_out_of_range_temperature() {
         let mut config = Config::default();
         config.providers.models.openrouter.insert(

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -14425,8 +14425,13 @@ impl Config {
                 .as_ref()
                 .and_then(|v| crate::migration::detect_version(v).ok())
                 .filter(|n| *n != crate::migration::CURRENT_SCHEMA_VERSION);
-            let mut config: Config = crate::migration::migrate_to_current(&contents)
-                .context("Failed to migrate config")?;
+            // Daemon load must never hard-fail on a malformed config: the
+            // operator needs the process up to repair it (gateway
+            // /api/config, `zeroclaw config migrate`, dashboard). The
+            // resilient path degrades — dropping invalid channel aliases and
+            // sections to their defaults with a WARN — instead of aborting.
+            // Strict validation lives in `zeroclaw config migrate`.
+            let mut config: Config = crate::migration::migrate_to_current_resilient(&contents);
             if let Some(from_version) = stale_version {
                 ::zeroclaw_log::record!(
                     WARN,

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -102,12 +102,10 @@ pub struct Config {
     /// per-path PATCH applied by `save_dirty()`.
     #[serde(skip)]
     pub dirty_paths: std::collections::HashSet<String>,
-    /// Top-level security-critical sections (`security`, `risk_profiles`,
-    /// `peer_groups`) that the resilient daemon loader had to reset to their
-    /// defaults because the on-disk block was malformed. Non-empty means the
-    /// running posture may be WEAKER than the operator intended; exposure-
-    /// gating code should refuse to trust the instance until the operator
-    /// repairs the file. Never serialized — purely a load-time signal.
+    /// Security-critical sections the resilient loader reset to `Default`
+    /// because the on-disk block was malformed. Non-empty = posture may be
+    /// weaker than intended; exposure gating should refuse to trust the
+    /// instance until repaired. Never serialized — a load-time signal.
     #[serde(skip)]
     pub degraded_security: Vec<String>,
     /// Config file schema version.
@@ -14434,15 +14432,11 @@ impl Config {
                 .as_ref()
                 .and_then(|v| crate::migration::detect_version(v).ok())
                 .filter(|n| *n != crate::migration::CURRENT_SCHEMA_VERSION);
-            // Daemon load must never hard-fail on a malformed config: the
-            // operator needs the process up to repair it (gateway
-            // /api/config, `zeroclaw config migrate`, dashboard). The
-            // resilient path degrades — dropping invalid channel aliases and
-            // sections to their defaults — instead of aborting. Non-security
-            // drops log at WARN; security-critical drops log at ERROR and are
-            // recorded on `config.degraded_security` so exposure-gating code
-            // can refuse to trust the instance until repaired. Strict
-            // validation lives in `zeroclaw config migrate`.
+            // Daemon load must never hard-fail on a malformed config — the
+            // operator needs the process up to repair it. The resilient path
+            // degrades (dropping invalid blocks to defaults); security-critical
+            // drops are recorded on `degraded_security` for exposure gating.
+            // Strict validation lives in `zeroclaw config migrate`.
             let salvage = crate::migration::migrate_to_current_salvaged(&contents);
             let mut config: Config = salvage.config;
             config.degraded_security = salvage.dropped_security;

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -102,6 +102,14 @@ pub struct Config {
     /// per-path PATCH applied by `save_dirty()`.
     #[serde(skip)]
     pub dirty_paths: std::collections::HashSet<String>,
+    /// Top-level security-critical sections (`security`, `risk_profiles`,
+    /// `peer_groups`) that the resilient daemon loader had to reset to their
+    /// defaults because the on-disk block was malformed. Non-empty means the
+    /// running posture may be WEAKER than the operator intended; exposure-
+    /// gating code should refuse to trust the instance until the operator
+    /// repairs the file. Never serialized — purely a load-time signal.
+    #[serde(skip)]
+    pub degraded_security: Vec<String>,
     /// Config file schema version.
     #[serde(default = "default_schema_version")]
     pub schema_version: u32,
@@ -13594,6 +13602,7 @@ impl Default for Config {
             env_overridden_paths: std::collections::HashSet::new(),
             pre_override_snapshots: std::collections::HashMap::new(),
             dirty_paths: std::collections::HashSet::new(),
+            degraded_security: Vec::new(),
             schema_version: crate::migration::CURRENT_SCHEMA_VERSION,
             providers: crate::providers::Providers::default(),
             model_routes: Vec::new(),
@@ -14429,9 +14438,14 @@ impl Config {
             // operator needs the process up to repair it (gateway
             // /api/config, `zeroclaw config migrate`, dashboard). The
             // resilient path degrades — dropping invalid channel aliases and
-            // sections to their defaults with a WARN — instead of aborting.
-            // Strict validation lives in `zeroclaw config migrate`.
-            let mut config: Config = crate::migration::migrate_to_current_resilient(&contents);
+            // sections to their defaults — instead of aborting. Non-security
+            // drops log at WARN; security-critical drops log at ERROR and are
+            // recorded on `config.degraded_security` so exposure-gating code
+            // can refuse to trust the instance until repaired. Strict
+            // validation lives in `zeroclaw config migrate`.
+            let salvage = crate::migration::migrate_to_current_salvaged(&contents);
+            let mut config: Config = salvage.config;
+            config.degraded_security = salvage.dropped_security;
             if let Some(from_version) = stale_version {
                 ::zeroclaw_log::record!(
                     WARN,
@@ -17012,6 +17026,7 @@ auto_save = true
     #[test]
     async fn config_toml_roundtrip() {
         let config = Config {
+            degraded_security: Vec::new(),
             schema_version: crate::migration::CURRENT_SCHEMA_VERSION,
             providers: {
                 let mut p = crate::providers::Providers::default();
@@ -17734,6 +17749,7 @@ default_temperature = 0.7
             },
         );
         let config = Config {
+            degraded_security: Vec::new(),
             schema_version: crate::migration::CURRENT_SCHEMA_VERSION,
             providers,
             model_routes: Vec::new(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,11 @@ Examples:
         /// Note: Binding to 0.0.0.0 requires `gateway.allow_public_bind = true` in config
         #[arg(long)]
         host: Option<String>,
+
+        /// Boot even when security-critical config sections were dropped to
+        /// their defaults during load (weakened posture). Off by default.
+        #[arg(long)]
+        allow_degraded_security: bool,
     },
     /// Restart the gateway server
     // i18n-exempt: clap derive help — framework requires a compile-time literal
@@ -152,6 +157,11 @@ Examples:
         /// Note: Binding to 0.0.0.0 requires `gateway.allow_public_bind = true` in config
         #[arg(long)]
         host: Option<String>,
+
+        /// Boot even when security-critical config sections were dropped to
+        /// their defaults during load (weakened posture). Off by default.
+        #[arg(long)]
+        allow_degraded_security: bool,
     },
     /// Show or generate the pairing code without restarting
     // i18n-exempt: clap derive help — framework requires a compile-time literal

--- a/src/main.rs
+++ b/src/main.rs
@@ -3335,7 +3335,12 @@ async fn main() -> Result<()> {
 
         Commands::Gateway { gateway_command } => {
             match gateway_command {
-                Some(zeroclaw::GatewayCommands::Restart { port, host }) => {
+                Some(zeroclaw::GatewayCommands::Restart {
+                    port,
+                    host,
+                    allow_degraded_security,
+                }) => {
+                    let _nag = gate_security_posture(&config, allow_degraded_security)?;
                     let (port, host) = resolve_gateway_addr(&config, port, host);
                     let addr = format!("{host}:{port}");
                     ::zeroclaw_log::record!(
@@ -3486,12 +3491,20 @@ async fn main() -> Result<()> {
                     }
                     Ok(())
                 }
-                Some(zeroclaw::GatewayCommands::Start { port, host }) => {
+                Some(zeroclaw::GatewayCommands::Start {
+                    port,
+                    host,
+                    allow_degraded_security,
+                }) => {
+                    let _nag = gate_security_posture(&config, allow_degraded_security)?;
                     let (port, host) = resolve_gateway_addr(&config, port, host);
                     log_gateway_start(&host, port);
                     Box::pin(run_gateway_if_enabled(&host, port, config, None)).await
                 }
                 None => {
+                    // Bare `zeroclaw gateway` has no flag, so degraded security
+                    // is never auto-allowed here — fail closed.
+                    let _nag = gate_security_posture(&config, false)?;
                     let port = config.gateway.port;
                     let host = config.gateway.host.clone();
                     log_gateway_start(&host, port);
@@ -3506,52 +3519,12 @@ async fn main() -> Result<()> {
             ephemeral,
             allow_degraded_security,
         } => {
-            // Security-critical config sections (`security`, `risk_profiles`,
-            // `peer_groups`) that failed to parse are dropped to their
-            // defaults during load and recorded on `degraded_security`. The
-            // running posture may then be WEAKER than intended, so the daemon
-            // refuses to boot by default — "secure by default" must fail loud
-            // here, not quiet. `--allow-degraded-security` lets the operator
-            // boot anyway to reach repair surfaces; the daemon then nags with
-            // a repeating warning until the config is fixed and reloaded.
-            if !config.degraded_security.is_empty() {
-                let sections = config.degraded_security.join(", ");
-                if !allow_degraded_security {
-                    anyhow::bail!(
-                        "Config contains malformed security-critical sections ({sections}); \
-                         they were reset to defaults, so the running posture may be weaker \
-                         than intended. The daemon will not start with a degraded security \
-                         posture. Repair these sections in {} and restart — run \
-                         `zeroclaw config migrate` to see the precise error. To boot anyway \
-                         (e.g. to reach the gateway config editor and repair from there), \
-                         re-run with `--allow-degraded-security`.",
-                        config.config_path.display()
-                    );
-                }
-                let config_path = config.config_path.display().to_string();
-                ::zeroclaw_spawn::spawn!(async move {
-                    let mut ticker = tokio::time::interval(std::time::Duration::from_secs(30));
-                    loop {
-                        ticker.tick().await;
-                        ::zeroclaw_log::record!(
-                            WARN,
-                            ::zeroclaw_log::Event::new(
-                                module_path!(),
-                                ::zeroclaw_log::Action::Note
-                            )
-                            .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                            .with_attrs(::serde_json::json!({
-                                "degraded_security": sections
-                            })),
-                            &format!(
-                                "Running with DEGRADED security: sections ({sections}) were \
-                                 reset to defaults and `--allow-degraded-security` was set. \
-                                 The posture may be weaker than intended — repair {config_path} \
-                                 and reload (SIGUSR1 / `zeroclaw admin reload`) as soon as possible."
-                            )
-                        );
-                    }
-                });
+            // Fail closed before any setup work: refuse to serve with a
+            // degraded security posture unless explicitly allowed. This branch
+            // never spawns the nag (the `!allow` path only bails); the nag is
+            // managed per reload-iteration in the loop below.
+            if !config.degraded_security.is_empty() && !allow_degraded_security {
+                gate_security_posture(&config, allow_degraded_security)?;
             }
             if let Ok(exe) = std::env::current_exe() {
                 let under_home = directories::UserDirs::new()
@@ -3664,6 +3637,11 @@ async fn main() -> Result<()> {
             // the same across reloads — only the in-process subsystems
             // tear down + re-instantiate.
             let mut current_config = config;
+            // Nag task for the degraded-security warning, scoped to the
+            // current config. Re-evaluated each reload iteration so a repaired
+            // config stops the warning and a freshly-degraded one starts it.
+            let mut degraded_nag: Option<tokio::task::JoinHandle<()>> =
+                gate_security_posture(&current_config, allow_degraded_security)?;
             loop {
                 // Per-iteration clones so the subsystem closures (which
                 // `move`-capture) don't consume the outer bindings on the
@@ -3788,9 +3766,22 @@ async fn main() -> Result<()> {
                             "🔄 Daemon reload — re-reading config from disk"
                         );
                         current_config = Box::pin(Config::load_or_init()).await?;
+                        // Stop the stale nag and re-gate against the fresh
+                        // config: a repaired posture silences the warning, a
+                        // newly-degraded one (still allowed) restarts it. A
+                        // newly-degraded posture without the allow flag set
+                        // hard-fails the reload, same as first boot.
+                        if let Some(handle) = degraded_nag.take() {
+                            handle.abort();
+                        }
+                        degraded_nag =
+                            gate_security_posture(&current_config, allow_degraded_security)?;
                         // Continue loop: fresh subsystems with the new config.
                     }
                 }
+            }
+            if let Some(handle) = degraded_nag.take() {
+                handle.abort();
             }
             Ok(())
         }
@@ -6068,6 +6059,61 @@ async fn handle_auth_command(auth_command: AuthCommands, config: &Config) -> Res
     }
 }
 
+/// Gate every serving entry point on the loaded security posture.
+///
+/// `Config.degraded_security` lists security-critical sections (`security`,
+/// `risk_profiles`, `peer_groups`) that failed to parse and were reset to
+/// their defaults during load — the running posture may then be WEAKER than
+/// intended. "Secure by default" must fail loud here (FND-006 §4.5), so every
+/// path that brings up the serving surface (daemon, `gateway start`,
+/// `gateway restart`) routes through this before binding.
+///
+/// Returns `Err` when degraded and `allow_degraded` is false (the caller
+/// propagates and the process never serves). When degraded and explicitly
+/// allowed, boots but returns the `JoinHandle` of a repeating-WARN nag task so
+/// the caller can abort it on reload; `Ok(None)` means a clean posture.
+fn gate_security_posture(
+    config: &zeroclaw::config::Config,
+    allow_degraded: bool,
+) -> anyhow::Result<Option<tokio::task::JoinHandle<()>>> {
+    if config.degraded_security.is_empty() {
+        return Ok(None);
+    }
+    let sections = config.degraded_security.join(", ");
+    if !allow_degraded {
+        anyhow::bail!(
+            "Config contains malformed security-critical sections ({sections}); \
+             they were reset to defaults, so the running posture may be weaker \
+             than intended. Refusing to serve with a degraded security posture. \
+             Repair these sections in {} and restart — run `zeroclaw config \
+             migrate` to see the precise error. To boot anyway (e.g. to reach \
+             the gateway config editor and repair from there), re-run with \
+             `--allow-degraded-security`.",
+            config.config_path.display()
+        );
+    }
+    let config_path = config.config_path.display().to_string();
+    let handle = ::zeroclaw_spawn::spawn!(async move {
+        let mut ticker = tokio::time::interval(std::time::Duration::from_secs(30));
+        loop {
+            ticker.tick().await;
+            ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                    .with_attrs(::serde_json::json!({ "degraded_security": sections })),
+                &format!(
+                    "Running with DEGRADED security: sections ({sections}) were reset to \
+                     defaults and `--allow-degraded-security` was set. The posture may be \
+                     weaker than intended — repair {config_path} and reload \
+                     (SIGUSR1 / `zeroclaw admin reload`) as soon as possible."
+                )
+            );
+        }
+    });
+    Ok(Some(handle))
+}
+
 #[cfg(feature = "gateway")]
 async fn run_gateway_if_enabled(
     host: &str,
@@ -6765,5 +6811,31 @@ mod tests {
         });
 
         assert!((final_temperature - 0.7).abs() < f64::EPSILON);
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "agent-runtime")]
+    async fn gate_security_posture_fails_closed_unless_allowed() {
+        use crate::config::schema::Config;
+
+        // Clean posture: no gate, no nag.
+        let clean = Config::default();
+        assert!(clean.degraded_security.is_empty());
+        let handle = gate_security_posture(&clean, false).expect("clean posture must pass");
+        assert!(handle.is_none(), "clean posture must not spawn a nag");
+
+        // Degraded posture, not allowed: must refuse to serve.
+        let mut degraded = Config::default();
+        degraded.degraded_security = vec!["security".to_string()];
+        assert!(
+            gate_security_posture(&degraded, false).is_err(),
+            "degraded posture must fail closed when not explicitly allowed"
+        );
+
+        // Degraded posture, explicitly allowed: boots and returns a nag handle.
+        let nag = gate_security_posture(&degraded, true)
+            .expect("degraded posture must boot when allowed")
+            .expect("allowed degraded posture must spawn a nag task");
+        nag.abort();
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -573,6 +573,13 @@ Examples:
         /// Self-terminate after all socket clients disconnect (with grace period)
         #[arg(long)]
         ephemeral: bool,
+
+        /// Boot even when security-critical config sections were dropped to
+        /// their defaults during load. Without this, the daemon refuses to
+        /// start with a weakened posture; with it, the daemon boots so the
+        /// operator can reach repair surfaces, emitting a repeating warning.
+        #[arg(long)]
+        allow_degraded_security: bool,
     },
 
     /// Manage OS service lifecycle (launchd/systemd user service)
@@ -3497,7 +3504,55 @@ async fn main() -> Result<()> {
             port,
             host,
             ephemeral,
+            allow_degraded_security,
         } => {
+            // Security-critical config sections (`security`, `risk_profiles`,
+            // `peer_groups`) that failed to parse are dropped to their
+            // defaults during load and recorded on `degraded_security`. The
+            // running posture may then be WEAKER than intended, so the daemon
+            // refuses to boot by default — "secure by default" must fail loud
+            // here, not quiet. `--allow-degraded-security` lets the operator
+            // boot anyway to reach repair surfaces; the daemon then nags with
+            // a repeating warning until the config is fixed and reloaded.
+            if !config.degraded_security.is_empty() {
+                let sections = config.degraded_security.join(", ");
+                if !allow_degraded_security {
+                    anyhow::bail!(
+                        "Config contains malformed security-critical sections ({sections}); \
+                         they were reset to defaults, so the running posture may be weaker \
+                         than intended. The daemon will not start with a degraded security \
+                         posture. Repair these sections in {} and restart — run \
+                         `zeroclaw config migrate` to see the precise error. To boot anyway \
+                         (e.g. to reach the gateway config editor and repair from there), \
+                         re-run with `--allow-degraded-security`.",
+                        config.config_path.display()
+                    );
+                }
+                let config_path = config.config_path.display().to_string();
+                ::zeroclaw_spawn::spawn!(async move {
+                    let mut ticker = tokio::time::interval(std::time::Duration::from_secs(30));
+                    loop {
+                        ticker.tick().await;
+                        ::zeroclaw_log::record!(
+                            WARN,
+                            ::zeroclaw_log::Event::new(
+                                module_path!(),
+                                ::zeroclaw_log::Action::Note
+                            )
+                            .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                            .with_attrs(::serde_json::json!({
+                                "degraded_security": sections
+                            })),
+                            &format!(
+                                "Running with DEGRADED security: sections ({sections}) were \
+                                 reset to defaults and `--allow-degraded-security` was set. \
+                                 The posture may be weaker than intended — repair {config_path} \
+                                 and reload (SIGUSR1 / `zeroclaw admin reload`) as soon as possible."
+                            )
+                        );
+                    }
+                });
+            }
             if let Ok(exe) = std::env::current_exe() {
                 let under_home = directories::UserDirs::new()
                     .map(|u| u.home_dir().to_path_buf())

--- a/src/main.rs
+++ b/src/main.rs
@@ -6837,5 +6837,14 @@ mod tests {
             .expect("degraded posture must boot when allowed")
             .expect("allowed degraded posture must spawn a nag task");
         nag.abort();
+
+        // Whole-config loss (sentinel marker) is degraded too: same fail-closed
+        // behavior so a defaulted security posture cannot serve silently.
+        let mut whole = Config::default();
+        whole.degraded_security = vec![crate::config::migration::WHOLE_CONFIG_SENTINEL.to_string()];
+        assert!(
+            gate_security_posture(&whole, false).is_err(),
+            "whole-config loss must fail closed when not explicitly allowed"
+        );
     }
 }


### PR DESCRIPTION
> **DO NOT MERGE - AUTHOR WILL MERGE WHEN READY. REVIEWS STILL REQUESTED**

## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `Config::load` funneled every daemon startup through the strict whole-config `try_into()`. A single malformed field anywhere (e.g. an email alias missing `imap_host`) aborted the daemon before any repair surface (gateway `/api/config`, `zeroclaw config migrate`, dashboard) could run. The daemon must boot no matter what so the operator can fix the config. Adds `migrate_to_current_resilient` / `migrate_to_current_salvaged` as the daemon load path: it degrades instead of failing — strict deserialize first (zero change for valid configs), then drop invalid channel aliases, invalid whole-`[channels.<type>]` blocks, and invalid top-level sections to their serde `Default`, each logged with the offending path.
  - Security-critical sections (`security`, `risk_profiles`, `peer_groups`) get louder treatment: resetting one to its `Default` can *weaken* the running posture. These drops log at ERROR, surface in `ResilientLoad::dropped_security`, and are recorded on `Config.degraded_security`.
  - **Gates the degraded posture at every serving entry point.** Populating `degraded_security` is not enough — "secure by default" must fail loud (FND-006 §4.5). A shared `gate_security_posture` chokepoint now sits in front of `daemon`, `gateway start`, and `gateway restart`: with security-critical sections dropped, the process refuses to serve unless the operator explicitly opts in with `--allow-degraded-security`. When allowed, it boots (so the operator can reach repair surfaces) but emits a repeating ERROR-context WARN until the config is repaired. The daemon re-gates on each SIGUSR1 reload, so a repaired posture silences the warning and a newly-degraded one without the flag hard-fails the reload. Bare `zeroclaw gateway` fails closed.
  - Fixes a real salvage defect: the original top-level pruner only dropped a section whose *individual* removal validated the whole config. Two unrelated malformed sections validated nothing, so salvage gave up and the **entire** config silently reset to `Config::default()` — losing every valid section. Reworked into a joint probe (sole offender) plus an isolated probe (each section judged alone) so independent offenders are each dropped and valid siblings are kept.
- **Scope boundary:** Does NOT change the strict `migrate_to_current` (repair tooling still gets precise errors), does NOT run `Config::validate()` on the resilient path (a config that fails validation must still load so it can be fixed), and does NOT touch the web dashboard or any channel runtime behavior.
- **Blast radius:** Daemon/gateway config-load and startup-gating path. Valid configs deserialize through the unchanged strict path first, so there is zero behavior change for a healthy config. The new gate only triggers when a security-critical section fails to parse; healthy and non-security degradations are unaffected. The `degraded_security` field is `#[serde(skip)]` and never persisted.
- **Linked issue(s):** None.
- **Labels:** `bug`, `risk: high`, `size: L`, `config`

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` → clean (no diff; exit 0).
  - `cargo clippy --all-targets -- -D warnings` → `Finished`, no warnings or errors (exit 0). Notably caught a bare `tokio::spawn` for the nag task, which was switched to `zeroclaw_spawn::spawn!` so the spawned WARN stays attributed.
  - `cargo test` → all suites pass, zero failures (exit 0). Representative tails:
    ```
    test result: ok. 274 passed; 0 failed; 0 ignored; ...
    test result: ok. 188 passed; 0 failed; 0 ignored; ...
    test result: ok. 159 passed; 0 failed; 0 ignored; ...
    ```
  - Crate-scoped detail for the touched crate (`zeroclaw-config`):
    `cargo test -p zeroclaw-config` → `728 passed; 0 failed` (lib) +
    `89 passed; 0 failed` (integration), 1 pre-existing ignored.
  - New gate test in the binary crate:
    `cargo test --bin zeroclaw -- gate_security_posture cli_definition_has_no_flag_conflicts`
    → `2 passed; 0 failed` (gate fail-closed behavior + CLI flag-conflict check).
  - **Beyond CI — what I manually verified:** Salvage paths — broken channel alias dropped (sibling kept), broken whole-type channel block dropped (sibling type kept), malformed `[security]` reported as a security-critical drop, malformed non-security section reported as a plain drop, two independent malformed sections both salvaged in one load (including the mixed security/non-security case), unparseable TOML and future schema version both falling back to `Config::default()`, and the strict path still erroring for repair tooling. Gating — `load_or_init` surfaces a dropped `[security]` on `degraded_security`; `gate_security_posture` returns `Ok(None)` for a clean posture, `Err` for degraded-not-allowed, and a live nag handle for degraded-allowed.
  - **If any command was intentionally skipped, why:** None skipped.

### Integration test checklist (`integration/zerocode-test`)

Validated as part of the aggregated integration branch. The items below are this PR's slice of that sign-off; `[x]` = verified (unit and/or live), `[~]` = code-verified pending live, `[ ]` = live-pending.

#### 15. Resilient config load + security gating (#7160) — Tier 5 ⚠️, can refuse boot

Commits `c3529d599`, `1040db8a1`, `d198d1ce5`, `16d25e8b1`.
**Run dead last, on a throwaway config dir.**

- [x] Single malformed TOML block → daemon loads, repairs, logs the bad block (`c3529d599`) — PASS (unit). `broken_non_security_section_is_plain_drop_not_security` (migration.rs:1100): a malformed `[heartbeat]` block is salvaged — dropped from the plain list, the rest of the config loads. `migrate_to_current_salvaged` degrades instead of failing; `broken_channel_type_block_is_dropped_not_fatal` proves a valid sibling survives a broken-type drop.
- [x] Multiple bad blocks → all salvaged, none silently dropped (`1040db8a1`) — PASS (unit). `multiple_independent_bad_sections_all_dropped` (migration.rs:1143): both `[heartbeat]` and `[backup]` offenders appear in `dropped` (none silently lost). `multiple_bad_sections_one_security_critical` (1168): a mixed batch correctly sorts `[security]`→`dropped_security` and `[heartbeat]`→`dropped`, with no double-listing. 17/17 migration tests green.
- [x] Corrupt a security-critical section (autonomy / gateway pairing / allowlists) → refuses boot or runs degraded; NO permissive fallback (`1040db8a1`, `d198d1ce5`) — PASS (unit). `broken_security_section_is_reported_as_degraded` (migration.rs:1082): malformed `[security]` → classified `dropped_security` (security-critical), NOT a plain drop. `load_or_init_assigns_degraded_security_for_malformed_section` (schema.rs:20305): the load path stamps `config.degraded_security`. The bad section is reset to DEFAULTS (deny-by-default), never a permissive fallback; the gate then refuses to serve (below).
- [x] Every serving entry point gated: `gateway`, `daemon`, `service` with degraded config → each blocks (`16d25e8b1`) — PASS (code + bin test). `gate_security_posture` (main.rs:6075) fails closed when `degraded_security` is non-empty unless `--allow-degraded-security`; called at ALL serving entry points: Gateway Restart (3343), Gateway Start (3499) + get-paircode (3507, always `false`), Daemon initial boot (3527), Daemon reload-iteration (3644), Daemon newly-degraded-on-reload (3778). `service` runs the daemon path → transitively gated. Bin test `gate_security_posture_fails_closed_unless_allowed` (main.rs:6818): clean→no gate/no nag; degraded+not-allowed→Err (refuses); degraded+allowed→boots with an abortable nag handle (no leak — handle returned, aborted per reload + shutdown).
- [x] Valid config → clean boot, no behavioral change — PASS (unit). `gate_security_posture(&Config::default(), false)` returns `Ok(None)` (clean posture, no gate, no nag) — asserted in the bin test. A valid config has empty `degraded_security`, so the gate is a no-op and boot is unchanged.
- [x] **`b1a4ae45a`** Whole-config fallback is gated too — section-level salvage marked `dropped_security`, but the whole-config fallbacks (unparseable TOML, future schema, broken migration chain, unsalvageable root) defaulted the whole config with an EMPTY `dropped_security`, losing every security-critical section unsignalled. Both fallbacks now push `WHOLE_CONFIG_SENTINEL` so `load_or_init` surfaces it and the gate fails closed. Tests: `unparseable_config_marks_whole_config_degraded`, `future_schema_version_marks_whole_config_degraded`, `unsalvageable_root_marks_whole_config_degraded`, `load_or_init_marks_whole_config_degraded_for_unparseable_file`, bin gate test on the sentinel. Verify a corrupt config refuses boot without `--allow-degraded-security`.

**§15 STATUS: config-layer salvage + security classification fully unit-green (17 migration tests + schema degraded-load test). Gate logic covered by the bin test `gate_security_posture_fails_closed_unless_allowed` and confirmed wired at all 6 serving entry points. Live throwaway-config boot-refusal smoke optional — the fail-closed contract is unit-proven. Re: handoff — local #7160 work is committed on this branch (`c3529d599`/`1040db8a1`/`d198d1ce5`/`16d25e8b1`); the upstream PR push + re-review-request remains a separate action awaiting user direction.**


## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No** — secret masking and the strict load path are unchanged.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No** — test fixtures use `example.com` placeholders only.
- If any `Yes`, describe the risk and mitigation: The change *improves* the security posture. Silent reset of `security` / `risk_profiles` / `peer_groups` to defaults is now an ERROR-level, machine-readable signal (`degraded_security`) that hard-stops every serving entry point (daemon, `gateway start`, `gateway restart`) unless the operator explicitly acknowledges it with `--allow-degraded-security` — closing the window where the daemon could serve a pairing/auth boundary with a weaker-than-intended posture.

## Compatibility (required)

- Backward compatible? **Yes** — valid configs go through the unchanged strict deserialize first; no on-disk format, schema, or behavior change for healthy configs. The new gate only fires when a security-critical section is malformed, which previously meant a silent reset.
- Config / env / CLI surface changed? **Yes** — adds an opt-in `--allow-degraded-security` flag to `zeroclaw daemon`, `zeroclaw gateway start`, and `zeroclaw gateway restart`. No new config keys or env vars; `degraded_security` is `#[serde(skip)]`.
- Upgrade steps: None for healthy configs. An operator whose config has a malformed `security` / `risk_profiles` / `peer_groups` section will now see the daemon refuse to start (previously it booted with a silently weakened posture). Repair the section (`zeroclaw config migrate` shows the precise error), or pass `--allow-degraded-security` to boot anyway and fix it via the gateway config editor.

## Rollback

Low-risk to revert despite the `risk: high` label (security-path scope, not blast radius): `git revert <sha>` across the PR's commits restores the prior strict-only load path and removes the gate + flag. No feature flags, no config toggles, no migration to undo.

- **Fast rollback command/path:** `git revert` the PR's squash commit (or the individual commits) and redeploy.
- **Feature flags or config toggles:** None. `--allow-degraded-security` is an opt-in CLI flag, not a persisted toggle.
- **Observable failure symptoms:** A daemon/gateway that previously started now exits at boot with `malformed security-critical sections (...)`; grep logs for `degraded_security` or `DEGRADED security`. Reverting restores the prior boot-anyway behavior.