### PR TITLE
fix(ci): fixes manual dev/ci.sh all test failure

### DIFF
--- a/tests/manual/test_dockerignore.sh
+++ b/tests/manual/test_dockerignore.sh
@@ -41,7 +41,6 @@ MUST_EXCLUDE=(
     "target"
     "docs"
     "examples"
-    "tests"
     "*.md"
     "*.png"
     "*.db"
@@ -108,7 +107,6 @@ CONTEXT_FILES=$(find . -type f \
     ! -path './target/*' \
     ! -path './docs/*' \
     ! -path './examples/*' \
-    ! -path './tests/*' \
     ! -name '*.md' \
     ! -name '*.png' \
     ! -name '*.svg' \


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
#7176 needs the 'tests' folder as part of the docker context, but `tests/manual/test_dockerignore.sh` still requires it. When a user runs `./dev/ci.sh all` as recommended in CONTRIBUTING.md, it exits early in the 'test_dockerignore' step. This PR updates `test_dockerignore.sh` in a similar way as `tests/components/dockerignore_test.rs` was edited in https://github.com/zeroclaw-labs/zeroclaw/pull/7176/changes/04d80ed73506f424bc8cc42340a00d1ffdd31894
- **Scope boundary:** no changes outside of the minimal amount to align two similar tests
- **Blast radius:** restores the existing function of the manual CI tests
- **Linked issue(s):** Related #7176
- **Labels:** `bug`, `size: XS`, `tests`

## Validation Evidence (required)

This change is only to the CI. Validation is for the CI itself

- **Commands run and tail output:**
**Before**
```bash
$ ./dev/ci.sh test-manual
Container zeroclaw-local-ci-local-ci-run-8ffcd984ee48 Creating 
Container zeroclaw-local-ci-local-ci-run-8ffcd984ee48 Created 
=== Testing .dockerignore ===
✓ .dockerignore file exists
✓ Excludes: .git
✓ Excludes: .githooks
✓ Excludes: target
✓ Excludes: docs
✓ Excludes: examples
✗ Missing exclusion: tests
✓ Excludes: *.md
✓ Excludes: *.png
✓ Excludes: *.db
✓ Excludes: *.db-journal
✓ Excludes: .DS_Store
✓ Excludes: .github
✓ Excludes: deny.toml
✓ Excludes: LICENSE
✓ Excludes: .env
✓ Excludes: .tmp_*
✓ Build essential NOT excluded: Cargo.toml
✓ Build essential NOT excluded: Cargo.lock
✓ Build essential NOT excluded: src
✓ No trailing whitespace in patterns

=== Simulating Docker build context ===
Total files in repo: 183704
Files in Docker context: 12417
✓ Docker context is smaller than full repo (12417 < 183704 files)

=== Security checks ===
✓ .git directory will be excluded (security)

=== Summary ===
Passed: 22
Failed: 1
FAILED: 1 tests failed
```

**After**
```bash
$ ./dev/ci.sh test-manual
Container zeroclaw-local-ci-local-ci-run-0c70b0141759 Creating 
Container zeroclaw-local-ci-local-ci-run-0c70b0141759 Created 
=== Testing .dockerignore ===
✓ .dockerignore file exists
✓ Excludes: .git
✓ Excludes: .githooks
✓ Excludes: target
✓ Excludes: docs
✓ Excludes: examples
✓ Excludes: *.md
✓ Excludes: *.png
✓ Excludes: *.db
✓ Excludes: *.db-journal
✓ Excludes: .DS_Store
✓ Excludes: .github
✓ Excludes: deny.toml
✓ Excludes: LICENSE
✓ Excludes: .env
✓ Excludes: .tmp_*
✓ Build essential NOT excluded: Cargo.toml
✓ Build essential NOT excluded: Cargo.lock
✓ Build essential NOT excluded: src
✓ No trailing whitespace in patterns

=== Simulating Docker build context ===
Total files in repo: 183704
Files in Docker context: 12479
✓ Docker context is smaller than full repo (12479 < 183704 files)

=== Security checks ===
✓ .git directory will be excluded (security)

=== Summary ===
Passed: 22
Failed: 0
PASSED: All tests passed
```
- **Beyond CI — what did you manually verify?**
Searched for text 'test_dockerignore.sh': found in
  - `dev/ci.sh`
  - `tests/manual/test_dockerignore.sh`

- **If any command was intentionally skipped, why:**

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation:

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: exact upgrade steps for existing users:

## Rollback (required for `risk: medium` and `risk: high`)

`git revert <sha>`
