### PR TITLE
fix(channels/telegram): clamp zero draft update interval

### DIFF
--- a/crates/zeroclaw-channels/src/telegram.rs
+++ b/crates/zeroclaw-channels/src/telegram.rs
@@ -360,6 +360,9 @@ fn parse_attachment_markers(message: &str) -> (String, Vec<TelegramAttachment>) 
 /// Telegram Bot API maximum file download size (20 MB).
 const TELEGRAM_MAX_FILE_DOWNLOAD_BYTES: u64 = 20 * 1024 * 1024;
 
+/// Default minimum interval between Telegram draft edits.
+const TELEGRAM_DRAFT_UPDATE_INTERVAL_MS: u64 = 1000;
+
 /// Telegram channel — long-polls the Bot API for updates
 pub struct TelegramChannel {
     bot_token: String,
@@ -453,7 +456,7 @@ impl TelegramChannel {
             pairing,
             client: reqwest::Client::new(),
             stream_mode: StreamMode::Off,
-            draft_update_interval_ms: 1000,
+            draft_update_interval_ms: TELEGRAM_DRAFT_UPDATE_INTERVAL_MS,
             last_draft_edit: Mutex::new(std::collections::HashMap::new()),
             typing_handle: Mutex::new(None),
             mention_only,
@@ -512,7 +515,11 @@ impl TelegramChannel {
         draft_update_interval_ms: u64,
     ) -> Self {
         self.stream_mode = stream_mode;
-        self.draft_update_interval_ms = draft_update_interval_ms;
+        self.draft_update_interval_ms = if draft_update_interval_ms == 0 {
+            TELEGRAM_DRAFT_UPDATE_INTERVAL_MS
+        } else {
+            draft_update_interval_ms
+        };
         self
     }
 
@@ -4189,6 +4196,22 @@ mod tests {
         .with_streaming(StreamMode::Partial, 750);
         assert!(partial.supports_draft_updates());
         assert_eq!(partial.draft_update_interval_ms, 750);
+    }
+
+    #[test]
+    fn with_streaming_uses_default_for_zero_draft_update_interval() {
+        let ch = TelegramChannel::new(
+            "fake-token".into(),
+            "telegram_test_alias",
+            Arc::new(|| vec!["*".into()]),
+            false,
+        )
+        .with_streaming(StreamMode::Partial, 0);
+
+        assert_eq!(
+            ch.draft_update_interval_ms,
+            TELEGRAM_DRAFT_UPDATE_INTERVAL_MS
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Closes #7332.

- Keep Telegram partial-streaming draft edits throttled when `draft_update_interval_ms` is configured as `0`.
- Reuse the existing Telegram draft edit default instead of storing a literal zero interval.
- Add a regression test covering the zero-interval fallback while preserving non-zero values unchanged.

## Validation Evidence

```text
$ cargo fmt --all -- --check
(exit 0)
```

```text
$ cargo test -p zeroclaw-channels with_streaming_uses_default_for_zero_draft_update_interval --lib
running 1 test
test telegram::tests::with_streaming_uses_default_for_zero_draft_update_interval ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 688 filtered out; finished in 0.17s
```

```text
$ cargo test -p zeroclaw-channels update_draft --lib
running 2 tests
test telegram::tests::update_draft_utf8_truncation_is_safe_for_multibyte_text ... ok
test telegram::tests::update_draft_rate_limit_short_circuits_network ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 687 filtered out; finished in 0.21s
```

```text
$ cargo clippy --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 21.06s
```

```text
$ cargo test
...
test result: ok. 243 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.40s
test result: ok. 188 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.79s
test result: ok. 159 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.26s
test result: ok. 0 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 0.00s
test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.05s
Doc-tests zeroclaw: ok
```

Validated after rebasing onto upstream `master` at `0f9442f44`.

## Security & Privacy Impact

No security boundary or privacy behavior changes. This does not add logging, persistence, identifiers, tokens, or external calls.

## Compatibility

Non-zero `draft_update_interval_ms` values keep their configured behavior. A zero interval now falls back to the Telegram draft edit default instead of disabling edit throttling, which aligns the channel with the documented rate-limit guard.

## Rollback

Revert this commit to restore direct use of the configured interval.

## Supersede Attribution

N/A. This is a narrow follow-up for #7332; duplicate searches for Telegram draft interval/edit throttling did not find an existing issue or PR covering this zero-interval path.
