### PR TITLE
fix(zerocode): prevent Cmd-C from triggering Quit on macOS

### DIFF
--- a/apps/zerocode/src/keymap/chord.rs
+++ b/apps/zerocode/src/keymap/chord.rs
@@ -234,7 +234,12 @@ impl<'de> Deserialize<'de> for Chord {
 
 #[cfg(target_os = "macos")]
 fn normalise_mods(code: KeyCode, mut m: KeyModifiers) -> KeyModifiers {
-    if m.contains(KeyModifiers::CONTROL) {
+    // Translate Ctrl→⌘ on macOS so Linux `Ctrl+K` and macOS `⌘K`
+    // map to the same chord.  Skip this translation for the `c` key
+    // because ⌘C is the system copy chord — mapping it to Ctrl+C
+    // would cause Quit to fire on a copy gesture. (#7378)
+    let is_c_key = matches!(code, KeyCode::Char('c') | KeyCode::Char('C'));
+    if m.contains(KeyModifiers::CONTROL) && !is_c_key {
         m.remove(KeyModifiers::CONTROL);
         m.insert(KeyModifiers::SUPER);
     }


### PR DESCRIPTION
## Summary

On macOS, `normalise_mods` translated `CONTROL→SUPER` for ALL key chords (so Linux `Ctrl+K` and macOS `⌘K` map to the same binding). This also mapped Quit (`Ctrl+C`) to the copy chord (`⌘C`), causing `Cmd+C` to trigger the quit flow instead of terminal copy.

## Fix

Skip the `CONTROL→SUPER` translation for the `c`/`C` key. `Ctrl+C` still quits but `⌘C` remains available for system copy.

## Linked context

Closes #7378

## Verification

```bash
cargo check -p zerocode   # ✅ passes
```

## Risk checklist

- **Breaking change?** No — only affects the 'c' key
- **Side effects:** Other chord bindings (`Ctrl+K`→`⌘K`) unaffected
- **macOS only:** `#[cfg(target_os = "macos")]` gated