### PR TITLE
fix(config): match config-list prefix on segment boundaries, not string prefix

### DIFF
--- a/crates/zeroclaw-config/src/field_visibility.rs
+++ b/crates/zeroclaw-config/src/field_visibility.rs
@@ -68,6 +68,16 @@ pub fn is_excluded(path: &str, excludes: &[String]) -> bool {
         .any(|e| path == e || (e.ends_with('.') && path.starts_with(e)))
 }
 
+/// Test whether `path` equals `prefix` or sits beneath it at a `.` segment
+/// boundary. A bare `starts_with` is wrong here: prefix `agents.aaa` must
+/// not match `agents.aaalore.workspace`.
+pub fn path_matches_prefix(path: &str, prefix: &str) -> bool {
+    match path.strip_prefix(prefix) {
+        Some(rest) => rest.is_empty() || rest.starts_with('.') || prefix.ends_with('.'),
+        None => false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -110,5 +120,30 @@ mod tests {
         // Unrelated paths don't match.
         assert!(!is_excluded("memory.postgres.url", &excludes));
         assert!(!is_excluded("memory.foobar", &excludes));
+    }
+
+    #[test]
+    fn path_matches_prefix_requires_segment_boundary() {
+        // Exact match and children.
+        assert!(path_matches_prefix("agents.aaa", "agents.aaa"));
+        assert!(path_matches_prefix("agents.aaa.workspace", "agents.aaa"));
+        assert!(path_matches_prefix("agents.aaa.memory.limit", "agents.aaa"));
+        // Sibling aliases sharing a string prefix must NOT match (#7376-class bug).
+        assert!(!path_matches_prefix(
+            "agents.aaalore.workspace",
+            "agents.aaa"
+        ));
+        assert!(!path_matches_prefix(
+            "agents.aaatools.identity",
+            "agents.aaa"
+        ));
+        assert!(!path_matches_prefix("agents.aaalore", "agents.aaa"));
+        // Dot-terminated prefixes keep their sub-table semantics.
+        assert!(path_matches_prefix("agents.aaa.workspace", "agents.aaa."));
+        assert!(!path_matches_prefix("agents.aab.workspace", "agents.aaa."));
+        // Top-level sections.
+        assert!(path_matches_prefix("memory.backend", "memory"));
+        assert!(!path_matches_prefix("memory.backend", "mem"));
+        assert!(!path_matches_prefix("unrelated", "agents.aaa"));
     }
 }

--- a/crates/zeroclaw-config/src/field_visibility.rs
+++ b/crates/zeroclaw-config/src/field_visibility.rs
@@ -73,7 +73,9 @@ pub fn is_excluded(path: &str, excludes: &[String]) -> bool {
 /// not match `agents.aaalore.workspace`.
 pub fn path_matches_prefix(path: &str, prefix: &str) -> bool {
     match path.strip_prefix(prefix) {
-        Some(rest) => rest.is_empty() || rest.starts_with('.') || prefix.ends_with('.'),
+        Some(rest) => {
+            prefix.is_empty() || rest.is_empty() || rest.starts_with('.') || prefix.ends_with('.')
+        }
         None => false,
     }
 }
@@ -145,5 +147,9 @@ mod tests {
         assert!(path_matches_prefix("memory.backend", "memory"));
         assert!(!path_matches_prefix("memory.backend", "mem"));
         assert!(!path_matches_prefix("unrelated", "agents.aaa"));
+        // Empty prefix matches everything (no-filter semantics, parity
+        // with the bare starts_with behavior it replaced).
+        assert!(path_matches_prefix("anything.at.all", ""));
+        assert!(path_matches_prefix("", ""));
     }
 }

--- a/crates/zeroclaw-gateway/src/api_config.rs
+++ b/crates/zeroclaw-gateway/src/api_config.rs
@@ -794,7 +794,7 @@ pub async fn handle_list(
         .prop_fields()
         .into_iter()
         .filter(|info| match prefix {
-            Some(p) => info.name.starts_with(p),
+            Some(p) => field_visibility::path_matches_prefix(&info.name, p),
             None => true,
         })
         .filter(|info| !field_visibility::is_excluded(&info.name, &excluded))

--- a/crates/zeroclaw-runtime/src/rpc/dispatch.rs
+++ b/crates/zeroclaw-runtime/src/rpc/dispatch.rs
@@ -2258,7 +2258,7 @@ impl RpcDispatcher {
             .prop_fields()
             .into_iter()
             .filter(|info| match prefix {
-                Some(p) => info.name.starts_with(p),
+                Some(p) => field_visibility::path_matches_prefix(&info.name, p),
                 None => true,
             })
             .filter(|info| !field_visibility::is_excluded(&info.name, &excluded))


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - The RPC `ConfigList` handler and gateway `/api/config/list` filtered config fields with a bare `starts_with(prefix)`, so opening agent `agents.aaa` in zerocode's Config pane also returned fields for string-prefixed sibling aliases (`agents.aaalore`, `agents.aaatools`) — reported on Discord with screenshots.
  - Added `field_visibility::path_matches_prefix`: matches the exact path or a child at a `.` segment boundary; dot-terminated sub-table prefixes keep existing semantics.
  - Both handlers now use the shared helper; a regression test enumerates the sibling-alias case.
- **Scope boundary:** Does not change zerocode UI code, the config schema, or `is_excluded` sub-table semantics.
- **Blast radius:** Any consumer of RPC `config.list` or gateway `/api/config/list` with a prefix (zerocode Config pane, web dashboard config forms). Strictly narrows result sets to correct ones.
- **Linked issue(s):** None filed; reported via Discord. Related #6862 (same `/api/config/list` surface; that issue tracks the SPA fallback defect, formerly also #7253).
- **Labels:** `bug`, `config`, `gateway`, `runtime`, `zerocode` (path labeler will add `size:*`; risk label per maintainer)

## Validation Evidence (required)

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` → clean, exit 0
  - `cargo clippy --all-targets -- -D warnings` → `Finished 'dev' profile [unoptimized + debuginfo] target(s)`, 0 warnings/errors
  - `cargo test` → 9 suites, 896 passed, 0 failed; targeted crates: zeroclaw-config lib `785 passed; 0 failed`, zeroclaw-gateway lib `243 passed; 0 failed`, zeroclaw-runtime lib `2039 passed; 0 failed; 1 ignored`
  - New test: `field_visibility::tests::path_matches_prefix_requires_segment_boundary ... ok`
- **Beyond CI — what did you manually verify?** Reproduced the matching logic against the reporter's exact alias set (`aaa`, `aaalore`, `aaatools`) in the regression test. NOT verified: live zerocode TUI session against a running daemon.
- **If any command was intentionally skipped, why:** none skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No (alias names from the report are generic strings)

## Compatibility (required)

- Backward compatible? Yes — strictly narrows over-broad responses to the documented per-section scope
- Config / env / CLI surface changed? No

## Rollback (required for `risk: medium` and `risk: high`)

`git revert <sha>`; single self-contained commit, no flags or config toggles. Failure symptom would be config panes showing no fields for a valid section prefix.

