### PR TITLE
feat(config): inherit max_context_tokens from model.max_context_window

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -666,6 +666,14 @@ pub enum AuthMode {
     OAuth,
 }
 
+/// Fallback `max_context_tokens` budget when neither the agent nor its resolved
+/// model provides an explicit value. Conservative 32K matches the historical
+/// default of `AliasedAgentConfig::max_context_tokens` before this field became
+/// optional. Operators wanting to take advantage of long-context models should
+/// set `max_context_window` on the model provider (preferred) or
+/// `max_context_tokens` on the agent.
+pub const DEFAULT_MAX_CONTEXT_TOKENS: usize = 32_000;
+
 /// Named model_provider profile definition.
 #[derive(Debug, Clone, Serialize, Deserialize, Configurable, Default)]
 #[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
@@ -740,6 +748,24 @@ pub struct ModelProviderConfig {
     #[tab(Model)]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_tokens: Option<u32>,
+    /// Maximum context window of this model in tokens, as documented by the provider.
+    /// Used as the default for `agent.max_context_tokens` when the agent does not
+    /// override. `None` (default) means ZeroClaw has no model-side hint, falls back
+    /// to `DEFAULT_MAX_CONTEXT_TOKENS` (32K) unless the agent overrides.
+    ///
+    /// This is the model's INPUT capacity (history + system prompt + user message),
+    /// distinct from `max_tokens` above which is the OUTPUT generation cap.
+    ///
+    /// Common values (operator must check provider docs):
+    ///   - DeepSeek-V4-Pro / V4-Flash: 1_000_000
+    ///   - Claude 3.5/4 Sonnet / Opus: 200_000
+    ///   - GPT-4o / GPT-4-Turbo: 128_000
+    ///   - Qwen3.6 series (dashscope coding plan): 1_000_000
+    ///   - Kimi-K2.5 / K2.6: 262_144
+    ///   - Moonshot-Kimi-K2-Instruct: 131_072
+    #[tab(Model)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_context_window: Option<usize>,
     /// ModelProvider-specific quirk: fold the system prompt into the first user message instead of sending a separate system role. Only needed for models that reject (or mishandle) a standalone system role, e.g. certain older Mistral variants.
     #[tab(Advanced)]
     #[serde(default, skip_serializing_if = "is_false")]
@@ -3176,6 +3202,23 @@ pub struct AliasedAgentConfig {
     #[serde(default)]
     pub classifier_provider: crate::providers::ModelProviderRef,
 
+    /// Maximum estimated tokens for conversation history before compaction triggers.
+    /// Uses ~4 chars/token heuristic. When this threshold is exceeded, older messages
+    /// are summarized to preserve context while staying within budget.
+    ///
+    /// `None` (default) inherits from the resolved model's `max_context_window`;
+    /// if neither this field nor `max_context_window` is set, falls back to
+    /// `DEFAULT_MAX_CONTEXT_TOKENS` (32K). Set explicitly to override the model hint
+    /// (e.g. for cost capping: even if model supports 1M, you may only want to pay
+    /// for 100K of input per request).
+    ///
+    /// Use `Config::resolved_max_context_tokens_for_agent` or
+    /// `AliasedAgentConfig::resolved_max_context_tokens` to consume this field,
+    /// never read it directly (you'd miss the inheritance chain).
+    #[tab(Tuning)]
+    #[serde(default)]
+    pub max_context_tokens: Option<usize>,
+
     // ── Resolved runtime tunables (populated by `resolved_agent_config`
     // from the runtime profile; not config-settable on the agent). ──
     #[serde(skip)]
@@ -3226,6 +3269,7 @@ impl Default for AliasedAgentConfig {
             tts_provider: crate::providers::TtsProviderRef::default(),
             transcription_provider: crate::providers::TranscriptionProviderRef::default(),
             classifier_provider: crate::providers::ModelProviderRef::default(),
+            max_context_tokens: None,
             resolved: ResolvedRuntime::default(),
             workspace: crate::multi_agent::AgentWorkspaceConfig::default(),
             memory: crate::multi_agent::AgentMemoryConfig::default(),
@@ -3245,6 +3289,21 @@ impl AliasedAgentConfig {
             && !self.model_provider.is_empty()
             && !self.risk_profile.trim().is_empty()
             && !self.runtime_profile.trim().is_empty()
+    }
+
+    /// Returns the effective `max_context_tokens` for this agent.
+    /// Priority: explicit `self.max_context_tokens` > `model_cfg.max_context_window` > `DEFAULT_MAX_CONTEXT_TOKENS` (32K).
+    #[must_use]
+    pub fn resolved_max_context_tokens(&self, model_cfg: Option<&ModelProviderConfig>) -> usize {
+        if let Some(explicit) = self.max_context_tokens {
+            return explicit;
+        }
+        if let Some(mc) = model_cfg
+            && let Some(window) = mc.max_context_window
+        {
+            return window;
+        }
+        DEFAULT_MAX_CONTEXT_TOKENS
     }
 }
 
@@ -3412,6 +3471,21 @@ impl Config {
         self.runtime_profile_for_agent(agent_alias)
             .and_then(|p| p.keep_tool_context_turns)
             .unwrap_or_else(default_keep_tool_context_turns)
+    }
+
+    /// Returns the effective `max_context_tokens` for the given agent alias.
+    /// Looks up the agent's `model_provider`, then delegates to
+    /// `AliasedAgentConfig::resolved_max_context_tokens`. Returns
+    /// `DEFAULT_MAX_CONTEXT_TOKENS` (32K) when the agent does not exist.
+    ///
+    /// Priority: `agent.max_context_tokens` (explicit) > `model.max_context_window` >
+    /// `DEFAULT_MAX_CONTEXT_TOKENS` (32K).
+    #[must_use]
+    pub fn resolved_max_context_tokens_for_agent(&self, agent_alias: &str) -> usize {
+        let Some(agent) = self.agents.get(agent_alias) else {
+            return DEFAULT_MAX_CONTEXT_TOKENS;
+        };
+        agent.resolved_max_context_tokens(self.model_provider_for_agent(agent_alias))
     }
 
     /// Return a clone of the named agent's `AliasedAgentConfig` with all
@@ -25833,5 +25907,125 @@ allowed_users = []
             .insert("primary".to_string(), entry);
 
         assert!(config.collect_warnings().is_empty());
+    }
+
+    #[test]
+    async fn resolved_max_context_tokens_uses_explicit_agent_value() {
+        let agent = AliasedAgentConfig {
+            max_context_tokens: Some(50_000),
+            ..AliasedAgentConfig::default()
+        };
+        let model_cfg = ModelProviderConfig {
+            max_context_window: Some(1_000_000),
+            ..Default::default()
+        };
+        assert_eq!(
+            agent.resolved_max_context_tokens(Some(&model_cfg)),
+            50_000,
+            "explicit agent override must win over model hint"
+        );
+    }
+
+    #[test]
+    async fn resolved_max_context_tokens_inherits_from_model_when_agent_unset() {
+        let agent = AliasedAgentConfig::default();
+        let model_cfg = ModelProviderConfig {
+            max_context_window: Some(1_000_000),
+            ..Default::default()
+        };
+        assert_eq!(
+            agent.resolved_max_context_tokens(Some(&model_cfg)),
+            1_000_000,
+            "unset agent must inherit model.max_context_window"
+        );
+    }
+
+    #[test]
+    async fn resolved_max_context_tokens_falls_back_to_default_when_both_unset() {
+        let agent = AliasedAgentConfig::default();
+        let model_cfg = ModelProviderConfig::default();
+        assert_eq!(
+            agent.resolved_max_context_tokens(Some(&model_cfg)),
+            DEFAULT_MAX_CONTEXT_TOKENS,
+            "both unset must fall back to 32K"
+        );
+        assert_eq!(
+            agent.resolved_max_context_tokens(None),
+            DEFAULT_MAX_CONTEXT_TOKENS,
+            "None model_cfg must also fall back"
+        );
+    }
+
+    #[test]
+    async fn config_resolved_max_context_tokens_for_agent_full_inheritance() {
+        let toml = r#"
+            [providers.models.deepseek.default]
+            api_key = "k"
+            model = "deepseek-v4-pro"
+            max_context_window = 1000000
+
+            [risk_profiles.default]
+            level = "supervised"
+
+            [agents.default]
+            enabled = true
+            model_provider = "deepseek.default"
+            risk_profile = "default"
+        "#;
+        let cfg: Config = toml::from_str(toml).unwrap();
+        cfg.validate().unwrap();
+        assert_eq!(
+            cfg.resolved_max_context_tokens_for_agent("default"),
+            1_000_000
+        );
+    }
+
+    #[test]
+    async fn config_resolved_max_context_tokens_for_agent_explicit_override() {
+        let toml = r#"
+            [providers.models.deepseek.default]
+            api_key = "k"
+            model = "deepseek-v4-pro"
+            max_context_window = 1000000
+
+            [risk_profiles.default]
+            level = "supervised"
+
+            [agents.default]
+            enabled = true
+            model_provider = "deepseek.default"
+            risk_profile = "default"
+            max_context_tokens = 50000
+        "#;
+        let cfg: Config = toml::from_str(toml).unwrap();
+        cfg.validate().unwrap();
+        assert_eq!(
+            cfg.resolved_max_context_tokens_for_agent("default"),
+            50_000,
+            "explicit agent override must win over model.max_context_window"
+        );
+    }
+
+    #[test]
+    async fn config_resolved_max_context_tokens_for_agent_fallback_32k() {
+        let toml = r#"
+            [providers.models.deepseek.default]
+            api_key = "k"
+            model = "deepseek-v4-pro"
+
+            [risk_profiles.default]
+            level = "supervised"
+
+            [agents.default]
+            enabled = true
+            model_provider = "deepseek.default"
+            risk_profile = "default"
+        "#;
+        let cfg: Config = toml::from_str(toml).unwrap();
+        cfg.validate().unwrap();
+        assert_eq!(
+            cfg.resolved_max_context_tokens_for_agent("default"),
+            DEFAULT_MAX_CONTEXT_TOKENS
+        );
     }
 }

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -3228,7 +3228,7 @@ pub async fn run(
         // See `Config::effective_*` helpers for precedence rules.
         let _eff_max_tool_iterations = config.effective_max_tool_iterations(agent_alias);
         let eff_max_history_messages = config.effective_max_history_messages(agent_alias);
-        let eff_max_context_tokens = config.effective_max_context_tokens(agent_alias);
+        let eff_max_context_tokens = config.resolved_max_context_tokens_for_agent(agent_alias);
         let eff_compact_context = config.effective_compact_context(agent_alias);
         let eff_max_system_prompt_chars = config.effective_max_system_prompt_chars(agent_alias);
         let _eff_max_tool_result_chars = config.effective_max_tool_result_chars(agent_alias);
@@ -3971,7 +3971,7 @@ pub async fn run(
                                 agent.resolved.strict_tool_parsing,
                                 agent.resolved.parallel_tools,
                                 agent.resolved.max_tool_result_chars,
-                                agent.resolved.max_context_tokens,
+                                config.resolved_max_context_tokens_for_agent(agent_alias),
                                 None, // shared_budget
                                 None, // channel: CLI mode — uses prompt_cli
                                 None, // receipt_generator
@@ -4376,7 +4376,7 @@ pub async fn run(
                                     agent.resolved.strict_tool_parsing,
                                     agent.resolved.parallel_tools,
                                     agent.resolved.max_tool_result_chars,
-                                    agent.resolved.max_context_tokens,
+                                    config.resolved_max_context_tokens_for_agent(agent_alias),
                                     None, // shared_budget
                                     None, // channel: interactive CLI — uses prompt_cli
                                     None, // receipt_generator
@@ -4653,7 +4653,7 @@ pub async fn process_message(
         // See `Config::effective_*` helpers for precedence rules.
         let _eff_max_tool_iterations = config.effective_max_tool_iterations(agent_alias);
         let _eff_max_history_messages = config.effective_max_history_messages(agent_alias);
-        let _eff_max_context_tokens = config.effective_max_context_tokens(agent_alias);
+        let _eff_max_context_tokens = config.resolved_max_context_tokens_for_agent(agent_alias);
         let eff_compact_context = config.effective_compact_context(agent_alias);
         let eff_max_system_prompt_chars = config.effective_max_system_prompt_chars(agent_alias);
         let _eff_max_tool_result_chars = config.effective_max_tool_result_chars(agent_alias);


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Adds `ModelProviderConfig.max_context_window: Option<usize>` so a model's
    documented input-context capacity (DeepSeek 1M, Claude 200K, GPT-4o 128K,
    Qwen 1M, Kimi 256K, …) can be declared once on the provider entry instead
    of repeated on every agent that uses the model.
  - Makes `AliasedAgentConfig.max_context_tokens` optional (`Option<usize>`)
    with `None` meaning "inherit". Resolution order is now:
    `agent.max_context_tokens` (explicit override) > `model.max_context_window`
    (model hint) > `DEFAULT_MAX_CONTEXT_TOKENS` (32K fallback).
  - Adds two read-time helpers — `AliasedAgentConfig::resolved_max_context_tokens`
    and `Config::resolved_max_context_tokens_for_agent` — and switches the four
    `agent/loop_.rs` call sites that previously read either
    `effective_max_context_tokens` or `agent.resolved.max_context_tokens` over
    to the inheritance-aware helper.
  - Ships six unit tests covering every branch of the inheritance matrix
    (explicit override wins, unset agent inherits, both unset falls back,
    `None` model_cfg falls back, plus two end-to-end TOML round-trips).
- **Scope boundary:** This PR does **not** touch the runtime-profile chain
  (`effective_max_context_tokens` keeps its existing precedence semantics for
  callers that need it, e.g. `crates/zeroclaw-runtime/src/rpc/dispatch.rs`
  and `Config::resolved_agent_config`). No documentation, channel, provider,
  tool, or CLI surface is renamed.
- **Blast radius:** `zeroclaw-config` (one struct field added, one struct
  field made optional with `serde(default)`) and `zeroclaw-runtime` (four
  call-site swaps inside `agent/loop_.rs`). Existing TOML configs deserialize
  unchanged: omitted `max_context_window` and omitted `max_context_tokens`
  both produce `None`, and the fallback collapses to the historic 32K value.
- **Linked issue(s):** None.
- **Labels:** suggested `type: feature`, `area: config`, `risk: low`,
  `size: M`.

## Validation Evidence (required)

Ran against `upstream/master` (HEAD `5fc58b27e`) with this branch applied:

```bash
cargo fmt --all -- --check
cargo clippy -p zeroclaw-config -p zeroclaw-runtime --all-targets -- -D warnings
cargo test -p zeroclaw-config --lib
cargo test -p zeroclaw-runtime --lib
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` → exit 0, no output.
  - `cargo clippy -p zeroclaw-config -p zeroclaw-runtime --all-targets -- -D warnings`
    → `Finished 'dev' profile … in 2m 20s`, no warnings.
  - `cargo test -p zeroclaw-config --lib` →
    `test result: ok. 799 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out`.
    The six new tests are visible in the focused run:
    ```
    test schema::tests::resolved_max_context_tokens_uses_explicit_agent_value ... ok
    test schema::tests::resolved_max_context_tokens_inherits_from_model_when_agent_unset ... ok
    test schema::tests::resolved_max_context_tokens_falls_back_to_default_when_both_unset ... ok
    test schema::tests::config_resolved_max_context_tokens_for_agent_fallback_32k ... ok
    test schema::tests::config_resolved_max_context_tokens_for_agent_full_inheritance ... ok
    test schema::tests::config_resolved_max_context_tokens_for_agent_explicit_override ... ok
    ```
  - `cargo test -p zeroclaw-runtime --lib` →
    `test result: ok. 2044 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out`.
- **Beyond CI — what did you manually verified:** confirmed the four call-site
  swaps in `agent/loop_.rs` (lines 3231, 3974, 4379, 4656) are the only edits
  to that file; verified `effective_max_context_tokens` still has two live
  callers (`schema.rs::resolved_agent_config` and
  `rpc/dispatch.rs::1309`) so removing it would break the runtime-profile
  precedence path — kept it on purpose. Did **not** run the full
  workspace `cargo test` (sandbox lacks docker for `dev/ci.sh`); the change is
  contained to two crates and their dependents compile clean under clippy.
- **Skipped:** `dev/ci.sh dry-check` (requires docker; not available in this
  environment). Equivalent gates ran manually above.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs?
  **No** — tests use generic alias names (`default`, `deepseek.default`) and
  fake API key `"k"`.

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **Yes (additive only)**
  - New optional TOML field
    `[providers.models.<type>.<alias>].max_context_window: Option<usize>`.
  - `[agents.<alias>].max_context_tokens` is now optional (was previously a
    non-optional 32K default). Configs that already set the field keep
    working; configs that omit it now inherit from the model (or fall back to
    32K as before).
- Upgrade steps for existing users: none required. To opt in, set
  `max_context_window` once on the model provider entry and drop the
  per-agent `max_context_tokens` overrides that just mirrored the model
  capacity.

## Rollback

`git revert <sha>` is sufficient — change is additive and contained to
two crates, with no schema-version bump, no migration, and no runtime
state. The historic 32K behaviour is restored automatically because every
new code path collapses to `DEFAULT_MAX_CONTEXT_TOKENS` when both new
fields are unset.

## Single-source-of-truth note (AGENTS.md SSOT)

`max_context_tokens` (operator override on an agent) and
`max_context_window` (model capability hint on a provider) are
semantically distinct fields with different owners. They are not
duplicate state: both flow through `resolved_max_context_tokens_for_agent`
at read time, nothing is cached, and the existing `ResolvedRuntime`
materialisation that holds a snapshot value already lives behind
`Config::resolved_agent_config` and is rebuilt from the canonical fields
on each call.