### PR TITLE
fix(channels): drop truncated tool-call envelopes at delivery, keep the reply

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -615,6 +615,58 @@ pub(crate) fn strip_tool_call_tags(message: &str) -> String {
         }
     }
 
+    // Does the tag structure run to the end of the message? A *real* truncated
+    // tool call is the model getting cut off, so the unterminated structure is
+    // the last thing in the message. If natural-language prose resumes after the
+    // tags, this is an inline *example* (the model is discussing tool calls), not
+    // a truncation — so we should keep it. Bias toward keeping: a little leaked
+    // XML beats eating the user's text.
+    fn tool_structure_runs_to_end(inner: &str) -> bool {
+        let mut rest = inner.trim_start();
+        while rest.starts_with('<') {
+            match rest.find('>') {
+                Some(gt) => rest = rest[gt + 1..].trim_start(),
+                None => return true,
+            }
+        }
+        let tail = rest.trim();
+        if tail.is_empty() {
+            return true;
+        }
+        !looks_like_prose(tail)
+    }
+
+    // Heuristic: does `text` read like resumed natural-language prose (as opposed
+    // to a cut-off parameter value)? True on an internal sentence boundary
+    // (". " / "! " / "? " + a letter) or a multi-word string that ends like a
+    // sentence. Deliberately lenient so ambiguous tails are kept, not dropped.
+    fn looks_like_prose(text: &str) -> bool {
+        let bytes = text.as_bytes();
+        for i in 0..bytes.len().saturating_sub(1) {
+            if matches!(bytes[i], b'.' | b'!' | b'?')
+                && matches!(bytes[i + 1], b' ' | b'\n' | b'\t')
+                && text[i + 1..]
+                    .trim_start()
+                    .chars()
+                    .next()
+                    .is_some_and(|c| c.is_alphabetic())
+            {
+                return true;
+            }
+        }
+        let trimmed = text.trim_end();
+        let ends_like_sentence = trimmed
+            .chars()
+            .last()
+            .is_some_and(|c| matches!(c, '.' | '!' | '?'))
+            && trimmed
+                .chars()
+                .rev()
+                .nth(1)
+                .is_some_and(|c| c.is_alphabetic());
+        ends_like_sentence && text.trim().contains(' ')
+    }
+
     let mut kept_segments = Vec::new();
     let mut remaining = message;
 
@@ -637,6 +689,26 @@ pub(crate) fn strip_tool_call_tags(message: &str) -> String {
         if let Some(consumed_end) = extract_first_json_end(after_open) {
             remaining = strip_leading_close_tags(&after_open[consumed_end..]);
             continue;
+        }
+
+        // Unterminated open tag with no parseable JSON body. Drop the broken
+        // tail ONLY when it looks like tool-call structure AND that structure
+        // runs to the end of the message — a real truncation where the model was
+        // cut off mid-call. If prose resumes after the structure, the model is
+        // showing an *example*, not making a call, so keep it verbatim (a little
+        // leaked XML beats eating the reply). Text merely mentioning a tag is
+        // likewise kept.
+        let inner = after_open.trim_start();
+        let inner_lower = inner.to_ascii_lowercase();
+        let looks_like_tool_structure = inner_lower.starts_with("<invoke")
+            || inner_lower.starts_with("<parameter")
+            || inner_lower.starts_with("<tool")
+            || inner_lower.starts_with("<function")
+            || inner.starts_with('{')
+            || inner.starts_with('[');
+        if looks_like_tool_structure && tool_structure_runs_to_end(inner) {
+            remaining = "";
+            break;
         }
 
         kept_segments.push(remaining[start..].to_string());

--- a/crates/zeroclaw-channels/src/util.rs
+++ b/crates/zeroclaw-channels/src/util.rs
@@ -78,6 +78,63 @@ pub fn strip_tool_call_tags(message: &str) -> String {
         }
     }
 
+    // Does the tag structure run to the end of the message? A *real* truncated
+    // tool call is the model getting cut off, so the unterminated structure is
+    // the last thing in the message. If natural-language prose resumes after the
+    // tags, this is an inline *example* (the model is discussing tool calls), not
+    // a truncation — so we should keep it. Bias toward keeping: a little leaked
+    // XML beats eating the user's text.
+    fn tool_structure_runs_to_end(inner: &str) -> bool {
+        let mut rest = inner.trim_start();
+        // Consume a run of `<...>` tags (and whitespace between them).
+        while rest.starts_with('<') {
+            match rest.find('>') {
+                Some(gt) => rest = rest[gt + 1..].trim_start(),
+                // Cut off mid-tag (no closing '>') — a classic truncation.
+                None => return true,
+            }
+        }
+        let tail = rest.trim();
+        if tail.is_empty() {
+            // Tags ran cleanly to the end → truncation.
+            return true;
+        }
+        // Non-empty tail: prose ⇒ inline example (keep); otherwise it's a
+        // truncated tag/param value (drop).
+        !looks_like_prose(tail)
+    }
+
+    // Heuristic: does `text` read like resumed natural-language prose (as opposed
+    // to a cut-off parameter value)? True on an internal sentence boundary
+    // (". " / "! " / "? " + a letter) or a multi-word string that ends like a
+    // sentence. Deliberately lenient so ambiguous tails are kept, not dropped.
+    fn looks_like_prose(text: &str) -> bool {
+        let bytes = text.as_bytes();
+        for i in 0..bytes.len().saturating_sub(1) {
+            if matches!(bytes[i], b'.' | b'!' | b'?')
+                && matches!(bytes[i + 1], b' ' | b'\n' | b'\t')
+                && text[i + 1..]
+                    .trim_start()
+                    .chars()
+                    .next()
+                    .is_some_and(|c| c.is_alphabetic())
+            {
+                return true;
+            }
+        }
+        let trimmed = text.trim_end();
+        let ends_like_sentence = trimmed
+            .chars()
+            .last()
+            .is_some_and(|c| matches!(c, '.' | '!' | '?'))
+            && trimmed
+                .chars()
+                .rev()
+                .nth(1)
+                .is_some_and(|c| c.is_alphabetic());
+        ends_like_sentence && text.trim().contains(' ')
+    }
+
     let mut kept_segments = Vec::new();
     let mut remaining = message;
 
@@ -100,6 +157,27 @@ pub fn strip_tool_call_tags(message: &str) -> String {
         if let Some(consumed_end) = extract_first_json_end(after_open) {
             remaining = strip_leading_close_tags(&after_open[consumed_end..]);
             continue;
+        }
+
+        // Unterminated open tag with no parseable JSON body. Drop the broken
+        // tail ONLY when it looks like tool-call structure (`<invoke>` /
+        // `<parameter>` / `<tool*>` / `<function*>` / `{` / `[`) AND that
+        // structure runs to the end of the message — i.e. a real truncation
+        // where the model was cut off mid-call. If prose resumes after the
+        // structure, the model is showing an *example*, not making a call, so
+        // keep it verbatim (a little leaked XML beats eating the user's reply).
+        // Text that merely mentions a tag is likewise kept.
+        let inner = after_open.trim_start();
+        let inner_lower = inner.to_ascii_lowercase();
+        let looks_like_tool_structure = inner_lower.starts_with("<invoke")
+            || inner_lower.starts_with("<parameter")
+            || inner_lower.starts_with("<tool")
+            || inner_lower.starts_with("<function")
+            || inner.starts_with('{')
+            || inner.starts_with('[');
+        if looks_like_tool_structure && tool_structure_runs_to_end(inner) {
+            remaining = "";
+            break;
         }
 
         kept_segments.push(remaining[start..].to_string());
@@ -232,6 +310,54 @@ pub fn conversation_history_key(msg: &zeroclaw_api::channel::ChannelMessage) -> 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn strip_drops_truncated_function_calls_envelope_keeps_prose() {
+        // Truncated `<function_calls><invoke …><parameter …` (model cut off):
+        // the broken tail is dropped, the preceding prose survives.
+        let msg = "Here's the result:\n<function_calls>\n<invoke name=\"shell\">\n<parameter name=\"command\">sed -n '1,5p' file.rs";
+        assert_eq!(strip_tool_call_tags(msg), "Here's the result:");
+
+        // Envelope-only (no prose) -> empty.
+        let only = "<function_calls>\n<invoke name=\"shell\">\n<parameter name=\"command\">date";
+        assert_eq!(strip_tool_call_tags(only), "");
+
+        // Complete envelope is still stripped (unchanged behaviour).
+        let complete = "before <function_calls><invoke name=\"shell\"><parameter name=\"command\">date</parameter></invoke></function_calls> after";
+        assert_eq!(strip_tool_call_tags(complete), "before  after");
+    }
+
+    #[test]
+    fn strip_keeps_prose_that_merely_mentions_a_tag() {
+        // An unterminated opener followed by ordinary prose (not tool structure)
+        // is kept — the model is talking about the tag, not calling a tool.
+        let msg =
+            "The bug is that models emit <function_calls> and never close it, hanging the parser.";
+        assert_eq!(strip_tool_call_tags(msg), msg);
+    }
+
+    #[test]
+    fn strip_keeps_unterminated_example_followed_by_prose() {
+        // An unterminated opener IS followed by tool structure, but prose
+        // resumes after it — so it's an inline example, not a truncation.
+        // Keep it verbatim (the EOF rule: a real truncation ends the message).
+        let xml_example = "The model emits <function_calls><invoke name=\"x\"> and then keeps going. This sentence matters.";
+        assert_eq!(strip_tool_call_tags(xml_example), xml_example);
+
+        let json_example = "Emit <tool_call> {then describe the schema} in your docs.";
+        assert_eq!(strip_tool_call_tags(json_example), json_example);
+    }
+
+    #[test]
+    fn strip_still_drops_genuine_truncation_to_end() {
+        // No prose after the structure — the model was cut off mid-call. Drop.
+        let truncated = "Here's the result:\n<function_calls>\n<invoke name=\"shell\">\n<parameter name=\"command\">sed -n '1,5p' file.rs";
+        assert_eq!(strip_tool_call_tags(truncated), "Here's the result:");
+
+        // Cut off mid-tag (no closing '>') is also a truncation.
+        let mid_tag = "Working on it <function_calls><invoke name=\"sh";
+        assert_eq!(strip_tool_call_tags(mid_tag), "Working on it");
+    }
 
     #[test]
     fn parse_attachment_markers_extracts_known_kinds() {


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - When a model is cut off **mid tool-call** it emits an *unterminated* tagged
    envelope, e.g. `<function_calls><invoke name="shell"><parameter name="command">…`
    with no closing tags. The channel delivery cleaner `strip_tool_call_tags`
    recovered unterminated **JSON** tool calls but fell through on the **XML**
    invoke/parameter form and **leaked the raw envelope into the channel**.
  - Fix: when an unterminated opener is followed by tool-call structure **and that
    structure runs to the end of the message** (a genuine truncation), drop the
    broken tail while keeping the preceding prose. If natural-language prose
    resumes after the structure, the model is showing an *example* rather than
    making a call, so the text is kept verbatim.
  - Applied to **both** delivery cleaners — `channels::util::strip_tool_call_tags`
    and the `orchestrator` copy.
  - Observed with MiniMax-family models in text-tool mode emitting Anthropic-style
    `<function_calls>` XML cut off after a long `<think>` block — gateway-independent,
    so it affects any such user, not only one gateway.
- **Scope boundary:** delivery-layer text cleaning only. It does **not** touch the
  malformed-tool detection / retry / suppression path, so legitimate replies are
  never suppressed or replaced with a placeholder.
- **Blast radius:** only ever *removes* text from the opener tag onward — it never
  garbles or rewrites the prose *before* the tag, and never routes through the
  suppression/retry path. Normal replies, prose that merely mentions a tag, and
  tags used as words are unaffected (see probe below).
- **Linked issue(s):** Related #7244 (parser hardening for malformed `<tool_call>`
  JSON args — a different failure mode). The native-tools alternative is ruled out
  for gateway endpoints — Related #5242, Related #6298. No existing issue tracks
  this specific delivery-layer leak; it was found via dogfooding.
- **Labels:** expect `channels`, `type: fix`, `risk: low`, `size: S`.

### Documented trade-off

The example-vs-truncation boundary is fundamentally ambiguous for unterminated
input (an inline `<function_calls><invoke…` example is byte-identical to a real
cut-off call). This PR biases toward **keeping** when unsure: a genuine truncated
tool call whose tail happens to read like a sentence (e.g. a cut-off `<parameter>`
value that is itself an English sentence) will leak that small fragment rather than
risk deleting a user's reply. That is a quieter, rarer failure than silently eating
content, and the surrounding prose is preserved either way. Optional future
tightening: also skip tags inside fenced code blocks.

## Validation Evidence (required)

Change is confined to one crate (`zeroclaw-channels`), so the battery is run scoped
to it (plus workspace-wide `fmt`). Literal tails:

```text
$ cargo fmt --all -- --check
# clean (exit 0)

$ cargo clippy -p zeroclaw-channels --features channel-discord --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s)
# clean (exit 0, no warnings)

$ cargo test -p zeroclaw-channels --features channel-discord strip_
test util::tests::strip_drops_truncated_function_calls_envelope_keeps_prose ... ok
test util::tests::strip_keeps_prose_that_merely_mentions_a_tag ... ok
test util::tests::strip_keeps_unterminated_example_followed_by_prose ... ok
test util::tests::strip_still_drops_genuine_truncation_to_end ... ok
test result: ok. 42 passed; 0 failed; 0 ignored; 0 measured; 763 filtered out
```

- **Commands run and tail output:** as above.
- **Beyond CI — what did you manually verify?** Ran a probe of `strip_tool_call_tags`
  against realistic legitimate messages:

  ```text
  plain prose ............................... unchanged              ✅
  prose mentioning <function_calls> ......... unchanged              ✅
  <tool> used as a word ..................... unchanged              ✅
  <function_calls> below. + a <note> line ... unchanged              ✅
  unterminated <invoke> example + prose ..... kept (prose resumes)   ✅
  "Emit <tool_call> {schema} in docs." ...... kept (prose resumes)   ✅
  real truncated call (cut off mid-value) ... tail dropped, prose kept ✅
  mid-tag cutoff "<invoke name=\"sh" ........ tail dropped, prose kept ✅
  complete fenced <function_calls> example .. XML removed (pre-existing strip)
  ```

  Also built a release with the change and ran it against a live instance whose
  MiniMax-via-gateway agent had been leaking `<function_calls>` XML to a channel;
  confirmed truncated envelopes no longer leak and that normal replies (including
  ones that *discuss* tool-call syntax) render unchanged.
- **If any command was intentionally skipped, why:** the full-workspace `cargo test`
  / `cargo clippy` were not run locally; the change is isolated to delivery-layer
  string handling in `zeroclaw-channels`, and CI runs the full battery.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes` — only strips envelopes that previously leaked; valid
  output (complete tool calls, JSON envelopes, ordinary prose) is unchanged.
- Config / env / CLI surface changed? `No`
- Upgrade steps: none.

## Rollback (required for `risk: medium` and `risk: high`)

Low risk: `git revert <sha>` — two delivery-cleaner functions plus tests.
