### PR TITLE
fix(cron): skip overdue jobs on startup when catch_up_on_startup is disabled (#7250)

### DIFF
--- a/crates/zeroclaw-runtime/src/cron/mod.rs
+++ b/crates/zeroclaw-runtime/src/cron/mod.rs
@@ -16,7 +16,7 @@ pub use schedule::{
 pub use store::{
     add_agent_job, all_overdue_jobs, due_jobs, get_job, list_jobs, list_runs, record_last_run,
     record_last_run_with_status, record_run, remove_job, reschedule_after_run,
-    reschedule_after_run_with_status, sync_declarative_jobs, update_job,
+    reschedule_after_run_with_status, skip_missed_run, sync_declarative_jobs, update_job,
 };
 pub use types::{
     CronJob, CronJobPatch, CronRun, DeliveryConfig, JobType, Schedule, SessionTarget,

--- a/crates/zeroclaw-runtime/src/cron/scheduler.rs
+++ b/crates/zeroclaw-runtime/src/cron/scheduler.rs
@@ -1,7 +1,7 @@
 use crate::cron::store::{RunCompletionAction, persist_run_completion_state, persist_run_result};
 use crate::cron::{
     CronJob, DeliveryConfig, JobType, Schedule, SessionTarget, all_overdue_jobs, due_jobs,
-    next_run_for_schedule, sync_declarative_jobs,
+    next_run_for_schedule, skip_missed_run, sync_declarative_jobs,
 };
 use crate::security::SecurityPolicy;
 use anyhow::Result;
@@ -194,6 +194,7 @@ pub async fn run(config: Config, event_tx: EventBroadcast) -> Result<()> {
             ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note),
             "Scheduler startup: catch-up disabled by config"
         );
+        skip_missed_jobs_on_startup(&config).await;
     }
 
     loop {
@@ -284,6 +285,80 @@ async fn catch_up_overdue_jobs(config: &Config, event_tx: &EventBroadcast) {
         INFO,
         ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note),
         "Scheduler startup: catch-up complete"
+    );
+}
+
+/// Advance `next_run` for all overdue jobs without executing them.
+///
+/// Called at scheduler startup when `catch_up_on_startup` is disabled so
+/// that the normal polling loop (which selects `next_run <= now`) doesn't
+/// pick up jobs that became overdue during daemon downtime.
+///
+/// - Recurring jobs: `next_run` is advanced to the next future occurrence.
+/// - One-shot `At` jobs: disabled with a `skipped` last status.
+async fn skip_missed_jobs_on_startup(config: &Config) {
+    let now = Utc::now();
+    let jobs = match all_overdue_jobs(config, now) {
+        Ok(jobs) => jobs,
+        Err(e) => {
+            ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                    .with_attrs(::serde_json::json!({"error": format!("{}", e)})),
+                "Scheduler startup skip: query failed",
+            );
+            return;
+        }
+    };
+
+    if jobs.is_empty() {
+        ::zeroclaw_log::record!(
+            INFO,
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note),
+            "Scheduler startup skip: no overdue jobs to advance",
+        );
+        return;
+    }
+
+    let mut skipped_recurring: u64 = 0;
+    let mut skipped_oneshot: u64 = 0;
+
+    for job in &jobs {
+        let is_oneshot = matches!(job.schedule, Schedule::At { .. });
+        match skip_missed_run(config, job, now) {
+            Ok(()) => {
+                if is_oneshot {
+                    skipped_oneshot += 1;
+                } else {
+                    skipped_recurring += 1;
+                }
+            }
+            Err(e) => {
+                ::zeroclaw_log::record!(
+                    WARN,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                        .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                        .with_attrs(::serde_json::json!({
+                            "job_id": job.id,
+                            "error": format!("{}", e),
+                        })),
+                    "Scheduler startup skip: failed to advance job",
+                );
+            }
+        }
+    }
+
+    ::zeroclaw_log::record!(
+        INFO,
+        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(
+            ::serde_json::json!({
+                "total": jobs.len(),
+                "skipped_recurring": skipped_recurring,
+                "skipped_oneshot": skipped_oneshot,
+            })
+        ),
+        "Scheduler startup skip: advanced overdue jobs without executing",
     );
 }
 

--- a/crates/zeroclaw-runtime/src/cron/store.rs
+++ b/crates/zeroclaw-runtime/src/cron/store.rs
@@ -471,6 +471,43 @@ pub fn reschedule_after_run_with_status(
     }
 }
 
+/// Advance `next_run` of an overdue recurring job to its next future
+/// occurrence without executing the missed run.  For one-shot `At` jobs
+/// there is no future occurrence, so the job is disabled and its last
+/// status is recorded as `skipped`.
+///
+/// Called at scheduler startup when `catch_up_on_startup` is disabled,
+/// so the subsequent normal polling loop won't pick up jobs whose
+/// `next_run` is still in the past.
+pub fn skip_missed_run(config: &Config, job: &CronJob, now: DateTime<Utc>) -> Result<()> {
+    if matches!(job.schedule, Schedule::At { .. }) {
+        // One-shot job whose scheduled moment has already passed —
+        // disable it so it won't execute late.
+        let bounded_output = truncate_cron_output("skipped — catch_up_on_startup disabled");
+        with_initialized_connection(config, |conn| {
+            conn.execute(
+                "UPDATE cron_jobs
+                 SET enabled = 0, last_run = ?1, last_status = 'skipped', last_output = ?2
+                 WHERE id = ?3",
+                params![now.to_rfc3339(), bounded_output, job.id],
+            )
+            .context("Failed to disable overdue one-shot cron job on startup skip")?;
+            Ok(())
+        })
+    } else {
+        // Recurring job — advance next_run to the next future occurrence.
+        let next_run = next_run_for_schedule(&job.schedule, now)?;
+        with_initialized_connection(config, |conn| {
+            conn.execute(
+                "UPDATE cron_jobs SET next_run = ?1 WHERE id = ?2",
+                params![next_run.to_rfc3339(), job.id],
+            )
+            .context("Failed to advance next_run on startup skip")?;
+            Ok(())
+        })
+    }
+}
+
 pub fn record_run(
     config: &Config,
     job_id: &str,
@@ -2247,5 +2284,152 @@ schedule = { kind = "every", every_ms = 300000 }
             health.schedule,
             zeroclaw_config::schema::CronScheduleDecl::Every { every_ms: 300_000 }
         ));
+    }
+
+    #[test]
+    fn skip_missed_run_advances_recurring_job_next_run() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(&tmp);
+
+        // Add a cron job that will be "overdue" — its next_run is set based
+        // on the schedule from the current time, so we need to make it past.
+        let job = add_job(&config, "test-agent", "* * * * *", "echo test").unwrap();
+
+        // Force next_run into the past so the job appears overdue.
+        let past = Utc::now() - ChronoDuration::hours(1);
+        with_initialized_connection(&config, |conn| {
+            conn.execute(
+                "UPDATE cron_jobs SET next_run = ?1 WHERE id = ?2",
+                params![past.to_rfc3339(), job.id],
+            )
+            .unwrap();
+            Ok(())
+        })
+        .unwrap();
+
+        // Verify it is overdue now.
+        assert!(
+            !all_overdue_jobs(&config, Utc::now()).unwrap().is_empty(),
+            "job with past next_run must appear in overdue"
+        );
+
+        // Skip the missed run.
+        let reloaded = get_job(&config, &job.id).unwrap();
+        skip_missed_run(&config, &reloaded, Utc::now()).unwrap();
+
+        // The job's next_run should now be in the future.
+        let updated = get_job(&config, &job.id).unwrap();
+        assert!(
+            updated.next_run > Utc::now(),
+            "skip_missed_run must advance next_run to the future"
+        );
+        assert!(updated.enabled, "recurring job must stay enabled");
+    }
+
+    #[test]
+    fn skip_missed_run_disables_overdue_oneshot_job() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(&tmp);
+
+        let run_at = Utc::now() - ChronoDuration::hours(2);
+        let schedule = Schedule::At { at: run_at };
+        let job = add_job_with_schedule(&config, "test-agent", &schedule, "echo once").unwrap();
+
+        // The add_job_with_schedule should have set next_run = run_at,
+        // so the job is overdue now.
+        assert!(
+            !all_overdue_jobs(&config, Utc::now()).unwrap().is_empty(),
+            "one-shot job with past at-time must be overdue"
+        );
+
+        let reloaded = get_job(&config, &job.id).unwrap();
+        skip_missed_run(&config, &reloaded, Utc::now()).unwrap();
+
+        let updated = get_job(&config, &job.id).unwrap();
+        assert!(
+            !updated.enabled,
+            "overdue one-shot job must be disabled after skip"
+        );
+        assert_eq!(
+            updated.last_status.as_deref(),
+            Some("skipped"),
+            "one-shot job last_status must be 'skipped'"
+        );
+    }
+
+    fn add_job_with_schedule(
+        config: &Config,
+        agent_alias: &str,
+        schedule: &Schedule,
+        command: &str,
+    ) -> Result<CronJob> {
+        let now = Utc::now();
+        let job = CronJob {
+            id: format!("test-job-{}", Uuid::new_v4()),
+            expression: String::new(),
+            schedule: schedule.clone(),
+            command: command.to_string(),
+            prompt: None,
+            name: None,
+            job_type: JobType::Shell,
+            session_target: SessionTarget::Isolated,
+            model: None,
+            agent_alias: agent_alias.to_string(),
+            enabled: true,
+            delivery: DeliveryConfig::default(),
+            delete_after_run: false,
+            allowed_tools: None,
+            uses_memory: false,
+            source: "imperative".to_string(),
+            created_at: now,
+            next_run: next_run_for_schedule(schedule, now).unwrap_or(now),
+            last_run: None,
+            last_status: None,
+            last_output: None,
+        };
+        let job_type_str: String = match &job.job_type {
+            JobType::Shell => "shell".to_string(),
+            JobType::Agent => "agent".to_string(),
+        };
+        let schedule_json = serde_json::to_string(&job.schedule).unwrap();
+        let delivery_json = serde_json::to_string(&job.delivery).unwrap();
+        let allowed_tools_json =
+            crate::cron::store::encode_allowed_tools(job.allowed_tools.as_ref()).unwrap();
+        with_initialized_connection(config, |conn| {
+            conn.execute(
+                "INSERT INTO cron_jobs
+                 (id, expression, command, schedule, job_type, prompt, name,
+                  session_target, model, enabled, delivery, delete_after_run,
+                  allowed_tools, next_run, last_run, last_status, last_output,
+                  uses_memory, source, created_at, agent_alias)
+                 VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20,?21)",
+                params![
+                    job.id,
+                    job.expression,
+                    job.command,
+                    schedule_json,
+                    job_type_str.to_string(),
+                    job.prompt,
+                    job.name,
+                    job.session_target.as_str(),
+                    job.model,
+                    if job.enabled { 1 } else { 0 },
+                    delivery_json,
+                    if job.delete_after_run { 1 } else { 0 },
+                    allowed_tools_json,
+                    job.next_run.to_rfc3339(),
+                    job.last_run.map(|t| t.to_rfc3339()),
+                    job.last_status,
+                    job.last_output,
+                    if job.uses_memory { 1 } else { 0 },
+                    job.source,
+                    job.created_at.to_rfc3339(),
+                    job.agent_alias,
+                ],
+            )
+            .context("Failed to insert test cron job")?;
+            Ok(())
+        })?;
+        Ok(job)
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Fixes #7250 by honoring `[scheduler] catch_up_on_startup = false` before the normal scheduler polling loop starts.
  - Adds startup skip handling for overdue jobs when catch-up is disabled: recurring jobs advance `next_run` to the next future occurrence, while overdue one-shot `At` jobs are disabled with `last_status = "skipped"`.
  - Adds store-level regression coverage for recurring and one-shot skip behavior.
- **Scope boundary:** Does not change normal `catch_up_on_startup = true` behavior, cron schedule parsing, delivery execution, retry behavior, or manual cron trigger paths.
- **Blast radius:** Runtime cron scheduler startup behavior and cron store state for overdue jobs when catch-up is disabled. No channel, provider, gateway, or CLI surface changes.
- **Linked issue(s):** Closes #7250.
- **Labels:** `bug`, `size: M`, `risk: high`, `cron`, `runtime`.

## Validation Evidence (required)

- **Commands run and tail output:**
  - Author reported: `cargo fmt` — clean.
  - Author reported: `cargo clippy -- -D warnings` — clean, no new warnings.
  - Author reported: `cargo test -p zeroclaw-runtime` — all 88 cron tests passed, including:
    - `skip_missed_run_advances_recurring_job_next_run`
    - `skip_missed_run_disables_overdue_oneshot_job`
  - GitHub visible Quality Gate passed on current head b8ced15e, including Format, Lint, Test, Security, platform builds, Checks, Nix Module Eval, and CI Required Gate.
- **Beyond CI — what did you manually verify?** Maintainer source review confirmed `skip_missed_jobs_on_startup()` runs after declarative sync and before the normal polling loop when `catch_up_on_startup` is false; `skip_missed_run()` advances recurring schedules and disables overdue one-shot schedules.
- **If any command was intentionally skipped, why:** Reviewer did not rerun local cargo for this pass; review relied on author-reported local validation plus green GitHub CI.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- If `No` or `Yes` to either: Existing `[scheduler] catch_up_on_startup = false` configs now honor the documented no-catch-up intent consistently; no config migration is required.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert b8ced15e07534c82e012748ab3e289cc17543224`
- **Feature flags or config toggles:** Set `[scheduler] catch_up_on_startup = true` to return to catch-up execution semantics; otherwise revert the commit.
- **Observable failure symptoms:** With `catch_up_on_startup = false`, overdue jobs still execute on the first scheduler poll after restart, or one-shot jobs scheduled during downtime run late instead of being marked skipped.
