### PR TITLE
fix(runtime): apply MCP policy to MCP registration

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -1177,10 +1177,9 @@ impl Agent {
         // `file_write`. Filtering here, before skill registration, is also
         // what lets a scoped elevation wrapper survive: the raw target is
         // removed while the distinct prefixed `{skill}__{tool}` wrapper is
-        // appended later. MCP tools are injected after this gate and are
-        // intentionally exempt from the built-in allow/deny filter (a
-        // restrictive allowlist must not silently drop all MCP tools); the
-        // risk-profile denylist below still applies to them.
+        // appended later. MCP tools are initialized after this built-in
+        // filter, then MCP registration and deferred discovery apply the same
+        // SecurityPolicy explicitly so denied MCP tools do not surface.
         let before_policy_filter = tools.len();
         crate::agent::loop_::apply_policy_tool_filter(&mut tools, Some(security.as_ref()), None);
         if tools.len() != before_policy_filter {
@@ -1217,6 +1216,8 @@ impl Agent {
                 Ok(registry) => {
                     let registry = std::sync::Arc::new(registry);
                     mcp_elevation_arcs = tools::collect_mcp_elevation_arcs(&registry).await;
+                    let mcp_policy =
+                        crate::agent::loop_::mcp_tool_access_policy(security.as_ref(), None);
                     if config.mcp.deferred_loading {
                         let deferred_set = tools::DeferredMcpToolSet::from_registry(
                             std::sync::Arc::clone(&registry),
@@ -1234,17 +1235,36 @@ impl Agent {
                                 registry.server_count()
                             )
                         );
-                        let activated =
-                            Arc::new(std::sync::Mutex::new(tools::ActivatedToolSet::new()));
-                        activated_tools = Some(Arc::clone(&activated));
-                        tools.push(Box::new(tools::ToolSearchTool::new(
-                            deferred_set,
-                            activated,
-                        )));
+                        let allowed_stub_count = crate::agent::loop_::mcp_allowed_tool_count(
+                            deferred_set
+                                .stubs
+                                .iter()
+                                .map(|stub| stub.prefixed_name.as_str()),
+                            mcp_policy.as_ref(),
+                        );
+                        if allowed_stub_count > 0 {
+                            let activated =
+                                Arc::new(std::sync::Mutex::new(tools::ActivatedToolSet::new()));
+                            activated_tools = Some(Arc::clone(&activated));
+                            let mut tool_search =
+                                tools::ToolSearchTool::new(deferred_set, activated);
+                            if let Some(policy) = mcp_policy {
+                                tool_search = tool_search.with_access_policy(policy);
+                            }
+                            tools.push(Box::new(tool_search));
+                        }
                     } else {
                         let names = registry.tool_names();
                         let mut registered = 0usize;
+                        let mut skipped = 0usize;
                         for name in names {
+                            if !crate::agent::loop_::eager_mcp_tool_allowed(
+                                &name,
+                                mcp_policy.as_ref(),
+                            ) {
+                                skipped += 1;
+                                continue;
+                            }
                             if let Some(def) = registry.get_tool_def(&name).await {
                                 let wrapper: std::sync::Arc<dyn tools::Tool> =
                                     std::sync::Arc::new(tools::McpToolWrapper::new(
@@ -1252,11 +1272,14 @@ impl Agent {
                                         def,
                                         std::sync::Arc::clone(&registry),
                                     ));
-                                if let Some(ref handle) = delegate_handle {
-                                    handle.write().push(std::sync::Arc::clone(&wrapper));
+                                if crate::agent::loop_::register_eager_mcp_tool_if_allowed(
+                                    wrapper,
+                                    &mut tools,
+                                    delegate_handle.as_ref(),
+                                    mcp_policy.as_ref(),
+                                ) {
+                                    registered += 1;
                                 }
-                                tools.push(Box::new(tools::ArcToolRef(wrapper)));
-                                registered += 1;
                             }
                         }
                         ::zeroclaw_log::record!(
@@ -1266,9 +1289,10 @@ impl Agent {
                                 ::zeroclaw_log::Action::Note
                             ),
                             &format!(
-                                "MCP: {} tool(s) registered from {} server(s)",
+                                "MCP: {} tool(s) registered from {} server(s), {} skipped by policy",
                                 registered,
-                                registry.server_count()
+                                registry.server_count(),
+                                skipped
                             )
                         );
                     }

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -220,6 +220,50 @@ pub fn apply_policy_tool_filter(
     });
 }
 
+pub(crate) fn mcp_tool_access_policy(
+    security: &zeroclaw_config::policy::SecurityPolicy,
+    caller_allowed: Option<&[String]>,
+) -> Option<zeroclaw_tools::tool_search::ToolAccessPolicy> {
+    zeroclaw_tools::tool_search::ToolAccessPolicy::from_security(
+        security.allowed_tools.as_deref(),
+        security.excluded_tools.as_deref(),
+        caller_allowed,
+    )
+}
+
+pub(crate) fn eager_mcp_tool_allowed(
+    name: &str,
+    policy: Option<&zeroclaw_tools::tool_search::ToolAccessPolicy>,
+) -> bool {
+    policy.is_none_or(|policy| policy.is_tool_allowed(name))
+}
+
+pub(crate) fn mcp_allowed_tool_count<'a>(
+    names: impl IntoIterator<Item = &'a str>,
+    policy: Option<&zeroclaw_tools::tool_search::ToolAccessPolicy>,
+) -> usize {
+    names
+        .into_iter()
+        .filter(|name| eager_mcp_tool_allowed(name, policy))
+        .count()
+}
+
+pub(crate) fn register_eager_mcp_tool_if_allowed(
+    wrapper: std::sync::Arc<dyn Tool>,
+    tools: &mut Vec<Box<dyn Tool>>,
+    delegate_handle: Option<&tools::DelegateParentToolsHandle>,
+    policy: Option<&zeroclaw_tools::tool_search::ToolAccessPolicy>,
+) -> bool {
+    if !eager_mcp_tool_allowed(wrapper.name(), policy) {
+        return false;
+    }
+    if let Some(handle) = delegate_handle {
+        handle.write().push(std::sync::Arc::clone(&wrapper));
+    }
+    tools.push(Box::new(tools::ArcToolRef(wrapper)));
+    true
+}
+
 /// Apply the SecurityPolicy built-in tool filter on the channel/daemon
 /// (`process_message`) path.
 ///
@@ -3316,9 +3360,8 @@ pub async fn run(
         // ── Wire MCP tools (non-fatal) — CLI path ────────────────────
         // NOTE: MCP tools are injected after built-in tool filtering
         // (filter_primary_agent_tools_or_fail / agent.allowed_tools / agent.denied_tools).
-        // MCP servers are user-declared external integrations; the built-in allow/deny
-        // filter is not appropriate for them and would silently drop all MCP tools when
-        // a restrictive allowlist is configured. Keep this block after any such filter call.
+        // MCP registration and deferred discovery then apply the same policy
+        // explicitly so denied MCP tools never surface in context or delegate handles.
         //
         // When `deferred_loading` is enabled, MCP tools are NOT added to the registry
         // eagerly. Instead, a `tool_search` built-in is registered so the LLM can
@@ -3342,6 +3385,8 @@ pub async fn run(
                 Ok(registry) => {
                     let registry = std::sync::Arc::new(registry);
                     mcp_elevation_arcs = crate::tools::collect_mcp_elevation_arcs(&registry).await;
+                    let mcp_policy =
+                        mcp_tool_access_policy(security.as_ref(), allowed_tools.as_deref());
                     if config.mcp.deferred_loading {
                         // Deferred path: build stubs and register tool_search
                         let deferred_set = crate::tools::DeferredMcpToolSet::from_registry(
@@ -3360,33 +3405,40 @@ pub async fn run(
                                 registry.server_count()
                             )
                         );
-                        // Build access policy from SecurityPolicy so blocked
-                        // MCP tools never surface anywhere in context.
-                        let mcp_policy =
-                            zeroclaw_tools::tool_search::ToolAccessPolicy::from_security(
-                                security.allowed_tools.as_deref(),
-                                security.excluded_tools.as_deref(),
-                                allowed_tools.as_deref(),
-                            );
+                        let allowed_stub_count = mcp_allowed_tool_count(
+                            deferred_set
+                                .stubs
+                                .iter()
+                                .map(|stub| stub.prefixed_name.as_str()),
+                            mcp_policy.as_ref(),
+                        );
                         deferred_section = crate::tools::build_deferred_tools_section_filtered(
                             &deferred_set,
                             mcp_policy.as_ref(),
                         );
-                        let activated = std::sync::Arc::new(std::sync::Mutex::new(
-                            crate::tools::ActivatedToolSet::new(),
-                        ));
-                        activated_handle = Some(std::sync::Arc::clone(&activated));
-                        let mut tool_search =
-                            crate::tools::ToolSearchTool::new(deferred_set, activated);
-                        if let Some(policy) = mcp_policy {
-                            tool_search = tool_search.with_access_policy(policy);
+                        if allowed_stub_count > 0 {
+                            let activated = std::sync::Arc::new(std::sync::Mutex::new(
+                                crate::tools::ActivatedToolSet::new(),
+                            ));
+                            activated_handle = Some(std::sync::Arc::clone(&activated));
+                            let mut tool_search =
+                                crate::tools::ToolSearchTool::new(deferred_set, activated);
+                            if let Some(policy) = mcp_policy {
+                                tool_search = tool_search.with_access_policy(policy);
+                            }
+                            tools_registry.push(Box::new(tool_search));
                         }
-                        tools_registry.push(Box::new(tool_search));
                     } else {
-                        // Eager path: register all MCP tools directly
+                        // Eager path: register only MCP tools admitted by the
+                        // same policy used by deferred MCP discovery.
                         let names = registry.tool_names();
                         let mut registered = 0usize;
+                        let mut skipped = 0usize;
                         for name in names {
+                            if !eager_mcp_tool_allowed(&name, mcp_policy.as_ref()) {
+                                skipped += 1;
+                                continue;
+                            }
                             if let Some(def) = registry.get_tool_def(&name).await {
                                 let wrapper: std::sync::Arc<dyn Tool> =
                                     std::sync::Arc::new(crate::tools::McpToolWrapper::new(
@@ -3394,11 +3446,14 @@ pub async fn run(
                                         def,
                                         std::sync::Arc::clone(&registry),
                                     ));
-                                if let Some(ref handle) = delegate_handle {
-                                    handle.write().push(std::sync::Arc::clone(&wrapper));
+                                if register_eager_mcp_tool_if_allowed(
+                                    wrapper,
+                                    &mut tools_registry,
+                                    delegate_handle.as_ref(),
+                                    mcp_policy.as_ref(),
+                                ) {
+                                    registered += 1;
                                 }
-                                tools_registry.push(Box::new(crate::tools::ArcToolRef(wrapper)));
-                                registered += 1;
                             }
                         }
                         ::zeroclaw_log::record!(
@@ -3408,9 +3463,10 @@ pub async fn run(
                                 ::zeroclaw_log::Action::Note
                             ),
                             &format!(
-                                "MCP: {} tool(s) registered from {} server(s)",
+                                "MCP: {} tool(s) registered from {} server(s), {} skipped by policy",
                                 registered,
-                                registry.server_count()
+                                registry.server_count(),
+                                skipped
                             )
                         );
                     }
@@ -4695,9 +4751,9 @@ pub async fn process_message(
         filter_channel_builtin_tools(&mut tools_registry, security.as_ref());
 
         // ── Wire MCP tools (non-fatal) — process_message path ────────
-        // NOTE: Same ordering contract as the CLI path above — MCP tools must be
-        // injected after the policy tool filter to avoid MCP tools being
-        // silently dropped by a restrictive allowlist.
+        // NOTE: Same ordering contract as the CLI path above. MCP tools are
+        // initialized after built-in filtering, then registration/discovery is
+        // gated explicitly by the agent's security policy.
         let mut deferred_section = String::new();
         let mut activated_handle_pm: Option<
             std::sync::Arc<std::sync::Mutex<crate::tools::ActivatedToolSet>>,
@@ -4717,6 +4773,7 @@ pub async fn process_message(
                 Ok(registry) => {
                     let registry = std::sync::Arc::new(registry);
                     mcp_elevation_arcs = crate::tools::collect_mcp_elevation_arcs(&registry).await;
+                    let mcp_policy_pm = mcp_tool_access_policy(security.as_ref(), None);
                     if config.mcp.deferred_loading {
                         let deferred_set = crate::tools::DeferredMcpToolSet::from_registry(
                             std::sync::Arc::clone(&registry),
@@ -4734,30 +4791,38 @@ pub async fn process_message(
                                 registry.server_count()
                             )
                         );
-                        let mcp_policy_pm =
-                            zeroclaw_tools::tool_search::ToolAccessPolicy::from_security(
-                                security.allowed_tools.as_deref(),
-                                security.excluded_tools.as_deref(),
-                                None, // no caller-supplied allowlist in channel path
-                            );
+                        let allowed_stub_count_pm = mcp_allowed_tool_count(
+                            deferred_set
+                                .stubs
+                                .iter()
+                                .map(|stub| stub.prefixed_name.as_str()),
+                            mcp_policy_pm.as_ref(),
+                        );
                         deferred_section = crate::tools::build_deferred_tools_section_filtered(
                             &deferred_set,
                             mcp_policy_pm.as_ref(),
                         );
-                        let activated = std::sync::Arc::new(std::sync::Mutex::new(
-                            crate::tools::ActivatedToolSet::new(),
-                        ));
-                        activated_handle_pm = Some(std::sync::Arc::clone(&activated));
-                        let mut tool_search_pm =
-                            crate::tools::ToolSearchTool::new(deferred_set, activated);
-                        if let Some(policy) = mcp_policy_pm {
-                            tool_search_pm = tool_search_pm.with_access_policy(policy);
+                        if allowed_stub_count_pm > 0 {
+                            let activated = std::sync::Arc::new(std::sync::Mutex::new(
+                                crate::tools::ActivatedToolSet::new(),
+                            ));
+                            activated_handle_pm = Some(std::sync::Arc::clone(&activated));
+                            let mut tool_search_pm =
+                                crate::tools::ToolSearchTool::new(deferred_set, activated);
+                            if let Some(policy) = mcp_policy_pm {
+                                tool_search_pm = tool_search_pm.with_access_policy(policy);
+                            }
+                            tools_registry.push(Box::new(tool_search_pm));
                         }
-                        tools_registry.push(Box::new(tool_search_pm));
                     } else {
                         let names = registry.tool_names();
                         let mut registered = 0usize;
+                        let mut skipped = 0usize;
                         for name in names {
+                            if !eager_mcp_tool_allowed(&name, mcp_policy_pm.as_ref()) {
+                                skipped += 1;
+                                continue;
+                            }
                             if let Some(def) = registry.get_tool_def(&name).await {
                                 let wrapper: std::sync::Arc<dyn Tool> =
                                     std::sync::Arc::new(crate::tools::McpToolWrapper::new(
@@ -4765,11 +4830,14 @@ pub async fn process_message(
                                         def,
                                         std::sync::Arc::clone(&registry),
                                     ));
-                                if let Some(ref handle) = delegate_handle_pm {
-                                    handle.write().push(std::sync::Arc::clone(&wrapper));
+                                if register_eager_mcp_tool_if_allowed(
+                                    wrapper,
+                                    &mut tools_registry,
+                                    delegate_handle_pm.as_ref(),
+                                    mcp_policy_pm.as_ref(),
+                                ) {
+                                    registered += 1;
                                 }
-                                tools_registry.push(Box::new(crate::tools::ArcToolRef(wrapper)));
-                                registered += 1;
                             }
                         }
                         ::zeroclaw_log::record!(
@@ -4779,9 +4847,10 @@ pub async fn process_message(
                                 ::zeroclaw_log::Action::Note
                             ),
                             &format!(
-                                "MCP: {} tool(s) registered from {} server(s)",
+                                "MCP: {} tool(s) registered from {} server(s), {} skipped by policy",
                                 registered,
-                                registry.server_count()
+                                registry.server_count(),
+                                skipped
                             )
                         );
                     }
@@ -11968,6 +12037,10 @@ Let me check the result."#;
         Box::new(NamedMockTool { the_name: name })
     }
 
+    fn mock_tool_arc(name: &'static str) -> std::sync::Arc<dyn TestTool> {
+        std::sync::Arc::new(NamedMockTool { the_name: name })
+    }
+
     fn tool_names(tools: &[Box<dyn TestTool>]) -> Vec<&str> {
         tools.iter().map(|t| t.name()).collect()
     }
@@ -12060,6 +12133,106 @@ Let me check the result."#;
             tools.is_empty(),
             "Some(vec![]) on policy must deny every tool"
         );
+    }
+
+    #[test]
+    fn eager_mcp_policy_allows_only_names_that_pass_policy_and_caller_gates() {
+        let policy = TestPolicy {
+            allowed_tools: Some(vec!["fs__read_file".into(), "slack__post".into()]),
+            excluded_tools: Some(vec!["slack__post".into()]),
+            ..TestPolicy::default()
+        };
+        let caller = vec!["fs__read_file".to_string(), "github__search".to_string()];
+        let access_policy = super::mcp_tool_access_policy(&policy, Some(&caller));
+
+        assert!(
+            super::eager_mcp_tool_allowed("fs__read_file", access_policy.as_ref()),
+            "name admitted by both policy and caller gates must be registered eagerly"
+        );
+        assert!(
+            !super::eager_mcp_tool_allowed("slack__post", access_policy.as_ref()),
+            "policy excluded_tools must block eager MCP registration"
+        );
+        assert!(
+            !super::eager_mcp_tool_allowed("github__search", access_policy.as_ref()),
+            "caller allowlist must compose with SecurityPolicy for run() eager MCP"
+        );
+    }
+
+    #[test]
+    fn eager_mcp_policy_uses_security_policy_without_caller_gate_on_process_message() {
+        let policy = TestPolicy {
+            allowed_tools: Some(vec!["fs__read_file".into()]),
+            ..TestPolicy::default()
+        };
+        let access_policy = super::mcp_tool_access_policy(&policy, None);
+
+        assert!(
+            super::eager_mcp_tool_allowed("fs__read_file", access_policy.as_ref()),
+            "process_message eager MCP should use the agent SecurityPolicy allowlist"
+        );
+        assert!(
+            !super::eager_mcp_tool_allowed("github__search", access_policy.as_ref()),
+            "non-allowlisted eager MCP names must not be registered on process_message"
+        );
+    }
+
+    #[test]
+    fn deferred_mcp_allowed_count_honors_deny_all_policy() {
+        let policy = TestPolicy {
+            allowed_tools: Some(vec![]),
+            ..TestPolicy::default()
+        };
+        let access_policy = super::mcp_tool_access_policy(&policy, None);
+
+        assert_eq!(
+            super::mcp_allowed_tool_count(
+                ["fs__read_file", "github__search"],
+                access_policy.as_ref()
+            ),
+            0,
+            "deferred MCP must not register tool_search when policy admits no MCP stubs"
+        );
+    }
+
+    #[test]
+    fn register_eager_mcp_tool_filters_tools_and_delegate_handle_together() {
+        let policy = TestPolicy {
+            allowed_tools: Some(vec!["fs__read_file".into()]),
+            excluded_tools: Some(vec!["slack__post".into()]),
+            ..TestPolicy::default()
+        };
+        let access_policy = super::mcp_tool_access_policy(&policy, None);
+        let delegate_handle: crate::tools::DelegateParentToolsHandle =
+            std::sync::Arc::new(parking_lot::RwLock::new(Vec::new()));
+        let mut tools: Vec<Box<dyn TestTool>> = Vec::new();
+
+        assert!(super::register_eager_mcp_tool_if_allowed(
+            mock_tool_arc("fs__read_file"),
+            &mut tools,
+            Some(&delegate_handle),
+            access_policy.as_ref(),
+        ));
+        assert!(!super::register_eager_mcp_tool_if_allowed(
+            mock_tool_arc("github__search"),
+            &mut tools,
+            Some(&delegate_handle),
+            access_policy.as_ref(),
+        ));
+        assert!(!super::register_eager_mcp_tool_if_allowed(
+            mock_tool_arc("slack__post"),
+            &mut tools,
+            Some(&delegate_handle),
+            access_policy.as_ref(),
+        ));
+
+        assert_eq!(tool_names(&tools), vec!["fs__read_file"]);
+        let delegate_names: Vec<String> = delegate_handle
+            .read()
+            .iter()
+            .map(|tool| tool.name().to_string())
+            .collect();
+        assert_eq!(delegate_names, vec!["fs__read_file"]);
     }
 
     // ── agent_provider_composite regression ───────────────────────────────


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Applies the same MCP `ToolAccessPolicy` to eager MCP registration that deferred MCP discovery already uses.
  - Gates eager MCP wrappers before adding them to the public tool roster or the delegate parent-tools handle.
  - Skips deferred `tool_search` registration when policy admits zero deferred MCP stubs, so a deny-all MCP policy does not leave a callable discovery helper.
  - Covers the CLI `run()`, channel `process_message()`, and `Agent::from_config` daemon/WebSocket setup paths.
- **Scope boundary:** This does not change the `SecurityPolicy` schema, MCP registry startup, built-in tool policy filtering, Composio tools, or skill tool registration. It only applies the existing policy to MCP registration/discovery surfaces that were still outside that gate.
- **Blast radius:** Agent runtime tool registration, MCP deferred discovery, eager MCP wrapper registration, and delegate parent-tools visibility. The most likely regression would be an allowed MCP tool being hidden or a denied MCP tool still appearing in the tool roster.
- **Linked issue(s):** Closes #6959 by covering the remaining eager-MCP filtering gaps across eager registration and deferred discovery after #6960. Related #6914.
- **Labels:** `bug`, `size: M`, `risk: high`, `agent`, `runtime`, `security`, `tool`, `priority:p1`, `tool:mcp`

## Validation Evidence (required)

- **Commands run and results:**

```text
PASS: cargo test -p zeroclaw-runtime deferred_mcp_allowed_count_honors_deny_all_policy -- --nocapture
PASS: cargo test -p zeroclaw-runtime register_eager_mcp_tool_filters_tools_and_delegate_handle_together -- --nocapture
PASS: cargo test -p zeroclaw-runtime eager_mcp_policy -- --nocapture
PASS: cargo test -p zeroclaw-runtime policy -- --nocapture
PASS: git diff --check
PASS: cargo fmt --all -- --check
PASS: cargo clippy -p zeroclaw-runtime --all-targets -- -D warnings
PASS: cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
PASS: cargo nextest run --locked --workspace --exclude zeroclaw-desktop
```

- **Beyond CI — what did you manually verify?** The diff now derives one MCP access policy per setup path, uses it for eager and deferred MCP surfaces, filters the delegate parent-tools handle together with the public tool vector, and leaves broader MCP wiring deduplication out of this issue slice. The broad checks above were run against the current-master merge result for this PR. The stale branch worktree hit delegate background-result timeout failures that did not reproduce on current master plus this PR.
- **If any command was intentionally skipped, why:** None.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: No new access is added. The change tightens existing MCP tool exposure so configured allowlists and exclusions also control eager MCP tools and the deferred discovery helper.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No config, env, or CLI migration is required. Existing policy configuration keeps the same shape, but denied MCP tools should now disappear from eager registration paths instead of remaining visible.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert f5e291b4af4a9252b683c7cce887f4ebb9dc7035`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Allowed MCP tools are missing from prompts, `tool_search`, or delegate-spawned agents; denied MCP tools still appear in the tool roster; MCP registration logs show an unexpected skipped-tool count.

## Supersede Attribution (required only when `Supersedes #` is used)

Not applicable.
