### PR TITLE
fix(runtime): refresh active sessions after provider config edits

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -883,6 +883,11 @@ impl Agent {
         self.temperature = temperature;
     }
 
+    #[cfg(test)]
+    pub fn temperature_for_test(&self) -> Option<f64> {
+        self.temperature
+    }
+
     pub fn set_model_name(&mut self, model_name: String) {
         self.model_name = model_name;
     }

--- a/crates/zeroclaw-runtime/src/rpc/dispatch.rs
+++ b/crates/zeroclaw-runtime/src/rpc/dispatch.rs
@@ -263,6 +263,17 @@ fn not_yet_implemented(method: Method) -> RpcResult {
     ))
 }
 
+fn model_provider_ref_from_provider_profile_prop(prop: &str) -> Option<String> {
+    let rest = prop.strip_prefix("providers.models.")?;
+    let (provider_type, rest) = rest.split_once('.')?;
+    let (provider_alias, field) = rest.split_once('.')?;
+    if provider_type.is_empty() || provider_alias.is_empty() || field.is_empty() {
+        None
+    } else {
+        Some(format!("{provider_type}.{provider_alias}"))
+    }
+}
+
 /// Per-connection dispatcher. Shared state lives in [`RpcContext`].
 pub struct RpcDispatcher {
     ctx: Arc<RpcContext>,
@@ -2173,6 +2184,7 @@ impl RpcDispatcher {
 
     async fn handle_config_set(&self, params: &Value) -> RpcResult {
         let req: ConfigSetParams = parse_params(params)?;
+        let refresh_model_provider_ref = model_provider_ref_from_provider_profile_prop(&req.prop);
         {
             let mut config = self.ctx.config.write();
             config.ensure_map_key_for_path(&req.prop);
@@ -2213,10 +2225,76 @@ impl RpcDispatcher {
                 .map_err(|e| rpc_err(INTERNAL_ERROR, format!("Config set failed: {e}")))?;
         }
         self.flush_config().await?;
+        if let Some(model_provider_ref) = refresh_model_provider_ref {
+            self.refresh_live_sessions_for_model_provider(&model_provider_ref)
+                .await;
+        }
         to_result(ConfigSetResult {
             prop: req.prop,
             set: true,
         })
+    }
+
+    async fn refresh_live_sessions_for_model_provider(&self, model_provider_ref: &str) {
+        let session_ids = self.ctx.sessions.list_ids().await;
+        for session_id in session_ids {
+            let Some(agent_alias) = self.ctx.sessions.get_agent_alias(&session_id).await else {
+                continue;
+            };
+            let Some(overrides) = self.ctx.sessions.get_overrides(&session_id).await else {
+                continue;
+            };
+            let uses_provider = {
+                let config = self.ctx.config.read();
+                let effective_ref = overrides.model_provider.as_deref().or_else(|| {
+                    config
+                        .agent(&agent_alias)
+                        .map(|agent| agent.model_provider.as_str())
+                });
+                effective_ref == Some(model_provider_ref)
+            };
+            if !uses_provider {
+                continue;
+            }
+
+            let (model_provider, model_provider_name, model_name) = {
+                let config = self.ctx.config.read();
+                match crate::agent::agent::build_session_model_provider(
+                    &config,
+                    model_provider_ref,
+                    overrides.model.as_deref(),
+                ) {
+                    Ok(built) => built,
+                    Err(e) => {
+                        ::zeroclaw_log::record!(
+                            WARN,
+                            ::zeroclaw_log::Event::new(
+                                module_path!(),
+                                ::zeroclaw_log::Action::Note
+                            )
+                            .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                            .with_attrs(::serde_json::json!({
+                                "session_id": session_id,
+                                "agent_alias": agent_alias,
+                                "model_provider": model_provider_ref,
+                                "error": e.to_string(),
+                            })),
+                            "config/set saved provider profile but live session refresh failed"
+                        );
+                        continue;
+                    }
+                }
+            };
+            if self
+                .ctx
+                .sessions
+                .apply_model_provider(&session_id, model_provider, model_provider_name)
+                .await
+                && let Some(agent) = self.ctx.sessions.get_agent(&session_id).await
+            {
+                agent.lock().await.set_model_name(model_name);
+            }
+        }
     }
 
     fn handle_config_validate(&self) -> RpcResult {
@@ -4057,6 +4135,142 @@ mod tests {
             .get("default")
             .and_then(|e| e.base.model.clone());
         assert_eq!(stored.as_deref(), Some("claude-sonnet-4-5"));
+    }
+
+    fn make_model_refresh_test_config(tmp: &tempfile::TempDir) -> zeroclaw_config::schema::Config {
+        use std::collections::HashMap;
+        use zeroclaw_config::schema::{AliasedAgentConfig, Config, RiskProfileConfig};
+
+        let workspace_dir = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace_dir).unwrap();
+
+        let mut config = Config {
+            config_path: tmp.path().join("config.toml"),
+            data_dir: tmp.path().join("data"),
+            ..Default::default()
+        };
+        let provider = config
+            .providers
+            .models
+            .ensure("openai", "test-provider")
+            .expect("openai provider slot exists");
+        provider.api_key = Some("test-key".into());
+        provider.uri = Some("http://127.0.0.1:1".into());
+        provider.model = Some("old-model".into());
+
+        config.agents = HashMap::from([(
+            "test-agent".to_string(),
+            AliasedAgentConfig {
+                enabled: true,
+                model_provider: "openai.test-provider".into(),
+                risk_profile: "test-profile".into(),
+                ..Default::default()
+            },
+        )]);
+        config
+            .risk_profiles
+            .insert("test-profile".into(), RiskProfileConfig::default());
+        config
+            .runtime_profiles
+            .insert("default".into(), Default::default());
+        config
+    }
+
+    async fn create_model_refresh_test_session(
+        dispatcher: &RpcDispatcher,
+        tmp: &tempfile::TempDir,
+    ) -> String {
+        let session_res = dispatcher
+            .handle_session_new_for_test(&json!({
+                "agent_alias": "test-agent",
+                "cwd": tmp.path().join("workspace"),
+            }))
+            .await
+            .expect("session/new should create the agent");
+        session_res
+            .get("session_id")
+            .and_then(|v| v.as_str())
+            .expect("session/new result includes session_id")
+            .to_string()
+    }
+
+    async fn model_name_for_session(dispatcher: &RpcDispatcher, session_id: &str) -> String {
+        let agent = dispatcher
+            .ctx
+            .sessions
+            .get_agent(session_id)
+            .await
+            .expect("session agent exists");
+        agent.lock().await.attribution_fields().2
+    }
+
+    #[tokio::test]
+    async fn config_set_provider_model_refreshes_matching_live_session() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dispatcher = make_config_set_test_dispatcher(make_model_refresh_test_config(&tmp));
+        let session_id = create_model_refresh_test_session(&dispatcher, &tmp).await;
+        assert_eq!(
+            model_name_for_session(&dispatcher, &session_id).await,
+            "old-model"
+        );
+
+        let res = dispatcher
+            .handle_config_set(&json!({
+                "prop": "providers.models.openai.test-provider.model",
+                "value": "new-model"
+            }))
+            .await;
+        assert!(res.is_ok(), "config/set must succeed: {res:?}");
+
+        let agent = dispatcher
+            .ctx
+            .sessions
+            .get_agent(&session_id)
+            .await
+            .expect("session agent still exists");
+        assert_eq!(
+            agent.lock().await.attribution_fields().2,
+            "new-model",
+            "config/set must refresh active sessions using the edited provider profile"
+        );
+    }
+
+    #[tokio::test]
+    async fn config_set_provider_refresh_failure_does_not_fail_saved_write() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dispatcher = make_config_set_test_dispatcher(make_model_refresh_test_config(&tmp));
+        let session_id = create_model_refresh_test_session(&dispatcher, &tmp).await;
+        assert_eq!(
+            model_name_for_session(&dispatcher, &session_id).await,
+            "old-model"
+        );
+
+        let res = dispatcher
+            .handle_config_set(&json!({
+                "prop": "providers.models.openai.test-provider.model",
+                "value": ""
+            }))
+            .await;
+        assert!(
+            res.is_ok(),
+            "config/set must report the saved write even if live refresh cannot rebuild: {res:?}"
+        );
+        let cfg = dispatcher.ctx.config.read().clone();
+        let stored = cfg
+            .providers
+            .models
+            .openai
+            .get("test-provider")
+            .and_then(|e| e.base.model.clone());
+        assert_eq!(
+            stored, None,
+            "config/set must still persist the requested provider-profile clear"
+        );
+        assert_eq!(
+            model_name_for_session(&dispatcher, &session_id).await,
+            "old-model",
+            "failed live refresh must leave the existing session provider intact"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/crates/zeroclaw-runtime/src/rpc/dispatch.rs
+++ b/crates/zeroclaw-runtime/src/rpc/dispatch.rs
@@ -2226,8 +2226,7 @@ impl RpcDispatcher {
         }
         self.flush_config().await?;
         if let Some(model_provider_ref) = refresh_model_provider_ref {
-            self.refresh_live_sessions_for_model_provider(&model_provider_ref)
-                .await;
+            self.schedule_live_sessions_refresh_for_model_provider(model_provider_ref);
         }
         to_result(ConfigSetResult {
             prop: req.prop,
@@ -2235,17 +2234,27 @@ impl RpcDispatcher {
         })
     }
 
-    async fn refresh_live_sessions_for_model_provider(&self, model_provider_ref: &str) {
-        let session_ids = self.ctx.sessions.list_ids().await;
+    fn schedule_live_sessions_refresh_for_model_provider(&self, model_provider_ref: String) {
+        let ctx = Arc::clone(&self.ctx);
+        zeroclaw_spawn::spawn!(async move {
+            Self::refresh_live_sessions_for_model_provider(ctx, &model_provider_ref).await;
+        });
+    }
+
+    async fn refresh_live_sessions_for_model_provider(
+        ctx: Arc<RpcContext>,
+        model_provider_ref: &str,
+    ) {
+        let session_ids = ctx.sessions.list_ids().await;
         for session_id in session_ids {
-            let Some(agent_alias) = self.ctx.sessions.get_agent_alias(&session_id).await else {
+            let Some(agent_alias) = ctx.sessions.get_agent_alias(&session_id).await else {
                 continue;
             };
-            let Some(overrides) = self.ctx.sessions.get_overrides(&session_id).await else {
+            let Some(overrides) = ctx.sessions.get_overrides(&session_id).await else {
                 continue;
             };
             let uses_provider = {
-                let config = self.ctx.config.read();
+                let config = ctx.config.read();
                 let effective_ref = overrides.model_provider.as_deref().or_else(|| {
                     config
                         .agent(&agent_alias)
@@ -2257,14 +2266,28 @@ impl RpcDispatcher {
                 continue;
             }
 
-            let (model_provider, model_provider_name, model_name) = {
-                let config = self.ctx.config.read();
+            let (model_provider, model_provider_name, model_name, temperature) = {
+                let config = ctx.config.read();
+                let provider_temperature = model_provider_ref.split_once('.').and_then(
+                    |(provider_type, provider_alias)| {
+                        config
+                            .providers
+                            .models
+                            .find(provider_type, provider_alias)
+                            .and_then(|entry| entry.temperature)
+                    },
+                );
                 match crate::agent::agent::build_session_model_provider(
                     &config,
                     model_provider_ref,
                     overrides.model.as_deref(),
                 ) {
-                    Ok(built) => built,
+                    Ok((model_provider, model_provider_name, model_name)) => (
+                        model_provider,
+                        model_provider_name,
+                        model_name,
+                        overrides.temperature.or(provider_temperature),
+                    ),
                     Err(e) => {
                         ::zeroclaw_log::record!(
                             WARN,
@@ -2285,14 +2308,15 @@ impl RpcDispatcher {
                     }
                 }
             };
-            if self
-                .ctx
+            if ctx
                 .sessions
                 .apply_model_provider(&session_id, model_provider, model_provider_name)
                 .await
-                && let Some(agent) = self.ctx.sessions.get_agent(&session_id).await
+                && let Some(agent) = ctx.sessions.get_agent(&session_id).await
             {
-                agent.lock().await.set_model_name(model_name);
+                let mut agent = agent.lock().await;
+                agent.set_model_name(model_name);
+                agent.set_temperature(temperature);
             }
         }
     }
@@ -2348,6 +2372,7 @@ impl RpcDispatcher {
 
     async fn handle_config_delete(&self, params: &Value) -> RpcResult {
         let req: ConfigDeleteParams = parse_params(params)?;
+        let refresh_model_provider_ref = model_provider_ref_from_provider_profile_prop(&req.prop);
         {
             let mut config = self.ctx.config.write();
             config
@@ -2355,6 +2380,9 @@ impl RpcDispatcher {
                 .map_err(|e| rpc_err(INTERNAL_ERROR, format!("Config delete failed: {e}")))?;
         }
         self.flush_config().await?;
+        if let Some(model_provider_ref) = refresh_model_provider_ref {
+            self.schedule_live_sessions_refresh_for_model_provider(model_provider_ref);
+        }
         to_result(ConfigDeleteResult {
             prop: req.prop,
             deleted: true,
@@ -4157,6 +4185,7 @@ mod tests {
         provider.api_key = Some("test-key".into());
         provider.uri = Some("http://127.0.0.1:1".into());
         provider.model = Some("old-model".into());
+        provider.temperature = Some(0.2);
 
         config.agents = HashMap::from([(
             "test-agent".to_string(),
@@ -4204,6 +4233,46 @@ mod tests {
         agent.lock().await.attribution_fields().2
     }
 
+    async fn temperature_for_session(dispatcher: &RpcDispatcher, session_id: &str) -> Option<f64> {
+        let agent = dispatcher
+            .ctx
+            .sessions
+            .get_agent(session_id)
+            .await
+            .expect("session agent exists");
+        agent.lock().await.temperature_for_test()
+    }
+
+    async fn wait_for_model_name(dispatcher: &RpcDispatcher, session_id: &str, expected: &str) {
+        for _ in 0..50 {
+            if model_name_for_session(dispatcher, session_id).await == expected {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert_eq!(
+            model_name_for_session(dispatcher, session_id).await,
+            expected
+        );
+    }
+
+    async fn wait_for_temperature(
+        dispatcher: &RpcDispatcher,
+        session_id: &str,
+        expected: Option<f64>,
+    ) {
+        for _ in 0..50 {
+            if temperature_for_session(dispatcher, session_id).await == expected {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert_eq!(
+            temperature_for_session(dispatcher, session_id).await,
+            expected
+        );
+    }
+
     #[tokio::test]
     async fn config_set_provider_model_refreshes_matching_live_session() {
         let tmp = tempfile::TempDir::new().unwrap();
@@ -4222,17 +4291,7 @@ mod tests {
             .await;
         assert!(res.is_ok(), "config/set must succeed: {res:?}");
 
-        let agent = dispatcher
-            .ctx
-            .sessions
-            .get_agent(&session_id)
-            .await
-            .expect("session agent still exists");
-        assert_eq!(
-            agent.lock().await.attribution_fields().2,
-            "new-model",
-            "config/set must refresh active sessions using the edited provider profile"
-        );
+        wait_for_model_name(&dispatcher, &session_id, "new-model").await;
     }
 
     #[tokio::test]
@@ -4271,6 +4330,82 @@ mod tests {
             "old-model",
             "failed live refresh must leave the existing session provider intact"
         );
+    }
+
+    #[tokio::test]
+    async fn config_set_provider_temperature_refreshes_matching_live_session() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dispatcher = make_config_set_test_dispatcher(make_model_refresh_test_config(&tmp));
+        let session_id = create_model_refresh_test_session(&dispatcher, &tmp).await;
+        assert_eq!(
+            temperature_for_session(&dispatcher, &session_id).await,
+            Some(0.2)
+        );
+
+        let res = dispatcher
+            .handle_config_set(&json!({
+                "prop": "providers.models.openai.test-provider.temperature",
+                "value": 0.4
+            }))
+            .await;
+        assert!(res.is_ok(), "config/set must succeed: {res:?}");
+
+        wait_for_temperature(&dispatcher, &session_id, Some(0.4)).await;
+    }
+
+    #[tokio::test]
+    async fn config_set_provider_refresh_preserves_session_temperature_override() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dispatcher = make_config_set_test_dispatcher(make_model_refresh_test_config(&tmp));
+        let session_id = create_model_refresh_test_session(&dispatcher, &tmp).await;
+        let merged = dispatcher
+            .ctx
+            .sessions
+            .set_overrides(
+                &session_id,
+                crate::rpc::session::SessionOverrides {
+                    temperature: Some(0.6),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("session override applies");
+        assert_eq!(merged.temperature, Some(0.6));
+
+        let res = dispatcher
+            .handle_config_set(&json!({
+                "prop": "providers.models.openai.test-provider.model",
+                "value": "new-model"
+            }))
+            .await;
+        assert!(res.is_ok(), "config/set must succeed: {res:?}");
+
+        wait_for_model_name(&dispatcher, &session_id, "new-model").await;
+        assert_eq!(
+            temperature_for_session(&dispatcher, &session_id).await,
+            Some(0.6),
+            "session temperature override must win over provider profile temperature"
+        );
+    }
+
+    #[tokio::test]
+    async fn config_delete_provider_temperature_refreshes_matching_live_session() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dispatcher = make_config_set_test_dispatcher(make_model_refresh_test_config(&tmp));
+        let session_id = create_model_refresh_test_session(&dispatcher, &tmp).await;
+        assert_eq!(
+            temperature_for_session(&dispatcher, &session_id).await,
+            Some(0.2)
+        );
+
+        let res = dispatcher
+            .handle_config_delete(&json!({
+                "prop": "providers.models.openai.test-provider.temperature",
+            }))
+            .await;
+        assert!(res.is_ok(), "config/delete must succeed: {res:?}");
+
+        wait_for_temperature(&dispatcher, &session_id, None).await;
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Refresh live sessions after provider profile edits under `providers.models.<family>.<alias>.*`.
  - Reuse the existing session provider rebuild path so active sessions get the same provider wiring as a fresh session.
  - Schedule the live refresh as best-effort background work after the config save, so `config/set` and `config/delete` can return without waiting behind an active turn's agent lock.
  - Refresh the live model name and effective temperature. Session temperature overrides still win over provider profile temperature.
  - Add regression coverage for successful refresh, refresh failure after a saved write, temperature refresh, session-override precedence, and provider-profile delete refresh.
- **Scope boundary:** This does not add a zerocode picker or title-click model switch UI. It only makes saved provider-profile config edits propagate to already-open sessions when those sessions can be rebuilt safely.
- **Blast radius:** `config/set` and `config/delete` for model provider profiles now schedule a scan of active sessions and may rebuild matching live provider boxes. Non-provider config edits are unchanged. Failed rebuilds leave the existing live session intact and log a warning.
- **Linked issue(s):** Closes #7395
- **Labels:** `bug`, `risk: high`, `size: M`, `agent`, `runtime`

## Validation Evidence (required)

- **Commands run and tail output:**
  - `cargo test -p zeroclaw-runtime config_set -- --nocapture` - passed: 7 tests passed, 0 failed.
  - `cargo test -p zeroclaw-runtime config_delete_provider_temperature_refreshes_matching_live_session -- --nocapture` - passed: 1 test passed, 0 failed.
  - `cargo fmt -p zeroclaw-runtime -- --check` - passed.
  - `cargo clippy -p zeroclaw-runtime --all-targets -- -D warnings` - passed.
  - `git diff --check` - passed.
  - `zc-cargo-broad --lane workspace-check clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings` - passed; the broad workspace-check timing log records a successful run for this branch after the final pushed commit.
- **Beyond CI - what did you manually verify?** The regression tests create an active session using `openai.test-provider`, update that provider profile through `config/set`, and verify the live agent refreshes from `old-model` to `new-model`. They also verify provider temperature edits reach the live session, session temperature overrides remain authoritative, refresh failures do not fail the saved config write, and `config/delete` refreshes a cleared provider temperature.
- **If any command was intentionally skipped, why:** CI-shaped local `nextest` was attempted after the final push, but no usable local passing result is available to cite. The current GitHub Quality Gate `Test` job is green on this head, so this PR relies on GitHub CI for full-workspace test coverage while citing focused runtime tests and broad local clippy as local evidence.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: Not applicable.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: Existing configs, CLI calls, and environment variables do not need migration.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert 9ac4fa02ef3126c09d2c0e973419f7573bfce7b3 de5040f262588f54b56264be616341721588cb2b`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** After a provider-profile config save or delete, active sessions using that provider may fail to pick up the new provider wiring, model name, or effective temperature. Logs may show `config/set saved provider profile but live session refresh failed` when the saved config cannot build a valid provider for an active session.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): Not applicable.
- Scope materially carried forward: Not applicable.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why: No superseded PR or incorporated contributor work.
