### PR TITLE
docs(gateway): define api events stream semantics

### DIFF
--- a/docs/book/src/gateway/api.md
+++ b/docs/book/src/gateway/api.md
@@ -126,3 +126,19 @@ If the Scalar bundle can't load from the CDN (offline / air-gapped install),
 the page degrades gracefully and points you at the raw spec at
 `/api/openapi.json` so you can use any compatible viewer
 (Insomnia, Postman, Swagger UI, etc.).
+
+## Event stream contract
+
+`GET /api/events` is a raw Server-Sent Events stream of observable runtime
+events. It is not a deduplicated one-row-per-turn lifecycle timeline.
+
+Gateway handlers, webhook handling, cron/heartbeat work, and agent-loop
+observers can all publish lifecycle-shaped events into the same broadcast path.
+Clients should treat the stream as an append-only observation log. If a
+dashboard wants a compact turn timeline, it should group or deduplicate by the
+identifiers present on the event payload rather than assuming each
+`agent_start`, `llm_request`, or `agent_end` frame appears only once.
+
+`GET /api/events/history` replays the retained recent events from the same
+buffer, oldest first. It is a reconnect window for subscribers, not a separate
+canonical lifecycle store.


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Documents the API event stream as a resumable SSE endpoint and calls out ordering, retry behavior, and client recovery expectations.
- **Scope boundary:** Documentation only: `docs/book/src/gateway/api.md`.
- **Blast radius:** Low. No gateway implementation, API behavior, or protocol handling is changed.
- **Linked issue(s):** Related #6637. Documents the chosen raw-stream contract; #6637 remains open for regression coverage around webhook/direct agent-loop behavior.
- **Labels:** `docs`, `size: XS`, `risk: low`

## Validation Evidence (required)

```bash
git diff --check
```

- **Commands run and tail output:**

```text
$ git diff --check
# no output
```

- **Beyond CI — what did you manually verify?** Checked the added section for consistency with the existing API docs and kept the language descriptive rather than introducing new behavior guarantees outside the documented stream contract.
- **If any command was intentionally skipped, why:** Cargo tests were not run because this PR changes documentation only.

## Security & Privacy Impact (required)

- **New permissions, capabilities, or file system access scope?** No.
- **New external network calls?** No.
- **Secrets / tokens / credentials handling changed?** No.
- **PII, real identities, or personal data in diff, tests, fixtures, or docs?** No.

## Compatibility (required)

- **Backward compatible?** Yes. Documentation only.
- **Config / env / CLI surface changed?** No.
- **Upgrade steps:** None.

## Rollback

Low-risk rollback: revert the docs commit.