### PR TITLE
ci(docker): add no-push PR image smoke

### DIFF
--- a/.github/workflows/docker-image-pr.yml
+++ b/.github/workflows/docker-image-pr.yml
@@ -1,0 +1,35 @@
+name: Docker Image PR Check
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - Dockerfile.ci
+      - Dockerfile.debian.ci
+      - .github/workflows/docker-image-pr.yml
+      - .github/workflows/release-stable-manual.yml
+      - scripts/ci/prepare_docker_context.sh
+
+concurrency:
+  group: docker-image-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  images:
+    name: Docker Images Build (no push)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Prepare Docker smoke context
+        run: bash scripts/ci/prepare_docker_context.sh smoke docker-ctx
+
+      - name: Build default image
+        run: docker build -f docker-ctx/Dockerfile -t zeroclaw-pr-default:smoke docker-ctx
+
+      - name: Build Debian compatibility image
+        run: docker build -f docker-ctx/Dockerfile.debian -t zeroclaw-pr-debian:smoke docker-ctx

--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -551,27 +551,7 @@ jobs:
           path: artifacts/
 
       - name: Prepare Docker context with pre-built binaries
-        run: |
-          mkdir -p docker-ctx/bin/amd64 docker-ctx/bin/arm64
-          tar xzf artifacts/zeroclaw-x86_64-unknown-linux-gnu.tar.gz -C docker-ctx/bin/amd64
-          tar xzf artifacts/zeroclaw-aarch64-unknown-linux-gnu.tar.gz -C docker-ctx/bin/arm64
-
-          mkdir -p docker-ctx/zeroclaw-data/.zeroclaw docker-ctx/zeroclaw-data/data
-          printf '%s\n' \
-            'api_key = ""' \
-            'default_provider = "openrouter"' \
-            'default_model = "anthropic/claude-sonnet-4-20250514"' \
-            'default_temperature = 0.7' \
-            '' \
-            '[gateway]' \
-            'port = 42617' \
-            'host = "[::]"' \
-            'allow_public_bind = true' \
-            'web_dist_dir = "/usr/share/zeroclawlabs/web/dist"' \
-            > docker-ctx/zeroclaw-data/.zeroclaw/config.toml
-
-          cp Dockerfile.ci docker-ctx/Dockerfile
-          cp Dockerfile.debian.ci docker-ctx/Dockerfile.debian
+        run: bash scripts/ci/prepare_docker_context.sh from-artifacts docker-ctx artifacts
 
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 

--- a/docs/book/src/maintainers/ci-and-actions.md
+++ b/docs/book/src/maintainers/ci-and-actions.md
@@ -27,6 +27,10 @@ Runs `cargo audit` nightly against the dependency tree. Opens an issue on findin
 
 Auto-applies scope and risk labels based on changed file paths. Runs silently on every PR — if a PR is missing labels, check whether the paths in `.github/labeler.yml` cover the changes.
 
+### Docker Image PR Check (`docker-image-pr.yml`)
+
+Runs only when Docker image or release-Docker context files change. It prepares a smoke `docker-ctx` with the same helper used by the stable release workflow, then builds the default and Debian compatibility images without pushing either image. This catches image dependency and `COPY` path breakage before release without giving PR runs registry write permission or running on every PR.
+
 ### Discord Release (`discord-release.yml`)
 
 Fires after a successful stable release. Posts the release notes to the community Discord.
@@ -104,9 +108,9 @@ The repository runs Actions in `selected` mode — only the actions in this allo
 | `dtolnay/rust-toolchain@stable` | All workflows | Install Rust toolchain |
 | `Swatinem/rust-cache@v2` | All workflows | Cargo build/dependency caching |
 | `softprops/action-gh-release@v2` | release | Create GitHub Releases |
-| `docker/setup-buildx-action@v3` | release | Docker Buildx setup |
+| `docker/setup-buildx-action@v4` | release | Docker Buildx setup |
 | `docker/login-action@v3` | release | GHCR authentication |
-| `docker/build-push-action@v6` | release | Multi-platform image build and push |
+| `docker/build-push-action@v7` | release | Multi-platform image build and push |
 
 Equivalent allowlist patterns (kept narrow on purpose):
 
@@ -132,6 +136,7 @@ Any PR that adds or changes a `uses:` action source must include an allowlist im
 - Keep `CI Required Gate` deterministic and small. Adding jobs to the gate needs a clear quality argument.
 - All third-party action refs must be pinned to a full commit SHA (per the allowlist policy above).
 - Keep `ci.yml`, `dev/ci.sh`, and `.githooks/pre-push` aligned — the same quality gates run locally and in CI.
+- Keep `scripts/ci/prepare_docker_context.sh`, `docker-image-pr.yml`, and the Docker job in `release-stable-manual.yml` aligned so PR validation exercises the same context shape the release workflow publishes.
 - `docs-quality` checks are not in the required gate. Run them locally with `bash scripts/ci/docs_quality_gate.sh`.
 
 ## Emergency rollback

--- a/scripts/ci/prepare_docker_context.sh
+++ b/scripts/ci/prepare_docker_context.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Prepare the release Docker build context used by CI and release workflows.
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+usage:
+  prepare_docker_context.sh from-artifacts <context-dir> <artifact-dir>
+  prepare_docker_context.sh smoke <context-dir>
+
+Modes:
+  from-artifacts  Extract release tarballs into the Docker context.
+  smoke           Create minimal executable/web placeholders for no-push PR builds.
+USAGE
+}
+
+mode="${1:-}"
+context_dir="${2:-docker-ctx}"
+artifact_dir="${3:-artifacts}"
+
+if [[ "$mode" != "from-artifacts" && "$mode" != "smoke" ]]; then
+  usage
+  exit 64
+fi
+
+mkdir -p \
+  "$context_dir/bin/amd64" \
+  "$context_dir/bin/arm64" \
+  "$context_dir/zeroclaw-data/.zeroclaw" \
+  "$context_dir/zeroclaw-data/data"
+
+case "$mode" in
+  from-artifacts)
+    tar xzf "$artifact_dir/zeroclaw-x86_64-unknown-linux-gnu.tar.gz" -C "$context_dir/bin/amd64"
+    tar xzf "$artifact_dir/zeroclaw-aarch64-unknown-linux-gnu.tar.gz" -C "$context_dir/bin/arm64"
+    for arch in amd64 arm64; do
+      [[ -x "$context_dir/bin/$arch/zeroclaw" ]] || {
+        echo "missing executable: $context_dir/bin/$arch/zeroclaw" >&2
+        exit 1
+      }
+      [[ -f "$context_dir/bin/$arch/web/dist/index.html" ]] || {
+        echo "missing dashboard bundle: $context_dir/bin/$arch/web/dist/index.html" >&2
+        exit 1
+      }
+    done
+    ;;
+  smoke)
+    for arch in amd64 arm64; do
+      mkdir -p "$context_dir/bin/$arch/web/dist"
+      cat > "$context_dir/bin/$arch/zeroclaw" <<'EOF'
+#!/usr/bin/env sh
+echo "zeroclaw smoke binary"
+EOF
+      chmod +x "$context_dir/bin/$arch/zeroclaw"
+      printf '<!doctype html><title>ZeroClaw smoke dashboard</title>\n' \
+        > "$context_dir/bin/$arch/web/dist/index.html"
+    done
+    ;;
+esac
+
+printf '%s\n' \
+  'api_key = ""' \
+  'default_provider = "openrouter"' \
+  'default_model = "anthropic/claude-sonnet-4-20250514"' \
+  'default_temperature = 0.7' \
+  '' \
+  '[gateway]' \
+  'port = 42617' \
+  'host = "[::]"' \
+  'allow_public_bind = true' \
+  'web_dist_dir = "/usr/share/zeroclawlabs/web/dist"' \
+  > "$context_dir/zeroclaw-data/.zeroclaw/config.toml"
+
+cp Dockerfile.ci "$context_dir/Dockerfile"
+cp Dockerfile.debian.ci "$context_dir/Dockerfile.debian"


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Adds `Docker Image PR Check`, a path-filtered pull-request workflow for Docker/release image surfaces.
  - Builds both the default and Debian CI images with `docker build` and no push, so PRs can catch image dependency and `COPY` path failures before release.
  - Moves release Docker context preparation into `scripts/ci/prepare_docker_context.sh` so the release workflow and PR smoke path share one context shape.
  - Documents the new PR image gate and runner-cost boundary in the maintainer CI/actions guide.
- **Scope boundary:** This does not add registry publishing from pull requests, widen the gate to every PR, change public image tags, change release credentials, or address the separate full Docker image variant tracked by #3642.
- **Blast radius:** GitHub Actions Docker/release validation, Docker context preparation for the stable release workflow, and maintainer CI documentation. Runtime behavior and shipped Rust code are unchanged.
- **Linked issue(s):** Closes #5908.
- **Labels:** `enhancement`, `type: ci`, `risk: high`, `size: S`, `ci`, `docs`, `scripts`.

## Validation Evidence (required)

- **Commands run and tail output:**
  - `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "ok #{path}" }' .github/workflows/docker-image-pr.yml .github/workflows/release-stable-manual.yml` — passed:
    - `ok .github/workflows/docker-image-pr.yml`
    - `ok .github/workflows/release-stable-manual.yml`
  - `bash -n scripts/ci/prepare_docker_context.sh` — passed with no output.
  - `rg -n "uses: [^@]+@(v[0-9]+|main|master|latest)(\\s|$)" .github/workflows/docker-image-pr.yml .github/workflows/release-stable-manual.yml` — no output; no mutable action refs found.
  - `git diff --check` — passed with no output.
  - `bash scripts/ci/prepare_docker_context.sh smoke docker-ctx` — passed with no output; created executable smoke binaries and dashboard bundles for both architectures.
  - `bash scripts/ci/prepare_docker_context.sh from-artifacts docker-ctx artifacts` with fake release tarballs containing executable `zeroclaw` binaries and `web/dist/index.html` bundles — passed with no output.
  - `bash scripts/ci/prepare_docker_context.sh from-artifacts docker-ctx artifacts` with an amd64 tarball missing `web/dist/index.html` — failed as expected:
    - `missing dashboard bundle: docker-ctx/bin/amd64/web/dist/index.html`
  - `BASE_SHA=none DOCS_FILES='docs/book/src/maintainers/ci-and-actions.md' bash scripts/ci/docs_quality_gate.sh` — passed:
    - `Summary: 0 error(s)`
  - `docker info --format '{{.ServerVersion}}'` — passed:
    - `27.4.0`
  - `docker build -f docker-ctx/Dockerfile -t zeroclaw-pr-default:smoke docker-ctx` — passed; the image was created locally with no push.
  - `docker build -f docker-ctx/Dockerfile.debian -t zeroclaw-pr-debian:smoke docker-ctx` — passed; the image was created locally with no push.
- **Beyond CI — what did you manually verify?** The shared context helper rejects missing dashboard bundles in artifact mode, which protects the release workflow from silently building an image without the web assets. The local no-push Docker builds exercised the generated context through both default and Debian Dockerfiles.
- **If any command was intentionally skipped, why:** The Rust cargo suite was not run because this PR does not change Rust source, Cargo manifests, runtime behavior, or generated Rust artifacts. Validation focused on the changed workflow, shell helper, docs, artifact-shape checks, and real Docker builds.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `Yes`.
- New external network calls? `Yes`.
- Secrets / tokens / credentials handling changed? `No`.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`.
- If any `Yes`, describe the risk and mitigation: The new workflow adds a PR-side Docker build capability, but it runs with `contents: read`, does not log in to a registry, and does not push images. Docker builds may fetch base image layers and Debian package metadata; the path filter keeps that runner and network cost limited to Docker/release context changes. Release publishing remains outside this PR.

## Compatibility (required)

- Backward compatible? `Yes`.
- Config / env / CLI surface changed? `No`.
- If `No` or `Yes` to either: No user upgrade steps are required.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert cb0f525f1bb8b16a3bdad7a060c487b502c57fc1`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** `Docker Image PR Check / Docker Images Build (no push)` fails or times out on PRs that touch Docker/release context files; stable release Docker jobs fail during `Prepare Docker context from release artifacts` if the shared helper regresses.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): Not applicable.
- Scope materially carried forward: Not applicable.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`.
- If `No`, why (inspiration-only, no direct code/design carry-over): No superseded PR scope or contributor-authored patch was incorporated.
