### PR TITLE
fix(zerocode): change default editor fallback from vi to nano (#7469)

### DIFF
--- a/apps/zerocode/src/chat.rs
+++ b/apps/zerocode/src/chat.rs
@@ -4366,7 +4366,7 @@ fn labelled_clipboard_text(entry: &ChatEntry) -> String {
 pub async fn open_editor_for_content(content: &str) -> String {
     let editor = std::env::var("EDITOR")
         .or_else(|_| std::env::var("VISUAL"))
-        .unwrap_or_else(|_| "vi".to_string());
+        .unwrap_or_else(|_| "nano".to_string());
 
     let tmp = match tempfile::NamedTempFile::new() {
         Ok(f) => f,

--- a/apps/zerocode/src/config_manager.rs
+++ b/apps/zerocode/src/config_manager.rs
@@ -3923,7 +3923,7 @@ fn edit_in_external_editor(
             if cfg!(windows) {
                 "notepad".into()
             } else {
-                "vi".into()
+                "nano".into()
             }
         });
 

--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -543,7 +543,7 @@ fn prompt_for_description(description: Option<String>) -> Result<String> {
 }
 
 fn open_in_editor(path: &std::path::Path) -> Result<()> {
-    let editor = std::env::var("EDITOR").unwrap_or_else(|_| "vi".to_string());
+    let editor = std::env::var("EDITOR").unwrap_or_else(|_| "nano".to_string());
     let status = std::process::Command::new(&editor).arg(path).status()?;
     if !status.success() {
         anyhow::bail!("{editor} exited with non-zero status");


### PR DESCRIPTION
## Summary

Fixes #7469. Container images (Debian, Alpine) include `nano` by default but often lack `vi`. When `EDITOR` and `VISUAL` are both unset, the TUI editor launcher fell back to `vi` which produced "command not found" on containers.

## Changes

Change the non-Windows fallback editor from `"vi"` to `"nano"` in all three editor-launch paths:
- `apps/zerocode/src/config_manager.rs`: external editor for config editing
- `apps/zerocode/src/chat.rs`: `open_editor_for_content` helper
- `src/skills/mod.rs`: `open_in_editor` helper

All three paths already handle launch failures gracefully (fall back to inline editor or return the original content unchanged), so a missing `nano` binary degrades the same way as a missing `vi` binary.

## Validation

- `cargo check -p zerocode` passes
- `cargo check --bin zeroclaw` passes

## Risk

Low. 3-line change. The existing error handling in all three call sites already tolerates a missing editor binary.