### PR TITLE
docs(maintainers): define issue stewardship process

### DIFF
--- a/.claude/skills/github-issue-triage/references/triage-protocol.md
+++ b/.claude/skills/github-issue-triage/references/triage-protocol.md
@@ -47,6 +47,10 @@ The project has contributors filing issues in non-English locales (the supported
 
 When the protocol refers to "maintainer comments" (e.g., stale clock computation), identify maintainers by checking the CODEOWNERS file or repository collaborator list. If neither is accessible, use org membership in `zeroclaw-labs`. Do not guess based on comment tone or authority — use an explicit check.
 
+### Issue stewardship
+
+For owner-path and stale-exemption decisions, use `docs/book/src/maintainers/issue-stewardship.md` as the source of truth. A label is not ownership by itself. Until the standing steward map is explicitly populated there, use only issue-visible assignees, maintainer comments, public Project fields, linked public trackers, or dated maintainer-triage plans as owner sources.
+
 ### Cross-mode session awareness
 
 If multiple modes run in the same session (e.g., triage then sweep), the later mode must be aware of actions taken by earlier modes. Specifically:
@@ -284,7 +288,7 @@ Activity is defined as: a follow-up comment or update from the **original author
 
 `status:in-progress` is a routing signal, not a permanent stale exemption by itself. During stale passes, verify that an open linked PR still exists. If the PR has closed without resolving the issue, remove or replace `status:in-progress` only after presenting the exact label change to the user.
 
-Target policy: `status:no-stale` protects an issue only when the reason and active owner or steward path are visible through the contributor-visible sources defined in the maintainer Project board contract. Assignees count as active owners. Public issue fields count only when they are visible to normal issue readers; organization-only or private issue and Project fields do not satisfy the contributor-visible requirement. Labels can identify the likely area, but they are not an owner source by themselves. Until the stale-exemption audit and repair packet lands, missing reason or owner evidence is an audit finding and proposed correction, not an automatic stale-closure trigger.
+Target policy: `status:no-stale` protects an issue only when the reason and active owner or steward path match the contributor-visible owner sources in `docs/book/src/maintainers/issue-stewardship.md`. Public issue fields count only when they are visible to normal issue readers; organization-only or private issue and Project fields do not satisfy the contributor-visible requirement. Labels can identify the likely area, but they are not an owner source by themselves. Until a standing steward map is explicitly populated there, use only assignees, issue-visible maintainer comments or body sections, public Project fields, linked public trackers, or dated maintainer-triage plans as owner sources. Missing reason or owner evidence is an audit finding and proposed correction, not an automatic stale-closure trigger.
 
 ### Stale enforcement steps
 
@@ -303,7 +307,7 @@ Target policy: `status:no-stale` protects an issue only when the reason and acti
 
 4. Before proposing stale action, verify exclusions against current state:
    - Check current labels for `priority:p0`, `type:rfc`, and `status:no-stale`.
-   - For `status:no-stale`, inspect the cited visible source first: assignee, issue body/comment, Public issue field, public Project field, or linked public tracker entry. Record whether both the reason and active owner or steward path are present. If the issue does not cite a visible source or the source is ambiguous, add it to the stale-exemption audit findings and present the proposed correction to the user; reserve exhaustive source gathering for the stale-exemption audit/repair packet.
+   - For `status:no-stale`, inspect the visible owner sources defined in `docs/book/src/maintainers/issue-stewardship.md`. Record whether both the reason and active owner or steward path are present. If the issue does not cite a visible source or the source is ambiguous, add it to the stale-exemption audit findings and present the proposed correction to the user.
    - For `status:blocked`, fetch the issue body and relevant maintainer comments or tracker entry, then verify the recorded blocker and whether it is still unresolved. If not, present the label correction to the user first and do not treat the issue as exempt until the user approves the change.
    - Check the open PR batch for issue references before relying on `status:in-progress` or stale eligibility. Fall back to a per-issue PR search only when the batch result is ambiguous.
    - Check opening-post reactions for the 10-or-more 👍 threshold.
@@ -426,7 +430,7 @@ For issues, risk labels estimate likely fix blast radius from the report. Reasse
 - `status:accepted` — RFC or work item accepted by the team; not stale-exempt by itself
 - `status:blocked` — waiting on external blocker; exempt from stale while the blocker is recorded and unresolved
 - `status:in-progress` — linked open PR exists; verify live PR state before stale decisions
-- `status:no-stale` — explicitly exempt from stale automation for accepted or otherwise long-lived work that is not already protected by another exclusion; target policy requires a recorded reason and contributor-visible active owner or steward path, with existing gaps handled by the stale-exemption audit packet
+- `status:no-stale` — explicitly exempt from stale automation for accepted or otherwise long-lived work that is not already protected by another exclusion; target policy requires a recorded reason and contributor-visible owner source from `docs/book/src/maintainers/issue-stewardship.md`
 
 ### Resolution
 

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -126,6 +126,7 @@
   - [CI & Actions](./maintainers/ci-and-actions.md)
   - [Claude Code Skills](./maintainers/skills.md)
   - [PR workflow](./maintainers/pr-workflow.md)
+  - [Issue stewardship](./maintainers/issue-stewardship.md)
   - [Reviewer playbook](./maintainers/reviewer-playbook.md)
   - [Labels](./maintainers/labels.md)
   - [Superseding PRs](./maintainers/superseding.md)

--- a/docs/book/src/contributing/communication.md
+++ b/docs/book/src/contributing/communication.md
@@ -41,18 +41,13 @@ Discussions are part of the GitHub handoff system, not a replacement for issues,
 
 [github.com/zeroclaw-labs/zeroclaw/discussions](https://github.com/zeroclaw-labs/zeroclaw/discussions)
 
-## Maintainer contacts
+## Maintainer routing
 
-Core maintainers and their focus areas:
+Default to filing the issue or starting the discussion rather than guessing which maintainer to mention. Labels help identify likely areas, but labels do not prove ownership.
 
-| Handle | Role | Focus |
-|---|---|---|
-| [@JordanTheJet](https://github.com/JordanTheJet) | Project lead | Hardware, edge deployments |
-| [@theonlyhennygod](https://github.com/theonlyhennygod) | Original creator | Channels, gateway |
-| [@WareWolf-MoonWall](https://github.com/WareWolf-MoonWall) | Maintainer | Governance, docs, reviewer playbook |
-| [@singlerider](https://github.com/singlerider) | Maintainer | Runtime, providers, infra |
+Maintainer-side owner-source rules live in [Issue stewardship](../maintainers/issue-stewardship.md). Use that process when an issue needs an assignee, steward path, public tracker, maintainer-triage date, or stale-exemption reason.
 
-`@`-mention sparingly — CC maintainers only when the issue genuinely needs their attention. Default to letting the team triage.
+`@`-mention sparingly. CC a maintainer only when the issue genuinely needs that person's attention or when the stewardship process names them as the current owner source.
 
 ## Security issues
 

--- a/docs/book/src/foundations/fnd-003-governance.md
+++ b/docs/book/src/foundations/fnd-003-governance.md
@@ -88,6 +88,7 @@ Operational details intentionally live close to the workflow that uses them:
 | Project board purpose and stage gates | This document |
 | PR lanes and merge/review queue discipline | [Maintainer PR workflow](../maintainers/pr-workflow.md) |
 | Label definitions, ownership boundaries, and cleanup protocol | [Maintainer labels guide](../maintainers/labels.md) |
+| Issue owner sources, stewardship assignment, and stale-exemption criteria | [Issue stewardship](../maintainers/issue-stewardship.md) |
 | Reviewer intake, risk depth, issue triage, and queue hygiene | [Reviewer playbook](../maintainers/reviewer-playbook.md) |
 | Mechanical issue-triage procedure and stale pass details | [Maintainer skills guide](../maintainers/skills.md#issue-triage-workflow) and [Reviewer playbook](../maintainers/reviewer-playbook.md#issue-triage) |
 | Contributor-facing filing and PR mechanics | Issue templates, PR template, and [How to contribute](../contributing/how-to.md) |
@@ -993,7 +994,7 @@ GitHub enforces CODEOWNERS automatically when the file exists and branch protect
 
 **Stale issue management (`.github/workflows/stale.yml`):**
 
-Issues with no activity for 45 days are labeled `status:stale` and a comment is posted asking if the issue is still relevant. Issues with no activity for 15 days after the stale label is applied are closed. This prevents the backlog from accumulating hundreds of issues that are months old and no longer relevant. Exclude `priority:p0`, `type:rfc`, issues with open linked PRs, and issues with `status:blocked` while a recorded blocker remains unresolved. The intended `status:no-stale` follow-up is to exclude it only while the operational source records both the stale-exemption reason and a contributor-visible active owner or steward path. The maintainer label guide and issue-triage protocol carry the current operational details.
+Issues with no activity for 45 days are labeled `status:stale` and a comment is posted asking if the issue is still relevant. Issues with no activity for 15 days after the stale label is applied are closed. This prevents the backlog from accumulating hundreds of issues that are months old and no longer relevant. Exclude `priority:p0`, `type:rfc`, issues with open linked PRs, and issues with `status:blocked` while a recorded blocker remains unresolved. The intended `status:no-stale` follow-up is to exclude it only while [Issue stewardship](../maintainers/issue-stewardship.md#stale-exemption-rule) records both the stale-exemption reason and a contributor-visible owner source. The maintainer issue-triage protocol carries the mechanical stale-pass procedure.
 
 **PR size labeling (`.github/workflows/pr-size.yml`):**
 

--- a/docs/book/src/maintainers/index.md
+++ b/docs/book/src/maintainers/index.md
@@ -8,6 +8,7 @@ This section covers everything beyond day-to-day development — docs, translati
 - [CI & Actions](./ci-and-actions.md) — workflow inventory, build cache behavior, allowed-actions policy, triage when CI goes red
 - [Claude Code Skills](./skills.md) — in-repo skills for PR reviews, issue triage, squash-merging, changelog generation
 - [PR workflow](./pr-workflow.md) — branch protection, DoR/DoD, AI-assisted contribution policy, failure recovery
+- [Issue stewardship](./issue-stewardship.md) — owner-source rules, maintainer-triage fallback, and future standing steward map process
 - [Reviewer playbook](./reviewer-playbook.md) — review depth matrix, intake triage, automation override, queue hygiene
 - [Labels](./labels.md) — single source of truth for every label and its automation status
 - [Superseding PRs](./superseding.md) — when to supersede, attribution rules, PR and commit templates

--- a/docs/book/src/maintainers/issue-stewardship.md
+++ b/docs/book/src/maintainers/issue-stewardship.md
@@ -1,0 +1,88 @@
+# Issue Stewardship
+
+Issue stewardship is the process for deciding who owns the next movement on an issue when nobody is actively implementing it.
+
+This page is the source of truth for issue stewardship assignment. The [Project board contract](./pr-workflow.md#issue-ownership-path), [Labels](./labels.md), and [Reviewer playbook](./reviewer-playbook.md) link here rather than maintaining separate steward maps.
+
+## Why this exists
+
+PRs have CODEOWNERS, requested reviewers, checks, and merge state. Issues need a parallel routing path so accepted work does not sit indefinitely without a visible next decision.
+
+Stewardship answers one question: who is responsible for deciding the next routing step?
+
+It does not mean the steward must implement the issue, guarantee staffing, or personally review every related PR.
+
+## Owner sources
+
+Use the narrowest visible owner source that honestly describes the current state:
+
+| Source | Use when | Expires when |
+|---|---|---|
+| Assignee | Someone is actively implementing, investigating, or shepherding the immediate issue. | They stop doing that work, the linked PR closes, or the issue moves back to triage. |
+| Issue-visible maintainer comment or body section | A maintainer records the steward path, decision needed, or next triage date on the issue. | The decision is made, the date passes, or the issue state changes. |
+| Public Project field | A public issue field or Project field names the active owner, steward path, or routing lane. | The field no longer matches live issue state. |
+| Linked public tracker | A release tracker, RFC, roadmap issue, or implementation tracker owns the current decision surface. | The tracker closes, drifts from live state, or stops representing an active decision. |
+| Standing steward map | The team has confirmed a current area steward for the relevant surface. | The steward steps back, the area map changes, or the entry's recorded review date passes. |
+
+Labels alone are not owner sources. They identify likely areas, but they do not prove that someone is currently responsible for routing the issue.
+
+## Standing steward map
+
+No standing area steward map is active yet.
+
+Until current maintainers confirm a map, do not treat labels such as `channel:*`, `provider:*`, `tool:*`, `gateway`, `runtime`, `security:*`, or `docs` as owner evidence by themselves. Route those issues through explicit owner sources instead: assignee, issue-visible comment, public Project field, linked tracker, or a dated maintainer-triage plan.
+
+When the team is ready to add a standing map, record it here with:
+
+- area or label family;
+- steward handle or team;
+- fallback when that steward is unavailable;
+- what decisions the steward owns;
+- what decisions still require broader maintainer review;
+- last confirmed date.
+- next review date or event.
+
+Do not add someone as a standing steward without their agreement. When a steward steps away, remove or replace that entry before using it for `status:no-stale`, maintainer triage, or board-routing decisions.
+
+## Assignment process
+
+When triaging an issue:
+
+1. Decide whether the issue is actionable, blocked, accepted, support-only, duplicate, invalid, or not planned.
+2. If someone is actively working it, assign them and use `status:in-progress` only while that active path exists.
+3. If no implementer is active, record the next routing owner source before adding durable protection such as `status:no-stale`.
+4. If the issue belongs to an active release tracker, RFC, design tracker, or roadmap tracker, link that tracker and use it as the steward surface while it remains active.
+5. If the issue needs maintainer triage but has no steward yet, record what decision is needed, where it will be decided, and when it should be revisited.
+6. If no owner source exists, keep the issue open if it is still useful, but do not use `status:no-stale` as a permanent shield.
+
+## Stale exemption rule
+
+`status:no-stale` requires both:
+
+- a reason the issue should stay open despite age; and
+- a contributor-visible owner source from this page.
+
+Active release trackers and active RFC or design trackers may supply both facts through the tracker itself. Ordinary accepted issues need a more specific owner source unless another stale exclusion already applies.
+
+Revisit a stale exemption when:
+
+- the assignee stops active work;
+- a linked PR merges, closes, or becomes inactive;
+- a milestone or release tracker closes;
+- an RFC is decided, superseded, or closed;
+- the issue no longer matches its tracker;
+- the recorded revisit date passes;
+- the documented steward steps away.
+
+## Maintainer-triage fallback
+
+Maintainer triage is a temporary routing state, not ownership by another name.
+
+Use it only when the issue records:
+
+- the decision needed;
+- the maintainer or meeting surface expected to make the decision;
+- the revisit date or event;
+- the possible outcomes.
+
+After that triage pass, replace the fallback with an active assignee, explicit steward path, linked tracker, blocked/deferred state, or closure rationale.

--- a/docs/book/src/maintainers/labels.md
+++ b/docs/book/src/maintainers/labels.md
@@ -26,9 +26,9 @@ Keep the split based on update frequency:
 
 The board should reduce maintainer work. If a field would need manual upkeep after every PR push or review, prefer labels, milestones, or native GitHub state instead.
 
-Labels can suggest likely ownership, but they are not ownership. A `channel:*`, `provider:*`, `tool:*`, `security:*`, or `docs` label identifies the surface that probably needs attention. Contributor-visible owner-source rules live in the [Project board contract](./pr-workflow.md#project-board-contract).
+Labels can suggest likely ownership, but they are not ownership. A `channel:*`, `provider:*`, `tool:*`, `security:*`, or `docs` label identifies the surface that probably needs attention. Contributor-visible owner-source rules live in [Issue stewardship](./issue-stewardship.md).
 
-Use assignees for active work. Use area stewardship for routing responsibility when nobody is implementing yet. The [Project board contract](./pr-workflow.md#issue-ownership-path) defines the accepted owner sources and routing outcomes.
+Use assignees for active work. Use area stewardship for routing responsibility when nobody is implementing yet. The [Project board contract](./pr-workflow.md#issue-ownership-path) defines why issues need an ownership path; [Issue stewardship](./issue-stewardship.md) defines the accepted owner sources and assignment process.
 
 ## Canonical spelling
 
@@ -219,7 +219,7 @@ Track lifecycle state of RFCs and tracked work items. Applied manually unless a 
 | `status:blocked` | Work is valid but waiting on an external dependency, maintainer decision, or linked prerequisite. Exempt from stale while the blocker is recorded and unresolved. Do not pair with `status:no-stale` for the same blocker. |
 | `status:in-progress` | An open PR is actively targeting this issue. Reconcile against live PR state during stale passes; the label is not a permanent exemption after the PR closes. |
 | `status:stale` | No author activity for the stale window; may close if not refreshed |
-| `status:no-stale` | Explicit stale exemption for accepted or otherwise long-lived work that is not already protected by another stale exclusion. Target policy: use only when the [Project board contract](./pr-workflow.md#issue-ownership-path) has a contributor-visible stale-exemption reason and owner path. Active release trackers and active RFC or design trackers may use the tracker itself as the visible reason and steward surface while they remain active; revisit them when the milestone closes, the tracker drifts from live state, the RFC reaches a decision, is superseded, or closes, or the issue stops representing an active project decision surface. Existing exemptions missing those facts should be audited and repaired before stale sweeps stop honoring them. |
+| `status:no-stale` | Explicit stale exemption for accepted or otherwise long-lived work that is not already protected by another stale exclusion. Use only when [Issue stewardship](./issue-stewardship.md#stale-exemption-rule) records both a contributor-visible stale-exemption reason and an owner source. Active release trackers and active RFC or design trackers may use the tracker itself as the visible reason and steward surface while they remain active. Existing exemptions missing those facts should be audited and repaired before stale sweeps stop honoring them. |
 
 ## Resolution labels
 

--- a/docs/book/src/maintainers/pr-workflow.md
+++ b/docs/book/src/maintainers/pr-workflow.md
@@ -46,7 +46,7 @@ Use these meanings consistently:
 | Project active owner | The board-visible person or steward source currently responsible for the next movement. | A replacement for live PR review state. |
 | Labels | Durable classification and likely area routing. | Ownership by themselves. |
 
-Area stewardship is the issue-side analogue to CODEOWNERS, but it is not implemented through CODEOWNERS. If GitHub issue fields are enabled and visible to the public on the issue page, prefer a Public issue field for `Area steward` or `Owner path`. Organization-only or private issue and Project fields do not satisfy contributor-visible ownership. Otherwise, the contributor-visible source can be a maintained steward table, a public Project field, an issue-visible maintainer comment, or a public tracker entry linked from the issue.
+Area stewardship is the issue-side analogue to CODEOWNERS, but it is not implemented through CODEOWNERS. The active owner-source rules and standing-map process live in [Issue stewardship](./issue-stewardship.md). If GitHub issue fields are enabled and visible to the public on the issue page, prefer a Public issue field for `Area steward` or `Owner path`. Organization-only or private issue and Project fields do not satisfy contributor-visible ownership.
 
 Identifying the next implementation path does not mean the steward must personally implement the issue or guarantee staffing. It means they make the next step explicit: assign an active owner, make the issue contributor-ready, route it to a tracker or milestone, schedule it for maintainer triage, or close/defer it with a recorded rationale.
 
@@ -54,16 +54,9 @@ Stewardship is decision ownership, not indefinite delivery ownership. A stewarde
 
 Scheduling an issue for maintainer triage is valid only when the issue records what decision is needed, where that decision will be tracked, and when it will be revisited. After that triage pass, replace the triage routing with an active owner, contributor-ready scope, tracker or milestone route, blocked/deferred state, or closure rationale.
 
-For accepted or protected issues, prefer one of these visible owner sources before adding or keeping `status:no-stale`:
+For accepted or protected issues, use [Issue stewardship](./issue-stewardship.md) for the accepted owner sources, assignment process, and stale-exemption rule. That page owns the detailed list so Project board policy, label policy, stale passes, and future steward maps do not drift apart.
 
-- an assignee doing active work;
-- a Public issue field, issue comment, or body section naming the steward path;
-- a public Project active-owner or area-steward field;
-- a linked public tracker entry that names the steward or owner source.
-
-Active release trackers and active RFC or design trackers are durable coordination surfaces. When the issue title, body, labels, or milestone clearly identify an active tracker or RFC, the tracker itself supplies the stale-exemption reason and contributor-visible steward surface; it does not need repetitive per-issue owner comments. Revisit the exemption when the milestone closes, the tracker drifts from live release state, the RFC reaches a decision, is superseded, or closes, or the issue no longer represents an active project decision surface.
-
-If none of those exists and the issue is not an active tracker or RFC, the issue can still stay open while triage continues, but it should not rely on `status:no-stale` as a permanent shield. Until the stale-exemption audit lands, missing reason or owner evidence is an audit finding and proposed correction, not an automatic stale-closure trigger.
+No standing area steward map is active until current maintainers confirm one in [Issue stewardship](./issue-stewardship.md#standing-steward-map). Until then, labels such as `channel:*`, `provider:*`, `tool:*`, `gateway`, `runtime`, `security:*`, or `docs` suggest likely routing but are not owner evidence by themselves.
 
 ## PR lanes
 

--- a/docs/book/src/maintainers/reviewer-playbook.md
+++ b/docs/book/src/maintainers/reviewer-playbook.md
@@ -91,11 +91,11 @@ Issue `risk:*` labels describe likely fix blast radius from the report. PR `risk
 | `status:accepted` | The team has accepted the RFC or work item. Add `status:no-stale` only when the issue also needs stale protection. |
 | `status:blocked` | Valid work is waiting on an external dependency, maintainer decision, or linked prerequisite. Record the blocker; this is stale protection only while that blocker remains unresolved. |
 | `status:in-progress` | An open PR is actively targeting the issue. Re-check live PR state before relying on it during stale passes. |
-| `status:no-stale` | Accepted or otherwise long-lived work should stay open and is not already protected by another stale exclusion. Record the reason and active owner or steward path using the contributor-visible owner sources in the [Project board contract](./pr-workflow.md#issue-ownership-path). Active release trackers and active RFC or design trackers may use the tracker itself as the visible reason and steward surface while they remain active. |
+| `status:no-stale` | Accepted or otherwise long-lived work should stay open and is not already protected by another stale exclusion. Record the reason and active owner or steward path using the contributor-visible owner sources in [Issue stewardship](./issue-stewardship.md). Active release trackers and active RFC or design trackers may use the tracker itself as the visible reason and steward surface while they remain active. |
 | `good first issue` | XS/S, self-contained, documented work with clear acceptance criteria, relevant code or docs links, a named mentor or contact, and low onboarding risk. |
 | `help wanted` | Actionable, unblocked work maintainers want external help on and can review. Do not use it as a generic valid/unowned marker. |
 
-Assignee means active work. Area steward means responsibility for the next issue-routing decision when no implementer is active. The [Project board contract](./pr-workflow.md#issue-ownership-path) defines the accepted owner sources and routing outcomes. Labels can identify the likely area, but labels alone are not an owner source.
+Assignee means active work. Area steward means responsibility for the next issue-routing decision when no implementer is active. [Issue stewardship](./issue-stewardship.md) defines the accepted owner sources and routing outcomes. Labels can identify the likely area, but labels alone are not an owner source.
 
 ### Resolution labels
 
@@ -139,7 +139,7 @@ This keeps context loss low and avoids the next reviewer redoing the same fetche
 
 ## Weekly queue hygiene
 
-- Walk the stale queue. Apply `status:no-stale` only when accepted or otherwise long-lived work has a recorded reason to stay open, a visible active owner or steward path, and no other stale exclusion already applies. Active release trackers and active RFC or design trackers may keep stale protection by default when the issue itself clearly identifies the active coordination or decision surface; revisit them when the milestone closes, the tracker drifts from live state, the RFC reaches a decision, is superseded, or closes, or the issue stops representing an active project decision surface. Until the stale-exemption audit lands, treat existing `status:no-stale` issues missing those facts as audit findings rather than automatic stale candidates.
+- Walk the stale queue. Apply `status:no-stale` only under the [Issue stewardship](./issue-stewardship.md#stale-exemption-rule) rule: accepted or otherwise long-lived work needs a recorded reason to stay open, a visible owner source, and no other stale exclusion already applies. Existing `status:no-stale` issues missing those facts are audit findings rather than automatic stale candidates.
 - Prioritize `size: XS/S` bug and security PRs first.
 - Convert recurring support questions into docs improvements and auto-response guidance.
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Adds a new maintainer page for issue stewardship owner sources, assignment process, stale-exemption criteria, and the future standing steward-map process.
  - Routes `status:no-stale`, labels, reviewer-playbook, PR-workflow, FND-003, and issue-triage skill guidance to that page so owner-source policy has one operational home.
  - Replaces the stale contributor-facing maintainer contact table with routing guidance that avoids guessing maintainers or treating labels as ownership.
- **Scope boundary:** This PR does not create a standing steward map, name area stewards, change CODEOWNERS, mutate GitHub labels, change Project fields, or change stale automation.
- **Blast radius:** Maintainer and contributor documentation only. It affects how maintainers interpret issue ownership and stale exemptions, but does not change runtime behavior or GitHub automation.
- **Linked issue(s):** Related #6808
- **Labels:** `type: docs`, `risk: low`, `size: S`, `docs`

## Validation Evidence (required)

- **Commands run and tail output:**

  ```bash
  git cherry -v origin/master HEAD
  # + 1359fa5d35283d0cc13b73779ce236a3e9259352 docs(maintainers): define issue stewardship process

  git diff --check origin/master...HEAD
  # passed with no output

  bash scripts/ci/docs_links_gate.sh
  # Collected 4 added link(s) from 9 docs file(s).
  # Checking added links with lychee (offline mode)...
  # Summary: 0 errors

  bash scripts/ci/docs_quality_gate.sh
  # Linting docs files: ...
  # Existing markdown issues outside changed lines (non-blocking): docs/book/src/foundations/fnd-003-governance.md baseline lint issues
  # No blocking markdown issues on changed lines.
  ```

- **Beyond CI — what did you manually verify?** Checked the open-PR overlap for nearby governance work. #7443 only touches `.github/CODEOWNERS`, so this docs slice has no file-level overlap with that PR.
- **If any command was intentionally skipped, why:** Cargo format, clippy, and tests were skipped because this is a docs-only governance change.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: Not applicable.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: Not applicable.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk docs-only change. Roll back with:

```bash
git revert 1359fa5d35283d0cc13b73779ce236a3e9259352
```

## Supersede Attribution (required only when `Supersedes #` is used)

Not applicable.
