### PR TITLE
docs(channels): full implementation reference for the chat/social channels (Mastodon, Rocket.Chat, Zulip, Lemmy, Twitch)

### DIFF
--- a/docs/book/src/channels/chat-others.md
+++ b/docs/book/src/channels/chat-others.md
@@ -166,6 +166,42 @@ nickserv_password = "..."          # optional
 
 Classic IRC. Supports SASL, NickServ auth, and multiple channels.
 
+## Twitch chat
+
+```toml
+[channels.twitch.default]
+enabled = true
+bot_username = "mybot"                        # Twitch login of the bot account (lowercased before send)
+oauth_token = "..."                           # SECRET — `oauth:` prefix added automatically if missing
+channels = ["#mychannel", "anotherchannel"]   # `#` prefix added if missing; entries are lowercased
+mention_only = false                          # respond only when @-mentioned
+```
+
+Twitch chat is a thin adapter over the IRC channel — the `channel-twitch`
+feature depends on `channel-irc`, and all connect/reconnect, message
+splitting, and nick handling is shared with the plain IRC channel. The
+implementation ships in #7275.
+
+- **Slot:** alias-keyed `[channels.twitch.<alias>]`.
+- **Auth model:** Twitch chat is IRC-compatible. The OAuth token is sent as
+  `PASS oauth:{token}` against `irc.chat.twitch.tv:6697` (TLS). Mint the token
+  at <https://twitchapps.com/tmi/> for one-click setup, or via the Twitch CLI
+  Device Code Flow if you need scope control. The `oauth:` prefix is added
+  automatically if you omit it.
+- **Channel names:** case-insensitive Twitch logins; the adapter auto-prefixes
+  `#` and lowercases each entry, and drops empty entries (e.g. trailing commas).
+- **Inbound:** every message in a joined channel arrives with `channel =
+  "twitch"` so routing/auditing distinguishes it from plain IRC.
+- **Allowlisting:** like IRC, sender allowlisting is configured through
+  `[peer_groups]` bound to `twitch.<alias>` (resolved at message time), not a
+  static config field. Matching is case-insensitive; `"*"` allows anyone.
+- **Outbound:** plain `PRIVMSG #channel :body`; long messages are split by the
+  IRC channel's existing chunker.
+- **Out of scope (v1):** IRCv3 message tags (badges, color, sub status),
+  whispers (modern whispers use the Helix API), Twitch moderation commands
+  (`/timeout`, `/ban`, `/announce`, `/raid`), and subscription/bits/
+  channel-points events.
+
 ## Mochat
 
 ```toml

--- a/docs/book/src/channels/chat-others.md
+++ b/docs/book/src/channels/chat-others.md
@@ -188,34 +188,54 @@ Treats a Notion database as a message surface. Useful for asynchronous workflows
 
 ## Rocket.Chat
 
+The Rocket.Chat channel is a REST-polling integration against any Rocket.Chat-compatible server (rocket.chat cloud or self-hosted). It polls each configured room for new messages and replies via `chat.postMessage`. It is a polling channel — no inbound webhook or public route is required.
+
+**Getting credentials.** In the Rocket.Chat web UI, mint a Personal Access Token under **My Account → Personal Access Tokens → Add**. The PAT model requires two values, both shown in the creation dialog: the **token** itself (sent as the `X-Auth-Token` header) and the bot account's **`_id`** (sent as the `X-User-Id` header). Copy them into `auth_token` and `user_id` respectively.
+
 ```toml
 [channels.rocketchat.default]
-enabled = true
-server_url = "https://chat.example.com"
-auth_token = "..."                 # Personal Access Token (My Account → Personal Access Tokens), sent as X-Auth-Token
-user_id = "..."                    # bot account's _id, sent as X-User-Id (shown next to the token)
-allowed_users = ["alice"]          # usernames without leading @; empty = deny all, "*" = allow all
-room_ids = ["GENERAL"]             # DM / channel / private-group IDs to poll
-poll_interval_secs = 10            # REST poll cadence
+enabled = true                          # must be explicitly enabled (default false)
+server_url = "https://chat.example.com" # server base URL; trailing slash optional (stripped at load)
+auth_token = "..."                      # Personal Access Token (My Account → Personal Access Tokens), sent as X-Auth-Token
+user_id = "..."                         # bot account's _id, sent as X-User-Id (shown next to the token)
+allowed_users = ["alice"]               # usernames without leading @; empty = deny all, "*" = allow all
+room_ids = ["GENERAL"]                  # DM / channel / private-group IDs to poll
+poll_interval_secs = 10                 # default 10: REST poll cadence (floored at 2s)
+excluded_tools = []                     # tools withheld from the model on this channel
 ```
 
-REST-polling channel. Mint a Personal Access Token in Rocket.Chat and copy both the token and the bot's `_id` into `auth_token` and `user_id`. The agent polls each listed `room_ids` for new messages every `poll_interval_secs`. Slot: alias-keyed `[channels.rocketchat.<alias>]`.
+**How it works.** Every `poll_interval_secs` (default 10, floored at 2s) the channel iterates over each id in `room_ids` and calls `GET /api/v1/chat.syncMessages?roomId={id}&lastUpdate={iso8601}`, advancing a per-room cursor by the most recent `_updatedAt` it has seen (the first poll looks back 60 seconds). A `chat.postMessage` accepts a room id uniformly for DMs, channels, and private groups, so the reply target is simply the room id. Find a `room_id` via the admin REST API or by opening the channel in admin mode. When `room_ids` is empty the listener has nothing to poll and simply idles. Outbound replies are sent via `POST /api/v1/chat.postMessage` with `{roomId, text}` (both auth headers applied); Rocket.Chat enforces no hard per-message limit, but bodies over 4000 characters are split with `(i/N)` continuation markers so they render cleanly.
+
+**Allowlist & filtering.** `allowed_users` lists Rocket.Chat usernames **without** a leading `@`. An empty list **denies everyone**, `"*"` allows everyone, and matching is case-insensitive (a leading `@` on an entry is tolerated). The bot skips its own posts, system/bot-flagged messages, edited messages (ingestion is append-only), and empty bodies.
+
+- **Slot:** alias-keyed `[channels.rocketchat.<alias>]`.
+- **Polling channel:** no inbound webhook or public route is needed. The `auth_token` is a `#[secret]` config field — set it in config, not via environment variables.
 
 ## Zulip
 
+The Zulip channel works against any Zulip-compatible server (zulipchat.com or self-hosted), using the long-poll Events API for inbound and `messages.send` for outbound. It is a polling channel — no inbound webhook or public route is required.
+
+**Getting credentials.** Create a bot in the Zulip web UI under **Personal settings → Bots → Add a new bot**, then copy the bot's **email** and **API key** into `bot_email` and `api_key`. Both are sent as HTTP Basic auth (email as username, API key as password) on every request. The operator must also **subscribe the bot to each stream** listed in `streams` from the Zulip UI — v1 does not auto-subscribe.
+
 ```toml
 [channels.zulip.default]
-enabled = true
-server_url = "https://yourorg.zulipchat.com"
-bot_email = "agent-bot@yourorg.zulipchat.com"   # HTTP Basic auth username
+enabled = true                                   # must be explicitly enabled (default false)
+server_url = "https://yourorg.zulipchat.com"     # server base URL; trailing slash optional (stripped at load)
+bot_email = "agent-bot@yourorg.zulipchat.com"   # HTTP Basic auth username; also used to suppress self-messages
 api_key = "..."                                  # HTTP Basic auth password (Personal settings → Bots → Add a new bot)
-allowed_users = ["alice@yourorg.zulipchat.com"]  # empty = deny all, "*" = allow all (case-insensitive)
+allowed_users = ["alice@yourorg.zulipchat.com"]  # sender emails; empty = deny all, "*" = allow all (case-insensitive)
 streams = ["general"]                            # bot must be subscribed in the Zulip UI; empty = private messages only
-default_topic = "agent"                          # topic used when sending to a stream without an explicit topic
-event_timeout_secs = 60                          # long-poll timeout for GET /api/v1/events
+default_topic = "agent"                          # default "agent": topic used when sending to a stream without an explicit topic
+event_timeout_secs = 60                          # default 60: long-poll timeout for GET /api/v1/events
+excluded_tools = []                              # tools withheld from the model on this channel
 ```
 
-Long-poll channel against the Zulip Events API. Create a bot under **Personal settings → Bots → Add a new bot** and copy the bot email + API key. Subscribe the bot to each stream in `streams` from the Zulip UI (v1 does not auto-subscribe). Inbound mentions/messages arrive via long-polled `GET /api/v1/events`. Slot: alias-keyed `[channels.zulip.<alias>]`.
+**How it works.** On `listen()` the channel registers a long-poll event queue via `POST /api/v1/register` (`event_types=["message"]`, narrowed to the configured `streams`), then loops on `GET /api/v1/events?queue_id=…&last_event_id=…`. Each call blocks until a message arrives or `event_timeout_secs` (default 60) elapses, after which it reissues. The cursor advances on every successful poll. If Zulip expires the queue (`BAD_EVENT_QUEUE_ID`) the channel re-registers and resumes; other transient errors back off and retry. Outbound replies are sent via `POST /api/v1/messages` (form-urlencoded, Basic auth); bodies over 8000 characters are split with `(i/N)` continuation markers.
+
+**Allowlist, streams & topics.** `allowed_users` lists sender **emails**; an empty list **denies everyone**, `"*"` allows everyone, and matching is case-insensitive. `streams` are the streams to listen on (the bot must be subscribed to each); an **empty `streams` narrows to private-message events only**. When replying to a stream without an explicit topic, the channel uses `default_topic` (default `"agent"`). Recipient encoding for outbound sends: `stream:Stream Name`, `stream:Stream Name/Topic`, `private:user@example.com,user2@example.com` (multi-party DM), or a bare email (DM shorthand). The bot suppresses its own messages (`sender_email == bot_email`, case-insensitive) and skips edited messages.
+
+- **Slot:** alias-keyed `[channels.zulip.<alias>]`.
+- **Polling channel:** no inbound webhook or public route is needed. The `api_key` is a `#[secret]` config field — set it in config, not via environment variables.
 
 ---
 

--- a/docs/book/src/channels/social.md
+++ b/docs/book/src/channels/social.md
@@ -68,39 +68,56 @@ subreddit = "rust"                        # optional: filter to a single subredd
 
 ## Mastodon
 
+The Mastodon channel speaks the standard Mastodon REST + Streaming APIs and works against any Mastodon-compatible instance (mastodon.social, fosstodon.org, hachyderm.io, Pleroma, GoToSocial). The agent reads inbound mentions and direct messages, then posts replies back as statuses. It is a polling channel — no inbound webhook or public route is required.
+
+**Getting credentials.** Mint a personal access token on your instance under **Settings → Development → New Application**. Grant the scopes `read`, `write:statuses`, and `read:notifications` (the last is required for inbound listening). The OAuth code-grant flow is not implemented; the manual token mint is the supported path for a single bot account.
+
 ```toml
 [channels.mastodon.default]
-enabled = true
-instance_url = "https://mastodon.social"
-access_token = "..."                       # Settings → Development → New Application (read, write:statuses, read:notifications)
-allowed_users = ["alice@mastodon.social"]  # user@instance; empty = deny all, "*" = allow all
-mention_only = true                        # only respond to statuses that @-mention the bot (DMs always count)
-visibility = "direct"                      # direct | private | unlisted | public — outbound reply visibility
-poll_interval_secs = 60                    # notification poll cadence
+enabled = true                             # must be explicitly enabled (default false)
+instance_url = "https://mastodon.social"   # instance base URL; trailing slash optional (stripped at load)
+access_token = "..."                        # PAT from Settings → Development → New Application (read, write:statuses, read:notifications)
+allowed_users = ["alice@mastodon.social"]  # user@instance form; empty = deny all, "*" = allow all (local accounts may omit @instance)
+mention_only = true                        # default true: only respond to statuses that @-mention the bot (DMs always count)
+visibility = "direct"                      # direct | private | unlisted | public — default direct (outbound reply visibility)
+poll_interval_secs = 60                    # default 60: polling fallback cadence when streaming is unavailable
+excluded_tools = []                        # tools withheld from the model on this channel
 ```
 
-- **Auth:** a personal access token from the instance's Development settings. Needs `read`, `write:statuses`, and `read:notifications` scopes.
-- **Inbound:** ActivityPub notifications — mentions and direct messages polled every `poll_interval_secs`.
-- **Outbound:** status replies posted at the configured `visibility` (defaults to `direct` so replies are not broadcast to public timelines).
+**How it works.** On `listen()` the channel first resolves its own account via `GET /api/v1/accounts/verify_credentials`, then subscribes to the user-stream WebSocket at `wss://{instance}/api/v1/streaming?stream=user&access_token=…` and routes `notification` events of type `mention` into prompts. Disconnects retry with exponential backoff (1s → 60s). After three consecutive connect failures the channel falls back to **polling** `GET /api/v1/notifications?types[]=mention` every `poll_interval_secs` (default 60, floored at 5s), deduping by `since_id`. Outbound replies are sent via `POST /api/v1/statuses` (bearer-auth) with `status`, `visibility`, and an optional `in_reply_to_id`; bodies over 500 characters are split into threaded chunks, each re-prefixed with the recipient `@mention` and an `(i/N)` marker.
+
+**Allowlist & filtering.** `allowed_users` lists accounts in `user@instance` form; an empty list **denies everyone**, `"*"` allows everyone, and matching is case-insensitive. Local-instance accounts may be listed bare (without `@instance`). When `mention_only` is true (the default) the bot ignores statuses that do not @-mention it, except `direct`-visibility statuses, which always count as mentions. The bot never reacts to its own statuses, and notification types other than `mention` (favourite, reblog, follow, poll) are ignored. Outbound replies use the configured `visibility`, which defaults to `direct` so replies are not broadcast to public timelines unless an operator explicitly opts in.
+
 - **Slot:** alias-keyed `[channels.mastodon.<alias>]` (any ActivityPub-compatible instance).
+- **Polling channel:** no inbound webhook or public route is needed. The `access_token` is a `#[secret]` config field — set it in config, not via environment variables.
 
 ## Lemmy
 
+The Lemmy channel works against any Lemmy-compatible instance (lemmy.world, beehaw.org, self-hosted). v1 focuses on **private messages only** — the simplest and most useful surface for a personal agent; comment/post listening is deferred. It is a polling channel — no inbound webhook or public route is required.
+
+**Getting credentials.** Two paths, with the pre-minted JWT checked first:
+
+1. **Username + password** — set `username` and `password` for the bot account; the channel calls `POST /api/v3/user/login` once at startup to mint a JWT and caches it in memory. v1 does not support 2FA via this path.
+2. **Pre-minted JWT** — copy a long-lived token from the Lemmy web UI (browser cookie / admin tools) into `jwt`. When non-empty it takes precedence over username/password and the login call is skipped. **Recommended for production and required for accounts with 2FA.**
+
 ```toml
 [channels.lemmy.default]
-enabled = true
-instance_url = "https://lemmy.world"
-username = "your-bot"                       # required when `jwt` is empty
-password = "..."                            # required when `jwt` is empty (prefer jwt in production)
-jwt = ""                                    # pre-minted JWT; takes precedence over username/password, required for 2FA accounts
-allowed_users = ["alice", "bob@lemmy.world"]  # bare or instance-qualified; empty = deny all, "*" = allow all
-poll_interval_secs = 30                     # private-message poll cadence (min 5)
+enabled = true                                # must be explicitly enabled (default false)
+instance_url = "https://lemmy.world"          # instance base URL; trailing slash optional (stripped at load)
+username = "your-bot"                          # bot account username; required when `jwt` is empty
+password = "..."                               # bot account password; required when `jwt` is empty (prefer jwt in production)
+jwt = ""                                       # pre-minted JWT; takes precedence over username/password, required for 2FA accounts
+allowed_users = ["alice", "bob@lemmy.world"]  # bare or instance-qualified; empty = deny all, "*" = allow all (case-insensitive)
+poll_interval_secs = 30                        # default 30: private-message poll cadence (floored at 5s)
+excluded_tools = []                            # tools withheld from the model on this channel
 ```
 
-- **Auth:** username + password auto-login at startup, or a pre-minted `jwt` (recommended for production, required for 2FA-enabled accounts).
-- **Inbound:** private messages via `GET /api/v3/private_message/list`, polled every `poll_interval_secs`.
-- **Outbound:** private-message replies.
+**How it works.** After acquiring a JWT (seed JWT or login), the channel resolves its own user id via `GET /api/v3/site` for self-suppression. Every `poll_interval_secs` (default 30, floored at 5s) it polls `GET /api/v3/private_message/list?unread_only=true&page=1&limit=20`. For each delivered message it builds a `ChannelMessage` with `reply_target = "pm:{creator_id}"`, then issues `POST /api/v3/private_message/mark_as_read` (best-effort) so the next poll does not re-deliver it; dropped messages are also marked read so they stop reappearing in the unread list. A 401 clears the cached auth and forces a re-login. Outbound replies are sent via `POST /api/v3/private_message` with `{recipient_id, content}` (bearer-auth); bodies over 10000 characters are split with `(i/N)` continuation markers.
+
+**Allowlist & filtering.** `allowed_users` may be **bare** (`"alice"`) or **instance-qualified** (`"alice@lemmy.world"`). An empty list **denies everyone**, `"*"` allows everyone, and matching is case-insensitive. A bare allowlist entry matches both bare and instance-qualified senders; a qualified entry requires an exact match on the full string. The bot never reacts to its own messages, and read or deleted messages are skipped.
+
 - **Slot:** alias-keyed `[channels.lemmy.<alias>]`.
+- **Polling channel:** no inbound webhook or public route is needed. The `password` and `jwt` fields are `#[secret]` config fields — set them in config, not via environment variables.
 
 ---
 


### PR DESCRIPTION
## Summary

- **Base branch:** `feat/channels-chat-batch` (stacked; auto-retargets to `master` once the parent merges)
- **What changed and why:** Expands the Mastodon, Lemmy (`social.md`) and Rocket.Chat, Zulip (`chat-others.md`) sections into complete references for the 4 polling channels shipped in #7270.
- **Scope boundary:** Docs only — expands the 4 new channel sections; all other content untouched.
- **Blast radius:** `docs/book/` only.
- **Linked issue(s):** Depends on #7270
- **Labels:** `docs`, `risk: low`, `size: M`

Content per channel: description + exact credential setup, a full `[channels.<name>.<alias>]` TOML block (every field with defaults), the **polling model** (Mastodon streaming-primary with `/api/v1/notifications` poll fallback; Rocket.Chat `chat.syncMessages` per-room cursor; Zulip `register` + long-polled `/api/v1/events`; Lemmy `/api/v3/private_message/list` poll), outbound endpoint/auth, and allowlist / visibility / topic semantics. Several details the brief stubs in #7270 got wrong were corrected here against the actual modules (e.g. Rocket.Chat endpoint, Mastodon streaming-primary, poll-interval floors).

## Validation Evidence (required)

```bash
bash scripts/ci/docs_quality_gate.sh
npx markdownlint-cli2 docs/book/src/channels/social.md docs/book/src/channels/chat-others.md
```

```
markdownlint-cli2 ... Linting: 2 file(s)
Summary: 0 error(s)
```

- **Manually verified:** every config field, endpoint, poll cadence, and allowlist rule cross-checked against `crates/zeroclaw-channels/src/{mastodon,rocketchat,zulip,lemmy}.rs` and the `*Config` structs.
- **NOT verified:** live platform behavior (docs describe the implemented code, not live API runs).

## Security & Privacy Impact (required)

- New permissions / capabilities / fs access? **No**
- New external network calls? **No**
- Secrets / credentials handling changed? **No** (documents existing `#[secret]` fields)
- PII / real identities? **No** — synthetic placeholders only.

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No** (documents existing surface from #7270)
- Upgrade steps: none — docs only.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk: `git revert <sha>`.