### PR TITLE
fix(openai): honor config timeout_secs instead of hardcoding 120s

### DIFF
--- a/crates/zeroclaw-providers/src/factory.rs
+++ b/crates/zeroclaw-providers/src/factory.rs
@@ -823,6 +823,9 @@ impl FamilyProviderFactory for OpenAIModelProviderConfig {
         }
         // Default: chat_completions wire with standard API key.
         let mut p = crate::openai::OpenAiModelProvider::with_base_url(alias, api_url, key);
+        if let Some(t) = opts.provider_timeout_secs {
+            p = p.with_timeout_secs(t);
+        }
         if let Some(mt) = opts.provider_max_tokens {
             p = p.with_max_tokens(Some(mt));
         }

--- a/crates/zeroclaw-providers/src/openai.rs
+++ b/crates/zeroclaw-providers/src/openai.rs
@@ -27,6 +27,7 @@ pub struct OpenAiModelProvider {
     base_url: String,
     credential: Option<String>,
     max_tokens: Option<u32>,
+    timeout_secs: u64,
 }
 
 #[derive(Debug, Serialize)]
@@ -216,7 +217,14 @@ impl OpenAiModelProvider {
                 .unwrap_or_else(|| BASE_URL.to_string()),
             credential: credential.map(ToString::to_string),
             max_tokens: None,
+            timeout_secs: 120,
         }
+    }
+
+    /// Override the HTTP request timeout for LLM API calls.
+    pub fn with_timeout_secs(mut self, secs: u64) -> Self {
+        self.timeout_secs = secs;
+        self
     }
 
     /// Set the maximum output tokens for API requests.
@@ -370,7 +378,7 @@ impl OpenAiModelProvider {
     fn http_client(&self) -> Client {
         zeroclaw_config::schema::build_runtime_proxy_client_with_timeouts(
             "model_provider.openai",
-            120,
+            self.timeout_secs,
             10,
         )
     }


### PR DESCRIPTION
## Summary

`OpenAiModelProvider::http_client()` hardcoded a 120-second request timeout and never read the `timeout_secs` config field. Users setting `timeout_secs = 900` for slow local/self-hosted models would see requests silently die at 120s with no diagnostic.

## Changes

- Add `timeout_secs: u64` field to `OpenAiModelProvider` struct (defaults to 120 for backward compat)
- Add `with_timeout_secs()` builder method (matching OpenRouter's pattern)
- Wire `opts.provider_timeout_secs` through the factory
- `http_client()` now uses `self.timeout_secs` instead of the literal `120`

## Linked context

Closes #6723

## Verification

```bash
cargo check -p zeroclawlabs    # ✅ passes
cargo test -p zeroclaw-providers -- openai   # ✅ 119 passed
```

## Risk checklist

- **Breaking change?** No — default is still 120s
- **Backward compat?** Yes — existing configs without timeout_secs get the same 120s default
- **Security impact?** None