### PR TITLE
feat(zerocode): hold back context-window usage bar until it bakes

### DIFF
--- a/apps/zerocode/src/app.rs
+++ b/apps/zerocode/src/app.rs
@@ -724,8 +724,11 @@ fn draw_status_bar(
     spans.push(Span::styled(label, style));
     frame.render_widget(Paragraph::new(Line::from(spans)), right_area);
 
-    // Left: ctx bar, left-aligned in its own column.
-    if let Some(w) = ctx.widget() {
+    // Left: ctx bar, left-aligned in its own column. The bar is held back
+    // until the context-accounting feature is ready to show; there is no
+    // user-facing switch — the gate flips when the work lands.
+    const SHOW_CTX_BAR: bool = false;
+    if SHOW_CTX_BAR && let Some(w) = ctx.widget() {
         frame.render_widget(w, left_area);
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Gate the `CtxBar` render in `draw_status_bar` behind a compile-time `SHOW_CTX_BAR` const set to `false`, so the context-window usage bar is no longer shown to users. The accounting feature needs more time to bake before it is shown off.
  - There is intentionally **no** keybinding, config, or UI affordance to re-enable it. Re-enabling is a one-line bool flip when the work is ready.
  - The `CtxBar` widget and the `ctx_tokens` token plumbing are left fully intact — live, type-checked, and just unreached — so bringing it back is a flip rather than a re-implementation.
- **Scope boundary:** Does NOT remove `CtxBar`, `ctx_tokens()`, or any token-accounting plumbing. Does NOT change the status-bar layout (the row and its left/right column split are unchanged; the left column simply renders empty). No keybinding, config, or schema changes.
- **Blast radius:** zerocode TUI status bar only. The bar was the sole consumer of the ctx render path; suppressing it has no effect on chat/acp panes, the daemon, or any other surface.
- **Linked issue(s):** none
- **Labels:** `risk: low`, `size: XS`

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` -> clean, exit 0 (no output)
  - `cargo clippy --all-targets -- -D warnings` -> `Finished \`dev\` profile [unoptimized + debuginfo] target(s)`, exit 0 (no warnings)
  - `cargo test` -> all suites pass, exit 0. Tails: zerocode unit suite `258 passed; 0 failed`; system suite `9 passed; 0 failed`; doc-tests `0 passed; 0 failed`.
- **Beyond CI — what did you manually verify?** Confirmed there is exactly one render site for the bar (`ctx.widget()` inside `draw_status_bar`); the const gate leaves `ctx.widget()` and the param consumed so no dead-code warning fires. Did NOT visually verify the re-enabled (`true`) path in this PR — that is the point of holding it back; it will be verified when the gate flips.
- **If any command was intentionally skipped, why:** none skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: n/a

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: exact upgrade steps for existing users: none — purely a visual suppression; no user-facing surface added or removed.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PR: `git revert <sha>` restores the original unconditional render. Alternatively, flip `SHOW_CTX_BAR` to `true` — that is the lower-risk re-enable path and survives surrounding churn better than a literal revert.