### PR TITLE
fix(tools): replace partial_cmp().unwrap() with total_cmp() in calculator

### DIFF
--- a/crates/zeroclaw-tools/src/calculator.rs
+++ b/crates/zeroclaw-tools/src/calculator.rs
@@ -200,7 +200,7 @@ fn calc_add(args: &serde_json::Value) -> Result<String, String> {
 fn calc_subtract(args: &serde_json::Value) -> Result<String, String> {
     let values = extract_values(args, 2)?;
     let mut iter = values.iter();
-    let mut result = *iter.next().unwrap();
+    let mut result = *iter.next().expect("extract_values guarantees min_len");
     for v in iter {
         result -= v;
     }
@@ -210,7 +210,7 @@ fn calc_subtract(args: &serde_json::Value) -> Result<String, String> {
 fn calc_divide(args: &serde_json::Value) -> Result<String, String> {
     let values = extract_values(args, 2)?;
     let mut iter = values.iter();
-    let mut result = *iter.next().unwrap();
+    let mut result = *iter.next().expect("extract_values guarantees min_len");
     for v in iter {
         if *v == 0.0 {
             return Err("Division by zero".to_string());
@@ -327,7 +327,7 @@ fn calc_median(args: &serde_json::Value) -> Result<String, String> {
     if values.is_empty() {
         return Err("Cannot compute median of an empty array".to_string());
     }
-    values.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    values.sort_by(|a, b| a.total_cmp(b));
     let len = values.len();
     if len % 2 == 0 {
         Ok(format_num(f64::midpoint(
@@ -349,7 +349,7 @@ fn calc_mode(args: &serde_json::Value) -> Result<String, String> {
         let key = v.to_bits();
         *freq.entry(key).or_insert(0) += 1;
     }
-    let max_freq = *freq.values().max().unwrap();
+    let max_freq = *freq.values().max().expect("freq is non-empty");
     let mut seen = std::collections::HashSet::new();
     let mut modes = Vec::new();
     for &v in &values {
@@ -421,7 +421,7 @@ fn calc_percentile(args: &serde_json::Value) -> Result<String, String> {
     if !(0..=100).contains(&p) {
         return Err("Percentile rank must be between 0 and 100".to_string());
     }
-    values.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    values.sort_by(|a, b| a.total_cmp(b));
 
     let idx_f = p as f64 / 100.0 * (values.len() - 1) as f64;
     #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]


### PR DESCRIPTION
## Summary

- **What changed:** Replace `a.partial_cmp(b).unwrap()` with `a.total_cmp(b)` in `calc_median` and `calc_percentile`; replace bare `unwrap()` with `.expect()` in `calc_subtract`, `calc_divide`, and `calc_mode`.
- **Why:** `partial_cmp` on `f64` returns `None` for NaN, causing a panic via `.unwrap()`. `total_cmp` (stable since Rust 1.62) provides a total ordering that never returns None — NaN sorts above all other values. The `.expect()` replacements document the invariant that makes the unwrap safe (e.g. `extract_values` guarantees `min_len` elements).
- **Scope boundary:** Only `crates/zeroclaw-tools/src/calculator.rs`. No other files touched.
- **Blast radius:** Calculator tool only. Changes behavior on NaN input from panic to sort (NaN sorts last).
- **Linked issue(s):** N/A
- **Labels:** `type: fix`, `risk: low`, `size: XS`

## Validation Evidence (required)

```bash
$ git diff --stat upstream/master...HEAD
 crates/zeroclaw-tools/src/calculator.rs | 10 +++++-----
 1 file changed, 5 insertions(+), 5 deletions(-)
```

- **Commands run and tail output:** `git diff --stat` — verified only the target file is changed.
- **Beyond CI — what did you manually verified:** Verified `total_cmp` is the correct replacement for `partial_cmp().unwrap()` on f64 (stable since Rust 1.62, project requires rust-version 1.87). Verified `.expect()` messages accurately describe the invariant.
- **If any command was intentionally skipped, why:** Remote CI will validate compilation and tests.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility (required)

- Backward compatible? **Yes** — changes panic-on-NaN to sort-NaN-last behavior
- Config / env / CLI surface changed? **No**

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PR: `git revert <sha>` is the plan.
---
