### PR TITLE
fix(channels): update image history fixture context field

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -15440,7 +15440,7 @@ BTC is currently around $65,000 based on latest tool output."#
         let runtime_ctx = Arc::new(ChannelRuntimeContext {
             channels_by_name: Arc::new(channels_by_name),
             model_provider: provider_impl.clone(),
-            default_model_provider: Arc::new("test-provider".to_string()),
+            model_provider_ref: Arc::new("test-provider".to_string()),
             agent_alias: Arc::new("test-agent".to_string()),
             agent_cfg: Arc::new(zeroclaw_config::schema::AliasedAgentConfig::default()),
             memory: Arc::new(NoopMemory),
@@ -15458,8 +15458,6 @@ BTC is currently around $65,000 based on latest tool output."#
             pending_new_sessions: Arc::new(Mutex::new(HashSet::new())),
             provider_cache: Arc::new(Mutex::new(HashMap::new())),
             route_overrides: Arc::new(Mutex::new(HashMap::new())),
-            api_key: None,
-            api_url: None,
             reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
             provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Update the #7268 channel image-history regression test fixture to use the current `ChannelRuntimeContext::model_provider_ref` field.
  - Remove stale `api_key` and `api_url` fixture fields that no longer exist after the model-provider routing cleanup on `master`.
  - Restore `zeroclaw-channels` test-target compilation on current `master`.
- **Scope boundary:** This only fixes the test fixture introduced by #7268. It does not change runtime image-history behavior, provider routing, media handling, or channel configuration.
- **Blast radius:** `zeroclaw-channels` test compilation only.
- **Linked issue(s):** Follow-up to #7268.
- **Labels:** `bug`, `risk: low`, `size: XS`, `channel`.

## Validation Evidence (required)

Local validation is the signal CI cannot replace. Run the full battery and paste literal output (tails, failures, warnings — not "all passed").

- **Commands run and tail output:**

`git diff --check` passed with no output.

`cargo fmt --all -- --check` passed with no output.

`scripts/zc-cargo check -p zeroclaw-channels --tests` tail:

```text
    Checking zeroclaw-runtime v0.8.0-beta-2
    Checking zeroclaw-channels v0.8.0-beta-2
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 9m 41s
```

`scripts/zc-cargo test -p zeroclaw-channels --lib process_channel_message_sends_image_payload_without_persisting_it -- --nocapture` tail:

```text
    Finished `test` profile [unoptimized + debuginfo] target(s) in 10m 53s
     Running unittests src/lib.rs

running 1 test
test orchestrator::tests::process_channel_message_sends_image_payload_without_persisting_it ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 709 filtered out; finished in 1.41s
```

- **Beyond CI — what did you manually verify?**
  - Verified the compile failure from current `master` was caused by the #7268 test fixture still using removed `ChannelRuntimeContext` fields: `default_model_provider`, `api_key`, and `api_url`.
  - Verified neighboring fixtures now use `model_provider_ref`, and this patch brings the new #7268 fixture into the same shape.
- **If any command was intentionally skipped, why:**
  - Full workspace CI was not run locally because this is a one-fixture compile fix and the targeted check covers the failing package/test target that broke PR CI.

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: No user action required. This only updates a test fixture to match the current internal context struct.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PRs: `git revert <sha>` is the plan unless otherwise noted.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Scope materially carried forward: N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`No`)
- If `No`, why (inspiration-only, no direct code/design carry-over): No superseded PR or external code/design carried forward.
