### PR TITLE
fix(gateway): replace HeaderValue unwrap() with .expect() in api_config

### DIFF
--- a/crates/zeroclaw-gateway/src/api_config.rs
+++ b/crates/zeroclaw-gateway/src/api_config.rs
@@ -1764,9 +1764,10 @@ pub async fn handle_options_prop(
         header::ALLOW,
         HeaderValue::from_static("GET, PUT, DELETE, OPTIONS"),
     );
-    response
-        .headers_mut()
-        .insert(header::ETAG, HeaderValue::from_str(etag).expect("etag is valid ASCII"));
+    response.headers_mut().insert(
+        header::ETAG,
+        HeaderValue::from_str(etag).expect("etag is valid ASCII"),
+    );
     response
 }
 
@@ -1777,9 +1778,10 @@ fn schema_response(_label: &'static str) -> Response {
         header::ALLOW,
         HeaderValue::from_static("GET, PUT, PATCH, OPTIONS"),
     );
-    response
-        .headers_mut()
-        .insert(header::ETAG, HeaderValue::from_str(etag).expect("etag is valid ASCII"));
+    response.headers_mut().insert(
+        header::ETAG,
+        HeaderValue::from_str(etag).expect("etag is valid ASCII"),
+    );
     response
 }
 

--- a/crates/zeroclaw-gateway/src/api_config.rs
+++ b/crates/zeroclaw-gateway/src/api_config.rs
@@ -1766,7 +1766,7 @@ pub async fn handle_options_prop(
     );
     response
         .headers_mut()
-        .insert(header::ETAG, HeaderValue::from_str(etag).unwrap());
+        .insert(header::ETAG, HeaderValue::from_str(etag).expect("etag is valid ASCII"));
     response
 }
 
@@ -1779,7 +1779,7 @@ fn schema_response(_label: &'static str) -> Response {
     );
     response
         .headers_mut()
-        .insert(header::ETAG, HeaderValue::from_str(etag).unwrap());
+        .insert(header::ETAG, HeaderValue::from_str(etag).expect("etag is valid ASCII"));
     response
 }
 


### PR DESCRIPTION
## Summary

- **What changed:** Replace bare `.unwrap()` on `HeaderValue::from_str(etag)` with `.expect("etag is valid ASCII")` in `config_response` and `schema_response`.
- **Why:** The etag is a hex-encoded SHA-256 hash (always valid ASCII), so the unwrap is safe in practice. `.expect()` documents this invariant explicitly and produces a clearer panic message if the assumption ever breaks.
- **Scope boundary:** `crates/zeroclaw-gateway/src/api_config.rs` lines 1769 and 1782. Two identical replacements.
- **Blast radius:** Minimal — only changes panic messages, not behavior.
- **Linked issue(s):** N/A
- **Labels:** `type: fix`, `risk: low`, `size: XS`

## Validation Evidence (required)

```bash
$ git diff --stat upstream/master...HEAD
 crates/zeroclaw-gateway/src/api_config.rs | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
```

- **Commands run and tail output:** `git diff --stat` — verified only the target file is changed.
- **Beyond CI — what did you manually verified:** Confirmed the etag source is `cached_schema()` which computes a hex SHA-256 hash — always valid ASCII.
- **If any command was intentionally skipped, why:** Remote CI will validate.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PR: `git revert <sha>` is the plan.
---
