### PR TITLE
fix(matrix): isolate session state per channel alias and repair key backup with the configured key

### DIFF
--- a/crates/zeroclaw-channels/src/matrix.rs
+++ b/crates/zeroclaw-channels/src/matrix.rs
@@ -726,6 +726,25 @@ mod client {
         has_password && has_user_id
     }
 
+    /// Decide whether a saved session belongs to a different Matrix account
+    /// than the one this channel block is configured for. Restoring a foreign
+    /// session would run the block as the wrong bot identity. Only a fully
+    /// qualified configured `user_id` (`@local:server`) is compared against the
+    /// saved canonical MXID; a bare localpart or unset `user_id` cannot be
+    /// compared without false positives, so those never flag.
+    pub(super) fn saved_session_is_foreign(
+        config: &MatrixConfig,
+        blob: &session::SessionBlob,
+    ) -> bool {
+        let Some(want) = config.user_id.as_deref().filter(|s| !s.is_empty()) else {
+            return false;
+        };
+        if !want.contains(':') {
+            return false;
+        }
+        want != blob.user_id.as_str()
+    }
+
     async fn build_attempt(
         config: &MatrixConfig,
         state_dir: &Path,
@@ -740,6 +759,25 @@ mod client {
         }
 
         let saved = session::load(state_dir)?;
+
+        // A saved session that belongs to a different account would run this
+        // channel block as the wrong Matrix identity. Wipe and re-login fresh
+        // under the configured account instead of impersonating.
+        if let Some(blob) = saved.as_ref()
+            && saved_session_is_foreign(config, blob)
+        {
+            return recover_or_bail(
+                config,
+                state_dir,
+                recovery_attempts,
+                &format!(
+                    "saved session user_id ({}) does not match configured channels.matrix user_id ({}); store belongs to a different account.",
+                    blob.user_id,
+                    config.user_id.as_deref().unwrap_or_default()
+                ),
+            )
+            .await;
+        }
 
         // The saved device_id is canonical — it's what the server actually
         // assigned at login. config.device_id is only a hint for first-ever
@@ -4594,7 +4632,8 @@ mod tests {
         //! corruption-recovery decisions verifiable without touching the SDK.
 
         use super::super::client::{
-            can_password_relogin, resolve_access_token_identity, store_has_orphan_data,
+            can_password_relogin, resolve_access_token_identity, saved_session_is_foreign,
+            store_has_orphan_data,
         };
         use tempfile::TempDir;
         use wiremock::{
@@ -4649,6 +4688,47 @@ mod tests {
         fn relogin_rejects_empty_strings() {
             assert!(!can_password_relogin(&cfg(Some(""), Some("@bot:m"))));
             assert!(!can_password_relogin(&cfg(Some("pw"), Some(""))));
+        }
+
+        fn blob_for(user_id: &str) -> super::super::session::SessionBlob {
+            super::super::session::SessionBlob {
+                user_id: user_id.to_string(),
+                device_id: "DEV1".to_string(),
+                access_token: "secret".to_string(),
+                refresh_token: None,
+            }
+        }
+
+        #[test]
+        fn foreign_session_detected_when_user_ids_differ() {
+            // The collision bug: two matrix blocks shared one state dir, so the
+            // second to start restored the first account's saved session and
+            // ran as the wrong bot. With the configured user_id known, a saved
+            // session for a different account must be flagged so the build flow
+            // wipes and re-logins instead of impersonating.
+            let cfg = cfg(Some("pw"), Some("@clamps-bot:matrix.org"));
+            let foreign = blob_for("@bender-bending-rodriguez-zeroclaw:matrix.org");
+            assert!(saved_session_is_foreign(&cfg, &foreign));
+        }
+
+        #[test]
+        fn matching_session_not_foreign() {
+            let cfg = cfg(Some("pw"), Some("@clamps-bot:matrix.org"));
+            let own = blob_for("@clamps-bot:matrix.org");
+            assert!(!saved_session_is_foreign(&cfg, &own));
+        }
+
+        #[test]
+        fn unset_or_bare_user_id_never_flags() {
+            // No configured user_id, or a bare localpart that cannot be
+            // compared against the canonical MXID, must not false-positive.
+            let any = blob_for("@whoever:matrix.org");
+            assert!(!saved_session_is_foreign(&cfg(Some("pw"), None), &any));
+            assert!(!saved_session_is_foreign(&cfg(Some("pw"), Some("")), &any));
+            assert!(!saved_session_is_foreign(
+                &cfg(Some("pw"), Some("clamps-bot")),
+                &any
+            ));
         }
 
         #[test]

--- a/crates/zeroclaw-channels/src/matrix.rs
+++ b/crates/zeroclaw-channels/src/matrix.rs
@@ -1254,11 +1254,10 @@ mod client {
     /// length (whitespace-stripped, not the value), and the full error
     /// debug chain (the SDK's `Display` masks fallback errors).
     async fn run_recovery(client: &Client, key: &str) {
+        use matrix_sdk::encryption::recovery::RecoveryState;
+
         let recovery = client.encryption().recovery();
-        if matches!(
-            recovery.state(),
-            matrix_sdk::encryption::recovery::RecoveryState::Enabled
-        ) {
+        if matches!(recovery.state(), RecoveryState::Enabled) {
             ::zeroclaw_log::record!(
                 DEBUG,
                 ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note),
@@ -1269,6 +1268,18 @@ mod client {
 
         let stripped_len = key.chars().filter(|c| !c.is_whitespace()).count();
         diagnose_secret_storage(client, stripped_len).await;
+
+        // No secret storage exists server-side: this account never had Secure
+        // Backup set up. The previous behavior only logged "set it up in
+        // Element first" and left the account with no key backup, spamming
+        // "no backup key was found" forever and risking unrecoverable room
+        // keys if the local store is wiped. Bootstrap it automatically,
+        // seeding secret storage with the operator's configured recovery_key
+        // so that same value unlocks it on future starts.
+        if matches!(recovery.state(), RecoveryState::Disabled) {
+            bootstrap_recovery(&recovery, key).await;
+            return;
+        }
 
         match recovery.recover(key).await {
             Ok(()) => {
@@ -1284,6 +1295,39 @@ mod client {
                     .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
                     .with_attrs(::serde_json::json!({"e": e.to_string()})),
                 "matrix: E2EE recovery failed: ; full error chain = . If the input length above is unexpected (base58 keys are typically ~58 chars, passphrases vary), the wrong value may be in channels.matrix.recovery-key."
+            ),
+        }
+    }
+
+    /// Create Secure Backup + secret storage for an account that has none.
+    /// Seeds secret storage with the operator's configured `recovery_key` as
+    /// the passphrase, so the same configured value unlocks it on later
+    /// starts. The SDK also returns a freshly generated base58 recovery key;
+    /// it is logged so an operator who prefers the generated key over a
+    /// passphrase can persist it into `channels.matrix.recovery-key`.
+    async fn bootstrap_recovery(
+        recovery: &matrix_sdk::encryption::recovery::Recovery,
+        passphrase: &str,
+    ) {
+        let enable = recovery.enable().wait_for_backups_to_upload();
+        let enable = if passphrase.is_empty() {
+            enable
+        } else {
+            enable.with_passphrase(passphrase)
+        };
+        match enable.await {
+            Ok(generated_key) => ::zeroclaw_log::record!(
+                INFO,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_attrs(::serde_json::json!({"generated_recovery_key": generated_key})),
+                "matrix: Secure Backup bootstrapped (created secret storage + key backup). Keep the generated_recovery_key safe; it (or the configured passphrase) unlocks backup on future starts."
+            ),
+            Err(e) => ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                    .with_attrs(::serde_json::json!({"e": e.to_string()})),
+                "matrix: failed to bootstrap Secure Backup; key backup remains unconfigured for this account"
             ),
         }
     }

--- a/crates/zeroclaw-channels/src/matrix.rs
+++ b/crates/zeroclaw-channels/src/matrix.rs
@@ -1299,16 +1299,23 @@ mod client {
         }
     }
 
-    /// Create Secure Backup + secret storage for an account that has none.
-    /// Seeds secret storage with the operator's configured `recovery_key` as
-    /// the passphrase, so the same configured value unlocks it on later
-    /// starts. The SDK also returns a freshly generated base58 recovery key;
-    /// it is logged so an operator who prefers the generated key over a
-    /// passphrase can persist it into `channels.matrix.recovery-key`.
+    /// Create or repair Secure Backup for an account whose secret storage is
+    /// absent (`RecoveryState::Disabled`). Seeds secret storage with the
+    /// operator's configured `recovery_key` as the passphrase so the same
+    /// configured value unlocks it on later starts. The SDK returns a freshly
+    /// generated base58 recovery key, logged so an operator who prefers it can
+    /// persist it into `channels.matrix.recovery-key`.
+    ///
+    /// Two shapes of `Disabled` are handled: no backup at all (`enable()`
+    /// creates one), and a stale server-side backup version with no secret
+    /// storage default key (`enable()` returns `BackupExistsOnServer`, so we
+    /// `reset_key()` to rotate fresh secret storage and re-link the backup).
     async fn bootstrap_recovery(
         recovery: &matrix_sdk::encryption::recovery::Recovery,
         passphrase: &str,
     ) {
+        use matrix_sdk::encryption::recovery::RecoveryError;
+
         let enable = recovery.enable().wait_for_backups_to_upload();
         let enable = if passphrase.is_empty() {
             enable
@@ -1316,12 +1323,42 @@ mod client {
             enable.with_passphrase(passphrase)
         };
         match enable.await {
-            Ok(generated_key) => ::zeroclaw_log::record!(
-                INFO,
-                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                    .with_attrs(::serde_json::json!({"generated_recovery_key": generated_key})),
-                "matrix: Secure Backup bootstrapped (created secret storage + key backup). Keep the generated_recovery_key safe; it (or the configured passphrase) unlocks backup on future starts."
-            ),
+            Ok(generated_key) => {
+                ::zeroclaw_log::record!(
+                    INFO,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                        .with_attrs(::serde_json::json!({"generated_recovery_key": generated_key})),
+                    "matrix: Secure Backup bootstrapped (created secret storage + key backup). Keep the generated_recovery_key safe; it (or the configured passphrase) unlocks backup on future starts."
+                );
+            }
+            // A backup version exists server-side but secret storage is absent
+            // (no m.secret_storage.default_key), so enable() refuses. Rotate
+            // fresh secret storage and re-link the existing backup instead.
+            Err(RecoveryError::BackupExistsOnServer) => {
+                let reset = recovery.reset_key();
+                let reset = if passphrase.is_empty() {
+                    reset
+                } else {
+                    reset.with_passphrase(passphrase)
+                };
+                match reset.await {
+                    Ok(generated_key) => ::zeroclaw_log::record!(
+                        INFO,
+                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                            .with_attrs(
+                                ::serde_json::json!({"generated_recovery_key": generated_key})
+                            ),
+                        "matrix: Secure Backup repaired (a server-side backup existed without secret storage; rotated fresh secret storage and re-linked). Keep the generated_recovery_key safe."
+                    ),
+                    Err(e) => ::zeroclaw_log::record!(
+                        WARN,
+                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                            .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                            .with_attrs(::serde_json::json!({"e": e.to_string()})),
+                        "matrix: failed to repair Secure Backup via reset_key; key backup remains unconfigured for this account"
+                    ),
+                }
+            }
             Err(e) => ::zeroclaw_log::record!(
                 WARN,
                 ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
@@ -3348,13 +3385,17 @@ impl MatrixChannel {
     }
 
     async fn ensure_client(&self) -> Result<&Client> {
+        use ::zeroclaw_log::__private::tracing::Instrument;
         self.client
-            .get_or_try_init(|| async {
-                let c = client::build(&self.config, &self.state_dir).await?;
-                if let Ok(Some(name)) = c.account().get_display_name().await {
-                    *self.bot_display_name.write().await = Some(name);
+            .get_or_try_init(|| {
+                async {
+                    let c = client::build(&self.config, &self.state_dir).await?;
+                    if let Ok(Some(name)) = c.account().get_display_name().await {
+                        *self.bot_display_name.write().await = Some(name);
+                    }
+                    Ok::<_, anyhow::Error>(c)
                 }
-                Ok::<_, anyhow::Error>(c)
+                .instrument(::zeroclaw_log::attribution_span!(self))
             })
             .await
     }

--- a/crates/zeroclaw-channels/src/matrix.rs
+++ b/crates/zeroclaw-channels/src/matrix.rs
@@ -1269,102 +1269,25 @@ mod client {
         let stripped_len = key.chars().filter(|c| !c.is_whitespace()).count();
         diagnose_secret_storage(client, stripped_len).await;
 
-        // No secret storage exists server-side: this account never had Secure
-        // Backup set up. The previous behavior only logged "set it up in
-        // Element first" and left the account with no key backup, spamming
-        // "no backup key was found" forever and risking unrecoverable room
-        // keys if the local store is wiped. Bootstrap it automatically,
-        // seeding secret storage with the operator's configured recovery_key
-        // so that same value unlocks it on future starts.
-        if matches!(recovery.state(), RecoveryState::Disabled) {
-            bootstrap_recovery(&recovery, key).await;
-            return;
-        }
-
-        match recovery.recover(key).await {
-            Ok(()) => {
-                ::zeroclaw_log::record!(
-                    INFO,
-                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note),
-                    "matrix: E2EE recovery completed (cross-signing + room keys imported)"
-                )
-            }
+        // Use the operator's configured recovery_key to open secret storage and
+        // import secrets. recover_and_fix_backup additionally repairs the key
+        // backup if the server-side backup is inconsistent with this key
+        // (missing/mismatched backup decryption key) WITHOUT rotating the
+        // recovery key, so the configured channels.matrix.recovery-key stays
+        // valid. This clears the "no backup key was found" loop that occurs
+        // when a backup version exists but the local backup link is broken.
+        match recovery.recover_and_fix_backup(key).await {
+            Ok(()) => ::zeroclaw_log::record!(
+                INFO,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note),
+                "matrix: E2EE recovery completed (cross-signing + room keys imported; key backup repaired if inconsistent)"
+            ),
             Err(e) => ::zeroclaw_log::record!(
                 WARN,
                 ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
                     .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
                     .with_attrs(::serde_json::json!({"e": e.to_string()})),
                 "matrix: E2EE recovery failed: ; full error chain = . If the input length above is unexpected (base58 keys are typically ~58 chars, passphrases vary), the wrong value may be in channels.matrix.recovery-key."
-            ),
-        }
-    }
-
-    /// Create or repair Secure Backup for an account whose secret storage is
-    /// absent (`RecoveryState::Disabled`). Seeds secret storage with the
-    /// operator's configured `recovery_key` as the passphrase so the same
-    /// configured value unlocks it on later starts. The SDK returns a freshly
-    /// generated base58 recovery key, logged so an operator who prefers it can
-    /// persist it into `channels.matrix.recovery-key`.
-    ///
-    /// Two shapes of `Disabled` are handled: no backup at all (`enable()`
-    /// creates one), and a stale server-side backup version with no secret
-    /// storage default key (`enable()` returns `BackupExistsOnServer`, so we
-    /// `reset_key()` to rotate fresh secret storage and re-link the backup).
-    async fn bootstrap_recovery(
-        recovery: &matrix_sdk::encryption::recovery::Recovery,
-        passphrase: &str,
-    ) {
-        use matrix_sdk::encryption::recovery::RecoveryError;
-
-        let enable = recovery.enable().wait_for_backups_to_upload();
-        let enable = if passphrase.is_empty() {
-            enable
-        } else {
-            enable.with_passphrase(passphrase)
-        };
-        match enable.await {
-            Ok(generated_key) => {
-                ::zeroclaw_log::record!(
-                    INFO,
-                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                        .with_attrs(::serde_json::json!({"generated_recovery_key": generated_key})),
-                    "matrix: Secure Backup bootstrapped (created secret storage + key backup). Keep the generated_recovery_key safe; it (or the configured passphrase) unlocks backup on future starts."
-                );
-            }
-            // A backup version exists server-side but secret storage is absent
-            // (no m.secret_storage.default_key), so enable() refuses. Rotate
-            // fresh secret storage and re-link the existing backup instead.
-            Err(RecoveryError::BackupExistsOnServer) => {
-                let reset = recovery.reset_key();
-                let reset = if passphrase.is_empty() {
-                    reset
-                } else {
-                    reset.with_passphrase(passphrase)
-                };
-                match reset.await {
-                    Ok(generated_key) => ::zeroclaw_log::record!(
-                        INFO,
-                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                            .with_attrs(
-                                ::serde_json::json!({"generated_recovery_key": generated_key})
-                            ),
-                        "matrix: Secure Backup repaired (a server-side backup existed without secret storage; rotated fresh secret storage and re-linked). Keep the generated_recovery_key safe."
-                    ),
-                    Err(e) => ::zeroclaw_log::record!(
-                        WARN,
-                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                            .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                            .with_attrs(::serde_json::json!({"e": e.to_string()})),
-                        "matrix: failed to repair Secure Backup via reset_key; key backup remains unconfigured for this account"
-                    ),
-                }
-            }
-            Err(e) => ::zeroclaw_log::record!(
-                WARN,
-                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                    .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                    .with_attrs(::serde_json::json!({"e": e.to_string()})),
-                "matrix: failed to bootstrap Secure Backup; key backup remains unconfigured for this account"
             ),
         }
     }

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -5510,12 +5510,8 @@ fn build_channel_by_id(
                     .matrix
                     .get("default")
                     .context("Matrix channel is not configured")?;
-                let state_dir = config
-                    .config_path
-                    .parent()
-                    .map(|p| p.join("state").join("matrix"))
-                    .unwrap_or_else(|| std::path::PathBuf::from(".zeroclaw/state/matrix"));
                 let alias = "default".to_string();
+                let state_dir = matrix_state_dir(&config.config_path, &alias);
                 let peer_resolver: Arc<dyn Fn() -> Vec<String> + Send + Sync> = {
                     let cfg_arc = config_arc.clone();
                     let alias = alias.clone();
@@ -6186,6 +6182,18 @@ pub fn register_channels_for_tools(
     names
 }
 
+/// Per-alias Matrix state directory. Each `[channels.matrix.<alias>]` block
+/// must own its own session/crypto store so two bots under one daemon don't
+/// restore each other's `session.json` and run as the wrong account. The
+/// alias component is what keeps them distinct.
+#[cfg(feature = "channel-matrix")]
+fn matrix_state_dir(config_path: &std::path::Path, alias: &str) -> std::path::PathBuf {
+    config_path
+        .parent()
+        .map(|p| p.join("state").join("matrix").join(alias))
+        .unwrap_or_else(|| std::path::PathBuf::from(".zeroclaw/state/matrix").join(alias))
+}
+
 fn collect_configured_channels(
     config_arc: &Arc<RwLock<Config>>,
     matrix_skip_context: &str,
@@ -6473,11 +6481,7 @@ fn collect_configured_channels(
         if !mx.enabled {
             continue;
         }
-        let state_dir = config
-            .config_path
-            .parent()
-            .map(|p| p.join("state").join("matrix"))
-            .unwrap_or_else(|| std::path::PathBuf::from(".zeroclaw/state/matrix"));
+        let state_dir = matrix_state_dir(&config.config_path, alias);
         let peer_resolver: Arc<dyn Fn() -> Vec<String> + Send + Sync> = {
             let cfg_arc = config_arc.clone();
             let alias = alias.clone();
@@ -15965,6 +15969,30 @@ This is an example JSON object for profile settings."#;
         .await;
         let state = classify_health_result(&result);
         assert_eq!(state, ChannelHealthState::Timeout);
+    }
+
+    #[cfg(feature = "channel-matrix")]
+    #[test]
+    fn matrix_state_dir_is_distinct_per_alias() {
+        // Regression: two [channels.matrix.<alias>] blocks previously resolved
+        // to the same <config>/state/matrix dir, so the second listener to
+        // start restored the first's session.json and ran as the wrong Matrix
+        // account. The alias component must keep them separate.
+        let config_path = std::path::Path::new("/home/u/.zeroclaw/config.toml");
+        let clamps = matrix_state_dir(config_path, "clamps");
+        let bender = matrix_state_dir(config_path, "bender");
+        assert_ne!(
+            clamps, bender,
+            "distinct matrix aliases must not share a state dir"
+        );
+        assert_eq!(
+            clamps,
+            std::path::Path::new("/home/u/.zeroclaw/state/matrix/clamps")
+        );
+        assert_eq!(
+            bender,
+            std::path::Path::new("/home/u/.zeroclaw/state/matrix/bender")
+        );
     }
 
     #[cfg(feature = "channel-mattermost")]


### PR DESCRIPTION
> ⚠️ **BREAKING CHANGE — Matrix session migration required.** Multiple Matrix blocks under one daemon previously shared a single session store at `<config_dir>/state/matrix/`; this PR moves each block to a per-alias path `<config_dir>/state/matrix/<alias>/`. There is no clean automatic migration: on first start after upgrade each block logs in fresh under its configured `user_id` and re-bootstraps E2EE. Operators who want to preserve an existing single-block session (avoid a re-login / E2EE re-bootstrap) can move the session manually before starting:
>
> ```bash
> # Stop the daemon first.
> cd <config_dir>/state/matrix
>
> # NOTE: <alias> is the name in your config block header
> #   [channels.matrix.<alias>]  ->  e.g. [channels.matrix.bot-a] means alias "bot-a".
> # A block written as plain [channels.matrix] (no name) uses the alias "default".
>
> # Single-block installs: move the existing top-level session into the
> # default alias dir (a block with no explicit alias uses "default").
> mkdir -p default
> mv session.json store default/ 2>/dev/null || true
>
> # Multi-block installs: there is only ONE old session.json, and it belongs
> # to whichever account logged in last. Move it under THAT block's alias
> # (its [channels.matrix.<alias>] header name) and let every OTHER block log
> # in fresh:
> #   mkdir -p <winning-alias>          # e.g. bot-a
> #   mv session.json store <winning-alias>/
> # The remaining aliases re-bootstrap from their own password/recovery_key.
> ```
>
> After moving, start the daemon and confirm `matrix: restored session from session.json` appears once per alias under its own `channel_alias`. The legacy top-level `session.json`/`store/` are unused after migration and can be deleted.

## Summary

This PR fixes two distinct Matrix multi-agent defects found while diagnosing a real "wrong bot answered my DM" report, both confirmed against a live daemon.

- **Base branch:** `master`
- **What changed and why:**
  - **(1) Per-alias session isolation.** Two `[channels.matrix.<alias>]` blocks under one daemon shared a single on-disk session store at `<config_dir>/state/matrix/`. Both listeners restored the same `session.json`, so both attached to whichever account wrote the blob first; the other block ran under the wrong Matrix account while still stamping inbound with its own config alias. A DM to one bot's account was answered by the other agent. Fix: derive `state_dir` per alias (`<config_dir>/state/matrix/<alias>`) via a single `matrix_state_dir` helper used at both construction sites. Adds `saved_session_is_foreign` as a defense-in-depth guard (a saved session whose canonical MXID does not match the configured `user_id` triggers wipe-and-relogin instead of impersonation).
  - **(2) Repair an inconsistent key backup with the configured key.** Separating the sessions exposed an account whose key backup was broken, looping forever on `Trying to backup room keys but no backup key was found`. The old `run_recovery` called `recovery.recover(key)`, which only *imports* secrets and cannot repair an inconsistent server-side backup. Fix: swap to `recovery.recover_and_fix_backup(key)`, which opens secret storage with the operator's configured `recovery_key`, imports secrets, and recreates **only the key backup** (never the secret-storage key) when it is inconsistent. The configured `recovery_key` stays valid; we never rotate keys or auto-create secret storage, since that would orphan the operator's configured key.
- **Scope boundary:** Does not change message routing/dispatch (verified correct), the password/token login flow, `channel_alias` stamping, or any non-Matrix channel.
- **Blast radius:** Matrix channel only. Multi-Matrix-block daemons are affected on upgrade (Compatibility). Single-block installs move from `state/matrix/` to `state/matrix/default/`. The recovery change affects every Matrix account that runs `run_recovery`: a healthy account whose key backup is consistent behaves as before; one whose backup is inconsistent now gets it repaired using the configured key. No account has its secret-storage key rotated.
- **Linked issue(s):** Closes #6487.
- **Labels:** `bug`, `channel:matrix`, `channel`, `risk: medium`, `size: S`.

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy -p zeroclaw-channels --features channel-matrix --all-targets -- -D warnings
cargo clippy -p zeroclaw-channels --all-targets -- -D warnings   # default build, no feature
cargo test -p zeroclaw-channels --features channel-matrix
```

- **Commands run and tail output:**

```
# cargo fmt --all -- --check                                   -> exit 0 (no output)
# cargo clippy ... --features channel-matrix ... -D warnings   -> exit 0
# cargo clippy ... (default, no feature) ... -D warnings        -> exit 0
# cargo test  ... --features channel-matrix
test result: ok. 834 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out
test result: ok. 3 passed; 0 failed; 0 ignored
test result: ok. 3 passed; 0 failed; 0 ignored
test result: ok. 4 passed; 0 failed; 0 ignored
```

- **Beyond CI — what was manually verified:** Both root causes were confirmed against a live multi-agent daemon (runtime trace + on-disk state), sanitized below, and the recovery fix is **runtime-verified**: after deploy, the affected account restored its own session, logged `E2EE recovery completed` via `recover_and_fix_backup`, the `no backup key was found` loop stopped, and the agent processed turns and delivered replies on its own account. The session-isolation fix has a regression test proven RED against the pre-fix shared path. The recovery change is verified against the pinned `matrix-sdk` 0.17.0 API (`recovery.recover_and_fix_backup(key) -> Result<()>`).
- **Both clippy invocations are intentional:** the helpers are `#[cfg(feature = "channel-matrix")]`; the default-build clippy run guards against a dead-code regression when the feature is off.

### RED evidence — defect (1): wrong account on the wire (sanitized)

Two agents, each bound to its own Matrix block with a distinct account, under one daemon. The config is correct; the blocks are separated by alias and credentials:

```toml
[channels.matrix.bot-b]
enabled = true
homeserver = "https://matrix.org"
user_id   = "@bot-b:matrix.org"
password  = "<REDACTED>"
recovery_key = "<REDACTED>"

[channels.matrix.bot-a]
enabled = true
homeserver = "https://matrix.org"
user_id   = "@bot-a:matrix.org"
password  = "<REDACTED>"
recovery_key = "<REDACTED>"
```

Pre-fix, both blocks resolved to the same `<config_dir>/state/matrix/` dir regardless of alias. The single shared session file held one account:

```json
{ "user_id": "@bot-a:matrix.org", "device_id": "<REDACTED>", "access_token": "<REDACTED>" }
```

Runtime trace at start (sync tokens, room/event ids redacted) — both blocks restore the same `session.json` with the identical secret-storage key id:

```
channel_alias=bot-a   matrix: restored session from session.json
channel_alias=bot-b   matrix: restored session from session.json
channel_alias=bot-a   matrix: secret-storage diagnostics: default_key_id=<KEYID-X> ...
channel_alias=bot-b   matrix: secret-storage diagnostics: default_key_id=<KEYID-X> ...
channel_alias=bot-b   matrix: E2EE recovery failed ...      # bot-b recovery_key vs bot-a store
channel_alias=bot-b   matrix: starting sync loop            # but attached to @bot-a
```

`bot-b` is attached to `@bot-a` while stamping inbound `channel_alias=bot-b`, so a DM to `@bot-a` is dispatched to the `bot-b` agent. Dispatch/routing is correct; the crossover is entirely at the shared session store. Regression test `matrix_state_dir_is_distinct_per_alias` asserts the two aliases resolve to distinct paths (RED against the pre-fix shared path).

### RED evidence — defect (2): broken key backup, recovery gave up (sanitized)

After the session split, `bot-b` logs in correctly as itself, then loops on a broken key backup. With the wrong/stale recovery key in config the secret-storage unlock fails outright; even with a valid key, the old `recover()` only imported and never repaired an inconsistent backup, so room-key backup stayed broken:

```
channel_alias=bot-b  WARN   matrix: secret-storage diagnostics: default_key_id=<KEYID>
channel_alias=bot-b  WARN   matrix: E2EE recovery failed: The MAC check for the
                            secret storage key failed
channel_alias=bot-b  WARN   matrix: starting sync loop   (degraded)
(repeating)          WARN   Trying to backup room keys but no backup key was found
```

`recover()` only *imports* secrets; it does not repair an inconsistent server-side key backup, so the `no backup key was found` loop persists. The fix swaps `recover()` for `recover_and_fix_backup(key)` (verified against matrix-sdk 0.17.0): it opens secret storage with the operator's configured `recovery_key`, imports secrets, and recreates **only the key backup** (never the secret-storage key) when the backup is inconsistent. The configured `recovery_key` stays valid; the loop clears. The MAC failure above is a wrong key in config, not a code fault, and surfaces clearly so the operator fixes the config.

### GREEN evidence — runtime-verified on a live multi-agent daemon (sanitized)

Same daemon, after the fix is deployed and the operator's `recovery_key` is correct. `bot-b` restores its **own** session (session isolation working) and `recover_and_fix_backup` succeeds:

```
channel_alias=bot-b  INFO  matrix: restored session from session.json
channel_alias=bot-b  WARN  matrix: secret-storage diagnostics: default_key_id=<KEYID>
channel_alias=bot-b  INFO  matrix: E2EE recovery completed (cross-signing + room keys imported)
channel_alias=bot-b  INFO  matrix: starting sync loop
```

After recovery completes there are **no further** `E2EE recovery failed`, `MAC check`, or `Trying to backup room keys but no backup key was found` events for that alias, and the agent processes turns end to end:

```
channel_alias=bot-b  INFO  LLM call completed
channel_alias=bot-b  INFO  channel_message_outbound
channel_alias=bot-b  INFO  reply delivered
```

Before the fix, `bot-b` was attached to `@bot-a`'s session and a DM to `@bot-a` was answered by the `bot-b` agent. After the fix, `bot-b` runs as itself, its key backup is healthy, and it replies on its own account. (Remaining non-E2EE WARNs in the trace — context-compression notes and a `{model_provider}/{model}` cost-pricing label — are pre-existing and out of scope.)


## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No** (same `state/` tree, one extra path component).
- New external network calls? **No new endpoints** — `recover_and_fix_backup` uses the same Matrix client/homeserver already in use; it exercises the secret-storage/key-backup APIs the import path already touched.
- Secrets / tokens / credentials handling changed? **Yes** — each Matrix block reads/writes its own `session.json` under a per-alias dir, strengthening isolation. Recovery opens secret storage with the configured `recovery_key` and never logs the password or access token. The configured recovery key is not rotated or logged.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No** — all evidence here is sanitized (`@bot-a`/`@bot-b`, redacted ids/tokens/keys). Test fixtures use example `@<name>:matrix.org` MXIDs consistent with the suite's conventions.
- If any `Yes`: no recovery key is generated or logged. Recovery uses the operator's configured `channels.matrix.recovery-key` to open existing secret storage; the key is never printed, rotated, or replaced.

## Compatibility (required)

- Backward compatible? **No** (session-isolation path change).
- Config / env / CLI surface changed? **No** (config unchanged; on-disk state path changed).
- Upgrade steps for existing users: Breaking change with no clean migration. On first start after upgrade, every Matrix block logs in fresh under its configured `user_id` at `<config_dir>/state/matrix/<alias>/` (one-time E2EE re-bootstrap per bot, using each block's `password`/`recovery_key`). The legacy `<config_dir>/state/matrix/session.json` and `store/` are left in place but unused and can be deleted. An account whose configured `recovery_key` matches its secret storage recovers cleanly; an account with a wrong/stale key logs a clear `recovery failed` WARN pointing at `channels.matrix.recovery-key`.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <sha>` per commit. Reverting restores the shared-path session behavior and the plain `recover()` (no backup repair) behavior.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Grep daemon logs for `matrix: restored session from session.json` appearing for two `channel_alias` values with the same `default_key_id` (shared store), `matrix: E2EE recovery failed` on a block whose `recovery_key` is correct for its own account, or a sustained `Trying to backup room keys but no backup key was found` loop (backup never created).



