### PR TITLE
feat(channels): recover Matrix room management

### DIFF
--- a/crates/zeroclaw-api/src/channel.rs
+++ b/crates/zeroclaw-api/src/channel.rs
@@ -378,6 +378,25 @@ pub trait Channel: Send + Sync + crate::attribution::Attributable {
         Ok(())
     }
 
+    /// Create a room, channel, or conversation on the platform.
+    ///
+    /// Channels without a room-creation API report unsupported explicitly.
+    async fn create_room(
+        &self,
+        _name: Option<&str>,
+        _topic: Option<&str>,
+        _invites: &[String],
+        _visibility: Option<&str>,
+        _encryption: Option<bool>,
+    ) -> anyhow::Result<String> {
+        anyhow::bail!("channel does not support room creation")
+    }
+
+    /// Invite a user to an existing room, channel, or conversation.
+    async fn invite_user(&self, _room_id: &str, _user_id: &str) -> anyhow::Result<()> {
+        anyhow::bail!("channel does not support room invites")
+    }
+
     /// Request interactive tool-call approval from the channel operator.
     ///
     /// Returns `Ok(Some(response))` when the operator answers within the
@@ -584,6 +603,37 @@ mod tests {
         let back: ChannelApprovalResponse = serde_json::from_str(&json).unwrap();
         assert!(
             matches!(back, ChannelApprovalResponse::DenyWithEdit { replacement } if replacement == "new content")
+        );
+    }
+
+    #[tokio::test]
+    async fn default_room_management_methods_report_unsupported() {
+        let channel = StubChannel { handle: None };
+
+        let room_err = channel
+            .create_room(
+                Some("Project Room"),
+                Some("Project discussion"),
+                &["@user:example.com".to_string()],
+                Some("private"),
+                Some(true),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            room_err
+                .to_string()
+                .contains("does not support room creation")
+        );
+        let invite_err = channel
+            .invite_user("!room:example.com", "@other:example.com")
+            .await
+            .unwrap_err();
+        assert!(
+            invite_err
+                .to_string()
+                .contains("does not support room invites")
         );
     }
 }

--- a/crates/zeroclaw-channels/src/matrix.rs
+++ b/crates/zeroclaw-channels/src/matrix.rs
@@ -1,4 +1,4 @@
-//! Matrix channel using matrix-rust-sdk 0.16.
+//! Matrix channel using matrix-rust-sdk 0.17.
 //!
 //! Organisation (single file, internal `mod` blocks):
 //! - `markers`: parse `[image:...] [voice:...]` etc. from outbound text
@@ -3461,6 +3461,75 @@ impl MatrixChannel {
     }
 }
 
+fn build_create_room_request(
+    name: Option<&str>,
+    topic: Option<&str>,
+    invites: &[String],
+    visibility: Option<&str>,
+    encryption: Option<bool>,
+) -> Result<matrix_sdk::ruma::api::client::room::create_room::v3::Request> {
+    use matrix_sdk::ruma::{
+        OwnedUserId,
+        api::client::room::{Visibility, create_room::v3::Request as CreateRoomRequest},
+        events::{InitialStateEvent, room::encryption::RoomEncryptionEventContent},
+    };
+
+    let mut request = CreateRoomRequest::new();
+    request.name = name.map(str::to_owned);
+    request.topic = topic.map(str::to_owned);
+    request.invite = invites
+        .iter()
+        .map(|user_id| {
+            user_id
+                .parse::<OwnedUserId>()
+                .with_context(|| format!("Invalid Matrix user ID: {user_id}"))
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    if let Some(visibility) = visibility {
+        request.visibility = match visibility {
+            "private" => Visibility::Private,
+            "public" => Visibility::Public,
+            other => bail!("Invalid visibility: expected `private` or `public`, got `{other}`"),
+        };
+    }
+
+    if encryption.unwrap_or(false) {
+        request.initial_state.push(
+            InitialStateEvent::with_empty_state_key(
+                RoomEncryptionEventContent::with_recommended_defaults(),
+            )
+            .to_raw_any(),
+        );
+    }
+
+    Ok(request)
+}
+
+fn build_invite_user_request(
+    room_id: &str,
+    user_id: &str,
+) -> Result<matrix_sdk::ruma::api::client::membership::invite_user::v3::Request> {
+    use matrix_sdk::ruma::{
+        OwnedRoomId, OwnedUserId,
+        api::client::membership::invite_user::v3::{
+            InvitationRecipient, InviteUserId, Request as InviteUserRequest,
+        },
+    };
+
+    let room_id = room_id
+        .parse::<OwnedRoomId>()
+        .with_context(|| format!("Invalid Matrix room ID: {room_id}"))?;
+    let user_id = user_id
+        .parse::<OwnedUserId>()
+        .with_context(|| format!("Invalid Matrix user ID: {user_id}"))?;
+
+    Ok(InviteUserRequest::new(
+        room_id,
+        InvitationRecipient::UserId(InviteUserId::new(user_id)),
+    ))
+}
+
 impl ::zeroclaw_api::attribution::Attributable for MatrixChannel {
     fn role(&self) -> ::zeroclaw_api::attribution::Role {
         ::zeroclaw_api::attribution::Role::Channel(::zeroclaw_api::attribution::ChannelKind::Matrix)
@@ -3835,6 +3904,28 @@ impl Channel for MatrixChannel {
         outbound::redact(client, channel_id, &event_id, reason).await
     }
 
+    async fn create_room(
+        &self,
+        name: Option<&str>,
+        topic: Option<&str>,
+        invites: &[String],
+        visibility: Option<&str>,
+        encryption: Option<bool>,
+    ) -> Result<String> {
+        let client = self.ensure_client().await?;
+        let request = build_create_room_request(name, topic, invites, visibility, encryption)?;
+        let room = client.create_room(request).await?;
+
+        Ok(room.room_id().to_string())
+    }
+
+    async fn invite_user(&self, room_id: &str, user_id: &str) -> Result<()> {
+        let client = self.ensure_client().await?;
+        let request = build_invite_user_request(room_id, user_id)?;
+        client.send(request).await?;
+        Ok(())
+    }
+
     async fn request_approval(
         &self,
         recipient: &str,
@@ -4192,6 +4283,90 @@ mod tests {
                 .remove_reaction("bad-room", "bad-event", "✅")
                 .await
                 .expect("ack-disabled reaction removal should be a no-op");
+        }
+    }
+
+    mod room_management {
+        use matrix_sdk::ruma::api::client::{
+            membership::invite_user::v3::InvitationRecipient, room::Visibility,
+        };
+
+        use super::super::{build_create_room_request, build_invite_user_request};
+
+        #[test]
+        fn create_room_request_maps_fields_and_encryption() {
+            let invites = vec![
+                "@user_a:example.com".to_string(),
+                "@user_b:example.com".to_string(),
+            ];
+
+            let request = build_create_room_request(
+                Some("Project Room"),
+                Some("Planning"),
+                &invites,
+                Some("public"),
+                Some(true),
+            )
+            .expect("room request");
+
+            assert_eq!(request.name.as_deref(), Some("Project Room"));
+            assert_eq!(request.topic.as_deref(), Some("Planning"));
+            assert_eq!(request.invite.len(), 2);
+            assert_eq!(request.invite[0].as_str(), "@user_a:example.com");
+            assert_eq!(request.invite[1].as_str(), "@user_b:example.com");
+            assert_eq!(request.visibility, Visibility::Public);
+            assert_eq!(request.initial_state.len(), 1);
+        }
+
+        #[test]
+        fn create_room_request_rejects_invalid_visibility() {
+            let err = build_create_room_request(None, None, &[], Some("shared"), None)
+                .expect_err("invalid visibility should fail");
+
+            assert!(err.to_string().contains("Invalid visibility"));
+        }
+
+        #[test]
+        fn create_room_request_rejects_invalid_invite_user_id() {
+            let invites = vec!["not-a-matrix-user".to_string()];
+            let err = build_create_room_request(None, None, &invites, None, None)
+                .expect_err("invalid Matrix user id should fail");
+
+            assert!(err.to_string().contains("Invalid Matrix user ID"));
+        }
+
+        #[test]
+        fn invite_user_request_maps_room_and_user_ids() {
+            let request = build_invite_user_request("!room:example.com", "@user:example.com")
+                .expect("invite request");
+
+            assert_eq!(request.room_id.as_str(), "!room:example.com");
+            match request.recipient {
+                InvitationRecipient::UserId(invite) => {
+                    assert_eq!(invite.user_id.as_str(), "@user:example.com");
+                    assert_eq!(invite.reason, None);
+                }
+                InvitationRecipient::ThirdPartyId(_) => {
+                    panic!("invite request should target a Matrix user ID")
+                }
+                _ => panic!("invite request should target a Matrix user ID"),
+            }
+        }
+
+        #[test]
+        fn invite_user_request_rejects_invalid_room_id() {
+            let err = build_invite_user_request("not-a-room", "@user:example.com")
+                .expect_err("invalid Matrix room id should fail");
+
+            assert!(err.to_string().contains("Invalid Matrix room ID"));
+        }
+
+        #[test]
+        fn invite_user_request_rejects_invalid_user_id() {
+            let err = build_invite_user_request("!room:example.com", "not-a-user")
+                .expect_err("invalid Matrix user id should fail");
+
+            assert!(err.to_string().contains("Invalid Matrix user ID"));
         }
     }
 

--- a/crates/zeroclaw-channels/src/paced_channel.rs
+++ b/crates/zeroclaw-channels/src/paced_channel.rs
@@ -469,6 +469,23 @@ impl Channel for PacedChannel {
             .await
     }
 
+    async fn create_room(
+        &self,
+        name: Option<&str>,
+        topic: Option<&str>,
+        invites: &[String],
+        visibility: Option<&str>,
+        encryption: Option<bool>,
+    ) -> Result<String> {
+        self.inner
+            .create_room(name, topic, invites, visibility, encryption)
+            .await
+    }
+
+    async fn invite_user(&self, room_id: &str, user_id: &str) -> Result<()> {
+        self.inner.invite_user(room_id, user_id).await
+    }
+
     async fn request_approval(
         &self,
         recipient: &str,
@@ -512,9 +529,12 @@ mod tests {
         }
     }
 
+    #[derive(Default)]
     struct CountingChannel {
         sends: AtomicUsize,
         finalize_drafts: AtomicUsize,
+        created_rooms: AtomicUsize,
+        invites: AtomicUsize,
     }
 
     impl Attributable for CountingChannel {
@@ -551,6 +571,21 @@ mod tests {
             self.finalize_drafts.fetch_add(1, Ordering::SeqCst);
             Ok(())
         }
+        async fn create_room(
+            &self,
+            _name: Option<&str>,
+            _topic: Option<&str>,
+            _invites: &[String],
+            _visibility: Option<&str>,
+            _encryption: Option<bool>,
+        ) -> Result<String> {
+            self.created_rooms.fetch_add(1, Ordering::SeqCst);
+            Ok("!created:example.com".to_string())
+        }
+        async fn invite_user(&self, _room_id: &str, _user_id: &str) -> Result<()> {
+            self.invites.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
     }
 
     #[tokio::test]
@@ -558,6 +593,7 @@ mod tests {
         let inner = Arc::new(CountingChannel {
             sends: AtomicUsize::new(0),
             finalize_drafts: AtomicUsize::new(0),
+            ..Default::default()
         });
         let cfg = PacingFixture {
             interval_secs: 0,
@@ -575,6 +611,7 @@ mod tests {
         let counting = Arc::new(CountingChannel {
             sends: AtomicUsize::new(0),
             finalize_drafts: AtomicUsize::new(0),
+            ..Default::default()
         });
         let inner: Arc<dyn Channel> = counting.clone();
         // Use 1h to make the wait long enough that we can assert the
@@ -602,6 +639,7 @@ mod tests {
         let counting = Arc::new(CountingChannel {
             sends: AtomicUsize::new(0),
             finalize_drafts: AtomicUsize::new(0),
+            ..Default::default()
         });
         let inner: Arc<dyn Channel> = counting.clone();
         // 1h interval again — we only ever send once per recipient, so
@@ -631,6 +669,7 @@ mod tests {
         let counting = Arc::new(CountingChannel {
             sends: AtomicUsize::new(0),
             finalize_drafts: AtomicUsize::new(0),
+            ..Default::default()
         });
         let inner: Arc<dyn Channel> = counting.clone();
         let cfg = PacingFixture {
@@ -660,6 +699,7 @@ mod tests {
         let counting = Arc::new(CountingChannel {
             sends: AtomicUsize::new(0),
             finalize_drafts: AtomicUsize::new(0),
+            ..Default::default()
         });
         let inner: Arc<dyn Channel> = counting.clone();
         let cfg = PacingFixture {
@@ -715,6 +755,7 @@ mod tests {
         let counting = Arc::new(CountingChannel {
             sends: AtomicUsize::new(0),
             finalize_drafts: AtomicUsize::new(0),
+            ..Default::default()
         });
         let inner: Arc<dyn Channel> = counting.clone();
         // 1h floor: the first op fires immediately, so no real time elapses.
@@ -743,10 +784,55 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn room_management_forwards_to_inner_channel() {
+        let counting = Arc::new(CountingChannel {
+            sends: AtomicUsize::new(0),
+            finalize_drafts: AtomicUsize::new(0),
+            created_rooms: AtomicUsize::new(0),
+            invites: AtomicUsize::new(0),
+        });
+        let inner: Arc<dyn Channel> = counting.clone();
+        let cfg = PacingFixture {
+            interval_secs: 3600,
+            depth: 4,
+        };
+        let paced = PacedChannel::wrap(inner, &cfg);
+        let invites = vec!["@user:example.com".to_string()];
+
+        let room_id = paced
+            .create_room(
+                Some("Project Room"),
+                Some("Planning"),
+                &invites,
+                Some("private"),
+                Some(false),
+            )
+            .await
+            .unwrap();
+        paced
+            .invite_user(&room_id, "@other:example.com")
+            .await
+            .unwrap();
+
+        assert_eq!(room_id, "!created:example.com");
+        assert_eq!(
+            counting.created_rooms.load(Ordering::SeqCst),
+            1,
+            "create_room must forward through the pacing wrapper",
+        );
+        assert_eq!(
+            counting.invites.load(Ordering::SeqCst),
+            1,
+            "invite_user must forward through the pacing wrapper",
+        );
+    }
+
+    #[tokio::test]
     async fn queued_finalize_draft_preserves_op_through_worker() {
         let counting = Arc::new(CountingChannel {
             sends: AtomicUsize::new(0),
             finalize_drafts: AtomicUsize::new(0),
+            ..Default::default()
         });
         let inner: Arc<dyn Channel> = counting.clone();
         let cfg = PacingFixture {


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Adds additive `Channel::create_room` and `Channel::invite_user` methods so room-management capable channels have a shared API again.
  - Implements Matrix room creation with name, topic, invite, visibility, and optional encryption request fields.
  - Implements Matrix user invites with the direct room invite endpoint so valid room IDs do not need to be present in the local SDK room cache first.
  - For unsupported channels, the default methods return explicit unsupported errors instead of silent success.
  - For paced outbound channels, forwards room-management calls to the inner channel so enabling reply pacing does not hide the new capability.
- **Scope boundary:** This PR does not add user-facing CLI tools or autonomous workflows that call these methods. It does not change #6297's separate `send_choice` trait work, and it does not implement room management for Signal, WhatsApp, or other channel backends.
- **Blast radius:** The changed surface is the experimental channel trait API, the Matrix channel implementation, and the `PacedChannel` wrapper. Existing channels remain source-compatible through default trait methods.
- **Linked issue(s):** Related #6074. Supersedes #4504.
- **Labels:** `bug`, `channel`, `channel:matrix`, `risk: medium`, `size: M`

## Validation Evidence (required)

- **Commands run and result summary:**

```text
cargo fmt --all -- --check
result: passed

git diff --check
result: passed

cargo test -p zeroclaw-api default_room_management_methods_report_unsupported
result: passed; 1 passed, 0 failed, 51 filtered out

cargo test -p zeroclaw-channels room_management --features channel-matrix --lib
result: passed; 7 passed, 0 failed, 883 filtered out
```

- **Beyond CI — what did you manually verify?** Compared the PR branch against the latest fetched `origin/master`: one surviving commit touches only `crates/zeroclaw-api/src/channel.rs`, `crates/zeroclaw-channels/src/matrix.rs`, and `crates/zeroclaw-channels/src/paced_channel.rs`. Also checked live overlap with #6297; it touches the `Channel` trait for `send_choice`, but does not implement room creation or invites.
- **If any command was intentionally skipped, why:** Full workspace clippy and full local CI-style tests were not run locally. This is a medium-risk, narrow experimental channel/API recovery slice with focused API and Matrix feature validation; the visible GitHub Quality Gate has passed, including Lint, Test, platform builds, Benchmarks Compile, and CI Required Gate.

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? `Yes` — this restores a channel capability surface for room creation and user invites. It does not grant new credentials or bypass platform authorization; Matrix still enforces the authenticated user's server-side permissions.
- New external network calls? `Yes` — Matrix `create_room` and `invite_user` send Matrix client-server API requests when a caller explicitly invokes these new methods.
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: The main risk is exposing a shared API that a future caller could invoke on a channel that does not support it. Unsupported channels now fail closed with explicit errors, and Matrix request builders validate room and user IDs before sending.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No operator upgrade steps are required. The trait methods are additive and have default implementations; there is no new config, env var, or CLI flag.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <merge-commit>`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Matrix callers of the new room APIs may receive Matrix API errors for room creation or invites. Unsupported channels should return errors containing `channel does not support room creation` or `channel does not support room invites`.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line):
  - #4504 by @theredspoon
- Scope materially carried forward: The shared channel room-management API shape and Matrix room creation / invite capability are carried forward, rebuilt against the current channel trait, Matrix SDK surface, and pacing wrapper.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `Yes`
- If `No`, why (inspiration-only, no direct code/design carry-over): N/A. A human `Co-authored-by` trailer is included for @theredspoon because the shared room-management API shape and Matrix capability from #4504 are materially carried forward, rebuilt against the current crate split and Matrix SDK surface.
