### PR TITLE
fix(runtime): resolve channel pricing via bare-type fallback in cost lookup

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/cost.rs
+++ b/crates/zeroclaw-runtime/src/agent/cost.rs
@@ -115,6 +115,27 @@ fn resolve_rates(pricing: &HashMap<String, f64>, model: &str) -> (f64, f64, f64)
     (0.0, 0.0, 0.0)
 }
 
+/// Resolve the per-model pricing map for a provider reference.
+///
+/// `model_provider_name` always arrives as the composite `<type>.<alias>`
+/// (see `agent_provider_composite`), but the outer pricing map may be keyed
+/// either way depending on which builder populated it: the CLI / cron / web
+/// agent loop keys by the composite alias, while the channel orchestrator keys
+/// by the bare provider `<type>` (rates are per provider type, not per alias).
+/// Try the composite verbatim first, then fall back to the bare type prefix so
+/// cost tracking resolves regardless of the builder — and so the type-keyed
+/// `cost.rates` sheet is honored on the alias paths too.
+fn provider_pricing<'a>(
+    map: &'a ModelProviderPricing,
+    model_provider_name: &str,
+) -> Option<&'a HashMap<String, f64>> {
+    map.get(model_provider_name).or_else(|| {
+        model_provider_name
+            .split_once('.')
+            .and_then(|(provider_type, _alias)| map.get(provider_type))
+    })
+}
+
 /// Record token usage from an LLM response via the task-local cost tracker.
 /// Returns `(total_tokens, cost_usd)` on success, `None` when not scoped or no usage.
 pub fn record_tool_loop_cost_usage(
@@ -134,7 +155,7 @@ pub fn record_tool_loop_cost_usage(
         .try_with(Clone::clone)
         .ok()
         .flatten()?;
-    let pricing = ctx.model_provider_pricing.get(model_provider_name);
+    let pricing = provider_pricing(&ctx.model_provider_pricing, model_provider_name);
     let (input_rate, output_rate, cached_rate) = pricing
         .map(|map| resolve_rates(map, model))
         .unwrap_or((0.0, 0.0, 0.0));
@@ -283,6 +304,36 @@ mod tests {
         assert!(
             missing_pricing_first_sighting(&seen, "minimax", "MiniMax-M3.0"),
             "different model under same model_provider is a distinct pair"
+        );
+    }
+
+    #[test]
+    fn provider_pricing_resolves_composite_and_bare_type_keys() {
+        let mut model_rates: HashMap<String, f64> = HashMap::new();
+        model_rates.insert("glm-5.1.input".to_string(), 1.4);
+        model_rates.insert("glm-5.1.output".to_string(), 4.4);
+
+        // CLI / agent-loop builder keys by the composite `<type>.<alias>`.
+        let mut composite_keyed: ModelProviderPricing = HashMap::new();
+        composite_keyed.insert("glm.default".to_string(), model_rates.clone());
+        assert!(
+            provider_pricing(&composite_keyed, "glm.default").is_some(),
+            "composite-keyed map must resolve via the verbatim composite lookup"
+        );
+
+        // Channel orchestrator builder keys by the bare provider `<type>`, yet
+        // the lookup still arrives as the composite alias — must fall back.
+        let mut type_keyed: ModelProviderPricing = HashMap::new();
+        type_keyed.insert("glm".to_string(), model_rates.clone());
+        assert!(
+            provider_pricing(&type_keyed, "glm.default").is_some(),
+            "type-keyed map must resolve the composite alias via the bare-type fallback"
+        );
+
+        // An unrelated provider must not accidentally match.
+        assert!(
+            provider_pricing(&type_keyed, "openai.default").is_none(),
+            "fallback must not resolve a provider type absent from the map"
         );
     }
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Channel cost tracking silently recorded `cost_usd = 0` and left per-day budget enforcement inert for every channel agent. Root cause: the channel orchestrator builds the pricing map keyed by the **bare provider `<type>`** (`crates/zeroclaw-channels/src/orchestrator/mod.rs`), while `record_tool_loop_cost_usage` always receives the **composite `<type>.<alias>`** from `agent_provider_composite`, so `model_provider_pricing.get(<composite>)` missed. The CLI / cron / web agent-loop builder keys by the composite instead, so the same lookup worked there — the two builders disagree. Fixed at the lookup site: try the composite verbatim, then fall back to the bare-type prefix.
- **Scope boundary:** Only the pricing-map lookup in `cost.rs`. No change to either builder, to `resolve_rates`, to rate values, or to the inference path.
- **Blast radius:** Cost/budget accounting only. Resolving the map cannot change inference behavior; worst case a previously-missed rate now applies (the intended behavior). The composite-keyed path is unaffected (verbatim `get` still hits first).
- **Linked issue(s):** none filed.
- **Labels:** `bug`, `risk: high`, `size: S`, `agent`, `runtime`

## Validation Evidence (required)

```bash
cargo fmt --all -- --check     # clean, no output
cargo clippy --all-targets -- -D warnings
#   Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 19s   (exit 0, no warnings)
cargo test
#   all suites ok — 0 failed across the workspace (exit 0)
#   new test: agent::cost::tests::provider_pricing_resolves_composite_and_bare_type_keys ... ok
```

- **Beyond CI — what was manually verified:** Built the patched binary, pointed an agent at a GLM provider (`glm.default`, model `glm-5.1`) with a per-alias `pricing` table (`"glm-5.1.input" = 1.4`, `"glm-5.1.output" = 4.4`), and sent a live Telegram message. Before the fix `costs.jsonl` recorded `cost_usd = 0.0` plus the "no pricing entry found" WARN; after the fix the same path recorded `cost_usd = 0.0185626` for `13149` input / `35` output tokens (`13149*1.4/1e6 + 35*4.4/1e6 = 0.0185626`), and the WARN stopped firing.
- **Not verified:** the `[cost.rates...]` sheet surface (type-keyed) — it benefits from the same fallback by construction but was not exercised end-to-end.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- Upgrade steps: none. Existing configs whose pricing previously resolved continue to resolve identically (verbatim composite lookup is tried first); configs that silently recorded zero cost on channels now resolve correctly.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** Revert this PR.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Unexpected channel-turn cost values for aliased providers, unexpected budget denials after channel LLM calls, or cost records whose token math does not match the configured provider pricing.
