### PR TITLE
docs(infra): add crate-level README.md

### DIFF
--- a/crates/zeroclaw-infra/README.md
+++ b/crates/zeroclaw-infra/README.md
@@ -1,0 +1,42 @@
+# zeroclaw-infra
+
+Channel infrastructure: session backends, debouncing, and stall watchdog.
+
+These are cross-cutting utilities used by multiple channel implementations in
+the ZeroClaw workspace.
+
+## Modules
+
+| Module | Purpose |
+|--------|---------|
+| `session_backend` | Trait definition for session persistence backends |
+| `session_sqlite` | SQLite-backed session store (default) |
+| `session_store` | JSONL-backed session store (legacy) |
+| `session_queue` | Ordered message queue for session delivery |
+| `acp_session_store` | ACP (Agent Communication Protocol) session storage |
+| `debounce` | Message deduplication and rate-limiting |
+| `stall_watchdog` | Detects and recovers stalled agent sessions |
+
+## Session Backends
+
+The crate provides two session-persistence backends via [`make_session_backend`]:
+
+- **`sqlite`** (default) — opens `{workspace}/sessions/sessions.db`. On first
+  open, automatically imports any pre-existing JSONL session files and renames
+  them to `*.jsonl.migrated` for rollback safety.
+- **`jsonl`** (legacy) — opens `{workspace}/sessions/*.jsonl`, one file per
+  session key.
+
+Unknown backend values fall back to SQLite with a warning so a typo in config
+never silently disables persistence.
+
+## Dependencies
+
+- `zeroclaw-api` — trait definitions
+- `zeroclaw-log` — structured logging via `record!`
+- `zeroclaw-spawn` — attribution-propagating task spawning
+- `rusqlite` (bundled) — SQLite session backend
+
+## Stability
+
+Beta — breaking changes permitted in MINOR with changelog notes.


### PR DESCRIPTION
## Summary

- **What changed:** Add a crate-level `README.md` for `zeroclaw-infra`.
- **Why:** `zeroclaw-infra` provides cross-cutting channel infrastructure (session backends, debouncing, stall watchdog) used by multiple channel implementations. A README documents the module layout, session backend options, and dependencies.
- **Scope boundary:** Only adds a new README file. No code changes.
- **Blast radius:** None — documentation only.
- **Linked issue(s):** N/A
- **Labels:** `type: docs`, `risk: low`, `size: XS`, `docs`

## Validation Evidence (required)

```bash
$ git diff --stat upstream/master...HEAD
 crates/zeroclaw-infra/README.md | 42 ++++++++++++++++++++++++++++++++++++++++++
 1 file changed, 42 insertions(+)
```

- **Commands run and tail output:** `git diff --stat` — verified only the new README is added.
- **Beyond CI — what did you manually verified:** Read the file to confirm accurate content matches the crate's `lib.rs` documentation and `Cargo.toml` description.
- **If any command was intentionally skipped, why:** Docs-only change; `cargo clippy`/`cargo test` not applicable.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PR: `git revert <sha>` is the plan.
---
