### PR TITLE
feat(plugins): default signature_mode to permissive + surface signature status

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -6741,7 +6741,9 @@ pub struct PluginsConfig {
 #[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
 #[prefix = "plugins.security"]
 pub struct PluginSecurityConfig {
-    /// Signature enforcement mode: "disabled", "permissive", or "strict".
+    /// Signature enforcement mode: "disabled", "permissive" (default), or
+    /// "strict". Permissive loads unsigned/untrusted plugins but logs a warning;
+    /// strict rejects them; disabled performs no checks.
     #[serde(default = "default_signature_mode")]
     pub signature_mode: String,
     /// Hex-encoded Ed25519 public keys of trusted plugin publishers.
@@ -6750,7 +6752,10 @@ pub struct PluginSecurityConfig {
 }
 
 fn default_signature_mode() -> String {
-    "disabled".to_string()
+    // Permissive (warn-but-load) is the default so operators see which plugins
+    // are unverified without breaking existing unsigned local plugins. Set
+    // "strict" to reject unsigned/untrusted plugins.
+    "permissive".to_string()
 }
 
 impl Default for PluginSecurityConfig {
@@ -6759,6 +6764,16 @@ impl Default for PluginSecurityConfig {
             signature_mode: default_signature_mode(),
             trusted_publisher_keys: Vec::new(),
         }
+    }
+}
+
+#[cfg(test)]
+mod plugin_security_tests {
+    use super::PluginSecurityConfig;
+
+    #[test]
+    fn default_signature_mode_is_permissive() {
+        assert_eq!(PluginSecurityConfig::default().signature_mode, "permissive");
     }
 }
 

--- a/crates/zeroclaw-gateway/src/api_plugins.rs
+++ b/crates/zeroclaw-gateway/src/api_plugins.rs
@@ -55,6 +55,7 @@ pub mod plugin_routes {
                                 "description": p.description,
                                 "capabilities": p.capabilities,
                                 "loaded": p.loaded,
+                                "signature": p.signature_status,
                             })
                         })
                         .collect(),

--- a/crates/zeroclaw-plugins/src/host.rs
+++ b/crates/zeroclaw-plugins/src/host.rs
@@ -22,7 +22,6 @@ struct LoadedPlugin {
     plugin_dir: PathBuf,
     /// Resolved path to the WASM file. `None` for skill-only plugins.
     wasm_path: Option<PathBuf>,
-    #[allow(dead_code)]
     verification: VerificationResult,
 }
 
@@ -304,6 +303,16 @@ impl PluginHost {
     }
 }
 
+/// Map a verification result to a short status string for display/API.
+fn signature_status_str(v: &VerificationResult) -> &'static str {
+    match v {
+        VerificationResult::Valid { .. } => "valid",
+        VerificationResult::Unsigned => "unsigned",
+        VerificationResult::Untrusted => "untrusted",
+        VerificationResult::Invalid { .. } => "invalid",
+    }
+}
+
 fn plugin_info_from_loaded(p: &LoadedPlugin) -> PluginInfo {
     let loaded = match &p.wasm_path {
         Some(path) => path.exists(),
@@ -318,6 +327,7 @@ fn plugin_info_from_loaded(p: &LoadedPlugin) -> PluginInfo {
         permissions: p.manifest.permissions.clone(),
         wasm_path: p.wasm_path.clone(),
         loaded,
+        signature_status: signature_status_str(&p.verification).to_string(),
     }
 }
 
@@ -468,6 +478,28 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<(), PluginError> {
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    #[test]
+    fn signature_status_strings() {
+        assert_eq!(
+            signature_status_str(&VerificationResult::Unsigned),
+            "unsigned"
+        );
+        assert_eq!(
+            signature_status_str(&VerificationResult::Untrusted),
+            "untrusted"
+        );
+        assert_eq!(
+            signature_status_str(&VerificationResult::Valid {
+                publisher_key: "k".into()
+            }),
+            "valid"
+        );
+        assert_eq!(
+            signature_status_str(&VerificationResult::Invalid { reason: "r".into() }),
+            "invalid"
+        );
+    }
 
     #[test]
     fn test_empty_plugin_dir() {

--- a/crates/zeroclaw-plugins/src/lib.rs
+++ b/crates/zeroclaw-plugins/src/lib.rs
@@ -100,4 +100,7 @@ pub struct PluginInfo {
     /// Resolved path to the WASM file. `None` for skill-only plugins.
     pub wasm_path: Option<PathBuf>,
     pub loaded: bool,
+    /// Signature verification status: `"valid"`, `"unsigned"`, `"untrusted"`,
+    /// or `"invalid"`. Computed regardless of the enforcement mode.
+    pub signature_status: String,
 }


### PR DESCRIPTION
> **Stacked on #7335** (base = `feat/plugin-sandbox-limits`). Review/merge that first; this retargets to `master` after.

## Summary

Raises the **default plugin trust posture** and makes verification state visible — completing the sandbox-hardening series.

- **`signature_mode` default: `disabled` → `permissive`.** Unsigned/untrusted plugins still **load** (with a warning), so the ~33 existing unsigned local plugins keep working — but operators now *see* which plugins are unverified. `strict` remains opt-in to reject them. Non-breaking: permissive never rejects.
- **Surfaced signature status.** `PluginInfo` gains `signature_status` (`valid` | `unsigned` | `untrusted` | `invalid`), computed from the already-stored `LoadedPlugin.verification` (independent of the enforcement mode). `GET /api/plugins` now returns a per-plugin `signature` field. Removed the now-obsolete `#[allow(dead_code)]` on `verification`.

## Validation
- ✅ `signature_status_str` mapping test (all four `VerificationResult` variants)
- ✅ config test: `PluginSecurityConfig::default().signature_mode == "permissive"`
- ✅ `cargo clippy -p zeroclaw-plugins -- -D warnings` clean · `cargo fmt --check` clean
- ✅ `zeroclaw-gateway` builds with `--features plugins-wasm` (the `/api/plugins` change)

## Back-compat
Permissive loads everything (just warns), so existing plugins are unaffected; the only visible changes are new WARN logs for unsigned plugins and the added `signature` field in `/api/plugins`.

Milestone: **v0.8.3**

🤖 Generated with [Claude Code](https://claude.com/claude-code)