### PR TITLE
fix(install): install web dashboard on source installs and point users at the installer

### DIFF
--- a/crates/zeroclaw-gateway/src/lib.rs
+++ b/crates/zeroclaw-gateway/src/lib.rs
@@ -1299,15 +1299,17 @@ pub async fn run_gateway(
             INFO,
             ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note),
             "Web dashboard: not available — configured gateway.web_dist_dir is missing on \
-             this machine and no fallback location was found. Build with `cargo web build` \
-             and point gateway.web_dist_dir at the resulting web/dist directory."
+             this machine and no fallback location was found. Reinstall with the supported \
+             installer (`./install.sh --source` on Linux/macOS, `setup.bat` on Windows) to \
+             build and place the dashboard where the gateway looks for it."
         );
     } else {
         ::zeroclaw_log::record!(
             INFO,
             ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note),
-            "Web dashboard: not available — no web/dist found. Build with `cargo web build` \
-             and point gateway.web_dist_dir at the resulting web/dist directory."
+            "Web dashboard: not available — no web/dist found. Reinstall with the supported \
+             installer (`./install.sh --source` on Linux/macOS, `setup.bat` on Windows) to \
+             build and place the dashboard where the gateway looks for it."
         );
     }
 

--- a/crates/zeroclaw-gateway/src/static_files.rs
+++ b/crates/zeroclaw-gateway/src/static_files.rs
@@ -50,11 +50,11 @@ pub async fn handle_spa_fallback(State(state): State<AppState>, uri: Uri) -> Res
     let Some(bytes) = load_index_html_bytes(state.web_dist_dir.as_ref()).await else {
         return (
             StatusCode::SERVICE_UNAVAILABLE,
-            "Web dashboard not available. Build the frontend with `cargo web build` \
-             (the supported entry point — it generates the TS API client and runs \
-             the Vite production build) and point gateway.web_dist_dir at the \
-             resulting web/dist. The daemon's API endpoints remain reachable \
-             independently of the dashboard.",
+            "Web dashboard not available. Reinstall with the supported installer \
+             so the dashboard is built and placed where the gateway looks for it: \
+             `./install.sh --source` on Linux/macOS, or `setup.bat` on Windows. \
+             The daemon's API endpoints remain reachable independently of the \
+             dashboard.",
         )
             .into_response();
     };

--- a/install.sh
+++ b/install.sh
@@ -276,17 +276,7 @@ install_prebuilt() {
   echo
 
   # Resolve platform-correct web data directory to match gateway auto-detect
-  case "$(uname -s)" in
-  Darwin)
-    web_data_dir="${HOME}/Library/Application Support/zeroclaw/web/dist"
-    ;;
-  MINGW* | CYGWIN* | MSYS*)
-    web_data_dir="${LOCALAPPDATA}/zeroclaw/web/dist"
-    ;;
-  *)
-    web_data_dir="${XDG_DATA_HOME:-${PREFIX}/.local/share}/zeroclaw/web/dist"
-    ;;
-  esac
+  web_data_dir=$(resolve_web_data_dir)
 
   if [ "$DRY_RUN" = true ]; then
     info "[dry-run] Would download $asset_url"
@@ -587,14 +577,49 @@ interactive_feature_picker() {
   PICKED_APPS=$(printf '%s' "$selected_apps" | tr ' ' ',')
 }
 
+# Resolve the platform data directory the gateway auto-detects for the
+# dashboard bundle. Single source of truth so the prebuilt and source
+# install paths cannot drift.
+resolve_web_data_dir() {
+  case "$(uname -s)" in
+  Darwin)
+    printf '%s' "${HOME}/Library/Application Support/zeroclaw/web/dist"
+    ;;
+  MINGW* | CYGWIN* | MSYS*)
+    printf '%s' "${LOCALAPPDATA}/zeroclaw/web/dist"
+    ;;
+  *)
+    printf '%s' "${XDG_DATA_HOME:-${PREFIX}/.local/share}/zeroclaw/web/dist"
+    ;;
+  esac
+}
+
+# Copy a built web/dist into the gateway data directory so a
+# systemd-launched daemon finds it regardless of CWD.
+install_web_dist() {
+  src_dist="$1"
+  if [ ! -f "$src_dist/index.html" ]; then
+    return 0
+  fi
+  web_data_dir=$(resolve_web_data_dir)
+  if [ "$DRY_RUN" = true ]; then
+    info "[dry-run] Would install web dashboard to $web_data_dir"
+    return 0
+  fi
+  mkdir -p "$web_data_dir"
+  cp -r "$src_dist/." "$web_data_dir/"
+  info "Web dashboard installed to $web_data_dir"
+}
+
 # ── Web dashboard build for source installs ──────────────────────
 #
 # When a source build includes the `gateway` feature, the dashboard
 # (`web/dist`) needs to be built so the gateway can serve it. If Node.js
 # is on PATH we run `cargo web build` from the source root so the
-# generated API client is refreshed before TypeScript compiles. Without
-# Node.js we warn — the gateway still starts but the dashboard route
-# returns 404 until `web/dist` is populated.
+# generated API client is refreshed before TypeScript compiles, then the
+# built bundle is copied into the gateway data directory. Without Node.js
+# we warn and tell the user to re-run the installer once Node.js is
+# present — never to run cargo by hand.
 build_web_dashboard() {
   src_dir="$1"
   if [ ! -d "$src_dir/web" ]; then
@@ -603,8 +628,8 @@ build_web_dashboard() {
   fi
   if ! command -v npm >/dev/null 2>&1; then
     warn "npm not found — skipping dashboard build. The gateway will run"
-    warn "  in API-only mode until you build the dashboard:"
-    warn "  cd $src_dir && cargo web build"
+    warn "  in API-only mode. Install Node.js (npm) and re-run ./install.sh"
+    warn "  --source to build and install the dashboard."
     return 0
   fi
   # Always rebuild — a stale dist from a prior revision serves outdated
@@ -616,6 +641,7 @@ build_web_dashboard() {
     return 0
   }
   info "Web dashboard built at $src_dir/web/dist"
+  install_web_dist "$src_dir/web/dist"
 }
 
 # ── Low-memory build heuristic ────────────────────────────────────

--- a/setup.bat
+++ b/setup.bat
@@ -277,6 +277,30 @@ if %ERRORLEVEL% NEQ 0 (
     echo   %GREEN%OK%RESET% Added to PATH
 )
 
+:: Build and install the web dashboard so the gateway serves it. Mirrors
+:: install.sh: assets must land where the gateway auto-detects them
+:: (%LOCALAPPDATA%\zeroclaw\web\dist) so a service-launched daemon finds
+:: them regardless of working directory.
+where npm >nul 2>&1
+if %ERRORLEVEL% EQU 0 (
+    echo   Building web dashboard ^(cargo web build^)...
+    cargo web build
+    if %ERRORLEVEL% EQU 0 (
+        if exist "web\dist\index.html" (
+            mkdir "%LOCALAPPDATA%\zeroclaw\web\dist" 2>nul
+            xcopy /E /I /Y "web\dist" "%LOCALAPPDATA%\zeroclaw\web\dist" >nul
+            echo   %GREEN%OK%RESET% Web dashboard installed to %LOCALAPPDATA%\zeroclaw\web\dist
+        )
+    ) else (
+        echo   %YELLOW%WARNING: dashboard build failed; gateway runs in API-only mode.%RESET%
+        echo   %YELLOW%Re-run setup.bat once the build issue is resolved.%RESET%
+    )
+) else (
+    echo   %YELLOW%npm not found - skipping dashboard build. The gateway will run%RESET%
+    echo   %YELLOW%in API-only mode. Install Node.js and re-run setup.bat to build%RESET%
+    echo   %YELLOW%and install the dashboard.%RESET%
+)
+
 goto verify
 
 :: ---- Post install ----


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Source installs built `web/dist` but never copied it into the gateway data directory, so a service-launched daemon resolved `web_dist_dir` to `None` and served no dashboard. This makes the supported source-install path (`./install.sh --source`) actually produce a working dashboard.
  - The prebuilt path already copied but resolved its target with an inline `case` block that could drift from the source path. Extracted `resolve_web_data_dir()` as the single source of truth used by both paths so they cannot diverge (the exact drift risk flagged on #7302).
  - Added Windows parity in `setup.bat`: source installs now `cargo web build` and copy `web/dist` to `%LOCALAPPDATA%\zeroclaw\web\dist`.
  - Stopped telling end users to run raw `cargo web build`. The gateway dashboard-unavailable 503 and the two startup log notes now point at the supported installer per platform (`./install.sh --source` on Linux/macOS, `setup.bat` on Windows).
- **Scope boundary:** Does not change the gateway's auto-detect logic, the `embedded-web` compile-time assert (developer-facing, keeps its cargo hint), or developer docs under `docs/book/src/developing/web.md` (correct audience for cargo invocations).
- **Blast radius:** Installer scripts (`install.sh`, `setup.bat`) and three user-facing gateway strings. No runtime behavior change beyond message wording; the install paths only add a copy step.
- **Linked issue(s):** Closes #7553. Supersedes #7302. Related #7457 (runtime JSON-fallback fix; complementary, addresses the symptom this PR removes the cause of).
- **Labels:** `bug`, `gateway`, `web`, `risk: medium`, `size: S`

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy -p zeroclaw-gateway --all-targets -- -D warnings
cargo test -p zeroclaw-gateway
bash -n install.sh && sh -n install.sh
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` — clean, no diff.
  - `cargo clippy -p zeroclaw-gateway --all-targets -- -D warnings` — `Finished`, 0 warnings.
  - `cargo test -p zeroclaw-gateway` — `test result: ok. 250 passed; 0 failed; 0 ignored`.
  - `bash -n install.sh && sh -n install.sh` — both OK (POSIX-clean).
- **Beyond CI — what did you manually verify?**
  - Unit-tested the extracted shell helpers in throwaway temp dirs: Linux default path (`$HOME/.local/share/zeroclaw/web/dist`, the #7253/#7553 repro), `XDG_DATA_HOME` honored, custom `PREFIX`, dry-run writes nothing and prints the would-install line, real recursive copy preserves nested assets, missing `index.html` is a no-op. 6/6 pass against the final `install.sh`.
  - Ran `install.sh --source --dry-run` and `install.sh --prebuilt --dry-run` with a temp `HOME`: confirmed no data-dir writes and correct messaging on both.
  - Verified the prebuilt path now resolves through the shared helper to the same `.local/share` location.
  - Did NOT run a full live source build/install end to end on a clean VM, nor execute `setup.bat` on Windows (no Windows host); the batch logic mirrors the verified `install.sh` copy step.
- **If any command was intentionally skipped, why:** Ran the gateway-scoped battery rather than the full workspace `cargo test` for turnaround; the diff only touches the gateway crate and the two shell installers.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No** (the installer already writes to the data dir on the prebuilt path; this extends the same write to the source path).
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No** (installer flags and gateway config unchanged; only adds a copy step and rewords messages).
- If `No` or `Yes` to either: no upgrade steps required. Existing installs are unaffected; re-running the installer now also populates the dashboard.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert af4e5925d`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Installer errors during the new copy step (grep installer output for `Web dashboard installed to`), or a source install that still serves no dashboard (gateway logs `Web dashboard: not available`). The copy is guarded on `index.html` existence and is a no-op when absent, so it cannot break an install that lacks a built bundle.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors:
  - #7302 by @hanZeng-08
- Scope materially carried forward: the source-install `web/dist` copy approach and its root-cause diagnosis originated in #7302. This PR carries that forward, corrects the path-resolution bug (the `$HOME/share` vs `$HOME/.local/share` expansion flagged in review), de-duplicates the directory resolution across both install paths, and extends the fix to Windows and the gateway messaging.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? **No**
- If `No`, why: the final implementation is a distinct rewrite (shared helper, dry-run guard, Windows parity, message changes); #7302's diff was not taken verbatim. Attribution is credited here and on the superseded PR rather than via a commit trailer.
