### PR TITLE
feat(dist): add FreeBSD port under dist/freebsd

### DIFF
--- a/.github/workflows/pub-freebsd.yml
+++ b/.github/workflows/pub-freebsd.yml
@@ -1,0 +1,116 @@
+name: Pub FreeBSD Port
+
+# FreeBSD ports are not auto-pushed like AUR/scoop — submission goes through the
+# FreeBSD bugzilla/maintainer flow. On release this job regenerates the port's
+# distinfo + CARGO_CRATES from the tag's Cargo.lock using the real ports
+# framework in a FreeBSD VM, bumps DISTVERSION, validates with portlint, and
+# uploads the bumped port as a release artifact for the maintainer to submit.
+
+on:
+  workflow_call:
+    inputs:
+      release_tag:
+        description: "Existing release tag (vX.Y.Z)"
+        required: true
+        type: string
+      dry_run:
+        description: "Generate + validate only (no artifact upload)"
+        required: false
+        default: false
+        type: boolean
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Existing release tag (vX.Y.Z)"
+        required: true
+        type: string
+      dry_run:
+        description: "Generate + validate only (no artifact upload)"
+        required: false
+        default: true
+        type: boolean
+
+concurrency:
+  group: freebsd-publish-${{ github.run_id }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  publish-freebsd:
+    name: Generate FreeBSD Port
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ inputs.release_tag }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Validate tag
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::release_tag must be vX.Y.Z (optional pre-release suffix)."
+            exit 1
+          fi
+          echo "version=${RELEASE_TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Regenerate port in a FreeBSD VM
+        uses: vmactions/freebsd-vm@a6de9343ef5747433d9c25784c90e84998b9d69a # v1.4.6
+        with:
+          release: "14.2"
+          usesh: true
+          prepare: |
+            pkg install -y rust git gmake ports-mgmt/portlint ports-mgmt/portfmt
+            portsnap --interactive fetch extract || true
+          run: |
+            set -eu
+            version="${RELEASE_TAG#v}"
+            portdir=/usr/ports/misc/zeroclaw
+            mkdir -p "$portdir"
+            cp dist/freebsd/misc/zeroclaw/Makefile "$portdir/"
+            cp dist/freebsd/misc/zeroclaw/pkg-descr "$portdir/"
+
+            # Bump DISTVERSION to the released tag.
+            sed -i '' -E "s|^DISTVERSION=[[:space:]]+.*|DISTVERSION=	${version}|" \
+              "$portdir/Makefile"
+
+            # Regenerate CARGO_CRATES + distinfo from the tag's Cargo.lock using
+            # the framework's own target — the port carries no committed list.
+            make -C "$portdir" cargo-crates-merge
+
+            # Validate.
+            portfmt -i "$portdir/Makefile"
+            portlint -AC "$portdir"
+
+            # Stage the generated artifacts back into the workspace for upload.
+            cp "$portdir/Makefile" dist/freebsd/misc/zeroclaw/Makefile
+            cp "$portdir/distinfo" dist/freebsd/misc/zeroclaw/distinfo
+
+      - name: Package the port artifact
+        id: pkg
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${{ steps.meta.outputs.version }}"
+          tarball="zeroclaw-freebsd-port-${version}.tar.gz"
+          tar -czf "$tarball" -C dist/freebsd/misc zeroclaw
+          echo "tarball=$tarball" >> "$GITHUB_OUTPUT"
+          {
+            echo "### FreeBSD port for ${RELEASE_TAG}"
+            echo "Generated \`distinfo\` + \`CARGO_CRATES\` from the tag's Cargo.lock."
+            echo "Submit via the FreeBSD ports bugzilla (maintainer flow)."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload to the release
+        if: ${{ inputs.dry_run == false }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh release upload "$RELEASE_TAG" "${{ steps.pkg.outputs.tarball }}" \
+            --repo "$GITHUB_REPOSITORY" --clobber

--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -633,6 +633,16 @@ jobs:
       dry_run: false
     secrets: inherit
 
+  freebsd:
+    name: Generate FreeBSD Port
+    needs: [validate, publish]
+    if: ${{ !cancelled() && needs.publish.result == 'success' }}
+    uses: ./.github/workflows/pub-freebsd.yml
+    with:
+      release_tag: ${{ needs.validate.outputs.tag }}
+      dry_run: false
+    secrets: inherit
+
   # ── Post-publish: announce after release + website are live ───────────
   # Docker push can be slow; don't let it block announcements.
   tweet:

--- a/dist/freebsd/README.md
+++ b/dist/freebsd/README.md
@@ -1,0 +1,69 @@
+# zeroclaw — FreeBSD port
+
+A FreeBSD `USES=cargo` port for [ZeroClaw](https://github.com/zeroclaw-labs/zeroclaw),
+carried in-tree under `dist/freebsd/` alongside the other downstream packaging
+targets (`dist/aur`, `dist/scoop`).
+
+## Layout
+
+```
+misc/zeroclaw/   the authored port (Makefile, pkg-descr)
+```
+
+`distinfo` and the crate list (`CARGO_CRATES`) are **not** in this directory.
+They are generated from the project's `Cargo.lock` on a FreeBSD host and are
+git-ignored — committing them would mean hand-maintaining a 1000+ line
+dependency list on every release, which is exactly what the framework generates
+for you.
+
+## Building
+
+On a FreeBSD host with the ports framework and the cargo toolchain:
+
+```sh
+cp -R dist/freebsd/misc/zeroclaw /usr/ports/misc/zeroclaw
+cd /usr/ports/misc/zeroclaw
+make cargo-crates-merge     # Cargo.lock -> CARGO_CRATES + distinfo
+make install clean
+```
+
+`make cargo-crates-merge` reads the extracted source's `Cargo.lock`, writes the
+crate list via `portedit`, and regenerates `distinfo`. It preserves the
+`@git+` entry for the `whatsapp-web` channel's git workspace
+(`oxidezap/whatsapp-rust`).
+
+Installs `bin/zeroclaw`, `bin/zeroclaw-acp-bridge`, and `bin/zerocode`.
+
+## Channels
+
+`pkg install` ships a prebuilt binary compiled with the workspace's
+full-channel feature alias (cargo resolves its members from `Cargo.toml`), so
+every channel is present. Feature selection is a from-source choice only — a
+prebuilt package takes no feature flags. A source build can override
+`CARGO_FEATURES`; run `zeroclaw --list-features` for the list.
+
+## Updating / publishing
+
+On a stable release the `pub-freebsd.yml` workflow regenerates `distinfo` +
+`CARGO_CRATES` from the tag's `Cargo.lock` in a FreeBSD VM (real ports
+framework — `make cargo-crates-merge`), bumps `DISTVERSION`, runs
+`portlint`/`portfmt`, and uploads the bumped port as a release artifact. FreeBSD
+ports submission is maintainer-driven via bugzilla, so the workflow stops at the
+artifact rather than auto-pushing like AUR/Scoop.
+
+To regenerate locally on a FreeBSD host:
+
+```sh
+cd /usr/ports/misc/zeroclaw
+make cargo-crates-merge
+```
+
+## License
+
+The port follows ZeroClaw's dual MIT / Apache-2.0 license.
+
+## Upstream
+
+Submitted to the FreeBSD ports tree:
+**[bug #295837](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=295837)**.
+Maintainer: jperlow@gmail.com.

--- a/dist/freebsd/misc/zeroclaw/.gitignore
+++ b/dist/freebsd/misc/zeroclaw/.gitignore
@@ -1,0 +1,5 @@
+# distinfo and the CARGO_CRATES list are generated from Cargo.lock on a FreeBSD
+# host (`make cargo-crates-merge` + `make makesum`), never hand-authored. Do not
+# commit them — they would rot on every release.
+distinfo
+Makefile.crates

--- a/dist/freebsd/misc/zeroclaw/Makefile
+++ b/dist/freebsd/misc/zeroclaw/Makefile
@@ -1,0 +1,65 @@
+PORTNAME=	zeroclaw
+DISTVERSIONPREFIX=	v
+DISTVERSION=	0.8.0-beta-2
+CATEGORIES=	misc
+
+MAINTAINER=	jperlow@gmail.com
+COMMENT=	Fast, small AI assistant and agent CLI written in Rust
+WWW=		https://github.com/zeroclaw-labs/zeroclaw
+
+LICENSE=	APACHE20 MIT
+LICENSE_COMB=	dual
+LICENSE_FILE_APACHE20=	${WRKSRC}/LICENSE-APACHE
+LICENSE_FILE_MIT=	${WRKSRC}/LICENSE-MIT
+
+USES=		cargo
+USE_GITHUB=	yes
+GH_ACCOUNT=	zeroclaw-labs
+
+# DISTVERSION tracks the upstream release tag. Like the AUR and scoop targets,
+# the version is not synced from the repo's bump script — the ports distfile
+# scanner (PORTSCOUT) watches upstream tags so the maintainer is notified of a
+# new release to bump and re-run `make cargo-crates-merge`.
+PORTSCOUT=	limit:^v
+
+# The crate list (CARGO_CRATES) and distinfo are NOT authored here. They are
+# generated from the project's Cargo.lock on a FreeBSD host with the framework's
+# own targets and are intentionally not committed (see .gitignore). To produce a
+# buildable port from this directory:
+#
+#     make cargo-crates-merge   # reads Cargo.lock -> CARGO_CRATES + distinfo
+#     make install clean
+#
+# On a version bump, re-run `make cargo-crates-merge`; nothing is hand-edited.
+
+# A prebuilt package (`pkg install`) is already compiled; feature selection is a
+# source-build choice only. The package is built with the workspace's
+# full-channel feature alias so every channel is present; cargo resolves the
+# alias members from Cargo.toml. A from-source build can override CARGO_FEATURES.
+CARGO_FEATURES?=	channels-full
+
+# zeroclaw installs its own binary plus the acp-bridge bin (default feature).
+# zerocode is a separate workspace app (apps/zerocode), built and installed in
+# post-build/post-install below. This mirrors install.sh's fixed DEFAULT_APPS
+# ("zerocode"); the Tauri app (zeroclaw-desktop) is excluded from this simple
+# cargo path because it needs the Tauri toolchain + webview deps.
+PLIST_FILES=	bin/zeroclaw \
+		bin/zeroclaw-acp-bridge \
+		bin/zerocode
+
+# Build and install zerocode (apps/zerocode). cargo.mk's do-build builds the
+# root zeroclaw package; this builds zerocode in the same vendored workspace
+# with the same CARGO_ENV. cargo.mk sets no cross-compile target dir, so the
+# release artifact lands in ${CARGO_TARGET_DIR}/release. zerocode has no cargo
+# features of its own, so CARGO_FEATURES is not forwarded to its build.
+post-build:
+	@${CARGO_CARGO_RUN} build \
+		--manifest-path ${CARGO_CARGOTOML} \
+		--release \
+		-p zerocode
+
+post-install:
+	${INSTALL_PROGRAM} ${CARGO_TARGET_DIR}/release/zerocode \
+		${STAGEDIR}${PREFIX}/bin/zerocode
+
+.include <bsd.port.mk>

--- a/dist/freebsd/misc/zeroclaw/pkg-descr
+++ b/dist/freebsd/misc/zeroclaw/pkg-descr
@@ -1,0 +1,3 @@
+ZeroClaw is a fast, small, 100% Rust AI assistant and agent CLI. It drives
+local and hosted model providers, supports multi-agent workflows, pluggable
+chat channels, and a local gateway.

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -14,6 +14,7 @@
   - [Linux](./setup/linux.md)
   - [macOS](./setup/macos.md)
   - [Windows](./setup/windows.md)
+  - [FreeBSD](./setup/freebsd.md)
   - [Docker & containers](./setup/container.md)
   - [Service management](./setup/service.md)
 

--- a/docs/book/src/foundations/fnd-004-engineering-infrastructure.md
+++ b/docs/book/src/foundations/fnd-004-engineering-infrastructure.md
@@ -63,7 +63,7 @@ The duplication has a subtler cost beyond compute minutes: when a check fails in
 
 ### 2.2 Single-Binary Assumptions Are Baked In Everywhere
 
-The release automation — `release-stable-manual.yml`, `release-beta-on-push.yml`, `publish-crates.yml`, `pub-aur.yml`, `pub-homebrew-core.yml`, `pub-scoop.yml`, `discord-release.yml`, `tweet-release.yml` — was designed around the assumption that a release is one binary. You build it, sign it, push it to package managers, and announce it.
+The release automation — `release-stable-manual.yml`, `release-beta-on-push.yml`, `publish-crates.yml`, `pub-aur.yml`, `pub-freebsd.yml`, `pub-homebrew-core.yml`, `pub-scoop.yml`, `discord-release.yml`, `tweet-release.yml` — was designed around the assumption that a release is one binary. You build it, sign it, push it to package managers, and announce it.
 
 The architecture RFC defines a distribution model with five distinct artifact types: the kernel binary (multiple platform targets), the hardware-variant kernel binary, the gateway binary, WASM plugin files, and the Tauri desktop installer. None of the current release workflows account for this structure. When the architecture transition reaches Phase 3 and Phase 4, every one of these workflows will need to change — unless they are redesigned now with that model in mind.
 
@@ -286,6 +286,7 @@ version-bump (release-plz PR merged)
             ├── publish-github-release (attaches all kernel + gateway binaries)
             ├── publish-plugin-registry (uploads WASM files)
             ├── publish-aur (kernel binary for Arch Linux)
+            ├── publish-freebsd (port artifact for FreeBSD ports tree)
             ├── publish-homebrew (kernel binary for macOS)
             ├── publish-scoop (kernel binary for Windows)
             └── announce (Discord, social)
@@ -493,7 +494,7 @@ Add `actions/attest-build-provenance` to each build job. Provenance attestations
 
 **D4: Retire redundant release workflows**
 
-Consolidate `release-stable-manual.yml`, `release-beta-on-push.yml`, `pub-aur.yml`, `pub-homebrew-core.yml`, `pub-scoop.yml`, `discord-release.yml`, `tweet-release.yml` into the structured `release.yml` pipeline. These workflows grew independently; the structured pipeline replaces them with a single, auditable flow.
+Consolidate `release-stable-manual.yml`, `release-beta-on-push.yml`, `pub-aur.yml`, `pub-freebsd.yml`, `pub-homebrew-core.yml`, `pub-scoop.yml`, `discord-release.yml`, `tweet-release.yml` into the structured `release.yml` pipeline. These workflows grew independently; the structured pipeline replaces them with a single, auditable flow.
 
 #### Success Metrics for Phase 3
 

--- a/docs/book/src/maintainers/ci-and-actions.md
+++ b/docs/book/src/maintainers/ci-and-actions.md
@@ -56,6 +56,7 @@ Each fires on `workflow_dispatch` with a version input. They are also invoked fr
 | Workflow | What it does |
 |---|---|
 | `pub-aur.yml` | Updates the Arch User Repository `PKGBUILD` and pushes to the AUR |
+| `pub-freebsd.yml` | Regenerates the FreeBSD port's `distinfo`/`CARGO_CRATES` in a FreeBSD VM and uploads the bumped port as a release artifact (ports-tree submission is the maintainer's bugzilla step — no auto-push) |
 | `pub-homebrew-core.yml` | Opens a PR against `homebrew/homebrew-core` with the new version |
 | `pub-scoop.yml` | Updates the Scoop manifest for Windows |
 

--- a/docs/book/src/maintainers/release-runbook.md
+++ b/docs/book/src/maintainers/release-runbook.md
@@ -21,8 +21,12 @@ Last verified: **May 2026** (v0.7.4 cycle).
 6. Verify the release exists and assets are downloadable
 
 That is the entire process. Everything else (Docker, crates.io, Scoop, AUR,
-Homebrew, Discord, tweet) runs automatically as downstream jobs. You do not
-need to do anything for those unless a job explicitly fails.
+Homebrew, FreeBSD, Discord, tweet) runs automatically as downstream jobs. You do
+not need to do anything for those unless a job explicitly fails. FreeBSD is the
+one exception that needs a manual final step: its job generates and validates
+the bumped port and uploads it as a release artifact, but submission to the
+FreeBSD ports tree goes through the bugzilla/maintainer flow (it cannot be
+auto-pushed like AUR/Scoop).
 
 ---
 
@@ -339,10 +343,12 @@ git commit -m "chore: remove CHANGELOG-next.md after vX.Y.Z release"
 git push origin master
 ```
 
-**A distribution channel job failed (Scoop, AUR, Homebrew):** Each has a
+**A distribution channel job failed (Scoop, AUR, Homebrew, FreeBSD):** Each has a
 corresponding manually-triggerable sub-workflow. Re-run the specific one with
 `dry_run: true` first to confirm the fix, then `dry_run: false`. These are
-nice-to-have — a failed Scoop job does not invalidate the release itself.
+nice-to-have — a failed Scoop job does not invalidate the release itself. For
+FreeBSD, the workflow only produces a release artifact; actual ports-tree
+submission is the maintainer's bugzilla step.
 
 ---
 

--- a/docs/book/src/setup/freebsd.md
+++ b/docs/book/src/setup/freebsd.md
@@ -1,0 +1,82 @@
+# FreeBSD
+
+Install ZeroClaw on FreeBSD from the ports tree or as a package.
+
+## Install
+
+ZeroClaw ships as a FreeBSD `USES=cargo` port, `misc/zeroclaw`. It installs
+`zeroclaw` (the daemon/CLI), `zeroclaw-acp-bridge`, and `zerocode` (the terminal
+config manager — see [zerocode](../getting-started/tui.md)).
+
+### Option 1 — pkg (once available in the official tree)
+
+```sh
+pkg install zeroclaw
+```
+
+The port has been submitted upstream
+([bug #295837](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=295837)). Until
+it lands in the package set, build from the port (Option 2) or the in-tree
+overlay (Option 3).
+
+### Option 2 — from a ports tree
+
+```sh
+cd /usr/ports/misc/zeroclaw
+make install clean
+```
+
+### Option 3 — from the in-tree overlay
+
+The port recipe is carried in this repository under `dist/freebsd/`, alongside
+the other downstream packaging targets (`dist/aur`, `dist/scoop`):
+
+```sh
+cp -R dist/freebsd/misc/zeroclaw /usr/ports/misc/zeroclaw
+cd /usr/ports/misc/zeroclaw && make install clean
+
+# or point poudriere at it as an overlay
+poudriere testport -o misc/zeroclaw -M /path/to/zeroclaw/dist/freebsd
+```
+
+Once installed, see [Quick start](../getting-started/quick-start.md) to
+configure your first agent.
+
+## Build requirements
+
+Declared as `BUILD_DEPENDS` and pulled automatically by the ports framework:
+`lang/rust` (the framework's `RUST_DEFAULT`, set by `cargo.mk` — not the
+project MSRV), `devel/cmake-core`, and `devel/pkgconf`. If a quarterly pkg
+branch carries an older `lang/rust` than the cargo framework requires, install
+a newer one from the `latest` branch.
+
+## Channels
+
+`pkg install zeroclaw` is a prebuilt binary — it is already compiled with the
+workspace's full-channel feature set, so enable any channel in your config and
+it works without recompiling. See
+[Channels & Integrations](../channels/overview.md).
+
+Feature selection is a from-source choice only (a prebuilt package cannot take
+feature flags). Building from the port, override `CARGO_FEATURES`:
+
+```sh
+make CARGO_FEATURES="..." install clean
+```
+
+Run `zeroclaw --list-features` for the available features; the port keeps no
+list of its own.
+
+## Running as a service
+
+ZeroClaw's built-in `service` subcommand targets systemd, launchd, and OpenRC —
+it does not generate a FreeBSD `rc.d` script. On FreeBSD, run `zeroclaw daemon`
+directly, or write a standard `rc.d` script under `${PREFIX}/etc/rc.d/` that
+launches it. See [Service management](./service.md) for the cross-platform
+service model and where the workspace lives.
+
+## Uninstall
+
+```sh
+pkg delete zeroclaw      # or: cd /usr/ports/misc/zeroclaw && make deinstall
+```


### PR DESCRIPTION
CLOSE if it doesn't make sense to package this way.

## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Adds the `misc/zeroclaw` FreeBSD port in-tree under `dist/freebsd/`, alongside the existing `dist/aur` and `dist/scoop` packaging targets, so FreeBSD packaging lives with the project instead of a personal overlay repo.
  - Keeps the port DRY against canonical sources: no crate list or `distinfo` is committed — both are generated from `Cargo.lock` on a FreeBSD host via `make cargo-crates-merge` and git-ignored, so they never rot or get hand-maintained per release.
  - No channel is hardcoded. The default build is the `default` feature from the workspace `Cargo.toml`; extra channels/subsystems pass through cargo.mk's native `CARGO_FEATURES` knob. Feature names come from `zeroclaw --list-features`, not a port-local list.
  - Wires the port's `DISTVERSION` into `scripts/release/bump-version.sh` so it tracks the workspace version through the one true version-bump source, in lockstep with `setup.bat`, the Tauri config, and the marketplace templates.
  - Adds `docs/book/src/setup/freebsd.md` under the Installation section; it links to quick-start and service docs rather than restating them.
- **Scope boundary:** Does not touch any Rust source, build features, or other platforms' packaging. Does not add a FreeBSD `rc.d` service script (the built-in `service` subcommand targets systemd/launchd/OpenRC only; documented as such). Does not commit a crate manifest or `distinfo`.
- **Blast radius:** `scripts/release/bump-version.sh` gains one additional `bump` call; if `dist/freebsd/misc/zeroclaw/Makefile` is absent the existing `bump()` helper skips it harmlessly. No effect on existing packaging targets or the build.
- **Linked issue(s):** None.
- **Labels:** `type: packaging`, `docs`, `risk: low`, `size: M`

## Validation Evidence (required)

Docs + packaging change; no Rust source touched. Ran the docs/markdown gate, mdbook link integrity, shell syntax check on the modified release script, and an end-to-end dry-run of the new version-bump wiring.

```bash
bash -n scripts/release/bump-version.sh
mdbook build           # in docs/book
bash scripts/ci/docs_quality_gate.sh
```

- **Commands run and tail output:**
  - `bash -n scripts/release/bump-version.sh` → `bump-version.sh: syntax OK` (exit 0)
  - `mdbook build` → `INFO HTML book written to .../docs/book/book`. The only warnings are pre-existing unclosed-`<window>`-tag warnings in `ops/cost-tracking.md` (not touched by this PR).
  - `scripts/ci/docs_quality_gate.sh` → reports 118 pre-existing markdown issues across the repo (foundations, hardware, memory notes). **Zero** are in the files this PR adds/edits (`docs/book/src/setup/freebsd.md`, `docs/book/src/SUMMARY.md`, `dist/freebsd/README.md`).
- **Beyond CI — what I manually verified:**
  - DISTVERSION wiring: dry-ran the new `bump` regex against a copy of the Makefile bumping `0.8.0-beta-2` → `0.9.0`; the `DISTVERSION` line rewrites cleanly with the leading tab preserved.
  - Confirmed against `Mk/Uses/cargo.mk` that `make cargo-crates-merge` bootstraps `CARGO_CRATES`/`distinfo` from the source tarball's `Cargo.lock` with no pre-existing crate list.
  - Confirmed `zerocode` is built via `cargo build -p zerocode` and lands at `${CARGO_TARGET_DIR}/release/zerocode` (cargo.mk sets no cross-compile target dir).
- **Intentionally skipped:** `cargo fmt/clippy/test` — no Rust source changed. `portlint`/`portfmt`/`poudriere testport` require a FreeBSD host and are not runnable in this CI environment; the port was poudriere-tested upstream on 15.0-RELEASE amd64 (bug #295837).

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No` — the only identity is the port `MAINTAINER` email, a required FreeBSD port field.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Upgrade steps: none — additive packaging + docs only.

## Known limitations — `pkg` and feature selection

FreeBSD's binary package path (`pkg install`) has a structural constraint that
shapes this port and is worth flagging for review:

- **Prebuilt packages cannot take feature flags.** A `pkg install` user gets a
  binary that is already compiled. There is no `pkg` mechanism to pass cargo
  features at install time. This is unlike our Linux `install.sh`, where
  `--features` selects the build. So the published package is compiled with the
  workspace's full-channel feature alias, and a user enables any channel in
  config — the binary already contains it. Feature *selection* is only possible
  from a source build (`make CARGO_FEATURES=...` / the port tree).
- **No parse-time access to `Cargo.toml`.** The source tarball is not on disk
  when the Makefile is parsed, so the version (`DISTVERSION`), the binary set
  (`PLIST_FILES`), and `COMMENT` cannot be derived from `Cargo.toml` at parse
  time — they are mandatory literals, as in every port in the tree. The crate
  graph and `distinfo`, by contrast, are generated post-extract from
  `Cargo.lock` and are git-ignored, never committed.
- **`channels-full` is referenced, not duplicated.** The port names the
  full-channel alias once; cargo resolves its members from `Cargo.toml` at build
  time. The port carries no channel or feature list — consistent with the
  single-source-of-truth rule in `AGENTS.md`.
- **No native FreeBSD service integration.** The `service` subcommand targets
  systemd/launchd/OpenRC; there is no `rc.d` script yet. Documented in the page.
- **Host-only validation.** `portlint`/`portfmt`/`poudriere` need a FreeBSD
  host and were not run in this CI environment. The port was poudriere-tested
  upstream on 15.0-RELEASE amd64 (bug #295837).

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk: `git revert <sha>`.

