### PR TITLE
docs(maintainers): correct zerocode locale resolution to the single file it reads

### DIFF
--- a/docs/book/src/maintainers/docs-and-translations.md
+++ b/docs/book/src/maintainers/docs-and-translations.md
@@ -87,7 +87,7 @@ Chord glyphs like `Ctrl+C`, `Esc`, `Shift+Up` are protocol, not language. The `H
 
 ### Locale resolution
 
-Locale comes from a top-level `locale` field in `zerocode-config.toml`. When unset, `i18n::detect_locale()` walks (in order) `<config-dir>/zerocode/zerocode-config.toml`, `~/.zeroclaw/zerocode-config.toml`, `~/.zeroclaw/config.toml`, then `<config-dir>/zeroclaw/config.toml`, finally falling back to `en`. The same lookup matches how the daemon resolves its own locale.
+Locale comes from a top-level `locale` field in `zerocode-config.toml`. When unset, `i18n::detect_locale()` reads a single file — `<config-dir>/zerocode-config.toml`, where the config dir is resolved as `--config-dir`, then `ZEROCLAW_CONFIG_DIR`, then `~/.zeroclaw` — and otherwise falls back to `en`. zerocode resolves its locale independently from its own `zerocode-config.toml`; it does not share the daemon's lookup.
 
 ### Adding strings
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** The "Locale resolution" section claimed `i18n::detect_locale()` walks four candidate paths (`<config-dir>/zerocode/zerocode-config.toml`, `~/.zeroclaw/zerocode-config.toml`, `~/.zeroclaw/config.toml`, `<config-dir>/zeroclaw/config.toml`) and that the lookup "matches how the daemon resolves its own locale". The code (`apps/zerocode/src/i18n.rs`) reads exactly one file — `<config-dir>/zerocode-config.toml` (config dir resolved as `--config-dir`, then `ZEROCLAW_CONFIG_DIR`, then `~/.zeroclaw`) — then falls back to `en`. zerocode is intentionally decoupled from the daemon and reads its own `zerocode-config.toml` independently. This rewrites the paragraph to match the real single-file read.
- **Scope boundary:** Only the "Locale resolution" paragraph. No other doc content, no code.
- **Blast radius:** Documentation only.
- **Linked issue(s):** None — proactively found.
- **Labels:** Expected `type: docs`, `risk: low`, `size: XS`, `docs` (no label permission; please adjust).

## Validation Evidence (required)

```bash
git grep -n "zerocode-config.toml" -- apps/zerocode/src/i18n.rs
```

```text
apps/zerocode/src/i18n.rs:147:/// `<config_dir>/zerocode-config.toml` (config_dir honoring `--config-dir`,
apps/zerocode/src/i18n.rs:160:    let contents = std::fs::read_to_string(dir.join("zerocode-config.toml")).ok()?;
```

- **Beyond CI — what did you manually verify?** Read `detect_locale` → `locale_from_config` → `locale_from_config_dir` (i18n.rs:160) to confirm the single-file read and the config-dir precedence, and the comment at i18n.rs:146 that records the old multi-path walk was removed.
- **If any command was intentionally skipped, why:** No cargo build — docs-only.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Upgrade steps: none.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk: `git revert <sha>`.
