### PR TITLE
feat(gateway): per-request agent dispatch for POST /webhook via ?agent=

### DIFF
--- a/crates/zeroclaw-gateway/src/lib.rs
+++ b/crates/zeroclaw-gateway/src/lib.rs
@@ -52,11 +52,9 @@ use anyhow::{Context, Result};
 use axum::body::Bytes;
 #[cfg(feature = "channel-linq")]
 use axum::extract::Path;
-#[cfg(any(feature = "channel-wati", feature = "channel-whatsapp-cloud"))]
-use axum::extract::Query;
 use axum::{
     Router,
-    extract::{ConnectInfo, State},
+    extract::{ConnectInfo, Query, State},
     http::{HeaderMap, StatusCode, header},
     response::{IntoResponse, Json},
     routing::{delete, get, post},
@@ -702,7 +700,9 @@ pub async fn run_gateway(
     // request. The shared SecurityPolicy / risk_profile / tools_registry
     // built here are vestiges driving the legacy single-agent
     // `/api/tools` listing and the `run_gateway_chat_with_tools` test
-    // mock; per-request agent dispatch is tracked as a follow-up.
+    // mock; `/webhook` honors `?agent=` per-request (validated against
+    // `config.agents`), while SSE / pairing per-request dispatch is still
+    // tracked as a follow-up.
     //
     // Agent count is unconstrained at boot. Zero agents is a valid
     // state — the gateway must come up so `/admin/reload` and
@@ -2119,10 +2119,15 @@ fn needs_quickstart_channel_reply() -> String {
 }
 
 /// Full-featured chat with tools for channel and webhook handlers.
+///
+/// `agent_override` is the caller-requested agent alias (`/webhook?agent=`),
+/// already validated against `config.agents` by the handler. `None` keeps the
+/// legacy default pick (migration-synthesized "default", else first enabled).
 async fn run_gateway_chat_with_tools(
     state: &AppState,
     message: &str,
     session_id: Option<&str>,
+    agent_override: Option<&str>,
 ) -> anyhow::Result<GatewayChatOutcome> {
     if let Some(err) = needs_quickstart_for(&state.model) {
         return Err(err);
@@ -2134,7 +2139,7 @@ async fn run_gateway_chat_with_tools(
     // doesn't go through the cost-tracking scope, so usage stays None.
     #[cfg(test)]
     {
-        let _ = session_id;
+        let _ = (session_id, agent_override);
         let response = state
             .model_provider
             .chat_with_system(None, message, &state.model, state.temperature)
@@ -2150,20 +2155,26 @@ async fn run_gateway_chat_with_tools(
     #[cfg(not(test))]
     {
         let config = state.config.read().clone();
-        // Legacy: webhook chat / SSE / pairing endpoints don't yet
-        // accept an explicit agent in the request payload. Pick the
-        // migration-synthesized "default" agent (or first enabled) until
-        // the per-request agent dispatch refactor lands.
-        let agent_alias = config
-            .agents
-            .keys()
-            .find(|k| k.as_str() == "default")
+        // Per-request dispatch: honor the caller's validated agent alias.
+        // Without one, fall back to the legacy pick — SSE / pairing
+        // endpoints still don't accept an explicit agent in the request
+        // payload, so the migration-synthesized "default" agent (or first
+        // enabled) remains their dispatch target.
+        let agent_alias = agent_override
+            .map(ToString::to_string)
             .or_else(|| {
                 config
                     .agents
-                    .iter()
-                    .find(|(_, a)| a.enabled)
-                    .map(|(alias, _)| alias)
+                    .keys()
+                    .find(|k| k.as_str() == "default")
+                    .or_else(|| {
+                        config
+                            .agents
+                            .iter()
+                            .find(|(_, a)| a.enabled)
+                            .map(|(alias, _)| alias)
+                    })
+                    .cloned()
             })
             .ok_or_else(|| {
                 ::zeroclaw_log::record!(
@@ -2175,8 +2186,7 @@ async fn run_gateway_chat_with_tools(
                 anyhow::Error::msg(
                     "webhook chat requires at least one configured [agents.<alias>] entry",
                 )
-            })?
-            .clone();
+            })?;
 
         // Scope the cost tracking context so per-LLM-call usage flows into the
         // gateway's cost tracker and costs.jsonl. Without this scope, the
@@ -2259,10 +2269,22 @@ pub struct WebhookBody {
     pub message: String,
 }
 
+/// Webhook query parameters
+#[derive(Default, serde::Deserialize)]
+pub struct WebhookQuery {
+    /// Configured agent alias to dispatch to. Optional — when omitted, the
+    /// legacy pick applies (migration-synthesized "default" agent, else the
+    /// first enabled one). Aliases mirror `WsQuery` so `/ws/chat` callers
+    /// can reuse their query string verbatim.
+    #[serde(default, alias = "agentAlias", alias = "agent_alias")]
+    pub agent: Option<String>,
+}
+
 /// POST /webhook — main webhook endpoint
 async fn handle_webhook(
     State(state): State<AppState>,
     ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
+    Query(query): Query<WebhookQuery>,
     headers: HeaderMap,
     body: Result<Json<WebhookBody>, axum::extract::rejection::JsonRejection>,
 ) -> impl IntoResponse {
@@ -2359,6 +2381,34 @@ async fn handle_webhook(
         }
     };
 
+    // ── Per-request agent dispatch (optional `?agent=` query param) ──
+    // Validate before idempotency / autosave so a typo'd alias doesn't
+    // consume the caller's idempotency key. Mirrors the `/ws/chat`
+    // unknown-agent rejection.
+    let agent_override = query
+        .agent
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    if let Some(alias) = agent_override {
+        let cfg = state.config.read();
+        if cfg.agent(alias).is_none() {
+            ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Reject)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                    .with_attrs(::serde_json::json!({"agent": alias})),
+                "webhook: rejected — unknown agent alias"
+            );
+            let err = serde_json::json!({
+                "error": format!(
+                    "Unknown agent `{alias}` — no [agents.{alias}] entry configured."
+                )
+            });
+            return (StatusCode::BAD_REQUEST, Json(err));
+        }
+    }
+
     // ── Idempotency (optional) ──
     if let Some(idempotency_key) = headers
         .get("X-Idempotency-Key")
@@ -2399,11 +2449,19 @@ async fn handle_webhook(
 
     let provider_label = {
         let cfg = state.config.read();
-        cfg.providers
-            .models
-            .iter_entries()
-            .next()
+        // When the request names an agent, label observability events with
+        // that agent's resolved provider; the first-entry pick is only the
+        // legacy-dispatch approximation.
+        agent_override
+            .and_then(|alias| cfg.resolved_model_provider_for_agent(alias))
             .map(|(ty, alias, _)| format!("{ty}.{alias}"))
+            .or_else(|| {
+                cfg.providers
+                    .models
+                    .iter_entries()
+                    .next()
+                    .map(|(ty, alias, _)| format!("{ty}.{alias}"))
+            })
             .unwrap_or_else(|| "unknown".to_string())
     };
     let model_label = state.model.clone();
@@ -2423,7 +2481,8 @@ async fn handle_webhook(
         },
     );
 
-    match run_gateway_chat_with_tools(&state, message, session_id.as_deref()).await {
+    match run_gateway_chat_with_tools(&state, message, session_id.as_deref(), agent_override).await
+    {
         Ok(GatewayChatOutcome {
             response,
             input_tokens,
@@ -2698,6 +2757,7 @@ async fn handle_whatsapp_message(
             &state,
             &msg.content,
             Some(&session_id),
+            None,
         ))
         .await
         {
@@ -2843,6 +2903,7 @@ async fn handle_linq_webhook(
             &state,
             &msg.content,
             Some(&session_id),
+            None,
         ))
         .await
         {
@@ -2982,6 +3043,7 @@ async fn handle_wati_webhook(State(state): State<AppState>, body: Bytes) -> impl
             &state,
             &msg.content,
             Some(&session_id),
+            None,
         ))
         .await
         {
@@ -3128,6 +3190,7 @@ async fn handle_nextcloud_talk_webhook(
                 &state,
                 &msg.content,
                 Some(&session_id),
+                None,
             ))
             .await
             {
@@ -4438,6 +4501,7 @@ mod tests {
         let first = handle_webhook(
             State(state.clone()),
             test_connect_info(),
+            Query(WebhookQuery::default()),
             headers.clone(),
             body,
         )
@@ -4448,15 +4512,196 @@ mod tests {
         let body = Ok(Json(WebhookBody {
             message: "hello".into(),
         }));
-        let second = handle_webhook(State(state), test_connect_info(), headers, body)
-            .await
-            .into_response();
+        let second = handle_webhook(
+            State(state),
+            test_connect_info(),
+            Query(WebhookQuery::default()),
+            headers,
+            body,
+        )
+        .await
+        .into_response();
         assert_eq!(second.status(), StatusCode::OK);
 
         let payload = second.into_body().collect().await.unwrap().to_bytes();
         let parsed: serde_json::Value = serde_json::from_slice(&payload).unwrap();
         assert_eq!(parsed["status"], "duplicate");
         assert_eq!(parsed["idempotent"], true);
+        assert_eq!(provider_impl.calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn webhook_unknown_agent_rejected_before_dispatch() {
+        let provider_impl = Arc::new(MockModelProvider::default());
+        let model_provider: Arc<dyn ModelProvider> = provider_impl.clone();
+        let memory: Arc<dyn Memory> = Arc::new(MockMemory);
+
+        let state = AppState {
+            config: Arc::new(RwLock::new(Config::default())),
+            model_provider,
+            model: "test-model".into(),
+            temperature: None,
+            mem: memory,
+            auto_save: false,
+            webhook_secret_hash: None,
+            pairing: Arc::new(PairingGuard::new(false, &[])),
+            trust_forwarded_headers: false,
+            rate_limiter: Arc::new(GatewayRateLimiter::new(100, 100, 100)),
+            auth_limiter: Arc::new(auth_rate_limit::AuthRateLimiter::new()),
+            idempotency_store: Arc::new(IdempotencyStore::new(Duration::from_secs(300), 1000)),
+            #[cfg(feature = "channel-whatsapp-cloud")]
+            whatsapp: None,
+            #[cfg(feature = "channel-whatsapp-cloud")]
+            whatsapp_app_secret: None,
+            #[cfg(feature = "channel-linq")]
+            linq: HashMap::new(),
+            #[cfg(feature = "channel-linq")]
+            linq_signing_secrets: HashMap::new(),
+            #[cfg(feature = "channel-nextcloud")]
+            nextcloud_talk: None,
+            #[cfg(feature = "channel-nextcloud")]
+            nextcloud_talk_webhook_secret: None,
+            #[cfg(feature = "channel-wati")]
+            wati: None,
+            #[cfg(feature = "channel-email")]
+            gmail_push: None,
+            observer: Arc::new(zeroclaw_runtime::observability::NoopObserver),
+            tools_registry: Arc::new(Vec::new()),
+            cost_tracker: None,
+            event_tx: tokio::sync::broadcast::channel(16).0,
+            event_buffer: Arc::new(sse::EventBuffer::new(16)),
+            shutdown_tx: tokio::sync::watch::channel(false).0,
+            reload_tx: None,
+            node_registry: Arc::new(nodes::NodeRegistry::new(16)),
+            path_prefix: String::new(),
+            web_dist_dir: None,
+            session_backend: None,
+            session_queue: std::sync::Arc::new(crate::session_queue::SessionActorQueue::new(
+                8, 30, 600,
+            )),
+            device_registry: None,
+            pending_pairings: None,
+            canvas_store: CanvasStore::new(),
+            cancel_tokens: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+            pending_reload: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            tui_registry: None,
+            #[cfg(feature = "webauthn")]
+            webauthn: None,
+        };
+
+        // An idempotency key on a rejected request must NOT be consumed.
+        let mut headers = HeaderMap::new();
+        headers.insert("X-Idempotency-Key", HeaderValue::from_static("ghost-key"));
+
+        let response = handle_webhook(
+            State(state.clone()),
+            test_connect_info(),
+            Query(WebhookQuery {
+                agent: Some("ghost".into()),
+            }),
+            headers,
+            Ok(Json(WebhookBody {
+                message: "hello".into(),
+            })),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let payload = response.into_body().collect().await.unwrap().to_bytes();
+        let parsed: serde_json::Value = serde_json::from_slice(&payload).unwrap();
+        assert!(
+            parsed["error"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("Unknown agent `ghost`")
+        );
+        assert_eq!(provider_impl.calls.load(Ordering::SeqCst), 0);
+        // Key still fresh — a corrected retry with the same key proceeds.
+        assert!(state.idempotency_store.record_if_new("ghost-key"));
+    }
+
+    #[tokio::test]
+    async fn webhook_explicit_agent_dispatches() {
+        let provider_impl = Arc::new(MockModelProvider::default());
+        let model_provider: Arc<dyn ModelProvider> = provider_impl.clone();
+        let memory: Arc<dyn Memory> = Arc::new(MockMemory);
+
+        let mut config = Config::default();
+        config.agents.insert(
+            "nova".to_string(),
+            zeroclaw_config::schema::AliasedAgentConfig {
+                enabled: true,
+                ..Default::default()
+            },
+        );
+
+        let state = AppState {
+            config: Arc::new(RwLock::new(config)),
+            model_provider,
+            model: "test-model".into(),
+            temperature: None,
+            mem: memory,
+            auto_save: false,
+            webhook_secret_hash: None,
+            pairing: Arc::new(PairingGuard::new(false, &[])),
+            trust_forwarded_headers: false,
+            rate_limiter: Arc::new(GatewayRateLimiter::new(100, 100, 100)),
+            auth_limiter: Arc::new(auth_rate_limit::AuthRateLimiter::new()),
+            idempotency_store: Arc::new(IdempotencyStore::new(Duration::from_secs(300), 1000)),
+            #[cfg(feature = "channel-whatsapp-cloud")]
+            whatsapp: None,
+            #[cfg(feature = "channel-whatsapp-cloud")]
+            whatsapp_app_secret: None,
+            #[cfg(feature = "channel-linq")]
+            linq: HashMap::new(),
+            #[cfg(feature = "channel-linq")]
+            linq_signing_secrets: HashMap::new(),
+            #[cfg(feature = "channel-nextcloud")]
+            nextcloud_talk: None,
+            #[cfg(feature = "channel-nextcloud")]
+            nextcloud_talk_webhook_secret: None,
+            #[cfg(feature = "channel-wati")]
+            wati: None,
+            #[cfg(feature = "channel-email")]
+            gmail_push: None,
+            observer: Arc::new(zeroclaw_runtime::observability::NoopObserver),
+            tools_registry: Arc::new(Vec::new()),
+            cost_tracker: None,
+            event_tx: tokio::sync::broadcast::channel(16).0,
+            event_buffer: Arc::new(sse::EventBuffer::new(16)),
+            shutdown_tx: tokio::sync::watch::channel(false).0,
+            reload_tx: None,
+            node_registry: Arc::new(nodes::NodeRegistry::new(16)),
+            path_prefix: String::new(),
+            web_dist_dir: None,
+            session_backend: None,
+            session_queue: std::sync::Arc::new(crate::session_queue::SessionActorQueue::new(
+                8, 30, 600,
+            )),
+            device_registry: None,
+            pending_pairings: None,
+            canvas_store: CanvasStore::new(),
+            cancel_tokens: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+            pending_reload: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            tui_registry: None,
+            #[cfg(feature = "webauthn")]
+            webauthn: None,
+        };
+
+        let response = handle_webhook(
+            State(state),
+            test_connect_info(),
+            Query(WebhookQuery {
+                agent: Some("nova".into()),
+            }),
+            HeaderMap::new(),
+            Ok(Json(WebhookBody {
+                message: "hello".into(),
+            })),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(provider_impl.calls.load(Ordering::SeqCst), 1);
     }
 
@@ -4529,6 +4774,7 @@ mod tests {
         let first = handle_webhook(
             State(state.clone()),
             test_connect_info(),
+            Query(WebhookQuery::default()),
             headers.clone(),
             body1,
         )
@@ -4539,9 +4785,15 @@ mod tests {
         let body2 = Ok(Json(WebhookBody {
             message: "hello two".into(),
         }));
-        let second = handle_webhook(State(state), test_connect_info(), headers, body2)
-            .await
-            .into_response();
+        let second = handle_webhook(
+            State(state),
+            test_connect_info(),
+            Query(WebhookQuery::default()),
+            headers,
+            body2,
+        )
+        .await
+        .into_response();
         assert_eq!(second.status(), StatusCode::OK);
 
         let keys = tracking_impl.keys.lock().clone();
@@ -4628,6 +4880,7 @@ mod tests {
         let response = handle_webhook(
             State(state),
             test_connect_info(),
+            Query(WebhookQuery::default()),
             HeaderMap::new(),
             Ok(Json(WebhookBody {
                 message: "hello".into(),
@@ -4710,6 +4963,7 @@ mod tests {
         let response = handle_webhook(
             State(state),
             test_connect_info(),
+            Query(WebhookQuery::default()),
             headers,
             Ok(Json(WebhookBody {
                 message: "hello".into(),
@@ -4788,6 +5042,7 @@ mod tests {
         let response = handle_webhook(
             State(state),
             test_connect_info(),
+            Query(WebhookQuery::default()),
             headers,
             Ok(Json(WebhookBody {
                 message: "hello".into(),


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `POST /webhook` now honors an optional `?agent=` query parameter (aliases `agentAlias` / `agent_alias`, mirroring `WsQuery` so `/ws/chat` query strings work verbatim). The boot-time comment already documented `/webhook?agent=` as taking agent context from the request, but `handle_webhook` never read the query string — every webhook drive landed on the migration-synthesized `default` agent (or the iteration-order first enabled one).
  - Why it matters: operators running per-provider agents (e.g. a Bedrock/Nova-backed agent next to a subscription-backed default) could not reach them over `/webhook`; drives silently dispatched to the default agent's provider, which misattributes cost and routes traffic to the wrong (potentially expensive) backend.
  - Unknown aliases are rejected with the same 400 shape `/ws/chat` returns, *before* idempotency/autosave so a typo'd alias doesn't consume the caller's idempotency key.
  - Observability events now label with the requested agent's resolved provider instead of the first config entry when an override is present.
- **Scope boundary:** does NOT change SSE / pairing endpoints (still legacy default pick — the refreshed comment says so), does NOT change channel handlers (they pass `None` and keep existing behavior), does NOT touch the response body's `model` field (it still echoes the boot-global `state.model` — pre-existing behavior, candidate follow-up).
- **Blast radius:** `/webhook` callers (no behavior change when the param is absent), channel handlers (signature-only change, `None` threaded), webhook unit tests (extractor arg added).
- **Linked issue(s):** none — implements the "per-request agent dispatch" follow-up referenced in the gateway boot comments.
- **Labels:** (maintainers set via sidebar)

## Validation Evidence (required)

Run on Linux x86_64 (Ubuntu, rustc stable):

```text
$ cargo fmt --all -- --check
(clean — exit 0)

$ cargo clippy --all-targets -p zeroclaw-gateway -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 4.43s
(exit 0)

$ cargo test
(workspace) exit 0 — all suites green, including:
test tests::webhook_autosave_stores_distinct_keys_per_request ... ok
test tests::webhook_explicit_agent_dispatches ... ok
test tests::webhook_idempotency_skips_duplicate_provider_calls ... ok
test tests::webhook_unknown_agent_rejected_before_dispatch ... ok
```

- **Beyond CI — what did you manually verify?** Built the `zeroclaw` binary from this branch and ran a live gateway with two agents (`default` → `deepseek.chat`, `nova` → `bedrock.nova_micro`, real credentials):

```text
=== 1. unknown agent ===
{"error":"Unknown agent `ghost` — no [agents.ghost] entry configured."}
HTTP=400
=== 2. ?agent=nova (bedrock) ===
{"model":"amazon.nova-micro-v1:0","response":"WEBHOOK-NOVA-OK"}
HTTP=200
=== 3. no agent (legacy default pick, deepseek) ===
{"response":"WEBHOOK-DEFAULT-OK"}
HTTP=200
```

  Not verified: SSE endpoints (out of scope), channel-feature builds beyond default features (clippy `--all-targets` covers compilation).
- **If any command was intentionally skipped, why:** none skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No` (drives existing configured providers; the param only selects *which* configured agent runs)
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes` — the parameter is optional; requests without it keep the exact legacy default-agent pick.
- Config / env / CLI surface changed? `No` (one optional HTTP query parameter added to an existing endpoint; no schema/config/CLI change)

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <sha>`. Requests using `?agent=` would return to being silently routed to the default agent (the pre-PR behavior).
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** watch for `webhook: rejected — unknown agent alias` log lines disappearing, or for provider/cost attribution on `/webhook?agent=<alias>` calls returning to the default provider instead of the requested agent's provider.
