### PR TITLE
fix(cron): diagnose past at schedules

### DIFF
--- a/crates/zeroclaw-runtime/src/cron/schedule.rs
+++ b/crates/zeroclaw-runtime/src/cron/schedule.rs
@@ -73,7 +73,15 @@ pub fn validate_schedule(schedule: &Schedule, now: DateTime<Utc>) -> Result<()> 
         }
         Schedule::At { at } => {
             if *at <= now {
-                anyhow::bail!("Invalid schedule: 'at' must be in the future");
+                anyhow::bail!(
+                    "Invalid schedule: 'at' must be in the future \
+                     (now_utc={}, now_local={}, at_utc={}, at_local={}, delta_seconds={})",
+                    now.to_rfc3339(),
+                    now.with_timezone(&chrono::Local).to_rfc3339(),
+                    at.to_rfc3339(),
+                    at.with_timezone(&chrono::Local).to_rfc3339(),
+                    (*at - now).num_seconds()
+                );
             }
             Ok(())
         }

--- a/crates/zeroclaw-runtime/src/tools/cron_add.rs
+++ b/crates/zeroclaw-runtime/src/tools/cron_add.rs
@@ -1010,6 +1010,34 @@ mod tests {
         assert!(jobs[0].delivery.best_effort);
     }
 
+    #[tokio::test]
+    async fn past_at_schedule_error_includes_clock_diagnostics() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = test_config(&tmp).await;
+        let tool = CronAddTool::new(cfg.clone(), test_security(&cfg), TEST_AGENT);
+
+        let result = tool
+            .execute(json!({
+                "schedule": { "kind": "at", "at": "2020-01-01T00:00:00Z" },
+                "job_type": "shell",
+                "command": "echo at"
+            }))
+            .await
+            .unwrap();
+
+        assert!(!result.success);
+        let error = result.error.unwrap_or_default();
+        assert!(error.contains("'at' must be in the future"));
+        assert!(error.contains("now_utc="), "{error}");
+        assert!(error.contains("now_local="), "{error}");
+        assert!(
+            error.contains("at_utc=2020-01-01T00:00:00+00:00"),
+            "{error}"
+        );
+        assert!(error.contains("at_local="), "{error}");
+        assert!(error.contains("delta_seconds="), "{error}");
+    }
+
     #[test]
     fn schedule_schema_is_oneof_with_cron_at_every_variants() {
         let tmp = tempfile::TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Include UTC and local clock diagnostics when an `at` schedule is rejected because it is not in the future.
  - Report the submitted `at` timestamp in both UTC and local time, plus `delta_seconds`, so users can distinguish stale timestamps from timezone or host-clock problems.
  - Add a regression test through `cron_add` to cover the user-visible tool error.
- **Scope boundary:** This PR does not change schedule parsing, next-run calculation, cron expressions, relative schedules, persistence, or execution semantics.
- **Blast radius:** Cron schedule validation errors for one-shot `schedule.kind="at"` jobs.
- **Linked issue(s):** None.
- **Labels:** `bug`, `risk: high`, `size: XS`, `cron`, `runtime`

## Validation Evidence (required)

Local validation is the signal CI cannot replace. Run the full battery and paste literal output (tails, failures, warnings — not "all passed").

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

Docs-only changes: replace with markdown lint + link-integrity (`scripts/ci/docs_quality_gate.sh`). Bootstrap scripts: add `bash -n install.sh`.

- **Commands run and tail output:**

```bash
$ cargo test -p zeroclaw-runtime past_at_schedule_error_includes_clock_diagnostics -- --nocapture
running 1 test
test tools::cron_add::tests::past_at_schedule_error_includes_clock_diagnostics ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1982 filtered out; finished in 0.01s
```

```bash
$ cargo fmt --all -- --check
# exit 0; no formatter output
```

```bash
$ cargo clippy --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 25s
```

```bash
$ cargo test
running 7 tests
... 7 ignored, requires live provider credentials ...
test result: ok. 0 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 0.00s

running 9 tests
... 9 system tests passed ...
test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.06s

Doc-tests zeroclaw
running 0 tests
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

- **Beyond CI — what did you manually verify?** Verified the regression test fails before the validation-message change with only `Invalid schedule: 'at' must be in the future`, then passes after adding `now_utc`, `now_local`, `at_utc`, `at_local`, and `delta_seconds` diagnostics.
- **If any command was intentionally skipped, why:** None.

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: Existing schedules and config need no migration. Only the validation error text for rejected past `at` schedules becomes more diagnostic.

## Rollback (required for `risk: medium` and `risk: high`)

High-risk rollback:

- **Fast rollback command/path:** `git revert <sha>`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Rejected one-shot `at` schedules still fail, but without the additional clock diagnostics.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Scope materially carried forward: N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`No`)
- If `No`, why (inspiration-only, no direct code/design carry-over): No superseded PR.
