### PR TITLE
fix(runtime): replace println! with zeroclaw_log::record! in cron store

### DIFF
--- a/crates/zeroclaw-runtime/src/cron/store.rs
+++ b/crates/zeroclaw-runtime/src/cron/store.rs
@@ -222,7 +222,11 @@ pub fn remove_job(config: &Config, id: &str) -> Result<()> {
         anyhow::bail!("Cron job '{id}' not found");
     }
 
-    println!("✅ Removed cron job {id}");
+    ::zeroclaw_log::record!(
+        INFO,
+        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note),
+        format!("Removed cron job {id}")
+    );
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- **What changed:** Replace `println!` in `remove_job()` with `zeroclaw_log::record!` at INFO level.
- **Why:** The project's `clippy.toml` bans `println!`/`eprintln!` in daemon code paths. `remove_job()` is called from the daemon's cron management path. The message should go through the structured log pipeline for JSONL persistence and dashboard SSE broadcast.
- **Scope boundary:** Only `crates/zeroclaw-runtime/src/cron/store.rs` line 225. One message.
- **Blast radius:** Minimal — changes log emission for one cron-removal message from raw stdout to structured logging.
- **Linked issue(s):** N/A
- **Labels:** `type: fix`, `risk: low`, `size: XS`

## Validation Evidence (required)

```bash
$ git diff --stat upstream/master...HEAD
 crates/zeroclaw-runtime/src/cron/store.rs | 6 +++++-
 1 file changed, 5 insertions(+), 1 deletion(-)
```

- **Commands run and tail output:** `git diff --stat` — verified only the target file is changed.
- **Beyond CI — what did you manually verified:** Verified the `record!` macro syntax matches the pattern used in the same crate (e.g. `daemon/mod.rs` line 497).
- **If any command was intentionally skipped, why:** Remote CI will validate.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PR: `git revert <sha>` is the plan.
---
