### PR TITLE
docs(governance): define discussions stewardship

### DIFF
--- a/docs/book/src/contributing/communication.md
+++ b/docs/book/src/contributing/communication.md
@@ -33,11 +33,25 @@ Search before filing. Duplicates get consolidated; the search box is your friend
 
 ## GitHub Discussions
 
-For community-facing threads that need more permanence than Discord but are not yet tracked work. Discussions work well for Q&A, ideas, show-and-tell, project or integration demos, polls, announcements, and "does anyone else see this?" threads where Discord would scroll away.
+For community-facing threads that need more permanence than Discord but are not yet tracked work. Discussions work well for Q&A, ideas, project show-and-tell, polls, maintainer announcements, and "does anyone else see this?" threads where Discord would scroll away.
 
-Treat Discussions as non-urgent community conversation. They are maintained intake only when a steward or review cadence is documented.
+Treat Discussions as non-urgent community conversation. They are maintained intake only when a steward or review cadence is documented. The maintainer routine and default cadence live in [Reviewer playbook: Discussions stewardship](../maintainers/reviewer-playbook.md#discussions-stewardship).
 
 Discussions are part of the GitHub handoff system, not a replacement for issues, RFCs, PR comments, or maintainer docs. Move a Discussion into the tracked surface once it produces a concrete bug, feature scope, owner, blocker, validation evidence, policy decision, or docs requirement.
+
+Use this split when choosing a surface:
+
+| Surface | Use it for | Move it when |
+|---|---|---|
+| Discord | Fast help, live coordination, early "is this a thing?" conversation | The project needs a durable record, decision, owner, validation note, blocker, or release-impact note |
+| Discussions | Searchable Q&A, ideas, show-and-tell, demos, polls, announcements, broad feedback, and exploratory architecture questions that are not ready for formal tracking | The thread produces a concrete bug, feature scope, architecture proposal, policy decision, docs gap, owner, blocker, or validation evidence |
+| Issues | Bugs, feature requests, support/configuration reports, contributor tasks, roadmap trackers, and other work that needs triage or tracking | The issue turns into an RFC, PR, tracker item, duplicate, support redirect, or closure decision |
+| RFC issues | Architecture, governance, lifecycle, compatibility, or process decisions that need formal review | The RFC is accepted, rejected, superseded, or split into implementation issues |
+| PR comments | Review feedback and implementation details for an active change | The detail becomes durable policy, reusable docs, a follow-up issue, or release note |
+
+Discussion categories should make the expected outcome obvious. Use Q&A for answerable questions, Ideas for proposals that need community shaping, Show and tell for project-related demos or integrations, Polls for community votes, Announcements for maintainer updates, and General for broad searchable conversation or early architecture exploration before an RFC exists.
+
+Close the loop when a Discussion moves. Add a short summary and link to the issue, RFC, PR, or doc that now owns the outcome. If the category supports accepted answers, mark the summary or tracked-work link as the answer when that accurately reflects the result.
 
 [github.com/zeroclaw-labs/zeroclaw/discussions](https://github.com/zeroclaw-labs/zeroclaw/discussions)
 
@@ -88,7 +102,7 @@ None offered. ZeroClaw is maintained by the community. If you're deploying at sc
 
 ## Feedback
 
-Open-ended feedback, "I tried to do X and it felt wrong", UX observations, direction thoughts, lands best as a thread in Discord `#general` or `#dev`. The team is more likely to see and discuss it there. If the thread turns into something concrete, move it to a GitHub Discussion or issue.
+Open-ended feedback, "I tried to do X and it felt wrong", UX observations, direction thoughts, lands best as a thread in Discord `#general` or `#dev` when it needs a fast live conversation. Use GitHub Discussions `General` or `Ideas` when the feedback should stay searchable for asynchronous community input. If the thread turns into something concrete, move it to an issue, RFC, PR comment, or doc.
 
 ## Contributor recognition
 

--- a/docs/book/src/contributing/communication.md
+++ b/docs/book/src/contributing/communication.md
@@ -49,7 +49,7 @@ Use this split when choosing a surface:
 | RFC issues | Architecture, governance, lifecycle, compatibility, or process decisions that need formal review | The RFC is accepted, rejected, superseded, or split into implementation issues |
 | PR comments | Review feedback and implementation details for an active change | The detail becomes durable policy, reusable docs, a follow-up issue, or release note |
 
-Discussion categories should make the expected outcome obvious. Use Q&A for answerable questions, Ideas for proposals that need community shaping, Show and tell for project-related demos or integrations, Polls for community votes, Announcements for maintainer updates, and General for broad searchable conversation or early architecture exploration before an RFC exists.
+Discussion categories should make the expected outcome obvious. Use Q&A for answerable questions, Ideas for proposals that need community shaping, Show and tell for project-related demos, integrations, or downstream forks people want to share, Polls for community votes, Announcements for maintainer updates, and General for broad searchable conversation, early architecture exploration, or downstream/fork/enterprise collaboration that is not yet tracked work. If downstream collaboration becomes recurring enough to need its own stewarded lane, maintainers can add a dedicated category later.
 
 Close the loop when a Discussion moves. Add a short summary and link to the issue, RFC, PR, or doc that now owns the outcome. If the category supports accepted answers, mark the summary or tracked-work link as the answer when that accurately reflects the result.
 

--- a/docs/book/src/maintainers/reviewer-playbook.md
+++ b/docs/book/src/maintainers/reviewer-playbook.md
@@ -107,6 +107,20 @@ For replaced PRs or issue paths, use [Superseding PRs](./superseding.md) and pre
 
 If logs or payloads in the report contain personal identifiers or sensitive data, request redaction before deeper triage. The triage process must not propagate the exposure.
 
+## Discussions stewardship
+
+Discussions are a maintained community surface only when a steward or review cadence exists. The default cadence is a weekly maintainer pass over new and recently active threads. A named steward may own that surface pass, but the steward maintains the surface; they do not become the owner of every question, idea, or implementation that appears there.
+
+During each Discussions pass:
+
+1. Check new and recently active threads for category fit, unanswered Q&A, spam, sensitive data, and threads that have produced a concrete project outcome.
+2. Keep lightweight community conversation in Discussions when it is still exploratory, answerable there, or useful as a showcase, demo, poll, announcement, or broad-feedback thread.
+3. Promote concrete outcomes to the owning tracked surface: bugs and accepted feature scopes to issues, architecture proposals to RFC issues, PR-specific details to PR comments, durable operating rules to maintainer or contributor docs.
+4. Close the loop in the originating Discussion with a short summary and link to the issue, RFC, PR, or doc that now owns the outcome. Mark an answer only when the category and result make that accurate.
+5. Redirect security-sensitive threads to the private vulnerability path in [Security issues](../contributing/communication.md#security-issues), handle sensitive data under [Privacy](../contributing/privacy.md), and close pure advertising or not-project-relevant threads. Preserve useful project-related demos or integrations as community showcase material when they are not asking maintainers to track work.
+
+If Discussions are not being reviewed on the documented cadence, do not present them as a required intake path. Treat them as a passive archive until a steward or cadence is restored.
+
 ### PR backlog pruning
 
 When review demand exceeds capacity:


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Defines the contributor-facing split between Discord, Discussions, issues, RFC issues, and PR comments so community conversation has a clear handoff path.
  - Aligns the Discussions guidance with the live category set: Announcements, General, Ideas, Polls, Q&A, and Show and tell.
  - Clarifies that downstream forks, integrations, and enterprise collaboration use the current General or Show and tell categories unless repeated activity later justifies a dedicated stewarded category.
  - Adds the maintainer-side Discussions stewardship routine, including the default weekly pass, promotion triggers, and close-the-loop expectations.
  - Keeps FND-003 as the durable governance source and leaves operational details in the contributor and maintainer workflow docs.
- **Scope boundary:** This PR does not change live GitHub Discussions settings, labels, issue templates, stale automation, Project board fields, FND-003 text, or any public issue/Discussion state.
- **Blast radius:** Docs-only guidance for contributors and maintainers. No runtime, CI, configuration, permission, or automation behavior changes.
- **Linked issue(s):** Related #6808
- **Labels:** `type: docs`, `risk: low`, `size: XS`, `docs`

## Validation Evidence (required)

- **Commands run and tail output:**

```text
git diff --check
# passed

DOCS_FILES='docs/book/src/contributing/communication.md
docs/book/src/maintainers/reviewer-playbook.md' scripts/ci/docs_links_gate.sh
Collected 0 added link(s) from 2 docs file(s).
No added links detected in changed docs lines.

DOCS_FILES='docs/book/src/contributing/communication.md
docs/book/src/maintainers/reviewer-playbook.md' scripts/ci/docs_quality_gate.sh
No prose em-dashes in changed docs files.
Linting docs files: docs/book/src/contributing/communication.md docs/book/src/maintainers/reviewer-playbook.md
markdownlint-cli2 v0.20.0 (markdownlint v0.40.0)
Linting: 2 file(s)
Summary: 0 error(s)

DOCS_FILES='docs/book/src/contributing/communication.md' scripts/ci/docs_links_gate.sh
Collected 1 added link(s) from 1 docs file(s).
Checking added links with lychee (offline mode)...
Errors: 0

DOCS_FILES='docs/book/src/contributing/communication.md' scripts/ci/docs_quality_gate.sh
No prose em-dashes in changed docs files.
Linting docs files: docs/book/src/contributing/communication.md
markdownlint-cli2 v0.20.0 (markdownlint v0.40.0)
Linting: 1 file(s)
Summary: 0 error(s)
```

- **Beyond CI — what did you manually verify?** Verified the live GitHub Discussions category names before wording the category guidance: Announcements, General, Ideas, Polls, Q&A, and Show and tell. Reviewed FND-003's Discussions section to keep this PR in the operational docs instead of restating durable governance. Confirmed the downstream/fork collaboration wording documents current category use and does not claim a new live category exists.
- **If any command was intentionally skipped, why:** Rust validation was skipped because this changes only Markdown docs.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No upgrade steps required.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk docs-only PR. Roll back by reverting the merged PR commit if the guidance needs to be replaced.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Scope materially carried forward: N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why (inspiration-only, no direct code/design carry-over): N/A

