### PR TITLE
fix(config): expose global channel settings in dashboard

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -27550,6 +27550,53 @@ allowed_users = []
         }
     }
 
+    /// The dashboard's `/config/channels` global-settings tab filters the
+    /// canonical `prop_fields()` list down to direct `[channels]` fields.
+    /// Keep root settings such as `show_tool_calls` discoverable there without
+    /// mixing per-alias fields into the same editor.
+    #[test]
+    async fn channels_root_settings_stay_on_direct_prop_surface() {
+        let mut config = Config::default();
+        config.init_defaults(None);
+        config
+            .channels
+            .matrix
+            .insert("default".into(), MatrixConfig::default());
+
+        let paths: Vec<_> = config
+            .prop_fields()
+            .into_iter()
+            .map(|field| field.name)
+            .collect();
+        let direct_channel_paths: Vec<_> = paths
+            .iter()
+            .filter_map(|path| {
+                path.strip_prefix("channels.")
+                    .filter(|rest| !rest.contains('.'))
+                    .map(|_| path.as_str())
+            })
+            .collect();
+
+        assert!(
+            direct_channel_paths.contains(&"channels.show_tool_calls"),
+            "root [channels] settings should include show_tool_calls: {direct_channel_paths:?}"
+        );
+        assert!(
+            direct_channel_paths.contains(&"channels.ack_reactions"),
+            "root [channels] settings should include other global channel controls"
+        );
+        assert!(
+            paths
+                .iter()
+                .any(|path| path == "channels.matrix.default.enabled"),
+            "fixture should include a nested channel alias field"
+        );
+        assert!(
+            !direct_channel_paths.contains(&"channels.matrix.default.enabled"),
+            "global channel settings must not include per-alias fields"
+        );
+    }
+
     /// Audit gate for RFC #6971 Phase 0: any credential-shaped property path
     /// that reaches the CLI/gateway/TUI property surface must have an explicit
     /// classification. This catches future config additions whose names imply

--- a/crates/zeroclaw-config/src/sections.rs
+++ b/crates/zeroclaw-config/src/sections.rs
@@ -449,8 +449,9 @@ sections! {
         key:   "channels",
         shape: TypedFamilyMap,
         group: Foundation,
-        help:  "Pick which chat platforms ZeroClaw should listen on. You can \
-                configure multiple — each channel gets its own alias.",
+        help:  "Pick which chat platforms ZeroClaw should listen on. Global \
+                channel settings live on [channels]; each configured platform \
+                still gets its own alias.",
     },
     Hardware => {
         key:   "hardware",

--- a/web/src/components/sections/FieldForm.tsx
+++ b/web/src/components/sections/FieldForm.tsx
@@ -141,11 +141,15 @@ interface FieldFormProps {
   drift?: DriftEntry[];
   /** Filter for which entries this form renders. Returning false hides
    *  the entry. Used to partition a section's fields across tabs (e.g.
-   *  Model providers: Connection / Model / Advanced). The form still
-   *  fetches every entry under `prefix`; the predicate only gates
-   *  rendering, so saves still validate against the full server-side
-   *  config. */
+   *  Model providers: Connection / Model / Advanced). By default, the
+   *  form still fetches every entry under `prefix`; the predicate only
+   *  gates rendering, so saves still validate against the full
+   *  server-side config. */
   includePath?: (path: string) => boolean;
+  /** When true, `includePath` also limits save, dirty-count, and
+   *  successful-save discard scope. Use this when hidden fields belong to a
+   *  different editor, not just another tab of the same editor. */
+  scopeActionsToIncludedPaths?: boolean;
   /** Render the save bar as a normal inline element instead of
    *  `sticky bottom-0`. Set when the FieldForm is embedded inside a
    *  taller composite editor (e.g. an expandable rate-sheet row) where
@@ -695,6 +699,7 @@ const FieldForm = forwardRef<FieldFormHandle, FieldFormProps>(
       title,
       drift,
       includePath,
+      scopeActionsToIncludedPaths = false,
       inlineSaveBar = false,
     },
     ref,
@@ -762,6 +767,16 @@ const FieldForm = forwardRef<FieldFormHandle, FieldFormProps>(
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [prefix]);
 
+    const actionableEntries = useMemo(() => {
+      if (!scopeActionsToIncludedPaths || !includePath) return entries;
+      return entries.filter((e) => includePath(e.path));
+    }, [entries, includePath, scopeActionsToIncludedPaths]);
+
+    const actionablePaths = useMemo(
+      () => actionableEntries.map((e) => e.path),
+      [actionableEntries],
+    );
+
     // Returns true when nothing was dirty or the save succeeded; false on
     // any error so callers (e.g. the wizard's Next button) can refuse to
     // advance past a broken state.
@@ -790,7 +805,7 @@ const FieldForm = forwardRef<FieldFormHandle, FieldFormProps>(
         }
         return value;
       };
-      for (const e of entries) {
+      for (const e of actionableEntries) {
         if (configDraft.tombstones.has(e.path)) {
           ops.push({ op: "remove", path: e.path });
           continue;
@@ -835,7 +850,11 @@ const FieldForm = forwardRef<FieldFormHandle, FieldFormProps>(
       try {
         const resp = await patchConfig(ops);
         setSavedAt(`${t("fieldform.saved_prefix")}${resp.results.length}${t("fieldform.saved_suffix")}`);
-        configDraft.discardSection(prefix);
+        if (scopeActionsToIncludedPaths && includePath) {
+          configDraft.discardPaths(actionablePaths);
+        } else {
+          configDraft.discardSection(prefix);
+        }
         await reload();
         onSaved?.();
         return true;
@@ -925,7 +944,7 @@ const FieldForm = forwardRef<FieldFormHandle, FieldFormProps>(
     // across the loading / loaded transition (React error #310).
     const unsavedCount = useMemo(() => {
       let n = 0;
-      for (const e of entries) {
+      for (const e of actionableEntries) {
         if (configDraft.tombstones.has(e.path)) {
           n += 1;
           continue;
@@ -938,7 +957,7 @@ const FieldForm = forwardRef<FieldFormHandle, FieldFormProps>(
         if (valueChanged || commentChanged) n += 1;
       }
       return n;
-    }, [entries, draft, comments, configDraft.tombstones]);
+    }, [actionableEntries, draft, comments, configDraft.tombstones]);
 
     // Warn user before navigating away with unsaved changes.
     useEffect(() => {

--- a/web/src/lib/draftStore.tsx
+++ b/web/src/lib/draftStore.tsx
@@ -41,6 +41,8 @@ type ConfigDraftCtx = ConfigDraftState & {
   clearComment: (path: string) => void;
   stageTombstone: (path: string) => void;
   unstageTombstone: (path: string) => void;
+  /** Drop drafts / comments / tombstones for exactly these paths. */
+  discardPaths: (paths: readonly string[]) => void;
   /** Drop every draft / comment / tombstone whose path begins with `prefix`. */
   discardSection: (prefix: string) => void;
   /** Drop everything. */
@@ -104,6 +106,47 @@ export function ConfigDraftProvider({ children }: { children: ReactNode }) {
       const next = new Set(prev);
       next.delete(path);
       return next;
+    });
+  }, []);
+
+  const discardPaths = useCallback((paths: readonly string[]) => {
+    const discard = new Set(paths);
+    if (discard.size === 0) return;
+    setDrafts((prev) => {
+      const next: Record<string, DraftEntry> = {};
+      let changed = false;
+      for (const [k, v] of Object.entries(prev)) {
+        if (discard.has(k)) {
+          changed = true;
+        } else {
+          next[k] = v;
+        }
+      }
+      return changed ? next : prev;
+    });
+    setComments((prev) => {
+      const next: Record<string, string> = {};
+      let changed = false;
+      for (const [k, v] of Object.entries(prev)) {
+        if (discard.has(k)) {
+          changed = true;
+        } else {
+          next[k] = v;
+        }
+      }
+      return changed ? next : prev;
+    });
+    setTombstones((prev) => {
+      let changed = false;
+      const next = new Set<string>();
+      for (const k of prev) {
+        if (discard.has(k)) {
+          changed = true;
+        } else {
+          next.add(k);
+        }
+      }
+      return changed ? next : prev;
     });
   }, []);
 
@@ -199,6 +242,7 @@ export function ConfigDraftProvider({ children }: { children: ReactNode }) {
       clearComment,
       stageTombstone,
       unstageTombstone,
+      discardPaths,
       discardSection,
       discardAll,
       saveAll,
@@ -213,6 +257,7 @@ export function ConfigDraftProvider({ children }: { children: ReactNode }) {
       clearComment,
       stageTombstone,
       unstageTombstone,
+      discardPaths,
       discardSection,
       discardAll,
       saveAll,

--- a/web/src/pages/Config.tsx
+++ b/web/src/pages/Config.tsx
@@ -1,16 +1,17 @@
 // Schema-driven config editor (#6175). Curated section explorer
 // but lands on a per-section overview: pick a section in the sidebar, see
 // what's currently configured under it, click an item to edit, click +Add
-// to instantiate a new entry.
+// to instantiate a new entry. Sections with root-level controls can also
+// compose a filtered FieldForm beside the picker.
 //
 // URL structure:
-//   /config/:section             — section overview (configured items list)
+//   /config/:section             — section overview plus root settings when any
 //   /config/:section/:type       — alias list for a provider/channel type
 //   /config/:section/:type/:alias — field form for a specific alias
 //
-// All section list / picker / field rendering comes from the shared
-// SectionPicker + FieldForm components. NO hardcoded section names, field
-// labels, dropdown options, or provider lists.
+// Section list / picker / field rendering comes from the shared
+// SectionPicker + FieldForm components. Per-section composition is limited to
+// routing and filtering around those shared surfaces, not duplicate schema data.
 
 import { useEffect, useMemo, useState } from "react";
 import { Link, useLocation, useNavigate, useParams } from "react-router-dom";
@@ -445,8 +446,7 @@ export default function Config() {
       );
     }
 
-    // /config/:section — overview + picker
-    return (
+    const sectionOverview = (
       <SectionOverview
         section={activeSection}
         onPickType={(typeKey) => {
@@ -488,6 +488,38 @@ export default function Config() {
         drifted={drifted}
       />
     );
+
+    if (activeSection.key === "channels") {
+      return (
+        <SectionTabs
+          tabs={[
+            {
+              key: "types",
+              label: "Channel types",
+              render: () => sectionOverview,
+            },
+            {
+              key: "global",
+              label: "Global settings",
+              render: () => (
+                <FieldForm
+                  key={`${reloadKey}-channels-global`}
+                  prefix="channels"
+                  title="Global channel settings"
+                  onSaved={fetchDrift}
+                  drift={drifted}
+                  includePath={isDirectChannelSetting}
+                  scopeActionsToIncludedPaths
+                />
+              ),
+            },
+          ]}
+        />
+      );
+    }
+
+    // /config/:section — overview + picker
+    return sectionOverview;
   })();
 
   // Breadcrumb segments
@@ -880,6 +912,13 @@ function costCategoryForSection(sectionKey: string): CostRatesCategory | null {
   if (sectionKey === "providers.tts") return "tts";
   if (sectionKey === "providers.transcription") return "transcription";
   return null;
+}
+
+function isDirectChannelSetting(path: string): boolean {
+  const prefix = "channels.";
+  if (!path.startsWith(prefix)) return false;
+  const rest = path.slice(prefix.length);
+  return rest.length > 0 && !rest.includes(".");
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Adds a `Global settings` tab to `/config/channels` so direct `[channels]` fields such as `show_tool_calls` are discoverable beside the existing channel-type picker.
  - Filters that tab to direct `channels.*` properties, keeping per-alias fields such as `channels.discord.default.*` out of the global editor.
  - Adds an opt-in `FieldForm` action scope so the global tab saves, counts, and clears only the fields it renders; existing tabbed forms keep the old full-prefix save behavior.
  - Updates the channel section help text and adds regression coverage for direct `[channels]` prop discovery.
- **Scope boundary:** This does not add per-channel `show_tool_calls` overrides, change runtime tool-call rendering, or address the older runtime/prompt behavior tracked separately by #5831.
- **Blast radius:** The changed surface is the config dashboard channel settings page, the shared `FieldForm` opt-in path, and `zeroclaw-config` schema metadata/tests. Existing `FieldForm` callers retain the default full-prefix action behavior unless they opt in.
- **Linked issue(s):** Closes #6856.
- **Labels:** `bug`, `risk: medium`, `size: S`, `channel`, `config`, `web`.

## Validation Evidence (required)

- **Commands run and tail output:**

```text
cargo fmt --all -- --check
Result: passed.

cargo test -p zeroclaw-config channels_root_settings_stay_on_direct_prop_surface
Result: passed.
Test result: 1 passed; 0 failed; 828 filtered out.

npm run build
Result: passed.
Note: Vite emitted the existing large chunk-size warnings.

git diff --check
Result: passed.

Browser smoke: /config/channels global settings tab
Result: passed.
Verified the real Vite/React route with a gateway-shaped mock: `Global settings` activates `/config/channels?tab=global`, `Global channel settings` renders, `channels.show_tool_calls` is visible, alias-scoped `channels.matrix.default.enabled` is filtered out, and no browser console errors or error boundary appeared.
```

- **Beyond CI - what did you manually verify?** Issue #6856 was refreshed before drafting; the reporter confirmed manual `[channels] show_tool_calls = true` works, so this PR keeps the canonical global setting and fixes the discoverability path. I also reviewed the hidden-save boundary in `FieldForm` and kept the narrowed save/dirty/discard behavior opt-in for the new global tab only.
- **If any command was intentionally skipped, why:** Workspace clippy and CI-shaped nextest were not run locally. The local checks cover the changed config schema regression, the web production build, and a browser smoke of the changed `/config/channels` dashboard path; GitHub CI should provide workspace-wide clippy/test coverage before merge.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: None.

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`Yes`)
- If `No` or `Yes` to either: This exposes an existing config key in the web config surface; it does not change TOML, env, or CLI semantics. Existing users can keep using:

```toml
[channels]
show_tool_calls = true
```

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <sha>`
- **Feature flags or config toggles:** None. Operators can still edit `[channels] show_tool_calls` manually if the dashboard path regresses.
- **Observable failure symptoms:** `/config/channels` fails to load the global settings tab, direct `[channels]` fields are missing from the tab, or saving from the global tab unexpectedly affects per-channel alias drafts.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Scope materially carried forward: N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`Yes/No`): N/A
- If `No`, why (inspiration-only, no direct code/design carry-over): N/A
