### PR TITLE
fix(web): make ReloadBanner dismissable

### DIFF
--- a/web/src/components/layout/ReloadBanner.tsx
+++ b/web/src/components/layout/ReloadBanner.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
-import { AlertTriangle } from 'lucide-react';
+import { AlertTriangle, X } from 'lucide-react';
 import { getDrift, getReloadStatus, type DriftEntry } from '@/lib/api';
 import ReloadDaemonButton from '@/components/sections/ReloadDaemonButton';
 
@@ -26,6 +26,10 @@ interface BannerState {
 export default function ReloadBanner() {
   const [state, setState] = useState<BannerState | null>(null);
   const [pollKey, setPollKey] = useState(0);
+  // Signature of the banner content the user last dismissed. The banner
+  // re-appears when the underlying signal changes (new drift paths, or
+  // pending flips back on) because the recomputed signature won't match.
+  const [dismissedSig, setDismissedSig] = useState<string | null>(null);
   const location = useLocation();
 
   useEffect(() => {
@@ -83,6 +87,16 @@ export default function ReloadBanner() {
     );
   }
 
+  // Content signature for the warning banner. Dismissal is keyed to this so
+  // a fresh change (different pending/drift state) surfaces the banner again.
+  const sig = `${pendingReload ? 1 : 0}|${drifted
+    .map((d) => d.path)
+    .sort()
+    .join(',')}`;
+  if (dismissedSig === sig) {
+    return null;
+  }
+
   return (
     <div
       className="px-4 py-3 border-b flex items-center gap-3"
@@ -131,6 +145,16 @@ export default function ReloadBanner() {
         )}
       </div>
       <ReloadDaemonButton onReloaded={() => setPollKey((k) => k + 1)} />
+      <button
+        type="button"
+        onClick={() => setDismissedSig(sig)}
+        aria-label="Dismiss"
+        title="Dismiss"
+        className="flex-shrink-0 p-1 rounded transition-colors hover:opacity-80"
+        style={{ color: 'var(--pc-text-muted)' }}
+      >
+        <X className="h-4 w-4" />
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Restructured after #7220 landed: the `gateway.paired_tokens` drift fix and the related kebab→snake `mark_dirty` alignment are superseded by #7220 (thanks @NiuBlibing) and have been dropped from this branch.
  - What remains is exactly one commit: a dismiss (X) button on the config reload/drift warning banner. Operators previously could not clear the banner even when the drift was expected.
  - Dismissal is keyed to a content signature (pending-reload flag + sorted drift paths), so the banner re-surfaces whenever the underlying state changes — it is never permanently hidden.
- **Scope boundary:** Web UI only (`web/src/components/layout/ReloadBanner.tsx`). No Rust changes; no scheduler/config alias cleanup (dropped per review guidance — `resolve_dirty_segments`' kebab→snake fallback covers those call sites and there is no concrete repro).
- **Blast radius:** The drift/reload banner component only. Dismissal state is per-session React state — no persistence, no API surface.
- **Linked issue(s):** Related #7156 (root cause fixed by #7220; this PR keeps only the UX half). Supersedes nothing.
- **Labels:** (snapshot after applied — expect `web`, `type: fix`, `risk: low`, `size: S`.)

## Validation Evidence (required)

- **Commands run and tail output:**
  ```text
  $ cd web && npm run build        # tsc -b && vite build
  (!) Some chunks are larger than 500 kB after minification. …(pre-existing warning)
  ✓ built in 3.74s
  ```
  Rust battery not run — zero Rust files in the diff (web-only change).
- **Beyond CI — what did you manually verify?** Banner dismisses on X; re-appears when the drift signature changes (different drift paths or pending-reload flips back on) because the recomputed signature no longer matches the dismissed one. NOT verified: cross-browser rendering of the X button.
- **If any command was intentionally skipped, why:** `cargo fmt/clippy/test` skipped — no Rust in the diff.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No** (uses the existing `getDrift`/`getReloadStatus` polls)
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- If any `Yes`, describe the risk and mitigation: n/a

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- If `No` or `Yes` to either: no upgrade steps.

## Rollback (required for `risk: medium` and `risk: high`)

Low risk: `git revert <sha>` — single web component change.
