### PR TITLE
docs(maintainers): define tracker stale exemptions

### DIFF
--- a/docs/book/src/maintainers/labels.md
+++ b/docs/book/src/maintainers/labels.md
@@ -58,7 +58,7 @@ Type labels capture the high-level work class. They are separate from path label
 | `type: ci` | CI, workflow, or repository automation work |
 | `type: dependencies` | Dependency or lockfile maintenance |
 | `type: docs` | Documentation-only or docs-primary work |
-| `type:rfc` | RFC issue or proposal; protected from stale closure |
+| `type:rfc` | RFC issue or proposal; protected from stale closure while active |
 
 ## Path labels
 
@@ -219,7 +219,7 @@ Track lifecycle state of RFCs and tracked work items. Applied manually unless a 
 | `status:blocked` | Work is valid but waiting on an external dependency, maintainer decision, or linked prerequisite. Exempt from stale while the blocker is recorded and unresolved. Do not pair with `status:no-stale` for the same blocker. |
 | `status:in-progress` | An open PR is actively targeting this issue. Reconcile against live PR state during stale passes; the label is not a permanent exemption after the PR closes. |
 | `status:stale` | No author activity for the stale window; may close if not refreshed |
-| `status:no-stale` | Explicit stale exemption for accepted or otherwise long-lived work that is not already protected by another stale exclusion. Target policy: use only when the [Project board contract](./pr-workflow.md#issue-ownership-path) has a contributor-visible stale-exemption reason and owner path. Existing exemptions missing those facts should be audited and repaired before stale sweeps stop honoring them. |
+| `status:no-stale` | Explicit stale exemption for accepted or otherwise long-lived work that is not already protected by another stale exclusion. Target policy: use only when the [Project board contract](./pr-workflow.md#issue-ownership-path) has a contributor-visible stale-exemption reason and owner path. Active release trackers and active RFC or design trackers may use the tracker itself as the visible reason and steward surface while they remain active; revisit them when the milestone closes, the tracker drifts from live state, the RFC reaches a decision, is superseded, or closes, or the issue stops representing an active project decision surface. Existing exemptions missing those facts should be audited and repaired before stale sweeps stop honoring them. |
 
 ## Resolution labels
 

--- a/docs/book/src/maintainers/pr-workflow.md
+++ b/docs/book/src/maintainers/pr-workflow.md
@@ -61,7 +61,9 @@ For accepted or protected issues, prefer one of these visible owner sources befo
 - a public Project active-owner or area-steward field;
 - a linked public tracker entry that names the steward or owner source.
 
-If none of those exists, the issue can still stay open while triage continues, but it should not rely on `status:no-stale` as a permanent shield. Until the stale-exemption audit lands, missing reason or owner evidence is an audit finding and proposed correction, not an automatic stale-closure trigger.
+Active release trackers and active RFC or design trackers are durable coordination surfaces. When the issue title, body, labels, or milestone clearly identify an active tracker or RFC, the tracker itself supplies the stale-exemption reason and contributor-visible steward surface; it does not need repetitive per-issue owner comments. Revisit the exemption when the milestone closes, the tracker drifts from live release state, the RFC reaches a decision, is superseded, or closes, or the issue no longer represents an active project decision surface.
+
+If none of those exists and the issue is not an active tracker or RFC, the issue can still stay open while triage continues, but it should not rely on `status:no-stale` as a permanent shield. Until the stale-exemption audit lands, missing reason or owner evidence is an audit finding and proposed correction, not an automatic stale-closure trigger.
 
 ## PR lanes
 
@@ -155,7 +157,7 @@ For AI-heavy PRs, reviewers focus on:
 
 - First maintainer triage target: **within 48 hours**.
 - Blocked PRs get one actionable checklist comment, not a series of partial reviews.
-- `status:no-stale` is reserved for accepted or otherwise long-lived work with a recorded stale-exemption reason and contributor-visible active owner or steward path when the issue is not already protected by another stale exclusion. Existing exemptions missing those facts are audit findings until the stale-exemption repair packet lands.
+- `status:no-stale` is reserved for accepted or otherwise long-lived work with a recorded stale-exemption reason and contributor-visible active owner or steward path when the issue is not already protected by another stale exclusion. Active release trackers and active RFC or design trackers may use the tracker itself as that visible reason and steward surface while they remain active. Existing exemptions missing those facts are audit findings until the stale-exemption repair packet lands.
 
 For stacked work, require explicit `Depends on #...` so review order is deterministic.
 

--- a/docs/book/src/maintainers/reviewer-playbook.md
+++ b/docs/book/src/maintainers/reviewer-playbook.md
@@ -91,7 +91,7 @@ Issue `risk:*` labels describe likely fix blast radius from the report. PR `risk
 | `status:accepted` | The team has accepted the RFC or work item. Add `status:no-stale` only when the issue also needs stale protection. |
 | `status:blocked` | Valid work is waiting on an external dependency, maintainer decision, or linked prerequisite. Record the blocker; this is stale protection only while that blocker remains unresolved. |
 | `status:in-progress` | An open PR is actively targeting the issue. Re-check live PR state before relying on it during stale passes. |
-| `status:no-stale` | Accepted or otherwise long-lived work should stay open and is not already protected by another stale exclusion. Record the reason and active owner or steward path using the contributor-visible owner sources in the [Project board contract](./pr-workflow.md#issue-ownership-path). |
+| `status:no-stale` | Accepted or otherwise long-lived work should stay open and is not already protected by another stale exclusion. Record the reason and active owner or steward path using the contributor-visible owner sources in the [Project board contract](./pr-workflow.md#issue-ownership-path). Active release trackers and active RFC or design trackers may use the tracker itself as the visible reason and steward surface while they remain active. |
 | `good first issue` | XS/S, self-contained, documented work with clear acceptance criteria, relevant code or docs links, a named mentor or contact, and low onboarding risk. |
 | `help wanted` | Actionable, unblocked work maintainers want external help on and can review. Do not use it as a generic valid/unowned marker. |
 
@@ -139,7 +139,7 @@ This keeps context loss low and avoids the next reviewer redoing the same fetche
 
 ## Weekly queue hygiene
 
-- Walk the stale queue. Apply `status:no-stale` only when accepted or otherwise long-lived work has a recorded reason to stay open, a visible active owner or steward path, and no other stale exclusion already applies. Until the stale-exemption audit lands, treat existing `status:no-stale` issues missing those facts as audit findings rather than automatic stale candidates.
+- Walk the stale queue. Apply `status:no-stale` only when accepted or otherwise long-lived work has a recorded reason to stay open, a visible active owner or steward path, and no other stale exclusion already applies. Active release trackers and active RFC or design trackers may keep stale protection by default when the issue itself clearly identifies the active coordination or decision surface; revisit them when the milestone closes, the tracker drifts from live state, the RFC reaches a decision, is superseded, or closes, or the issue stops representing an active project decision surface. Until the stale-exemption audit lands, treat existing `status:no-stale` issues missing those facts as audit findings rather than automatic stale candidates.
 - Prioritize `size: XS/S` bug and security PRs first.
 - Convert recurring support questions into docs improvements and auto-response guidance.
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Define active release trackers and active RFC/design trackers as durable coordination surfaces for stale-exemption purposes.
  - Clarify that those tracker issues can supply their own visible stale-exemption reason and steward surface while they remain active.
  - Add revisit triggers for closed milestones, drift from live release state, decided/superseded/closed RFCs, and inactive decision surfaces.
- **Scope boundary:** This PR only updates maintainer policy docs. It does not mutate live GitHub labels, issue state, Project fields, stale automation, issue templates, or live release trackers.
- **Blast radius:** Maintainer stale sweeps and issue triage guidance now have a narrower tracker/RFC exception to the ordinary `status:no-stale` reason-plus-owner requirement.
- **Linked issue(s):** Related #6808.
- **Labels:** `type: docs`, `docs`, `risk: low`, `size: XS`

## Validation Evidence (required)

- **Commands run and tail output:**
  - `git diff --check -- docs/book/src/maintainers/pr-workflow.md docs/book/src/maintainers/reviewer-playbook.md docs/book/src/maintainers/labels.md` — passed with no output.
  - `DOCS_FILES=$'docs/book/src/maintainers/pr-workflow.md\ndocs/book/src/maintainers/reviewer-playbook.md\ndocs/book/src/maintainers/labels.md' bash scripts/ci/docs_links_gate.sh` — passed: `Collected 0 added link(s) from 3 docs file(s).` / `No added links detected in changed docs lines.`
  - `DOCS_FILES=$'docs/book/src/maintainers/pr-workflow.md\ndocs/book/src/maintainers/reviewer-playbook.md\ndocs/book/src/maintainers/labels.md' bash scripts/ci/docs_quality_gate.sh` — passed: `markdownlint-cli2 v0.20.0 (markdownlint v0.40.0)` / `Summary: 0 error(s)`.
- **Beyond CI — what did you manually verify?** Confirmed the branch diff is limited to `docs/book/src/maintainers/pr-workflow.md`, `docs/book/src/maintainers/reviewer-playbook.md`, and `docs/book/src/maintainers/labels.md`; checked the policy wording keeps the ordinary owner/reason requirement intact while adding only the active tracker/RFC default.
- **If any command was intentionally skipped, why:** Rust formatting, clippy, and tests were skipped because this is a docs-only maintainer-policy change.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: None.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No upgrade steps required.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PR: `git revert 58671e5aa542ecffd662fd6afb03f57bd08be8f1`.

## Supersede Attribution (required only when `Supersedes #` is used)

Not applicable.
