### PR TITLE
fix(quickstart): use snake_case api_key instead of kebab-case api-key

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1205,7 +1205,7 @@ async fn run_quickstart_cli(
             let mut fields: std::collections::HashMap<String, String> =
                 std::collections::HashMap::new();
             if let Some(key) = api_key.as_deref().filter(|s| !s.is_empty()) {
-                fields.insert("api-key".to_string(), key.to_string());
+                fields.insert("api_key".to_string(), key.to_string());
             }
             form.provider = Some(ProviderChoice::Fresh {
                 kind: found.kind.clone(),


### PR DESCRIPTION
## Summary

The quickstart non-interactive flow inserts the `--api-key` value under the config key `api-key` (kebab-case), but the TOML config schema expects `api_key` (snake_case). This causes the final **Create agent** step to fail with:

```
Unknown property 'providers.models.openai.default.api-key'
```

## Linked context

Closes #7505

## Verification

```bash
cargo check -p zeroclawlabs  # ✅ passes
```

## Risk checklist

- **Breaking change?** No — the field name now matches what the schema expects
- **Backward compat?** Yes — this was never working before (always rejected)