### PR TITLE
fix(runtime): replace println! with zeroclaw_log::record! in daemon startup

### DIFF
--- a/crates/zeroclaw-runtime/src/daemon/mod.rs
+++ b/crates/zeroclaw-runtime/src/daemon/mod.rs
@@ -501,17 +501,38 @@ pub async fn run(
         );
     }
 
-    println!("🧠 ZeroClaw daemon started");
-    println!("   Gateway:  http://{host}:{port}");
-    println!(
-        "   Socket:   {}",
-        crate::rpc::local::socket_path(&config).display()
+    ::zeroclaw_log::record!(
+        INFO,
+        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note),
+        "ZeroClaw daemon started"
     );
-    println!("   Components: gateway, channels, heartbeat, scheduler");
+    ::zeroclaw_log::record!(
+        INFO,
+        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note),
+        format!("Gateway: http://{host}:{port}")
+    );
+    ::zeroclaw_log::record!(
+        INFO,
+        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note),
+        format!("Socket: {}", crate::rpc::local::socket_path(&config).display())
+    );
+    ::zeroclaw_log::record!(
+        INFO,
+        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note),
+        "Components: gateway, channels, heartbeat, scheduler"
+    );
     if config.gateway.require_pairing {
-        println!("   Pairing:    enabled (code appears in gateway output above)");
+        ::zeroclaw_log::record!(
+            INFO,
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note),
+            "Pairing: enabled (code appears in gateway output above)"
+        );
     }
-    println!("   Ctrl+C or SIGTERM to stop");
+    ::zeroclaw_log::record!(
+        INFO,
+        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note),
+        "Ctrl+C or SIGTERM to stop"
+    );
 
     // Wait for shutdown (SIGINT/SIGTERM/Ctrl+C) or reload (in-process channel).
     let exit = wait_for_exit_signal(reload_rx, ephemeral, socket_client_count).await?;

--- a/crates/zeroclaw-runtime/src/daemon/mod.rs
+++ b/crates/zeroclaw-runtime/src/daemon/mod.rs
@@ -514,7 +514,10 @@ pub async fn run(
     ::zeroclaw_log::record!(
         INFO,
         ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note),
-        format!("Socket: {}", crate::rpc::local::socket_path(&config).display())
+        format!(
+            "Socket: {}",
+            crate::rpc::local::socket_path(&config).display()
+        )
     );
     ::zeroclaw_log::record!(
         INFO,


### PR DESCRIPTION
## Summary

- **What changed:** Replace 6 `println!` calls in daemon startup banner with structured `zeroclaw_log::record!` calls at INFO level.
- **Why:** The project's `clippy.toml` bans `println!`/`eprintln!` in daemon code paths — all output must go through `::zeroclaw_log::record!` for consistent structured logging, JSONL persistence, and dashboard SSE broadcast. This is a known violation tracked in the codebase (~430 total).
- **Scope boundary:** Only the daemon startup banner in `daemon/mod.rs`. Does not touch other `println!` violations elsewhere.
- **Blast radius:** Minimal — changes the log emission surface for 6 startup messages from raw stdout to the structured log pipeline. Users will see the same information via the tracing subscriber instead of direct println.
- **Linked issue(s):** N/A (proactive cleanup of known clippy.toml violation)
- **Labels:** `type: fix`, `risk: low`, `size: XS`

## Validation Evidence (required)

```bash
$ cargo fmt --all -- --check
(no output — formatted correctly)

$ cargo clippy --all-targets -- -D warnings
(note: requires full Rust toolchain with C compiler for native deps)

$ git diff --stat upstream/master...HEAD
 crates/zeroclaw-runtime/src/daemon/mod.rs | 37 ++++++++++++++++++++++++-------
 1 file changed, 29 insertions(+), 8 deletions(-)
```

- **Commands run and tail output:** `git diff --stat`, `git diff` — verified only the target file is changed, no unrelated modifications.
- **Beyond CI — what did you manually verified:** Verified the diff shows exactly 6 println! → record! replacements with correct macro syntax matching existing usage patterns in the same file.
- **If any command was intentionally skipped, why:** Full `cargo clippy`/`cargo test` skipped due to environment constraint (missing C compiler for native deps); remote CI will validate.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PR: `git revert <sha>` is the plan.

---
