### PR TITLE
fix(bedrock): skip prompt caching for models that don't support it

### DIFF
--- a/crates/zeroclaw-providers/src/bedrock.rs
+++ b/crates/zeroclaw-providers/src/bedrock.rs
@@ -626,6 +626,20 @@ fn bedrock_model_supports_native_thinking(model: &str) -> bool {
     !model.contains("claude-opus-4-7")
 }
 
+/// Whether a Bedrock model accepts `cachePoint` blocks for prompt caching.
+///
+/// Only Anthropic Claude and Amazon Nova models support prompt caching on
+/// Bedrock; other families (Qwen, Llama, Mistral, DeepSeek, …) reject a request
+/// that contains a `cachePoint` with a 400: "You invoked an unsupported model or
+/// your request did not allow prompt caching". Caching is purely an
+/// optimization, so we allowlist the known-supported families and skip
+/// `cachePoint` insertion everywhere else rather than risk that error.
+/// AWS docs: <https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html>
+fn bedrock_model_supports_prompt_caching(model: &str) -> bool {
+    let model = model.to_ascii_lowercase();
+    model.contains("claude") || model.contains("nova")
+}
+
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct ToolConfig {
@@ -1485,11 +1499,12 @@ impl ModelProvider for BedrockModelProvider {
     ) -> anyhow::Result<String> {
         let auth = self.resolve_auth().await?;
 
+        let supports_caching = bedrock_model_supports_prompt_caching(model);
         let system = system_prompt.map(|text| {
             let mut blocks = vec![SystemBlock::Text(TextBlock {
                 text: text.to_string(),
             })];
-            if Self::should_cache_system(text) {
+            if supports_caching && Self::should_cache_system(text) {
                 blocks.push(SystemBlock::CachePoint(CachePointWrapper {
                     cache_point: CachePoint::default_cache(),
                 }));
@@ -1540,12 +1555,17 @@ impl ModelProvider for BedrockModelProvider {
         // Strip empty text ContentBlocks that would cause Bedrock 400 errors.
         Self::sanitize_empty_content_blocks(&mut converse_messages);
 
+        // Prompt caching (cachePoint) is only accepted by Claude/Nova models;
+        // sending it to e.g. Qwen or Llama returns a 400. Gate all cachePoint
+        // insertion on model support (see issue #7312).
+        let supports_caching = bedrock_model_supports_prompt_caching(model);
+
         // Apply cachePoint to system if large.
         let system = system_blocks.map(|mut blocks| {
             let has_large_system = blocks
                 .iter()
                 .any(|b| matches!(b, SystemBlock::Text(tb) if Self::should_cache_system(&tb.text)));
-            if has_large_system {
+            if supports_caching && has_large_system {
                 blocks.push(SystemBlock::CachePoint(CachePointWrapper {
                     cache_point: CachePoint::default_cache(),
                 }));
@@ -1554,7 +1574,8 @@ impl ModelProvider for BedrockModelProvider {
         });
 
         // Apply cachePoint to last message if conversation is long.
-        if Self::should_cache_conversation(request.messages)
+        if supports_caching
+            && Self::should_cache_conversation(request.messages)
             && let Some(last_msg) = converse_messages.last_mut()
         {
             last_msg
@@ -2082,6 +2103,46 @@ mod tests {
         assert!(bedrock_model_supports_native_thinking(
             "us.anthropic.claude-haiku-4-5-v1"
         ));
+    }
+
+    #[test]
+    fn prompt_caching_supported_for_claude_and_nova() {
+        for model in [
+            "anthropic.claude-3-5-sonnet-20241022-v2:0",
+            "us.anthropic.claude-sonnet-4-6-v1",
+            "anthropic.claude-3-7-sonnet-20250219-v1:0",
+            "amazon.nova-pro-v1:0",
+            "us.amazon.nova-lite-v1:0",
+        ] {
+            assert!(
+                bedrock_model_supports_prompt_caching(model),
+                "expected prompt caching support for {model}"
+            );
+        }
+    }
+
+    #[test]
+    fn prompt_caching_unsupported_for_other_families() {
+        // Regression for #7312: Qwen (and other non-Claude/Nova families) reject
+        // cachePoint blocks, so caching must be disabled for them.
+        for model in [
+            "qwen.qwen3-coder-next",
+            "meta.llama3-1-70b-instruct-v1:0",
+            "mistral.mistral-large-2407-v1:0",
+            "deepseek.r1-v1:0",
+        ] {
+            assert!(
+                !bedrock_model_supports_prompt_caching(model),
+                "expected NO prompt caching support for {model}"
+            );
+        }
+    }
+
+    #[test]
+    fn prompt_caching_match_is_case_insensitive() {
+        assert!(bedrock_model_supports_prompt_caching("ANTHROPIC.CLAUDE-X"));
+        assert!(bedrock_model_supports_prompt_caching("Amazon.Nova-Pro"));
+        assert!(!bedrock_model_supports_prompt_caching("QWEN.qwen3"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Fixes #7312 — Bedrock + a non-Claude/Nova model (e.g. `qwen.qwen3-coder-next`) fails on the second prompt with `400: You invoked an unsupported model or your request did not allow prompt caching`.
  - Root cause: `bedrock.rs` inserted a `cachePoint` block whenever the system prompt was large (`should_cache_system`) or the conversation exceeded four messages (`should_cache_conversation`), **without checking whether the target model supports prompt caching**. On Bedrock only Anthropic Claude and Amazon Nova accept `cachePoint`; Qwen/Llama/Mistral/DeepSeek reject it. The first prompt is short enough to avoid the threshold; by the second prompt the history (incl. tool calls) crosses it and the cachePoint triggers the 400.
  - Fix: add `bedrock_model_supports_prompt_caching(model)` (allowlists `claude`/`nova`, case-insensitive) and gate **all three** cachePoint insertion sites on it — system prompt in `chat_with_system`, system prompt in `chat`, and the long-conversation message cachePoint in `chat`. Caching is purely an optimization, so unsupported models now send no cachePoint instead of erroring.
- **Scope boundary:** Only changes when ZeroClaw *adds* a `cachePoint` to a Bedrock request. No change to auth, message conversion, tool handling, thinking, or any other provider. Supported models (Claude/Nova) keep identical caching behavior.
- **Blast radius:** Bedrock provider only. For Claude/Nova: unchanged. For all other Bedrock models: requests no longer carry a `cachePoint` (slightly less caching, no behavior change otherwise).
- **Linked issue(s):** Closes #7312
- **Labels:** Expect `bug`, `provider`, `provider:bedrock`, `risk: low`, `size: S`.

## Validation Evidence (required)

Scoped to the `zeroclaw-providers` crate:

```bash
cargo fmt -p zeroclaw-providers
cargo test -p zeroclaw-providers bedrock     # 73 passed; 0 failed
cargo clippy -p zeroclaw-providers --all-targets -- -D warnings   # clean
```

- **Commands run and tail output:**
  - `cargo test -p zeroclaw-providers bedrock` → `test result: ok. 73 passed; 0 failed; 0 ignored` (incl. 3 new: `prompt_caching_supported_for_claude_and_nova`, `prompt_caching_unsupported_for_other_families`, `prompt_caching_match_is_case_insensitive`)
  - `cargo clippy -p zeroclaw-providers --all-targets -- -D warnings` → `Finished` (no warnings)
  - `cargo fmt -p zeroclaw-providers` → clean
- **Beyond CI — what did you manually verify?** Confirmed every `CachePoint::default_cache()` insertion site in the request path (3 of them) is now gated on `supports_caching`; the remaining hits are tests/definition. New tests assert Qwen/Llama/Mistral/DeepSeek get no caching while Claude/Nova still do. I did NOT exercise a live Bedrock call against Qwen (no AWS credentials here); the fix is verified by the gating logic + unit tests against the documented model families.
- **If any command was intentionally skipped, why:** Did not run the full-workspace `cargo test`; the change is isolated to the Bedrock provider, so validation is scoped to `zeroclaw-providers`.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No.**
- New external network calls? **No** (it removes a request field for some models; makes no new calls).
- Secrets / tokens / credentials handling changed? **No.**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No** — test data uses public Bedrock model ids only.
- If any `Yes`, describe the risk and mitigation: n/a.

## Compatibility (required)

- Backward compatible? **Yes** — Claude/Nova caching behavior is unchanged; other models stop sending an unsupported field (which previously errored).
- Config / env / CLI surface changed? **No.**
- If `No` or `Yes` to either: no upgrade steps; existing Bedrock configs work as-is, and the Qwen failure path is fixed.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk: `git revert <sha>` restores the prior unconditional caching behavior.