### PR TITLE
fix(channels/whatsapp-web): forward quoted media attachments

### DIFF
--- a/crates/zeroclaw-channels/src/whatsapp_web.rs
+++ b/crates/zeroclaw-channels/src/whatsapp_web.rs
@@ -729,6 +729,7 @@ impl WhatsAppWebChannel {
         client: &whatsapp_rust::Client,
         msg: &waproto::whatsapp::Message,
         file_prefix: &str,
+        include_audio: bool,
         attachments: &mut Vec<MediaAttachment>,
     ) {
         use wacore::proto_helpers::MessageExt;
@@ -774,24 +775,18 @@ impl WhatsAppWebChannel {
             .await;
         }
 
-        if let Some(ref document) = base.document_message {
-            let mime = document
+        if include_audio && let Some(ref audio) = base.audio_message {
+            let mime = audio
                 .mimetype
                 .clone()
-                .unwrap_or_else(|| "application/octet-stream".to_string());
-            let file_name = document
-                .file_name
-                .as_deref()
-                .map(|name| format!("{file_prefix}{name}"))
-                .unwrap_or_else(|| {
-                    format!(
-                        "{file_prefix}whatsapp-document.{}",
-                        Self::mime_extension(&mime, "bin")
-                    )
-                });
+                .unwrap_or_else(|| "audio/ogg".to_string());
+            let file_name = format!(
+                "{file_prefix}whatsapp-audio.{}",
+                Self::mime_extension(&mime, "ogg")
+            );
             Self::push_downloaded_attachment(
                 client,
-                document.as_ref() as &dyn Downloadable,
+                audio.as_ref() as &dyn Downloadable,
                 file_name,
                 Some(mime),
                 attachments,
@@ -1603,6 +1598,7 @@ impl Channel for WhatsAppWebChannel {
                                     &client,
                                     msg,
                                     "",
+                                    false,
                                     &mut attachments,
                                 )
                                 .await;
@@ -1611,6 +1607,7 @@ impl Channel for WhatsAppWebChannel {
                                         &client,
                                         quoted,
                                         "quoted-",
+                                        true,
                                         &mut attachments,
                                     )
                                     .await;

--- a/crates/zeroclaw-channels/src/whatsapp_web.rs
+++ b/crates/zeroclaw-channels/src/whatsapp_web.rs
@@ -36,6 +36,8 @@ use std::sync::Arc;
 use tokio::select;
 use waproto::whatsapp::device_props::PlatformType;
 use zeroclaw_api::channel::{Channel, ChannelMessage, SendMessage};
+#[cfg(feature = "whatsapp-web")]
+use zeroclaw_api::media::MediaAttachment;
 #[cfg(not(feature = "whatsapp-web"))]
 use zeroclaw_runtime::i18n;
 
@@ -620,6 +622,228 @@ impl WhatsAppWebChannel {
         }
     }
 
+    #[cfg(feature = "whatsapp-web")]
+    fn extract_context_info(
+        msg: &waproto::whatsapp::Message,
+    ) -> Option<&waproto::whatsapp::ContextInfo> {
+        use wacore::proto_helpers::MessageExt;
+        let base = msg.get_base_message();
+
+        if let Some(ref ext) = base.extended_text_message
+            && let Some(ref ctx) = ext.context_info
+        {
+            return Some(ctx);
+        }
+        if let Some(ref img) = base.image_message
+            && let Some(ref ctx) = img.context_info
+        {
+            return Some(ctx);
+        }
+        if let Some(ref vid) = base.video_message
+            && let Some(ref ctx) = vid.context_info
+        {
+            return Some(ctx);
+        }
+        if let Some(ref doc) = base.document_message
+            && let Some(ref ctx) = doc.context_info
+        {
+            return Some(ctx);
+        }
+        if let Some(ref aud) = base.audio_message
+            && let Some(ref ctx) = aud.context_info
+        {
+            return Some(ctx);
+        }
+        if let Some(ref stk) = base.sticker_message
+            && let Some(ref ctx) = stk.context_info
+        {
+            return Some(ctx);
+        }
+
+        None
+    }
+
+    #[cfg(feature = "whatsapp-web")]
+    fn extract_quoted_message(
+        msg: &waproto::whatsapp::Message,
+    ) -> Option<&waproto::whatsapp::Message> {
+        Self::extract_context_info(msg).and_then(|ctx| ctx.quoted_message.as_deref())
+    }
+
+    #[cfg(feature = "whatsapp-web")]
+    fn mime_extension(mime: &str, fallback: &str) -> String {
+        let subtype = mime
+            .split(';')
+            .next()
+            .and_then(|clean| clean.split_once('/').map(|(_, subtype)| subtype))
+            .and_then(|subtype| subtype.split('+').next())
+            .filter(|subtype| {
+                !subtype.is_empty()
+                    && subtype
+                        .chars()
+                        .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '.')
+            })
+            .unwrap_or(fallback);
+
+        match subtype {
+            "jpeg" => "jpg".to_string(),
+            "svg+xml" => "svg".to_string(),
+            other => other.to_string(),
+        }
+    }
+
+    #[cfg(feature = "whatsapp-web")]
+    async fn push_downloaded_attachment(
+        client: &whatsapp_rust::Client,
+        downloadable: &dyn whatsapp_rust::download::Downloadable,
+        file_name: String,
+        mime_type: Option<String>,
+        attachments: &mut Vec<MediaAttachment>,
+    ) {
+        let data = match client.download(downloadable).await {
+            Ok(data) => data,
+            Err(e) => {
+                ::zeroclaw_log::record!(
+                    WARN,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                        .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                        .with_attrs(::serde_json::json!({
+                            "file": file_name,
+                            "error": format!("{}", e),
+                        })),
+                    "failed to download WhatsApp media attachment"
+                );
+                return;
+            }
+        };
+
+        attachments.push(MediaAttachment {
+            file_name,
+            data,
+            mime_type,
+        });
+    }
+
+    #[cfg(feature = "whatsapp-web")]
+    async fn collect_media_attachments(
+        client: &whatsapp_rust::Client,
+        msg: &waproto::whatsapp::Message,
+        file_prefix: &str,
+        attachments: &mut Vec<MediaAttachment>,
+    ) {
+        use wacore::proto_helpers::MessageExt;
+        use whatsapp_rust::download::Downloadable;
+
+        let base = msg.get_base_message();
+
+        if let Some(ref image) = base.image_message {
+            let mime = image
+                .mimetype
+                .clone()
+                .unwrap_or_else(|| "image/jpeg".to_string());
+            let file_name = format!(
+                "{file_prefix}whatsapp-image.{}",
+                Self::mime_extension(&mime, "jpg")
+            );
+            Self::push_downloaded_attachment(
+                client,
+                image.as_ref() as &dyn Downloadable,
+                file_name,
+                Some(mime),
+                attachments,
+            )
+            .await;
+        }
+
+        if let Some(ref video) = base.video_message {
+            let mime = video
+                .mimetype
+                .clone()
+                .unwrap_or_else(|| "video/mp4".to_string());
+            let file_name = format!(
+                "{file_prefix}whatsapp-video.{}",
+                Self::mime_extension(&mime, "mp4")
+            );
+            Self::push_downloaded_attachment(
+                client,
+                video.as_ref() as &dyn Downloadable,
+                file_name,
+                Some(mime),
+                attachments,
+            )
+            .await;
+        }
+
+        if let Some(ref document) = base.document_message {
+            let mime = document
+                .mimetype
+                .clone()
+                .unwrap_or_else(|| "application/octet-stream".to_string());
+            let file_name = document
+                .file_name
+                .as_deref()
+                .map(|name| format!("{file_prefix}{name}"))
+                .unwrap_or_else(|| {
+                    format!(
+                        "{file_prefix}whatsapp-document.{}",
+                        Self::mime_extension(&mime, "bin")
+                    )
+                });
+            Self::push_downloaded_attachment(
+                client,
+                document.as_ref() as &dyn Downloadable,
+                file_name,
+                Some(mime),
+                attachments,
+            )
+            .await;
+        }
+
+        if let Some(ref sticker) = base.sticker_message {
+            let mime = sticker
+                .mimetype
+                .clone()
+                .unwrap_or_else(|| "image/webp".to_string());
+            let file_name = format!(
+                "{file_prefix}whatsapp-sticker.{}",
+                Self::mime_extension(&mime, "webp")
+            );
+            Self::push_downloaded_attachment(
+                client,
+                sticker.as_ref() as &dyn Downloadable,
+                file_name,
+                Some(mime),
+                attachments,
+            )
+            .await;
+        }
+    }
+
+    #[cfg(feature = "whatsapp-web")]
+    fn media_fallback_content(content: String, msg: &waproto::whatsapp::Message) -> String {
+        if !content.is_empty() {
+            return content;
+        }
+
+        use wacore::proto_helpers::MessageExt;
+        let base = msg.get_base_message();
+
+        if base.sticker_message.is_some() {
+            return "[Sticker]".to_string();
+        }
+        if base.image_message.is_some() {
+            return "[Image]".to_string();
+        }
+        if base.video_message.is_some() {
+            return "[Video]".to_string();
+        }
+        if base.document_message.is_some() {
+            return "[Document]".to_string();
+        }
+
+        String::new()
+    }
+
     /// Synthesize text to speech and send as a WhatsApp voice note (static version for spawned tasks).
     #[cfg(feature = "whatsapp-web")]
     async fn synthesize_voice_static(
@@ -749,26 +973,11 @@ impl WhatsAppWebChannel {
     }
 
     /// Extract mentioned JIDs from the base (unwrapped) message's context_info.
-    ///
-    /// Uses `get_base_message()` to see through ephemeral/view-once/edited/document wrappers,
-    /// matching the same unwrapping that `text_content()` performs.
-    ///
-    /// NOTE: Only checks `extended_text_message.context_info`. Media messages (image, video,
-    /// document) carry mentions in their own `context_info`, but `text_content()` already
-    /// ignores captions so those messages are filtered out upstream as empty text.
     #[cfg(feature = "whatsapp-web")]
     fn extract_mentioned_jids(msg: &waproto::whatsapp::Message) -> Vec<String> {
-        use wacore::proto_helpers::MessageExt;
-        let base = msg.get_base_message();
-
-        if let Some(ref ext) = base.extended_text_message
-            && let Some(ref ctx) = ext.context_info
-            && !ctx.mentioned_jid.is_empty()
-        {
-            return ctx.mentioned_jid.clone();
-        }
-
-        Vec::new()
+        Self::extract_context_info(msg)
+            .map(|ctx| ctx.mentioned_jid.clone())
+            .unwrap_or_default()
     }
 
     /// Check whether the bot is mentioned -- either structurally or via text fallback.
@@ -818,16 +1027,10 @@ impl WhatsAppWebChannel {
         has_text_mention(text, bot_phone) || bot_lid.is_some_and(|lid| has_text_mention(text, lid))
     }
 
-    /// Extract the author JID of the message quoted by an extended-text reply.
+    /// Extract the author JID of the message quoted by a reply.
     #[cfg(feature = "whatsapp-web")]
     fn extract_reply_participant(msg: &waproto::whatsapp::Message) -> Option<&str> {
-        use wacore::proto_helpers::MessageExt;
-        let base = msg.get_base_message();
-
-        base.extended_text_message
-            .as_ref()
-            .and_then(|ext| ext.context_info.as_ref())
-            .and_then(|ctx| ctx.participant.as_deref())
+        Self::extract_context_info(msg).and_then(|ctx| ctx.participant.as_deref())
     }
 
     #[cfg(feature = "whatsapp-web")]
@@ -1348,6 +1551,7 @@ impl Channel for WhatsAppWebChannel {
                                     let text = msg.text_content().unwrap_or("");
                                     text.trim().to_string()
                                 };
+                                let content = Self::media_fallback_content(content, msg);
 
                                 ::zeroclaw_log::record!(INFO, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note), &format!("WhatsApp Web message received (sender_len={}, chat_len={}, content_len={})", sender.len(), chat.len(), content.len()));
                                 ::zeroclaw_log::record!(DEBUG, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note), &format!("WhatsApp Web message content: {}", content));
@@ -1394,6 +1598,24 @@ impl Channel for WhatsAppWebChannel {
                                         }
                                     };
 
+                                let mut attachments = Vec::new();
+                                Self::collect_media_attachments(
+                                    &client,
+                                    msg,
+                                    "",
+                                    &mut attachments,
+                                )
+                                .await;
+                                if let Some(quoted) = Self::extract_quoted_message(msg) {
+                                    Self::collect_media_attachments(
+                                        &client,
+                                        quoted,
+                                        "quoted-",
+                                        &mut attachments,
+                                    )
+                                    .await;
+                                }
+
                                 if let Err(e) = tx_inner
                                     .send(ChannelMessage {
                                         id: uuid::Uuid::new_v4().to_string(),
@@ -1408,7 +1630,7 @@ impl Channel for WhatsAppWebChannel {
                                         timestamp: chrono::Utc::now().timestamp() as u64,
                                         thread_ts: None,
                                         interruption_scope_id: None,
-                    attachments: vec![],
+                                        attachments,
                                         subject: None,
                                     })
                                     .await
@@ -2238,6 +2460,43 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "whatsapp-web")]
+    fn sticker_reply(
+        participant: &str,
+        quoted_message: Option<waproto::whatsapp::Message>,
+    ) -> waproto::whatsapp::Message {
+        waproto::whatsapp::Message {
+            sticker_message: Some(Box::new(waproto::whatsapp::message::StickerMessage {
+                mimetype: Some("image/webp".to_string()),
+                context_info: Some(Box::new(waproto::whatsapp::ContextInfo {
+                    participant: Some(participant.to_string()),
+                    quoted_message: quoted_message.map(Box::new),
+                    ..Default::default()
+                })),
+                ..Default::default()
+            })),
+            ..Default::default()
+        }
+    }
+
+    #[cfg(feature = "whatsapp-web")]
+    fn image_mention(mentioned_jids: &[&str]) -> waproto::whatsapp::Message {
+        waproto::whatsapp::Message {
+            image_message: Some(Box::new(waproto::whatsapp::message::ImageMessage {
+                mimetype: Some("image/jpeg".to_string()),
+                context_info: Some(Box::new(waproto::whatsapp::ContextInfo {
+                    mentioned_jid: mentioned_jids
+                        .iter()
+                        .map(|jid| (*jid).to_string())
+                        .collect(),
+                    ..Default::default()
+                })),
+                ..Default::default()
+            })),
+            ..Default::default()
+        }
+    }
+
     #[test]
     #[cfg(feature = "whatsapp-web")]
     fn jid_digits_extracts_phone_from_jid() {
@@ -2387,6 +2646,16 @@ mod tests {
 
     #[test]
     #[cfg(feature = "whatsapp-web")]
+    fn extract_mentioned_jids_reads_media_context_info() {
+        let msg = image_mention(&["100@s.whatsapp.net"]);
+        assert_eq!(
+            WhatsAppWebChannel::extract_mentioned_jids(&msg),
+            vec!["100@s.whatsapp.net".to_string()]
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "whatsapp-web")]
     fn message_addressed_to_bot_accepts_reply_to_phone_jid() {
         let msg = extended_text_reply("100@s.whatsapp.net", &[]);
         assert!(WhatsAppWebChannel::is_message_addressed_to_bot(
@@ -2407,6 +2676,75 @@ mod tests {
             "100",
             Some("200"),
         ));
+    }
+
+    #[test]
+    #[cfg(feature = "whatsapp-web")]
+    fn message_addressed_to_bot_accepts_media_reply_to_lid_jid() {
+        let msg = sticker_reply("200@lid", None);
+        assert!(WhatsAppWebChannel::is_message_addressed_to_bot(
+            &msg,
+            "[Sticker]",
+            "100",
+            Some("200"),
+        ));
+    }
+
+    #[test]
+    #[cfg(feature = "whatsapp-web")]
+    fn extract_quoted_message_reads_media_context_info() {
+        let quoted = waproto::whatsapp::Message {
+            image_message: Some(Box::new(waproto::whatsapp::message::ImageMessage {
+                mimetype: Some("image/png".to_string()),
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+        let msg = sticker_reply("200@lid", Some(quoted));
+        let quoted = WhatsAppWebChannel::extract_quoted_message(&msg)
+            .expect("sticker reply should expose the quoted message");
+        assert!(quoted.image_message.is_some());
+    }
+
+    #[test]
+    #[cfg(feature = "whatsapp-web")]
+    fn media_fallback_content_keeps_sticker_messages_addressable() {
+        let msg = sticker_reply("200@lid", None);
+        assert_eq!(
+            WhatsAppWebChannel::media_fallback_content(String::new(), &msg),
+            "[Sticker]"
+        );
+        assert_eq!(
+            WhatsAppWebChannel::media_fallback_content("hello".to_string(), &msg),
+            "hello"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "whatsapp-web")]
+    fn media_fallback_content_leaves_non_media_messages_empty() {
+        let msg = waproto::whatsapp::Message::default();
+        assert_eq!(
+            WhatsAppWebChannel::media_fallback_content(String::new(), &msg),
+            ""
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "whatsapp-web")]
+    fn mime_extension_uses_safe_subtype() {
+        assert_eq!(
+            WhatsAppWebChannel::mime_extension("image/jpeg; name=photo", "jpg"),
+            "jpg"
+        );
+        assert_eq!(
+            WhatsAppWebChannel::mime_extension("application/vnd.ms-excel", "bin"),
+            "vnd.ms-excel"
+        );
+        assert_eq!(
+            WhatsAppWebChannel::mime_extension("image/../../png", "bin"),
+            "bin"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Forward accepted WhatsApp Web image, video, and sticker messages as `MediaAttachment`s instead of dropping them at the channel boundary.
  - Forward consumable media from quoted/replied-to WhatsApp messages with a `quoted-` filename prefix, including quoted audio for the existing audio transcription pipeline.
  - Read `context_info` from media message variants, not only `extended_text_message`, so media replies and structured mentions still satisfy bot-addressing checks.
  - Add lightweight `[Sticker]` / `[Image]` / `[Video]` / `[Document]` placeholders only for media-only messages, preserving the existing empty-message drop for non-media messages.
- **Scope boundary:** This PR does not change media-pipeline behavior, provider vision support, document parsing/download semantics, session/history scoping, read receipts, or outbound media sending.
- **Blast radius:** WhatsApp Web inbound handling only, behind the existing `whatsapp-web` feature. Accepted consumable media messages can now trigger existing media pipeline processing when configured.
- **Linked issue(s):** None.
- **Labels:** `bug`, `size: M`, `risk: medium`, `channel`, `channel:whatsapp`.

## Validation Evidence (required)

- **Commands run and tail output:**

```bash
$ cargo fmt --all -- --check
# exit 0

$ cargo test -p zeroclaw-channels --features whatsapp-web
...
test result: ok. 878 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 7.75s
...
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.01s
...
Doc-tests zeroclaw_channels

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

$ cargo clippy -p zeroclaw-channels --features whatsapp-web --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 9.20s

$ cargo test -p zeroclaw-channels --features whatsapp-web whatsapp_web::tests::
running 53 tests
...
test result: ok. 53 passed; 0 failed; 0 ignored; 0 measured; 826 filtered out; finished in 0.02s
```

- **Beyond CI — what did you manually verify?** Reviewed the WhatsApp Web inbound path to confirm media downloads occur after allowlist / mention gating, and before `ChannelMessage` delivery to the orchestrator. Verified regression tests cover media `context_info`, reply-to-bot detection for sticker replies, quoted-message extraction, and empty non-media messages remaining dropped. After review feedback, also verified that collected attachments now line up with media kinds consumed by the existing media pipeline: image, video, sticker-as-image, and quoted audio.
- **If any command was intentionally skipped, why:** Full workspace `cargo clippy --all-targets -- -D warnings` and `cargo test` were not run locally; this is a WhatsApp Web channel-only patch, so I ran the channel crate with the `whatsapp-web` feature enabled. Full workspace CI should still exercise the broader matrix.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`Yes`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: Accepted WhatsApp Web image/video/sticker messages and quoted audio/image/video/sticker messages now trigger WhatsApp media download calls so the existing media pipeline can consume the bytes. The downloads are gated after existing sender policy and bot-addressing checks, and attachments remain in memory instead of being written to disk. Documents are not downloaded because the current media pipeline has no document consumer.

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: No upgrade steps. Existing text-only behavior remains unchanged; media-only accepted messages now carry a compact placeholder and consumable attachments where supported by the existing media pipeline.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert ad571a1ed 95fde54a8`
- **Feature flags or config toggles:** Existing `whatsapp-web` feature and `[media_pipeline]` configuration still control the surrounding behavior; no new toggle added.
- **Observable failure symptoms:** Unexpected WhatsApp Web logs containing `failed to download WhatsApp media attachment`, increased media-download latency for accepted image/video/sticker or quoted audio messages, or media messages reaching the agent when they should have been filtered.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Scope materially carried forward: N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`Yes/No`): N/A
- If `No`, why (inspiration-only, no direct code/design carry-over): N/A