### PR TITLE
fix(zerocode): let quickstart agent name accept hotkey letters

### DIFF
--- a/apps/zerocode/src/quickstart_pane.rs
+++ b/apps/zerocode/src/quickstart_pane.rs
@@ -113,6 +113,20 @@ fn synth_enter() -> KeyEvent {
     KeyEvent::new(KeyCode::Enter, crossterm::event::KeyModifiers::NONE)
 }
 
+/// The character a key press contributes to a free-text buffer (the
+/// agent-name field), or `None` for control chords and non-character
+/// keys. Letters that double as modal hotkeys on file rows — `e` (edit
+/// in $EDITOR), `t` (from template), `c` (clear), `d` (delete) — are
+/// still plain text on a text row, so this deliberately ignores the
+/// chord mapping: the hotkey arms are gated on `on_file` and never fire
+/// while the cursor is on the name field.
+fn typed_char(key: &KeyEvent) -> Option<char> {
+    match key.code {
+        KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => Some(c),
+        _ => None,
+    }
+}
+
 fn action_row_line(label: &str, is_cursor: bool) -> Line<'static> {
     let glyph = if is_cursor { " › " } else { "   " };
     let style = if is_cursor {
@@ -1018,7 +1032,7 @@ impl QuickstartPane {
         let Some(modal) = self.active_modal.as_mut() else {
             return;
         };
-        use crate::keymap::{Chord, QuickstartModalAction};
+        use crate::keymap::QuickstartModalAction;
         let action = QuickstartModalAction::from_chord(&key);
         match modal {
             Modal::Picker(p) => match action {
@@ -1120,9 +1134,7 @@ impl QuickstartPane {
                     t.buf.pop();
                 }
                 _ => {
-                    if let KeyCode::Char(c) = key.code
-                        && !key.modifiers.contains(KeyModifiers::CONTROL)
-                    {
+                    if let Some(c) = typed_char(&key) {
                         t.buf.push(c);
                     }
                 }
@@ -1335,15 +1347,8 @@ impl QuickstartPane {
                         a.files.insert(filename, String::new());
                     }
                     _ => {
-                        if on_name
-                            && let KeyCode::Char(c) = key.code
-                            && !key.modifiers.contains(KeyModifiers::CONTROL)
-                        {
-                            if action.is_none() {
-                                a.name.push(c);
-                            } else {
-                                let _ = Chord::char(c);
-                            }
+                        if on_name && let Some(c) = typed_char(&key) {
+                            a.name.push(c);
                         }
                     }
                 }
@@ -2312,6 +2317,34 @@ mod tests {
         let mut f = complete_form();
         f.agent_name.clear();
         assert!(!f.all_selectors_satisfied());
+    }
+
+    #[test]
+    fn name_field_accepts_hotkey_letters() {
+        // Regression: e/t/c/d double as Agent-modal hotkeys (edit in
+        // $EDITOR, from template, clear, delete) on file rows. On the
+        // name row they are plain text, but the old handler routed every
+        // keypress through the chord mapping and dropped any char that
+        // resolved to an action — so agent names could not contain those
+        // letters. `typed_char` is the text-buffer path; assert it keeps
+        // them, and that they really are bound actions (bug was reachable).
+        use crate::keymap::QuickstartModalAction;
+        for ch in ['e', 'c', 't', 'd', 'E', 'C', 'T', 'D'] {
+            let key = KeyEvent::new(KeyCode::Char(ch), KeyModifiers::NONE);
+            assert_eq!(typed_char(&key), Some(ch), "name field must accept '{ch}'");
+            assert!(
+                QuickstartModalAction::from_chord(&key).is_some(),
+                "'{ch}' must be a modal hotkey for this regression to be real"
+            );
+        }
+    }
+
+    #[test]
+    fn typed_char_ignores_control_and_non_char_keys() {
+        let ctrl_c = KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL);
+        assert_eq!(typed_char(&ctrl_c), None);
+        let enter = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
+        assert_eq!(typed_char(&enter), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** In the zerocode Quickstart "agent" modal, the **name** field silently dropped any character that doubles as a modal hotkey — `e` (edit in \$EDITOR), `t` (from template), `c` (clear), `d` (delete), plus their uppercase. The catch-all key arm pushed to the buffer only when `action.is_none()`, so whenever `QuickstartModalAction::from_chord` resolved a key to an action the char was discarded — even though those hotkeys are only meaningful on personality-file rows (already gated on `on_file`). Result: agent names couldn't contain `e`, `c`, `t`, or `d`.
- Extracted a small pure `typed_char(key)` helper that yields the printable char for a keypress (ignoring the chord mapping; rejecting only CONTROL chords and non-character keys) and used it for both the name field and the text-input modal (which had the same shape, sans bug).
- Added regression tests covering `e`/`t`/`c`/`d` (both cases) and the control/non-char rejection path.
- **Scope boundary:** Only the Quickstart modal key handling in `apps/zerocode/src/quickstart_pane.rs`. No change to the personality/"soul" `.md` file rows (those are edited via \$EDITOR/template/clear and never took inline typing), no change to the keymap/chord definitions, no daemon/wire changes.
- **Blast radius:** zerocode TUI Quickstart pane only. The `typed_char` helper is also now used by the existing TextInput modal, which previously had equivalent inline logic (behavior unchanged there).
- **Linked issue(s):** None (no existing issue/PR found for this).
- **Labels:** `type: fix`, `risk: low`, `size: S`

## Validation Evidence (required)

Scoped to the affected crate (`zerocode`); the change is isolated to one file in that crate.

\`\`\`
=== cargo fmt --all -- --check ===
OK: fmt clean

=== cargo clippy -p zerocode --all-targets -- -D warnings ===
    Checking zerocode v0.8.0-beta-2 (/Users/jordantian/zeroclaw/apps/zerocode)
    Finished \`dev\` profile [unoptimized + debuginfo] target(s) in 2m 23s

=== cargo test -p zerocode ===
running 14 tests
test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
running 203 tests
test result: ok. 203 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
\`\`\`

- **Beyond CI — what did you manually verify?** Built `zerocode` from this branch and reproduced the original bug on master (typing `test` in the agent name yielded `s` only). Confirmed the new regression test `name_field_accepts_hotkey_letters` fails against the pre-fix handler shape and passes after. Did NOT manually re-walk every modal (picker/channel/peer-group) since they don't route through the changed arms.
- **If any command was intentionally skipped, why:** Ran the battery scoped to `zerocode` rather than the full workspace — the diff touches a single file in that crate and doesn't change any shared/public API.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**

## Rollback

Low-risk: \`git revert 2af7bb880\`.