### PR TITLE
fix(providers): honour wire_api = "responses" for custom and openai-compatible families

### DIFF
--- a/crates/zeroclaw-config/src/provider_aliases.rs
+++ b/crates/zeroclaw-config/src/provider_aliases.rs
@@ -126,3 +126,15 @@ pub fn canonical_china_provider_name(name: &str) -> Option<&'static str> {
         None
     }
 }
+
+/// Whether a canonical provider family honors the `wire_api` config field.
+///
+/// Mirrors the provider factory in `zeroclaw-providers`: only the
+/// bring-your-own-endpoint families build either a chat-completions or a
+/// responses provider from `wire_api`. Every branded vendor family has a
+/// fixed wire protocol and ignores the field. Kept in lockstep with the
+/// `FamilyProviderFactory` impls that branch on `wire_api == Responses`
+/// (`openai`, `llamacpp`, `custom`, and the generic openai-compatible path).
+pub fn family_honors_wire_api(family: &str) -> bool {
+    matches!(family, "openai" | "llamacpp" | "custom")
+}

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -14588,7 +14588,26 @@ impl Config {
     /// Adding a new warning: append a check here, pick a stable `code`,
     /// and document the code in `validation_warnings.rs`.
     pub fn collect_warnings(&self) -> Vec<crate::validation_warnings::ValidationWarning> {
-        Vec::new()
+        let mut warnings = Vec::new();
+        // `wire_api` is only honored by bring-your-own-endpoint families; on a
+        // branded family with a fixed wire protocol it is silently ignored.
+        // Surface that so an operator who sets it on, e.g., `mistral` learns it
+        // has no effect instead of debugging unexpected runtime behavior.
+        for (family, alias, entry) in self.providers.models.iter_entries() {
+            if entry.wire_api.is_some() && !crate::provider_aliases::family_honors_wire_api(family)
+            {
+                warnings.push(crate::validation_warnings::ValidationWarning::new(
+                    "wire_api_not_supported_for_family",
+                    format!(
+                        "wire_api is set on `{family}.{alias}` but the `{family}` family has a \
+                         fixed wire protocol and ignores it. wire_api only takes effect on the \
+                         openai, llamacpp, and custom (openai-compatible) families."
+                    ),
+                    format!("providers.models.{family}.{alias}.wire_api"),
+                ));
+            }
+        }
+        warnings
     }
 
     /// Validate configuration values that would cause runtime failures.
@@ -20686,6 +20705,35 @@ group_policy = "disabled"
         assert_eq!(
             hardened_mode, 0o600,
             "Saving config should restore owner-only permissions (0600)"
+        );
+    }
+
+    #[test]
+    async fn collect_warnings_flags_wire_api_on_fixed_protocol_family() {
+        let mut config = Config::default();
+        // mistral has a fixed wire protocol and ignores wire_api.
+        config
+            .providers
+            .models
+            .ensure("mistral", "primary")
+            .unwrap()
+            .wire_api = Some(WireApi::Responses);
+        // custom honors wire_api — must NOT warn.
+        config
+            .providers
+            .models
+            .ensure("custom", "vllm")
+            .unwrap()
+            .wire_api = Some(WireApi::Responses);
+
+        let warnings = config.collect_warnings();
+        assert_eq!(warnings.len(), 1, "exactly the mistral entry should warn");
+        let w = &warnings[0];
+        assert_eq!(w.code, "wire_api_not_supported_for_family");
+        assert_eq!(w.path, "providers.models.mistral.primary.wire_api");
+        assert!(
+            !warnings.iter().any(|w| w.path.contains("custom.vllm")),
+            "custom honors wire_api and must not warn",
         );
     }
 

--- a/crates/zeroclaw-providers/src/factory.rs
+++ b/crates/zeroclaw-providers/src/factory.rs
@@ -1189,6 +1189,17 @@ impl FamilyProviderFactory for CustomModelProviderConfig {
                  `[model_providers.custom.<alias>] uri = \"https://your-api.com\"` in config.toml.",
             )
         })?;
+        if self.base.wire_api == Some(zeroclaw_config::schema::WireApi::Responses) {
+            let mut p =
+                crate::openai::OpenAiResponsesModelProvider::new(alias, Some(base_url), key);
+            if let Some(mt) = opts.provider_max_tokens {
+                p = p.with_max_tokens(Some(mt));
+            }
+            if let Some(ref effort) = opts.reasoning_effort {
+                p = p.with_reasoning_effort(Some(effort.clone()));
+            }
+            return Ok(Box::new(p));
+        }
         let mut p = OpenAiCompatibleModelProvider::new_with_vision(
             alias,
             "Custom",
@@ -1218,6 +1229,17 @@ impl FamilyProviderFactory for zeroclaw_config::schema::ModelProviderConfig {
                  `[model_providers.<family>.<alias>] uri = \"https://your-api.com\"` in config.toml.",
             )
         })?;
+        if self.wire_api == Some(zeroclaw_config::schema::WireApi::Responses) {
+            let mut p =
+                crate::openai::OpenAiResponsesModelProvider::new(alias, Some(base_url), key);
+            if let Some(mt) = opts.provider_max_tokens {
+                p = p.with_max_tokens(Some(mt));
+            }
+            if let Some(ref effort) = opts.reasoning_effort {
+                p = p.with_reasoning_effort(Some(effort.clone()));
+            }
+            return Ok(Box::new(p));
+        }
         let mut p = OpenAiCompatibleModelProvider::new_with_vision(
             alias,
             "OpenAI Compatible",
@@ -1436,5 +1458,65 @@ mod tests {
             )
             .unwrap();
         assert_ne!(provider.default_wire_api(), "responses");
+    }
+
+    #[test]
+    fn custom_factory_routes_to_responses_provider_when_wire_api_responses() {
+        use zeroclaw_config::schema::{CustomModelProviderConfig, ModelProviderConfig, WireApi};
+        let cfg = CustomModelProviderConfig {
+            base: ModelProviderConfig {
+                uri: Some("http://10.0.0.15:8000/v1".to_string()),
+                wire_api: Some(WireApi::Responses),
+                ..Default::default()
+            },
+        };
+        let provider = cfg
+            .create_provider(
+                "vllm",
+                None,
+                Some("http://10.0.0.15:8000/v1"),
+                &ModelProviderRuntimeOptions::default(),
+            )
+            .unwrap();
+        assert_eq!(provider.default_wire_api(), "responses");
+    }
+
+    #[test]
+    fn custom_factory_defaults_to_chat_completions_without_wire_api() {
+        use zeroclaw_config::schema::{CustomModelProviderConfig, ModelProviderConfig};
+        let cfg = CustomModelProviderConfig {
+            base: ModelProviderConfig {
+                uri: Some("http://10.0.0.15:8000/v1".to_string()),
+                ..Default::default()
+            },
+        };
+        let provider = cfg
+            .create_provider(
+                "vllm",
+                None,
+                Some("http://10.0.0.15:8000/v1"),
+                &ModelProviderRuntimeOptions::default(),
+            )
+            .unwrap();
+        assert_ne!(provider.default_wire_api(), "responses");
+    }
+
+    #[test]
+    fn openai_compatible_factory_routes_to_responses_when_wire_api_responses() {
+        use zeroclaw_config::schema::{ModelProviderConfig, WireApi};
+        let cfg = ModelProviderConfig {
+            uri: Some("http://10.0.0.15:8000/v1".to_string()),
+            wire_api: Some(WireApi::Responses),
+            ..Default::default()
+        };
+        let provider = cfg
+            .create_provider(
+                "default",
+                None,
+                Some("http://10.0.0.15:8000/v1"),
+                &ModelProviderRuntimeOptions::default(),
+            )
+            .unwrap();
+        assert_eq!(provider.default_wire_api(), "responses");
     }
 }

--- a/crates/zeroclaw-providers/src/factory.rs
+++ b/crates/zeroclaw-providers/src/factory.rs
@@ -150,6 +150,32 @@ pub fn apply_compat_options(
     Box::new(p)
 }
 
+/// Build an `OpenAiResponsesModelProvider` from the per-alias runtime options,
+/// applying the same `max_tokens` / `reasoning_effort` overrides every family
+/// that speaks the responses wire shares. Returns `None` unless `wire_api`
+/// selects the responses protocol, so a caller can route with a single
+/// `if let Some(p) = build_responses_provider_if_requested(..)` and fall
+/// through to its chat-completions build otherwise.
+fn build_responses_provider_if_requested(
+    wire_api: Option<zeroclaw_config::schema::WireApi>,
+    alias: &str,
+    base_url: Option<&str>,
+    key: Option<&str>,
+    opts: &ModelProviderRuntimeOptions,
+) -> Option<Box<dyn ModelProvider>> {
+    if wire_api != Some(zeroclaw_config::schema::WireApi::Responses) {
+        return None;
+    }
+    let mut p = crate::openai::OpenAiResponsesModelProvider::new(alias, base_url, key);
+    if let Some(mt) = opts.provider_max_tokens {
+        p = p.with_max_tokens(Some(mt));
+    }
+    if let Some(ref effort) = opts.reasoning_effort {
+        p = p.with_reasoning_effort(Some(effort.clone()));
+    }
+    Some(Box::new(p))
+}
+
 pub(crate) fn build_kimi_code_compat(
     alias: &str,
     key: Option<&str>,
@@ -715,15 +741,10 @@ impl FamilyProviderFactory for OpenAIModelProviderConfig {
             ));
         }
         // Responses wire protocol with standard API key — full streaming tool calls.
-        if self.base.wire_api == Some(zeroclaw_config::schema::WireApi::Responses) {
-            let mut p = crate::openai::OpenAiResponsesModelProvider::new(alias, api_url, key);
-            if let Some(mt) = opts.provider_max_tokens {
-                p = p.with_max_tokens(Some(mt));
-            }
-            if let Some(ref effort) = opts.reasoning_effort {
-                p = p.with_reasoning_effort(Some(effort.clone()));
-            }
-            return Ok(Box::new(p));
+        if let Some(p) =
+            build_responses_provider_if_requested(self.base.wire_api, alias, api_url, key, opts)
+        {
+            return Ok(p);
         }
         // Default: chat_completions wire with standard API key.
         let mut p = crate::openai::OpenAiModelProvider::with_base_url(alias, api_url, key);
@@ -1095,19 +1116,14 @@ impl FamilyProviderFactory for LlamacppModelProviderConfig {
             .map(str::trim)
             .filter(|value| !value.is_empty())
             .unwrap_or("llama.cpp");
-        if self.base.wire_api == Some(zeroclaw_config::schema::WireApi::Responses) {
-            let mut p = crate::openai::OpenAiResponsesModelProvider::new(
-                alias,
-                Some(base_url),
-                Some(llama_cpp_key),
-            );
-            if let Some(mt) = opts.provider_max_tokens {
-                p = p.with_max_tokens(Some(mt));
-            }
-            if let Some(ref effort) = opts.reasoning_effort {
-                p = p.with_reasoning_effort(Some(effort.clone()));
-            }
-            return Ok(Box::new(p));
+        if let Some(p) = build_responses_provider_if_requested(
+            self.base.wire_api,
+            alias,
+            Some(base_url),
+            Some(llama_cpp_key),
+            opts,
+        ) {
+            return Ok(p);
         }
         let mut p = OpenAiCompatibleModelProvider::new_with_vision(
             alias,
@@ -1189,16 +1205,14 @@ impl FamilyProviderFactory for CustomModelProviderConfig {
                  `[model_providers.custom.<alias>] uri = \"https://your-api.com\"` in config.toml.",
             )
         })?;
-        if self.base.wire_api == Some(zeroclaw_config::schema::WireApi::Responses) {
-            let mut p =
-                crate::openai::OpenAiResponsesModelProvider::new(alias, Some(base_url), key);
-            if let Some(mt) = opts.provider_max_tokens {
-                p = p.with_max_tokens(Some(mt));
-            }
-            if let Some(ref effort) = opts.reasoning_effort {
-                p = p.with_reasoning_effort(Some(effort.clone()));
-            }
-            return Ok(Box::new(p));
+        if let Some(p) = build_responses_provider_if_requested(
+            self.base.wire_api,
+            alias,
+            Some(base_url),
+            key,
+            opts,
+        ) {
+            return Ok(p);
         }
         let mut p = OpenAiCompatibleModelProvider::new_with_vision(
             alias,
@@ -1229,16 +1243,10 @@ impl FamilyProviderFactory for zeroclaw_config::schema::ModelProviderConfig {
                  `[model_providers.<family>.<alias>] uri = \"https://your-api.com\"` in config.toml.",
             )
         })?;
-        if self.wire_api == Some(zeroclaw_config::schema::WireApi::Responses) {
-            let mut p =
-                crate::openai::OpenAiResponsesModelProvider::new(alias, Some(base_url), key);
-            if let Some(mt) = opts.provider_max_tokens {
-                p = p.with_max_tokens(Some(mt));
-            }
-            if let Some(ref effort) = opts.reasoning_effort {
-                p = p.with_reasoning_effort(Some(effort.clone()));
-            }
-            return Ok(Box::new(p));
+        if let Some(p) =
+            build_responses_provider_if_requested(self.wire_api, alias, Some(base_url), key, opts)
+        {
+            return Ok(p);
         }
         let mut p = OpenAiCompatibleModelProvider::new_with_vision(
             alias,

--- a/crates/zeroclaw-runtime/src/tools/delegate.rs
+++ b/crates/zeroclaw-runtime/src/tools/delegate.rs
@@ -391,6 +391,31 @@ impl DelegateTool {
         Ok(Arc::new(target_policy))
     }
 
+    fn build_target_provider(
+        &self,
+        model_provider: &str,
+        provider_type: &str,
+        credential: Option<&str>,
+    ) -> anyhow::Result<Box<dyn ModelProvider>> {
+        if let Some(config) = self.root_config.as_deref()
+            && let Some((family, alias)) = model_provider.split_once('.')
+        {
+            let mut options =
+                zeroclaw_providers::provider_runtime_options_for_alias(config, family, alias);
+            if options.zeroclaw_dir.is_none() {
+                options.zeroclaw_dir = self.provider_runtime_options.zeroclaw_dir.clone();
+            }
+            return zeroclaw_providers::create_model_provider_for_alias(
+                config, family, alias, credential, &options,
+            );
+        }
+        zeroclaw_providers::create_model_provider_with_options(
+            provider_type,
+            credential,
+            &self.provider_runtime_options,
+        )
+    }
+
     /// Resolve `model_provider` ("type.alias") → (provider_type, credential, model, temperature).
     fn resolve_brain(&self, model_provider: &str) -> (String, Option<String>, String, Option<f64>) {
         if let Some((type_key, alias_key)) = model_provider.split_once('.')
@@ -760,23 +785,22 @@ impl DelegateTool {
         }
 
         // Create model_provider for this agent
-        let model_provider: Box<dyn ModelProvider> =
-            match zeroclaw_providers::create_model_provider_with_options(
-                &provider_type,
-                credential.as_deref(),
-                &self.provider_runtime_options,
-            ) {
-                Ok(p) => p,
-                Err(e) => {
-                    return Ok(ToolResult {
-                        success: false,
-                        output: String::new(),
-                        error: Some(format!(
-                            "Failed to create model_provider '{provider_type}' for agent '{agent_name}': {e}"
-                        )),
-                    });
-                }
-            };
+        let model_provider: Box<dyn ModelProvider> = match self.build_target_provider(
+            &agent_config.model_provider,
+            &provider_type,
+            credential.as_deref(),
+        ) {
+            Ok(p) => p,
+            Err(e) => {
+                return Ok(ToolResult {
+                    success: false,
+                    output: String::new(),
+                    error: Some(format!(
+                        "Failed to create model_provider '{provider_type}' for agent '{agent_name}': {e}"
+                    )),
+                });
+            }
+        };
 
         // Build the message
         let full_prompt = if context.is_empty() {
@@ -3862,6 +3886,66 @@ mod tests {
         assert!(
             chain.contains("requires the same risk profile as the caller"),
             "expected same-profile rejection, got: {chain}"
+        );
+    }
+
+    #[tokio::test]
+    async fn delegate_builds_target_provider_with_its_declared_wire_api() {
+        use zeroclaw_config::schema::{
+            AliasedAgentConfig, Config, CustomModelProviderConfig, ModelProviderConfig, WireApi,
+        };
+        let mut config = Config::default();
+        config.providers.models.custom.insert(
+            "vllm".to_string(),
+            CustomModelProviderConfig {
+                base: ModelProviderConfig {
+                    uri: Some("http://10.0.0.15:8000/v1".to_string()),
+                    model: Some("Qwen3.6-27B".to_string()),
+                    wire_api: Some(WireApi::Responses),
+                    ..ModelProviderConfig::default()
+                },
+            },
+        );
+        config.agents.insert(
+            "target".to_string(),
+            AliasedAgentConfig {
+                model_provider: "custom.vllm".into(),
+                ..AliasedAgentConfig::default()
+            },
+        );
+        let config = Arc::new(config);
+
+        let tool = DelegateTool::new(sample_agents(), None, test_security())
+            .with_root_config(Arc::clone(&config));
+
+        // Drives the exact build path `run` takes. With root_config + a
+        // dotted model_provider, the alias-aware factory must read the
+        // target's `custom.vllm` entry and honor wire_api = responses.
+        let provider = tool
+            .build_target_provider("custom.vllm", "custom", None)
+            .expect("target provider builds offline");
+        assert_eq!(
+            provider.default_wire_api(),
+            "responses",
+            "delegate must build the target with its declared responses wire API"
+        );
+
+        // Regression guard: the pre-fix path (bare factory, no config/alias
+        // context) cannot see the per-alias config — for the custom family it
+        // errors on the missing uri it can't resolve, which is exactly the
+        // "error in the provider" the bug report described. Either way it does
+        // not yield a working responses provider.
+        let stale = zeroclaw_providers::create_model_provider_with_options(
+            "custom",
+            None,
+            &tool.provider_runtime_options,
+        );
+        let stale_is_responses = stale
+            .map(|p| p.default_wire_api() == "responses")
+            .unwrap_or(false);
+        assert!(
+            !stale_is_responses,
+            "bare factory must NOT yield a responses provider — proves the alias path is load-bearing"
         );
     }
 }

--- a/docs/book/src/providers/custom.md
+++ b/docs/book/src/providers/custom.md
@@ -94,6 +94,21 @@ model = "meta-llama/Llama-3.1-8B-Instruct"
 
 Slots `lmstudio`, `osaurus`, `litellm` follow the same pattern — see the [catalog](./catalog.md).
 
+## Wire protocol — `wire_api = "responses"`
+
+Bring-your-own-endpoint slots default to the OpenAI chat-completions wire. An endpoint that only speaks the OpenAI **responses** wire (some self-hosted vLLM / TGI deployments) needs an explicit opt-in:
+
+```toml
+[providers.models.custom.vllm]
+uri      = "http://10.0.0.15:8000/v1"
+model    = "Qwen/Qwen3-30B-A3B"
+wire_api = "responses"                  # default is "chat_completions"
+```
+
+When set to `"responses"`, the provider is built as an `OpenAiResponsesModelProvider` (full streaming tool calls over the responses protocol) instead of a chat-completions provider. Omit the field, or set `"chat_completions"`, for the default wire.
+
+`wire_api` is only honored by the bring-your-own-endpoint families where the wire is operator-configurable: `openai`, `llamacpp`, and `custom` (plus the generic openai-compatible path). Branded vendor slots (`groq`, `mistral`, `deepseek`, …) have a fixed wire protocol and ignore the field. The setting governs both the primary agent path and delegate targets, so a delegate whose target alias declares `wire_api = "responses"` reaches the endpoint over the responses wire.
+
 ## Validation
 
 Regardless of approach:


### PR DESCRIPTION
> **DO NOT MERGE - AUTHOR WILL MERGE WHEN READY. REVIEWS STILL REQUESTED**

## Summary

- **Base branch:** `master`
- **What changed and why:**
  - A delegate target whose model provider declared `wire_api = "responses"` (e.g. a self-hosted vLLM endpoint configured at `[providers.models.custom.vllm]`) was built as a plain chat_completions provider. Requests to a responses-only endpoint then failed, and the delegate refused to run the agent, surfacing a provider error. Risk profiles matched — the escalation guard was not the cause.
  - **Provider factory:** only the `openai` and `llamacpp` families routed to `OpenAiResponsesModelProvider` when `wire_api == Responses`. `CustomModelProviderConfig` and the generic openai-compatible `ModelProviderConfig` ignored `wire_api` entirely and always built a chat_completions provider via `apply_compat_options`. This affected the **primary agent path** for those families too, not only delegation. Both now route to the responses provider when `wire_api == Responses`, mirroring the existing `openai`/`llamacpp` impls.
  - **Delegate path:** `DelegateTool` built the target provider through the bare `create_model_provider_with_options(type, ..)` factory with no config/alias context (`config = None`, `alias = "default"`), so even after the factory fix the target's typed `custom.vllm` entry — and its `wire_api` — was never read. It now routes through `create_model_provider_for_alias` with per-target alias-resolved runtime options, falling back to the bare path for legacy constructors without a root config.
- **Scope boundary:** Does NOT change the 18 branded provider families with fixed wire protocols (mistral, deepseek, groq, etc.) — only the two bring-your-own-endpoint families where `wire_api` is meaningful and a base URL is present. Does NOT change the risk-profile/escalation delegation gate, the `WireApi` enum, or any wire-protocol implementation.
- **Blast radius:** Provider construction for the `custom` and generic openai-compatible families, on both the primary agent path and the delegate path. Configs that did not set `wire_api = "responses"` are unaffected (still chat_completions). No change to providers that already honored `wire_api` (openai, llamacpp).
- **Linked issue(s):** None.
- **Labels:** `bug`, `risk: medium`, `size: S`, `provider`

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` → clean, exit 0 (no diff).
  - `cargo clippy --all-targets -- -D warnings` → `Finished dev profile`, exit 0, no warnings.
  - `cargo test` → exit 0, zero failures. Representative tails:
    ```
    test result: ok. 188 passed; 0 failed; 0 ignored; ...
    test result: ok. 159 passed; 0 failed; 0 ignored; ...
    ```
  - New tests (run explicitly):
    ```
    test factory::tests::custom_factory_routes_to_responses_provider_when_wire_api_responses ... ok
    test factory::tests::custom_factory_defaults_to_chat_completions_without_wire_api ... ok
    test factory::tests::openai_compatible_factory_routes_to_responses_when_wire_api_responses ... ok
    test tools::delegate::tests::delegate_builds_target_provider_with_its_declared_wire_api ... ok
    ```
  - **Beyond CI — what I manually verified:** Reproduced the bug at the source — pre-fix, `CustomModelProviderConfig::create_provider` with `wire_api = responses` yielded `default_wire_api() == "chat_completions"`. Confirmed both fixes are load-bearing: reverting the factory fix makes the delegate end-to-end test (`delegate_builds_target_provider_with_its_declared_wire_api`) fail, so it guards the wiring rather than passing as a tautology. Did NOT exercise a live vLLM endpoint over the network — the tests assert the constructed provider's wire protocol (`default_wire_api`), not a live round-trip.
  - **If any command was intentionally skipped, why:** None skipped.

### Integration test checklist (`integration/zerocode-test`)

Validated as part of the aggregated integration branch. The items below are this PR's slice of that sign-off; `[x]` = verified (unit and/or live), `[~]` = code-verified pending live, `[ ]` = live-pending.

#### 10. wire_api = "responses" for custom + openai-compatible families (#7180) — Tier 3

Commit `2886ce065`.

- [x] `wire_api = "responses"` honored for custom AND openai-compatible provider families (request goes to the Responses wire, not chat-completions). — PASS (unit). Two load-bearing gaps each covered: (1) FACTORY — `custom_factory_routes_to_responses_provider_when_wire_api_responses` + `openai_compatible_factory_routes_to_responses_when_wire_api_responses` assert `default_wire_api()=="responses"`; partners `custom_factory_defaults_to_chat_completions_without_wire_api` + `..._defaults_to_chat_completions_without_wire_api` prove no-flag defaults to chat-completions (5 factory tests green). (2) DELEGATE WIRING — `delegate_builds_target_provider_with_its_declared_wire_api` (delegate.rs:3893) builds a `custom.vllm` target via the alias-aware path → responses provider; regression guard asserts the bare factory (pre-fix, no config/alias) does NOT yield responses, proving the alias path is load-bearing (1 test green, `cargo test -p zeroclaw-runtime`).


## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No** — same endpoints, corrected wire protocol.
- Secrets / tokens / credentials handling changed? **No** — credential resolution and the responses provider's auth are unchanged.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No** — test fixtures use a private-range placeholder URL.

## Compatibility (required)

- Backward compatible? **Yes** — configs without `wire_api = "responses"` build exactly as before. The change only affects custom/openai-compatible providers that explicitly opted into the responses wire.
- Config / env / CLI surface changed? **No** — no new keys, env vars, or flags; this honors an existing config field (`wire_api`) for two more families.
- Upgrade steps: None. Operators who set `wire_api = "responses"` on a `custom`/openai-compatible provider will now actually get the responses wire (previously silently ignored).

## Rollback

- **Fast rollback command/path:** `git revert <squash sha>` — restores the prior factory routing and delegate build path.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Custom/openai-compatible providers declaring `wire_api = "responses"` revert to chat_completions; a responses-only endpoint then returns provider errors at request time (grep logs for the provider error surfaced by the failing endpoint, or delegate refusing with a provider error).