### PR TITLE
docs(readme): fix broken providers routing doc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Full walkthrough: [Quick start](docs/book/src/getting-started/quick-start.md) �
 ## What ZeroClaw does
 
 - **Multi-channel** — one agent answering you across [every channel you configure](docs/book/src/channels/overview.md). Inbound messages from Discord, Telegram, Matrix, email, webhooks, CLI — all delivered to the same agent loop.
-- **Provider-agnostic** — [model providers](docs/book/src/providers/overview.md) are pluggable. Configure Anthropic, OpenAI, local Ollama, or any OpenAI-compatible endpoint. [Fallback chains and routing](docs/book/src/providers/fallback-and-routing.md) keep the agent running when a provider flakes.
+- **Provider-agnostic** — [model providers](docs/book/src/providers/overview.md) are pluggable. Configure Anthropic, OpenAI, local Ollama, or any OpenAI-compatible endpoint. [Fallback chains and routing](docs/book/src/providers/routing.md) keep the agent running when a provider flakes.
 - **Security-first, with escape hatches** — default autonomy is `supervised`: medium-risk ops require approval, high-risk blocked. Workspace boundaries, command policy, OS-level sandboxes (Landlock / Bubblewrap / Seatbelt / Docker), and cryptographic [tool receipts](docs/book/src/security/tool-receipts.md) on every action. [YOLO mode](docs/book/src/getting-started/yolo.md) exists for trusted dev environments.
 - **Hardware-capable** — GPIO / I2C / SPI / USB on Raspberry Pi, STM32, Arduino, and ESP32 via the `Peripheral` trait. See [Hardware](docs/book/src/hardware/index.md).
 - **Gateway + dashboard** — HTTP / WebSocket gateway for clients, with a web dashboard for chat, memory browsing, config editing, cron management, and tool inspection.


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** `README.md` linked "Fallback chains and routing" to `docs/book/src/providers/fallback-and-routing.md`, which does not exist on `master` and renders as a 404 on GitHub. The canonical doc is `docs/book/src/providers/routing.md` (the only routing page listed in `docs/book/src/SUMMARY.md`); it covers both per-call backend selection and provider reliability/fallback, so the existing link text stays accurate.
- **Scope boundary:** Only the single link target on `README.md` line 77 changes. No prose, no other links, no docs content.
- **Blast radius:** Documentation only. No code, build, or runtime impact.
- **Linked issue(s):** None — proactively found broken link.
- **Labels:** Expected `type: docs`, `risk: low`, `size: XS` (I do not have label permission; please adjust if needed).

## Validation Evidence (required)

Docs-only change — verified link target resolution (the repo's link gate, `scripts/ci/docs_links_gate.sh`, checks changed links with lychee):

```bash
test -f docs/book/src/providers/routing.md && echo "target exists: OK"
! grep -q fallback-and-routing README.md && echo "broken link removed: OK"
grep -n "providers/routing.md" docs/book/src/SUMMARY.md
```

```text
target exists: OK
broken link removed: OK
41:  - [Routing](./providers/routing.md)
```

- **Beyond CI — what did you manually verify?** Confirmed `fallback-and-routing.md` exists nowhere in the repo (`git grep` returns only this README occurrence) and that `routing.md` is the canonical page referenced by `SUMMARY.md`.
- **If any command was intentionally skipped, why:** No cargo build — change touches no Rust.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- No upgrade steps; documentation link correction only.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk: `git revert <sha>`.
