### PR TITLE
feat(zerocode): two-level pane cursor, agent-picker mouse, registry-driven config help

### DIFF
--- a/apps/zerocode/locales/en/zerocode.ftl
+++ b/apps/zerocode/locales/en/zerocode.ftl
@@ -64,6 +64,10 @@ zc-zerocode-help-rebind = Rebind selected action
 zc-zerocode-help-reset-default = Reset action to default
 zc-zerocode-help-mouse-label = Mouse
 zc-zerocode-help-mouse-desc = Click pane / row, scroll, click section tab
+zc-zerocode-help-choose-section = Choose section
+zc-zerocode-help-open-section = Open section
+zc-zerocode-help-navigate-rows = Navigate rows
+zc-zerocode-help-back-to-sections = Back to sections
 
 zc-input-no-pending-attachments = No pending attachments.
 zc-input-no-clipboard-image = Clipboard is empty.

--- a/apps/zerocode/src/acp.rs
+++ b/apps/zerocode/src/acp.rs
@@ -42,8 +42,8 @@ impl Acp {
         self.inner.wants_text_input()
     }
 
-    pub(crate) fn handle_mouse(&mut self, mouse: MouseEvent, area: Rect) {
-        self.inner.handle_mouse(mouse, area);
+    pub(crate) async fn handle_mouse(&mut self, mouse: MouseEvent, area: Rect) {
+        self.inner.handle_mouse(mouse, area).await;
     }
 
     pub(crate) fn handle_paste(&mut self, text: &str) {

--- a/apps/zerocode/src/app.rs
+++ b/apps/zerocode/src/app.rs
@@ -440,10 +440,10 @@ pub async fn run(
                             logs_pane.handle_mouse(mouse, content_area);
                         }
                         Mode::Acp => {
-                            acp_pane.handle_mouse(mouse, content_area);
+                            acp_pane.handle_mouse(mouse, content_area).await;
                         }
                         Mode::Chat => {
-                            chat_pane.handle_mouse(mouse, content_area);
+                            chat_pane.handle_mouse(mouse, content_area).await;
                         }
                         Mode::Quickstart => {
                             quickstart.handle_mouse(mouse, content_area).await;

--- a/apps/zerocode/src/chat.rs
+++ b/apps/zerocode/src/chat.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use crossterm::event::{KeyEvent, MouseEvent, MouseEventKind};
+use crossterm::event::{KeyEvent, MouseButton, MouseEvent, MouseEventKind};
 use pulldown_cmark::{Event as MdEvent, Options as MdOptions, Parser as MdParser, Tag, TagEnd};
 use ratatui::{
     Frame,
@@ -90,6 +90,12 @@ pub(crate) struct Chat {
     git_branch_inflight: bool,
     phase: ChatPhase,
     pane_kind: PaneKind,
+    /// List rect of the agent picker, recorded each draw so mouse clicks in the
+    /// PickAgent phase can map a row to a selection. Default until first draw.
+    pick_agent_list_area: Rect,
+    /// Double-click tracker for the agent picker: a second click on the same row
+    /// confirms (enters the session), matching the keyboard Enter.
+    pick_agent_double_click: crate::mouse::DoubleClickTracker,
 }
 
 fn should_retry_on_entry(phase: &ChatPhase) -> bool {
@@ -112,6 +118,8 @@ impl Chat {
                 loading: true,
             },
             pane_kind,
+            pick_agent_list_area: Rect::default(),
+            pick_agent_double_click: crate::mouse::DoubleClickTracker::new(),
         }
     }
 
@@ -310,7 +318,7 @@ impl Chat {
                 list_state,
                 loading,
             } => {
-                draw_agent_picker(
+                let list_area = draw_agent_picker(
                     frame,
                     area,
                     agents,
@@ -318,6 +326,7 @@ impl Chat {
                     *loading,
                     &self.pane_kind.name(),
                 );
+                self.pick_agent_list_area = list_area;
             }
             ChatPhase::PickCwd { explorer, .. } => {
                 explorer.render(frame, area);
@@ -824,10 +833,47 @@ impl Chat {
         false
     }
 
-    pub(crate) fn handle_mouse(&mut self, mouse: MouseEvent, area: Rect) {
+    pub(crate) async fn handle_mouse(&mut self, mouse: MouseEvent, area: Rect) {
         // Dir-picker explorer handles its own mouse events.
         if let ChatPhase::PickCwd { explorer, .. } = &mut self.phase {
             explorer.handle_mouse(mouse);
+            return;
+        }
+
+        // Agent picker: click highlights a row, double-click confirms (enters
+        // the session), wheel moves the selection.
+        if matches!(self.phase, ChatPhase::PickAgent { loading: false, .. }) {
+            let mut confirm_alias: Option<String> = None;
+            if let ChatPhase::PickAgent {
+                agents, list_state, ..
+            } = &mut self.phase
+            {
+                let list_area = self.pick_agent_list_area;
+                match mouse.kind {
+                    MouseEventKind::Down(MouseButton::Left) => {
+                        if let Some(idx) = mouse::list_click_index(
+                            mouse.row,
+                            list_area,
+                            list_state.offset(),
+                            agents.len(),
+                        ) {
+                            list_state.select(Some(idx));
+                            if self.pick_agent_double_click.click(mouse.column, mouse.row) {
+                                confirm_alias = agents.get(idx).cloned();
+                            }
+                        }
+                    }
+                    MouseEventKind::ScrollUp | MouseEventKind::ScrollDown => {
+                        let up = matches!(mouse.kind, MouseEventKind::ScrollUp);
+                        let i = list_state.selected().unwrap_or(0);
+                        list_state.select(Some(mouse::list_scroll(i, agents.len(), up, 1)));
+                    }
+                    _ => {}
+                }
+            }
+            if let Some(alias) = confirm_alias {
+                self.pick_or_start_session(&alias).await;
+            }
             return;
         }
 
@@ -877,7 +923,7 @@ impl Chat {
                 return;
             }
 
-            use crossterm::event::{KeyModifiers as KM, MouseButton};
+            use crossterm::event::KeyModifiers as KM;
             let col = mouse.column;
             let row = mouse.row;
             match mouse.kind {
@@ -1103,6 +1149,29 @@ impl crate::widgets::HelpContext for Chat {
 
 // ── Agent picker rendering ───────────────────────────────────────
 
+/// Build the agent-picker nav hint from the live keymap (browse up/down + the
+/// modal confirm chord), never hardcoded literals.
+fn picker_nav_keys() -> String {
+    use crate::keymap::{ChatTabAction, Chord, ModalAction, RebindableActions};
+    let mut parts: Vec<String> = Vec::new();
+    let mut push = |c: &Chord| {
+        let d = c.display();
+        if !parts.contains(&d) {
+            parts.push(d);
+        }
+    };
+    for c in ChatTabAction::BrowseUp.resolved() {
+        push(&c);
+    }
+    for c in ChatTabAction::BrowseDown.resolved() {
+        push(&c);
+    }
+    for c in ModalAction::Confirm.resolved() {
+        push(&c);
+    }
+    parts.join("/")
+}
+
 fn draw_agent_picker(
     frame: &mut Frame,
     area: Rect,
@@ -1110,7 +1179,7 @@ fn draw_agent_picker(
     list_state: &mut ListState,
     loading: bool,
     tab_title: &str,
-) {
+) -> Rect {
     let block = Block::default()
         .title(Span::styled(format!(" {tab_title} "), theme::title_style()))
         .borders(Borders::ALL)
@@ -1132,7 +1201,7 @@ fn draw_agent_picker(
             ])
             .split(inner);
         frame.render_widget(p, vert[1]);
-        return;
+        return Rect::default();
     }
 
     let chunks = Layout::default()
@@ -1150,7 +1219,10 @@ fn draw_agent_picker(
             theme::body_style(),
         ),
         Span::styled(
-            crate::i18n::t_args("zc-chat-picker-header-hint", &[("keys", "Up/Down, Enter")]),
+            crate::i18n::t_args(
+                "zc-chat-picker-header-hint",
+                &[("keys", &picker_nav_keys())],
+            ),
             theme::dim_style(),
         ),
     ]));
@@ -1162,6 +1234,15 @@ fn draw_agent_picker(
         .collect();
     let list = List::new(items).highlight_style(theme::list_highlight_style());
     frame.render_stateful_widget(list, chunks[1], list_state);
+    // The list rect is unbordered, but `mouse::list_click_index` assumes a
+    // 1-cell top border. Hand back a rect shifted up one row (and one taller) so
+    // the helper's border compensation lands on the true first item.
+    Rect::new(
+        chunks[1].x,
+        chunks[1].y.saturating_sub(1),
+        chunks[1].width,
+        chunks[1].height + 1,
+    )
 }
 
 // ── Error rendering ──────────────────────────────────────────────
@@ -2995,6 +3076,42 @@ mod tests {
 
     fn state() -> ChatState {
         ChatState::new("sess-1".to_string(), "myagent".to_string())
+    }
+
+    #[tokio::test]
+    async fn agent_picker_click_selects_row() {
+        use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+        let (tx, _rx) = mpsc::channel::<String>(16);
+        let rpc = Arc::new(RpcOutbound::new(tx));
+        let client = Arc::new(RpcClient::with_rpc(Arc::clone(&rpc)));
+        let mut chat = Chat::new(client, PaneKind::Chat);
+        let mut list_state = ListState::default();
+        list_state.select(Some(0));
+        chat.phase = ChatPhase::PickAgent {
+            agents: vec!["alpha".into(), "beta".into(), "gamma".into()],
+            list_state,
+            loading: false,
+        };
+        // Stored rect is the draw's shifted form: list_click_index treats (y+1)
+        // as the first item. With y=1, first item maps to row 2.
+        chat.pick_agent_list_area = Rect::new(1, 1, 20, 6);
+        // Click the third item → row 2 + 2 = 4.
+        let click = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: 3,
+            row: 4,
+            modifiers: KeyModifiers::NONE,
+        };
+        chat.handle_mouse(click, Rect::new(0, 0, 40, 10)).await;
+        if let ChatPhase::PickAgent { list_state, .. } = &chat.phase {
+            assert_eq!(
+                list_state.selected(),
+                Some(2),
+                "click selects the clicked row"
+            );
+        } else {
+            panic!("expected PickAgent phase");
+        }
     }
 
     fn authoritative_rows(s: &ChatState, width: u16) -> u16 {

--- a/apps/zerocode/src/config_manager.rs
+++ b/apps/zerocode/src/config_manager.rs
@@ -133,6 +133,69 @@ impl ConfigSection {
     }
 }
 
+// ── Keymap-derived chord glyphs (footers + help) ─────────────────
+//
+// Footer hints and the help overlay must show the live, possibly-overridden
+// chord for each action — never a hardcoded glyph.
+
+/// First display chord for a `ConfigTabAction`, or its fallback label.
+fn tab_key(action: crate::keymap::ConfigTabAction) -> String {
+    use crate::keymap::RebindableActions;
+    action
+        .resolved()
+        .first()
+        .map(crate::keymap::Chord::display)
+        .unwrap_or_default()
+}
+
+/// All display chords for a `ConfigTabAction`, joined for help rows.
+fn tab_keys(action: crate::keymap::ConfigTabAction) -> Vec<String> {
+    use crate::keymap::RebindableActions;
+    action
+        .resolved()
+        .iter()
+        .map(crate::keymap::Chord::display)
+        .collect()
+}
+
+/// First display chord for a `ConfigEditorAction` (Enter/Esc/Ctrl+S in edits).
+fn editor_key(action: crate::keymap::ConfigEditorAction) -> String {
+    use crate::keymap::RebindableActions;
+    action
+        .resolved()
+        .first()
+        .map(crate::keymap::Chord::display)
+        .unwrap_or_default()
+}
+
+/// Joined up/down display chords for list navigation footers.
+fn nav_keys() -> String {
+    use crate::keymap::ConfigTabAction as A;
+    tab_keys(A::Up)
+        .into_iter()
+        .chain(tab_keys(A::Down))
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+/// Up+down display chords as a vec, for help rows that render each chord.
+fn nav_keys_split() -> Vec<String> {
+    use crate::keymap::ConfigTabAction as A;
+    tab_keys(A::Up)
+        .into_iter()
+        .chain(tab_keys(A::Down))
+        .collect()
+}
+
+/// Left+right display chords, used by composite-tab switch help rows.
+fn switch_tabs_keys() -> Vec<String> {
+    use crate::keymap::ConfigTabAction as A;
+    tab_keys(A::TabLeft)
+        .into_iter()
+        .chain(tab_keys(A::TabRight))
+        .collect()
+}
+
 // ── App state ────────────────────────────────────────────────────
 
 pub(crate) struct App<'a> {
@@ -1058,6 +1121,11 @@ impl<'a> App<'a> {
                 self.section_cursor += 1;
             }
             Some(ConfigTabAction::Enter) => {
+                return self.enter_section(self.section_cursor).await;
+            }
+            // Right drills into the highlighted section, mirroring the zerocode
+            // tab's cursor model (Enter and Right both step inward).
+            Some(ConfigTabAction::TabRight) => {
                 return self.enter_section(self.section_cursor).await;
             }
             _ => {}
@@ -2411,11 +2479,16 @@ impl<'a> App<'a> {
         self.last_tab_area = None;
 
         let hints = if self.filter.is_some() {
-            "↑↓  Enter=open  Esc=clear filter"
+            format!(
+                "{}  {}=open  {}=clear filter",
+                nav_keys(),
+                tab_key(crate::keymap::ConfigTabAction::Enter),
+                tab_key(crate::keymap::ConfigTabAction::Back),
+            )
         } else {
-            "?=help"
+            "?=help".to_string()
         };
-        self.draw_footer(frame, r, hints);
+        self.draw_footer(frame, r, &hints);
     }
 
     fn draw_type_list(&mut self, frame: &mut Frame, area: Rect, section_idx: usize) {
@@ -2488,11 +2561,16 @@ impl<'a> App<'a> {
         self.last_tab_area = None;
 
         let hints = if self.filter.is_some() {
-            "↑↓  Enter=open  Esc=clear filter"
+            format!(
+                "{}  {}=open  {}=clear filter",
+                nav_keys(),
+                tab_key(crate::keymap::ConfigTabAction::Enter),
+                tab_key(crate::keymap::ConfigTabAction::Back),
+            )
         } else {
-            "?=help"
+            "?=help".to_string()
         };
-        self.draw_footer(frame, r, hints);
+        self.draw_footer(frame, r, &hints);
     }
 
     fn draw_alias_list(
@@ -2567,11 +2645,16 @@ impl<'a> App<'a> {
         self.last_tab_area = None;
 
         let hints = if self.filter.is_some() {
-            "↑↓  Enter=open  Esc=clear filter"
+            format!(
+                "{}  {}=open  {}=clear filter",
+                nav_keys(),
+                tab_key(crate::keymap::ConfigTabAction::Enter),
+                tab_key(crate::keymap::ConfigTabAction::Back),
+            )
         } else {
-            "?=help"
+            "?=help".to_string()
         };
-        self.draw_footer(frame, r, hints);
+        self.draw_footer(frame, r, &hints);
     }
 
     fn draw_alias_create(&mut self, frame: &mut Frame, area: Rect, breadcrumb: &[String]) {
@@ -2599,8 +2682,10 @@ impl<'a> App<'a> {
         frame.render_widget(input, r.main);
 
         let footer = format!(
-            "Enter={}  Esc={}",
+            "{}={}  {}={}",
+            editor_key(crate::keymap::ConfigEditorAction::Confirm),
             crate::i18n::t("zc-config-footer-action-create"),
+            editor_key(crate::keymap::ConfigEditorAction::Cancel),
             crate::i18n::t("zc-config-footer-action-cancel"),
         );
         self.draw_footer(frame, r, &footer);
@@ -2744,11 +2829,16 @@ impl<'a> App<'a> {
         self.last_tab_area = tab_area;
 
         let hints = if self.filter.is_some() {
-            "↑↓  Enter=edit  Esc=clear filter"
+            format!(
+                "{}  {}=edit  {}=clear filter",
+                nav_keys(),
+                tab_key(crate::keymap::ConfigTabAction::Enter),
+                tab_key(crate::keymap::ConfigTabAction::Back),
+            )
         } else {
-            "?=help"
+            "?=help".to_string()
         };
-        self.draw_footer(frame, r, hints);
+        self.draw_footer(frame, r, &hints);
     }
 
     // ── Composite tab draw methods ──────────────────────────────
@@ -2789,8 +2879,10 @@ impl<'a> App<'a> {
             );
 
             let footer = format!(
-                "Ctrl+S={}  Esc={}",
+                "{}={}  {}={}",
+                editor_key(crate::keymap::ConfigEditorAction::Save),
                 crate::i18n::t("zc-config-footer-action-save"),
+                editor_key(crate::keymap::ConfigEditorAction::Cancel),
                 crate::i18n::t("zc-config-footer-action-back-to-files"),
             );
             self.draw_footer(frame, r, &footer);
@@ -2888,8 +2980,10 @@ impl<'a> App<'a> {
             );
 
             let footer = format!(
-                "Ctrl+S={}  Esc={}",
+                "{}={}  {}={}",
+                editor_key(crate::keymap::ConfigEditorAction::Save),
                 crate::i18n::t("zc-config-footer-action-save"),
+                editor_key(crate::keymap::ConfigEditorAction::Cancel),
                 crate::i18n::t("zc-config-footer-action-back-to-skills"),
             );
             self.draw_footer(frame, r, &footer);
@@ -2899,7 +2993,16 @@ impl<'a> App<'a> {
                 Paragraph::new(Span::styled(
                     crate::i18n::t_args(
                         "zc-config-skills-help-blurb",
-                        &[("enter_chord", "Enter"), ("archive_chord", "x")],
+                        &[
+                            (
+                                "enter_chord",
+                                &tab_key(crate::keymap::ConfigTabAction::Enter),
+                            ),
+                            (
+                                "archive_chord",
+                                &tab_key(crate::keymap::ConfigTabAction::ToggleSecret),
+                            ),
+                        ],
                     ),
                     theme::dim_style(),
                 ))
@@ -3008,11 +3111,16 @@ impl<'a> App<'a> {
             self.last_tab_area = None;
 
             let hints = if self.filter.is_some() {
-                "↑↓  Enter=save  Esc=clear filter"
+                format!(
+                    "{}  {}=save  {}=clear filter",
+                    nav_keys(),
+                    tab_key(crate::keymap::ConfigTabAction::Enter),
+                    tab_key(crate::keymap::ConfigTabAction::Back),
+                )
             } else {
-                "?=help"
+                "?=help".to_string()
             };
-            self.draw_footer(frame, r, hints);
+            self.draw_footer(frame, r, &hints);
         } else {
             // Text input (masked for secrets) — help text always visible.
             frame.render_widget(
@@ -3057,9 +3165,12 @@ impl<'a> App<'a> {
                     r.main,
                 );
                 let footer = format!(
-                    "Enter={}  Ctrl+S={}  Esc={}",
+                    "{}={}  {}={}  {}={}",
+                    editor_key(crate::keymap::ConfigEditorAction::Confirm),
                     crate::i18n::t("zc-config-footer-action-new-line"),
+                    editor_key(crate::keymap::ConfigEditorAction::Save),
                     crate::i18n::t("zc-config-footer-action-save"),
+                    editor_key(crate::keymap::ConfigEditorAction::Cancel),
                     crate::i18n::t("zc-config-footer-action-cancel"),
                 );
                 self.draw_footer(frame, r, &footer);
@@ -3081,8 +3192,10 @@ impl<'a> App<'a> {
             frame.render_widget(input, r.main);
 
             let footer = format!(
-                "Enter={}  Esc={}",
+                "{}={}  {}={}",
+                editor_key(crate::keymap::ConfigEditorAction::Confirm),
                 crate::i18n::t("zc-config-footer-action-save"),
+                editor_key(crate::keymap::ConfigEditorAction::Cancel),
                 crate::i18n::t("zc-config-footer-action-cancel"),
             );
             self.draw_footer(frame, r, &footer);
@@ -3205,117 +3318,128 @@ impl crate::widgets::HelpContext for App<'_> {
 
 impl App<'_> {
     fn zeroclaw_help_context(&self) -> crate::widgets::HelpNode {
+        use crate::keymap::ConfigTabAction as A;
         use crate::widgets::{HelpEntry as E, HelpNode};
+
+        // All chords resolve from the live keymap so overrides/vim/emacs show.
+        let nav = || E::new(nav_keys_split(), crate::i18n::t("zc-config-help-navigate"));
+        let k = |a: A, label: &str| E::new(tab_keys(a), crate::i18n::t(label));
+        let help = || E::key("?", crate::i18n::t("zc-config-help-this-help"));
+        let filter = || E::key("/", crate::i18n::t("zc-config-help-filter"));
+        let clear_filter = || k(A::Back, "zc-config-help-clear-filter");
+        let back = || k(A::Back, "zc-config-help-back");
+        let mouse_open = || E::key("Mouse", crate::i18n::t("zc-config-help-mouse-open"));
+
         match &self.screen {
             Screen::SectionList => {
                 if self.filter.is_some() {
                     HelpNode::entries(vec![
-                        E::new(vec!["↑", "↓"], crate::i18n::t("zc-config-help-navigate")),
-                        E::key("Enter", crate::i18n::t("zc-config-help-open-section")),
-                        E::key("Esc", crate::i18n::t("zc-config-help-clear-filter")),
-                        E::key("?", crate::i18n::t("zc-config-help-this-help")),
+                        nav(),
+                        k(A::Enter, "zc-config-help-open-section"),
+                        clear_filter(),
+                        help(),
                     ])
                 } else {
+                    let open = [tab_keys(A::Enter), tab_keys(A::TabRight)].concat();
                     HelpNode::entries(vec![
-                        E::new(
-                            vec!["↑↓", "j", "k"],
-                            crate::i18n::t("zc-config-help-navigate"),
-                        ),
-                        E::key("Enter", crate::i18n::t("zc-config-help-open-section")),
-                        E::key("/", crate::i18n::t("zc-config-help-filter")),
-                        E::key("q", crate::i18n::t("zc-config-help-quit")),
-                        E::key("?", crate::i18n::t("zc-config-help-this-help")),
+                        nav(),
+                        E::new(open, crate::i18n::t("zc-config-help-open-section")),
+                        filter(),
+                        k(A::Back, "zc-config-help-quit"),
+                        help(),
                         E::spacer(),
-                        E::key("Mouse", crate::i18n::t("zc-config-help-mouse-open")),
+                        mouse_open(),
                     ])
                 }
             }
             Screen::TypeList { .. } => {
                 if self.filter.is_some() {
                     HelpNode::entries(vec![
-                        E::new(vec!["↑", "↓"], crate::i18n::t("zc-config-help-navigate")),
-                        E::key("Enter", crate::i18n::t("zc-config-help-open-type")),
-                        E::key("Esc", crate::i18n::t("zc-config-help-clear-filter")),
-                        E::key("?", crate::i18n::t("zc-config-help-this-help")),
+                        nav(),
+                        k(A::Enter, "zc-config-help-open-type"),
+                        clear_filter(),
+                        help(),
                     ])
                 } else {
+                    let open = [tab_keys(A::Enter), tab_keys(A::TabRight)].concat();
                     HelpNode::entries(vec![
-                        E::new(
-                            vec!["↑↓", "j", "k"],
-                            crate::i18n::t("zc-config-help-navigate"),
-                        ),
-                        E::key("Enter", crate::i18n::t("zc-config-help-open-type")),
-                        E::key("/", crate::i18n::t("zc-config-help-filter")),
-                        E::key("Esc", crate::i18n::t("zc-config-help-back")),
-                        E::key("?", crate::i18n::t("zc-config-help-this-help")),
+                        nav(),
+                        E::new(open, crate::i18n::t("zc-config-help-open-type")),
+                        filter(),
+                        back(),
+                        help(),
                         E::spacer(),
-                        E::key("Mouse", crate::i18n::t("zc-config-help-mouse-open")),
+                        mouse_open(),
                     ])
                 }
             }
             Screen::AliasList { .. } => {
                 if self.filter.is_some() {
                     HelpNode::entries(vec![
-                        E::new(vec!["↑", "↓"], crate::i18n::t("zc-config-help-navigate")),
-                        E::key("Enter", crate::i18n::t("zc-config-help-open-alias")),
-                        E::key("Esc", crate::i18n::t("zc-config-help-clear-filter")),
-                        E::key("?", crate::i18n::t("zc-config-help-this-help")),
+                        nav(),
+                        k(A::Enter, "zc-config-help-open-alias"),
+                        clear_filter(),
+                        help(),
                     ])
                 } else {
+                    let open = [tab_keys(A::Enter), tab_keys(A::TabRight)].concat();
                     HelpNode::entries(vec![
-                        E::new(
-                            vec!["↑↓", "j", "k"],
-                            crate::i18n::t("zc-config-help-navigate"),
-                        ),
-                        E::key("Enter", crate::i18n::t("zc-config-help-open-alias")),
-                        E::key("x", crate::i18n::t("zc-config-help-delete-alias")),
-                        E::key("/", crate::i18n::t("zc-config-help-filter")),
-                        E::key("Esc", crate::i18n::t("zc-config-help-back")),
-                        E::key("?", crate::i18n::t("zc-config-help-this-help")),
+                        nav(),
+                        E::new(open, crate::i18n::t("zc-config-help-open-alias")),
+                        k(A::ToggleSecret, "zc-config-help-delete-alias"),
+                        filter(),
+                        back(),
+                        help(),
                         E::spacer(),
-                        E::key("Mouse", crate::i18n::t("zc-config-help-mouse-open")),
+                        mouse_open(),
                     ])
                 }
             }
             Screen::AliasCreate { .. } => HelpNode::entries(vec![
-                E::key("Enter", crate::i18n::t("zc-config-help-create-alias")),
-                E::key("Esc", crate::i18n::t("zc-config-help-cancel")),
-                E::key("?", crate::i18n::t("zc-config-help-this-help")),
+                E::new(
+                    vec![editor_key(crate::keymap::ConfigEditorAction::Confirm)],
+                    crate::i18n::t("zc-config-help-create-alias"),
+                ),
+                E::new(
+                    vec![editor_key(crate::keymap::ConfigEditorAction::Cancel)],
+                    crate::i18n::t("zc-config-help-cancel"),
+                ),
+                help(),
             ]),
             Screen::FieldList { .. } => {
                 if self.filter.is_some() {
                     HelpNode::entries(vec![
-                        E::new(vec!["↑", "↓"], crate::i18n::t("zc-config-help-navigate")),
-                        E::key("Enter", crate::i18n::t("zc-config-help-edit-field")),
-                        E::key("Esc", crate::i18n::t("zc-config-help-clear-filter")),
-                        E::key("?", crate::i18n::t("zc-config-help-this-help")),
+                        nav(),
+                        k(A::Enter, "zc-config-help-edit-field"),
+                        clear_filter(),
+                        help(),
                     ])
                 } else if self.is_composite_tab() {
                     match self.tab_names.get(self.active_tab) {
                         Some(ConfigTab::Personality) => {
                             if self.personality_active_file.is_some() {
                                 HelpNode::entries(vec![
-                                    E::key("Ctrl+S", crate::i18n::t("zc-config-help-save")),
-                                    E::key("Esc", crate::i18n::t("zc-config-help-back-to-files")),
-                                    E::key("?", crate::i18n::t("zc-config-help-this-help")),
+                                    E::new(
+                                        vec![editor_key(crate::keymap::ConfigEditorAction::Save)],
+                                        crate::i18n::t("zc-config-help-save"),
+                                    ),
+                                    E::new(
+                                        vec![editor_key(crate::keymap::ConfigEditorAction::Cancel)],
+                                        crate::i18n::t("zc-config-help-back-to-files"),
+                                    ),
+                                    help(),
                                 ])
                             } else {
                                 HelpNode::entries(vec![
                                     E::new(
-                                        vec!["←→", "h", "l"],
+                                        switch_tabs_keys(),
                                         crate::i18n::t("zc-config-help-switch-tabs"),
                                     ),
-                                    E::new(
-                                        vec!["↑↓", "j", "k"],
-                                        crate::i18n::t("zc-config-help-navigate"),
-                                    ),
-                                    E::key("Enter", crate::i18n::t("zc-config-help-edit-file")),
-                                    E::key(
-                                        "t",
-                                        crate::i18n::t("zc-config-help-fill-from-template"),
-                                    ),
-                                    E::key("Esc", crate::i18n::t("zc-config-help-back")),
-                                    E::key("?", crate::i18n::t("zc-config-help-this-help")),
+                                    nav(),
+                                    k(A::Enter, "zc-config-help-edit-file"),
+                                    k(A::ApplyTemplate, "zc-config-help-fill-from-template"),
+                                    back(),
+                                    help(),
                                     E::spacer(),
                                     E::key("Mouse", crate::i18n::t("zc-config-help-mouse-tabs")),
                                 ])
@@ -3324,24 +3448,27 @@ impl App<'_> {
                         Some(ConfigTab::Skills) => {
                             if self.skills_active.is_some() {
                                 HelpNode::entries(vec![
-                                    E::key("Ctrl+S", crate::i18n::t("zc-config-help-save")),
-                                    E::key("Esc", crate::i18n::t("zc-config-help-back-to-skills")),
-                                    E::key("?", crate::i18n::t("zc-config-help-this-help")),
+                                    E::new(
+                                        vec![editor_key(crate::keymap::ConfigEditorAction::Save)],
+                                        crate::i18n::t("zc-config-help-save"),
+                                    ),
+                                    E::new(
+                                        vec![editor_key(crate::keymap::ConfigEditorAction::Cancel)],
+                                        crate::i18n::t("zc-config-help-back-to-skills"),
+                                    ),
+                                    help(),
                                 ])
                             } else {
                                 HelpNode::entries(vec![
                                     E::new(
-                                        vec!["←→", "h", "l"],
+                                        switch_tabs_keys(),
                                         crate::i18n::t("zc-config-help-switch-tabs"),
                                     ),
-                                    E::new(
-                                        vec!["↑↓", "j", "k"],
-                                        crate::i18n::t("zc-config-help-navigate"),
-                                    ),
-                                    E::key("Enter", crate::i18n::t("zc-config-help-edit-skill")),
-                                    E::key("x", crate::i18n::t("zc-config-help-archive-skill")),
-                                    E::key("Esc", crate::i18n::t("zc-config-help-back")),
-                                    E::key("?", crate::i18n::t("zc-config-help-this-help")),
+                                    nav(),
+                                    k(A::Enter, "zc-config-help-edit-skill"),
+                                    k(A::ToggleSecret, "zc-config-help-archive-skill"),
+                                    back(),
+                                    help(),
                                     E::spacer(),
                                     E::key("Mouse", crate::i18n::t("zc-config-help-mouse-tabs")),
                                 ])
@@ -3362,37 +3489,49 @@ impl App<'_> {
                 if self.is_select_edit() {
                     if self.filter.is_some() {
                         HelpNode::entries(vec![
-                            E::new(vec!["↑", "↓"], crate::i18n::t("zc-config-help-navigate")),
-                            E::key("Enter", crate::i18n::t("zc-config-help-save-selection")),
-                            E::key("Esc", crate::i18n::t("zc-config-help-clear-filter")),
-                            E::key("?", crate::i18n::t("zc-config-help-this-help")),
+                            nav(),
+                            k(A::Enter, "zc-config-help-save-selection"),
+                            clear_filter(),
+                            help(),
                         ])
                     } else {
                         HelpNode::entries(vec![
-                            E::new(
-                                vec!["↑↓", "j", "k"],
-                                crate::i18n::t("zc-config-help-navigate"),
-                            ),
-                            E::key("Enter", crate::i18n::t("zc-config-help-save-selection")),
-                            E::key("/", crate::i18n::t("zc-config-help-filter")),
-                            E::key("Esc", crate::i18n::t("zc-config-help-cancel")),
-                            E::key("?", crate::i18n::t("zc-config-help-this-help")),
+                            nav(),
+                            k(A::Enter, "zc-config-help-save-selection"),
+                            filter(),
+                            k(A::Back, "zc-config-help-cancel"),
+                            help(),
                             E::spacer(),
                             E::key("Mouse", crate::i18n::t("zc-config-help-mouse-save")),
                         ])
                     }
                 } else if is_string_array {
                     HelpNode::entries(vec![
-                        E::key("Enter", crate::i18n::t("zc-config-help-new-line-entry")),
-                        E::key("Ctrl+S", crate::i18n::t("zc-config-help-save-array")),
-                        E::key("Esc", crate::i18n::t("zc-config-help-cancel")),
-                        E::key("?", crate::i18n::t("zc-config-help-this-help")),
+                        E::new(
+                            vec![editor_key(crate::keymap::ConfigEditorAction::Confirm)],
+                            crate::i18n::t("zc-config-help-new-line-entry"),
+                        ),
+                        E::new(
+                            vec![editor_key(crate::keymap::ConfigEditorAction::Save)],
+                            crate::i18n::t("zc-config-help-save-array"),
+                        ),
+                        E::new(
+                            vec![editor_key(crate::keymap::ConfigEditorAction::Cancel)],
+                            crate::i18n::t("zc-config-help-cancel"),
+                        ),
+                        help(),
                     ])
                 } else {
                     HelpNode::entries(vec![
-                        E::key("Enter", crate::i18n::t("zc-config-help-save-value")),
-                        E::key("Esc", crate::i18n::t("zc-config-help-cancel")),
-                        E::key("?", crate::i18n::t("zc-config-help-this-help")),
+                        E::new(
+                            vec![editor_key(crate::keymap::ConfigEditorAction::Confirm)],
+                            crate::i18n::t("zc-config-help-save-value"),
+                        ),
+                        E::new(
+                            vec![editor_key(crate::keymap::ConfigEditorAction::Cancel)],
+                            crate::i18n::t("zc-config-help-cancel"),
+                        ),
+                        help(),
                     ])
                 }
             }
@@ -3402,23 +3541,33 @@ impl App<'_> {
 
 impl App<'_> {
     fn field_list_context(&self) -> crate::widgets::HelpNode {
+        use crate::keymap::ConfigTabAction as A;
         use crate::widgets::{HelpEntry as E, HelpNode};
         let has_tabs = !self.tab_names.is_empty();
         let mut entries = Vec::new();
         if has_tabs {
             entries.push(E::new(
-                vec!["←→", "h", "l"],
+                switch_tabs_keys(),
                 crate::i18n::t("zc-config-help-switch-tabs"),
             ));
         }
         entries.push(E::new(
-            vec!["↑↓", "j", "k"],
+            nav_keys_split(),
             crate::i18n::t("zc-config-help-navigate"),
         ));
-        entries.push(E::key("Enter", crate::i18n::t("zc-config-help-edit-field")));
-        entries.push(E::key("d", crate::i18n::t("zc-config-help-reset-default")));
+        entries.push(E::new(
+            tab_keys(A::Enter),
+            crate::i18n::t("zc-config-help-edit-field"),
+        ));
+        entries.push(E::new(
+            tab_keys(A::DeleteRow),
+            crate::i18n::t("zc-config-help-reset-default"),
+        ));
         entries.push(E::key("/", crate::i18n::t("zc-config-help-filter")));
-        entries.push(E::key("Esc", crate::i18n::t("zc-config-help-back")));
+        entries.push(E::new(
+            tab_keys(A::Back),
+            crate::i18n::t("zc-config-help-back"),
+        ));
         entries.push(E::key("?", crate::i18n::t("zc-config-help-this-help")));
         entries.push(E::spacer());
         let mouse = if has_tabs {

--- a/apps/zerocode/src/logs.rs
+++ b/apps/zerocode/src/logs.rs
@@ -1249,14 +1249,11 @@ impl crate::widgets::HelpContext for Logs<'_> {
                 E::key("c", crate::i18n::t("zc-logs-help-clear-search")),
                 E::key("?", crate::i18n::t("zc-logs-help-this-help")),
                 E::spacer(),
-                E::new(
-                    vec![],
-                    format!(
-                        "{}: {}",
-                        crate::i18n::t("zc-logs-help-mouse-label"),
-                        crate::i18n::t("zc-logs-help-mouse-desc"),
-                    ),
-                ),
+                E::desc(format!(
+                    "{}: {}",
+                    crate::i18n::t("zc-logs-help-mouse-label"),
+                    crate::i18n::t("zc-logs-help-mouse-desc"),
+                )),
             ])
         }
     }

--- a/apps/zerocode/src/theme.rs
+++ b/apps/zerocode/src/theme.rs
@@ -245,6 +245,14 @@ pub(crate) fn selected_style() -> Style {
         .add_modifier(Modifier::BOLD)
 }
 
+/// Retained ("you are here") selection for a pane that does NOT currently hold
+/// the cursor. Distinct from `selected_style` (the active cursor): no bold and a
+/// dim foreground so the row reads as a remembered position, not the live focus.
+pub(crate) fn selected_inactive_style() -> Style {
+    let t = active();
+    Style::default().fg(t.dim).bg(t.selection_bg)
+}
+
 pub(crate) fn input_style() -> Style {
     Style::default().fg(active().body)
 }

--- a/apps/zerocode/src/widgets.rs
+++ b/apps/zerocode/src/widgets.rs
@@ -7,23 +7,26 @@
 #[derive(Debug, Clone, Default)]
 pub struct HelpEntry {
     /// Keys that trigger this action, e.g. ["↑", "k"].
-    pub keys: Vec<&'static str>,
+    pub keys: Vec<String>,
     /// Human-readable description of the action.
     pub action: String,
 }
 
 impl HelpEntry {
-    pub fn new(keys: Vec<&'static str>, action: impl Into<String>) -> Self {
+    pub fn new<K: Into<String>>(
+        keys: impl IntoIterator<Item = K>,
+        action: impl Into<String>,
+    ) -> Self {
         Self {
-            keys,
+            keys: keys.into_iter().map(Into::into).collect(),
             action: action.into(),
         }
     }
 
     /// Convenience: single key.
-    pub fn key(key: &'static str, action: impl Into<String>) -> Self {
+    pub fn key(key: impl Into<String>, action: impl Into<String>) -> Self {
         Self {
-            keys: vec![key],
+            keys: vec![key.into()],
             action: action.into(),
         }
     }
@@ -33,6 +36,14 @@ impl HelpEntry {
         Self {
             keys: vec![],
             action: String::new(),
+        }
+    }
+
+    /// Keyless description row (no key column, just text).
+    pub fn desc(action: impl Into<String>) -> Self {
+        Self {
+            keys: vec![],
+            action: action.into(),
         }
     }
 

--- a/apps/zerocode/src/zerocode_pane.rs
+++ b/apps/zerocode/src/zerocode_pane.rs
@@ -21,7 +21,7 @@ use crate::keymap::{Chord, overrides, reserved_reason};
 use crate::theme;
 
 /// Which sub-pane of the zerocode tab is focused.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum Focus {
     Theme,
     Presets,
@@ -37,6 +37,16 @@ const FOCI: [Focus; 5] = [
     Focus::Locale,
     Focus::Connection,
 ];
+
+/// Which side of the split holds the live cursor. `Sections` is the left list
+/// of section names; `Detail` is the right pane for the highlighted section. The
+/// inactive side keeps a dimmed "you are here" highlight so the user never loses
+/// their place.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum PaneCursor {
+    Sections,
+    Detail,
+}
 
 impl Focus {
     fn fluent_key(self) -> &'static str {
@@ -100,6 +110,9 @@ struct Capture {
 pub(crate) struct ZerocodePane {
     config_dir: PathBuf,
     focus: Focus,
+    /// Which split side holds the live cursor. Section navigation is on the left
+    /// (Sections); entering a section moves the cursor to the right (Detail).
+    cursor: PaneCursor,
     // Theme
     themes: Vec<String>,
     theme_cursor: usize,
@@ -151,6 +164,7 @@ impl ZerocodePane {
         let mut pane = Self {
             config_dir: config_dir.to_path_buf(),
             focus: Focus::Theme,
+            cursor: PaneCursor::Sections,
             themes,
             theme_cursor,
             presets,
@@ -222,6 +236,16 @@ impl ZerocodePane {
         }
     }
 
+    /// Highlight style + symbol for a detail-pane list: active (full) when the
+    /// cursor is in the detail, dimmed "you are here" when it has stepped back to
+    /// the section list.
+    fn detail_highlight(&self) -> (ratatui::style::Style, &'static str) {
+        match self.cursor {
+            PaneCursor::Detail => (theme::selected_style(), "› "),
+            PaneCursor::Sections => (theme::selected_inactive_style(), "  "),
+        }
+    }
+
     fn draw_focus_list(&self, frame: &mut Frame, area: Rect) {
         let items: Vec<ListItem> = FOCI
             .iter()
@@ -234,11 +258,17 @@ impl ZerocodePane {
             .collect();
         let mut state = ListState::default();
         state.select(FOCI.iter().position(|f| *f == self.focus));
+        // Active highlight when the cursor lives in the section list; a dimmed
+        // "you are here" highlight when the cursor has stepped into the detail.
+        let (style, symbol) = match self.cursor {
+            PaneCursor::Sections => (theme::selected_style(), "› "),
+            PaneCursor::Detail => (theme::selected_inactive_style(), "  "),
+        };
         frame.render_stateful_widget(
             List::new(items)
                 .block(theme::panel_block(" zerocode "))
-                .highlight_style(theme::selected_style())
-                .highlight_symbol("› "),
+                .highlight_style(style)
+                .highlight_symbol(symbol),
             area,
             &mut state,
         );
@@ -257,8 +287,8 @@ impl ZerocodePane {
         frame.render_stateful_widget(
             List::new(items)
                 .block(theme::panel_block(" Theme "))
-                .highlight_style(theme::selected_style())
-                .highlight_symbol("› "),
+                .highlight_style(self.detail_highlight().0)
+                .highlight_symbol(self.detail_highlight().1),
             area,
             &mut state,
         );
@@ -277,8 +307,8 @@ impl ZerocodePane {
         frame.render_stateful_widget(
             List::new(items)
                 .block(theme::panel_block(" Keybinding Presets "))
-                .highlight_style(theme::selected_style())
-                .highlight_symbol("› "),
+                .highlight_style(self.detail_highlight().0)
+                .highlight_symbol(self.detail_highlight().1),
             area,
             &mut state,
         );
@@ -312,8 +342,8 @@ impl ZerocodePane {
         frame.render_stateful_widget(
             List::new(items)
                 .block(theme::panel_block(" Keybindings (Enter to rebind) "))
-                .highlight_style(theme::selected_style())
-                .highlight_symbol("› "),
+                .highlight_style(self.detail_highlight().0)
+                .highlight_symbol(self.detail_highlight().1),
             area,
             &mut state,
         );
@@ -379,8 +409,8 @@ impl ZerocodePane {
         frame.render_stateful_widget(
             List::new(items)
                 .block(theme::panel_block(" Locale (Enter to select / download) "))
-                .highlight_style(theme::selected_style())
-                .highlight_symbol("› "),
+                .highlight_style(self.detail_highlight().0)
+                .highlight_symbol(self.detail_highlight().1),
             area,
             &mut state,
         );
@@ -469,8 +499,8 @@ impl ZerocodePane {
                 .block(theme::panel_block(&crate::i18n::t(
                     "zc-zerocode-conn-title",
                 )))
-                .highlight_style(theme::selected_style())
-                .highlight_symbol("› "),
+                .highlight_style(self.detail_highlight().0)
+                .highlight_symbol(self.detail_highlight().1),
             area,
             &mut state,
         );
@@ -656,16 +686,47 @@ impl ZerocodePane {
         }
         use crate::keymap::ConfigTabAction;
         match ConfigTabAction::from_chord(&key) {
-            Some(ConfigTabAction::Up) => self.move_cursor(-1),
-            Some(ConfigTabAction::Down) => self.move_cursor(1),
-            Some(ConfigTabAction::TabLeft) => self.cycle_focus(-1),
-            Some(ConfigTabAction::TabRight) => self.cycle_focus(1),
-            Some(ConfigTabAction::Enter) => self.activate(),
-            Some(ConfigTabAction::DeleteRow) if self.focus == Focus::Bindings => {
+            // Up/Down move within whichever side holds the cursor: the section
+            // list on the left, or the detail rows on the right.
+            Some(ConfigTabAction::Up) => match self.cursor {
+                PaneCursor::Sections => self.cycle_focus(-1),
+                PaneCursor::Detail => self.move_cursor(-1),
+            },
+            Some(ConfigTabAction::Down) => match self.cursor {
+                PaneCursor::Sections => self.cycle_focus(1),
+                PaneCursor::Detail => self.move_cursor(1),
+            },
+            // Right enters the detail pane; at the detail level it is a no-op
+            // (deepest level — cross-tab nav stays on the global PaneNav chord).
+            Some(ConfigTabAction::TabRight) => self.enter_detail(),
+            // Left walks back to the section list; at the section level it is a
+            // no-op ("home").
+            Some(ConfigTabAction::TabLeft) => self.leave_detail(),
+            // Enter: from Sections steps into the detail; from Detail activates
+            // the highlighted row.
+            Some(ConfigTabAction::Enter) => match self.cursor {
+                PaneCursor::Sections => self.enter_detail(),
+                PaneCursor::Detail => self.activate(),
+            },
+            // Back walks one level toward home: Detail -> Sections, then stays.
+            Some(ConfigTabAction::Back) => self.leave_detail(),
+            Some(ConfigTabAction::DeleteRow)
+                if self.cursor == PaneCursor::Detail && self.focus == Focus::Bindings =>
+            {
                 self.reset_row();
             }
             _ => {}
         }
+    }
+
+    /// Move the cursor into the detail pane for the highlighted section.
+    fn enter_detail(&mut self) {
+        self.cursor = PaneCursor::Detail;
+    }
+
+    /// Move the cursor back to the section list. No-op if already there (home).
+    fn leave_detail(&mut self) {
+        self.cursor = PaneCursor::Sections;
     }
 
     fn cycle_focus(&mut self, delta: isize) {
@@ -902,59 +963,96 @@ impl ZerocodePane {
     // ── Contextual help ──────────────────────────────────────────
 
     pub(crate) fn help_context(&self) -> crate::widgets::HelpNode {
+        use crate::keymap::ConfigTabAction as A;
         use crate::widgets::{HelpEntry as E, HelpNode};
+        // Render the live chords for an action, never a hardcoded glyph, so the
+        // help tracks the actual (possibly overridden) keymap.
+        let keys = |a: A| -> Vec<String> {
+            use crate::keymap::RebindableActions;
+            a.resolved().iter().map(Chord::display).collect()
+        };
+
         if self.capture.is_some() {
             return HelpNode::entries(vec![
                 E::key("any key", crate::i18n::t("zc-zerocode-capture-assign")),
-                E::key("Esc", crate::i18n::t("zc-zerocode-capture-cancel")),
+                E::new(keys(A::Back), crate::i18n::t("zc-zerocode-capture-cancel")),
             ]);
         }
-        let mut entries = vec![
+
+        let mouse = || {
             E::new(
-                vec!["←", "→", "h", "l"],
-                crate::i18n::t("zc-zerocode-help-switch-pane"),
-            ),
-            E::new(
-                vec!["↑", "↓", "j", "k"],
-                crate::i18n::t("zc-zerocode-help-navigate"),
-            ),
-        ];
+                Vec::<String>::new(),
+                format!(
+                    "{}: {}",
+                    crate::i18n::t("zc-zerocode-help-mouse-label"),
+                    crate::i18n::t("zc-zerocode-help-mouse-desc"),
+                ),
+            )
+        };
+
+        // Cursor in the section list: navigate sections and step into one.
+        if self.cursor == PaneCursor::Sections {
+            return HelpNode::entries(vec![
+                E::new(
+                    [keys(A::Up), keys(A::Down)].concat(),
+                    crate::i18n::t("zc-zerocode-help-choose-section"),
+                ),
+                E::new(
+                    [keys(A::TabRight), keys(A::Enter)].concat(),
+                    crate::i18n::t("zc-zerocode-help-open-section"),
+                ),
+                E::spacer(),
+                mouse(),
+            ]);
+        }
+
+        // Cursor in the detail pane: navigate rows, act, walk back.
+        let mut entries = vec![E::new(
+            [keys(A::Up), keys(A::Down)].concat(),
+            crate::i18n::t("zc-zerocode-help-navigate-rows"),
+        )];
         match self.focus {
             Focus::Theme => {
-                entries.push(E::key(
-                    "Enter",
+                entries.push(E::new(
+                    keys(A::Enter),
                     crate::i18n::t("zc-zerocode-help-apply-theme"),
                 ));
             }
             Focus::Presets => {
-                entries.push(E::key(
-                    "Enter",
+                entries.push(E::new(
+                    keys(A::Enter),
                     crate::i18n::t("zc-zerocode-help-apply-preset"),
                 ));
             }
             Focus::Bindings => {
-                entries.push(E::key("Enter", crate::i18n::t("zc-zerocode-help-rebind")));
-                entries.push(E::key(
-                    "d",
+                entries.push(E::new(
+                    keys(A::Enter),
+                    crate::i18n::t("zc-zerocode-help-rebind"),
+                ));
+                entries.push(E::new(
+                    keys(A::DeleteRow),
                     crate::i18n::t("zc-zerocode-help-reset-default"),
                 ));
             }
             Focus::Locale => {
-                entries.push(E::key("Enter", crate::i18n::t("zc-zerocode-help-locale")));
+                entries.push(E::new(
+                    keys(A::Enter),
+                    crate::i18n::t("zc-zerocode-help-locale"),
+                ));
             }
             Focus::Connection => {
-                entries.push(E::key("Enter", crate::i18n::t("zc-zerocode-help-conn")));
+                entries.push(E::new(
+                    keys(A::Enter),
+                    crate::i18n::t("zc-zerocode-help-conn"),
+                ));
             }
         }
-        entries.push(E::spacer());
         entries.push(E::new(
-            vec![],
-            format!(
-                "{}: {}",
-                crate::i18n::t("zc-zerocode-help-mouse-label"),
-                crate::i18n::t("zc-zerocode-help-mouse-desc"),
-            ),
+            [keys(A::TabLeft), keys(A::Back)].concat(),
+            crate::i18n::t("zc-zerocode-help-back-to-sections"),
         ));
+        entries.push(E::spacer());
+        entries.push(mouse());
         HelpNode::entries(entries)
     }
 
@@ -972,20 +1070,24 @@ impl ZerocodePane {
 
         match mouse.kind {
             MouseEventKind::Down(MouseButton::Left) => {
-                // Focus column click selects the pane.
+                // Focus column click selects the section and parks the cursor on
+                // the left list.
                 if mouse::in_rect(mouse.column, mouse.row, self.focus_area) {
                     if let Some(idx) =
                         mouse::list_click_index(mouse.row, self.focus_area, 0, FOCI.len())
                     {
                         self.focus = FOCI[idx.min(FOCI.len() - 1)];
+                        self.cursor = PaneCursor::Sections;
                     }
                     return;
                 }
-                // Content list click selects (double-click activates).
+                // Content list click moves the cursor into the detail pane and
+                // selects (double-click activates).
                 if mouse::in_rect(mouse.column, mouse.row, self.content_area) {
                     let len = self.current_len();
                     if let Some(idx) = mouse::list_click_index(mouse.row, self.content_area, 0, len)
                     {
+                        self.cursor = PaneCursor::Detail;
                         self.set_current_cursor(idx);
                         if self.double_click.click(mouse.column, mouse.row) {
                             self.activate();
@@ -1120,10 +1222,13 @@ mod tests {
     fn locale_tab_never_claims_text_input() {
         let dir = tempfile::tempdir().unwrap();
         let mut pane = ZerocodePane::new(dir.path());
+        // Down moves the cursor through the section list (cursor starts left).
         while pane.focus != Focus::Locale {
-            pane.handle_key(key(KeyCode::Right));
+            pane.handle_key(key(KeyCode::Down));
         }
-        // Pressing Enter on the (empty) list must not open any text buffer.
+        // Enter steps into the detail; a second Enter on the (empty) list must
+        // not open any text buffer.
+        pane.handle_key(key(KeyCode::Enter));
         pane.handle_key(key(KeyCode::Enter));
         assert!(!pane.wants_text_input());
     }
@@ -1136,7 +1241,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let mut pane = ZerocodePane::new(dir.path());
         while pane.focus != Focus::Locale {
-            pane.handle_key(key(KeyCode::Right));
+            pane.handle_key(key(KeyCode::Down));
         }
         assert!(pane.locale_needs_list(), "empty list should need a fetch");
         pane.report_list_error("daemon unreachable");
@@ -1151,5 +1256,47 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let pane = ZerocodePane::new(dir.path());
         assert!(!pane.wants_text_input());
+    }
+
+    #[test]
+    fn right_enters_detail_left_returns_to_sections() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut pane = ZerocodePane::new(dir.path());
+        assert_eq!(pane.cursor, PaneCursor::Sections);
+        let start = pane.focus;
+        pane.handle_key(key(KeyCode::Right));
+        assert_eq!(pane.cursor, PaneCursor::Detail);
+        assert_eq!(pane.focus, start);
+        pane.handle_key(key(KeyCode::Left));
+        assert_eq!(pane.cursor, PaneCursor::Sections);
+        // Left at the section list is a no-op (home), no cross-tab jump.
+        pane.handle_key(key(KeyCode::Left));
+        assert_eq!(pane.cursor, PaneCursor::Sections);
+        assert_eq!(pane.focus, start);
+    }
+
+    #[test]
+    fn esc_walks_back_to_sections() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut pane = ZerocodePane::new(dir.path());
+        pane.handle_key(key(KeyCode::Right));
+        assert_eq!(pane.cursor, PaneCursor::Detail);
+        pane.handle_key(key(KeyCode::Esc));
+        assert_eq!(pane.cursor, PaneCursor::Sections);
+        pane.handle_key(key(KeyCode::Esc));
+        assert_eq!(pane.cursor, PaneCursor::Sections);
+    }
+
+    #[test]
+    fn up_down_navigate_sections_when_cursor_in_sections() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut pane = ZerocodePane::new(dir.path());
+        let first = pane.focus;
+        pane.handle_key(key(KeyCode::Down));
+        assert_ne!(
+            pane.focus, first,
+            "Down in Sections moves to the next section"
+        );
+        assert_eq!(pane.cursor, PaneCursor::Sections);
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - The zerocode Config tab used Left/Right to move the left section list and Up/Down to move the right detail, giving no sense of which nested level the cursor was at. Introduce a two-level `PaneCursor {Sections, Detail}`: Up/Down move within the focused side, Right/Enter steps into the detail, Left/Back/Esc walks home, and edges are no-ops (tab switching stays on the global PaneNav chord). The inactive side keeps a dimmed "you are here" highlight so the user never loses their place.
  - All navigation matches on `ConfigTabAction` variants, never key literals, so vim (h/j/k/l), arrows, emacs chords, and user overrides all work. Help context and footers reflect the live cursor state with registry-resolved chords.
  - The Chat agent picker gains mouse support: click highlights a row, double-click confirms (enters the session), the wheel moves the selection. `handle_mouse` becomes async to route a double-click confirm through `pick_or_start_session`.
  - The zeroclaw Config tab drills into a section with Right (alias of Enter), and every daemon Config footer and help key now resolves from the keymap registry instead of hardcoded glyphs.
- **Scope boundary:** Does NOT change the zeroclaw Config tab's deeper drill-down screens (Model Providers, Agents, Channels — type/alias/field lists). Those keep their existing Enter-to-drill / Esc-to-walk-home behavior; no split-pane cursor is applied there (that surface is a full-screen drill-down, not a left/right split). No daemon/runtime behavior changes.
- **Blast radius:** zerocode TUI only (`apps/zerocode/**`). `HelpEntry` now owns `Vec<String>` keys instead of `Vec<&'static str>`; all in-crate callers updated.
- **Linked issue(s):** None.
- **Labels:** `enhancement` (size/risk auto-applied).

## Validation Evidence (required)

Deferring the full battery to CI. Locally during development the zerocode bin built clean, `cargo test -p zerocode --bins` passed (207 tests), `cargo fmt --all -- --check` was clean, and `cargo clippy -p zerocode --all-targets -- -D warnings` was clean.

- **Commands run and tail output:** see CI.
- **Beyond CI — what did you manually verify?** Cursor transitions (enter/leave detail, Esc walk-home, section nav), active vs inactive highlight, agent-picker click selection — covered by new unit tests in `zerocode_pane` and `chat`.
- **If any command was intentionally skipped, why:** Full local battery deferred to CI per maintainer direction.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Upgrade steps: None. Key bindings remain registry-driven; existing overrides continue to work.

## Rollback (required for `risk: medium` and `risk: high`)

- `git revert <sha>` is the rollback plan. No feature flags or config toggles; TUI-only change.