### PR TITLE
fix(ci): complete runtime tool sub-label mappings

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -428,6 +428,13 @@
           - "src/tools/cron_run.rs"
           - "src/tools/cron_runs.rs"
           - "src/tools/cron_update.rs"
+          - "crates/zeroclaw-runtime/src/tools/cron_add.rs"
+          - "crates/zeroclaw-runtime/src/tools/cron_common.rs"
+          - "crates/zeroclaw-runtime/src/tools/cron_list.rs"
+          - "crates/zeroclaw-runtime/src/tools/cron_remove.rs"
+          - "crates/zeroclaw-runtime/src/tools/cron_run.rs"
+          - "crates/zeroclaw-runtime/src/tools/cron_runs.rs"
+          - "crates/zeroclaw-runtime/src/tools/cron_update.rs"
 
 "tool:file":
   - changed-files:
@@ -497,6 +504,11 @@
           - "src/tools/sop_execute.rs"
           - "src/tools/sop_list.rs"
           - "src/tools/sop_status.rs"
+          - "crates/zeroclaw-runtime/src/tools/sop_advance.rs"
+          - "crates/zeroclaw-runtime/src/tools/sop_approve.rs"
+          - "crates/zeroclaw-runtime/src/tools/sop_execute.rs"
+          - "crates/zeroclaw-runtime/src/tools/sop_list.rs"
+          - "crates/zeroclaw-runtime/src/tools/sop_status.rs"
 
 "tool:web":
   - changed-files:
@@ -515,6 +527,8 @@
       - any-glob-to-any-file:
           - "src/tools/security_ops.rs"
           - "src/tools/verifiable_intent.rs"
+          - "crates/zeroclaw-runtime/src/tools/security_ops.rs"
+          - "crates/zeroclaw-runtime/src/tools/verifiable_intent.rs"
 
 "tool:cloud":
   - changed-files:

--- a/docs/book/src/maintainers/labels.md
+++ b/docs/book/src/maintainers/labels.md
@@ -160,15 +160,15 @@ Tools are grouped by logical function rather than one label per file.
 | `tool:browser` | `browser.rs`, `browser_delegate.rs`, `browser_open.rs`, `text_browser.rs`, `screenshot.rs` |
 | `tool:cloud` | `cloud_ops.rs`, `cloud_patterns.rs` |
 | `tool:composio` | `composio.rs` |
-| `tool:cron` | `cron_add.rs`, `cron_list.rs`, `cron_remove.rs`, `cron_run.rs`, `cron_runs.rs`, `cron_update.rs` |
-| `tool:file` | `file_edit.rs`, `file_read.rs`, `file_write.rs`, `glob_search.rs`, `content_search.rs` |
+| `tool:cron` | `src/tools/cron_add.rs`, `src/tools/cron_list.rs`, `src/tools/cron_remove.rs`, `src/tools/cron_run.rs`, `src/tools/cron_runs.rs`, `src/tools/cron_update.rs`, `crates/zeroclaw-runtime/src/tools/cron_add.rs`, `crates/zeroclaw-runtime/src/tools/cron_common.rs`, `crates/zeroclaw-runtime/src/tools/cron_list.rs`, `crates/zeroclaw-runtime/src/tools/cron_remove.rs`, `crates/zeroclaw-runtime/src/tools/cron_run.rs`, `crates/zeroclaw-runtime/src/tools/cron_runs.rs`, `crates/zeroclaw-runtime/src/tools/cron_update.rs` |
+| `tool:file` | `src/tools/file_edit.rs`, `src/tools/file_read.rs`, `src/tools/file_write.rs`, `src/tools/glob_search.rs`, `src/tools/content_search.rs`, `crates/zeroclaw-tools/src/file_edit.rs`, `crates/zeroclaw-runtime/src/tools/file_read.rs`, `crates/zeroclaw-tools/src/file_write.rs`, `crates/zeroclaw-tools/src/glob_search.rs`, `crates/zeroclaw-tools/src/content_search.rs` |
 | `tool:google-workspace` | `google_workspace.rs` |
 | `tool:mcp` | `mcp_client.rs`, `mcp_deferred.rs`, `mcp_protocol.rs`, `mcp_tool.rs`, `mcp_transport.rs` |
 | `tool:memory` | `memory_forget.rs`, `memory_recall.rs`, `memory_store.rs` |
 | `tool:microsoft365` | `microsoft365/**` |
-| `tool:security` | `security_ops.rs`, `verifiable_intent.rs` |
-| `tool:shell` | `shell.rs`, `node_tool.rs`, `cli_discovery.rs` |
-| `tool:sop` | `sop_advance.rs`, `sop_approve.rs`, `sop_execute.rs`, `sop_list.rs`, `sop_status.rs` |
+| `tool:security` | `src/tools/security_ops.rs`, `src/tools/verifiable_intent.rs`, `crates/zeroclaw-runtime/src/tools/security_ops.rs`, `crates/zeroclaw-runtime/src/tools/verifiable_intent.rs` |
+| `tool:shell` | `src/tools/shell.rs`, `src/tools/node_tool.rs`, `src/tools/cli_discovery.rs`, `crates/zeroclaw-runtime/src/tools/shell.rs`, `crates/zeroclaw-gateway/src/node_tool.rs`, `crates/zeroclaw-tools/src/cli_discovery.rs` |
+| `tool:sop` | `src/tools/sop_advance.rs`, `src/tools/sop_approve.rs`, `src/tools/sop_execute.rs`, `src/tools/sop_list.rs`, `src/tools/sop_status.rs`, `crates/zeroclaw-runtime/src/tools/sop_advance.rs`, `crates/zeroclaw-runtime/src/tools/sop_approve.rs`, `crates/zeroclaw-runtime/src/tools/sop_execute.rs`, `crates/zeroclaw-runtime/src/tools/sop_list.rs`, `crates/zeroclaw-runtime/src/tools/sop_status.rs` |
 | `tool:web` | `web_fetch.rs`, `web_search_tool.rs`, `web_search_provider_routing.rs`, `http_request.rs` |
 
 ## Size labels


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Adds runtime crate paths for `tool:cron`, `tool:sop`, and `tool:security`.
  - Includes `crates/zeroclaw-runtime/src/tools/cron_common.rs` because it is shared cron-tool implementation.
  - Updates the maintainer label documentation so it matches the labeler file, including the file and shell mappings added by #7383.
  - Follows #7383 by applying the same crate-path pattern to the remaining runtime tool sub-label gaps.
- **Scope boundary:** This only updates label automation metadata and maintainer documentation. It does not change workflow triggers, workflow permissions, runtime code, or tool behavior.
- **Blast radius:** Limited to GitHub PR labels for future changes touching these tool files.
- **Linked issue(s):** Closes #7408. Follows #7383.
- **Labels:** `bug`, `ci`, `docs`, `tool`, `type: ci`, `risk: low`, `size: XS`

## Validation Evidence (required)

- **Commands run and tail output:**
  - `ruby -e 'require "yaml"; y=YAML.load_file(".github/labeler.yml"); wanted={"tool:cron"=>["crates/zeroclaw-runtime/src/tools/cron_add.rs","crates/zeroclaw-runtime/src/tools/cron_common.rs","crates/zeroclaw-runtime/src/tools/cron_list.rs","crates/zeroclaw-runtime/src/tools/cron_remove.rs","crates/zeroclaw-runtime/src/tools/cron_run.rs","crates/zeroclaw-runtime/src/tools/cron_runs.rs","crates/zeroclaw-runtime/src/tools/cron_update.rs"],"tool:sop"=>["crates/zeroclaw-runtime/src/tools/sop_advance.rs","crates/zeroclaw-runtime/src/tools/sop_approve.rs","crates/zeroclaw-runtime/src/tools/sop_execute.rs","crates/zeroclaw-runtime/src/tools/sop_list.rs","crates/zeroclaw-runtime/src/tools/sop_status.rs"],"tool:security"=>["crates/zeroclaw-runtime/src/tools/security_ops.rs","crates/zeroclaw-runtime/src/tools/verifiable_intent.rs"]}; wanted.each{|label,paths| globs=y.dig(label,0,"changed-files",0,"any-glob-to-any-file") || []; paths.each{|p| abort "#{label} missing #{p}" unless globs.include?(p)}}; puts "labeler yaml/mappings ok"'` passed:
    ```text
    labeler yaml/mappings ok
    ```
  - `git diff --check` passed with no output.
  - Format check for `cargo fmt --all -- --check` passed.
  - `git ls-files crates/zeroclaw-runtime/src/tools/cron_add.rs crates/zeroclaw-runtime/src/tools/cron_common.rs crates/zeroclaw-runtime/src/tools/cron_list.rs crates/zeroclaw-runtime/src/tools/cron_remove.rs crates/zeroclaw-runtime/src/tools/cron_run.rs crates/zeroclaw-runtime/src/tools/cron_runs.rs crates/zeroclaw-runtime/src/tools/cron_update.rs crates/zeroclaw-runtime/src/tools/sop_advance.rs crates/zeroclaw-runtime/src/tools/sop_approve.rs crates/zeroclaw-runtime/src/tools/sop_execute.rs crates/zeroclaw-runtime/src/tools/sop_list.rs crates/zeroclaw-runtime/src/tools/sop_status.rs crates/zeroclaw-runtime/src/tools/security_ops.rs crates/zeroclaw-runtime/src/tools/verifiable_intent.rs` passed and listed all fourteen expected files.
- **Beyond CI - what did you manually verify?** Reviewed the diff as a metadata-only labeler and maintainer-doc update, and included `cron_common.rs` because it is shared cron-tool implementation.
- **If any command was intentionally skipped, why:** Cargo validation was skipped because this PR only changes GitHub labeler metadata and maintainer documentation. Workflow execution was skipped because this does not change any workflow trigger or job.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: `N/A`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No upgrade steps required.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PR: `git revert <sha>` is the rollback plan.

Medium/high-risk fields are not applicable.

## Supersede Attribution (required only when `Supersedes #` is used)

Not applicable.
