### PR TITLE
fix(ollama): pass defaulted temperature as option

### DIFF
--- a/crates/zeroclaw-providers/src/ollama.rs
+++ b/crates/zeroclaw-providers/src/ollama.rs
@@ -1046,6 +1046,7 @@ impl ModelProvider for OllamaModelProvider {
         model: &str,
         temperature: Option<f64>,
     ) -> anyhow::Result<ChatResponse> {
+        let temperature = temperature.unwrap_or(self.default_temperature());
         let (normalized_model, should_auth) = self.resolve_request_details(model)?;
         let messages =
             self.with_prompt_guided_tool_instructions(request.messages, request.tools)?;
@@ -1054,7 +1055,7 @@ impl ModelProvider for OllamaModelProvider {
             .send_request(
                 api_messages,
                 &normalized_model,
-                temperature,
+                Some(temperature),
                 should_auth,
                 None,
             )


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Fixes the Ollama provider compile regression introduced by https://github.com/zeroclaw-labs/zeroclaw/pull/7095.
  - Wraps the defaulted `f64` temperature in `Some(...)` before passing it to `send_request`, whose signature expects `Option<f64>`.
  - Keeps the existing behavior where `chat()` falls back to `self.default_temperature()` when no explicit temperature is supplied.
- **Scope boundary:** This PR does not change Ollama request construction, tool prompting behavior, provider config, or sccache/Cargo configuration.
- **Blast radius:** Limited to the Ollama provider `chat()` path in `zeroclaw-providers`; it restores type compatibility with the existing `send_request` API.
- **Linked issue(s):** Related #7095.
- **Labels:** `bug`, `provider:ollama`, `risk: medium`, `size: XS`

## Validation Evidence (required)

Local validation is the signal CI cannot replace. Run the full battery and paste literal output (tails, failures, warnings — not "all passed").

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

Docs-only changes: replace with markdown lint + link-integrity (`scripts/ci/docs_quality_gate.sh`). Bootstrap scripts: add `bash -n install.sh`.

- **Commands run and tail output:**

`env SCCACHE_SERVER_UDS=/home/salvatore-zeroclaw/src/zeroclaw/.cargo/pr-sccache.sock cargo fmt --all -- --check`

```text
error: no such command: `fmt`

help: a command with a similar name exists: `fix`

help: view all installed commands with `cargo --list`
help: find a package to install `fmt` with `cargo search cargo-fmt`
```

`env SCCACHE_SERVER_UDS=/home/salvatore-zeroclaw/src/zeroclaw/.cargo/pr-sccache.sock cargo clippy --all-targets -- -D warnings`

```text
error: no such command: `clippy`

help: view all installed commands with `cargo --list`
help: find a package to install `clippy` with `cargo search cargo-clippy`
```

`env SCCACHE_SERVER_UDS=/home/salvatore-zeroclaw/src/zeroclaw/.cargo/pr-sccache.sock cargo test`

```text
test result: ok. 159 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.44s

     Running tests/test_live.rs (target/debug/deps/live-f751e2fc0bc648c6)

running 7 tests
test live::gemini_fallback_oauth_refresh::gemini_warmup_refreshes_expired_oauth_token ... ignored, requires live Gemini OAuth credentials with refresh_token
test live::gemini_fallback_oauth_refresh::gemini_warmup_with_valid_credentials ... ignored, requires live Gemini OAuth credentials
test live::openai_codex_vision_e2e::openai_codex_second_vision_support ... ignored, requires live OpenAI Codex OAuth credentials (second profile)
test live::openai_codex_vision_e2e::provider_vision_support ... ignored, requires live model_provider OAuth credentials
test live::providers::e2e_live_openai_codex_multi_turn ... ignored, requires live OpenAI Codex OAuth credentials
test live::zai_jwt_auth::live_zai_jwt_auth_chat ... ignored, requires live ZAI_API_KEY
test live::zai_jwt_auth::live_zai_jwt_auth_multi_turn ... ignored, requires live ZAI_API_KEY

test result: ok. 0 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/test_system.rs (target/debug/deps/system-140caf93f837d518)

running 9 tests
test system::multi_agent_e2e::legacy_install_upgrades_cleanly_with_backup ... ok
test system::multi_agent_e2e::peer_group_routes_messages_only_within_resolved_peer_set ... ok
test system::multi_agent_e2e::peer_group_dotted_channel_refs_remain_alias_scoped_for_dispatch ... ok
test system::full_stack::system_tool_execution_flow ... ok
test system::full_stack::system_parallel_tool_execution ... ok
test system::full_stack::system_multi_turn_conversation ... ok
test system::full_stack::system_tool_arguments_passed_correctly ... ok
test system::full_stack::system_simple_text_response ... ok
test system::multi_agent_e2e::two_sqlite_agents_on_one_install_have_isolated_memory ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.06s

   Doc-tests zeroclaw

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

Targeted regression check:

`env SCCACHE_SERVER_UDS=/home/salvatore-zeroclaw/src/zeroclaw/.cargo/pr-sccache.sock cargo build --release`

```text
Finished `release` profile [optimized] target(s) in 3m 33s
```

- **Beyond CI — what did you manually verify?** Verified that the failing `zeroclaw-providers` release compile path now progresses through `zeroclaw-providers` and completes the full workspace release build.
- **If any command was intentionally skipped, why:** `cargo fmt` and `cargo clippy` were attempted but unavailable in this Fedora toolchain (`cargo --list` has no `fmt` or `clippy`, and `rustup` is not installed). They were not skipped.

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: No user action required.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PRs: `git revert <sha>` is the plan unless otherwise noted.

Medium/high-risk PRs must fill:

- **Fast rollback command/path:** `git revert 7de92cb34`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Rollback would restore `error[E0308]: mismatched types` in `crates/zeroclaw-providers/src/ollama.rs`, where `send_request` expects `Option<f64>` but receives `f64`.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Scope materially carried forward: N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`No`)
- If `No`, why (inspiration-only, no direct code/design carry-over): No superseded PR.
