### PR TITLE
docs(mcp): clarify MCP tool control boundaries

### DIFF
--- a/docs/book/src/tools/mcp.md
+++ b/docs/book/src/tools/mcp.md
@@ -48,4 +48,31 @@ MCP tool calls go through the same approval gate as every other tool, governed b
 - Otherwise, an MCP tool call prompts for approval unless its **prefixed** name (`<server>__<tool>`) is in the profile's `auto_approve` list. `auto_approve = ["*"]` approves everything; an exact entry like `auto_approve = ["filesystem__read_file"]` approves just that tool.
 - `always_ask` is the inverse: a name (or `"*"`) there always prompts, overriding `auto_approve`.
 
+Keep the exposure and approval controls separate:
+
+| Control | Scope | Use it for |
+|---|---|---|
+| `tool_filter_groups` | Prompt/context exposure | Decide which MCP tool schemas are visible to the model for a turn. |
+| `auto_approve` / `always_ask` | Approval policy | Decide whether a selected MCP tool call requires operator approval. |
+| `allowed_tools` / `excluded_tools` | Capability policy | Decide which prefixed tool names the risk profile may use at all. |
+
+For a hard allowlist, include the MCP tool's prefixed name in
+`allowed_tools` as well as any approval rule:
+
+```toml
+[risk_profiles.assistant]
+allowed_tools = [
+  "file_read",
+  "filesystem__read_file",
+]
+auto_approve = [
+  "filesystem__read_file",
+]
+```
+
+`auto_approve` alone does not hide a tool from the model; it only answers the
+approval question after the model selects that tool. Use `tool_filter_groups`
+to reduce prompt noise and `allowed_tools` / `excluded_tools` to enforce a
+capability boundary.
+
 See [Autonomy levels](../security/autonomy.md) for the full per-profile field surface, and the [Config reference](../reference/config.md#mcp) for every MCP field and default.


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Clarifies MCP tool-control documentation by separating prompt/context exposure, approval policy, and actual capability filtering. Adds a compact configuration example showing `tool_filter_groups`, `auto_approve`, `always_ask`, `allowed_tools`, and `excluded_tools` together.
- **Scope boundary:** Documentation only: `docs/book/src/tools/mcp.md`.
- **Blast radius:** Low. No runtime behavior, configuration schema, or defaults are changed.
- **Linked issue(s):** Fixes #6876
- **Labels:** `docs`, `size: XS`, `risk: low`, `tool:mcp`

## Validation Evidence (required)

```bash
git diff --check
```

- **Commands run and tail output:**

```text
$ git diff --check
# no output
```

- **Beyond CI — what did you manually verify?** Reviewed the rendered wording for consistency with existing MCP documentation terminology and confirmed the example stays scoped to documented configuration keys.
- **If any command was intentionally skipped, why:** Cargo tests were not run because this PR changes documentation only.

## Security & Privacy Impact (required)

- **New permissions, capabilities, or file system access scope?** No.
- **New external network calls?** No.
- **Secrets / tokens / credentials handling changed?** No.
- **PII, real identities, or personal data in diff, tests, fixtures, or docs?** No.

## Compatibility (required)

- **Backward compatible?** Yes. Documentation only.
- **Config / env / CLI surface changed?** No.
- **Upgrade steps:** None.

## Rollback

Low-risk rollback: revert the docs commit.