### PR TITLE
fix(config): salvage valid provider aliases instead of dropping all of [providers]

### DIFF
--- a/crates/zeroclaw-config/src/migration.rs
+++ b/crates/zeroclaw-config/src/migration.rs
@@ -1130,6 +1130,22 @@ temperature = "hot"
     }
 
     #[test]
+    fn provider_pruner_never_panics_on_non_table_shapes() {
+        // Array-of-tables where a family map is expected, scalar [providers],
+        // array alias value. The salvage path is the daemon's never-fail
+        // loader, and prune_bad_provider_aliases carries expect() calls that
+        // rely on the scalar pre-passes; pin that invariant here.
+        for raw in [
+            "schema_version = 3\nproviders = 3\n",
+            "schema_version = 3\n[[providers.models.ollama]]\nmodel = \"x\"\n",
+            "schema_version = 3\n[providers.models.ollama]\nai = [1, 2]\n",
+            "schema_version = 3\n[providers.models]\nollama = [1]\n",
+        ] {
+            let _ = migrate_to_current_salvaged(raw);
+        }
+    }
+
+    #[test]
     fn scalar_provider_nodes_pruned_without_sinking_section() {
         // A scalar where a family/kind table is required must drop only
         // that node, not the whole [providers] section.

--- a/crates/zeroclaw-config/src/migration.rs
+++ b/crates/zeroclaw-config/src/migration.rs
@@ -548,14 +548,34 @@ fn prune_bad_provider_aliases(value: &mut toml::Value, dropped: &mut Vec<String>
         return;
     };
 
+    // Non-table nodes where a kind/family map is required (e.g.
+    // `[providers.models] ollama = "oops"`) would otherwise still sink the
+    // whole section in prune_bad_top_level_sections. Drop just the node.
+    let scalar_kinds: Vec<String> = provider_kinds
+        .iter()
+        .filter(|(_, v)| !v.is_table())
+        .map(|(k, _)| k.clone())
+        .collect();
+    for kind in scalar_kinds {
+        provider_kinds.remove(&kind);
+        dropped.push(format!("providers.{kind}"));
+    }
+
     for (kind, families) in provider_kinds.iter_mut() {
-        let Some(family_table) = families.as_table_mut() else {
-            continue;
-        };
+        let family_table = families.as_table_mut().expect("scalar kinds pruned above");
+        let scalar_families: Vec<String> = family_table
+            .iter()
+            .filter(|(_, v)| !v.is_table())
+            .map(|(k, _)| k.clone())
+            .collect();
+        for family in scalar_families {
+            family_table.remove(&family);
+            dropped.push(format!("providers.{kind}.{family}"));
+        }
         for (family, aliases) in family_table.iter_mut() {
-            let Some(alias_table) = aliases.as_table_mut() else {
-                continue;
-            };
+            let alias_table = aliases
+                .as_table_mut()
+                .expect("scalar families pruned above");
             let invalid: Vec<String> = alias_table
                 .iter()
                 .filter(|(_, v)| provider_alias_is_invalid(kind, family, v))
@@ -1106,6 +1126,32 @@ temperature = "hot"
                 .find("custom", "broken")
                 .is_none(),
             "only the malformed alias is pruned"
+        );
+    }
+
+    #[test]
+    fn scalar_provider_nodes_pruned_without_sinking_section() {
+        // A scalar where a family/kind table is required must drop only
+        // that node, not the whole [providers] section.
+        let raw = r#"
+schema_version = 3
+
+[providers.models]
+ollama = "oops"
+
+[providers.models.custom.rag_bot]
+uri = "http://localhost:8000/v1"
+model = "m"
+"#;
+        let load = migrate_to_current_salvaged(raw);
+        assert_eq!(load.dropped, vec!["providers.models.ollama"]);
+        assert!(
+            load.config
+                .providers
+                .models
+                .find("custom", "rag_bot")
+                .is_some(),
+            "valid alias must survive a scalar sibling family"
         );
     }
 

--- a/crates/zeroclaw-config/src/migration.rs
+++ b/crates/zeroclaw-config/src/migration.rs
@@ -383,6 +383,7 @@ fn deserialize_resilient(value: toml::Value) -> ResilientLoad {
     let mut dropped: Vec<String> = Vec::new();
     prune_bad_channel_aliases(&mut salvaged, &mut dropped);
     prune_bad_channel_types(&mut salvaged, &mut dropped);
+    prune_bad_provider_aliases(&mut salvaged, &mut dropped);
     prune_bad_top_level_sections(&mut salvaged, &mut dropped);
 
     let mut whole_config_lost = false;
@@ -530,6 +531,57 @@ fn prune_bad_channel_aliases(value: &mut toml::Value, dropped: &mut Vec<String>)
             dropped.push(format!("channels.{chan_type}.{alias}"));
         }
     }
+}
+
+/// Drop each `[providers.<kind>.<family>.<alias>]` that fails to deserialize,
+/// checked in isolation so valid siblings survive. Without this, one
+/// malformed provider alias makes `prune_bad_top_level_sections` drop the
+/// whole `providers` section: every model/tts/transcription provider
+/// vanishes on reload while agents.*.model_provider references dangle.
+/// Appends `providers.<kind>.<family>.<alias>`.
+fn prune_bad_provider_aliases(value: &mut toml::Value, dropped: &mut Vec<String>) {
+    let Some(provider_kinds) = value
+        .as_table_mut()
+        .and_then(|root| root.get_mut("providers"))
+        .and_then(toml::Value::as_table_mut)
+    else {
+        return;
+    };
+
+    for (kind, families) in provider_kinds.iter_mut() {
+        let Some(family_table) = families.as_table_mut() else {
+            continue;
+        };
+        for (family, aliases) in family_table.iter_mut() {
+            let Some(alias_table) = aliases.as_table_mut() else {
+                continue;
+            };
+            let invalid: Vec<String> = alias_table
+                .iter()
+                .filter(|(_, v)| provider_alias_is_invalid(kind, family, v))
+                .map(|(k, _)| k.clone())
+                .collect();
+            for alias in invalid {
+                alias_table.remove(&alias);
+                dropped.push(format!("providers.{kind}.{family}.{alias}"));
+            }
+        }
+    }
+}
+
+/// True when `[providers.<kind>.<family>.<alias>]`, wrapped alone, fails to
+/// deserialize. Unknown families pass (serde ignores them); only a
+/// known-family alias with bad field data is invalid.
+fn provider_alias_is_invalid(kind: &str, family: &str, alias_value: &toml::Value) -> bool {
+    let mut inner = toml::value::Table::new();
+    inner.insert("probe".to_string(), alias_value.clone());
+    let mut family_table = toml::value::Table::new();
+    family_table.insert(family.to_string(), toml::Value::Table(inner));
+    let mut kind_table = toml::value::Table::new();
+    kind_table.insert(kind.to_string(), toml::Value::Table(family_table));
+    let mut root = toml::value::Table::new();
+    root.insert("providers".to_string(), toml::Value::Table(kind_table));
+    toml::Value::Table(root).try_into::<Config>().is_err()
 }
 
 /// Drop each `[channels.<type>]` block still blocking the load after alias
@@ -1010,6 +1062,50 @@ from_address = "a@example.com"
         assert!(
             !cfg.channels.email.contains_key("fakeemail"),
             "invalid alias must be pruned"
+        );
+    }
+
+    #[test]
+    fn valid_provider_aliases_survive_broken_sibling() {
+        // Repro for the zerocode "all providers vanish after restart" report:
+        // one malformed provider alias must not take the whole [providers]
+        // section (and every other provider) down with it.
+        let raw = r#"
+schema_version = 3
+
+[providers.models.ollama.ai]
+model = "qwen3:30b"
+
+[providers.models.custom.rag_bot]
+uri = "http://localhost:8000/v1"
+model = "m"
+
+[providers.models.custom.broken]
+uri = "http://localhost:9000/v1"
+model = "m"
+temperature = "hot"
+"#;
+        let load = migrate_to_current_salvaged(raw);
+        assert_eq!(load.dropped, vec!["providers.models.custom.broken"]);
+        assert!(
+            load.config.providers.models.find("ollama", "ai").is_some(),
+            "valid alias in another family must survive"
+        );
+        assert!(
+            load.config
+                .providers
+                .models
+                .find("custom", "rag_bot")
+                .is_some(),
+            "valid sibling alias must survive"
+        );
+        assert!(
+            load.config
+                .providers
+                .models
+                .find("custom", "broken")
+                .is_none(),
+            "only the malformed alias is pruned"
         );
     }
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Field report (Discord, screenshots): on zerocode start, every configured model provider is missing from the provider list, agents cannot use their configured provider models, and a freshly defined provider works only until zerocode quits.
  - Root cause: the resilient config load (`migrate_to_current_salvaged`) prunes bad **channel** aliases individually, but had no provider equivalent. One malformed `[providers.<kind>.<family>.<alias>]` block (e.g. a wrong-typed field like `temperature = "hot"`) pushed the failure up to `prune_bad_top_level_sections`, which dropped the **entire `providers` section** — every model/tts/transcription provider — on every load. In-memory state created during a session was fine, which is why a new provider "worked until quit".
  - Added `prune_bad_provider_aliases`, mirroring `prune_bad_channel_aliases`: probe each alias in isolation, drop only the malformed ones, keep valid siblings and families. Runs before top-level pruning. Dropped paths surface as `providers.<kind>.<family>.<alias>` in the salvage WARN log.
- **Scope boundary:** No change to strict load, validation, schema shape, or zerocode UI. Only the salvage path in `migration.rs`.
- **Blast radius:** Daemon/CLI resilient config load. Configs that previously lost their whole `providers` section now keep all valid entries; configs with no malformed aliases are untouched (strict deserialize short-circuits before pruning).
- **Linked issue(s):** Related #7488 (unknown-family detection — the sibling failure mode from the same report).
- **Labels:** `bug`, `config`, `risk: medium`, `size: S`

## Validation Evidence (required)

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` → clean, exit 0
  - `cargo clippy --all-targets -- -D warnings` → `Finished 'dev' profile [unoptimized + debuginfo] target(s) in 51.37s`, 0 warnings
  - `cargo test` → 9 suites, 896 passed, 0 failed; targeted: zeroclaw-config lib `785 passed`, migration integration suite `89 passed`
  - New test: `valid_provider_aliases_survive_broken_sibling ... ok` — asserts `dropped == ["providers.models.custom.broken"]`, valid sibling and cross-family aliases survive
- **Beyond CI — what did you manually verify?** Probe-tested the exact failure: pre-fix, the same TOML produced `dropped: ["providers"]` with zero surviving provider aliases. NOT verified: live zerocode session against a daemon carrying a malformed alias.
- **If any command was intentionally skipped, why:** none skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No

## Compatibility (required)

- Backward compatible? Yes — strictly increases what survives a degraded load; `providers` is not in `SECURITY_CRITICAL_KEYS`, so gating semantics are unchanged
- Config / env / CLI surface changed? No

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <sha>`; single self-contained commit
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** salvage WARN logs naming `providers.<kind>.<family>.<alias>` paths that should not have been dropped, or a malformed provider alias surviving load and failing later at provider construction
