### PR TITLE
fix(update,skills): harden error handling — log remove_file failures …

### DIFF
--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -199,8 +199,16 @@ pub async fn run(target_version: Option<&str>) -> Result<()> {
     match smoke_test(&current_exe).await {
         Ok(()) => {
             // Cleanup backup on success
-            let _ = tokio::fs::remove_file(&backup_path).await;
-            println!("{}", update_success_message(&update_info.latest_version));
+            if let Err(e) = tokio::fs::remove_file(&backup_path).await {
+                ::zeroclaw_log::record!(
+                    WARN,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                        .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                        .with_attrs(::serde_json::json!({"error": format!("{}", e), "path": backup_path.display().to_string()})),
+                    "Failed to remove post-update backup"
+                );
+            }
+            println!("Successfully updated to v{}!", update_info.latest_version);
             Ok(())
         }
         Err(e) => {
@@ -589,7 +597,15 @@ async fn swap_binary(new: &Path, target: &Path) -> Result<()> {
 
 async fn rollback_binary(backup: &Path, target: &Path) -> Result<()> {
     // Remove-then-copy to avoid ETXTBSY if the target is somehow still mapped.
-    let _ = tokio::fs::remove_file(target).await;
+    if let Err(e) = tokio::fs::remove_file(target).await {
+        ::zeroclaw_log::record!(
+            WARN,
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                .with_attrs(::serde_json::json!({"error": format!("{}", e), "path": target.display().to_string()})),
+            "Failed to remove old binary during rollback; proceeding with copy anyway"
+        );
+    }
     tokio::fs::copy(backup, target)
         .await
         .context("failed to restore backup binary")?;

--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -195,11 +195,12 @@ pub async fn handle_command(
             // Verify the resolved path is actually inside the skills directory
             let canonical_skills = skills_dir(workspace_dir)
                 .canonicalize()
-                .unwrap_or_else(|_| skills_dir(workspace_dir));
-            if let Ok(canonical_skill) = skill_path.canonicalize() {
-                if !canonical_skill.starts_with(&canonical_skills) {
-                    anyhow::bail!("Skill path escapes skills directory: {name}");
-                }
+                .context("failed to canonicalize skills directory")?;
+            let canonical_skill = skill_path
+                .canonicalize()
+                .context("failed to canonicalize skill path")?;
+            if !canonical_skill.starts_with(&canonical_skills) {
+                anyhow::bail!("Skill path escapes skills directory: {name}");
             }
 
             if !skill_path.exists() {


### PR DESCRIPTION
…and strengthen path traversal guard

- Replace silent let _ = with WARN logging when post-update backup cleanup or rollback target removal fails, making these non-fatal failures observable in structured logs while preserving control flow.

- Replace unwrap_or_else fallback and if let Ok skip in skills path traversal guard with proper ? propagation via .context(). If either canonicalize() fails, the handler now bails with a descriptive error instead of silently bypassing the traversal check.

## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:** (2–5 bullets — the diff shows *what*, you explain *why*)
- **Scope boundary:** (what this PR explicitly does NOT change)
- **Blast radius:** (what other subsystems or consumers could be affected)
- **Linked issue(s):** Use plain text outside backticks. Use `Closes #`,
  `Fixes #`, or `Resolves #` only for issues this PR fully resolves. Use
  `Related #`, `Depends on #`, or `Supersedes #` for non-closing relationships.
- **Labels:** Snapshot the current GitHub labels after labels are applied, for
  example `type: docs`, `risk: low`, `size: S`, `docs`.

## Validation Evidence (required)

Local validation is the signal CI cannot replace. Run the full battery and paste literal output (tails, failures, warnings — not "all passed").

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

Docs-only changes: replace with markdown lint + link-integrity (`scripts/ci/docs_quality_gate.sh`). Bootstrap scripts: add `bash -n install.sh`.

- **Commands run and tail output:**
- **Beyond CI — what did you manually verify?** (scenarios, edge cases, what you did NOT verify)
- **If any command was intentionally skipped, why:**

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? (`Yes/No`)
- New external network calls? (`Yes/No`)
- Secrets / tokens / credentials handling changed? (`Yes/No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`Yes/No`)
- If any `Yes`, describe the risk and mitigation:

## Compatibility (required)

- Backward compatible? (`Yes/No`)
- Config / env / CLI surface changed? (`Yes/No`)
- If `No` or `Yes` to either: exact upgrade steps for existing users:

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PRs: `git revert <sha>` is the plan unless otherwise noted.

Medium/high-risk PRs must fill:

- **Fast rollback command/path:**
- **Feature flags or config toggles:** (or `None`)
- **Observable failure symptoms:** (what to grep logs for, which metric moves, which alert fires)

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line):
- Scope materially carried forward:
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`Yes/No`)
- If `No`, why (inspiration-only, no direct code/design carry-over):

---

**Labels** live in the GitHub label UI, not in the body. Maintainers and reviewers with label permissions set `risk:*`, `size:*`, and scope labels via the sidebar. If auto-labels need correction, add `risk: manual` and the intended label. Contributors without label permission can note the mismatch in a comment.

**Do not add bot/AI attribution footers** such as `Co-authored-by: Claude ...`
or `Created with Claude Code` to the PR body or commit-message tail. Human
co-author trailers are appropriate only for incorporated contributor work under
the supersede-attribution section and privacy contract.

**Privacy contract** (`docs/book/src/contributing/privacy.md`) is a merge gate. Never commit real identities, secrets, personal emails, or PII in diff, tests, fixtures, or docs.
