### PR TITLE
feat(cron): add a pause/resume toggle to scheduled tasks

### DIFF
--- a/crates/zeroclaw-gateway/src/api.rs
+++ b/crates/zeroclaw-gateway/src/api.rs
@@ -109,7 +109,10 @@ pub struct CronAddBody {
 #[derive(Deserialize)]
 pub struct CronPatchBody {
     /// Configured agent alias whose risk profile gates the new shell
-    /// command (when `command` is being patched). Required.
+    /// command. Only consulted when `command` is being patched; optional
+    /// otherwise (e.g. a pure schedule/name change or an enable/disable
+    /// toggle), so non-command patches need not supply it.
+    #[serde(default)]
     pub agent: String,
     pub name: Option<String>,
     pub schedule: Option<String>,
@@ -117,6 +120,9 @@ pub struct CronPatchBody {
     pub clear_tz: Option<bool>,
     pub command: Option<String>,
     pub prompt: Option<String>,
+    /// Toggle the job on/off without deleting it (pause/resume). `None` leaves
+    /// the current state unchanged.
+    pub enabled: Option<bool>,
 }
 
 enum CronTimezonePatch {
@@ -606,7 +612,10 @@ pub async fn handle_api_cron_patch(
     }
 
     let config = state.config.read().clone();
-    if config.agent(&body.agent).is_none() {
+    // The agent only gates a shell `command` change (risk profile). Skip the
+    // existence check for patches that don't touch the command — schedule, name,
+    // and enable/disable toggles don't need an agent supplied.
+    if body.command.is_some() && config.agent(&body.agent).is_none() {
         return (
             StatusCode::BAD_REQUEST,
             Json(serde_json::json!({"error": format!(
@@ -625,6 +634,7 @@ pub async fn handle_api_cron_patch(
         clear_tz,
         command,
         prompt,
+        enabled,
     } = body;
     let timezone_patch = match parse_timezone_patch(tz, clear_tz) {
         Ok(patch) => patch,
@@ -687,6 +697,7 @@ pub async fn handle_api_cron_patch(
         schedule,
         command: patch_command,
         prompt: patch_prompt,
+        enabled,
         ..zeroclaw_runtime::cron::CronJobPatch::default()
     };
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1465,6 +1465,7 @@ export function patchCronJob(
     clear_tz?: boolean;
     command?: string;
     prompt?: string;
+    enabled?: boolean;
   },
 ): Promise<CronJob> {
   return apiFetch<CronJob | { status: string; job: CronJob }>(

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -559,6 +559,8 @@ const translations: Record<Locale, Record<string, string>> = {
     'cron.allowed_tools_placeholder': 'e.g. shell, file_read, memory_store',
     'cron.trigger': 'Run now',
     'cron.trigger_error': 'Failed to trigger job',
+    'cron.pause': 'Pause',
+    'cron.resume': 'Resume',
     'cron.dismiss': 'Dismiss',
 
     // Integrations

--- a/web/src/pages/Cron.tsx
+++ b/web/src/pages/Cron.tsx
@@ -20,9 +20,11 @@ import {
   ChevronDown,
   ChevronRight,
   Clock,
+  Pause,
   Pencil,
   Play,
   Plus,
+  Power,
   RefreshCw,
   Trash2,
   X,
@@ -455,6 +457,17 @@ export default function Cron() {
       setError(err instanceof Error ? err.message : t('cron.delete_error'));
     } finally {
       setConfirmDelete(null);
+    }
+  };
+
+  // Pause/resume a job without deleting it — toggles the existing `enabled`
+  // flag the scheduler already honours.
+  const handleToggleEnabled = async (job: CronJob) => {
+    try {
+      const updated = await patchCronJob(job.id, { enabled: !job.enabled });
+      setJobs((prev) => prev.map((j) => (j.id === job.id ? updated : j)));
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : t('cron.edit_error'));
     }
   };
 
@@ -970,6 +983,17 @@ export default function Cron() {
                             <RefreshCw className="h-4 w-4 animate-spin" />
                           ) : (
                             <Play className="h-4 w-4" />
+                          )}
+                        </button>
+                        <button
+                          onClick={() => handleToggleEnabled(job)}
+                          className="btn-icon"
+                          title={job.enabled ? t('cron.pause') : t('cron.resume')}
+                        >
+                          {job.enabled ? (
+                            <Pause className="h-4 w-4" />
+                          ) : (
+                            <Power className="h-4 w-4" />
                           )}
                         </button>
                         <button


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Scheduled Tasks had no way to **pause** a job from the dashboard — only delete it. The data model already supported it (`CronJobDecl.enabled`, the scheduler honours it, the store applies it, the `cron_update` agent tool toggles it); the gaps were the HTTP `PATCH /api/cron/:id` body (didn't expose `enabled`) and the UI (showed the enabled/disabled badge but had no control).
  - **gateway:** add `enabled: Option<bool>` to `CronPatchBody` and thread it into `CronJobPatch`. Make `agent` optional on the patch body, and **gate the agent-existence check on `command.is_some()`** — a schedule/name/enable patch doesn't touch a shell command, so it needn't supply (or validate) an agent. (This also fixes a latent failure for non-command edits.)
  - **web:** add `enabled` to the `patchCronJob` type, and a **Pause/Resume** button in the Scheduled Tasks actions column that flips `enabled`. Resume uses a distinct `Power` icon so it isn't confused with the `Play` "Run now" button.
- **Scope boundary:** exposing + toggling the **existing** `enabled` flag. No schema change, no scheduler logic change, no new endpoint.
- **Blast radius:** one HTTP body field + the cron page actions column. The agent change only loosens a previously-required field and skips an unnecessary validation for non-command patches.
- **Linked issue(s):** Closes #7356.
- **Labels:** expect `cron`, `web`, `type: feat`/`enhancement`, `risk: low`, `size: S`.

## Validation Evidence (required)

```text
$ cargo fmt --all -- --check                 # clean (exit 0)
$ cargo check -p zeroclaw-gateway            # clean (exit 0)
$ cargo test -p zeroclaw-gateway
test result: ok. 226 passed; 0 failed; 0 ignored; 0 measured
$ cd web && npm run build                    # tsc -b + vite — clean (exit 0)
```

- **Deployed and verified live** (multi-agent instance): the Pause button flips a job to *Disabled* (scheduler stops firing it); Resume reverses it. Direct PATCH round-trip confirmed against a real job: `{"enabled":false}` with no `agent` → HTTP 200, `job.enabled=false`; `{"enabled":true}` → 200, restored. Both the earlier required-`agent` 422 and the `Unknown agent ""` 400 are gone (the existence check is now gated on `command.is_some()`).
- **Also covered by existing tests:** the scheduler's enable/disable behaviour (`cron/scheduler.rs` — `assert!(!updated.enabled)` paths).
- **Skipped:** `cargo clippy -- -D warnings` fails on a pre-existing, unrelated `zeroclaw-channels` unused import (`crate::paced_channel::PacedChannel`, `orchestrator/mod.rs:115`) — not in this diff.

## Security & Privacy Impact (required)

- New permissions / capabilities / FS access? `No`
- New external network calls? `No`
- Secrets / tokens handling changed? `No`
- PII / real identities in diff/tests/fixtures? `No`

## Compatibility (required)

- Backward compatible? `Yes` — `enabled` is an additive optional field; making `agent` optional only loosens a previously-required field. New i18n keys (`cron.pause`, `cron.resume`) added to `en`; other locales fall back to English.
- Config / env / CLI surface changed? `No`
- Upgrade steps: none.

## Rollback

Low risk: `git revert <sha>` — one handler field + gate, one UI button.
