### PR TITLE
fix(channels/whatsapp-web): treat replies to bot as mentions

### DIFF
--- a/crates/zeroclaw-channels/src/whatsapp_web.rs
+++ b/crates/zeroclaw-channels/src/whatsapp_web.rs
@@ -803,6 +803,14 @@ impl WhatsAppWebChannel {
         }
     }
 
+    #[cfg(feature = "whatsapp-web")]
+    fn jid_matches_bot(jid: &str, bot_phone: &str, bot_lid: Option<&str>) -> bool {
+        let digits = Self::jid_digits(jid);
+        !digits.is_empty()
+            && ((!bot_phone.is_empty() && digits == bot_phone)
+                || bot_lid.is_some_and(|lid| !lid.is_empty() && digits == lid))
+    }
+
     /// Extract mentioned JIDs from the base (unwrapped) message's context_info.
     ///
     /// Uses `get_base_message()` to see through ephemeral/view-once/edited/document wrappers,
@@ -836,11 +844,7 @@ impl WhatsAppWebChannel {
     ) -> bool {
         // 1. Structured: check if any mentioned_jid's digits match the bot's phone or LID digits
         for jid in mentioned_jids {
-            let digits = Self::jid_digits(jid);
-            if !digits.is_empty()
-                && ((!bot_phone.is_empty() && digits == bot_phone)
-                    || bot_lid.is_some_and(|lid| !lid.is_empty() && digits == lid))
-            {
+            if Self::jid_matches_bot(jid, bot_phone, bot_lid) {
                 return true;
             }
         }
@@ -875,6 +879,40 @@ impl WhatsAppWebChannel {
         }
 
         has_text_mention(text, bot_phone) || bot_lid.is_some_and(|lid| has_text_mention(text, lid))
+    }
+
+    /// Extract the author JID of the message quoted by an extended-text reply.
+    #[cfg(feature = "whatsapp-web")]
+    fn extract_reply_participant(msg: &waproto::whatsapp::Message) -> Option<&str> {
+        use wacore::proto_helpers::MessageExt;
+        let base = msg.get_base_message();
+
+        base.extended_text_message
+            .as_ref()
+            .and_then(|ext| ext.context_info.as_ref())
+            .and_then(|ctx| ctx.participant.as_deref())
+    }
+
+    #[cfg(feature = "whatsapp-web")]
+    fn is_reply_to_bot(
+        msg: &waproto::whatsapp::Message,
+        bot_phone: &str,
+        bot_lid: Option<&str>,
+    ) -> bool {
+        Self::extract_reply_participant(msg)
+            .is_some_and(|participant| Self::jid_matches_bot(participant, bot_phone, bot_lid))
+    }
+
+    #[cfg(feature = "whatsapp-web")]
+    fn is_message_addressed_to_bot(
+        msg: &waproto::whatsapp::Message,
+        text: &str,
+        bot_phone: &str,
+        bot_lid: Option<&str>,
+    ) -> bool {
+        let mentioned_jids = Self::extract_mentioned_jids(msg);
+        Self::contains_bot_mention(text, &mentioned_jids, bot_phone, bot_lid)
+            || Self::is_reply_to_bot(msg, bot_phone, bot_lid)
     }
 }
 
@@ -1444,17 +1482,10 @@ impl Channel for WhatsAppWebChannel {
                                     let bot_phone = bot_phone_inner.lock();
                                     let bot_lid = bot_lid_inner.lock();
                                     if bot_phone.is_some() || bot_lid.is_some() {
-                                        let mentioned_jids =
-                                            Self::extract_mentioned_jids(msg);
                                         let bp = bot_phone.as_deref().unwrap_or("");
                                         let bl = bot_lid.as_deref();
-                                        if !Self::contains_bot_mention(
-                                            &content,
-                                            &mentioned_jids,
-                                            bp,
-                                            bl,
-                                        ) {
-                                            ::zeroclaw_log::record!(DEBUG, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note), "ignoring group message without bot mention");
+                                        if !Self::is_message_addressed_to_bot(msg, &content, bp, bl) {
+                                            ::zeroclaw_log::record!(DEBUG, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note), "ignoring group message not addressed to bot");
                                             return;
                                         }
                                     } else {
@@ -2408,6 +2439,30 @@ mod tests {
 
     // ── Mention detection tests ──
 
+    #[cfg(feature = "whatsapp-web")]
+    fn extended_text_reply(
+        participant: &str,
+        mentioned_jids: &[&str],
+    ) -> waproto::whatsapp::Message {
+        waproto::whatsapp::Message {
+            extended_text_message: Some(Box::new(
+                waproto::whatsapp::message::ExtendedTextMessage {
+                    text: Some("expand the previous response".to_string()),
+                    context_info: Some(Box::new(waproto::whatsapp::ContextInfo {
+                        participant: Some(participant.to_string()),
+                        mentioned_jid: mentioned_jids
+                            .iter()
+                            .map(|jid| (*jid).to_string())
+                            .collect(),
+                        ..Default::default()
+                    })),
+                    ..Default::default()
+                },
+            )),
+            ..Default::default()
+        }
+    }
+
     #[test]
     #[cfg(feature = "whatsapp-web")]
     fn jid_digits_extracts_phone_from_jid() {
@@ -2552,6 +2607,54 @@ mod tests {
             &[],
             "",
             None
+        ));
+    }
+
+    #[test]
+    #[cfg(feature = "whatsapp-web")]
+    fn message_addressed_to_bot_accepts_reply_to_phone_jid() {
+        let msg = extended_text_reply("100@s.whatsapp.net", &[]);
+        assert!(WhatsAppWebChannel::is_message_addressed_to_bot(
+            &msg,
+            "expand the previous response",
+            "100",
+            None,
+        ));
+    }
+
+    #[test]
+    #[cfg(feature = "whatsapp-web")]
+    fn message_addressed_to_bot_accepts_reply_to_lid_jid() {
+        let msg = extended_text_reply("200@lid", &[]);
+        assert!(WhatsAppWebChannel::is_message_addressed_to_bot(
+            &msg,
+            "expand the previous response",
+            "100",
+            Some("200"),
+        ));
+    }
+
+    #[test]
+    #[cfg(feature = "whatsapp-web")]
+    fn message_addressed_to_bot_rejects_reply_to_other_participant() {
+        let msg = extended_text_reply("300@s.whatsapp.net", &[]);
+        assert!(!WhatsAppWebChannel::is_message_addressed_to_bot(
+            &msg,
+            "expand the previous response",
+            "100",
+            Some("200"),
+        ));
+    }
+
+    #[test]
+    #[cfg(feature = "whatsapp-web")]
+    fn message_addressed_to_bot_accepts_explicit_mention_in_other_reply() {
+        let msg = extended_text_reply("300@s.whatsapp.net", &["100@s.whatsapp.net"]);
+        assert!(WhatsAppWebChannel::is_message_addressed_to_bot(
+            &msg,
+            "expand the previous response",
+            "100",
+            Some("200"),
         ));
     }
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Treat plain-text WhatsApp Web group replies to a prior bot message as addressed to the bot when `mention_only = true`.
  - Read the quoted message participant from extended-text `context_info` and match it against both the bot phone JID and LID JID.
  - Preserve existing explicit mention behavior and reject replies to other participants without a bot mention.
- **Scope boundary:** This does not change sticker/media handling, quoted-media downloads, mention-pattern gating, WhatsApp Cloud API behavior, read receipts, or group session/history scope.
- **Blast radius:** WhatsApp Web inbound group-message gating when `mention_only = true`.
- **Linked issue(s):** Closes #7225.
- **Labels:** `bug`, `risk: medium`, `size: S`, `channel`, `channel:whatsapp`

## Validation Evidence (required)

- **Commands run and tail output:**

```text
cargo fmt --all -- --check
result: passed locally; GitHub Actions Format passed on current head.

cargo clippy --all-targets -- -D warnings
result: passed locally; GitHub Actions Lint passed on current head.

cargo test
result: passed locally.

cargo test -p zeroclaw-channels --features whatsapp-web
result: passed locally; includes reply-to-phone-JID, reply-to-LID-JID, reject-other-participant, and explicit-mention fallback coverage.

GitHub Actions Quality Gate
result: passed on current head d31e287cccc477b9f67683c6cab14b46ccbce7b1, including Test and CI Required Gate, after #7231 restored compiling master.
```

- **Beyond CI — what did you manually verify?** Verified focused unit coverage for phone-JID replies, LID-JID replies, replies to other participants, and explicit mention fallback. Reviewed the source path so `mention_only` group admission expands only when the quoted participant matches the bot phone or LID identity. Did not run a live WhatsApp Web session from this branch.
- **If any command was intentionally skipped, why:** No listed command was skipped. Live WhatsApp Web smoke was not run; validation is unit-level plus green hosted CI on the current head.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`Yes`) This expands `mention_only` admission only for group replies whose quoted participant JID matches the bot phone JID or LID JID. Replies to other participants remain gated and are covered by a regression test.
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: The admission boundary is intentionally narrow and reuses the same normalized bot JID matching as explicit mentions.

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: No upgrade steps are required.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <merge-sha>`
- **Feature flags or config toggles:** None; revert the PR.
- **Observable failure symptoms:** Plain-text replies to prior bot messages are accepted unexpectedly, or unrelated group replies pass the `mention_only` gate.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors: N/A
- Scope materially carried forward: N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`No`)
- If `No`, why: No superseded PR or external contributor code is incorporated.
