### PR TITLE
docs(setup): add FreeBSD setup guide + installable rc.d/jail dist files

### DIFF
--- a/dist/freebsd/README.md
+++ b/dist/freebsd/README.md
@@ -1,0 +1,58 @@
+# FreeBSD `rc.d` service files
+
+Ready-to-install service scripts for running ZeroClaw under FreeBSD's
+[`daemon(8)`](https://man.freebsd.org/cgi/man.cgi?daemon%288%29) supervisor.
+FreeBSD is not a target of `zeroclaw service install`, so these are installed by
+hand. The full walkthrough — build from source, provider auth, logs, and the
+rationale behind every `daemon(8)` flag — is in the handbook under
+**Setup → FreeBSD** (`docs/book/src/setup/freebsd.md`).
+
+| File | Installs as | Purpose |
+|---|---|---|
+| `zeroclaw-run.sh` | `/usr/local/libexec/zeroclaw-run.sh` | Launcher: sets `HOME`/`PATH`, execs `zeroclaw daemon`. |
+| `zeroclaw.rc` | `/usr/local/etc/rc.d/zeroclaw` | Basic single-instance service. |
+| `zeroclaw-hardened.rc` | `/usr/local/etc/rc.d/zeroclaw` | Hardened variant for unattended/remote operation. Use this **or** `zeroclaw.rc`, not both. |
+
+The two `rc.d` scripts carry a `@@ZEROCLAW_USER@@` placeholder for the owning
+account — substitute it on install. The launcher needs no substitution: it runs
+through `daemon -u <user>`, so it derives `HOME` from the service account at
+runtime.
+
+## Install (hardened variant)
+
+```sh
+user=youruser     # the account that owns ~/.zeroclaw
+
+# Launcher: no substitution needed (derives HOME from the daemon -u account).
+doas install -m 755 zeroclaw-run.sh /usr/local/libexec/zeroclaw-run.sh
+
+sed "s/@@ZEROCLAW_USER@@/${user}/g" zeroclaw-hardened.rc \
+    | doas tee /usr/local/etc/rc.d/zeroclaw >/dev/null
+doas chmod 755 /usr/local/etc/rc.d/zeroclaw
+
+doas sysrc zeroclaw_enable=YES
+doas service zeroclaw start
+doas service zeroclaw status
+```
+
+Swap `zeroclaw-hardened.rc` for `zeroclaw.rc` if you want the basic service.
+
+## Why the hardened variant
+
+It addresses three `daemon(8)` behaviours that surface the moment you drive the
+service over `ssh` or restart it unattended:
+
+- **Remote `service start` hangs** — `daemon -r` inherits the caller's std fds,
+  so an `ssh host 'service zeroclaw start'` never gets EOF. The hardened start
+  detaches the supervisor's own descriptors (`</dev/null >/dev/null 2>&1`); the
+  child's output still goes to the logfile via `-o`.
+- **Repeated `start` stacks orphan supervisors** that fight over the gateway
+  port. The hardened start refuses when a live supervisor already exists.
+- **A stale pidfile breaks stop/status.** The hardened script identifies its
+  supervisor by the `daemon(8)` process retitle (`daemon: …zeroclaw-run.sh…`),
+  not by trusting the pidfile alone, and verifies the supervisor actually died.
+
+The handbook page documents the FreeBSD-specific traps these work around
+(`pgrep -f` ignoring a leading `^` anchor; `daemon -P` pidfiles having no
+trailing newline) for anyone adapting the scripts — e.g. to a multi-instance
+pool.

--- a/dist/freebsd/README.md
+++ b/dist/freebsd/README.md
@@ -12,6 +12,9 @@ rationale behind every `daemon(8)` flag — is in the handbook under
 | `zeroclaw-run.sh` | `/usr/local/libexec/zeroclaw-run.sh` | Launcher: sets `HOME`/`PATH`, execs `zeroclaw daemon`. |
 | `zeroclaw.rc` | `/usr/local/etc/rc.d/zeroclaw` | Basic single-instance service. |
 | `zeroclaw-hardened.rc` | `/usr/local/etc/rc.d/zeroclaw` | Hardened variant for unattended/remote operation. Use this **or** `zeroclaw.rc`, not both. |
+| `rc.conf.zeroclaw` | `/etc/rc.conf.d/zeroclaw` | Optional per-service `rc.conf` drop-in (`zeroclaw_enable`, `zeroclaw_runas`) — a file alternative to the `sysrc` lines below. |
+| `jail.conf.sample` | append to `/etc/jail.conf` | Sample thick-jail entry for running the service inside a jail. |
+| `zeroclaw-jail-setup.sh` | run on the host | Helper that provisions the jail end to end (dataset, base extract, jail.conf entry, service files) — see [Running in a jail](#running-in-a-jail). |
 
 The two `rc.d` scripts carry a `@@ZEROCLAW_USER@@` placeholder for the owning
 account — substitute it on install. The launcher needs no substitution: it runs
@@ -36,6 +39,30 @@ doas service zeroclaw status
 ```
 
 Swap `zeroclaw-hardened.rc` for `zeroclaw.rc` if you want the basic service.
+
+To set the rc.conf knobs from a file instead of `sysrc`, install the drop-in:
+
+```sh
+doas install -m 644 rc.conf.zeroclaw /etc/rc.conf.d/zeroclaw   # edit youruser first
+```
+
+## Running in a jail
+
+To run the service inside a thick jail, provision it end to end with the helper
+(run on the host as root); it creates the jail, extracts a matching base, adds
+the `/etc/jail.conf` entry, starts the jail, and installs the launcher + hardened
+`rc.d` script inside it:
+
+```sh
+doas sh zeroclaw-jail-setup.sh
+# override defaults via env, e.g.:
+#   JAIL_NAME=zc ZPOOL=tank ZEROCLAW_USER=agent doas sh zeroclaw-jail-setup.sh
+```
+
+It prints the remaining steps (install the `zeroclaw` binary, set up auth, start
+the service). To do it by hand instead, `jail.conf.sample` is the entry to append
+to `/etc/jail.conf`; the full manual walkthrough is in the handbook under
+**Setup → FreeBSD → Running in a jail**.
 
 ## Why the hardened variant
 

--- a/dist/freebsd/jail.conf.sample
+++ b/dist/freebsd/jail.conf.sample
@@ -1,0 +1,21 @@
+# Sample /etc/jail.conf entry for running ZeroClaw in a thick jail.
+#
+# Append this block to /etc/jail.conf (host side). It shares the host network;
+# to give the jail its own address instead, drop the host-network assumption
+# and add e.g.  ip4.addr = "192.0.2.10";  with an  interface = "...";  line.
+#
+# Adjust `path` to wherever you extracted the base system. See the FreeBSD
+# setup guide (docs/book/src/setup/freebsd.md, "Running in a jail") and
+# dist/freebsd/README.md for the full walkthrough, or run
+# dist/freebsd/zeroclaw-jail-setup.sh to provision the jail end to end.
+
+zeroclaw {
+    host.hostname = "zeroclaw";
+    path = "/jails/zeroclaw";
+    exec.start = "/bin/sh /etc/rc";
+    exec.stop  = "/bin/sh /etc/rc.shutdown";
+    exec.clean;
+    mount.devfs;
+    devfs_ruleset = 4;          # devfsrules_jail: restrict device nodes
+    persist;
+}

--- a/dist/freebsd/rc.conf.zeroclaw
+++ b/dist/freebsd/rc.conf.zeroclaw
@@ -1,0 +1,12 @@
+# Per-service rc.conf(5) drop-in for the ZeroClaw rc.d script.
+#
+# Install as /etc/rc.conf.d/zeroclaw (the basename must match the rc.d script
+# name, which both zeroclaw.rc and zeroclaw-hardened.rc install as "zeroclaw"):
+#
+#     doas install -m 644 rc.conf.zeroclaw /etc/rc.conf.d/zeroclaw
+#
+# Equivalent to the sysrc lines in README.md, but version-controllable as a
+# file. Replace youruser with the account that owns ~/.zeroclaw.
+
+zeroclaw_enable="YES"
+zeroclaw_runas="youruser"

--- a/dist/freebsd/zeroclaw-hardened.rc
+++ b/dist/freebsd/zeroclaw-hardened.rc
@@ -1,0 +1,163 @@
+#!/bin/sh
+#
+# PROVIDE: zeroclaw
+# REQUIRE: NETWORKING DAEMON
+# KEYWORD: shutdown
+#
+# Hardened single-instance rc.d script for zeroclaw, for unattended and remote
+# operation. Compared to the basic zeroclaw.rc it adds:
+#   * idempotent start  — refuses to stack a second daemon(8) supervisor;
+#   * thorough stop      — TERMs then KILLs the supervisor and verifies it died;
+#   * detached supervisor std fds — so `ssh host service zeroclaw start` does
+#     not hang waiting on EOF;
+#   * status orphan check — reports supervisors not tracked by the pidfile.
+#
+# Install as /usr/local/etc/rc.d/zeroclaw (use this OR zeroclaw.rc, not both)
+# and replace @@ZEROCLAW_USER@@ with the account that owns ~/.zeroclaw (see
+# dist/freebsd/README.md).
+
+. /etc/rc.subr
+
+name="zeroclaw"
+rcvar="zeroclaw_enable"
+
+load_rc_config $name
+
+: ${zeroclaw_enable:="NO"}
+# NOTE: do NOT name this ${name}_user — rc.subr would then do its own user
+# switch and collide with daemon -u ("failed to set user environment").
+: ${zeroclaw_runas:="@@ZEROCLAW_USER@@"}
+
+rundir="/var/run/zeroclaw"
+pidfile="${rundir}/zeroclaw.pid"          # daemon -P: the SUPERVISOR pid
+child_pidfile="${rundir}/zeroclaw.child.pid"  # daemon -p: the CHILD (zeroclaw) pid
+logfile="/var/log/${name}.log"
+launcher="/usr/local/libexec/zeroclaw-run.sh"
+# daemon(8) retitles its supervisor to "daemon: <launcher>[childpid] (daemon)".
+# Bind the pgrep on the "daemon: " prefix AND the trailing "[" that opens
+# daemon's [childpid], so it matches ONLY a supervisor for THIS launcher (never
+# the zeroclaw child, never a hand-run of the launcher, never this rc shell,
+# and never a sibling launcher whose name merely starts with zeroclaw-run.sh).
+# The dots/brackets are escaped so .sh and the "[" are literal. FreeBSD pgrep
+# does NOT honor a leading "^" anchor on this retitle, so we bind on the prefix.
+launcher_pat="daemon: /usr/local/libexec/zeroclaw-run[.]sh[[]"
+
+command="/usr/sbin/daemon"
+
+start_precmd="zeroclaw_prestart"
+start_cmd="zeroclaw_start"
+stop_cmd="zeroclaw_stop"
+status_cmd="zeroclaw_status"
+
+# Echo every live daemon(8) supervisor pid for this service, one per line.
+zeroclaw_pids()
+{
+    pgrep -f "${launcher_pat}" 2>/dev/null | while IFS= read -r _pid; do
+        case "${_pid}" in
+        ''|*[!0-9]*)
+            continue
+            ;;
+        esac
+        if kill -0 "${_pid}" 2>/dev/null; then
+            printf '%s\n' "${_pid}"
+        fi
+    done
+}
+
+zeroclaw_prestart()
+{
+    # rundir is root-owned: rc.d (root) writes the daemon -P pidfile here and
+    # trusts it later; the unprivileged service user must not be able to forge
+    # control-plane pidfiles.
+    install -d -o root -g wheel -m 755 "${rundir}"
+    [ -e "${logfile}" ] || install -o root -g wheel -m 640 /dev/null "${logfile}"
+    return 0
+}
+
+zeroclaw_start()
+{
+    _pids=$(zeroclaw_pids)
+    if [ -n "${_pids}" ]; then
+        echo "${name} already running; refusing to start duplicate supervisor pid(s): $(printf '%s' "${_pids}" | tr '\n' ' ')"
+        return 0
+    fi
+    rm -f "${pidfile}" "${child_pidfile}"
+    echo "Starting ${name}."
+    # Redirect daemon's own std{in,out,err} to /dev/null: -o already routes the
+    # child's output to the logfile, and without this the supervisor inherits
+    # (and holds open) the caller's fds, so `ssh host service ... start` never
+    # gets EOF and hangs.
+    # -p records the CHILD pid so a forced stop can reap an orphaned child if the
+    # supervisor has to be KILLed (see zeroclaw_stop).
+    /usr/sbin/daemon -r -P "${pidfile}" -p "${child_pidfile}" -o "${logfile}" \
+        -u "${zeroclaw_runas}" "${launcher}" \
+        </dev/null >/dev/null 2>&1
+}
+
+zeroclaw_stop()
+{
+    _pids=$(zeroclaw_pids)
+    if [ -z "${_pids}" ]; then
+        echo "${name} not running."
+        rm -f "${pidfile}" "${child_pidfile}"
+        return 0
+    fi
+    echo "Stopping ${name} supervisor pid(s): $(printf '%s' "${_pids}" | tr '\n' ' ')"
+    for _pid in ${_pids}; do
+        kill -TERM "${_pid}" 2>/dev/null || :
+    done
+    _wait=10
+    while [ "${_wait}" -gt 0 ]; do
+        _pids=$(zeroclaw_pids)
+        [ -z "${_pids}" ] && break
+        sleep 1
+        _wait=$((_wait - 1))
+    done
+    _pids=$(zeroclaw_pids)
+    if [ -n "${_pids}" ]; then
+        # KILL the supervisor FIRST so it can no longer respawn the child, then
+        # reap the now-orphaned child. Doing it in this order avoids a race
+        # where the supervisor restarts the child between the two kills.
+        echo "Forcing ${name} supervisor pid(s): $(printf '%s' "${_pids}" | tr '\n' ' ')"
+        for _pid in ${_pids}; do
+            kill -KILL "${_pid}" 2>/dev/null || :
+        done
+        # daemon -p writes the child pid with NO trailing newline, so `read`
+        # returns nonzero at EOF even though it populated ${_child}; do not gate
+        # on its exit status.
+        if [ -f "${child_pidfile}" ]; then
+            IFS= read -r _child < "${child_pidfile}" 2>/dev/null || :
+            case "${_child}" in
+            ''|*[!0-9]*)
+                ;;
+            *)
+                if kill -0 "${_child}" 2>/dev/null; then
+                    echo "Reaping orphaned ${name} child pid: ${_child}"
+                    kill -KILL "${_child}" 2>/dev/null || :
+                fi
+                ;;
+            esac
+        fi
+        sleep 1
+    fi
+    _pids=$(zeroclaw_pids)
+    if [ -n "${_pids}" ]; then
+        echo "Failed to stop ${name} supervisor pid(s): $(printf '%s' "${_pids}" | tr '\n' ' ')" >&2
+        return 1
+    fi
+    rm -f "${pidfile}" "${child_pidfile}"
+    return 0
+}
+
+zeroclaw_status()
+{
+    _pids=$(zeroclaw_pids)
+    if [ -n "${_pids}" ]; then
+        echo "${name} is running as supervisor pid(s): $(printf '%s' "${_pids}" | tr '\n' ' ')"
+        return 0
+    fi
+    echo "${name} is not running."
+    return 1
+}
+
+run_rc_command "$1"

--- a/dist/freebsd/zeroclaw-jail-setup.sh
+++ b/dist/freebsd/zeroclaw-jail-setup.sh
@@ -1,0 +1,180 @@
+#!/bin/sh
+#
+# Provision a thick FreeBSD jail for ZeroClaw end to end: create the dataset,
+# extract a matching base system, register the jail, start it, and install the
+# launcher + hardened rc.d script inside it. Installing the zeroclaw binary
+# itself is left to you (pkg, or a build copied in) — see the printed next steps.
+#
+# Run on the HOST as root (or via doas/sudo). It validates its inputs and
+# refuses to clobber an existing jail path or an existing jail.conf entry. If a
+# run fails partway, it tells you what to remove before retrying.
+#
+#   doas sh dist/freebsd/zeroclaw-jail-setup.sh
+#
+# Override the defaults with environment variables, e.g.:
+#   JAIL_NAME=zc JAIL_PATH=/jails/zc ZPOOL=tank ZEROCLAW_USER=agent \
+#       doas sh dist/freebsd/zeroclaw-jail-setup.sh
+#
+# See docs/book/src/setup/freebsd.md ("Running in a jail") for the manual steps.
+
+set -eu
+
+JAIL_NAME="${JAIL_NAME:-zeroclaw}"
+JAIL_PATH="${JAIL_PATH:-/jails/${JAIL_NAME}}"
+ZEROCLAW_USER="${ZEROCLAW_USER:-zeroclaw}"
+# ZPOOL: if set, a ZFS dataset is created at <ZPOOL>/jails/<JAIL_NAME>.
+# Leave empty to use a plain directory (UFS, or a pre-existing dataset).
+ZPOOL="${ZPOOL:-}"
+
+script_dir=$(cd "$(dirname "$0")" && pwd)
+launcher_src="${script_dir}/zeroclaw-run.sh"
+rcd_src="${script_dir}/zeroclaw-hardened.rc"
+
+base_tmp=""
+completed=0
+err() { echo "zeroclaw-jail-setup: $*" >&2; exit 1; }
+cleanup() {
+    [ -n "${base_tmp}" ] && rm -f "${base_tmp}" 2>/dev/null || :
+    if [ "${completed}" -ne 1 ]; then
+        echo "zeroclaw-jail-setup: did not complete. If a partial jail was" \
+             "created at ${JAIL_PATH}, remove it (and any '${JAIL_NAME}'" \
+             "jail.conf entry) before retrying." >&2
+    fi
+}
+trap cleanup EXIT INT TERM
+
+# --- 0. Preflight + input validation -----------------------------------------
+# These values are written into /etc/jail.conf, rc.conf, and a sed replacement,
+# so anything outside a conservative allowlist could corrupt config or inject
+# parameters. Validate everything before mutating any host state.
+[ "$(id -u)" -eq 0 ] || err "must run as root (try: doas sh $0)"
+
+# Disallow a leading '-' so the name can never be mistaken for an option by
+# jexec(8)/service(8) etc.
+case "${JAIL_NAME}" in
+    ''|[!A-Za-z0-9_]*|*[!A-Za-z0-9_-]*)
+        err "JAIL_NAME must match [A-Za-z0-9_][A-Za-z0-9_-]* (got: '${JAIL_NAME}')" ;;
+esac
+case "${ZEROCLAW_USER}" in
+    ''|[!A-Za-z_]*|*[!A-Za-z0-9_-]*)
+        err "ZEROCLAW_USER must be a valid username [A-Za-z_][A-Za-z0-9_-]* (got: '${ZEROCLAW_USER}')" ;;
+esac
+case "${JAIL_PATH}" in
+    /*) : ;;
+    *) err "JAIL_PATH must be an absolute path (got: '${JAIL_PATH}')" ;;
+esac
+case "${JAIL_PATH}" in
+    *[!A-Za-z0-9_/.-]*) err "JAIL_PATH contains unsafe characters (got: '${JAIL_PATH}')" ;;
+esac
+if [ -n "${ZPOOL}" ]; then
+    case "${ZPOOL}" in
+        *[!A-Za-z0-9_/.-]*) err "ZPOOL contains unsafe characters (got: '${ZPOOL}')" ;;
+    esac
+fi
+
+[ -f "${launcher_src}" ] || err "missing ${launcher_src}"
+[ -f "${rcd_src}" ] || err "missing ${rcd_src}"
+for _cmd in jail jexec sysrc fetch tar install sed mktemp freebsd-version; do
+    command -v "${_cmd}" >/dev/null 2>&1 || err "required command not found: ${_cmd} (is this FreeBSD?)"
+done
+[ -z "${ZPOOL}" ] || command -v zfs >/dev/null 2>&1 || err "ZPOOL set but zfs(8) not found"
+
+# Refuse to populate anything that already exists — a symlink, a file, or any
+# pre-existing directory (even an empty one, which could be a sensitive mount
+# point). The jail root must be a fresh path this script creates itself.
+if [ -e "${JAIL_PATH}" ] || [ -L "${JAIL_PATH}" ]; then
+    err "${JAIL_PATH} already exists; refusing to populate it (remove it or pick a fresh JAIL_PATH)"
+fi
+
+# --- 1. Create the jail root --------------------------------------------------
+if [ -n "${ZPOOL}" ]; then
+    echo "==> Creating ZFS dataset ${ZPOOL}/jails/${JAIL_NAME}"
+    zfs create -p -o mountpoint="${JAIL_PATH}" "${ZPOOL}/jails/${JAIL_NAME}"
+else
+    echo "==> Creating directory ${JAIL_PATH}"
+    mkdir -p "${JAIL_PATH}"
+fi
+
+# --- 2. Extract a base system matching the host release -----------------------
+arch=$(uname -m)
+release=$(freebsd-version -u | sed 's/-p[0-9]*$//')
+base_url="https://download.freebsd.org/releases/${arch}/${release}/base.txz"
+base_tmp=$(mktemp -t zeroclaw-jail-base) || err "mktemp failed"
+echo "==> Fetching base.txz for ${arch} ${release}"
+fetch -o "${base_tmp}" "${base_url}"
+echo "==> Extracting base into ${JAIL_PATH}"
+tar -xpf "${base_tmp}" -C "${JAIL_PATH}"
+cp /etc/resolv.conf "${JAIL_PATH}/etc/resolv.conf"
+
+# --- 3. Register the jail in /etc/jail.conf -----------------------------------
+[ -f /etc/jail.conf ] || : >/etc/jail.conf
+# JAIL_NAME is allowlisted above, so it is safe as both a literal and an ERE here.
+if grep -qE "^[[:space:]]*${JAIL_NAME}[[:space:]]*\{" /etc/jail.conf; then
+    echo "==> /etc/jail.conf already has a '${JAIL_NAME}' entry; leaving it untouched"
+else
+    echo "==> Appending '${JAIL_NAME}' entry to /etc/jail.conf"
+    cat >>/etc/jail.conf <<EOF
+
+${JAIL_NAME} {
+    host.hostname = "${JAIL_NAME}";
+    path = "${JAIL_PATH}";
+    exec.start = "/bin/sh /etc/rc";
+    exec.stop  = "/bin/sh /etc/rc.shutdown";
+    exec.clean;
+    mount.devfs;
+    devfs_ruleset = 4;          # devfsrules_jail: restrict device nodes
+    persist;
+}
+EOF
+fi
+
+sysrc jail_enable=YES >/dev/null
+# Append to jail_list only if not already present (idempotent across retries).
+current_list=$(sysrc -n jail_list 2>/dev/null || echo "")
+case " ${current_list} " in
+    *" ${JAIL_NAME} "*) echo "==> jail_list already contains ${JAIL_NAME}" ;;
+    *) sysrc "jail_list+=${JAIL_NAME}" >/dev/null ;;
+esac
+
+# --- 4. Start the jail --------------------------------------------------------
+echo "==> Starting jail ${JAIL_NAME}"
+service jail start "${JAIL_NAME}"
+
+# --- 5. Create the service account + install the service files inside ---------
+echo "==> Creating service account '${ZEROCLAW_USER}' inside the jail"
+if ! jexec "${JAIL_NAME}" pw usershow "${ZEROCLAW_USER}" >/dev/null 2>&1; then
+    jexec "${JAIL_NAME}" pw useradd "${ZEROCLAW_USER}" -m -s /usr/sbin/nologin
+fi
+
+echo "==> Installing launcher + hardened rc.d into the jail"
+install -d "${JAIL_PATH}/usr/local/libexec"
+install -d "${JAIL_PATH}/usr/local/etc/rc.d"
+install -m 755 "${launcher_src}" "${JAIL_PATH}/usr/local/libexec/zeroclaw-run.sh"
+# ZEROCLAW_USER is allowlisted above (no /, &, backslash, or newline), so it is
+# a safe sed replacement.
+sed "s/@@ZEROCLAW_USER@@/${ZEROCLAW_USER}/g" "${rcd_src}" \
+    >"${JAIL_PATH}/usr/local/etc/rc.d/zeroclaw"
+chmod 755 "${JAIL_PATH}/usr/local/etc/rc.d/zeroclaw"
+jexec "${JAIL_NAME}" sysrc zeroclaw_enable=YES >/dev/null
+
+completed=1
+cat <<EOF
+
+Jail '${JAIL_NAME}' is up at ${JAIL_PATH} with the ZeroClaw service files in place.
+
+Next steps (run inside the jail):
+
+  # 1. Install the zeroclaw binary — either from a package mirror that carries
+  #    it, or build it on the host and copy it in. To build inside the jail:
+  doas jexec ${JAIL_NAME} pkg install -y rust git
+  doas jexec ${JAIL_NAME} /bin/sh -c 'cd /root && git clone \\
+      https://github.com/zeroclaw-labs/zeroclaw && cd zeroclaw && \\
+      cargo build --release && install -m 755 target/release/zeroclaw \\
+      /usr/local/bin/zeroclaw'
+
+  # 2. Set up provider auth for the '${ZEROCLAW_USER}' account, then start it:
+  doas jexec ${JAIL_NAME} service zeroclaw start
+  doas jexec ${JAIL_NAME} service zeroclaw status
+
+See docs/book/src/setup/freebsd.md for auth, logs, and the gateway bind note.
+EOF

--- a/dist/freebsd/zeroclaw-run.sh
+++ b/dist/freebsd/zeroclaw-run.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+#
+# Launcher for the zeroclaw FreeBSD rc.d service.
+#
+# daemon(8) starts its child with a minimal environment, so we export a full
+# PATH here: FreeBSD keeps git, python3, etc. under /usr/local/bin, which is NOT
+# on the default service PATH.
+#
+# The rc.d script runs this through `daemon -u <user>`, so this launcher already
+# executes AS the service account. HOME is taken from that account's passwd
+# entry (via tilde expansion) rather than hardcoded to /home/<user>, so accounts
+# whose home is elsewhere — and rc.conf run-as overrides — work unchanged.
+#
+# Install as /usr/local/libexec/zeroclaw-run.sh (see dist/freebsd/README.md).
+
+: "${HOME:=$(eval echo ~)}"
+export HOME
+export PATH="/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin:${HOME}/bin"
+exec /usr/local/bin/zeroclaw daemon --config-dir "${HOME}/.zeroclaw"

--- a/dist/freebsd/zeroclaw.rc
+++ b/dist/freebsd/zeroclaw.rc
@@ -1,0 +1,51 @@
+#!/bin/sh
+#
+# PROVIDE: zeroclaw
+# REQUIRE: NETWORKING DAEMON
+# KEYWORD: shutdown
+#
+# Basic single-instance rc.d script for zeroclaw. Install as
+# /usr/local/etc/rc.d/zeroclaw and replace @@ZEROCLAW_USER@@ with the account
+# that owns ~/.zeroclaw (see dist/freebsd/README.md).
+#
+# For unattended or remote operation (idempotent start, thorough stop, and a
+# `ssh host service zeroclaw start` that does not hang), use the hardened
+# variant zeroclaw-hardened.rc in this directory instead of this one.
+
+. /etc/rc.subr
+
+name="zeroclaw"
+rcvar="zeroclaw_enable"
+
+load_rc_config $name
+
+: ${zeroclaw_enable:="NO"}
+# NOTE: do NOT name this ${name}_user — rc.subr would then run its own user
+# switch (su) and collide with daemon -u ("failed to set user environment").
+: ${zeroclaw_runas:="@@ZEROCLAW_USER@@"}
+
+rundir="/var/run/zeroclaw"
+pidfile="${rundir}/zeroclaw.pid"
+logfile="/var/log/${name}.log"
+launcher="/usr/local/libexec/zeroclaw-run.sh"
+
+command="/usr/sbin/daemon"
+# -r supervise+restart the child; -P write the SUPERVISOR pid; -o route the
+# child's stdout/stderr to the logfile; -u run as an unprivileged user.
+# daemon -u (not `su -m`) so SIGTERM is forwarded to zeroclaw on stop.
+command_args="-r -P ${pidfile} -o ${logfile} -u ${zeroclaw_runas} ${launcher}"
+
+start_precmd="zeroclaw_precmd"
+
+zeroclaw_precmd()
+{
+    # rundir + logfile stay root-owned: rc.d (root) writes the daemon -P pidfile
+    # here and trusts it later, so the unprivileged service user must not be
+    # able to forge the supervisor pidfile. daemon -o opens the logfile before
+    # dropping to ${zeroclaw_runas}, so root ownership is fine.
+    install -d -o root -g wheel -m 755 "${rundir}"
+    [ -e "${logfile}" ] || install -o root -g wheel -m 640 /dev/null "${logfile}"
+    return 0
+}
+
+run_rc_command "$1"

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -14,6 +14,7 @@
   - [Linux](./setup/linux.md)
   - [macOS](./setup/macos.md)
   - [Windows](./setup/windows.md)
+  - [FreeBSD](./setup/freebsd.md)
   - [Docker & containers](./setup/container.md)
   - [Service management](./setup/service.md)
 

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -17,6 +17,7 @@
   - [FreeBSD](./setup/freebsd.md)
   - [Docker & containers](./setup/container.md)
   - [Service management](./setup/service.md)
+  - [Platform install files](./setup/dist-files.md)
 
 - [Architecture]()
   - [Overview](./architecture/overview.md)

--- a/docs/book/src/setup/dist-files.md
+++ b/docs/book/src/setup/dist-files.md
@@ -1,0 +1,11 @@
+# Platform-specific install files
+
+ZeroClaw ships ready-to-use packaging and service files for several platforms under [`dist/`](https://github.com/zeroclaw-labs/zeroclaw/tree/master/dist). These are operator-facing — copy them to your host instead of hand-writing package or service definitions.
+
+| Platform | Directory | Contents |
+|---|---|---|
+| Arch Linux | [`dist/aur/`](https://github.com/zeroclaw-labs/zeroclaw/tree/master/dist/aur) | `PKGBUILD` for the AUR package. |
+| Windows | [`dist/scoop/`](https://github.com/zeroclaw-labs/zeroclaw/tree/master/dist/scoop) | `zeroclaw.json` Scoop manifest. |
+| FreeBSD | [`dist/freebsd/`](https://github.com/zeroclaw-labs/zeroclaw/tree/master/dist/freebsd) | `rc.d` service scripts, a hardened variant, an end-to-end jail provisioner, and sample configs. See the [FreeBSD setup guide](./freebsd.md). |
+
+Linux (systemd), macOS (launchd), and Windows (Task Scheduler) service units are generated for you by `zeroclaw service install` — see [Service management](./service.md). The files above cover the platforms that command does not target.

--- a/docs/book/src/setup/freebsd.md
+++ b/docs/book/src/setup/freebsd.md
@@ -272,6 +272,77 @@ doas jexec zeroclaw service zeroclaw status
 - **Prefer the hardened `rc.d` script in a jail.** You'll typically drive `service` non-interactively via `jexec`/`ssh`, which is exactly where the basic script's `start` hang and orphan-stacking bite — see [Hardening](#4-hardening-for-unattended-and-remote-operation). It also keeps `/var/run/zeroclaw` root-owned inside the jail so the unprivileged service user can't forge the supervisor pidfile.
 - **Running several daemons in one jail** (e.g. a worker pool) follows the pool note in the hardening section: one pidfile/logfile per instance and a `pgrep` bound to the launcher retitle, since the jail shares one process table.
 
+## Running the Linux image under Podman + Linuxulator
+
+The native build above is the right path for ZeroClaw itself. But some Python-backed
+tools and skills depend on **manylinux-only wheels** — `polars`, `pyarrow`, and
+`oracledb`, for example, publish no FreeBSD wheels, so a tool that imports them can't
+run under the native FreeBSD `python3`. FreeBSD's [Linuxulator](https://docs.freebsd.org/en/books/handbook/linuxemu/)
+(Linux binary-compatibility layer) plus Podman lets you run the **official Linux
+container image** on a FreeBSD host, giving those tools the Linux ABI they expect.
+This complements the native `rc.d` daemon — you can run either, or both side by side.
+
+### 1. Prerequisites
+
+Load the Linuxulator modules and confirm they report a Linux release:
+
+```sh
+doas kldload linux linux64
+sysctl compat.linux.osrelease        # e.g. compat.linux.osrelease: 5.15.0
+```
+
+To load them on boot, add `linux_enable="YES"` to `/etc/rc.conf`. Then install Podman:
+
+```sh
+doas pkg install -y podman
+```
+
+### 2. Pull the image — force the Linux platform
+
+FreeBSD Podman defaults to `os=freebsd` when resolving a manifest list. ZeroClaw's
+images are published only for `linux/amd64` and `linux/arm64`, so a plain `podman pull`
+fails with `no image found in manifest list for architecture ..., OS freebsd`. Force
+the Linux platform explicitly:
+
+```sh
+doas podman pull --os linux --arch amd64 ghcr.io/zeroclaw-labs/zeroclaw:debian
+```
+
+> Use the `debian` tag rather than `latest`: the distroless `latest` image has no
+> shell, which makes it awkward to debug under emulation. See
+> [Docker & Containers](./container.md) for the full image list.
+
+### 3. Run the container
+
+The Linux image behaves exactly as documented in [Docker & Containers](./container.md) —
+it expects persistent state at `/zeroclaw-data` and bootstraps a config on first run:
+
+```sh
+doas podman run -d --name zeroclaw --restart=always \
+    --os linux --arch amd64 \
+    -p 42617:42617 \
+    -v /var/db/zeroclaw:/zeroclaw-data \
+    ghcr.io/zeroclaw-labs/zeroclaw:debian
+
+doas podman exec -it zeroclaw zeroclaw onboard
+```
+
+Keep the `--os linux --arch amd64` flags on every `run` (not just `pull`) so Podman
+doesn't re-resolve to the FreeBSD default.
+
+### Linuxulator notes
+
+- **Boot persistence.** Podman's own `--restart=always` only restarts the container
+  within a running Podman; it won't survive a host reboot on its own. Supervise the
+  `podman start` from an `rc.d` script (same pattern as the [native service](#running-as-a-service-rcd))
+  or a `@reboot` cron entry so the container comes back after the host restarts.
+- **Networking.** `-p 42617:42617` publishes the gateway through Podman's bridge. If
+  the bridge/CNI setup isn't configured on your host, `--network host` is the simplest
+  alternative — the container then shares the host's network stack directly.
+- **Not everything emulates cleanly.** Linuxulator covers the common syscall surface,
+  but exotic binaries may hit unimplemented calls. If a tool misbehaves, check
+  `dmesg` for `linux:` warnings before assuming a ZeroClaw bug.
+
 ## Logs
 
 ```sh

--- a/docs/book/src/setup/freebsd.md
+++ b/docs/book/src/setup/freebsd.md
@@ -1,0 +1,195 @@
+# FreeBSD
+
+ZeroClaw runs natively on FreeBSD (tested on FreeBSD 15.0-RELEASE, `amd64`). Two things differ from the Linux/macOS/Windows paths:
+
+1. **No prebuilt binary and no `install.sh` support.** FreeBSD is not a target of the bootstrap installer, so you build from source with the system Rust toolchain.
+2. **No `zeroclaw service` backend.** The `zeroclaw service install` command knows systemd, launchd, and Windows Task Scheduler — not FreeBSD `rc.d`. You install a small `rc.d` script yourself. This page gives you a complete, tested one.
+
+Everything else — config, providers, channels, the daemon, the gateway — is identical to any other platform.
+
+## System dependencies
+
+Install the toolchain and runtime from `pkg`:
+
+```sh
+doas pkg install -y rust git
+```
+
+| Package | Why |
+|---|---|
+| `rust` | Provides `cargo` and `rustc` to build the binary. The port tracks a recent stable (1.94+ at time of writing). |
+| `git` | Cloning the repo, and required at runtime if you use any git-backed tools. |
+
+> **`doas`, not `sudo`.** FreeBSD ships `doas` as the base privilege-escalation tool; `sudo` is an optional port. The examples here use `doas`. A minimal `/usr/local/etc/doas.conf` granting the `wheel` group passwordless escalation is:
+>
+> ```
+> permit nopass keepenv :wheel
+> ```
+
+## Build from source
+
+```sh
+git clone https://github.com/zeroclaw-labs/zeroclaw.git
+cd zeroclaw
+cargo build --release
+```
+
+The release binary lands at `target/release/zeroclaw`. A clean build of the default feature set takes a while on modest hardware — this is expected; ZeroClaw is a large Rust workspace.
+
+To trim the build, disable features you don't need (see `./install.sh --list-features` on a Linux box, or `Cargo.toml`):
+
+```sh
+cargo build --release --no-default-features --features agent-runtime
+```
+
+## Install the binary
+
+Put it somewhere on `PATH`. `/usr/local/bin` is the conventional location for ports-installed binaries on FreeBSD:
+
+```sh
+doas install -m 755 target/release/zeroclaw /usr/local/bin/zeroclaw
+zeroclaw --version
+```
+
+(`~/.cargo/bin/zeroclaw` works just as well if you'd rather keep it per-user.)
+
+## First-run configuration
+
+```sh
+zeroclaw onboard
+```
+
+This creates `~/.zeroclaw/` with a starter `config.toml` and walks you through provider setup. Config layout and precedence are identical to every other platform — see [Reference → Config](../reference/config.md).
+
+## Provider authentication
+
+API-key providers need nothing FreeBSD-specific — set the key in `config.toml` or the environment and you're done.
+
+For OAuth-based providers (e.g. an OpenAI/Codex ChatGPT subscription), import the credential with:
+
+```sh
+zeroclaw auth login --model-provider openai-codex --import /path/to/auth.json
+zeroclaw auth status
+```
+
+> **Auth profiles are encrypted per-host and are *not* portable.** ZeroClaw stores resolved credentials in `~/.zeroclaw/auth-profiles.json`, encrypted with the host-local key at `~/.zeroclaw/.secret_key`. **Do not copy `auth-profiles.json` between machines** — the target host's `.secret_key` won't decrypt it and every request fails with `enc2: decryption failed`. Instead, copy the *raw* upstream credential (the un-encrypted `auth.json` your provider's own login produced) and re-run `zeroclaw auth login --import` on each host so it re-encrypts locally. If you hit a stale/undecryptable profile, move it aside (`mv ~/.zeroclaw/auth-profiles.json ~/.zeroclaw/auth-profiles.json.bak`) before re-importing.
+
+## Running as a service (`rc.d`)
+
+Because `zeroclaw service install` has no FreeBSD backend, supervise the daemon with FreeBSD's native [`daemon(8)`](https://man.freebsd.org/cgi/man.cgi?daemon%288%29) under an `rc.d` script. This gives you `service zeroclaw start|stop|restart|status`, restart-on-crash, a pidfile, and boot-time startup.
+
+### 1. Launcher script
+
+`daemon(8)` starts the child with a minimal environment, so export `HOME` and a full `PATH` (FreeBSD puts `git`, `python3`, etc. under `/usr/local/bin`, which is *not* on the default service `PATH`). Save as `/usr/local/libexec/zeroclaw-run.sh`:
+
+```sh
+#!/bin/sh
+export HOME=/home/youruser
+export PATH=/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin:/home/youruser/bin
+exec /usr/local/bin/zeroclaw daemon --config-dir "$HOME/.zeroclaw"
+```
+
+```sh
+doas install -m 755 zeroclaw-run.sh /usr/local/libexec/zeroclaw-run.sh
+```
+
+### 2. `rc.d` script
+
+Save as `/usr/local/etc/rc.d/zeroclaw`:
+
+```sh
+#!/bin/sh
+#
+# PROVIDE: zeroclaw
+# REQUIRE: NETWORKING DAEMON
+# KEYWORD: shutdown
+
+. /etc/rc.subr
+
+name="zeroclaw"
+rcvar="zeroclaw_enable"
+
+load_rc_config $name
+
+: ${zeroclaw_enable:="NO"}
+: ${zeroclaw_user:="youruser"}
+
+rundir="/var/run/zeroclaw"
+pidfile="${rundir}/zeroclaw.pid"
+logfile="/var/log/${name}.log"
+launcher="/usr/local/libexec/zeroclaw-run.sh"
+
+command="/usr/sbin/daemon"
+command_args="-r -P ${pidfile} -o ${logfile} -u ${zeroclaw_user} ${launcher}"
+
+start_precmd="zeroclaw_precmd"
+
+zeroclaw_precmd()
+{
+    install -d -o ${zeroclaw_user} -g wheel -m 755 "${rundir}"
+    install -o ${zeroclaw_user} -m 640 /dev/null "${logfile}"
+}
+
+run_rc_command "$1"
+```
+
+```sh
+doas install -m 755 zeroclaw /usr/local/etc/rc.d/zeroclaw
+```
+
+What the flags do:
+
+- `-r` — supervise and restart the child if it exits (crash recovery).
+- `-P ${pidfile}` — write the *supervisor's* pid so `service zeroclaw stop` can signal it.
+- `-o ${logfile}` — redirect the child's stdout/stderr to a logfile.
+- `-u ${zeroclaw_user}` — run zeroclaw as an unprivileged user, not root.
+
+> **Why `daemon -u` and not `su -m`.** A common pattern is `daemon ... su -m user -c launcher`. Avoid it: `su(1)` does **not** forward `SIGTERM` to its child, so `service zeroclaw stop` kills the `daemon` supervisor but leaves an orphaned `zeroclaw` process behind — and the next `start` stacks a second copy. `daemon -u user` makes `daemon(8)` the direct parent of `zeroclaw`, so it forwards the stop signal and shuts down cleanly. (If you're stuck with a `su`-based script for other reasons, add a `pkill -f "zeroclaw daemon"` sweep to its stop path.)
+
+### 3. Enable and start
+
+```sh
+doas sysrc zeroclaw_enable=YES
+doas sysrc zeroclaw_user=youruser      # the account that owns ~/.zeroclaw
+
+doas service zeroclaw start
+doas service zeroclaw status
+```
+
+`service zeroclaw stop` / `restart` work as expected. Because `zeroclaw_enable=YES` is in `/etc/rc.conf` (written by `sysrc`), the daemon also starts on boot.
+
+## Logs
+
+```sh
+tail -f /var/log/zeroclaw.log
+```
+
+Set the log level via the standard config / env knobs — see [Operations → Logs & observability](../ops/observability.md).
+
+## Verify
+
+```sh
+zeroclaw --version
+service zeroclaw status
+# if the daemon exposes the local gateway (default 127.0.0.1:42617):
+fetch -qo - http://127.0.0.1:42617/health
+```
+
+A `"status":"ok"` health payload means the gateway, daemon, and channels came up.
+
+## Uninstall
+
+```sh
+doas service zeroclaw stop
+doas sysrc -x zeroclaw_enable
+doas rm /usr/local/etc/rc.d/zeroclaw /usr/local/libexec/zeroclaw-run.sh
+doas rm /usr/local/bin/zeroclaw
+rm -rf ~/.zeroclaw        # optional — deletes config + history
+```
+
+## Next
+
+- [Service management](./service.md) — how the first-party backends work on other platforms
+- [Reference → Config](../reference/config.md) — config file layout
+- [Quick start](../getting-started/quick-start.md) — first conversation
+- [Operations → Overview](../ops/overview.md) — running in production

--- a/docs/book/src/setup/freebsd.md
+++ b/docs/book/src/setup/freebsd.md
@@ -158,6 +158,46 @@ doas service zeroclaw status
 
 `service zeroclaw stop` / `restart` work as expected. Because `zeroclaw_enable=YES` is in `/etc/rc.conf` (written by `sysrc`), the daemon also starts on boot.
 
+### 4. Hardening for unattended and remote operation
+
+The script above is correct for an interactive, single-instance install. Three `daemon(8)` behaviours will surprise you the moment you drive the service remotely (over `ssh`) or run more than one copy. All three bit a production deployment; the fixes are small.
+
+**Remote `service ... start` hangs.** `daemon -r` inherits and holds open whatever stdin/stdout/stderr it was launched with. Run `ssh host 'service zeroclaw start'` and the supervisor keeps your `ssh` session's stdout fd open forever, so `ssh` never sees EOF and the command hangs even though the daemon started fine. Detach the supervisor's own descriptors — `-o ${logfile}` already routes the *child's* output, so nothing is lost:
+
+```sh
+command_args="-r -P ${pidfile} -o ${logfile} -u ${zeroclaw_user} ${launcher}"
+# ...invoke daemon with its own std{in,out,err} sent to /dev/null:
+/usr/sbin/daemon ${command_args} </dev/null >/dev/null 2>&1
+```
+
+If you use the stock `command`/`command_args` form, wrap the start in a custom `start_cmd` so you control the redirection. This one change is what makes `service zeroclaw start` safe to call from `ssh`, CI, or a config-management push.
+
+**Repeated `start` stacks orphan supervisors.** A plain `start` does not check whether a supervisor is already running, so a second `start` (or a `start` after a crash that left a stale pidfile) launches another `daemon` that fights the first over the gateway port. Make `start` idempotent by refusing when a live supervisor already exists. Match the supervisor by the launcher path, **not** the pidfile alone (the pidfile can be stale). Two FreeBSD-specific traps when you do this:
+
+- `daemon(8)` *retitles its supervisor* to `daemon: /usr/local/libexec/zeroclaw-run.sh[<childpid>] (daemon)`. So `pgrep -f zeroclaw-run.sh` matches the supervisor, but a `pgrep -f` for the binary name does not. Bind on the literal `daemon: ` prefix — that matches the supervisor and never the child, a hand-run of the launcher, or the rc shell itself.
+- FreeBSD `pgrep -f` does **not** honour a leading `^` anchor against that retitle string — `pgrep -f '^daemon: ...'` matches nothing. Drop the `^`; rely on the `daemon: ` prefix for specificity and escape the dot in `.sh` as `[.]` so it is literal.
+
+```sh
+launcher_pat="daemon: /usr/local/libexec/zeroclaw-run[.]sh"
+
+zeroclaw_running()
+{
+    pgrep -f "${launcher_pat}" >/dev/null 2>&1
+}
+```
+
+**`read` from a `daemon -P` pidfile reports a false negative.** `daemon -P` writes the pid with **no trailing newline**, so `IFS= read -r pid < "${pidfile}"` returns a *non-zero* status (EOF before newline) even though it set `pid` correctly. If you guard it as `read -r pid < "$pf" || return 1`, every running instance looks stopped and your idempotent `start` happily launches a duplicate. Don't key the success path on `read`'s exit status — validate the value instead:
+
+```sh
+pid=""
+IFS= read -r pid < "${pidfile}"     # do NOT `|| return 1` here
+case "${pid}" in
+    ''|*[!0-9]*) return 1 ;;        # empty or non-numeric → treat as not running
+esac
+```
+
+**Running a pool of instances.** To run N daemons (e.g. a worker pool), give each its own pidfile and logfile (`worker.$i.pid`, `worker.$i.log`) and loop the start/stop over `$i`. Because the supervisor retitle is identical for every instance and does not include per-instance arguments, the **pidfile is the only per-instance handle** — drive stop/status from the pidfile, and on a full stop sweep any leftover supervisor that no live pidfile points at (started by hand, or whose pidfile went stale).
+
 ## Logs
 
 ```sh

--- a/docs/book/src/setup/freebsd.md
+++ b/docs/book/src/setup/freebsd.md
@@ -7,6 +7,10 @@ ZeroClaw runs natively on FreeBSD (tested on FreeBSD 15.0-RELEASE, `amd64`). Two
 
 Everything else — config, providers, channels, the daemon, the gateway — is identical to any other platform.
 
+> **When to use FreeBSD.** FreeBSD deployments are common in network-appliance, embedded, and jail-based hosting where operators want the base system’s stability, ZFS + jail primitives, or need FreeBSD for policy/licensing reasons. Because there is no prebuilt binary and the `rc.d` setup is manual, this path suits operators comfortable with FreeBSD conventions. If you are only evaluating platforms with no specific FreeBSD requirement, Linux (systemd) or macOS (launchd) onboard faster via `install.sh` and `zeroclaw service install`.
+>
+> **Grab the files instead of copy-pasting.** Every shell script and sample config shown below ships in [`dist/freebsd/`](https://github.com/zeroclaw-labs/zeroclaw/tree/master/dist/freebsd) — copy them to your host directly. The walkthrough explains what each piece does and why.
+
 ## System dependencies
 
 Install the toolchain and runtime from `pkg`:

--- a/docs/book/src/setup/freebsd.md
+++ b/docs/book/src/setup/freebsd.md
@@ -78,15 +78,18 @@ zeroclaw auth status
 
 Because `zeroclaw service install` has no FreeBSD backend, supervise the daemon with FreeBSD's native [`daemon(8)`](https://man.freebsd.org/cgi/man.cgi?daemon%288%29) under an `rc.d` script. This gives you `service zeroclaw start|stop|restart|status`, restart-on-crash, a pidfile, and boot-time startup.
 
+> **Ready-to-install copies of every script below live in [`dist/freebsd/`](https://github.com/zeroclaw-labs/zeroclaw/tree/master/dist/freebsd)** (`zeroclaw-run.sh`, the basic `zeroclaw.rc`, and the hardened `zeroclaw-hardened.rc`). The two `rc.d` scripts carry a `@@ZEROCLAW_USER@@` placeholder you `sed` in on install, so you can grab the files instead of copy-pasting — see `dist/freebsd/README.md`. The walkthrough below explains what each piece does.
+
 ### 1. Launcher script
 
-`daemon(8)` starts the child with a minimal environment, so export `HOME` and a full `PATH` (FreeBSD puts `git`, `python3`, etc. under `/usr/local/bin`, which is *not* on the default service `PATH`). Save as `/usr/local/libexec/zeroclaw-run.sh`:
+`daemon(8)` starts the child with a minimal environment, so export a full `PATH` (FreeBSD puts `git`, `python3`, etc. under `/usr/local/bin`, which is *not* on the default service `PATH`). The `rc.d` script runs this through `daemon -u <user>`, so the launcher already executes as the service account — derive `HOME` from that account's passwd entry rather than hardcoding `/home/<user>`, so accounts whose home is elsewhere (and `rc.conf` run-as overrides) keep working. Save as `/usr/local/libexec/zeroclaw-run.sh`:
 
 ```sh
 #!/bin/sh
-export HOME=/home/youruser
-export PATH=/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin:/home/youruser/bin
-exec /usr/local/bin/zeroclaw daemon --config-dir "$HOME/.zeroclaw"
+: "${HOME:=$(eval echo ~)}"
+export HOME
+export PATH="/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin:${HOME}/bin"
+exec /usr/local/bin/zeroclaw daemon --config-dir "${HOME}/.zeroclaw"
 ```
 
 ```sh
@@ -112,7 +115,9 @@ rcvar="zeroclaw_enable"
 load_rc_config $name
 
 : ${zeroclaw_enable:="NO"}
-: ${zeroclaw_user:="youruser"}
+# Do NOT name this ${name}_user — rc.subr would then run its own su user-switch
+# and collide with daemon -u ("failed to set user environment").
+: ${zeroclaw_runas:="youruser"}
 
 rundir="/var/run/zeroclaw"
 pidfile="${rundir}/zeroclaw.pid"
@@ -120,14 +125,17 @@ logfile="/var/log/${name}.log"
 launcher="/usr/local/libexec/zeroclaw-run.sh"
 
 command="/usr/sbin/daemon"
-command_args="-r -P ${pidfile} -o ${logfile} -u ${zeroclaw_user} ${launcher}"
+command_args="-r -P ${pidfile} -o ${logfile} -u ${zeroclaw_runas} ${launcher}"
 
 start_precmd="zeroclaw_precmd"
 
 zeroclaw_precmd()
 {
-    install -d -o ${zeroclaw_user} -g wheel -m 755 "${rundir}"
-    install -o ${zeroclaw_user} -m 640 /dev/null "${logfile}"
+    # rundir + logfile stay root-owned: rc.d (root) writes the daemon -P pidfile
+    # here and trusts it later, so the unprivileged service user must not be able
+    # to forge it. daemon -o opens the logfile before dropping to ${zeroclaw_runas}.
+    install -d -o root -g wheel -m 755 "${rundir}"
+    install -o root -g wheel -m 640 /dev/null "${logfile}"
 }
 
 run_rc_command "$1"
@@ -142,7 +150,7 @@ What the flags do:
 - `-r` — supervise and restart the child if it exits (crash recovery).
 - `-P ${pidfile}` — write the *supervisor's* pid so `service zeroclaw stop` can signal it.
 - `-o ${logfile}` — redirect the child's stdout/stderr to a logfile.
-- `-u ${zeroclaw_user}` — run zeroclaw as an unprivileged user, not root.
+- `-u ${zeroclaw_runas}` — run zeroclaw as an unprivileged user, not root.
 
 > **Why `daemon -u` and not `su -m`.** A common pattern is `daemon ... su -m user -c launcher`. Avoid it: `su(1)` does **not** forward `SIGTERM` to its child, so `service zeroclaw stop` kills the `daemon` supervisor but leaves an orphaned `zeroclaw` process behind — and the next `start` stacks a second copy. `daemon -u user` makes `daemon(8)` the direct parent of `zeroclaw`, so it forwards the stop signal and shuts down cleanly. (If you're stuck with a `su`-based script for other reasons, add a `pkill -f "zeroclaw daemon"` sweep to its stop path.)
 
@@ -150,7 +158,7 @@ What the flags do:
 
 ```sh
 doas sysrc zeroclaw_enable=YES
-doas sysrc zeroclaw_user=youruser      # the account that owns ~/.zeroclaw
+doas sysrc zeroclaw_runas=youruser     # the account that owns ~/.zeroclaw
 
 doas service zeroclaw start
 doas service zeroclaw status
@@ -160,12 +168,12 @@ doas service zeroclaw status
 
 ### 4. Hardening for unattended and remote operation
 
-The script above is correct for an interactive, single-instance install. Three `daemon(8)` behaviours will surprise you the moment you drive the service remotely (over `ssh`) or run more than one copy. All three bit a production deployment; the fixes are small.
+The script above is correct for an interactive, single-instance install. Three `daemon(8)` behaviours will surprise you the moment you drive the service remotely (over `ssh`) or run more than one copy. All three bit a production deployment; the fixes are small. A complete script folding in every fix below ships as [`dist/freebsd/zeroclaw-hardened.rc`](https://github.com/zeroclaw-labs/zeroclaw/tree/master/dist/freebsd) — install it in place of the basic `zeroclaw` script.
 
 **Remote `service ... start` hangs.** `daemon -r` inherits and holds open whatever stdin/stdout/stderr it was launched with. Run `ssh host 'service zeroclaw start'` and the supervisor keeps your `ssh` session's stdout fd open forever, so `ssh` never sees EOF and the command hangs even though the daemon started fine. Detach the supervisor's own descriptors — `-o ${logfile}` already routes the *child's* output, so nothing is lost:
 
 ```sh
-command_args="-r -P ${pidfile} -o ${logfile} -u ${zeroclaw_user} ${launcher}"
+command_args="-r -P ${pidfile} -o ${logfile} -u ${zeroclaw_runas} ${launcher}"
 # ...invoke daemon with its own std{in,out,err} sent to /dev/null:
 /usr/sbin/daemon ${command_args} </dev/null >/dev/null 2>&1
 ```
@@ -174,11 +182,11 @@ If you use the stock `command`/`command_args` form, wrap the start in a custom `
 
 **Repeated `start` stacks orphan supervisors.** A plain `start` does not check whether a supervisor is already running, so a second `start` (or a `start` after a crash that left a stale pidfile) launches another `daemon` that fights the first over the gateway port. Make `start` idempotent by refusing when a live supervisor already exists. Match the supervisor by the launcher path, **not** the pidfile alone (the pidfile can be stale). Two FreeBSD-specific traps when you do this:
 
-- `daemon(8)` *retitles its supervisor* to `daemon: /usr/local/libexec/zeroclaw-run.sh[<childpid>] (daemon)`. So `pgrep -f zeroclaw-run.sh` matches the supervisor, but a `pgrep -f` for the binary name does not. Bind on the literal `daemon: ` prefix — that matches the supervisor and never the child, a hand-run of the launcher, or the rc shell itself.
-- FreeBSD `pgrep -f` does **not** honour a leading `^` anchor against that retitle string — `pgrep -f '^daemon: ...'` matches nothing. Drop the `^`; rely on the `daemon: ` prefix for specificity and escape the dot in `.sh` as `[.]` so it is literal.
+- `daemon(8)` *retitles its supervisor* to `daemon: /usr/local/libexec/zeroclaw-run.sh[<childpid>] (daemon)`. So `pgrep -f zeroclaw-run.sh` matches the supervisor, but a `pgrep -f` for the binary name does not. Bind on the literal `daemon:` prefix — that matches the supervisor and never the child, a hand-run of the launcher, or the rc shell itself. Bind the trailing `[` that opens daemon's `[<childpid>]` too, so a sibling launcher whose name merely *starts with* `zeroclaw-run.sh` can't match (this matters once you run a pool — see [Running a pool of instances](#4-hardening-for-unattended-and-remote-operation) below).
+- FreeBSD `pgrep -f` does **not** honour a leading `^` anchor against that retitle string — `pgrep -f '^daemon: ...'` matches nothing. Drop the `^`; rely on the `daemon:` prefix for specificity and escape the dot in `.sh` as `[.]` (and the bracket as `[[]`) so they are literal.
 
 ```sh
-launcher_pat="daemon: /usr/local/libexec/zeroclaw-run[.]sh"
+launcher_pat="daemon: /usr/local/libexec/zeroclaw-run[.]sh[[]"
 
 zeroclaw_running()
 {
@@ -197,6 +205,70 @@ esac
 ```
 
 **Running a pool of instances.** To run N daemons (e.g. a worker pool), give each its own pidfile and logfile (`worker.$i.pid`, `worker.$i.log`) and loop the start/stop over `$i`. Because the supervisor retitle is identical for every instance and does not include per-instance arguments, the **pidfile is the only per-instance handle** — drive stop/status from the pidfile, and on a full stop sweep any leftover supervisor that no live pidfile points at (started by hand, or whose pidfile went stale).
+
+## Running in a jail
+
+[Jails](https://docs.freebsd.org/en/books/handbook/jails/) give ZeroClaw an isolated root with its own packages, service user, and optionally its own IP — useful if the host runs other services or you want to constrain the agent. **The service setup is identical to the host case; you just run it *inside* the jail.** This walks through a classic thick jail with base-system tooling (no jail manager required).
+
+### 1. Create the jail
+
+```sh
+# ZFS dataset for the jail (use a plain directory if you're on UFS).
+doas zfs create -o mountpoint=/jails/zeroclaw zroot/jails/zeroclaw   # adjust pool
+
+# Extract a base matching the HOST's release into it.
+doas fetch -o /tmp/base.txz \
+    "https://download.freebsd.org/releases/$(uname -m)/$(freebsd-version -u)/base.txz"
+doas tar -xpf /tmp/base.txz -C /jails/zeroclaw
+doas cp /etc/resolv.conf /jails/zeroclaw/etc/
+```
+
+### 2. Configure and start
+
+Add a jail entry to `/etc/jail.conf` (host side). This example shares the host network; set `ip4.addr` instead if you give the jail a dedicated address.
+
+```
+zeroclaw {
+    host.hostname = "zeroclaw";
+    path = "/jails/zeroclaw";
+    exec.start = "/bin/sh /etc/rc";
+    exec.stop  = "/bin/sh /etc/rc.shutdown";
+    exec.clean;
+    mount.devfs;
+    persist;
+}
+```
+
+```sh
+doas sysrc jail_enable=YES
+doas sysrc jail_list+=" zeroclaw"
+doas service jail start zeroclaw
+```
+
+### 3. Install ZeroClaw inside the jail
+
+Everything from the sections above runs *inside* the jail — prefix commands with `doas jexec zeroclaw …`, or open a shell with `doas jexec zeroclaw /bin/sh`:
+
+```sh
+doas jexec zeroclaw pkg install -y rust git     # or copy a binary built on the host
+# build + install zeroclaw to /usr/local/bin/zeroclaw exactly as above, then:
+doas jexec zeroclaw pw useradd zeroclaw -m -s /usr/sbin/nologin
+```
+
+Install the launcher and `rc.d` script into the **jail's** filesystem (from the host, the jail root is prefixed: `/jails/zeroclaw/usr/local/libexec/…` and `/jails/zeroclaw/usr/local/etc/rc.d/…`). Then enable and start the service *inside* the jail:
+
+```sh
+doas jexec zeroclaw sysrc zeroclaw_enable=YES
+doas jexec zeroclaw service zeroclaw start
+doas jexec zeroclaw service zeroclaw status
+```
+
+### Jail-specific notes
+
+- **Edit jail files from the host with `tee`, not `cp /dev/stdin`.** Pipe through `… | doas tee /jails/zeroclaw/usr/local/etc/rc.d/zeroclaw >/dev/null`; `doas cp /dev/stdin …` can fail mid-copy with `cp: /dev/stdin: File changed`.
+- **The gateway binds inside the jail.** The daemon listens on loopback by default — to reach it from the host or LAN, launch zeroclaw with `--host 0.0.0.0` (edit `zeroclaw-run.sh`) and give the jail a reachable address, or proxy from the host.
+- **Prefer the hardened `rc.d` script in a jail.** You'll typically drive `service` non-interactively via `jexec`/`ssh`, which is exactly where the basic script's `start` hang and orphan-stacking bite — see [Hardening](#4-hardening-for-unattended-and-remote-operation). It also keeps `/var/run/zeroclaw` root-owned inside the jail so the unprivileged service user can't forge the supervisor pidfile.
+- **Running several daemons in one jail** (e.g. a worker pool) follows the pool note in the hardening section: one pidfile/logfile per instance and a `pgrep` bound to the launcher retitle, since the jail shares one process table.
 
 ## Logs
 

--- a/docs/book/src/setup/freebsd.md
+++ b/docs/book/src/setup/freebsd.md
@@ -210,6 +210,8 @@ esac
 
 [Jails](https://docs.freebsd.org/en/books/handbook/jails/) give ZeroClaw an isolated root with its own packages, service user, and optionally its own IP — useful if the host runs other services or you want to constrain the agent. **The service setup is identical to the host case; you just run it *inside* the jail.** This walks through a classic thick jail with base-system tooling (no jail manager required).
 
+> **One-step option.** [`dist/freebsd/zeroclaw-jail-setup.sh`](https://github.com/zeroclaw-labs/zeroclaw/tree/master/dist/freebsd) automates steps 1–3 below — it creates the jail, extracts a matching base, adds the `/etc/jail.conf` entry, starts the jail, and installs the launcher + hardened `rc.d` script inside it (`doas sh zeroclaw-jail-setup.sh`, with `JAIL_NAME` / `JAIL_PATH` / `ZPOOL` / `ZEROCLAW_USER` overridable via env). The manual walkthrough below explains what it does.
+
 ### 1. Create the jail
 
 ```sh


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** FreeBSD isn't a `zeroclaw service install` target, so there's no supported install path. This adds a handbook page plus a self-contained `dist/freebsd/` bundle (launcher, basic + hardened `rc.d` scripts, jail sample/drop-in, and a host-side provisioner) so operators can run ZeroClaw under `daemon(8)` — bare or in a thick jail — by hand. The hardened variant works around three documented `daemon(8)`/`pgrep` traps that surface under `ssh`-driven and unattended restarts. The page also documents a **Podman + Linuxulator** path: running the official Linux container image on a FreeBSD host for tools that need manylinux-only Python wheels (e.g. `polars`, `pyarrow`, `oracledb`) with no FreeBSD build, including the `os=freebsd` manifest-resolution trap (`--os linux --arch amd64`).
- **Scope boundary:** Docs + sample shell files only. No Rust, no build system, no CI, no runtime code. Does not make FreeBSD a `service install` target.
- **Blast radius:** None at runtime — nothing here is compiled or executed by the project. The only consumers are operators who copy these files onto a FreeBSD host.
- **Linked issue(s):** none.
- **Labels:** `type: docs`, `docs`, `size: L`, `risk: medium`.

## Validation Evidence (required)

Docs + shell-script PR (no Rust touched), so the battery is the docs quality gate plus `sh -n` on every shipped script, per the template's docs/bootstrap guidance.

```bash
$ for f in dist/freebsd/*.sh dist/freebsd/*.rc; do sh -n "$f" && echo "OK $f"; done
OK dist/freebsd/zeroclaw-jail-setup.sh
OK dist/freebsd/zeroclaw-run.sh
OK dist/freebsd/zeroclaw-hardened.rc
OK dist/freebsd/zeroclaw.rc

$ DOCS_FILES="docs/book/src/setup/freebsd.md" bash scripts/ci/docs_quality_gate.sh
Linting docs files: docs/book/src/setup/freebsd.md
markdownlint-cli2 v0.20.0 (markdownlint v0.40.0)
Summary: 0 error(s)
```

- **Beyond CI — what did you manually verify?** All four shell files parse under `/bin/sh`. The hardened `rc.d` logic was exercised on a real FreeBSD host (start/stop/status, remote `ssh ... service start`, repeated-start guard, stale-pidfile recovery). The Podman + Linuxulator path was exercised on a real FreeBSD host: `kldload linux linux64`, `podman pull --os linux --arch amd64`, and running the published Linux image under emulation (this is what surfaced the `os=freebsd` manifest-resolution failure documented in the page). The new section is plain CommonMark with only public image references (`ghcr.io/zeroclaw-labs/zeroclaw`) — no infrastructure-specific hostnames, addresses, or registries.
- **What I did NOT verify:** mdBook render of the new page in this run (no Rust toolchain present); the page is plain CommonMark and the repo links use `/tree/master/` paths.
- **If any command was intentionally skipped, why:** The Rust battery (`cargo fmt`/`clippy`/`test`) is N/A — no Rust files are touched.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **Yes** — `zeroclaw-jail-setup.sh` runs as root on the host: it creates a ZFS dataset or directory, extracts `base.txz`, edits `/etc/jail.conf` and `rc.conf`, and `jexec`s into the jail. It validates every env input against tight allowlists (`JAIL_NAME` `[A-Za-z0-9_][A-Za-z0-9_-]*`, an absolute symlink-free `JAIL_PATH` that must not already exist, plus username/zpool charsets), preflights required commands, uses `mktemp`, and traps EXIT/INT/TERM to clean up and print recovery guidance on partial failure. The Linuxulator section documents loading the `linux`/`linux64` kernel modules (`kldload`) and running a container as root via Podman — standard operator actions, shown as documentation rather than executed by the project.
- New external network calls? **Yes** — the provisioner fetches `base.txz` from `download.freebsd.org` (the standard FreeBSD release mirror) to populate the thick jail. The Linuxulator section's `podman pull` fetches the public image from `ghcr.io` (documented command, operator-run).
- Secrets / tokens / credentials handling changed? **No.**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No** — the scripts use generic placeholders (`@@ZEROCLAW_USER@@`, `youruser`); the container examples use generic paths (`/var/db/zeroclaw`) and the public `ghcr.io` image only.
- **If any `Yes`, describe the risk and mitigation:** The root-run provisioner is the main risk surface. Mitigations: strict env-input allowlisting (closes config/sed injection and option-injection via a leading `-`), refusal to populate any pre-existing path (closes symlink/empty-sensitive-dir clobber), explicit `devfs_ruleset = 4` jail confinement, idempotent `jail.conf`/`jail_list` edits, and a cleanup trap that prints exact recovery steps if a run aborts mid-way. Codex adversarially reviewed the provisioner twice: the first pass raised 7 findings (config/sed injection, unsafe jail path, regex idempotency, `jail_list` idempotency, missing devfs ruleset, partial-failure recovery, unescaped sed), all addressed; the second pass confirmed 5 fully resolved and two more were fixed in this revision (leading-`-` `JAIL_NAME` option injection; empty-existing-dir clobber). The remaining notes — no automatic rollback, no full parent-path canonicalization — are acceptable for a documented sample provisioner that refuses pre-existing paths and prints recovery guidance.

## Compatibility (required)

- Backward compatible? **Yes** — purely additive; no existing file behavior changes.
- Config / env / CLI surface changed? **No** project surface. The new sample scripts read their own env knobs (`JAIL_NAME`, `JAIL_PATH`, `ZEROCLAW_USER`, `ZPOOL`); the `rc.d` scripts use `zeroclaw_enable`/`zeroclaw_runas`.
- If `No` or `Yes` to either: exact upgrade steps for existing users: none — nothing to upgrade.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <merge-sha>` or revert the PR from GitHub. This removes the FreeBSD handbook page, `dist/freebsd/`, and the platform install-files index entry.
- **Feature flags or config toggles:** None — this PR only adds docs and sample files; no runtime path is enabled by config.
- **Observable failure symptoms:** Operators following the FreeBSD guide report failed `rc.d` start/stop/status behavior, jail setup failures, Podman/Linuxulator pull/run errors, or docs-link/render problems in the setup book.
