### PR TITLE
refactor(channels): tighten Nextcloud Talk draft updates

### DIFF
--- a/crates/zeroclaw-channels/src/nextcloud_talk.rs
+++ b/crates/zeroclaw-channels/src/nextcloud_talk.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use hmac::{Hmac, Mac};
 use parking_lot::Mutex;
+use reqwest::Method;
 use sha2::Sha256;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -480,22 +481,47 @@ impl NextcloudTalkChannel {
         messages
     }
 
-    async fn send_to_room(&self, room_token: &str, content: &str) -> anyhow::Result<()> {
+    fn ocs_chat_url(&self, room_token: &str, message_id: Option<&str>) -> String {
         let encoded_room = urlencoding::encode(room_token);
-        let url = format!(
-            "{}/ocs/v2.php/apps/spreed/api/v1/chat/{}?format=json",
-            self.base_url, encoded_room
-        );
+        match message_id {
+            Some(message_id) => format!(
+                "{}/ocs/v2.php/apps/spreed/api/v1/chat/{}/{}?format=json",
+                self.base_url, encoded_room, message_id
+            ),
+            None => format!(
+                "{}/ocs/v2.php/apps/spreed/api/v1/chat/{}?format=json",
+                self.base_url, encoded_room
+            ),
+        }
+    }
 
-        let response = self
-            .client
-            .post(&url)
+    fn ocs_chat_request(
+        &self,
+        method: Method,
+        room_token: &str,
+        message_id: Option<&str>,
+    ) -> reqwest::RequestBuilder {
+        self.client
+            .request(method, self.ocs_chat_url(room_token, message_id))
             .bearer_auth(&self.app_token)
             .header("OCS-APIRequest", "true")
             .header("Accept", "application/json")
+    }
+
+    async fn post_to_room(
+        &self,
+        room_token: &str,
+        content: &str,
+    ) -> anyhow::Result<reqwest::Response> {
+        Ok(self
+            .ocs_chat_request(Method::POST, room_token, None)
             .json(&serde_json::json!({ "message": content }))
             .send()
-            .await?;
+            .await?)
+    }
+
+    async fn send_to_room(&self, room_token: &str, content: &str) -> anyhow::Result<()> {
+        let response = self.post_to_room(room_token, content).await?;
 
         if response.status().is_success() {
             return Ok(());
@@ -519,21 +545,7 @@ impl NextcloudTalkChannel {
         room_token: &str,
         content: &str,
     ) -> anyhow::Result<String> {
-        let encoded_room = urlencoding::encode(room_token);
-        let url = format!(
-            "{}/ocs/v2.php/apps/spreed/api/v1/chat/{}?format=json",
-            self.base_url, encoded_room
-        );
-
-        let response = self
-            .client
-            .post(&url)
-            .bearer_auth(&self.app_token)
-            .header("OCS-APIRequest", "true")
-            .header("Accept", "application/json")
-            .json(&serde_json::json!({ "message": content }))
-            .send()
-            .await?;
+        let response = self.post_to_room(room_token, content).await?;
 
         if !response.status().is_success() {
             let status = response.status();
@@ -576,18 +588,8 @@ impl NextcloudTalkChannel {
         message_id: &str,
         content: &str,
     ) -> anyhow::Result<()> {
-        let encoded_room = urlencoding::encode(room_token);
-        let url = format!(
-            "{}/ocs/v2.php/apps/spreed/api/v1/chat/{}/{}?format=json",
-            self.base_url, encoded_room, message_id
-        );
-
         let response = self
-            .client
-            .put(&url)
-            .bearer_auth(&self.app_token)
-            .header("OCS-APIRequest", "true")
-            .header("Accept", "application/json")
+            .ocs_chat_request(Method::PUT, room_token, Some(message_id))
             .json(&serde_json::json!({ "message": content }))
             .send()
             .await?;
@@ -598,32 +600,15 @@ impl NextcloudTalkChannel {
 
         let status = response.status();
         let body = response.text().await.unwrap_or_default();
-        ::zeroclaw_log::record!(
-            WARN,
-            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                .with_attrs(::serde_json::json!({"status": status.to_string(), "body": body})),
-            "Talk edit_message failed"
-        );
-        anyhow::bail!("Talk edit API error: {status}");
+        anyhow::bail!("Talk edit API error: {status}: {body}");
     }
 
     /// Delete a message via the Nextcloud Talk OCS API.
     ///
     /// `DELETE /ocs/v2.php/apps/spreed/api/v1/chat/{token}/{messageId}`
     async fn delete_message(&self, room_token: &str, message_id: &str) -> anyhow::Result<()> {
-        let encoded_room = urlencoding::encode(room_token);
-        let url = format!(
-            "{}/ocs/v2.php/apps/spreed/api/v1/chat/{}/{}?format=json",
-            self.base_url, encoded_room, message_id
-        );
-
         let response = self
-            .client
-            .delete(&url)
-            .bearer_auth(&self.app_token)
-            .header("OCS-APIRequest", "true")
-            .header("Accept", "application/json")
+            .ocs_chat_request(Method::DELETE, room_token, Some(message_id))
             .send()
             .await?;
 
@@ -645,16 +630,10 @@ impl NextcloudTalkChannel {
 
     /// Truncate text to the Nextcloud Talk character limit (UTF-8 char boundary safe).
     fn truncate_to_nc_limit(text: &str) -> &str {
-        if text.chars().count() <= NC_MAX_MESSAGE_LENGTH {
-            return text;
+        match text.char_indices().nth(NC_MAX_MESSAGE_LENGTH) {
+            Some((end, _)) => &text[..end],
+            None => text,
         }
-        // Find the byte offset of the NC_MAX_MESSAGE_LENGTH-th character boundary.
-        let end = text
-            .char_indices()
-            .nth(NC_MAX_MESSAGE_LENGTH)
-            .map(|(idx, _)| idx)
-            .unwrap_or(text.len());
-        &text[..end]
     }
 }
 
@@ -753,10 +732,11 @@ impl Channel for NextcloudTalkChannel {
                 // Non-fatal: log and continue. The final send will still deliver the
                 // complete response even if mid-stream edits fail.
                 ::zeroclaw_log::record!(
-                    DEBUG,
+                    WARN,
                     ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                        .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
                         .with_attrs(::serde_json::json!({"error": format!("{}", e)})),
-                    "Talk update_draft skipped"
+                    "Talk update_draft edit failed; final response will still be delivered"
                 );
             }
         }
@@ -887,6 +867,8 @@ pub fn verify_nextcloud_talk_signature(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use wiremock::matchers::{method, path, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     #[test]
     fn nextcloud_talk_channel_name() {
@@ -997,6 +979,93 @@ mod tests {
             .await;
         assert!(result.is_ok());
         assert!(result.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn send_succeeds_without_message_id_in_response() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/ocs/v2.php/apps/spreed/api/v1/chat/room-token-123"))
+            .and(query_param("format", "json"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ocs": { "data": {} }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let channel = NextcloudTalkChannel::new(
+            server.uri(),
+            "app-token".into(),
+            "zeroclaw".into(),
+            "nextcloud_talk_test_alias",
+            Arc::new(|| vec!["user_a".into()]),
+        );
+        let result = channel
+            .send(&SendMessage::new("hello", "room-token-123"))
+            .await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn send_draft_returns_message_id_from_response() {
+        use zeroclaw_config::schema::StreamMode;
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/ocs/v2.php/apps/spreed/api/v1/chat/room-token-123"))
+            .and(query_param("format", "json"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ocs": { "data": { "id": 42 } }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let channel = NextcloudTalkChannel::new(
+            server.uri(),
+            "app-token".into(),
+            "zeroclaw".into(),
+            "nextcloud_talk_test_alias",
+            Arc::new(|| vec!["user_a".into()]),
+        )
+        .with_streaming(StreamMode::Partial, 1000);
+        let result = channel
+            .send_draft(&SendMessage::new("hello", "room-token-123"))
+            .await;
+
+        assert_eq!(result.unwrap(), Some("42".to_string()));
+    }
+
+    #[tokio::test]
+    async fn send_draft_errors_when_message_id_missing() {
+        use zeroclaw_config::schema::StreamMode;
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/ocs/v2.php/apps/spreed/api/v1/chat/room-token-123"))
+            .and(query_param("format", "json"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ocs": { "data": {} }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let channel = NextcloudTalkChannel::new(
+            server.uri(),
+            "app-token".into(),
+            "zeroclaw".into(),
+            "nextcloud_talk_test_alias",
+            Arc::new(|| vec!["user_a".into()]),
+        )
+        .with_streaming(StreamMode::Partial, 1000);
+        let result = channel
+            .send_draft(&SendMessage::new("hello", "room-token-123"))
+            .await;
+
+        assert!(result.is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Shares the Nextcloud Talk OCS chat URL and request setup used by normal sends, draft sends, edits, and deletes.
  - Keeps normal `send` success-only behavior: a successful Talk response no longer needs to include an OCS message ID.
  - Keeps message ID parsing on the draft-send path, where the ID is needed for later draft edits.
  - Makes Talk message-limit truncation find the UTF-8 boundary in one pass.
  - Logs unexpected draft edit failures once, with context that the final response will still be delivered.
- **Scope boundary:** This PR does not change Nextcloud Talk configuration, authentication, room routing, HMAC handling, or streaming mode selection.
- **Blast radius:** Nextcloud Talk outbound sends and streaming draft updates. Other channels and shared channel traits are not changed.
- **Linked issue(s):** Related PR #6048 and PR #5718.
- **Labels:** `enhancement`, `risk: medium`, `size: S`, `channel`, `channel:nextcloud-talk`

## Validation Evidence (required)

- **Commands run and tail output:**

```text
cargo fmt --all -- --check
tail output:
(no formatter diagnostics emitted)
result: passed

cargo test -p zeroclaw-channels --features channel-nextcloud nextcloud_talk --lib
tail output:
test nextcloud_talk::tests::nextcloud_talk_parse_as2_skips_bot_by_name ... ok

test result: ok. 27 passed; 0 failed; 0 ignored; 0 measured; 742 filtered out; finished in 1.08s
result: passed; 27 passed, 0 failed

cargo clippy -p zeroclaw-channels --features channel-nextcloud --lib -- -D warnings
tail output:
Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.88s
result: passed

git diff --check
tail output:
(no whitespace diagnostics emitted)
result: passed
```

- **Beyond CI — what did you manually verify?** Reviewed the Nextcloud Talk send and draft-send split so normal sends still only require a 2xx response, while draft sends still require the OCS message ID needed for later edits. Added behavior tests for both sides of that boundary.
- **If any command was intentionally skipped, why:** Workspace-wide clippy and full CI-equivalent tests were not run locally. The change is confined to one Nextcloud Talk channel file, focused local validation passed, and GitHub CI is green.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: None.

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: No upgrade steps required.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <merge-commit>`
- **Feature flags or config toggles:** `channel-nextcloud` controls compilation of this channel code; there is no runtime toggle for this cleanup.
- **Observable failure symptoms:** Nextcloud Talk messages fail to send or draft-update warnings appear in logs with `Talk update_draft edit failed; final response will still be delivered`.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): Not applicable.
- Scope materially carried forward: Not applicable.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`No`)
- If `No`, why (inspiration-only, no direct code/design carry-over): This is a follow-up cleanup to merged PR #6048. It does not directly carry forward code from a superseded branch.
