### PR TITLE
fix(runtime/subagent): inherit ACP session cwd into spawn_subagent and delegate

### DIFF
--- a/crates/zeroclaw-runtime/src/subagent/mod.rs
+++ b/crates/zeroclaw-runtime/src/subagent/mod.rs
@@ -106,17 +106,59 @@ impl SubAgentSpawn {
     /// configured agent — the spawn site surfaces a structured
     /// failure instead of invoking the agent loop on a nonexistent
     /// identity.
+    ///
+    /// The parent policy is rebuilt from config via
+    /// [`SecurityPolicy::for_agent`]. This is the right entry point
+    /// for spawn sites with **no live parent context** — most
+    /// importantly the cron scheduler's `JobType::Agent` dispatch,
+    /// which has no session and must use the per-agent install
+    /// workspace as the sandbox boundary.
+    ///
+    /// Interactive spawn sites that hold the parent's live
+    /// `Arc<SecurityPolicy>` (the agent-loop `spawn_subagent` tool and
+    /// the `delegate` tool when called from an ACP/gateway session)
+    /// must use [`Self::for_agent_with_policy`] instead, so that
+    /// session-scoped policy fields — most importantly
+    /// `workspace_dir`, which IDE/ACP clients pin to the session cwd
+    /// — survive the spawn. See issue #7263.
     pub fn for_agent(config: &Config, agent_alias: &str) -> Result<Self> {
-        let agent = config
-            .agents
-            .get(agent_alias)
-            .with_context(|| format!("no agent configured under alias {agent_alias:?}"))?;
-
+        // Upfront alias check so a missing-agent failure surfaces with
+        // the "no agent configured under alias …" message rather than
+        // the policy resolver's less specific "no resolvable
+        // risk_profile" wrapping.
+        if !config.agents.contains_key(agent_alias) {
+            anyhow::bail!("no agent configured under alias {agent_alias:?}");
+        }
         let parent_policy = SecurityPolicy::for_agent(config, agent_alias)
             .map(Arc::new)
             .with_context(|| {
                 format!("could not resolve security policy for agent {agent_alias:?}")
             })?;
+        Self::for_agent_with_policy(config, agent_alias, parent_policy)
+    }
+
+    /// Resolve a parent's identity using a **pre-built** security
+    /// policy — the live `Arc<SecurityPolicy>` that the parent's tool
+    /// registry is using. This is the spawn path interactive sites
+    /// (ACP `spawn_subagent`, ACP `delegate`) must take so that
+    /// session-scoped policy fields — most importantly
+    /// `workspace_dir`, which IDE/ACP clients pin to the session cwd
+    /// — survive the spawn. Without this hook the policy is rebuilt
+    /// from config and the session override is silently dropped
+    /// (issue #7263).
+    ///
+    /// The memory allowlist is still resolved from config because it
+    /// is declared statically per agent and the policy carries no
+    /// equivalent field.
+    pub fn for_agent_with_policy(
+        config: &Config,
+        agent_alias: &str,
+        parent_policy: Arc<SecurityPolicy>,
+    ) -> Result<Self> {
+        let agent = config
+            .agents
+            .get(agent_alias)
+            .with_context(|| format!("no agent configured under alias {agent_alias:?}"))?;
 
         let mut parent_allowed_agent_aliases: HashSet<String> = agent
             .workspace
@@ -349,6 +391,68 @@ mod tests {
             "child must inherit parent's exhausted action budget; \
              a fresh bucket here means the budget is bypass-able by \
              spawning a SubAgent"
+        );
+    }
+
+    /// Regression for issue #7263: when an interactive spawn site
+    /// (ACP `spawn_subagent` / `delegate`) supplies a pre-built parent
+    /// policy whose `workspace_dir` was pinned to the session cwd,
+    /// `for_agent_with_policy` must propagate that policy verbatim
+    /// instead of regenerating one from config. Without this the
+    /// child's file/shell tools jail to `~/.zeroclaw/agents/<alias>/
+    /// workspace` rather than the IDE's session cwd, breaking
+    /// subagent-driven workflows in repos outside the install root.
+    #[test]
+    fn for_agent_with_policy_preserves_session_workspace_dir() {
+        let config = config_with_agent("alpha");
+
+        // The session cwd is some directory that is NOT
+        // `config.agent_workspace_dir("alpha")`. Pick an absolute path
+        // that's stable across hosts.
+        let session_cwd = PathBuf::from("/tmp/zeroclaw-test-session-cwd-7263");
+        let config_workspace = config.agent_workspace_dir("alpha");
+        assert_ne!(
+            session_cwd, config_workspace,
+            "test precondition: session cwd must differ from config workspace"
+        );
+
+        // Build the "live" parent policy the way the interactive
+        // builders do (config-derived, then session_cwd override).
+        let mut live_policy = SecurityPolicy::for_agent(&config, "alpha").unwrap();
+        live_policy.workspace_dir = session_cwd.clone();
+        let live_policy = Arc::new(live_policy);
+
+        let ctx = SubAgentSpawn::for_agent_with_policy(&config, "alpha", live_policy.clone())
+            .expect("for_agent_with_policy must accept a live parent policy")
+            .build(SubAgentOverrides::default())
+            .expect("inherits-verbatim build must succeed");
+
+        // The child policy must be the same Arc (no clone, no rebuild)
+        // and must carry the session cwd through to the loop.
+        assert!(
+            Arc::ptr_eq(&ctx.policy, &live_policy),
+            "default overrides must reuse the parent's Arc, not regenerate"
+        );
+        assert_eq!(
+            ctx.policy.workspace_dir, session_cwd,
+            "session cwd must survive the spawn; regression for issue #7263"
+        );
+    }
+
+    /// `for_agent` (the cron-style entry point) must continue to
+    /// resolve the workspace from config so scheduled jobs — which
+    /// have no session — jail to the per-agent install dir.
+    #[test]
+    fn for_agent_uses_config_workspace_dir() {
+        let config = config_with_agent("alpha");
+        let ctx = SubAgentSpawn::for_agent(&config, "alpha")
+            .unwrap()
+            .build(SubAgentOverrides::default())
+            .unwrap();
+        assert_eq!(
+            ctx.policy.workspace_dir,
+            config.agent_workspace_dir("alpha"),
+            "for_agent (cron path) must use the per-agent install workspace"
         );
     }
 }

--- a/crates/zeroclaw-runtime/src/tools/delegate.rs
+++ b/crates/zeroclaw-runtime/src/tools/delegate.rs
@@ -392,6 +392,19 @@ impl DelegateTool {
             )));
         }
         target_policy.tracker = self.security.tracker.clone();
+
+        // Inherit the caller's runtime workspace boundary so delegate
+        // children spawned from an ACP/gateway session see the same
+        // session cwd as the caller instead of falling back to the
+        // per-agent install dir declared in config. Identical risk
+        // profile is enforced above, so this carries no extra
+        // privilege — it copies the sandbox boundary the caller
+        // already runs under. Without this, delegating to a sibling
+        // inside an IDE session jails the child to
+        // `~/.zeroclaw/agents/<target>/workspace` even when the user
+        // opened the IDE in their own repo. See issue #7263.
+        target_policy.workspace_dir = self.security.workspace_dir.clone();
+
         Ok(Arc::new(target_policy))
     }
 
@@ -1851,7 +1864,7 @@ impl Observer for NoopObserver {
 mod tests {
     use super::*;
     use crate::security::{AutonomyLevel, SecurityPolicy};
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
     use tokio::time::{Instant, sleep};
     use zeroclaw_config::schema::{
         DEFAULT_DELEGATE_AGENTIC_TIMEOUT_SECS, DEFAULT_DELEGATE_TIMEOUT_SECS,
@@ -3961,6 +3974,51 @@ mod tests {
         assert!(
             !target_policy.tracker.record_within(bucket_key, max),
             "delegated target must consume from the caller's bucket; spawning the target should not reset the budget"
+        );
+    }
+
+    /// Regression for issue #7263: when the caller's policy was built
+    /// with a session cwd (the ACP / gateway path), delegating to a
+    /// sibling agent must carry that cwd into the target's policy.
+    /// Without this, the child run's file/shell tools jail to the
+    /// per-agent install dir declared in config rather than the IDE's
+    /// session cwd, breaking delegate-driven workflows in repos
+    /// outside the install root.
+    #[tokio::test]
+    async fn delegate_target_inherits_caller_session_workspace_dir() {
+        let config = config_with_two_agents("caller", 5, "target", 5);
+
+        // Build the caller's policy the way the interactive builders
+        // do: config-derived, then session_cwd override.
+        let session_cwd = PathBuf::from("/tmp/zeroclaw-test-delegate-session-cwd-7263");
+        let mut caller_policy =
+            SecurityPolicy::for_agent(&config, "caller").expect("caller policy resolves");
+        caller_policy.workspace_dir = session_cwd.clone();
+        let caller_policy = Arc::new(caller_policy);
+
+        // Sanity: the target's config-derived workspace must differ so
+        // the assertion below is actually exercising the inheritance,
+        // not a coincidental match.
+        let target_config_workspace = config.agent_workspace_dir("target");
+        assert_ne!(
+            session_cwd, target_config_workspace,
+            "test precondition: session cwd must differ from target's config workspace"
+        );
+
+        let mut delegate_agents = HashMap::new();
+        for (name, agent) in &config.agents {
+            delegate_agents.insert(name.clone(), agent.clone());
+        }
+        let tool = DelegateTool::new(delegate_agents, None, Arc::clone(&caller_policy))
+            .with_root_config(config.clone());
+
+        let target_policy = tool
+            .policy_for_target("target")
+            .expect("same-profile target resolves");
+        assert_eq!(
+            target_policy.workspace_dir, session_cwd,
+            "delegated target must inherit the caller's session cwd; \
+             regression for issue #7263"
         );
     }
 

--- a/crates/zeroclaw-runtime/src/tools/spawn_subagent.rs
+++ b/crates/zeroclaw-runtime/src/tools/spawn_subagent.rs
@@ -28,6 +28,12 @@ pub struct SpawnSubagentTool {
     /// mirroring `DelegateTool`, so the dedup exemption for re-entrant
     /// agent tools cannot turn one model turn into unbounded child
     /// agent starts.
+    ///
+    /// Also carries session-scoped policy fields — most importantly
+    /// `workspace_dir`, which IDE/ACP clients pin to the session cwd —
+    /// into the SubAgent context via `SubAgentSpawn::for_agent_with_policy`,
+    /// so child file/shell tools jail to the same boundary as the
+    /// parent rather than the per-agent install dir (issue #7263).
     security: Arc<SecurityPolicy>,
     /// `true` when this tool is registered inside a run that is itself
     /// a SubAgent. Triggers a depth-1 cap refusal in `execute` before
@@ -173,8 +179,12 @@ impl Tool for SpawnSubagentTool {
             });
         }
 
-        let subagent_ctx = match SubAgentSpawn::for_agent(&self.config, &self.parent_alias)
-            .and_then(|spawn| spawn.build(SubAgentOverrides::default()))
+        let subagent_ctx = match SubAgentSpawn::for_agent_with_policy(
+            &self.config,
+            &self.parent_alias,
+            Arc::clone(&self.security),
+        )
+        .and_then(|spawn| spawn.build(SubAgentOverrides::default()))
         {
             Ok(ctx) => ctx,
             Err(e) => {
@@ -291,7 +301,7 @@ mod tests {
 
     #[tokio::test]
     async fn unknown_parent_alias_surfaces_spawn_failure() {
-        // Parent alias that is not configured: SubAgentSpawn::for_agent
+        // Parent alias that is not configured: SubAgentSpawn::for_agent_with_policy
         // returns Err, the tool reports a structured spawn failure
         // (no panic, no recursion attempt).
         let tool = SpawnSubagentTool::new(


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:** Subagents and delegates spawned from an ACP/gateway WS session were ignoring the client-supplied `cwd` and jailing the child to `~/.zeroclaw/agents/<alias>/workspace` instead of the user's repo. Root cause: both spawn sites went through `SecurityPolicy::for_agent(config, alias)` which rebuilds the policy from config and drops the session override the parent agent had already applied to its own live `Arc<SecurityPolicy>`. This PR threads the parent's live policy into both spawn paths so the child inherits the session boundary.
  - Added `SubAgentSpawn::for_agent_with_policy(config, alias, parent_policy)` for spawn sites that hold the parent's live `Arc<SecurityPolicy>`. Kept `SubAgentSpawn::for_agent` as the cron-only path (no session ⇒ config-derived workspace is correct).
  - Switched `SpawnSubagentTool::execute` to `for_agent_with_policy` using `Arc::clone(&self.security)` — the tool already holds the live policy, no constructor changes needed.
  - In `DelegateTool::policy_for_target`, after the existing risk-profile and `delegation_policy` gates pass, copy `self.security.workspace_dir` into the target policy. Identical risk-profile is already enforced (caller and target must match), so this is a sandbox-boundary copy, not a privilege grant.
- **Scope boundary:** Does NOT change cron `JobType::Agent` behavior — scheduled jobs continue to use `SubAgentSpawn::for_agent` and jail to the per-agent install workspace, which is the correct boundary when there is no session. Does NOT change the ACP back-channel inheritance for `ask_user` / `escalate_to_human` from inside a child run (separate concern, separate issue). Does NOT introduce new public surface in `SecurityPolicy` itself.
- **Blast radius:** Touches three files inside `crates/zeroclaw-runtime`: `subagent/mod.rs`, `tools/spawn_subagent.rs`, `tools/delegate.rs`. Affects: ACP server (channel-acp-server), gateway WS (`zeroclaw-gateway`), and cron-launched agent jobs (`zeroclaw-runtime::cron`) — verified cron is unaffected. All consumers of `SubAgentSpawn::for_agent` (cron is the only one after this PR) keep their existing behavior.
- **Linked issue(s):** Closes #7263
- **Labels:** Will be set by the auto-labeler. Expected: `bug`, `agent`, `runtime`, `tool`, `size: S`, and `risk: high` (touches runtime/tools paths).

## Validation Evidence (required)

- **Commands run and tail output:**

  `cargo fmt --all -- --check` — no output, exit 0.

  `cargo clippy --all-targets -- -D warnings`:
  ```
      Checking zeroclaw-runtime v0.8.0-beta-2 (...)
      Checking zeroclaw-hardware v0.8.0-beta-2 (...)
      Checking zeroclaw-channels v0.8.0-beta-2 (...)
      Checking zeroclaw-gateway v0.8.0-beta-2 (...)
      Checking zeroclawlabs v0.8.0-beta-2 (...)
      Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 06s
  ```

  `cargo test --lib --bins --tests` — full battery green, including all three new regression tests. Concrete tails:
  ```
  # crates/zeroclaw-runtime --lib
  test subagent::tests::for_agent_with_policy_preserves_session_workspace_dir ... ok
  test subagent::tests::for_agent_uses_config_workspace_dir ... ok
  test tools::delegate::tests::delegate_target_inherits_caller_session_workspace_dir ... ok
  ...
  test result: ok. 2072 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 5.21s
  ```
  ```
  # other suites (summary lines, no failures anywhere)
  test result: ok. 243 passed; 0 failed; 0 ignored; ...
  test result: ok. 275 passed; 0 failed; 0 ignored; ...
  test result: ok.  19 passed; 0 failed; 0 ignored; ...
  test result: ok.   3 passed; 0 failed; 0 ignored; ...
  test result: ok. 188 passed; 0 failed; 0 ignored; ...
  test result: ok. 159 passed; 0 failed; 0 ignored; ...
  test result: ok.   9 passed; 0 failed; 0 ignored; ...
  ```

- **Beyond CI — what did you manually verify?**
  - **End-to-end interactive test on a separate machine:** Built the fix branch on a second host, launched Zerocode in ACP mode against a repo that lives **outside** `~/.zeroclaw/agents/<alias>/workspace`, and exercised the subagent-driven-development pattern that originally tripped #7263. The parent agent successfully delegated implementation tasks to a subagent which then performed `file_read`, `file_edit`, and `shell` calls inside the IDE's session cwd (the repo). Pre-fix, the child refused those calls with "path outside workspace"; post-fix, the operations succeed against the repo path. Screenshots below.
  - Re-read the SubAgentSpawn call sites (`tools/spawn_subagent.rs`, `tools/delegate.rs`, `cron/scheduler.rs`) and confirmed cron is the only remaining caller of `for_agent`, so the cron path's config-derived workspace is preserved.
  - Confirmed `policy_for_target`'s new line runs *after* `delegation_policy.permits()` and `risk_profile_name` equality checks — so `workspace_dir` is only copied for already-authorized targets with an identical risk profile.
  - Verified the new `for_agent_with_policy_preserves_session_workspace_dir` test asserts both `Arc::ptr_eq` (no clone/regenerate) and the actual `workspace_dir` equality, so a future refactor that accidentally reverts to the rebuild path will fail loudly.
  - **Not verified:** delegate-driven workflows (as opposed to spawn_subagent), and testing against a non-zerocode ACP client. The `delegate` path is covered by the unit-level regression test at the `policy_for_target` boundary, which is where the bug lives, but a live ACP delegate-into-sibling-agent run was not performed in this session.

### Screenshots

<img width="1212" height="227" alt="Screenshot 2026-06-11 at 11 44 04 AM" src="https://github.com/user-attachments/assets/d8e5f50b-ddd5-47d2-ad1b-a40839dc96c2" />
<br />
<br />
<img width="470" height="278" alt="Screenshot 2026-06-11 at 11 44 14 AM" src="https://github.com/user-attachments/assets/b20ee335-243c-4021-87b5-45f5d2a9a4fd" />
<br />


- **If any command was intentionally skipped, why:** `cargo test --doc` was not included in the tail above. It fails on `upstream/master` (commit `d06ed2525`) with the same checkout: `rustdoc` is invoked with `--default-theme=ayu --default-theme=ayu` (option specified twice) and exits non-zero. I reproduced this on a clean working tree (my changes stashed) and confirmed the failure is pre-existing and unrelated to this PR — the diff adds no `///` doctests. Treating this as a pre-existing toolchain quirk to flag separately, not a blocker for this fix.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No** — `SpawnSubagentTool` already held the parent's live `Arc<SecurityPolicy>` and the child agent run already ran under it; this PR makes that consistent. `DelegateTool::policy_for_target` copies the caller's `workspace_dir` into the target policy *after* the existing identical-risk-profile gate, so the child runs under the same boundary the caller already runs under — not a wider one.
- New external network calls? **No**.
- Secrets / tokens / credentials handling changed? **No**.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**. Test paths are `/tmp/zeroclaw-test-…-7263` placeholders.

## Compatibility (required)

- Backward compatible? **Yes**.
- Config / env / CLI surface changed? **No**.
- Behavior change for end users: subagents and delegates spawned from inside an ACP/gateway WS session will now correctly see the IDE's session cwd as their sandbox boundary. Users with workflows that explicitly relied on the previous broken behavior (subagent jailed to install dir even when session cwd was supplied) would need to revert — but that pattern is the bug reported in #7263, not a documented contract.
- Cron `JobType::Agent` behavior is unchanged. Public APIs in `SubAgentSpawn` are additive (`for_agent_with_policy`); `for_agent` keeps its signature.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert ` efda1d2e54fc4f08076cf269561ddc7f378ae40b on master.
- **Feature flags or config toggles:** None — the cwd plumbing is unconditional. The previous behavior can be restored by reverting; there is no runtime toggle.
- **Observable failure symptoms:**
  - If the fix misbehaves on cron jobs (it should not — cron's path is untouched), grep daemon logs for `cron` lines mentioning `policy` plus filesystem errors against `~/.zeroclaw/agents/<alias>/workspace`. The cron regression test `subagent::tests::for_agent_uses_config_workspace_dir` is the contract.
  - If a delegate target receives a wider workspace than intended (it should not — risk-profile equality is gated before the copy), grep agent run logs for `delegate refused` *not* firing where it previously did. The existing delegate cross-profile test (`delegate_rejects_target_on_a_different_risk_profile`) covers this gate.
  - User-facing symptom of a regression would be the original bug returning: child agents reporting "path outside workspace" / shell jailed to install dir from within an ACP session.