### PR TITLE
feat(channels): configure in-flight message budget

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -9511,8 +9511,10 @@ mod tests {
 
     #[test]
     fn max_in_flight_messages_for_config_uses_channel_budget() {
-        let mut config = zeroclaw_config::schema::ChannelsConfig::default();
-        config.max_concurrent_per_channel = 8;
+        let config = zeroclaw_config::schema::ChannelsConfig {
+            max_concurrent_per_channel: 8,
+            ..Default::default()
+        };
 
         assert_eq!(max_in_flight_messages_for_config(3, &config), 24);
     }

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -226,7 +226,6 @@ const MIN_CHANNEL_MESSAGE_TIMEOUT_SECS: u64 = 30;
 const CHANNEL_MESSAGE_TIMEOUT_SECS: u64 = 300;
 /// Cap timeout scaling so large max_tool_iterations values do not create unbounded waits.
 const CHANNEL_MESSAGE_TIMEOUT_SCALE_CAP: u64 = 4;
-const CHANNEL_PARALLELISM_PER_CHANNEL: usize = 4;
 const CHANNEL_MIN_IN_FLIGHT_MESSAGES: usize = 8;
 const CHANNEL_MAX_IN_FLIGHT_MESSAGES: usize = 64;
 const CHANNEL_TYPING_REFRESH_INTERVAL_SECS: u64 = 4;
@@ -3398,13 +3397,23 @@ fn is_non_retryable_channel_listener_error(channel_name: &str, error: &anyhow::E
     }
 }
 
-fn compute_max_in_flight_messages(channel_count: usize) -> usize {
+fn compute_max_in_flight_messages(
+    channel_count: usize,
+    max_concurrent_per_channel: usize,
+) -> usize {
     channel_count
-        .saturating_mul(CHANNEL_PARALLELISM_PER_CHANNEL)
+        .saturating_mul(max_concurrent_per_channel)
         .clamp(
             CHANNEL_MIN_IN_FLIGHT_MESSAGES,
             CHANNEL_MAX_IN_FLIGHT_MESSAGES,
         )
+}
+
+fn max_in_flight_messages_for_config(
+    channel_count: usize,
+    config: &zeroclaw_config::schema::ChannelsConfig,
+) -> usize {
+    compute_max_in_flight_messages(channel_count, config.max_concurrent_per_channel)
 }
 
 fn log_worker_join_result(result: Result<(), tokio::task::JoinError>) {
@@ -8349,7 +8358,7 @@ pub async fn start_channels(
                 .write()
                 .unwrap_or_else(|e| e.into_inner()) = Some(Arc::clone(&cbn));
 
-            let in_flight = compute_max_in_flight_messages(channels.len());
+            let in_flight = max_in_flight_messages_for_config(channels.len(), &config.channels);
             println!("  🚦 In-flight message limit: {in_flight}");
 
             max_in_flight_messages = Some(in_flight);
@@ -9492,6 +9501,32 @@ mod tests {
             MIN_CHANNEL_MESSAGE_TIMEOUT_SECS
         );
         assert_eq!(effective_channel_message_timeout_secs(300), 300);
+    }
+
+    #[test]
+    fn compute_max_in_flight_messages_uses_configured_per_channel_budget() {
+        assert_eq!(compute_max_in_flight_messages(3, 4), 12);
+        assert_eq!(compute_max_in_flight_messages(3, 8), 24);
+    }
+
+    #[test]
+    fn max_in_flight_messages_for_config_uses_channel_budget() {
+        let mut config = zeroclaw_config::schema::ChannelsConfig::default();
+        config.max_concurrent_per_channel = 8;
+
+        assert_eq!(max_in_flight_messages_for_config(3, &config), 24);
+    }
+
+    #[test]
+    fn compute_max_in_flight_messages_preserves_global_bounds() {
+        assert_eq!(
+            compute_max_in_flight_messages(1, 1),
+            CHANNEL_MIN_IN_FLIGHT_MESSAGES
+        );
+        assert_eq!(
+            compute_max_in_flight_messages(100, 4),
+            CHANNEL_MAX_IN_FLIGHT_MESSAGES
+        );
     }
 
     #[test]

--- a/crates/zeroclaw-config/fixtures/v1.toml
+++ b/crates/zeroclaw-config/fixtures/v1.toml
@@ -214,6 +214,7 @@ schedule = { kind = "every", every_ms = 60000 }
 [channels_config]
 cli = true
 message_timeout_secs = 300
+max_concurrent_per_channel = 4
 ack_reactions = true
 show_tool_calls = false
 session_persistence = true

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -10547,6 +10547,12 @@ pub struct ChannelsConfig {
     /// Default: 300s for on-device LLMs (Ollama) which are slower than cloud APIs.
     #[serde(default = "default_channel_message_timeout_secs")]
     pub message_timeout_secs: u64,
+    /// Per-channel multiplier for the global channel message in-flight budget.
+    /// Runtime multiplies this value by the configured channel count, then
+    /// applies its global minimum and maximum bounds to one shared dispatcher
+    /// semaphore. Default: `4`.
+    #[serde(default = "default_channel_max_concurrent_per_channel")]
+    pub max_concurrent_per_channel: usize,
     /// Whether to add acknowledgement reactions (👀 on receipt, ✅/⚠️ on
     /// completion) to incoming channel messages. Default: `true`.
     #[serde(default = "default_true")]
@@ -10825,6 +10831,10 @@ fn default_channel_message_timeout_secs() -> u64 {
     300
 }
 
+fn default_channel_max_concurrent_per_channel() -> usize {
+    4
+}
+
 fn default_session_backend() -> String {
     "sqlite".into()
 }
@@ -10866,6 +10876,7 @@ impl Default for ChannelsConfig {
             voice_duplex: HashMap::new(),
             mqtt: HashMap::new(),
             message_timeout_secs: default_channel_message_timeout_secs(),
+            max_concurrent_per_channel: default_channel_max_concurrent_per_channel(),
             ack_reactions: true,
             show_tool_calls: false,
             session_persistence: true,
@@ -15086,6 +15097,13 @@ impl Config {
                 "transcription.max_audio_bytes must be greater than zero"
             );
         }
+        if self.channels.max_concurrent_per_channel == 0 {
+            validation_bail!(
+                InvalidNumericRange,
+                "channels.max_concurrent_per_channel",
+                "channels.max_concurrent_per_channel must be greater than 0"
+            );
+        }
         // Heartbeat agent: when heartbeat is enabled, the agent field
         // must name a configured agent.
         if self.heartbeat.enabled {
@@ -17500,6 +17518,42 @@ auto_save = true
         assert!(c.discord.is_empty());
         assert!(c.wecom_ws.is_empty());
         assert!(!c.show_tool_calls);
+        assert_eq!(
+            c.max_concurrent_per_channel,
+            default_channel_max_concurrent_per_channel()
+        );
+    }
+
+    #[test]
+    async fn channels_max_concurrent_per_channel_defaults_and_round_trips() {
+        let parsed: ChannelsConfig = toml::from_str("cli = true").unwrap();
+        assert_eq!(
+            parsed.max_concurrent_per_channel,
+            default_channel_max_concurrent_per_channel()
+        );
+
+        let parsed: ChannelsConfig =
+            toml::from_str("cli = true\nmax_concurrent_per_channel = 2").unwrap();
+        assert_eq!(parsed.max_concurrent_per_channel, 2);
+
+        let toml_str = toml::to_string_pretty(&parsed).unwrap();
+        let reparsed: ChannelsConfig = toml::from_str(&toml_str).unwrap();
+        assert_eq!(reparsed.max_concurrent_per_channel, 2);
+    }
+
+    #[test]
+    async fn validate_rejects_zero_channel_max_concurrent_per_channel() {
+        let mut config = Config::default();
+        config.channels.max_concurrent_per_channel = 0;
+
+        let err = config
+            .validate()
+            .expect_err("zero channel concurrency budget must fail validate");
+        assert!(
+            err.to_string()
+                .contains("channels.max_concurrent_per_channel must be greater than 0"),
+            "got: {err}"
+        );
     }
 
     #[test]
@@ -17690,6 +17744,7 @@ auto_save = true
                 voice_wake: HashMap::new(),
                 mqtt: HashMap::new(),
                 message_timeout_secs: 300,
+                max_concurrent_per_channel: default_channel_max_concurrent_per_channel(),
                 ack_reactions: true,
                 show_tool_calls: true,
                 session_persistence: true,
@@ -19146,6 +19201,7 @@ allowed_users = ["@u:matrix.org"]
             voice_wake: HashMap::new(),
             mqtt: HashMap::new(),
             message_timeout_secs: 300,
+            max_concurrent_per_channel: default_channel_max_concurrent_per_channel(),
             ack_reactions: true,
             show_tool_calls: true,
             session_persistence: true,
@@ -19586,6 +19642,7 @@ allowed_numbers = ["+1", "+2"]
             voice_wake: HashMap::new(),
             mqtt: HashMap::new(),
             message_timeout_secs: 300,
+            max_concurrent_per_channel: default_channel_max_concurrent_per_channel(),
             ack_reactions: true,
             show_tool_calls: true,
             session_persistence: true,


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Added `channels.max_concurrent_per_channel` so operators can tune the channel dispatcher in-flight message budget without editing source.
  - Kept the current default behavior by defaulting the new setting to `4`.
  - Rejected `0` during config validation so the new concurrency knob cannot silently coerce to the runtime floor.
  - Wired the channel orchestrator to compute the shared in-flight semaphore from configured channel count times the configured per-channel multiplier, then clamp through the existing global min/max bounds.
  - Added config round-trip, validation, generated-fixture, and orchestrator budget coverage.
- **Scope boundary:** This does not add direct-message precheck skipping from #5418, does not add per-channel fairness/keyed semaphores, and does not lower the existing global minimum in-flight floor.
- **Blast radius:** `zeroclaw-config` schema/load/validation and `zeroclaw-channels` dispatcher startup. Existing configs keep the default value and existing runtime behavior unless the new key is set.
- **Linked issue(s):** Supersedes #5418.
- **Labels:** enhancement, risk: medium, size: S, channel, config

## Validation Evidence (required)

- **Commands run and tail output:**
  - `git diff --check origin/master`: passed; tail output: no output, exit 0.
  - `cargo fmt --all -- --check`: passed; tail output: no output, exit 0.
  - `cargo test -p zeroclaw-config channels_max_concurrent_per_channel_defaults_and_round_trips -- --nocapture`: passed; tail output: `test result: ok. 1 passed; 0 failed`.
  - `cargo test -p zeroclaw-config validate_rejects_zero_channel_max_concurrent_per_channel -- --nocapture`: passed; tail output: `test result: ok. 1 passed; 0 failed`.
  - `cargo test -p zeroclaw-config generate_every_version_migrates_and_validates -- --nocapture`: passed; tail output: `test result: ok`.
  - `cargo test -p zeroclaw-channels max_in_flight_messages -- --nocapture`: passed; tail output: `test result: ok. 3 passed; 0 failed`.
  - `cargo clippy -p zeroclaw-channels --all-targets -- -D warnings`: passed after the CI lint cleanup; tail output: `Finished dev profile`.
  - GitHub Actions Quality Gate on head `2f0b1dea9023dcc7c78211f64a54dd733d5fc803`: passed, including Format, Lint, Test, Security, platform builds, Benchmarks Compile, and CI Required Gate.
- **Beyond CI — what did you manually verify?** Checked that the new field defaults to `4`, round-trips through TOML, rejects `0`, is exposed by the generated v1 fixture path, and is read by the channel orchestrator helper used at startup.
- **If any command was intentionally skipped, why:** Workspace-shaped `cargo clippy --all-targets -- -D warnings` and CI-shaped local nextest were not rerun locally after the follow-up lint cleanup. That cleanup only changed test initialization style to satisfy clippy; focused local `zeroclaw-channels` clippy passed on the touched crate, and GitHub Actions then passed Format, Lint, Test, Security, platform builds, Benchmarks Compile, and CI Required Gate on the head `2f0b1dea9023dcc7c78211f64a54dd733d5fc803`.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: `N/A`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `Yes`
- If `No` or `Yes` to either: Existing configs continue to load with the default value of `4`. Operators who want a different global channel in-flight budget can set `channels.max_concurrent_per_channel` to a positive integer. `0` is rejected during validation.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <merge-commit>`
- **Feature flags or config toggles:** Set `channels.max_concurrent_per_channel = 4` or remove the key to return to the current default budget behavior.
- **Observable failure symptoms:** Channel startup validation errors mentioning `channels.max_concurrent_per_channel`; unexpected `In-flight message limit` startup output; channel messages queueing more or less aggressively than expected after changing the setting.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line):
  - #5418 by @DaBlitzStein
- Scope materially carried forward:
  - The configurable channel in-flight budget idea and `max_concurrent_per_channel` config shape.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `Yes`
- If `No`, why (inspiration-only, no direct code/design carry-over): `N/A`
