### PR TITLE
docs(delegation): document agentic target's allowed_tools requirement

### DIFF
--- a/docs/book/src/agents/delegation.md
+++ b/docs/book/src/agents/delegation.md
@@ -131,6 +131,14 @@ This is a thin signal for the agent-loop spawn path. A dedicated "subagent start
 
 Because reachability is gated by the shared risk profile, the advertised roster (the `agent` parameter's enum in the tool schema) lists only the configured agents that share the caller's risk profile, minus the caller itself, and only when `delegation_policy.mode = "allow"`. There is no separate per-agent allow-list: the shared profile *is* the allow-list.
 
+#### Extra precondition when the target is agentic
+
+If the target agent's `[runtime_profiles.<target>].agentic = true`, a third gate fires on the target's side of the call:
+
+3. **Target's `risk_profile.allowed_tools` must be non-empty.** The agentic sub-loop builds its child tool registry by intersecting the parent's available tools with the **target's** `[risk_profiles.<target_profile>].allowed_tools`. An empty (or unset) list yields an empty intersection, which the tool refuses before invoking the model; see refusal string #10 below. The sub-loop additionally drops `delegate` from the intersection unconditionally (no recursive delegation), so a target whose entire allowlist is `["delegate"]` also refuses with #11 below.
+
+This precondition lives on the target, not the caller, but because gate 2 forces caller and target to share a risk profile, in practice it's a constraint on the **shared** profile. If the shared profile's `allowed_tools` is empty, no agentic target on that profile is reachable until the operator adds at least one tool name.
+
 ### `delegate`: output strings the model sees
 
 Exact, sourced from `crates/zeroclaw-runtime/src/tools/delegate.rs`.
@@ -150,6 +158,16 @@ Exact, sourced from `crates/zeroclaw-runtime/src/tools/delegate.rs`.
 7. Unknown target agent: error is `Unknown agent '<target>'. Available agents: <comma-separated list>`.
 8. Depth exceeded (controlled by the parent's `runtime_profile.max_delegation_depth`, default 3): error is `Delegation depth limit reached (<depth>/<max>).`
 9. Unknown action: error is `Unknown action '<value>'. Use delegate/check_result/list_results/cancel_task.`
+10. **Agentic target with empty `allowed_tools`**: when the target agent's `runtime_profile.agentic = true`, the target's `risk_profile.allowed_tools` must be non-empty. If it is empty (or unset), the refusal is:
+    ```text
+    Agent '<target>' is agentic but risk_profile '<target_profile>' has no allowed_tools
+    ```
+    The check fires before any sub-loop work. Fix it by adding at least one tool name to `[risk_profiles.<target_profile>].allowed_tools` (or by switching the target off agentic mode). The `<target_profile>` in the message is the target agent's risk profile, which, because delegation requires a shared profile (gate 2 above), is also the caller's.
+11. **Agentic target with no matching tools**: if `allowed_tools` is non-empty but, after intersecting with the parent's tool registry and excluding `delegate` (the sub-loop is never given another `delegate`), no tools remain, the refusal is:
+    ```text
+    Agent '<target>' has no executable tools after filtering allowlist (<comma-separated names>)
+    ```
+    Typical cause: every entry on `allowed_tools` is a typo, an MCP/skill tool that isn't currently registered, or the literal name `delegate`.
 
 ### `delegate`: how to verify it actually fired
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - The `delegate` tool refuses with two distinct error strings when the target agent runs in agentic mode but the target's risk profile has empty / missing / unmatched `allowed_tools`. Neither refusal was documented in `docs/book/src/agents/delegation.md`, so the user-facing failure mode was "operator trips over it in production and has to grep the source to find out which risk profile is at fault." This PR adds both refusal strings to the documented output-string list and adds a short "Extra precondition when the target is agentic" subsection under *Delegation gating* so the rule is discoverable before the refusal fires.
- **Scope boundary:** Documentation only. No source changes, no schema changes, no behavior changes to the `delegate` tool. The existing refusal strings and existing tests (`agentic_mode_rejects_empty_allowed_tools`, `agentic_mode_rejects_unmatched_allowed_tools`) are unchanged; both were re-run locally to confirm the doc wording matches the literal source.
- **Blast radius:** Reader-facing only. The mdBook page `docs/book/src/agents/delegation.md` gains ~18 lines under existing section structure. No links, anchors, or `SUMMARY.md` entries change.
- **Linked issue(s):** None. Raised directly from operator feedback that the delegation docs did not surface the `allowed_tools` precondition.
- **Labels:** Snapshot after path-labeler runs; expected `documentation`, `type: docs`, `docs`, `risk: low`, `size: XS`.

## Validation Evidence (required)

Docs-only change, so the Rust battery is replaced by the docs quality gate per `AGENTS.md` / template.

- **Commands run and tail output:**

  ```
  $ git fetch origin master
  $ bash scripts/ci/docs_quality_gate.sh
  No prose em-dashes in changed docs files.
  Linting docs files: docs/book/src/agents/delegation.md
  Existing markdown issues outside changed lines (non-blocking):
    - docs/book/src/agents/delegation.md:138:1 MD029/ol-prefix Ordered list item prefix [Expected: 1; Actual: 3; Style: 1/1/1]
  No blocking markdown issues on changed lines.
  ```

  The single `MD029` notice is non-blocking and intentional: the new "Extra precondition when the target is agentic" subsection numbers its single bullet `3.` to continue the gating list from the parent section (gates 1 and 2 are `delegation_policy.mode` and the shared risk profile, gate 3 is the new agentic-only precondition). Renumbering it `1.` would lose the gate-numbering correspondence the prose explicitly references.

  Also re-ran the two unit tests that pin the documented refusal strings, to confirm wording matches source:

  ```
  $ cargo test -p zeroclaw-runtime --lib -- \
      tools::delegate::tests::agentic_mode_rejects_empty_allowed_tools \
      tools::delegate::tests::agentic_mode_rejects_unmatched_allowed_tools
  running 2 tests
  test tools::delegate::tests::agentic_mode_rejects_empty_allowed_tools ... ok
  test tools::delegate::tests::agentic_mode_rejects_unmatched_allowed_tools ... ok
  test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 2072 filtered out
  ```

- **Beyond CI, what did you manually verify?**
  - Cross-checked both new refusal strings against the source at `crates/zeroclaw-runtime/src/tools/delegate.rs:1666` and `:1693` (`execute_agentic`). Verbatim match including punctuation.
  - Verified `resolve_allowed_tools` (`delegate.rs:543`) reads from `agent_config.risk_profile`, i.e., the *target's* risk profile, which is the basis for the "lives on the target, not the caller, but constrains the shared profile" framing in the new subsection.
  - Re-read the rendered markdown source for structural sanity (heading nesting, fenced code blocks, list continuation).
  - I did **not** verify `mdbook build` produces a clean render: the local build is blocked by a missing `peer-groups` preprocessor binary (pre-existing setup issue, unrelated to this PR). CI is expected to be the authoritative render check.
- **If any command was intentionally skipped, why:** Full `cargo fmt` / `cargo clippy` / `cargo test` battery skipped because no Rust files changed (`git diff --numstat` reports 0 non-doc lines). The two targeted unit tests that anchor the documented strings were run instead.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- The documented behavior already exists in code; this PR only describes it. Existing config files, scripts, and operator runbooks are unaffected.

## Rollback

Low-risk docs-only PR. Single commit; rollback is git revert 21fb7061ecfe799cb21f5494f7f7c79a3e6c81b1.

