### PR TITLE
fix(web): bump react-router to 7.16.0 to clear 5 advisories

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -22,7 +22,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-markdown": "^10.1.0",
-        "react-router-dom": "^7.1.1",
+        "react-router-dom": "^7.16.0",
         "rehype-highlight": "^7.0.2",
         "remark-gfm": "^4.0.1"
       },
@@ -4171,9 +4171,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.0.tgz",
-      "integrity": "sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
+      "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -4193,12 +4193,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.0.tgz",
-      "integrity": "sha512-5CO/l5Yahi2SKC6rGZ+HDEjpjkGaG/ncEP7eWFTvFxbHP8yeeI0PxTDjimtpXYlR3b3i9/WIL4VJttPrESIf2g==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.16.0.tgz",
+      "integrity": "sha512-kMUAbimWB5FVbF4Bce4bJsiKJWLIUHq/mEG8+CFDnCSgltptBiG5nguducmsJeGKytlCvQud9Qhzpn49iduTlA==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.13.0"
+        "react-router": "7.16.0"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/web/package.json
+++ b/web/package.json
@@ -28,7 +28,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-markdown": "^10.1.0",
-    "react-router-dom": "^7.1.1",
+    "react-router-dom": "^7.16.0",
     "rehype-highlight": "^7.0.2",
     "remark-gfm": "^4.0.1"
   },


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** `web/` pinned `react-router` / `react-router-dom` 7.13.0, which is flagged by 5 GitHub advisories (Dependabot). Bumped both to 7.16.0 and raised the `package.json` range to `^7.16.0`.
  - GHSA-49rj-9fvp-4h2h — vendored turbo-stream v2 RCE (High, fixed >7.14.1)
  - GHSA-8x6r-g9mw-2r78 — `__manifest` DoS (High, fixed >=7.15.0, the binding floor)
  - GHSA-8646-j5j9-6r62 / GHSA-f22v-gfqf-p8f3 — XSS (fixed >=7.13.2)
  - GHSA-2j2x-hqr9-3h42 — open redirect (fixed >=7.14.1)
  - Range raised from `^7.1.1` to `^7.16.0` so a lockfile regeneration cannot resolve back into the vulnerable range.
- **Scope boundary:** Only `web/package.json` + `web/package-lock.json`. No application code, no Rust, no other deps. The web client is a client-only SPA — the turbo-stream/server-runtime framework code paths in the advisories are not actually reachable here, but the vulnerable `react-router` version was present, so the bump is correct regardless.
- **Blast radius:** Frontend routing only (`react-router-dom`). 7.13.0 → 7.16.0 is same-major (7.x), no breaking API changes.
- **Linked issue(s):** None.
- **Labels:** `type: dependencies`, `risk: medium`, `size: XS`.

## Validation Evidence (required)

The Rust battery (`cargo fmt`/`clippy`/`test`) is N/A — this is a `web/` JavaScript dependency change with no Rust diff. Ran the JS-equivalent validation:

\`\`\`
$ npm audit
found 0 vulnerabilities

$ npm run build
✓ built in 3.06s
\`\`\`

- **Commands run and tail output:** `npm audit` → `found 0 vulnerabilities` (was 2 High before). `npm run build` (`tsc -b && vite build`) → builds clean. `npm install --package-lock-only` confirmed the lock stays at 7.16.0 with no drift against the tightened range.
- **Beyond CI — what did you manually verify?** Confirmed the lockfile tree never pulled in `turbo-stream` or `@remix-run/server-runtime` (the SPA uses only `react-router-dom`), and that 7.16.0 clears the highest advisory floor (7.15.0). Did not manually exercise every route at runtime.
- **If any command was intentionally skipped, why:** Rust battery skipped — no Rust changes in this PR.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- This PR removes risk: it patches 5 advisories (2 High after dedup) in a transitive dependency.

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Same-major version bump (7.13.0 → 7.16.0); no upgrade steps required for existing users.

## Rollback (required for risk: medium and risk: high)

- **Fast rollback command/path:** `git revert <sha>`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Frontend build failure (`vite build`) or client-side routing breakage in the web UI.