### PR TITLE
fix(sop): wire audit logger into registered SOP tools

### DIFF
--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -1124,10 +1124,17 @@ pub fn all_tools_with_runtime(
         let mut engine = crate::sop::SopEngine::new(root_config.sop.clone());
         engine.reload(workspace_dir);
         let sop_engine = Arc::new(std::sync::Mutex::new(engine));
+        let sop_audit = Arc::new(crate::sop::SopAuditLogger::new(memory.clone()));
         tool_arcs.push(Arc::new(SopListTool::new(Arc::clone(&sop_engine))));
-        tool_arcs.push(Arc::new(SopExecuteTool::new(Arc::clone(&sop_engine))));
-        tool_arcs.push(Arc::new(SopAdvanceTool::new(Arc::clone(&sop_engine))));
-        tool_arcs.push(Arc::new(SopApproveTool::new(Arc::clone(&sop_engine))));
+        tool_arcs.push(Arc::new(
+            SopExecuteTool::new(Arc::clone(&sop_engine)).with_audit(Arc::clone(&sop_audit)),
+        ));
+        tool_arcs.push(Arc::new(
+            SopAdvanceTool::new(Arc::clone(&sop_engine)).with_audit(Arc::clone(&sop_audit)),
+        ));
+        tool_arcs.push(Arc::new(
+            SopApproveTool::new(Arc::clone(&sop_engine)).with_audit(Arc::clone(&sop_audit)),
+        ));
         tool_arcs.push(Arc::new(SopStatusTool::new(Arc::clone(&sop_engine))));
     }
 
@@ -1622,6 +1629,79 @@ mod tests {
         assert!(names.contains(&"model_routing_config"));
         assert!(names.contains(&"pushover"));
         assert!(names.contains(&"proxy_config"));
+    }
+
+    /// Wiring guard for issue #6689: SOP tools registered via `all_tools` must
+    /// carry a real audit logger, so a tool-driven run persists the documented
+    /// `sop_run_*` Memory key. The per-tool unit tests prove `with_audit` works;
+    /// this is the only test proving registration actually wires it. Without the
+    /// `.with_audit(...)` calls in the SOP block, the audit trail is silently a
+    /// no-op on the agent path (the path the AMQP/sop_execute deployment uses).
+    #[tokio::test]
+    async fn registered_sop_tools_persist_audit_trail() {
+        let tmp = TempDir::new().unwrap();
+        let sops_dir = tmp.path().join("sops");
+        let sop_subdir = sops_dir.join("canary");
+        std::fs::create_dir_all(&sop_subdir).unwrap();
+        std::fs::write(
+            sop_subdir.join("SOP.toml"),
+            "[sop]\nname = \"canary\"\ndescription = \"audit wiring guard\"\nversion = \"1.0.0\"\n\n[[triggers]]\ntype = \"manual\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            sop_subdir.join("SOP.md"),
+            "## Steps\n\n1. **Resolve** Do the first step\n   - tools: shell\n",
+        )
+        .unwrap();
+
+        let mem_cfg = MemoryConfig {
+            backend: "sqlite".into(),
+            ..MemoryConfig::default()
+        };
+        let mem: Arc<dyn Memory> =
+            Arc::from(zeroclaw_memory::create_memory(&mem_cfg, tmp.path(), None).unwrap());
+
+        let security = Arc::new(SecurityPolicy::default());
+        let mut cfg = test_config(&tmp);
+        cfg.sop.sops_dir = Some(sops_dir.to_string_lossy().into_owned());
+
+        let tools = all_tools(
+            Arc::new(Config::default()),
+            &security,
+            &zeroclaw_config::schema::RiskProfileConfig::default(),
+            "test-agent",
+            mem.clone(),
+            None,
+            None,
+            &BrowserConfig::default(),
+            &zeroclaw_config::schema::HttpRequestConfig::default(),
+            &zeroclaw_config::schema::WebFetchConfig::default(),
+            tmp.path(),
+            &HashMap::new(),
+            None,
+            &cfg,
+            None,
+            false,
+            None,
+        )
+        .tools;
+
+        let execute = tools
+            .iter()
+            .find(|t| t.name() == "sop_execute")
+            .expect("sop_execute must be registered when sops_dir is set");
+        let result = execute
+            .execute(serde_json::json!({"name": "canary"}))
+            .await
+            .unwrap();
+        assert!(result.success, "sop_execute failed: {result:?}");
+
+        let audit = crate::sop::SopAuditLogger::new(mem.clone());
+        let run_keys = audit.list_runs().await.unwrap();
+        assert!(
+            !run_keys.is_empty(),
+            "registered sop_execute must persist a sop_run_* audit entry; got none (audit not wired)"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `SopExecuteTool` / `SopAdvanceTool` / `SopApproveTool` accept an audit logger via `with_audit(...)`, but `all_tools_with_runtime` constructed them with bare `::new(...)`, leaving `self.audit` permanently `None`. Every audit branch (`log_run_start`, `log_step_result`, `log_run_complete`, `log_approval`) was dead code on the agent path, so the `sop_run_*` / `sop_step_*` / `sop_approval_*` Memory keys documented under category `sop` were never written.
  - This is the agent-driven path real deployments use: an inbound event (e.g. AMQP) enters the agent loop and fires the SOP via the `sop_execute` tool, not via the MQTT listener. Without the audit trail the run is not reconstructable and `SopMetricsCollector::rebuild_from_memory` returns empty after a restart.
  - Construct a single `SopAuditLogger` over the agent's real Memory backend and pass it to the execute/advance/approve tools at registration.
  - Add a registration-level test that fires `sop_execute` through `all_tools` and asserts a `sop_run_*` entry is persisted. The per-tool unit tests already cover audit behavior; none proved the wiring.
- **Scope boundary:** Only the agent tool-registration path. Does NOT change the MQTT listener's `NoneMemory` use (`src/main.rs`), which is the other half of #6689 and is entangled with engine unification (#6687). Does NOT change the audit logger, key format, or memory backend.
- **Blast radius:** SOP tool registration only. When `[sop].sops_dir` is set, the execute/advance/approve tools now write audit entries to the agent's existing Memory backend. No new tools, no schema change. Agents with no SOPs configured are unaffected (the block is gated on `sops_dir.is_some()`).
- **Linked issue(s):** Related #6689 (resolves the agent-path half; the MQTT/NoneMemory half remains, see #6687)
- **Labels:** `type: bug`, `risk: low`, `size: S`

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy -p zeroclaw-runtime --all-targets -- -D warnings
cargo test -p zeroclaw-runtime --lib sop
```

- **Commands run and tail output:**

```
$ cargo fmt --all -- --check
FMT_EXIT=0   (no output, clean)

$ cargo clippy -p zeroclaw-runtime --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.00s

$ cargo test -p zeroclaw-runtime --lib sop
test tools::sop_advance::tests::advance_success_writes_step_audit ... ok
test tools::sop_approve::tests::approve_writes_audit ... ok
test tools::tests::registered_sop_tools_persist_audit_trail ... ok
test result: ok. 183 passed; 0 failed; 0 ignored; 0 measured; 1930 filtered out; finished in 0.39s
```

- **Beyond CI — what I manually verified:** New test `registered_sop_tools_persist_audit_trail` fails on the pre-fix tree (tools registered with `::new`, no audit) and passes after wiring. Confirmed the channel orchestrator and agent-loop call sites pass the real per-agent Memory backend (`Arc::clone(&mem)`), so the persisted entries land in production memory, not a no-op. Verified the audit key (`sop_run_<id>`, category `Custom("sop")`) matches `docs/book/src/sop/observability.md`.
- **Beyond CI — what I did NOT verify:** Full workspace `cargo test` was not run; scoped to the touched crate. The MQTT listener path is out of scope and unverified here.
- **If any command was intentionally skipped, why:** Ran crate-scoped clippy/test rather than the full workspace battery because the change is a one-file, single-crate wiring fix with no cross-crate surface.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Existing agents with `[sop].sops_dir` set begin persisting the documented audit entries automatically; no action required.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk: `git revert <sha>` is the plan.