### PR TITLE
feat: add pause/resume for scheduled tasks (#7356)

### DIFF
--- a/crates/zeroclaw-gateway/src/api.rs
+++ b/crates/zeroclaw-gateway/src/api.rs
@@ -106,7 +106,10 @@ pub struct CronAddBody {
 #[derive(Deserialize)]
 pub struct CronPatchBody {
     /// Configured agent alias whose risk profile gates the new shell
-    /// command (when `command` is being patched). Required.
+    /// command. Only consulted when `command` is being patched; optional
+    /// otherwise (e.g. a pure schedule/name change or an enable/disable
+    /// toggle), so non-command patches need not supply it.
+    #[serde(default)]
     pub agent: String,
     pub name: Option<String>,
     pub schedule: Option<String>,
@@ -114,6 +117,9 @@ pub struct CronPatchBody {
     pub clear_tz: Option<bool>,
     pub command: Option<String>,
     pub prompt: Option<String>,
+    /// Toggle the job on/off without deleting it (pause/resume). `None` leaves
+    /// the current state unchanged.
+    pub enabled: Option<bool>,
 }
 
 enum CronTimezonePatch {
@@ -603,7 +609,10 @@ pub async fn handle_api_cron_patch(
     }
 
     let config = state.config.read().clone();
-    if config.agent(&body.agent).is_none() {
+    // The agent only gates a shell `command` change (risk profile). Skip the
+    // existence check for patches that don't touch the command — schedule, name,
+    // and enable/disable toggles don't need an agent supplied.
+    if body.command.is_some() && config.agent(&body.agent).is_none() {
         return (
             StatusCode::BAD_REQUEST,
             Json(serde_json::json!({"error": format!(
@@ -613,7 +622,11 @@ pub async fn handle_api_cron_patch(
         )
             .into_response();
     }
-    let agent_alias = body.agent.clone();
+    let agent_alias = if body.command.is_some() {
+        Some(body.agent.clone())
+    } else {
+        None
+    };
     let CronPatchBody {
         agent: _,
         name,
@@ -622,6 +635,7 @@ pub async fn handle_api_cron_patch(
         clear_tz,
         command,
         prompt,
+        enabled,
     } = body;
     let timezone_patch = match parse_timezone_patch(tz, clear_tz) {
         Ok(patch) => patch,
@@ -684,12 +698,13 @@ pub async fn handle_api_cron_patch(
         schedule,
         command: patch_command,
         prompt: patch_prompt,
+        enabled,
         ..zeroclaw_runtime::cron::CronJobPatch::default()
     };
 
     match zeroclaw_runtime::cron::update_shell_job_with_approval(
         &config,
-        &agent_alias,
+        agent_alias.as_deref().unwrap_or(""),
         &id,
         patch,
         false,

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1456,6 +1456,7 @@ export function patchCronJob(
     clear_tz?: boolean;
     command?: string;
     prompt?: string;
+    enabled?: boolean;
   },
 ): Promise<CronJob> {
   return apiFetch<CronJob | { status: string; job: CronJob }>(

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -559,6 +559,8 @@ const translations: Record<Locale, Record<string, string>> = {
     'cron.allowed_tools_placeholder': 'e.g. shell, file_read, memory_store',
     'cron.trigger': 'Run now',
     'cron.trigger_error': 'Failed to trigger job',
+    'cron.pause': 'Pause',
+    'cron.resume': 'Resume',
     'cron.dismiss': 'Dismiss',
 
     // Integrations

--- a/web/src/pages/Cron.tsx
+++ b/web/src/pages/Cron.tsx
@@ -19,9 +19,11 @@ import {
   ChevronDown,
   ChevronRight,
   Clock,
+  Pause,
   Pencil,
   Play,
   Plus,
+  Power,
   RefreshCw,
   Trash2,
   X,
@@ -434,6 +436,17 @@ export default function Cron() {
       setError(err instanceof Error ? err.message : t('cron.delete_error'));
     } finally {
       setConfirmDelete(null);
+    }
+  };
+
+  // Pause/resume a job without deleting it — toggles the existing `enabled`
+  // flag the scheduler already honours.
+  const handleToggleEnabled = async (job: CronJob) => {
+    try {
+      const updated = await patchCronJob(job.id, { enabled: !job.enabled });
+      setJobs((prev) => prev.map((j) => (j.id === job.id ? updated : j)));
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : t('cron.edit_error'));
     }
   };
 
@@ -949,6 +962,17 @@ export default function Cron() {
                             <RefreshCw className="h-4 w-4 animate-spin" />
                           ) : (
                             <Play className="h-4 w-4" />
+                          )}
+                        </button>
+                        <button
+                          onClick={() => handleToggleEnabled(job)}
+                          className="btn-icon"
+                          title={job.enabled ? t('cron.pause') : t('cron.resume')}
+                        >
+                          {job.enabled ? (
+                            <Pause className="h-4 w-4" />
+                          ) : (
+                            <Power className="h-4 w-4" />
                           )}
                         </button>
                         <button


### PR DESCRIPTION
Allow toggling job enabled state without deleting and recreating.

**Changes:**
- `cron_add`: accept `enabled` field (default `true`) so callers can create jobs in a paused state
- `cron_update`: accept `enabled` field to toggle on/off without altering schedule/command
- `PATCH /api/cron/:id`: thread `enabled` through to `CronJobPatch`; make `agent` optional for non-command patches (e.g. pure enable/disable)
- Frontend Cron page: add Pause/Resume icon button per job; i18n keys for pause/resume
- Frontend API: expose `enabled` in `patchCronJob` type

Closes #7356