### PR TITLE
refactor(api): make before_llm_call take mutable borrows

### DIFF
--- a/crates/zeroclaw-api/src/hook.rs
+++ b/crates/zeroclaw-api/src/hook.rs
@@ -54,10 +54,10 @@ pub trait HookHandler: Send + Sync {
 
     async fn before_llm_call(
         &self,
-        messages: Vec<ChatMessage>,
-        model: String,
-    ) -> HookResult<(Vec<ChatMessage>, String)> {
-        HookResult::Continue((messages, model))
+        _messages: &mut Vec<ChatMessage>,
+        _model: &mut String,
+    ) -> HookResult<()> {
+        HookResult::Continue(())
     }
 
     async fn before_tool_call(&self, name: String, args: Value) -> HookResult<(String, Value)> {

--- a/crates/zeroclaw-runtime/src/hooks/runner.rs
+++ b/crates/zeroclaw-runtime/src/hooks/runner.rs
@@ -186,19 +186,16 @@ impl HookRunner {
 
     pub async fn run_before_llm_call(
         &self,
-        mut messages: Vec<ChatMessage>,
-        mut model: String,
-    ) -> HookResult<(Vec<ChatMessage>, String)> {
+        messages: &mut Vec<ChatMessage>,
+        model: &mut String,
+    ) -> HookResult<()> {
         for h in &self.handlers {
             let hook_name = h.name();
-            match AssertUnwindSafe(h.before_llm_call(messages.clone(), model.clone()))
+            match AssertUnwindSafe(h.before_llm_call(messages, model))
                 .catch_unwind()
                 .await
             {
-                Ok(HookResult::Continue((m, mdl))) => {
-                    messages = m;
-                    model = mdl;
-                }
+                Ok(HookResult::Continue(())) => {}
                 Ok(HookResult::Cancel(reason)) => {
                     ::zeroclaw_log::record!(INFO, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(::serde_json::json!({"hook": hook_name, "reason": reason.to_string()})), "before_llm_call cancelled by hook");
                     return HookResult::Cancel(reason);
@@ -214,7 +211,7 @@ impl HookRunner {
                 }
             }
         }
-        HookResult::Continue((messages, model))
+        HookResult::Continue(())
     }
 
     pub async fn run_before_tool_call(


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Changed `HookHandler::before_llm_call` to accept `&mut Vec<ChatMessage>` and `&mut String` instead of taking them by value. This avoids cloning the entire provider-visible transcript on every LLM request, which matters because `Vec<ChatMessage>` can be large (long tool histories, image/data URLs).
  - Updated `HookRunner::run_before_llm_call` in zeroclaw-runtime to match the new trait signature.
- **Scope boundary:** This PR only changes the hook API and dispatcher; it does not add any call sites. Hook invocation at LLM call sites will be added in a follow-up PR. No other modifying hooks are changed.
- **Blast radius:** Very low. `before_llm_call` currently has no callers in the repository. The only consumers affected are future plugin implementations that override `before_llm_call`; they will need to use the new mutable-borrow signature.
- **Linked issue(s):** None
- **Labels:** `type: refactor`, `risk: low`, `size: S`

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test -p zeroclaw-api -p zeroclaw-runtime --lib
cargo test -p zeroclaw-runtime --tests
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check`: passed (no output)
  - `cargo clippy --all-targets -- -D warnings`: passed
  - `cargo test -p zeroclaw-api -p zeroclaw-runtime --lib`: `test result: ok. 2163 passed; 0 failed; 1 ignored`
  - `cargo test -p zeroclaw-runtime --tests`: `test result: ok. 2163 passed; 0 failed; 1 ignored` plus `scheduled_run_does_not_leak_conversation_memory_into_provider_request ... ok`
- **Beyond CI — what did you manually verify?** Confirmed the new signature eliminates the `Vec<ChatMessage>` clone in `HookRunner::run_before_llm_call`. Verified the previously failing CI test `turn_cache_hit_emits_agent_end_with_none_tokens` passes after rebasing onto latest `zero/master`.
- **If any command was intentionally skipped, why:** Full `cargo test` was not run locally because the repository’s full test suite is large and CI already covers it; targeted tests for the affected crates were run instead.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? (`No`)
  - The `before_llm_call` trait method signature changed. Code that overrides this method must update to the `&mut` borrow signature. However, the method currently has no callers in the repo and is part of the new plugin-hook extension mechanism, so no in-tree consumers are broken.
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: exact upgrade steps for existing users: N/A

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PR: `git revert <sha>` is the plan.