### PR TITLE
fix(install): copy built web/dist to system data dir on source instal…

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1037,6 +1037,24 @@ See all available features:
       info "[dry-run] Would build web dashboard"
     else
       build_web_dashboard "$INSTALL_DIR"
+      # Install built dashboard assets to the system data directory so
+      # systemd-launched daemon can find them regardless of CWD.
+      if [ -d "$INSTALL_DIR/web/dist" ] && [ -f "$INSTALL_DIR/web/dist/index.html" ]; then
+        case "$(uname -s)" in
+        Darwin)
+          web_data_dir="${HOME}/Library/Application Support/zeroclaw/web/dist"
+          ;;
+        MINGW* | CYGWIN* | MSYS*)
+          web_data_dir="${LOCALAPPDATA}/zeroclaw/web/dist"
+          ;;
+        *)
+          web_data_dir="${XDG_DATA_HOME:-${PREFIX:-$HOME/.local}/share}/zeroclaw/web/dist"
+          ;;
+        esac
+        mkdir -p "$web_data_dir"
+        cp -r "$INSTALL_DIR/web/dist/." "$web_data_dir/"
+        info "Web dashboard installed to $web_data_dir"
+      fi
     fi
   fi
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -111,7 +111,17 @@ export async function apiFetch<T = unknown>(
     return undefined as unknown as T;
   }
 
-  return response.json() as Promise<T>;
+  return response.json().catch((err) => {
+    if (err instanceof SyntaxError) {
+      throw new Error(
+        `Gateway returned a non-JSON response (likely HTML). ` +
+          `This usually means the API endpoint was not reached — ` +
+          `check that the daemon is running and the dashboard assets are installed. ` +
+          `Original: ${err.message}`
+      );
+    }
+    throw err;
+  }) as Promise<T>;
 }
 
 function unwrapField<T>(value: T | Record<string, T>, key: string): T {


### PR DESCRIPTION
fix #7553

# Comment for Issue #7253 — Web console - Config: Couldn't load sections

## Summary

The web dashboard's `/config` page fails to load config sections with:

```
Couldn't load sections: JSON.parse: unexpected character at line 1 column 1 of the JSON data
```

This `SyntaxError` means the frontend received an **HTML (or non-JSON) response** when it expected JSON from `/api/config/sections`.

## Root Cause

**Primary defect — source install omits `web/dist` replication.**

`install.sh --source` runs `cargo web build` inside the source tree (`$INSTALL_DIR/web/dist`) but **never copies the built assets to the system data directory** (`$XDG_DATA_HOME/zeroclaw/web/dist`).

Pre-built installs *do* copy:

```bash
# install.sh (pre-built path)
if [ -d "$tmp_dir/web/dist" ]; then
    mkdir -p "$web_data_dir"
    cp -r "$tmp_dir/web/dist/." "$web_data_dir/"
fi
```

The source path has no equivalent step.

**Why this breaks the dashboard after `zeroclaw service start`:**

1. `cargo install --path .` places the binary in `~/.cargo/bin/zeroclaw`.
2. `zeroclaw service install` writes a systemd unit with `ExecStart=~/.cargo/bin/zeroclaw daemon`.
3. systemd user services default to `WorkingDirectory=%h` (home dir) on Debian 12 / systemd 252.
4. Gateway auto-detects `web_dist_dir` by checking, in order:
   - `web/dist` relative to CWD (`~/web/dist` — missing)
   - `web/dist` relative to the binary (`~/.cargo/bin/web/dist` — missing)
   - `/zeroclaw-data/web/dist`, `/usr/share/zeroclawlabs/web/dist`
   - `dirs_data_local()/zeroclaw/web/dist` — **missing because source install never copies**
5. When `web_dist_dir` resolves to `None`, `handle_spa_fallback` returns **503 + plain text** (`"Web dashboard not available..."`), which is correct.

However, if a stale `web/dist` exists from a prior pre-built install (or a manual build), the gateway serves an **old or incomplete dashboard** whose frontend JS calls `/api/config/sections`. If the call is mis-routed (e.g. by a path-prefix mismatch, a missing route in an older build, or a proxy returning HTML) the `fetch → response.json()` path throws the `SyntaxError` observed in the issue.

**Secondary defect — opaque frontend error.**

`web/src/lib/api.ts` calls `response.json()` directly on 2xx responses. If the body is HTML (SPA fallback, 404 page, proxy error), the raw `SyntaxError` bubbles up to the UI with no context about *why* the gateway returned non-JSON.

## Proposed Fix

### `install.sh` — replicate `web/dist` on source installs

After `build_web_dashboard "$INSTALL_DIR"`, copy the built assets to the platform-appropriate data directory so systemd-launched daemons can find them regardless of CWD.

```bash
      build_web_dashboard "$INSTALL_DIR"
      # Install built dashboard assets to the system data directory so
      # systemd-launched daemon can find them regardless of CWD.
      if [ -d "$INSTALL_DIR/web/dist" ] && [ -f "$INSTALL_DIR/web/dist/index.html" ]; then
        case "$(uname -s)" in
        Darwin)
          web_data_dir="${HOME}/Library/Application Support/zeroclaw/web/dist"
          ;;
        MINGW* | CYGWIN* | MSYS*)
          web_data_dir="${LOCALAPPDATA}/zeroclaw/web/dist"
          ;;
        *)
          web_data_dir="${XDG_DATA_HOME:-${PREFIX:-$HOME/.local}/share}/zeroclaw/web/dist"
          ;;
        esac
        mkdir -p "$web_data_dir"
        cp -r "$INSTALL_DIR/web/dist/." "$web_data_dir/"
        info "Web dashboard installed to $web_data_dir"
      fi
```

### `web/src/lib/api.ts` — detect HTML fallback and surface a clear error

Wrap `response.json()` to turn a bare `SyntaxError` into an actionable message.

```typescript
  return response.json().catch((err) => {
    if (err instanceof SyntaxError) {
      throw new Error(
        `Gateway returned a non-JSON response (likely HTML). ` +
          `This usually means the API endpoint was not reached — ` +
          `check that the daemon is running and the dashboard assets are installed. ` +
          `Original: ${err.message}`
      );
    }
    throw err;
  }) as Promise<T>;
```

## Files Changed

| File | Change |
|------|--------|
| `install.sh` | After source `build_web_dashboard`, copy `web/dist` to platform data dir |
| `web/src/lib/api.ts` | Wrap `response.json()` to detect HTML/non-JSON and emit a clear error |

## Test Plan

1. **Source install on clean Debian 12 VM:**
   ```bash
   ./install.sh --source --features agent-runtime,gateway,schema-export
   ls ~/.local/share/zeroclaw/web/dist/index.html   # should exist
   ```
2. **Systemd service start:**
   ```bash
   zeroclaw service install
   zeroclaw service start
   curl -s http://127.0.0.1:42617/api/config/sections -H "Authorization: Bearer <token>" | head -c 1
   # should output '{' (JSON), not '<' (HTML)
   ```
3. **Dashboard load:** Open `http://127.0.0.1:42617/config` and verify sections load without `JSON.parse` error.

## Verification Command

```bash
# After source install
ls ~/.local/share/zeroclaw/web/dist/index.html && echo "PASS" || echo "FAIL"

# After service start
curl -s -o /dev/null -w "%{http_type}" http://127.0.0.1:42617/api/config/sections
# Expected: application/json
```

## Next Step

Ready branch with both fixes. If the direction looks good I can open a PR immediately.