### PR TITLE
docs(providers): fix stale code reference in streaming.md

### DIFF
--- a/docs/book/src/providers/streaming.md
+++ b/docs/book/src/providers/streaming.md
@@ -95,7 +95,7 @@ If a provider returns the entire response in one shot (older OpenAI-compat endpo
 
 ## Code references
 
-- `crates/zeroclaw-api/src/provider.rs` — `Provider` trait, `StreamEvent` enum
+- `crates/zeroclaw-api/src/model_provider.rs` — `ModelProvider` trait, `StreamEvent` enum
 - `crates/zeroclaw-providers/src/compatible.rs` — OpenAI-compat SSE parser
 - `crates/zeroclaw-providers/src/anthropic.rs` — Anthropic streaming
 - `crates/zeroclaw-providers/src/ollama.rs` — Ollama streaming


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** The "Code references" list in `docs/book/src/providers/streaming.md` pointed readers to `crates/zeroclaw-api/src/provider.rs` for the "`Provider` trait, `StreamEvent` enum". After the workspace refactor that file no longer exists, and the trait is named `ModelProvider` (defined in `crates/zeroclaw-api/src/model_provider.rs`, alongside the `StreamEvent` enum). This points the reference at the real file and trait name. The other three references in the same list (`compatible.rs`, `anthropic.rs`, `ollama.rs`) are correct and unchanged.
- **Scope boundary:** Only the single stale bullet on line 98. No other doc content.
- **Blast radius:** Documentation only.
- **Linked issue(s):** None — proactively found.
- **Labels:** Expected `type: docs`, `risk: low`, `size: XS`, `docs` (no label permission; please adjust).

## Validation Evidence (required)

```bash
git cat-file -e HEAD:crates/zeroclaw-api/src/provider.rs        # absent after refactor
git grep -n "pub trait ModelProvider|pub enum StreamEvent" -- crates/zeroclaw-api/src/model_provider.rs
```

```text
fatal: Not a valid object name HEAD:crates/zeroclaw-api/src/provider.rs   # provider.rs no longer exists
crates/zeroclaw-api/src/model_provider.rs:229:pub enum StreamEvent {
crates/zeroclaw-api/src/model_provider.rs:367:pub trait ModelProvider: Send + Sync + crate::attribution::Attributable {
```

- **Beyond CI — what did you manually verify?** Confirmed `provider.rs` exists nowhere in the repo and that the `ModelProvider` trait + `StreamEvent` enum live in `model_provider.rs`; the other three references resolve to existing files.
- **If any command was intentionally skipped, why:** No cargo build — docs-only.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Upgrade steps: none.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk: `git revert <sha>`.
