### PR TITLE
fix(memory): drop postgres client on OS thread to avoid nested runtime panic

### DIFF
--- a/crates/zeroclaw-memory/src/postgres.rs
+++ b/crates/zeroclaw-memory/src/postgres.rs
@@ -43,11 +43,26 @@ impl<T: Send + 'static> DropOnThread<T> {
 
 impl<T: Send + 'static> Drop for DropOnThread<T> {
     fn drop(&mut self) {
-        if let Some(value) = self.0.take() {
-            std::thread::Builder::new()
-                .name("postgres-client-drop".to_string())
-                .spawn(move || drop(value))
-                .ok();
+        let Some(value) = self.0.take() else { return };
+        // Wrap in ManuallyDrop so the value is NOT dropped on the current
+        // thread if spawn fails — ManuallyDrop's own Drop is a no-op.
+        let slot = std::mem::ManuallyDrop::new(value);
+        if std::thread::Builder::new()
+            .name("postgres-client-drop".to_string())
+            .spawn(move || drop(std::mem::ManuallyDrop::into_inner(slot)))
+            .is_err()
+        {
+            // The OS refused to spawn a thread. Intentionally leak the value
+            // rather than drop it here: postgres::Client::drop calls
+            // Runtime::block_on, which panics on a Tokio runtime thread.
+            // A controlled leak is preferable to an unrecoverable panic.
+            ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Unknown),
+                "postgres-client-drop thread spawn failed; leaking client to avoid nested-runtime panic"
+            );
+            // `slot` is ManuallyDrop — T is intentionally not dropped.
         }
     }
 }
@@ -816,6 +831,38 @@ mod tests {
         assert_eq!(
             PostgresMemory::parse_category("custom_notes"),
             MemoryCategory::Custom("custom_notes".into())
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn drop_on_thread_drops_value_on_plain_os_thread() {
+        // Regression for the nested-runtime drop path: DropOnThread must ensure
+        // its wrapped value's destructor runs on a plain OS thread, not on the
+        // Tokio runtime thread, even when dropped from within a runtime context.
+        //
+        // Before this patch, PostgresMemory::drop released the Arc<Mutex<Client>>
+        // inline, which called postgres::Client::drop → Runtime::block_on and
+        // panicked. This test fails on that old behavior and passes with DropOnThread.
+        let (tx, rx) = oneshot::channel::<bool>();
+
+        struct DropGuard(Option<oneshot::Sender<bool>>);
+        impl Drop for DropGuard {
+            fn drop(&mut self) {
+                // true  → dropped on a plain OS thread (no active Tokio runtime) ✓
+                // false → dropped on a Tokio runtime thread ✗
+                let on_plain_thread = tokio::runtime::Handle::try_current().is_err();
+                let _ = self.0.take().unwrap().send(on_plain_thread);
+            }
+        }
+
+        // Drop DropOnThread from inside the Tokio runtime — this is the
+        // scenario that caused the nested-runtime panic in production.
+        drop(DropOnThread::new(DropGuard(Some(tx))));
+
+        let on_plain_thread = rx.await.expect("DropGuard did not fire");
+        assert!(
+            on_plain_thread,
+            "DropOnThread must run Drop on a plain OS thread, not a Tokio runtime thread"
         );
     }
 

--- a/crates/zeroclaw-memory/src/postgres.rs
+++ b/crates/zeroclaw-memory/src/postgres.rs
@@ -24,6 +24,34 @@ use zeroclaw_api::session_keys::sanitize_session_key;
 /// Maximum allowed connect timeout (seconds) to avoid unreasonable waits.
 const POSTGRES_CONNECT_TIMEOUT_CAP_SECS: u64 = 300;
 
+/// Drops its inner value on a background OS thread.
+///
+/// `postgres::Client::drop` calls `Runtime::block_on` internally to send a
+/// clean-shutdown message. That panics if called from inside an existing Tokio
+/// runtime. Wrapping the `Arc<Mutex<Client>>` in this type ensures the final
+/// drop always happens on a plain OS thread.
+struct DropOnThread<T: Send + 'static>(Option<T>);
+
+impl<T: Send + 'static> DropOnThread<T> {
+    fn new(value: T) -> Self {
+        Self(Some(value))
+    }
+    fn get(&self) -> &T {
+        self.0.as_ref().expect("DropOnThread value already taken")
+    }
+}
+
+impl<T: Send + 'static> Drop for DropOnThread<T> {
+    fn drop(&mut self) {
+        if let Some(value) = self.0.take() {
+            std::thread::Builder::new()
+                .name("postgres-client-drop".to_string())
+                .spawn(move || drop(value))
+                .ok();
+        }
+    }
+}
+
 /// PostgreSQL-backed persistent memory.
 ///
 /// Reliable CRUD and keyword recall via SQL. Hybrid keyword + vector recall
@@ -32,7 +60,7 @@ const POSTGRES_CONNECT_TIMEOUT_CAP_SECS: u64 = 300;
 /// warning at construction.
 pub struct PostgresMemory {
     alias: String,
-    client: Arc<Mutex<Client>>,
+    client: DropOnThread<Arc<Mutex<Client>>>,
     qualified_table: String,
     qualified_agents: String,
 }
@@ -81,14 +109,14 @@ impl PostgresMemory {
             }
             Ok(Self {
                 alias: alias.to_string(),
-                client: client_ref,
+                client: DropOnThread::new(client_ref),
                 qualified_table,
                 qualified_agents,
             })
         } else {
             Ok(Self {
                 alias: alias.to_string(),
-                client: Arc::new(Mutex::new(client)),
+                client: DropOnThread::new(Arc::new(Mutex::new(client))),
                 qualified_table,
                 qualified_agents,
             })
@@ -375,7 +403,7 @@ impl Memory for PostgresMemory {
         since: Option<&str>,
         until: Option<&str>,
     ) -> Result<Vec<MemoryEntry>> {
-        let client = self.client.clone();
+        let client = self.client.get().clone();
         let qualified_table = self.qualified_table.clone();
         let qualified_agents = self.qualified_agents.clone();
         let query = normalize_recent_recall_query(query).trim().to_string();
@@ -435,7 +463,7 @@ impl Memory for PostgresMemory {
     }
 
     async fn get(&self, key: &str) -> Result<Option<MemoryEntry>> {
-        let client = self.client.clone();
+        let client = self.client.get().clone();
         let qualified_table = self.qualified_table.clone();
         let qualified_agents = self.qualified_agents.clone();
         let key = key.to_string();
@@ -459,7 +487,7 @@ impl Memory for PostgresMemory {
     }
 
     async fn get_for_agent(&self, key: &str, agent_id: &str) -> Result<Option<MemoryEntry>> {
-        let client = self.client.clone();
+        let client = self.client.get().clone();
         let qualified_table = self.qualified_table.clone();
         let qualified_agents = self.qualified_agents.clone();
         let key = key.to_string();
@@ -488,7 +516,7 @@ impl Memory for PostgresMemory {
         category: Option<&MemoryCategory>,
         session_id: Option<&str>,
     ) -> Result<Vec<MemoryEntry>> {
-        let client = self.client.clone();
+        let client = self.client.get().clone();
         let qualified_table = self.qualified_table.clone();
         let qualified_agents = self.qualified_agents.clone();
         let category = category.map(Self::category_to_str);
@@ -518,7 +546,7 @@ impl Memory for PostgresMemory {
     }
 
     async fn forget(&self, key: &str) -> Result<bool> {
-        let client = self.client.clone();
+        let client = self.client.get().clone();
         let qualified_table = self.qualified_table.clone();
         let key = key.to_string();
 
@@ -532,7 +560,7 @@ impl Memory for PostgresMemory {
     }
 
     async fn forget_for_agent(&self, key: &str, agent_id: &str) -> Result<bool> {
-        let client = self.client.clone();
+        let client = self.client.get().clone();
         let qualified_table = self.qualified_table.clone();
         let key = key.to_string();
         let agent_id = agent_id.to_string();
@@ -547,7 +575,7 @@ impl Memory for PostgresMemory {
     }
 
     async fn purge_session_for_agent(&self, session_id: &str, agent_id: &str) -> Result<usize> {
-        let client = self.client.clone();
+        let client = self.client.get().clone();
         let qualified_table = self.qualified_table.clone();
         let session_id = session_id.to_string();
         let agent_id = agent_id.to_string();
@@ -563,7 +591,7 @@ impl Memory for PostgresMemory {
     }
 
     async fn count(&self) -> Result<usize> {
-        let client = self.client.clone();
+        let client = self.client.get().clone();
         let qualified_table = self.qualified_table.clone();
 
         run_on_os_thread(move || -> Result<usize> {
@@ -578,7 +606,7 @@ impl Memory for PostgresMemory {
     }
 
     async fn health_check(&self) -> bool {
-        let client = self.client.clone();
+        let client = self.client.get().clone();
         run_on_os_thread(move || Ok(client.lock().simple_query("SELECT 1").is_ok()))
             .await
             .unwrap_or(false)
@@ -594,7 +622,7 @@ impl Memory for PostgresMemory {
         _importance: Option<f64>,
         agent_id: Option<&str>,
     ) -> Result<()> {
-        let client = self.client.clone();
+        let client = self.client.get().clone();
         let qualified_table = self.qualified_table.clone();
         let qualified_agents = self.qualified_agents.clone();
         let key = key.to_string();
@@ -652,7 +680,7 @@ impl Memory for PostgresMemory {
             return self.recall(query, limit, session_id, since, until).await;
         }
 
-        let client = self.client.clone();
+        let client = self.client.get().clone();
         let qualified_table = self.qualified_table.clone();
         let qualified_agents = self.qualified_agents.clone();
         let q = normalize_recent_recall_query(query).trim().to_string();
@@ -722,7 +750,7 @@ impl Memory for PostgresMemory {
     }
 
     async fn ensure_agent_uuid(&self, alias: &str) -> Result<String> {
-        let client = self.client.clone();
+        let client = self.client.get().clone();
         let qualified_agents = self.qualified_agents.clone();
         let alias = alias.to_string();
         run_on_os_thread(move || -> Result<String> {


### PR DESCRIPTION
## Problem

When `zeroclaw agent -a <alias>` exits after a conversation turn, the Tokio runtime drops `PostgresMemory` as part of cleanup. The `postgres` crate's `Client::drop` implementation sends a clean-shutdown message to the server by calling `Runtime::block_on` internally. Because `Drop` runs inside the existing Tokio runtime context, this triggers:

```
thread 'main' panicked at postgres-0.19.13/src/connection.rs:66:
Cannot start a runtime from within a runtime. This happens because a function
(like `block_on`) attempted to block the current thread while the thread is
being used to drive asynchronous tasks.
```

The full backtrace confirmed the panic originates in `<postgres::client::Client as Drop>::drop` → `Client::close_inner` → `Connection::poll_block_on`, reached via:

```
zeroclaw_runtime::agent::loop_::run   (end-of-turn cleanup)
  → drop(Arc<dyn Memory>)
    → drop(AgentScopedMemory)
      → drop(PostgresMemory)
        → drop(Arc<Mutex<postgres::Client>>)
          → postgres::Client::drop  ← panic here
```

The existing `run_on_os_thread` helper correctly handles *async* operations by executing every SQL call on a plain OS thread (avoiding the same nested-runtime issue for queries). The `Drop` path was not covered.

## Fix

Introduce a `DropOnThread<T>` wrapper whose `Drop` implementation moves the inner value to a freshly spawned OS thread before releasing it:

```rust
struct DropOnThread<T: Send + 'static>(Option<T>);

impl<T: Send + 'static> Drop for DropOnThread<T> {
    fn drop(&mut self) {
        if let Some(value) = self.0.take() {
            std::thread::Builder::new()
                .name("postgres-client-drop".to_string())
                .spawn(move || drop(value))
                .ok();
        }
    }
}
```

`PostgresMemory.client` is changed from `Arc<Mutex<Client>>` to `DropOnThread<Arc<Mutex<Client>>>`. All async methods that previously called `self.client.clone()` now call `self.client.get().clone()` to reach through the wrapper.

**Why this works:** A plain OS thread spawned with `std::thread::Builder` has no Tokio runtime context. `postgres::Client::drop` can call `Runtime::block_on` freely on such a thread. By the time `PostgresMemory` drops, all `run_on_os_thread` futures have completed (they are awaited inline), so the Arc's strong count is 1. The background thread becomes the sole owner and the client closes cleanly.

## Test plan

- [x] `cargo build --features memory-postgres` compiles without errors
- [x] `zeroclaw agent -a <alias> -m "hello"` returns a response and exits cleanly — no panic
- [x] Existing unit tests in `zeroclaw-memory` pass (`cargo test -p zeroclaw-memory --features memory-postgres`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)