### PR TITLE
fix(ollama): restore compiling master build

### DIFF
--- a/crates/zeroclaw-providers/src/ollama.rs
+++ b/crates/zeroclaw-providers/src/ollama.rs
@@ -1267,7 +1267,7 @@ mod tests {
             .await
             .expect("test listener should bind");
         let addr = listener.local_addr().expect("listener should have address");
-        let server = tokio::spawn(async move {
+        let server = zeroclaw_spawn::spawn!(async move {
             axum::serve(listener, app)
                 .await
                 .expect("test server should run");

--- a/crates/zeroclaw-providers/src/ollama.rs
+++ b/crates/zeroclaw-providers/src/ollama.rs
@@ -1046,7 +1046,6 @@ impl ModelProvider for OllamaModelProvider {
         model: &str,
         temperature: Option<f64>,
     ) -> anyhow::Result<ChatResponse> {
-        let temperature = temperature.unwrap_or(self.default_temperature());
         let (normalized_model, should_auth) = self.resolve_request_details(model)?;
         let messages =
             self.with_prompt_guided_tool_instructions(request.messages, request.tools)?;


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** `master` does not build. Two defects, both in `crates/zeroclaw-providers/src/ollama.rs`, both latent because PR #7095's CI ran against a two-day-stale base and never validated against current master:
  1. **`error[E0308]: mismatched types`** — #7095 added `let temperature = temperature.unwrap_or(self.default_temperature());` in `OllamaModelProvider::chat()`, shadowing the `Option<f64>` parameter into a bare `f64`, then passed it to `send_request(.., temperature: Option<f64>, ..)`. This breaks `cargo build` outright — users hit it via the `curl | bash` source install. Fix: drop the shadowing so `Option<f64>` flows through unchanged, matching the file's three other `send_request` callers. Temperature is still honoured downstream in `build_chat_request_with_think` via `self.tuning.temperature_override.or(temperature)`; `None` correctly defers to Ollama's native model default. No behavioural loss.
  2. **`use of a disallowed method tokio::spawn`** — a bare `tokio::spawn` in the prompt-guided-tools test (also added by #7095) trips the `disallowed_methods` clippy lint under `-D warnings`, failing the CI lint gate. Fix: use `zeroclaw_spawn::spawn!`, matching the established test-server pattern in `factory.rs` and `openrouter.rs`, so the spawned task inherits the caller's attribution span.
- **Scope boundary:** Two minimal edits in `ollama.rs`. Does not touch the prompt-guided-tools logic #7095 introduced; only the compile error and lint violation it shipped alongside.
- **Blast radius:** Ollama provider only. Restores compilation of `zeroclaw-providers`, unblocking the entire workspace build, and clears the lint gate.
- **Linked issue(s):** Related #7095 (introduced both regressions).
- **Labels:** `bug`, `risk: medium`, `size: XS`

## Validation Evidence (required)

```bash
cargo fmt -p zeroclaw-providers -- --check                    # exit 0, clean
cargo clippy -p zeroclaw-providers --all-targets -- -D warnings # Finished, clean (was: disallowed tokio::spawn)
cargo check -p zeroclaw-providers                             # Finished (was: E0308)
cargo test -p zeroclaw-providers ollama                      # 68 passed; 0 failed
```

- **Commands run and tail output:**
  - `cargo clippy --all-targets -- -D warnings`: `Finished dev profile` — failed before with `error: use of a disallowed method tokio::spawn` at `ollama.rs:1270`.
  - `cargo check`: `Finished dev profile` — failed before with `error[E0308]: mismatched types ... expected Option<f64>, found f64`.
  - `cargo test ollama`: `test result: ok. 68 passed; 0 failed; 0 ignored`
  - `cargo fmt --check`: clean
- **Beyond CI — what did you manually verify?** Reproduced the original E0308 on a clean worktree at `master` (`a1b641e01`) before fixing, confirming this is the exact failure users reported on the source install. Confirmed the lint failure by running the CI lint command verbatim.
- **If any command was intentionally skipped, why:** None.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Upgrade steps: none.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <sha>`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** `cargo build` fails with `error[E0308]: mismatched types`, or `cargo clippy --all-targets -- -D warnings` fails with `use of a disallowed method tokio::spawn`, in `crates/zeroclaw-providers/src/ollama.rs`.