### PR TITLE
fix(memory): bind postgres schema version as int4

### DIFF
--- a/crates/zeroclaw-config/src/schema/v2.rs
+++ b/crates/zeroclaw-config/src/schema/v2.rs
@@ -3213,6 +3213,12 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> MigResult<()> {
 /// PRAGMA detection.
 pub const SQLITE_MEMORY_SCHEMA_VERSION: i64 = 1;
 
+#[cfg(feature = "memory-postgres")]
+fn postgres_memory_schema_version() -> MigResult<i32> {
+    i32::try_from(SQLITE_MEMORY_SCHEMA_VERSION)
+        .context("Postgres memory schema version exceeds INTEGER range")
+}
+
 /// Migrate a SQLite memory database to the V3 multi-agent shape.
 ///
 /// Adds the `agents` table, the `agent_id` column on `memories`,
@@ -3602,13 +3608,14 @@ pub fn migrate_postgres_memory_to_v3(
             applied_at TIMESTAMPTZ NOT NULL
         );"
     ))?;
+    let memory_schema_version = postgres_memory_schema_version()?;
     client.execute(
         &format!(
             "INSERT INTO {schema_ident}.schema_version (component, version, applied_at) \
              VALUES ('memories', $1, NOW()) \
              ON CONFLICT (component) DO UPDATE SET version = EXCLUDED.version, applied_at = EXCLUDED.applied_at"
         ),
-        &[&SQLITE_MEMORY_SCHEMA_VERSION],
+        &[&memory_schema_version],
     )?;
     Ok(())
 }
@@ -4084,6 +4091,20 @@ mod fs_db_migration_tests {
             )
             .unwrap();
         assert_eq!(count, 1, "existing memory row must survive the migration");
+    }
+
+    #[cfg(feature = "memory-postgres")]
+    #[test]
+    fn memory_schema_version_binds_to_postgres_int4() {
+        use postgres::types::{ToSql, Type};
+
+        fn accepts_int4<T: ToSql>(_: &T) -> bool {
+            T::accepts(&Type::INT4)
+        }
+
+        let version = postgres_memory_schema_version().expect("version fits Postgres INTEGER");
+        assert_eq!(i64::from(version), SQLITE_MEMORY_SCHEMA_VERSION);
+        assert!(accepts_int4(&version));
     }
 
     /// Predict the V3 absolute path for a legacy path relative to


### PR DESCRIPTION
## Summary

Fixes #7421 by binding the Postgres memory schema version as an `i32`, matching the `INTEGER` / `int4` column used by `schema_version.version`.

## Why

The Postgres memory migration creates `schema_version.version` as `INTEGER NOT NULL`, but the insert previously bound `SQLITE_MEMORY_SCHEMA_VERSION` directly. That constant is an `i64`, and the `postgres` crate rejects serializing an `i64` parameter into an `int4` column, which matches the reported startup failure: `cannot convert between the Rust type i64 and the Postgres type int4`.

## Changes

- Added a small Postgres-only helper that derives a checked `i32` value from the existing canonical memory schema version.
- Updated the Postgres memory migration to bind that `i32` value.
- Added a focused regression test for the `ToSql` / `INT4` bind contract.

This keeps `SQLITE_MEMORY_SCHEMA_VERSION` as the single source of truth and does not change the schema or SQLite behavior.

## Verification

```bash
cargo test -p zeroclaw-config --features memory-postgres memory_schema_version_binds_to_postgres_int4
cargo test -p zeroclaw-config --features memory-postgres schema::v2::fs_db_migration_tests
cargo test -p zeroclaw-config --features memory-postgres
cargo test -p zeroclaw-memory --features memory-postgres
cargo fmt --all -- --check
cargo clippy -p zeroclaw-config --features memory-postgres --all-targets -- -D warnings
cargo clippy -p zeroclaw-memory --features memory-postgres --all-targets -- -D warnings
```
