### PR TITLE
fix(ci): restore master compile after merge batch

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -10381,6 +10381,8 @@ temperature = 0.3
         tokio::fs::write(
             &config_path,
             r#"
+schema_version = 3
+
 [agents.agent_a]
 model_provider = "openrouter.hot"
 

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -9362,7 +9362,7 @@ temperature = 0.3
         // before returning. The value is synthetic and not a real credential.
         unsafe { std::env::set_var(env_name, "sk-or-v1-test-channel-reload") };
 
-        let result = load_runtime_config_and_defaults(&config_path, "openrouter.agent_demo").await;
+        let result = load_runtime_config_and_defaults(&config_path, "demo").await;
 
         // SAFETY: undo the test-only process env mutation above.
         unsafe { std::env::remove_var(env_name) };

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -9362,7 +9362,7 @@ temperature = 0.3
         // before returning. The value is synthetic and not a real credential.
         unsafe { std::env::set_var(env_name, "sk-or-v1-test-channel-reload") };
 
-        let result = load_runtime_config_and_provider(&config_path, "openrouter.agent_demo").await;
+        let result = load_runtime_config_and_defaults(&config_path, "openrouter.agent_demo").await;
 
         // SAFETY: undo the test-only process env mutation above.
         unsafe { std::env::remove_var(env_name) };

--- a/crates/zeroclaw-hardware/examples/esp32_sim.rs
+++ b/crates/zeroclaw-hardware/examples/esp32_sim.rs
@@ -38,7 +38,9 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::sync::{RwLock, broadcast};
-use zeroclaw_hardware::util::{serial_open_baud, should_open_serial_nonexclusive};
+use zeroclaw_hardware::util::serial_open_baud;
+#[cfg(unix)]
+use zeroclaw_hardware::util::should_open_serial_nonexclusive;
 
 const PTY_FIRMWARE_PATH: &str = "/tmp/zc-sim-firmware";
 const PTY_HOST_PATH: &str = "/tmp/zc-sim-esp32";
@@ -276,6 +278,7 @@ async fn open_firmware_serial() -> Result<tokio_serial::SerialStream> {
 
         let mut builder =
             tokio_serial::new(PTY_FIRMWARE_PATH, serial_open_baud(PTY_FIRMWARE_PATH, BAUD));
+        #[cfg(unix)]
         if should_open_serial_nonexclusive(PTY_FIRMWARE_PATH) {
             builder = builder.exclusive(false);
         }

--- a/crates/zeroclaw-hardware/examples/esp32_sim.rs
+++ b/crates/zeroclaw-hardware/examples/esp32_sim.rs
@@ -276,12 +276,14 @@ async fn open_firmware_serial() -> Result<tokio_serial::SerialStream> {
             announced_paths = true;
         }
 
-        let mut builder =
+        let builder =
             tokio_serial::new(PTY_FIRMWARE_PATH, serial_open_baud(PTY_FIRMWARE_PATH, BAUD));
         #[cfg(unix)]
-        if should_open_serial_nonexclusive(PTY_FIRMWARE_PATH) {
-            builder = builder.exclusive(false);
-        }
+        let builder = if should_open_serial_nonexclusive(PTY_FIRMWARE_PATH) {
+            builder.exclusive(false)
+        } else {
+            builder
+        };
 
         match builder.open_native_async() {
             Ok(port) => return Ok(port),

--- a/crates/zeroclaw-hardware/src/peripherals/serial.rs
+++ b/crates/zeroclaw-hardware/src/peripherals/serial.rs
@@ -5,10 +5,9 @@
 //! Response: {"id":"1","ok":true,"result":"done"}
 
 use crate::peripherals::Peripheral;
-use crate::util::{
-    is_serial_path_allowed, serial_open_baud, serial_path_allowlist_hint,
-    should_open_serial_nonexclusive,
-};
+#[cfg(unix)]
+use crate::util::should_open_serial_nonexclusive;
+use crate::util::{is_serial_path_allowed, serial_open_baud, serial_path_allowlist_hint};
 use async_trait::async_trait;
 use portable_atomic::{AtomicU64, Ordering};
 use serde_json::{Value, json};
@@ -140,6 +139,7 @@ impl SerialPeripheral {
         }
 
         let mut builder = tokio_serial::new(path, serial_open_baud(path, config.baud));
+        #[cfg(unix)]
         if should_open_serial_nonexclusive(path) {
             builder = builder.exclusive(false);
         }

--- a/crates/zeroclaw-hardware/src/peripherals/serial.rs
+++ b/crates/zeroclaw-hardware/src/peripherals/serial.rs
@@ -138,11 +138,13 @@ impl SerialPeripheral {
             );
         }
 
-        let mut builder = tokio_serial::new(path, serial_open_baud(path, config.baud));
+        let builder = tokio_serial::new(path, serial_open_baud(path, config.baud));
         #[cfg(unix)]
-        if should_open_serial_nonexclusive(path) {
-            builder = builder.exclusive(false);
-        }
+        let builder = if should_open_serial_nonexclusive(path) {
+            builder.exclusive(false)
+        } else {
+            builder
+        };
         let port = builder.open_native_async().map_err(|e| {
             ::zeroclaw_log::record!(
                 ERROR,


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Replaces one stale channel test helper call with the current `load_runtime_config_and_defaults` helper so `zeroclaw-channels` test builds compile again.
  - Gates `tokio_serial::SerialPortBuilderExt::exclusive(false)` behind `#[cfg(unix)]` in the serial peripheral and ESP32 simulator path because that extension method is Unix-only.
  - Keeps the hotfix scoped to the two CI failures introduced by the recent merge batch.
- **Scope boundary:** Does not change runtime serial behavior on Unix platforms, provider/default resolution behavior, or the hardware feature surface beyond platform-gating an existing Unix-only call.
- **Blast radius:** Channel orchestrator tests and hardware serial builds/examples. Existing Linux/macOS serial behavior should remain unchanged; Windows builds no longer see the Unix-only builder method.
- **Linked issue(s):** Related #7234. Related #7363.
- **Labels:** `bug`, `risk: low`, `size: XS`, `channel`

## Validation Evidence (required)

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` — passed.
  - `git diff --check` — passed.
  - `scripts/zc-cargo test -p zeroclaw-channels --lib --no-run` — passed; `Finished test profile ... zeroclaw-channels`.
  - `scripts/zc-cargo check -p zeroclaw-hardware` — passed; `Finished dev profile ... zeroclaw-hardware`.
  - `scripts/zc-cargo check -p zeroclaw-hardware --all-targets --features hardware,dev-sim` — passed; `Finished dev profile ... zeroclaw-hardware`.
  - `scripts/zc-cargo clippy -p zeroclaw-hardware --all-targets --features hardware,dev-sim -- -D warnings` — passed; `Finished dev profile ... zeroclaw-hardware`.
- **Beyond CI — what did you manually verify?** Confirmed the stale helper name no longer appears in the touched orchestrator test area, and both remaining `exclusive(false)` call sites are guarded with `#[cfg(unix)]`.
- **If any command was intentionally skipped, why:** A local `x86_64-pc-windows-msvc` probe was attempted but failed in `ring` before reaching this crate because the local macOS environment lacks the MSVC C/header setup. Windows GitHub Actions should be the authoritative check for that target.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: None.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No upgrade steps required.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PR: `git revert c08e35cc5dfc5c82c62ae4e6f5eabb23a612e97d` is the rollback plan unless otherwise noted.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors: N/A
- Scope materially carried forward: N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why: No superseded PR or incorporated contributor work.
