### PR TITLE
fix(runtime): expose deferred MCP tools to delegates

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -1059,6 +1059,20 @@ pub async fn run(
                             if let Some(policy) = mcp_policy {
                                 tool_search = tool_search.with_access_policy(policy);
                             }
+                            if let Some(ref handle) = delegate_handle {
+                                let delegate_tools = std::sync::Arc::clone(handle);
+                                tool_search = tool_search.with_activation_hook(
+                                    std::sync::Arc::new(move |tool| {
+                                        let mut tools = delegate_tools.write();
+                                        let already_registered = tools
+                                            .iter()
+                                            .any(|existing| existing.name() == tool.name());
+                                        if !already_registered {
+                                            tools.push(tool);
+                                        }
+                                    }),
+                                );
+                            }
                             tools_registry.push(Box::new(tool_search));
                         }
                     } else {
@@ -2476,6 +2490,20 @@ pub async fn process_message(
                                 crate::tools::ToolSearchTool::new(deferred_set, activated);
                             if let Some(policy) = mcp_policy_pm {
                                 tool_search_pm = tool_search_pm.with_access_policy(policy);
+                            }
+                            if let Some(ref handle) = delegate_handle_pm {
+                                let delegate_tools = std::sync::Arc::clone(handle);
+                                tool_search_pm = tool_search_pm.with_activation_hook(
+                                    std::sync::Arc::new(move |tool| {
+                                        let mut tools = delegate_tools.write();
+                                        let already_registered = tools
+                                            .iter()
+                                            .any(|existing| existing.name() == tool.name());
+                                        if !already_registered {
+                                            tools.push(tool);
+                                        }
+                                    }),
+                                );
                             }
                             tools_registry.push(Box::new(tool_search_pm));
                         }

--- a/crates/zeroclaw-runtime/src/tools/delegate.rs
+++ b/crates/zeroclaw-runtime/src/tools/delegate.rs
@@ -3630,6 +3630,47 @@ mod tests {
         }
     }
 
+    struct FinalOnlyModelProvider;
+
+    #[async_trait]
+    impl ModelProvider for FinalOnlyModelProvider {
+        async fn chat_with_system(
+            &self,
+            _system_prompt: Option<&str>,
+            _message: &str,
+            _model: &str,
+            _temperature: Option<f64>,
+        ) -> anyhow::Result<String> {
+            Ok("delegate saw tool".to_string())
+        }
+
+        async fn chat(
+            &self,
+            _request: ChatRequest<'_>,
+            _model: &str,
+            _temperature: Option<f64>,
+        ) -> anyhow::Result<ChatResponse> {
+            Ok(ChatResponse {
+                text: Some("delegate saw tool".to_string()),
+                tool_calls: Vec::new(),
+                usage: None,
+                reasoning_content: None,
+            })
+        }
+    }
+    impl ::zeroclaw_api::attribution::Attributable for FinalOnlyModelProvider {
+        fn role(&self) -> ::zeroclaw_api::attribution::Role {
+            ::zeroclaw_api::attribution::Role::Provider(
+                ::zeroclaw_api::attribution::ProviderKind::Model(
+                    ::zeroclaw_api::attribution::ModelProviderKind::Custom,
+                ),
+            )
+        }
+        fn alias(&self) -> &str {
+            "FinalOnlyModelProvider"
+        }
+    }
+
     #[tokio::test]
     async fn mcp_tools_included_in_subagent_tool_list() {
         // Build DelegateTool with NO parent tools initially
@@ -3661,6 +3702,79 @@ mod tests {
         assert!(
             result.output.contains("mcp done"),
             "Expected output containing 'mcp done', got: {}",
+            result.output
+        );
+    }
+
+    #[tokio::test]
+    async fn deferred_mcp_activation_updates_delegate_parent_tools() {
+        let config = agentic_agent_config();
+        let parent_tools: Arc<RwLock<Vec<Arc<dyn Tool>>>> = Arc::new(RwLock::new(Vec::new()));
+        let delegate = DelegateTool::new(HashMap::new(), None, test_security())
+            .with_runtime_profiles(agentic_runtime_profiles(10))
+            .with_risk_profiles(agentic_risk_profiles(vec![
+                "mcp_service_a__list_projects".to_string(),
+            ]))
+            .with_parent_tools(Arc::clone(&parent_tools));
+
+        let activated = Arc::new(std::sync::Mutex::new(crate::tools::ActivatedToolSet::new()));
+        let deferred = crate::tools::DeferredMcpToolSet {
+            stubs: vec![{
+                let def = zeroclaw_tools::mcp_protocol::McpToolDef {
+                    name: "list_projects".to_string(),
+                    description: Some("List projects".to_string()),
+                    input_schema: serde_json::json!({"type": "object", "properties": {}}),
+                };
+                zeroclaw_tools::mcp_deferred::DeferredMcpToolStub::new(
+                    "mcp_service_a__list_projects".to_string(),
+                    def,
+                )
+            }],
+            registry: Arc::new(
+                zeroclaw_tools::mcp_client::McpRegistry::connect_all(&[])
+                    .await
+                    .unwrap(),
+            ),
+        };
+        let handle = Arc::clone(&parent_tools);
+        let tool_search = crate::tools::ToolSearchTool::new(deferred, Arc::clone(&activated))
+            .with_activation_hook(Arc::new(move |tool| {
+                let mut tools = handle.write();
+                if !tools.iter().any(|existing| existing.name() == tool.name()) {
+                    tools.push(tool);
+                }
+            }));
+
+        let search = tool_search
+            .execute(serde_json::json!({"query": "select:mcp_service_a__list_projects"}))
+            .await
+            .unwrap();
+        assert!(search.success);
+
+        {
+            let tools = parent_tools.read();
+            assert_eq!(tools.len(), 1);
+            assert_eq!(tools[0].name(), "mcp_service_a__list_projects");
+        }
+
+        let model_provider = FinalOnlyModelProvider;
+        let result = delegate
+            .execute_agentic(
+                "agentic",
+                &config,
+                "openrouter",
+                "model-test",
+                &model_provider,
+                "run mcp",
+                Some(0.2),
+            )
+            .await
+            .unwrap();
+
+        assert!(result.success, "Expected success, got: {:?}", result.error);
+        assert!(
+            result.output.contains("delegate saw tool"),
+            "Expected final output from delegate loop, got: {}",
             result.output
         );
     }

--- a/crates/zeroclaw-tools/src/tool_search.rs
+++ b/crates/zeroclaw-tools/src/tool_search.rs
@@ -16,6 +16,8 @@ use zeroclaw_api::tool::{Tool, ToolResult};
 /// Default maximum number of search results.
 const DEFAULT_MAX_RESULTS: usize = 5;
 
+type ActivationHook = Arc<dyn Fn(Arc<dyn Tool>) + Send + Sync>;
+
 /// Tool-level access policy applied at discovery time.
 ///
 /// When set on `ToolSearchTool`, deferred tools that fail this check are
@@ -74,6 +76,7 @@ pub struct ToolSearchTool {
     deferred: DeferredMcpToolSet,
     activated: Arc<Mutex<ActivatedToolSet>>,
     access_policy: Option<ToolAccessPolicy>,
+    activation_hook: Option<ActivationHook>,
 }
 
 impl ToolSearchTool {
@@ -82,6 +85,7 @@ impl ToolSearchTool {
             deferred,
             activated,
             access_policy: None,
+            activation_hook: None,
         }
     }
 
@@ -90,10 +94,23 @@ impl ToolSearchTool {
         self
     }
 
+    pub fn with_activation_hook(mut self, hook: ActivationHook) -> Self {
+        self.activation_hook = Some(hook);
+        self
+    }
+
     fn is_allowed(&self, tool_name: &str) -> bool {
         self.access_policy
             .as_ref()
             .is_none_or(|p| p.is_tool_allowed(tool_name))
+    }
+
+    fn notify_activated(&self, tools: Vec<Arc<dyn Tool>>) {
+        if let Some(hook) = &self.activation_hook {
+            for tool in tools {
+                hook(tool);
+            }
+        }
     }
 }
 
@@ -175,6 +192,7 @@ impl Tool for ToolSearchTool {
         let mut output = String::from("<functions>\n");
         let mut activated_count = 0;
         let mut returned_count = 0;
+        let mut newly_activated = Vec::new();
         let mut guard = self.activated.lock().unwrap();
 
         for stub in &results {
@@ -196,7 +214,9 @@ impl Tool for ToolSearchTool {
                 if !guard.is_activated(&stub.prefixed_name)
                     && let Some(tool) = self.deferred.activate(&stub.prefixed_name)
                 {
-                    guard.activate(stub.prefixed_name.clone(), Arc::from(tool));
+                    let tool: Arc<dyn Tool> = Arc::from(tool);
+                    guard.activate(stub.prefixed_name.clone(), Arc::clone(&tool));
+                    newly_activated.push(tool);
                     activated_count += 1;
                 }
                 let _ = writeln!(
@@ -212,6 +232,7 @@ impl Tool for ToolSearchTool {
 
         output.push_str("</functions>\n");
         drop(guard);
+        self.notify_activated(newly_activated);
 
         ::zeroclaw_log::record!(
             DEBUG,
@@ -235,6 +256,7 @@ impl ToolSearchTool {
         let mut output = String::from("<functions>\n");
         let mut not_found = Vec::new();
         let mut activated_count = 0;
+        let mut newly_activated = Vec::new();
         let mut guard = self.activated.lock().unwrap();
 
         for name in names {
@@ -255,7 +277,9 @@ impl ToolSearchTool {
                     if !guard.is_activated(name)
                         && let Some(tool) = self.deferred.activate(name)
                     {
-                        guard.activate(String::from(*name), Arc::from(tool));
+                        let tool: Arc<dyn Tool> = Arc::from(tool);
+                        guard.activate(String::from(*name), Arc::clone(&tool));
+                        newly_activated.push(tool);
                         activated_count += 1;
                     }
                     let _ = writeln!(
@@ -274,6 +298,7 @@ impl ToolSearchTool {
 
         output.push_str("</functions>\n");
         drop(guard);
+        self.notify_activated(newly_activated);
 
         if !not_found.is_empty() {
             let _ = write!(output, "\nNot found: {}", not_found.join(", "));
@@ -470,6 +495,29 @@ mod tests {
             .unwrap();
 
         assert_eq!(activated.lock().unwrap().tool_specs().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn activation_hook_receives_newly_activated_tools_once() {
+        let activated = Arc::new(Mutex::new(ActivatedToolSet::new()));
+        let seen = Arc::new(Mutex::new(Vec::<String>::new()));
+        let seen_hook = Arc::clone(&seen);
+        let tool = ToolSearchTool::new(
+            make_deferred_set(vec![make_stub("srv__tool", "A tool")]).await,
+            Arc::clone(&activated),
+        )
+        .with_activation_hook(Arc::new(move |tool| {
+            seen_hook.lock().unwrap().push(tool.name().to_string());
+        }));
+
+        tool.execute(serde_json::json!({"query": "select:srv__tool"}))
+            .await
+            .unwrap();
+        tool.execute(serde_json::json!({"query": "select:srv__tool"}))
+            .await
+            .unwrap();
+
+        assert_eq!(seen.lock().unwrap().as_slice(), ["srv__tool"]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **Linked issue(s):** Fixes #6136
- **Scope boundary:** This does not change eager MCP registration, MCP access-policy filtering, skill elevation, or delegate risk-profile filtering.
- **Blast radius:** Runtime deferred MCP loading and delegate tool visibility. Default behavior remains gated by the existing MCP access policy and delegate `allowed_tools` filtering.
- **Labels:** suggested `bug`, `runtime`, `tool:delegate`, `tool:mcp`, `risk: high`, `size: S`

## Changes

- Add an activation hook to deferred MCP `tool_search` so newly activated tools can be surfaced to shared delegate-visible tool registries.
- Wire deferred MCP activation into the existing delegate `parent_tools` handle in both runtime entry points.
- Add regressions for the `select:` activation path and for a delegate allowed to use an MCP tool activated by the parent.

## Validation Evidence (required)

- **Commands run and tail output:** See the verification command block below. Output tails included `test result: ok. 1 passed` for each focused regression, `test result: ok. 17 passed` for `tool_search`, `test result: ok. 78 passed` for `delegate`, `Finished dev profile` for clippy, and full `cargo test` tails ending with integration, live-gated, system, and doc-test success summaries.
- **Beyond CI - what did you manually verify?** The regression exercises the issue's `select:mcp_service_a__list_projects` shape: `tool_search` activates the deferred MCP tool, the tool is appended to the shared delegate parent-tool handle only once, and a delegate with that tool in its risk-profile allowlist can complete its agentic loop.
- **If any command was intentionally skipped, why:** None.

## Verification

```bash
cargo test -p zeroclaw-tools activation_hook_receives_newly_activated_tools_once
cargo test -p zeroclaw-runtime deferred_mcp_activation_updates_delegate_parent_tools
cargo test -p zeroclaw-tools tool_search
cargo test -p zeroclaw-runtime delegate
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1-2 sentence explanation.

- New permissions, capabilities, or file system access scope? `No`. The change only surfaces an already activated deferred MCP tool to delegates after existing MCP access policy and delegate allowlist checks permit it.
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: None.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No upgrade steps required.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** Revert this PR commit.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Deferred MCP tools activated through `tool_search` stop appearing in delegate sessions, or delegates allowed to use those tools report no executable tools after allowlist filtering.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors: Not applicable.
- Scope materially carried forward: Not applicable.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why: No superseded contributor code or design was incorporated.
