### PR TITLE
fix(providers): honour wire_api = "responses" for llamacpp provider

### DIFF
--- a/crates/zeroclaw-providers/src/factory.rs
+++ b/crates/zeroclaw-providers/src/factory.rs
@@ -1095,6 +1095,20 @@ impl FamilyProviderFactory for LlamacppModelProviderConfig {
             .map(str::trim)
             .filter(|value| !value.is_empty())
             .unwrap_or("llama.cpp");
+        if self.base.wire_api == Some(zeroclaw_config::schema::WireApi::Responses) {
+            let mut p = crate::openai::OpenAiResponsesModelProvider::new(
+                alias,
+                Some(base_url),
+                Some(llama_cpp_key),
+            );
+            if let Some(mt) = opts.provider_max_tokens {
+                p = p.with_max_tokens(Some(mt));
+            }
+            if let Some(ref effort) = opts.reasoning_effort {
+                p = p.with_reasoning_effort(Some(effort.clone()));
+            }
+            return Ok(Box::new(p));
+        }
         let mut p = OpenAiCompatibleModelProvider::new_with_vision(
             alias,
             "llama.cpp",
@@ -1387,5 +1401,40 @@ mod tests {
         );
 
         assert_eq!(provider.credential.as_deref(), Some("ollama-key"));
+    }
+
+    #[test]
+    fn llamacpp_factory_routes_to_responses_provider_when_wire_api_responses() {
+        use zeroclaw_config::schema::{LlamacppModelProviderConfig, ModelProviderConfig, WireApi};
+        let cfg = LlamacppModelProviderConfig {
+            base: ModelProviderConfig {
+                wire_api: Some(WireApi::Responses),
+                ..Default::default()
+            },
+        };
+        let provider = cfg
+            .create_provider(
+                "default",
+                None,
+                Some("http://localhost:8080/v1"),
+                &ModelProviderRuntimeOptions::default(),
+            )
+            .unwrap();
+        assert_eq!(provider.default_wire_api(), "responses");
+    }
+
+    #[test]
+    fn llamacpp_factory_defaults_to_chat_completions_without_wire_api() {
+        use zeroclaw_config::schema::LlamacppModelProviderConfig;
+        let cfg = LlamacppModelProviderConfig::default();
+        let provider = cfg
+            .create_provider(
+                "default",
+                None,
+                Some("http://localhost:8080/v1"),
+                &ModelProviderRuntimeOptions::default(),
+            )
+            .unwrap();
+        assert_ne!(provider.default_wire_api(), "responses");
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:** `LlamacppModelProviderConfig::create_provider` unconditionally built an `OpenAiCompatibleModelProvider` (→ `/chat/completions`) even when the operator had set `wire_api = "responses"` in `config.toml`. The field was parsed and propagated into `opts.wire_api` but never consulted by the factory. This PR adds the same `wire_api` branch that `OpenAIModelProviderConfig` already has: when `wire_api = "responses"`, the factory now constructs `OpenAiResponsesModelProvider` (→ `/v1/responses`) instead.
- **Scope boundary:** Only `LlamacppModelProviderConfig::create_provider` in `factory.rs` is touched. No other providers, config schema, or wire formats are changed.
- **Blast radius:** Operators without `wire_api = "responses"` in their llamacpp config are unaffected — the default path is identical to before. Operators who set it will now get the Responses API they intended.
- **Linked issue(s):** None
- **Labels:** `type: fix`, `risk: low`, `size: XS`

## Validation Evidence (required)

- **Commands run and tail output:**

  ```
  $ cargo fmt --all -- --check
  (no output — exit 0)

  $ cargo clippy --all-targets -- -D warnings
      Checking zeroclaw-providers v0.8.0-beta-2
      Checking zeroclaw-runtime v0.8.0-beta-2
      Checking zeroclaw-channels v0.8.0-beta-2
      Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 12s
  exit 0

  $ cargo test -p zeroclaw-providers --lib
  test result: ok. 900 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.07s
  exit 0
  ```

- **Beyond CI — what did you manually verify?** Traced the full config → factory dispatch → provider construction path to confirm `wire_api` is parsed into `self.base.wire_api`, propagated into `opts.wire_api`, and now checked in the factory. Did not test against a live llama-server instance (no local server available); the two new factory unit tests cover both code paths.
- **If any command was intentionally skipped, why:** Full `cargo test` (workspace-wide) not run — only `zeroclaw-providers` is touched, and its 900-test suite passes. CI will run the full workspace.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No

## Compatibility (required)

- Backward compatible? Yes — operators with no `wire_api` set get identical behaviour.
- Config / env / CLI surface changed? No — `wire_api = "responses"` was already a valid config value (accepted by the parser); it was just silently ignored. This PR makes it functional without changing the schema.

## Rollback (required for `risk: medium` and `risk: high`)

`git revert 9380ec545` is the plan.