### PR TITLE
docs(log): add crate-level README.md

### DIFF
--- a/crates/zeroclaw-log/README.md
+++ b/crates/zeroclaw-log/README.md
@@ -1,0 +1,50 @@
+# zeroclaw-log
+
+Unified log emission surface for the ZeroClaw workspace.
+
+Every crate that emits domain events (agent activity, channel I/O, cron runs,
+tool calls, memory ops, session lifecycle, errors) goes through the [`record!`]
+macro. That single emission point fans out to:
+
+1. A `tracing::event!` at the matching severity so `RUST_LOG`-gated terminal
+   output and any external `tracing-subscriber` consumer see the event with
+   structured `key=value` fields.
+2. The persisted JSONL log at `<workspace>/state/runtime-trace.jsonl` (when
+   `[observability] log_persistence` is `"rolling"` or `"full"`).
+3. The process-wide broadcast channel so the dashboard's SSE stream sees every
+   event live.
+
+## Usage
+
+```rust
+use zeroclaw_log::{record, Event, Action, EventOutcome};
+
+// Simple informational message
+record!(INFO, Event::new(module_path!(), Action::Note), "starting step");
+
+// Warning with structured attributes
+record!(
+    WARN,
+    Event::new(module_path!(), Action::Fail)
+        .with_outcome(EventOutcome::Failure)
+        .with_attrs(serde_json::json!({"err": "timeout"})),
+    "tool failed"
+);
+```
+
+## Architecture
+
+- **`record!`** — the sole logging surface. Direct `tracing::info!` / `warn!` /
+  etc. are banned workspace-wide via `clippy.toml` `disallowed-macros`.
+- **`Event`** — structured event payload carrying name, action, outcome,
+  category, duration, and arbitrary JSON attributes.
+- **`LogEvent`** — the full wire schema (OTel/ECS hybrid with ZeroClaw-domain
+  `zeroclaw.*` namespace for attribution fields).
+- **Broadcast hook** — every `record!` emission reaches the dashboard's SSE
+  stream via a process-wide `tokio::sync::broadcast` channel.
+- **JSONL writer** — rolling/full persistence to `runtime-trace.jsonl`.
+
+## Stability
+
+Beta — breaking changes permitted in MINOR with changelog notes. Targeting
+stable at v0.8.0.


### PR DESCRIPTION
## Summary

- **What changed:** Add a crate-level `README.md` for `zeroclaw-log`.
- **Why:** All 16 crates under `crates/` are missing README files. Per-crate READMEs help new contributors understand what each crate does without reading source code. `zeroclaw-log` is the workspace's unified log emission surface — a critical crate worth documenting first.
- **Scope boundary:** Only adds a new README file. No code changes.
- **Blast radius:** None — documentation only.
- **Linked issue(s):** N/A
- **Labels:** `type: docs`, `risk: low`, `size: XS`, `docs`

## Validation Evidence (required)

```bash
$ git diff --stat upstream/master...HEAD
 crates/zeroclaw-log/README.md | 50 ++++++++++++++++++++++++++++++++++++++++++++++++++
 1 file changed, 50 insertions(+)
```

- **Commands run and tail output:** `git diff --stat` — verified only the new README is added.
- **Beyond CI — what did you manually verified:** Read the file to confirm accurate content matches the crate's `lib.rs` documentation and `Cargo.toml` description.
- **If any command was intentionally skipped, why:** Docs-only change; `cargo clippy`/`cargo test` not applicable.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PR: `git revert <sha>` is the plan.
---
