### PR TITLE
feat(obs): instrument runtime memory ops with OTel GenAI spans

### DIFF
--- a/CHANGELOG-next.md
+++ b/CHANGELOG-next.md
@@ -71,6 +71,19 @@ Guided agent creation end to end: pick a provider, paste a key, choose a model f
 
 The daemon's structured log stream, filterable and attribution-aware, in the same terminal you work in.
 
+### Observability
+
+- **OTel memory and RAG observability** — every agent turn now produces visible
+  `memory.recall`, `memory.store`, and `rag.retrieve` spans plus five OTel meter
+  instruments (`zeroclaw.memory.recall.{count,duration}`, `zeroclaw.memory.store.count`,
+  `zeroclaw.rag.retrieve.{count,duration}`). The recall/retrieve spans set
+  `gen_ai.operation.name = "retrieval"` and carry a scrubbed/truncated `query_summary`
+  on `input.value`; the store span uses `db.system` / `db.operation = "INSERT"`. These
+  are partial GenAI-compatible attributes: `SpanKind::Internal` is used, and span names
+  are `memory.recall` / `rag.retrieve` / `memory.store` for compatibility with the
+  existing ZeroClaw / Langfuse retrieval views. New spans and instruments live behind
+  the existing `observability-otel` feature gate (#6190).
+
 ### Providers
 
 - [New providers](https://docs.zeroclawlabs.ai/master/en/providers/catalog.html): Kilo AI Gateway, GitHub Models (#6445), Morph (#6440), Manifest (#6268), atomic-chat (#6513), a dedicated llama.cpp provider (#6417), seven more OpenAI-compatible providers (#7260), and MiniMax split into Global and China entries (#6758).
@@ -122,6 +135,8 @@ For those tracking the beta line, the 184 commits since beta-2 concentrate on st
 - **[Schema V3](https://docs.zeroclawlabs.ai/master/en/reference/config.html)** (#6398): configs migrate automatically on first load. Profile settings are split between runtime behavior and risk policy, cost rates are reorganized per provider, and scheduled jobs must name the agent they run as.
 - **[Lean default channel bundle](https://docs.zeroclawlabs.ai/master/en/channels/overview.html)** (#6904): prebuilt binaries ship a core channel set; social channels move to opt-in build features.
 - **[Logging](https://docs.zeroclawlabs.ai/master/en/architecture/logging.html)** (#6398 train): the legacy trace-event path is retired in favor of the unified structured logging pipeline; third-party logging macros are banned workspace-wide.
+- **Observer events** (#6190): `zeroclaw_api::observability::ObserverEvent` is now `#[non_exhaustive]` and adds `MemoryRecall`, `MemoryStore`, and `RagRetrieve`. Out-of-tree observers that exhaustively match events must add a wildcard arm.
+- **Memory observability hook** (#6190): `MemoryStrategy::load_context` now receives an observer reference so the runtime can emit `MemoryRecall` events at the implicit recall boundary. Out-of-tree strategy implementations must update their signature; implementations that do not emit observability can ignore the parameter.
 
 ## Contributors
 

--- a/crates/zeroclaw-api/src/memory_traits.rs
+++ b/crates/zeroclaw-api/src/memory_traits.rs
@@ -433,7 +433,12 @@ pub trait Memory: Send + Sync + crate::attribution::Attributable {
 #[async_trait]
 pub trait MemoryStrategy: Send + Sync {
     /// Load and format relevant memory context for a conversation turn.
-    async fn load_context(&self, query: &str, session_id: Option<&str>) -> anyhow::Result<String>;
+    async fn load_context(
+        &self,
+        observer: &dyn crate::observability_traits::Observer,
+        query: &str,
+        session_id: Option<&str>,
+    ) -> anyhow::Result<String>;
 
     /// Consolidate a conversation turn into long-term memory.
     async fn consolidate_turn(

--- a/crates/zeroclaw-api/src/observability_traits.rs
+++ b/crates/zeroclaw-api/src/observability_traits.rs
@@ -13,7 +13,13 @@ pub struct TurnTokenUsage {
 /// aggregate, or forward to external monitoring systems. Events carry
 /// just enough context for tracing and diagnostics without exposing
 /// sensitive prompt or response content.
+///
+/// Marked `#[non_exhaustive]` so out-of-tree observer implementations
+/// degrade gracefully when new variants are added in future minor
+/// releases — they must include a wildcard arm in their `match`
+/// expressions and will simply ignore unknown event kinds.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum ObserverEvent {
     /// The agent orchestration loop has started a new session.
     AgentStart {
@@ -102,6 +108,54 @@ pub enum ObserverEvent {
         channel: Option<String>,
         agent_alias: Option<String>,
         turn_id: Option<String>,
+    },
+    /// A memory recall (search) operation has completed.
+    ///
+    /// Emitted at the runtime boundary after a hybrid-search query against
+    /// the brain DB. Carries an optional `query_summary` for diagnostics —
+    /// scrubbed and truncated user text, not a privacy-clean token. The
+    /// runtime applies `scrub_credentials` first and then truncates to ≤200
+    /// content chars (with a 3-char `...` ellipsis appended when truncation
+    /// occurred); short non-credential queries pass through unchanged.
+    MemoryRecall {
+        /// Scrubbed and truncated query summary. `None` when the caller has
+        /// no meaningful query to record (e.g., session-scoped fetches).
+        query_summary: Option<String>,
+        duration: Duration,
+        /// Number of `MemoryEntry` rows returned by the recall call.
+        num_entries: usize,
+        /// Bounded backend identifier (e.g. `"sqlite"`, `"qdrant"`, `"none"`).
+        backend: String,
+        success: bool,
+    },
+    /// A memory store (write) operation has completed.
+    ///
+    /// Emitted after persisting a memory entry. Carries only bounded
+    /// fields — the raw memory `key` is intentionally omitted because
+    /// keys can encode high-cardinality identifiers (UUIDs, phone
+    /// numbers, message timestamps) that would blow up Prometheus label
+    /// series.
+    MemoryStore {
+        /// Memory category (`"core"`, `"daily"`, `"conversation"`, etc.) —
+        /// bounded set, safe to use as a Prometheus label.
+        category: String,
+        /// Bounded backend identifier (e.g. `"sqlite"`, `"qdrant"`).
+        backend: String,
+        duration: Duration,
+        success: bool,
+    },
+    /// A RAG retrieval pass has completed.
+    ///
+    /// Emitted after vector + keyword retrieval against the hardware
+    /// datasheet index. Reports cardinalities only; carries an optional
+    /// scrubbed-and-truncated query summary on the same terms as
+    /// [`MemoryRecall`]. Has no `success` field because the underlying
+    /// `rag.retrieve` call is synchronous and infallible.
+    RagRetrieve {
+        query_summary: Option<String>,
+        duration: Duration,
+        num_chunks: usize,
+        num_boards: usize,
     },
     /// The agent produced a final answer for the current user message.
     TurnComplete,
@@ -359,5 +413,32 @@ mod tests {
 
         assert!(matches!(cloned_event, ObserverEvent::ToolCall { .. }));
         assert!(matches!(cloned_metric, ObserverMetric::RequestLatency(_)));
+    }
+
+    #[test]
+    fn memory_event_variants_are_cloneable() {
+        let recall = ObserverEvent::MemoryRecall {
+            query_summary: Some("user asked about coffee orders".into()),
+            duration: Duration::from_millis(40),
+            num_entries: 3,
+            backend: "sqlite".into(),
+            success: true,
+        };
+        let store = ObserverEvent::MemoryStore {
+            category: "conversation".into(),
+            backend: "sqlite".into(),
+            duration: Duration::from_millis(8),
+            success: true,
+        };
+        let rag = ObserverEvent::RagRetrieve {
+            query_summary: None,
+            duration: Duration::from_millis(120),
+            num_chunks: 5,
+            num_boards: 2,
+        };
+
+        assert!(matches!(recall.clone(), ObserverEvent::MemoryRecall { .. }));
+        assert!(matches!(store.clone(), ObserverEvent::MemoryStore { .. }));
+        assert!(matches!(rag.clone(), ObserverEvent::RagRetrieve { .. }));
     }
 }

--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -799,12 +799,17 @@ impl Agent {
     ) {
         let context = self
             .memory_strategy
-            .load_context(user_message, self.memory_session_id.as_deref())
+            .load_context(
+                &*self.observer,
+                user_message,
+                self.memory_session_id.as_deref(),
+            )
             .await
             .unwrap_or_default();
 
         if self.auto_save {
-            let _ = self
+            let store_start = std::time::Instant::now();
+            let store_result = self
                 .memory
                 .store(
                     "user_msg",
@@ -813,6 +818,12 @@ impl Agent {
                     self.memory_session_id.as_deref(),
                 )
                 .await;
+            self.observer.record_event(&ObserverEvent::MemoryStore {
+                category: MemoryCategory::Conversation.to_string(),
+                backend: self.memory.name().to_string(),
+                duration: store_start.elapsed(),
+                success: store_result.is_ok(),
+            });
         }
 
         let now = chrono::Local::now().format("%Y-%m-%d %H:%M:%S %Z");
@@ -1807,12 +1818,17 @@ impl Agent {
 
         let context = self
             .memory_strategy
-            .load_context(user_message, self.memory_session_id.as_deref())
+            .load_context(
+                &*self.observer,
+                user_message,
+                self.memory_session_id.as_deref(),
+            )
             .await
             .unwrap_or_default();
 
         if self.auto_save {
-            let _ = self
+            let store_start = std::time::Instant::now();
+            let store_result = self
                 .memory
                 .store(
                     "user_msg",
@@ -1821,6 +1837,12 @@ impl Agent {
                     self.memory_session_id.as_deref(),
                 )
                 .await;
+            self.observer.record_event(&ObserverEvent::MemoryStore {
+                category: MemoryCategory::Conversation.to_string(),
+                backend: self.memory.name().to_string(),
+                duration: store_start.elapsed(),
+                success: store_result.is_ok(),
+            });
         }
 
         let now = chrono::Local::now();

--- a/crates/zeroclaw-runtime/src/agent/context_compressor.rs
+++ b/crates/zeroclaw-runtime/src/agent/context_compressor.rs
@@ -1,5 +1,5 @@
 use std::fmt::Write;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::Result;
 use std::sync::Arc;
@@ -7,6 +7,8 @@ use std::sync::Arc;
 use zeroclaw_api::model_provider::{ChatMessage, ModelProvider};
 use zeroclaw_memory::traits::Memory;
 use zeroclaw_providers::multimodal;
+
+use crate::observability::{Observer, ObserverEvent};
 
 pub use zeroclaw_config::scattered_types::ContextCompressionConfig;
 
@@ -120,6 +122,7 @@ pub struct ContextCompressor {
     config: ContextCompressionConfig,
     context_window: usize,
     memory: Option<Arc<dyn Memory>>,
+    observer: Option<Arc<dyn Observer>>,
 }
 
 impl ContextCompressor {
@@ -128,6 +131,7 @@ impl ContextCompressor {
             config,
             context_window,
             memory: None,
+            observer: None,
         }
     }
 
@@ -135,6 +139,15 @@ impl ContextCompressor {
     /// old messages are discarded. Without this, compressed facts are lost.
     pub fn with_memory(mut self, memory: Arc<dyn Memory>) -> Self {
         self.memory = Some(memory);
+        self
+    }
+
+    /// Attach an observer so compression-summary stores emit
+    /// `ObserverEvent::MemoryStore` alongside the other agent-loop write
+    /// sites. Optional — when not set, stores still happen but are
+    /// invisible to OTel/log observers.
+    pub fn with_observer(mut self, observer: Arc<dyn Observer>) -> Self {
+        self.observer = Some(observer);
         self
     }
 
@@ -391,28 +404,38 @@ impl ContextCompressor {
         // This ensures facts from compressed turns remain retrievable via memory recall.
         if let Some(ref memory) = self.memory {
             let facts_key = format!("compressed_context_{}", uuid::Uuid::new_v4());
-            if let Err(e) = memory
-                .store(
-                    &facts_key,
-                    &summary,
-                    zeroclaw_memory::traits::MemoryCategory::Daily,
-                    None,
-                )
-                .await
-            {
-                ::zeroclaw_log::record!(
-                    DEBUG,
-                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                        .with_attrs(::serde_json::json!({"error": format!("{}", e)})),
-                    "Failed to save compression summary to memory"
-                );
-            } else {
-                ::zeroclaw_log::record!(
-                    DEBUG,
-                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                        .with_attrs(::serde_json::json!({"message_count": message_count})),
-                    "Saved compression summary to memory before discarding  messages"
-                );
+            let category = zeroclaw_memory::traits::MemoryCategory::Daily;
+            let store_start = Instant::now();
+            let store_result = memory
+                .store(&facts_key, &summary, category.clone(), None)
+                .await;
+            let store_duration = store_start.elapsed();
+            let success = store_result.is_ok();
+            match &store_result {
+                Ok(_) => {
+                    ::zeroclaw_log::record!(
+                        DEBUG,
+                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                            .with_attrs(::serde_json::json!({"message_count": message_count})),
+                        "Saved compression summary to memory before discarding messages"
+                    );
+                }
+                Err(e) => {
+                    ::zeroclaw_log::record!(
+                        DEBUG,
+                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                            .with_attrs(::serde_json::json!({"error": format!("{}", e)})),
+                        "Failed to save compression summary to memory"
+                    );
+                }
+            }
+            if let Some(ref observer) = self.observer {
+                observer.record_event(&ObserverEvent::MemoryStore {
+                    category: category.to_string(),
+                    backend: memory.name().to_string(),
+                    duration: store_duration,
+                    success,
+                });
             }
         }
 

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -108,6 +108,7 @@ use crate::observability::{self, Observer, ObserverEvent};
 use crate::platform;
 use crate::security::{AutonomyLevel, SecurityPolicy};
 use crate::tools::{self, Tool};
+use crate::util::truncate_with_ellipsis;
 use anyhow::{Context, Result};
 use std::collections::HashSet;
 use std::fmt::Write;
@@ -401,6 +402,26 @@ fn compute_excluded_mcp_tools(
         .collect()
 }
 
+/// Build a `query_summary` field for memory observability events from a raw
+/// user query.
+///
+/// Applies [`scrub_credentials`] first, then truncates to ≤200 content
+/// chars via [`truncate_with_ellipsis`] (which appends a 3-char `...`
+/// ellipsis when truncation occurred, so summaries are ≤203 chars total).
+/// The order matters: `scrub_credentials` may insert placeholder
+/// substrings, so truncating first risks chopping a half-token.
+///
+/// Returns `None` for empty input so observers can distinguish "no query
+/// recorded" from "empty query string". Always call this helper at memory
+/// emit sites — never inline the scrub-then-truncate pattern, since that
+/// invites drift where one site accidentally skips the scrubber.
+pub fn make_query_summary(raw: &str) -> Option<String> {
+    if raw.is_empty() {
+        return None;
+    }
+    Some(truncate_with_ellipsis(&scrub_credentials(raw), 200))
+}
+
 pub use zeroclaw_api::TOOL_CHOICE_OVERRIDE;
 
 /// Convert a tool registry to OpenAI function-calling format for native tool support.
@@ -436,66 +457,99 @@ fn autosave_memory_key(prefix: &str) -> String {
 /// the user did not initiate. / #5456.
 async fn build_context(
     mem: &dyn Memory,
+    observer: &dyn Observer,
     user_msg: &str,
     min_relevance_score: f64,
     session_id: Option<&str>,
     exclude_conversation: bool,
 ) -> String {
     let mut context = String::new();
+    let backend = mem.name().to_string();
 
-    // Pull relevant memories for this message
-    if let Ok(mut entries) = mem.recall(user_msg, 5, session_id, None, None).await {
-        // Apply time decay: older non-Core memories score lower
-        decay::apply_time_decay(&mut entries, decay::DEFAULT_HALF_LIFE_DAYS);
+    // Pull relevant memories for this message. The original code used
+    // `if let Ok(...)` to silently swallow recall errors; we keep that
+    // behavior but refactor to an explicit match so the failure path can
+    // still emit a `MemoryRecall` observer event.
+    let start = std::time::Instant::now();
+    let recall_result = mem.recall(user_msg, 5, session_id, None, None).await;
+    let duration = start.elapsed();
+    let query_summary = make_query_summary(user_msg);
 
-        let relevant: Vec<_> = entries
-            .iter()
-            .filter(|e| match e.score {
-                Some(score) => score >= min_relevance_score,
-                None => true,
-            })
-            .collect();
+    match recall_result {
+        Ok(mut entries) => {
+            observer.record_event(&ObserverEvent::MemoryRecall {
+                query_summary,
+                duration,
+                num_entries: entries.len(),
+                backend,
+                success: true,
+            });
 
-        if !relevant.is_empty() {
-            let mut included = false;
-            for entry in &relevant {
-                // Scheduled (cron / heartbeat) runs must not see chat-origin
-                // memories. The autosave-key checks below catch the agent's
-                // own autosaves but miss Conversation entries written by
-                // channel handlers (Discord, gateway, WhatsApp, …) under
-                // their own keys. / #5456.
-                if exclude_conversation && matches!(entry.category, MemoryCategory::Conversation) {
-                    continue;
+            // Apply time decay: older non-Core memories score lower
+            decay::apply_time_decay(&mut entries, decay::DEFAULT_HALF_LIFE_DAYS);
+
+            let relevant: Vec<_> = entries
+                .iter()
+                .filter(|e| match e.score {
+                    Some(score) => score >= min_relevance_score,
+                    None => true,
+                })
+                .collect();
+
+            if !relevant.is_empty() {
+                let mut included = false;
+                for entry in &relevant {
+                    // Scheduled (cron / heartbeat) runs must not see chat-origin
+                    // memories. The autosave-key checks below catch the agent's
+                    // own autosaves but miss Conversation entries written by
+                    // channel handlers (Discord, gateway, WhatsApp, …) under
+                    // their own keys. / #5456.
+                    if exclude_conversation
+                        && matches!(entry.category, MemoryCategory::Conversation)
+                    {
+                        continue;
+                    }
+                    if zeroclaw_memory::is_assistant_autosave_key(&entry.key) {
+                        continue;
+                    }
+                    // Skip raw per-turn user messages: re-injecting them causes each
+                    // recalled entry to embed all prior generations, growing exponentially.
+                    // Consolidated knowledge is already promoted to Core/Daily entries.
+                    if zeroclaw_memory::is_user_autosave_key(&entry.key) {
+                        continue;
+                    }
+                    if zeroclaw_memory::should_skip_autosave_content(&entry.content) {
+                        continue;
+                    }
+                    // Skip entries containing tool_result blocks — they can leak
+                    // stale tool output from previous heartbeat ticks into new
+                    // sessions, presenting the LLM with orphan tool_result data.
+                    if entry.content.contains("<tool_result") {
+                        continue;
+                    }
+                    if !included {
+                        context.push_str(MEMORY_CONTEXT_OPEN);
+                        context.push('\n');
+                        included = true;
+                    }
+                    let _ = writeln!(context, "- {}: {}", entry.key, entry.content);
                 }
-                if zeroclaw_memory::is_assistant_autosave_key(&entry.key) {
-                    continue;
+                if included {
+                    context.push_str(MEMORY_CONTEXT_CLOSE);
+                    context.push_str("\n\n");
                 }
-                // Skip raw per-turn user messages: re-injecting them causes each
-                // recalled entry to embed all prior generations, growing exponentially.
-                // Consolidated knowledge is already promoted to Core/Daily entries.
-                if zeroclaw_memory::is_user_autosave_key(&entry.key) {
-                    continue;
-                }
-                if zeroclaw_memory::should_skip_autosave_content(&entry.content) {
-                    continue;
-                }
-                // Skip entries containing tool_result blocks — they can leak
-                // stale tool output from previous heartbeat ticks into new
-                // sessions, presenting the LLM with orphan tool_result data.
-                if entry.content.contains("<tool_result") {
-                    continue;
-                }
-                if !included {
-                    context.push_str(MEMORY_CONTEXT_OPEN);
-                    context.push('\n');
-                    included = true;
-                }
-                let _ = writeln!(context, "- {}: {}", entry.key, entry.content);
             }
-            if included {
-                context.push_str(MEMORY_CONTEXT_CLOSE);
-                context.push_str("\n\n");
-            }
+        }
+        Err(_) => {
+            observer.record_event(&ObserverEvent::MemoryRecall {
+                query_summary,
+                duration,
+                num_entries: 0,
+                backend,
+                success: false,
+            });
+            // Preserve original swallow behavior — recall errors are not
+            // propagated; an empty context string is returned.
         }
     }
 
@@ -506,6 +560,7 @@ async fn build_context(
 /// Includes pin-alias lookup (e.g. "red_led" → 13) when query matches, plus retrieved chunks.
 fn build_hardware_context(
     rag: &crate::rag::HardwareRag,
+    observer: &dyn Observer,
     user_msg: &str,
     boards: &[String],
     chunk_limit: usize,
@@ -522,7 +577,16 @@ fn build_hardware_context(
         context.push_str(&pin_ctx);
     }
 
+    let start = std::time::Instant::now();
     let chunks = rag.retrieve(user_msg, boards, chunk_limit);
+    let duration = start.elapsed();
+    observer.record_event(&ObserverEvent::RagRetrieve {
+        query_summary: make_query_summary(user_msg),
+        duration,
+        num_chunks: chunks.len(),
+        num_boards: boards.len(),
+    });
+
     if chunks.is_empty() && pin_ctx.is_empty() {
         return String::new();
     }
@@ -1539,7 +1603,8 @@ pub async fn run(
                 && !zeroclaw_memory::should_skip_autosave_content(&effective_msg)
             {
                 let user_key = autosave_memory_key("user_msg");
-                let _ = mem
+                let store_start = std::time::Instant::now();
+                let store_result = mem
                     .store(
                         &user_key,
                         &effective_msg,
@@ -1547,6 +1612,12 @@ pub async fn run(
                         memory_session_id.as_deref(),
                     )
                     .await;
+                observer.record_event(&ObserverEvent::MemoryStore {
+                    category: MemoryCategory::Conversation.to_string(),
+                    backend: mem.name().to_string(),
+                    duration: store_start.elapsed(),
+                    success: store_result.is_ok(),
+                });
             }
 
             // Inject memory + hardware RAG context into user message.
@@ -1559,6 +1630,7 @@ pub async fn run(
             let exclude_conv = !interactive || memory_session_id.is_none();
             let mem_context = build_context(
                 mem.as_ref(),
+                &*observer,
                 &effective_msg,
                 config.memory.min_relevance_score,
                 memory_session_id.as_deref(),
@@ -1568,7 +1640,9 @@ pub async fn run(
             let rag_limit = if eff_compact_context { 2 } else { 5 };
             let hw_context = hardware_rag
                 .as_ref()
-                .map(|r| build_hardware_context(r, &effective_msg, &board_names, rag_limit))
+                .map(|r| {
+                    build_hardware_context(r, &*observer, &effective_msg, &board_names, rag_limit)
+                })
                 .unwrap_or_default();
             let context = format!("{mem_context}{hw_context}");
             let now = chrono::Local::now().format("%Y-%m-%d %H:%M:%S %Z");
@@ -1980,7 +2054,8 @@ pub async fn run(
                     && !zeroclaw_memory::should_skip_autosave_content(&effective_input)
                 {
                     let user_key = autosave_memory_key("user_msg");
-                    let _ = mem
+                    let store_start = std::time::Instant::now();
+                    let store_result = mem
                         .store(
                             &user_key,
                             &effective_input,
@@ -1988,6 +2063,12 @@ pub async fn run(
                             memory_session_id.as_deref(),
                         )
                         .await;
+                    observer.record_event(&ObserverEvent::MemoryStore {
+                        category: MemoryCategory::Conversation.to_string(),
+                        backend: mem.name().to_string(),
+                        duration: store_start.elapsed(),
+                        success: store_result.is_ok(),
+                    });
                 }
 
                 // Inject memory + hardware RAG context into user message.
@@ -1996,6 +2077,7 @@ pub async fn run(
                 // Discord, …) would bleed into this interactive session.
                 let mem_context = build_context(
                     mem.as_ref(),
+                    &*observer,
                     &effective_input,
                     config.memory.min_relevance_score,
                     memory_session_id.as_deref(),
@@ -2005,7 +2087,15 @@ pub async fn run(
                 let rag_limit = if eff_compact_context { 2 } else { 5 };
                 let hw_context = hardware_rag
                     .as_ref()
-                    .map(|r| build_hardware_context(r, &effective_input, &board_names, rag_limit))
+                    .map(|r| {
+                        build_hardware_context(
+                            r,
+                            &*observer,
+                            &effective_input,
+                            &board_names,
+                            rag_limit,
+                        )
+                    })
                     .unwrap_or_default();
                 let context = format!("{mem_context}{hw_context}");
                 let now = chrono::Local::now().format("%Y-%m-%d %H:%M:%S %Z");
@@ -2894,6 +2984,7 @@ pub async fn process_message(
         // user's own Conversation history within their session is intended.
         let mem_context = build_context(
             mem.as_ref(),
+            &*observer,
             effective_msg_ref,
             config.memory.min_relevance_score,
             session_id,
@@ -2903,7 +2994,9 @@ pub async fn process_message(
         let rag_limit = if eff_compact_context { 2 } else { 5 };
         let hw_context = hardware_rag
             .as_ref()
-            .map(|r| build_hardware_context(r, effective_msg_ref, &board_names, rag_limit))
+            .map(|r| {
+                build_hardware_context(r, &*observer, effective_msg_ref, &board_names, rag_limit)
+            })
             .unwrap_or_default();
         let context = format!("{mem_context}{hw_context}");
         let now = chrono::Local::now().format("%Y-%m-%d %H:%M:%S %Z");
@@ -2966,10 +3059,10 @@ pub async fn process_message(
 #[cfg(test)]
 mod tests {
     use super::{
-        apply_text_tool_prompt_policy, emergency_history_trim, estimate_history_tokens,
-        fast_trim_tool_results, load_interactive_session_history,
-        maybe_inject_channel_delivery_defaults, save_interactive_session_history,
-        truncate_tool_result,
+        apply_text_tool_prompt_policy, build_context, emergency_history_trim,
+        estimate_history_tokens, fast_trim_tool_results, load_interactive_session_history,
+        make_query_summary, maybe_inject_channel_delivery_defaults,
+        save_interactive_session_history, truncate_tool_result,
     };
     use crate::agent::history::{DEFAULT_MAX_HISTORY_MESSAGES, InteractiveSessionState};
     use crate::agent::tool_execution::execute_one_tool;
@@ -9011,7 +9104,7 @@ This is an example, not an invocation."#;
         .await
         .unwrap();
 
-        let context = build_context(&mem, "status updates", 0.0, None, false).await;
+        let context = build_context(&mem, &NoopObserver, "status updates", 0.0, None, false).await;
         assert!(context.contains("user_preference"));
         assert!(!context.contains("assistant_resp_poisoned"));
         assert!(!context.contains("fabricated event"));
@@ -9046,7 +9139,7 @@ This is an example, not an invocation."#;
         .await
         .unwrap();
 
-        let context = build_context(&mem, "answers", 0.0, None, false).await;
+        let context = build_context(&mem, &NoopObserver, "answers", 0.0, None, false).await;
         assert!(context.contains("user_preference"));
         assert!(!context.contains("user_msg"));
         assert!(!context.contains("embedding prior context"));
@@ -9081,7 +9174,7 @@ This is an example, not an invocation."#;
         .await
         .unwrap();
 
-        let context = build_context(&mem, "Alice on-call", 0.0, None, true).await;
+        let context = build_context(&mem, &NoopObserver, "Alice on-call", 0.0, None, true).await;
         assert!(
             !context.contains("Alice"),
             "Conversation memory leaked into scheduled context: {context}"
@@ -9093,6 +9186,220 @@ This is an example, not an invocation."#;
         assert!(
             context.contains("team_oncall"),
             "Non-Conversation memory should still surface: {context}"
+        );
+    }
+
+    #[test]
+    fn make_query_summary_redacts_credentials_and_caps_length() {
+        // Empty input → None (so observers can distinguish "no query
+        // recorded" from "empty query string").
+        assert!(make_query_summary("").is_none());
+
+        // Plain query passes through unchanged when within the cap.
+        let plain = make_query_summary("hello world").unwrap();
+        assert_eq!(plain, "hello world");
+
+        // Credential pattern is scrubbed by `scrub_credentials` before
+        // the truncation step. The raw token must not appear in the
+        // emitted summary.
+        let scrubbed =
+            make_query_summary("connect with api_key: sk-proj-abcdef1234567890zzz").unwrap();
+        assert!(
+            !scrubbed.contains("sk-proj-abcdef1234567890zzz"),
+            "raw credential leaked into query_summary: {scrubbed:?}"
+        );
+
+        // Long input is truncated. `truncate_with_ellipsis(s, 200)` keeps up
+        // to 200 content chars and appends "..." when it had to truncate,
+        // for a total ceiling of 203 chars.
+        let long_input = "a".repeat(500);
+        let truncated = make_query_summary(&long_input).unwrap();
+        assert!(
+            truncated.chars().count() <= 203,
+            "expected ≤203 chars (200 content + ellipsis), got {}",
+            truncated.chars().count()
+        );
+        assert!(
+            truncated.ends_with("..."),
+            "expected trailing ellipsis on truncated input, got {truncated:?}"
+        );
+    }
+
+    /// Captured `MemoryRecall` event used by the wiring-contract tests below.
+    struct CapturedRecall {
+        query_summary: Option<String>,
+        backend: String,
+        success: bool,
+    }
+
+    /// Counting observer that records every `MemoryRecall` event so the test
+    /// can assert that the runtime hot path emits the variant once per
+    /// `build_context` call. Locks in the wiring contract that motivated the
+    /// memory-OTel work.
+    #[derive(Default)]
+    struct RecallCountingObserver {
+        recalls: parking_lot::Mutex<Vec<CapturedRecall>>,
+    }
+
+    impl crate::observability::Observer for RecallCountingObserver {
+        fn record_event(&self, event: &crate::observability::ObserverEvent) {
+            if let crate::observability::ObserverEvent::MemoryRecall {
+                query_summary,
+                backend,
+                success,
+                ..
+            } = event
+            {
+                self.recalls.lock().push(CapturedRecall {
+                    query_summary: query_summary.clone(),
+                    backend: backend.clone(),
+                    success: *success,
+                });
+            }
+        }
+
+        fn record_metric(&self, _metric: &zeroclaw_api::observability_traits::ObserverMetric) {}
+
+        fn name(&self) -> &str {
+            "recall-counting-observer"
+        }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    #[tokio::test]
+    async fn build_context_emits_memory_recall_event() {
+        let tmp = TempDir::new().unwrap();
+        let mem = SqliteMemory::new("test", tmp.path()).unwrap();
+        let observer = RecallCountingObserver::default();
+
+        let _ = build_context(&mem, &observer, "any query", 0.0, None, false).await;
+
+        let recalls = observer.recalls.lock();
+        assert_eq!(
+            recalls.len(),
+            1,
+            "build_context must emit exactly one MemoryRecall event per call"
+        );
+        assert_eq!(recalls[0].query_summary.as_deref(), Some("any query"));
+        assert_eq!(recalls[0].backend, "sqlite");
+        assert!(
+            recalls[0].success,
+            "successful recall must report success = true"
+        );
+    }
+
+    /// Memory backend whose `recall` always returns `Err`. Used to exercise
+    /// the failure arm of `build_context`'s explicit match — the runtime
+    /// swallows the error and returns an empty context, but observers must
+    /// still see a `MemoryRecall { success: false }` event.
+    struct FailingRecallMemory;
+
+    #[async_trait]
+    impl zeroclaw_memory::Memory for FailingRecallMemory {
+        fn name(&self) -> &str {
+            "failing-recall"
+        }
+        async fn store(
+            &self,
+            _key: &str,
+            _content: &str,
+            _category: MemoryCategory,
+            _session_id: Option<&str>,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+        async fn recall(
+            &self,
+            _query: &str,
+            _limit: usize,
+            _session_id: Option<&str>,
+            _since: Option<&str>,
+            _until: Option<&str>,
+        ) -> anyhow::Result<Vec<zeroclaw_memory::MemoryEntry>> {
+            anyhow::bail!("simulated recall failure")
+        }
+        async fn get(&self, _key: &str) -> anyhow::Result<Option<zeroclaw_memory::MemoryEntry>> {
+            Ok(None)
+        }
+        async fn list(
+            &self,
+            _category: Option<&MemoryCategory>,
+            _session_id: Option<&str>,
+        ) -> anyhow::Result<Vec<zeroclaw_memory::MemoryEntry>> {
+            Ok(Vec::new())
+        }
+        async fn forget(&self, _key: &str) -> anyhow::Result<bool> {
+            Ok(false)
+        }
+        async fn forget_for_agent(&self, _key: &str, _agent_id: &str) -> anyhow::Result<bool> {
+            Ok(false)
+        }
+        async fn count(&self) -> anyhow::Result<usize> {
+            Ok(0)
+        }
+        async fn health_check(&self) -> bool {
+            false
+        }
+        async fn store_with_agent(
+            &self,
+            _key: &str,
+            _content: &str,
+            _category: MemoryCategory,
+            _session_id: Option<&str>,
+            _namespace: Option<&str>,
+            _importance: Option<f64>,
+            _agent_id: Option<&str>,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+        async fn recall_for_agents(
+            &self,
+            _allowed_agent_ids: &[&str],
+            query: &str,
+            limit: usize,
+            session_id: Option<&str>,
+            since: Option<&str>,
+            until: Option<&str>,
+        ) -> anyhow::Result<Vec<zeroclaw_memory::MemoryEntry>> {
+            self.recall(query, limit, session_id, since, until).await
+        }
+    }
+    impl ::zeroclaw_api::attribution::Attributable for FailingRecallMemory {
+        fn role(&self) -> ::zeroclaw_api::attribution::Role {
+            ::zeroclaw_api::attribution::Role::Memory(
+                ::zeroclaw_api::attribution::MemoryKind::InMemory,
+            )
+        }
+        fn alias(&self) -> &str {
+            "FailingRecallMemory"
+        }
+    }
+
+    #[tokio::test]
+    async fn build_context_emits_memory_recall_event_on_failure() {
+        let mem = FailingRecallMemory;
+        let observer = RecallCountingObserver::default();
+
+        let context = build_context(&mem, &observer, "any query", 0.0, None, false).await;
+        assert!(
+            context.is_empty(),
+            "recall failure must still produce empty context (swallow behavior)"
+        );
+
+        let recalls = observer.recalls.lock();
+        assert_eq!(
+            recalls.len(),
+            1,
+            "build_context must emit exactly one MemoryRecall event even on Err"
+        );
+        assert_eq!(recalls[0].query_summary.as_deref(), Some("any query"));
+        assert_eq!(recalls[0].backend, "failing-recall");
+        assert!(
+            !recalls[0].success,
+            "failed recall must report success = false"
         );
     }
 

--- a/crates/zeroclaw-runtime/src/agent/memory_loader.rs
+++ b/crates/zeroclaw-runtime/src/agent/memory_loader.rs
@@ -1,12 +1,25 @@
 use async_trait::async_trait;
 use std::fmt::Write;
+use std::time::Instant;
 use zeroclaw_memory::{self, MEMORY_CONTEXT_CLOSE, MEMORY_CONTEXT_OPEN, Memory, decay};
+
+use crate::observability::{Observer, ObserverEvent};
+
+use super::loop_::make_query_summary;
 
 #[async_trait]
 pub trait MemoryLoader: Send + Sync {
+    /// Loads a memory-context preamble for a user message.
+    ///
+    /// Implementations MUST emit a `ObserverEvent::MemoryRecall` event via
+    /// `observer` for every recall call they perform — both on success and
+    /// failure paths — so OTel/log observers can attribute per-turn memory
+    /// cost. The agent runtime relies on this for end-to-end visibility
+    /// of the implicit recall that runs at the start of each turn.
     async fn load_context(
         &self,
         memory: &dyn Memory,
+        observer: &dyn Observer,
         user_message: &str,
         session_id: Option<&str>,
     ) -> anyhow::Result<String>;
@@ -40,12 +53,41 @@ impl MemoryLoader for DefaultMemoryLoader {
     async fn load_context(
         &self,
         memory: &dyn Memory,
+        observer: &dyn Observer,
         user_message: &str,
         session_id: Option<&str>,
     ) -> anyhow::Result<String> {
-        let mut entries = memory
+        let backend = memory.name().to_string();
+        let query_summary = make_query_summary(user_message);
+
+        let start = Instant::now();
+        let recall_result = memory
             .recall(user_message, self.limit, session_id, None, None)
-            .await?;
+            .await;
+        let duration = start.elapsed();
+
+        let mut entries = match recall_result {
+            Ok(entries) => {
+                observer.record_event(&ObserverEvent::MemoryRecall {
+                    query_summary,
+                    duration,
+                    num_entries: entries.len(),
+                    backend,
+                    success: true,
+                });
+                entries
+            }
+            Err(e) => {
+                observer.record_event(&ObserverEvent::MemoryRecall {
+                    query_summary,
+                    duration,
+                    num_entries: 0,
+                    backend,
+                    success: false,
+                });
+                return Err(e);
+            }
+        };
         if entries.is_empty() {
             return Ok(String::new());
         }
@@ -92,6 +134,7 @@ impl MemoryLoader for DefaultMemoryLoader {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::observability::NoopObserver;
     use std::sync::Arc;
     use zeroclaw_memory::{
         MEMORY_CONTEXT_CLOSE, MEMORY_CONTEXT_OPEN, Memory, MemoryCategory, MemoryEntry,
@@ -304,7 +347,7 @@ mod tests {
     async fn default_loader_formats_context() {
         let loader = DefaultMemoryLoader::default();
         let context = loader
-            .load_context(&MockMemory, "hello", None)
+            .load_context(&MockMemory, &NoopObserver, "hello", None)
             .await
             .unwrap();
         assert_eq!(
@@ -350,7 +393,7 @@ mod tests {
         };
 
         let context = loader
-            .load_context(&memory, "answer style", None)
+            .load_context(&memory, &NoopObserver, "answer style", None)
             .await
             .unwrap();
         assert!(context.contains("user_fact"));
@@ -395,7 +438,7 @@ mod tests {
         };
 
         let context = loader
-            .load_context(&memory, "answer style", None)
+            .load_context(&memory, &NoopObserver, "answer style", None)
             .await
             .unwrap();
         assert!(context.contains("user_fact"));

--- a/crates/zeroclaw-runtime/src/agent/memory_strategy.rs
+++ b/crates/zeroclaw-runtime/src/agent/memory_strategy.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 use zeroclaw_api::memory_traits::{Memory, MemoryStrategy};
 use zeroclaw_api::model_provider::ModelProvider;
+use zeroclaw_api::observability_traits::Observer;
 
 use crate::agent::memory_loader::{DefaultMemoryLoader, MemoryLoader};
 
@@ -76,10 +77,15 @@ impl DefaultMemoryStrategy {
 
 #[async_trait::async_trait]
 impl MemoryStrategy for DefaultMemoryStrategy {
-    async fn load_context(&self, query: &str, session_id: Option<&str>) -> anyhow::Result<String> {
+    async fn load_context(
+        &self,
+        observer: &dyn Observer,
+        query: &str,
+        session_id: Option<&str>,
+    ) -> anyhow::Result<String> {
         let loader = DefaultMemoryLoader::new(self.limit, self.min_relevance_score);
         loader
-            .load_context(self.memory.as_ref(), query, session_id)
+            .load_context(self.memory.as_ref(), observer, query, session_id)
             .await
     }
 

--- a/crates/zeroclaw-runtime/src/observability/log.rs
+++ b/crates/zeroclaw-runtime/src/observability/log.rs
@@ -113,6 +113,67 @@ impl Observer for LogObserver {
                     "error"
                 );
             }
+            ObserverEvent::MemoryRecall {
+                duration,
+                num_entries,
+                backend,
+                success,
+                ..
+            } => {
+                // Bounded labels only — `query_summary` intentionally omitted
+                // from the log surface to avoid forwarding scrubbed-but-still-
+                // identifying user query text into structured-log sinks
+                // (Datadog, Loki) that the OD4 analysis did not cover.
+                let ms = u64::try_from(duration.as_millis()).unwrap_or(u64::MAX);
+                ::zeroclaw_log::record!(
+                    INFO,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                        .with_attrs(::serde_json::json!({
+                            "backend": backend,
+                            "num_entries": num_entries,
+                            "duration_ms": ms,
+                            "success": success
+                        })),
+                    "memory.recall"
+                );
+            }
+            ObserverEvent::MemoryStore {
+                category,
+                backend,
+                duration,
+                success,
+            } => {
+                let ms = u64::try_from(duration.as_millis()).unwrap_or(u64::MAX);
+                ::zeroclaw_log::record!(
+                    INFO,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                        .with_attrs(::serde_json::json!({
+                            "category": category,
+                            "backend": backend,
+                            "duration_ms": ms,
+                            "success": success
+                        })),
+                    "memory.store"
+                );
+            }
+            ObserverEvent::RagRetrieve {
+                duration,
+                num_chunks,
+                num_boards,
+                ..
+            } => {
+                let ms = u64::try_from(duration.as_millis()).unwrap_or(u64::MAX);
+                ::zeroclaw_log::record!(
+                    INFO,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                        .with_attrs(::serde_json::json!({
+                            "num_chunks": num_chunks,
+                            "num_boards": num_boards,
+                            "duration_ms": ms
+                        })),
+                    "rag.retrieve"
+                );
+            }
             ObserverEvent::LlmRequest {
                 model_provider,
                 model,
@@ -170,6 +231,9 @@ impl Observer for LogObserver {
                     "recovery.completed"
                 );
             }
+            // `ObserverEvent` is `#[non_exhaustive]` — silently ignore any
+            // future variant added by upstream `zeroclaw-api`.
+            _ => {}
         }
     }
 

--- a/crates/zeroclaw-runtime/src/observability/otel.rs
+++ b/crates/zeroclaw-runtime/src/observability/otel.rs
@@ -8,6 +8,7 @@ use opentelemetry_sdk::trace::SdkTracerProvider;
 use std::any::Any;
 use std::collections::HashMap;
 use std::sync::Mutex;
+use std::time::SystemTime;
 
 /// OpenTelemetry-backed observer — exports traces and metrics via OTLP.
 pub struct OtelObserver {
@@ -28,6 +29,11 @@ pub struct OtelObserver {
     tokens_used: Counter<u64>,
     active_sessions: Gauge<u64>,
     queue_depth: Gauge<u64>,
+    memory_recall_count: Counter<u64>,
+    memory_recall_duration: Histogram<f64>,
+    memory_store_count: Counter<u64>,
+    rag_retrieve_count: Counter<u64>,
+    rag_retrieve_duration: Histogram<f64>,
 
     // Turn span tracking for parent/child correlation
     active_agent_spans: Mutex<HashMap<String, (global::BoxedSpan, Context)>>,
@@ -168,6 +174,38 @@ impl OtelObserver {
             .with_description("Current message queue depth")
             .build();
 
+        // ── Memory observability instruments (Unit 2 of memory-OTel PR) ──
+        // The OTel SDK's PeriodicReader is non-blocking: aggregations are
+        // updated synchronously in record_event, but export happens on a
+        // background interval. New instruments cannot back-pressure the
+        // runtime hot path under burst writes.
+        let memory_recall_count = meter
+            .u64_counter("zeroclaw.memory.recall.count")
+            .with_description("Total memory.recall calls from the runtime boundary")
+            .build();
+
+        let memory_recall_duration = meter
+            .f64_histogram("zeroclaw.memory.recall.duration")
+            .with_description("memory.recall duration in seconds")
+            .with_unit("s")
+            .build();
+
+        let memory_store_count = meter
+            .u64_counter("zeroclaw.memory.store.count")
+            .with_description("Total memory.store calls from the runtime boundary")
+            .build();
+
+        let rag_retrieve_count = meter
+            .u64_counter("zeroclaw.rag.retrieve.count")
+            .with_description("Total rag.retrieve calls from the runtime boundary")
+            .build();
+
+        let rag_retrieve_duration = meter
+            .f64_histogram("zeroclaw.rag.retrieve.duration")
+            .with_description("rag.retrieve duration in seconds")
+            .with_unit("s")
+            .build();
+
         Ok(Self {
             tracer_provider,
             meter_provider: meter_provider_clone,
@@ -184,6 +222,11 @@ impl OtelObserver {
             tokens_used,
             active_sessions,
             queue_depth,
+            memory_recall_count,
+            memory_recall_duration,
+            memory_store_count,
+            rag_retrieve_count,
+            rag_retrieve_duration,
             active_agent_spans: Mutex::new(HashMap::new()),
         })
     }
@@ -310,6 +353,152 @@ impl Observer for OtelObserver {
             ObserverEvent::TurnComplete
             | ObserverEvent::CacheHit { .. }
             | ObserverEvent::CacheMiss { .. } => {}
+            ObserverEvent::MemoryRecall {
+                query_summary,
+                duration,
+                num_entries,
+                backend,
+                success,
+            } => {
+                let secs = duration.as_secs_f64();
+                let start_time = SystemTime::now()
+                    .checked_sub(*duration)
+                    .unwrap_or(SystemTime::now());
+
+                let mut span_attrs = vec![
+                    // Legacy / ZeroClaw-specific attrs
+                    KeyValue::new("memory.backend", backend.clone()),
+                    KeyValue::new("memory.hits", *num_entries as i64),
+                    KeyValue::new("memory.success", *success),
+                    KeyValue::new("duration_s", secs),
+                    // Partial GenAI-compatible attributes. The retrieval
+                    // operation value is canonical, but the surrounding
+                    // span (`SpanKind::Internal` and the `memory.recall`
+                    // name rather than `{operation} {data_source.id}`) is
+                    // shaped for ZeroClaw / Langfuse compatibility, not
+                    // strict OTel GenAI conformance.
+                    KeyValue::new("gen_ai.operation.name", "retrieval"),
+                    KeyValue::new("gen_ai.system", backend.clone()),
+                ];
+                if let Some(q) = query_summary {
+                    // Langfuse-specific Input/Output pane attrs. Emitting
+                    // both keeps vendor-agnostic backends happy while
+                    // Langfuse renders the query and the hit count in its
+                    // GenAI-aware retrieval view.
+                    span_attrs.push(KeyValue::new("input.value", q.clone()));
+                    span_attrs.push(KeyValue::new(
+                        "output.value",
+                        format!("{} hits", num_entries),
+                    ));
+                }
+
+                let mut span = tracer.build(
+                    opentelemetry::trace::SpanBuilder::from_name("memory.recall")
+                        .with_kind(SpanKind::Internal)
+                        .with_start_time(start_time)
+                        .with_attributes(span_attrs),
+                );
+                if *success {
+                    span.set_status(Status::Ok);
+                } else {
+                    span.set_status(Status::error(""));
+                }
+                span.end();
+
+                let metric_attrs = [KeyValue::new("backend", backend.clone())];
+                self.memory_recall_count.add(1, &metric_attrs);
+                self.memory_recall_duration.record(secs, &metric_attrs);
+            }
+            ObserverEvent::RagRetrieve {
+                query_summary,
+                duration,
+                num_chunks,
+                num_boards,
+            } => {
+                let secs = duration.as_secs_f64();
+                let start_time = SystemTime::now()
+                    .checked_sub(*duration)
+                    .unwrap_or(SystemTime::now());
+
+                // NOTE: `rag.num_chunks` / `rag.num_boards` are
+                // ZeroClaw-specific. OTel GenAI semconv defines
+                // `gen_ai.operation.name = "retrieval"` but no canonical
+                // attribute for chunk count or domain partitioning yet.
+                // Revisit when the GenAI WG publishes retrieval-attribute
+                // extensions.
+                let mut span_attrs = vec![
+                    KeyValue::new("rag.num_chunks", *num_chunks as i64),
+                    KeyValue::new("rag.num_boards", *num_boards as i64),
+                    KeyValue::new("duration_s", secs),
+                    KeyValue::new("gen_ai.operation.name", "retrieval"),
+                    KeyValue::new("gen_ai.system", "zeroclaw_rag"),
+                ];
+                if let Some(q) = query_summary {
+                    span_attrs.push(KeyValue::new("input.value", q.clone()));
+                    span_attrs.push(KeyValue::new(
+                        "output.value",
+                        format!("{} chunks across {} boards", num_chunks, num_boards),
+                    ));
+                }
+
+                let mut span = tracer.build(
+                    opentelemetry::trace::SpanBuilder::from_name("rag.retrieve")
+                        .with_kind(SpanKind::Internal)
+                        .with_start_time(start_time)
+                        .with_attributes(span_attrs),
+                );
+                span.set_status(Status::Ok);
+                span.end();
+
+                self.rag_retrieve_count.add(1, &[]);
+                self.rag_retrieve_duration.record(secs, &[]);
+            }
+            ObserverEvent::MemoryStore {
+                category,
+                backend,
+                duration,
+                success,
+            } => {
+                let secs = duration.as_secs_f64();
+                let start_time = SystemTime::now()
+                    .checked_sub(*duration)
+                    .unwrap_or(SystemTime::now());
+
+                // NOTE: OTel GenAI semconv has no canonical "store"
+                // operation value (canonical: chat, create_agent,
+                // embeddings, execute_tool, generate_content,
+                // invoke_agent, retrieval, text_completion). We omit
+                // `gen_ai.operation.name` and lean on `db.*` conventions
+                // instead.
+                let span_attrs = vec![
+                    KeyValue::new("memory.category", category.clone()),
+                    KeyValue::new("memory.backend", backend.clone()),
+                    KeyValue::new("memory.success", *success),
+                    KeyValue::new("duration_s", secs),
+                    KeyValue::new("db.system", backend.clone()),
+                    KeyValue::new("db.operation", "INSERT"),
+                ];
+
+                let mut span = tracer.build(
+                    opentelemetry::trace::SpanBuilder::from_name("memory.store")
+                        .with_kind(SpanKind::Internal)
+                        .with_start_time(start_time)
+                        .with_attributes(span_attrs),
+                );
+                if *success {
+                    span.set_status(Status::Ok);
+                } else {
+                    span.set_status(Status::error(""));
+                }
+                span.end();
+
+                let metric_attrs = [
+                    KeyValue::new("category", category.clone()),
+                    KeyValue::new("backend", backend.clone()),
+                    KeyValue::new("success", success.to_string()),
+                ];
+                self.memory_store_count.add(1, &metric_attrs);
+            }
             ObserverEvent::LlmResponse {
                 model_provider,
                 model,
@@ -504,6 +693,9 @@ impl Observer for OtelObserver {
             | ObserverEvent::RecoveryCompleted { .. } => {
                 // DORA deployment events: OTel pass-through not yet implemented.
             }
+            // `ObserverEvent` is `#[non_exhaustive]` — silently ignore any
+            // future variant added by upstream `zeroclaw-api`.
+            _ => {}
         }
     }
 
@@ -700,6 +892,65 @@ mod tests {
         let obs = test_observer();
         obs.record_event(&ObserverEvent::HeartbeatTick);
         obs.flush();
+    }
+
+    /// Regression test for memory observability — the three new memory/RAG
+    /// event variants must accept fully populated payloads without panicking
+    /// and must exercise the optional `query_summary` field on
+    /// `MemoryRecall` and `RagRetrieve` (Some/None). We cannot assert on
+    /// exported span attributes here (OTLP pipeline runs asynchronously),
+    /// but verifying the recording path for all three arms is sufficient
+    /// regression coverage.
+    #[test]
+    fn memory_rag_events_do_not_panic() {
+        let obs = test_observer();
+
+        // MemoryRecall with populated query_summary (Langfuse path).
+        obs.record_event(&ObserverEvent::MemoryRecall {
+            query_summary: Some("what did the user say about coffee".into()),
+            duration: Duration::from_millis(45),
+            num_entries: 7,
+            backend: "sqlite".into(),
+            success: true,
+        });
+        // MemoryRecall failure path with query_summary: None.
+        obs.record_event(&ObserverEvent::MemoryRecall {
+            query_summary: None,
+            duration: Duration::from_millis(12),
+            num_entries: 0,
+            backend: "qdrant".into(),
+            success: false,
+        });
+
+        // RagRetrieve with populated query_summary.
+        obs.record_event(&ObserverEvent::RagRetrieve {
+            query_summary: Some("ESP32-S3 GPIO pinout".into()),
+            duration: Duration::from_millis(120),
+            num_chunks: 12,
+            num_boards: 3,
+        });
+        // RagRetrieve with query_summary: None.
+        obs.record_event(&ObserverEvent::RagRetrieve {
+            query_summary: None,
+            duration: Duration::ZERO,
+            num_chunks: 0,
+            num_boards: 0,
+        });
+
+        // MemoryStore success path.
+        obs.record_event(&ObserverEvent::MemoryStore {
+            category: "conversation".into(),
+            backend: "sqlite".into(),
+            duration: Duration::from_millis(8),
+            success: true,
+        });
+        // MemoryStore failure path.
+        obs.record_event(&ObserverEvent::MemoryStore {
+            category: "fact".into(),
+            backend: "qdrant".into(),
+            duration: Duration::from_millis(3),
+            success: false,
+        });
     }
 
     /// Regression test for upstream issue #5980 — tool spans must accept a

--- a/crates/zeroclaw-runtime/src/observability/prometheus.rs
+++ b/crates/zeroclaw-runtime/src/observability/prometheus.rs
@@ -353,7 +353,10 @@ impl Observer for PrometheusObserver {
             | ObserverEvent::TurnComplete
             | ObserverEvent::LlmRequest { .. }
             | ObserverEvent::DeploymentStarted { .. }
-            | ObserverEvent::RecoveryCompleted { .. } => {}
+            | ObserverEvent::RecoveryCompleted { .. }
+            | ObserverEvent::MemoryRecall { .. }
+            | ObserverEvent::MemoryStore { .. }
+            | ObserverEvent::RagRetrieve { .. } => {}
             ObserverEvent::ToolCall {
                 tool,
                 duration,
@@ -422,6 +425,9 @@ impl Observer for PrometheusObserver {
                     self.deployment_failure_rate.set(f as f64 / total as f64);
                 }
             }
+            // `ObserverEvent` is `#[non_exhaustive]` — silently ignore any
+            // future variant added by upstream `zeroclaw-api`.
+            _ => {}
         }
     }
 

--- a/tests/support/helpers.rs
+++ b/tests/support/helpers.rs
@@ -133,6 +133,7 @@ impl StaticMemoryStrategy {
 impl MemoryStrategy for StaticMemoryStrategy {
     async fn load_context(
         &self,
+        _observer: &dyn Observer,
         _query: &str,
         _session_id: Option<&str>,
     ) -> anyhow::Result<String> {


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Supersedes #6190 because the original branch is conflict-blocked and the contributor fork rejected maintainer push access even though the PR reports `maintainerCanModify`.
  - Preserves #6190's runtime memory/RAG observability work: `MemoryRecall`, `MemoryStore`, and `RagRetrieve` observer events, OTel spans/meters, and log/prometheus handling.
  - Refreshes the implementation across the current `MemoryStrategy` boundary so implicit recall instrumentation still fires after the memory-strategy refactor landed.
  - Keeps the changelog breaking-change note aligned with the current v0.8.0 release-note shape.
- **Scope boundary:** This PR does not add new observability behavior beyond #6190, change memory backend semantics, change OTel export configuration, or alter channel/provider behavior.
- **Blast radius:** Agent runtime memory recall/store paths, RAG retrieval instrumentation, observer implementations, OTel metrics/traces, log/prometheus observer event handling, and out-of-tree code implementing `MemoryStrategy`.
- **Linked issue(s):** Supersedes #6190. Related #5849.
- **Labels:** `enhancement`, `risk: high`, `size: XL`, `docs`, `agent`, `observability`, `runtime`, `tests`.

## Validation Evidence (required)

- **Commands run and tail output:**

```text
cargo fmt --all -- --check
=> passed

cargo check -p zeroclaw-api -p zeroclaw-runtime
=> passed; Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.65s after the current-master refresh
```

- **Beyond CI — what did you manually verify?** Verified the refreshed branch has no unresolved merge files, no conflict markers, and a clean `git diff --cached --check origin/master`. Compared the final PR-shaped diff against current `origin/master` and confirmed it is limited to the #6190 observability surface plus the current `MemoryStrategy` adapter and changelog note.
- **If any command was intentionally skipped, why:** Workspace clippy and CI-shaped full tests were not run locally for this takeover branch. This branch should not be treated as merge-ready until GitHub CI is green, or until maintainers run/accept the broader high-risk validation requirement.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: No new secret, credential, PII, permission, or network surface is introduced. The change emits memory/RAG observability metadata with scrubbed/truncated query summaries, matching the original #6190 scope.

## Compatibility (required)

- Backward compatible? (`No`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: `ObserverEvent` is now `#[non_exhaustive]` and adds `MemoryRecall`, `MemoryStore`, and `RagRetrieve`; out-of-tree exhaustive matches must add a wildcard arm. `MemoryStrategy::load_context` now receives an observer reference so implementations can report implicit recall. Out-of-tree `MemoryStrategy` implementations must update their signature and can ignore the observer if they do not emit observability.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** Revert this PR's squash commit.
- **Feature flags or config toggles:** OTel export remains behind the existing `observability-otel` feature gate. Log/prometheus observer handling compiles with existing defaults.
- **Observable failure symptoms:** Build failures in out-of-tree `MemoryStrategy` implementations; missing or unexpected `memory.recall`, `memory.store`, or `rag.retrieve` spans/metrics in OTel; observer logs containing failed memory recall/store events.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line):
  - #6190 by @alexandme
- Scope materially carried forward: Runtime memory/RAG observer events, OTel/log/prometheus handling, memory recall/store instrumentation, RAG retrieval instrumentation, tests, and changelog notes from #6190 are carried forward. The maintainer delta is the current-master conflict refresh and `MemoryStrategy` adaptation.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`Yes`)
- If `No`, why (inspiration-only, no direct code/design carry-over): N/A — after the maintainer cleanup rewrite, the refreshed branch preserves Sasha Alyushin as the authored commit author, and GitHub's generated squash body includes the human co-author attribution for #6190. Bot/AI trailers were removed.

