### PR TITLE
fix(gateway): return JSON for unknown API fallback

### DIFF
--- a/crates/zeroclaw-gateway/src/lib.rs
+++ b/crates/zeroclaw-gateway/src/lib.rs
@@ -3680,7 +3680,7 @@ async fn handle_pair_code(State(state): State<AppState>) -> impl IntoResponse {
 mod tests {
     use super::*;
     use async_trait::async_trait;
-    use axum::http::HeaderValue;
+    use axum::http::{HeaderValue, Uri};
     use axum::response::IntoResponse;
     use http_body_util::BodyExt;
     use parking_lot::{Mutex, RwLock};
@@ -3812,6 +3812,27 @@ mod tests {
             #[cfg(feature = "webauthn")]
             webauthn: None,
         }
+    }
+
+    fn spa_fallback_state(tmp: &tempfile::TempDir) -> AppState {
+        let dist_dir = tmp.path().join("web").join("dist");
+        std::fs::create_dir_all(&dist_dir).unwrap();
+        std::fs::write(
+            dist_dir.join("index.html"),
+            r#"<!DOCTYPE html><html><head></head><body>dashboard shell</body></html>"#,
+        )
+        .unwrap();
+
+        let mut state = admin_paircode_state(tmp, false, false);
+        state.web_dist_dir = Some(dist_dir);
+        state
+    }
+
+    async fn spa_fallback_response(
+        path: &'static str,
+        state: AppState,
+    ) -> axum::response::Response {
+        static_files::handle_spa_fallback(State(state), Uri::from_static(path)).await
     }
 
     /// Pair a device into both the pairing guard and the device registry,
@@ -4035,6 +4056,96 @@ mod tests {
     fn app_state_is_clone() {
         fn assert_clone<T: Clone>() {}
         assert_clone::<AppState>();
+    }
+
+    #[tokio::test]
+    async fn spa_fallback_returns_json_not_html_for_unknown_api_path() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let state = spa_fallback_state(&tmp);
+
+        let response = spa_fallback_response("/api/agents", state).await;
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        assert!(
+            response
+                .headers()
+                .get(header::CONTENT_TYPE)
+                .and_then(|value| value.to_str().ok())
+                .is_some_and(|value| value.starts_with("application/json")),
+            "unknown API paths must not be served as HTML"
+        );
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["error"], "not_found");
+        assert_eq!(json["path"], "/api/agents");
+    }
+
+    #[tokio::test]
+    async fn spa_fallback_returns_json_for_api_root_path() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let state = spa_fallback_state(&tmp);
+
+        let response = spa_fallback_response("/api", state).await;
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["path"], "/api");
+    }
+
+    #[tokio::test]
+    async fn spa_fallback_returns_json_for_path_prefixed_api_miss() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mut state = spa_fallback_state(&tmp);
+        state.path_prefix = "/gw".to_string();
+
+        let response = spa_fallback_response("/gw/api/agents", state).await;
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["path"], "/api/agents");
+    }
+
+    #[tokio::test]
+    async fn spa_fallback_still_serves_dashboard_routes() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let state = spa_fallback_state(&tmp);
+
+        let response = spa_fallback_response("/config", state).await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(
+            response
+                .headers()
+                .get(header::CONTENT_TYPE)
+                .and_then(|value| value.to_str().ok())
+                .is_some_and(|value| value.starts_with("text/html")),
+            "dashboard routes should still receive the SPA shell"
+        );
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let text = String::from_utf8(body.to_vec()).unwrap();
+        assert!(text.contains("dashboard shell"));
+    }
+
+    #[tokio::test]
+    async fn spa_fallback_does_not_treat_api_like_spa_paths_as_api() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let state = spa_fallback_state(&tmp);
+
+        let response = spa_fallback_response("/apiary", state).await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(
+            response
+                .headers()
+                .get(header::CONTENT_TYPE)
+                .and_then(|value| value.to_str().ok())
+                .is_some_and(|value| value.starts_with("text/html")),
+            "similarly named SPA routes should not be reserved as API paths"
+        );
     }
 
     /// Regression: the gateway must boot with zero configured agents so

--- a/crates/zeroclaw-gateway/src/static_files.rs
+++ b/crates/zeroclaw-gateway/src/static_files.rs
@@ -4,6 +4,7 @@
 //! The directory path is configured via `gateway.web_dist_dir`.
 
 use axum::{
+    Json,
     extract::State,
     http::{StatusCode, Uri, header},
     response::{IntoResponse, Response},
@@ -36,7 +37,16 @@ pub async fn handle_static(State(state): State<AppState>, uri: Uri) -> Response 
 
 /// SPA fallback: serve index.html for any non-API, non-static GET request.
 /// Injects `window.__ZEROCLAW_BASE__` so the frontend knows the path prefix.
-pub async fn handle_spa_fallback(State(state): State<AppState>) -> Response {
+pub async fn handle_spa_fallback(State(state): State<AppState>, uri: Uri) -> Response {
+    if let Some(path) = api_fallback_path(uri.path(), &state.path_prefix) {
+        let body = serde_json::json!({
+            "error": "not_found",
+            "message": "No backend route matched this path.",
+            "path": path,
+        });
+        return (StatusCode::NOT_FOUND, Json(body)).into_response();
+    }
+
     let Some(bytes) = load_index_html_bytes(state.web_dist_dir.as_ref()).await else {
         return (
             StatusCode::SERVICE_UNAVAILABLE,
@@ -73,6 +83,25 @@ pub async fn handle_spa_fallback(State(state): State<AppState>) -> Response {
         html,
     )
         .into_response()
+}
+
+fn api_fallback_path<'a>(path: &'a str, path_prefix: &str) -> Option<&'a str> {
+    let path = strip_path_prefix(path, path_prefix);
+    (path == "/api" || path.strip_prefix("/api/").is_some()).then_some(path)
+}
+
+fn strip_path_prefix<'a>(path: &'a str, path_prefix: &str) -> &'a str {
+    if path_prefix.is_empty() || path_prefix == "/" {
+        return path;
+    }
+
+    if path == path_prefix {
+        return "/";
+    }
+
+    path.strip_prefix(path_prefix)
+        .filter(|rest| rest.starts_with('/'))
+        .unwrap_or(path)
 }
 
 async fn load_index_html_bytes(dist_dir: Option<&PathBuf>) -> Option<Vec<u8>> {


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Makes the web dashboard SPA fallback path-aware so unknown `/api` and `/api/*` GETs return a JSON 404 instead of `index.html`.
  - Preserves the existing SPA fallback for dashboard routes such as `/config`.
  - Normalizes `gateway.path_prefix` before classifying API fallback paths, so prefixed deployments return the same JSON error shape for `{prefix}/api/*` misses.
  - Adds focused gateway regressions for `/api`, `/api/agents`, prefixed `/gw/api/agents`, normal `/config`, and the `/apiary` false-positive case.
- **Scope boundary:** This PR fixes the gateway fallback boundary only. It does not change source-install web asset copying, frontend JSON parsing/error copy, auth behavior, or add new API endpoints.
- **Blast radius:** Gateway HTTP fallback behavior for unknown GET paths. Known API routes continue to use their existing handlers; non-API dashboard routes continue to receive the SPA shell.
- **Linked issue(s):** Closes #6862. Closes #7253.
- **Labels:** `bug`, `risk: high`, `size: S`, `gateway`, `web`

## Validation Evidence (required)

- **Commands run and tail output:**

```text
cargo fmt --all -- --check
Result: passed

cargo test -p zeroclaw-gateway spa_fallback --lib
Result: passed

running 5 tests
test tests::spa_fallback_returns_json_not_html_for_unknown_api_path ... ok
test tests::spa_fallback_returns_json_for_path_prefixed_api_miss ... ok
test tests::spa_fallback_returns_json_for_api_root_path ... ok
test tests::spa_fallback_does_not_treat_api_like_spa_paths_as_api ... ok
test tests::spa_fallback_still_serves_dashboard_routes ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 226 filtered out; finished in 0.07s
```

The focused test build also emitted an unrelated pre-existing warning in `zeroclaw-channels` for an unused `PacedChannel` import.

- **Beyond CI — what did you manually verify?** I verified the diff is limited to `crates/zeroclaw-gateway/src/static_files.rs` and gateway unit tests in `crates/zeroclaw-gateway/src/lib.rs`. The focused tests cover the reported `/api/*` HTML fallback failure, path-prefix handling, normal SPA fallback behavior, and a similarly named non-API route.
- **If any command was intentionally skipped, why:** Workspace-shaped clippy and CI-shaped full tests were not run locally before opening this draft. This tiny 2-file gateway slice relies on GitHub CI coverage for the broader validation layer.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: `N/A`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No upgrade steps required. Existing dashboard routes continue to fall back to the SPA shell; unknown API fallback responses become JSON 404s instead of HTML.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** Revert this PR.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** If this regresses, dashboard deep links such as `/config` may stop serving the SPA shell, or unknown `/api/*` requests may again return `text/html` and trigger frontend `JSON.parse` errors.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): `N/A`
- Scope materially carried forward: `N/A`
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why (inspiration-only, no direct code/design carry-over): No superseded PR code or design was incorporated.
