### PR TITLE
fix(docker): resolve workspace build failures from apps/zerocode and embedded assets

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -69,9 +69,13 @@ coverage
 lcov.info
 
 # Application and script directories (not needed for Docker runtime)
-# Note: apps/tauri/Cargo.toml is required for workspace resolution in Docker build.
+# Note: apps/tauri and apps/zerocode are desktop/TUI apps not shipped in the
+# server image; only their Cargo.toml is needed for workspace resolution in the
+# Docker dependency-cache stage (their src + build.rs are stubbed in the
+# Dockerfile). Whitelisting just the manifest avoids cache-busting on app source.
 apps/*
 !apps/tauri/
 !apps/tauri/Cargo.toml
 !apps/zerocode/
+!apps/zerocode/Cargo.toml
 scripts/

--- a/.dockerignore
+++ b/.dockerignore
@@ -68,14 +68,13 @@ LICENSE
 coverage
 lcov.info
 
-# Application and script directories (not needed for Docker runtime)
-# Note: apps/tauri and apps/zerocode are desktop/TUI apps not shipped in the
-# server image; only their Cargo.toml is needed for workspace resolution in the
-# Docker dependency-cache stage (their src + build.rs are stubbed in the
-# Dockerfile). Whitelisting just the manifest avoids cache-busting on app source.
+# Application and script directories.
+# apps/tauri is a desktop app not shipped in the server image; only its
+# Cargo.toml is needed for workspace resolution (src + build.rs are stubbed in
+# the Dockerfile). apps/zerocode IS shipped (the TUI binary), so its full source
+# is whitelisted and copied for the real build.
 apps/*
 !apps/tauri/
 !apps/tauri/Cargo.toml
 !apps/zerocode/
-!apps/zerocode/Cargo.toml
 scripts/

--- a/Dockerfile
+++ b/Dockerfile
@@ -96,11 +96,15 @@ COPY benches/ benches/
 COPY crates/ crates/
 COPY xtask/ xtask/
 COPY tools/fill-translations/ tools/fill-translations/
+# apps/zerocode ships in the image; copy its real source. Its build.rs reads the
+# dashboard theme registry under web/src/contexts, so that path must be present.
+COPY apps/zerocode/ apps/zerocode/
+COPY web/src/ web/src/
 # locales.toml lives at repo root and is embedded by zeroclaw-runtime via
 # include_str!("../../../locales.toml"); the real build needs it present.
 COPY locales.toml .
 COPY *.rs .
-RUN touch src/main.rs
+RUN touch src/main.rs apps/zerocode/src/main.rs
 RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,id=zeroclaw-cargo-git,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,id=zeroclaw-target,target=/app/target,sharing=locked \
@@ -113,16 +117,22 @@ RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/regist
            target/release/.fingerprint/xtask-* \
            target/release/deps/xtask-* \
            target/release/.fingerprint/fill-translations-* \
-           target/release/deps/fill_translations-* && \
+           target/release/deps/fill_translations-* \
+           target/release/.fingerprint/zerocode-* \
+           target/release/deps/zerocode-* \
+           target/release/incremental/zerocode-* && \
     if [ -n "$ZEROCLAW_CARGO_FEATURES" ]; then \
       cargo build --release --locked --features "$ZEROCLAW_CARGO_FEATURES"; \
     else \
       cargo build --release --locked; \
     fi && \
     cp target/release/zeroclaw /app/zeroclaw && \
-    strip /app/zeroclaw
-RUN size=$(stat -c%s /app/zeroclaw) && \
-    if [ "$size" -lt 1000000 ]; then echo "ERROR: binary too small (${size} bytes), likely dummy build artifact" && exit 1; fi
+    cp target/release/zerocode /app/zerocode && \
+    strip /app/zeroclaw /app/zerocode
+RUN for b in zeroclaw zerocode; do \
+      size=$(stat -c%s "/app/$b") && \
+      if [ "$size" -lt 1000000 ]; then echo "ERROR: $b too small (${size} bytes), likely dummy build artifact" && exit 1; fi; \
+    done
 
 # Prepare runtime directory structure and default config inline (no extra stage).
 # Dashboard assets live at /usr/share/zeroclawlabs/web/dist (outside the documented
@@ -158,6 +168,7 @@ RUN apt-get update && apt-get install -y \
 
 COPY --from=builder /zeroclaw-data /zeroclaw-data
 COPY --from=builder /app/zeroclaw /usr/local/bin/zeroclaw
+COPY --from=builder /app/zerocode /usr/local/bin/zerocode
 # Install the dashboard at /usr/share/zeroclawlabs/web/dist (outside the
 # documented /zeroclaw-data mount) so user volumes do not shadow it (#6400).
 COPY --from=web-builder /app/web/dist /usr/share/zeroclawlabs/web/dist
@@ -192,6 +203,7 @@ CMD ["daemon"]
 FROM gcr.io/distroless/cc-debian13:nonroot@sha256:84fcd3c223b144b0cb6edc5ecc75641819842a9679a3a58fd6294bec47532bf7 AS release
 
 COPY --from=builder /app/zeroclaw /usr/local/bin/zeroclaw
+COPY --from=builder /app/zerocode /usr/local/bin/zerocode
 COPY --from=builder /zeroclaw-data /zeroclaw-data
 # Install the dashboard at /usr/share/zeroclawlabs/web/dist (outside the
 # documented /zeroclaw-data mount) so user volumes do not shadow it (#6400).

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,11 @@ COPY --parents crates/*/Cargo.toml ./
 COPY --parents crates/aardvark-sys/build.rs ./
 # apps/tauri: .dockerignore whitelists only Cargo.toml; src and build.rs are stubbed below.
 COPY apps/tauri/Cargo.toml apps/tauri/Cargo.toml
+# apps/zerocode: TUI app not shipped in the server image; copy only its manifest
+# so Cargo can resolve the workspace, then stub its src/main.rs and build.rs
+# below. Its real build.rs reads web/src/contexts/themes.json and would panic in
+# this pre-fetch stage, so it is stubbed exactly like apps/tauri.
+COPY apps/zerocode/Cargo.toml apps/zerocode/Cargo.toml
 # tools/fill-translations and xtask are dev/build tools; copy manifests only so
 # Cargo can resolve the workspace, then stub their entry points so the
 # dependency pre-fetch step succeeds without building them into the image.
@@ -58,18 +63,22 @@ COPY xtask/Cargo.toml xtask/Cargo.toml
 # `src/bin/zeroclaw-acp-bridge.rs` is required because the `acp-bridge` feature
 # is in the root crate's default set; cargo selects the bin target during the
 # pre-fetch build even with only the workspace lib stubbed.
-RUN mkdir -p src src/bin benches apps/tauri/src tools/fill-translations/src xtask/src/bin \
+RUN mkdir -p src src/bin benches apps/tauri/src apps/zerocode/src tools/fill-translations/src xtask/src/bin \
     && echo "fn main() {}" > src/main.rs \
     && echo "" > src/lib.rs \
     && echo "fn main() {}" > src/bin/zeroclaw-acp-bridge.rs \
     && echo "fn main() {}" > benches/agent_benchmarks.rs \
     && echo "fn main() {}" > apps/tauri/src/main.rs \
     && echo "fn main() {}" > apps/tauri/build.rs \
+    && echo "fn main() {}" > apps/zerocode/src/main.rs \
+    && echo "fn main() {}" > apps/zerocode/build.rs \
     && echo "fn main() {}" > tools/fill-translations/src/main.rs \
     && echo "" > xtask/src/lib.rs \
     && echo "fn main() {}" > xtask/src/bin/mdbook.rs \
     && echo "fn main() {}" > xtask/src/bin/fluent.rs \
     && echo "fn main() {}" > xtask/src/bin/web.rs \
+    && mkdir -p crates/zeroclaw-hardware/examples \
+    && echo "fn main() {}" > crates/zeroclaw-hardware/examples/esp32_sim.rs \
     && for d in crates/*/; do mkdir -p "${d}src" && printf '' > "${d}src/lib.rs"; done
 RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,id=zeroclaw-cargo-git,target=/usr/local/cargo/git,sharing=locked \
@@ -87,6 +96,9 @@ COPY benches/ benches/
 COPY crates/ crates/
 COPY xtask/ xtask/
 COPY tools/fill-translations/ tools/fill-translations/
+# locales.toml lives at repo root and is embedded by zeroclaw-runtime via
+# include_str!("../../../locales.toml"); the real build needs it present.
+COPY locales.toml .
 COPY *.rs .
 RUN touch src/main.rs
 RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,11 +31,14 @@ FROM rust:1.94-slim@sha256:da9dab7a6b8dd428e71718402e97207bb3e54167d37b570861605
 WORKDIR /app
 ARG ZEROCLAW_CARGO_FEATURES="channel-lark,whatsapp-web"
 
-# Install build dependencies
+# Install build dependencies. g++ is required by inkjet (zerocode's syntax
+# highlighter) to compile its tree-sitter grammars; the slim base ships cc but
+# not a C++ compiler.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get update && apt-get install -y \
         pkg-config \
+        g++ \
     && rm -rf /var/lib/apt/lists/*
 
 # 1. Copy manifests to cache dependencies
@@ -84,9 +87,9 @@ RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/regist
     --mount=type=cache,id=zeroclaw-cargo-git,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,id=zeroclaw-target,target=/app/target,sharing=locked \
     if [ -n "$ZEROCLAW_CARGO_FEATURES" ]; then \
-      cargo build --release --locked --features "$ZEROCLAW_CARGO_FEATURES"; \
+      cargo build --release --locked -p zeroclawlabs -p zerocode --features "$ZEROCLAW_CARGO_FEATURES"; \
     else \
-      cargo build --release --locked; \
+      cargo build --release --locked -p zeroclawlabs -p zerocode; \
     fi
 RUN rm -rf src benches crates xtask tools/fill-translations
 
@@ -122,9 +125,9 @@ RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/regist
            target/release/deps/zerocode-* \
            target/release/incremental/zerocode-* && \
     if [ -n "$ZEROCLAW_CARGO_FEATURES" ]; then \
-      cargo build --release --locked --features "$ZEROCLAW_CARGO_FEATURES"; \
+      cargo build --release --locked -p zeroclawlabs -p zerocode --features "$ZEROCLAW_CARGO_FEATURES"; \
     else \
-      cargo build --release --locked; \
+      cargo build --release --locked -p zeroclawlabs -p zerocode; \
     fi && \
     cp target/release/zeroclaw /app/zeroclaw && \
     cp target/release/zerocode /app/zerocode && \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -51,6 +51,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get update && apt-get install -y \
         pkg-config \
+        g++ \
     && rm -rf /var/lib/apt/lists/*
 
 # 1. Copy manifests to cache dependencies
@@ -99,9 +100,9 @@ RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/regist
     --mount=type=cache,id=zeroclaw-cargo-git,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,id=zeroclaw-target,target=/app/target,sharing=locked \
     if [ -n "$ZEROCLAW_CARGO_FEATURES" ]; then \
-      cargo build --release --locked --features "$ZEROCLAW_CARGO_FEATURES"; \
+      cargo build --release --locked -p zeroclawlabs -p zerocode --features "$ZEROCLAW_CARGO_FEATURES"; \
     else \
-      cargo build --release --locked; \
+      cargo build --release --locked -p zeroclawlabs -p zerocode; \
     fi
 RUN rm -rf src benches crates xtask tools/fill-translations
 
@@ -137,9 +138,9 @@ RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/regist
            target/release/deps/zerocode-* \
            target/release/incremental/zerocode-* && \
     if [ -n "$ZEROCLAW_CARGO_FEATURES" ]; then \
-      cargo build --release --locked --features "$ZEROCLAW_CARGO_FEATURES"; \
+      cargo build --release --locked -p zeroclawlabs -p zerocode --features "$ZEROCLAW_CARGO_FEATURES"; \
     else \
-      cargo build --release --locked; \
+      cargo build --release --locked -p zeroclawlabs -p zerocode; \
     fi && \
     cp target/release/zeroclaw /app/zeroclaw && \
     cp target/release/zerocode /app/zerocode && \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -62,8 +62,13 @@ COPY Cargo.toml Cargo.lock ./
 # Cargo must compile during the dependency pre-fetch step; copy it explicitly.
 COPY --parents crates/*/Cargo.toml ./
 COPY --parents crates/aardvark-sys/build.rs ./
-# apps/tauri: .dockerignore whitelists only Cargo.toml; src is stubbed below.
+# apps/tauri: .dockerignore whitelists only Cargo.toml; src and build.rs are stubbed below.
 COPY apps/tauri/Cargo.toml apps/tauri/Cargo.toml
+# apps/zerocode: TUI app not shipped in the server image; copy only its manifest
+# so Cargo can resolve the workspace, then stub its src/main.rs and build.rs
+# below. Its real build.rs reads web/src/contexts/themes.json and would panic in
+# this pre-fetch stage, so it is stubbed exactly like apps/tauri.
+COPY apps/zerocode/Cargo.toml apps/zerocode/Cargo.toml
 # tools/fill-translations and xtask are dev/build tools; copy manifests only so
 # Cargo can resolve the workspace, then stub their entry points so the
 # dependency pre-fetch step succeeds without building them into the image.
@@ -73,17 +78,22 @@ COPY xtask/Cargo.toml xtask/Cargo.toml
 # `src/bin/zeroclaw-acp-bridge.rs` is required because the `acp-bridge` feature
 # is in the root crate's default set; cargo selects the bin target during the
 # pre-fetch build even with only the workspace lib stubbed.
-RUN mkdir -p src src/bin benches apps/tauri/src tools/fill-translations/src xtask/src/bin \
+RUN mkdir -p src src/bin benches apps/tauri/src apps/zerocode/src tools/fill-translations/src xtask/src/bin \
     && echo "fn main() {}" > src/main.rs \
     && echo "" > src/lib.rs \
     && echo "fn main() {}" > src/bin/zeroclaw-acp-bridge.rs \
     && echo "fn main() {}" > benches/agent_benchmarks.rs \
     && echo "fn main() {}" > apps/tauri/src/main.rs \
+    && echo "fn main() {}" > apps/tauri/build.rs \
+    && echo "fn main() {}" > apps/zerocode/src/main.rs \
+    && echo "fn main() {}" > apps/zerocode/build.rs \
     && echo "fn main() {}" > tools/fill-translations/src/main.rs \
     && echo "" > xtask/src/lib.rs \
     && echo "fn main() {}" > xtask/src/bin/mdbook.rs \
     && echo "fn main() {}" > xtask/src/bin/fluent.rs \
     && echo "fn main() {}" > xtask/src/bin/web.rs \
+    && mkdir -p crates/zeroclaw-hardware/examples \
+    && echo "fn main() {}" > crates/zeroclaw-hardware/examples/esp32_sim.rs \
     && for d in crates/*/; do mkdir -p "${d}src" && printf '' > "${d}src/lib.rs"; done
 RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,id=zeroclaw-cargo-git,target=/usr/local/cargo/git,sharing=locked \
@@ -101,6 +111,9 @@ COPY benches/ benches/
 COPY crates/ crates/
 COPY xtask/ xtask/
 COPY tools/fill-translations/ tools/fill-translations/
+# locales.toml lives at repo root and is embedded by zeroclaw-runtime via
+# include_str!("../../../locales.toml"); the real build needs it present.
+COPY locales.toml .
 COPY --from=web-builder /app/web/dist web/dist
 RUN touch src/main.rs src/lib.rs
 RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -111,11 +111,15 @@ COPY benches/ benches/
 COPY crates/ crates/
 COPY xtask/ xtask/
 COPY tools/fill-translations/ tools/fill-translations/
+# apps/zerocode ships in the image; copy its real source. Its build.rs reads the
+# dashboard theme registry under web/src/contexts, so that path must be present.
+COPY apps/zerocode/ apps/zerocode/
+COPY web/src/ web/src/
 # locales.toml lives at repo root and is embedded by zeroclaw-runtime via
 # include_str!("../../../locales.toml"); the real build needs it present.
 COPY locales.toml .
 COPY --from=web-builder /app/web/dist web/dist
-RUN touch src/main.rs src/lib.rs
+RUN touch src/main.rs src/lib.rs apps/zerocode/src/main.rs
 RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,id=zeroclaw-cargo-git,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,id=zeroclaw-target,target=/app/target,sharing=locked \
@@ -128,16 +132,22 @@ RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/regist
            target/release/.fingerprint/xtask-* \
            target/release/deps/xtask-* \
            target/release/.fingerprint/fill-translations-* \
-           target/release/deps/fill_translations-* && \
+           target/release/deps/fill_translations-* \
+           target/release/.fingerprint/zerocode-* \
+           target/release/deps/zerocode-* \
+           target/release/incremental/zerocode-* && \
     if [ -n "$ZEROCLAW_CARGO_FEATURES" ]; then \
       cargo build --release --locked --features "$ZEROCLAW_CARGO_FEATURES"; \
     else \
       cargo build --release --locked; \
     fi && \
     cp target/release/zeroclaw /app/zeroclaw && \
-    strip /app/zeroclaw
-RUN size=$(stat -c%s /app/zeroclaw) && \
-    if [ "$size" -lt 1000000 ]; then echo "ERROR: binary too small (${size} bytes), likely dummy build artifact" && exit 1; fi
+    cp target/release/zerocode /app/zerocode && \
+    strip /app/zeroclaw /app/zerocode
+RUN for b in zeroclaw zerocode; do \
+      size=$(stat -c%s "/app/$b") && \
+      if [ "$size" -lt 1000000 ]; then echo "ERROR: $b too small (${size} bytes), likely dummy build artifact" && exit 1; fi; \
+    done
 
 # Prepare runtime directory structure and default config inline (no extra stage).
 # The web dashboard bundle is installed in the runtime stage at
@@ -174,6 +184,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app/zeroclaw /usr/local/bin/zeroclaw
+COPY --from=builder /app/zerocode /usr/local/bin/zerocode
 COPY --from=builder /zeroclaw-data /zeroclaw-data
 # Install the dashboard at /usr/share/zeroclawlabs/web/dist (outside the
 # documented /zeroclaw-data mount) so user volumes do not shadow it (#6400).


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** The Docker build broke at the cargo dependency pre-fetch stage with `failed to load manifest for workspace member /app/apps/zerocode`. #6848 added `apps/zerocode` to the workspace `members` but never updated the Docker build context. Fixing the build surfaced a second goal: the `zerocode` TUI binary must actually **ship** in the image (it was stubbed and never copied, so `zerocode` was `command not found` inside the container). This PR does both — repairs the build chain and ships a working `zerocode`:
  - `apps/zerocode/Cargo.toml` was never copied → cargo could not resolve the workspace. Copy the manifest in the dep-cache stage.
  - `crates/zeroclaw-hardware` declares an `[[example]]` (`esp32_sim`) whose source is absent in the stub stage → manifest parse failed once zerocode resolved. Stub `examples/esp32_sim.rs` alongside the per-crate lib stubs.
  - `locales.toml` (repo root) is embedded by `zeroclaw-runtime` at compile time via an `include_str!` of the repo-root file; the final source-copy stage copied `*.rs` but not the `.toml` → the real build failed to compile. Copy it.
  - Ship zerocode for real: copy real `apps/zerocode/` source plus `web/src/` (its `build.rs` reads the dashboard theme registry under `web/src/contexts` to generate the TUI theme presets), build `-p zeroclawlabs -p zerocode` (a bare `cargo build` at the workspace root builds only the `zeroclawlabs` package, not sibling members — so `target/release/zerocode` never existed and the cp failed), install `g++` (zerocode's `inkjet` highlighter compiles tree-sitter grammars in C++; the slim base ships `cc` but no C++ compiler), then cp + strip + size-guard the binary and install `/usr/local/bin/zerocode` in every runtime stage.
  - `.dockerignore`: whitelist the full `apps/zerocode/` source (was manifest-only) since the binary now ships.
  - `Dockerfile.debian`: apply the same fixes; it had additionally drifted and was missing the `apps/tauri/build.rs` stub the default Dockerfile carries.
- **Scope boundary:** Both build-from-source Dockerfiles only. `ZEROCLAW_CARGO_FEATURES` differing between the variants (`channel-lark,whatsapp-web` vs `rag-pdf`) is intentional and left as-is. `Dockerfile.ci` / `Dockerfile.debian.ci` use pre-built binaries (no cargo build) and are unaffected. Does not consolidate the duplicated Dockerfiles or touch the StageX `Containerfile` (tracked as a follow-up).
- **Blast radius:** Both build-from-source Docker images (`Dockerfile` distroless, `Dockerfile.debian` shell variant) and the release workflows that build them. Image contents now include the `zerocode` binary. No effect on the application, config schema, or the `zeroclaw` daemon binary.
- **Linked issue(s):** None filed; reported directly. Root cause traced to #6848 (introduced `apps/zerocode` to the workspace).
- **Labels:** `risk: medium`, `size: XS`, `ci`

## Validation Evidence (required)

Docker build is the signal here, not the Rust battery.

```bash
DOCKER_BUILDKIT=1 docker build --target builder -t zeroclaw-builder-test .
docker run --rm --entrypoint /usr/local/bin/zerocode zeroclaw-builder-test --help
```

- **Commands run and tail output:**

Default `Dockerfile` builder target — built end to end, both binaries pass the size guard:
```
#30 299.8     Finished `release` profile [optimized] target(s) in 4m 59s
#31 [builder 25/26] RUN for b in zeroclaw zerocode; do size=$(stat -c%s "/app/$b") ... done   (passed)
#33 writing image sha256:0eb3a0d7... done
```

Both binaries present in the image, real (not dummy stubs):
```
-rwxr-xr-x  /app/zeroclaw  36600832 bytes
-rwxr-xr-x  /app/zerocode  36001712 bytes
```

`zerocode --help` runs from inside the image (exit 0):
```
Interactive TUI config manager for ZeroClaw

Usage: zerocode [OPTIONS]

Options:
      --config-dir <CONFIG_DIR>  Path to the ZeroClaw config directory
  -a, --agent <AGENT>            Start in chat mode with this agent alias...
```

- **Beyond CI — what did you manually verify?** Reproduced each failure in the chain (`failed to load manifest`, `can't find esp32_sim example`, `couldn't read locales.toml`, `cp: cannot stat 'target/release/zerocode'`, `failed to find tool "c++"`) and confirmed each fix advances the build to the next stage until the image completes. **Owner-confirmed live:** `docker run -it --entrypoint zerocode <image>` launches the zerocode TUI in BOTH the debian and distroless flavors.
- **Beyond CI — what I did NOT verify:** A full `Dockerfile.debian` end-to-end run on the build host (one attempt tripped on a transient `npm ci` SIGTERM in the unrelated web-builder stage; the builder stage itself cleared all manifest/compile failures and compiled zerocode). The shared builder-stage logic is identical between the two Dockerfiles.
- **If any command was intentionally skipped, why:** The Rust `cargo` battery is not the relevant signal for a Docker-context change; the `docker build` + in-image run above is.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- If any `Yes`, describe the risk and mitigation: N/A. (Adds the `zerocode` TUI binary to the image; it is built from the same workspace source under the same features.)

## Compatibility (required)

- Backward compatible? **Yes** — the `zeroclaw` daemon binary and entrypoint are unchanged; the image now additionally carries `zerocode`. Reach it with `--entrypoint zerocode` (an entrypoint-dispatch UX improvement so `docker run ... zerocode` works without the override is tracked as a follow-up).
- Config / env / CLI surface changed? **No**
- If `No` or `Yes` to either: exact upgrade steps for existing users: None.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <merge-sha>` — self-contained Docker-context commits, no migration.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** A regression returns one of the original errors (`failed to load manifest for workspace member /app/apps/zerocode`, `can't find esp32_sim example`, `couldn't read locales.toml`, `cp: cannot stat 'target/release/zerocode'`, or `failed to find tool "c++"`) at the cargo pre-fetch / real-build stage, or `zerocode: command not found` inside the container.
