### PR TITLE
fix(config): warn on unknown security.otp.gated_actions entries

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -12527,7 +12527,9 @@ pub struct OtpConfig {
     #[serde(default = "default_otp_cache_valid_secs")]
     pub cache_valid_secs: u64,
 
-    /// Tool/action names gated by OTP.
+    /// Tool/action names gated by OTP. Empty or malformed entries are rejected
+    /// at config load; an entry that does not match a known gated action is
+    /// accepted but logged at WARN, since it cannot be enforced.
     #[serde(default = "default_otp_gated_actions")]
     pub gated_actions: Vec<String>,
 
@@ -15242,6 +15244,21 @@ impl Config {
             {
                 anyhow::bail!(
                     "security.otp.gated_actions[{i}] contains invalid characters: {normalized}"
+                );
+            }
+            if !default_otp_gated_actions()
+                .iter()
+                .any(|known| known == normalized)
+            {
+                ::zeroclaw_log::record!(
+                    WARN,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                        .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                        .with_attrs(::serde_json::json!({
+                            "action": normalized,
+                            "known_actions": default_otp_gated_actions(),
+                        })),
+                    "security.otp.gated_actions entry does not match a known gated action and will not be enforced: "
                 );
             }
         }
@@ -21693,6 +21710,45 @@ require_otp_to_resume = true
 
         let err = config.validate().expect_err("expected invalid domain glob");
         assert!(err.to_string().contains("gated_domains"));
+    }
+
+    #[test]
+    async fn security_validation_accepts_all_default_gated_actions_without_warning() {
+        let mut config = Config::default();
+        config.security.otp.gated_actions = default_otp_gated_actions();
+
+        config
+            .validate()
+            .expect("the canonical default gated actions must validate clean");
+    }
+
+    #[test]
+    async fn security_validation_accepts_unknown_gated_action_but_does_not_bail() {
+        // An unknown but well-formed action name is a silent no-op today
+        // (OTP enforcement of gated_actions is not wired through). Config load
+        // must not fail on it — the operator's whole config would be rejected
+        // for a typo'd gate — but the runtime emits a WARN so the no-op is not
+        // silent. This asserts the warn-and-continue contract: load succeeds.
+        let mut config = Config::default();
+        config.security.otp.gated_actions = vec!["kubectl_write".into()];
+
+        config
+            .validate()
+            .expect("an unknown gated action must warn, not reject the config");
+    }
+
+    #[test]
+    async fn security_validation_still_rejects_malformed_gated_action() {
+        // The unknown-name warn must not weaken the existing hard checks from
+        // the charset/empty validation: a name with invalid characters still
+        // bails rather than degrading to a warn.
+        let mut config = Config::default();
+        config.security.otp.gated_actions = vec!["kubectl write".into()];
+
+        let err = config
+            .validate()
+            .expect_err("malformed gated action must still be rejected");
+        assert!(err.to_string().contains("gated_actions"));
     }
 
     // The two `validate_*_transcription_default_provider` tests were removed


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** `security.otp.gated_actions` accepted any well-formed string with no feedback, so a typo'd, renamed, or invented action name (e.g. `kubectl_write`) loaded cleanly and the operator believed they had a TOTP gate that does not exist. The empty/charset validation added in #7160 rejects malformed strings but still lets unknown-but-well-formed names through. This extends the existing validation loop to emit a WARN for any entry that is not one of the canonical gated actions.
- The warn is warn-and-continue, matching the existing proxy-URL precedent in the same `validate()` function. Config load still **succeeds**: OTP enforcement of `gated_actions` is not wired through (tracked in #3767), so an unknown name is provably a no-op today, and rejecting the operator's entire config for a typo'd gate would be worse than a warning.
- **Scope boundary:** name validation only. Does not add or change OTP enforcement (still unwired, #3767). Name validation is deliberately scoped to the canonical defaults from `default_otp_gated_actions()` — see Compatibility note below for why a fully-general check is out of scope.
- **Blast radius:** `Config::validate()` in `zeroclaw-config` and the generated config reference doc. No runtime/enforcement behavior changes; the only new effect is a WARN log line on an unknown entry.
- **Linked issue(s):** Closes #5810. Related #3767 (the orthogonal OTP enforcement gap).
- **Labels:** `bug`, `risk: low`, `size: S`, `config`, `security`

## Validation Evidence (required)

Full battery run locally against this branch (1 tracked source file changed, `crates/zeroclaw-config/src/schema.rs`; the generated `docs/.../reference/config.md` is gitignored and regenerated from the field doc comment):

```
$ cargo fmt --all -- --check
(no output)                                  # exit 0

$ cargo clippy --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s)   # exit 0, full workspace

$ cargo test
... all suites ok, 0 failed ...
test result: ok. 275 passed; 0 failed   (zeroclaw-config lib slice shown)
test result: ok. 9 passed; 0 failed     (test_system.rs)

$ cargo test -p zeroclaw-config
test result: ok. 773 passed; 0 failed; 0 ignored
test result: ok. 89 passed; 0 failed; 0 ignored
```

- **Commands run and tail output:** all pass clean (tails above). New tests:
  `security_validation_accepts_all_default_gated_actions_without_warning`,
  `security_validation_accepts_unknown_gated_action_but_does_not_bail`,
  `security_validation_still_rejects_malformed_gated_action`.
- **Beyond CI — what did you manually verify?** Confirmed the bug is live on master: `gated_actions = ["kubectl_write"]` validates clean before this change (#7160 only added empty/charset checks). Confirmed OTP enforcement does not read `gated_actions` anywhere in `policy.rs`/`loop_.rs`/`otp.rs`, so the warn (not bail) is the correct contract. Confirmed the doc table is generated from the field `///` comment (via `xtask mdbook refs`), so I edited the schema source comment, not the gitignored generated file, and regenerated to verify it flows through.
- **What I did NOT verify:** no live daemon run; coverage rests on the unit tests against `Config::validate()`.
- **If any command was intentionally skipped, why:** none skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: N/A. Security-visible in that it removes a false sense of security (a configured-but-unenforceable gate), but adds no new capability or attack surface.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No` (existing valid configs are unaffected; only an unknown `gated_actions` entry now produces a WARN at load)
- If `No` or `Yes` to either: no upgrade steps. Note on scope: the warn checks against the canonical defaults (`shell`, `file_write`, `browser_open`, `browser`, `memory_forget`). `zeroclaw-config` sits below `zeroclaw-tools`/`zeroclaw-runtime` and cannot reach the live tool registry, so a fully general check against every registered tool name would require a shared tool-name registry in `zeroclaw-api`. That is intentionally deferred — it is unnecessary while enforcement is unwired (#3767), and the warn against defaults is correct today since any name outside that set is a guaranteed no-op.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk: `git revert <sha>` removes the warn pass. The pre-existing empty/charset validation and all other behavior are untouched.