### PR TITLE
refactor(runtime): replace daemon subsystem callbacks with registry

### DIFF
--- a/crates/zeroclaw-runtime/src/daemon/mod.rs
+++ b/crates/zeroclaw-runtime/src/daemon/mod.rs
@@ -1,11 +1,13 @@
 use anyhow::Result;
 use chrono::Utc;
-use std::future::Future;
 use std::path::PathBuf;
 use tokio::task::JoinHandle;
 use tokio::time::Duration;
 use zeroclaw_config::schema::Config;
 use zeroclaw_memory::{MEMORY_CONTEXT_CLOSE, MEMORY_CONTEXT_OPEN};
+
+mod registry;
+pub use registry::DaemonRegistry;
 
 const STATUS_FLUSH_SECONDS: u64 = 5;
 
@@ -169,85 +171,11 @@ async fn wait_for_ephemeral(client_count: std::sync::Arc<std::sync::atomic::Atom
     }
 }
 
-/// Optional subsystem start functions injected by the binary crate.
-/// This allows the daemon to spawn subsystems without depending on their crates.
-#[allow(clippy::type_complexity)]
-pub struct DaemonSubsystems {
-    /// Start the gateway HTTP server. Injected by the binary when `gateway` feature is on.
-    /// The fifth argument is the reload sender — the gateway hands it to its
-    /// AppState so /admin/reload can signal the daemon to re-init.
-    /// The sixth argument is the TUI registry for the /api/tuis endpoint.
-    pub gateway_start: Option<
-        Box<
-            dyn Fn(
-                    String,
-                    u16,
-                    Config,
-                    Option<tokio::sync::broadcast::Sender<serde_json::Value>>,
-                    Option<tokio::sync::watch::Sender<bool>>,
-                    Option<std::sync::Arc<crate::rpc::tui_identity::TuiRegistry>>,
-                ) -> std::pin::Pin<Box<dyn Future<Output = Result<()>> + Send>>
-                + Send
-                + Sync,
-        >,
-    >,
-    /// Start supervised channels. Injected by the binary when channels crate is available.
-    /// The cancellation token is fired on reload so listener tasks drop their channel Arcs
-    /// before the new supervisor starts.
-    pub channels_start: Option<
-        Box<
-            dyn Fn(
-                    Config,
-                    tokio_util::sync::CancellationToken,
-                ) -> std::pin::Pin<Box<dyn Future<Output = Result<()>> + Send>>
-                + Send
-                + Sync,
-        >,
-    >,
-    /// Start the local IPC RPC listener (Unix socket on Unix, Named Pipe on
-    /// Windows). First argument is the shared `RpcContext`; third is the
-    /// client count for `--ephemeral` shutdown.
-    pub socket_start: Option<
-        Box<
-            dyn Fn(
-                    std::sync::Arc<crate::rpc::context::RpcContext>,
-                    tokio_util::sync::CancellationToken,
-                    std::sync::Arc<std::sync::atomic::AtomicUsize>,
-                ) -> std::pin::Pin<Box<dyn Future<Output = Result<()>> + Send>>
-                + Send
-                + Sync,
-        >,
-    >,
-    /// Start the WSS (WebSocket Secure) RPC listener for remote TUI connections.
-    /// Same signature as `socket_start`; shares `RpcContext` and `client_count`.
-    pub wss_start: Option<
-        Box<
-            dyn Fn(
-                    std::sync::Arc<crate::rpc::context::RpcContext>,
-                    tokio_util::sync::CancellationToken,
-                    std::sync::Arc<std::sync::atomic::AtomicUsize>,
-                ) -> std::pin::Pin<Box<dyn Future<Output = Result<()>> + Send>>
-                + Send
-                + Sync,
-        >,
-    >,
-    /// Start the MQTT SOP listener. Injected by the binary when channels crate is available.
-    pub mqtt_start: Option<
-        Box<
-            dyn Fn(
-                    zeroclaw_config::schema::MqttConfig,
-                ) -> std::pin::Pin<Box<dyn Future<Output = Result<()>> + Send>>
-                + Send
-                + Sync,
-        >,
-    >,
-}
-
 pub async fn run(
     config: Config,
     host: String,
     port: u16,
-    subsystems: DaemonSubsystems,
+    mut registry: DaemonRegistry,
     ephemeral: bool,
 ) -> Result<DaemonExit> {
     let initial_backoff = config.reliability.channel_initial_backoff_secs.max(1);
@@ -285,7 +213,7 @@ pub async fn run(
     let tui_registry =
         std::sync::Arc::new(crate::rpc::tui_identity::TuiRegistry::new(&config.data_dir));
 
-    if let Some(gateway_start) = subsystems.gateway_start {
+    if let Some(gateway_start) = registry.take_gateway_start() {
         let gateway_cfg = config.clone();
         let gateway_host = host.clone();
         let gateway_event_tx = event_tx.clone();
@@ -310,7 +238,7 @@ pub async fn run(
 
     let channels_cancel = tokio_util::sync::CancellationToken::new();
 
-    if let Some(channels_start) = subsystems.channels_start {
+    if let Some(channels_start) = registry.take_channels_start() {
         if has_supervised_channels(&config) {
             let channels_cfg = config.clone();
             let channels_start = std::sync::Arc::new(channels_start);
@@ -346,7 +274,7 @@ pub async fn run(
     // RPC transports: Unix socket (#6837) and WSS (remote TUI connections).
     // Build the shared RpcContext if either transport is configured.
     let socket_client_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
-    let need_rpc_ctx = subsystems.socket_start.is_some() || subsystems.wss_start.is_some();
+    let need_rpc_ctx = registry.has_socket_start() || registry.has_wss_start();
 
     let rpc_ctx = if need_rpc_ctx {
         use crate::rpc::context::RpcContext;
@@ -460,7 +388,7 @@ pub async fn run(
     };
 
     // Local IPC RPC listener (Unix socket on Unix, Named Pipe on Windows).
-    if let Some(socket_start) = subsystems.socket_start {
+    if let Some(socket_start) = registry.take_socket_start() {
         let rpc_ctx = rpc_ctx
             .clone()
             .expect("rpc_ctx built when socket_start is Some");
@@ -482,7 +410,7 @@ pub async fn run(
     }
 
     // WSS RPC listener (remote TUI connections).
-    if let Some(wss_start) = subsystems.wss_start {
+    if let Some(wss_start) = registry.take_wss_start() {
         let rpc_ctx = rpc_ctx
             .clone()
             .expect("rpc_ctx built when wss_start is Some");
@@ -504,7 +432,7 @@ pub async fn run(
     }
 
     // Wire up MQTT SOP listener if configured and referenced by an enabled agent
-    if let Some(mqtt_start) = subsystems.mqtt_start {
+    if let Some(mqtt_start) = registry.take_mqtt_start() {
         let active_mqtt: std::collections::HashSet<String> = config
             .agents
             .values()
@@ -1479,7 +1407,7 @@ fn has_supervised_channels(config: &Config) -> bool {
 }
 
 // run_mqtt_sop_listener has been moved to zeroclaw-channels::orchestrator::mqtt.
-// The daemon now receives it as a callback via DaemonSubsystems::mqtt_start.
+// The daemon now receives it as a starter via DaemonRegistry::register_mqtt.
 
 #[cfg(test)]
 mod tests {
@@ -1905,6 +1833,62 @@ mod tests {
             .expect("task should not panic")
             .expect("signal handler should not error");
         assert_eq!(result, DaemonExit::Reload);
+    }
+
+    #[tokio::test]
+    async fn registry_gateway_starter_can_trigger_daemon_reload() {
+        use tokio::time::{Duration, timeout};
+
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(&tmp);
+        let expected_data_dir = config.data_dir.clone();
+        let (seen_tx, mut seen_rx) = tokio::sync::mpsc::unbounded_channel();
+
+        let mut registry = DaemonRegistry::new();
+        registry.register_gateway(Box::new(
+            move |host, port, config, event_tx, reload_tx, tui_registry| {
+                let seen_tx = seen_tx.clone();
+                Box::pin(async move {
+                    let has_event_tx = event_tx.is_some();
+                    let has_reload_tx = reload_tx.is_some();
+                    let has_tui_registry = tui_registry.is_some();
+                    seen_tx
+                        .send((
+                            host,
+                            port,
+                            config.data_dir.clone(),
+                            has_event_tx,
+                            has_reload_tx,
+                            has_tui_registry,
+                        ))
+                        .expect("record gateway starter inputs");
+                    reload_tx
+                        .expect("daemon should pass reload sender to gateway starter")
+                        .send(true)
+                        .expect("send reload signal");
+                    std::future::pending::<Result<()>>().await
+                })
+            },
+        ));
+
+        let exit = timeout(
+            Duration::from_secs(2),
+            run(config, "127.0.0.1".to_string(), 4242, registry, false),
+        )
+        .await
+        .expect("daemon should return after gateway-triggered reload")
+        .expect("daemon run should succeed");
+
+        assert_eq!(exit, DaemonExit::Reload);
+        let (host, port, data_dir, has_event_tx, has_reload_tx, has_tui_registry) = seen_rx
+            .try_recv()
+            .expect("gateway starter should record its daemon inputs");
+        assert_eq!(host, "127.0.0.1");
+        assert_eq!(port, 4242);
+        assert_eq!(data_dir, expected_data_dir);
+        assert!(has_event_tx);
+        assert!(has_reload_tx);
+        assert!(has_tui_registry);
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-runtime/src/daemon/registry.rs
+++ b/crates/zeroclaw-runtime/src/daemon/registry.rs
@@ -1,0 +1,205 @@
+use anyhow::Result;
+use serde_json::Value;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
+use tokio::sync::{broadcast, watch};
+use tokio_util::sync::CancellationToken;
+use zeroclaw_config::schema::{Config, MqttConfig};
+
+use crate::rpc::context::RpcContext;
+use crate::rpc::tui_identity::TuiRegistry;
+
+pub type StarterFuture = Pin<Box<dyn Future<Output = Result<()>> + Send>>;
+
+/// Starts the gateway HTTP server for one daemon run/reload iteration.
+///
+/// The optional broadcast sender carries daemon events, the optional reload
+/// sender lets the gateway trigger in-process reloads, and the optional TUI
+/// registry powers the gateway's TUI identity endpoints.
+pub type GatewayStarter = Box<
+    dyn Fn(
+            String,
+            u16,
+            Config,
+            Option<broadcast::Sender<Value>>,
+            Option<watch::Sender<bool>>,
+            Option<Arc<TuiRegistry>>,
+        ) -> StarterFuture
+        + Send
+        + Sync,
+>;
+
+/// Starts the supervised channel orchestrator for one daemon run/reload iteration.
+pub type ChannelsStarter = Box<dyn Fn(Config, CancellationToken) -> StarterFuture + Send + Sync>;
+
+/// Starts an RPC transport using the shared daemon RPC context.
+pub type RpcStarter = Box<
+    dyn Fn(Arc<RpcContext>, CancellationToken, Arc<AtomicUsize>) -> StarterFuture + Send + Sync,
+>;
+
+/// Starts the MQTT SOP listener for one configured MQTT channel alias.
+pub type MqttStarter = Box<dyn Fn(MqttConfig) -> StarterFuture + Send + Sync>;
+
+/// Typed startup registry injected by the binary crate.
+///
+/// This registry is the source of truth for startup hook values for the current
+/// daemon run/reload iteration. It deliberately does not copy config-derived
+/// facts; `Config` remains the source of truth for which subsystems are enabled.
+#[derive(Default)]
+pub struct DaemonRegistry {
+    gateway_start: Option<GatewayStarter>,
+    channels_start: Option<ChannelsStarter>,
+    socket_start: Option<RpcStarter>,
+    wss_start: Option<RpcStarter>,
+    mqtt_start: Option<MqttStarter>,
+}
+
+impl DaemonRegistry {
+    /// Create an empty registry. Missing starters are treated as unwired
+    /// optional subsystems by `daemon::run`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn register_gateway(&mut self, starter: GatewayStarter) -> &mut Self {
+        self.gateway_start = Some(starter);
+        self
+    }
+
+    #[cfg(test)]
+    fn has_gateway_start(&self) -> bool {
+        self.gateway_start.is_some()
+    }
+
+    pub fn register_channels(&mut self, starter: ChannelsStarter) -> &mut Self {
+        self.channels_start = Some(starter);
+        self
+    }
+
+    #[cfg(test)]
+    fn has_channels_start(&self) -> bool {
+        self.channels_start.is_some()
+    }
+
+    pub fn register_socket(&mut self, starter: RpcStarter) -> &mut Self {
+        self.socket_start = Some(starter);
+        self
+    }
+
+    pub(crate) fn has_socket_start(&self) -> bool {
+        self.socket_start.is_some()
+    }
+
+    pub fn register_wss(&mut self, starter: RpcStarter) -> &mut Self {
+        self.wss_start = Some(starter);
+        self
+    }
+
+    pub(crate) fn has_wss_start(&self) -> bool {
+        self.wss_start.is_some()
+    }
+
+    pub fn register_mqtt(&mut self, starter: MqttStarter) -> &mut Self {
+        self.mqtt_start = Some(starter);
+        self
+    }
+
+    #[cfg(test)]
+    fn has_mqtt_start(&self) -> bool {
+        self.mqtt_start.is_some()
+    }
+
+    pub(crate) fn take_gateway_start(&mut self) -> Option<GatewayStarter> {
+        self.gateway_start.take()
+    }
+
+    pub(crate) fn take_channels_start(&mut self) -> Option<ChannelsStarter> {
+        self.channels_start.take()
+    }
+
+    pub(crate) fn take_socket_start(&mut self) -> Option<RpcStarter> {
+        self.socket_start.take()
+    }
+
+    pub(crate) fn take_wss_start(&mut self) -> Option<RpcStarter> {
+        self.wss_start.take()
+    }
+
+    pub(crate) fn take_mqtt_start(&mut self) -> Option<MqttStarter> {
+        self.mqtt_start.take()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn gateway_starter() -> GatewayStarter {
+        Box::new(|_, _, _, _, _, _| Box::pin(async { Ok(()) }))
+    }
+
+    fn channels_starter() -> ChannelsStarter {
+        Box::new(|_, _| Box::pin(async { Ok(()) }))
+    }
+
+    fn rpc_starter() -> RpcStarter {
+        Box::new(|_, _, _| Box::pin(async { Ok(()) }))
+    }
+
+    fn mqtt_starter() -> MqttStarter {
+        Box::new(|_| Box::pin(async { Ok(()) }))
+    }
+
+    #[test]
+    fn new_registry_has_no_start_hooks() {
+        let registry = DaemonRegistry::new();
+
+        assert!(!registry.has_gateway_start());
+        assert!(!registry.has_channels_start());
+        assert!(!registry.has_socket_start());
+        assert!(!registry.has_wss_start());
+        assert!(!registry.has_mqtt_start());
+    }
+
+    #[test]
+    fn builder_records_typed_start_hooks() {
+        let mut registry = DaemonRegistry::new();
+        registry
+            .register_gateway(gateway_starter())
+            .register_channels(channels_starter())
+            .register_socket(rpc_starter())
+            .register_wss(rpc_starter())
+            .register_mqtt(mqtt_starter());
+
+        assert!(registry.has_gateway_start());
+        assert!(registry.has_channels_start());
+        assert!(registry.has_socket_start());
+        assert!(registry.has_wss_start());
+        assert!(registry.has_mqtt_start());
+    }
+
+    #[test]
+    fn taking_start_hooks_consumes_slots() {
+        let mut registry = DaemonRegistry::new();
+        registry
+            .register_gateway(gateway_starter())
+            .register_channels(channels_starter())
+            .register_socket(rpc_starter())
+            .register_wss(rpc_starter())
+            .register_mqtt(mqtt_starter());
+
+        assert!(registry.take_gateway_start().is_some());
+        assert!(registry.take_channels_start().is_some());
+        assert!(registry.take_socket_start().is_some());
+        assert!(registry.take_wss_start().is_some());
+        assert!(registry.take_mqtt_start().is_some());
+
+        assert!(!registry.has_gateway_start());
+        assert!(!registry.has_channels_start());
+        assert!(!registry.has_socket_start());
+        assert!(!registry.has_wss_start());
+        assert!(!registry.has_mqtt_start());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3676,109 +3676,105 @@ async fn main() -> Result<()> {
                 // first iteration; reload would otherwise see a moved value.
                 let canvas_store_for_gateway = canvas_store_for_gateway.clone();
                 let canvas_store_for_channels = canvas_store_for_channels.clone();
-                let subsystems = daemon::DaemonSubsystems {
-                    #[cfg(feature = "gateway")]
-                    gateway_start: Some(Box::new(
-                        move |host, port, config, tx, reload_tx, tui_registry| {
-                            let canvas_store = canvas_store_for_gateway.clone();
-                            Box::pin(async move {
-                                Box::pin(zeroclaw_gateway::run_gateway(
-                                    &host,
-                                    port,
-                                    config,
-                                    tx,
-                                    reload_tx,
-                                    tui_registry,
-                                    Some(canvas_store),
-                                ))
-                                .await
-                            })
-                        },
-                    )),
-                    #[cfg(not(feature = "gateway"))]
-                    gateway_start: None,
-                    channels_start: Some(Box::new(move |config, cancel| {
-                        let canvas_store = canvas_store_for_channels.clone();
+                let mut registry = daemon::DaemonRegistry::new();
+
+                #[cfg(feature = "gateway")]
+                registry.register_gateway(Box::new(
+                    move |host, port, config, tx, reload_tx, tui_registry| {
+                        let canvas_store = canvas_store_for_gateway.clone();
                         Box::pin(async move {
-                            Box::pin(zeroclaw_channels::orchestrator::start_channels(
+                            zeroclaw_gateway::run_gateway(
+                                &host,
+                                port,
                                 config,
+                                tx,
+                                reload_tx,
+                                tui_registry,
                                 Some(canvas_store),
-                                cancel,
-                            ))
-                            .await
-                        })
-                    })),
-                    #[cfg(feature = "channel-mqtt")]
-                    mqtt_start: Some(Box::new({
-                        use std::sync::{Arc, Mutex};
-                        use zeroclaw_config::schema::SopConfig;
-                        use zeroclaw_memory::NoneMemory;
-                        use zeroclaw_runtime::sop::{SopAuditLogger, SopEngine};
-                        let sop_config = current_config.sop.clone();
-                        let workspace_dir = current_config.data_dir.clone();
-                        move |mqtt_config| {
-                            let engine = if sop_config.sops_dir.is_some() {
-                                let mut e = SopEngine::new(sop_config.clone());
-                                e.reload(&workspace_dir);
-                                e
-                            } else {
-                                SopEngine::new(SopConfig::default())
-                            };
-                            let engine = Arc::new(Mutex::new(engine));
-                            let audit =
-                                Arc::new(SopAuditLogger::new(Arc::new(NoneMemory::new("none"))));
-                            Box::pin(async move {
-                                zeroclaw_channels::orchestrator::mqtt::run_mqtt_sop_listener(
-                                    &mqtt_config,
-                                    engine,
-                                    audit,
-                                )
-                                .await
-                            })
-                        }
-                    })),
-                    socket_start: Some(Box::new(|ctx, cancel, client_count| {
-                        Box::pin(async move {
-                            Box::pin(zeroclaw_runtime::rpc::local::run_local_listener(
-                                ctx,
-                                cancel,
-                                client_count,
-                            ))
-                            .await
-                        })
-                    })),
-                    wss_start: Some(Box::new(|ctx, cancel, client_count| {
-                        Box::pin(async move {
-                            let wss_cfg = ctx.config.read().wss.clone();
-                            if !wss_cfg.enabled {
-                                // WSS disabled — park until cancelled.
-                                cancel.cancelled().await;
-                                return Ok(());
-                            }
-                            let tls_acceptor = zeroclaw_runtime::rpc::wss::build_tls_acceptor(
-                                &wss_cfg.cert_path,
-                                &wss_cfg.key_path,
-                            )?;
-                            let bind_addr: std::net::SocketAddr =
-                                format!("{}:{}", wss_cfg.bind, wss_cfg.port).parse()?;
-                            zeroclaw_runtime::rpc::wss::run_wss_listener(
-                                ctx,
-                                cancel,
-                                client_count,
-                                tls_acceptor,
-                                bind_addr,
                             )
                             .await
                         })
-                    })),
-                    #[cfg(not(feature = "channel-mqtt"))]
-                    mqtt_start: None,
-                };
+                    },
+                ));
+
+                registry.register_channels(Box::new(move |config, cancel| {
+                    let canvas_store = canvas_store_for_channels.clone();
+                    Box::pin(async move {
+                        zeroclaw_channels::orchestrator::start_channels(
+                            config,
+                            Some(canvas_store),
+                            cancel,
+                        )
+                        .await
+                    })
+                }));
+
+                #[cfg(feature = "channel-mqtt")]
+                registry.register_mqtt(Box::new({
+                    use std::sync::{Arc, Mutex};
+                    use zeroclaw_config::schema::SopConfig;
+                    use zeroclaw_memory::NoneMemory;
+                    use zeroclaw_runtime::sop::{SopAuditLogger, SopEngine};
+                    let sop_config = current_config.sop.clone();
+                    let workspace_dir = current_config.data_dir.clone();
+                    move |mqtt_config| {
+                        let engine = if sop_config.sops_dir.is_some() {
+                            let mut e = SopEngine::new(sop_config.clone());
+                            e.reload(&workspace_dir);
+                            e
+                        } else {
+                            SopEngine::new(SopConfig::default())
+                        };
+                        let engine = Arc::new(Mutex::new(engine));
+                        let audit =
+                            Arc::new(SopAuditLogger::new(Arc::new(NoneMemory::new("none"))));
+                        Box::pin(async move {
+                            zeroclaw_channels::orchestrator::mqtt::run_mqtt_sop_listener(
+                                &mqtt_config,
+                                engine,
+                                audit,
+                            )
+                            .await
+                        })
+                    }
+                }));
+
+                registry.register_socket(Box::new(|ctx, cancel, client_count| {
+                    Box::pin(async move {
+                        zeroclaw_runtime::rpc::local::run_local_listener(ctx, cancel, client_count)
+                            .await
+                    })
+                }));
+
+                registry.register_wss(Box::new(|ctx, cancel, client_count| {
+                    Box::pin(async move {
+                        let wss_cfg = ctx.config.read().wss.clone();
+                        if !wss_cfg.enabled {
+                            // WSS disabled — park until cancelled.
+                            cancel.cancelled().await;
+                            return Ok(());
+                        }
+                        let tls_acceptor = zeroclaw_runtime::rpc::wss::build_tls_acceptor(
+                            &wss_cfg.cert_path,
+                            &wss_cfg.key_path,
+                        )?;
+                        let bind_addr: std::net::SocketAddr =
+                            format!("{}:{}", wss_cfg.bind, wss_cfg.port).parse()?;
+                        zeroclaw_runtime::rpc::wss::run_wss_listener(
+                            ctx,
+                            cancel,
+                            client_count,
+                            tls_acceptor,
+                            bind_addr,
+                        )
+                        .await
+                    })
+                }));
                 let exit = Box::pin(daemon::run(
                     current_config.clone(),
                     host.clone(),
                     port,
-                    subsystems,
+                    registry,
                     ephemeral,
                 ))
                 .await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3683,7 +3683,7 @@ async fn main() -> Result<()> {
                     move |host, port, config, tx, reload_tx, tui_registry| {
                         let canvas_store = canvas_store_for_gateway.clone();
                         Box::pin(async move {
-                            zeroclaw_gateway::run_gateway(
+                            Box::pin(zeroclaw_gateway::run_gateway(
                                 &host,
                                 port,
                                 config,
@@ -3691,7 +3691,7 @@ async fn main() -> Result<()> {
                                 reload_tx,
                                 tui_registry,
                                 Some(canvas_store),
-                            )
+                            ))
                             .await
                         })
                     },
@@ -3700,11 +3700,11 @@ async fn main() -> Result<()> {
                 registry.register_channels(Box::new(move |config, cancel| {
                     let canvas_store = canvas_store_for_channels.clone();
                     Box::pin(async move {
-                        zeroclaw_channels::orchestrator::start_channels(
+                        Box::pin(zeroclaw_channels::orchestrator::start_channels(
                             config,
                             Some(canvas_store),
                             cancel,
-                        )
+                        ))
                         .await
                     })
                 }));


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Added a typed `DaemonRegistry` for daemon startup hooks so runtime startup wiring is named, chainable, and type-checked.
  - Replaced the `DaemonSubsystems` callback bag in daemon execution and binary setup with registry registration and one-shot startup hook consumption.
  - Preserved config as the source of truth for enabled subsystems; the registry only carries per-run startup hooks for the current daemon run or reload iteration.
  - Added daemon registry unit coverage plus a reload-handoff behavior test so gateway-triggered reloads still exit through `DaemonExit::Reload`.
- **Scope boundary:** This PR does not migrate provider, channel, tool, memory, observer, or process-global registration into the registry. It keeps the slice to daemon startup hooks only.
- **Blast radius:** Daemon startup and reload wiring for gateway, channel orchestrator, local RPC socket, WSS RPC, and MQTT SOP listener startup. Config parsing and subsystem enablement remain unchanged.
- **Linked issue(s):** Related #5618
- **Labels:** risk: high, size: L, runtime, daemon, core

## Validation Evidence (required)

- **Commands run and tail output:** Final command outcomes are summarized below as a public-safe validation digest.

```text
cargo fmt --all -- --check
passed

cargo test -p zeroclaw-runtime daemon::registry --lib
passed: 3 passed; 0 failed; 2032 filtered out

cargo test -p zeroclaw-runtime registry_gateway_starter_can_trigger_daemon_reload --lib
passed: 1 passed; 0 failed; 2034 filtered out

git diff --check origin/master...HEAD
passed

cargo check -p zeroclawlabs --bin zeroclaw
passed

cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
first run found clippy::large_futures in daemon starter closure futures; commit 2 (`fix(runtime): box daemon starter futures`) addressed that, the rerun passed, and the latest post-rebase rerun also passed

cargo nextest run --locked --workspace --exclude zeroclaw-desktop
passed: 8175 tests run; 8175 passed; 10 skipped; nextest reported 1 leaky test

git diff --check
passed

cargo fmt --all -- --check
passed
```

After the latest local validation, `origin/master` advanced to `af50475a` with CI/cache workflow and CI documentation changes only. The cited clippy and nextest commands were unchanged, `git diff --check origin/master...HEAD` passed, and the merge-tree remained conflict-free.

- **Beyond CI — what did you manually verify?** Verified that registry startup hooks are consumed once, daemon socket/WSS enablement still reflects registered hooks, gateway-triggered reload still propagates through the daemon reload sender, and the binary still rebuilds a fresh registry for each reload-loop iteration.
- **If any command was intentionally skipped, why:** None for this slice. Broad local clippy and CI-shaped nextest both passed after the large-future boxing follow-up described above.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No migration or upgrade steps required.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert 3963093775e6e292b9f0afad37a3383b0833fc80 6e4178995270148c032d14bc7de81a771b7c1ffb`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Daemon startup fails for gateway, local RPC socket, WSS RPC, channels, or MQTT listener; reload requests do not return `DaemonExit::Reload`; related errors should appear around daemon subsystem startup or reload handling logs.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Scope materially carried forward: N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why (inspiration-only, no direct code/design carry-over): No superseded PR scope is carried forward.
