### PR TITLE
fix(docs): add .nojekyll so Pages serves _shared/ chrome

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -206,6 +206,13 @@ jobs:
           # or GitHub Pages will remove it (re-introduced fix from #6142).
           echo "docs.zeroclawlabs.ai" > CNAME
 
+          # Disable Jekyll. Pages runs Jekyll by default, which drops every
+          # top-level underscore-prefixed dir (`_shared/`) from the served
+          # site — so the shared chrome (CSS/JS/favicons) 404s on every page
+          # while non-underscore paths serve fine. Re-assert each deploy, same
+          # as CNAME, so a tree rewrite can never silently re-enable Jekyll.
+          touch .nojekyll
+
           SCRIPTS="${GITHUB_WORKSPACE}/.workflow-scripts/.github/scripts"
 
           # Shared chrome (_shared/) is owned by master only. Every deployed
@@ -290,6 +297,7 @@ jobs:
             fi
 
             echo "docs.zeroclawlabs.ai" > CNAME
+            touch .nojekyll
             cargo run --manifest-path "${GITHUB_WORKSPACE}/.workflow-scripts/Cargo.toml" -p xtask --bin mdbook -- gen-versions > versions.json
             cargo run --manifest-path "${GITHUB_WORKSPACE}/.workflow-scripts/Cargo.toml" -p xtask --bin mdbook -- prune-root
             cargo run --manifest-path "${GITHUB_WORKSPACE}/.workflow-scripts/Cargo.toml" -p xtask --bin mdbook -- retrofit-selector


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:** The published docs site lost all chrome (sidebar, theme palette, layout, custom overrides, favicons) because every page references absolute-root `/_shared/` assets that 404 on the live site. The `_shared/` tree is correctly present on `gh-pages` — the break is GitHub Pages itself: Pages runs Jekyll by default, and Jekyll excludes every top-level underscore-prefixed directory from the served output, so `_shared/` is silently dropped while non-underscore paths (`master/en/...`) serve fine. This adds `touch .nojekyll` on every `gh-pages` push, alongside the existing `CNAME` re-assert, on both the initial sync and the push-retry path. A tracked `.nojekyll` at the root disables Jekyll and serves the tree verbatim; re-asserting each run means a tree rewrite or orphan rebuild can never silently re-enable Jekyll and regress the chrome again.
- **Scope boundary:** Does not touch the chrome-extraction logic, `_shared` reference-depth math, theme generation, or any xtask code. Workflow-only, one file.
- **Blast radius:** `docs-deploy.yml` only. No runtime, channel, provider, library, or build-tool code changed.
- **Linked issue(s):** none
- **Labels:** `docs`, `type: docs`, `risk: low`, `size: S`

## Validation Evidence (required)

Workflow-only change. Validated the live fix end-to-end and the YAML.

```bash
# applied .nojekyll to live gh-pages, then verified every _shared asset:
for f in css/chrome.css theme/pc-themes.css theme/custom.css \
         theme/version-selector.js theme/pc-enhance.js theme/lang-switcher.js \
         favicon.svg favicon.png; do
  curl -s -o /dev/null -w "$f -> %{http_code}\n" "https://docs.zeroclawlabs.ai/_shared/$f"
done
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/docs-deploy.yml'))"
```

- **Commands run and tail output:**
  - Before fix: `_shared/css/chrome.css -> 404` (all eight `_shared/*` assets 404; `master/en/css/general-*.css -> 200`)
  - After pushing `.nojekyll` to `gh-pages`: all eight `_shared/*` assets `-> 200`; `master/en/sop/example.html -> 200`
  - `python3 ... yaml.safe_load(...)` → `YAML OK`
- **Beyond CI — what did you manually verify?** Cloned `gh-pages` and confirmed `_shared/` was fully populated on the branch (chrome.css, pc-themes.css, custom.css, all theme JS, favicons) while every `_shared/` URL 404d on the live site and non-underscore paths served 200 — isolating the cause to Jekyll dropping the underscore dir, not a missing/empty tree. Applied the one-line `.nojekyll` fix to live `gh-pages` and re-verified all assets serve 200. Did NOT run a full multi-locale `mdbook build` (requires the mdbook toolchain in CI); this change is workflow shell only and does not alter the build.
- **If any command was intentionally skipped, why:** The Rust battery (`fmt`/`clippy`/`test`) is N/A — no Rust changed. The diff is a 2-line shell addition to one workflow file.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: exact upgrade steps for existing users: none.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk: `git revert <sha>`. Reverting only re-enables Jekyll on the next deploy; the live `gh-pages` already carries a tracked `.nojekyll` independent of this workflow change.

## Incident attribution — what broke the live docs

Two distinct regressions surfaced together, both originating from the versioned-docs deploy system introduced in **#7023** (`feat(docs): implement versioned documentation deployment and version selector`, commit `40be7738f3`, merged 2026-06-03).

1. **Chrome 404 (this PR fixes it).** Every page references absolute-root `/_shared/` assets. The `_shared/` tree is published to `gh-pages` correctly, but GitHub Pages runs Jekyll by default and Jekyll excludes top-level underscore-prefixed directories from the served site, so `_shared/` is silently dropped. #7023 introduced the `_shared/` layout without a `.nojekyll`. Fixed here by re-asserting `.nojekyll` on every deploy.

2. **Pinned version dirs wiped (separate latent bug, not fixed by this PR).** docs-deploy run **27461126807** (push of `fix(install)...` to master, 2026-06-13 08:14:07 UTC) took the orphan-branch path in `docs-deploy.yml` (lines 162-174: `git switch --orphan gh-pages` + `git rm -rf .`) even though `gh-pages` already existed. The run committed only the current `master/` build from an empty tree (`8758 files changed, 1264001 insertions(+)`) and force-replaced the branch as unrelated history (`* [new branch] gh-pages -> gh-pages`). This destroyed `stable/` and every `v0.x.x/` version dir. The current `gh-pages` root commit `115f181e3b` is parentless, confirming the wipe. The 12:20 UTC run found master unchanged and made no further change (`nothing to commit`), so the branch has carried only `master/` since 08:14 UTC.

The orphan-path trigger in #7023's deploy script is tracked separately and is **out of scope for this PR** — this PR ships only the `.nojekyll` chrome fix. The wiped version dirs need recovery from the orphaned `gh-pages` history or a rebuild from release tags.
