### PR TITLE
fix(channels): avoid unused PacedChannel import

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -112,7 +112,6 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime};
 use tokio_util::sync::CancellationToken;
 
-use crate::paced_channel::PacedChannel;
 use zeroclaw_api::session_keys::sanitize_session_key;
 use zeroclaw_config::schema::Config;
 use zeroclaw_memory::{self, MEMORY_CONTEXT_CLOSE, MEMORY_CONTEXT_OPEN, Memory};
@@ -6227,7 +6226,7 @@ fn collect_configured_channels(
         channels.push(ConfiguredChannel {
             display_name: "Telegram",
             alias: Some(alias.clone()),
-            channel: PacedChannel::wrap(
+            channel: crate::paced_channel::PacedChannel::wrap(
                 Arc::new(
                     TelegramChannel::new(
                         tg.bot_token.clone(),
@@ -6313,7 +6312,7 @@ fn collect_configured_channels(
         channels.push(ConfiguredChannel {
             display_name: "Discord",
             alias: Some(alias.clone()),
-            channel: PacedChannel::wrap(Arc::new(discord_ch), dc),
+            channel: crate::paced_channel::PacedChannel::wrap(Arc::new(discord_ch), dc),
         });
     }
 
@@ -6344,7 +6343,7 @@ fn collect_configured_channels(
         channels.push(ConfiguredChannel {
             display_name: "Slack",
             alias: Some(alias.clone()),
-            channel: PacedChannel::wrap(
+            channel: crate::paced_channel::PacedChannel::wrap(
                 Arc::new(
                     SlackChannel::new(
                         sl.bot_token.clone(),
@@ -6396,7 +6395,7 @@ fn collect_configured_channels(
         channels.push(ConfiguredChannel {
             display_name: "Mattermost",
             alias: Some(alias.clone()),
-            channel: PacedChannel::wrap(
+            channel: crate::paced_channel::PacedChannel::wrap(
                 Arc::new(
                     MattermostChannel::new(
                         mm.url.clone(),
@@ -6447,7 +6446,7 @@ fn collect_configured_channels(
         channels.push(ConfiguredChannel {
             display_name: "iMessage",
             alias: Some(alias.clone()),
-            channel: PacedChannel::wrap(
+            channel: crate::paced_channel::PacedChannel::wrap(
                 Arc::new(IMessageChannel::new(alias.clone(), peer_resolver)),
                 im,
             ),
@@ -6493,7 +6492,7 @@ fn collect_configured_channels(
                 channels.push(ConfiguredChannel {
                     display_name: "Matrix",
                     alias: Some(alias.clone()),
-                    channel: PacedChannel::wrap(Arc::new(channel), mx),
+                    channel: crate::paced_channel::PacedChannel::wrap(Arc::new(channel), mx),
                 });
             }
             Err(e) => {
@@ -6537,7 +6536,7 @@ fn collect_configured_channels(
         channels.push(ConfiguredChannel {
             display_name: "Signal",
             alias: Some(alias.clone()),
-            channel: PacedChannel::wrap(
+            channel: crate::paced_channel::PacedChannel::wrap(
                 Arc::new(
                     SignalChannel::new(
                         sig.http_url.clone(),
@@ -6598,7 +6597,7 @@ fn collect_configured_channels(
                     channels.push(ConfiguredChannel {
                         display_name: "WhatsApp",
                         alias: Some(alias.clone()),
-                        channel: PacedChannel::wrap(
+                        channel: crate::paced_channel::PacedChannel::wrap(
                             Arc::new(
                                 WhatsAppChannel::new(
                                     wa.access_token.clone().unwrap_or_default(),
@@ -6654,7 +6653,7 @@ fn collect_configured_channels(
                     channels.push(ConfiguredChannel {
                         display_name: "WhatsApp",
                         alias: Some(alias.clone()),
-                        channel: PacedChannel::wrap(
+                        channel: crate::paced_channel::PacedChannel::wrap(
                             Arc::new(
                                 WhatsAppWebChannel::new(wa, alias.clone(), peer_resolver)
                                     .with_transcription(config.transcription.clone())
@@ -7491,7 +7490,7 @@ fn collect_configured_channels(
         channels.push(ConfiguredChannel {
             display_name: "Webhook",
             alias: Some(alias.clone()),
-            channel: PacedChannel::wrap(
+            channel: crate::paced_channel::PacedChannel::wrap(
                 Arc::new(WebhookChannel::new(
                     alias.clone(),
                     wh.port,


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Remove the unconditional `PacedChannel` import from `orchestrator/mod.rs`.
  - Qualify the `PacedChannel::wrap(...)` call sites directly inside the existing feature-gated channel blocks.
  - Keep `clippy -D warnings` from tripping on an unused import when those channel features are not active for the current target.
- **Scope boundary:** This only fixes the `PacedChannel` unused-import lint path in `zeroclaw-channels`. It does not change channel behavior or pacing logic.
- **Blast radius:** `zeroclaw-channels` compile/lint behavior only.
- **Linked issue(s):** None
- **Related PR(s):** Related #7379
- **Current labels:** `bug`, `risk: medium`, `size: XS`, `channel`

## Validation Evidence (required)

- **Commands run and tail output:**

```text
zc-cargo fmt -p zeroclaw-channels -- --check
  Finished `dev` profile [unoptimized + debuginfo] target(s)

zc-cargo clippy -p zeroclaw-channels --lib -- -D warnings
  Finished `dev` profile [unoptimized + debuginfo] target(s) in 10m 52s

git diff --check
  No output.
```

- **Beyond CI — what did you manually verify?** Checked that the only change is replacing the top-level import with fully qualified `crate::paced_channel::PacedChannel::wrap(...)` calls in the already feature-gated channel setup paths.
- **If any command was intentionally skipped, why:** I kept validation scoped to the crate and lint path that was failing. No broader workspace validation was needed for this one-file lint-only fix.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: `Not applicable`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: exact upgrade steps for existing users: `No upgrade steps needed`

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert cbaf6b3b20af3433e799045b49be225cbaa77812`
- **Feature flags or config toggles:** `None`
- **Observable failure symptoms:** Feature-gated channel builds fail in `crates/zeroclaw-channels/src/orchestrator/mod.rs`, or the original `unused import: crate::paced_channel::PacedChannel` clippy error reappears when channel features are not active.
