### PR TITLE
fix(ci): install cross g++ for ARM glibc release builds

### DIFF
--- a/.github/workflows/cross-platform-build-manual.yml
+++ b/.github/workflows/cross-platform-build-manual.yml
@@ -57,18 +57,18 @@ jobs:
             # CI gate (`ci.yml`) uses clang+mold for throughput optimization.
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
-            cross_compiler: gcc-aarch64-linux-gnu
+            cross_compiler: gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
             linker_env: CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER
             linker: aarch64-linux-gnu-gcc
           - os: ubuntu-latest
             target: armv7-unknown-linux-gnueabihf
-            cross_compiler: gcc-arm-linux-gnueabihf
+            cross_compiler: gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
             linker_env: CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER
             linker: arm-linux-gnueabihf-gcc
             skip_prometheus: true
           - os: ubuntu-latest
             target: arm-unknown-linux-gnueabihf
-            cross_compiler: gcc-arm-linux-gnueabihf
+            cross_compiler: gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
             linker_env: CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_LINKER
             linker: arm-linux-gnueabihf-gcc
             skip_prometheus: true
@@ -131,6 +131,7 @@ jobs:
             # Ubuntu 22.04's gcc-arm-linux-gnueabihf defaults to ARMv7+NEON,
             # which segfaults on ARMv6 devices (e.g., Raspberry Pi Zero W).
             export CFLAGS_arm_unknown_linux_gnueabihf="-march=armv6 -mfpu=vfp -mfloat-abi=hard"
+            export CXXFLAGS_arm_unknown_linux_gnueabihf="-march=armv6 -mfpu=vfp -mfloat-abi=hard"
             export CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUSTFLAGS="-C target-feature=-neon"
           fi
           FEATURES="channel-matrix,channel-lark"

--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -218,7 +218,7 @@ jobs:
             target: aarch64-unknown-linux-gnu
             artifact: zeroclaw
             ext: tar.gz
-            cross_compiler: gcc-aarch64-linux-gnu
+            cross_compiler: gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
             linker_env: CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER
             linker: aarch64-linux-gnu-gcc
           - os: ubuntu-22.04
@@ -230,7 +230,7 @@ jobs:
             target: armv7-unknown-linux-gnueabihf
             artifact: zeroclaw
             ext: tar.gz
-            cross_compiler: gcc-arm-linux-gnueabihf
+            cross_compiler: gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
             linker_env: CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER
             linker: arm-linux-gnueabihf-gcc
             skip_prometheus: true
@@ -238,7 +238,7 @@ jobs:
             target: arm-unknown-linux-gnueabihf
             artifact: zeroclaw
             ext: tar.gz
-            cross_compiler: gcc-arm-linux-gnueabihf
+            cross_compiler: gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
             linker_env: CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_LINKER
             linker: arm-linux-gnueabihf-gcc
             skip_prometheus: true
@@ -300,6 +300,7 @@ jobs:
           # which segfaults on ARMv6 devices (e.g. Raspberry Pi Zero W).
           if [ "${{ matrix.target }}" = "arm-unknown-linux-gnueabihf" ]; then
             export CFLAGS_arm_unknown_linux_gnueabihf="-march=armv6 -mfpu=vfp -mfloat-abi=hard"
+            export CXXFLAGS_arm_unknown_linux_gnueabihf="-march=armv6 -mfpu=vfp -mfloat-abi=hard"
             export CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUSTFLAGS="-C target-feature=-neon"
           fi
           # Use matrix-level feature override if set, otherwise use global RELEASE_CARGO_FEATURES


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - The v0.8.0 Release Stable run ([27382533280](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/27382533280)) failed on all three ARM glibc targets (`aarch64-unknown-linux-gnu`, `armv7-unknown-linux-gnueabihf`, `arm-unknown-linux-gnueabihf`) with `error: failed to run custom build command for inkjet v0.11.1 — failed to find tool "aarch64-linux-gnu-g++": No such file or directory`.
  - Root cause: the release workflow builds zerocode alongside the main binary, and zerocode depends on `inkjet`, whose build script compiles tree-sitter grammars containing C++ scanners (`cc-rs` with `cpp(true)`). The build matrix only installed the C cross-compilers (`gcc-<triple>`), so cc-rs could not find the derived `<triple>-g++`. The main `zeroclaw` binary has no C++ build deps, which is why these targets built fine before zerocode joined the release archive.
  - Fix: add the matching `g++-<triple>` package to each of the three matrix `cross_compiler` entries. The install step (`apt-get install -y ${{ matrix.cross_compiler }}`) word-splits, so no other plumbing changes.
  - Also mirror the ARMv6 `CFLAGS` into `CXXFLAGS_arm_unknown_linux_gnueabihf` so inkjet's C++ scanner objects get ARMv6 codegen too — otherwise they'd compile at the toolchain's ARMv7+NEON default and reintroduce the #4556 Pi Zero W segfault class through the C++ side.
  - `cross-platform-build-manual.yml` carries the identical latent bug (same gcc-only matrix, same zerocode build step), so it gets the same four changes.
- **Scope boundary:** Does NOT touch the MUSL targets (cross-rs containers ship g++), Android (NDK), or the native Apple/Windows builds — none of them failed and none use the apt cross-toolchain path. No Rust code, no Cargo manifests, no other workflows.
- **Blast radius:** Only the two manual workflows (`release-stable-manual.yml`, `cross-platform-build-manual.yml`), and within them only the three ARM glibc matrix entries. Worst case is unchanged behavior on the already-failing jobs.
- **Linked issue(s):** Related #4556 (the ARMv6 codegen forcing this PR extends to CXXFLAGS).
- **Labels:** expect `ci` from the path labeler; suggest `bug`, `risk: low`, `size: XS`.

## Validation Evidence (required)

Workflow-only diff — the Rust battery does not exercise `.github/workflows/*.yml`, so it was intentionally skipped (no Rust, docs, or bootstrap-script changes in the diff). Validation performed instead:

```text
$ python3 -c "import yaml; [yaml.safe_load(open(f)) for f in ['.github/workflows/release-stable-manual.yml','.github/workflows/cross-platform-build-manual.yml']]" && echo YAML OK
YAML OK
```

- **Beyond CI — what did you manually verify?**
  - Read the failed job logs for all three targets: identical `ToolNotFound: aarch64-linux-gnu-g++` / `arm-linux-gnueabihf-g++` failure inside inkjet's build script, during the zerocode build step (the main binary built clean first).
  - Confirmed `inkjet v0.11.1`'s build script compiles `scanner.cc` files with `cc::Build::cpp(true)` (registry source, `build/language.rs`), which makes cc-rs derive `<triple>-g++` from the target.
  - Confirmed Ubuntu 22.04/24.04 ship `g++-aarch64-linux-gnu` and `g++-arm-linux-gnueabihf` in main; the workflow's existing `apt-get install` line handles multi-package values via word-splitting.
  - NOT verified: an actual green run of the release workflow on this branch — it is `workflow_dispatch` on master with a version gate, so the proof is the next dispatch after merge.
- **If any command was intentionally skipped, why:** `cargo fmt`/`clippy`/`test` skipped — zero Rust files in the diff.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No` — same apt archive, two more packages from it.
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No` — CI-internal env vars only.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk: `git revert <sha>`. Failure symptom if this is somehow wrong: the same three release jobs fail at the `Install cross compiler` step (bad package name) instead of at inkjet — immediately visible in the next dispatch.