### PR TITLE
fix(nix): allow shared users when createUser is false

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,6 +230,20 @@ jobs:
       - name: Check licenses, sources, and advisories
         run: cargo deny check
 
+  nix-eval:
+    name: Nix Module Eval
+    needs: [fmt]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Install Nix
+        run: sudo apt-get update -qq && sudo apt-get install -y nix-bin nix-setup-systemd
+      - name: Verify Nix
+        run: sudo nix --version
+      - name: Evaluate Nix module assertions
+        run: sudo nix --extra-experimental-features "nix-command flakes" build .#checks.x86_64-linux.nixos-module-eval --no-link
+
   # ── Required gate ─────────────────────────────────────────────────────────
   # Branch protection requires only this single job — internal structure
   # can change without touching branch protection settings.
@@ -237,7 +251,7 @@ jobs:
   gate:
     name: CI Required Gate
     if: always()
-    needs: [fmt, lint, build, check, check-32bit, bench, test, security]
+    needs: [fmt, lint, build, check, check-32bit, bench, test, security, nix-eval]
     runs-on: ubuntu-latest
     steps:
       - name: Check results

--- a/flake.nix
+++ b/flake.nix
@@ -37,8 +37,16 @@
           "rustc"
           "rustfmt"
         ];
+        nixosModuleEvalTests = import ./nix/eval-tests.nix {
+          inherit nixpkgs system;
+        };
       in {
         packages.default = fenix.packages.${system}.stable.toolchain;
+        checks = pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
+          nixos-module-eval = pkgs.writeText "zeroclaw-nixos-module-eval" (
+            builtins.toJSON nixosModuleEvalTests
+          );
+        };
         devShells.default = pkgs.mkShell {
           packages = [
             rustToolchain

--- a/nix/README.md
+++ b/nix/README.md
@@ -85,8 +85,10 @@ services.zeroclaw.instances = {
 
 Each instance gets its own systemd unit, state directory, and per-instance
 system user. The module asserts at evaluation time that no two instances
-share a `dataDir` or `user`, and that instance names are valid systemd unit
-component names (`[A-Za-z0-9._-]+`).
+share a `dataDir`, that no two module-created users have the same `user`, and
+that instance names are valid systemd unit component names
+(`[A-Za-z0-9._-]+`). Instances may intentionally share a user when exactly one
+instance creates it and the others set `createUser = false`.
 
 ## Option summary
 
@@ -218,6 +220,8 @@ Requires KVM on the builder.
 
 ## Status
 
-Initial drop, not yet wired into ZeroClaw's CI. The CI workflow at
-`.github/workflows/ci.yml` is Rust-only today; adding a `nix-test` job to
-exercise `nix/test.nix` is a natural follow-up.
+The required CI gate runs a low-cost Nix module eval check through
+`checks.x86_64-linux.nixos-module-eval`. That check covers assertion-level
+contract regressions without requiring KVM. The full `nix/test.nix` VM test
+remains a manual or future heavier CI check because it needs a KVM-capable
+builder.

--- a/nix/eval-tests.nix
+++ b/nix/eval-tests.nix
@@ -1,0 +1,109 @@
+{
+  nixpkgs ? <nixpkgs>,
+  system ? "x86_64-linux",
+}:
+
+let
+  pkgs = import nixpkgs { inherit system; };
+  lib = pkgs.lib;
+
+  stubPackage =
+    pkgs.runCommand "zeroclaw-eval-stub"
+      {
+        meta.mainProgram = "zeroclaw";
+      }
+      ''
+        mkdir -p $out/bin
+        cat > $out/bin/zeroclaw <<'EOF'
+        #!${pkgs.runtimeShell}
+        exit 0
+        EOF
+        chmod +x $out/bin/zeroclaw
+      '';
+
+  mkInstance =
+    attrs:
+    {
+      package = stubPackage;
+      settings.default_provider = "anthropic";
+    }
+    // attrs;
+
+  evalConfig =
+    instances:
+    (import "${nixpkgs}/nixos/lib/eval-config.nix" {
+      inherit system;
+      modules = [
+        ./module.nix
+        {
+          boot.loader.grub.enable = false;
+          fileSystems."/" = {
+            device = "none";
+            fsType = "tmpfs";
+          };
+          system.stateVersion = "26.05";
+        }
+        {
+          services.zeroclaw.instances = instances;
+        }
+      ];
+    }).config;
+
+  failedAssertions =
+    instances:
+    builtins.filter (assertion: !assertion.assertion) (evalConfig instances).assertions;
+
+  assertionMessages =
+    assertions:
+    lib.concatStringsSep "\n" (map (assertion: assertion.message) assertions);
+
+  assertPasses =
+    name: instances:
+    let
+      failed = failedAssertions instances;
+    in
+    if failed == [ ] then
+      true
+    else
+      throw "${name}: expected module eval to pass, but assertion(s) failed: ${assertionMessages failed}";
+
+  assertFailsWith =
+    name: expectedSubstring: instances:
+    let
+      failed = failedAssertions instances;
+      matched = lib.any (assertion: lib.hasInfix expectedSubstring assertion.message) failed;
+    in
+    if matched then
+      true
+    else
+      throw "${name}: expected assertion containing `${expectedSubstring}`, got: ${assertionMessages failed}";
+in
+{
+  duplicateCreatedUsersFail = assertFailsWith "duplicate created users" "same `user` while also setting `createUser = true`" {
+    first = mkInstance {
+      user = "zeroclaw-shared";
+    };
+    second = mkInstance {
+      user = "zeroclaw-shared";
+    };
+  };
+
+  sharedUserWithSingleCreatorPasses = assertPasses "shared user with one creator" {
+    owner = mkInstance { };
+    shared = mkInstance {
+      user = "zeroclaw-owner";
+      group = "zeroclaw-owner";
+      createUser = false;
+      dataDir = "/var/lib/zeroclaw-shared";
+    };
+  };
+
+  distinctCreatedUsersMayShareGroup = assertPasses "distinct created users sharing group" {
+    first = mkInstance {
+      group = "zeroclaw-shared-group";
+    };
+    second = mkInstance {
+      group = "zeroclaw-shared-group";
+    };
+  };
+}

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -485,7 +485,8 @@ in
         badNames = lib.filter (n: !nameOk n) names;
 
         dirs = mapAttrsToList (_: i: i.dataDir) cfg.instances;
-        users = mapAttrsToList (_: i: i.user) cfg.instances;
+        createdInstances = filterAttrs (_: i: i.createUser) cfg.instances;
+        createdUsers = mapAttrsToList (_: i: i.user) createdInstances;
       in
       [
         {
@@ -506,11 +507,12 @@ in
           '';
         }
         {
-          assertion = lib.length users == lib.length (lib.unique users);
+          assertion = lib.length createdUsers == lib.length (lib.unique createdUsers);
           message = ''
             services.zeroclaw.instances: two or more instances declare the
-            same `user`. If you intend to share a user across instances,
-            set `createUser = false` on all but one.
+            same `user` while also setting `createUser = true`. If you intend
+            to share a user across instances, set `createUser = false` on all
+            but one.
           '';
         }
       ];

--- a/nix/test.nix
+++ b/nix/test.nix
@@ -31,6 +31,9 @@
 #      with the correct ownership, and the unit starts cleanly. Regression
 #      guard for the previous `StateDirectory = baseNameOf dataDir` shape
 #      that silently created the wrong directory.
+#   8. A second instance may share another instance's user/group when it sets
+#      `createUser = false`, matching the documented "bring your own user"
+#      contract.
 #
 # A no-op stub binary stands in for the real `zeroclaw daemon` so the test
 # does not depend on a working ZeroClaw build. The stub validates everything
@@ -129,6 +132,20 @@ in
         };
       };
 
+      # Fifth instance shares the `test` user/group but does not ask the
+      # module to create them again. This is the documented shared-user
+      # contract and should not trip the eval-time uniqueness assertion.
+      services.zeroclaw.instances.shared-user = {
+        package = stubPackage;
+        user = "zeroclaw-test";
+        group = "zeroclaw-test";
+        createUser = false;
+        dataDir = "/var/lib/zeroclaw-shared-user";
+        settings = {
+          default_provider = "anthropic";
+        };
+      };
+
       # `yq -p toml` (binary name from `pkgs.yq-go`) parses the rendered
       # TOML for the round-trip check.
       environment.systemPackages = [
@@ -213,5 +230,16 @@ in
         # of the configured /srv/zeroclaw-srv path.
         machine.fail("test -d /var/lib/zeroclaw-srv")
         machine.succeed("test -f /srv/zeroclaw-srv/config.toml")
+
+    with subtest("shared user is allowed when createUser=false"):
+        machine.wait_for_unit("zeroclaw-shared-user.service", timeout=30)
+        machine.succeed("test -d /var/lib/zeroclaw-shared-user")
+        owner_shared = machine.succeed(
+            "stat -c '%U:%G' /var/lib/zeroclaw-shared-user"
+        ).strip()
+        assert owner_shared == "zeroclaw-test:zeroclaw-test", (
+            f"unexpected owner {owner_shared}"
+        )
+        machine.succeed("test -f /var/lib/zeroclaw-shared-user/config.toml")
   '';
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Fix the NixOS module duplicate-user assertion so it rejects only duplicate module-created users, and document/exercise the `createUser = false` bring-your-own-user path.
  - Add assertion-level Nix eval tests for duplicate created users, one creator plus one shared user, and distinct users sharing a primary group.
  - Add a required low-cost CI job that builds `checks.x86_64-linux.nixos-module-eval`, so this contract is exercised without requiring a KVM VM test on every run.
  - Extend the existing NixOS VM test with a positive shared-user instance and update the Nix README status/contract notes.
- **Scope boundary:** This PR does not package ZeroClaw with Nix, change runtime Rust behavior, or add the full KVM-backed `nix/test.nix` VM run to required CI.
- **Blast radius:** NixOS module evaluation, flake checks, and the required GitHub Actions gate. Runtime behavior for non-Nix users is unchanged.
- **Linked issue(s):** None.
- **Labels:** `bug`, `type: ci`, `ci`, `docs`, `risk: high`, `size: S`

## Validation Evidence (required)

- **Commands run and tail output:**

```text
cargo fmt --all -- --check
result: passed
tail: zc-cargo fmt --all -- --check  10.81s user 1.14s system 7% cpu 2:42.64 total

git diff --check
result: passed with no output

ruby -ryaml -e 'YAML.load_file(".github/workflows/ci.yml"); puts "yaml ok"'
result: passed
output: yaml ok

command -v nix
result: no local nix binary found
```

- **Beyond CI — what did you manually verify?**
  - Confirmed the assertion now uses only instances with `createUser = true` when checking duplicate `user` values.
  - Confirmed the documented shared-user path does not add a duplicate group restriction.
  - Checked the first `Nix Module Eval` CI failure. Ubuntu's apt-provided `nix` installed successfully, but the unprivileged runner user could not read the Nix daemon socket. The workflow now runs the apt-provided `nix` command with `sudo`.
  - Checked the second `Nix Module Eval` CI failure. Nix reached module evaluation, but the eval harness was also seeing base NixOS assertions for root filesystem and bootloader configuration. The eval harness now supplies a minimal test-host module so these tests cover the ZeroClaw module assertions instead of generic NixOS bootability assertions.
  - Confirmed the updated `Nix Module Eval` CI job passes on the current PR head.
  - Latest GitHub Actions snapshot for the current code head has `Nix Module Eval`, `Test`, `Lint`, `Benchmarks Compile`, `Security`, Linux build, macOS build, Windows build, check jobs, `CI Required Gate`, and the fresh metadata/title-validation rerun passing.
- **If any command was intentionally skipped, why:**
  - `nix build .#checks.x86_64-linux.nixos-module-eval --no-link` was not run locally because the local validation environment does not have `nix` installed. The equivalent `Nix Module Eval` CI job now passes on Ubuntu.
  - The full KVM-backed `nix/test.nix` VM test was not run locally because it requires Nix and a KVM-capable builder. The VM test was extended with the shared-user positive case, but it remains a manual/heavier validation path.
  - `cargo clippy --all-targets -- -D warnings` and `cargo test` were not run locally because this PR changes Nix module logic, flake check wiring, CI YAML, and Nix docs, not Rust production code. The standard Rust CI jobs still run on the PR, but the central claim for this slice is the new `Nix Module Eval` job.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `Yes`
- New external network calls? `Yes`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation:
  - The new CI job runs `apt-get update`, installs Ubuntu's Nix packages, and evaluates the flake check with `sudo` because the apt-provided Nix store/daemon socket is root-owned on GitHub-hosted Ubuntu runners. It uses no additional third-party GitHub Action beyond the existing pinned checkout action, does not use new secrets, and does not change runtime network or filesystem behavior.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `Yes`
- If `No` or `Yes` to either: exact upgrade steps for existing users:
  - The accepted Nix module configuration surface is widened. Existing configurations that already use unique module-created users remain unchanged. Configurations that intentionally share a user should set `createUser = false` on all but one instance using that user.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** Revert this PR. That restores the previous all-instances user uniqueness assertion and removes the required `nix-eval` CI job.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** GitHub Actions may fail in the `Nix Module Eval` job if Ubuntu's Nix packages do not provide a working flakes-capable `nix` command or if the eval assertions fail. NixOS users would see module evaluation failures mentioning `services.zeroclaw.instances` duplicate `user` or `dataDir` assertions.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): None.
- Scope materially carried forward: None.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why (inspiration-only, no direct code/design carry-over): No PR is superseded and no contributor code is incorporated.

