### PR TITLE
docs(api): add crate-level README.md

### DIFF
--- a/crates/zeroclaw-api/README.md
+++ b/crates/zeroclaw-api/README.md
@@ -1,0 +1,43 @@
+# zeroclaw-api
+
+Trait definitions and shared types for ZeroClaw — the API layer.
+
+This crate defines the fundamental abstractions that all ZeroClaw subsystems
+depend on. No implementations, no heavy dependencies. Every other crate in the
+workspace depends on this. The compiler enforces that no implementation crate
+can import another without going through these interfaces.
+
+## Traits
+
+| Trait | Module | Purpose |
+|-------|--------|---------|
+| `ModelProvider` | `model_provider` | LLM inference backends |
+| `Channel` | `channel` | Messaging platform integrations |
+| `Tool` | `tool` | Agent-callable capabilities |
+| `Memory` | `memory_traits` | Conversation memory backends |
+| `Observer` | `observability_traits` | Metrics and tracing |
+| `RuntimeAdapter` | `runtime_traits` | Execution environment adapters |
+| `Peripheral` | `peripherals_traits` | Hardware board integrations (STM32, RPi GPIO) |
+
+## Key Modules
+
+- **`agent`** — agent configuration and identity types
+- **`attribution`** — alias-bound attribution for log events (channel, agent, session)
+- **`hook`** — lifecycle hooks for channel and agent events
+- **`jsonrpc`** — JSON-RPC message types for gateway communication
+- **`media`** — media attachment types for channel messages
+- **`schema`** — shared schema types
+- **`session_keys`** — session key construction and parsing
+- **`vad`** — voice activity detection types
+
+## Layering
+
+`zeroclaw-api` is the bottom of the dependency graph. It intentionally does NOT
+depend on `zeroclaw-log` or `zeroclaw-spawn` — its small handful of internal
+spawn needs go through the workspace-wide `disallowed_methods` exemption
+documented in `clippy.toml`. This keeps the API surface free of runtime
+dependencies.
+
+## Stability
+
+Experimental — targeting stable at v1.0.0 (formal milestone).


### PR DESCRIPTION
## Summary

- **What changed:** Add a crate-level `README.md` for `zeroclaw-api`.
- **Why:** `zeroclaw-api` is the foundation crate — every other workspace crate depends on it. A README documents the trait definitions, module layout, dependency layering rules, and stability tier for new contributors.
- **Scope boundary:** Only adds a new README file. No code changes.
- **Blast radius:** None — documentation only.
- **Linked issue(s):** N/A
- **Labels:** `type: docs`, `risk: low`, `size: XS`, `docs`

## Validation Evidence (required)

```bash
$ git diff --stat upstream/master...HEAD
 crates/zeroclaw-api/README.md | 43 +++++++++++++++++++++++++++++++++++++++++++
 1 file changed, 43 insertions(+)
```

- **Commands run and tail output:** `git diff --stat` — verified only the new README is added.
- **Beyond CI — what did you manually verified:** Read the file to confirm accurate content matches the crate's `lib.rs` documentation, `Cargo.toml` description, and AGENTS.md stability tier table.
- **If any command was intentionally skipped, why:** Docs-only change; `cargo clippy`/`cargo test` not applicable.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PR: `git revert <sha>` is the plan.
---
