### PR TITLE
docs(spawn): add crate-level README.md

### DIFF
--- a/crates/zeroclaw-spawn/README.md
+++ b/crates/zeroclaw-spawn/README.md
@@ -1,0 +1,50 @@
+# zeroclaw-spawn
+
+Attribution-propagating, lifecycle-logged wrapper around `tokio::spawn` for
+the ZeroClaw workspace.
+
+Every call site that needs to fan out a background task must go through
+[`spawn!`] instead of reaching for `tokio::spawn` directly. Direct
+`tokio::spawn` is banned workspace-wide via `clippy.toml` `disallowed-methods`.
+
+## What `spawn!` adds
+
+1. **Attribution propagation.** The spawned future is wrapped with
+   `.in_current_span()` so any `record!` it emits inherits the caller's
+   `attribution_span` (channel, agent, session, cron job, ...). Without this,
+   tokio detaches the task from the caller's span stack and records appear
+   orphaned.
+
+2. **Lifecycle telemetry.** Two structured log events are emitted through the
+   standard `zeroclaw_log::record!` pipeline:
+   - `runtime.task.spawn` (`Action::Spawn`) at spawn time.
+   - `runtime.task.spawn` (`Action::Complete`) when the future resolves, with
+     elapsed `duration_ms`.
+
+## Usage
+
+```rust
+use zeroclaw_spawn::spawn;
+
+let handle = spawn!(async move {
+    do_work().await
+});
+let output = handle.await?;
+```
+
+The returned `JoinHandle<T>` is the unmodified handle from `tokio::spawn` —
+panics propagate as `JoinError::Panic`, cancel semantics are unchanged, and
+the future's output type is preserved. `zeroclaw-spawn` adds telemetry, not
+control flow.
+
+## Layering
+
+`zeroclaw-spawn` depends on `zeroclaw-log`. Crates that already depend on
+`zeroclaw-log` (i.e. almost everything in the workspace) can add
+`zeroclaw-spawn` as a peer dependency without inverting the graph. The
+lowest-level crate (`zeroclaw-api`) intentionally does NOT depend on
+`zeroclaw-spawn`.
+
+## Stability
+
+Beta — breaking changes permitted in MINOR with changelog notes.


### PR DESCRIPTION
## Summary

- **What changed:** Add a crate-level `README.md` for `zeroclaw-spawn`.
- **Why:** `zeroclaw-spawn` provides the workspace-wide `spawn!` macro that replaces `tokio::spawn` with attribution propagation and lifecycle telemetry. A README documents the macro usage, what it adds over raw `tokio::spawn`, and the dependency layering rules.
- **Scope boundary:** Only adds a new README file. No code changes.
- **Blast radius:** None — documentation only.
- **Linked issue(s):** N/A
- **Labels:** `type: docs`, `risk: low`, `size: XS`, `docs`

## Validation Evidence (required)

```bash
$ git diff --stat upstream/master...HEAD
 crates/zeroclaw-spawn/README.md | 50 ++++++++++++++++++++++++++++++++++++++++++++++++++
 1 file changed, 50 insertions(+)
```

- **Commands run and tail output:** `git diff --stat` — verified only the new README is added.
- **Beyond CI — what did you manually verified:** Read the file to confirm accurate content matches the crate's `lib.rs` documentation, `Cargo.toml` description, and the `spawn!` macro implementation.
- **If any command was intentionally skipped, why:** Docs-only change; `cargo clippy`/`cargo test` not applicable.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PR: `git revert <sha>` is the plan.
---
