### PR TITLE
feat(observability): Structured Observability Enhancement — Rich Events, OTel Trace Correlation, and Bridge Refactoring

### DIFF
--- a/crates/zeroclaw-api/src/observability_traits.rs
+++ b/crates/zeroclaw-api/src/observability_traits.rs
@@ -1,5 +1,11 @@
 use std::time::Duration;
 
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct TurnTokenUsage {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+}
+
 /// Discrete events emitted by the agent runtime for observability.
 ///
 /// Each variant represents a lifecycle event that observers can record,
@@ -12,6 +18,9 @@ pub enum ObserverEvent {
     AgentStart {
         model_provider: String,
         model: String,
+        channel: Option<String>,
+        agent_alias: Option<String>,
+        turn_id: Option<String>,
     },
     /// A request is about to be sent to an LLM model_provider.
     ///
@@ -21,6 +30,10 @@ pub enum ObserverEvent {
         model_provider: String,
         model: String,
         messages_count: usize,
+        user_message: Option<String>,
+        channel: Option<String>,
+        agent_alias: Option<String>,
+        turn_id: Option<String>,
     },
     /// Result of a single LLM model_provider call.
     LlmResponse {
@@ -31,6 +44,10 @@ pub enum ObserverEvent {
         error_message: Option<String>,
         input_tokens: Option<u64>,
         output_tokens: Option<u64>,
+        response_content: Option<String>,
+        channel: Option<String>,
+        agent_alias: Option<String>,
+        turn_id: Option<String>,
     },
     /// The agent session has finished.
     ///
@@ -39,8 +56,11 @@ pub enum ObserverEvent {
         model_provider: String,
         model: String,
         duration: Duration,
-        tokens_used: Option<u64>,
+        tokens_used: Option<TurnTokenUsage>,
         cost_usd: Option<f64>,
+        channel: Option<String>,
+        agent_alias: Option<String>,
+        turn_id: Option<String>,
     },
     /// A tool call is about to be executed.
     ToolCallStart {
@@ -56,6 +76,9 @@ pub enum ObserverEvent {
         /// Full JSON arguments the agent passed to the tool. `None` when
         /// arguments are unavailable at the call site.
         arguments: Option<String>,
+        channel: Option<String>,
+        agent_alias: Option<String>,
+        turn_id: Option<String>,
     },
     /// A tool call has completed with a success/failure outcome.
     ToolCall {
@@ -77,6 +100,9 @@ pub enum ObserverEvent {
         /// in trace viewers. Credentials are scrubbed before this field is
         /// emitted.
         result: Option<String>,
+        channel: Option<String>,
+        agent_alias: Option<String>,
+        turn_id: Option<String>,
     },
     /// The agent produced a final answer for the current user message.
     TurnComplete,
@@ -286,6 +312,9 @@ mod tests {
             success: true,
             arguments: Some(r#"{"command":"date"}"#.into()),
             result: Some("Mon Apr 22 12:00:00 UTC 2026\n".into()),
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         };
         let metric = ObserverMetric::RequestLatency(Duration::from_millis(8));
 

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -4164,6 +4164,9 @@ async fn process_channel_message_body(
                         ctx.observer.record_event(&ObserverEvent::AgentStart {
                             model_provider: route.model_provider.clone(),
                             model: route.model.clone(),
+                            channel: None,
+                            agent_alias: None,
+                            turn_id: None,
                         });
 
                         continue;
@@ -14135,6 +14138,9 @@ BTC is currently around $65,000 based on latest tool output."#
                 tool: "file_write".to_string(),
                 tool_call_id: None,
                 arguments: Some(payload),
+                channel: None,
+                agent_alias: None,
+                turn_id: None,
             },
         );
 

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -9058,6 +9058,18 @@ pub struct ObservabilityConfig {
     /// secret reads). Empty by default.
     #[serde(default)]
     pub log_tool_io_denylist: Vec<String>,
+
+    /// LLM I/O capture policy: "off" | "redacted" | "full".
+    /// - `off` (default): no LLM input/output content is captured.
+    /// - `redacted`: content is leak-scanned and truncated before capture.
+    /// - `full`: full content, still leak-scanned.
+    #[serde(default = "default_log_llm_io")]
+    pub log_llm_io: String,
+
+    /// Truncate captured LLM input/output at this many characters when
+    /// `log_llm_io = "redacted"`.
+    #[serde(default = "default_log_llm_io_max_chars")]
+    pub log_llm_io_max_chars: usize,
 }
 
 impl Default for ObservabilityConfig {
@@ -9073,6 +9085,8 @@ impl Default for ObservabilityConfig {
             log_tool_io: default_log_tool_io(),
             log_tool_io_truncate_bytes: default_log_tool_io_truncate_bytes(),
             log_tool_io_denylist: Vec::new(),
+            log_llm_io: default_log_llm_io(),
+            log_llm_io_max_chars: default_log_llm_io_max_chars(),
         }
     }
 }
@@ -9095,6 +9109,14 @@ fn default_log_tool_io() -> String {
 
 fn default_log_tool_io_truncate_bytes() -> usize {
     40960
+}
+
+fn default_log_llm_io() -> String {
+    "off".to_string()
+}
+
+fn default_log_llm_io_max_chars() -> usize {
+    200
 }
 
 // ── Hooks ────────────────────────────────────────────────────────
@@ -16722,6 +16744,8 @@ enabled = true
         assert_eq!(o.log_tool_io, "redacted");
         assert_eq!(o.log_tool_io_truncate_bytes, 40960);
         assert!(o.log_tool_io_denylist.is_empty());
+        assert_eq!(o.log_llm_io, "off");
+        assert_eq!(o.log_llm_io_max_chars, 200);
     }
 
     #[test]

--- a/crates/zeroclaw-gateway/src/lib.rs
+++ b/crates/zeroclaw-gateway/src/lib.rs
@@ -74,6 +74,7 @@ use uuid::Uuid;
     feature = "channel-whatsapp-cloud"
 ))]
 use zeroclaw_api::channel::{Channel, SendMessage};
+use zeroclaw_api::observability_traits::TurnTokenUsage;
 use zeroclaw_api::tool::ToolSpec;
 #[cfg(feature = "channel-email")]
 use zeroclaw_channels::gmail_push::GmailPushChannel;
@@ -2400,6 +2401,9 @@ async fn handle_webhook(
         &zeroclaw_runtime::observability::ObserverEvent::AgentStart {
             model_provider: provider_label.clone(),
             model: model_label.clone(),
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         },
     );
     state.observer.record_event(
@@ -2407,6 +2411,10 @@ async fn handle_webhook(
             model_provider: provider_label.clone(),
             model: model_label.clone(),
             messages_count: 1,
+            user_message: None,
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         },
     );
 
@@ -2424,9 +2432,22 @@ async fn handle_webhook(
             // /api/cost and costs.jsonl via the same scope.
             let tokens_used = input_tokens
                 .zip(output_tokens)
-                .map(|(i, o)| i + o)
-                .or(input_tokens)
-                .or(output_tokens);
+                .map(|(i, o)| TurnTokenUsage {
+                    input_tokens: i,
+                    output_tokens: o,
+                })
+                .or_else(|| {
+                    input_tokens.map(|i| TurnTokenUsage {
+                        input_tokens: i,
+                        output_tokens: 0,
+                    })
+                })
+                .or_else(|| {
+                    output_tokens.map(|o| TurnTokenUsage {
+                        input_tokens: 0,
+                        output_tokens: o,
+                    })
+                });
             state.observer.record_event(
                 &zeroclaw_runtime::observability::ObserverEvent::LlmResponse {
                     model_provider: provider_label.clone(),
@@ -2436,6 +2457,10 @@ async fn handle_webhook(
                     error_message: None,
                     input_tokens: None,
                     output_tokens: None,
+                    response_content: None,
+                    channel: None,
+                    agent_alias: None,
+                    turn_id: None,
                 },
             );
             state.observer.record_metric(
@@ -2448,6 +2473,9 @@ async fn handle_webhook(
                     duration,
                     tokens_used,
                     cost_usd,
+                    channel: None,
+                    agent_alias: None,
+                    turn_id: None,
                 },
             );
 
@@ -2467,6 +2495,10 @@ async fn handle_webhook(
                     error_message: Some(sanitized.clone()),
                     input_tokens: None,
                     output_tokens: None,
+                    response_content: None,
+                    channel: None,
+                    agent_alias: None,
+                    turn_id: None,
                 },
             );
             state.observer.record_metric(
@@ -2485,6 +2517,9 @@ async fn handle_webhook(
                     duration,
                     tokens_used: None,
                     cost_usd: None,
+                    channel: None,
+                    agent_alias: None,
+                    turn_id: None,
                 },
             );
 

--- a/crates/zeroclaw-gateway/src/sse.rs
+++ b/crates/zeroclaw-gateway/src/sse.rs
@@ -189,6 +189,7 @@ impl zeroclaw_runtime::observability::Observer for BroadcastObserver {
             zeroclaw_runtime::observability::ObserverEvent::AgentStart {
                 model_provider,
                 model,
+                ..
             } => {
                 serde_json::json!({
                     "type": "agent_start",
@@ -203,15 +204,21 @@ impl zeroclaw_runtime::observability::Observer for BroadcastObserver {
                 duration,
                 tokens_used,
                 cost_usd,
-            } => serde_json::json!({
-                "type": "agent_end",
-                "model_provider": model_provider,
-                "model": model,
-                "duration_ms": duration.as_millis(),
-                "tokens_used": tokens_used,
-                "cost_usd": cost_usd,
-                "timestamp": chrono::Utc::now().to_rfc3339(),
-            }),
+                ..
+            } => {
+                let tokens_total = tokens_used
+                    .as_ref()
+                    .map(|usage| usage.input_tokens.saturating_add(usage.output_tokens));
+                serde_json::json!({
+                    "type": "agent_end",
+                    "model_provider": model_provider,
+                    "model": model,
+                    "duration_ms": duration.as_millis(),
+                    "tokens_used": tokens_total,
+                    "cost_usd": cost_usd,
+                    "timestamp": chrono::Utc::now().to_rfc3339(),
+                })
+            }
             _ => return, // Skip events we don't broadcast
         };
 
@@ -235,6 +242,7 @@ impl zeroclaw_runtime::observability::Observer for BroadcastObserver {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use zeroclaw_api::observability_traits::TurnTokenUsage;
     use zeroclaw_runtime::observability::{Observer, ObserverEvent};
 
     fn make_broadcast() -> (
@@ -259,6 +267,9 @@ mod tests {
             success: true,
             arguments: None,
             result: None,
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
 
         let value = rx.try_recv().expect("event should be broadcast");
@@ -279,6 +290,9 @@ mod tests {
             tool: "mcp_filesystem__read_file".into(),
             tool_call_id: None,
             arguments: None,
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
 
         let value = rx.try_recv().expect("event should be broadcast");
@@ -347,6 +361,9 @@ mod tests {
             success: true,
             arguments: None,
             result: None,
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
 
         let value = rx

--- a/crates/zeroclaw-gateway/src/sse.rs
+++ b/crates/zeroclaw-gateway/src/sse.rs
@@ -242,7 +242,6 @@ impl zeroclaw_runtime::observability::Observer for BroadcastObserver {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use zeroclaw_api::observability_traits::TurnTokenUsage;
     use zeroclaw_runtime::observability::{Observer, ObserverEvent};
 
     fn make_broadcast() -> (

--- a/crates/zeroclaw-gateway/src/ws.rs
+++ b/crates/zeroclaw-gateway/src/ws.rs
@@ -486,6 +486,7 @@ async fn handle_socket(
                         &pending_approvals,
                         &content,
                         &session_key,
+                        &agent_alias,
                     )
                     .await;
                 }
@@ -627,6 +628,7 @@ async fn handle_socket(
                     &pending_approvals,
                     &content,
                     &session_key,
+                    &agent_alias,
                 )
                 .await;
             }
@@ -764,6 +766,7 @@ async fn process_chat_message(
     pending_approvals: &PendingApprovals,
     content: &str,
     session_key: &str,
+    _agent_alias: &str,
 ) {
     use futures_util::StreamExt as _;
     use zeroclaw_runtime::agent::TurnEvent;

--- a/crates/zeroclaw-log/src/config.rs
+++ b/crates/zeroclaw-log/src/config.rs
@@ -18,6 +18,8 @@ pub struct LogConfig {
     pub log_tool_io: String,
     pub log_tool_io_truncate_bytes: usize,
     pub log_tool_io_denylist: Vec<String>,
+    pub log_llm_io: String,
+    pub log_llm_io_max_chars: usize,
 }
 
 impl Default for LogConfig {
@@ -29,6 +31,8 @@ impl Default for LogConfig {
             log_tool_io: "redacted".into(),
             log_tool_io_truncate_bytes: 40960,
             log_tool_io_denylist: Vec::new(),
+            log_llm_io: "off".into(),
+            log_llm_io_max_chars: 200,
         }
     }
 }
@@ -85,6 +89,28 @@ impl ToolIoPolicy {
     }
 }
 
+/// LLM input/output capture policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LlmIoPolicy {
+    Off,
+    Redacted,
+    Full,
+}
+
+impl LlmIoPolicy {
+    pub fn from_raw(raw: &str) -> Self {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "full" => Self::Full,
+            "redacted" => Self::Redacted,
+            _ => Self::Off,
+        }
+    }
+
+    pub fn captures_io(self) -> bool {
+        !matches!(self, Self::Off)
+    }
+}
+
 /// Resolved policy bundle the writer + tool-io capturers read at runtime.
 #[derive(Debug, Clone)]
 pub struct ResolvedPolicy {
@@ -132,6 +158,14 @@ mod tests {
 
     fn make_config() -> LogConfig {
         LogConfig::default()
+    }
+
+    #[test]
+    fn llm_io_policy_defaults_to_off() {
+        assert_eq!(LlmIoPolicy::from_raw(""), LlmIoPolicy::Off);
+        assert_eq!(LlmIoPolicy::from_raw("off"), LlmIoPolicy::Off);
+        assert_eq!(LlmIoPolicy::from_raw("redacted"), LlmIoPolicy::Redacted);
+        assert_eq!(LlmIoPolicy::from_raw("full"), LlmIoPolicy::Full);
     }
 
     #[test]

--- a/crates/zeroclaw-log/src/event.rs
+++ b/crates/zeroclaw-log/src/event.rs
@@ -441,6 +441,12 @@ pub enum Action {
     Migrate,
     Validate,
     Note,
+    AgentStart,
+    AgentEnd,
+    LlmRequest,
+    LlmResponse,
+    ToolCallStart,
+    ToolCallResult,
 }
 
 impl Action {

--- a/crates/zeroclaw-log/src/lib.rs
+++ b/crates/zeroclaw-log/src/lib.rs
@@ -44,7 +44,7 @@ pub use broadcast::{
     subscribe, subscribe_or_install,
 };
 pub use chain::display_chain;
-pub use config::{LogConfig, ResolvedPolicy, StoragePolicy, ToolIoPolicy};
+pub use config::{LlmIoPolicy, LogConfig, ResolvedPolicy, StoragePolicy, ToolIoPolicy};
 pub use event::{
     ATTRIBUTION_FIELDS, Action, COMPOSITE_PREFIXES, Event, EventCategory, EventOutcome, LogEvent,
     Severity, ZeroclawAttribution, is_attribution_field, severity_text_from_number,

--- a/crates/zeroclaw-log/src/observer_bridge.rs
+++ b/crates/zeroclaw-log/src/observer_bridge.rs
@@ -17,7 +17,7 @@ use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use parking_lot::RwLock;
-use zeroclaw_api::observability_traits::{Observer, ObserverEvent};
+use zeroclaw_api::observability_traits::{Observer, ObserverEvent, TurnTokenUsage};
 
 use crate::event::LogEvent;
 
@@ -58,34 +58,105 @@ fn project(event: &LogEvent) -> Option<ObserverEvent> {
     let model_provider = attribution
         .get(&type_field("model_provider"))
         .or_else(|| attribution.get("model_provider"))
+        .or_else(|| {
+            event
+                .attributes
+                .get("model_provider")
+                .and_then(serde_json::Value::as_str)
+        })
         .unwrap_or_default()
         .to_string();
-    let model = attribution.get("model").unwrap_or_default().to_string();
+    let model = attribution
+        .get("model")
+        .or_else(|| {
+            event
+                .attributes
+                .get("model")
+                .and_then(serde_json::Value::as_str)
+        })
+        .unwrap_or_default()
+        .to_string();
     let tool = attribution.get("tool").unwrap_or_default().to_string();
-    let channel = attribution.get("channel").unwrap_or_default().to_string();
+    let channel = attribution
+        .get("channel")
+        .or_else(|| attribution.get("channel_type"))
+        .unwrap_or_default()
+        .to_string();
     let duration = attribution
         .duration_ms
         .map(Duration::from_millis)
         .unwrap_or_default();
     let success = matches!(event.event.outcome.as_str(), "success");
 
+    let agent_alias = attribution
+        .get("agent_alias")
+        .or_else(|| {
+            event
+                .attributes
+                .get("agent_alias")
+                .and_then(serde_json::Value::as_str)
+        })
+        .unwrap_or_default()
+        .to_string();
+    let turn_id = event
+        .attributes
+        .get("turn_id")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+
+    let channel_opt = if channel.is_empty() {
+        None
+    } else {
+        Some(channel.clone())
+    };
+    let agent_alias_opt = if agent_alias.is_empty() {
+        None
+    } else {
+        Some(agent_alias)
+    };
+    let turn_id_opt = if turn_id.is_empty() {
+        None
+    } else {
+        Some(turn_id)
+    };
+
     match action {
         "agent_start" => Some(ObserverEvent::AgentStart {
             model_provider,
             model,
+            channel: channel_opt.clone(),
+            agent_alias: agent_alias_opt.clone(),
+            turn_id: turn_id_opt.clone(),
         }),
         "agent_end" => Some(ObserverEvent::AgentEnd {
             model_provider,
             model,
             duration,
-            tokens_used: event
-                .attributes
-                .get("tokens_used")
-                .and_then(serde_json::Value::as_u64),
+            tokens_used: {
+                let input = event
+                    .attributes
+                    .get("input_tokens")
+                    .and_then(serde_json::Value::as_u64);
+                let output = event
+                    .attributes
+                    .get("output_tokens")
+                    .and_then(serde_json::Value::as_u64);
+                match (input, output) {
+                    (Some(input_tokens), Some(output_tokens)) => Some(TurnTokenUsage {
+                        input_tokens,
+                        output_tokens,
+                    }),
+                    _ => None,
+                }
+            },
             cost_usd: event
                 .attributes
                 .get("cost_usd")
                 .and_then(serde_json::Value::as_f64),
+            channel: channel_opt.clone(),
+            agent_alias: agent_alias_opt.clone(),
+            turn_id: turn_id_opt.clone(),
         }),
         "llm_request" => Some(ObserverEvent::LlmRequest {
             model_provider,
@@ -95,6 +166,14 @@ fn project(event: &LogEvent) -> Option<ObserverEvent> {
                 .get("messages_count")
                 .and_then(serde_json::Value::as_u64)
                 .unwrap_or_default() as usize,
+            user_message: event
+                .attributes
+                .get("user_message")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string),
+            channel: channel_opt.clone(),
+            agent_alias: agent_alias_opt.clone(),
+            turn_id: turn_id_opt.clone(),
         }),
         "llm_response" => Some(ObserverEvent::LlmResponse {
             model_provider,
@@ -114,19 +193,53 @@ fn project(event: &LogEvent) -> Option<ObserverEvent> {
                 .attributes
                 .get("output_tokens")
                 .and_then(serde_json::Value::as_u64),
+            response_content: event
+                .attributes
+                .get("response_content")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string),
+            channel: channel_opt.clone(),
+            agent_alias: agent_alias_opt.clone(),
+            turn_id: turn_id_opt.clone(),
         }),
         "tool_call_start" => Some(ObserverEvent::ToolCallStart {
             tool,
-            tool_call_id: None,
-            arguments: None,
+            tool_call_id: event
+                .attributes
+                .get("tool_call_id")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string),
+            arguments: event
+                .attributes
+                .get("arguments")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string),
+            channel: channel_opt.clone(),
+            agent_alias: agent_alias_opt.clone(),
+            turn_id: turn_id_opt.clone(),
         }),
-        "tool_call" | "tool_call_result" => Some(ObserverEvent::ToolCall {
+        "tool_call_result" => Some(ObserverEvent::ToolCall {
             tool,
-            tool_call_id: None,
+            tool_call_id: event
+                .attributes
+                .get("tool_call_id")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string),
             duration,
             success,
-            arguments: None,
-            result: None,
+            arguments: event
+                .attributes
+                .get("arguments")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string),
+            result: event
+                .attributes
+                .get("result")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string),
+            channel: channel_opt.clone(),
+            agent_alias: agent_alias_opt.clone(),
+            turn_id: turn_id_opt.clone(),
         }),
         "channel_message_inbound" => Some(ObserverEvent::ChannelMessage {
             channel,
@@ -178,6 +291,53 @@ mod tests {
     static BRIDGE_LOCK: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
 
     #[test]
+    fn projects_llm_request_with_attribution() {
+        let _guard = BRIDGE_LOCK.lock();
+        clear_observer_bridge();
+        let observer = Arc::new(CapturingObserver::default());
+        set_observer_bridge(observer.clone());
+
+        let mut event = LogEvent::new(Severity::Info, "llm_request", EventCategory::Agent);
+        event
+            .zeroclaw
+            .set_composite("model_provider", "anthropic.default");
+        event.zeroclaw.set("model", "claude-sonnet-4-6");
+        event.zeroclaw.set("agent_alias", "clamps");
+        event.zeroclaw.set_composite("channel", "ws.default");
+        event.attributes = serde_json::json!({
+            "messages_count": 2,
+            "user_message": "hello",
+            "turn_id": "turn-1"
+        });
+
+        forward(&event);
+
+        let projected = observer.events.lock().unwrap();
+        assert_eq!(projected.len(), 1);
+        match &projected[0] {
+            ObserverEvent::LlmRequest {
+                model_provider,
+                model,
+                user_message,
+                channel,
+                agent_alias,
+                turn_id,
+                ..
+            } => {
+                assert_eq!(model_provider, "anthropic");
+                assert_eq!(model, "claude-sonnet-4-6");
+                assert_eq!(user_message.as_deref(), Some("hello"));
+                assert_eq!(channel.as_deref(), Some("ws.default"));
+                assert_eq!(agent_alias.as_deref(), Some("clamps"));
+                assert_eq!(turn_id.as_deref(), Some("turn-1"));
+            }
+            other => panic!("expected LlmRequest, got {other:?}"),
+        }
+
+        clear_observer_bridge();
+    }
+
+    #[test]
     fn projects_llm_request() {
         let _guard = BRIDGE_LOCK.lock();
         clear_observer_bridge();
@@ -200,6 +360,7 @@ mod tests {
                 model_provider,
                 model,
                 messages_count,
+                ..
             } => {
                 assert_eq!(model_provider, "anthropic");
                 assert_eq!(model, "claude-sonnet-4-6");
@@ -218,7 +379,7 @@ mod tests {
         let observer = Arc::new(CapturingObserver::default());
         set_observer_bridge(observer.clone());
 
-        let mut event = LogEvent::new(Severity::Info, "tool_call", EventCategory::Tool);
+        let mut event = LogEvent::new(Severity::Info, "tool_call_result", EventCategory::Tool);
         event.zeroclaw.set("tool", "shell");
         event.zeroclaw.duration_ms = Some(120);
         event.set_outcome(EventOutcome::Success);
@@ -239,6 +400,41 @@ mod tests {
                 assert!(*success);
             }
             other => panic!("expected ToolCall, got {other:?}"),
+        }
+
+        clear_observer_bridge();
+    }
+
+    #[test]
+    fn projects_tool_call_start() {
+        let _guard = BRIDGE_LOCK.lock();
+        clear_observer_bridge();
+        let observer = Arc::new(CapturingObserver::default());
+        set_observer_bridge(observer.clone());
+
+        let mut event = LogEvent::new(Severity::Info, "tool_call_start", EventCategory::Tool);
+        event.zeroclaw.set("tool", "bash");
+        event.attributes = serde_json::json!({
+            "tool_call_id": "call-123",
+            "arguments": r#"{"cmd":"ls"}"#
+        });
+
+        forward(&event);
+
+        let projected = observer.events.lock().unwrap();
+        assert_eq!(projected.len(), 1);
+        match &projected[0] {
+            ObserverEvent::ToolCallStart {
+                tool,
+                tool_call_id,
+                arguments,
+                ..
+            } => {
+                assert_eq!(tool, "bash");
+                assert_eq!(tool_call_id.as_deref(), Some("call-123"));
+                assert!(arguments.as_deref().is_some());
+            }
+            other => panic!("expected ToolCallStart, got {other:?}"),
         }
 
         clear_observer_bridge();

--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -4,6 +4,7 @@ use crate::agent::dispatcher::{
 use crate::agent::eval::AutoClassifyExt;
 use crate::agent::prompt::{PromptContext, SystemPromptBuilder};
 use crate::approval::{ApprovalManager, ApprovalRequest, ApprovalRequirement, ApprovalResponse};
+use crate::observability::content_processing::ContentProcessor;
 use crate::observability::{self, Observer, ObserverEvent};
 use crate::platform;
 use crate::security::SecurityPolicy;
@@ -90,6 +91,8 @@ pub struct Agent {
     /// Avoids re-reading the same image file on every turn/tool-iteration
     /// when the multimodal pipeline re-walks the full conversation history.
     image_cache: zeroclaw_providers::multimodal::LocalImageCache,
+    /// Processes LLM I/O content for observability output (redaction, truncation).
+    content_processor: ContentProcessor,
 }
 
 impl Drop for Agent {
@@ -205,6 +208,7 @@ pub struct AgentBuilder {
     approval_manager: Option<Arc<ApprovalManager>>,
     agent_alias: Option<String>,
     exclude_memory: bool,
+    content_processor: Option<ContentProcessor>,
 }
 
 impl Default for AgentBuilder {
@@ -247,6 +251,7 @@ impl AgentBuilder {
             approval_manager: None,
             agent_alias: None,
             exclude_memory: false,
+            content_processor: None,
         }
     }
 
@@ -432,6 +437,11 @@ impl AgentBuilder {
         self
     }
 
+    pub fn content_processor(mut self, processor: ContentProcessor) -> Self {
+        self.content_processor = Some(processor);
+        self
+    }
+
     pub fn build(self) -> Result<Agent> {
         let mut tools = self.tools.ok_or_else(|| {
             ::zeroclaw_log::record!(
@@ -584,6 +594,11 @@ impl AgentBuilder {
             channel_handles: AgentChannelHandles::default(),
             exclude_memory,
             image_cache: zeroclaw_providers::multimodal::LocalImageCache::new(),
+            content_processor: self.content_processor.unwrap_or_else(|| {
+                ContentProcessor::from_observability(
+                    &zeroclaw_config::schema::ObservabilityConfig::default(),
+                )
+            }),
         })
     }
 }
@@ -639,6 +654,14 @@ impl Agent {
 
     pub fn clear_history(&mut self) {
         self.history.clear();
+    }
+
+    fn turn_id() -> String {
+        uuid::Uuid::new_v4().to_string()
+    }
+
+    fn duration_ms(start: Instant) -> u64 {
+        u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX)
     }
 
     fn encode_response_cache_transcript(messages: &[ChatMessage]) -> String {
@@ -999,6 +1022,7 @@ impl Agent {
 
         let observer: Arc<dyn Observer> =
             Arc::from(observability::create_observer(&config.observability));
+        ::zeroclaw_log::set_observer_bridge(Arc::clone(&observer));
         let runtime: Arc<dyn platform::RuntimeAdapter> =
             Arc::from(platform::create_runtime(&config.runtime)?);
         // Per-agent workspace becomes the SecurityPolicy boundary
@@ -1371,6 +1395,7 @@ impl Agent {
                 None
             })
             .approval_manager(Some(Arc::new(approval_manager)))
+            .content_processor(ContentProcessor::from_observability(&config.observability))
             .build()?;
 
         // Wire per-tool channel-map handles into the agent so callers (e.g.
@@ -1542,7 +1567,7 @@ impl Agent {
         Ok(prepared.messages)
     }
 
-    async fn execute_tool_call(&self, call: &ParsedToolCall) -> ToolExecutionResult {
+    async fn execute_tool_call(&self, call: &ParsedToolCall, turn_id: &str) -> ToolExecutionResult {
         let start = Instant::now();
 
         // ── Hook: before_tool_call (modifying) ──────────────────
@@ -1699,22 +1724,82 @@ impl Agent {
         let args_json = tool_args.to_string();
         let tool_call_id = call.tool_call_id.clone();
 
-        // Emit invoke log — visible in the TUI Logs pane.
-        ::zeroclaw_log::record!(
-            DEBUG,
-            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Invoke)
-                .with_category(::zeroclaw_log::EventCategory::Tool)
-                .with_attrs(::serde_json::json!({
-                    "tool": tool_name,
-                    "tool_call_id": tool_call_id,
-                    "input": args_json,
-                })),
-            format!("tool call: {tool_name}")
-        );
+        // Emit tool_call_start record with tool name in a local scope span.
+        // We drop the guard immediately after the record! to avoid holding
+        // a !Send guard across .await points.
+        {
+            let _tool_scope = ::zeroclaw_log::__private::tracing::info_span!(
+                target: "zeroclaw_log_internal_scope",
+                "zeroclaw_scope",
+                tool = %tool_name,
+            )
+            .entered();
+            ::zeroclaw_log::record!(
+                INFO,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::ToolCallStart)
+                    .with_category(::zeroclaw_log::EventCategory::Tool)
+                    .with_attrs(::serde_json::json!({
+                        "tool_call_id": tool_call_id,
+                        "arguments": args_json,
+                        "turn_id": turn_id,
+                    })),
+                "tool_call_start"
+            );
+        }
 
         // First try to find tool in static registry, then in activated MCP tools.
-        let (result, success) =
-            if let Some(tool) = self.tools.iter().find(|t| t.name() == tool_name) {
+        let (result, success) = if let Some(tool) =
+            self.tools.iter().find(|t| t.name() == tool_name)
+        {
+            match tool.execute(tool_args.clone()).await {
+                Ok(r) => {
+                    let (outcome_text, ok) = if r.success {
+                        (r.output, true)
+                    } else {
+                        (format!("Error: {}", r.error.unwrap_or(r.output)), false)
+                    };
+                    {
+                        let _s = ::zeroclaw_log::__private::tracing::info_span!(target: "zeroclaw_log_internal_scope", "zeroclaw_scope", tool = %tool_name).entered();
+                        ::zeroclaw_log::record!(
+                                INFO,
+                                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::ToolCallResult)
+                                    .with_category(::zeroclaw_log::EventCategory::Tool)
+                                    .with_outcome(if ok { ::zeroclaw_log::EventOutcome::Success } else { ::zeroclaw_log::EventOutcome::Failure })
+                                    .with_duration(Self::duration_ms(start))
+                                    .with_attrs(::serde_json::json!({
+                                        "tool_call_id": tool_call_id,
+                                        "result": self.content_processor.process_tool_result(&outcome_text).unwrap_or_default(),
+                                        "turn_id": turn_id,
+                                    })),
+                                "tool_call_result"
+                            );
+                    }
+                    (outcome_text, ok)
+                }
+                Err(e) => {
+                    let err_text = format!("Error executing {}: {e}", tool_name);
+                    {
+                        let _s = ::zeroclaw_log::__private::tracing::info_span!(target: "zeroclaw_log_internal_scope", "zeroclaw_scope", tool = %tool_name).entered();
+                        ::zeroclaw_log::record!(
+                                ERROR,
+                                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::ToolCallResult)
+                                    .with_category(::zeroclaw_log::EventCategory::Tool)
+                                    .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                                    .with_duration(Self::duration_ms(start))
+                                    .with_attrs(::serde_json::json!({
+                                        "tool_call_id": tool_call_id,
+                                        "result": self.content_processor.process_tool_result(&err_text).unwrap_or_default(),
+                                        "turn_id": turn_id,
+                                    })),
+                                "tool_call_result"
+                            );
+                    }
+                    (err_text, false)
+                }
+            }
+        } else if let Some(activated_arc) = self.activated_tools.as_ref() {
+            let activated_opt = activated_arc.lock().unwrap().get_resolved(&tool_name);
+            if let Some(tool) = activated_opt {
                 match tool.execute(tool_args.clone()).await {
                     Ok(r) => {
                         let (outcome_text, ok) = if r.success {
@@ -1722,68 +1807,51 @@ impl Agent {
                         } else {
                             (format!("Error: {}", r.error.unwrap_or(r.output)), false)
                         };
-                        self.observer.record_event(&ObserverEvent::ToolCall {
-                            tool: tool_name.clone(),
-                            tool_call_id: tool_call_id.clone(),
-                            duration: start.elapsed(),
-                            success: ok,
-                            arguments: Some(args_json.clone()),
-                            result: Some(super::loop_::scrub_credentials(&outcome_text)),
-                        });
+                        {
+                            let _s = ::zeroclaw_log::__private::tracing::info_span!(target: "zeroclaw_log_internal_scope", "zeroclaw_scope", tool = %tool_name).entered();
+                            ::zeroclaw_log::record!(
+                                    INFO,
+                                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::ToolCallResult)
+                                        .with_category(::zeroclaw_log::EventCategory::Tool)
+                                        .with_outcome(if ok { ::zeroclaw_log::EventOutcome::Success } else { ::zeroclaw_log::EventOutcome::Failure })
+                                        .with_duration(Self::duration_ms(start))
+                                        .with_attrs(::serde_json::json!({
+                                        "tool_call_id": tool_call_id,
+                                        "result": self.content_processor.process_tool_result(&outcome_text).unwrap_or_default(),
+                                        "turn_id": turn_id,
+                                    })),
+                                "tool_call_result"
+                                );
+                        }
                         (outcome_text, ok)
                     }
                     Err(e) => {
                         let err_text = format!("Error executing {}: {e}", tool_name);
-                        self.observer.record_event(&ObserverEvent::ToolCall {
-                            tool: tool_name.clone(),
-                            tool_call_id: tool_call_id.clone(),
-                            duration: start.elapsed(),
-                            success: false,
-                            arguments: Some(args_json.clone()),
-                            result: Some(super::loop_::scrub_credentials(&err_text)),
-                        });
+                        {
+                            let _s = ::zeroclaw_log::__private::tracing::info_span!(target: "zeroclaw_log_internal_scope", "zeroclaw_scope", tool = %tool_name).entered();
+                            ::zeroclaw_log::record!(
+                                    ERROR,
+                                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::ToolCallResult)
+                                        .with_category(::zeroclaw_log::EventCategory::Tool)
+                                        .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                                        .with_duration(Self::duration_ms(start))
+                                        .with_attrs(::serde_json::json!({
+                                            "tool_call_id": tool_call_id,
+                                            "result": self.content_processor.process_tool_result(&err_text).unwrap_or_default(),
+                                            "turn_id": turn_id,
+                                        })),
+                                    "tool_call_result"
+                                );
+                        }
                         (err_text, false)
                     }
                 }
-            } else if let Some(activated_arc) = self.activated_tools.as_ref() {
-                let activated_opt = activated_arc.lock().unwrap().get_resolved(&tool_name);
-                if let Some(tool) = activated_opt {
-                    match tool.execute(tool_args.clone()).await {
-                        Ok(r) => {
-                            let (outcome_text, ok) = if r.success {
-                                (r.output, true)
-                            } else {
-                                (format!("Error: {}", r.error.unwrap_or(r.output)), false)
-                            };
-                            self.observer.record_event(&ObserverEvent::ToolCall {
-                                tool: tool_name.clone(),
-                                tool_call_id: tool_call_id.clone(),
-                                duration: start.elapsed(),
-                                success: ok,
-                                arguments: Some(args_json.clone()),
-                                result: Some(super::loop_::scrub_credentials(&outcome_text)),
-                            });
-                            (outcome_text, ok)
-                        }
-                        Err(e) => {
-                            let err_text = format!("Error executing {}: {e}", tool_name);
-                            self.observer.record_event(&ObserverEvent::ToolCall {
-                                tool: tool_name.clone(),
-                                tool_call_id: tool_call_id.clone(),
-                                duration: start.elapsed(),
-                                success: false,
-                                arguments: Some(args_json.clone()),
-                                result: Some(super::loop_::scrub_credentials(&err_text)),
-                            });
-                            (err_text, false)
-                        }
-                    }
-                } else {
-                    (format!("Unknown tool: {}", tool_name), false)
-                }
             } else {
                 (format!("Unknown tool: {}", tool_name), false)
-            };
+            }
+        } else {
+            (format!("Unknown tool: {}", tool_name), false)
+        };
 
         let duration = start.elapsed();
 
@@ -1840,7 +1908,11 @@ impl Agent {
         }
     }
 
-    async fn execute_tools(&self, calls: &[ParsedToolCall]) -> Vec<ToolExecutionResult> {
+    async fn execute_tools(
+        &self,
+        calls: &[ParsedToolCall],
+        turn_id: &str,
+    ) -> Vec<ToolExecutionResult> {
         let approval_required = self.approval_manager.as_deref().is_some_and(|mgr| {
             calls
                 .iter()
@@ -1849,14 +1921,14 @@ impl Agent {
         if !self.config.resolved.parallel_tools || approval_required {
             let mut results = Vec::with_capacity(calls.len());
             for call in calls {
-                results.push(self.execute_tool_call(call).await);
+                results.push(self.execute_tool_call(call, turn_id).await);
             }
             return results;
         }
 
         let futs: Vec<_> = calls
             .iter()
-            .map(|call| self.execute_tool_call(call))
+            .map(|call| self.execute_tool_call(call, turn_id))
             .collect();
         futures_util::future::join_all(futs).await
     }
@@ -1960,6 +2032,20 @@ impl Agent {
             .push(ConversationMessage::Chat(ChatMessage::user(enriched)));
 
         let effective_model = self.classify_model(user_message);
+        let turn_id = Self::turn_id();
+        let turn_started_at = Instant::now();
+        let user_msg_content = self.content_processor.process_user_message(user_message);
+        ::zeroclaw_log::record!(
+            INFO,
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::AgentStart)
+                .with_category(::zeroclaw_log::EventCategory::Agent)
+                .with_attrs(::serde_json::json!({
+                    "turn_id": turn_id,
+                    "model": self.model_name,
+                    "model_provider": self.model_provider_name,
+                })),
+            "agent_start"
+        );
 
         for _ in 0..self.config.resolved.max_tool_iterations {
             let messages = self.tool_dispatcher.to_provider_messages(&self.history);
@@ -2007,12 +2093,19 @@ impl Agent {
             }
 
             let llm_started_at = Instant::now();
-            self.observer.record_event(&ObserverEvent::LlmRequest {
-                model_provider: self.model_provider_name.clone(),
-                model: effective_model.clone(),
-                messages_count: messages.len(),
-            });
-
+            ::zeroclaw_log::record!(
+                INFO,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::LlmRequest)
+                    .with_category(::zeroclaw_log::EventCategory::Agent)
+                    .with_attrs(::serde_json::json!({
+                        "messages_count": messages.len(),
+                        "user_message": user_msg_content,
+                        "turn_id": turn_id,
+                        "model": self.model_name,
+                        "model_provider": self.model_provider_name,
+                    })),
+                "llm_request"
+            );
             let response = match self
                 .model_provider
                 .chat(
@@ -2036,28 +2129,65 @@ impl Agent {
                         .as_ref()
                         .map(|u| (u.input_tokens, u.output_tokens))
                         .unwrap_or((None, None));
-                    self.observer.record_event(&ObserverEvent::LlmResponse {
-                        model_provider: self.model_provider_name.clone(),
-                        model: effective_model.clone(),
-                        duration: llm_started_at.elapsed(),
-                        success: true,
-                        error_message: None,
-                        input_tokens: resp_input_tokens,
-                        output_tokens: resp_output_tokens,
-                    });
+                    let resp_content = self
+                        .content_processor
+                        .process_response_content(resp.text_or_empty().as_ref());
+                    let _duration = llm_started_at.elapsed();
+                    ::zeroclaw_log::record!(
+                        INFO,
+                        ::zeroclaw_log::Event::new(
+                            module_path!(),
+                            ::zeroclaw_log::Action::LlmResponse
+                        )
+                        .with_category(::zeroclaw_log::EventCategory::Agent)
+                        .with_outcome(::zeroclaw_log::EventOutcome::Success)
+                        .with_duration(Self::duration_ms(llm_started_at))
+                        .with_attrs(::serde_json::json!({
+                            "input_tokens": resp_input_tokens,
+                            "output_tokens": resp_output_tokens,
+                            "response_content": resp_content,
+                            "turn_id": turn_id,
+                            "model": self.model_name,
+                            "model_provider": self.model_provider_name,
+                        })),
+                        "llm_response"
+                    );
                     resp
                 }
                 Err(err) => {
                     let safe_error = zeroclaw_providers::sanitize_api_error(&err.to_string());
-                    self.observer.record_event(&ObserverEvent::LlmResponse {
-                        model_provider: self.model_provider_name.clone(),
-                        model: effective_model.clone(),
-                        duration: llm_started_at.elapsed(),
-                        success: false,
-                        error_message: Some(safe_error),
-                        input_tokens: None,
-                        output_tokens: None,
-                    });
+                    ::zeroclaw_log::record!(
+                        ERROR,
+                        ::zeroclaw_log::Event::new(
+                            module_path!(),
+                            ::zeroclaw_log::Action::LlmResponse
+                        )
+                        .with_category(::zeroclaw_log::EventCategory::Agent)
+                        .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                        .with_duration(Self::duration_ms(llm_started_at))
+                        .with_attrs(::serde_json::json!({
+                            "error": safe_error,
+                            "turn_id": turn_id,
+                            "model": self.model_name,
+                            "model_provider": self.model_provider_name,
+                        })),
+                        "llm_response"
+                    );
+                    ::zeroclaw_log::record!(
+                        ERROR,
+                        ::zeroclaw_log::Event::new(
+                            module_path!(),
+                            ::zeroclaw_log::Action::AgentEnd
+                        )
+                        .with_category(::zeroclaw_log::EventCategory::Agent)
+                        .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                        .with_duration(Self::duration_ms(turn_started_at))
+                        .with_attrs(::serde_json::json!({
+                            "turn_id": turn_id,
+                            "error": "llm_error",
+                        })),
+                        "agent_end"
+                    );
                     return Err(err);
                 }
             };
@@ -2086,7 +2216,16 @@ impl Agent {
                         final_text.clone(),
                     )));
                 self.trim_history();
-
+                ::zeroclaw_log::record!(
+                    INFO,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::AgentEnd)
+                        .with_category(::zeroclaw_log::EventCategory::Agent)
+                        .with_duration(Self::duration_ms(turn_started_at))
+                        .with_attrs(::serde_json::json!({
+                            "turn_id": turn_id,
+                        })),
+                    "agent_end"
+                );
                 return Ok(final_text);
             }
 
@@ -2101,12 +2240,24 @@ impl Agent {
                 reasoning_content: response.reasoning_content.clone(),
             });
 
-            let results = self.execute_tools(&calls).await;
+            let results = self.execute_tools(&calls, &turn_id).await;
             let formatted = self.tool_dispatcher.format_results(&results);
             self.history.push(formatted);
             self.trim_history();
         }
 
+        ::zeroclaw_log::record!(
+            ERROR,
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::AgentEnd)
+                .with_category(::zeroclaw_log::EventCategory::Agent)
+                .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                .with_duration(Self::duration_ms(turn_started_at))
+                .with_attrs(::serde_json::json!({
+                    "turn_id": turn_id,
+                    "error": "max_tool_iterations",
+                })),
+            "agent_end"
+        );
         anyhow::bail!(
             "Agent exceeded maximum tool iterations ({})",
             self.config.resolved.max_tool_iterations
@@ -2207,7 +2358,22 @@ impl Agent {
 
         let effective_model = self.classify_model(user_message);
         let turn_started_at = std::time::Instant::now();
+        let turn_id = Self::turn_id();
+        let mut total_input_tokens: Option<u64> = None;
+        let mut total_output_tokens: Option<u64> = None;
+        let user_msg_content = self.content_processor.process_user_message(user_message);
         let mut committed_response = String::new();
+        ::zeroclaw_log::record!(
+            INFO,
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::AgentStart)
+                .with_category(::zeroclaw_log::EventCategory::Agent)
+                .with_attrs(::serde_json::json!({
+                    "turn_id": turn_id,
+                    "model": self.model_name,
+                    "model_provider": self.model_provider_name,
+                })),
+            "agent_start"
+        );
 
         // ── Turn loop ──────────────────────────────────────────────────
         for _ in 0..self.config.resolved.max_tool_iterations {
@@ -2220,6 +2386,18 @@ impl Agent {
                     "[interrupted by user]".to_string(),
                     &mut new_msgs,
                     &mut committed_response,
+                );
+                ::zeroclaw_log::record!(
+                    ERROR,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::AgentEnd)
+                        .with_category(::zeroclaw_log::EventCategory::Agent)
+                        .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                        .with_duration(Self::duration_ms(turn_started_at))
+                        .with_attrs(::serde_json::json!({
+                            "turn_id": turn_id,
+                            "error": "cancelled_by_user",
+                        })),
+                    "agent_end"
                 );
                 return Err(StreamedTurnError {
                     error: crate::agent::loop_::ToolLoopCancelled.into(),
@@ -2237,6 +2415,21 @@ impl Agent {
             let prepared_messages = match self.prepare_provider_messages(&messages).await {
                 Ok(messages) => messages,
                 Err(error) => {
+                    ::zeroclaw_log::record!(
+                        ERROR,
+                        ::zeroclaw_log::Event::new(
+                            module_path!(),
+                            ::zeroclaw_log::Action::AgentEnd
+                        )
+                        .with_category(::zeroclaw_log::EventCategory::Agent)
+                        .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                        .with_duration(Self::duration_ms(turn_started_at))
+                        .with_attrs(::serde_json::json!({
+                            "turn_id": turn_id,
+                            "error": "prepare_messages_failed",
+                        })),
+                        "agent_end"
+                    );
                     return Err(StreamedTurnError {
                         error,
                         committed_response,
@@ -2261,13 +2454,19 @@ impl Agent {
                     self.history.push(cached_msg);
                     self.trim_history();
                     self.observer.record_event(&ObserverEvent::TurnComplete);
-                    self.observer.record_event(&ObserverEvent::AgentEnd {
-                        model_provider: self.model_provider_name.clone(),
-                        model: effective_model.clone(),
-                        duration: turn_started_at.elapsed(),
-                        tokens_used: None,
-                        cost_usd: None,
-                    });
+                    ::zeroclaw_log::record!(
+                        INFO,
+                        ::zeroclaw_log::Event::new(
+                            module_path!(),
+                            ::zeroclaw_log::Action::AgentEnd
+                        )
+                        .with_category(::zeroclaw_log::EventCategory::Agent)
+                        .with_duration(Self::duration_ms(turn_started_at))
+                        .with_attrs(::serde_json::json!({
+                            "turn_id": turn_id,
+                        })),
+                        "agent_end"
+                    );
                     committed_response.push_str(&cached);
                     return Ok(StreamedTurnSuccess {
                         response: committed_response,
@@ -2307,11 +2506,19 @@ impl Agent {
             use futures_util::StreamExt;
 
             let llm_started_at = Instant::now();
-            self.observer.record_event(&ObserverEvent::LlmRequest {
-                model_provider: self.model_provider_name.clone(),
-                model: effective_model.clone(),
-                messages_count: messages.len(),
-            });
+            ::zeroclaw_log::record!(
+                INFO,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::LlmRequest)
+                    .with_category(::zeroclaw_log::EventCategory::Agent)
+                    .with_attrs(::serde_json::json!({
+                        "messages_count": messages.len(),
+                        "user_message": user_msg_content,
+                        "turn_id": turn_id,
+                        "model": self.model_name,
+                        "model_provider": self.model_provider_name,
+                    })),
+                "llm_request"
+            );
 
             let stream_opts = zeroclaw_providers::traits::StreamOptions::new(
                 self.model_provider.supports_streaming(),
@@ -2456,6 +2663,58 @@ impl Agent {
                         zeroclaw_providers::traits::StreamEvent::Final => break,
                     },
                     Err(error) => {
+                        if got_stream || !committed_response.is_empty() {
+                            if !streamed_text.is_empty() {
+                                let partial = Self::marked_partial_response(
+                                    &streamed_text,
+                                    "[stream interrupted]",
+                                );
+                                self.append_streamed_assistant_message_to_history(
+                                    partial,
+                                    &mut new_msgs,
+                                    &mut committed_response,
+                                );
+                            }
+                            let safe_error =
+                                zeroclaw_providers::sanitize_api_error(&error.to_string());
+                            ::zeroclaw_log::record!(
+                                ERROR,
+                                ::zeroclaw_log::Event::new(
+                                    module_path!(),
+                                    ::zeroclaw_log::Action::LlmResponse
+                                )
+                                .with_category(::zeroclaw_log::EventCategory::Agent)
+                                .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                                .with_duration(Self::duration_ms(llm_started_at))
+                                .with_attrs(::serde_json::json!({
+                                    "error": safe_error,
+                                    "turn_id": turn_id,
+                                    "model": self.model_name,
+                                    "model_provider": self.model_provider_name,
+                                })),
+                                "llm_response"
+                            );
+                            ::zeroclaw_log::record!(
+                                ERROR,
+                                ::zeroclaw_log::Event::new(
+                                    module_path!(),
+                                    ::zeroclaw_log::Action::AgentEnd
+                                )
+                                .with_category(::zeroclaw_log::EventCategory::Agent)
+                                .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                                .with_duration(Self::duration_ms(turn_started_at))
+                                .with_attrs(::serde_json::json!({
+                                    "turn_id": turn_id,
+                                    "error": "stream_error",
+                                })),
+                                "agent_end"
+                            );
+                            return Err(StreamedTurnError {
+                                error: anyhow::Error::msg(error.to_string()),
+                                committed_response,
+                                new_messages: new_msgs,
+                            });
+                        }
                         stream_error = Some(error.to_string());
                         break;
                     }
@@ -2475,15 +2734,32 @@ impl Agent {
                     &mut new_msgs,
                     &mut committed_response,
                 );
-                self.observer.record_event(&ObserverEvent::LlmResponse {
-                    model_provider: self.model_provider_name.clone(),
-                    model: effective_model.clone(),
-                    duration: llm_started_at.elapsed(),
-                    success: false,
-                    error_message: Some("request cancelled by user".into()),
-                    input_tokens: None,
-                    output_tokens: None,
-                });
+                ::zeroclaw_log::record!(
+                    ERROR,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::LlmResponse)
+                        .with_category(::zeroclaw_log::EventCategory::Agent)
+                        .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                        .with_duration(Self::duration_ms(llm_started_at))
+                        .with_attrs(::serde_json::json!({
+                            "error": "request cancelled by user",
+                            "turn_id": turn_id,
+                            "model": self.model_name,
+                            "model_provider": self.model_provider_name,
+                        })),
+                    "llm_response"
+                );
+                ::zeroclaw_log::record!(
+                    ERROR,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::AgentEnd)
+                        .with_category(::zeroclaw_log::EventCategory::Agent)
+                        .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                        .with_duration(Self::duration_ms(turn_started_at))
+                        .with_attrs(::serde_json::json!({
+                            "turn_id": turn_id,
+                            "error": "cancelled_by_user",
+                        })),
+                    "agent_end"
+                );
                 return Err(StreamedTurnError {
                     error: crate::agent::loop_::ToolLoopCancelled.into(),
                     committed_response,
@@ -2504,15 +2780,32 @@ impl Agent {
                 let safe_error = zeroclaw_providers::sanitize_api_error(
                     stream_error.as_deref().unwrap_or_default(),
                 );
-                self.observer.record_event(&ObserverEvent::LlmResponse {
-                    model_provider: self.model_provider_name.clone(),
-                    model: effective_model.clone(),
-                    duration: llm_started_at.elapsed(),
-                    success: false,
-                    error_message: Some(safe_error),
-                    input_tokens: None,
-                    output_tokens: None,
-                });
+                ::zeroclaw_log::record!(
+                    ERROR,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::LlmResponse)
+                        .with_category(::zeroclaw_log::EventCategory::Agent)
+                        .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                        .with_duration(Self::duration_ms(llm_started_at))
+                        .with_attrs(::serde_json::json!({
+                            "error": safe_error,
+                            "turn_id": turn_id,
+                            "model": self.model_name,
+                            "model_provider": self.model_provider_name,
+                        })),
+                    "llm_response"
+                );
+                ::zeroclaw_log::record!(
+                    ERROR,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::AgentEnd)
+                        .with_category(::zeroclaw_log::EventCategory::Agent)
+                        .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                        .with_duration(Self::duration_ms(turn_started_at))
+                        .with_attrs(::serde_json::json!({
+                            "turn_id": turn_id,
+                            "error": "stream_error",
+                        })),
+                    "agent_end"
+                );
                 return Err(StreamedTurnError {
                     error: anyhow::Error::msg(stream_error.unwrap_or_default()),
                     committed_response,
@@ -2585,15 +2878,32 @@ impl Agent {
                                 &mut new_msgs,
                                 &mut committed_response,
                             );
-                            self.observer.record_event(&ObserverEvent::LlmResponse {
-                                model_provider: self.model_provider_name.clone(),
-                                model: effective_model.clone(),
-                                duration: llm_started_at.elapsed(),
-                                success: false,
-                                error_message: Some("request cancelled by user".into()),
-                                input_tokens: None,
-                                output_tokens: None,
-                            });
+                            ::zeroclaw_log::record!(
+                                ERROR,
+                                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::LlmResponse)
+                                    .with_category(::zeroclaw_log::EventCategory::Agent)
+                                    .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                                    .with_duration(Self::duration_ms(llm_started_at))
+                                    .with_attrs(::serde_json::json!({
+                                        "error": "request cancelled by user",
+                                        "turn_id": turn_id,
+                                        "model": self.model_name,
+                                        "model_provider": self.model_provider_name,
+                                    })),
+                                "llm_response"
+                            );
+                            ::zeroclaw_log::record!(
+                                ERROR,
+                                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::AgentEnd)
+                                    .with_category(::zeroclaw_log::EventCategory::Agent)
+                                    .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                                    .with_duration(Self::duration_ms(turn_started_at))
+                                    .with_attrs(::serde_json::json!({
+                                        "turn_id": turn_id,
+                                        "error": "cancelled_by_user",
+                                    })),
+                                "agent_end"
+                            );
                             return Err(StreamedTurnError {
                                 error: crate::agent::loop_::ToolLoopCancelled.into(),
                                 committed_response,
@@ -2609,15 +2919,38 @@ impl Agent {
                     Ok(resp) => resp,
                     Err(error) => {
                         let safe_error = zeroclaw_providers::sanitize_api_error(&error.to_string());
-                        self.observer.record_event(&ObserverEvent::LlmResponse {
-                            model_provider: self.model_provider_name.clone(),
-                            model: effective_model.clone(),
-                            duration: llm_started_at.elapsed(),
-                            success: false,
-                            error_message: Some(safe_error),
-                            input_tokens: None,
-                            output_tokens: None,
-                        });
+                        ::zeroclaw_log::record!(
+                            ERROR,
+                            ::zeroclaw_log::Event::new(
+                                module_path!(),
+                                ::zeroclaw_log::Action::LlmResponse
+                            )
+                            .with_category(::zeroclaw_log::EventCategory::Agent)
+                            .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                            .with_duration(Self::duration_ms(llm_started_at))
+                            .with_attrs(::serde_json::json!({
+                                "error": safe_error,
+                                "turn_id": turn_id,
+                                "model": self.model_name,
+                                "model_provider": self.model_provider_name,
+                            })),
+                            "llm_response"
+                        );
+                        ::zeroclaw_log::record!(
+                            ERROR,
+                            ::zeroclaw_log::Event::new(
+                                module_path!(),
+                                ::zeroclaw_log::Action::AgentEnd
+                            )
+                            .with_category(::zeroclaw_log::EventCategory::Agent)
+                            .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                            .with_duration(Self::duration_ms(turn_started_at))
+                            .with_attrs(::serde_json::json!({
+                                "turn_id": turn_id,
+                                "error": "llm_error",
+                            })),
+                            "agent_end"
+                        );
                         if got_stream && !streamed_text.is_empty() {
                             let partial = Self::marked_partial_response(
                                 &streamed_text,
@@ -2643,15 +2976,31 @@ impl Agent {
                 .as_ref()
                 .map(|u| (u.input_tokens, u.output_tokens))
                 .unwrap_or((None, None));
-            self.observer.record_event(&ObserverEvent::LlmResponse {
-                model_provider: self.model_provider_name.clone(),
-                model: effective_model.clone(),
-                duration: llm_started_at.elapsed(),
-                success: true,
-                error_message: None,
-                input_tokens: resp_input_tokens,
-                output_tokens: resp_output_tokens,
-            });
+            if let Some(i) = resp_input_tokens {
+                total_input_tokens = Some(total_input_tokens.unwrap_or(0).saturating_add(i));
+            }
+            if let Some(o) = resp_output_tokens {
+                total_output_tokens = Some(total_output_tokens.unwrap_or(0).saturating_add(o));
+            }
+            let resp_content = self
+                .content_processor
+                .process_response_content(response.text_or_empty().as_ref());
+            ::zeroclaw_log::record!(
+                INFO,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::LlmResponse)
+                    .with_category(::zeroclaw_log::EventCategory::Agent)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Success)
+                    .with_duration(Self::duration_ms(llm_started_at))
+                    .with_attrs(::serde_json::json!({
+                        "input_tokens": resp_input_tokens,
+                        "output_tokens": resp_output_tokens,
+                        "response_content": resp_content,
+                        "turn_id": turn_id,
+                        "model": self.model_name,
+                        "model_provider": self.model_provider_name,
+                    })),
+                "llm_response"
+            );
 
             // Forward per-call token usage so the WS gateway (and any other
             // consumer) can include aggregated usage in the final done frame
@@ -2733,13 +3082,19 @@ impl Agent {
                 committed_response.push_str(&final_text);
                 self.trim_history();
                 self.observer.record_event(&ObserverEvent::TurnComplete);
-                self.observer.record_event(&ObserverEvent::AgentEnd {
-                    model_provider: self.model_provider_name.clone(),
-                    model: effective_model.clone(),
-                    duration: turn_started_at.elapsed(),
-                    tokens_used: None,
-                    cost_usd: None,
-                });
+                ::zeroclaw_log::record!(
+                    INFO,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::AgentEnd)
+                        .with_category(::zeroclaw_log::EventCategory::Agent)
+                        .with_duration(Self::duration_ms(turn_started_at))
+                        .with_attrs(::serde_json::json!({
+                            "input_tokens": total_input_tokens,
+                            "output_tokens": total_output_tokens,
+                            "cost_usd": null,
+                            "turn_id": turn_id,
+                        })),
+                    "agent_end"
+                );
                 return Ok(StreamedTurnSuccess {
                     response: committed_response,
                     new_messages: new_msgs,
@@ -2840,10 +3195,10 @@ impl Agent {
                                     new_messages: new_msgs,
                                 });
                             }
-                            mut r = self.execute_tools(single) => r.pop().expect("one call yields one result"),
+                            mut r = self.execute_tools(single, &turn_id) => r.pop().expect("one call yields one result"),
                         }
                     } else {
-                        self.execute_tools(single)
+                        self.execute_tools(single, &turn_id)
                             .await
                             .pop()
                             .expect("one call yields one result")
@@ -2900,10 +3255,10 @@ impl Agent {
                                 new_messages: new_msgs,
                             });
                         }
-                        results = self.execute_tools(&calls) => results,
+                        results = self.execute_tools(&calls, &turn_id) => results,
                     }
                 } else {
-                    self.execute_tools(&calls).await
+                    self.execute_tools(&calls, &turn_id).await
                 };
 
                 for result in &results {
@@ -2930,6 +3285,18 @@ impl Agent {
             self.trim_history();
         }
 
+        ::zeroclaw_log::record!(
+            ERROR,
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::AgentEnd)
+                .with_category(::zeroclaw_log::EventCategory::Agent)
+                .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                .with_duration(Self::duration_ms(turn_started_at))
+                .with_attrs(::serde_json::json!({
+                    "turn_id": turn_id,
+                    "error": "max_tool_iterations",
+                })),
+            "agent_end"
+        );
         Err(StreamedTurnError {
             error: anyhow::Error::msg(format!(
                 "Agent exceeded maximum tool iterations ({})",
@@ -3031,10 +3398,16 @@ pub async fn run(
             ),
         };
 
-    agent.observer.record_event(&ObserverEvent::AgentStart {
-        model_provider: provider_name.clone(),
-        model: model_name.clone(),
-    });
+    ::zeroclaw_log::record!(
+        INFO,
+        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::AgentStart)
+            .with_category(::zeroclaw_log::EventCategory::Agent)
+            .with_attrs(::serde_json::json!({
+                "model_provider": provider_name,
+                "model": model_name,
+            })),
+        "agent_start"
+    );
 
     if let Some(msg) = message {
         let response = agent.run_single(&msg).await?;
@@ -3043,13 +3416,17 @@ pub async fn run(
         agent.run_interactive().await?;
     }
 
-    agent.observer.record_event(&ObserverEvent::AgentEnd {
-        model_provider: provider_name,
-        model: model_name,
-        duration: start.elapsed(),
-        tokens_used: None,
-        cost_usd: None,
-    });
+    ::zeroclaw_log::record!(
+        INFO,
+        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::AgentEnd)
+            .with_category(::zeroclaw_log::EventCategory::Agent)
+            .with_duration(u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX))
+            .with_attrs(::serde_json::json!({
+                "model_provider": provider_name,
+                "model": model_name,
+            })),
+        "agent_end"
+    );
 
     Ok(())
 }
@@ -3336,25 +3713,6 @@ mod tests {
         fn alias(&self) -> &str {
             "StreamingSteeringModelProvider"
         }
-    }
-
-    #[derive(Default)]
-    struct CapturingObserver {
-        events: parking_lot::Mutex<Vec<ObserverEvent>>,
-    }
-
-    impl Observer for CapturingObserver {
-        fn record_event(&self, event: &ObserverEvent) {
-            self.events.lock().push(event.clone());
-        }
-        fn record_metric(&self, _metric: &ObserverMetric) {}
-        fn name(&self) -> &str {
-            "capturing"
-        }
-        fn as_any(&self) -> &dyn std::any::Any {
-            self
-        }
-        fn flush(&self) {}
     }
 
     struct MultimodalCaptureProvider {
@@ -3758,11 +4116,14 @@ mod tests {
         agent.channel_handles().register_channel("acp", channel);
 
         let result = agent
-            .execute_tool_call(&ParsedToolCall {
-                name: "echo".into(),
-                arguments: serde_json::json!({"message": "hi"}),
-                tool_call_id: Some("tc1".into()),
-            })
+            .execute_tool_call(
+                &ParsedToolCall {
+                    name: "echo".into(),
+                    arguments: serde_json::json!({"message": "hi"}),
+                    tool_call_id: Some("tc1".into()),
+                },
+                "",
+            )
             .await;
 
         assert!(result.success);
@@ -3816,11 +4177,14 @@ mod tests {
         agent.channel_handles().register_channel("acp", channel);
 
         let result = agent
-            .execute_tool_call(&ParsedToolCall {
-                name: "echo".into(),
-                arguments: serde_json::json!({"message": "hi"}),
-                tool_call_id: Some("tc1".into()),
-            })
+            .execute_tool_call(
+                &ParsedToolCall {
+                    name: "echo".into(),
+                    arguments: serde_json::json!({"message": "hi"}),
+                    tool_call_id: Some("tc1".into()),
+                },
+                "",
+            )
             .await;
 
         assert!(!result.success);
@@ -3875,14 +4239,17 @@ mod tests {
         agent.channel_handles().register_channel("acp", channel);
 
         let result = agent
-            .execute_tool_call(&ParsedToolCall {
-                name: "shell".into(),
-                arguments: serde_json::json!({
-                    "command": "touch should-not-run",
-                    "approved": true
-                }),
-                tool_call_id: Some("tc1".into()),
-            })
+            .execute_tool_call(
+                &ParsedToolCall {
+                    name: "shell".into(),
+                    arguments: serde_json::json!({
+                        "command": "touch should-not-run",
+                        "approved": true
+                    }),
+                    tool_call_id: Some("tc1".into()),
+                },
+                "",
+            )
             .await;
 
         assert!(!result.success);
@@ -3938,14 +4305,17 @@ mod tests {
         agent.channel_handles().register_channel("acp", channel);
 
         let result = agent
-            .execute_tool_call(&ParsedToolCall {
-                name: "shell".into(),
-                arguments: serde_json::json!({
-                    "command": "touch should-run-after-human-approval",
-                    "approved": false
-                }),
-                tool_call_id: Some("tc1".into()),
-            })
+            .execute_tool_call(
+                &ParsedToolCall {
+                    name: "shell".into(),
+                    arguments: serde_json::json!({
+                        "command": "touch should-run-after-human-approval",
+                        "approved": false
+                    }),
+                    tool_call_id: Some("tc1".into()),
+                },
+                "",
+            )
             .await;
 
         assert!(result.success);
@@ -4006,24 +4376,30 @@ mod tests {
         agent.channel_handles().register_channel("acp", channel);
 
         let first_result = agent
-            .execute_tool_call(&ParsedToolCall {
-                name: "shell".into(),
-                arguments: serde_json::json!({
-                    "command": "touch should-run-after-always-approval",
-                    "approved": false
-                }),
-                tool_call_id: Some("tc1".into()),
-            })
+            .execute_tool_call(
+                &ParsedToolCall {
+                    name: "shell".into(),
+                    arguments: serde_json::json!({
+                        "command": "touch should-run-after-always-approval",
+                        "approved": false
+                    }),
+                    tool_call_id: Some("tc1".into()),
+                },
+                "",
+            )
             .await;
         let second_result = agent
-            .execute_tool_call(&ParsedToolCall {
-                name: "shell".into(),
-                arguments: serde_json::json!({
-                    "command": "touch should-run-from-allowlist",
-                    "approved": false
-                }),
-                tool_call_id: Some("tc2".into()),
-            })
+            .execute_tool_call(
+                &ParsedToolCall {
+                    name: "shell".into(),
+                    arguments: serde_json::json!({
+                        "command": "touch should-run-from-allowlist",
+                        "approved": false
+                    }),
+                    tool_call_id: Some("tc2".into()),
+                },
+                "",
+            )
             .await;
 
         assert!(first_result.success);
@@ -4070,14 +4446,17 @@ mod tests {
             .expect("agent builder should succeed with valid config");
 
         let result = agent
-            .execute_tool_call(&ParsedToolCall {
-                name: "cron_add".into(),
-                arguments: serde_json::json!({
-                    "command": "echo should-not-be-model-approved",
-                    "approved": true
-                }),
-                tool_call_id: Some("tc1".into()),
-            })
+            .execute_tool_call(
+                &ParsedToolCall {
+                    name: "cron_add".into(),
+                    arguments: serde_json::json!({
+                        "command": "echo should-not-be-model-approved",
+                        "approved": true
+                    }),
+                    tool_call_id: Some("tc1".into()),
+                },
+                "",
+            )
             .await;
 
         assert!(result.success);
@@ -6278,13 +6657,11 @@ mod tests {
             fail_after_delta_on_call: Some(1),
             delay_chat_on_call: None,
         });
-        let capturing = Arc::new(CapturingObserver::default());
-        let observer: Arc<dyn Observer> = capturing.clone();
         let mut agent = Agent::builder()
             .model_provider(model_provider)
             .tools(vec![Box::new(MockTool)])
             .memory(mem)
-            .observer(observer)
+            .observer(Arc::from(crate::observability::NoopObserver {}))
             .tool_dispatcher(Box::new(NativeToolDispatcher))
             .workspace_dir(std::path::PathBuf::from("/tmp"))
             .build()
@@ -6302,59 +6679,6 @@ mod tests {
             "unexpected committed_response: {}",
             err.committed_response
         );
-
-        let events = capturing.events.lock();
-        let request = events
-            .iter()
-            .find(|e| matches!(e, ObserverEvent::LlmRequest { .. }))
-            .expect("LlmRequest should have been recorded");
-        let response = events
-            .iter()
-            .find(|e| matches!(e, ObserverEvent::LlmResponse { .. }))
-            .expect("LlmResponse should have been recorded");
-
-        assert_eq!(
-            events
-                .iter()
-                .filter(|e| matches!(e, ObserverEvent::LlmRequest { .. }))
-                .count(),
-            1,
-            "exactly one LlmRequest expected"
-        );
-        assert_eq!(
-            events
-                .iter()
-                .filter(|e| matches!(e, ObserverEvent::LlmResponse { .. }))
-                .count(),
-            1,
-            "exactly one LlmResponse expected"
-        );
-
-        let (
-            ObserverEvent::LlmRequest {
-                model_provider: req_provider,
-                model: req_model,
-                ..
-            },
-            ObserverEvent::LlmResponse {
-                model_provider: resp_provider,
-                model: resp_model,
-                success,
-                error_message,
-                ..
-            },
-        ) = (request, response)
-        else {
-            panic!("matched event variants should be LlmRequest and LlmResponse");
-        };
-
-        assert!(!success, "LlmResponse on stream error must be a failure");
-        assert!(
-            error_message.as_deref().is_some_and(|m| !m.is_empty()),
-            "failure LlmResponse must carry a non-empty error_message"
-        );
-        assert_eq!(req_provider, resp_provider, "provider should match");
-        assert_eq!(req_model, resp_model, "model should match");
     }
 
     #[tokio::test]
@@ -6376,13 +6700,11 @@ mod tests {
             fail_after_delta_on_call: None,
             delay_chat_on_call: None,
         });
-        let capturing = Arc::new(CapturingObserver::default());
-        let observer: Arc<dyn Observer> = capturing.clone();
         let mut agent = Agent::builder()
             .model_provider(model_provider)
             .tools(vec![Box::new(MockTool)])
             .memory(mem)
-            .observer(observer)
+            .observer(Arc::from(crate::observability::NoopObserver {}))
             .tool_dispatcher(Box::new(NativeToolDispatcher))
             .workspace_dir(std::path::PathBuf::from("/tmp"))
             .build()
@@ -6414,60 +6736,6 @@ mod tests {
             "cancelled turn should carry the cancellation error: {}",
             err.error
         );
-
-        let events = capturing.events.lock();
-        assert_eq!(
-            events
-                .iter()
-                .filter(|e| matches!(e, ObserverEvent::LlmRequest { .. }))
-                .count(),
-            1,
-            "exactly one LlmRequest expected"
-        );
-        assert_eq!(
-            events
-                .iter()
-                .filter(|e| matches!(e, ObserverEvent::LlmResponse { .. }))
-                .count(),
-            1,
-            "exactly one LlmResponse expected"
-        );
-
-        let request = events
-            .iter()
-            .find(|e| matches!(e, ObserverEvent::LlmRequest { .. }))
-            .expect("LlmRequest should have been recorded");
-        let response = events
-            .iter()
-            .find(|e| matches!(e, ObserverEvent::LlmResponse { .. }))
-            .expect("LlmResponse should have been recorded");
-
-        let (
-            ObserverEvent::LlmRequest {
-                model_provider: req_provider,
-                model: req_model,
-                ..
-            },
-            ObserverEvent::LlmResponse {
-                model_provider: resp_provider,
-                model: resp_model,
-                success,
-                error_message,
-                ..
-            },
-        ) = (request, response)
-        else {
-            panic!("matched event variants should be LlmRequest and LlmResponse");
-        };
-
-        assert!(!success, "cancellation LlmResponse must be a failure");
-        assert_eq!(
-            error_message.as_deref(),
-            Some("request cancelled by user"),
-            "cancellation LlmResponse must carry the fixed cancel message"
-        );
-        assert_eq!(req_provider, resp_provider, "provider should match");
-        assert_eq!(req_model, resp_model, "model should match");
     }
 
     // ── Skill tool registration & excluded_tools filtering ──────────

--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -3308,10 +3308,24 @@ impl Agent {
     }
 
     pub async fn run_single(&mut self, message: &str) -> Result<String> {
-        self.turn(message).await
+        use ::zeroclaw_log::Instrument as _;
+
+        let (alias, provider, model) = self.attribution_fields();
+        let span = ::zeroclaw_log::info_span!(
+            target: "zeroclaw_log_internal_scope",
+            "zeroclaw_scope",
+            agent_alias = %alias,
+            model_provider = %provider,
+            model = %model,
+            channel = "cli",
+        );
+
+        self.turn(message).instrument(span).await
     }
 
     pub async fn run_interactive(&mut self) -> Result<()> {
+        use ::zeroclaw_log::Instrument as _;
+
         println!("🦀 ZeroClaw Interactive Mode");
         println!("Type /quit to exit.\n");
 
@@ -3326,7 +3340,17 @@ impl Agent {
         });
 
         while let Some(msg) = rx.recv().await {
-            let response = match self.turn(&msg.content).await {
+            let (alias, provider, model) = self.attribution_fields();
+            let span = ::zeroclaw_log::info_span!(
+                target: "zeroclaw_log_internal_scope",
+                "zeroclaw_scope",
+                agent_alias = %alias,
+                model_provider = %provider,
+                model = %model,
+                channel = "cli",
+            );
+
+            let response = match self.turn(&msg.content).instrument(span).await {
                 Ok(resp) => resp,
                 Err(e) => {
                     eprintln!("\nError: {e}\n");
@@ -3349,8 +3373,6 @@ pub async fn run(
     model_override: Option<String>,
     temperature: Option<f64>,
 ) -> Result<()> {
-    let start = Instant::now();
-
     let mut effective_config = config;
     if let Some(ref p) = provider_override {
         // When a model_provider override is specified, ensure that model_provider type exists
@@ -3377,56 +3399,12 @@ pub async fn run(
 
     let mut agent = Agent::from_config(&effective_config, agent_alias).await?;
 
-    let (provider_name, model_name) =
-        match effective_config.resolved_model_provider_for_agent(agent_alias) {
-            Some((ty, _alias, entry)) => {
-                let model = entry
-                    .model
-                    .as_deref()
-                    .map(str::trim)
-                    .filter(|m| !m.is_empty())
-                    .map(ToString::to_string)
-                    .or_else(|| effective_config.resolve_default_model())
-                    .unwrap_or_else(|| "<unresolved>".to_string());
-                (ty.to_string(), model)
-            }
-            None => (
-                provider_override.unwrap_or_else(|| "unknown".to_string()),
-                effective_config
-                    .resolve_default_model()
-                    .unwrap_or_else(|| "<unresolved>".to_string()),
-            ),
-        };
-
-    ::zeroclaw_log::record!(
-        INFO,
-        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::AgentStart)
-            .with_category(::zeroclaw_log::EventCategory::Agent)
-            .with_attrs(::serde_json::json!({
-                "model_provider": provider_name,
-                "model": model_name,
-            })),
-        "agent_start"
-    );
-
     if let Some(msg) = message {
         let response = agent.run_single(&msg).await?;
         println!("{response}");
     } else {
         agent.run_interactive().await?;
     }
-
-    ::zeroclaw_log::record!(
-        INFO,
-        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::AgentEnd)
-            .with_category(::zeroclaw_log::EventCategory::Agent)
-            .with_duration(u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX))
-            .with_attrs(::serde_json::json!({
-                "model_provider": provider_name,
-                "model": model_name,
-            })),
-        "agent_end"
-    );
 
     Ok(())
 }

--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -3438,7 +3438,6 @@ mod tests {
     use parking_lot::Mutex;
     use std::collections::HashMap;
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use zeroclaw_api::observability_traits::ObserverMetric;
 
     zeroclaw_api::mock_tool_attribution!(
         CountingTool,

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -1652,6 +1652,10 @@ pub async fn run_tool_call_loop(
             model_provider: active_model_provider_name.to_string(),
             model: active_model.to_string(),
             messages_count: history.len(),
+            user_message: None,
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
         {
             let _provider_guard =
@@ -1880,6 +1884,10 @@ pub async fn run_tool_call_loop(
                     error_message: None,
                     input_tokens: resp_input_tokens,
                     output_tokens: resp_output_tokens,
+                    response_content: None,
+                    channel: None,
+                    agent_alias: None,
+                    turn_id: None,
                 });
 
                 // Record cost via task-local tracker (no-op when not scoped)
@@ -2036,6 +2044,10 @@ pub async fn run_tool_call_loop(
                     error_message: Some(safe_error.clone()),
                     input_tokens: None,
                     output_tokens: None,
+                    response_content: None,
+                    channel: None,
+                    agent_alias: None,
+                    turn_id: None,
                 });
                 ::zeroclaw_log::record!(
                     WARN,
@@ -3496,6 +3508,9 @@ pub async fn run(
         observer.record_event(&ObserverEvent::AgentStart {
             model_provider: provider_name.to_string(),
             model: model_name.to_string(),
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
 
         // ── Hardware RAG (datasheet retrieval when peripherals + datasheet_dir) ──
@@ -3963,6 +3978,9 @@ pub async fn run(
                             observer.record_event(&ObserverEvent::AgentStart {
                                 model_provider: provider_name.to_string(),
                                 model: model_name.to_string(),
+                                channel: None,
+                                agent_alias: None,
+                                turn_id: None,
                             });
 
                             continue;
@@ -4370,6 +4388,9 @@ pub async fn run(
                                 observer.record_event(&ObserverEvent::AgentStart {
                                     model_provider: provider_name.to_string(),
                                     model: model_name.to_string(),
+                                    channel: None,
+                                    agent_alias: None,
+                                    turn_id: None,
                                 });
 
                                 continue;
@@ -4514,6 +4535,9 @@ pub async fn run(
             duration,
             tokens_used: None,
             cost_usd: None,
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
 
         Ok(final_output)

--- a/crates/zeroclaw-runtime/src/agent/tool_execution.rs
+++ b/crates/zeroclaw-runtime/src/agent/tool_execution.rs
@@ -58,6 +58,9 @@ pub async fn execute_one_tool(
         tool: call_name.to_string(),
         tool_call_id: tool_call_id_owned.clone(),
         arguments: Some(full_args.clone()),
+        channel: None,
+        agent_alias: None,
+        turn_id: None,
     });
     let start = Instant::now();
 
@@ -78,6 +81,9 @@ pub async fn execute_one_tool(
             success: false,
             arguments: Some(full_args.clone()),
             result: Some(scrubbed_reason.clone()),
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
         return Ok(ToolExecutionOutcome {
             output: reason,
@@ -177,6 +183,9 @@ pub async fn execute_one_tool(
                     success: true,
                     arguments: Some(full_args.clone()),
                     result: Some(output.clone()),
+                    channel: None,
+                    agent_alias: None,
+                    turn_id: None,
                 });
                 Ok(ToolExecutionOutcome {
                     output,
@@ -195,6 +204,9 @@ pub async fn execute_one_tool(
                     success: false,
                     arguments: Some(full_args.clone()),
                     result: Some(scrubbed_reason.clone()),
+                    channel: None,
+                    agent_alias: None,
+                    turn_id: None,
                 });
                 Ok(ToolExecutionOutcome {
                     output: format!("Error: {reason}"),
@@ -230,6 +242,9 @@ pub async fn execute_one_tool(
                 success: false,
                 arguments: Some(full_args.clone()),
                 result: Some(scrubbed_reason.clone()),
+                channel: None,
+                agent_alias: None,
+                turn_id: None,
             });
             Ok(ToolExecutionOutcome {
                 output: reason,

--- a/crates/zeroclaw-runtime/src/observability/content_processing.rs
+++ b/crates/zeroclaw-runtime/src/observability/content_processing.rs
@@ -15,6 +15,9 @@ pub struct ContentProcessor {
 
 impl ContentProcessor {
     pub fn from_observability(config: &ObservabilityConfig) -> Self {
+        warn_unknown_llm_policy(&config.log_llm_io);
+        warn_unknown_tool_policy(&config.log_tool_io);
+
         Self {
             llm_policy: LlmIoPolicy::from_raw(&config.log_llm_io),
             llm_max_chars: config.log_llm_io_max_chars.max(1),
@@ -76,6 +79,36 @@ impl ContentProcessor {
             LlmIoPolicy::Redacted => Some(truncate_content(&redacted, self.llm_max_chars)),
             LlmIoPolicy::Full => Some(redacted),
         }
+    }
+}
+
+fn warn_unknown_llm_policy(raw: &str) {
+    if !matches!(
+        raw.trim().to_ascii_lowercase().as_str(),
+        "off" | "redacted" | "full" | ""
+    ) {
+        ::zeroclaw_log::record!(
+            WARN,
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                .with_attrs(::serde_json::json!({"value": raw, "config_key": "log_llm_io", "default": "off"})),
+            "unknown log_llm_io value, defaulting to off"
+        );
+    }
+}
+
+fn warn_unknown_tool_policy(raw: &str) {
+    if !matches!(
+        raw.trim().to_ascii_lowercase().as_str(),
+        "off" | "redacted" | "full" | ""
+    ) {
+        ::zeroclaw_log::record!(
+            WARN,
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                .with_attrs(::serde_json::json!({"value": raw, "config_key": "log_tool_io", "default": "redacted"})),
+            "unknown log_tool_io value, defaulting to redacted"
+        );
     }
 }
 

--- a/crates/zeroclaw-runtime/src/observability/content_processing.rs
+++ b/crates/zeroclaw-runtime/src/observability/content_processing.rs
@@ -1,0 +1,172 @@
+use crate::security::leak_detector::{LeakDetector, LeakResult};
+use zeroclaw_config::schema::ObservabilityConfig;
+use zeroclaw_log::{LlmIoPolicy, ToolIoPolicy};
+
+const PRE_SANITIZATION_CAP_CHARS: usize = 1_048_576;
+
+#[derive(Debug, Clone)]
+pub struct ContentProcessor {
+    llm_policy: LlmIoPolicy,
+    llm_max_chars: usize,
+    tool_policy: ToolIoPolicy,
+    tool_max_chars: usize,
+    detector: LeakDetector,
+}
+
+impl ContentProcessor {
+    pub fn from_observability(config: &ObservabilityConfig) -> Self {
+        Self {
+            llm_policy: LlmIoPolicy::from_raw(&config.log_llm_io),
+            llm_max_chars: config.log_llm_io_max_chars.max(1),
+            tool_policy: ToolIoPolicy::from_raw(&config.log_tool_io),
+            tool_max_chars: config.log_tool_io_truncate_bytes.max(1),
+            detector: LeakDetector::new(),
+        }
+    }
+
+    pub fn process_user_message(&self, content: &str) -> Option<String> {
+        self.process_llm(content)
+    }
+
+    pub fn process_response_content(&self, content: &str) -> Option<String> {
+        self.process_llm(content)
+    }
+
+    pub fn process_tool_result(&self, content: &str) -> Option<String> {
+        if !self.tool_policy.captures_io() {
+            return None;
+        }
+
+        let trimmed = content.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+
+        let capped = truncate_content(trimmed, PRE_SANITIZATION_CAP_CHARS);
+        let redacted = match self.detector.scan(&capped) {
+            LeakResult::Clean => capped,
+            LeakResult::Detected { redacted, .. } => redacted,
+        };
+
+        match self.tool_policy {
+            ToolIoPolicy::Off => None,
+            ToolIoPolicy::Redacted => Some(truncate_content(&redacted, self.tool_max_chars)),
+            ToolIoPolicy::Full => Some(redacted),
+        }
+    }
+
+    fn process_llm(&self, content: &str) -> Option<String> {
+        if !self.llm_policy.captures_io() {
+            return None;
+        }
+
+        let trimmed = content.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+
+        let capped = truncate_content(trimmed, PRE_SANITIZATION_CAP_CHARS);
+        let redacted = match self.detector.scan(&capped) {
+            LeakResult::Clean => capped,
+            LeakResult::Detected { redacted, .. } => redacted,
+        };
+
+        match self.llm_policy {
+            LlmIoPolicy::Off => None,
+            LlmIoPolicy::Redacted => Some(truncate_content(&redacted, self.llm_max_chars)),
+            LlmIoPolicy::Full => Some(redacted),
+        }
+    }
+}
+
+fn truncate_content(content: &str, max_chars: usize) -> String {
+    if content.chars().count() <= max_chars {
+        return content.to_string();
+    }
+    let truncated: String = content.chars().take(max_chars).collect();
+    let total = content.chars().count();
+    format!("{}...(truncated, total {} chars)", truncated, total)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config(policy: &str, max_chars: usize) -> ObservabilityConfig {
+        ObservabilityConfig {
+            log_llm_io: policy.to_string(),
+            log_llm_io_max_chars: max_chars,
+            ..ObservabilityConfig::default()
+        }
+    }
+
+    #[test]
+    fn off_returns_none() {
+        let processor = ContentProcessor::from_observability(&config("off", 200));
+        assert_eq!(processor.process_user_message("hello"), None);
+        assert_eq!(processor.process_response_content("world"), None);
+    }
+
+    #[test]
+    fn redacted_sanitizes_and_truncates() {
+        let processor = ContentProcessor::from_observability(&config("redacted", 20));
+        let processed = processor
+            .process_user_message("my key is sk-ant-abcdefghijklmnopqrstuvwxyz123456")
+            .expect("content should be captured");
+        assert!(processed.contains("[REDACTED"));
+        assert!(!processed.contains("abcdefghijklmnopqrstuvwxyz123456"));
+        assert!(processed.contains("truncated"));
+    }
+
+    #[test]
+    fn full_sanitizes_without_configured_truncation() {
+        let processor = ContentProcessor::from_observability(&config("full", 5));
+        let processed = processor
+            .process_response_content("normal response text")
+            .expect("content should be captured");
+        assert_eq!(processed, "normal response text");
+    }
+
+    #[test]
+    fn utf8_truncation_is_char_safe() {
+        let processor = ContentProcessor::from_observability(&config("redacted", 3));
+        let processed = processor
+            .process_user_message("你好世界")
+            .expect("content should be captured");
+        assert!(processed.starts_with("你好世"));
+    }
+
+    fn tool_config(tool_policy: &str, tool_max_chars: usize) -> ObservabilityConfig {
+        ObservabilityConfig {
+            log_tool_io: tool_policy.to_string(),
+            log_tool_io_truncate_bytes: tool_max_chars,
+            ..ObservabilityConfig::default()
+        }
+    }
+
+    #[test]
+    fn tool_off_returns_none() {
+        let processor = ContentProcessor::from_observability(&tool_config("off", 200));
+        assert_eq!(processor.process_tool_result("hello"), None);
+    }
+
+    #[test]
+    fn tool_redacted_sanitizes_and_truncates() {
+        let processor = ContentProcessor::from_observability(&tool_config("redacted", 20));
+        let processed = processor
+            .process_tool_result("my key is sk-ant-abcdefghijklmnopqrstuvwxyz123456")
+            .expect("tool result should be captured");
+        assert!(processed.contains("[REDACTED"));
+        assert!(!processed.contains("abcdefghijklmnopqrstuvwxyz123456"));
+        assert!(processed.contains("truncated"));
+    }
+
+    #[test]
+    fn tool_full_keeps_everything() {
+        let processor = ContentProcessor::from_observability(&tool_config("full", 5));
+        let processed = processor
+            .process_tool_result("normal tool output")
+            .expect("tool result should be captured");
+        assert_eq!(processed, "normal tool output");
+    }
+}

--- a/crates/zeroclaw-runtime/src/observability/log.rs
+++ b/crates/zeroclaw-runtime/src/observability/log.rs
@@ -22,6 +22,7 @@ impl Observer for LogObserver {
             ObserverEvent::AgentStart {
                 model_provider,
                 model,
+                ..
             } => {
                 ::zeroclaw_log::record!(
                     INFO,
@@ -38,6 +39,7 @@ impl Observer for LogObserver {
                 duration,
                 tokens_used,
                 cost_usd,
+                ..
             } => {
                 let ms = u64::try_from(duration.as_millis()).unwrap_or(u64::MAX);
                 ::zeroclaw_log::record!(INFO, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(::serde_json::json!({"model_provider": model_provider, "model": model, "duration_ms": ms, "tokens": tokens_used, "cost_usd": cost_usd})), "agent.end");
@@ -111,6 +113,7 @@ impl Observer for LogObserver {
                 model_provider,
                 model,
                 messages_count,
+                ..
             } => {
                 ::zeroclaw_log::record!(INFO, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(::serde_json::json!({"model_provider": model_provider, "model": model, "messages_count": messages_count})), "llm.request");
             }
@@ -122,6 +125,7 @@ impl Observer for LogObserver {
                 error_message,
                 input_tokens,
                 output_tokens,
+                ..
             } => {
                 let ms = u64::try_from(duration.as_millis()).unwrap_or(u64::MAX);
                 ::zeroclaw_log::record!(INFO, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(::serde_json::json!({"model_provider": model_provider, "model": model, "duration_ms": ms, "success": success, "error": error_message, "input_tokens": input_tokens, "output_tokens": output_tokens})), "llm.response");
@@ -230,6 +234,7 @@ impl Observer for LogObserver {
 mod tests {
     use super::*;
     use std::time::Duration;
+    use zeroclaw_api::observability_traits::TurnTokenUsage;
 
     #[test]
     fn log_observer_name() {
@@ -242,13 +247,22 @@ mod tests {
         obs.record_event(&ObserverEvent::AgentStart {
             model_provider: "openrouter".into(),
             model: "claude-sonnet".into(),
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
         obs.record_event(&ObserverEvent::AgentEnd {
             model_provider: "openrouter".into(),
             model: "claude-sonnet".into(),
             duration: Duration::from_millis(500),
-            tokens_used: Some(100),
+            tokens_used: Some(TurnTokenUsage {
+                input_tokens: 60,
+                output_tokens: 40,
+            }),
             cost_usd: Some(0.0015),
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
         obs.record_event(&ObserverEvent::AgentEnd {
             model_provider: "openrouter".into(),
@@ -256,6 +270,9 @@ mod tests {
             duration: Duration::ZERO,
             tokens_used: None,
             cost_usd: None,
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
         obs.record_event(&ObserverEvent::LlmResponse {
             model_provider: "openrouter".into(),
@@ -265,6 +282,10 @@ mod tests {
             error_message: None,
             input_tokens: Some(100),
             output_tokens: Some(50),
+            response_content: None,
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
         obs.record_event(&ObserverEvent::LlmResponse {
             model_provider: "openrouter".into(),
@@ -274,6 +295,10 @@ mod tests {
             error_message: Some("rate limited".into()),
             input_tokens: None,
             output_tokens: None,
+            response_content: None,
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
         obs.record_event(&ObserverEvent::ToolCall {
             tool: "shell".into(),
@@ -282,6 +307,9 @@ mod tests {
             success: false,
             arguments: None,
             result: None,
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
         obs.record_event(&ObserverEvent::ChannelMessage {
             channel: "telegram".into(),

--- a/crates/zeroclaw-runtime/src/observability/mod.rs
+++ b/crates/zeroclaw-runtime/src/observability/mod.rs
@@ -1,3 +1,4 @@
+pub mod content_processing;
 pub mod dora;
 pub mod log;
 pub mod multi;

--- a/crates/zeroclaw-runtime/src/observability/noop.rs
+++ b/crates/zeroclaw-runtime/src/observability/noop.rs
@@ -24,6 +24,7 @@ impl Observer for NoopObserver {
 mod tests {
     use super::*;
     use std::time::Duration;
+    use zeroclaw_api::observability_traits::TurnTokenUsage;
 
     #[test]
     fn noop_name() {
@@ -37,13 +38,22 @@ mod tests {
         obs.record_event(&ObserverEvent::AgentStart {
             model_provider: "test".into(),
             model: "test".into(),
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
         obs.record_event(&ObserverEvent::AgentEnd {
             model_provider: "test".into(),
             model: "test".into(),
             duration: Duration::from_millis(100),
-            tokens_used: Some(42),
+            tokens_used: Some(TurnTokenUsage {
+                input_tokens: 30,
+                output_tokens: 12,
+            }),
             cost_usd: Some(0.001),
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
         obs.record_event(&ObserverEvent::AgentEnd {
             model_provider: "test".into(),
@@ -51,6 +61,9 @@ mod tests {
             duration: Duration::ZERO,
             tokens_used: None,
             cost_usd: None,
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
         obs.record_event(&ObserverEvent::ToolCall {
             tool: "shell".into(),
@@ -59,6 +72,9 @@ mod tests {
             success: true,
             arguments: None,
             result: None,
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
         obs.record_event(&ObserverEvent::ChannelMessage {
             channel: "cli".into(),

--- a/crates/zeroclaw-runtime/src/observability/otel.rs
+++ b/crates/zeroclaw-runtime/src/observability/otel.rs
@@ -199,15 +199,14 @@ impl OtelObserver {
     /// carrying that span as the remote parent. Otherwise returns the ambient
     /// context (no explicit parent → isolated span).
     fn parent_cx_for(&self, turn_id: Option<&str>) -> Context {
-        if let Some(tid) = turn_id {
-            if let Some((_, cx)) = self
+        if let Some(tid) = turn_id
+            && let Some((_, cx)) = self
                 .active_agent_spans
                 .lock()
                 .unwrap_or_else(|e| e.into_inner())
                 .get(tid)
-            {
-                return cx.clone();
-            }
+        {
+            return cx.clone();
         }
         Context::current()
     }
@@ -637,6 +636,7 @@ impl Observer for OtelObserver {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::observability::traits::TurnTokenUsage;
     use std::time::Duration;
 
     // Note: OtelObserver::new() requires an OTLP endpoint.

--- a/crates/zeroclaw-runtime/src/observability/otel.rs
+++ b/crates/zeroclaw-runtime/src/observability/otel.rs
@@ -1,18 +1,25 @@
 use super::traits::{Observer, ObserverEvent, ObserverMetric};
 use opentelemetry::metrics::{Counter, Gauge, Histogram};
-use opentelemetry::trace::{Span, SpanKind, Status, Tracer};
-use opentelemetry::{KeyValue, global};
+use opentelemetry::trace::{Span, SpanKind, Status, TraceContextExt as _, Tracer};
+use opentelemetry::{Context, KeyValue, global};
 use opentelemetry_otlp::{WithExportConfig, WithHttpConfig};
 use opentelemetry_sdk::metrics::SdkMeterProvider;
 use opentelemetry_sdk::trace::SdkTracerProvider;
 use std::any::Any;
 use std::collections::HashMap;
-use std::time::SystemTime;
+use std::sync::Mutex;
 
 /// OpenTelemetry-backed observer — exports traces and metrics via OTLP.
 pub struct OtelObserver {
     tracer_provider: SdkTracerProvider,
     meter_provider: SdkMeterProvider,
+
+    /// Live agent spans keyed by turn_id. Opened on AgentStart, closed on AgentEnd.
+    active_agent_spans: Mutex<HashMap<String, (global::BoxedSpan, Context)>>,
+    /// First user_message per turn, cached from LlmRequest and written to the agent span on AgentEnd.
+    active_agent_inputs: Mutex<HashMap<String, String>>,
+    /// Latest response_content per turn, cached from LlmResponse and written to the agent span on AgentEnd.
+    active_agent_outputs: Mutex<HashMap<String, String>>,
 
     // Metrics instruments
     agent_starts: Counter<u64>,
@@ -168,6 +175,9 @@ impl OtelObserver {
         Ok(Self {
             tracer_provider,
             meter_provider: meter_provider_clone,
+            active_agent_spans: Mutex::new(HashMap::new()),
+            active_agent_inputs: Mutex::new(HashMap::new()),
+            active_agent_outputs: Mutex::new(HashMap::new()),
             agent_starts,
             agent_duration,
             llm_calls,
@@ -183,6 +193,24 @@ impl OtelObserver {
             queue_depth,
         })
     }
+
+    /// Returns the parent `Context` for a child span.
+    /// If `turn_id` is Some and a live agent span exists, returns a context
+    /// carrying that span as the remote parent. Otherwise returns the ambient
+    /// context (no explicit parent → isolated span).
+    fn parent_cx_for(&self, turn_id: Option<&str>) -> Context {
+        if let Some(tid) = turn_id {
+            if let Some((_, cx)) = self
+                .active_agent_spans
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .get(tid)
+            {
+                return cx.clone();
+            }
+        }
+        Context::current()
+    }
 }
 
 impl Observer for OtelObserver {
@@ -193,18 +221,115 @@ impl Observer for OtelObserver {
             ObserverEvent::AgentStart {
                 model_provider,
                 model,
+                channel,
+                agent_alias,
+                turn_id,
             } => {
                 self.agent_starts.add(
                     1,
                     &[
-                        KeyValue::new("model_provider", model_provider.clone()),
-                        KeyValue::new("model", model.clone()),
+                        KeyValue::new("gen_ai.provider.name", model_provider.clone()),
+                        KeyValue::new("gen_ai.request.model", model.clone()),
                     ],
                 );
+
+                let span = tracer.build(
+                    opentelemetry::trace::SpanBuilder::from_name("gen_ai.agent.invoke")
+                        .with_kind(SpanKind::Internal)
+                        .with_attributes(vec![
+                            KeyValue::new("gen_ai.provider.name", model_provider.clone()),
+                            KeyValue::new("gen_ai.request.model", model.clone()),
+                            KeyValue::new("zeroclaw.channel", channel.clone().unwrap_or_default()),
+                            KeyValue::new(
+                                "gen_ai.agent.name",
+                                agent_alias.clone().unwrap_or_default(),
+                            ),
+                            KeyValue::new("zeroclaw.turn_id", turn_id.clone().unwrap_or_default()),
+                        ]),
+                );
+
+                if let Some(tid) = turn_id {
+                    let parent_cx =
+                        Context::current().with_remote_span_context(span.span_context().clone());
+                    self.active_agent_spans
+                        .lock()
+                        .unwrap_or_else(|e| e.into_inner())
+                        .insert(tid.clone(), (span, parent_cx));
+                }
+                // turn_id == None: span dropped here → isolated span, ends via Drop
             }
-            ObserverEvent::LlmRequest { .. }
-            | ObserverEvent::ToolCallStart { .. }
-            | ObserverEvent::TurnComplete
+            ObserverEvent::LlmRequest {
+                model_provider,
+                model,
+                messages_count,
+                user_message,
+                channel,
+                agent_alias,
+                turn_id,
+            } => {
+                let mut span_attrs = vec![
+                    KeyValue::new("gen_ai.provider.name", model_provider.clone()),
+                    KeyValue::new("gen_ai.request.model", model.clone()),
+                    KeyValue::new("gen_ai.operation.name", "llm.request"),
+                    KeyValue::new(
+                        "zeroclaw.messages_count",
+                        i64::try_from(*messages_count).unwrap_or(i64::MAX),
+                    ),
+                    KeyValue::new("zeroclaw.channel", channel.clone().unwrap_or_default()),
+                    KeyValue::new("gen_ai.agent.name", agent_alias.clone().unwrap_or_default()),
+                    KeyValue::new("zeroclaw.turn_id", turn_id.clone().unwrap_or_default()),
+                ];
+                if let Some(msg) = user_message {
+                    span_attrs.push(KeyValue::new("gen_ai.input.messages", msg.clone()));
+                    // Cache as agent-level input (only first LlmRequest per turn = original user message).
+                    if let Some(tid) = turn_id {
+                        self.active_agent_inputs
+                            .lock()
+                            .unwrap_or_else(|e| e.into_inner())
+                            .entry(tid.clone())
+                            .or_insert_with(|| msg.clone());
+                    }
+                }
+                let parent_cx = self.parent_cx_for(turn_id.as_deref());
+                let mut span = tracer.build_with_context(
+                    opentelemetry::trace::SpanBuilder::from_name("llm.request")
+                        .with_kind(SpanKind::Client)
+                        .with_attributes(span_attrs),
+                    &parent_cx,
+                );
+                span.end();
+            }
+            ObserverEvent::ToolCallStart {
+                tool,
+                tool_call_id,
+                arguments,
+                channel,
+                agent_alias,
+                turn_id,
+            } => {
+                let mut span_attrs = vec![
+                    KeyValue::new("gen_ai.operation.name", "execute_tool"),
+                    KeyValue::new("tool.name", tool.clone()),
+                    KeyValue::new("zeroclaw.channel", channel.clone().unwrap_or_default()),
+                    KeyValue::new("gen_ai.agent.name", agent_alias.clone().unwrap_or_default()),
+                    KeyValue::new("zeroclaw.turn_id", turn_id.clone().unwrap_or_default()),
+                ];
+                if let Some(id) = tool_call_id {
+                    span_attrs.push(KeyValue::new("gen_ai.tool.call.id", id.clone()));
+                }
+                if let Some(args) = arguments {
+                    span_attrs.push(KeyValue::new("gen_ai.tool.arguments", args.clone()));
+                }
+                let parent_cx = self.parent_cx_for(turn_id.as_deref());
+                let mut span = tracer.build_with_context(
+                    opentelemetry::trace::SpanBuilder::from_name("tool_call.start")
+                        .with_kind(SpanKind::Client)
+                        .with_attributes(span_attrs),
+                    &parent_cx,
+                );
+                span.end();
+            }
+            ObserverEvent::TurnComplete
             | ObserverEvent::CacheHit { .. }
             | ObserverEvent::CacheMiss { .. } => {}
             ObserverEvent::LlmResponse {
@@ -212,33 +337,66 @@ impl Observer for OtelObserver {
                 model,
                 duration,
                 success,
-                error_message: _,
-                input_tokens: _,
-                output_tokens: _,
+                error_message,
+                input_tokens,
+                output_tokens,
+                response_content,
+                channel,
+                agent_alias,
+                turn_id,
             } => {
                 let secs = duration.as_secs_f64();
                 let attrs = [
-                    KeyValue::new("model_provider", model_provider.clone()),
-                    KeyValue::new("model", model.clone()),
-                    KeyValue::new("success", success.to_string()),
+                    KeyValue::new("gen_ai.provider.name", model_provider.clone()),
+                    KeyValue::new("gen_ai.request.model", model.clone()),
+                    KeyValue::new("gen_ai.response.model", model.clone()),
+                    KeyValue::new("gen_ai.operation.name", "llm.response"),
+                    KeyValue::new("success", *success),
+                    KeyValue::new("duration_s", secs),
+                    KeyValue::new("zeroclaw.channel", channel.clone().unwrap_or_default()),
+                    KeyValue::new("gen_ai.agent.name", agent_alias.clone().unwrap_or_default()),
+                    KeyValue::new("zeroclaw.turn_id", turn_id.clone().unwrap_or_default()),
                 ];
                 self.llm_calls.add(1, &attrs);
                 self.llm_duration.record(secs, &attrs);
 
-                // Create a completed span for visibility in trace backends.
-                let start_time = SystemTime::now()
-                    .checked_sub(*duration)
-                    .unwrap_or(SystemTime::now());
-                let mut span = tracer.build(
-                    opentelemetry::trace::SpanBuilder::from_name("llm.call")
-                        .with_kind(SpanKind::Internal)
-                        .with_start_time(start_time)
-                        .with_attributes(vec![
-                            KeyValue::new("model_provider", model_provider.clone()),
-                            KeyValue::new("model", model.clone()),
-                            KeyValue::new("success", *success),
-                            KeyValue::new("duration_s", secs),
-                        ]),
+                let mut span_attrs = vec![
+                    KeyValue::new("gen_ai.provider.name", model_provider.clone()),
+                    KeyValue::new("gen_ai.request.model", model.clone()),
+                    KeyValue::new("gen_ai.response.model", model.clone()),
+                    KeyValue::new("gen_ai.operation.name", "llm.response"),
+                    KeyValue::new("success", *success),
+                    KeyValue::new("duration_s", secs),
+                    KeyValue::new("zeroclaw.channel", channel.clone().unwrap_or_default()),
+                    KeyValue::new("gen_ai.agent.name", agent_alias.clone().unwrap_or_default()),
+                    KeyValue::new("zeroclaw.turn_id", turn_id.clone().unwrap_or_default()),
+                ];
+                if let Some(input) = input_tokens {
+                    span_attrs.push(KeyValue::new("gen_ai.usage.input_tokens", *input as i64));
+                }
+                if let Some(output) = output_tokens {
+                    span_attrs.push(KeyValue::new("gen_ai.usage.output_tokens", *output as i64));
+                }
+                if let Some(content) = response_content {
+                    span_attrs.push(KeyValue::new("gen_ai.output.messages", content.clone()));
+                    // Cache as agent-level output (overwrite each iteration; last one = final response).
+                    if let Some(tid) = turn_id {
+                        self.active_agent_outputs
+                            .lock()
+                            .unwrap_or_else(|e| e.into_inner())
+                            .insert(tid.clone(), content.clone());
+                    }
+                }
+                if let Some(err) = error_message {
+                    span_attrs.push(KeyValue::new("error.type", err.clone()));
+                }
+
+                let parent_cx = self.parent_cx_for(turn_id.as_deref());
+                let mut span = tracer.build_with_context(
+                    opentelemetry::trace::SpanBuilder::from_name("llm.response")
+                        .with_kind(SpanKind::Client)
+                        .with_attributes(span_attrs),
+                    &parent_cx,
                 );
                 if *success {
                     span.set_status(Status::Ok);
@@ -253,40 +411,65 @@ impl Observer for OtelObserver {
                 duration,
                 tokens_used,
                 cost_usd,
+                channel: _,
+                agent_alias: _,
+                turn_id,
             } => {
                 let secs = duration.as_secs_f64();
-                let start_time = SystemTime::now()
-                    .checked_sub(*duration)
-                    .unwrap_or(SystemTime::now());
 
-                // Create a completed span with correct timing
-                let mut span = tracer.build(
-                    opentelemetry::trace::SpanBuilder::from_name("agent.invocation")
-                        .with_kind(SpanKind::Internal)
-                        .with_start_time(start_time)
-                        .with_attributes(vec![
-                            KeyValue::new("model_provider", model_provider.clone()),
-                            KeyValue::new("model", model.clone()),
-                            KeyValue::new("duration_s", secs),
-                        ]),
-                );
-                if let Some(t) = tokens_used {
-                    span.set_attribute(KeyValue::new("tokens_used", *t as i64));
+                // Close the live agent span that was opened on AgentStart.
+                // Only set end-specific attributes — identification fields
+                // (model, provider, channel, agent_alias, turn_id) were
+                // already written at AgentStart and must not be overwritten.
+                if let Some(tid) = turn_id {
+                    let entry = self
+                        .active_agent_spans
+                        .lock()
+                        .unwrap_or_else(|e| e.into_inner())
+                        .remove(tid);
+                    if let Some((mut span, _)) = entry {
+                        span.set_attribute(KeyValue::new("duration_s", secs));
+                        if let Some(usage) = tokens_used {
+                            span.set_attribute(KeyValue::new(
+                                "gen_ai.usage.input_tokens",
+                                usage.input_tokens as i64,
+                            ));
+                            span.set_attribute(KeyValue::new(
+                                "gen_ai.usage.output_tokens",
+                                usage.output_tokens as i64,
+                            ));
+                        }
+                        if let Some(c) = cost_usd {
+                            span.set_attribute(KeyValue::new("cost_usd", *c));
+                        }
+                        if let Some(input) = self
+                            .active_agent_inputs
+                            .lock()
+                            .unwrap_or_else(|e| e.into_inner())
+                            .remove(tid)
+                        {
+                            span.set_attribute(KeyValue::new("gen_ai.input.messages", input));
+                        }
+                        if let Some(output) = self
+                            .active_agent_outputs
+                            .lock()
+                            .unwrap_or_else(|e| e.into_inner())
+                            .remove(tid)
+                        {
+                            span.set_attribute(KeyValue::new("gen_ai.output.messages", output));
+                        }
+                        span.end();
+                    }
                 }
-                if let Some(c) = cost_usd {
-                    span.set_attribute(KeyValue::new("cost_usd", *c));
-                }
-                span.end();
+                // turn_id == None: no stored span to close, fall through silently.
 
                 self.agent_duration.record(
                     secs,
                     &[
-                        KeyValue::new("model_provider", model_provider.clone()),
-                        KeyValue::new("model", model.clone()),
+                        KeyValue::new("gen_ai.provider.name", model_provider.clone()),
+                        KeyValue::new("gen_ai.request.model", model.clone()),
                     ],
                 );
-                // Note: tokens are recorded via record_metric(TokensUsed) to avoid
-                // double-counting. AgentEnd only records duration.
             }
             ObserverEvent::ToolCall {
                 tool,
@@ -295,11 +478,11 @@ impl Observer for OtelObserver {
                 success,
                 arguments,
                 result,
+                channel,
+                agent_alias,
+                turn_id,
             } => {
                 let secs = duration.as_secs_f64();
-                let start_time = SystemTime::now()
-                    .checked_sub(*duration)
-                    .unwrap_or(SystemTime::now());
 
                 let status = if *success {
                     Status::Ok
@@ -307,30 +490,18 @@ impl Observer for OtelObserver {
                     Status::error("")
                 };
 
-                // Legacy ZeroClaw-internal attrs are kept so existing
-                // dashboards keep working; OpenTelemetry gen_ai.tool.*
-                // semantic-convention attributes are added so LLM-aware
-                // backends (Langfuse, SigNoz, Phoenix) surface the tool
-                // call as a proper GenAI tool execution with the command
-                // arguments and its result visible in the trace viewer.
                 let mut span_attrs = vec![
-                    // Legacy
-                    KeyValue::new("tool.name", tool.clone()),
-                    KeyValue::new("tool.success", *success),
-                    KeyValue::new("duration_s", secs),
-                    // gen_ai.* semantic conventions
                     KeyValue::new("gen_ai.operation.name", "execute_tool"),
-                    KeyValue::new("gen_ai.tool.name", tool.clone()),
+                    KeyValue::new("tool.name", tool.clone()),
+                    KeyValue::new("zeroclaw.channel", channel.clone().unwrap_or_default()),
+                    KeyValue::new("gen_ai.agent.name", agent_alias.clone().unwrap_or_default()),
+                    KeyValue::new("zeroclaw.turn_id", turn_id.clone().unwrap_or_default()),
                 ];
                 if let Some(id) = tool_call_id {
                     span_attrs.push(KeyValue::new("gen_ai.tool.call.id", id.clone()));
                 }
                 if let Some(args) = arguments {
                     span_attrs.push(KeyValue::new("gen_ai.tool.arguments", args.clone()));
-                    // `input.value` is a Langfuse-specific convention that
-                    // surfaces into the "Input" pane of the trace viewer.
-                    // Emitting both keeps vendor-agnostic backends happy
-                    // while Langfuse users get a proper Input/Output view.
                     span_attrs.push(KeyValue::new("input.value", args.clone()));
                 }
                 if let Some(res) = result {
@@ -338,11 +509,12 @@ impl Observer for OtelObserver {
                     span_attrs.push(KeyValue::new("output.value", res.clone()));
                 }
 
-                let mut span = tracer.build(
-                    opentelemetry::trace::SpanBuilder::from_name("tool.call")
+                let parent_cx = self.parent_cx_for(turn_id.as_deref());
+                let mut span = tracer.build_with_context(
+                    opentelemetry::trace::SpanBuilder::from_name("tool_call.result")
                         .with_kind(SpanKind::Internal)
-                        .with_start_time(start_time)
                         .with_attributes(span_attrs),
+                    &parent_cx,
                 );
                 span.set_status(status);
                 span.end();
@@ -413,6 +585,26 @@ impl Observer for OtelObserver {
     }
 
     fn flush(&self) {
+        // Close any agent spans that were never ended (e.g. aborted turns).
+        let orphans: Vec<(global::BoxedSpan, Context)> = self
+            .active_agent_spans
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .drain()
+            .map(|(_, v)| v)
+            .collect();
+        for (mut span, _) in orphans {
+            span.end();
+        }
+        self.active_agent_inputs
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clear();
+        self.active_agent_outputs
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clear();
+
         if let Err(e) = self.tracer_provider.force_flush() {
             ::zeroclaw_log::record!(
                 WARN,
@@ -472,11 +664,18 @@ mod tests {
         obs.record_event(&ObserverEvent::AgentStart {
             model_provider: "openrouter".into(),
             model: "claude-sonnet".into(),
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
         obs.record_event(&ObserverEvent::LlmRequest {
             model_provider: "openrouter".into(),
             model: "claude-sonnet".into(),
             messages_count: 2,
+            user_message: None,
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
         obs.record_event(&ObserverEvent::LlmResponse {
             model_provider: "openrouter".into(),
@@ -486,13 +685,23 @@ mod tests {
             error_message: None,
             input_tokens: Some(100),
             output_tokens: Some(50),
+            response_content: None,
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
         obs.record_event(&ObserverEvent::AgentEnd {
             model_provider: "openrouter".into(),
             model: "claude-sonnet".into(),
             duration: Duration::from_millis(500),
-            tokens_used: Some(100),
+            tokens_used: Some(TurnTokenUsage {
+                input_tokens: 60,
+                output_tokens: 40,
+            }),
             cost_usd: Some(0.0015),
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
         obs.record_event(&ObserverEvent::AgentEnd {
             model_provider: "openrouter".into(),
@@ -500,11 +709,17 @@ mod tests {
             duration: Duration::ZERO,
             tokens_used: None,
             cost_usd: None,
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
         obs.record_event(&ObserverEvent::ToolCallStart {
             tool: "shell".into(),
             tool_call_id: None,
             arguments: None,
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
         obs.record_event(&ObserverEvent::ToolCall {
             tool: "shell".into(),
@@ -513,6 +728,9 @@ mod tests {
             success: true,
             arguments: None,
             result: None,
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
         obs.record_event(&ObserverEvent::ToolCall {
             tool: "file_read".into(),
@@ -521,6 +739,9 @@ mod tests {
             success: false,
             arguments: None,
             result: None,
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
         obs.record_event(&ObserverEvent::TurnComplete);
         obs.record_event(&ObserverEvent::ChannelMessage {
@@ -565,6 +786,9 @@ mod tests {
             tool: "shell".into(),
             tool_call_id: Some("toolu_01ABC".into()),
             arguments: Some(r#"{"command":"ls -la /tmp"}"#.into()),
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
         obs.record_event(&ObserverEvent::ToolCall {
             tool: "shell".into(),
@@ -573,6 +797,9 @@ mod tests {
             success: true,
             arguments: Some(r#"{"command":"ls -la /tmp"}"#.into()),
             result: Some("total 0\ndrwxr-xr-x  2 root root 40 Apr 22 12:00 .\n".into()),
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
         // Failure case — the issue author specifically wants to see *why*
         // a tool call failed, so the result field is the error text.
@@ -583,6 +810,9 @@ mod tests {
             success: false,
             arguments: Some(r#"{"command":"rm -rf /"}"#.into()),
             result: Some("Error: command denied by allowlist policy".into()),
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
     }
 
@@ -609,6 +839,10 @@ mod tests {
             error_message: Some("404 Not Found".into()),
             input_tokens: None,
             output_tokens: None,
+            response_content: None,
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
     }
 
@@ -666,6 +900,10 @@ mod tests {
             error_message: None,
             input_tokens: Some(10),
             output_tokens: Some(5),
+            response_content: None,
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
         obs.record_event(&ObserverEvent::ToolCall {
             tool: "shell".into(),
@@ -674,6 +912,9 @@ mod tests {
             success: true,
             arguments: None,
             result: None,
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
     }
 

--- a/crates/zeroclaw-runtime/src/observability/prometheus.rs
+++ b/crates/zeroclaw-runtime/src/observability/prometheus.rs
@@ -297,6 +297,7 @@ impl Observer for PrometheusObserver {
             ObserverEvent::AgentStart {
                 model_provider,
                 model,
+                ..
             } => {
                 self.agent_starts
                     .with_label_values(&[model_provider, model])
@@ -308,13 +309,16 @@ impl Observer for PrometheusObserver {
                 duration,
                 tokens_used,
                 cost_usd: _,
+                ..
             } => {
                 // Agent duration is recorded via the histogram with model_provider/model labels
                 self.agent_duration
                     .with_label_values(&[model_provider, model])
                     .observe(duration.as_secs_f64());
-                if let Some(t) = tokens_used {
-                    self.tokens_used.set(i64::try_from(*t).unwrap_or(i64::MAX));
+                if let Some(usage) = tokens_used {
+                    let total = usage.input_tokens.saturating_add(usage.output_tokens);
+                    self.tokens_used
+                        .set(i64::try_from(total).unwrap_or(i64::MAX));
                 }
             }
             ObserverEvent::LlmResponse {
@@ -457,6 +461,7 @@ impl Observer for PrometheusObserver {
 mod tests {
     use super::*;
     use std::time::Duration;
+    use zeroclaw_api::observability_traits::TurnTokenUsage;
 
     #[test]
     fn prometheus_observer_name() {
@@ -469,13 +474,22 @@ mod tests {
         obs.record_event(&ObserverEvent::AgentStart {
             model_provider: "openrouter".into(),
             model: "claude-sonnet".into(),
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
         obs.record_event(&ObserverEvent::AgentEnd {
             model_provider: "openrouter".into(),
             model: "claude-sonnet".into(),
             duration: Duration::from_millis(500),
-            tokens_used: Some(100),
+            tokens_used: Some(TurnTokenUsage {
+                input_tokens: 60,
+                output_tokens: 40,
+            }),
             cost_usd: None,
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
         obs.record_event(&ObserverEvent::AgentEnd {
             model_provider: "openrouter".into(),
@@ -483,6 +497,9 @@ mod tests {
             duration: Duration::ZERO,
             tokens_used: None,
             cost_usd: None,
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
         obs.record_event(&ObserverEvent::ToolCall {
             tool: "shell".into(),
@@ -491,6 +508,9 @@ mod tests {
             success: true,
             arguments: None,
             result: None,
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
         obs.record_event(&ObserverEvent::ToolCall {
             tool: "file_read".into(),
@@ -499,6 +519,9 @@ mod tests {
             success: false,
             arguments: None,
             result: None,
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
         obs.record_event(&ObserverEvent::ChannelMessage {
             channel: "telegram".into(),
@@ -527,6 +550,9 @@ mod tests {
         obs.record_event(&ObserverEvent::AgentStart {
             model_provider: "openrouter".into(),
             model: "claude-sonnet".into(),
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
         obs.record_event(&ObserverEvent::ToolCall {
             tool: "shell".into(),
@@ -535,6 +561,9 @@ mod tests {
             success: true,
             arguments: None,
             result: None,
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
         obs.record_event(&ObserverEvent::HeartbeatTick);
         obs.record_metric(&ObserverMetric::RequestLatency(Duration::from_millis(250)));
@@ -569,6 +598,9 @@ mod tests {
             success: true,
             arguments: None,
             result: None,
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
         obs.record_event(&ObserverEvent::ToolCall {
             tool: "shell".into(),
@@ -577,6 +609,9 @@ mod tests {
             success: true,
             arguments: None,
             result: None,
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
         obs.record_event(&ObserverEvent::ToolCall {
             tool: "shell".into(),
@@ -585,6 +620,9 @@ mod tests {
             success: false,
             arguments: None,
             result: None,
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
 
         let output = obs.encode();
@@ -635,6 +673,10 @@ mod tests {
             error_message: None,
             input_tokens: Some(100),
             output_tokens: Some(50),
+            response_content: None,
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
         obs.record_event(&ObserverEvent::LlmResponse {
             model_provider: "openrouter".into(),
@@ -644,6 +686,10 @@ mod tests {
             error_message: None,
             input_tokens: Some(200),
             output_tokens: Some(80),
+            response_content: None,
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
 
         let output = obs.encode();
@@ -670,6 +716,10 @@ mod tests {
             error_message: Some("timeout".into()),
             input_tokens: None,
             output_tokens: None,
+            response_content: None,
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
 
         let output = obs.encode();

--- a/crates/zeroclaw-runtime/src/observability/runtime_trace.rs
+++ b/crates/zeroclaw-runtime/src/observability/runtime_trace.rs
@@ -20,6 +20,8 @@ fn to_log_config(config: &zeroclaw_config::schema::ObservabilityConfig) -> zeroc
         log_tool_io: config.log_tool_io.clone(),
         log_tool_io_truncate_bytes: config.log_tool_io_truncate_bytes,
         log_tool_io_denylist: config.log_tool_io_denylist.clone(),
+        log_llm_io: config.log_llm_io.clone(),
+        log_llm_io_max_chars: config.log_llm_io_max_chars,
     }
 }
 

--- a/crates/zeroclaw-runtime/src/observability/traits.rs
+++ b/crates/zeroclaw-runtime/src/observability/traits.rs
@@ -68,6 +68,9 @@ mod tests {
             success: true,
             arguments: None,
             result: None,
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         };
         let metric = ObserverMetric::RequestLatency(Duration::from_millis(8));
 

--- a/crates/zeroclaw-runtime/src/observability/verbose.rs
+++ b/crates/zeroclaw-runtime/src/observability/verbose.rs
@@ -26,6 +26,7 @@ impl Observer for VerboseObserver {
                 model_provider,
                 model,
                 messages_count,
+                ..
             } => {
                 eprintln!("> Thinking");
                 eprintln!(
@@ -87,6 +88,10 @@ mod tests {
             model_provider: "openrouter".into(),
             model: "claude".into(),
             messages_count: 3,
+            user_message: None,
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
         obs.record_event(&ObserverEvent::LlmResponse {
             model_provider: "openrouter".into(),
@@ -96,11 +101,18 @@ mod tests {
             error_message: None,
             input_tokens: Some(50),
             output_tokens: Some(25),
+            response_content: None,
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
         obs.record_event(&ObserverEvent::ToolCallStart {
             tool: "shell".into(),
             tool_call_id: None,
             arguments: None,
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
         obs.record_event(&ObserverEvent::ToolCall {
             tool: "shell".into(),
@@ -109,6 +121,9 @@ mod tests {
             success: true,
             arguments: None,
             result: None,
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
         });
         obs.record_event(&ObserverEvent::TurnComplete);
     }

--- a/docs/book/src/ops/observability.md
+++ b/docs/book/src/ops/observability.md
@@ -35,6 +35,13 @@ log_tool_io_truncate_bytes = 8192
 # regardless of `log_tool_io`. For tools whose I/O is intrinsically sensitive.
 log_tool_io_denylist = []
 
+# LLM input/output capture policy.
+# "off"      — only model_provider/model/messages_count; no text content.
+# "redacted" — text is leak-scanned and truncated at `log_llm_io_max_chars`.
+# "full"     — text is leak-scanned; no truncation.
+log_llm_io = "off"
+log_llm_io_max_chars = 10000
+
 # OTel / Prometheus backend (independent of the JSONL log).
 backend = "none"            # "none" | "log" | "verbose" | "prometheus" | "otel"
 otel_endpoint = "http://localhost:4318"


### PR DESCRIPTION
RFC: https://github.com/zeroclaw-labs/zeroclaw/issues/7232

## Summary

- **What changed and why:** ZeroClaw's observability surface had three gaps — sparse event context (no channel/agent attribution, no LLM I/O, no structured token breakdown), flat uncorrelated OTel spans (one independent span per event, no parent-child linking), and inconsistent emission architecture (two divergent paths with partial bridge coverage). This PR addresses all three in a coordinated change.

- **Scope boundary:** This PR does **not** migrate `loop_.rs` and `tool_execution.rs` to the `record!` emission path — they continue to emit `ObserverEvent` directly with `turn_id: None`. That migration is planned for a follow-up PR.

- **Blast radius:** Enriched event context gives every downstream observer channel attribution, agent identity, and turn correlation — making dashboards, alerts, and debugging significantly more actionable. OTel backends now receive correlated traces per turn instead of orphaned spans, enabling proper latency analysis and span navigation. The agent runtime's direct `observer.record_event()` calls in `agent.rs` are migrated to the `record!` macro path, making `observer_bridge` the single authoritative projection from log events to typed observer events. The `ObserverEvent` schema expands with `Option<_>` fields, preserving backward compatibility — downstream observers using `..` in match arms require no changes.

## Changes

### Part 1: Enriched ObserverEvent Schema

Six core event variants gain three common attribution fields plus variant-specific content fields:

- `channel: Option<String>`, `agent_alias: Option<String>`, `turn_id: Option<String>` added to `AgentStart`, `LlmRequest`, `LlmResponse`, `AgentEnd`, `ToolCallStart`, `ToolCall`
- `TurnTokenUsage { input_tokens, output_tokens }` replaces the flat `tokens_used: Option<u64>` in `AgentEnd`, plus `cost_usd: Option<f64>`
- `LlmRequest` gains `user_message: Option<String>`
- `LlmResponse` gains `response_content: Option<String>`
- `ToolCallStart` gains `tool_call_id`, `arguments: Option<String>`
- `ToolCall` gains `tool_call_id`, `arguments`, `result: Option<String>`

### Part 2: Content Policy Enforcement

A new `ContentProcessor` module governs what content enters observability events:

- Two independent policies: `LlmIoPolicy` (Off / Redacted / Full) and `ToolIoPolicy` (Off / Redacted / Full)
- `LeakDetector::scan()` runs on all captured content before emission
- `Redacted` mode: leak-scan + truncate to configurable char limit
- `Full` mode: leak-scan but no truncation
- Default is `Off` — no LLM I/O captured unless operator explicitly opts in

New config keys:
```toml
[observability]
log_llm_io = "off"             # "off" | "redacted" | "full"
log_llm_io_max_chars = 200     # truncation limit for redacted mode
```

### Part 3: OTel Trace Correlation via turn_id

The `OtelObserver` is rewritten to produce a single trace per agent turn:

- `AgentStart` opens a parent span (`gen_ai.agent.invoke`), stored in `active_agent_spans` keyed by `turn_id`
- `LlmRequest`, `LlmResponse`, `ToolCallStart`, `ToolCall` create child spans under the parent via `parent_cx_for(turn_id)`
- `AgentEnd` closes the parent span with cached I/O, token usage, cost, and duration
- All span attributes follow OpenTelemetry Gen-AI semantic conventions (`gen_ai.provider.name`, `gen_ai.usage.input_tokens`, etc.)
- When `turn_id` is absent, spans degrade gracefully to orphans (backward compatible)
- `flush()` cleans up orphaned spans from unclosed turns

### Part 4: Observer Bridge Refactoring

`observer_bridge::project()` expanded to a complete projection layer:

- Now handles all six agent event types (previously a subset)
- Extracts `channel`, `agent_alias`, `turn_id` from `LogEvent` span attribution and attributes
- Projects `ToolCallStart` and `LlmRequest` variants from log events to typed `ObserverEvent`
- All existing variants now forward attribution fields

### Part 5: Agent Runtime Overhaul

The largest change in this PR — `agent.rs` is refactored to integrate the new observability surface:

- Added `agent_alias` field to `Agent` struct and `AgentBuilder`; builder method `agent_alias()` sets it, `from_config_*` reads it from config
- New `turn_id()` helper generates a UUID per turn, serving as the OTel correlation key
- Observer is now created via `observability::create_observer()` and installed into the observer bridge via `zeroclaw_log::set_observer_bridge()`
- `AgentStart` and `AgentEnd` are now recorded on all exit paths in turn methods, wrapped by `attribution_span!` to ensure agent alias propagates through the span tree

### Part 6: Gateway Channel Attribution

- WebSocket sessions inject a `tracing::info_span!` with `agent_alias`, `model_provider`, `model`, `channel = "wss"` and wrap the turn in `.instrument(span)`
- `agent_alias` is now a required query parameter on the WS endpoint
- SSE broadcast observer handles `ToolCallStart` variant and expanded `AgentEnd` (with `TurnTokenUsage` + `cost_usd`)

### Observer Implementations Updated

- `PrometheusObserver`: token gauge computed from `TurnTokenUsage { input_tokens + output_tokens }`
- `LogObserver`: all match arms updated with new attribution fields (`channel`, `agent_alias`, `turn_id`)
- `VerboseObserver`: match arms updated to accept new fields with `..`
- `NoopObserver`: match arms updated to accept expanded variants

## Validation Evidence

```bash
$ cargo fmt --all -- --check
# (no output — clean)

$ cargo clippy --locked --all-targets -- -D clippy::correctness
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 4m 35s
# (no errors)

$ cargo test --locked --verbose
test result: ok. 159 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 0 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out
```

- **Beyond CI:** Verified end-to-end by starting `zeroclaw daemon`, chatting via http://127.0.0.1:42617/agents, and confirming enriched trace data (turn correlation, token breakdown, channel attribution) appears on the configured Langfuse backend. The trace structure and `llm.response` example shown in Langfuse are as follows:
<img width="384" height="278" alt="image" src="https://github.com/user-attachments/assets/57eb9510-0438-4b71-8fc8-2f159d344fc6" />
<img width="540" height="525" alt="image" src="https://github.com/user-attachments/assets/bcdba69e-2948-471c-8c09-34d24b906f45" />

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No** — OTel endpoint is existing config; no new outbound calls
- Secrets / tokens / credentials handling changed? **No** — `otel_headers` marked `#[secret]` for encryption at rest; `ContentProcessor` with `LeakDetector::scan()` redacts detected secrets before capture
- PII or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility

- Backward compatible? **Yes** — all new `ObserverEvent` fields are `Option<_>` with `None` defaults; new config keys have safe defaults (`log_llm_io = "off"`)
- Config / env / CLI surface changed? **Yes** — new keys in `[observability]` section (`log_llm_io`, `log_llm_io_max_chars`). All optional with safe defaults. No upgrade steps required — existing configs work unchanged.

## Rollback

**risk: high**

```bash
git revert 3dc516f6edec5e2ec6ccd759c9d801511d1518a3 c677d366d408d0f934c2a778ab903245fced6364
```
