### PR TITLE
chore(zerocode): drop macOS default-theme override, use icy_blue everywhere

### DIFF
--- a/apps/zerocode/src/theme.rs
+++ b/apps/zerocode/src/theme.rs
@@ -54,23 +54,15 @@ const TERMINAL: Theme = Theme {
 // source of truth shared with the React dashboard and mdBook docs. See
 // `build.rs` for the var→role mapping. `TERMINAL` and `ICY_BLUE` are authored
 // here because they have no registry entry: `terminal` is the inherit-shell
-// sentinel, and `icy_blue` is the non-macOS default.
+// sentinel, and `icy_blue` is the default.
 include!(concat!(env!("OUT_DIR"), "/theme_presets.rs"));
 
-pub(crate) const DEFAULT_THEME_NAME: &str = if cfg!(target_os = "macos") {
-    "terminal"
-} else {
-    "icy_blue"
-};
+pub(crate) const DEFAULT_THEME_NAME: &str = "icy_blue";
 
-const DEFAULT_THEME: Theme = if cfg!(target_os = "macos") {
-    TERMINAL
-} else {
-    ICY_BLUE
-};
+const DEFAULT_THEME: Theme = ICY_BLUE;
 
 /// The two authored presets with no dashboard-registry entry: the
-/// inherit-shell sentinel and the non-macOS default. All other presets come
+/// inherit-shell sentinel and the default. All other presets come
 /// from `GENERATED_THEMES`.
 const AUTHORED_THEMES: &[(&str, Theme)] = &[("terminal", TERMINAL), ("icy_blue", ICY_BLUE)];
 
@@ -445,13 +437,8 @@ mod tests {
     }
 
     #[test]
-    fn default_theme_is_platform_conditional() {
-        let expected = if cfg!(target_os = "macos") {
-            "terminal"
-        } else {
-            "icy_blue"
-        };
-        assert_eq!(DEFAULT_THEME_NAME, expected);
+    fn default_theme_is_icy_blue() {
+        assert_eq!(DEFAULT_THEME_NAME, "icy_blue");
         assert!(theme_by_name(DEFAULT_THEME_NAME).is_some());
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** The theme-enhancements work in #7249 introduced a platform split for the default zerocode TUI theme — macOS defaulted to the inherit-shell `terminal` preset while every other platform got `icy_blue`. This removes the `cfg!(target_os = "macos")` override so `icy_blue` is the default on all platforms, giving a consistent out-of-the-box look. macOS users who prefer their terminal's own palette can still select the `terminal` preset explicitly.
- **Scope boundary:** Only the default-theme selection in `apps/zerocode/src/theme.rs` changes. The `terminal` and `icy_blue` presets themselves, the registry-generated themes, color-depth detection, and per-agent overrides are untouched.
- **Blast radius:** zerocode TUI default appearance on macOS for users who have not explicitly set `theme.name`. No effect on users with an explicit theme in config, and no effect on non-macOS platforms.
- **Linked issue(s):** None.
- **Labels:** Auto-applied by the labeler — expect `risk: low` (chore-only path) and `size: XS` (<=80 non-doc lines). No manual type label needed (no `type: chore` label in the repo).

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy -p zerocode --all-targets -- -D warnings
cargo test -p zerocode
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` → exit 0, no diff.
  - `cargo clippy -p zerocode --all-targets -- -D warnings` →
    ```
    Compiling zerocode v0.8.0-beta-2 (/Users/jordantian/zeroclaw/apps/zerocode)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 20.35s
    ```
    (no warnings)
  - `cargo test -p zerocode` →
    ```
    test result: ok. 320 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
    ```
    Includes the updated `theme::tests::default_theme_is_icy_blue` (replaces the prior `default_theme_is_platform_conditional`).
- **Beyond CI — what did you manually verify?** Confirmed `DEFAULT_THEME_NAME` and `DEFAULT_THEME` now resolve to `icy_blue` / `ICY_BLUE` unconditionally, and that `terminal` remains a selectable named preset via `theme_by_name`. Did not rebuild/launch the TUI on a non-macOS host (change is a compile-time constant with no platform-specific code path remaining).
- **If any command was intentionally skipped, why:** Clippy and tests were scoped to `-p zerocode` rather than the full workspace because the change is a 6-line edit isolated to one file in that crate; `cargo fmt --all` was run workspace-wide.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No` — no config keys, env vars, or CLI flags change. Only the implicit default value of `theme.name` when unset.
- If `No` or `Yes` to either: Users with an explicit `theme.name` in config are unaffected. macOS users who relied on the implicit `terminal` default will now see `icy_blue`; they can restore the previous behavior by setting `theme.name = "terminal"`. No migration steps required.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk: `git revert <sha>` restores the platform-conditional default.