### PR TITLE
feat(web): rename "Scheduled Jobs" tab to "Automations"

### DIFF
--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -406,7 +406,7 @@ const translations: Record<Locale, Record<string, string>> = {
     'nav.agent': 'Agent',
     'nav.agents': 'Agents',
     'nav.tools': 'Tools',
-    'nav.cron': 'Scheduled Jobs',
+    'nav.cron': 'Automations',
     'nav.integrations': 'Integrations',
     'nav.memory': 'Memory',
     'nav.config': 'Config',
@@ -500,8 +500,8 @@ const translations: Record<Locale, Record<string, string>> = {
     'tools.load_error': 'Failed to load tools',
 
     // Cron
-    'cron.title': 'Scheduled Jobs',
-    'cron.scheduled_tasks': 'Scheduled Tasks',
+    'cron.title': 'Automations',
+    'cron.scheduled_tasks': 'Automations',
     'cron.add': 'Add Job',
     'cron.add_job': 'Add Job',
     'cron.add_modal_title': 'Add Cron Job',


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Renames the user-facing "Scheduled Jobs" / "Scheduled Tasks" labels to "Automations" in the web UI i18n table (`nav.cron`, `cron.title`, `cron.scheduled_tasks`). The new term better reflects what the feature does and aligns the navigation tab with product naming.
- **Scope boundary:** UI display strings only. The underlying cron subsystem, API routes, config keys, i18n message keys (`nav.cron`, `cron.*`), and the "Add Job" / "Add Cron Job" labels are unchanged.
- **Blast radius:** Web frontend only (`web/src/lib/i18n.ts`). No backend, API, or config surface touched. No other locale entries affected.
- **Linked issue(s):** None.
- **Labels:** `size: XS`, `risk: low`

## Validation Evidence (required)

Frontend-only change (no Rust touched), so the cargo battery does not apply. The edit changes three string literal values inside an existing translations object — no logic, imports, or type surface.

```bash
$ git diff master...HEAD --stat
 web/src/lib/i18n.ts | 6 +++---
 1 file changed, 3 insertions(+), 3 deletions(-)

$ grep -rn "Scheduled Jobs\|Scheduled Tasks" web/src
# (no matches — rename is complete)
```

- **Commands run and tail output:** `npm run build` failed in this environment, but the failure is pre-existing/environmental: the project pins `typescript ~5.7.2` which is not installed in the worktree, so a stale global `tsc` ran and emitted toolchain errors (`TS6046`, `TS5023`, `Cannot find global type 'Array'`). None reference the changed file or lines.
- **Beyond CI — what did you manually verify?** Confirmed via grep that no remaining "Scheduled Jobs"/"Scheduled Tasks" strings exist in `web/src`. Confirmed the diff only edits string values, not keys, so no lookups break.
- **If any command was intentionally skipped, why:** Cargo battery skipped — no Rust files changed.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No upgrade steps. Display-string-only change; i18n keys, config, and CLI surface are untouched.

## Rollback (required for \`risk: medium\` and \`risk: high\`)

Low-risk PR: \`git revert ed1440280\` is the plan.