### PR TITLE
fix(quickstart): add missing -a flag to agent command in success message

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2110,7 +2110,7 @@ async fn run_quickstart_cli(
             println!();
             println!("{}", t("cli-next-steps", "Next steps:"));
             println!(
-                "  zeroclaw agent {}  # chat with this agent in your terminal",
+                "  zeroclaw agent -a {}  # chat with this agent in your terminal",
                 applied.alias
             );
             if which_zerocode_on_path() {


### PR DESCRIPTION
## Summary

The quickstart success message prints `zeroclaw agent <alias>` which fails because the `--agent`/`-a` flag is required. Fix the hint to include the flag.

**Before:**
```
Next steps:
  zeroclaw agent sanity  # chat with this agent in your terminal
```

**After:**
```
Next steps:
  zeroclaw agent -a sanity  # chat with this agent in your terminal
```

## Linked context

Closes #7506

## Verification

```bash
cargo check -p zeroclawlabs  # ✅ passes
```

## Risk checklist

- **Breaking change?** No — single character fix in user-facing text
- **Localization?** The interpolated `{}` is the agent alias; the flag fix applies to all languages