### PR TITLE
fix(channels): telegram delivery prompt no longer discourages tool use (#6646)

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -708,7 +708,12 @@ fn channel_delivery_instructions(channel_name: &str) -> Option<&'static str> {
              - Structure longer answers with bold headers, not raw markdown ## headers\n\
              - For media attachments use markers: [IMAGE:<path-or-url>], [DOCUMENT:<path-or-url>], [VIDEO:<path-or-url>], [AUDIO:<path-or-url>], or [VOICE:<path-or-url>]\n\
              - Keep normal text outside markers and never wrap markers in code fences.\n\
-             - Use tool results silently: answer the latest user message directly, and do not narrate delayed/internal tool execution bookkeeping.",
+             - When a question needs current, real-time, or external information \
+               (prices, news, weather, web pages, lookups, etc.), use your tools — \
+               e.g. web_search_tool and web_fetch — to obtain it before answering; \
+               never guess or answer from memory alone when a tool can verify it.\n\
+             - Present the final answer to the latest user message directly from the \
+               tool results, without narrating delayed/internal tool-execution bookkeeping.",
         ),
         "qq" => Some(
             "When responding on QQ:\n\
@@ -16324,6 +16329,44 @@ BTC is currently around $65,000 based on latest tool output."#
         assert!(
             block.contains("[IMAGE:<absolute-path>]"),
             "discord block must show the absolute-path marker form"
+        );
+    }
+
+    // Regression guard for #6646: web_search_tool / web_fetch never fired via
+    // the Telegram channel because the delivery-instructions block told the
+    // model to "answer the latest user message directly" and to "use tool
+    // results silently". On a small OpenAI-compatible local model that reads as
+    // "answer from memory, do not call tools", so the agent hallucinated with
+    // zero tool activity — while the identical query worked via CLI and the web
+    // dashboard, which do not inject this Telegram-only block. The block must
+    // encourage tool use for real-time/external information and must not tell
+    // the model to answer directly *instead of* using tools.
+    #[test]
+    fn channel_delivery_instructions_for_telegram_encourage_tool_use() {
+        let block = channel_delivery_instructions("telegram")
+            .expect("telegram channel must have a delivery-instructions block");
+        assert!(
+            block.contains("When responding on Telegram:"),
+            "telegram block must identify itself"
+        );
+        // Positive: it must actively steer the model toward its tools for
+        // real-time/external information.
+        assert!(
+            block.contains("use your tools"),
+            "telegram block must instruct the model to use its tools"
+        );
+        assert!(
+            block.contains("web_search_tool") && block.contains("web_fetch"),
+            "telegram block must name the real-time tools so the model knows to reach for them"
+        );
+        assert!(
+            block.contains("never guess or answer from memory alone"),
+            "telegram block must forbid answering from memory when a tool can verify"
+        );
+        // Negative: the exact regressed phrasing must never come back.
+        assert!(
+            !block.contains("Use tool results silently: answer the latest user message directly"),
+            "telegram block must not tell the model to answer directly instead of using tools (#6646)"
         );
     }
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** The Telegram delivery-instructions block told the model to "use tool results silently" and to "answer the latest user message directly." On a smaller OpenAI-compatible model (the reporter runs qwen3 through LM Studio) that wording reads as "answer from what you already know, don't call tools." So over Telegram `web_search_tool` and `web_fetch` never fire, the agent makes up an answer, and nothing shows up in the logs. That block is injected only for Telegram, which is exactly why the same query works over the CLI and the web dashboard but fails here. I reworded it to keep the original point (don't narrate tool-execution bookkeeping) while making it explicit that the model should reach for `web_search_tool`/`web_fetch` when a question needs current or external data instead of guessing.
- **Why it's the prompt and not the tool plumbing:** I chased the plumbing first and ruled it out. The CLI and the channel both run through `run_tool_call_loop` and resolve to the same provider instance (`get_or_create_provider` hands back the cached `ctx.model_provider` for the default route), the streaming path captures native tool calls correctly (`consume_provider_streaming_response` handles `StreamEvent::ToolCall`), and `excluded_tools`, approval, and `strict_tool_parsing` all sit at defaults that leave tools enabled. A stock OpenAI-compatible provider is native (`native_tool_calling = !merge_system_into_user`), so the tools are sent on the wire. The only tool-relevant thing that differs for Telegram specifically is this instruction block.
- **Scope boundary:** Only the Telegram instruction string and a unit test that covers it. The tool dispatch loop, registry assembly, approval flow, provider layer, and the other channels' instruction blocks are untouched.
- **Blast radius:** Telegram system prompt only. It's one static `&'static str`, so there's no change to runtime, config, or any other channel's behavior.
- **Linked issue(s):** Related #6646 (prompt hardening; the issue stays open for reporter/maintainer re-verification on current `master` rather than auto-closing on merge)
- **Labels:** `bug`, `channel`, `channel:telegram`, `runtime`, `tool`, `tool: web_search_tool`, `tool: web_fetch`, `priority:p1`. The change itself is a one-line prompt edit plus a test, so `risk: low` / `size: S` fit better than the issue's original `risk: high`.

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
# clean, no output

cargo clippy -p zeroclaw-channels --all-targets -- -D warnings
# Finished `dev` profile ... in 54.33s, no warnings

cargo test -p zeroclaw-channels --lib
# test result: ok. 715 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out
# includes channel_delivery_instructions_for_telegram_encourage_tool_use ... ok
```

- **Commands run and tail output:** above. `fmt` ran across the whole workspace; clippy and tests are scoped to `zeroclaw-channels` since that's the only crate touched and the new test lives there.
- **Beyond CI — what did you manually verify?** The new test fails against the old string (both the positive checks and the guard against the old phrasing) and passes after the edit, so it's a real two-way regression guard rather than a tautology.
- **If any command was intentionally skipped, why:** I did not re-run the full-workspace clippy/test, since nothing outside `zeroclaw-channels` changed. The one thing I could not verify locally is the end-to-end behavior on a live Telegram + LM Studio/qwen3 setup. The last link (this wording causes this model to skip tools) is model behavior, not something a unit test can prove, so a live smoke check on the reporter's config is the right way to close it out.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Upgrade steps: none. The new wording takes effect the next time the daemon starts.

## Rollback (required for `risk: medium` and `risk: high`)

Low risk, so `git revert <sha>` is the plan.

