### PR TITLE
docs(providers): worked-example usage for the 7 new schema-v3 providers

### DIFF
--- a/docs/book/src/providers/catalog.md
+++ b/docs/book/src/providers/catalog.md
@@ -167,6 +167,86 @@ model   = "my-model-id"
 api_key = "..."
 ```
 
+### Worked examples: Morph, GitHub Models, Upstage, Featherless, Arcee, Lambda AI, Inception
+
+Each of these is a standard OpenAI-compatible slot: set `model` and `api_key`, leave
+`uri` off (the typed endpoint supplies it). None of them ship a public model index,
+so the model picker stays empty until you paste a credential — once a key is set,
+ZeroClaw lists models from the provider's live `/models` endpoint. The model IDs
+below are illustrative; confirm the current catalog in the vendor dashboard.
+
+**Morph** — slot `morph`. Fast apply-edits models (`morph-v3-large`, `morph-v3-fast`, or
+`auto`). Key from the [Morph dashboard](https://morphllm.com).
+
+```toml
+[providers.models.morph.apply]
+model   = "morph-v3-large"
+api_key = "..."
+```
+
+**GitHub Models** — slot `github_models` (alias `github-models`). OpenAI / Meta /
+Microsoft models behind a single GitHub Personal Access Token. Create a PAT with the
+**`models`** permission (fine-grained) — a Copilot token is *not* the same credential.
+Model IDs are publisher-prefixed.
+
+```toml
+[providers.models.github_models.home]
+model   = "openai/gpt-4o"
+api_key = "github_pat_..."
+```
+
+**Upstage** — slot `upstage`. Solar Pro / Solar Mini. Key from the
+[Upstage console](https://console.upstage.ai/api-keys).
+
+```toml
+[providers.models.upstage.home]
+model   = "solar-pro2"
+api_key = "..."
+```
+
+**Featherless** — slot `featherless`. Serverless open-weight models, addressed by their
+Hugging Face repo IDs. Key from [featherless.ai](https://featherless.ai).
+
+```toml
+[providers.models.featherless.home]
+model   = "meta-llama/Meta-Llama-3.1-8B-Instruct"
+api_key = "..."
+```
+
+**Arcee** — slot `arcee`. Native models include `conductor`, `maestro`,
+`virtuoso-large`, `coder-large`, and `blitz`. Key from the
+[Arcee platform](https://www.arcee.ai). Arcee's Platform API uses the non-standard
+`/api/v1` base path; the typed endpoint already accounts for this, so still leave
+`uri` off.
+
+```toml
+[providers.models.arcee.home]
+model   = "conductor"
+api_key = "..."
+```
+
+**Lambda AI** — slot `lambda_ai` (alias `lambda-ai`). Lambda's hosted inference. Key
+from the [Lambda Cloud](https://cloud.lambda.ai) API-keys page.
+
+```toml
+[providers.models.lambda_ai.home]
+model   = "hermes3-405b"
+api_key = "..."
+```
+
+**Inception** — slot `inception`. The Mercury diffusion-LLM family (`mercury-coder` and
+the newer `mercury-2`). Key from the
+[Inception platform](https://platform.inceptionlabs.ai).
+
+```toml
+[providers.models.inception.home]
+model   = "mercury-coder"
+api_key = "..."
+```
+
+> Credentials come only from config (`api_key`) or the `--credential` override at run
+> time — these slots do **not** read a per-provider `*_API_KEY` environment variable.
+
 ---
 
 ## Multi-region families


### PR DESCRIPTION
## Summary

- **Base branch:** `feat/providers-v3-batch` (stacked; auto-retargets to `master` once the parent merges)
- **What changed and why:** Adds a "Worked examples" subsection to `docs/book/src/providers/catalog.md` covering the 7 new schema-v3 providers (Morph, GitHub Models, Upstage, Featherless, Arcee, Lambda AI, Inception). The parent PR (#7260) ships the typed provider slots; this PR gives users copy-paste TOML config blocks, per-provider credential sources, and slot/alias names so the new providers are discoverable from the docs.
- **Scope boundary:** Docs only. No code, no provider schema, no config parsing, no defaults.
- **Blast radius:** None at runtime — `docs/book/` only. Affects the rendered mdBook provider catalog page.
- **Linked issue(s):** Depends on #7260
- **Labels:** `docs`, `risk: low`, `size: S`

## Validation Evidence (required)

Docs-only change, so the docs quality gate is the relevant check.

```bash
bash scripts/ci/docs_quality_gate.sh
```

```
Linting docs files: docs/book/src/providers/catalog.md
markdownlint-cli2 v0.20.0 (markdownlint v0.40.0)
Finding: docs/book/src/providers/catalog.md !target/** !docs/book/src/SUMMARY.md
Linting: 1 file(s)
Summary: 0 error(s)
```

- **Commands run and tail output:** `docs_quality_gate.sh` (markdownlint-cli2) — `Summary: 0 error(s)`.
- **Beyond CI — what did you manually verify?** Reviewed every TOML block for correct `[providers.models.<slot>.<id>]` syntax; confirmed slot names and aliases (`github_models`/`github-models`, `lambda_ai`/`lambda-ai`) match the parent PR; verified the credential note (config/`--credential` only, no `*_API_KEY` env var) is accurate. Did NOT live-test any provider endpoint or credential — model IDs are flagged as illustrative.
- **If any command was intentionally skipped, why:** Rust gates (`cargo fmt`/`clippy`/`test`) skipped — no Rust or other code changed.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No` — all API keys are placeholders (`sk-...`, `github_pat_...`, etc.) and links point to vendor public dashboards only.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No` (documents existing surface from #7260)
- Upgrade steps for existing users: None — docs only.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PR: `git revert <sha>` is the plan.