### PR TITLE
feat(gateway/cron): accept enabled on CronPatchBody for pause/resume; scope the agent check to shell-command patches

### DIFF
--- a/crates/zeroclaw-gateway/src/api.rs
+++ b/crates/zeroclaw-gateway/src/api.rs
@@ -3259,6 +3259,280 @@ mod tests {
         );
     }
 
+    // --- PATCH agent-requirement boundary (#7666) ---------------------------
+    // These pin the relaxed `agent` rule: it is required only when a patch sets a
+    // *shell command* (the risk-profile gate), and not for enable/disable,
+    // metadata-only patches, or agent-type jobs. Regression coverage for the
+    // `#[serde(default)] agent` + `setting_shell_command` scoping so a future
+    // refactor can't silently reopen the gate or re-require agent where it isn't.
+
+    #[tokio::test]
+    async fn cron_api_patch_enabled_without_agent() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let config = zeroclaw_config::schema::Config {
+            data_dir: tmp.path().join("data"),
+            config_path: tmp.path().join("config.toml"),
+            ..zeroclaw_config::schema::Config::default()
+        };
+        std::fs::create_dir_all(&config.data_dir).unwrap();
+        let state = test_state(with_test_agent(config));
+        let job = zeroclaw_runtime::cron::add_shell_job_with_approval(
+            &state.config.read().clone(),
+            "test-agent",
+            Some("toggle-job".to_string()),
+            zeroclaw_runtime::cron::Schedule::Cron {
+                expr: "*/5 * * * *".to_string(),
+                tz: None,
+            },
+            "echo hello",
+            None,
+            true,
+        )
+        .expect("job added");
+
+        // No `agent` field at all — pause/resume must not require one.
+        let response = handle_api_cron_patch(
+            State(state.clone()),
+            HeaderMap::new(),
+            Path(job.id.clone()),
+            Json(
+                serde_json::from_value::<CronPatchBody>(serde_json::json!({ "enabled": false }))
+                    .expect("body should deserialize"),
+            ),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "enable/disable toggle must not require an agent"
+        );
+        let updated = zeroclaw_runtime::cron::get_job(&state.config.read().clone(), &job.id)
+            .expect("updated job");
+        assert!(!updated.enabled, "job should be disabled after the patch");
+    }
+
+    #[tokio::test]
+    async fn cron_api_patch_name_and_schedule_without_agent() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let config = zeroclaw_config::schema::Config {
+            data_dir: tmp.path().join("data"),
+            config_path: tmp.path().join("config.toml"),
+            ..zeroclaw_config::schema::Config::default()
+        };
+        std::fs::create_dir_all(&config.data_dir).unwrap();
+        let state = test_state(with_test_agent(config));
+        let job = zeroclaw_runtime::cron::add_shell_job_with_approval(
+            &state.config.read().clone(),
+            "test-agent",
+            Some("old-name".to_string()),
+            zeroclaw_runtime::cron::Schedule::Cron {
+                expr: "*/5 * * * *".to_string(),
+                tz: None,
+            },
+            "echo hello",
+            None,
+            true,
+        )
+        .expect("job added");
+
+        // Metadata-only patch (no command/prompt) — agent must be optional.
+        let response = handle_api_cron_patch(
+            State(state.clone()),
+            HeaderMap::new(),
+            Path(job.id.clone()),
+            Json(
+                serde_json::from_value::<CronPatchBody>(serde_json::json!({
+                    "name": "new-name",
+                    "schedule": "30 9 * * *"
+                }))
+                .expect("body should deserialize"),
+            ),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "name/schedule patch must not require an agent"
+        );
+        let updated = zeroclaw_runtime::cron::get_job(&state.config.read().clone(), &job.id)
+            .expect("updated job");
+        assert_eq!(updated.name.as_deref(), Some("new-name"));
+        assert_eq!(
+            updated.schedule,
+            zeroclaw_runtime::cron::Schedule::Cron {
+                expr: "30 9 * * *".to_string(),
+                tz: None,
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn cron_api_patch_shell_command_requires_known_agent() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let config = zeroclaw_config::schema::Config {
+            data_dir: tmp.path().join("data"),
+            config_path: tmp.path().join("config.toml"),
+            ..zeroclaw_config::schema::Config::default()
+        };
+        std::fs::create_dir_all(&config.data_dir).unwrap();
+        let state = test_state(with_test_agent(config));
+        let job = zeroclaw_runtime::cron::add_shell_job_with_approval(
+            &state.config.read().clone(),
+            "test-agent",
+            Some("shell-job".to_string()),
+            zeroclaw_runtime::cron::Schedule::Cron {
+                expr: "*/5 * * * *".to_string(),
+                tz: None,
+            },
+            "echo hello",
+            None,
+            true,
+        )
+        .expect("job added");
+
+        // Setting a shell `command` still hits the risk gate: a missing agent
+        // must be a clean 400, not a fall-through.
+        let response = handle_api_cron_patch(
+            State(state.clone()),
+            HeaderMap::new(),
+            Path(job.id.clone()),
+            Json(
+                serde_json::from_value::<CronPatchBody>(
+                    serde_json::json!({ "command": "echo bye" }),
+                )
+                .expect("body should deserialize"),
+            ),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(
+            response.status(),
+            StatusCode::BAD_REQUEST,
+            "shell command patch with no agent must be rejected at the risk gate"
+        );
+        let json = response_json(response).await;
+        assert!(
+            json["error"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("Unknown agent"),
+            "error should name the unknown agent"
+        );
+    }
+
+    #[tokio::test]
+    async fn cron_api_patch_shell_prompt_unknown_agent_is_bad_request_not_500() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let config = zeroclaw_config::schema::Config {
+            data_dir: tmp.path().join("data"),
+            config_path: tmp.path().join("config.toml"),
+            ..zeroclaw_config::schema::Config::default()
+        };
+        std::fs::create_dir_all(&config.data_dir).unwrap();
+        let state = test_state(with_test_agent(config));
+        let job = zeroclaw_runtime::cron::add_shell_job_with_approval(
+            &state.config.read().clone(),
+            "test-agent",
+            Some("shell-job".to_string()),
+            zeroclaw_runtime::cron::Schedule::Cron {
+                expr: "*/5 * * * *".to_string(),
+                tz: None,
+            },
+            "echo hello",
+            None,
+            true,
+        )
+        .expect("job added");
+
+        // For a shell job a new command can arrive via `prompt`; it still routes
+        // through the command-risk gate, so an unknown agent is a 400 — not the
+        // 500 that an unguarded path would surface.
+        let response = handle_api_cron_patch(
+            State(state.clone()),
+            HeaderMap::new(),
+            Path(job.id.clone()),
+            Json(
+                serde_json::from_value::<CronPatchBody>(serde_json::json!({
+                    "agent": "ghost",
+                    "prompt": "echo bye"
+                }))
+                .expect("body should deserialize"),
+            ),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(
+            response.status(),
+            StatusCode::BAD_REQUEST,
+            "shell-job prompt with unknown agent must be 400, not 500"
+        );
+    }
+
+    #[tokio::test]
+    async fn cron_api_patch_agent_prompt_without_agent() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let config = zeroclaw_config::schema::Config {
+            data_dir: tmp.path().join("data"),
+            config_path: tmp.path().join("config.toml"),
+            ..zeroclaw_config::schema::Config::default()
+        };
+        std::fs::create_dir_all(&config.data_dir).unwrap();
+        let state = test_state(with_test_agent(config));
+
+        let add_response = handle_api_cron_add(
+            State(state.clone()),
+            HeaderMap::new(),
+            Json(
+                serde_json::from_value::<CronAddBody>(serde_json::json!({
+                    "name": "agent-job",
+                    "agent": "test-agent",
+                    "schedule": "*/5 * * * *",
+                    "job_type": "agent",
+                    "command": "ignored",
+                    "prompt": "old prompt"
+                }))
+                .expect("body should deserialize"),
+            ),
+        )
+        .await
+        .into_response();
+        assert_eq!(add_response.status(), StatusCode::OK);
+        let id = zeroclaw_runtime::cron::list_jobs(&state.config.read().clone()).unwrap()[0]
+            .id
+            .clone();
+
+        // For an agent-type job `prompt` is an LLM prompt, not a shell command,
+        // so it is not agent-gated and may omit `agent`.
+        let response = handle_api_cron_patch(
+            State(state.clone()),
+            HeaderMap::new(),
+            Path(id.clone()),
+            Json(
+                serde_json::from_value::<CronPatchBody>(
+                    serde_json::json!({ "prompt": "new prompt" }),
+                )
+                .expect("body should deserialize"),
+            ),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "agent-type prompt patch must not require an agent"
+        );
+        let updated = zeroclaw_runtime::cron::get_job(&state.config.read().clone(), &id)
+            .expect("updated job");
+        assert_eq!(updated.prompt.as_deref(), Some("new prompt"));
+    }
+
     #[tokio::test]
     async fn cron_api_rejects_announce_delivery_without_target() {
         let tmp = tempfile::TempDir::new().unwrap();

--- a/crates/zeroclaw-gateway/src/api.rs
+++ b/crates/zeroclaw-gateway/src/api.rs
@@ -624,19 +624,6 @@ pub async fn handle_api_cron_patch(
     }
 
     let config = state.config.read().clone();
-    // The agent only gates a shell `command` change (risk profile). Skip the
-    // existence check for patches that don't touch the command — schedule, name,
-    // and enable/disable toggles don't need an agent supplied.
-    if body.command.is_some() && config.agent(&body.agent).is_none() {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({"error": format!(
-                "Unknown agent {a:?} (no [agents.{a}] entry configured)",
-                a = body.agent
-            )})),
-        )
-            .into_response();
-    }
     let agent_alias = body.agent.clone();
     let CronPatchBody {
         agent: _,
@@ -663,6 +650,26 @@ pub async fn handle_api_cron_patch(
                 .into_response();
         }
     };
+    let is_agent = matches!(existing.job_type, zeroclaw_runtime::cron::JobType::Agent);
+    // The agent only gates a shell `command` change (risk profile). For a shell
+    // job the new command can arrive via either `command` OR `prompt` (the
+    // `prompt` field is folded into the command below), so the existence check
+    // must cover both. Skip it for patches that don't set a shell command —
+    // schedule, name, and enable/disable toggles don't need an agent supplied —
+    // and for agent-type jobs, where `prompt` is an LLM prompt, not a shell
+    // command, and so is not agent-gated. This needs `existing.job_type`, hence
+    // it runs after the job is fetched.
+    let setting_shell_command = !is_agent && (command.is_some() || prompt.is_some());
+    if setting_shell_command && config.agent(&agent_alias).is_none() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": format!(
+                "Unknown agent {a:?} (no [agents.{a}] entry configured)",
+                a = agent_alias
+            )})),
+        )
+            .into_response();
+    }
     let new_expr = schedule_expr
         .as_deref()
         .map(str::trim)
@@ -697,7 +704,6 @@ pub async fn handle_api_cron_patch(
     } else {
         None
     };
-    let is_agent = matches!(existing.job_type, zeroclaw_runtime::cron::JobType::Agent);
     let (patch_command, patch_prompt) = if is_agent {
         (None, command.or(prompt))
     } else {

--- a/crates/zeroclaw-gateway/src/api.rs
+++ b/crates/zeroclaw-gateway/src/api.rs
@@ -121,7 +121,10 @@ pub struct CronAddBody {
 #[derive(Deserialize)]
 pub struct CronPatchBody {
     /// Configured agent alias whose risk profile gates the new shell
-    /// command (when `command` is being patched). Required.
+    /// command. Only consulted when `command` is being patched; optional
+    /// otherwise (e.g. a pure schedule/name change or an enable/disable
+    /// toggle), so non-command patches need not supply it.
+    #[serde(default)]
     pub agent: String,
     pub name: Option<String>,
     pub schedule: Option<String>,
@@ -129,6 +132,9 @@ pub struct CronPatchBody {
     pub clear_tz: Option<bool>,
     pub command: Option<String>,
     pub prompt: Option<String>,
+    /// Toggle the job on/off without deleting it (pause/resume). `None` leaves
+    /// the current state unchanged.
+    pub enabled: Option<bool>,
 }
 
 enum CronTimezonePatch {
@@ -618,7 +624,10 @@ pub async fn handle_api_cron_patch(
     }
 
     let config = state.config.read().clone();
-    if config.agent(&body.agent).is_none() {
+    // The agent only gates a shell `command` change (risk profile). Skip the
+    // existence check for patches that don't touch the command — schedule, name,
+    // and enable/disable toggles don't need an agent supplied.
+    if body.command.is_some() && config.agent(&body.agent).is_none() {
         return (
             StatusCode::BAD_REQUEST,
             Json(serde_json::json!({"error": format!(
@@ -637,6 +646,7 @@ pub async fn handle_api_cron_patch(
         clear_tz,
         command,
         prompt,
+        enabled,
     } = body;
     let timezone_patch = match parse_timezone_patch(tz, clear_tz) {
         Ok(patch) => patch,
@@ -699,6 +709,7 @@ pub async fn handle_api_cron_patch(
         schedule,
         command: patch_command,
         prompt: patch_prompt,
+        enabled,
         ..zeroclaw_runtime::cron::CronJobPatch::default()
     };
 


### PR DESCRIPTION
> Maintainer note (2026-06-17): Audacity88 refreshed the label snapshot and validation evidence after d0cd25809e. The implementation summary remains the author's.

## Summary

- **Base branch:** `master`
- **What changed and why:**
  - **Pause/resume over HTTP:** add `enabled: Option<bool>` to `CronPatchBody` and thread it into `CronJobPatch`. The runtime cron store/scheduler already honor `enabled` (disabled jobs don't run), but the gateway PATCH handler dropped the field, so a job could never be paused/resumed via the API. This wires it through. `None` leaves the state unchanged.
  - **Agent requirement scoped to shell-command patches:** `agent` becomes `#[serde(default)]`, and the agent-existence check now runs **only** when a shell `command` is actually being set — i.e. a non-agent (shell) job whose patch carries `command` **or** `prompt` (the `prompt` field is folded into the shell command downstream). Schedule/name/timezone changes and enable/disable toggles no longer need an `agent` field, fixing the `422 "missing field agent"` they previously returned. Agent-type jobs (where `prompt` is an LLM prompt, not a shell command) are correctly not agent-gated.
  - **400 not 500:** because the existence check now also covers the `prompt`-as-shell-command path, an unknown agent on that path returns a clean `400` instead of falling through to a `500` downstream.
- **Scope boundary:** the gateway cron PATCH handler + `CronPatchBody` only. No change to the runtime cron store/scheduler (they already support `enabled`), the WS protocol, or any other endpoint.
- **Blast radius:** `PATCH /api/cron/{id}` request shape and validation. Existing callers that always sent `agent` keep working (it's still accepted); callers can now omit it for non-command patches and supply `enabled` to toggle.
- **Linked issue(s):**
  - `Closes #7356` — "Add a pause/disable button to Scheduled Tasks." This is the gateway half; the web button shipped in the redesign PR (#7665, merged). The two work together to make pause/resume work end-to-end.
  - `Supersedes #7384` — replaces the earlier pause/resume PR (see Supersede Attribution).
- **Labels:** `enhancement`, `gateway`, `risk: high`, `size: S`.

## Validation Evidence (required)

Rust change — focused validation reported on current head d0cd25809e:

```bash
cargo fmt --all -- --check
cargo clippy -p zeroclaw-gateway --all-targets -- -D warnings
cargo test -p zeroclaw-gateway
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` → **exit 0** (clean).
  - `cargo clippy -p zeroclaw-gateway --all-targets -- -D warnings` → **exit 0** (clean).
  - `cargo test -p zeroclaw-gateway` → `test result: ok. **262 passed; 0 failed**`, exit 0.
- **Beyond CI — what did you manually verify?** Companion PR #7665 shipped the web pause/resume control. This PR wires the gateway endpoint that control needs, and the new gateway handler regression tests cover `enabled` without `agent`, name/schedule without `agent`, shell-command patches without a known `agent`, shell-job `prompt` with unknown `agent` returning 400 instead of 500, and agent-job `prompt` without `agent`.
- **If any command was intentionally skipped, why:** full-workspace local `cargo test` was not rerun; this PR touches `crates/zeroclaw-gateway/src/api.rs`, and the focused gateway crate tests plus the visible GitHub checks are green on current head d0cd25809e. No fresh web E2E smoke is included in this PR-body update.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- **Risk-gating note:** the `agent` field gates the risk profile for **shell-command** changes. This PR *preserves* that gate — and in fact *widens* its coverage to the `prompt`-as-shell-command path — while correctly skipping it only for patches that do not modify the executed command (schedule/name/enable). No risk-profile bypass is introduced.

## Compatibility (required)

- Backward compatible? **Yes** — `enabled` is optional (`None` = unchanged); `agent` moving to `#[serde(default)]` only *relaxes* a previously-required field, so existing clients that send it are unaffected.
- Config / env / CLI surface changed? **No.**
- Upgrade steps: none.

## Rollback (required for `risk: high`)

- **Fast rollback command/path:** revert this PR's eventual squash merge — single file, no state/schema migration.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** cron PATCH returns 422/400 on valid toggles, or pause/resume no longer takes effect; jobs still run/dispatch normally otherwise.

## Supersede Attribution (required — `Supersedes #7384` is used)

- **Superseded PRs + authors:** `#7384 by @Nillth`
- **Scope materially carried forward:** the pause/resume capability (`enabled` on `CronPatchBody` + threading into `CronJobPatch`) from #7384, refined and combined here with the agent-requirement scoping and the 400-not-500 fix so non-command patches and the `prompt`-as-command path are handled correctly.
- **`Co-authored-by` trailers added for incorporated contributors?** N/A — same author (@Nillth); no external contributor code incorporated.
