### PR TITLE
fix(zerocode): prevent macOS Cmd-C from triggering the Quit chord (#7378)

### DIFF
--- a/apps/zerocode/src/keymap/chord.rs
+++ b/apps/zerocode/src/keymap/chord.rs
@@ -43,6 +43,15 @@ impl Chord {
     }
 
     pub fn matches(&self, event: &KeyEvent) -> bool {
+        // On macOS, Cmd-C (Super+c) is the system Copy shortcut. Never
+        // consume it as a TUI chord so Copy works regardless of terminal
+        // emulator forwarding behaviour. See #7378.
+        #[cfg(target_os = "macos")]
+        if event.code == KeyCode::Char('c')
+            && event.modifiers.contains(KeyModifiers::SUPER)
+        {
+            return false;
+        }
         event.code == self.code
             && normalise_mods(self.code, self.modifiers)
                 == normalise_mods(event.code, event.modifiers)


### PR DESCRIPTION
## Summary

Fixes #7378. On macOS, pressing Cmd-C (system Copy) could trigger the Quit action instead of copying text.

## Root Cause

The macOS `normalise_mods()` in `Chord::matches()` translates `CONTROL` → `SUPER` so Linux `Ctrl+K` and macOS `⌘K` resolve to the same chord. This caused `Ctrl+C` (Quit) to share a modifier with `Cmd+C` (system Copy). Terminal emulators that forward `Super+C` events triggered Quit instead of Copy.

## Changes

Add a macOS-only guard in `Chord::matches()` that never matches `Super+c`, preserving the system Copy shortcut regardless of terminal emulator forwarding behaviour.

## Validation

- `cargo check -p zerocode` passes
- Existing keymap tests pass (the guard only affects incoming events, not chord definitions)

## Risk

Low. The guard only affects macOS and only for the `c` key with `SUPER` modifier. All other keyboard shortcuts are unaffected.