### PR TITLE
fix(channels/slack): make empty-peer-set rejections self-diagnosing

### DIFF
--- a/crates/zeroclaw-channels/src/slack.rs
+++ b/crates/zeroclaw-channels/src/slack.rs
@@ -3215,13 +3215,26 @@ impl SlackChannel {
                 if user.is_empty() || user == bot_user_id {
                     continue;
                 }
-                if !self.is_user_allowed(user) {
+                let allowed_peers = (self.peer_resolver)();
+                if !crate::allowlist::is_user_allowed(
+                    &allowed_peers,
+                    user,
+                    crate::allowlist::Match::Sensitive,
+                ) {
                     ::zeroclaw_log::record!(
                         WARN,
                         ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
                             .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                            .with_attrs(::serde_json::json!({"user": user})),
-                        "ignoring message from unauthorized user"
+                            .with_attrs(::serde_json::json!({
+                                "user": user,
+                                "alias": self.alias,
+                                "allowed_peer_count": allowed_peers.len(),
+                            })),
+                        if allowed_peers.is_empty() {
+                            "ignoring message: no peers resolved for this channel — add a [peer_groups.<name>] with channel = \"slack.<alias>\" and external_peers (use [\"*\"] to allow everyone)"
+                        } else {
+                            "ignoring message from unauthorized user"
+                        }
                     );
                     continue;
                 }
@@ -4361,7 +4374,12 @@ impl Channel for SlackChannel {
                         }
 
                         // Sender validation
-                        if !self.is_user_allowed(user) {
+                        let allowed_peers = (self.peer_resolver)();
+                        if !crate::allowlist::is_user_allowed(
+                            &allowed_peers,
+                            user,
+                            crate::allowlist::Match::Sensitive,
+                        ) {
                             ::zeroclaw_log::record!(
                                 WARN,
                                 ::zeroclaw_log::Event::new(
@@ -4369,8 +4387,16 @@ impl Channel for SlackChannel {
                                     ::zeroclaw_log::Action::Note
                                 )
                                 .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                                .with_attrs(::serde_json::json!({"user": user})),
-                                "ignoring message from unauthorized user"
+                                .with_attrs(::serde_json::json!({
+                                    "user": user,
+                                    "alias": self.alias,
+                                    "allowed_peer_count": allowed_peers.len(),
+                                })),
+                                if allowed_peers.is_empty() {
+                                    "ignoring message: no peers resolved for this channel — add a [peer_groups.<name>] with channel = \"slack.<alias>\" and external_peers (use [\"*\"] to allow everyone)"
+                                } else {
+                                    "ignoring message from unauthorized user"
+                                }
                             );
                             continue;
                         }
@@ -4954,6 +4980,19 @@ mod tests {
             Arc::new(|| vec!["*".into()]),
         );
         assert!(ch.is_user_allowed("U12345"));
+    }
+
+    #[test]
+    fn explicit_user_peer_is_allowed() {
+        let ch = SlackChannel::new(
+            "xoxb-fake".into(),
+            None,
+            vec![],
+            "slack_test_alias",
+            Arc::new(|| vec!["U01EXAMPLE".into()]),
+        );
+        assert!(ch.is_user_allowed("U01EXAMPLE"));
+        assert!(!ch.is_user_allowed("U99OTHER"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - The Socket Mode rejection WARN (`slack.rs`) said only `ignoring message from unauthorized user` with the user ID. That hides the one distinction an operator needs: an **empty resolved peer set** (no `[peer_groups]` block matches this channel, so every user is denied) versus a populated allowlist that legitimately excludes the sender. The reporter hit the empty-set case and had to read the source to reverse-engineer the `is_user_allowed -> peer_resolver -> channel_external_peers -> [peer_groups]` chain.
  - On current `master` the resolution path is correct: `channel_external_peers("slack", "<alias>")` matches a `channel = "slack.<alias>"` peer group and `is_user_allowed` short-circuits the `"*"` wildcard. I verified this in isolation (a direct `Config` with a `slack.my-channel` group + `external_peers = ["*"]` resolves to `["*"]`), and the existing `wildcard_allows_everyone` / `empty_allowlist_denies_everyone` tests already pin the allowlist logic. The actionable defect is the diagnostic: an empty peer set is the most common cause and was undetectable from logs.
  - Resolve the peer set once at each rejection site, add the channel `alias` and `allowed_peer_count` to the WARN attrs, and when the set is empty emit a message naming the `[peer_groups.<name>]` block, the `channel = "slack.<alias>"` key, and `external_peers` (including the `["*"]` allow-all form). Added a regression test pinning explicit-user allow / non-listed deny.
- **Scope boundary:** Only the two Slack rejection WARN sites (Socket Mode and the sibling inbound path) and a test. No change to allowlist semantics, peer resolution, or wiring. The thread-reply fast path that intentionally stays silent is untouched.
- **Blast radius:** Slack inbound rejection logging only. No behavioral change to which messages are accepted.
- **Linked issue(s):** Closes #6992
- **Labels:** `bug`, `channel`, `channel:slack`, `risk: medium`, `priority:p1`, `size: S`

## Validation Evidence (required)

\`\`\`bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
\`\`\`

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` -> clean (exit 0)
  - `cargo clippy -p zeroclaw-channels --features channel-slack --lib -- -D warnings` -> `Finished`, 0 warnings
  - `cargo test -p zeroclaw-channels --features channel-slack --lib slack::tests::` -> allowlist suite green incl. new `explicit_user_peer_is_allowed`, existing `wildcard_allows_everyone` and `empty_allowlist_denies_everyone`
- **Beyond CI — what did you manually verify?** Built a `Config` with `[peer_groups.my-group] channel = "slack.my-channel" external_peers = ["*"]` and confirmed `channel_external_peers("slack", "my-channel")` returns `["*"]` and the wildcard short-circuit admits any user — i.e. the documented repro resolves correctly on current `master`. The remaining gap, and what this PR fixes, is that an empty peer set (the actual failure mode, e.g. a peer group keyed to the wrong channel ref) produced an undiagnosable rejection.
- **If any command was intentionally skipped, why:** full-workspace `cargo test` not run end-to-end here; CI runs the full battery.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No` — tests use synthetic Slack user IDs.

## Compatibility (required)

- Backward compatible? `Yes` — log-message and attribute change only; acceptance logic unchanged.
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: exact upgrade steps for existing users: None.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <sha>`
- **Feature flags or config toggles:** `None`.
- **Observable failure symptoms:** N/A — diagnostic-only change. If reverted, an empty-peer-set rejection again logs only `ignoring message from unauthorized user` with no peer count.