### PR TITLE
fix(web): strip server timestamp prefix from chat bubble content

### DIFF
--- a/web/src/pages/AgentChat.tsx
+++ b/web/src/pages/AgentChat.tsx
@@ -453,6 +453,23 @@ function AgentChatInner({ agentAlias }: { agentAlias: string }) {
   );
 }
 
+const SERVER_TIMESTAMP_RE = /\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} [^\]]+)\]\s*/;
+
+function extractServerTimestamp(content: string): {
+  cleanContent: string;
+  serverTimestamp: Date | null;
+} {
+  const m = content.match(SERVER_TIMESTAMP_RE);
+  if (!m) return { cleanContent: content, serverTimestamp: null };
+  const tsStr = m[1];
+  if (!tsStr) return { cleanContent: content, serverTimestamp: null };
+  const ts = new Date(tsStr);
+  if (isNaN(ts.getTime())) return { cleanContent: content, serverTimestamp: null };
+  const prefix = content.slice(0, m.index!);
+  const suffix = content.slice(m.index! + m[0].length);
+  return { cleanContent: prefix + suffix, serverTimestamp: ts };
+}
+
 // Each chat message is rendered through this memoized component so that
 // typing into the input does not re-render every existing message (and
 // re-run ReactMarkdown on each one). Keep the prop surface small and pass
@@ -475,6 +492,8 @@ const MessageItem = memo(function MessageItem({
   onCopy,
   onDelete,
 }: MessageItemProps) {
+  const { cleanContent } = extractServerTimestamp(msg.content);
+
   return (
     <div
       className={`group flex items-start ${compact ? 'gap-2' : 'gap-3'} ${
@@ -515,9 +534,9 @@ const MessageItem = memo(function MessageItem({
           {msg.toolCall ? (
             <ToolCallCard toolCall={msg.toolCall} />
           ) : msg.markdown ? (
-            <div className={`${compact ? 'text-xs' : 'text-sm'} break-words leading-relaxed chat-markdown`}><ReactMarkdown remarkPlugins={[remarkGfm]}>{msg.content}</ReactMarkdown></div>
+            <div className={`${compact ? 'text-xs' : 'text-sm'} break-words leading-relaxed chat-markdown`}><ReactMarkdown remarkPlugins={[remarkGfm]}>{cleanContent}</ReactMarkdown></div>
           ) : (
-            <p className={`${compact ? 'text-xs' : 'text-sm'} whitespace-pre-wrap break-words leading-relaxed`}>{msg.content}</p>
+            <p className={`${compact ? 'text-xs' : 'text-sm'} whitespace-pre-wrap break-words leading-relaxed`}>{cleanContent}</p>
           )}
           {!compact && (
             <p
@@ -528,7 +547,7 @@ const MessageItem = memo(function MessageItem({
         </div>
         <div className="flex items-center justify-end gap-1 mt-1 opacity-0 group-hover:opacity-100 transition-opacity">
           <button
-            onClick={() => onCopy(msg.id, msg.content)}
+            onClick={() => onCopy(msg.id, cleanContent)}
             aria-label={t('agent.copy_message')}
             className="p-1 rounded-lg"
             style={{ color: 'var(--pc-text-muted)' }}


### PR DESCRIPTION
## Summary

Fix the server timestamp prefix `[YYYY-MM-DD HH:MM:SS TZ]` being rendered inline inside chat bubbles in the Web UI.

**Approach**: Pure frontend fix. Strip the timestamp prefix from message content at render time using a regex in `MessageItem`, and display only the clean content. Copy also uses clean content so users don't paste the timestamp prefix.

## Changes

- `web/src/pages/AgentChat.tsx` — add `extractServerTimestamp()` helper + use `cleanContent` for rendering and copy in `MessageItem`

## Design notes

- **No `^` anchor**: The timestamp may appear at the start (no context) or mid-string (after memory context), so the regex matches anywhere
- **Compact mode unaffected**: Timestamp is hidden in compact mode, content stripping still applies
- **Safe fallback**: Failed date parsing or no regex match silently returns the original content
- **Bottom timestamp unchanged**: Preserves the original master behavior of showing `msg.timestamp` at the bubble bottom in non-compact mode

## Test plan

- [ ] Send a message in Web Chat, refresh the page — bubble content does not contain the timestamp prefix
- [ ] Copy message — clipboard does not include the timestamp prefix
- [ ] Compact mode — messages render correctly (no timestamp shown)
- [ ] Messages with memory context — timestamp prefix is still correctly stripped

Closes #7157
