### PR TITLE
fix(zerocode): avoid hardcoded vi editor fallback

### DIFF
--- a/apps/zerocode/src/chat.rs
+++ b/apps/zerocode/src/chat.rs
@@ -4360,13 +4360,37 @@ fn labelled_clipboard_text(entry: &ChatEntry) -> String {
     }
 }
 
-/// Suspend the TUI, open `$EDITOR` with `content`, return the edited text.
+fn editor_from_env_or_path() -> Option<String> {
+    std::env::var("VISUAL")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| {
+            std::env::var("EDITOR")
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+        })
+        .or_else(|| {
+            ["nano", "vi", "vim", "editor"]
+                .into_iter()
+                .find(|candidate| executable_on_path(candidate))
+                .map(str::to_string)
+        })
+}
+
+fn executable_on_path(name: &str) -> bool {
+    let Some(paths) = std::env::var_os("PATH") else {
+        return false;
+    };
+    std::env::split_paths(&paths).any(|dir| dir.join(name).is_file())
+}
+
+/// Suspend the TUI, open `$VISUAL` / `$EDITOR` with `content`, return the edited text.
 /// Restores raw mode and alternate screen before returning.
-/// Falls back to `content` unchanged if `$EDITOR` is unset or the process fails.
+/// Falls back to `content` unchanged if no editor is available or the process fails.
 pub async fn open_editor_for_content(content: &str) -> String {
-    let editor = std::env::var("EDITOR")
-        .or_else(|_| std::env::var("VISUAL"))
-        .unwrap_or_else(|_| "vi".to_string());
+    let Some(editor) = editor_from_env_or_path() else {
+        return content.to_string();
+    };
 
     let tmp = match tempfile::NamedTempFile::new() {
         Ok(f) => f,

--- a/apps/zerocode/src/chat.rs
+++ b/apps/zerocode/src/chat.rs
@@ -4360,35 +4360,11 @@ fn labelled_clipboard_text(entry: &ChatEntry) -> String {
     }
 }
 
-fn editor_from_env_or_path() -> Option<String> {
-    std::env::var("VISUAL")
-        .ok()
-        .filter(|value| !value.trim().is_empty())
-        .or_else(|| {
-            std::env::var("EDITOR")
-                .ok()
-                .filter(|value| !value.trim().is_empty())
-        })
-        .or_else(|| {
-            ["nano", "vi", "vim", "editor"]
-                .into_iter()
-                .find(|candidate| executable_on_path(candidate))
-                .map(str::to_string)
-        })
-}
-
-fn executable_on_path(name: &str) -> bool {
-    let Some(paths) = std::env::var_os("PATH") else {
-        return false;
-    };
-    std::env::split_paths(&paths).any(|dir| dir.join(name).is_file())
-}
-
 /// Suspend the TUI, open `$VISUAL` / `$EDITOR` with `content`, return the edited text.
 /// Restores raw mode and alternate screen before returning.
 /// Falls back to `content` unchanged if no editor is available or the process fails.
 pub async fn open_editor_for_content(content: &str) -> String {
-    let Some(editor) = editor_from_env_or_path() else {
+    let Some(editor) = crate::editor::editor_from_env_or_path() else {
         return content.to_string();
     };
 

--- a/apps/zerocode/src/config_manager.rs
+++ b/apps/zerocode/src/config_manager.rs
@@ -3917,15 +3917,9 @@ fn edit_in_external_editor(
     content: &str,
     filename_hint: &str,
 ) -> Result<String, String> {
-    let editor = std::env::var("VISUAL")
-        .or_else(|_| std::env::var("EDITOR"))
-        .unwrap_or_else(|_| {
-            if cfg!(windows) {
-                "notepad".into()
-            } else {
-                "vi".into()
-            }
-        });
+    let Some(editor) = crate::editor::editor_from_env_or_path() else {
+        return Err("no external editor found; set VISUAL or EDITOR".to_string());
+    };
 
     // Write content to a temp file with the right extension.
     let dir = std::env::temp_dir();

--- a/apps/zerocode/src/editor.rs
+++ b/apps/zerocode/src/editor.rs
@@ -1,0 +1,32 @@
+pub(crate) fn editor_from_env_or_path() -> Option<String> {
+    std::env::var("VISUAL")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| {
+            std::env::var("EDITOR")
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+        })
+        .or_else(|| {
+            fallback_editors()
+                .iter()
+                .copied()
+                .find(|candidate| executable_on_path(candidate))
+                .map(str::to_string)
+        })
+}
+
+fn executable_on_path(name: &str) -> bool {
+    let Some(paths) = std::env::var_os("PATH") else {
+        return false;
+    };
+    std::env::split_paths(&paths).any(|dir| dir.join(name).is_file())
+}
+
+fn fallback_editors() -> &'static [&'static str] {
+    if cfg!(windows) {
+        &["notepad.exe", "nano", "vim"]
+    } else {
+        &["nano", "vi", "vim", "editor"]
+    }
+}

--- a/apps/zerocode/src/main.rs
+++ b/apps/zerocode/src/main.rs
@@ -28,6 +28,7 @@ mod config;
 mod config_manager;
 mod dashboard;
 mod diff;
+mod editor;
 mod file_explorer;
 mod i18n;
 mod input_bar;

--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -543,10 +543,45 @@ fn prompt_for_description(description: Option<String>) -> Result<String> {
 }
 
 fn open_in_editor(path: &std::path::Path) -> Result<()> {
-    let editor = std::env::var("EDITOR").unwrap_or_else(|_| "vi".to_string());
+    let Some(editor) = editor_from_env_or_path() else {
+        anyhow::bail!("no editor found; set VISUAL or EDITOR");
+    };
     let status = std::process::Command::new(&editor).arg(path).status()?;
     if !status.success() {
         anyhow::bail!("{editor} exited with non-zero status");
     }
     Ok(())
+}
+
+fn editor_from_env_or_path() -> Option<String> {
+    std::env::var("VISUAL")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| {
+            std::env::var("EDITOR")
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+        })
+        .or_else(|| {
+            fallback_editors()
+                .iter()
+                .copied()
+                .find(|candidate| executable_on_path(candidate))
+                .map(str::to_string)
+        })
+}
+
+fn executable_on_path(name: &str) -> bool {
+    let Some(paths) = std::env::var_os("PATH") else {
+        return false;
+    };
+    std::env::split_paths(&paths).any(|dir| dir.join(name).is_file())
+}
+
+fn fallback_editors() -> &'static [&'static str] {
+    if cfg!(windows) {
+        &["notepad.exe", "nano", "vim"]
+    } else {
+        &["nano", "vi", "vim", "editor"]
+    }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Replace hardcoded `vi` editor fallbacks with editor discovery that prefers `VISUAL`, then `EDITOR`, then installed terminal editors. This now covers all reviewed launch paths: queued-message editing, the zerocode config manager external editor, and the root skills editor flow.
- **Scope boundary:** Editor discovery only. This does not change queued-message storage, config serialization, skill file format, or editor buffer handling.
- **Blast radius:** Low-to-medium. Affects only external editor launch paths; no runtime path is touched unless a user explicitly opens an external editor.
- **Linked issue(s):** Fixes #7469
- **Labels expected:** `bug`, `area: zerocode`

## Validation Evidence (required)

```bash
git diff --check
cargo test -p zerocode chat
cargo check --bin zeroclaw
```

- **Commands run and tail output:**

```text
$ git diff --check
# no output

$ cargo test -p zerocode chat
running 70 tests
...
test result: ok. 70 passed; 0 failed; 0 ignored; 0 measured; 252 filtered out; finished in 0.17s

$ cargo check --bin zeroclaw
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.85s
```

- **Beyond CI — what did you manually verify?** I checked the diff for all hardcoded editor launch paths mentioned in review and confirmed the PR now covers the queued-message editor, config manager editor, and `src/skills/mod.rs` editor flow.
- **If any command was intentionally skipped, why:** Full workspace test suite was not run because this change is limited to editor discovery and targeted tests plus root binary check cover the touched paths.

## Security & Privacy Impact (required)

- **New permissions, capabilities, or file system access scope?** No. It only changes how the existing editor command is selected.
- **New external network calls?** No.
- **Secrets / tokens / credentials handling changed?** No.
- **PII, real identities, or personal data in diff, tests, fixtures, or docs?** No.

## Compatibility (required)

- **Backward compatible?** Yes. Existing `VISUAL` and `EDITOR` values remain preferred.
- **Config / env / CLI surface changed?** No new env vars or CLI flags. The fallback behavior now reports a clear error when no editor can be found instead of assuming `vi` exists.
- **Upgrade steps:** None.

## Rollback

Low-risk rollback: revert the PR commits.
