### PR TITLE
fix(quickstart): fail fast when stdin is not a TTY instead of infinite redraw loop

### DIFF
--- a/crates/zeroclaw-runtime/locales/en/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/en/cli.ftl
@@ -504,6 +504,8 @@ cli-press-enter = Press Enter to exit...
 cli-quickstart-title = Quickstart — create one working agent end-to-end.
 cli-quickstart-cancelled = Quickstart cancelled. No config written.
 cli-quickstart-incomplete = {"  "}Not all selectors are filled yet.
+cli-quickstart-needs-tty = quickstart requires an interactive terminal with both input and output attached.
+    Re-run inside a terminal (or via ZeroCode TUI) to complete setup interactively.
 cli-no-channels-compiled = {"  "}No channel types are compiled into this binary.
 cli-quickstart-complete = Quickstart complete. Created agent `{$alias}`.
 cli-next-steps = Next steps:

--- a/crates/zeroclaw-runtime/locales/es/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/es/cli.ftl
@@ -444,6 +444,7 @@ cli-press-enter = Presiona Enter para salir...
 cli-quickstart-title = Quickstart — crea un agente funcional de principio a fin.
 cli-quickstart-cancelled = Quickstart cancelado. No se escribió ninguna configuración.
 cli-quickstart-incomplete = {"  "}Aún no se han completado todos los selectores.
+cli-quickstart-needs-tty = quickstart requires an interactive terminal with both input and output attached.n    Re-run inside a terminal (or via ZeroCode TUI) to complete setup interactively.
 cli-no-channels-compiled = {"  "}No hay tipos de canal compilados en este binario.
 cli-quickstart-complete = Quickstart completado. Se creó el agente `{$alias}`.
 cli-next-steps = Siguientes pasos:

--- a/crates/zeroclaw-runtime/locales/fr/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/fr/cli.ftl
@@ -447,6 +447,7 @@ cli-press-enter = Appuyez sur Entrée pour quitter...
 cli-quickstart-title = Quickstart — créez un agent fonctionnel de bout en bout.
 cli-quickstart-cancelled = Quickstart annulé. Aucune configuration écrite.
 cli-quickstart-incomplete = {"  "}Tous les sélecteurs ne sont pas encore renseignés.
+cli-quickstart-needs-tty = quickstart requires an interactive terminal with both input and output attached.n    Re-run inside a terminal (or via ZeroCode TUI) to complete setup interactively.
 cli-no-channels-compiled = {"  "}Aucun type de canal n'est compilé dans ce binaire.
 cli-quickstart-complete = Quickstart terminé. Agent `{$alias}` créé.
 cli-next-steps = Étapes suivantes :

--- a/crates/zeroclaw-runtime/locales/ja/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/ja/cli.ftl
@@ -444,6 +444,7 @@ cli-press-enter = 終了するにはEnterキーを押してください...
 cli-quickstart-title = クイックスタート — 1つの動作するエージェントをエンドツーエンドで作成します。
 cli-quickstart-cancelled = クイックスタートをキャンセルしました。設定は書き込まれていません。
 cli-quickstart-incomplete = {"  "}すべてのセレクターがまだ入力されていません。
+cli-quickstart-needs-tty = quickstart requires an interactive terminal with both input and output attached.n    Re-run inside a terminal (or via ZeroCode TUI) to complete setup interactively.
 cli-no-channels-compiled = {"  "}このバイナリにコンパイルされているチャンネルタイプはありません。
 cli-quickstart-complete = クイックスタートが完了しました。エージェント `{$alias}` を作成しました。
 cli-next-steps = 次のステップ:

--- a/crates/zeroclaw-runtime/locales/zh-CN/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/zh-CN/cli.ftl
@@ -443,6 +443,7 @@ cli-press-enter = 按 Enter 退出...
 cli-quickstart-title = Quickstart — 端到端创建一个可用的 agent。
 cli-quickstart-cancelled = 已取消 quickstart。未写入配置。
 cli-quickstart-incomplete = {"  "}尚未填写所有选择器。
+cli-quickstart-needs-tty = quickstart requires an interactive terminal with both input and output attached.n    Re-run inside a terminal (or via ZeroCode TUI) to complete setup interactively.
 cli-no-channels-compiled = {"  "}此二进制文件中未编译任何通道类型。
 cli-quickstart-complete = Quickstart 完成。已创建 agent `{$alias}`。
 cli-next-steps = 后续步骤：

--- a/src/main.rs
+++ b/src/main.rs
@@ -1084,8 +1084,7 @@ async fn run_quickstart_cli(
     // Guard: dialoguer reads from Term::stderr() and redraws infinitely
     // when stderr is redirected or non-attended (#7507).  Check both the
     // stdin handle (console user input) and stderr (dialoguer output).
-    let terminal_attended =
-        std::io::stdin().is_terminal() && std::io::stderr().is_terminal();
+    let terminal_attended = std::io::stdin().is_terminal() && std::io::stderr().is_terminal();
     if !terminal_attended {
         let msg = t(
             "cli-quickstart-needs-tty",

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ use anyhow::{Context, Result, bail};
 use clap::{CommandFactory, FromArgMatches, Parser, Subcommand, ValueEnum};
 use dialoguer::{Password, Select};
 use serde::{Deserialize, Serialize};
-use std::io::Write;
+use std::io::{IsTerminal, Write};
 use std::path::{Path, PathBuf};
 use zeroclaw_config::api_error::{ConfigApiCode, ConfigApiError};
 
@@ -1080,6 +1080,17 @@ async fn run_quickstart_cli(
         FieldSection, QuickstartTypeOption, Surface, apply_with_surface, field_shape,
         snapshot_state,
     };
+
+    // Guard: dialoguer checklist requires an interactive terminal.
+    // Without a TTY the loop redraws infinitely, flooding stdout (#7507).
+    let stdin_is_tty = std::io::stdin().is_terminal();
+    if !stdin_is_tty {
+        anyhow::bail!(
+            "quickstart requires an interactive terminal.\n\
+             Re-run with all required flags for non-interactive use:\n\
+               zeroclaw quickstart --model-provider <type> --model <name> --api-key <key> --agent <alias>"
+        );
+    }
 
     // ── Form state ──────────────────────────────────────────────
     //

--- a/src/main.rs
+++ b/src/main.rs
@@ -1081,15 +1081,18 @@ async fn run_quickstart_cli(
         snapshot_state,
     };
 
-    // Guard: dialoguer checklist requires an interactive terminal.
-    // Without a TTY the loop redraws infinitely, flooding stdout (#7507).
-    let stdin_is_tty = std::io::stdin().is_terminal();
-    if !stdin_is_tty {
-        anyhow::bail!(
-            "quickstart requires an interactive terminal.\n\
-             Re-run with all required flags for non-interactive use:\n\
-               zeroclaw quickstart --model-provider <type> --model <name> --api-key <key> --agent <alias>"
+    // Guard: dialoguer reads from Term::stderr() and redraws infinitely
+    // when stderr is redirected or non-attended (#7507).  Check both the
+    // stdin handle (console user input) and stderr (dialoguer output).
+    let terminal_attended =
+        std::io::stdin().is_terminal() && std::io::stderr().is_terminal();
+    if !terminal_attended {
+        let msg = t(
+            "cli-quickstart-needs-tty",
+            "quickstart requires an interactive terminal with both input and output attached.\n\
+             Re-run inside a terminal (or via ZeroCode TUI) to complete setup interactively.",
         );
+        anyhow::bail!("{}", msg);
     }
 
     // ── Form state ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

When `zeroclaw quickstart` runs without an interactive terminal (piped stdin, CI jobs, scripts, agent harnesses), the dialoguer checklist enters a tight redraw loop that floods stdout indefinitely. Observed: 4.3 GB output in ~3 minutes.

Add an early check: if stdin is not a terminal, bail immediately with a helpful error message directing users to the flag-based non-interactive path.

## Linked context

Closes #7507

## Verification

```bash
cargo check -p zeroclawlabs  # ✅ passes
```

## Risk checklist

- **Breaking change?** No — only adds an early-exit guard for non-TTY environments
- **Prior behavior:** Infinite flood of output
- **New behavior:** Clear error message