### PR TITLE
fix(cron): block scheduler mutation tools in agent jobs

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -9948,7 +9948,8 @@ pub struct CronJobDecl {
     /// Model override for agent jobs.
     #[serde(default)]
     pub model: Option<String>,
-    /// Allowlist of tool names for agent jobs.
+    /// Optional allowlist of tool names for agent jobs. When omitted, scheduler
+    /// defaults may still exclude scheduler mutation tools for cron agent jobs.
     #[serde(default)]
     pub allowed_tools: Option<Vec<String>>,
     /// Whether to recall and inject memory context before this agent job runs.

--- a/crates/zeroclaw-runtime/src/cron/scheduler.rs
+++ b/crates/zeroclaw-runtime/src/cron/scheduler.rs
@@ -19,6 +19,13 @@ use zeroclaw_memory::{MEMORY_CONTEXT_CLOSE, MEMORY_CONTEXT_OPEN};
 const MIN_POLL_SECONDS: u64 = 5;
 const SHELL_JOB_TIMEOUT_SECS: u64 = 120;
 const SCHEDULER_COMPONENT: &str = "scheduler";
+const CRON_AGENT_DEFAULT_EXCLUDED_TOOLS: &[&str] = &[
+    "cron_add",
+    "cron_update",
+    "cron_remove",
+    "cron_run",
+    "schedule",
+];
 
 /// Type alias for the optional broadcast sender used to push cron results
 /// to connected dashboard/SSE clients.
@@ -302,6 +309,21 @@ pub async fn execute_job_now(config: &Config, job: &CronJob) -> (bool, String) {
         .await
 }
 
+fn cron_agent_run_security_policy(base: &SecurityPolicy, job: &CronJob) -> SecurityPolicy {
+    let mut policy = base.clone();
+    if !matches!(job.job_type, JobType::Agent) || job.allowed_tools.is_some() {
+        return policy;
+    }
+
+    let excluded = policy.excluded_tools.get_or_insert_with(Vec::new);
+    for tool in CRON_AGENT_DEFAULT_EXCLUDED_TOOLS {
+        if !excluded.iter().any(|existing| existing == tool) {
+            excluded.push((*tool).to_string());
+        }
+    }
+    policy
+}
+
 async fn execute_job_with_retry(
     config: &Config,
     security: &SecurityPolicy,
@@ -546,8 +568,9 @@ async fn run_agent_job(
     // a future refactor that flips the default can't quietly promote
     // every cron-launched agent to a depth-1 subagent — they're
     // top-level runs by design, despite riding through SubAgentSpawn.
+    let run_security = cron_agent_run_security_policy(subagent_ctx.policy.as_ref(), job);
     let run_overrides = crate::agent::loop_::AgentRunOverrides {
-        security: Some(subagent_ctx.policy.clone()),
+        security: Some(Arc::new(run_security)),
         memory: None,
         is_subagent: false,
     };
@@ -1098,6 +1121,48 @@ mod tests {
             ..test_job("echo test")
         };
         assert!(!is_high_frequency_agent_job(&job));
+    }
+
+    #[test]
+    fn cron_agent_run_security_policy_excludes_scheduler_mutation_tools_by_default() {
+        let security = SecurityPolicy::default();
+        let mut job = test_job("");
+        job.job_type = JobType::Agent;
+        job.allowed_tools = None;
+
+        let policy = cron_agent_run_security_policy(&security, &job);
+
+        for tool in [
+            "cron_add",
+            "cron_update",
+            "cron_remove",
+            "cron_run",
+            "schedule",
+        ] {
+            assert!(
+                !policy.is_tool_allowed(tool),
+                "{tool} must be excluded from default cron agent runs"
+            );
+        }
+        assert!(
+            policy.is_tool_allowed("http_request"),
+            "non-scheduler tools remain available when the base policy is unrestricted"
+        );
+    }
+
+    #[test]
+    fn cron_agent_run_security_policy_respects_explicit_allowed_tools() {
+        let security = SecurityPolicy::default();
+        let mut job = test_job("");
+        job.job_type = JobType::Agent;
+        job.allowed_tools = Some(vec!["cron_add".into()]);
+
+        let policy = cron_agent_run_security_policy(&security, &job);
+
+        assert!(
+            policy.is_tool_allowed("cron_add"),
+            "explicit cron job allowed_tools should remain the override for intentional scheduler automation"
+        );
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-runtime/src/cron/types.rs
+++ b/crates/zeroclaw-runtime/src/cron/types.rs
@@ -161,7 +161,9 @@ pub struct CronJob {
     pub delete_after_run: bool,
     /// Optional allowlist of tool names this cron job may use.
     /// When `Some(list)`, only tools whose name is in the list are available.
-    /// When `None`, all tools are available (backward compatible default).
+    /// When `None`, this job does not add an allowlist. Agent cron jobs may
+    /// still receive scheduler-level default exclusions for scheduler mutation
+    /// tools unless they opt back in with an explicit allowlist.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub allowed_tools: Option<Vec<String>>,
     /// Whether to recall and inject memory context before this agent job runs.

--- a/crates/zeroclaw-runtime/src/tools/cron_add.rs
+++ b/crates/zeroclaw-runtime/src/tools/cron_add.rs
@@ -163,7 +163,7 @@ impl Tool for CronAddTool {
                 "allowed_tools": {
                     "type": "array",
                     "items": { "type": "string" },
-                    "description": "Optional allowlist of tool names for agent jobs. When omitted, all tools remain available."
+                    "description": "Optional allowlist of tool names for agent jobs. When omitted, cron-launched agent runs keep non-scheduler tools available but exclude scheduler mutation tools such as cron_add, cron_update, cron_remove, cron_run, and schedule. Include those names explicitly to opt back in."
                 },
                 "delivery": {
                     "type": "object",
@@ -936,6 +936,22 @@ mod tests {
             jobs[0].allowed_tools, None,
             "empty allowed_tools should be stored as None"
         );
+    }
+
+    #[tokio::test]
+    async fn allowed_tools_schema_documents_scheduler_mutation_default() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = test_config(&tmp).await;
+        let tool = CronAddTool::new(cfg.clone(), test_security(&cfg), TEST_AGENT);
+
+        let schema = tool.parameters_schema();
+        let description = schema["properties"]["allowed_tools"]["description"]
+            .as_str()
+            .unwrap_or_default();
+
+        assert!(description.contains("exclude scheduler mutation tools"));
+        assert!(description.contains("cron_add"));
+        assert!(description.contains("opt back in"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Cron-launched agent jobs now derive a run-time `SecurityPolicy` that excludes scheduler mutation tools by default when the job does not set an explicit `allowed_tools` list.
  - The default guard blocks `cron_add`, `cron_update`, `cron_remove`, `cron_run`, and the legacy `schedule` tool so a scheduled agent job cannot self-schedule, remove, run, or recursively mutate scheduler state unless the job opts in.
  - Explicit cron job `allowed_tools` remains the opt-in path for jobs that intentionally automate scheduler management.
  - `cron_add` schema text and cron job field comments now describe the default exclusion so tool callers do not see stale “all tools remain available” guidance.
- **Scope boundary:** This PR does not add new config fields, does not change shell cron jobs, does not change generic agent `allowed_tools` / `excluded_tools` behavior, and does not block non-scheduler tools for default cron agent jobs.
- **Blast radius:** Cron agent job execution and `cron_add` parameter documentation. Default cron agent jobs lose only scheduler mutation tools; non-scheduler tools stay governed by the existing risk profile. Jobs with explicit `allowed_tools` keep their configured tool set.
- **Linked issue(s):** Related #6914. That issue is broader tool policy work; this PR only covers the cron agent job default scheduler mutation guard.
- **Labels:** Intended labels: `bug`, `risk: high`, `size: S`, `cron`, `runtime`, `tool`, `config`, `cron:scheduler`, `tool: cron_add`.

## Validation Evidence (required)

- **Commands run and tail output:**

  ```bash
  $ cargo test -p zeroclaw-runtime --lib cron_agent_run_security_policy -- --nocapture
  running 2 tests
  test cron::scheduler::tests::cron_agent_run_security_policy_respects_explicit_allowed_tools ... ok
  test cron::scheduler::tests::cron_agent_run_security_policy_excludes_scheduler_mutation_tools_by_default ... ok

  test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 1983 filtered out; finished in 0.00s
  ```

  ```bash
  $ cargo test -p zeroclaw-runtime --lib allowed_tools_schema_documents_scheduler_mutation_default -- --nocapture
  running 1 test
  test tools::cron_add::tests::allowed_tools_schema_documents_scheduler_mutation_default ... ok

  test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1984 filtered out; finished in 0.00s
  ```

  ```bash
  $ cargo fmt --all -- --check
  # clean; exit 0
  ```

  ```bash
  $ cargo clippy --all-targets -- -D warnings
      Checking zeroclaw-config v0.8.0-beta-2
      Checking zeroclaw-memory v0.8.0-beta-2
      Checking zeroclaw-providers v0.8.0-beta-2
      Checking zeroclaw-tools v0.8.0-beta-2
      Checking zeroclaw-runtime v0.8.0-beta-2
      Checking zeroclaw-hardware v0.8.0-beta-2
      Checking zeroclaw-channels v0.8.0-beta-2
      Finished `dev` profile [unoptimized + debuginfo] target(s) in 3m 26s
  ```

  ```bash
  $ cargo test
  test result: ok. 159 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.37s

       Running tests/test_live.rs

  running 7 tests
  test live::gemini_fallback_oauth_refresh::gemini_warmup_refreshes_expired_oauth_token ... ignored, requires live Gemini OAuth credentials with refresh_token
  test live::gemini_fallback_oauth_refresh::gemini_warmup_with_valid_credentials ... ignored, requires live Gemini OAuth credentials
  test live::openai_codex_vision_e2e::openai_codex_second_vision_support ... ignored, requires live OpenAI Codex OAuth credentials (second profile)
  test live::openai_codex_vision_e2e::provider_vision_support ... ignored, requires live model_provider OAuth credentials
  test live::providers::e2e_live_openai_codex_multi_turn ... ignored, requires live OpenAI Codex OAuth credentials
  test live::zai_jwt_auth::live_zai_jwt_auth_chat ... ignored, requires live ZAI_API_KEY
  test live::zai_jwt_auth::live_zai_jwt_auth_multi_turn ... ignored, requires live ZAI_API_KEY

  test result: ok. 0 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 0.00s

       Running tests/test_system.rs

  running 9 tests
  test system::multi_agent_e2e::peer_group_routes_messages_only_within_resolved_peer_set ... ok
  test system::multi_agent_e2e::peer_group_dotted_channel_refs_remain_alias_scoped_for_dispatch ... ok
  test system::multi_agent_e2e::legacy_install_upgrades_cleanly_with_backup ... ok
  test system::full_stack::system_multi_turn_conversation ... ok
  test system::full_stack::system_parallel_tool_execution ... ok
  test system::full_stack::system_simple_text_response ... ok
  test system::full_stack::system_tool_arguments_passed_correctly ... ok
  test system::full_stack::system_tool_execution_flow ... ok
  test system::multi_agent_e2e::two_sqlite_agents_on_one_install_have_isolated_memory ... ok

  test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.20s

     Doc-tests zeroclaw

  running 0 tests

  test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
  ```

- **Beyond CI — what did you manually verify?** The targeted scheduler tests verify both sides of the cron-specific policy: default cron agent runs deny scheduler mutation tools while preserving non-scheduler tools, and explicit job `allowed_tools` can opt back in to `cron_add`. The schema test verifies the tool-facing `cron_add` parameter description documents the new default.
- **If any command was intentionally skipped, why:** None.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No** — this narrows the default cron agent job tool surface.
- New external network calls? **No.**
- Secrets / tokens / credentials handling changed? **No.**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No.**
- If any `Yes`, describe the risk and mitigation: N/A.

## Compatibility (required)

- Backward compatible? **Yes**, for jobs that do not intentionally mutate the scheduler. Cron agent jobs still run with non-scheduler tools under the existing risk profile, and shell jobs are unchanged.
- Config / env / CLI surface changed? **No** new fields or flags. Existing cron job `allowed_tools` remains the explicit opt-in for scheduler automation.
- If `No` or `Yes` to either: exact upgrade steps for existing users: Existing cron agent jobs that intentionally call `cron_add`, `cron_update`, `cron_remove`, `cron_run`, or `schedule` should set `allowed_tools` explicitly for those tool names.

## Rollback (required for `risk: high`)

- **Fast rollback command/path:** `git revert fee76bdc6` after merge or revert this PR branch commit before merge.
- **Feature flags or config toggles:** No new flag. Per-job explicit `allowed_tools` can opt back in for intentional scheduler automation.
- **Observable failure symptoms:** A cron-launched agent job that previously self-managed scheduler state without an explicit `allowed_tools` list will stop seeing or executing scheduler mutation tools. Add the scheduler tool names to that job’s `allowed_tools` only when that automation is intentional.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Scope materially carried forward: N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`Yes/No`): No
- If `No`, why (inspiration-only, no direct code/design carry-over): No superseded PR.
