### PR TITLE
fix(gateway): attribute WS turn telemetry and cost to the agent's model

### DIFF
--- a/crates/zeroclaw-gateway/src/ws.rs
+++ b/crates/zeroclaw-gateway/src/ws.rs
@@ -823,21 +823,20 @@ async fn process_chat_message(
     use futures_util::StreamExt as _;
     use zeroclaw_runtime::agent::TurnEvent;
 
-    let provider_label = {
-        let cfg = state.config.read();
-        cfg.providers
-            .models
-            .iter_entries()
-            .next()
-            .map(|(ty, alias, _)| format!("{ty}.{alias}"))
-            .unwrap_or_else(|| "unknown".to_string())
-    };
+    // Attribute telemetry, broadcasts, and cost to THIS agent's actual model
+    // (resolved per-turn), not the global default model or the first configured
+    // provider. Previously `provider_label` took the first `providers.models`
+    // entry and the model came from `model_label` (the global default), so every
+    // gateway_ws_turn / agent_start / cost record mislabelled the model.
+    let (turn_alias, turn_provider, turn_model) = agent.attribution_fields();
+    let provider_label = turn_provider.clone();
+    let model_label = turn_model.clone();
 
     // Broadcast agent_start event
     let _ = state.event_tx.send(serde_json::json!({
         "type": "agent_start",
         "model_provider": provider_label,
-        "model": state.model,
+        "model": model_label,
     }));
 
     // Set session state to running
@@ -870,7 +869,6 @@ async fn process_chat_message(
     // from the other branch.
     let content_owned = content.to_string();
     let session_key_owned = session_key.to_string();
-    let (turn_alias, turn_provider, turn_model) = agent.attribution_fields();
     let turn_fut = async {
         use ::zeroclaw_log::Instrument as _;
         let span = ::zeroclaw_log::info_span!(
@@ -1175,7 +1173,7 @@ async fn process_chat_message(
         let _ = state.event_tx.send(serde_json::json!({
             "type": "agent_end",
             "model_provider": provider_label,
-            "model": state.model,
+            "model": model_label,
         }));
 
         // Trace the cancelled turn so the doctor / replay tool sees it
@@ -1186,7 +1184,7 @@ async fn process_chat_message(
                 .with_outcome(::zeroclaw_log::EventOutcome::Failure)
                 .with_attrs(::serde_json::json!({
                     "model_provider": provider_label,
-                    "model": state.model,
+                    "model": model_label,
                     "session_key": session_key,
                     "reason": "interrupted by user",
                     "cancelled": true,
@@ -1249,7 +1247,7 @@ async fn process_chat_message(
             let cost_usd = record_turn_cost(
                 state,
                 &provider_label,
-                &state.model,
+                &model_label,
                 total_input_tokens,
                 total_output_tokens,
                 None,
@@ -1262,7 +1260,7 @@ async fn process_chat_message(
                 "output_tokens": total_output_tokens,
                 "tokens_used": total_tokens,
                 "cost_usd": cost_usd,
-                "model": state.model,
+                "model": model_label,
                 "provider": provider_label,
             });
             let _ = sender.send(Message::Text(done.to_string().into())).await;
@@ -1276,7 +1274,7 @@ async fn process_chat_message(
             let _ = state.event_tx.send(serde_json::json!({
                 "type": "agent_end",
                 "model_provider": provider_label,
-                "model": state.model,
+                "model": model_label,
             }));
 
             // Append a runtime-trace.jsonl record so a `zeroclaw doctor`
@@ -1288,7 +1286,7 @@ async fn process_chat_message(
                     .with_outcome(::zeroclaw_log::EventOutcome::Success)
                     .with_attrs(::serde_json::json!({
                         "model_provider": provider_label,
-                        "model": state.model,
+                        "model": model_label,
                         "session_key": session_key,
                         "input_tokens": total_input_tokens,
                         "output_tokens": total_output_tokens,
@@ -1354,7 +1352,7 @@ async fn process_chat_message(
                     .with_outcome(::zeroclaw_log::EventOutcome::Failure)
                     .with_attrs(::serde_json::json!({
                         "model_provider": provider_label,
-                        "model": state.model,
+                        "model": model_label,
                         "session_key": session_key,
                         "error": sanitized,
                         "error_code": error_code,


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - In `process_chat_message` (the chat WebSocket turn handler), the `agent_start`
    broadcast, **every `gateway_ws_turn` trace event**, and the **per-turn cost
    record** were labelled with:
    - `provider_label` = the **first** `providers.models` entry (`iter_entries().next()`), and
    - `state.model` = the **global default** model (`resolve_default_model()`),

    regardless of which agent/model actually served the turn. So a web-chat turn
    served by e.g. `kilo` / `deepseek-v4-flash` was traced **and costed** as
    `ollama.default` / granite — on every agent.
  - Fix: use the agent's own per-turn attribution — `agent.attribution_fields()`,
    which is **already** used (correctly) in the turn's trace span — for the
    broadcast, the `gateway_ws_turn` events, and `record_turn_cost`.
- **Scope boundary:** attribution/labels only. **Inference was already correct**
  (the agent runs its configured model); this only fixes what's *reported*. The
  auto-save / memory-consolidation path keeps using the session provider object
  unchanged, and the onboarding default-model check is untouched.
- **Blast radius:** `gateway_ws_turn` trace events, the `agent_start` WS broadcast,
  and per-turn cost attribution in the chat-WS path. No behaviour/inference change.
- **Linked issue(s):** Related #7381 (WebUI per-agent model button) — same
  global-vs-per-agent attribution class, surfaced from the same investigation.
- **Labels:** `bug`, `size: XS`, `risk: medium`, `gateway`, `observability`.

## Validation Evidence (required)

```text
$ cargo fmt --all -- --check
# clean (exit 0)

$ cargo test -p zeroclaw-gateway
test result: ok. 226 passed; 0 failed; 0 ignored; 0 measured

$ cargo check -p zeroclaw-gateway
    Finished `dev` profile  # clean (exit 0)
```

- **Beyond CI — what did you manually verify?** This bug was caught by an
  instrumented run: a runtime probe at the provider call site logged the *actual*
  dispatched model for 8 consecutive web-chat turns across 6 models / 2 provider
  families (`kilo`, `opencode`) — every one matching the agent's configured model
  — while the `gateway_ws_turn` events for those same turns logged `ollama.default`.
  That mismatch is exactly what this patch removes: the events now read from the
  same `attribution_fields()` the trace span already uses.
- **If any command was intentionally skipped, why:** `cargo clippy --
  -D warnings` currently fails to compile the transitive `zeroclaw-channels` dep
  on an **unrelated pre-existing** unused import
  (`crate::paced_channel::PacedChannel`, `orchestrator/mod.rs:115`) — not in this
  diff. The `zeroclaw-gateway` crate itself is clippy-clean.

## Security & Privacy Impact (required)

- New permissions / capabilities / FS access? `No`
- New external network calls? `No`
- Secrets / tokens handling changed? `No`
- PII / real identities in diff/tests/fixtures? `No`

## Compatibility (required)

- Backward compatible? `Yes` — only changes the model/provider labels on telemetry
  + cost records to the correct per-agent values. No schema/config/API change.
- Config / env / CLI surface changed? `No`
- Upgrade steps: none.

## Rollback (required for risk: medium/high)

- **Fast rollback command/path:** `git revert <sha>` — a single handler in
  `crates/zeroclaw-gateway/src/ws.rs`.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** web-chat `agent_start` / `agent_end`,
  `gateway_ws_turn`, or `/api/cost` entries show the gateway boot/default model
  instead of the selected agent model.
