### PR TITLE
docs(container): add rootless Debian compose example

### DIFF
--- a/docs/book/src/setup/container.md
+++ b/docs/book/src/setup/container.md
@@ -102,6 +102,42 @@ docker compose exec zeroclaw zeroclaw quickstart
 
 With the official image you can omit the {{#env-var-name gateway.allow_public_bind}} override entirely; it is already enabled in the baked config.
 
+### Rootless Compose with the Debian image
+
+For rootless Docker or Podman Compose deployments that need shell tools inside
+the container, use the Debian image and bind a host data directory. This mirrors
+the tested v0.7.5 Debian layout while keeping the dashboard bundle outside the
+mutable data mount:
+
+```yaml
+services:
+  zeroclaw:
+    image: ghcr.io/zeroclaw-labs/zeroclaw:v0.7.5-debian
+    container_name: zeroclaw
+    restart: unless-stopped
+    environment:
+      ZEROCLAW_GATEWAY_HOST: 0.0.0.0
+      ZEROCLAW_GATEWAY_PORT: "42617"
+      ZEROCLAW_ALLOW_PUBLIC_BIND: "1"
+      ZEROCLAW_WEB_DIST_DIR: /dist
+    ports:
+      - "42617:42617"
+    volumes:
+      - ./data:/zeroclaw-data
+      - ./dist:/dist:ro
+    healthcheck:
+      test: ["CMD", "zeroclaw", "status", "--format=exit-code"]
+      interval: 60s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+```
+
+Build the dashboard into `./dist` before starting this service if you set
+`ZEROCLAW_WEB_DIST_DIR=/dist`. If you use an image that already contains the
+dashboard bundle, remove that environment variable and the `./dist:/dist:ro`
+mount so the gateway can auto-detect the packaged bundle.
+
 ## macOS: OrbStack vs Colima
 
 macOS has no native Linux kernel, so every option (Docker Desktop, Podman, OrbStack, Colima) runs the container inside a lightweight Linux VM. For a Mac dev box, the two mac-native VMs worth comparing are OrbStack and Colima, both run the container with the same `docker run`/Compose commands above.

--- a/docs/book/src/setup/container.md
+++ b/docs/book/src/setup/container.md
@@ -105,26 +105,18 @@ With the official image you can omit the {{#env-var-name gateway.allow_public_bi
 ### Rootless Compose with the Debian image
 
 For rootless Docker or Podman Compose deployments that need shell tools inside
-the container, use the Debian image and bind a host data directory. This mirrors
-the tested v0.7.5 Debian layout while keeping the dashboard bundle outside the
-mutable data mount:
+the container, use the current Debian image and bind a host data directory:
 
 ```yaml
 services:
   zeroclaw:
-    image: ghcr.io/zeroclaw-labs/zeroclaw:v0.7.5-debian
+    image: ghcr.io/zeroclaw-labs/zeroclaw:debian
     container_name: zeroclaw
     restart: unless-stopped
-    environment:
-      ZEROCLAW_GATEWAY_HOST: 0.0.0.0
-      ZEROCLAW_GATEWAY_PORT: "42617"
-      ZEROCLAW_ALLOW_PUBLIC_BIND: "1"
-      ZEROCLAW_WEB_DIST_DIR: /dist
     ports:
       - "42617:42617"
     volumes:
       - ./data:/zeroclaw-data
-      - ./dist:/dist:ro
     healthcheck:
       test: ["CMD", "zeroclaw", "status", "--format=exit-code"]
       interval: 60s
@@ -133,10 +125,13 @@ services:
       start_period: 10s
 ```
 
-Build the dashboard into `./dist` before starting this service if you set
-`ZEROCLAW_WEB_DIST_DIR=/dist`. If you use an image that already contains the
-dashboard bundle, remove that environment variable and the `./dist:/dist:ro`
-mount so the gateway can auto-detect the packaged bundle.
+The current Debian image carries the packaged dashboard outside
+`/zeroclaw-data`, so the bind mount does not hide it and no
+`gateway.web_dist_dir` override is needed. The official image also carries the
+container-friendly gateway bind defaults. Only add an `environment:` block if
+you bind-mount your own localhost-default config; use the schema-mirror env-var
+spelling shown by {{#env-var-name gateway.allow_public_bind}} rather than the
+legacy all-uppercase aliases.
 
 ## macOS: OrbStack vs Colima
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Adds a rootless Docker/Podman Compose example for the current Debian image, using the current `:debian` tag and relying on the packaged dashboard auto-detection instead of the legacy v0.7.5 `web_dist_dir` workaround.
- **Scope boundary:** Documentation only: `docs/book/src/setup/container.md`.
- **Blast radius:** Low. No container image, compose file in repo, runtime, or packaging behavior is changed.
- **Linked issue(s):** Fixes #6760
- **Labels expected:** `documentation`, `area: container`

## Validation Evidence (required)

```bash
git diff --check
```

- **Commands run and tail output:**

```text
$ git diff --check
# no output
```

- **Beyond CI — what did you manually verify?** Rechecked the current container docs around the official image defaults and dashboard bind-mount note. The rootless Debian Compose example now uses `ghcr.io/zeroclaw-labs/zeroclaw:debian`, removes the legacy `ZEROCLAW_WEB_DIST_DIR=/dist` override, removes the `./dist:/dist:ro` mount, and points readers to the schema-mirror env-var form if they override a localhost-default config.
- **If any command was intentionally skipped, why:** Cargo tests were not run because this PR changes documentation only.

## Security & Privacy Impact (required)

- **New permissions, capabilities, or file system access scope?** No.
- **New external network calls?** No.
- **Secrets / tokens / credentials handling changed?** No.
- **PII, real identities, or personal data in diff, tests, fixtures, or docs?** No.

## Compatibility (required)

- **Backward compatible?** Yes. Documentation only.
- **Config / env / CLI surface changed?** No.
- **Upgrade steps:** None.

## Rollback

Low-risk rollback: revert the docs commits.
