### PR TITLE
fix(quickstart): pre-seed --api-key under snake_case api_key

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1205,7 +1205,10 @@ async fn run_quickstart_cli(
             let mut fields: std::collections::HashMap<String, String> =
                 std::collections::HashMap::new();
             if let Some(key) = api_key.as_deref().filter(|s| !s.is_empty()) {
-                fields.insert("api-key".to_string(), key.to_string());
+                // Submission field keys are snake_case (`api_key`) — the apply
+                // path round-trips them verbatim into `set_prop_persistent`,
+                // which rejects kebab-case with "Unknown property".
+                fields.insert("api_key".to_string(), key.to_string());
             }
             form.provider = Some(ProviderChoice::Fresh {
                 kind: found.kind.clone(),


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `run_quickstart_cli`'s flag pre-seed inserted the provider API key into the submission `fields` map under kebab-case `"api-key"` (`src/main.rs:1208`).
  - The quickstart apply path round-trips submission field keys verbatim into `Config::set_prop_persistent` (`crates/zeroclaw-runtime/src/quickstart/mod.rs:1006`), which rejects kebab paths — so `zeroclaw quickstart --api-key …` always failed at **Create agent** with `Unknown property 'providers.models.<type>.<alias>.api-key'` for every hosted provider.
  - Changed the pre-seed key to snake_case `"api_key"`, matching the submission contract pinned by the existing test `apply_serializes_provider_fields_as_snake_case` (`crates/zeroclaw-runtime/src/quickstart/mod.rs:1722`) and matching what the interactive `api_key` Password prompt already produces.
- **Scope boundary:** does NOT change the apply path, `field_shape()`, the interactive prompt flow, or add a non-interactive mode (see #7507 for the non-TTY loop; #7506 for the next-steps hint).
- **Blast radius:** only the CLI quickstart flag pre-seed; the zerocode TUI and web quickstart surfaces build their own submissions and are unaffected.
- **Linked issue(s):** Fixes #7505. Related #7506, #7507 (separate quickstart defects found in the same release sanity check).
- **Labels:** (path labeler will apply scope labels; suggest `risk: low`, `size: XS`)

## Validation Evidence (required)

- **Commands run and tail output:**

`cargo fmt --all -- --check` — exit 0, no output.

`cargo clippy --all-targets -- -D warnings` — exit 0:

```
    Checking zeroclaw-tools v0.8.0-beta-2 (...\crates\zeroclaw-tools)
    Checking zeroclaw-runtime v0.8.0-beta-2 (...\crates\zeroclaw-runtime)
    Checking zeroclaw-hardware v0.8.0-beta-2 (...\crates\zeroclaw-hardware)
    Checking zeroclaw-channels v0.8.0-beta-2 (...\crates\zeroclaw-channels)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 45s
```

`cargo test` — exit 101 with exactly one failure, **pre-existing on clean master** (verified by re-running the same test on `master` @ 3932ed8a7 before this change — identical panic). It is a host-OS-dependent test gap, unrelated to this diff, root-caused and tracked in #7509 (`is_installable_release_asset` only accepts `.tar.gz`/`.tgz`, but the test's Windows assets are `.zip`, so on a `x86_64-pc-windows-msvc` host no asset qualifies):

```
failures:

---- commands::update::tests::find_asset_url_picks_correct_gnu_over_android stdout ----

thread 'commands::update::tests::find_asset_url_picks_correct_gnu_over_android' (75976) panicked at src\commands\update.rs:681:9:
should find an asset

failures:
    commands::update::tests::find_asset_url_picks_correct_gnu_over_android

test result: FAILED. 242 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.84s
```

- **Beyond CI — what did you manually verify?**
  - End-to-end repro on Windows 11: drove the real quickstart TUI through a ConPTY harness with `--config-dir <isolated> quickstart --model-provider openai --model gpt-4o-mini --api-key sk-… --agent sanity`, completed Risk/Memory/Channels selectors, picked **Create agent**.
    - Before this fix: `• Model provider: Unknown property 'providers.models.openai.default.api-key'` → `Error: quickstart could not finish: 1 problem(s) to fix`.
    - With this fix: `Quickstart complete. Created agent 'sanity'.`, and the written `config.toml` contains `providers.models.openai.default.api_key` as an encrypted (`enc2:…`) value with the correct `model`.
  - Verified a follow-up `zeroclaw agent -a sanity -m "Reply with exactly: PONG"` returns `PONG` (exit 0) against the quickstart-written config.
  - NOT verified: zerocode TUI / web quickstart surfaces (out of scope — they don't use this pre-seed path).
- **If any command was intentionally skipped, why:** none skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No — the key still flows through the same submission map into the encrypted-secret persistence path; this only fixes the map key casing so that path is actually reachable from the CLI flag.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- If any `Yes`, describe the risk and mitigation: n/a

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No — same flags; the documented invocation simply works now.
- If `No` or `Yes` to either: exact upgrade steps for existing users: n/a

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk: `git revert <sha>`.
