### PR TITLE
feat(config): declarative section grouping for the Config menu

### DIFF
--- a/apps/zerocode/src/client.rs
+++ b/apps/zerocode/src/client.rs
@@ -1332,6 +1332,12 @@ pub struct ConfigSectionEntry {
     pub label: String,
     pub help: String,
     pub completed: bool,
+    /// Display group label (`"Foundation"`, `"Tools"`, …) from
+    /// `zeroclaw_config::sections::SectionGroup::label()`. Empty when
+    /// the daemon predates group plumbing — the sections pane falls
+    /// back to the flat ungrouped list.
+    #[serde(default)]
+    pub group: String,
     #[serde(default)]
     pub shape: Option<SectionShape>,
 }

--- a/apps/zerocode/src/config_manager.rs
+++ b/apps/zerocode/src/config_manager.rs
@@ -269,6 +269,10 @@ pub(crate) struct App {
     last_section_pane_area: Rect,
     last_section_list_area: Rect,
     last_list_offset: usize,
+    /// Draw-time map of section-pane display rows to `sections` indices.
+    /// `None` rows are group headers; mouse clicks resolve through this
+    /// so headers are dead zones instead of off-by-N selections.
+    last_section_rows: Vec<Option<usize>>,
     last_tab_area: Option<Rect>,
     double_click: crate::mouse::DoubleClickTracker,
 }
@@ -322,6 +326,7 @@ impl App {
             last_section_pane_area: Rect::default(),
             last_section_list_area: Rect::default(),
             last_list_offset: 0,
+            last_section_rows: Vec::new(),
             last_tab_area: None,
             double_click: crate::mouse::DoubleClickTracker::new(),
         }
@@ -330,6 +335,13 @@ impl App {
     /// Load initial data from the daemon. Call once before draw/handle_key.
     pub(crate) async fn init(&mut self) -> Result<()> {
         self.sections = self.rpc.config_sections().await?;
+        // Group the section list for display: stable sort by group rank
+        // keeps the canonical (dependency-correct) order within each
+        // group. Daemons that predate group plumbing send "" for every
+        // entry — all ranks tie, the sort is a no-op, and the pane
+        // renders the flat list exactly as before.
+        self.sections
+            .sort_by_key(|s| Self::group_rank(&s.group));
         self.templates = self.rpc.config_templates().await?;
         // Eagerly load the first section so the right pane previews content on
         // first paint, matching the zerocode Config tab.
@@ -2667,6 +2679,30 @@ impl App {
     /// Persistent left pane: the section list. `active` is true while the
     /// SectionList screen holds focus (bright highlight); once a section is
     /// entered the list dims to a "you are here" marker.
+    /// Display rank of a section-group label. Mirror of
+    /// `zeroclaw_config::sections::SECTION_GROUPS` — zerocode talks to
+    /// remote daemons over the wire, so like the dashboard's
+    /// `GROUP_ORDER` (web/src/pages/Config.tsx) it carries its own copy
+    /// of the order instead of linking the config crate. Unknown and
+    /// empty labels rank with "Other" so nothing ever vanishes.
+    fn group_rank(label: &str) -> usize {
+        const ORDER: &[&str] = &[
+            "Foundation",
+            "Agent",
+            "Multi-agent",
+            "Tools",
+            "Integrations",
+            "Network",
+            "Storage",
+            "Operations",
+            "Other",
+        ];
+        ORDER
+            .iter()
+            .position(|g| *g == label)
+            .unwrap_or(ORDER.len() - 1)
+    }
+
     fn draw_sections_pane(&mut self, frame: &mut Frame, area: Rect, active: bool) {
         use ratatui::layout::{Constraint, Direction, Layout};
         // Reserve one line at the top for the filter bar when filtering.
@@ -2690,24 +2726,48 @@ impl App {
         let labels: Vec<String> = self.sections.iter().map(|s| s.label.clone()).collect();
         let visible = self.filtered_indices(&labels);
 
-        let items: Vec<ListItem> = visible
-            .iter()
-            .map(|&i| {
-                let s = &self.sections[i];
-                let badge = if s.completed { " ✓" } else { "" };
-                ListItem::new(Line::from(Span::styled(
-                    format!("{}{badge}", s.label),
-                    theme::body_style(),
-                )))
-            })
-            .collect();
+        // Grouped display: dim header rows between groups, sections
+        // beneath. Active only when the daemon sent group labels and no
+        // filter narrows the list — filtering and old daemons render the
+        // flat all-sections list unchanged. `row_map` records what each
+        // display row is so the cursor and mouse hit-testing resolve
+        // through it instead of assuming row == section position.
+        let grouped = self.filter.is_none() && self.sections.iter().any(|s| !s.group.is_empty());
+        let mut row_map: Vec<Option<usize>> = Vec::with_capacity(visible.len());
+        let mut items: Vec<ListItem> = Vec::with_capacity(visible.len());
+        let mut last_group: Option<&str> = None;
+        for &i in &visible {
+            let s = &self.sections[i];
+            if grouped {
+                let group = if s.group.is_empty() {
+                    "Other"
+                } else {
+                    s.group.as_str()
+                };
+                if last_group != Some(group) {
+                    items.push(ListItem::new(Line::from(Span::styled(
+                        group.to_string(),
+                        theme::dim_style().add_modifier(Modifier::BOLD),
+                    ))));
+                    row_map.push(None);
+                    last_group = Some(group);
+                }
+            }
+            let badge = if s.completed { " ✓" } else { "" };
+            let indent = if grouped { " " } else { "" };
+            items.push(ListItem::new(Line::from(Span::styled(
+                format!("{indent}{}{badge}", s.label),
+                theme::body_style(),
+            ))));
+            row_map.push(Some(i));
+        }
 
         let cursor = if self.filter.is_some() {
             self.filter_cursor
         } else {
-            visible
+            row_map
                 .iter()
-                .position(|&i| i == self.section_cursor)
+                .position(|r| *r == Some(self.section_cursor))
                 .unwrap_or(0)
         };
 
@@ -2732,6 +2792,7 @@ impl App {
         );
         self.last_main_area = list_area;
         self.last_section_list_area = list_area;
+        self.last_section_rows = row_map;
         self.last_list_offset = state.offset();
         self.last_tab_area = None;
     }

--- a/apps/zerocode/src/config_manager.rs
+++ b/apps/zerocode/src/config_manager.rs
@@ -273,6 +273,11 @@ pub(crate) struct App {
     /// `None` rows are group headers; mouse clicks resolve through this
     /// so headers are dead zones instead of off-by-N selections.
     last_section_rows: Vec<Option<usize>>,
+    /// Scroll offset of the section-pane list at last draw. Dedicated to
+    /// the sections pane (not the shared `last_list_offset`, which the
+    /// right-pane draws overwrite) so a click on a scrolled section list
+    /// maps to the right row in any screen.
+    last_section_list_offset: usize,
     last_tab_area: Option<Rect>,
     double_click: crate::mouse::DoubleClickTracker,
 }
@@ -327,6 +332,7 @@ impl App {
             last_section_list_area: Rect::default(),
             last_list_offset: 0,
             last_section_rows: Vec::new(),
+            last_section_list_offset: 0,
             last_tab_area: None,
             double_click: crate::mouse::DoubleClickTracker::new(),
         }
@@ -626,7 +632,7 @@ impl App {
                     if let Some(pos) = mouse::list_click_index(
                         mouse.row,
                         self.last_section_list_area,
-                        0,
+                        self.last_section_list_offset,
                         self.last_section_rows.len(),
                     ) && let Some(&Some(orig)) = self.last_section_rows.get(pos)
                     {
@@ -2792,6 +2798,7 @@ impl App {
         self.last_section_list_area = list_area;
         self.last_section_rows = row_map;
         self.last_list_offset = state.offset();
+        self.last_section_list_offset = state.offset();
         self.last_tab_area = None;
     }
 

--- a/apps/zerocode/src/config_manager.rs
+++ b/apps/zerocode/src/config_manager.rs
@@ -620,17 +620,16 @@ impl App {
                 }
 
                 // Section pane click: select the clicked section, return focus to
-                // the left pane, and preview that section on the right.
+                // the left pane, and preview that section on the right. Display
+                // rows resolve through the draw-time `last_section_rows` map so
+                // group headers are dead zones rather than off-by-N selections.
                 if mouse::in_rect(mouse.column, mouse.row, self.last_section_pane_area) {
-                    let labels: Vec<String> =
-                        self.sections.iter().map(|s| s.label.clone()).collect();
-                    let visible = self.filtered_indices(&labels);
                     if let Some(pos) = mouse::list_click_index(
                         mouse.row,
                         self.last_section_list_area,
                         0,
-                        visible.len(),
-                    ) && let Some(&orig) = visible.get(pos)
+                        self.last_section_rows.len(),
+                    ) && let Some(&Some(orig)) = self.last_section_rows.get(pos)
                     {
                         self.section_cursor = orig;
                     }

--- a/apps/zerocode/src/config_manager.rs
+++ b/apps/zerocode/src/config_manager.rs
@@ -340,8 +340,7 @@ impl App {
         // group. Daemons that predate group plumbing send "" for every
         // entry — all ranks tie, the sort is a no-op, and the pane
         // renders the flat list exactly as before.
-        self.sections
-            .sort_by_key(|s| Self::group_rank(&s.group));
+        self.sections.sort_by_key(|s| Self::group_rank(&s.group));
         self.templates = self.rpc.config_templates().await?;
         // Eagerly load the first section so the right pane previews content on
         // first paint, matching the zerocode Config tab.

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -142,31 +142,37 @@ pub struct Config {
     /// Observability backend configuration (`[observability]`).
     #[serde(default)]
     #[nested]
+    #[group = "Operations"]
     pub observability: ObservabilityConfig,
 
     /// Trust scoring and regression detection configuration (`[trust]`).
     #[serde(default)]
     #[nested]
+    #[group = "Operations"]
     pub trust: crate::scattered_types::TrustConfig,
 
     /// Security subsystem configuration (`[security]`).
     #[serde(default)]
     #[nested]
+    #[group = "Operations"]
     pub security: SecurityConfig,
 
     /// Backup tool configuration (`[backup]`).
     #[serde(default)]
     #[nested]
+    #[group = "Operations"]
     pub backup: BackupConfig,
 
     /// Data retention and purge configuration (`[data_retention]`).
     #[serde(default)]
     #[nested]
+    #[group = "Operations"]
     pub data_retention: DataRetentionConfig,
 
     /// Cloud transformation accelerator configuration (`[cloud_ops]`).
     #[serde(default)]
     #[nested]
+    #[group = "Operations"]
     pub cloud_ops: CloudOpsConfig,
 
     /// Conversational AI agent builder configuration (`[conversational_ai]`).
@@ -177,31 +183,37 @@ pub struct Config {
     /// deserialize correctly thanks to `#[serde(default)]`.
     #[serde(default, skip_serializing_if = "ConversationalAiConfig::is_disabled")]
     #[nested]
+    #[group = "Operations"]
     pub conversational_ai: ConversationalAiConfig,
 
     /// Managed cybersecurity service configuration (`[security_ops]`).
     #[serde(default)]
     #[nested]
+    #[group = "Operations"]
     pub security_ops: SecurityOpsConfig,
 
     /// Runtime adapter configuration (`[runtime]`). Controls native vs Docker execution.
     #[serde(default)]
     #[nested]
+    #[group = "Agent"]
     pub runtime: RuntimeConfig,
 
     /// Reliability settings: retries, backoff, key rotation (`[reliability]`).
     #[serde(default)]
     #[nested]
+    #[group = "Agent"]
     pub reliability: ReliabilityConfig,
 
     /// Scheduler configuration for periodic task execution (`[scheduler]`).
     #[serde(default)]
     #[nested]
+    #[group = "Agent"]
     pub scheduler: SchedulerConfig,
 
     /// Pacing controls for slow/local LLM workloads (`[pacing]`).
     #[serde(default)]
     #[nested]
+    #[group = "Agent"]
     pub pacing: PacingConfig,
 
     /// Skills loading and community repository behavior (`[skills]`).
@@ -212,16 +224,19 @@ pub struct Config {
     /// Pipeline tool configuration (`[pipeline]`).
     #[serde(default)]
     #[nested]
+    #[group = "Agent"]
     pub pipeline: PipelineConfig,
 
     /// Automatic query classification — maps user messages to model hints.
     #[serde(default)]
     #[nested]
+    #[group = "Agent"]
     pub query_classification: QueryClassificationConfig,
 
     /// Heartbeat configuration for periodic health pings (`[heartbeat]`).
     #[serde(default)]
     #[nested]
+    #[group = "Agent"]
     pub heartbeat: HeartbeatConfig,
 
     /// Declarative cron jobs (`[cron.<alias>]`), alias-keyed.
@@ -236,6 +251,7 @@ pub struct Config {
     /// ACP (Agent Client Protocol) server configuration (`[acp]`).
     #[serde(default)]
     #[nested]
+    #[group = "Integrations"]
     pub acp: AcpConfig,
 
     /// Channel configurations: Telegram, Discord, Slack, etc. (`[channels]`).
@@ -261,6 +277,7 @@ pub struct Config {
     /// Gateway server configuration: host, port, pairing, rate limits (`[gateway]`).
     #[serde(default)]
     #[nested]
+    #[group = "Network"]
     pub gateway: GatewayConfig,
 
     /// WebSocket Secure (WSS) transport for remote TUI connections (`[wss]`).
@@ -271,6 +288,7 @@ pub struct Config {
     /// Composio managed OAuth tools integration (`[composio]`).
     #[serde(default)]
     #[nested]
+    #[group = "Integrations"]
     pub composio: ComposioConfig,
 
     /// Microsoft 365 Graph API integration (`[microsoft365]`).
@@ -281,11 +299,13 @@ pub struct Config {
     /// Secrets encryption configuration (`[secrets]`).
     #[serde(default)]
     #[nested]
+    #[group = "Storage"]
     pub secrets: SecretsConfig,
 
     /// Browser automation configuration (`[browser]`).
     #[serde(default)]
     #[nested]
+    #[group = "Tools"]
     pub browser: BrowserConfig,
 
     /// Browser delegation configuration (`[browser_delegate]`).
@@ -311,56 +331,67 @@ pub struct Config {
     /// Rollback/migration: remove `[browser_delegate]` or keep `enabled = false` to disable.
     #[serde(default)]
     #[nested]
+    #[group = "Tools"]
     pub browser_delegate: crate::scattered_types::BrowserDelegateConfig,
 
     /// HTTP request tool configuration (`[http_request]`).
     #[serde(default)]
     #[nested]
+    #[group = "Tools"]
     pub http_request: HttpRequestConfig,
 
     /// Multimodal (image) handling configuration (`[multimodal]`).
     #[serde(default)]
     #[nested]
+    #[group = "Tools"]
     pub multimodal: MultimodalConfig,
 
     /// Automatic media understanding pipeline (`[media_pipeline]`).
     #[serde(default)]
     #[nested]
+    #[group = "Tools"]
     pub media_pipeline: MediaPipelineConfig,
 
     /// Web fetch tool configuration (`[web_fetch]`).
     #[serde(default)]
     #[nested]
+    #[group = "Tools"]
     pub web_fetch: WebFetchConfig,
 
     /// Link enricher configuration (`[link_enricher]`).
     #[serde(default)]
     #[nested]
+    #[group = "Tools"]
     pub link_enricher: LinkEnricherConfig,
 
     /// Text browser tool configuration (`[text_browser]`).
     #[serde(default)]
     #[nested]
+    #[group = "Tools"]
     pub text_browser: TextBrowserConfig,
 
     /// Web search tool configuration (`[web_search]`).
     #[serde(default)]
     #[nested]
+    #[group = "Tools"]
     pub web_search: WebSearchConfig,
 
     /// Project delivery intelligence configuration (`[project_intel]`).
     #[serde(default)]
     #[nested]
+    #[group = "Tools"]
     pub project_intel: ProjectIntelConfig,
 
     /// Google Workspace CLI (`gws`) tool configuration (`[google_workspace]`).
     #[serde(default)]
     #[nested]
+    #[group = "Integrations"]
     pub google_workspace: GoogleWorkspaceConfig,
 
     /// Proxy configuration for outbound HTTP/HTTPS/SOCKS5 traffic (`[proxy]`).
     #[serde(default)]
     #[nested]
+    #[group = "Network"]
     pub proxy: ProxyConfig,
 
     /// Cost tracking and budget enforcement configuration (`[cost]`).
@@ -368,16 +399,19 @@ pub struct Config {
     /// `[cost.rates.<type>.<model>]`.
     #[serde(default)]
     #[nested]
+    #[group = "Operations"]
     pub cost: CostConfig,
 
     /// Peripheral board configuration for hardware integration (`[peripherals]`).
     #[serde(default)]
     #[nested]
+    #[group = "Operations"]
     pub peripherals: PeripheralsConfig,
 
     /// Delegate tool global default configuration (`[delegate]`).
     #[serde(default)]
     #[nested]
+    #[group = "Multi-agent"]
     pub delegate: DelegateToolConfig,
 
     /// Aliased agents in this install. Each entry under `[agents.<alias>]`
@@ -427,6 +461,7 @@ pub struct Config {
     /// Hooks configuration (lifecycle hooks and built-in hook toggles).
     #[serde(default)]
     #[nested]
+    #[group = "Agent"]
     pub hooks: HooksConfig,
 
     /// Hardware configuration (wizard-driven physical world setup).
@@ -437,11 +472,13 @@ pub struct Config {
     /// Voice transcription configuration (Whisper API via Groq).
     #[serde(default)]
     #[nested]
+    #[group = "Tools"]
     pub transcription: TranscriptionConfig,
 
     /// Text-to-Speech configuration (`[tts]`).
     #[serde(default)]
     #[nested]
+    #[group = "Tools"]
     pub tts: TtsConfig,
 
     /// External MCP server connections (`[mcp]`).
@@ -452,6 +489,7 @@ pub struct Config {
     /// Dynamic node discovery configuration (`[nodes]`).
     #[serde(default)]
     #[nested]
+    #[group = "Network"]
     pub nodes: NodesConfig,
 
     /// Meta-state for the Quickstart flow (which sections the user has
@@ -463,31 +501,37 @@ pub struct Config {
     /// Notion integration configuration (`[notion]`).
     #[serde(default)]
     #[nested]
+    #[group = "Integrations"]
     pub notion: NotionConfig,
 
     /// Jira integration configuration (`[jira]`).
     #[serde(default)]
     #[nested]
+    #[group = "Integrations"]
     pub jira: JiraConfig,
 
     /// Secure inter-node transport configuration (`[node_transport]`).
     #[serde(default)]
     #[nested]
+    #[group = "Network"]
     pub node_transport: NodeTransportConfig,
 
     /// Knowledge graph configuration (`[knowledge]`).
     #[serde(default)]
     #[nested]
+    #[group = "Tools"]
     pub knowledge: KnowledgeConfig,
 
     /// LinkedIn integration configuration (`[linkedin]`).
     #[serde(default)]
     #[nested]
+    #[group = "Integrations"]
     pub linkedin: LinkedInConfig,
 
     /// Standalone image generation tool configuration (`[image_gen]`).
     #[serde(default)]
     #[nested]
+    #[group = "Tools"]
     pub image_gen: ImageGenConfig,
 
     /// Standalone file upload tool configuration (`[file_upload]`).
@@ -509,6 +553,7 @@ pub struct Config {
     /// Plugin system configuration (`[plugins]`).
     #[serde(default)]
     #[nested]
+    #[group = "Tools"]
     pub plugins: PluginsConfig,
 
     /// Locale for tool descriptions (e.g. `"en"`, `"zh-CN"`).
@@ -525,41 +570,49 @@ pub struct Config {
     /// Verifiable Intent (VI) credential verification and issuance (`[verifiable_intent]`).
     #[serde(default)]
     #[nested]
+    #[group = "Agent"]
     pub verifiable_intent: VerifiableIntentConfig,
 
     /// Claude Code tool configuration (`[claude_code]`).
     #[serde(default)]
     #[nested]
+    #[group = "Integrations"]
     pub claude_code: ClaudeCodeConfig,
 
     /// Claude Code task runner with Slack progress and SSH session handoff (`[claude_code_runner]`).
     #[serde(default)]
     #[nested]
+    #[group = "Integrations"]
     pub claude_code_runner: ClaudeCodeRunnerConfig,
 
     /// Codex CLI tool configuration (`[codex_cli]`).
     #[serde(default)]
     #[nested]
+    #[group = "Integrations"]
     pub codex_cli: CodexCliConfig,
 
     /// Gemini CLI tool configuration (`[gemini_cli]`).
     #[serde(default)]
     #[nested]
+    #[group = "Integrations"]
     pub gemini_cli: GeminiCliConfig,
 
     /// OpenCode CLI tool configuration (`[opencode_cli]`).
     #[serde(default)]
     #[nested]
+    #[group = "Integrations"]
     pub opencode_cli: OpenCodeCliConfig,
 
     /// Standard Operating Procedures engine configuration (`[sop]`).
     #[serde(default)]
     #[nested]
+    #[group = "Agent"]
     pub sop: SopConfig,
 
     /// Shell tool configuration (`[shell_tool]`).
     #[serde(default)]
     #[nested]
+    #[group = "Tools"]
     pub shell_tool: ShellToolConfig,
 
     /// Escalation routing configuration (`[escalation]`).

--- a/crates/zeroclaw-config/src/sections.rs
+++ b/crates/zeroclaw-config/src/sections.rs
@@ -88,6 +88,16 @@ impl SectionGroup {
             Self::Other => "Other",
         }
     }
+
+    /// Inverse of [`label`](Self::label): parse a group label string
+    /// back into the enum, or `None` for an unrecognized label. The
+    /// bridge for `#[group = "..."]` attributes resolved through the
+    /// schema — the derive emits the label as a string the macro can't
+    /// type-check, so this validates it on the way back in.
+    #[must_use]
+    pub fn from_label(label: &str) -> Option<Self> {
+        SECTION_GROUPS.iter().copied().find(|g| g.label() == label)
+    }
 }
 
 impl std::fmt::Display for SectionGroup {
@@ -112,60 +122,34 @@ pub const SECTION_GROUPS: &[SectionGroup] = &[
     SectionGroup::Other,
 ];
 
-/// Display group for any section key. Curated [`Section`]s read the
-/// `group:` cell of their `sections!` row; everything else — the
-/// schema-derived top-level `Config` roots the section explorer
-/// surfaces without a curated row — is hand-mapped here. This match
-/// moved from the gateway (`api_sections.rs`) so the dashboard, the
-/// RPC `config/sections` handler, and the TUI all read one table.
-/// Unknown keys fall into [`SectionGroup::Other`] so new schema
-/// additions still surface — they just land in the catch-all bucket
-/// until someone curates them.
+/// Display group for any section key. Two declarative sources, no
+/// hand-maintained table:
+///
+/// 1. Curated [`Section`]s read the `group:` cell of their `sections!`
+///    row.
+/// 2. The long tail of top-level `Config` roots the section explorer
+///    surfaces without a curated row declares its group inline via
+///    `#[group = "..."]`, harvested by the `Configurable` derive into
+///    [`crate::schema::Config::nested_section_group`]. This mirrors how
+///    [`section_help`] falls through to `Config::nested_section_help`.
+///
+/// Unknown keys — and roots whose `#[group]` label fails to parse — fall
+/// into [`SectionGroup::Other`] so new schema additions still surface;
+/// they just land in the catch-all bucket until someone annotates them.
+/// The `every_surfaced_root_has_a_group` test guards against a real root
+/// silently landing there.
 #[must_use]
 pub fn section_group_for_key(key: &str) -> SectionGroup {
     if let Some(s) = Section::from_key(key) {
         return s.group();
     }
-    match key.replace('-', "_").as_str() {
-        // Agent loop, scheduling, and orchestration.
-        "agent"
-        | "heartbeat"
-        | "hooks"
-        | "pacing"
-        | "pipeline"
-        | "query_classification"
-        | "reliability"
-        | "runtime"
-        | "scheduler"
-        | "sop"
-        | "verifiable_intent" => SectionGroup::Agent,
-        // Multi-agent / delegation.
-        "delegate" => SectionGroup::MultiAgent,
-        // Tool integrations.
-        "browser" | "browser_delegate" | "http_request" | "image_gen" | "knowledge"
-        | "link_enricher" | "media_pipeline" | "multimodal" | "plugins" | "project_intel"
-        | "shell_tool" | "text_browser" | "transcription" | "tts" | "web_fetch" | "web_search" => {
-            SectionGroup::Tools
-        }
-        // External services / vendor integrations. ACP is included
-        // because it is always client-paired — you cannot use it
-        // without a client.
-        "acp" | "claude_code" | "claude_code_runner" | "codex_cli" | "composio" | "gemini_cli"
-        | "google_workspace" | "jira" | "linkedin" | "notion" | "opencode_cli" => {
-            SectionGroup::Integrations
-        }
-        // Networking / multi-node infrastructure.
-        "gateway" | "node_transport" | "nodes" | "proxy" => SectionGroup::Network,
-        // Storage, identity, secrets. (`storage` itself is a curated
-        // row and resolves above.)
-        "identity" | "secrets" => SectionGroup::Storage,
-        // Operations / monitoring / safety / cost.
-        "backup" | "cloud_ops" | "conversational_ai" | "cost" | "data_retention"
-        | "observability" | "peripherals" | "security" | "security_ops" | "trust" => {
-            SectionGroup::Operations
-        }
-        _ => SectionGroup::Other,
-    }
+    // `nested_section_group` arms are keyed kebab-case (the derive runs
+    // each field name through `snake_to_kebab`). Section keys reaching
+    // here may be either spelling, so try as-is then kebab-normalized.
+    crate::schema::Config::nested_section_group(key)
+        .or_else(|| crate::schema::Config::nested_section_group(&key.replace('_', "-")))
+        .and_then(SectionGroup::from_label)
+        .unwrap_or(SectionGroup::Other)
 }
 
 /// Humanize a section wire key for display (`risk_profiles` → `Risk profiles`,
@@ -939,6 +923,105 @@ mod tests {
         assert_eq!(section_group_for_key("secrets"), SectionGroup::Storage);
         // Unknown keys land in the catch-all, never disappear.
         assert_eq!(section_group_for_key("not_a_section"), SectionGroup::Other);
+    }
+
+    /// Drift guard for the schema-attribute grouping: every top-level
+    /// config root the section explorer can surface must resolve to a
+    /// real [`SectionGroup`], not the `Other` catch-all — either through
+    /// the `sections!` table (curated rows) or a `#[group = "..."]`
+    /// annotation harvested into `Config::nested_section_group`.
+    ///
+    /// This is what makes grouping declarative-by-construction: add a
+    /// new top-level `#[nested]` section without a group and this test
+    /// fails, naming the root, rather than the section silently landing
+    /// in `Other`. A root that genuinely has no curated group yet goes
+    /// in `UNGROUPED` with intent; `HIDDEN` covers system roots the
+    /// explorer never shows.
+    #[test]
+    fn every_surfaced_root_has_a_group() {
+        use crate::schema::Config;
+        let cfg = Config::default();
+        let roots: std::collections::BTreeSet<String> = cfg
+            .prop_fields()
+            .iter()
+            .filter_map(|f| f.name.split('.').next().map(str::to_string))
+            .collect();
+
+        // System/bookkeeping root the explorer hides; resolved at
+        // runtime, never user-edited, so intentionally ungrouped.
+        const HIDDEN: &[&str] = &["schema_version"];
+
+        // Roots with no curated group yet: they render in the `Other`
+        // bucket. Pre-existing — ungrouped before grouping moved into
+        // the schema. Annotating one with `#[group]` (e.g. `microsoft365`
+        // and the `file_*` tool sections are obvious candidates) means
+        // removing it from this list. The assertions below keep the list
+        // honest: every entry must still be a real, still-ungrouped root.
+        const UNGROUPED: &[&str] = &[
+            "escalation",
+            "locale",
+            "microsoft365",
+            "model_routes",
+            "embedding_routes",
+            "file_upload",
+            "file_upload_bundle",
+            "file_download",
+            "wss",
+        ];
+
+        let violations: Vec<&String> = roots
+            .iter()
+            .filter(|r| !HIDDEN.contains(&r.as_str()) && !UNGROUPED.contains(&r.as_str()))
+            .filter(|r| section_group_for_key(r) == SectionGroup::Other)
+            .collect();
+        assert!(
+            violations.is_empty(),
+            "these surfaced config roots resolve to SectionGroup::Other — add a \
+             `#[group = \"...\"]` to each in schema.rs (or, if intentionally \
+             uncurated, to the UNGROUPED allowlist): {violations:?}",
+        );
+
+        // Keep the allowlist from rotting: each entry must still be a
+        // surfaced root and still ungrouped.
+        for u in UNGROUPED {
+            assert!(
+                roots.contains(*u),
+                "UNGROUPED lists `{u}` but it is no longer a surfaced root — remove it",
+            );
+            assert_eq!(
+                section_group_for_key(u),
+                SectionGroup::Other,
+                "`{u}` now resolves to a real group — remove it from UNGROUPED",
+            );
+        }
+    }
+
+    /// The regression roots that the pre-migration gateway hand-list
+    /// grouped must still resolve the same way through the schema
+    /// attributes — pins that the move from hand-list to `#[group]`
+    /// didn't silently drop any of them back into `Other`.
+    #[test]
+    fn migrated_hand_list_roots_keep_their_groups() {
+        let expected = [
+            ("claude_code", SectionGroup::Integrations),
+            ("codex_cli", SectionGroup::Integrations),
+            ("gemini_cli", SectionGroup::Integrations),
+            ("opencode_cli", SectionGroup::Integrations),
+            ("sop", SectionGroup::Agent),
+            ("verifiable_intent", SectionGroup::Agent),
+            ("shell_tool", SectionGroup::Tools),
+            ("observability", SectionGroup::Operations),
+            ("gateway", SectionGroup::Network),
+            ("delegate", SectionGroup::MultiAgent),
+            ("secrets", SectionGroup::Storage),
+        ];
+        for (key, group) in expected {
+            assert_eq!(
+                section_group_for_key(key),
+                group,
+                "`{key}` should resolve to {group:?} via its #[group] attribute",
+            );
+        }
     }
 
     /// Storage help must steer first-time operators toward SQLite as the

--- a/crates/zeroclaw-config/src/sections.rs
+++ b/crates/zeroclaw-config/src/sections.rs
@@ -143,11 +143,14 @@ pub fn section_group_for_key(key: &str) -> SectionGroup {
     if let Some(s) = Section::from_key(key) {
         return s.group();
     }
-    // `nested_section_group` arms are keyed kebab-case (the derive runs
-    // each field name through `snake_to_kebab`). Section keys reaching
-    // here may be either spelling, so try as-is then kebab-normalized.
+    // `nested_section_group` arms are keyed by the Rust field ident,
+    // i.e. snake_case (the derive's `snake_to_kebab` is currently an
+    // identity passthrough). Section keys reaching here are snake too
+    // (the RPC/gateway pass `prop_fields()` first segments), so the
+    // direct lookup hits; tolerate a kebab-spelled caller by normalizing
+    // back to snake, matching `Section::from_key`'s leniency.
     crate::schema::Config::nested_section_group(key)
-        .or_else(|| crate::schema::Config::nested_section_group(&key.replace('_', "-")))
+        .or_else(|| crate::schema::Config::nested_section_group(&key.replace('-', "_")))
         .and_then(SectionGroup::from_label)
         .unwrap_or(SectionGroup::Other)
 }
@@ -921,6 +924,15 @@ mod tests {
         assert_eq!(section_group_for_key("delegate"), SectionGroup::MultiAgent);
         assert_eq!(section_group_for_key("web_search"), SectionGroup::Tools);
         assert_eq!(section_group_for_key("secrets"), SectionGroup::Storage);
+        // Kebab spelling of a SCHEMA-grouped (non-curated) root resolves
+        // through the kebab→snake fallback to the snake-keyed
+        // `nested_section_group` arm. (`web_search`/`data_retention` are
+        // schema `#[group]` fields, not curated `sections!` rows.)
+        assert_eq!(section_group_for_key("web-search"), SectionGroup::Tools);
+        assert_eq!(
+            section_group_for_key("data-retention"),
+            SectionGroup::Operations
+        );
         // Unknown keys land in the catch-all, never disappear.
         assert_eq!(section_group_for_key("not_a_section"), SectionGroup::Other);
     }

--- a/crates/zeroclaw-config/src/sections.rs
+++ b/crates/zeroclaw-config/src/sections.rs
@@ -128,17 +128,25 @@ pub fn section_group_for_key(key: &str) -> SectionGroup {
     }
     match key.replace('-', "_").as_str() {
         // Agent loop, scheduling, and orchestration.
-        "agent" | "heartbeat" | "hooks" | "pacing" | "pipeline" | "query_classification"
-        | "reliability" | "runtime" | "scheduler" | "sop" | "verifiable_intent" => {
-            SectionGroup::Agent
-        }
+        "agent"
+        | "heartbeat"
+        | "hooks"
+        | "pacing"
+        | "pipeline"
+        | "query_classification"
+        | "reliability"
+        | "runtime"
+        | "scheduler"
+        | "sop"
+        | "verifiable_intent" => SectionGroup::Agent,
         // Multi-agent / delegation.
         "delegate" => SectionGroup::MultiAgent,
         // Tool integrations.
         "browser" | "browser_delegate" | "http_request" | "image_gen" | "knowledge"
         | "link_enricher" | "media_pipeline" | "multimodal" | "plugins" | "project_intel"
-        | "shell_tool" | "text_browser" | "transcription" | "tts" | "web_fetch"
-        | "web_search" => SectionGroup::Tools,
+        | "shell_tool" | "text_browser" | "transcription" | "tts" | "web_fetch" | "web_search" => {
+            SectionGroup::Tools
+        }
         // External services / vendor integrations. ACP is included
         // because it is always client-paired — you cannot use it
         // without a client.
@@ -841,7 +849,11 @@ mod tests {
                 "{g:?} missing from SECTION_GROUPS",
             );
         }
-        assert_eq!(SECTION_GROUPS.len(), all.len(), "duplicate group in SECTION_GROUPS");
+        assert_eq!(
+            SECTION_GROUPS.len(),
+            all.len(),
+            "duplicate group in SECTION_GROUPS"
+        );
         assert_eq!(
             SECTION_GROUPS.last(),
             Some(&SectionGroup::Other),
@@ -895,18 +907,33 @@ mod tests {
     #[test]
     fn section_group_for_key_resolves_curated_tail_and_unknown() {
         // Curated rows, including former gap sections.
-        assert_eq!(section_group_for_key("providers.models"), SectionGroup::Foundation);
-        assert_eq!(section_group_for_key("providers.tts"), SectionGroup::Foundation);
+        assert_eq!(
+            section_group_for_key("providers.models"),
+            SectionGroup::Foundation
+        );
+        assert_eq!(
+            section_group_for_key("providers.tts"),
+            SectionGroup::Foundation
+        );
         assert_eq!(section_group_for_key("mcp.servers"), SectionGroup::Tools);
         assert_eq!(section_group_for_key("mcp_bundles"), SectionGroup::Tools);
-        assert_eq!(section_group_for_key("knowledge_bundles"), SectionGroup::Tools);
+        assert_eq!(
+            section_group_for_key("knowledge_bundles"),
+            SectionGroup::Tools
+        );
         assert_eq!(section_group_for_key("cron"), SectionGroup::Agent);
         assert_eq!(section_group_for_key("storage"), SectionGroup::Storage);
         // Kebab spelling resolves like snake.
-        assert_eq!(section_group_for_key("peer-groups"), SectionGroup::Foundation);
+        assert_eq!(
+            section_group_for_key("peer-groups"),
+            SectionGroup::Foundation
+        );
         // Hand-mapped long tail (formerly in the gateway).
         assert_eq!(section_group_for_key("gateway"), SectionGroup::Network);
-        assert_eq!(section_group_for_key("observability"), SectionGroup::Operations);
+        assert_eq!(
+            section_group_for_key("observability"),
+            SectionGroup::Operations
+        );
         assert_eq!(section_group_for_key("delegate"), SectionGroup::MultiAgent);
         assert_eq!(section_group_for_key("web_search"), SectionGroup::Tools);
         assert_eq!(section_group_for_key("secrets"), SectionGroup::Storage);

--- a/crates/zeroclaw-config/src/sections.rs
+++ b/crates/zeroclaw-config/src/sections.rs
@@ -3,11 +3,11 @@
 //! a working ZeroClaw deployment.
 //!
 //! Every fact about a section (its enum variant, its on-the-wire key,
-//! its UI shape, its help blurb, its canonical position) lives in ONE
-//! table — the `sections!` invocation below. The macro expands that
-//! table into the [`Section`] enum, every per-variant `match` helper,
-//! and the [`QUICKSTART_SECTIONS`] const, so adding a section is exactly
-//! one row, no hand-listed variant set anywhere else.
+//! its UI shape, its display group, its help blurb, its canonical
+//! position) lives in ONE table — the `sections!` invocation below. The
+//! macro expands that table into the [`Section`] enum, every per-variant
+//! `match` helper, and the [`QUICKSTART_SECTIONS`] const, so adding a
+//! section is exactly one row, no hand-listed variant set anywhere else.
 //!
 //! Consumers (CLI runtime, gateway, dashboard) dispatch off this enum;
 //! drift is a compile error.
@@ -33,6 +33,131 @@ pub enum SectionShape {
     /// flips a top-level field, then the schema form for the chosen
     /// backend/provider renders.
     BackendPicker,
+}
+
+/// Display group for the Config menu. Every curated [`Section`] row
+/// names one in its `group:` cell; the long tail of schema-derived
+/// top-level roots (`gateway`, `observability`, …) that surface in the
+/// section explorer without a curated row resolves through
+/// [`section_group_for_key`]. [`SECTION_GROUPS`] fixes the display
+/// order across every surface.
+///
+/// `Other` is the catch-all: unknown keys land there so new schema
+/// additions still surface in the menu until someone curates them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum SectionGroup {
+    /// Quickstart-walked essentials: providers, profiles, channels,
+    /// agents — the most-edited sections, surfaced first.
+    Foundation,
+    /// Agent loop, scheduling, and orchestration tuning.
+    Agent,
+    /// Multi-agent / delegation.
+    MultiAgent,
+    /// Tool integrations the agent can call.
+    Tools,
+    /// External services / vendor integrations.
+    Integrations,
+    /// Networking / multi-node infrastructure.
+    Network,
+    /// Storage, identity, secrets.
+    Storage,
+    /// Operations / monitoring / safety / cost.
+    Operations,
+    /// Catch-all for keys no one has curated yet.
+    Other,
+}
+
+impl SectionGroup {
+    /// UI label. These exact strings are what `ConfigSectionEntry.group`
+    /// carries on the wire and what the dashboard's `GROUP_ORDER`
+    /// (web/src/pages/Config.tsx) and the zerocode Config pane group
+    /// by — change one, change all of them together.
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Foundation => "Foundation",
+            Self::Agent => "Agent",
+            Self::MultiAgent => "Multi-agent",
+            Self::Tools => "Tools",
+            Self::Integrations => "Integrations",
+            Self::Network => "Network",
+            Self::Storage => "Storage",
+            Self::Operations => "Operations",
+            Self::Other => "Other",
+        }
+    }
+}
+
+impl std::fmt::Display for SectionGroup {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.label())
+    }
+}
+
+/// Canonical display order for section groups across every Config
+/// surface (dashboard sidebar, zerocode Config pane). "All sections"
+/// is not a group — a surface that offers a flat default view renders
+/// that view itself; this list orders the grouped presentation.
+pub const SECTION_GROUPS: &[SectionGroup] = &[
+    SectionGroup::Foundation,
+    SectionGroup::Agent,
+    SectionGroup::MultiAgent,
+    SectionGroup::Tools,
+    SectionGroup::Integrations,
+    SectionGroup::Network,
+    SectionGroup::Storage,
+    SectionGroup::Operations,
+    SectionGroup::Other,
+];
+
+/// Display group for any section key. Curated [`Section`]s read the
+/// `group:` cell of their `sections!` row; everything else — the
+/// schema-derived top-level `Config` roots the section explorer
+/// surfaces without a curated row — is hand-mapped here. This match
+/// moved from the gateway (`api_sections.rs`) so the dashboard, the
+/// RPC `config/sections` handler, and the TUI all read one table.
+/// Unknown keys fall into [`SectionGroup::Other`] so new schema
+/// additions still surface — they just land in the catch-all bucket
+/// until someone curates them.
+#[must_use]
+pub fn section_group_for_key(key: &str) -> SectionGroup {
+    if let Some(s) = Section::from_key(key) {
+        return s.group();
+    }
+    match key.replace('-', "_").as_str() {
+        // Agent loop, scheduling, and orchestration.
+        "agent" | "heartbeat" | "hooks" | "pacing" | "pipeline" | "query_classification"
+        | "reliability" | "runtime" | "scheduler" | "sop" | "verifiable_intent" => {
+            SectionGroup::Agent
+        }
+        // Multi-agent / delegation.
+        "delegate" => SectionGroup::MultiAgent,
+        // Tool integrations.
+        "browser" | "browser_delegate" | "http_request" | "image_gen" | "knowledge"
+        | "link_enricher" | "media_pipeline" | "multimodal" | "plugins" | "project_intel"
+        | "shell_tool" | "text_browser" | "transcription" | "tts" | "web_fetch"
+        | "web_search" => SectionGroup::Tools,
+        // External services / vendor integrations. ACP is included
+        // because it is always client-paired — you cannot use it
+        // without a client.
+        "acp" | "claude_code" | "claude_code_runner" | "codex_cli" | "composio" | "gemini_cli"
+        | "google_workspace" | "jira" | "linkedin" | "notion" | "opencode_cli" => {
+            SectionGroup::Integrations
+        }
+        // Networking / multi-node infrastructure.
+        "gateway" | "node_transport" | "nodes" | "proxy" => SectionGroup::Network,
+        // Storage, identity, secrets. (`storage` itself is a curated
+        // row and resolves above.)
+        "identity" | "secrets" => SectionGroup::Storage,
+        // Operations / monitoring / safety / cost.
+        "backup" | "cloud_ops" | "conversational_ai" | "cost" | "data_retention"
+        | "observability" | "peripherals" | "security" | "security_ops" | "trust" => {
+            SectionGroup::Operations
+        }
+        _ => SectionGroup::Other,
+    }
 }
 
 /// Humanize a section wire key for display (`risk_profiles` → `Risk profiles`,
@@ -74,6 +199,7 @@ macro_rules! sections {
             $var:ident => {
                 key:   $key:literal,
                 shape: $shape:ident,
+                group: $group:ident,
                 help:  $help:expr $(,)?
             }
         ),+ $(,)?
@@ -118,6 +244,18 @@ macro_rules! sections {
             pub const fn shape(self) -> SectionShape {
                 match self {
                     $( Self::$var => SectionShape::$shape, )+
+                }
+            }
+
+            /// Display group for the Config menu — the bucket this
+            /// section renders under in the dashboard sidebar and the
+            /// zerocode Config pane. Read the `group:` cell of the
+            /// `sections!` row; the long tail of non-curated section
+            /// keys resolves through [`section_group_for_key`] instead.
+            #[must_use]
+            pub const fn group(self) -> SectionGroup {
+                match self {
+                    $( Self::$var => SectionGroup::$group, )+
                 }
             }
 
@@ -198,6 +336,7 @@ sections! {
     ModelProviders => {
         key:   "providers.models",
         shape: TypedFamilyMap,
+        group: Foundation,
         help:  "Pick a model provider to configure (Anthropic, OpenAI, OpenRouter, \
                 Ollama, custom OpenAI-compatible gateways, etc.). Multiple aliases per \
                 provider are supported — e.g. anthropic.production and anthropic.dev \
@@ -210,12 +349,14 @@ sections! {
     RiskProfiles => {
         key:   "risk_profiles",
         shape: OneTierAliasMap,
+        group: Foundation,
         help:  "Named risk profiles binding allowlists, denylists, and approval \
                 thresholds. Agents reference one via `agents.<alias>.risk_profile`.",
     },
     RuntimeProfiles => {
         key:   "runtime_profiles",
         shape: OneTierAliasMap,
+        group: Foundation,
         help:  "Named runtime tuning profiles (token limits, retry policy, timeouts). \
                 Agents reference one via `agents.<alias>.runtime_profile`.",
     },
@@ -225,6 +366,7 @@ sections! {
     Storage => {
         key:   "storage",
         shape: TypedFamilyMap,
+        group: Storage,
         help:  "SQLite is the safe default for single-node installs (file-based, \
                 zero-config, no extra services). Pick Postgres for shared or \
                 multi-instance deployments, Qdrant for vector search, Markdown or \
@@ -234,6 +376,7 @@ sections! {
     Memory => {
         key:   "memory",
         shape: BackendPicker,
+        group: Foundation,
         help:  "Persistent memory backend. SQLite is the default; pick `none` to \
                 disable long-term recall entirely.",
     },
@@ -243,6 +386,7 @@ sections! {
     Skills => {
         key:   "skills",
         shape: DirectForm,
+        group: Foundation,
         help:  "Skills tool settings — where skill markdown lives on disk (defaults \
                 to the data dir), and how the skills loader handles community \
                 repositories. Add skill BUNDLES under `skill-bundles` below.",
@@ -250,18 +394,21 @@ sections! {
     SkillBundles => {
         key:   "skill_bundles",
         shape: OneTierAliasMap,
+        group: Foundation,
         help:  "Named bundles of skill files. Agents reference a bundle to load a \
                 set of capabilities at startup.",
     },
     Mcp => {
         key:   "mcp",
         shape: DirectForm,
+        group: Tools,
         help:  "Model Context Protocol settings. Toggle `enabled` and pick deferred \
                 or eager loading. Individual MCP servers live under `mcp.servers[]`.",
     },
     McpServers => {
         key:   "mcp.servers",
         shape: OneTierAliasMap,
+        group: Tools,
         help:  "Individual Model Context Protocol servers. Each entry binds a \
                 transport (stdio, http, sse), the command or URL to reach it, \
                 optional headers, and a `tool_timeout_secs` cap (≤ 600). Each \
@@ -272,12 +419,14 @@ sections! {
     McpBundles => {
         key:   "mcp_bundles",
         shape: OneTierAliasMap,
+        group: Tools,
         help:  "Named bundles of MCP servers. Agents reference a bundle to pull in \
                 a set of MCP tools as one unit.",
     },
     KnowledgeBundles => {
         key:   "knowledge_bundles",
         shape: OneTierAliasMap,
+        group: Tools,
         help:  "Named bundles of knowledge sources (RAG indexes, doc folders). Agents \
                 reference a bundle to surface relevant snippets at inference time.",
     },
@@ -286,12 +435,14 @@ sections! {
     TtsProviders => {
         key:   "providers.tts",
         shape: TypedFamilyMap,
+        group: Foundation,
         help:  "Text-to-speech providers (OpenAI, ElevenLabs, Google, Edge, Piper). \
                 Configure one per voice / language; agents reference them by alias.",
     },
     TranscriptionProviders => {
         key:   "providers.transcription",
         shape: TypedFamilyMap,
+        group: Foundation,
         help:  "Speech-to-text providers (OpenAI Whisper, Groq, Deepgram, AssemblyAI, \
                 Google, local Whisper). Configure one per pipeline; agents reference \
                 them by alias.",
@@ -302,12 +453,14 @@ sections! {
     Channels => {
         key:   "channels",
         shape: TypedFamilyMap,
+        group: Foundation,
         help:  "Pick which chat platforms ZeroClaw should listen on. You can \
                 configure multiple — each channel gets its own alias.",
     },
     Hardware => {
         key:   "hardware",
         shape: DirectForm,
+        group: Foundation,
         help:  "Optional: hardware peripherals (Arduino, STM32, GPIO, etc.). \
                 Skip if you don't need them.",
     },
@@ -320,6 +473,7 @@ sections! {
     Agents => {
         key:   "agents",
         shape: OneTierAliasMap,
+        group: Foundation,
         help:  "An agent binds a model provider, profiles, bundles, and channels \
                 into one dispatchable unit. Add one per persona; reuse the same \
                 alias across channels to share state.",
@@ -330,6 +484,7 @@ sections! {
     PeerGroups => {
         key:   "peer_groups",
         shape: OneTierAliasMap,
+        group: Foundation,
         help:  "Named groups binding a channel, member agents, and external peers. \
                 Mutual opt-in: two agents become peers only when both appear in the \
                 same group's `agents` list.",
@@ -337,6 +492,7 @@ sections! {
     Cron => {
         key:   "cron",
         shape: OneTierAliasMap,
+        group: Agent,
         help:  "Scheduled tasks. Each cron entry binds a schedule expression to a \
                 prompt, channel, and target.",
     },
@@ -346,6 +502,7 @@ sections! {
     Tunnel => {
         key:   "tunnel",
         shape: BackendPicker,
+        group: Foundation,
         help:  "Optional: expose your gateway over the public internet via Cloudflare \
                 or ngrok. Pick `none` to keep it localhost-only.",
     },
@@ -359,6 +516,7 @@ sections! {
     QuickstartState => {
         key:   "onboard_state",
         shape: DirectForm,
+        group: Operations,
         help:  "Quickstart lifecycle state. `quickstart_completed` flips to true \
                 once the Quickstart finishes a successful run; while false, the \
                 web gateway and TUI auto-launch the Quickstart on startup. \
@@ -646,6 +804,114 @@ mod tests {
                 "{downstream:?} references agents and must follow Agents in the canonical order",
             );
         }
+    }
+
+    /// Every variant of `SectionGroup` appears in `SECTION_GROUPS`
+    /// exactly once, and `Other` is last so the catch-all bucket
+    /// renders at the bottom of every grouped surface.
+    #[test]
+    fn section_groups_const_is_exhaustive_unique_and_other_last() {
+        // Exhaustiveness guard: adding a SectionGroup variant without
+        // updating this list (and SECTION_GROUPS) fails to compile here.
+        let all = [
+            SectionGroup::Foundation,
+            SectionGroup::Agent,
+            SectionGroup::MultiAgent,
+            SectionGroup::Tools,
+            SectionGroup::Integrations,
+            SectionGroup::Network,
+            SectionGroup::Storage,
+            SectionGroup::Operations,
+            SectionGroup::Other,
+        ];
+        for g in all {
+            match g {
+                SectionGroup::Foundation
+                | SectionGroup::Agent
+                | SectionGroup::MultiAgent
+                | SectionGroup::Tools
+                | SectionGroup::Integrations
+                | SectionGroup::Network
+                | SectionGroup::Storage
+                | SectionGroup::Operations
+                | SectionGroup::Other => {}
+            }
+            assert!(
+                SECTION_GROUPS.contains(&g),
+                "{g:?} missing from SECTION_GROUPS",
+            );
+        }
+        assert_eq!(SECTION_GROUPS.len(), all.len(), "duplicate group in SECTION_GROUPS");
+        assert_eq!(
+            SECTION_GROUPS.last(),
+            Some(&SectionGroup::Other),
+            "Other must render last in every grouped surface",
+        );
+    }
+
+    /// Group labels are a wire contract: the dashboard's `GROUP_ORDER`
+    /// (web/src/pages/Config.tsx) and the zerocode Config pane match
+    /// these exact strings from `ConfigSectionEntry.group`. Renaming a
+    /// label means updating those consumers in the same change.
+    #[test]
+    fn group_labels_are_pinned_for_ui_compat() {
+        let expected = [
+            "Foundation",
+            "Agent",
+            "Multi-agent",
+            "Tools",
+            "Integrations",
+            "Network",
+            "Storage",
+            "Operations",
+            "Other",
+        ];
+        for (g, want) in SECTION_GROUPS.iter().zip(expected) {
+            assert_eq!(g.label(), want);
+            assert_eq!(g.to_string(), want);
+        }
+    }
+
+    /// Every curated section resolves to a real bucket — `Other` exists
+    /// only for the uncurated long tail, so a curated row landing there
+    /// means someone forgot to pick a group for a new section.
+    #[test]
+    fn curated_sections_never_fall_into_other() {
+        for s in QUICKSTART_SECTIONS {
+            assert_ne!(
+                s.group(),
+                SectionGroup::Other,
+                "Section::{s:?} needs a real group in its sections! row",
+            );
+        }
+    }
+
+    /// `section_group_for_key` resolves curated rows through the table
+    /// (both snake and kebab spellings), hand-mapped long-tail roots
+    /// through the match, and unknown keys into `Other`. Pins the gap
+    /// fixes that motivated moving grouping into this crate: the MCP
+    /// and provider sub-sections used to fall into `Other` in the
+    /// gateway's hand-list.
+    #[test]
+    fn section_group_for_key_resolves_curated_tail_and_unknown() {
+        // Curated rows, including former gap sections.
+        assert_eq!(section_group_for_key("providers.models"), SectionGroup::Foundation);
+        assert_eq!(section_group_for_key("providers.tts"), SectionGroup::Foundation);
+        assert_eq!(section_group_for_key("mcp.servers"), SectionGroup::Tools);
+        assert_eq!(section_group_for_key("mcp_bundles"), SectionGroup::Tools);
+        assert_eq!(section_group_for_key("knowledge_bundles"), SectionGroup::Tools);
+        assert_eq!(section_group_for_key("cron"), SectionGroup::Agent);
+        assert_eq!(section_group_for_key("storage"), SectionGroup::Storage);
+        // Kebab spelling resolves like snake.
+        assert_eq!(section_group_for_key("peer-groups"), SectionGroup::Foundation);
+        // Hand-mapped long tail (formerly in the gateway).
+        assert_eq!(section_group_for_key("gateway"), SectionGroup::Network);
+        assert_eq!(section_group_for_key("observability"), SectionGroup::Operations);
+        assert_eq!(section_group_for_key("delegate"), SectionGroup::MultiAgent);
+        assert_eq!(section_group_for_key("web_search"), SectionGroup::Tools);
+        assert_eq!(section_group_for_key("secrets"), SectionGroup::Storage);
+        // Unknown keys land in the catch-all, never disappear.
+        assert_eq!(section_group_for_key("not_a_section"), SectionGroup::Other);
     }
 
     /// Storage help must steer first-time operators toward SQLite as the

--- a/crates/zeroclaw-gateway/src/api_sections.rs
+++ b/crates/zeroclaw-gateway/src/api_sections.rs
@@ -464,52 +464,18 @@ const HIDDEN_TOP_LEVEL: &[&str] = &[
     "pre_override_snapshots",
 ];
 
-/// Display group for a section. Hand-curated until v3 / #5947 lands a
-/// schema attribute that encodes grouping declaratively. Unknown keys
-/// fall into `Other` so new schema additions still surface — they just
-/// land in the catch-all bucket until someone curates them.
+/// Display group for a section. Delegates to
+/// `zeroclaw_config::sections::section_group_for_key` — grouping lives
+/// in the `sections!` table (curated rows) plus its long-tail map, so
+/// the dashboard, the RPC `config/sections` handler, and the TUI all
+/// read one source. Unknown keys fall into `Other` so new schema
+/// additions still surface — they just land in the catch-all bucket
+/// until someone curates them.
 ///
 /// Group order in the dashboard sidebar is governed by the frontend (see
-/// `Config.tsx`), not this list.
+/// `Config.tsx`), mirroring `zeroclaw_config::sections::SECTION_GROUPS`.
 fn section_group(key: &str) -> &'static str {
-    match key {
-        "providers.models" | "channels" | "memory" | "hardware" | "tunnel" | "agents"
-        | "skills" | "skill_bundles" | "risk_profiles" | "runtime_profiles" | "peer_groups" => {
-            "Foundation"
-        }
-        // Agent loop, scheduling, and orchestration.
-        "agent"
-        | "cron"
-        | "heartbeat"
-        | "hooks"
-        | "pacing"
-        | "pipeline"
-        | "query_classification"
-        | "reliability"
-        | "runtime"
-        | "scheduler"
-        | "sop"
-        | "verifiable_intent" => "Agent",
-        // Multi-agent / delegation.
-        "delegate" => "Multi-agent",
-        // Tool integrations.
-        "browser" | "browser_delegate" | "http_request" | "image_gen" | "knowledge"
-        | "link_enricher" | "mcp" | "media_pipeline" | "multimodal" | "plugins"
-        | "project_intel" | "shell_tool" | "text_browser" | "transcription" | "tts"
-        | "web_fetch" | "web_search" => "Tools",
-        // External services / vendor integrations. ACP is included because
-        // it is always client-paired — you cannot use it without a client.
-        "acp" | "claude_code" | "claude_code_runner" | "codex_cli" | "composio" | "gemini_cli"
-        | "google_workspace" | "jira" | "linkedin" | "notion" | "opencode_cli" => "Integrations",
-        // Networking / multi-node infrastructure.
-        "gateway" | "node_transport" | "nodes" | "proxy" => "Network",
-        // Storage, identity, secrets.
-        "identity" | "secrets" | "storage" => "Storage",
-        // Operations / monitoring / safety / cost.
-        "backup" | "cloud_ops" | "conversational_ai" | "cost" | "data_retention"
-        | "observability" | "peripherals" | "security" | "security_ops" | "trust" => "Operations",
-        _ => "Other",
-    }
+    zeroclaw_config::sections::section_group_for_key(key).label()
 }
 
 /// Help text for a section. Delegates to `zeroclaw_config::sections::section_help`

--- a/crates/zeroclaw-macros/src/lib.rs
+++ b/crates/zeroclaw-macros/src/lib.rs
@@ -129,7 +129,8 @@ fn has_serde_meta(field: &syn::Field, ident: &str) -> bool {
         resource_key,
         credential_class,
         natural_key,
-        tab
+        tab,
+        group
     )
 )]
 pub fn derive_configurable(input: TokenStream) -> TokenStream {
@@ -222,6 +223,12 @@ pub fn derive_configurable(input: TokenStream) -> TokenStream {
     // schema's `///` on `pub gateway: GatewayConfig` describes the
     // section's role in this Config, which is what the operator needs.
     let mut nested_section_help_arms: Vec<proc_macro2::TokenStream> = Vec::new();
+    // Parallel to `nested_section_help_arms`: each `#[nested]` field that
+    // carries a `#[group = "..."]` annotation contributes one arm to the
+    // generated `nested_section_group(name)` lookup. This is what lets
+    // the section explorer resolve a top-level config root's display
+    // group from the schema itself instead of a hand-maintained table.
+    let mut nested_section_group_arms: Vec<proc_macro2::TokenStream> = Vec::new();
 
     // Static enumeration of every `#[secret]` field's terminal name
     // reachable from this Configurable type. Direct `#[secret]` fields
@@ -432,6 +439,11 @@ pub fn derive_configurable(input: TokenStream) -> TokenStream {
                 if !field_doc.is_empty() {
                     nested_section_help_arms.push(quote! {
                         #field_name_lit => Some(#field_doc),
+                    });
+                }
+                if let Some(group) = extract_string_attr(&field.attrs, "group") {
+                    nested_section_group_arms.push(quote! {
+                        #field_name_lit => Some(#group),
                     });
                 }
 
@@ -1152,6 +1164,11 @@ pub fn derive_configurable(input: TokenStream) -> TokenStream {
                         #opt_field_name_lit => Some(#opt_field_doc),
                     });
                 }
+                if let Some(group) = extract_string_attr(&field.attrs, "group") {
+                    nested_section_group_arms.push(quote! {
+                        #opt_field_name_lit => Some(#group),
+                    });
+                }
                 let display_name_lit = extract_string_attr(&field.attrs, "display_name")
                     .unwrap_or_else(|| snake_to_title(&field_name_str));
                 let description_lit =
@@ -1336,6 +1353,11 @@ pub fn derive_configurable(input: TokenStream) -> TokenStream {
                 if !field_doc.is_empty() {
                     nested_section_help_arms.push(quote! {
                         #vec_field_name_lit => Some(#field_doc),
+                    });
+                }
+                if let Some(group) = extract_string_attr(&field.attrs, "group") {
+                    nested_section_group_arms.push(quote! {
+                        #vec_field_name_lit => Some(#group),
                     });
                 }
                 map_key_section_entries.push(quote! {
@@ -1780,6 +1802,11 @@ pub fn derive_configurable(input: TokenStream) -> TokenStream {
                 if !plain_field_doc.is_empty() {
                     nested_section_help_arms.push(quote! {
                         #plain_field_name_lit => Some(#plain_field_doc),
+                    });
+                }
+                if let Some(group) = extract_string_attr(&field.attrs, "group") {
+                    nested_section_group_arms.push(quote! {
+                        #plain_field_name_lit => Some(#group),
                     });
                 }
                 nested_collect.push(quote! {
@@ -2400,6 +2427,21 @@ pub fn derive_configurable(input: TokenStream) -> TokenStream {
             pub fn nested_section_help(name: &str) -> Option<&'static str> {
                 match name {
                     #(#nested_section_help_arms)*
+                    _ => None,
+                }
+            }
+
+            /// Display-group label for a `#[nested]` field on this struct,
+            /// sourced from its `#[group = "..."]` annotation. Returns
+            /// `None` for fields without the annotation (and for unknown
+            /// names) so callers can fall through to a different lookup —
+            /// the section explorer uses this to resolve a top-level
+            /// config root's group from the schema rather than a
+            /// hand-maintained table.
+            #[must_use]
+            pub fn nested_section_group(name: &str) -> Option<&'static str> {
+                match name {
+                    #(#nested_section_group_arms)*
                     _ => None,
                 }
             }

--- a/crates/zeroclaw-runtime/src/rpc/dispatch.rs
+++ b/crates/zeroclaw-runtime/src/rpc/dispatch.rs
@@ -2940,7 +2940,9 @@ impl RpcDispatcher {
                     has_picker,
                     completed,
                     ready: false,
-                    group: String::new(),
+                    group: zeroclaw_config::sections::section_group_for_key(&key)
+                        .label()
+                        .to_string(),
                     is_quickstart: wizard.is_some(),
                     shape: wizard.map(Section::shape),
                     label,


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Section grouping is now a declarative cell in the one `sections!` table in `zeroclaw-config`. Each curated section names its display group (`Foundation`, `Tools`, …) in a new `group:` row field; a `SectionGroup` enum + `SECTION_GROUPS` order const + `section_group_for_key()` live alongside it. This is the single source of truth the gateway dashboard, the RPC `config/sections` handler, and the zerocode TUI all read.
  - **Moved grouping out of the gateway.** The gateway's hand-curated `section_group()` match (flagged in-code as *"hand-curated until v3 / #5947 lands a schema attribute that encodes grouping declaratively"*) is now a one-line delegate to `zeroclaw_config::sections::section_group_for_key()`.
  - **Filled the gap in the RPC path.** `handle_config_sections` (the path zerocode uses) previously sent `group: ""` for every section, so the TUI had no grouping at all. It now fills the real group label.
  - **Grouped rendering in the zerocode Config pane.** The section list is stably group-sorted at load (canonical dependency order preserved within each group) and renders dim bold group headers between buckets. Filtering and daemons that send no group label fall back to the flat all-sections list unchanged. Mouse clicks resolve through a draw-time display-row map so group headers are dead zones, not off-by-N selections, and respect the list scroll offset.
  - **Fixed five mis-grouped sections.** `providers.tts`, `providers.transcription`, `mcp.servers`, `mcp_bundles`, and `knowledge_bundles` previously fell into the gateway's `Other` catch-all; they now resolve to `Foundation` / `Tools` like their siblings. This is the one observable behavior change for the existing web dashboard.
  - **Closes #5947 with a schema attribute (no hand-list left).** The long tail of top-level config roots no longer lives in any hand-maintained match. The `Configurable` derive now harvests a `#[group = "..."]` field attribute (at all four nested-field shapes) into a generated `Config::nested_section_group(name)`, mirroring how `nested_section_help` is harvested from field docstrings. The 45 long-tail roots (`observability`, `gateway`, `cost`, the tool sections, vendor integrations, …) declare their group inline on the field; `section_group_for_key` resolves curated rows via the `sections!` table and everything else via the harvested attribute, then `Other`. The 85-key match is deleted. A `every_surfaced_root_has_a_group` drift test enumerates real roots from `prop_fields()` and fails (naming the root) if a non-allowlisted one lands in `Other` — so a future section added without a group is a test failure, not a silent catch-all.
- **Scope boundary:** No new sections, fields, tools, channels, or agent capabilities. Grouping is display-only metadata; the set of configurable sections and their values is unchanged. Group assignments replicate the prior hand-list exactly (the migration restored 8 roots — `claude_code`/`claude_code_runner`/`codex_cli`/`gemini_cli`/`opencode_cli` → Integrations, `sop`/`verifiable_intent` → Agent, `shell_tool` → Tools — that a partial sweep would have dropped; the no-regression test pins them).
- **Blast radius:** `zeroclaw-macros` (the `#[group]` harvester), `zeroclaw-config` (`sections!` table + enum/helpers + field annotations on `Config`), `zeroclaw-gateway` (delegates), `zeroclaw-runtime` (RPC handler fills the field), `zerocode` (TUI rendering + wire mirror). Group **labels** are byte-identical to what the gateway already emitted, so the web dashboard's `GROUP_ORDER` (`web/src/pages/Config.tsx`) needs no change. The macro change is additive (new generated method + helper attr); all existing `Configurable` structs compile unchanged.
- **Linked issue(s):** Closes #5947 (declarative section grouping via a schema attribute). Grouping is now declarative end-to-end: curated rows in the `sections!` table, the long tail on `#[group]` field attributes, zero hand-maintained mapping.
- **Known follow-up (intentionally out of scope):** `microsoft365` and the `file_upload`/`file_upload_bundle`/`file_download` tool sections are obvious grouping candidates (Integrations / Tools) but were left ungrouped (allowlisted) to keep this a faithful refactor — one-line `#[group]` each when someone wants them curated. Also ungrouped today: `escalation`, `locale`, `model_routes`, `embedding_routes`, `wss`.
- **Labels:** suggested `type: feature`, `risk: low`, `size: M` (maintainers set risk/size).

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` → clean (exit 0)
  - `cargo clippy --all-targets -- -D warnings` → **full workspace, 0 warnings / 0 errors** (`Finished` in 1m49s)
  - `cargo test` → **could not complete: `error: No space left on device (os error 28)`** while compiling test binaries — the build disk (`/opt/cargo-build`, 196G) hit 100%. Environment limit, not a code failure. Scoped suites for every touched crate pass on the same tree:
    - `cargo test -p zeroclaw-config --lib` → `ok. 834 passed; 0 failed` (incl. 12 `sections::` tests)
    - `cargo test -p zeroclaw-gateway api_sections` → `ok. 18 passed; 0 failed`
    - `cargo test -p zerocode` → `ok. 339 passed; 0 failed`
    - `cargo check -p zeroclawlabs --bin zeroclaw` → compiles (macro re-expands over every `Configurable` struct)
- **New tests (zeroclaw-config `sections::`):** `section_groups_const_is_exhaustive_unique_and_other_last`; `group_labels_are_pinned_for_ui_compat` (labels pinned as a wire contract vs the web `GROUP_ORDER`/TUI); `curated_sections_never_fall_into_other`; `every_surfaced_root_has_a_group` (drift guard — enumerates real roots from `prop_fields()`, fails naming any non-allowlisted root that resolves to `Other`); `migrated_hand_list_roots_keep_their_groups` (no-regression pin); plus kebab/snake resolution cases.
- **Beyond CI — manual verification:** Built `zeroclaw` + `zerocode` and ran `zerocode --config-dir <throwaway>` (auto-spawns the sibling daemon). Config pane shows Foundation first, then Agent/Tools/Integrations/Network/Storage/Operations with dim headers; `/` filter collapses to the flat list and restores on clear; clicking a header is a no-op while clicking a section selects exactly that row.
- **If any command was intentionally skipped, why:** the full-workspace `cargo test` aborted on `No space left on device` (build-disk full), not a test/compile error. `fmt` and `clippy --all-targets -D warnings` complete clean over the whole workspace; the per-crate suites above cover all touched code. CI will run the full battery on clean infra.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No` — secret masking in `ConfigFieldEntry::from_prop_field` is untouched.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: _(n/a)_

## Compatibility (required)

- Backward compatible? `Yes` — wire-compatible in both directions. The new `group` field has `#[serde(default)]`: a new zerocode against an old daemon receives `""` and renders the flat list; an old client against a new daemon ignores the extra field.
- Config / env / CLI surface changed? `No` — no new config keys, no on-disk format change. Grouping is derived metadata.
- If `No` or `Yes` to either: exact upgrade steps for existing users: None. To see grouping in the TUI, the daemon must be rebuilt and restarted (SIGTERM) so it emits `group`; until then the TUI shows the unchanged flat list.

## Rollback

- **Fast rollback command/path:** `git revert` (low risk — display/metadata only, additive field).
- **Feature flags or config toggles:** `None`. Grouping auto-disables (flat list) whenever the daemon sends no group labels, so a daemon-only rollback degrades the client gracefully.
- **Observable failure symptoms:** Worst case is cosmetic — sections render flat/ungrouped, or a section lands in the wrong group bucket. No effect on config values, picker dispatch, or editing.

## Design notes for reviewers

- **"Default all-sections view":** inline group headers over the full flat list (the default view still shows every section), not a drill-in group menu. The data layer (`SECTION_GROUPS`, per-entry `group`) supports a drill-in variant if preferred — contained follow-up in `draw_sections_pane`.
- **Two copies of the group order, by design:** `zeroclaw-config::sections::SECTION_GROUPS` is canonical. The web (`GROUP_ORDER` in `Config.tsx`) and the TUI (`group_rank` in `config_manager.rs`) each carry their own copy because they're wire clients of a remote daemon, not linkers of the crate — matching the existing dashboard pattern. `group_labels_are_pinned_for_ui_compat` guards drift.
- **Why `#[group]` carries a string, not a `SectionGroup`:** the derive macro lives in `zeroclaw-macros` and can't name `SectionGroup` (defined in `zeroclaw-config`, which depends on the macro — naming it would invert the dependency). So `nested_section_group` returns `Option<&'static str>` (the label, like `nested_section_help`) and `SectionGroup::from_label` validates the string on the way back in. A typo'd label resolves to `Other` and is caught by the drift test rather than at compile time — the one trade-off versus a compile-checked enum.

## Supersede Attribution

_(not applicable)_
