### PR TITLE
fix(multimodal): make image_info images reach vision models end-to-end

### DIFF
--- a/crates/zeroclaw-providers/src/multimodal.rs
+++ b/crates/zeroclaw-providers/src/multimodal.rs
@@ -261,6 +261,23 @@ pub fn contains_image_markers(messages: &[ChatMessage]) -> bool {
     count_image_markers(messages) > 0
 }
 
+/// Count image markers that originate from genuine **user** messages (i.e.
+/// inbound attachments), excluding tool-result carriers (`role == "tool"` and
+/// `[Tool results]` user messages).
+///
+/// Callers use this to distinguish "the user sent an image we cannot see"
+/// (which should surface a user-facing capability error so the attachment is
+/// not silently ignored) from "an image marker arrived only via a tool result"
+/// (e.g. `image_info`/`screenshot`/`image_gen`), which can degrade to text-only
+/// on a non-vision provider without misleading the user.
+pub fn count_user_image_markers(messages: &[ChatMessage]) -> usize {
+    messages
+        .iter()
+        .filter(|message| message.role == "user" && !is_prompt_tool_result_message(message))
+        .map(|message| parse_image_markers(&message.content).1.len())
+        .sum()
+}
+
 /// Replace media markers (`[IMAGE:...]`, `[PHOTO:...]`, `[DOCUMENT:...]`,
 /// `[FILE:...]`, `[VIDEO:...]`, `[VOICE:...]`, `[AUDIO:...]`) with
 /// `[media attachment]`. Match is case-insensitive to align with the channel

--- a/crates/zeroclaw-providers/src/multimodal.rs
+++ b/crates/zeroclaw-providers/src/multimodal.rs
@@ -6,13 +6,14 @@ use zeroclaw_api::model_provider::ChatMessage;
 use zeroclaw_config::schema::{MultimodalConfig, build_runtime_proxy_client_with_timeouts};
 
 const IMAGE_MARKER_PREFIX: &str = "[IMAGE:";
-const ALLOWED_IMAGE_MIME_TYPES: &[&str] = &[
-    "image/png",
-    "image/jpeg",
-    "image/webp",
-    "image/gif",
-    "image/bmp",
-];
+// MIME types we will inline for vision providers. Deliberately excludes
+// `image/bmp`: no major vision provider (Anthropic, OpenAI) accepts BMP, so
+// inlining it would make the *entire* provider request fail rather than just
+// dropping the one image. Rejecting it here instead surfaces a clean
+// "could not be loaded" note while the request (and any accompanying text or
+// metadata) still goes through. BMP is still detected by `detect_mime` so the
+// skip is logged as an explicit unsupported-MIME event rather than "unknown".
+const ALLOWED_IMAGE_MIME_TYPES: &[&str] = &["image/png", "image/jpeg", "image/webp", "image/gif"];
 
 /// Per-path cache for resolved local image data URIs. Keyed by absolute
 /// path; stores `(len, mtime)` for freshness checks (`(0, 0)` sentinel
@@ -127,6 +128,7 @@ fn is_loadable_image_reference(candidate: &str) -> bool {
         || candidate.starts_with("https://")
         || candidate.starts_with("data:")
         || is_windows_path(candidate)
+        || is_windows_unc_path(candidate)
 }
 
 /// Returns true for Windows-style absolute paths like `C:\…` or `D:/…`.
@@ -145,6 +147,29 @@ fn is_windows_path(candidate: &str) -> bool {
         return false;
     }
     matches!(chars.next(), Some('\\') | Some('/'))
+}
+
+/// Returns true for Windows UNC share paths like `\\server\share\…`.
+///
+/// `image_info` emits these after unwrapping the verbatim-UNC prefix
+/// (`\\?\UNC\…`) that `canonicalize` produces on Windows. Without recognizing
+/// the unwrapped form here, [`is_loadable_image_reference`] would reject the
+/// marker (it is neither a `/`-rooted POSIX path nor a `C:\` drive path), so
+/// [`parse_image_markers`] would leave it as literal text and the image would
+/// never be inlined for vision models. Requires a non-empty server component
+/// and at least one further path segment; the verbatim/device prefixes
+/// (`\\?\…`, `\\.\…`) are rejected because they are not plain shares.
+fn is_windows_unc_path(candidate: &str) -> bool {
+    let Some(rest) = candidate.strip_prefix(r"\\") else {
+        return false;
+    };
+    if rest.starts_with('?') || rest.starts_with('.') {
+        return false;
+    }
+    let mut parts = rest.splitn(2, ['\\', '/']);
+    let server = parts.next().unwrap_or("");
+    let share = parts.next().unwrap_or("");
+    !server.is_empty() && !share.is_empty()
 }
 
 /// Normalize a marker payload that may have been line-wrapped when pasted
@@ -1287,6 +1312,48 @@ mod tests {
         assert_eq!(refs.len(), 2);
         assert_eq!(refs[0], "/tmp/a.png");
         assert_eq!(refs[1], "https://example.com/b.jpg");
+    }
+
+    #[test]
+    fn is_windows_unc_path_accepts_shares_and_rejects_others() {
+        assert!(is_windows_unc_path(r"\\server\share\pic.png"));
+        assert!(is_windows_unc_path(r"\\server\share\sub\pic.png"));
+        // Verbatim / device prefixes are not plain shares.
+        assert!(!is_windows_unc_path(r"\\?\C:\Users\me\a.png"));
+        assert!(!is_windows_unc_path(r"\\?\UNC\server\share\a.png"));
+        assert!(!is_windows_unc_path(r"\\.\PhysicalDrive0"));
+        // Needs both a server and a further segment.
+        assert!(!is_windows_unc_path(r"\\server"));
+        assert!(!is_windows_unc_path(r"\\"));
+        // Non-UNC inputs.
+        assert!(!is_windows_unc_path("/home/me/a.png"));
+        assert!(!is_windows_unc_path(r"C:\Users\me\a.png"));
+    }
+
+    #[test]
+    fn parse_image_markers_extracts_unc_path() {
+        // Regression for the #7446 Windows follow-up: `image_info` unwraps the
+        // verbatim-UNC prefix (`\\?\UNC\…`) to a plain `\\server\share\…`
+        // path, which must be treated as a loadable image reference (not left
+        // as literal text) so the image reaches vision models.
+        let input = r"File: [IMAGE:\\server\share\pic.png]";
+        let (_, refs) = parse_image_markers(input);
+        assert_eq!(refs.len(), 1, "UNC marker should be extracted as a ref");
+        assert_eq!(refs[0], r"\\server\share\pic.png");
+    }
+
+    #[test]
+    fn validate_mime_rejects_bmp_but_accepts_provider_supported_types() {
+        for mime in ["image/png", "image/jpeg", "image/webp", "image/gif"] {
+            assert!(
+                validate_mime("src", mime).is_ok(),
+                "{mime} should be allowed"
+            );
+        }
+        // BMP is detectable but unsupported by vision providers; it must be
+        // rejected here so it never breaks the whole provider request.
+        let err = validate_mime("src", "image/bmp").unwrap_err();
+        assert_eq!(multimodal_error_kind(&err), "unsupported_mime");
     }
 
     #[test]

--- a/crates/zeroclaw-runtime/src/agent/history.rs
+++ b/crates/zeroclaw-runtime/src/agent/history.rs
@@ -11,8 +11,20 @@ use zeroclaw_providers::ChatMessage;
 /// used when callers omit the parameter.
 pub const DEFAULT_MAX_HISTORY_MESSAGES: usize = 50;
 
+// Matches a local image path that a tool printed as bare text so it can be
+// promoted to an `[IMAGE:…]` marker. Three rooted forms are recognized:
+//   - POSIX absolute:      `/path/to/a.png`
+//   - Windows drive:       `C:\path\a.png` or `C:/path/a.png`
+//   - Windows UNC share:   `\\server\share\a.png`
+// Only rooted paths are promoted; `is_existing_local_image_path` further
+// requires the path to be absolute and to point at a real file, so on
+// non-Windows hosts the Windows forms match here but are filtered out there
+// (their `is_absolute()` is false), leaving behavior unchanged off-Windows.
 static LOCAL_IMAGE_PATH_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"/[^\s<>'"`\]\)]+?\.(?i:png|jpe?g|webp|gif|bmp)"#).expect("valid image path regex")
+    Regex::new(
+        r#"(?:[A-Za-z]:[\\/]|\\\\[^\s<>'"`\]\)/\\]+[\\/]|/)[^\s<>'"`\]\)]+?\.(?i:png|jpe?g|webp|gif|bmp)"#,
+    )
+    .expect("valid image path regex")
 });
 
 /// Find the largest byte index `<= i` that is a valid char boundary.
@@ -145,11 +157,35 @@ fn is_existing_local_image_path(path: &str) -> bool {
             })
 }
 
+/// Collect the inner payloads of every explicit `[IMAGE:…]` marker already
+/// present in `output`. A bare path matching one of these must not be promoted
+/// into a *second* marker, otherwise the same image would be counted (and
+/// inlined) twice. This lets a tool emit both a durable human-readable path
+/// line and an explicit marker for the same file (e.g. `image_info`, which
+/// keeps a `File: <path>` line so the path survives in history after the image
+/// marker is stripped from older turns) without the pipeline double-counting.
+fn existing_marker_payloads(output: &str) -> std::collections::HashSet<&str> {
+    const OPEN: &str = "[IMAGE:";
+    let mut set = std::collections::HashSet::new();
+    let mut from = 0usize;
+    while let Some(rel) = output[from..].find(OPEN) {
+        let inner_start = from + rel + OPEN.len();
+        let Some(rel_end) = output[inner_start..].find(']') else {
+            break;
+        };
+        let inner_end = inner_start + rel_end;
+        set.insert(output[inner_start..inner_end].trim());
+        from = inner_end + 1;
+    }
+    set
+}
+
 /// Rewrite real local image file paths in tool output into `[IMAGE:...]`
 /// markers so the multimodal pipeline can normalize them before the next
 /// provider call. This targets shell/skill outputs that print filesystem
 /// paths directly rather than returning explicit media markers.
 pub fn canonicalize_tool_result_media_markers(output: &str) -> String {
+    let existing_markers = existing_marker_payloads(output);
     let mut rewritten = String::with_capacity(output.len());
     let mut cursor = 0usize;
     let mut changed = false;
@@ -161,6 +197,13 @@ pub fn canonicalize_tool_result_media_markers(output: &str) -> String {
 
         // Skip paths that are already part of an explicit media marker.
         if output[..start].ends_with("[IMAGE:") {
+            continue;
+        }
+
+        // Skip a bare path that already appears inside an explicit marker
+        // elsewhere in the same output — promoting it would double-count the
+        // image (see `existing_marker_payloads`).
+        if existing_markers.contains(path) {
             continue;
         }
 
@@ -486,6 +529,27 @@ mod tests {
         let input = "Already tagged [IMAGE:/tmp/already-tagged.png]";
         let output = canonicalize_tool_result_media_markers(input);
         assert_eq!(output, input);
+    }
+
+    #[test]
+    fn canonicalize_tool_result_media_markers_dedups_path_already_in_marker() {
+        // `image_info` emits a durable `File: <path>` line *and* an explicit
+        // `[IMAGE:<path>]` marker for the same file (so the path survives in
+        // history once the marker is stripped from older turns). The promoter
+        // must not wrap the bare `File:` path into a second marker, which would
+        // double-count the image. Order-independent: the bare path appears
+        // before the marker here.
+        let input = "File: /tmp/pic.png\nFormat: png\n[IMAGE:/tmp/pic.png]";
+        let output = canonicalize_tool_result_media_markers(input);
+        assert_eq!(
+            output, input,
+            "bare path duplicating an existing marker must not be promoted"
+        );
+        assert_eq!(
+            output.matches("[IMAGE:").count(),
+            1,
+            "exactly one image marker expected, got: {output}"
+        );
     }
 
     /// Regression: when `truncate_tool_result`'s head boundary fell inside an

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -1571,7 +1571,10 @@ pub async fn run_tool_call_loop(
         // ── Vision model_provider routing ──────────────────────────
         // When the default model_provider lacks vision support but a dedicated
         // vision_model_provider is configured, create it on demand and use it
-        // for this iteration.  Otherwise, preserve the original error.
+        // for this iteration. When no vision route exists at all, degrade
+        // gracefully (strip the image markers, keep the surrounding text)
+        // rather than aborting the whole turn — see `degrade_strip_images`.
+        let mut degrade_strip_images = false;
         let vision_model_provider_box: Option<Box<dyn ModelProvider>> = if image_marker_count > 0
             && !model_provider.supports_vision()
         {
@@ -1596,6 +1599,9 @@ pub async fn run_tool_call_loop(
                         ))
                     })?;
                 if !vp_instance.supports_vision() {
+                    // Operator misconfiguration (named a non-vision provider as
+                    // the vision route) — surface it loudly rather than silently
+                    // degrading.
                     return Err(ProviderCapabilityError {
                         model_provider: vp.clone(),
                         capability: "vision".to_string(),
@@ -1607,14 +1613,26 @@ pub async fn run_tool_call_loop(
                 }
                 Some(vp_instance)
             } else {
-                return Err(ProviderCapabilityError {
-                        model_provider: provider_name.to_string(),
-                        capability: "vision".to_string(),
-                        message: format!(
-                            "received {image_marker_count} image marker(s), but this model_provider does not support vision input"
-                        ),
-                    }
-                    .into());
+                // No vision route configured. Previously this aborted the entire
+                // turn with a capability error, which turned an otherwise
+                // successful tool call (e.g. `image_info`, which always returns
+                // useful metadata text alongside its `[IMAGE:]` marker) into a
+                // hard failure. Instead, degrade: strip the image markers from
+                // the messages sent to the text-only provider while preserving
+                // the surrounding text, so the conversation continues and the
+                // model still receives any accompanying metadata/caption.
+                ::zeroclaw_log::record!(
+                    WARN,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                        .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                        .with_attrs(::serde_json::json!({
+                            "model_provider": provider_name,
+                            "image_marker_count": image_marker_count,
+                        })),
+                    "no vision route for image marker(s); degrading to text-only (markers stripped)"
+                );
+                degrade_strip_images = true;
+                None
             }
         } else {
             None
@@ -1635,8 +1653,22 @@ pub async fn run_tool_call_loop(
             (model_provider, provider_name, model)
         };
 
-        let prepared_messages =
-            multimodal::prepare_messages_for_provider(history, multimodal_config).await?;
+        let prepared_messages = if degrade_strip_images {
+            // Text-only fallback: replace every media marker with a
+            // `[media attachment]` placeholder so no filesystem path or data
+            // URI reaches the text-only provider, while surrounding text
+            // (captions, tool metadata) survives.
+            let stripped: Vec<ChatMessage> = history
+                .iter()
+                .map(|m| ChatMessage {
+                    role: m.role.clone(),
+                    content: multimodal::strip_media_markers(&m.content),
+                })
+                .collect();
+            multimodal::prepare_messages_for_provider(&stripped, multimodal_config).await?
+        } else {
+            multimodal::prepare_messages_for_provider(history, multimodal_config).await?
+        };
 
         // ── Progress: LLM thinking ────────────────────────────
         if let Some(ref tx) = on_delta {
@@ -6471,8 +6503,12 @@ mod tests {
         }
     }
 
+    /// A non-vision provider with no configured `vision_model_provider` no
+    /// longer aborts the turn: the loop degrades to text-only (stripping image
+    /// markers) and still calls the provider. See the text-only fallback in
+    /// the vision-routing block.
     #[tokio::test]
-    async fn run_tool_call_loop_returns_structured_error_for_non_vision_provider() {
+    async fn run_tool_call_loop_degrades_to_text_for_non_vision_provider() {
         let calls = Arc::new(AtomicUsize::new(0));
         let model_provider = NonVisionModelProvider {
             calls: Arc::clone(&calls),
@@ -6484,7 +6520,7 @@ mod tests {
         let tools_registry: Vec<Box<dyn Tool>> = Vec::new();
         let observer = NoopObserver;
 
-        let err = run_tool_call_loop(
+        let result = run_tool_call_loop(
             &model_provider,
             &mut history,
             &tools_registry,
@@ -6516,11 +6552,10 @@ mod tests {
             None, // collected_receipts
         )
         .await
-        .expect_err("model_provider without vision support should fail");
+        .expect("non-vision provider should degrade to text, not abort");
 
-        assert!(err.to_string().contains("provider_capability_error"));
-        assert!(err.to_string().contains("capability=vision"));
-        assert_eq!(calls.load(Ordering::SeqCst), 0);
+        assert_eq!(result, "ok");
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]
@@ -6642,10 +6677,13 @@ mod tests {
         assert_eq!(calls.load(Ordering::SeqCst), 1);
     }
 
-    /// When `vision_model_provider` is not set and the default model_provider lacks vision
-    /// support, the original `ProviderCapabilityError` should be returned.
+    /// When `vision_model_provider` is not set and the default model_provider
+    /// lacks vision support, the loop must NOT abort the turn. Instead it
+    /// degrades gracefully: image markers are stripped and the text-only
+    /// provider is still called so the conversation continues (and any
+    /// accompanying text/metadata survives).
     #[tokio::test]
-    async fn run_tool_call_loop_no_vision_provider_config_preserves_error() {
+    async fn run_tool_call_loop_no_vision_provider_config_degrades_to_text() {
         let calls = Arc::new(AtomicUsize::new(0));
         let model_provider = NonVisionModelProvider {
             calls: Arc::clone(&calls),
@@ -6657,7 +6695,7 @@ mod tests {
         let tools_registry: Vec<Box<dyn Tool>> = Vec::new();
         let observer = NoopObserver;
 
-        let err = run_tool_call_loop(
+        let result = run_tool_call_loop(
             &model_provider,
             &mut history,
             &tools_registry,
@@ -6689,10 +6727,11 @@ mod tests {
             None, // collected_receipts
         )
         .await
-        .expect_err("should fail without vision_model_provider config");
+        .expect("text-only fallback should succeed, not abort the turn");
 
-        assert!(err.to_string().contains("capability=vision"));
-        assert_eq!(calls.load(Ordering::SeqCst), 0);
+        // Provider was invoked (no hard capability error) and returned text.
+        assert_eq!(result, "ok");
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
     }
 
     /// When `vision_model_provider` is set but the model_provider factory cannot resolve

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -1573,13 +1573,20 @@ pub async fn run_tool_call_loop(
         let use_native_tools = model_provider.supports_native_tools() && !tool_specs.is_empty();
 
         let image_marker_count = multimodal::count_image_markers(history);
+        // Image markers that came from the user (inbound attachments), as
+        // opposed to tool results. A missing vision capability is handled
+        // differently for the two: a user image must surface an error (we
+        // cannot silently ignore what the user sent), while a tool-result
+        // image may degrade to text-only.
+        let user_image_marker_count = multimodal::count_user_image_markers(history);
 
         // ── Vision model_provider routing ──────────────────────────
         // When the default model_provider lacks vision support but a dedicated
         // vision_model_provider is configured, create it on demand and use it
-        // for this iteration. When no vision route exists at all, degrade
-        // gracefully (strip the image markers, keep the surrounding text)
-        // rather than aborting the whole turn — see `degrade_strip_images`.
+        // for this iteration. When no vision route exists at all, either
+        // surface a capability error (the user sent an image) or degrade
+        // gracefully (the markers came only from tool results) — see the
+        // no-vision-route branch below and `degrade_strip_images`.
         let mut degrade_strip_images = false;
         let vision_model_provider_box: Option<Box<dyn ModelProvider>> = if image_marker_count > 0
             && !model_provider.supports_vision()
@@ -1618,15 +1625,31 @@ pub async fn run_tool_call_loop(
                     .into());
                 }
                 Some(vp_instance)
+            } else if user_image_marker_count > 0 {
+                // The user sent an image we cannot see. Surface a capability
+                // error so the attachment is not silently ignored — channels
+                // render this back to the user (e.g. "⚠️ Error … does not
+                // support vision"). Configuring a `vision_model_provider`
+                // routes around it.
+                return Err(ProviderCapabilityError {
+                        model_provider: provider_name.to_string(),
+                        capability: "vision".to_string(),
+                        message: format!(
+                            "received {image_marker_count} image marker(s), but this model_provider does not support vision input"
+                        ),
+                    }
+                    .into());
             } else {
-                // No vision route configured. Previously this aborted the entire
-                // turn with a capability error, which turned an otherwise
-                // successful tool call (e.g. `image_info`, which always returns
-                // useful metadata text alongside its `[IMAGE:]` marker) into a
-                // hard failure. Instead, degrade: strip the image markers from
-                // the messages sent to the text-only provider while preserving
-                // the surrounding text, so the conversation continues and the
-                // model still receives any accompanying metadata/caption.
+                // Markers came only from tool results (e.g. `image_info`,
+                // `screenshot`, `image_gen`). Previously this aborted the
+                // entire turn with a capability error, which turned an
+                // otherwise successful tool call (e.g. `image_info`, which
+                // always returns useful metadata text alongside its `[IMAGE:]`
+                // marker) into a hard failure. Instead, degrade: strip the
+                // image markers from the messages sent to the text-only
+                // provider while preserving the surrounding text, so the
+                // conversation continues and the model still receives any
+                // accompanying metadata/caption.
                 ::zeroclaw_log::record!(
                     WARN,
                     ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
@@ -1635,7 +1658,7 @@ pub async fn run_tool_call_loop(
                             "model_provider": provider_name,
                             "image_marker_count": image_marker_count,
                         })),
-                    "no vision route for image marker(s); degrading to text-only (markers stripped)"
+                    "no vision route for tool-result image marker(s); degrading to text-only (markers stripped)"
                 );
                 degrade_strip_images = true;
                 None
@@ -6548,12 +6571,12 @@ mod tests {
         }
     }
 
-    /// A non-vision provider with no configured `vision_model_provider` no
-    /// longer aborts the turn: the loop degrades to text-only (stripping image
-    /// markers) and still calls the provider. See the text-only fallback in
-    /// the vision-routing block.
+    /// A **user-supplied** image on a non-vision provider with no configured
+    /// `vision_model_provider` must surface a structured capability error
+    /// (channels render it back to the user) — we never silently ignore an
+    /// image the user actually sent.
     #[tokio::test]
-    async fn run_tool_call_loop_degrades_to_text_for_non_vision_provider() {
+    async fn run_tool_call_loop_returns_structured_error_for_non_vision_provider() {
         let calls = Arc::new(AtomicUsize::new(0));
         let model_provider = NonVisionModelProvider {
             calls: Arc::clone(&calls),
@@ -6565,7 +6588,7 @@ mod tests {
         let tools_registry: Vec<Box<dyn Tool>> = Vec::new();
         let observer = NoopObserver;
 
-        let result = run_tool_call_loop(
+        let err = run_tool_call_loop(
             &model_provider,
             &mut history,
             &tools_registry,
@@ -6597,10 +6620,11 @@ mod tests {
             None, // collected_receipts
         )
         .await
-        .expect("non-vision provider should degrade to text, not abort");
+        .expect_err("user image on a non-vision provider should error");
 
-        assert_eq!(result, "ok");
-        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert!(err.to_string().contains("provider_capability_error"));
+        assert!(err.to_string().contains("capability=vision"));
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
     }
 
     #[tokio::test]
@@ -6722,21 +6746,26 @@ mod tests {
         assert_eq!(calls.load(Ordering::SeqCst), 1);
     }
 
-    /// When `vision_model_provider` is not set and the default model_provider
-    /// lacks vision support, the loop must NOT abort the turn. Instead it
-    /// degrades gracefully: image markers are stripped and the text-only
-    /// provider is still called so the conversation continues (and any
-    /// accompanying text/metadata survives).
+    /// A **tool-result** image marker (e.g. from `image_info`/`screenshot`)
+    /// on a non-vision provider with no `vision_model_provider` must NOT abort
+    /// the turn. The user did not send an image, so the loop degrades
+    /// gracefully: markers are stripped and the text-only provider is still
+    /// called so the conversation continues (and any accompanying
+    /// text/metadata survives).
     #[tokio::test]
-    async fn run_tool_call_loop_no_vision_provider_config_degrades_to_text() {
+    async fn run_tool_call_loop_degrades_tool_result_image_for_non_vision_provider() {
         let calls = Arc::new(AtomicUsize::new(0));
         let model_provider = NonVisionModelProvider {
             calls: Arc::clone(&calls),
         };
 
-        let mut history = vec![ChatMessage::user(
-            "check [IMAGE:data:image/png;base64,iVBORw0KGgo=]".to_string(),
-        )];
+        // Marker lives in a tool result, not a user message.
+        let mut history = vec![
+            ChatMessage::user("inspect the screenshot".to_string()),
+            ChatMessage::tool(
+                "File: /tmp/x.png\n[IMAGE:data:image/png;base64,iVBORw0KGgo=]".to_string(),
+            ),
+        ];
         let tools_registry: Vec<Box<dyn Tool>> = Vec::new();
         let observer = NoopObserver;
 

--- a/crates/zeroclaw-tools/src/image_info.rs
+++ b/crates/zeroclaw-tools/src/image_info.rs
@@ -5,8 +5,18 @@ use std::sync::Arc;
 use zeroclaw_api::tool::{Tool, ToolResult};
 use zeroclaw_config::policy::SecurityPolicy;
 
-/// Maximum image file size we will read for metadata extraction (5 MB).
-const MAX_IMAGE_BYTES: u64 = 5_242_880;
+/// Upper bound on the image file size we will read for metadata extraction.
+///
+/// This is a coarse safety ceiling, not the multimodal size policy. The
+/// per-request decision on whether an image is small enough to inline for a
+/// vision model is the pipeline's `multimodal.max_image_size_mb`
+/// (`MultimodalConfig::effective_limits`, clamped to 1..=20 MB). We size this
+/// ceiling to that clamp's upper bound (20 MiB) so `image_info` never refuses
+/// to read — and therefore never silently withholds metadata for — a file the
+/// pipeline would otherwise have been configured to accept. When the pipeline
+/// limit is lower, the pipeline does the rejecting (with a model-facing note);
+/// `image_info` still returns the metadata text either way.
+const MAX_IMAGE_BYTES: u64 = 20 * 1024 * 1024;
 
 /// Tool to read image metadata and expose the image to vision-capable models.
 ///
@@ -254,29 +264,38 @@ impl Tool for ImageInfoTool {
         let format = Self::detect_format(&bytes);
         let dimensions = Self::extract_dimensions(&bytes, format);
 
-        // Emit an explicit `[IMAGE:<absolute path>]` marker so the multimodal
-        // pipeline inlines the image bytes for vision-capable models. We use
-        // the canonicalized absolute `resolved_path` rather than the
-        // caller-supplied `path_str` (which may be workspace-relative): the
-        // tool-result marker promoter only recognizes absolute paths, so a
-        // relative path would be silently dropped and never reach the model.
-        // Referencing the path only inside the marker also avoids emitting a
-        // second bare path that the promoter would wrap into a duplicate
-        // marker. See issue #7436.
+        // We emit two things for the resolved image:
+        //   1. A durable `File: <absolute path>` line, and
+        //   2. A standalone `[IMAGE:<absolute path>]` marker
+        // both using the canonicalized absolute path (not the caller-supplied
+        // `path_str`, which may be workspace-relative — the tool-result marker
+        // promoter only recognizes absolute paths, so a relative path would be
+        // silently dropped and never reach the model; see issue #7436).
+        //
+        // The `[IMAGE:]` marker is what the multimodal pipeline inlines for
+        // vision models, but it is stripped from older turns to control
+        // context size. The separate `File:` line keeps the path visible in
+        // history *after* the marker is gone, so the model retains the path
+        // (and can re-read the file via `image_info`) across turns. Emitting
+        // the same path twice is safe: the promoter
+        // (`canonicalize_tool_result_media_markers`) dedups a bare path that
+        // already appears inside an explicit marker, so the `File:` line is
+        // not wrapped into a second, double-counted marker.
         //
         // On Windows `canonicalize` returns a verbatim path (`\\?\C:\…`); we
-        // strip that prefix so the marker carries a plain `C:\…` path the
-        // multimodal pipeline's `is_windows_path` detector accepts. Otherwise
-        // the leading backslashes make it drop the marker and the image never
-        // reaches the vision model. See #7436 (Windows follow-up to #7446).
+        // strip that prefix so both the `File:` line and the marker carry a
+        // plain `C:\…` path the multimodal pipeline's `is_windows_path`
+        // detector accepts. Using the identical string for both also keeps the
+        // promoter's dedup exact. See #7436 (Windows follow-up to #7446).
         let resolved_display = resolved_path.display().to_string();
         let marker_path = Self::strip_windows_verbatim_prefix(&resolved_display);
-        let mut output =
-            format!("File: [IMAGE:{marker_path}]\nFormat: {format}\nSize: {file_size} bytes");
+        let mut output = format!("File: {marker_path}\nFormat: {format}\nSize: {file_size} bytes");
 
         if let Some((w, h)) = dimensions {
             let _ = write!(output, "\nDimensions: {w}x{h}");
         }
+
+        let _ = write!(output, "\n[IMAGE:{marker_path}]");
 
         Ok(ToolResult {
             success: true,

--- a/crates/zeroclaw-tools/src/image_info.rs
+++ b/crates/zeroclaw-tools/src/image_info.rs
@@ -5,14 +5,14 @@ use std::sync::Arc;
 use zeroclaw_api::tool::{Tool, ToolResult};
 use zeroclaw_config::policy::SecurityPolicy;
 
-/// Maximum file size we will read and base64-encode (5 MB).
+/// Maximum image file size we will read for metadata extraction (5 MB).
 const MAX_IMAGE_BYTES: u64 = 5_242_880;
 
-/// Tool to read image metadata and optionally return base64-encoded data.
+/// Tool to read image metadata and expose the image to vision-capable models.
 ///
-/// Since model_providers are currently text-only, this tool extracts what it can
-/// (file size, format, dimensions from header bytes) and provides base64
-/// data for future multimodal model_provider support.
+/// Extracts file size, format, and dimensions from header bytes, and emits an
+/// `[IMAGE:<absolute path>]` marker so the multimodal pipeline inlines the
+/// image bytes for the next provider call when the model supports vision.
 pub struct ImageInfoTool {
     // Pre-canonicalization path-allowlist enforcement lives in the
     // PathGuardedTool wrapper. The concrete tool still resolves raw tool
@@ -127,7 +127,7 @@ impl Tool for ImageInfoTool {
     }
 
     fn description(&self) -> &str {
-        "Read image file metadata (format, dimensions, size) and optionally return base64-encoded data."
+        "Read image file metadata (format, dimensions, size). The image is also made available to vision-capable models via an inline image marker."
     }
 
     fn parameters_schema(&self) -> serde_json::Value {
@@ -137,10 +137,6 @@ impl Tool for ImageInfoTool {
                 "path": {
                     "type": "string",
                     "description": "Path to the image file (absolute or relative to workspace)"
-                },
-                "include_base64": {
-                    "type": "boolean",
-                    "description": "Include base64-encoded image data in output (default: false)"
                 }
             },
             "required": ["path"]
@@ -158,11 +154,6 @@ impl Tool for ImageInfoTool {
             );
             anyhow::Error::msg("Missing 'path' parameter")
         })?;
-
-        let include_base64 = args
-            .get("include_base64")
-            .and_then(serde_json::Value::as_bool)
-            .unwrap_or(false);
 
         // Path-allowlist checks are applied by the PathGuardedTool wrapper at
         // registration time (see zeroclaw-runtime::tools::mod). Successful
@@ -241,24 +232,22 @@ impl Tool for ImageInfoTool {
         let format = Self::detect_format(&bytes);
         let dimensions = Self::extract_dimensions(&bytes, format);
 
-        let mut output = format!("File: {path_str}\nFormat: {format}\nSize: {file_size} bytes");
+        // Emit an explicit `[IMAGE:<absolute path>]` marker so the multimodal
+        // pipeline inlines the image bytes for vision-capable models. We use
+        // the canonicalized absolute `resolved_path` rather than the
+        // caller-supplied `path_str` (which may be workspace-relative): the
+        // tool-result marker promoter only recognizes absolute paths, so a
+        // relative path would be silently dropped and never reach the model.
+        // Referencing the path only inside the marker also avoids emitting a
+        // second bare path that the promoter would wrap into a duplicate
+        // marker. See issue #7436.
+        let mut output = format!(
+            "File: [IMAGE:{}]\nFormat: {format}\nSize: {file_size} bytes",
+            resolved_path.display()
+        );
 
         if let Some((w, h)) = dimensions {
             let _ = write!(output, "\nDimensions: {w}x{h}");
-        }
-
-        if include_base64 {
-            use base64::Engine;
-            let encoded = base64::engine::general_purpose::STANDARD.encode(&bytes);
-            let mime = match format {
-                "png" => "image/png",
-                "jpeg" => "image/jpeg",
-                "gif" => "image/gif",
-                "webp" => "image/webp",
-                "bmp" => "image/bmp",
-                _ => "application/octet-stream",
-            };
-            let _ = write!(output, "\ndata:{mime};base64,{encoded}");
         }
 
         Ok(ToolResult {
@@ -353,7 +342,9 @@ mod tests {
         let tool = ImageInfoTool::new(test_security());
         let schema = tool.parameters_schema();
         assert!(schema["properties"]["path"].is_object());
-        assert!(schema["properties"]["include_base64"].is_object());
+        // `include_base64` was removed: the image now reaches vision models via
+        // an inline `[IMAGE:]` marker, not a bare base64 blob (issue #7436).
+        assert!(schema["properties"]["include_base64"].is_null());
         let required = schema["required"].as_array().unwrap();
         assert!(required.contains(&json!("path")));
     }
@@ -531,6 +522,16 @@ mod tests {
         assert!(result.output.contains("Format: png"));
         assert!(result.output.contains("Dimensions: 1x1"));
         assert!(!result.output.contains("data:"));
+        // The output carries an absolute-path [IMAGE:] marker so the
+        // multimodal pipeline can inline the image for vision models.
+        let canonical = tokio::fs::canonicalize(&png_path).await.unwrap();
+        assert!(
+            result
+                .output
+                .contains(&format!("[IMAGE:{}]", canonical.display())),
+            "expected absolute-path image marker, got: {}",
+            result.output
+        );
     }
 
     #[tokio::test]
@@ -611,6 +612,22 @@ mod tests {
             result.error
         );
         assert!(result.output.contains("Format: png"));
+        // Regression for issue #7436: a workspace-relative path must still be
+        // emitted as an absolute-path [IMAGE:] marker. Before the fix the tool
+        // echoed the relative input, which the marker promoter (anchored on a
+        // leading `/`) silently dropped, so the image never reached the model.
+        let canonical = tokio::fs::canonicalize(&png_path).await.unwrap();
+        assert!(
+            result
+                .output
+                .contains(&format!("[IMAGE:{}]", canonical.display())),
+            "expected absolute-path image marker, got: {}",
+            result.output
+        );
+        assert!(
+            canonical.is_absolute(),
+            "marker path must be absolute so the multimodal pipeline can load it"
+        );
     }
 
     #[cfg(unix)]
@@ -699,17 +716,30 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn execute_with_base64() {
+    async fn emits_inline_image_marker_with_absolute_path() {
+        // The image must be exposed to vision models via an [IMAGE:] marker
+        // carrying the canonical absolute path, regardless of how the caller
+        // spelled the input path (issue #7436).
         let dir = TempDir::new().unwrap();
-        let png_path = dir.path().join("test_b64.png");
+        let png_path = dir.path().join("marker.png");
         tokio::fs::write(&png_path, MINIMAL_PNG).await.unwrap();
 
         let tool = ImageInfoTool::new(test_security());
         let result = tool
-            .execute(json!({"path": png_path.to_string_lossy(), "include_base64": true}))
+            .execute(json!({"path": png_path.to_string_lossy()}))
             .await
             .unwrap();
+
         assert!(result.success);
-        assert!(result.output.contains("data:image/png;base64,"));
+        let canonical = tokio::fs::canonicalize(&png_path).await.unwrap();
+        assert!(
+            result
+                .output
+                .contains(&format!("[IMAGE:{}]", canonical.display())),
+            "expected absolute-path image marker, got: {}",
+            result.output
+        );
+        // No bare base64 blob should leak into the text output anymore.
+        assert!(!result.output.contains("base64,"));
     }
 }

--- a/crates/zeroclaw-tools/src/image_info.rs
+++ b/crates/zeroclaw-tools/src/image_info.rs
@@ -25,6 +25,28 @@ impl ImageInfoTool {
         Self { security }
     }
 
+    /// Strip the Windows verbatim (`\\?\`) prefix that `canonicalize` prepends
+    /// on Windows, so the emitted `[IMAGE:]` marker carries a plain
+    /// drive-letter path (`C:\…`) instead of `\\?\C:\…`.
+    ///
+    /// This matters because the multimodal pipeline's path detector
+    /// (`zeroclaw-providers::multimodal::is_windows_path`) only recognizes
+    /// paths beginning with a drive letter; the leading backslashes of the
+    /// verbatim form make it reject the marker, so the image would never be
+    /// inlined for vision-capable models. The verbatim UNC form
+    /// (`\\?\UNC\server\share\…`) is unwrapped back to its `\\server\share\…`
+    /// spelling. Inputs without a verbatim prefix (e.g. all POSIX paths) are
+    /// returned unchanged and without allocating.
+    fn strip_windows_verbatim_prefix(path: &str) -> std::borrow::Cow<'_, str> {
+        if let Some(rest) = path.strip_prefix(r"\\?\UNC\") {
+            std::borrow::Cow::Owned(format!(r"\\{rest}"))
+        } else if let Some(rest) = path.strip_prefix(r"\\?\") {
+            std::borrow::Cow::Borrowed(rest)
+        } else {
+            std::borrow::Cow::Borrowed(path)
+        }
+    }
+
     /// Detect image format from first few bytes (magic numbers).
     fn detect_format(bytes: &[u8]) -> &'static str {
         if bytes.len() < 4 {
@@ -241,10 +263,16 @@ impl Tool for ImageInfoTool {
         // Referencing the path only inside the marker also avoids emitting a
         // second bare path that the promoter would wrap into a duplicate
         // marker. See issue #7436.
-        let mut output = format!(
-            "File: [IMAGE:{}]\nFormat: {format}\nSize: {file_size} bytes",
-            resolved_path.display()
-        );
+        //
+        // On Windows `canonicalize` returns a verbatim path (`\\?\C:\…`); we
+        // strip that prefix so the marker carries a plain `C:\…` path the
+        // multimodal pipeline's `is_windows_path` detector accepts. Otherwise
+        // the leading backslashes make it drop the marker and the image never
+        // reaches the vision model. See #7436 (Windows follow-up to #7446).
+        let resolved_display = resolved_path.display().to_string();
+        let marker_path = Self::strip_windows_verbatim_prefix(&resolved_display);
+        let mut output =
+            format!("File: [IMAGE:{marker_path}]\nFormat: {format}\nSize: {file_size} bytes");
 
         if let Some((w, h)) = dimensions {
             let _ = write!(output, "\nDimensions: {w}x{h}");
@@ -355,6 +383,44 @@ mod tests {
         let spec = tool.spec();
         assert_eq!(spec.name, "image_info");
         assert!(spec.parameters.is_object());
+    }
+
+    // ── Windows verbatim-prefix stripping ───────────────────────
+
+    #[test]
+    fn strip_verbatim_disk_prefix() {
+        // `canonicalize` on Windows yields `\\?\C:\…`; the marker must carry
+        // the plain drive-letter path so `is_windows_path` accepts it.
+        assert_eq!(
+            ImageInfoTool::strip_windows_verbatim_prefix(r"\\?\C:\Users\me\Downloads\a.png"),
+            r"C:\Users\me\Downloads\a.png"
+        );
+    }
+
+    #[test]
+    fn strip_verbatim_unc_prefix() {
+        // Verbatim UNC unwraps back to the `\\server\share\…` spelling.
+        assert_eq!(
+            ImageInfoTool::strip_windows_verbatim_prefix(r"\\?\UNC\server\share\pic.png"),
+            r"\\server\share\pic.png"
+        );
+    }
+
+    #[test]
+    fn strip_verbatim_prefix_leaves_plain_paths_unchanged() {
+        // POSIX paths and already-plain Windows paths must pass through
+        // untouched (and without allocating).
+        for input in [
+            "/home/me/pictures/a.png",
+            r"C:\Users\me\a.png",
+            "relative/a.png",
+        ] {
+            assert!(matches!(
+                ImageInfoTool::strip_windows_verbatim_prefix(input),
+                std::borrow::Cow::Borrowed(_)
+            ));
+            assert_eq!(ImageInfoTool::strip_windows_verbatim_prefix(input), input);
+        }
     }
 
     // ── Format detection ────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - **(original)** `image_info` only delivered its image to a vision model when called with an **absolute POSIX path** — its `File:` line echoed the caller-supplied `path_str`, and the tool-result marker promoter (`canonicalize_tool_result_media_markers`) is anchored on a leading `/` + `is_absolute()`, so a workspace-relative path was silently dropped. Now it emits an explicit `[IMAGE:<canonical absolute path>]` marker from the resolved path, removes the dead `include_base64` parameter, and strips the Windows verbatim prefix (`\\?\C:\…`, `\\?\UNC\…`) so the marker carries a plain path.
  - **(follow-up) UNC actually reaches the model.** The verbatim-UNC unwrap above produced `\\server\share\…`, but the downstream loadability gate (`is_loadable_image_reference` / `is_windows_path`) only accepted `/`-rooted and `C:\` drive paths — so the marker was left as literal text and never inlined. Added `is_windows_unc_path` to the gate and extended the promoter regex to recognize Windows drive **and** UNC bare paths. Without this, the verbatim-UNC handling was inert.
  - **(follow-up) Non-vision handling, split by marker origin.** Emitting an image marker on a model without vision support (and no `vision_model_provider` configured) previously returned a hard `ProviderCapabilityError` that killed the whole turn — even when the image came from a tool, not the user. Now:
    - A **user-supplied** image still surfaces the capability error, so channels render it back to the user (\"⚠️ Error … does not support vision\") and the attachment is not silently ignored.
    - A **tool-result** image marker (`image_info` / `screenshot` / `image_gen`) degrades to text-only — markers are stripped, surrounding text/metadata is kept, and the provider is still called so the turn completes.
    - A configured-but-non-vision `vision_model_provider` is still a hard error (operator misconfiguration).
  - **(follow-up) Size cap aligned with the pipeline.** `image_info`'s hard 5 MB read ceiling was decoupled from `multimodal.max_image_size_mb` (clamped 1..=20 MB); it could refuse a file the pipeline was configured to accept. The ceiling is now the clamp's upper bound (20 MiB); the per-request decision is the pipeline's config.
  - **(follow-up) Durable path survives marker stripping.** Putting the path *only* inside the marker meant that once the marker was stripped from older turns, the path vanished entirely — the model could not even re-read the file. `image_info` now emits a `File: <abs path>` line **and** the marker; the promoter dedups a bare path already present in a marker so the extra line is not double-counted.
  - **(follow-up) BMP no longer breaks the request.** `image/bmp` was in the inline-allowed MIME list, but no major vision provider (Anthropic, OpenAI) accepts BMP — inlining it made the *entire* provider request fail. BMP is dropped from the allowed list, so it is skipped with a \"could not be loaded\" note while the rest of the request goes through.
- **Scope boundary:** Touches `crates/zeroclaw-tools/src/image_info.rs`, `crates/zeroclaw-providers/src/multimodal.rs`, and `crates/zeroclaw-runtime/src/agent/{history.rs,loop_.rs}`. Does **not** change `image_gen`/`screenshot`, channel code, or the provider adapters' image-block conversion. Does not rework the stale-tool-result stripping policy (kept for context control).
- **Blast radius:**
  - `image_info` output shape (now a `File:` line + standalone `[IMAGE:]` marker; no base64 blob) and schema (`include_base64` removed).
  - Multimodal loadability gate + promoter regex now accept UNC/drive paths — affects any tool output printing image paths, not just `image_info`.
  - Non-vision degradation applies to **tool-result** markers only (so `screenshot`/`image_gen` on a non-vision model now degrade rather than abort); **user** image attachments still surface the capability error unchanged.
  - `image/bmp` is no longer inlined for any source.
- **Linked issue(s):** Addresses #7436.

## Validation Evidence (required)

- **Commands run and tail output** (scoped to the crates this PR touches, plus `zeroclaw-channels` which has the photo-attachment e2e contract):

\`\`\`
$ cargo fmt -p zeroclaw-providers -p zeroclaw-tools -p zeroclaw-runtime -p zeroclaw-channels -- --check
(clean — no output)

$ cargo clippy -p zeroclaw-providers -p zeroclaw-tools -p zeroclaw-runtime -p zeroclaw-channels --lib --all-targets -- -D warnings
    Finished \`dev\` profile [unoptimized + debuginfo] target(s) in 6m 43s
(no warnings)

$ cargo test --no-fail-fast -p zeroclaw-providers -p zeroclaw-tools -p zeroclaw-runtime -p zeroclaw-channels --lib
  zeroclaw_channels  test result: ok. 726 passed; 0 failed; 1 ignored
  zeroclaw_providers test result: ok. 922 passed; 0 failed; 0 ignored
  zeroclaw_runtime   test result: ok. 2033 passed; 0 failed; 1 ignored
  zeroclaw_tools     test result: ok. 1312 passed; 0 failed; 0 ignored
\`\`\`

- **Beyond CI — what did you manually verify?** Added regression tests for: UNC recognition (`is_windows_unc_path`) and extraction (`parse_image_markers` treats `\\server\share\…` as a loadable ref); BMP rejection by `validate_mime`; promoter dedup (a bare path already inside an `[IMAGE:]` marker is not promoted to a second marker, order-independent); the **user-image** capability error (preserved); and the **tool-result** text-only degradation path. The two `zeroclaw-channels` orchestrator e2e tests (`e2e_photo_attachment_rejected_by_non_vision_provider`, `e2e_failed_vision_turn_does_not_poison_follow_up_text_turn`) confirm a user photo on a non-vision provider still replies with the capability error. Not exercised end-to-end against a live vision provider on Windows.
- **If any command was intentionally skipped, why:** Validation is scoped to the four crates this PR touches/affects. Note: `zeroclaw-tools`'s `browser::tests::is_service_environment_*` tests mutate shared process env vars (`JOURNAL_STREAM` / `INVOCATION_ID`) and can race under parallel execution; they pass in isolation (`--test-threads=1`) and are unrelated to this diff (which does not touch `browser.rs`). The whole-repo `cargo test` **doc-test** phase fails to start with `error: Option 'default-theme' given more than once` — a pre-existing environment issue (`.cargo/config.toml` `rustdocflags = [\"--default-theme=ayu\"]` received duplicated), unrelated to this diff, which adds no doctests.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No` — images are still read through the same `PathGuardedTool` allowlist + readable-root checks; the multimodal loader reads marker paths exactly as before.
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes`, with two intentional behavior changes that make the pipeline more robust:
  - A **tool-result** image marker on a non-vision model with no `vision_model_provider` no longer aborts the turn — it degrades to text-only. (User-supplied images are unchanged: they still surface the capability error.)
  - `image/bmp` images are no longer inlined; they are skipped with a note rather than failing the whole provider request.
  - (From the original change) an agent still passing `include_base64` has it ignored.
- Config / env / CLI surface changed? `Yes` — the `image_info` parameter schema drops `include_base64` and the output no longer carries a `data:…;base64,…` blob. No new config/env/CLI keys; existing `multimodal.*` keys are unchanged (the size cap now honors `max_image_size_mb` more faithfully).
- Upgrade steps for existing users: None required. Prompts/tooling referencing `image_info`'s `include_base64` should drop it (now a no-op).

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk: `git revert <sha>` is the plan.