### PR TITLE
feat(plugins): namespace plugin tools (plugin__tool) + RateLimitedTool wrapping

### DIFF
--- a/crates/zeroclaw-plugins/src/wasm_tool.rs
+++ b/crates/zeroclaw-plugins/src/wasm_tool.rs
@@ -116,6 +116,14 @@ impl WasmTool {
             env_allowlist,
         }
     }
+
+    /// Namespace the exposed tool name as `<plugin>__<tool>` (the same `__`
+    /// convention MCP uses) so plugin tools can't collide with or shadow native
+    /// or MCP tools. The plugin's internal `execute` export is unaffected.
+    pub fn with_prefixed_name(mut self, plugin_name: &str) -> Self {
+        self.name = format!("{plugin_name}__{}", self.name);
+        self
+    }
 }
 
 /// The JSON Schema returned when a plugin lacks a `tool_metadata` export or fails
@@ -183,5 +191,23 @@ impl Tool for WasmTool {
                 error: Some("plugin execution timed out".into()),
             }),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prefixes_tool_name() {
+        let tool = WasmTool::new(
+            "generate_music".into(),
+            "desc".into(),
+            serde_json::json!({}),
+            PathBuf::from("/x.wasm"),
+            vec![],
+        )
+        .with_prefixed_name("ace-step");
+        assert_eq!(tool.name(), "ace-step__generate_music");
     }
 }

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -1276,14 +1276,19 @@ pub fn all_tools_with_runtime(
                     let details = host.tool_plugin_details();
                     let count = details.len();
                     for (manifest, wasm_path) in details {
-                        tool_arcs.push(Arc::new(zeroclaw_plugins::wasm_tool::WasmTool::from_wasm(
+                        // Namespace plugin tools (`<plugin>__<tool>`) and wrap them
+                        // in RateLimitedTool so they get the same rate-limit/approval
+                        // treatment as native and MCP tools (previously pushed bare).
+                        let tool = zeroclaw_plugins::wasm_tool::WasmTool::from_wasm(
                             wasm_path.to_path_buf(),
                             manifest.permissions.clone(),
                             manifest.name.clone(),
                             manifest.description.clone().unwrap_or_default(),
                             manifest.allowed_hosts.clone(),
                             manifest.env_allowlist.clone(),
-                        )));
+                        )
+                        .with_prefixed_name(&manifest.name);
+                        tool_arcs.push(Arc::new(RateLimitedTool::new(tool, security.clone())));
                     }
                     ::zeroclaw_log::record!(
                         INFO,


### PR DESCRIPTION
> **Stacked on #7335** (base = `feat/plugin-sandbox-limits`). Retargets to `master` after that merges.

## Summary

Closes the last two plugin-tool gaps, bringing them to parity with native/MCP tools.

- **Namespacing.** Plugin tools were exposed with their **bare** name, so a plugin tool named `shell` would collide with — and be indistinguishable from — the guarded native `shell` at approval time. They're now `<plugin>__<tool>` (the same `__` convention MCP uses, e.g. `ace-step__generate_music`). The plugin's internal `execute` export is unchanged — prefixing is host-side only.
- **Guard parity.** Plugin tools were pushed **bare** into the registry, bypassing the `RateLimitedTool` rate-limit/approval gate that every native tool gets. They're now wrapped in `RateLimitedTool` (`security` is already in scope in `all_tools_with_runtime`).

## Back-compat
- Plugin tools are new, so renaming is safe. **Audited:** no in-repo skill (`kind=builtin`) targets a plugin tool by bare name. External skills referencing a bare plugin-tool name would need the `plugin__tool` form (documented convention).
- `RateLimitedTool::name()` delegates to the inner tool, so the prefixed name is what the LLM and approval system see.

## Validation
- ✅ test: `with_prefixed_name` → `ace-step__generate_music`
- ✅ `cargo clippy -p zeroclaw-plugins -- -D warnings` clean · `cargo fmt --check` clean
- ✅ `zeroclaw-runtime` builds with `--features plugins-wasm` (the wrapping site)

This completes the plugin sandbox-hardening series (#7335 limits/egress/env, #7336 signing, this one tool isolation).

Milestone: **v0.8.3**

🤖 Generated with [Claude Code](https://claude.com/claude-code)