### PR TITLE
fix(runtime/doctor): ensure workspace doctor checks support multi agents

### DIFF
--- a/crates/zeroclaw-runtime/src/doctor/mod.rs
+++ b/crates/zeroclaw-runtime/src/doctor/mod.rs
@@ -832,25 +832,43 @@ fn check_workspace(config: &Config, items: &mut Vec<DiagItem>) {
         }
     }
 
-    // Key workspace files
-    check_file_exists(ws, "SOUL.md", false, cat, items);
-    check_file_exists(ws, "AGENTS.md", false, cat, items);
+    // Per-agent personality files. These are resolved per agent from
+    // `<install>/agents/<alias>/workspace/` (or an explicit
+    // `[agents.<alias>.workspace.path]` override) — never from `data_dir`.
+    // Iterate every enabled agent so multi-agent installs each get checked,
+    // and name the alias in the result so the report is unambiguous. Sorted
+    // for deterministic output (HashMap iteration order is unspecified).
+    let mut agent_aliases: Vec<&String> = config.agents.keys().collect();
+    agent_aliases.sort();
+    for alias in agent_aliases {
+        let agent = config.agents.get(alias).expect("alias from keys()");
+        if !agent.enabled {
+            continue;
+        }
+        let agent_ws = config.agent_workspace_dir(alias);
+        check_agent_file(&agent_ws, "SOUL.md", alias, cat, items);
+        check_agent_file(&agent_ws, "AGENTS.md", alias, cat, items);
+    }
 }
 
-fn check_file_exists(
-    base: &Path,
+/// Existence check for an optional per-agent workspace file. Prefixes the
+/// owning agent alias as `[alias]` so a multi-agent report stays legible and
+/// `(optional)` keeps its single, consistent meaning as the severity hint
+/// (e.g. `[default] SOUL.md present`, `[default] AGENTS.md not found (optional)`).
+fn check_agent_file(
+    workspace_dir: &Path,
     name: &str,
-    required: bool,
+    alias: &str,
     cat: &'static str,
     items: &mut Vec<DiagItem>,
 ) {
-    let path = base.join(name);
-    if path.is_file() {
-        items.push(DiagItem::ok(cat, format!("{name} present")));
-    } else if required {
-        items.push(DiagItem::error(cat, format!("{name} missing")));
+    if workspace_dir.join(name).is_file() {
+        items.push(DiagItem::ok(cat, format!("[{alias}] {name} present")));
     } else {
-        items.push(DiagItem::warn(cat, format!("{name} not found (optional)")));
+        items.push(DiagItem::warn(
+            cat,
+            format!("[{alias}] {name} not found (optional)"),
+        ));
     }
 }
 
@@ -1389,6 +1407,118 @@ mod tests {
                 .and_then(|name| name.to_str())
                 .is_some_and(|name| name.starts_with(".zeroclaw_doctor_probe_"))
         );
+    }
+
+    /// Build a Config whose install root is `root`, with an existing
+    /// `data_dir` (so `check_workspace` doesn't early-return) and no agents.
+    /// `config_path` anchors `install_root_dir()` → `agent_workspace_dir()`.
+    fn workspace_test_config(root: &Path) -> Config {
+        let mut config = Config::default();
+        config.config_path = root.join("config.toml");
+        config.data_dir = root.join("data");
+        std::fs::create_dir_all(&config.data_dir).unwrap();
+        config.agents.clear();
+        config
+    }
+
+    fn add_enabled_agent(config: &mut Config, alias: &str) {
+        config.agents.insert(
+            alias.to_string(),
+            zeroclaw_config::schema::AliasedAgentConfig {
+                enabled: true,
+                ..Default::default()
+            },
+        );
+    }
+
+    #[test]
+    fn check_workspace_finds_soul_in_agent_workspace_not_data_dir() {
+        let tmp = TempDir::new().unwrap();
+        let mut config = workspace_test_config(tmp.path());
+        add_enabled_agent(&mut config, "default");
+
+        // SOUL.md lives in the agent workspace — the real load location.
+        let ws = config.agent_workspace_dir("default");
+        std::fs::create_dir_all(&ws).unwrap();
+        std::fs::write(ws.join("SOUL.md"), b"# soul").unwrap();
+        // A decoy in data_dir must NOT satisfy the check (proves we don't
+        // probe data_dir for personality files).
+        std::fs::write(config.data_dir.join("SOUL.md"), b"# decoy").unwrap();
+
+        let mut items = Vec::new();
+        check_workspace(&config, &mut items);
+
+        let soul = items
+            .iter()
+            .find(|i| i.message.contains("SOUL.md"))
+            .expect("SOUL.md diagnostic present");
+        assert_eq!(soul.severity, Severity::Ok);
+        assert_eq!(soul.message, "[default] SOUL.md present");
+        // No bare data_dir-style message ever surfaces.
+        assert!(
+            !items.iter().any(|i| i.message == "SOUL.md present"),
+            "doctor must not report SOUL.md from data_dir"
+        );
+    }
+
+    #[test]
+    fn check_workspace_warns_when_agent_soul_missing() {
+        let tmp = TempDir::new().unwrap();
+        let mut config = workspace_test_config(tmp.path());
+        add_enabled_agent(&mut config, "default");
+        // Workspace dir need not exist; the file simply isn't there.
+
+        let mut items = Vec::new();
+        check_workspace(&config, &mut items);
+
+        let soul = items
+            .iter()
+            .find(|i| i.message.contains("SOUL.md"))
+            .expect("SOUL.md diagnostic present");
+        assert_eq!(soul.severity, Severity::Warn);
+        assert_eq!(soul.message, "[default] SOUL.md not found (optional)");
+    }
+
+    #[test]
+    fn check_workspace_skips_disabled_agents() {
+        let tmp = TempDir::new().unwrap();
+        let mut config = workspace_test_config(tmp.path());
+        config.agents.insert(
+            "dormant".to_string(),
+            zeroclaw_config::schema::AliasedAgentConfig {
+                enabled: false,
+                ..Default::default()
+            },
+        );
+
+        let mut items = Vec::new();
+        check_workspace(&config, &mut items);
+
+        assert!(
+            !items.iter().any(|i| i.message.contains("dormant")),
+            "disabled agents must not produce workspace-file diagnostics"
+        );
+    }
+
+    #[test]
+    fn check_workspace_checks_each_enabled_agent() {
+        let tmp = TempDir::new().unwrap();
+        let mut config = workspace_test_config(tmp.path());
+        add_enabled_agent(&mut config, "alpha");
+        add_enabled_agent(&mut config, "zeta");
+
+        let mut items = Vec::new();
+        check_workspace(&config, &mut items);
+
+        // Each enabled agent gets its own SOUL.md + AGENTS.md probe, named.
+        let messages: Vec<&str> = items.iter().map(|i| i.message.as_str()).collect();
+        for alias in ["alpha", "zeta"] {
+            let expected = format!("[{alias}] SOUL.md not found (optional)");
+            assert!(
+                messages.contains(&expected.as_str()),
+                "expected per-agent SOUL.md diagnostic for {alias}; got {messages:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/zeroclaw-runtime/src/doctor/mod.rs
+++ b/crates/zeroclaw-runtime/src/doctor/mod.rs
@@ -1413,9 +1413,11 @@ mod tests {
     /// `data_dir` (so `check_workspace` doesn't early-return) and no agents.
     /// `config_path` anchors `install_root_dir()` → `agent_workspace_dir()`.
     fn workspace_test_config(root: &Path) -> Config {
-        let mut config = Config::default();
-        config.config_path = root.join("config.toml");
-        config.data_dir = root.join("data");
+        let mut config = Config {
+            config_path: root.join("config.toml"),
+            data_dir: root.join("data"),
+            ..Config::default()
+        };
         std::fs::create_dir_all(&config.data_dir).unwrap();
         config.agents.clear();
         config


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
   - Doctor checks testing for `SOUL.md` and `AGENT.md` were searching in the wrong directory, still assuming it was a single agent setup (pre-0.8).
   - This PR ensures doctor is multi agent aware and probes those files for all agents.
  - **Scope boundary:** Diagnostic-only. The only behavioral change is *where `zeroclaw doctor` looks* and *how it labels* the workspace-file checks. No change to config loading, agent runtime, or how personality files are actually read.
  - **Blast radius:** `zeroclaw doctor` CLI output and the dashboard Doctor page. No other subsystem consumes these diagnostics.
  - **Linked issue(s):** None.
  - **Labels:** `doctor`, `runtime`, `risk: high`, `size: S`.

## Validation Evidence (required)

  ```bash
  cargo fmt --all -- --check
  cargo clippy --all-targets -- -D warnings
  cargo test
  ```

  - **Commands run and tail output:**
    - `cargo fmt --all -- --check` → no output, exit 0 (clean).
    - `cargo clippy --all-targets -- -D warnings` →
      ```
          Checking zeroclaw-runtime v0.8.0 (/Users/tomi/git/tmigone/zeroclaw/crates/zeroclaw-runtime)
          Checking zeroclaw-channels v0.8.0 (/Users/tomi/git/tmigone/zeroclaw/crates/zeroclaw-channels)
          Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 02s
      ```
      No warnings emitted.
    - `cargo test` → all suites pass, 0 failures. Relevant tails:
      ```
      test doctor::tests::check_workspace_finds_soul_in_agent_workspace_not_data_dir ... ok
      test doctor::tests::check_workspace_warns_when_agent_soul_missing ... ok
      test doctor::tests::check_workspace_skips_disabled_agents ... ok
      test doctor::tests::check_workspace_checks_each_enabled_agent ... ok
      test result: ok. 25 passed; 0 failed; 0 ignored; 0 measured; 2057 filtered out

      test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out   (test_system: multi_agent_e2e)
         Doc-tests zeroclaw
      test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
      ```
  - **Beyond CI — what did you manually verify?** Ran the dashboard Doctor against my local install: before, it warned `SOUL.md not found (optional)` despite the file existing at `.zeroclaw/agents/default/workspace/SOUL.md`; after, it reports `[default] SOUL.md present`. `AGENTS.md` correctly reports `[default] AGENTS.md not found (optional)` (none exists in that workspace). Added unit coverage for: `found-in-workspace-not-data_dir` (decoy in `data_dir` does not satisfy the check), missing→warn, disabled agents skipped, and per-alias probing across multiple enabled agents.
  - **What I did NOT verify:** an explicit `[agents.<alias>.workspace.path]` override pointing at a non-default mount (only the derived `<install>/agents/<alias>/workspace/` path was exercised end-to-end; the override branch is covered by the existing `agent_workspace_dir` impl).
  - **If any command was intentionally skipped, why:** None skipped.

  ## Security & Privacy Impact (required)

  - New permissions, capabilities, or file system access scope? **No**.
  - New external network calls? **No**
  - Secrets / tokens / credentials handling changed? **No**
  - PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**.
  - If any `Yes`, describe the risk and mitigation: N/A

  ## Compatibility (required)

  - Backward compatible? **Yes**
  - Config / env / CLI surface changed? **No**, no flags, env vars, or config keys added/changed. The only observable difference  is the wording of the doctor's workspace diagnostic lines (now `[alias]`-prefixed and resolved per agent).
  - If `No` or `Yes` to either: exact upgrade steps for existing users: None required.