### PR TITLE
fix(quickstart): validate agent and provider aliases at input time

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1480,6 +1480,9 @@ async fn run_quickstart_cli(
                     .with_prompt(format!("Alias for {}", chosen.display_name))
                     .default("default".to_string())
                     .allow_empty(false)
+                    .validate_with(|input: &String| {
+                        zeroclaw_config::helpers::validate_alias_key(input)
+                    })
                     .interact_text()
                 else {
                     continue;
@@ -1877,7 +1880,10 @@ async fn run_quickstart_cli(
                     .unwrap_or_default();
                 let mut input = Input::<String>::new()
                     .with_prompt("Agent alias")
-                    .allow_empty(false);
+                    .allow_empty(false)
+                    .validate_with(|input: &String| {
+                        zeroclaw_config::helpers::validate_alias_key(input)
+                    });
                 if !default_name.is_empty() {
                     input = input.default(default_name);
                 }


### PR DESCRIPTION
## Summary

- **What changed:** Add `.validate_with()` to the `dialoguer::Input` prompts for both agent alias and model provider alias in the quickstart CLI flow.
- **Why:** Currently, any non-empty string is accepted at the prompt, but validation only happens at apply time via `create_map_key` → `validate_alias_key`. If the user enters an invalid alias (e.g. capitalized "MyAgent"), the error is only shown after all other setup steps are completed, discarding all previous input (USER.md edits, model provider setup, etc.).
- **Scope boundary:** Only `src/main.rs` — two prompt builders. No changes to the validation logic itself.
- **Blast radius:** Quickstart CLI only. Changes the UX from "fail at end" to "fail at input".
- **Linked issue(s):** Closes #7591
- **Labels:** `type: fix`, `risk: low`, `size: XS`

## Validation Evidence (required)

```bash
$ git diff --stat upstream/master...HEAD
 src/main.rs | 8 +++++++-
 1 file changed, 7 insertions(+), 1 deletion(-)
```

- **Commands run and tail output:** `git diff --stat` — verified only `src/main.rs` is changed with 7 insertions.
- **Beyond CI — what did you manually verified:** Verified `validate_alias_key` is `pub` in `zeroclaw_config::helpers` (line 641 of `helpers.rs`). Verified `dialoguer 0.12` supports `.validate_with()` with `Fn(&T) -> Result<(), E>` where `E: Display`. Verified the validator closure signature matches: `|input: &String| -> Result<(), String>`.
- **If any command was intentionally skipped, why:** Remote CI will validate compilation.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility (required)

- Backward compatible? **Yes** — stricter input validation at prompt time, same validation rules as before
- Config / env / CLI surface changed? **No**

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PR: `git revert <sha>` is the plan.
---
