### PR TITLE
docs(maintainers): define label automation contract

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -61,7 +61,7 @@ Medium/high-risk PRs must fill:
 
 ---
 
-**Labels** live in the GitHub label UI, not in the body. Maintainers and reviewers with label permissions set `risk:*`, `size:*`, and scope labels via the sidebar. If auto-labels need correction, add `risk: manual` and the intended label. Contributors without label permission can note the mismatch in a comment.
+**Labels** live in the GitHub label UI, not in the body. Maintainers and reviewers with label permissions set `risk:*`, `size:*`, and any missing manual labels via the sidebar. The PR path labeler only owns path/scope labels from `.github/labeler.yml`. Contributors without label permission can note obvious label mismatches in a comment.
 
 **Do not add bot/AI attribution footers** such as `Co-authored-by: Claude ...`
 or `Created with Claude Code` to the PR body or commit-message tail. Human

--- a/docs/book/src/maintainers/ci-and-actions.md
+++ b/docs/book/src/maintainers/ci-and-actions.md
@@ -25,7 +25,11 @@ Runs `cargo audit` nightly against the dependency tree. Opens an issue on findin
 
 ### PR Path Labeler (`pr-path-labeler.yml`)
 
-Auto-applies scope and risk labels based on changed file paths. Runs silently on every PR — if a PR is missing labels, check whether the paths in `.github/labeler.yml` cover the changes.
+Auto-applies path and scope labels based on changed files. It runs on PR open, reopen, and every pushed update to the PR branch. Because `sync-labels: true` is enabled, labels defined in `.github/labeler.yml` are recalculated from the current PR file set.
+
+This workflow does not currently apply `risk:*`, `size:*`, `type:*`, contributor-tier, status, resolution, stale, or pickup labels. If a PR is missing a path/scope label, check whether the paths in `.github/labeler.yml` cover the changes.
+
+Dependabot has separate label configuration in `.github/dependabot.yml` for its own PRs. Cargo update PRs start with `dependencies`; GitHub Actions and Docker update PRs start with `ci` and `dependencies`.
 
 ### Discord Release (`discord-release.yml`)
 
@@ -100,7 +104,7 @@ The repository runs Actions in `selected` mode — only the actions in this allo
 | `actions/checkout@v4` | All workflows | Repository checkout |
 | `actions/upload-artifact@v4` | release | Upload build artifacts |
 | `actions/download-artifact@v4` | release | Download build artifacts for packaging |
-| `actions/labeler@v5` | `pr-path-labeler.yml` | Apply path/scope labels from `.github/labeler.yml` |
+| `actions/labeler@v6` | `pr-path-labeler.yml` | Apply path/scope labels from `.github/labeler.yml` |
 | `dtolnay/rust-toolchain@stable` | All workflows | Install Rust toolchain |
 | `Swatinem/rust-cache@v2` | All workflows | Cargo build/dependency caching |
 | `softprops/action-gh-release@v2` | release | Create GitHub Releases |

--- a/docs/book/src/maintainers/labels.md
+++ b/docs/book/src/maintainers/labels.md
@@ -32,9 +32,19 @@ Use assignees for active work. Use area stewardship for routing responsibility w
 
 ## Canonical spelling
 
-Use the live no-space module spelling for scoped module labels: `provider:openai`, `channel:telegram`, `tool:shell`, `security:policy`, and similar labels. The size and risk families intentionally keep a space after the colon: `size: XS`, `risk: low`, `risk: medium`, `risk: high`.
+Use the live no-space module spelling for scoped module labels: `provider:openai`, `channel:telegram`, `tool:shell`, `security:policy`, and similar labels. The size, risk, and most type families currently keep a space after the colon: `size: XS`, `risk: low`, `risk: medium`, `risk: high`, and `type: docs`.
 
-Legacy duplicate labels such as `provider: openai`, `channel: telegram`, or `tool: shell` are cleanup candidates. Migrate open issues/PRs to the canonical no-space spelling before deletion. Do not delete labels with open references, broadly rename label families, or remove stale-policy labels without a maintainer decision for that cleanup batch.
+Legacy duplicate labels such as `provider: openai`, `channel: telegram`, or `tool: shell` are cleanup candidates. Future no-space spelling for size, risk, or type labels is also a migration question, not a casual rename. Migrate open issues/PRs to the canonical label before deletion. Do not delete labels with open references, broadly rename label families, or remove stale-policy labels without a maintainer decision for that cleanup batch.
+
+## Automation contract
+
+Live PR label automation is split by source. `pr-path-labeler.yml` runs `actions/labeler` from `.github/labeler.yml` on PR open, reopen, and every pushed update. Because that workflow uses `sync-labels: true`, labels owned by `.github/labeler.yml` are recalculated from the current PR file set: matching path labels are added, and path labels that no longer match are removed.
+
+Dependabot also seeds configured labels on its own PRs from `.github/dependabot.yml`: Cargo updates get `dependencies`; GitHub Actions and Docker updates get `ci` and `dependencies`. Those labels are initial Dependabot PR metadata, not the synchronized path-labeler contract.
+
+Today `.github/labeler.yml` owns only path and scope labels such as `docs`, `ci`, `channel`, `provider:openai`, and `tool:file`. It does not own `risk:*`, `size:*`, `type:*`, contributor-tier, status, resolution, stale, or pickup labels.
+
+If risk or size automation is added later, it should recalculate on every pushed PR update so the labels continue to describe the actual diff under review. Risk automation must honor `risk: manual` as an override that prevents future automated risk replacement for that PR until a maintainer removes the override.
 
 ## Cleanup protocol
 
@@ -62,7 +72,7 @@ Type labels capture the high-level work class. They are separate from path label
 
 ## Path labels
 
-Applied automatically by `pr-path-labeler.yml` (the only labeling automation currently active). Globs live in `.github/labeler.yml`.
+Applied automatically by `pr-path-labeler.yml`. Globs live in `.github/labeler.yml`; when this page and the config disagree, treat `.github/labeler.yml` as the operational source and update this page.
 
 ### Base scope labels
 
@@ -72,27 +82,27 @@ Applied automatically by `pr-path-labeler.yml` (the only labeling automation cur
 | `dependencies` | `Cargo.toml`, `Cargo.lock`, `deny.toml`, `.github/dependabot.yml` |
 | `ci` | `.github/codeql/**`, `.github/workflows/**`, `.github/*.yaml`, `.github/*.yml`, `.github/*.json`, `.githooks/**` |
 | `core` | `src/*.rs` |
-| `agent` | `src/agent/**` |
-| `channel` | `src/channels/**` |
-| `gateway` | `src/gateway/**` |
-| `config` | `src/config/**` |
-| `cron` | `src/cron/**` |
-| `daemon` | `src/daemon/**` |
-| `doctor` | `src/doctor/**` |
-| `health` | `src/health/**` |
-| `heartbeat` | `src/heartbeat/**` |
-| `integration` | `src/integrations/**` |
-| `memory` | `src/memory/**` |
-| `security` | `src/security/**` |
-| `runtime` | `src/runtime/**` |
-| `onboard` | `src/onboard/**` |
-| `provider` | `src/providers/**` |
-| `service` | `src/service/**` |
-| `skillforge` | `src/skillforge/**` |
-| `skills` | `src/skills/**` |
-| `tool` | `src/tools/**` |
-| `tunnel` | `src/tunnel/**` |
-| `observability` | `src/observability/**` |
+| `agent` | `src/agent/**`, `crates/zeroclaw-runtime/src/agent/**` |
+| `channel` | `src/channels/**`, `crates/zeroclaw-channels/src/**` |
+| `gateway` | `src/gateway/**`, `crates/zeroclaw-gateway/src/**` |
+| `config` | `src/config/**`, `crates/zeroclaw-config/src/**` |
+| `cron` | `src/cron/**`, `crates/zeroclaw-runtime/src/cron/**` |
+| `daemon` | `src/daemon/**`, `crates/zeroclaw-runtime/src/daemon/**` |
+| `doctor` | `src/doctor/**`, `crates/zeroclaw-runtime/src/doctor/**` |
+| `health` | `src/health/**`, `crates/zeroclaw-runtime/src/health/**` |
+| `heartbeat` | `src/heartbeat/**`, `crates/zeroclaw-runtime/src/heartbeat/**` |
+| `integration` | `src/integrations/**`, `crates/zeroclaw-runtime/src/integrations/**` |
+| `memory` | `src/memory/**`, `crates/zeroclaw-memory/src/**` |
+| `security` | `src/security/**`, `crates/zeroclaw-runtime/src/security/**` |
+| `runtime` | `src/runtime/**`, `crates/zeroclaw-runtime/src/**` |
+| `quickstart` | `crates/zeroclaw-runtime/src/quickstart/**`, `crates/zeroclaw-gateway/src/api_quickstart.rs`, `apps/zerocode/src/quickstart_pane.rs`, `web/src/pages/quickstart/**` |
+| `provider` | `src/providers/**`, `crates/zeroclaw-providers/src/**` |
+| `service` | `src/service/**`, `crates/zeroclaw-runtime/src/service/**` |
+| `skillforge` | `src/skillforge/**`, `crates/zeroclaw-runtime/src/skillforge/**` |
+| `skills` | `src/skills/**`, `crates/zeroclaw-runtime/src/skills/**` |
+| `tool` | `src/tools/**`, `crates/zeroclaw-tools/src/**` |
+| `tunnel` | `src/tunnel/**`, `crates/zeroclaw-runtime/src/tunnel/**` |
+| `observability` | `src/observability/**`, `crates/zeroclaw-runtime/src/observability/**` |
 | `tests` | `tests/**` |
 | `scripts` | `scripts/**` |
 | `dev` | `dev/**` |
@@ -173,7 +183,7 @@ Tools are grouped by logical function rather than one label per file.
 
 ## Size labels
 
-Based on effective changed line count, normalized for docs-only and lockfile-heavy PRs. Currently applied **manually** — the size automation that previously computed these was removed during CI simplification.
+Based on effective changed line count, normalized for docs-only and lockfile-heavy PRs. Currently applied **manually** — the size automation that previously computed these was removed during CI simplification. Future size automation should follow the [automation contract](#automation-contract).
 
 | Label | Threshold |
 |---|---|
@@ -185,7 +195,7 @@ Based on effective changed line count, normalized for docs-only and lockfile-hea
 
 ## Risk labels
 
-For PRs, risk labels describe the actual diff under review: touched paths, behavior change, security boundary exposure, and rollback difficulty. For issues, risk labels describe the likely fix blast radius based on the report, help triage reviewer depth and contributor fit, and may change once a concrete PR shows the actual implementation path. Currently applied **manually**.
+For PRs, risk labels describe the actual diff under review: touched paths, behavior change, security boundary exposure, and rollback difficulty. For issues, risk labels describe the likely fix blast radius based on the report, help triage reviewer depth and contributor fit, and may change once a concrete PR shows the actual implementation path. Currently applied **manually**. Future risk automation should follow the [automation contract](#automation-contract).
 
 | Label | Meaning |
 |---|---|

--- a/docs/book/src/maintainers/pr-workflow.md
+++ b/docs/book/src/maintainers/pr-workflow.md
@@ -19,7 +19,7 @@ The control loop that delivers this is layered on purpose:
 - **Risk-based review depth** — high-risk paths get deep review, low-risk paths stay fast.
 - **Rollback-first merge contract** — every merge path includes a concrete recovery story.
 
-Automation handles intake labels and CI gating. Final merge accountability stays with human maintainers and PR authors.
+Automation handles path/scope labels and CI gating. Risk, size, type, and contributor-tier labels are maintainer intake decisions unless a maintained workflow explicitly owns them. Final merge accountability stays with human maintainers and PR authors.
 
 ## Project board contract
 

--- a/docs/book/src/maintainers/reviewer-playbook.md
+++ b/docs/book/src/maintainers/reviewer-playbook.md
@@ -27,7 +27,7 @@ Use [PR lanes](./pr-workflow.md#pr-lanes) for routing expectations; use this pla
 
 When uncertain, treat as higher risk.
 
-If the path-labeler's risk inference is contextually wrong, apply `risk: manual` and set the final `risk:*` label explicitly — manual freezes any future automated recalculation.
+Risk labels are currently manual. If future risk automation is restored, follow the [labels automation contract](./labels.md#automation-contract): apply `risk: manual` when a maintainer correction should not be overwritten on the next pushed update.
 
 Labels are maintainer metadata. If the correct label is obvious and you have permission, fix it yourself before finalizing the review. Ask the author only when the right label choice is ambiguous or nobody with label permissions is available.
 
@@ -120,7 +120,7 @@ When review demand exceeds capacity:
 
 Use this when automation output creates review side effects:
 
-1. **Incorrect risk label** — add `risk: manual`, then set the intended `risk:*` label.
+1. **Incorrect risk label** — set the intended `risk:*` label. If future risk automation is active, also follow the [labels automation contract](./labels.md#automation-contract) for `risk: manual`.
 2. **Incorrect auto-close on issue triage** — reopen, remove the route label, leave one clarifying comment.
 3. **Label spam or noise** — keep one canonical maintainer comment, remove redundant route labels.
 4. **Ambiguous PR scope** — request a split before deep review; don't try to review across two concerns at once.


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Define the live label automation contract: `pr-path-labeler.yml` owns synchronized path/scope label recalculation from `.github/labeler.yml`.
  - Document Dependabot's separate initial label seeding for dependency PRs so maintainers do not treat it as part of the path-labeler contract.
  - Clarify that `risk:*`, `size:*`, `type:*`, contributor-tier, status, resolution, stale, and pickup labels are not currently owned by the path labeler.
  - Sync maintainer docs with current labeler config for crate-side path labels and the `actions/labeler` major version.
- **Scope boundary:** This PR only updates maintainer docs and the PR template. It does not change `.github/labeler.yml`, Dependabot config, workflow triggers, live labels, issue labels, Project fields, or automation behavior.
- **Blast radius:** Maintainer PR intake and label-correction guidance now describe the current automation split more precisely. No runtime, CI behavior, or GitHub label state changes.
- **Linked issue(s):** Related #6808.
- **Labels:** `type: docs`, `docs`, `risk: low`, `size: XS`

## Validation Evidence (required)

- **Commands run and tail output:**
  - `ruby -EUTF-8 -e 'require "yaml"; labeler=YAML.load_file(".github/labeler.yml").keys; doc=File.read("docs/book/src/maintainers/labels.md", encoding: "UTF-8").scan(/^\| `([^`]+)` \|/).flatten; missing=labeler-doc; extra=doc.select{|l| !labeler.include?(l) && l =~ /^(docs|dependencies|ci|core|agent|channel|gateway|config|cron|daemon|doctor|health|heartbeat|integration|memory|security|runtime|quickstart|provider|service|skillforge|skills|tool|tunnel|observability|tests|scripts|dev|channel:|provider:|tool:)/}; puts "missing_from_docs=#{missing.inspect}"; puts "extra_pathish_in_docs=#{extra.inspect}"'` — passed: `missing_from_docs=[]` / `extra_pathish_in_docs=[]`.
  - `git diff --check` — passed with no output.
  - `DOCS_FILES=$'docs/book/src/maintainers/labels.md\ndocs/book/src/maintainers/ci-and-actions.md\ndocs/book/src/maintainers/reviewer-playbook.md\ndocs/book/src/maintainers/pr-workflow.md' bash scripts/ci/docs_links_gate.sh` — passed: `Collected 0 added link(s) from 4 docs file(s).` / `No added links detected in changed docs lines.`
  - `DOCS_FILES=$'docs/book/src/maintainers/labels.md\ndocs/book/src/maintainers/ci-and-actions.md\ndocs/book/src/maintainers/reviewer-playbook.md\ndocs/book/src/maintainers/pr-workflow.md' bash scripts/ci/docs_quality_gate.sh` — passed: `markdownlint-cli2 v0.20.0 (markdownlint v0.40.0)` / `Summary: 0 error(s)`.
- **Beyond CI — what did you manually verify?** Checked `.github/workflows/pr-path-labeler.yml` for `pull_request_target` open/synchronize/reopened triggers and `sync-labels: true`; checked `.github/dependabot.yml` for Cargo, GitHub Actions, and Docker PR label seeding; checked the changed maintainer docs and PR template now describe those separate label sources without claiming risk/size/type automation exists today.
- **If any command was intentionally skipped, why:** Rust formatting, clippy, and tests were skipped because this is a docs/template-only policy change.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: None.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No upgrade steps required.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PR: `git revert c1b6199ee`.

## Supersede Attribution (required only when `Supersedes #` is used)

Not applicable.
