### PR TITLE
fix(update): use .tar.gz for Windows assets in gnu-vs-android test

### DIFF
--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -673,8 +673,8 @@ mod tests {
             "zeroclaw-x86_64-unknown-linux-gnu.tar.gz",
             "zeroclaw-x86_64-apple-darwin.tar.gz",
             "zeroclaw-aarch64-apple-darwin.tar.gz",
-            "zeroclaw-x86_64-pc-windows-msvc.zip",
-            "zeroclaw-aarch64-pc-windows-msvc.zip",
+            "zeroclaw-x86_64-pc-windows-msvc.tar.gz",
+            "zeroclaw-aarch64-pc-windows-msvc.tar.gz",
         ]);
 
         let url = find_asset_url(&release);


### PR DESCRIPTION
## Summary

`find_asset_url_picks_correct_gnu_over_android` hardcoded `.zip` assets for Windows targets, but `is_installable_release_asset` only accepts `.tar.gz` / `.tgz`. On a Windows host the test panics with "should find an asset" because no qualifying asset matches the host triple.

## Fix

Use `.tar.gz` for all platform entries so the test is host-triple independent — its purpose is to assert the URL picks gnu over android, not to validate the asset format filter.

## Validation Evidence

```bash
cargo fmt --all -- --check
# (no output — formatting is clean)

cargo test --lib find_asset_url
# All 6 tests pass, including find_asset_url_picks_correct_gnu_over_android

cargo test
# all tests passing — CI green (Quality Gate)
```

- **Beyond CI — what did you manually verify?**
  - Confirmed the test's actual invariant (gnu-vs-android target priority) is preserved and independent of archive format
  - The format filter is tested separately by `ignores_non_installable_assets`
- **If any command was intentionally skipped, why:** None

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility

- Backward compatible? **Yes** — test-only change, no production code touched
- Config / env / CLI surface changed? **No**
- If `No` or `Yes` to either: exact upgrade steps for existing users: N/A

## Rollback

Low-risk PR: `git revert <sha>` is the plan.

Fixes #7509
