### PR TITLE
ci(quality-gate): run on merge_group to support merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,15 @@ on:
     branches: [master]
   push:
     branches: [master]
+  # Merge queue: GitHub builds a temporary `gh-readonly-queue/master/…` branch
+  # and fires `merge_group`. The required `CI Required Gate` must report on that
+  # branch or queued PRs stall, so the full gate runs here too.
+  merge_group:
 
 concurrency:
+  # Merge-queue runs key on the unique queue ref (github.ref →
+  # `refs/heads/gh-readonly-queue/master/pr-N-<sha>`) so speculative entries
+  # never cancel each other; PRs still key on the PR number.
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 

--- a/.github/workflows/master-branch-flow.md
+++ b/.github/workflows/master-branch-flow.md
@@ -7,7 +7,7 @@ Use with:
 - [`docs/book/src/maintainers/ci-and-actions.md`](../../docs/book/src/maintainers/ci-and-actions.md)
 - [`docs/book/src/maintainers/release-runbook.md`](../../docs/book/src/maintainers/release-runbook.md)
 
-Last updated: **May 2026** (post-v0.7.4 cleanup).
+Last updated: **June 2026** (merge queue enabled on `master`).
 
 ---
 
@@ -24,7 +24,7 @@ Maintainers with merge authority: `theonlyhennygod` and `JordanTheJet`.
 
 | File | Trigger | Purpose |
 |---|---|---|
-| `ci.yml` | `pull_request` → `master`; `push` → `master` | Lint + test + build on PRs and trusted post-merge cache-warming runs |
+| `ci.yml` | `pull_request` → `master`; `push` → `master`; `merge_group` | Lint + test + build on PRs, merge-queue batches, and trusted post-merge cache-warming runs |
 | `release-stable-manual.yml` | `workflow_dispatch`, tag push `v*` | Stable release (manual, version-gated) |
 | `cross-platform-build-manual.yml` | `workflow_dispatch` | Full platform build matrix (manual smoke check) |
 | `pr-path-labeler.yml` | `pull_request` lifecycle | Automatic path-based PR labeling |
@@ -36,6 +36,7 @@ Maintainers with merge authority: `theonlyhennygod` and `JordanTheJet`.
 | Event | What runs |
 |---|---|
 | PR opened or updated against `master` | `ci.yml` (full lint + test + build) |
+| PR added to the merge queue (`merge_group`) | `ci.yml` runs the full gate on a temporary `gh-readonly-queue/master/…` branch that stacks the base + earlier queue entries + this PR |
 | Push to `master` | `ci.yml` (post-merge quality signal + trusted Rust cache warming) |
 | Manual dispatch | `cross-platform-build-manual.yml` or `release-stable-manual.yml` |
 | Tag push `vX.Y.Z` | `release-stable-manual.yml` (full release pipeline) |
@@ -64,8 +65,15 @@ tag push.
    - `test` — `cargo nextest run --locked --workspace --exclude zeroclaw-desktop` on `ubuntu-latest`.
    - `security` — `cargo deny check`.
    - `CI Required Gate` — composite job; branch protection requires this.
-3. Maintainer reviews and merges once the gate is green and review policy is
-   satisfied.
+3. Maintainer reviews. Once the gate is green and review policy is satisfied,
+   they click **Merge when ready** to add the PR to the merge queue rather than
+   merging directly.
+4. The merge queue builds a temporary `gh-readonly-queue/master/…` branch
+   stacking `master` + any earlier queued PRs + this PR, and re-runs `ci.yml`
+   (the `merge_group` event) against it. The PR lands only when
+   `CI Required Gate` is green on that combined branch; if it fails, the PR is
+   ejected from the queue and the author is notified, while PRs ahead of it
+   continue unaffected.
 
 ### 2) Stable Release (manual)
 
@@ -120,7 +128,10 @@ flowchart TD
   L --> SEC["security\ncargo deny check"]
   T & BLD & CHK & C32 & BCH & SEC --> G["CI Required Gate"]
   G -->|red| D["PR stays open"]
-  G -->|green| R["Maintainer merges"]
+  G -->|green| Q["Maintainer: Merge when ready → merge queue"]
+  Q --> MG["merge_group: ci.yml on\ngh-readonly-queue/master/…"]
+  MG -->|red| E["PR ejected from queue\nauthor notified"]
+  MG -->|green| R["PR lands on master"]
 ```
 
 ### Stable release


### PR DESCRIPTION
## What

Adds the `merge_group` trigger to the **Quality Gate** workflow (`ci.yml`) so the required `CI Required Gate` check runs against the temporary `gh-readonly-queue/master/…` branch GitHub builds for each merge-queue entry.

This is **step 1 of 2** for enabling a merge queue on `master`. It must land *before* "Require merge queue" is switched on — otherwise every queued PR would stall waiting for `CI Required Gate` to report on a `merge_group` branch the workflow doesn't yet listen for.

## Changes

- **`ci.yml`** — add `merge_group:` to the `on:` triggers. The existing concurrency group already falls back to `github.ref` (the unique per-entry queue ref), so speculative queue builds won't cancel each other.
- **`master-branch-flow.md`** — document the merge-queue flow (event summary, step-by-step, diagram).

## Rollout

1. Merge this PR.
2. Enable "Require merge queue" on `master` (squash method) — done separately once this is on `master`.

## Risk

Additive only. PR and post-merge `push` behavior are unchanged; this just makes the same gate also run on `merge_group` events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)