### PR TITLE
fix(providers): wire timeout_secs config into native OpenAI provider (#6723)

### DIFF
--- a/crates/zeroclaw-providers/src/factory.rs
+++ b/crates/zeroclaw-providers/src/factory.rs
@@ -800,6 +800,9 @@ impl FamilyProviderFactory for OpenAIModelProviderConfig {
         if let Some(mt) = opts.provider_max_tokens {
             p = p.with_max_tokens(Some(mt));
         }
+        if let Some(t) = opts.provider_timeout_secs {
+            p = p.with_timeout_secs(t);
+        }
         Ok(Box::new(p))
     }
 }

--- a/crates/zeroclaw-providers/src/openai.rs
+++ b/crates/zeroclaw-providers/src/openai.rs
@@ -27,6 +27,9 @@ pub struct OpenAiModelProvider {
     base_url: String,
     credential: Option<String>,
     max_tokens: Option<u32>,
+    /// Per-request timeout in seconds. Falls back to 120 when unset,
+    /// matching the historical hardcoded default.
+    timeout_secs: Option<u64>,
 }
 
 #[derive(Debug, Serialize)]
@@ -216,12 +219,20 @@ impl OpenAiModelProvider {
                 .unwrap_or_else(|| BASE_URL.to_string()),
             credential: credential.map(ToString::to_string),
             max_tokens: None,
+            timeout_secs: None,
         }
     }
 
     /// Set the maximum output tokens for API requests.
     pub fn with_max_tokens(mut self, max_tokens: Option<u32>) -> Self {
         self.max_tokens = max_tokens;
+        self
+    }
+
+    /// Override the per-request timeout in seconds.
+    /// Falls back to 120 when unset, matching the historical default.
+    pub fn with_timeout_secs(mut self, timeout_secs: u64) -> Self {
+        self.timeout_secs = Some(timeout_secs);
         self
     }
 
@@ -368,9 +379,10 @@ impl OpenAiModelProvider {
     }
 
     fn http_client(&self) -> Client {
+        let timeout = self.timeout_secs.unwrap_or(120);
         zeroclaw_config::schema::build_runtime_proxy_client_with_timeouts(
             "model_provider.openai",
-            120,
+            timeout,
             10,
         )
     }


### PR DESCRIPTION
## Summary

- **Issue:** Closes #6723
- **What changed:** The native OpenAI provider (`OpenAiModelProvider`) now honors the `timeout_secs` config field instead of hardcoding a 120-second request timeout.
- **Why:** Users pointing the native OpenAI provider at slow upstreams (local llama.cpp / vLLM / Ollama via OpenAI-compat shim, high-latency regional endpoints) would see failures at exactly 120s regardless of their configured `timeout_secs`. The compatible provider path already honors this setting.
- **Scope boundary:** Confined to `crates/zeroclaw-providers/src/openai.rs` (struct, setter, http_client) and `factory.rs` (wire `opts.provider_timeout_secs`). No config schema, web UI, or docs changes.
- **Labels:** `bug`, `size: XS`, `risk: medium`, `provider`, `provider:openai`

## Files Changed

- `crates/zeroclaw-providers/src/openai.rs` — add `timeout_secs: Option<u64>` field, `with_timeout_secs()` setter, use configured value in `http_client()` (default 120)
- `crates/zeroclaw-providers/src/factory.rs` — wire `opts.provider_timeout_secs` through the factory

## Validation

- `cargo check -p zeroclaw-providers` — passes
- Backward compatible: when `timeout_secs` is `None`, the 120-second default is preserved
- All existing tests continue to pass (tests construct via `OpenAiModelProvider::new()` which uses the default `None` timeout)

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Upgrade steps: None.

## Rollback

`git revert <sha>` restores the previous hardcoded 120-second timeout. No config schema or runtime changes are included.