### PR TITLE
fix(gateway): route chat workspaces per agent

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -5611,6 +5611,18 @@ fn maybe_restart_managed_daemon_service() -> Result<bool> {
     Ok(false)
 }
 
+#[cfg(any(
+    test,
+    feature = "channel-discord",
+    feature = "channel-matrix",
+    feature = "channel-slack",
+    feature = "channel-telegram",
+    feature = "channel-wechat",
+))]
+fn one_shot_channel_workspace_dir(config: &Config, channel_type: &str, alias: &str) -> PathBuf {
+    config.channel_workspace_dir(&format!("{channel_type}.{alias}"))
+}
+
 /// Build a single channel instance by config section name (e.g. "telegram").
 fn build_channel_by_id(
     config_arc: &Arc<RwLock<Config>>,
@@ -5633,6 +5645,7 @@ fn build_channel_by_id(
                 let alias = alias.clone();
                 Arc::new(move || cfg_arc.read().channel_external_peers("telegram", &alias))
             };
+            let workspace_dir = one_shot_channel_workspace_dir(&config, "telegram", &alias);
             Ok(Arc::new(
                 TelegramChannel::new(
                     tg.bot_token.clone(),
@@ -5646,7 +5659,7 @@ fn build_channel_by_id(
                 .with_transcription(config.transcription.clone())
                 .with_tts(&config)
                 .with_voice_peer_prefs(&config, "telegram", alias)
-                .with_workspace_dir(config.data_dir.clone())
+                .with_workspace_dir(workspace_dir)
                 .with_approval_timeout_secs(tg.approval_timeout_secs),
             ))
         }
@@ -5667,6 +5680,7 @@ fn build_channel_by_id(
                 let alias = alias.clone();
                 Arc::new(move || cfg_arc.read().channel_external_peers("discord", &alias))
             };
+            let workspace_dir = one_shot_channel_workspace_dir(&config, "discord", &alias);
             Ok(Arc::new(
                 DiscordChannel::new(
                     dc.bot_token.clone(),
@@ -5677,7 +5691,7 @@ fn build_channel_by_id(
                     dc.mention_only,
                 )
                 .with_channel_ids(dc.channel_ids.clone())
-                .with_workspace_dir(config.data_dir.clone())
+                .with_workspace_dir(workspace_dir)
                 .with_streaming(
                     dc.stream_mode,
                     dc.draft_update_interval_ms,
@@ -5705,6 +5719,7 @@ fn build_channel_by_id(
                 let alias = alias.clone();
                 Arc::new(move || cfg_arc.read().channel_external_peers("slack", &alias))
             };
+            let workspace_dir = one_shot_channel_workspace_dir(&config, "slack", &alias);
             Ok(Arc::new(
                 SlackChannel::new(
                     sl.bot_token.clone(),
@@ -5713,7 +5728,7 @@ fn build_channel_by_id(
                     alias,
                     peer_resolver,
                 )
-                .with_workspace_dir(config.data_dir.clone())
+                .with_workspace_dir(workspace_dir)
                 .with_markdown_blocks(sl.use_markdown_blocks)
                 .with_transcription(config.transcription.clone())
                 .with_streaming(sl.stream_drafts, sl.draft_update_interval_ms)
@@ -5805,10 +5820,11 @@ fn build_channel_by_id(
                     Arc::new(move || cfg_arc.read().channel_external_peers("matrix", &alias))
                 };
                 let ack = mx.ack_reactions.unwrap_or(config.channels.ack_reactions);
+                let workspace_dir = one_shot_channel_workspace_dir(&config, "matrix", &alias);
                 Ok(Arc::new(
                     MatrixChannel::new(mx.clone(), alias, peer_resolver, state_dir)?
                         .with_transcription(config.transcription.clone())
-                        .with_workspace_dir(config.data_dir.clone())
+                        .with_workspace_dir(workspace_dir)
                         .with_ack_reactions(ack),
                 ))
             }
@@ -6008,6 +6024,7 @@ fn build_channel_by_id(
                 let alias = alias.clone();
                 Arc::new(move || cfg_arc.read().channel_external_peers("wechat", &alias))
             };
+            let workspace_dir = one_shot_channel_workspace_dir(&config, "wechat", &alias);
             Ok(Arc::new(
                 WeChatChannel::new(
                     alias,
@@ -6017,7 +6034,7 @@ fn build_channel_by_id(
                     wc.state_dir.as_ref().map(|s| expand_tilde_in_path(s)),
                 )?
                 .with_persistence(config_arc.clone())
-                .with_workspace_dir(config.data_dir.clone()),
+                .with_workspace_dir(workspace_dir),
             ))
         }
         #[cfg(not(feature = "channel-wechat"))]
@@ -18374,6 +18391,31 @@ This is an example JSON object for profile settings."#;
             }
             Ok(_) => panic!("should fail for unknown channel"),
         }
+    }
+
+    #[test]
+    fn one_shot_channel_workspace_dir_uses_owning_agent_workspace() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut config = Config {
+            data_dir: tmp.path().join("data"),
+            config_path: tmp.path().join("config.toml"),
+            ..Config::default()
+        };
+        config.agents.insert(
+            "alice".to_string(),
+            zeroclaw_config::schema::AliasedAgentConfig {
+                enabled: true,
+                channels: vec![zeroclaw_config::providers::ChannelRef(
+                    "telegram.default".to_string(),
+                )],
+                ..Default::default()
+            },
+        );
+
+        let resolved = one_shot_channel_workspace_dir(&config, "telegram", "default");
+
+        assert_eq!(resolved, config.agent_workspace_dir("alice"));
+        assert_ne!(resolved, config.data_dir);
     }
 
     // ── Query classification in channel message processing ─────────

--- a/crates/zeroclaw-gateway/src/ws.rs
+++ b/crates/zeroclaw-gateway/src/ws.rs
@@ -388,7 +388,8 @@ async fn handle_socket(
         }
     }
 
-    let session_cwd = match resolve_session_cwd(requested_cwd.as_deref(), &config.data_dir) {
+    let session_cwd = match resolve_ws_session_cwd(requested_cwd.as_deref(), &config, &agent_alias)
+    {
         Ok(cwd) => cwd,
         Err(e) => {
             let err = serde_json::json!({
@@ -735,6 +736,34 @@ fn resolve_session_cwd(
             cwd.display()
         ))
     })
+}
+
+fn resolve_ws_session_cwd(
+    requested_cwd: Option<&str>,
+    config: &zeroclaw_config::schema::Config,
+    agent_alias: &str,
+) -> anyhow::Result<PathBuf> {
+    let agent_workspace = config.agent_workspace_dir(agent_alias);
+    if requested_cwd.is_none() {
+        std::fs::create_dir_all(&agent_workspace).map_err(|e| {
+            ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Reject)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                    .with_attrs(::serde_json::json!({
+                        "agent": agent_alias,
+                        "cwd": agent_workspace.display().to_string(),
+                        "error": format!("{}", e),
+                    })),
+                "ws agent workspace cwd rejected"
+            );
+            anyhow::Error::msg(format!(
+                "cwd is not a usable directory ({}): {e}",
+                agent_workspace.display()
+            ))
+        })?;
+    }
+    resolve_session_cwd(requested_cwd, &agent_workspace)
 }
 
 fn session_queue_ws_error_code(error: &crate::session_queue::SessionQueueError) -> &'static str {
@@ -1760,6 +1789,55 @@ mod tests {
         let resolved = resolve_session_cwd(None, fallback.path()).unwrap();
 
         assert_eq!(resolved, fallback.path().canonicalize().unwrap());
+    }
+
+    #[test]
+    fn resolve_ws_session_cwd_defaults_to_agent_workspace_without_request() {
+        use tempfile::TempDir;
+        use zeroclaw_config::schema::{AliasedAgentConfig, Config};
+
+        let tmp = TempDir::new().unwrap();
+        let mut config = Config {
+            data_dir: tmp.path().join("data"),
+            config_path: tmp.path().join("config.toml"),
+            ..Config::default()
+        };
+        config
+            .agents
+            .insert("web".to_string(), AliasedAgentConfig::default());
+        std::fs::create_dir_all(&config.data_dir).unwrap();
+        let agent_workspace = config.agent_workspace_dir("web");
+        assert!(!agent_workspace.exists());
+
+        let resolved = resolve_ws_session_cwd(None, &config, "web").unwrap();
+
+        assert!(agent_workspace.exists());
+        assert_eq!(resolved, agent_workspace.canonicalize().unwrap());
+        assert_ne!(resolved, config.data_dir.canonicalize().unwrap());
+    }
+
+    #[test]
+    fn resolve_ws_session_cwd_keeps_requested_cwd_strict() {
+        use tempfile::TempDir;
+        use zeroclaw_config::schema::{AliasedAgentConfig, Config};
+
+        let tmp = TempDir::new().unwrap();
+        let mut config = Config {
+            data_dir: tmp.path().join("data"),
+            config_path: tmp.path().join("config.toml"),
+            ..Config::default()
+        };
+        config
+            .agents
+            .insert("web".to_string(), AliasedAgentConfig::default());
+        let agent_workspace = config.agent_workspace_dir("web");
+        let missing_requested = tmp.path().join("missing");
+
+        let err = resolve_ws_session_cwd(Some(missing_requested.to_str().unwrap()), &config, "web")
+            .expect_err("explicit missing cwd should be rejected");
+
+        assert!(!agent_workspace.exists());
+        assert!(err.to_string().contains("cwd is not a usable directory"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Gateway WS chat now defaults omitted session cwd requests to the selected agent's configured workspace, instead of the shared `data_dir`, so the WS path matches per-agent workspace policy.
  - One-shot `channel send` construction now resolves Telegram, Discord, Slack, Matrix, and WeChat workspace roots through `Config::channel_workspace_dir("<type>.default")`, matching the daemon channel path and preserving the existing orphan-channel fallback behavior.
  - Tests verify the WS no-cwd default and the one-shot channel owner workspace resolution.
- **Scope boundary:** This PR does not change config schema, env vars, CLI arguments, explicit WS cwd handling, daemon channel startup, or how one-shot channel send selects the existing `default` alias.
- **Blast radius:** Gateway WS chat session cwd defaults and one-shot `channel send` file/tool workspace behavior for Telegram, Discord, Slack, Matrix, and WeChat. Explicit WS cwd callers remain unchanged. Channel refs with no owning agent still use the existing `channel_workspace_dir` fallback behavior.
- **Linked issue(s):** Fixes #7541
- **Labels:** `bug`, `risk: high`, `size: S`, `channel`, `channel: core`, `gateway`, `gateway: ws`

## Validation Evidence (required)

- **Commands run and tail output:**

```text
$ cargo test -p zeroclaw-gateway resolve_ws_session_cwd
running 2 tests
test ws::tests::resolve_ws_session_cwd_keeps_requested_cwd_strict ... ok
test ws::tests::resolve_ws_session_cwd_defaults_to_agent_workspace_without_request ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 250 filtered out; finished in 0.00s

$ cargo test -p zeroclaw-channels one_shot_channel_workspace_dir_uses_owning_agent_workspace
running 1 test
test orchestrator::tests::one_shot_channel_workspace_dir_uses_owning_agent_workspace ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 742 filtered out; finished in 0.04s

$ cargo fmt --all -- --check
exit 0

$ git diff --check
exit 0

$ cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 98m 47s

$ cargo nextest run --locked --workspace --exclude zeroclaw-desktop
exit 100; stopped after 5508/8491 tests with 5505 passed, 3 failed, and 10 skipped. The three failures were unrelated `zeroclaw-runtime tools::delegate` background-task timeout tests; no touched gateway or channel tests failed.
```

- **Beyond CI — what did you manually verify?** Audited the reported gateway WS chat and one-shot `channel send` paths for remaining `data_dir` workspace handoffs. The reported `with_workspace_dir(config.data_dir.clone())` one-shot builder calls are removed, and the WS no-request session cwd route now creates/canonicalizes the selected agent workspace instead of failing before runtime startup can create it.
- **If any command was intentionally skipped, why:** Full local nextest did not complete green because of the unrelated runtime delegate timeout failures listed above. A focused rerun of those delegate tests was started for extra classification evidence but interrupted while still compiling under concurrent machine Cargo load. Remote GitHub CI, including the required Test job, passed.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`Yes`) This changes the implicit WS cwd and one-shot channel workspace from shared `data_dir` to the selected or owning agent workspace.
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: This is an intended narrowing correction. Explicit WS cwd validation remains unchanged, implicit WS defaults create only the selected agent workspace, and orphan channel refs keep the existing `channel_workspace_dir` fallback behavior.

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: No upgrade steps required. WS clients that omit cwd now use the selected agent's workspace by default; WS clients that pass an explicit cwd keep the existing validation behavior.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** After merge, `git revert <merge-sha>` restores the previous workspace routing. Before merge, revert the changes in `crates/zeroclaw-gateway/src/ws.rs` and `crates/zeroclaw-channels/src/orchestrator/mod.rs`.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Gateway WS file writes or relative tool paths unexpectedly landing outside the selected agent workspace; one-shot `channel send` attachments or skills resolving against the wrong workspace; `workspace_dir` regressions in channel send logs or user-visible attachment-not-found errors.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Scope materially carried forward: N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`Yes/No`): N/A
- If `No`, why (inspiration-only, no direct code/design carry-over): N/A
