### PR TITLE
fix(runtime): make parallel SubAgents and Delegates return reliably

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -2493,7 +2493,8 @@ pub async fn run_tool_call_loop(
                     serde_json::to_string(&canonical_args).unwrap_or_else(|_| "{}".to_string());
                 (tool_name.trim().to_ascii_lowercase(), args_json)
             };
-            let dedup_exempt = dedup_exempt_tools.iter().any(|e| e == &tool_name);
+            let dedup_exempt = dedup_exempt_tools.iter().any(|e| e == &tool_name)
+                || crate::tools::REENTRANT_AGENT_TOOLS.contains(&tool_name.as_str());
             if !dedup_exempt && !seen_tool_signatures.insert(signature) {
                 let duplicate = format!(
                     "Skipped duplicate tool call '{tool_name}' with identical arguments in this turn."
@@ -2844,11 +2845,15 @@ pub async fn run_tool_call_loop(
                 history.push(ChatMessage::user(format!("[Tool results]\n{tool_results}")));
             }
         } else {
-            for (native_call, (_, result)) in
-                native_tool_calls.iter().zip(individual_results.iter())
-            {
+            // `zip` would drop trailing results on any length divergence,
+            // leaving a native tool_use id with no matching tool_result.
+            // Pair on each result's own id instead.
+            for (idx, (tool_call_id, result)) in individual_results.iter().enumerate() {
+                let resolved_id = tool_call_id
+                    .clone()
+                    .or_else(|| native_tool_calls.get(idx).map(|call| call.id.clone()));
                 let tool_msg = serde_json::json!({
-                    "tool_call_id": native_call.id,
+                    "tool_call_id": resolved_id,
                     "content": result,
                 });
                 history.push(ChatMessage::tool(tool_msg.to_string()));
@@ -5815,6 +5820,39 @@ mod tests {
             self.capabilities.native_tool_calling = true;
             self
         }
+
+        /// Build a native-tool-calling provider: one turn of structured
+        /// `tool_calls`, then a plain-text turn.
+        fn from_native_tool_calls(calls: Vec<(&str, &str, &str)>, final_text: &str) -> Self {
+            let tool_turn = ChatResponse {
+                text: None,
+                tool_calls: calls
+                    .into_iter()
+                    .map(|(id, name, args)| ToolCall {
+                        id: id.to_string(),
+                        name: name.to_string(),
+                        arguments: args.to_string(),
+                        extra_content: None,
+                    })
+                    .collect(),
+                usage: None,
+                reasoning_content: None,
+            };
+            let final_turn = ChatResponse {
+                text: Some(final_text.to_string()),
+                tool_calls: Vec::new(),
+                usage: None,
+                reasoning_content: None,
+            };
+            let capabilities = ProviderCapabilities {
+                native_tool_calling: true,
+                ..ProviderCapabilities::default()
+            };
+            Self {
+                responses: Arc::new(Mutex::new(VecDeque::from(vec![tool_turn, final_turn]))),
+                capabilities,
+            }
+        }
     }
 
     #[async_trait]
@@ -7162,6 +7200,112 @@ mod tests {
         );
     }
 
+    /// Regression: a native provider emitting multiple parallel tool calls
+    /// in one turn must yield one role=tool message per call, each keyed to
+    /// its own tool_call_id and output.
+    #[tokio::test]
+    async fn run_tool_call_loop_native_emits_tool_message_per_parallel_call() {
+        let model_provider = ScriptedModelProvider::from_native_tool_calls(
+            vec![
+                ("call_a", "delay_a", r#"{"value":"A"}"#),
+                ("call_b", "delay_b", r#"{"value":"B"}"#),
+                ("call_c", "delay_c", r#"{"value":"C"}"#),
+            ],
+            "done",
+        );
+
+        let active = Arc::new(AtomicUsize::new(0));
+        let max_active = Arc::new(AtomicUsize::new(0));
+        let tools_registry: Vec<Box<dyn Tool>> = vec![
+            Box::new(DelayTool::new(
+                "delay_a",
+                10,
+                Arc::clone(&active),
+                Arc::clone(&max_active),
+            )),
+            Box::new(DelayTool::new(
+                "delay_b",
+                10,
+                Arc::clone(&active),
+                Arc::clone(&max_active),
+            )),
+            Box::new(DelayTool::new(
+                "delay_c",
+                10,
+                Arc::clone(&active),
+                Arc::clone(&max_active),
+            )),
+        ];
+
+        let approval_cfg = zeroclaw_config::schema::RiskProfileConfig {
+            level: crate::security::AutonomyLevel::Full,
+            ..zeroclaw_config::schema::RiskProfileConfig::default()
+        };
+        let approval_mgr = ApprovalManager::from_risk_profile(&approval_cfg);
+
+        let mut history = vec![
+            ChatMessage::system("test-system"),
+            ChatMessage::user("run three tool calls"),
+        ];
+        let observer = NoopObserver;
+
+        let result = run_tool_call_loop(
+            &model_provider,
+            &mut history,
+            &tools_registry,
+            &observer,
+            "mock-provider",
+            "mock-model",
+            Some(0.0),
+            true,
+            Some(&approval_mgr),
+            "telegram",
+            None,
+            &zeroclaw_config::schema::MultimodalConfig::default(),
+            4,
+            None,
+            None,
+            None,
+            &[],
+            &[],
+            None,
+            None,
+            &zeroclaw_config::schema::PacingConfig::default(),
+            false,
+            true, // parallel_tools
+            0,
+            0,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("native parallel execution should complete");
+
+        assert!(result.ends_with("done"), "got: {result}");
+
+        let tool_messages: Vec<&ChatMessage> =
+            history.iter().filter(|msg| msg.role == "tool").collect();
+        assert_eq!(
+            tool_messages.len(),
+            3,
+            "every parallel native call must yield its own role=tool message, got: {tool_messages:?}"
+        );
+
+        for (id, value) in [("call_a", "A"), ("call_b", "B"), ("call_c", "C")] {
+            let msg = tool_messages
+                .iter()
+                .find(|m| m.content.contains(id))
+                .unwrap_or_else(|| panic!("missing tool message for {id}: {tool_messages:?}"));
+            assert!(
+                msg.content.contains(&format!("ok:{value}")),
+                "tool_call_id {id} must carry its own output ok:{value}, got: {}",
+                msg.content
+            );
+        }
+    }
+
     #[tokio::test]
     async fn run_tool_call_loop_injects_channel_delivery_defaults_for_cron_add() {
         let model_provider = ScriptedModelProvider::from_text_responses(vec![
@@ -7531,6 +7675,75 @@ mod tests {
         assert!(
             !tool_results.content.contains("Skipped duplicate tool call"),
             "exempt tool calls should not be suppressed"
+        );
+    }
+
+    /// Identical-prompt calls to re-entrant agent tools (spawn_subagent /
+    /// delegate) must both run even with no config exemption — fan-out is
+    /// intentional, not a duplicate to collapse.
+    #[tokio::test]
+    async fn run_tool_call_loop_reentrant_agent_tools_are_dedup_exempt_by_default() {
+        let model_provider = ScriptedModelProvider::from_text_responses(vec![
+            r#"<tool_call>
+{"name":"spawn_subagent","arguments":{"prompt":"same"}}
+</tool_call>
+<tool_call>
+{"name":"spawn_subagent","arguments":{"prompt":"same"}}
+</tool_call>"#,
+            "done",
+        ]);
+
+        let invocations = Arc::new(AtomicUsize::new(0));
+        let tools_registry: Vec<Box<dyn Tool>> = vec![Box::new(CountingTool::new(
+            "spawn_subagent",
+            Arc::clone(&invocations),
+        ))];
+
+        let mut history = vec![
+            ChatMessage::system("test-system"),
+            ChatMessage::user("fan out two identical subagents"),
+        ];
+        let observer = NoopObserver;
+
+        let result = run_tool_call_loop(
+            &model_provider,
+            &mut history,
+            &tools_registry,
+            &observer,
+            "mock-provider",
+            "mock-model",
+            Some(0.0),
+            true,
+            None,
+            "cli",
+            None,
+            &zeroclaw_config::schema::MultimodalConfig::default(),
+            4,
+            None,
+            None,
+            None,
+            &[],
+            &[], // no config-provided dedup exemptions
+            None,
+            None,
+            &zeroclaw_config::schema::PacingConfig::default(),
+            false,
+            false,
+            0,
+            0,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("loop should finish running both identical subagent calls");
+
+        assert!(result.ends_with("done"), "got: {result}");
+        assert_eq!(
+            invocations.load(Ordering::SeqCst),
+            2,
+            "both identical spawn_subagent calls must execute"
         );
     }
 

--- a/crates/zeroclaw-runtime/src/tools/delegate.rs
+++ b/crates/zeroclaw-runtime/src/tools/delegate.rs
@@ -112,6 +112,10 @@ pub struct DelegateTool {
 }
 
 impl DelegateTool {
+    /// Canonical tool name. Referenced by `REENTRANT_AGENT_TOOLS` so a
+    /// rename cannot desync the two.
+    pub const NAME: &'static str = "delegate";
+
     pub fn new(
         agents: HashMap<String, AliasedAgentConfig>,
         global_credential: Option<String>,
@@ -550,7 +554,7 @@ impl DelegateTool {
 #[async_trait]
 impl Tool for DelegateTool {
     fn name(&self) -> &str {
-        "delegate"
+        Self::NAME
     }
 
     fn description(&self) -> &str {

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -541,7 +541,7 @@ pub fn all_tools_with_runtime(
             agent_alias,
         )),
         Arc::new(
-            SpawnSubagentTool::new(Arc::new(root_config.clone()), agent_alias)
+            SpawnSubagentTool::new(Arc::new(root_config.clone()), agent_alias, security.clone())
                 .with_subagent_caller(is_subagent_caller),
         ),
         Arc::new(SendMessageToPeerTool::new(

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -146,6 +146,12 @@ pub use sop_status::SopStatusTool;
 pub use spawn_subagent::SpawnSubagentTool;
 pub use verifiable_intent::VerifiableIntentTool;
 
+/// Re-entrant agent-spawning tools that must never be collapsed by the
+/// per-turn duplicate-call guard: launching several with the same prompt
+/// (redundancy, sampling, fan-out) is intentional, not an accidental
+/// repeat. Unioned with config-provided exemptions in the tool-call loop.
+pub const REENTRANT_AGENT_TOOLS: &[&str] = &[SpawnSubagentTool::NAME, DelegateTool::NAME];
+
 use crate::platform::{NativeRuntime, RuntimeAdapter};
 use crate::security::{SecurityPolicy, create_sandbox};
 use async_trait::async_trait;
@@ -560,6 +566,13 @@ pub fn all_tools_with_runtime(
         Arc::new(WeatherTool::new()),
         Arc::new(CanvasTool::new(canvas_store.unwrap_or_default())),
     ];
+
+    // A SubAgent runs as an ephemeral clone of its parent and inherits the
+    // parent's model verbatim; it must not be able to switch the active
+    // model out from under the parent (the switch signal is process-wide).
+    if is_subagent_caller {
+        tool_arcs.retain(|tool| tool.name() != ModelSwitchTool::NAME);
+    }
 
     // Register discord_search if any configured Discord alias has
     // archive enabled. Multiple Discord aliases are supported (one per
@@ -1703,5 +1716,55 @@ mod tests {
         .tools;
         let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
         assert!(!names.contains(&"read_skill"));
+    }
+
+    fn registry_names(tmp: &TempDir, is_subagent_caller: bool) -> Vec<String> {
+        let security = Arc::new(SecurityPolicy::default());
+        let mem_cfg = MemoryConfig {
+            backend: "markdown".into(),
+            ..MemoryConfig::default()
+        };
+        let mem: Arc<dyn Memory> =
+            Arc::from(zeroclaw_memory::create_memory(&mem_cfg, tmp.path(), None).unwrap());
+        let cfg = test_config(tmp);
+
+        all_tools(
+            Arc::new(cfg.clone()),
+            &security,
+            &zeroclaw_config::schema::RiskProfileConfig::default(),
+            "test-agent",
+            mem,
+            None,
+            None,
+            &BrowserConfig::default(),
+            &zeroclaw_config::schema::HttpRequestConfig::default(),
+            &zeroclaw_config::schema::WebFetchConfig::default(),
+            tmp.path(),
+            &HashMap::new(),
+            None,
+            &cfg,
+            None,
+            is_subagent_caller,
+            None,
+        )
+        .tools
+        .iter()
+        .map(|t| t.name().to_string())
+        .collect()
+    }
+
+    #[test]
+    fn model_switch_present_for_top_level_absent_for_subagent() {
+        let tmp = TempDir::new().unwrap();
+        let top = registry_names(&tmp, false);
+        assert!(
+            top.iter().any(|n| n == ModelSwitchTool::NAME),
+            "top-level agent must keep model_switch"
+        );
+        let subagent = registry_names(&tmp, true);
+        assert!(
+            !subagent.iter().any(|n| n == ModelSwitchTool::NAME),
+            "subagent must not be able to switch the inherited model"
+        );
     }
 }

--- a/crates/zeroclaw-runtime/src/tools/model_switch.rs
+++ b/crates/zeroclaw-runtime/src/tools/model_switch.rs
@@ -54,6 +54,10 @@ pub struct ModelSwitchTool {
 }
 
 impl ModelSwitchTool {
+    /// Canonical tool name. Referenced by the subagent registry filter so
+    /// a rename cannot desync the two.
+    pub const NAME: &'static str = "model_switch";
+
     pub fn new(security: Arc<SecurityPolicy>, config: Arc<Config>) -> Self {
         Self { security, config }
     }
@@ -62,7 +66,7 @@ impl ModelSwitchTool {
 #[async_trait]
 impl Tool for ModelSwitchTool {
     fn name(&self) -> &str {
-        "model_switch"
+        Self::NAME
     }
 
     fn description(&self) -> &str {

--- a/crates/zeroclaw-runtime/src/tools/spawn_subagent.rs
+++ b/crates/zeroclaw-runtime/src/tools/spawn_subagent.rs
@@ -28,6 +28,10 @@ pub struct SpawnSubagentTool {
 }
 
 impl SpawnSubagentTool {
+    /// Canonical tool name. Referenced by `REENTRANT_AGENT_TOOLS` so a
+    /// rename cannot desync the two.
+    pub const NAME: &'static str = "spawn_subagent";
+
     pub fn new(config: Arc<Config>, parent_alias: impl Into<String>) -> Self {
         Self {
             config,
@@ -49,7 +53,7 @@ impl SpawnSubagentTool {
 #[async_trait]
 impl Tool for SpawnSubagentTool {
     fn name(&self) -> &str {
-        "spawn_subagent"
+        Self::NAME
     }
 
     fn description(&self) -> &str {

--- a/crates/zeroclaw-runtime/src/tools/spawn_subagent.rs
+++ b/crates/zeroclaw-runtime/src/tools/spawn_subagent.rs
@@ -6,6 +6,8 @@
 //! tracing-span shape, and audit attribution stay uniform.
 
 use crate::agent::loop_::AgentRunOverrides;
+use crate::security::SecurityPolicy;
+use crate::security::policy::ToolOperation;
 use crate::subagent::{SubAgentOverrides, SubAgentSpawn};
 use anyhow::Result;
 use async_trait::async_trait;
@@ -20,6 +22,13 @@ use zeroclaw_log::scope;
 pub struct SpawnSubagentTool {
     config: Arc<Config>,
     parent_alias: String,
+    /// The caller's live policy (the same `Arc` the agent loop and the
+    /// other acting tools share). Each launch attempt consumes one slot
+    /// from its action budget via `enforce_tool_operation(Act, ..)`,
+    /// mirroring `DelegateTool`, so the dedup exemption for re-entrant
+    /// agent tools cannot turn one model turn into unbounded child
+    /// agent starts.
+    security: Arc<SecurityPolicy>,
     /// `true` when this tool is registered inside a run that is itself
     /// a SubAgent. Triggers a depth-1 cap refusal in `execute` before
     /// any spawn work happens. Set by the agent loop from
@@ -32,10 +41,15 @@ impl SpawnSubagentTool {
     /// rename cannot desync the two.
     pub const NAME: &'static str = "spawn_subagent";
 
-    pub fn new(config: Arc<Config>, parent_alias: impl Into<String>) -> Self {
+    pub fn new(
+        config: Arc<Config>,
+        parent_alias: impl Into<String>,
+        security: Arc<SecurityPolicy>,
+    ) -> Self {
         Self {
             config,
             parent_alias: parent_alias.into(),
+            security,
             is_subagent_caller: false,
         }
     }
@@ -139,6 +153,26 @@ impl Tool for SpawnSubagentTool {
             }
         };
 
+        // Launch-side budget gate: every spawn attempt past validation
+        // consumes one slot from the caller's shared action budget,
+        // mirroring DelegateTool (which validates target + depth, then
+        // calls enforce_tool_operation before spawning). The re-entrant
+        // dedup exemption means identical calls are not collapsed
+        // per-turn, so without this gate a single model turn could
+        // request unbounded child launches; with it, fan-out is bounded
+        // by `max_actions_per_hour` at launch time, not merely by work
+        // performed downstream.
+        if let Err(error) = self
+            .security
+            .enforce_tool_operation(ToolOperation::Act, Self::NAME)
+        {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(error),
+            });
+        }
+
         let subagent_ctx = match SubAgentSpawn::for_agent(&self.config, &self.parent_alias)
             .and_then(|spawn| spawn.build(SubAgentOverrides::default()))
         {
@@ -232,7 +266,11 @@ mod tests {
 
     #[tokio::test]
     async fn empty_or_missing_prompt_is_rejected() {
-        let tool = SpawnSubagentTool::new(Arc::new(config_with_agent("alpha")), "alpha");
+        let tool = SpawnSubagentTool::new(
+            Arc::new(config_with_agent("alpha")),
+            "alpha",
+            Arc::new(SecurityPolicy::default()),
+        );
         for args in [json!({}), json!({ "prompt": "   " })] {
             let result = tool
                 .execute(args)
@@ -256,7 +294,11 @@ mod tests {
         // Parent alias that is not configured: SubAgentSpawn::for_agent
         // returns Err, the tool reports a structured spawn failure
         // (no panic, no recursion attempt).
-        let tool = SpawnSubagentTool::new(Arc::new(Config::default()), "missing-alpha");
+        let tool = SpawnSubagentTool::new(
+            Arc::new(Config::default()),
+            "missing-alpha",
+            Arc::new(SecurityPolicy::default()),
+        );
         let result = tool
             .execute(json!({ "prompt": "hello" }))
             .await
@@ -277,8 +319,12 @@ mod tests {
 
     #[tokio::test]
     async fn refuses_recursive_spawn_when_caller_is_subagent() {
-        let tool = SpawnSubagentTool::new(Arc::new(config_with_agent("alpha")), "alpha")
-            .with_subagent_caller(true);
+        let tool = SpawnSubagentTool::new(
+            Arc::new(config_with_agent("alpha")),
+            "alpha",
+            Arc::new(SecurityPolicy::default()),
+        )
+        .with_subagent_caller(true);
         let result = tool
             .execute(json!({ "prompt": "hello" }))
             .await
@@ -297,8 +343,12 @@ mod tests {
         // (e.g. no model provider configured in this minimal harness),
         // but it MUST NOT trip the depth-cap refusal. Pin that the
         // depth-cap error is absent.
-        let tool = SpawnSubagentTool::new(Arc::new(config_with_agent("alpha")), "alpha")
-            .with_subagent_caller(false);
+        let tool = SpawnSubagentTool::new(
+            Arc::new(config_with_agent("alpha")),
+            "alpha",
+            Arc::new(SecurityPolicy::default()),
+        )
+        .with_subagent_caller(false);
         let result = tool
             .execute(json!({ "prompt": "hello" }))
             .await
@@ -337,7 +387,11 @@ mod tests {
         // the tool itself refuses pre-spawn so the dispatch-site filter
         // doesn't have to be the only line of defense.
         let config = config_with_allowed_tools("alpha", vec!["shell".into()]);
-        let tool = SpawnSubagentTool::new(Arc::new(config), "alpha");
+        let tool = SpawnSubagentTool::new(
+            Arc::new(config),
+            "alpha",
+            Arc::new(SecurityPolicy::default()),
+        );
         let result = tool
             .execute(json!({ "prompt": "hello" }))
             .await
@@ -358,7 +412,11 @@ mod tests {
         // the gate refusal is absent.
         let config =
             config_with_allowed_tools("alpha", vec!["spawn_subagent".into(), "shell".into()]);
-        let tool = SpawnSubagentTool::new(Arc::new(config), "alpha");
+        let tool = SpawnSubagentTool::new(
+            Arc::new(config),
+            "alpha",
+            Arc::new(SecurityPolicy::default()),
+        );
         let result = tool
             .execute(json!({ "prompt": "hello" }))
             .await
@@ -367,6 +425,95 @@ mod tests {
         assert!(
             !(err.contains("risk_profile") && err.contains("spawn_subagent")),
             "spawn_subagent in allowed_tools must not trigger the gate refusal, got: {err:?}"
+        );
+    }
+
+    // ── Launch-side fan-out bound: shared action budget ──
+
+    #[tokio::test]
+    async fn repeated_spawns_blocked_once_action_budget_is_exhausted() {
+        // The dedup exemption lets identical spawn_subagent calls all
+        // reach execute(); the launch-side budget gate must be what
+        // bounds them. With a budget of 2, the 3rd validated launch
+        // attempt is refused before any spawn work, regardless of
+        // whether the spawns themselves succeed.
+        let security = Arc::new(SecurityPolicy {
+            max_actions_per_hour: 2,
+            ..SecurityPolicy::default()
+        });
+        let tool = SpawnSubagentTool::new(
+            Arc::new(config_with_agent("alpha")),
+            "alpha",
+            Arc::clone(&security),
+        );
+
+        for attempt in 1..=2 {
+            let result = tool
+                .execute(json!({ "prompt": "same fan-out prompt" }))
+                .await
+                .expect("execute returns Ok");
+            let err = result.error.as_deref().unwrap_or_default();
+            assert!(
+                !err.contains("Rate limit exceeded"),
+                "attempt {attempt} within budget must not be rate-limited, got: {err:?}"
+            );
+        }
+
+        let result = tool
+            .execute(json!({ "prompt": "same fan-out prompt" }))
+            .await
+            .expect("execute returns Ok with structured failure");
+        assert!(!result.success);
+        assert!(
+            result
+                .error
+                .as_deref()
+                .unwrap_or_default()
+                .contains("Rate limit exceeded"),
+            "3rd launch attempt past a budget of 2 must be refused, got: {:?}",
+            result.error
+        );
+    }
+
+    #[tokio::test]
+    async fn validation_failures_do_not_consume_launch_budget() {
+        // The budget gate sits after prompt validation: malformed calls
+        // must not burn launch slots (matching RateLimitedTool's
+        // only-work-consumes-budget semantics).
+        let security = Arc::new(SecurityPolicy {
+            max_actions_per_hour: 1,
+            ..SecurityPolicy::default()
+        });
+        let tool = SpawnSubagentTool::new(
+            Arc::new(config_with_agent("alpha")),
+            "alpha",
+            Arc::clone(&security),
+        );
+
+        for _ in 0..3 {
+            let result = tool
+                .execute(json!({ "prompt": "   " }))
+                .await
+                .expect("execute returns Ok with structured failure");
+            assert!(
+                result
+                    .error
+                    .as_deref()
+                    .unwrap_or_default()
+                    .contains("prompt"),
+                "invalid-prompt refusal expected, got: {:?}",
+                result.error
+            );
+        }
+
+        let result = tool
+            .execute(json!({ "prompt": "valid" }))
+            .await
+            .expect("execute returns Ok");
+        let err = result.error.as_deref().unwrap_or_default();
+        assert!(
+            !err.contains("Rate limit exceeded"),
+            "validation failures must not have consumed the budget, got: {err:?}"
         );
     }
 
@@ -406,6 +553,7 @@ mod tests {
         let tool: Box<dyn Tool> = Box::new(SpawnSubagentTool::new(
             Arc::new(config_with_agent("alpha")),
             "alpha",
+            Arc::new(SecurityPolicy::default()),
         ));
         assert_eq!(
             Attributable::role(tool.as_ref()),


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Exempt the re-entrant agent-spawning tools (`spawn_subagent`, `delegate`) from the per-turn duplicate-call guard. Two identical-argument calls are intentional fan-out (redundancy, sampling), not an accidental repeat; the guard was dropping the 2nd+ so only the earliest identical call returned. Exemption set (`REENTRANT_AGENT_TOOLS`) is built from `SpawnSubagentTool::NAME` / `DelegateTool::NAME` consts so a rename cannot desync it.
  - **Gate `spawn_subagent` launches on the caller's action budget** (review feedback): `SpawnSubagentTool` now holds the caller's `Arc<SecurityPolicy>` and every validated launch attempt goes through `enforce_tool_operation(Act)`, consuming one slot from the shared `max_actions_per_hour` bucket before any spawn work — the same safety model `DelegateTool` already uses. The dedup exemption can no longer turn one model turn into unbounded child launches; fan-out is bounded at launch time, not merely by work performed downstream.
  - Drop `model_switch` from a SubAgent's tool registry (gated on `is_subagent_caller`). A SubAgent runs as an ephemeral clone inheriting the parent's model verbatim and must not switch the active model out from under the parent; the switch signal is a process-global slot that also races across concurrent runs. Excluding the tool enforces the documented inheritance and removes the cross-talk.
  - Pair native `role=tool` history messages on each result's own `tool_call_id` instead of a positional `zip` against `native_tool_calls`. `zip` stops at the shorter side, so any length divergence would orphan a native `tool_use` id with no matching `tool_result`. Defensive: the positional `zip` was correct for well-formed native turns, so this is robustness, not a behavior fix.
- **Scope boundary:** No change to SubAgent/Delegate identity inheritance semantics (provider, model, risk profile, memory, budgets all still inherited verbatim). No config-surface or schema change. No new tools. No general per-turn tool-call count cap is added — the launch bound is budget-based, matching `delegate`. Docs for `delegation.md` are tracked separately under #7365.
- **Blast radius:** `zeroclaw-runtime` tool-registry assembly and the tool-call loop's result-to-history mapping. Affects every agent turn that emits tool calls (native and prompt mode) and every SubAgent/Delegate spawn.
  - **Fan-out bound:** identical re-entrant calls are no longer collapsed per-turn, and both spawn paths now consume the caller's shared action budget at launch time: `delegate` via its existing `enforce_tool_operation(Act)` gate, `spawn_subagent` via the new launch-side gate. SubAgents and Delegates additionally share the parent/caller `Arc<SecurityPolicy>` tracker (`SubAgentSpawn::build` inherit path; `DelegateTool::policy_for_target` copies `self.security.tracker`), so child work also draws from the same `max_actions_per_hour` / `max_cost_per_day_cents` bucket.
  - `SpawnSubagentTool::new` gains a third parameter (caller policy); single non-test construction site updated in `tools/mod.rs`.
  - No effect on channels, gateway, or providers beyond what flows through the loop.
- **Linked issue(s):** Related #7365 (docs addition for `delegation.md` lands there). Related #7080 (delegate memory-namespace loss in the same background/parallel paths; not resolved here).
- **Labels:** `risk: high`, `size: M`, `runtime`, `agent`

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace
```

- **Commands run and tail output** (on the PR head `a9954d0af2`, including the launch-gate commit):

`cargo fmt --all -- --check` — clean (exit 0, no output).

`cargo clippy --workspace --all-targets -- -D warnings`:
```
    Finished `dev` profile [unoptimized + debuginfo] target(s)
exit 0
```

`cargo test --workspace` — 62 `test result:` blocks, every block `0 failed`. Aggregate: **8183 passed, 0 failed** (8181 prior + 2 new launch-gate regressions). Representative literal tail:
```
test tools::spawn_subagent::tests::repeated_spawns_blocked_once_action_budget_is_exhausted ... ok
test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 2015 filtered out; finished in 0.01s   (spawn_subagent filter)
```

- **Beyond CI — what did you manually verify?** Five targeted regression tests: native parallel return yields one `role=tool` message per call keyed to its own id; identical-prompt `spawn_subagent` calls both execute with no config dedup exemption; `model_switch` present in a top-level registry and absent in a SubAgent registry; **with `max_actions_per_hour: 2`, the 3rd identical `spawn_subagent` launch is refused with "Rate limit exceeded"**; **repeated validation failures (blank prompt) consume zero launch budget**. Confirmed `model_switch` has a single registration site and that the cron spawn site sets `is_subagent: false`. Verified gate ordering matches `DelegateTool` (validate args first, then `enforce_tool_operation`) so malformed calls don't burn slots, consistent with `RateLimitedTool`'s only-work-consumes-budget semantics.
- **Beyond CI — what I did NOT verify:** No live-provider run; the new tests use scripted/mock providers. No end-to-end parallel SubAgent run against a real model.
- **If any command was intentionally skipped, why:** None skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No** — this narrows capabilities twice over (SubAgents lose `model_switch`; `spawn_subagent` launches now consume the action budget).
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- If any `Yes`, describe the risk and mitigation: N/A.

## Compatibility (required)

- Backward compatible? **Yes** — no config/schema/CLI change. A SubAgent losing `model_switch` matches the documented inheritance contract and was never a supported way to change a child's model. `spawn_subagent` calls now count against the existing `max_actions_per_hour` budget like every other acting tool; operators with very low budgets and heavy fan-out usage will see launches refused once the bucket drains, which is the intended bound.
- Config / env / CLI surface changed? **No**
- If `No` or `Yes` to either: exact upgrade steps for existing users: None required.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <merge-sha>` — self-contained commits, no migration.
- **Feature flags or config toggles:** None. (`parallel_tools` already gates concurrent execution and is unchanged; the launch bound reuses the existing `max_actions_per_hour` knob.)
- **Observable failure symptoms:** If the dedup exemption regressed, a turn with two identical `spawn_subagent`/`delegate` calls would log `"Skipped duplicate tool call"` for the 2nd. If the launch gate regressed open, a single turn could start more SubAgent runs than `max_actions_per_hour` permits (grep runtime trace for `spawn_subagent` invoke counts per turn); if it regressed closed, every spawn would fail with `"Rate limit exceeded: action budget exhausted"`. If native pairing regressed, native providers would reject the next request for a `tool_use` id lacking a matching `tool_result` (provider 400). If the registry filter regressed, a SubAgent would expose `model_switch` (grep the child run's tool list).

