### PR TITLE
fix(cli): print model names in 'zeroclaw models list' output

### DIFF
--- a/crates/zeroclaw-runtime/src/doctor/mod.rs
+++ b/crates/zeroclaw-runtime/src/doctor/mod.rs
@@ -267,6 +267,7 @@ pub async fn run_models(
     config: &Config,
     provider_override: Option<&str>,
     _use_cache: bool,
+    show_model_names: bool,
 ) -> Result<()> {
     let targets = doctor_model_targets(config, provider_override);
 
@@ -298,6 +299,11 @@ pub async fn run_models(
             Ok(models) => {
                 ok_count += 1;
                 println!("    ✅ {} models", models.len());
+                if show_model_names && !models.is_empty() {
+                    for m in &models {
+                        println!("      • {}", m);
+                    }
+                }
                 matrix_rows.push((
                     provider_name.clone(),
                     ModelProbeOutcome::Ok,

--- a/src/main.rs
+++ b/src/main.rs
@@ -4148,12 +4148,12 @@ async fn main() -> Result<()> {
         Commands::Cron { cron_command } => cron::handle_command(cron_command, &config),
 
         Commands::Models { model_command } => {
-            let model_provider = match &model_command {
-                ModelCommands::Refresh { model_provider, .. }
-                | ModelCommands::List { model_provider } => model_provider.as_deref(),
-                _ => None,
+            let (model_provider, show_names) = match &model_command {
+                ModelCommands::Refresh { model_provider, .. } => (model_provider.as_deref(), false),
+                ModelCommands::List { model_provider } => (model_provider.as_deref(), true),
+                _ => (None, false),
             };
-            doctor::run_models(&config, model_provider, false).await
+            doctor::run_models(&config, model_provider, false, show_names).await
         }
 
         Commands::Providers => {
@@ -4196,7 +4196,7 @@ async fn main() -> Result<()> {
             Some(DoctorCommands::Models {
                 model_provider,
                 use_cache,
-            }) => doctor::run_models(&config, model_provider.as_deref(), use_cache).await,
+            }) => doctor::run_models(&config, model_provider.as_deref(), use_cache, false).await,
             Some(DoctorCommands::Traces {
                 id,
                 event,


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - `zeroclaw models list` only reported a per-provider **count** (e.g. `openai: 42 models`) — it never showed *which* models, so the subcommand couldn't actually answer "what can I select?".
  - Adds a `show_model_names` flag to `doctor::run_models()`; when set, each resolved model name is printed under its provider. The flag is `true` only for the `models list` subcommand and `false` for `models refresh` and the doctor health path, so the diagnostic output stays terse.
- **Scope boundary:** CLI output only — `src/main.rs` (subcommand wiring) and `crates/zeroclaw-runtime/src/doctor/mod.rs` (the print). No change to model resolution, catalog fetching, provider construction, or the doctor health checks. `+12 / −6`, 2 files.
- **Blast radius:** The `models list` command's stdout. `models refresh` and `doctor` output are unchanged (flag passed as `false`).
- **Linked issue(s):** None.
- **Labels:** (snapshot after applied — expect `cli`, `type: fix`, `risk: low`, `size: XS`.)

## Validation Evidence (required)

- **Commands run and tail output:**
  ```text
  $ cargo fmt --all -- --check
  (clean)

  $ cargo clippy -p zeroclaw-runtime --bin zeroclaw
  (no findings)

  $ cargo test -p zeroclaw-runtime
  test result: ok. 2004 passed; 0 failed; 1 ignored

  # behavior (illustrative provider/model names; real run verified locally):
  #
  # BEFORE (master) — count only:
  #   [openai.default]
  #     ✅ 42 models
  #
  # AFTER (this branch) — names listed:
  #   [openai.default]
  #     ✅ 42 models
  #       • gpt-4o
  #       • gpt-4o-mini
  #       • o3
  #       • …
  #
  # `zeroclaw models refresh` is unchanged (counts only — flag=false):
  #   ✅ 42 models   (no bullets)
  ```
- **Beyond CI — what did you manually verify?** Ran `zeroclaw models list` on a configured instance and confirmed model names now print under each provider; `zeroclaw models refresh` output unchanged (counts only, no name list). Example above uses placeholder model names — real catalog output omitted intentionally (it reflects an operator's local model set; see Privacy). NOT verified: providers that need a live credential to enumerate (their list depends on configured keys).
- **If any command was intentionally skipped, why:** —

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No` — uses the same model enumeration the count already relied on.
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No` — the diff prints model names the operator's own providers already return at runtime; nothing personal is added to the code, tests, or docs. (The PR's example output uses placeholder model names rather than a real local catalog.)
- If any `Yes`, describe the risk and mitigation: n/a

## Compatibility (required)

- Backward compatible? `Yes` — additive output; the command's exit behavior and existing fields are unchanged.
- Config / env / CLI surface changed? `No` (same `models list` invocation; richer output).
- If `No` or `Yes` to either: no upgrade steps.

## Rollback (required for `risk: medium` and `risk: high`)

Low risk: `git revert <sha>` — output-only change in 2 files.
