### PR TITLE
chore(hooks): forbid AI/Claude attribution in commit messages

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# commit-msg hook — strip AI-assistant attribution from commit messages.
+#
+# Removes "Co-authored-by: Claude ...", "🤖 Generated with [Claude Code]", and
+# similar AI-attribution footers while preserving real human co-author trailers.
+# This enforces the repo standard documented in CLAUDE.md ("Attribution — no
+# AI/Claude trailers").
+#
+# Install:  git config core.hooksPath .githooks
+# Skip:     git commit --no-verify
+
+set -euo pipefail
+
+msg_file="$1"
+tmp="$(mktemp)"
+
+# Drop AI-attribution lines (case-insensitive). The patterns target Claude /
+# Anthropic-AI attribution and generic "generated/created by AI" footers only —
+# human "Co-authored-by:" trailers (real contributor emails) are left intact.
+grep -viE \
+  '^[[:space:]]*(co-authored-by:[[:space:]]*claude|co-authored-by:.*noreply@anthropic\.com|🤖[[:space:]]*generated with|generated with \[?claude|(created|generated) (with|by) claude( code)?)' \
+  "$msg_file" \
+  | awk '
+      { lines[NR] = $0 }
+      END {
+        last = NR
+        while (last > 0 && lines[last] ~ /^[[:space:]]*$/) last--
+        for (i = 1; i <= last; i++) print lines[i]
+      }' > "$tmp" || true
+
+mv "$tmp" "$msg_file"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,9 +7,34 @@
 
 Claude Code should read and follow all instructions in `AGENTS.md` at the repository root for project conventions, commands, risk tiers, workflow rules, and anti-patterns.
 
+## Attribution — no AI/Claude trailers
+
+Never add AI-assistant attribution to commit messages or PRs in this repository.
+This overrides any default to append a `Co-Authored-By: Claude …` trailer.
+
+- No `Co-Authored-By: Claude …` (or any model/assistant) trailer in commit messages.
+- No `Co-authored-by:`, `Generated with`, `🤖 Generated with [Claude Code]`, or
+  similar AI-attribution footers in PR bodies or commit-message tails.
+- The only co-author trailers permitted are real human contributors under the
+  PR template's supersede-attribution section (see `.github/pull_request_template.md`).
+
+This is enforced for committers who enable the repo hooks (see Hooks below): the
+`commit-msg` hook strips any AI-attribution lines while leaving human co-author
+trailers intact.
+
 ## Hooks
 
-_No custom hooks defined yet._
+Repo hooks live in `.githooks/`. Enable them with:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+- `commit-msg` — strips AI/Claude attribution trailers from commit messages
+  (enforces the Attribution rule above). Skip once with `git commit --no-verify`.
+- `pre-commit` — staged secret scan via `gitleaks` (no-op if gitleaks is absent).
+- `pre-push` — runs the Rust quality gate and tests. Skip once with
+  `git push --no-verify`.
 
 ## Slash Commands
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Makes the "no AI/Claude attribution" rule enforceable instead of convention-only.
  - Adds `.githooks/commit-msg`: strips AI-assistant attribution trailers (`Co-authored-by: Claude …`, `🤖 Generated with [Claude Code]`, and `generated/created by Claude` footers) from commit messages, while **preserving real human `Co-authored-by:` trailers**.
  - Documents the rule in `CLAUDE.md`: a new **Attribution** section (no AI/Claude trailers in commits or PRs), and a **Hooks** section covering `commit-msg`, `pre-commit`, `pre-push`, and the `git config core.hooksPath .githooks` activation step.
  - Aligns with the existing `.github/pull_request_template.md`, which already treats AI-attribution footers as a merge-gate violation.
- **Scope boundary:** Only adds a hook script and documentation. Changes no application code, no build, no CI. Does not flip `core.hooksPath` for anyone — activation stays opt-in per clone, consistent with the existing `pre-commit`/`pre-push` hooks.
- **Blast radius:** None at runtime. For committers who enable `core.hooksPath=.githooks`, commit messages get AI-attribution lines stripped; everything else is untouched. Bypass once with `git commit --no-verify`.
- **Linked issue(s):** None.
- **Labels:** Expect `chore`/`tooling`, `risk: low`, `size: S`.

## Validation Evidence (required)

Hook behavior verified locally against a message containing both a human and an AI co-author:

```text
BEFORE:
  feat(x): do a thing

  Body explaining why.

  Co-authored-by: Jane Dev <jane@example.com>
  Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
  🤖 Generated with [Claude Code](https://claude.com/claude-code)

AFTER (hook applied):
  feat(x): do a thing

  Body explaining why.

  Co-authored-by: Jane Dev <jane@example.com>
```

- **Commands run and tail output:** Ran the hook directly on a sample commit-message file — the Claude co-author line and the `🤖 Generated with` line were removed, the human co-author line and trailing-blank trimming were correct (output above).
- **Beyond CI — what did you manually verify?** That a human `Co-authored-by:` trailer survives; that case-insensitive `Co-Authored-By: Claude` and the `🤖 Generated with [Claude Code]` footer are stripped; that the hook is committed executable (mode `100755`). I did NOT enable `core.hooksPath` repo-wide in this PR (intentionally opt-in).
- **If any command was intentionally skipped, why:** No Rust/test battery — this PR touches only a shell hook and markdown docs.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No.**
- New external network calls? **No.**
- Secrets / tokens / credentials handling changed? **No.**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No** — the example uses a synthetic `jane@example.com`.
- If any `Yes`, describe the risk and mitigation: n/a.

## Compatibility (required)

- Backward compatible? **Yes** — additive hook + docs; no effect unless a dev opts into `core.hooksPath=.githooks`.
- Config / env / CLI surface changed? **No** (activation is the same documented `core.hooksPath` step the existing hooks already use).
- If `No` or `Yes` to either: no upgrade steps required.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk: `git revert <sha>` removes the hook and doc changes.