### PR TITLE
fix(providers): default custom endpoints to prompt-guided tools

### DIFF
--- a/crates/zeroclaw-providers/src/factory.rs
+++ b/crates/zeroclaw-providers/src/factory.rs
@@ -1222,6 +1222,9 @@ impl FamilyProviderFactory for CustomModelProviderConfig {
             AuthStyle::Bearer,
             true,
         );
+        if opts.native_tools != Some(true) {
+            p = p.without_native_tools();
+        }
         if opts.merge_system_into_user {
             p = p.with_merge_system_into_user();
         }
@@ -1507,6 +1510,51 @@ mod tests {
             )
             .unwrap();
         assert_ne!(provider.default_wire_api(), "responses");
+    }
+
+    #[test]
+    fn custom_factory_disables_native_tools_by_default() {
+        use zeroclaw_config::schema::{CustomModelProviderConfig, ModelProviderConfig};
+        let cfg = CustomModelProviderConfig {
+            base: ModelProviderConfig {
+                uri: Some("http://10.0.0.15:8000/v1".to_string()),
+                ..Default::default()
+            },
+        };
+        let provider = cfg
+            .create_provider(
+                "vllm",
+                None,
+                Some("http://10.0.0.15:8000/v1"),
+                &ModelProviderRuntimeOptions::default(),
+            )
+            .unwrap();
+        assert!(
+            !provider.supports_native_tools(),
+            "custom OpenAI-compatible endpoints must default to prompt-guided tools"
+        );
+    }
+
+    #[test]
+    fn custom_factory_honors_native_tools_override_true() {
+        use zeroclaw_config::schema::{CustomModelProviderConfig, ModelProviderConfig};
+        let cfg = CustomModelProviderConfig {
+            base: ModelProviderConfig {
+                uri: Some("http://10.0.0.15:8000/v1".to_string()),
+                ..Default::default()
+            },
+        };
+        let options = ModelProviderRuntimeOptions {
+            native_tools: Some(true),
+            ..Default::default()
+        };
+        let provider = cfg
+            .create_provider("vllm", None, Some("http://10.0.0.15:8000/v1"), &options)
+            .unwrap();
+        assert!(
+            provider.supports_native_tools(),
+            "custom endpoints with `native_tools = true` must keep native tool calling available"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Custom OpenAI-compatible endpoints now default to prompt-guided tool use instead of native tool-call payloads.
  - This preserves the #5242 fix direction for strict custom endpoints that reject persisted native tool-result history with errors such as `No tool call found for function call output with call_id ...`.
  - Operators who know their custom endpoint supports native tool calling can still opt in with `native_tools = true`.
  - Regression coverage now checks both the safe default and the explicit native-tools override in the current `zeroclaw-providers` factory layout.
- **Scope boundary:** This does not change first-party OpenAI/OpenRouter/Anthropic provider behavior, the Responses wire path, channel delivery, session persistence, or native-tool history construction.
- **Blast radius:** Only `[providers.models.custom.<alias>]` entries that use the chat-completions wire path change default tool mode. Those endpoints may use prompt-guided tools instead of provider-native function calls unless `native_tools = true` is set.
- **Linked issue(s):** Supersedes #5242. Related #6298 and #5941.
- **Labels:** `bug`, `risk: medium`, `size: XS`, `provider`

## Validation Evidence (required)

- **Commands run and tail output:**

```bash
$ git diff --check
# clean, exit 0

$ rustfmt --edition 2024 --check crates/zeroclaw-providers/src/factory.rs
# clean, exit 0

$ cargo fmt --all -- --check
# clean, exit 0

$ cargo test -p zeroclaw-providers custom_factory_ --lib
    Finished `test` profile [unoptimized + debuginfo] target(s) in 8m 58s
     Running unittests src/lib.rs (target/debug/deps/zeroclaw_providers-90fcc1d3d6dfaaf4)

running 4 tests
test factory::tests::custom_factory_routes_to_responses_provider_when_wire_api_responses ... ok
test factory::tests::custom_factory_defaults_to_chat_completions_without_wire_api ... ok
test factory::tests::custom_factory_honors_native_tools_override_true ... ok
test factory::tests::custom_factory_disables_native_tools_by_default ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 909 filtered out; finished in 0.00s
```

- **Beyond CI — what did you manually verify?** Checked current `master` provider construction directly: the old #5242 path was deleted, and the live custom provider factory now lives in `crates/zeroclaw-providers/src/factory.rs`. The Responses-wire custom path returns before the chat-completions provider is built, so this change does not affect `wire_api = "responses"`.
- **If any command was intentionally skipped, why:** Full workspace clippy and full tests were not run locally. The patch is a one-file provider factory default plus focused tests; broader checks can run in CI.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? `No` for custom chat-completions endpoints that relied on native tool calling by default; existing configs still load.
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: Operators whose custom endpoint requires native tool calling should set `native_tools = true` on that custom provider entry.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert 2becaca285f792ddfc121b0ea9a6fc01a0271130`
- **Feature flags or config toggles:** Existing `native_tools = true` per custom provider entry restores native tool calling without reverting.
- **Observable failure symptoms:** If prompt-guided fallback regresses a custom endpoint, tool calls may become less structured or less reliable for that endpoint. If native tools remain enabled on a strict endpoint, provider errors may include `No tool call found for function call output with call_id ...` or related native tool-history validation failures.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line):
  - #5242 by @bellman-move
- Scope materially carried forward: the custom-provider default should disable native tool calling for strict OpenAI-compatible endpoints; this PR rebuilds that fix in the current `zeroclaw-providers` factory layout and adds the current-layout default/override regression tests.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why (inspiration-only, no direct code/design carry-over): The patch was rebuilt against the current crate layout instead of cherry-picking the deleted `src/providers/mod.rs` implementation. The superseded PR and author are credited here.
