### PR TITLE
fix(config): fail loud on unknown provider families and correct stale section paths

### DIFF
--- a/crates/zeroclaw-config/src/providers.rs
+++ b/crates/zeroclaw-config/src/providers.rs
@@ -265,7 +265,7 @@ macro_rules! emit_model_providers_struct {
         /// extras visible at the type level).
         ///
         /// TOML shape is preserved byte-identical: each named field deserializes
-        /// from the same `[model_providers.<type>.<alias>]` block as before.
+        /// from the same `[providers.models.<type>.<alias>]` block as before.
         ///
         /// Adding a new model_provider family means: define the typed config in
         /// `schema.rs`, then add one row to `for_each_model_provider_slot!`,
@@ -445,6 +445,21 @@ impl ModelProviders {
             };
         }
         for_each_model_provider_slot!(emit_aliases)
+    }
+
+    /// Canonical family slot names, straight from
+    /// `for_each_model_provider_slot!`. Use this to distinguish "unknown
+    /// family" from "known family, missing alias" in validation messages,
+    /// and to detect raw-TOML sections that deserialization silently drops.
+    #[must_use]
+    pub fn slot_names() -> &'static [&'static str] {
+        macro_rules! emit_slot_names {
+            ($(($field:ident, $type_str:literal, $cfg_ty:ty)),+ $(,)?) => {
+                &[$($type_str),+]
+            };
+        }
+        const NAMES: &[&str] = for_each_model_provider_slot!(emit_slot_names);
+        NAMES
     }
 
     /// Remove the entry for `<provider_type>.<alias>`, returning whether it

--- a/crates/zeroclaw-config/src/providers.rs
+++ b/crates/zeroclaw-config/src/providers.rs
@@ -790,34 +790,6 @@ macro_rules! for_each_tts_provider_slot {
     };
 }
 
-impl TtsProviders {
-    /// Canonical TTS family slot names. Mirrors
-    /// `ModelProviders::slot_names`; closed set, listed inline because
-    /// `for_each_tts_provider_slot!` carries a rate-type parameter that
-    /// makes it awkward for name-only collection. The
-    /// `provider_slot_names_match_struct_fields` test guards drift.
-    #[must_use]
-    pub fn slot_names() -> &'static [&'static str] {
-        &["openai", "elevenlabs", "google", "edge", "piper"]
-    }
-}
-
-impl TranscriptionProviders {
-    /// Canonical transcription family slot names. See
-    /// [`TtsProviders::slot_names`] for the drift guard.
-    #[must_use]
-    pub fn slot_names() -> &'static [&'static str] {
-        &[
-            "groq",
-            "openai",
-            "deepgram",
-            "assemblyai",
-            "google",
-            "local_whisper",
-        ]
-    }
-}
-
 /// Slot list for transcription providers.
 #[macro_export]
 macro_rules! for_each_transcription_provider_slot {
@@ -832,6 +804,36 @@ macro_rules! for_each_transcription_provider_slot {
             (local_whisper, "local_whisper"),
         }
     };
+}
+
+/// Collect the `$type_str` names out of a rate-typed slot macro
+/// (`for_each_tts_provider_slot!` / `for_each_transcription_provider_slot!`).
+/// The `$rate_ty` head is consumed and ignored; the macro exists so
+/// `slot_names()` derives from the same source the structs are built from.
+macro_rules! collect_rate_slot_names {
+    ($rate_ty:ty, $(($field:ident, $type_str:literal)),+ $(,)?) => {
+        &[$($type_str),+]
+    };
+}
+
+impl TtsProviders {
+    /// Canonical TTS family slot names, derived from
+    /// `for_each_tts_provider_slot!`.
+    #[must_use]
+    pub fn slot_names() -> &'static [&'static str] {
+        const NAMES: &[&str] = for_each_tts_provider_slot!(collect_rate_slot_names, ());
+        NAMES
+    }
+}
+
+impl TranscriptionProviders {
+    /// Canonical transcription family slot names, derived from
+    /// `for_each_transcription_provider_slot!`.
+    #[must_use]
+    pub fn slot_names() -> &'static [&'static str] {
+        const NAMES: &[&str] = for_each_transcription_provider_slot!(collect_rate_slot_names, ());
+        NAMES
+    }
 }
 
 /// Emit a `<Family>CostRatesByProvider` struct from a slot list. Used

--- a/crates/zeroclaw-config/src/providers.rs
+++ b/crates/zeroclaw-config/src/providers.rs
@@ -790,6 +790,34 @@ macro_rules! for_each_tts_provider_slot {
     };
 }
 
+impl TtsProviders {
+    /// Canonical TTS family slot names. Mirrors
+    /// `ModelProviders::slot_names`; closed set, listed inline because
+    /// `for_each_tts_provider_slot!` carries a rate-type parameter that
+    /// makes it awkward for name-only collection. The
+    /// `provider_slot_names_match_struct_fields` test guards drift.
+    #[must_use]
+    pub fn slot_names() -> &'static [&'static str] {
+        &["openai", "elevenlabs", "google", "edge", "piper"]
+    }
+}
+
+impl TranscriptionProviders {
+    /// Canonical transcription family slot names. See
+    /// [`TtsProviders::slot_names`] for the drift guard.
+    #[must_use]
+    pub fn slot_names() -> &'static [&'static str] {
+        &[
+            "groq",
+            "openai",
+            "deepgram",
+            "assemblyai",
+            "google",
+            "local_whisper",
+        ]
+    }
+}
+
 /// Slot list for transcription providers.
 #[macro_export]
 macro_rules! for_each_transcription_provider_slot {

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -15303,15 +15303,23 @@ impl Config {
             // Unknown provider families are dropped by serde, so an alias
             // created under a typo'd or unsupported family silently vanishes
             // on reload while agents.*.model_provider still references it.
-            for family in Self::unknown_provider_families(&contents) {
+            for entry in Self::unknown_provider_families(&contents) {
+                let (kind, family) = entry.split_once('.').unwrap_or(("models", entry.as_str()));
+                let reference = if kind == "models" {
+                    "any agents.*.model_provider referencing them will fail to resolve; \
+                     run `zeroclaw providers` for valid family names"
+                } else {
+                    "references to its aliases will fail to resolve"
+                };
                 ::zeroclaw_log::record!(
                     WARN,
                     ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
                         .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                        .with_attrs(::serde_json::json!({"family": family})),
-                    "[providers.models.<family>] section dropped: not a known provider family. \
-                     Its aliases will not load and any agents.*.model_provider referencing them \
-                     will fail to resolve. Run `zeroclaw providers` for valid family names."
+                        .with_attrs(::serde_json::json!({"kind": kind, "family": family})),
+                    &format!(
+                        "[providers.{kind}.{family}] section dropped: not a known {kind} \
+                         provider family. Its aliases will not load and {reference}."
+                    )
                 );
             }
             // Set computed paths that are skipped during serialization

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -24507,6 +24507,16 @@ model = "gpt-4o"
             vec!["tts.bogustts".to_string()]
         );
         assert!(Config::unknown_provider_families("not even toml {{{").is_empty());
+        // Hostile shapes: scalar providers node, scalar kind node,
+        // array-of-tables family. as_table() filters all of them; the
+        // detector must stay silent rather than panic or false-positive.
+        assert!(Config::unknown_provider_families("providers = 3\n").is_empty());
+        assert!(Config::unknown_provider_families("[providers]\nmodels = 3\n").is_empty());
+        assert_eq!(
+            Config::unknown_provider_families("[[providers.models.weird]]\nx = 1\n"),
+            vec!["models.weird".to_string()],
+            "array-of-tables under an unknown family is still an unknown family"
+        );
     }
 
     #[test]

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -24430,6 +24430,32 @@ auto_approve = ["file_read", "file_write", "file_edit", "memory_recall", "memory
     }
 
     #[test]
+    async fn unknown_provider_families_flags_silent_serde_drop() {
+        // serde ignores unknown keys under providers.models, so a typo'd
+        // family parses cleanly and its aliases vanish on reload. The
+        // detector must flag it; known families must pass.
+        let raw = r#"
+schema_version = 3
+
+[providers.models.antropic.main]
+model = "claude-sonnet-4-6"
+
+[providers.models.openai.work]
+model = "gpt-4o"
+"#;
+        let parsed: Config = toml::from_str(raw).expect("unknown family must not fail parse");
+        assert!(
+            parsed.providers.models.find("antropic", "main").is_none(),
+            "precondition: serde silently drops the unknown family"
+        );
+        assert_eq!(
+            Config::unknown_provider_families(raw),
+            vec!["antropic".to_string()]
+        );
+        assert!(Config::unknown_provider_families("not even toml {{{").is_empty());
+    }
+
+    #[test]
     async fn map_key_create_survives_incremental_save() {
         // Repro for the zerocode "providers vanish after restart" report:
         // the RPC config/map-key-create path is create_map_key + mark_dirty

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -8901,7 +8901,7 @@ fn find_header_end(buf: &[u8]) -> Option<usize> {
 /// Persistent storage configuration (`[storage]` section).
 ///
 /// Storage is a two-tier alias-keyed map: `[storage.<backend>.<alias>]`,
-/// parallel to `[model_providers.<type>.<alias>]`. Each backend has its own typed
+/// parallel to `[providers.models.<type>.<alias>]`. Each backend has its own typed
 /// config struct. `MemoryConfig.backend` carries a dotted reference (`"sqlite.default"`,
 /// `"postgres.work"`) that resolves to one of these entries via
 /// [`Config::resolve_active_storage`].
@@ -15035,6 +15035,32 @@ impl Config {
             .collect()
     }
 
+    /// Return `providers.models.<family>` table keys in `raw_toml` that are
+    /// not a known typed family slot. Serde silently drops these sections
+    /// at deserialize time, so a typo'd family (`[providers.models.antropic.x]`)
+    /// or one from a newer binary vanishes on reload — the alias "works"
+    /// in the session that created it, then disappears after restart.
+    pub fn unknown_provider_families(raw_toml: &str) -> Vec<String> {
+        let raw: toml::Table = match raw_toml.parse() {
+            Ok(t) => t,
+            Err(_) => return Vec::new(),
+        };
+        let Some(models) = raw
+            .get("providers")
+            .and_then(toml::Value::as_table)
+            .and_then(|p| p.get("models"))
+            .and_then(toml::Value::as_table)
+        else {
+            return Vec::new();
+        };
+        let slots = crate::providers::ModelProviders::slot_names();
+        models
+            .keys()
+            .filter(|k| !slots.contains(&k.as_str()))
+            .cloned()
+            .collect()
+    }
+
     /// Returns `true` if `path` was populated by a `ZEROCLAW_*` env-var
     /// override at load time. O(1) HashSet lookup; safe to call per row in
     /// list-rendering paths (`config list`, dashboard, quickstart).
@@ -15261,6 +15287,20 @@ impl Config {
                         .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
                         .with_attrs(::serde_json::json!({"key": key})),
                     "Unknown config key ignored: \"\". Check config.toml for typos or deprecated options."
+                );
+            }
+            // Unknown provider families are dropped by serde, so an alias
+            // created under a typo'd or unsupported family silently vanishes
+            // on reload while agents.*.model_provider still references it.
+            for family in Self::unknown_provider_families(&contents) {
+                ::zeroclaw_log::record!(
+                    WARN,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                        .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                        .with_attrs(::serde_json::json!({"family": family})),
+                    "[providers.models.<family>] section dropped: not a known provider family. \
+                     Its aliases will not load and any agents.*.model_provider referencing them \
+                     will fail to resolve. Run `zeroclaw providers` for valid family names."
                 );
             }
             // Set computed paths that are skipped during serialization
@@ -15853,7 +15893,7 @@ impl Config {
                 );
             }
             // Route refs are dotted `<type>.<alias>` and must resolve to a
-            // configured `[model_providers.<type>.<alias>]` entry. Unresolved
+            // configured `[providers.models.<type>.<alias>]` entry. Unresolved
             // routes are dropped at runtime construction; rejecting them here
             // keeps that drift visible at config-load time.
             match mp.split_once('.') {
@@ -16448,6 +16488,13 @@ impl Config {
             }
             match mp.split_once('.') {
                 Some((ty, inner)) if !ty.is_empty() && !inner.is_empty() => {
+                    if !crate::providers::ModelProviders::slot_names().contains(&ty) {
+                        validation_bail!(
+                            DanglingReference,
+                            format!("agents.{alias}.model_provider"),
+                            "agents.{alias}.model_provider = {mp:?} but {ty:?} is not a known provider family — check [providers.models.<family>.<alias>] in config.toml (valid families: see `zeroclaw providers`)",
+                        );
+                    }
                     let exists = self
                         .get_map_keys(&format!("providers.models.{ty}"))
                         .is_some_and(|keys| keys.iter().any(|k| k == inner));
@@ -16455,7 +16502,7 @@ impl Config {
                         validation_bail!(
                             DanglingReference,
                             format!("agents.{alias}.model_provider"),
-                            "agents.{alias}.model_provider = {mp:?} but providers.models.{ty}.{inner} is not configured",
+                            "agents.{alias}.model_provider = {mp:?} but [providers.models.{ty}.{inner}] is not configured",
                         );
                     }
                 }
@@ -18115,7 +18162,7 @@ auto_save = true
         // Ollama-specific tuning lives on `OllamaModelProviderConfig`,
         // not on the generic `ModelProviderConfig` base. These knobs
         // ride alongside the flattened `base` so a TOML alias like
-        // `[model_providers.ollama.local]` accepts them at the same
+        // `[providers.models.ollama.local]` accepts them at the same
         // level as `model`, `api_key`, etc.
         let toml = r#"
             num_ctx = 16384
@@ -24380,6 +24427,48 @@ auto_approve = ["file_read", "file_write", "file_edit", "memory_recall", "memory
             .create_map_key("not.a.real.section", "anything")
             .expect_err("unknown section path should error");
         assert!(err.contains("not.a.real.section"));
+    }
+
+    #[test]
+    async fn map_key_create_survives_incremental_save() {
+        // Repro for the zerocode "providers vanish after restart" report:
+        // the RPC config/map-key-create path is create_map_key + mark_dirty
+        // + save_dirty. The new alias must reach config.toml, otherwise it
+        // exists only in-memory and a daemon restart silently drops it
+        // (and any agents.*.model_provider referencing it dangles).
+        let tmp = tempfile::TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+
+        // Seed a non-empty on-disk file so the incremental path runs, not
+        // the new-file fallback to full save().
+        std::fs::write(
+            &config_path,
+            "schema_version = 9\n\n[observability]\nbackend = \"none\"\n",
+        )
+        .unwrap();
+
+        let mut config = Config {
+            config_path: config_path.clone(),
+            ..Default::default()
+        };
+        let created = config
+            .create_map_key("providers.models.openai", "myalias")
+            .expect("typed family slot accepts a new alias");
+        assert!(created);
+        config.mark_dirty("providers.models.openai.myalias");
+        config.save_dirty().await.unwrap();
+
+        let written = std::fs::read_to_string(&config_path).unwrap();
+        let reloaded: Config = toml::from_str(&written)
+            .unwrap_or_else(|e| panic!("rewritten config must reparse: {e}\n---\n{written}"));
+        assert!(
+            reloaded
+                .providers
+                .models
+                .find("openai", "myalias")
+                .is_some(),
+            "created alias must survive save_dirty + reload; got:\n{written}"
+        );
     }
 
     #[test]

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -15035,30 +15035,41 @@ impl Config {
             .collect()
     }
 
-    /// Return `providers.models.<family>` table keys in `raw_toml` that are
-    /// not a known typed family slot. Serde silently drops these sections
-    /// at deserialize time, so a typo'd family (`[providers.models.antropic.x]`)
-    /// or one from a newer binary vanishes on reload — the alias "works"
-    /// in the session that created it, then disappears after restart.
+    /// Return `<kind>.<family>` entries under `[providers]` in `raw_toml`
+    /// whose family is not a known typed slot (kinds: models, tts,
+    /// transcription). Serde silently drops these sections at deserialize
+    /// time, so a typo'd family (`[providers.models.antropic.x]`) or one
+    /// from a newer binary vanishes on reload: the alias "works" in the
+    /// session that created it, then disappears after restart.
     pub fn unknown_provider_families(raw_toml: &str) -> Vec<String> {
         let raw: toml::Table = match raw_toml.parse() {
             Ok(t) => t,
             Err(_) => return Vec::new(),
         };
-        let Some(models) = raw
-            .get("providers")
-            .and_then(toml::Value::as_table)
-            .and_then(|p| p.get("models"))
-            .and_then(toml::Value::as_table)
-        else {
+        let Some(kinds) = raw.get("providers").and_then(toml::Value::as_table) else {
             return Vec::new();
         };
-        let slots = crate::providers::ModelProviders::slot_names();
-        models
-            .keys()
-            .filter(|k| !slots.contains(&k.as_str()))
-            .cloned()
-            .collect()
+        let kind_slots: &[(&str, &[&str])] = &[
+            ("models", crate::providers::ModelProviders::slot_names()),
+            ("tts", crate::providers::TtsProviders::slot_names()),
+            (
+                "transcription",
+                crate::providers::TranscriptionProviders::slot_names(),
+            ),
+        ];
+        let mut out = Vec::new();
+        for (kind, slots) in kind_slots {
+            let Some(families) = kinds.get(*kind).and_then(toml::Value::as_table) else {
+                continue;
+            };
+            out.extend(
+                families
+                    .keys()
+                    .filter(|k| !slots.contains(&k.as_str()))
+                    .map(|k| format!("{kind}.{k}")),
+            );
+        }
+        out
     }
 
     /// Returns `true` if `path` was populated by a `ZEROCLAW_*` env-var
@@ -16492,7 +16503,7 @@ impl Config {
                         validation_bail!(
                             DanglingReference,
                             format!("agents.{alias}.model_provider"),
-                            "agents.{alias}.model_provider = {mp:?} but {ty:?} is not a known provider family — check [providers.models.<family>.<alias>] in config.toml (valid families: see `zeroclaw providers`)",
+                            "agents.{alias}.model_provider = {mp:?} but {ty:?} is not a known provider family; check [providers.models.<family>.<alias>] in config.toml (valid families: `zeroclaw providers`)",
                         );
                     }
                     let exists = self
@@ -24430,6 +24441,43 @@ auto_approve = ["file_read", "file_write", "file_edit", "memory_recall", "memory
     }
 
     #[test]
+    async fn provider_slot_names_match_struct_fields() {
+        // TtsProviders/TranscriptionProviders::slot_names are inline lists
+        // (their slot macros carry a rate-type param); pin them against the
+        // actual serialized field names so adding a family without updating
+        // slot_names fails here.
+        let tts = toml::Value::try_from(crate::providers::TtsProviders {
+            openai: std::iter::once(("a".to_string(), Default::default())).collect(),
+            elevenlabs: std::iter::once(("a".to_string(), Default::default())).collect(),
+            google: std::iter::once(("a".to_string(), Default::default())).collect(),
+            edge: std::iter::once(("a".to_string(), Default::default())).collect(),
+            piper: std::iter::once(("a".to_string(), Default::default())).collect(),
+        })
+        .unwrap();
+        let mut tts_fields: Vec<&str> =
+            tts.as_table().unwrap().keys().map(String::as_str).collect();
+        tts_fields.sort_unstable();
+        let mut tts_slots = crate::providers::TtsProviders::slot_names().to_vec();
+        tts_slots.sort_unstable();
+        assert_eq!(tts_fields, tts_slots);
+
+        let tr = toml::Value::try_from(crate::providers::TranscriptionProviders {
+            groq: std::iter::once(("a".to_string(), Default::default())).collect(),
+            openai: std::iter::once(("a".to_string(), Default::default())).collect(),
+            deepgram: std::iter::once(("a".to_string(), Default::default())).collect(),
+            assemblyai: std::iter::once(("a".to_string(), Default::default())).collect(),
+            google: std::iter::once(("a".to_string(), Default::default())).collect(),
+            local_whisper: std::iter::once(("a".to_string(), Default::default())).collect(),
+        })
+        .unwrap();
+        let mut tr_fields: Vec<&str> = tr.as_table().unwrap().keys().map(String::as_str).collect();
+        tr_fields.sort_unstable();
+        let mut tr_slots = crate::providers::TranscriptionProviders::slot_names().to_vec();
+        tr_slots.sort_unstable();
+        assert_eq!(tr_fields, tr_slots);
+    }
+
+    #[test]
     async fn unknown_provider_families_flags_silent_serde_drop() {
         // serde ignores unknown keys under providers.models, so a typo'd
         // family parses cleanly and its aliases vanish on reload. The
@@ -24450,7 +24498,13 @@ model = "gpt-4o"
         );
         assert_eq!(
             Config::unknown_provider_families(raw),
-            vec!["antropic".to_string()]
+            vec!["models.antropic".to_string()]
+        );
+        assert_eq!(
+            Config::unknown_provider_families(
+                "schema_version = 3\n[providers.tts.bogustts.x]\nenabled = true\n",
+            ),
+            vec!["tts.bogustts".to_string()]
         );
         assert!(Config::unknown_provider_families("not even toml {{{").is_empty());
     }

--- a/crates/zeroclaw-gateway/src/ws.rs
+++ b/crates/zeroclaw-gateway/src/ws.rs
@@ -1388,7 +1388,7 @@ fn record_turn_cost(
     // V3 per-provider pricing lookup. Mirrors how the channels
     // orchestrator and the gateway lib.rs cost-tracking scope build
     // their `ModelProviderPricing`: walk every
-    // `[model_providers.<type>.<alias>]` and key the per-profile
+    // `[providers.models.<type>.<alias>]` and key the per-profile
     // pricing map by `<type>.<alias>`. The streaming and non-streaming
     // paths derive identical costs because both bottom out in the same
     // `<type>.<alias>` key shape.

--- a/crates/zeroclaw-providers/src/anthropic.rs
+++ b/crates/zeroclaw-providers/src/anthropic.rs
@@ -25,7 +25,7 @@ const SSE_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(90)
 use crate::stream_guard::AbortOnDrop;
 
 pub struct AnthropicModelProvider {
-    /// `[model_providers.anthropic.<alias>]` config-key alias.
+    /// `[providers.models.anthropic.<alias>]` config-key alias.
     alias: String,
     credential: Option<String>,
     base_url: String,

--- a/crates/zeroclaw-providers/src/auth/mod.rs
+++ b/crates/zeroclaw-providers/src/auth/mod.rs
@@ -262,7 +262,7 @@ impl AuthService {
     /// Get a valid Gemini OAuth access token, refreshing if necessary.
     ///
     /// `client_id` and `client_secret` are the OAuth app credentials from
-    /// the per-alias `[model_providers.gemini.<alias>]` typed config —
+    /// the per-alias `[providers.models.gemini.<alias>]` typed config —
     /// required when a refresh is triggered. Required when the cached
     /// access token is near expiry; ignored when the access token is
     /// still valid. Pass empty strings only if the caller is certain
@@ -1014,7 +1014,7 @@ pub struct GeminiFlow;
 impl GeminiFlow {
     /// Look up the per-alias OAuth client credentials. The auth profile
     /// name doubles as the Gemini family alias key
-    /// (`[model_providers.gemini.<profile>]`); the alias config carries
+    /// (`[providers.models.gemini.<profile>]`); the alias config carries
     /// the operator's Google Cloud OAuth app credentials.
     fn alias_creds<'a>(config: &'a Config, profile: &str) -> Result<(&'a str, &'a str)> {
         let alias_cfg = config.providers.models.gemini.get(profile).ok_or_else(|| {
@@ -1030,7 +1030,7 @@ impl GeminiFlow {
                 "auth: gemini OAuth missing alias config"
             );
             anyhow::Error::msg(format!(
-                "Gemini OAuth requires `[model_providers.gemini.{profile}]` to exist with \
+                "Gemini OAuth requires `[providers.models.gemini.{profile}]` to exist with \
                  `oauth_client_id` and `oauth_client_secret` set. Register a Google Cloud \
                  OAuth app and configure the credentials before running this auth flow.",
             ))
@@ -1053,7 +1053,7 @@ impl GeminiFlow {
                     "auth: gemini OAuth missing oauth_client_id"
                 );
                 anyhow::Error::msg(format!(
-                    "Gemini OAuth requires `oauth_client_id` on `[model_providers.gemini.{profile}]`.",
+                    "Gemini OAuth requires `oauth_client_id` on `[providers.models.gemini.{profile}]`.",
                 ))
             })?;
         let client_secret = alias_cfg
@@ -1074,7 +1074,7 @@ impl GeminiFlow {
                     "auth: gemini OAuth missing oauth_client_secret"
                 );
                 anyhow::Error::msg(format!(
-                    "Gemini OAuth requires `oauth_client_secret` on `[model_providers.gemini.{profile}]`.",
+                    "Gemini OAuth requires `oauth_client_secret` on `[providers.models.gemini.{profile}]`.",
                 ))
             })?;
         Ok((client_id, client_secret))

--- a/crates/zeroclaw-providers/src/azure_openai.rs
+++ b/crates/zeroclaw-providers/src/azure_openai.rs
@@ -10,7 +10,7 @@ use zeroclaw_api::tool::ToolSpec;
 const DEFAULT_API_VERSION: &str = "2024-08-01-preview";
 
 pub struct AzureOpenAiModelProvider {
-    /// `[model_providers.azure.<alias>]` config-key alias.
+    /// `[providers.models.azure.<alias>]` config-key alias.
     alias: String,
     credential: Option<String>,
     #[allow(dead_code)]

--- a/crates/zeroclaw-providers/src/bedrock.rs
+++ b/crates/zeroclaw-providers/src/bedrock.rs
@@ -748,7 +748,7 @@ struct ResponseToolUseWrapper {
 // ── BedrockModelProvider ─────────────────────────────────────────────
 
 pub struct BedrockModelProvider {
-    /// `[model_providers.<family>.<alias>]` config-key alias.
+    /// `[providers.models.<family>.<alias>]` config-key alias.
     alias: String,
     auth: Option<BedrockAuth>,
     max_tokens: u32,

--- a/crates/zeroclaw-providers/src/copilot.rs
+++ b/crates/zeroclaw-providers/src/copilot.rs
@@ -189,7 +189,7 @@ struct ResponseMessage {
 /// Tokens are cached to `~/.config/zeroclaw/copilot/` and refreshed
 /// automatically.
 pub struct CopilotModelProvider {
-    /// `[model_providers.<family>.<alias>]` config-key alias.
+    /// `[providers.models.<family>.<alias>]` config-key alias.
     alias: String,
     github_token: Option<String>,
     /// Mutex ensures only one caller refreshes tokens at a time,

--- a/crates/zeroclaw-providers/src/factory.rs
+++ b/crates/zeroclaw-providers/src/factory.rs
@@ -260,7 +260,7 @@ pub fn dispatch_family_factory(
                     Err(anyhow::Error::msg(format!(
                         "Unknown model_provider family: {family}. After the V2 to typed-family migration, \
                          only canonical family names are valid. Run `zeroclaw quickstart` to reconfigure, \
-                         or set `[model_providers.custom.<alias>] uri = \"https://your-api.com\"` for \
+                         or set `[providers.models.custom.<alias>] uri = \"https://your-api.com\"` for \
                          OpenAI-compatible custom endpoints."
                     )))
                 },
@@ -912,7 +912,7 @@ impl FamilyProviderFactory for AzureModelProviderConfig {
         _opts: &ModelProviderRuntimeOptions,
     ) -> Result<Box<dyn ModelProvider>> {
         // Reads typed Azure alias fields directly. Operator sets these
-        // under `[model_providers.azure.<alias>]` or via the schema-mirror
+        // under `[providers.models.azure.<alias>]` or via the schema-mirror
         // env grammar — env-var fallback eradicated.
         let resource = self.resource.as_deref().ok_or_else(|| {
             ::zeroclaw_log::record!(
@@ -928,7 +928,7 @@ impl FamilyProviderFactory for AzureModelProviderConfig {
             );
             anyhow::Error::msg(
                 "Azure model_provider requires `resource`: set \
-                 `[model_providers.azure.<alias>] resource = \"...\"` in config.toml.",
+                 `[providers.models.azure.<alias>] resource = \"...\"` in config.toml.",
             )
         })?;
         let deployment = self.deployment.as_deref().ok_or_else(|| {
@@ -945,7 +945,7 @@ impl FamilyProviderFactory for AzureModelProviderConfig {
             );
             anyhow::Error::msg(
                 "Azure model_provider requires `deployment`: set \
-                 `[model_providers.azure.<alias>] deployment = \"...\"` in config.toml.",
+                 `[providers.models.azure.<alias>] deployment = \"...\"` in config.toml.",
             )
         })?;
         let api_version = self.api_version.as_deref();
@@ -1077,7 +1077,7 @@ impl FamilyProviderFactory for GroqModelProviderConfig {
         .with_models_dev_key("groq");
         // Groq's llama-family models reject native tool calls with HTTP
         // 400; default to text-fallback. Operators can override per-alias
-        // via `[model_providers.groq.<alias>] native_tools = true`.
+        // via `[providers.models.groq.<alias>] native_tools = true`.
         if opts.native_tools != Some(true) {
             p = p.without_native_tools();
         }
@@ -1264,7 +1264,7 @@ impl FamilyProviderFactory for CustomModelProviderConfig {
             );
             anyhow::Error::msg(
                 "Custom model_provider requires `uri`: set \
-                 `[model_providers.custom.<alias>] uri = \"https://your-api.com\"` in config.toml.",
+                 `[providers.models.custom.<alias>] uri = \"https://your-api.com\"` in config.toml.",
             )
         })?;
         if let Some(p) = build_responses_provider_if_requested(
@@ -1305,7 +1305,7 @@ impl FamilyProviderFactory for zeroclaw_config::schema::ModelProviderConfig {
         let base_url = api_url.ok_or_else(|| {
             anyhow::Error::msg(
                 "OpenAI-compatible model_provider requires `uri`: set \
-                 `[model_providers.<family>.<alias>] uri = \"https://your-api.com\"` in config.toml.",
+                 `[providers.models.<family>.<alias>] uri = \"https://your-api.com\"` in config.toml.",
             )
         })?;
         if let Some(p) =

--- a/crates/zeroclaw-providers/src/gemini.rs
+++ b/crates/zeroclaw-providers/src/gemini.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 
 /// Gemini model_provider supporting multiple authentication methods.
 pub struct GeminiModelProvider {
-    /// `[model_providers.gemini.<alias>]` config-key alias.
+    /// `[providers.models.gemini.<alias>]` config-key alias.
     alias: String,
     auth: Option<GeminiAuth>,
     oauth_project: Arc<tokio::sync::Mutex<Option<String>>>,
@@ -527,7 +527,7 @@ impl GeminiModelProvider {
     /// Create a new Gemini model_provider.
     ///
     /// Authentication priority:
-    /// 1. Explicit API key passed in (from `[model_providers.gemini.<alias>]
+    /// 1. Explicit API key passed in (from `[providers.models.gemini.<alias>]
     ///    api_key`, reachable via the schema-mirror env grammar)
     /// 2. Gemini CLI OAuth tokens (`~/.gemini/oauth_creds.json`)
     pub fn new(alias: &str, api_key: Option<&str>) -> Self {
@@ -556,7 +556,7 @@ impl GeminiModelProvider {
     /// Create a new Gemini model_provider with managed OAuth from auth-profiles.json.
     ///
     /// Authentication priority:
-    /// 1. Explicit API key passed in (from `[model_providers.gemini.<alias>]`)
+    /// 1. Explicit API key passed in (from `[providers.models.gemini.<alias>]`)
     /// 2. Managed OAuth from auth-profiles.json (if auth_service provided)
     /// 3. Gemini CLI OAuth tokens (`~/.gemini/oauth_creds.json`)
     pub fn new_with_auth(

--- a/crates/zeroclaw-providers/src/gemini_cli.rs
+++ b/crates/zeroclaw-providers/src/gemini_cli.rs
@@ -58,7 +58,7 @@ const TEMP_EPSILON: f64 = 1e-9;
 /// Each inference request spawns a fresh `gemini` process. This is the
 /// non-interactive approach: the process handles the prompt and exits.
 pub struct GeminiCliModelProvider {
-    /// `[model_providers.<family>.<alias>]` config-key alias.
+    /// `[providers.models.<family>.<alias>]` config-key alias.
     alias: String,
     /// Path to the `gemini` binary.
     binary_path: PathBuf,

--- a/crates/zeroclaw-providers/src/kilocli.rs
+++ b/crates/zeroclaw-providers/src/kilocli.rs
@@ -55,7 +55,7 @@ const TEMP_EPSILON: f64 = 1e-9;
 /// Each inference request spawns a fresh `kilo` process. This is the
 /// non-interactive approach: the process handles the prompt and exits.
 pub struct KiloCliModelProvider {
-    /// `[model_providers.<family>.<alias>]` config-key alias.
+    /// `[providers.models.<family>.<alias>]` config-key alias.
     alias: String,
     /// Path to the `kilo` binary.
     binary_path: PathBuf,

--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -56,7 +56,7 @@ const MAX_API_ERROR_CHARS: usize = 500;
 const MINIMAX_INTL_BASE_URL: &str = "https://api.minimax.io/v1";
 /// MiniMax-published OAuth client_id (same one their portal uses).
 /// Operators with a custom OAuth app override via
-/// `[model_providers.minimax.<alias>] oauth_client_id = "..."`.
+/// `[providers.models.minimax.<alias>] oauth_client_id = "..."`.
 const MINIMAX_OAUTH_DEFAULT_CLIENT_ID: &str = "78257093-7e40-4613-99e0-527b14b39113";
 const GLM_GLOBAL_BASE_URL: &str = "https://api.z.ai/api/paas/v4";
 const MOONSHOT_INTL_BASE_URL: &str = "https://api.moonshot.ai/v1";
@@ -961,8 +961,8 @@ fn check_api_key_prefix(model_provider_name: &str, key: &str) -> Option<&'static
 // `parse_custom_provider_url` was deleted in #6273. The legacy colon-URL form
 // (`custom:https://...` and `anthropic-custom:https://...`) is collapsed
 // at TOML load time by `normalize_model_provider_type` in `schema/v2.rs` into
-// `[model_providers.custom.<alias>] uri = "..."` (or
-// `[model_providers.anthropic.custom] uri = "..."`). The factory's
+// `[providers.models.custom.<alias>] uri = "..."` (or
+// `[providers.models.anthropic.custom] uri = "..."`). The factory's
 // `"custom"` arm reads `uri` from the alias entry via
 // `options.provider_api_url`; URL parsing/validation now happens at
 // schema validation time, not at runtime construction.
@@ -1139,7 +1139,7 @@ pub fn canonicalize_v2_model_provider_name(name: &str) -> &str {
 
 /// Split a V2 colon-URL family name (`custom:https://...`,
 /// `anthropic-custom:https://...`) into a `(name, url)` pair. The V3 typed
-/// schema stores custom endpoints as `[model_providers.<family>.<alias>]
+/// schema stores custom endpoints as `[providers.models.<family>.<alias>]
 /// uri = "..."`; this helper preserves runtime-factory compatibility for
 /// callers that still pass the legacy single-token form.
 fn split_v2_colon_url(name: &str) -> (&str, Option<&str>) {
@@ -1186,7 +1186,7 @@ fn create_model_provider_inner(
         {
             anyhow::bail!(
                 "Custom model_provider `{prefix}:<url>` requires a URL beginning with http:// or https://. \
-                 Set `[model_providers.custom.<alias>] uri = \"https://your-api.com\"` or pass a valid URL."
+                 Set `[providers.models.custom.<alias>] uri = \"https://your-api.com\"` or pass a valid URL."
             );
         }
     }
@@ -1485,7 +1485,7 @@ fn append_fallback_chain(
 /// Build a resilient model provider from a name that may be either a bare
 /// family (`"openai"`) or a dotted alias (`"openai.work"`). Dotted names
 /// dispatch through the typed alias factory so endpoint URI, family
-/// extras, and per-alias credentials from `[model_providers.<family>.<alias>]`
+/// extras, and per-alias credentials from `[providers.models.<family>.<alias>]`
 /// are honored; bare names route through the family factory directly.
 pub fn create_resilient_model_provider_from_ref(
     config: &zeroclaw_config::schema::Config,
@@ -1517,7 +1517,7 @@ pub fn create_resilient_model_provider_from_ref(
 
 /// Build a router fronted by `primary_name` plus one provider per unique
 /// `model_routes` entry. Each dotted `<family>.<alias>` name resolves
-/// through the typed `[model_providers.<family>.<alias>]` config (endpoint
+/// through the typed `[providers.models.<family>.<alias>]` config (endpoint
 /// URI, Azure resource, Gemini OAuth, etc.); bare family names use family
 /// defaults.
 pub fn create_routed_model_provider_with_options(
@@ -2129,7 +2129,7 @@ mod tests {
     #[test]
     fn factory_openai_codex() {
         // Codex is now selected by the typed `base.requires_openai_auth`
-        // flag on an `[model_providers.openai.codex]` alias entry — the
+        // flag on an `[providers.models.openai.codex]` alias entry — the
         // factory's legacy escape hatch for the bare "openai-codex" /
         // "openai_codex" / "codex" family names still routes through
         // `OpenAiCodexModelProvider::new` when a real Config + alias is
@@ -2465,7 +2465,7 @@ mod tests {
 
     #[test]
     fn factory_groq_honors_native_tools_override_true() {
-        // Operator opt-in via `[model_providers.groq.<alias>] native_tools = true`
+        // Operator opt-in via `[providers.models.groq.<alias>] native_tools = true`
         // skips the default disable so non-llama Groq models can use native
         // tool calling.
         let options = ModelProviderRuntimeOptions {
@@ -2808,8 +2808,8 @@ mod tests {
     //
     // The legacy colon-URL form ("custom:https://..." / "anthropic-custom:...")
     // and its in-process URL parser were deleted in #6273. The surface is
-    // `[model_providers.custom.<alias>] uri = "https://..."` for OpenAI-
-    // compatible endpoints (or `[model_providers.anthropic.<alias>] uri = ...`
+    // `[providers.models.custom.<alias>] uri = "https://..."` for OpenAI-
+    // compatible endpoints (or `[providers.models.anthropic.<alias>] uri = ...`
     // for Anthropic-compatible). URL validation now happens at schema-load
     // time in `crates/zeroclaw-config/src/schema.rs::validate`, not at runtime
     // construction; tests for that validation belong with the schema, not here.

--- a/crates/zeroclaw-providers/src/ollama.rs
+++ b/crates/zeroclaw-providers/src/ollama.rs
@@ -89,7 +89,7 @@ impl OllamaTuning {
 }
 
 pub struct OllamaModelProvider {
-    /// `[model_providers.ollama.<alias>]` config-key alias.
+    /// `[providers.models.ollama.<alias>]` config-key alias.
     alias: String,
     base_url: String,
     api_key: Option<String>,

--- a/crates/zeroclaw-providers/src/openai.rs
+++ b/crates/zeroclaw-providers/src/openai.rs
@@ -22,7 +22,7 @@ pub(crate) const BASE_URL: &str = "https://api.openai.com/v1";
 const RESPONSES_URL: &str = "https://api.openai.com/v1/responses";
 
 pub struct OpenAiModelProvider {
-    /// `[model_providers.openai.<alias>]` config-key alias.
+    /// `[providers.models.openai.<alias>]` config-key alias.
     alias: String,
     base_url: String,
     credential: Option<String>,

--- a/crates/zeroclaw-providers/src/openai_codex.rs
+++ b/crates/zeroclaw-providers/src/openai_codex.rs
@@ -28,7 +28,7 @@ const RESPONSES_HISTORY_KIND: &str = "responses_output_items";
 
 #[derive(Clone)]
 pub struct OpenAiCodexModelProvider {
-    /// `[model_providers.<family>.<alias>]` config-key alias.
+    /// `[providers.models.<family>.<alias>]` config-key alias.
     alias: String,
     auth: AuthService,
     auth_profile_override: Option<String>,

--- a/crates/zeroclaw-providers/src/openrouter.rs
+++ b/crates/zeroclaw-providers/src/openrouter.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 use zeroclaw_api::tool::ToolSpec;
 
 pub struct OpenRouterModelProvider {
-    /// `[model_providers.<family>.<alias>]` config-key alias.
+    /// `[providers.models.<family>.<alias>]` config-key alias.
     alias: String,
     credential: Option<String>,
     timeout_secs: u64,

--- a/crates/zeroclaw-providers/src/reliable.rs
+++ b/crates/zeroclaw-providers/src/reliable.rs
@@ -388,7 +388,7 @@ fn is_empty_completion(resp: &ChatResponse) -> bool {
 /// passes a single primary. Per-model failover chains are also test-only —
 /// the schema no longer surfaces them.
 pub struct ReliableModelProvider {
-    /// `[model_providers.<family>.<alias>]` config-key alias.
+    /// `[providers.models.<family>.<alias>]` config-key alias.
     alias: String,
     model_providers: Vec<(String, Box<dyn ModelProvider>)>,
     max_retries: u32,

--- a/crates/zeroclaw-providers/src/router.rs
+++ b/crates/zeroclaw-providers/src/router.rs
@@ -43,7 +43,7 @@ pub struct Route {
 ///
 /// This wraps multiple pre-created model_providers and selects the right one per request.
 pub struct RouterModelProvider {
-    /// `[model_providers.<family>.<alias>]` config-key alias.
+    /// `[providers.models.<family>.<alias>]` config-key alias.
     alias: String,
     routes: HashMap<String, (usize, String)>, // hint → (provider_index, model)
     model_providers: Vec<(String, Box<dyn ModelProvider>)>,
@@ -183,7 +183,7 @@ impl RouterModelProvider {
 /// model_provider from the route table based on per-provider pricing maps.
 ///
 /// Pricing is keyed by model_provider name (the alias under
-/// `[model_providers.<model_provider>.<alias>]`); each model_provider's pricing map
+/// `[providers.models.<model_provider>.<alias>]`); each model_provider's pricing map
 /// holds user-defined keys (model identifiers, optionally suffixed with
 /// `.input` / `.output`) mapped to USD-per-1M-token rates.
 #[derive(Debug, Clone)]

--- a/crates/zeroclaw-providers/src/telnyx.rs
+++ b/crates/zeroclaw-providers/src/telnyx.rs
@@ -37,7 +37,7 @@ pub(crate) const BASE_URL: &str = "https://api.telnyx.com/v2/ai";
 /// let response = model_provider.chat("Hello!", "openai/gpt-4o", 0.7).await?;
 /// ```
 pub struct TelnyxModelProvider {
-    /// `[model_providers.telnyx.<alias>]` config-key alias.
+    /// `[providers.models.telnyx.<alias>]` config-key alias.
     alias: String,
     /// Telnyx API key
     api_key: Option<String>,

--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -1111,7 +1111,7 @@ impl Agent {
                     if !agent_ref.is_empty() {
                         anyhow::bail!(
                             "agents.{agent_alias}.model_provider = \"{agent_ref}\" does not \
-                             resolve to a configured [model_providers.<type>.<alias>] entry"
+                             resolve to a configured [providers.models.<type>.<alias>] entry"
                         );
                     }
                     // V3 schema requires every agent to set model_provider.
@@ -1293,7 +1293,7 @@ impl Agent {
             Some(m) => m.to_string(),
             None => anyhow::bail!(
                 "agents.{agent_alias}.model_provider resolves to a model_provider entry \
-                 with no `model` set. Configure [model_providers.{provider_name}.<alias>] \
+                 with no `model` set. Configure [providers.models.{provider_name}.<alias>] \
                  model = \"...\".",
             ),
         };

--- a/crates/zeroclaw-runtime/src/agent/cost.rs
+++ b/crates/zeroclaw-runtime/src/agent/cost.rs
@@ -233,7 +233,7 @@ fn warn_once_missing_pricing(model_provider: &str, model: &str) {
             "Cost tracking: no pricing entry found for {model_provider}/{model} — \
              token usage will be recorded with zero cost and budget enforcement \
              is inert for this model. Add a `pricing` table to the model provider \
-             entry in config.toml (under `[model_providers.\"{model_provider}\"]`) \
+             entry in config.toml (under `[providers.models.\"{model_provider}\"]`) \
              with `\"{model}.input\"` and `\"{model}.output\"` keys (USD per 1M tokens). \
              This warning fires once per (model_provider, model) pair per process."
         );

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -3516,7 +3516,7 @@ pub async fn run(
             Some(m) => m.to_string(),
             None => anyhow::bail!(
                 "no model configured for agent {agent_alias}: \
-             [model_providers.{provider_name}.<alias>].model is unset and --model was not passed"
+             [providers.models.{provider_name}.<alias>].model is unset and --model was not passed"
             ),
         };
 
@@ -4668,7 +4668,7 @@ pub async fn process_message(
                 if !agent_ref.is_empty() {
                     anyhow::bail!(
                         "agents.{agent_alias}.model_provider = \"{agent_ref}\" does not resolve to \
-                     a configured [model_providers.<type>.<alias>] entry"
+                     a configured [providers.models.<type>.<alias>] entry"
                     );
                 }
                 anyhow::bail!(
@@ -4868,7 +4868,7 @@ pub async fn process_message(
             Some(m) => m.to_string(),
             None => anyhow::bail!(
                 "agents.{agent_alias}.model_provider resolves to a model_provider entry with no \
-             `model` set. Configure [model_providers.{provider_name}.<alias>] model = \"...\"."
+             `model` set. Configure [providers.models.{provider_name}.<alias>] model = \"...\"."
             ),
         };
         let provider_runtime_options = zeroclaw_providers::provider_runtime_options_for_alias(

--- a/src/main.rs
+++ b/src/main.rs
@@ -431,7 +431,7 @@ enum Commands {
         api_key: Option<String>,
 
         /// ModelProvider name. Used as the type key for the synthesized
-        /// `[model_providers.<type>.default]` entry.
+        /// `[providers.models.<type>.default]` entry.
         #[arg(long, hide = true)]
         model_provider: Option<String>,
 
@@ -4159,8 +4159,8 @@ async fn main() -> Result<()> {
                 }
             }
             println!(
-                "\n  Set [model_providers.custom.<alias>] uri = \"<URL>\" for any \
-                 OpenAI-compatible endpoint, or [model_providers.anthropic.<alias>] \
+                "\n  Set [providers.models.custom.<alias>] uri = \"<URL>\" for any \
+                 OpenAI-compatible endpoint, or [providers.models.anthropic.<alias>] \
                  uri = \"<URL>\" for an Anthropic-compatible endpoint."
             );
             Ok(())


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Field report (Discord): model-provider aliases configured in zerocode vanish after restarting, and `agents.X.model_provider` fails with an error citing `[model_providers.<type>.<alias>]` — a section that does not exist in V3 configs. Root cause: unknown family keys under `[providers.models]` parse cleanly and are silently dropped by serde, so a typo'd or unsupported family works in-session and disappears on reload; meanwhile ~50 user-facing error/doc strings still pointed at the dead V2 `[model_providers.*]` path, sending users to edit the wrong section.
  - Added `ModelProviders::slot_names()` (derived from `for_each_model_provider_slot!`, no hardcoded list) and `Config::unknown_provider_families()`; config load now WARNs naming any dropped family.
  - `agents.*.model_provider` validation now distinguishes "unknown provider family" from "known family, missing alias".
  - Corrected the stale `[model_providers.*]` strings to `[providers.models.*]`. V1/V2 migration code and legacy-TOML test fixtures intentionally keep the old name.
  - Regression tests: created alias survives `save_dirty` + reload (persistence path verified clean); unknown-family detection covers the serde silent-drop precondition and garbage input.
- **Scope boundary:** No schema shape change, no serde `deny_unknown_fields` (load stays resilient — warn, not fail, at parse time; `validate()` fails loud only on dangling agent refs). No zerocode UI changes.
- **Blast radius:** Config load logging, `Config::validate()` error text, error strings across providers/runtime/main. No behavior change for valid configs.
- **Linked issue(s):** Related #7439 (same misleading `[model_providers.*]` guidance in Doctor errors). Related #7395 (same zerocode Config/provider surface; its live-session-rebuild gap remains open).
- **Labels:** `bug`, `core`, `agent`, `config`, `gateway`, `provider`, `runtime`, + per-provider module labels from the path labeler

## Validation Evidence (required)

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` → clean, exit 0
  - `cargo clippy --all-targets -- -D warnings` → `Finished 'dev' profile [unoptimized + debuginfo] target(s) in 1m 32s`, 0 warnings
  - `cargo test` → 9 suites, 896 passed, 0 failed. Targeted: zeroclaw-config lib `786 passed`, migration suite `89 passed`, zeroclaw-providers `932 passed`, zeroclaw-runtime `2039 passed`, zeroclaw-channels `734 passed`
  - New tests: `map_key_create_survives_incremental_save ... ok`, `unknown_provider_families_flags_silent_serde_drop ... ok`
  - Post-review: `slot_names()` for TTS/transcription now derived from `for_each_tts_provider_slot!`/`for_each_transcription_provider_slot!` via a name-collecting macro shim; load-time WARN is kind-aware (`[providers.<kind>.<family>]` + kind-appropriate guidance). Re-ran: config lib 787 passed, migration suite 89 passed, fmt/clippy clean.
- **Beyond CI — what did you manually verify?** Probe-tested that `[providers.models.bogusfamily.myalias]` parses silently and `find()` misses it (the reported failure mode); verified the two legacy-TOML test fixtures that a blanket rename would have corrupted were excluded. NOT verified: live zerocode session against a daemon with a typo'd family.
- **If any command was intentionally skipped, why:** none skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No

## Compatibility (required)

- Backward compatible? Yes — valid configs load identically; only logging and error text change
- Config / env / CLI surface changed? No

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert` of the two commits; no migrations, no persisted state
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** false-positive `[providers.models.<family>] section dropped` WARNs at load, or validate() rejecting a previously-accepted agents.*.model_provider ref



