### PR TITLE
fix(ci): skip advisory issue creation when disabled

### DIFF
--- a/.github/workflows/daily-audit.yml
+++ b/.github/workflows/daily-audit.yml
@@ -40,12 +40,20 @@ jobs:
           exit "${PIPESTATUS[0]}"
 
       - name: Open issue on advisory failure
+        id: advisory_issue
         if: steps.scan.outcome == 'failure'
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
+          issues_enabled=$(gh api "repos/$GITHUB_REPOSITORY" --jq '.has_issues')
+          if [[ "$issues_enabled" != "true" ]]; then
+            echo "issue_url=" >> "$GITHUB_OUTPUT"
+            echo "::notice::Repository issues are disabled; skipping advisory issue creation."
+            exit 0
+          fi
+
           # Avoid opening a duplicate while an advisory issue is still open.
           open_count=$(gh issue list \
             --repo "$GITHUB_REPOSITORY" \
@@ -72,15 +80,22 @@ jobs:
             printf 'cc @JordanTheJet @theonlyhennygod\n'
           } > /tmp/issue-body.md
 
-          gh issue create \
+          issue_url=$(gh issue create \
             --repo "$GITHUB_REPOSITORY" \
             --title "ci: Advisory scan failed — $(date -u +%Y-%m-%d)" \
             --label "security" \
             --label "risk: high" \
-            --body-file /tmp/issue-body.md
+            --body-file /tmp/issue-body.md)
+          echo "issue_url=$issue_url" >> "$GITHUB_OUTPUT"
 
       - name: Propagate scan failure
         if: steps.scan.outcome == 'failure'
+        env:
+          ISSUE_URL: ${{ steps.advisory_issue.outputs.issue_url }}
         run: |
-          echo "::error::Advisory scan failed. See the issue opened above for details."
+          if [[ -n "$ISSUE_URL" ]]; then
+            echo "::error::Advisory scan failed. See $ISSUE_URL for details."
+          else
+            echo "::error::Advisory scan failed. Repository issues are disabled or issue creation was skipped; inspect this workflow log for details."
+          fi
           exit 1


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Adds a repository metadata check before the daily advisory workflow calls `gh issue` commands.
  - Skips advisory issue creation with a workflow notice when Issues are disabled on the repository.
  - Keeps the advisory failure propagated so the failed scan remains visible in Actions.
- **Scope boundary:** Does not change the advisory scan itself, `deny.toml`, dependency policy, labels, or repository issue settings.
- **Blast radius:** Limited to `.github/workflows/daily-audit.yml`; affects only the failure-handling path after `cargo deny check advisories` fails.
- **Linked issue(s):** Fixes #7301.
- **Labels:** `risk: high`, `size: S`, `ci`.

## Validation Evidence (required)

- **Commands run and tail output:**

```bash
ruby -e 'require "yaml"; YAML.load_file(".github/workflows/daily-audit.yml"); puts "workflow yaml ok"'
workflow yaml ok
```

```bash
git diff --check
# no output
```

- **Beyond CI — what did you manually verify?** Confirmed the diff is limited to `.github/workflows/daily-audit.yml` and that the workflow still exits non-zero when the advisory scan fails.
- **If any command was intentionally skipped, why:** `cargo fmt`, `cargo clippy`, and `cargo test` were skipped because this is a workflow-only shell/YAML change with no Rust source changes. `actionlint` was not available locally; YAML syntax was verified with Ruby `YAML.load_file` instead.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `Yes`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: Adds one GitHub repository metadata read using the existing workflow `GITHUB_TOKEN`; no new external service, permission, secret, or user data is introduced.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: `N/A`

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** Revert this PR. That restores the previous advisory failure issue-creation path.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Daily Advisory Scan fails after `cargo deny check advisories` because issue creation is attempted while repository Issues are disabled, or the propagated failure message no longer explains where maintainers should inspect the advisory failure.

## Supersede Attribution (required only when `Supersedes #` is used)

`N/A`

