### PR TITLE
docs(reference): document ZEROCLAW_DATA_DIR in bootstrap env vars

### DIFF
--- a/docs/book/src/reference/env-vars.md
+++ b/docs/book/src/reference/env-vars.md
@@ -51,11 +51,12 @@ The `<alias>` segments above (`home`, `prod_v2`) are operator-chosen — substit
 
 ## Bootstrap (uppercase tail)
 
-Two env vars decide *where* the config file lives, before any `Config` exists. They keep their UPPERCASE form so the case rule disambiguates them from the schema-mirror surface:
+These env vars decide *where* the config file and instance data live, before any `Config` exists. They keep their UPPERCASE form so the case rule disambiguates them from the schema-mirror surface. They resolve in the order `ZEROCLAW_CONFIG_DIR` > `ZEROCLAW_DATA_DIR` > `ZEROCLAW_WORKSPACE` (deprecated):
 
 ```sh
-ZEROCLAW_WORKSPACE=/srv/zeroclaw          # workspace root
-ZEROCLAW_CONFIG_DIR=/etc/zeroclaw         # config-file location
+ZEROCLAW_CONFIG_DIR=/etc/zeroclaw         # config-file location (takes precedence)
+ZEROCLAW_DATA_DIR=/srv/zeroclaw           # instance data directory (canonical)
+ZEROCLAW_WORKSPACE=/srv/zeroclaw          # DEPRECATED — alias for ZEROCLAW_DATA_DIR
 ```
 
 The gateway's web-dashboard location is configured via the standard


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** The env-vars reference's "Bootstrap (uppercase tail)" section listed only `ZEROCLAW_WORKSPACE` (labeled as the current "workspace root") and `ZEROCLAW_CONFIG_DIR`. But the runtime resolver (`resolve_runtime_config_dirs`) and `.env.example` treat `ZEROCLAW_DATA_DIR` as the **canonical** instance-data directory and `ZEROCLAW_WORKSPACE` as a **deprecated alias** (the resolver even emits `WARN`: *"ZEROCLAW_WORKSPACE is deprecated; use ZEROCLAW_DATA_DIR instead"*). The reference therefore steered operators to a deprecated variable and hid the canonical one. This documents all three in the resolver's true precedence order `ZEROCLAW_CONFIG_DIR` > `ZEROCLAW_DATA_DIR` > `ZEROCLAW_WORKSPACE` (deprecated), matching the wording `.env.example` already uses.
- **Scope boundary:** Only the bootstrap-env-vars doc section. No code, no schema, no resolver behavior touched.
- **Blast radius:** Documentation only (`docs/book/src/reference/env-vars.md`).
- **Linked issue(s):** None — proactively found.
- **Labels:** Expected `type: docs`, `risk: low`, `size: XS`, `docs` (no label permission; please adjust).

## Validation Evidence (required)

Docs-only — verified the page now matches the resolver and `.env.example`:

```bash
grep -n "ZEROCLAW_CONFIG_DIR.*ZEROCLAW_DATA_DIR.*ZEROCLAW_WORKSPACE" crates/zeroclaw-config/src/schema.rs   # resolver precedence
grep -n "DEPRECATED .* ZEROCLAW_DATA_DIR" .env.example                                                      # canonical wording
sed -n '52,59p' docs/book/src/reference/env-vars.md                                                         # updated section
```

```text
13792:/// `ZEROCLAW_CONFIG_DIR` > `ZEROCLAW_DATA_DIR` > `ZEROCLAW_WORKSPACE`
# .env.example: ZEROCLAW_WORKSPACE=/path/to/legacy/workspace  # DEPRECATED — use ZEROCLAW_DATA_DIR
# env-vars.md now lists CONFIG_DIR (precedence) / DATA_DIR (canonical) / WORKSPACE (DEPRECATED alias)
```

- **Beyond CI — what did you manually verify?** Read `resolve_runtime_config_dirs` (schema.rs) to confirm the precedence and the deprecation, and cross-checked the wording against `.env.example`.
- **If any command was intentionally skipped, why:** No cargo build — docs-only change.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No` (documents existing variables; no behavior change).
- Upgrade steps: none.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk: `git revert <sha>`.
