### PR TITLE
fix(quickstart): print working 'zeroclaw agent -a <alias>' next-step hint

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2110,7 +2110,7 @@ async fn run_quickstart_cli(
             println!();
             println!("{}", t("cli-next-steps", "Next steps:"));
             println!(
-                "  zeroclaw agent {}  # chat with this agent in your terminal",
+                "  zeroclaw agent -a {}  # chat with this agent in your terminal",
                 applied.alias
             );
             if which_zerocode_on_path() {


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Quickstart's success message printed `zeroclaw agent <alias>` as the next step, but `agent` takes no positional argument — the alias must be passed via the required `-a/--agent` flag — so the first command a new user copies after a successful onboarding fails with `error: unexpected argument '<alias>' found` (exit 2).
  - Changed the printed hint to `zeroclaw agent -a <alias>` (`src/main.rs:2113`). One line.
- **Scope boundary:** does NOT add a positional-alias form to `zeroclaw agent`, and does NOT touch the localized strings (the hint line is a literal command example; verified no `.ftl` entry carries the broken form).
- **Blast radius:** the printed string only; no behavior change.
- **Linked issue(s):** Fixes #7506. Related #7505, #7507 (separate quickstart defects from the same release sanity check).
- **Labels:** (path labeler applies scope labels; suggest `risk: low`, `size: XS`)

## Validation Evidence (required)

- **Commands run and tail output:**

`cargo fmt --all -- --check` — exit 0, no output.

`cargo clippy --all-targets -- -D warnings` — exit 0:

```
    Checking zeroclawlabs v0.8.0-beta-2 (...\zeroclaw)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.48s
```

`cargo test` — exit 101 with exactly one failure, **pre-existing on clean master** (verified by running the identical test on `master` @ 3932ed8a7 with no local changes — same panic). Host-OS-dependent test gap, unrelated to this diff, root-caused and tracked in #7509:

```
failures:

---- commands::update::tests::find_asset_url_picks_correct_gnu_over_android stdout ----

thread 'commands::update::tests::find_asset_url_picks_correct_gnu_over_android' (65164) panicked at src\commands\update.rs:681:9:
should find an asset

failures:
    commands::update::tests::find_asset_url_picks_correct_gnu_over_android

test result: FAILED. 242 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.37s
```

- **Beyond CI — what did you manually verify?**
  - Drove the full interactive quickstart (ConPTY harness, Windows 11, isolated `--config-dir`) on this branch's binary and confirmed the success output now prints `zeroclaw agent -a sanity  # chat with this agent in your terminal`.
  - Confirmed the printed command works as-is: `zeroclaw agent -a sanity -m "Reply with exactly: PONG"` → `PONG`, exit 0.
  - Verified via grep that no other source or `.ftl` locale string carries the broken positional form.
- **If any command was intentionally skipped, why:** none skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- If any `Yes`, describe the risk and mitigation: n/a

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No — only a printed hint string.
- If `No` or `Yes` to either: exact upgrade steps for existing users: n/a

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk: `git revert <sha>`.
