### PR TITLE
docs(esp32-ui): fix hardware design doc link to mdbook path

### DIFF
--- a/firmware/esp32-ui/README.md
+++ b/firmware/esp32-ui/README.md
@@ -103,4 +103,4 @@ MIT - See root `LICENSE`
 
 - [Slint ESP32 Documentation](https://slint.dev/esp32)
 - [ESP-IDF Rust Book](https://esp-rs.github.io/book/)
-- [ZeroClaw Hardware Design](../../docs/hardware/hardware-peripherals-design.md)
+- [ZeroClaw Hardware Design](../../docs/book/src/hardware/hardware-peripherals-design.md)


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** `firmware/esp32-ui/README.md` linked the hardware design doc to `../../docs/hardware/hardware-peripherals-design.md`, a pre-mdbook-layout path that resolves to a nonexistent `docs/hardware/` directory. The book docs now live under `docs/book/src/`, so the correct relative target from `firmware/esp32-ui/` is `../../docs/book/src/hardware/hardware-peripherals-design.md`.
- **Scope boundary:** Only the single link target changes. No other content in the firmware README.
- **Blast radius:** Documentation only. No firmware code or build impact.
- **Linked issue(s):** None — proactively found broken link.
- **Labels:** Expected `type: docs`, `risk: low`, `size: XS` (no label permission; please adjust).

## Validation Evidence (required)

```bash
python3 -c "import os;print('resolves:', os.path.exists(os.path.normpath('firmware/esp32-ui/../../docs/book/src/hardware/hardware-peripherals-design.md')))"
test ! -d docs/hardware && echo "old docs/hardware dir absent: OK"
```

```text
resolves: True
old docs/hardware dir absent: OK
```

- **Beyond CI — what did you manually verify?** Confirmed the target exists under the mdbook layout and that `docs/hardware/` does not exist anywhere.
- **If any command was intentionally skipped, why:** No cargo build — change touches no Rust.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- No upgrade steps; documentation link correction only.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk: `git revert <sha>`.
