### PR TITLE
fix(runtime): restore native sandbox hardening

### DIFF
--- a/crates/zeroclaw-runtime/src/security/bubblewrap.rs
+++ b/crates/zeroclaw-runtime/src/security/bubblewrap.rs
@@ -2,6 +2,14 @@
 
 use crate::security::traits::Sandbox;
 use std::process::Command;
+use std::sync::OnceLock;
+
+const CAPABILITY_DROPS: &[&str] = &["CAP_SYS_ADMIN", "CAP_SYS_PTRACE"];
+
+#[derive(Debug, Clone, Copy, Default)]
+struct BubblewrapHardeningSupport {
+    cap_drop: bool,
+}
 
 /// Bubblewrap sandbox backend
 #[derive(Debug, Clone, Default)]
@@ -30,10 +38,69 @@ impl BubblewrapSandbox {
             .map(|o| o.status.success())
             .unwrap_or(false)
     }
-}
 
-impl Sandbox for BubblewrapSandbox {
-    fn wrap_command(&self, cmd: &mut Command) -> std::io::Result<()> {
+    fn hardening_support() -> BubblewrapHardeningSupport {
+        static SUPPORT: OnceLock<BubblewrapHardeningSupport> = OnceLock::new();
+        *SUPPORT.get_or_init(Self::detect_hardening_support)
+    }
+
+    fn detect_hardening_support() -> BubblewrapHardeningSupport {
+        let support = Command::new("bwrap")
+            .arg("--help")
+            .env_clear()
+            .output()
+            .map(|output| {
+                Self::support_from_help(
+                    &String::from_utf8_lossy(&output.stdout),
+                    &String::from_utf8_lossy(&output.stderr),
+                )
+            })
+            .unwrap_or_default();
+
+        Self::log_incomplete_hardening_support(support);
+        support
+    }
+
+    fn support_from_help(stdout: &str, stderr: &str) -> BubblewrapHardeningSupport {
+        let contains = |flag| stdout.contains(flag) || stderr.contains(flag);
+
+        BubblewrapHardeningSupport {
+            cap_drop: contains("--cap-drop"),
+        }
+    }
+
+    fn log_incomplete_hardening_support(support: BubblewrapHardeningSupport) {
+        if support.cap_drop {
+            return;
+        }
+
+        ::zeroclaw_log::record!(
+            WARN,
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                .with_attrs(::serde_json::json!({
+                    "backend": "bubblewrap",
+                    "cap_drop": support.cap_drop,
+                })),
+            "bubblewrap sandbox hardening support is incomplete"
+        );
+    }
+
+    fn append_capability_drops(cmd: &mut Command, support: BubblewrapHardeningSupport) {
+        if !support.cap_drop {
+            return;
+        }
+
+        for capability in CAPABILITY_DROPS {
+            cmd.args(["--cap-drop", capability]);
+        }
+    }
+
+    fn wrap_command_with_support(
+        &self,
+        cmd: &mut Command,
+        support: BubblewrapHardeningSupport,
+    ) -> std::io::Result<()> {
         let program = cmd.get_program().to_string_lossy().to_string();
         let args: Vec<String> = cmd
             .get_args()
@@ -64,6 +131,7 @@ impl Sandbox for BubblewrapSandbox {
             "--unshare-all",
             "--die-with-parent",
         ]);
+        Self::append_capability_drops(&mut bwrap_cmd, support);
         // Conditionally bind dynamic-loader library directories that may exist
         // on the host.  On Fedora / RHEL systems the ELF interpreter and shared
         // libraries live in /lib64; on some older or non-merged-usr distros they
@@ -80,6 +148,12 @@ impl Sandbox for BubblewrapSandbox {
 
         *cmd = bwrap_cmd;
         Ok(())
+    }
+}
+
+impl Sandbox for BubblewrapSandbox {
+    fn wrap_command(&self, cmd: &mut Command) -> std::io::Result<()> {
+        self.wrap_command_with_support(cmd, Self::hardening_support())
     }
 
     fn is_available(&self) -> bool {
@@ -98,6 +172,12 @@ impl Sandbox for BubblewrapSandbox {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn args(cmd: &Command) -> Vec<String> {
+        cmd.get_args()
+            .map(|s| s.to_string_lossy().to_string())
+            .collect()
+    }
 
     #[test]
     fn bubblewrap_sandbox_name() {
@@ -130,10 +210,7 @@ mod tests {
             "wrapped command should use bwrap as program"
         );
 
-        let args: Vec<String> = cmd
-            .get_args()
-            .map(|s| s.to_string_lossy().to_string())
-            .collect();
+        let args = args(&cmd);
 
         assert!(
             args.contains(&"--unshare-all".to_string()),
@@ -150,6 +227,77 @@ mod tests {
     }
 
     #[test]
+    fn bubblewrap_supported_capability_drops_include_admin_and_ptrace() {
+        let mut cmd = Command::new("bwrap");
+        BubblewrapSandbox::append_capability_drops(
+            &mut cmd,
+            BubblewrapHardeningSupport { cap_drop: true },
+        );
+
+        let args = args(&cmd);
+        let expected_capability_drops = ["CAP_SYS_ADMIN", "CAP_SYS_PTRACE"];
+        for capability in expected_capability_drops {
+            assert!(
+                args.windows(2)
+                    .any(|window| window == ["--cap-drop", capability]),
+                "supported bubblewrap hardening must drop {capability}"
+            );
+        }
+    }
+
+    #[test]
+    fn bubblewrap_skips_capability_drops_when_not_advertised() {
+        let mut cmd = Command::new("bwrap");
+        BubblewrapSandbox::append_capability_drops(
+            &mut cmd,
+            BubblewrapHardeningSupport { cap_drop: false },
+        );
+
+        assert!(
+            args(&cmd).is_empty(),
+            "unsupported bubblewrap capability drops should not be appended"
+        );
+    }
+
+    #[test]
+    fn bubblewrap_support_from_help_detects_stdout_and_stderr_flags() {
+        assert!(BubblewrapSandbox::support_from_help("--cap-drop", "").cap_drop);
+        assert!(BubblewrapSandbox::support_from_help("", "--cap-drop").cap_drop);
+        assert!(!BubblewrapSandbox::support_from_help("", "").cap_drop);
+    }
+
+    #[test]
+    fn bubblewrap_wrap_command_applies_supported_capability_drops() {
+        let sandbox = BubblewrapSandbox;
+        let mut cmd = Command::new("echo");
+        sandbox
+            .wrap_command_with_support(&mut cmd, BubblewrapHardeningSupport { cap_drop: true })
+            .unwrap();
+
+        let args = args(&cmd);
+        let expected_capability_drops = ["CAP_SYS_ADMIN", "CAP_SYS_PTRACE"];
+        for capability in expected_capability_drops {
+            assert!(
+                args.windows(2)
+                    .any(|window| window == ["--cap-drop", capability]),
+                "wrap_command must apply supported bubblewrap drop for {capability}"
+            );
+        }
+    }
+
+    #[test]
+    fn bubblewrap_wrap_command_does_not_add_bare_seccomp_without_profile_fd() {
+        let sandbox = BubblewrapSandbox;
+        let mut cmd = Command::new("echo");
+        sandbox.wrap_command(&mut cmd).unwrap();
+
+        assert!(
+            !args(&cmd).contains(&"--seccomp".to_string()),
+            "bubblewrap --seccomp requires a seccomp BPF profile fd and must not be added bare"
+        );
+    }
+
+    #[test]
     fn bubblewrap_wrap_command_preserves_original_command() {
         let sandbox = BubblewrapSandbox;
         let mut cmd = Command::new("ls");
@@ -157,10 +305,7 @@ mod tests {
         cmd.arg("/tmp");
         sandbox.wrap_command(&mut cmd).unwrap();
 
-        let args: Vec<String> = cmd
-            .get_args()
-            .map(|s| s.to_string_lossy().to_string())
-            .collect();
+        let args = args(&cmd);
 
         assert!(
             args.contains(&"ls".to_string()),
@@ -186,10 +331,7 @@ mod tests {
         let mut cmd = Command::new("echo");
         sandbox.wrap_command(&mut cmd).unwrap();
 
-        let args: Vec<String> = cmd
-            .get_args()
-            .map(|s| s.to_string_lossy().to_string())
-            .collect();
+        let args = args(&cmd);
 
         for lib_dir in &["/lib64", "/lib"] {
             if std::path::Path::new(lib_dir).exists() {
@@ -215,10 +357,7 @@ mod tests {
         let mut cmd = Command::new("echo");
         sandbox.wrap_command(&mut cmd).unwrap();
 
-        let args: Vec<String> = cmd
-            .get_args()
-            .map(|s| s.to_string_lossy().to_string())
-            .collect();
+        let args = args(&cmd);
 
         assert!(
             args.contains(&"--ro-bind".to_string()),

--- a/crates/zeroclaw-runtime/src/security/firejail.rs
+++ b/crates/zeroclaw-runtime/src/security/firejail.rs
@@ -4,6 +4,14 @@
 
 use crate::security::traits::Sandbox;
 use std::process::Command;
+use std::sync::OnceLock;
+
+#[derive(Debug, Clone, Copy, Default)]
+struct FirejailHardeningSupport {
+    seccomp: bool,
+    caps_drop: bool,
+    noroot: bool,
+}
 
 /// Firejail sandbox backend for Linux
 #[derive(Debug, Clone, Default)]
@@ -35,10 +43,77 @@ impl FirejailSandbox {
             .map(|o| o.status.success())
             .unwrap_or(false)
     }
-}
 
-impl Sandbox for FirejailSandbox {
-    fn wrap_command(&self, cmd: &mut Command) -> std::io::Result<()> {
+    fn hardening_support() -> FirejailHardeningSupport {
+        static SUPPORT: OnceLock<FirejailHardeningSupport> = OnceLock::new();
+        *SUPPORT.get_or_init(Self::detect_hardening_support)
+    }
+
+    fn detect_hardening_support() -> FirejailHardeningSupport {
+        let support = Command::new("firejail")
+            .arg("--help")
+            .env_clear()
+            .output()
+            .map(|output| {
+                Self::support_from_help(
+                    &String::from_utf8_lossy(&output.stdout),
+                    &String::from_utf8_lossy(&output.stderr),
+                )
+            })
+            .unwrap_or_default();
+
+        Self::log_incomplete_hardening_support(support);
+        support
+    }
+
+    fn support_from_help(stdout: &str, stderr: &str) -> FirejailHardeningSupport {
+        let contains = |flag| stdout.contains(flag) || stderr.contains(flag);
+
+        FirejailHardeningSupport {
+            seccomp: contains("--seccomp"),
+            caps_drop: contains("--caps.drop"),
+            noroot: contains("--noroot"),
+        }
+    }
+
+    fn log_incomplete_hardening_support(support: FirejailHardeningSupport) {
+        if support.seccomp && support.caps_drop && support.noroot {
+            return;
+        }
+
+        ::zeroclaw_log::record!(
+            WARN,
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                .with_attrs(::serde_json::json!({
+                    "backend": "firejail",
+                    "seccomp": support.seccomp,
+                    "caps_drop": support.caps_drop,
+                    "noroot": support.noroot,
+                })),
+            "firejail sandbox hardening support is incomplete"
+        );
+    }
+
+    fn append_hardening_flags(cmd: &mut Command, support: FirejailHardeningSupport) {
+        if support.seccomp {
+            cmd.arg("--seccomp");
+        }
+
+        if support.caps_drop {
+            cmd.arg("--caps.drop=all");
+        }
+
+        if support.noroot {
+            cmd.arg("--noroot");
+        }
+    }
+
+    fn wrap_command_with_support(
+        &self,
+        cmd: &mut Command,
+        support: FirejailHardeningSupport,
+    ) -> std::io::Result<()> {
         // Prepend firejail to the command
         let program = cmd.get_program().to_string_lossy().to_string();
         let args: Vec<String> = cmd
@@ -59,6 +134,7 @@ impl Sandbox for FirejailSandbox {
             "--noprofile",    // Skip profile loading
             "--quiet",        // Suppress warnings
         ]);
+        Self::append_hardening_flags(&mut firejail_cmd, support);
 
         // Add the original command
         firejail_cmd.arg(&program);
@@ -67,6 +143,12 @@ impl Sandbox for FirejailSandbox {
         // Replace the command
         *cmd = firejail_cmd;
         Ok(())
+    }
+}
+
+impl Sandbox for FirejailSandbox {
+    fn wrap_command(&self, cmd: &mut Command) -> std::io::Result<()> {
+        self.wrap_command_with_support(cmd, Self::hardening_support())
     }
 
     fn is_available(&self) -> bool {
@@ -85,6 +167,12 @@ impl Sandbox for FirejailSandbox {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn args(cmd: &Command) -> Vec<String> {
+        cmd.get_args()
+            .map(|s| s.to_string_lossy().to_string())
+            .collect()
+    }
 
     #[test]
     fn firejail_sandbox_name() {
@@ -141,10 +229,7 @@ mod tests {
             "wrapped command should use firejail as program"
         );
 
-        let args: Vec<String> = cmd
-            .get_args()
-            .map(|s| s.to_string_lossy().to_string())
-            .collect();
+        let args = args(&cmd);
 
         let expected_flags = [
             "--private=home",
@@ -167,6 +252,79 @@ mod tests {
     }
 
     #[test]
+    fn firejail_supported_hardening_flags_include_seccomp_cap_drop_and_noroot() {
+        let mut cmd = Command::new("firejail");
+        FirejailSandbox::append_hardening_flags(
+            &mut cmd,
+            FirejailHardeningSupport {
+                seccomp: true,
+                caps_drop: true,
+                noroot: true,
+            },
+        );
+
+        let args = args(&cmd);
+        assert!(
+            args.windows(3)
+                .any(|window| window == ["--seccomp", "--caps.drop=all", "--noroot"]),
+            "supported firejail hardening flags must be appended together"
+        );
+    }
+
+    #[test]
+    fn firejail_support_from_help_detects_stdout_and_stderr_flags() {
+        let support = FirejailSandbox::support_from_help("--seccomp --caps.drop", "--noroot");
+
+        assert!(support.seccomp);
+        assert!(support.caps_drop);
+        assert!(support.noroot);
+    }
+
+    #[test]
+    fn firejail_wrap_command_applies_supported_hardening_flags() {
+        let sandbox = FirejailSandbox;
+        let mut cmd = Command::new("echo");
+        cmd.arg("test");
+        sandbox
+            .wrap_command_with_support(
+                &mut cmd,
+                FirejailHardeningSupport {
+                    seccomp: true,
+                    caps_drop: true,
+                    noroot: true,
+                },
+            )
+            .unwrap();
+
+        let args = args(&cmd);
+        let expected_flags = ["--seccomp", "--caps.drop=all", "--noroot"];
+        for flag in expected_flags {
+            assert!(
+                args.contains(&flag.to_string()),
+                "wrap_command must apply supported hardening flag: {flag}"
+            );
+        }
+    }
+
+    #[test]
+    fn firejail_skips_unadvertised_hardening_flags() {
+        let mut cmd = Command::new("firejail");
+        FirejailSandbox::append_hardening_flags(
+            &mut cmd,
+            FirejailHardeningSupport {
+                seccomp: true,
+                caps_drop: false,
+                noroot: true,
+            },
+        );
+
+        let args = args(&cmd);
+        assert!(args.contains(&"--seccomp".to_string()));
+        assert!(!args.contains(&"--caps.drop=all".to_string()));
+        assert!(args.contains(&"--noroot".to_string()));
+    }
+
+    #[test]
     fn firejail_wrap_command_preserves_original_command() {
         let sandbox = FirejailSandbox;
         let mut cmd = Command::new("ls");
@@ -174,10 +332,7 @@ mod tests {
         cmd.arg("/workspace");
         sandbox.wrap_command(&mut cmd).unwrap();
 
-        let args: Vec<String> = cmd
-            .get_args()
-            .map(|s| s.to_string_lossy().to_string())
-            .collect();
+        let args = args(&cmd);
 
         assert!(
             args.contains(&"ls".to_string()),


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Restores native sandbox hardening for Firejail when the installed backend advertises `--seccomp`, `--caps.drop`, and `--noroot`.
  - Restores Bubblewrap capability drops for `CAP_SYS_ADMIN` and `CAP_SYS_PTRACE` when the installed backend advertises `--cap-drop`.
  - Caches backend support detection so command wrapping does not probe or warn on every wrapped command.
  - Sanitizes backend `--help` probes with an empty environment and keeps Bubblewrap from adding bare `--seccomp`, which requires a seccomp BPF profile fd.
- **Scope boundary:** This PR does not add a fail-closed fallback path, change sandbox auto-detection, add seccomp profile generation, change config/env/CLI surface, or touch Docker/Landlock backends.
- **Blast radius:** Runtime command wrapping when `firejail` or `bubblewrap` is the selected sandbox backend. Unsupported backend hardening flags are skipped rather than forced.
- **Linked issue(s):** Related #6074, #4812.
- **Labels:**
  - bug
  - risk: high
  - size: M
  - runtime
  - security
  - security:bubblewrap
  - security:firejail

## Validation Evidence (required)

- **Commands run and tail output:**

```text
cargo fmt --all -- --check
Result: passed
Tail: no output

git diff --check
Result: passed
Tail: no output

cargo test -p zeroclaw-runtime --features sandbox-bubblewrap --lib bubblewrap
Result: passed, 11 tests
Tail: test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 2179 filtered out; finished in 0.07s

cargo clippy -p zeroclaw-runtime --features sandbox-bubblewrap --lib -- -D warnings
Result: passed
Tail: Finished dev profile in 2m33s

cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
Result: passed in 82m22s
Tail: Finished dev profile in 82m22s

cargo nextest run --locked --workspace --exclude zeroclaw-desktop
Result: passed locally with loopback proxy routing disabled, 8670 tests run, 8670 passed, 10 skipped
Tail: Summary [142.088s] 8670 tests run: 8670 passed, 10 skipped
```

- **Beyond CI — what did you manually verify?** Checked that the final diff is limited to `crates/zeroclaw-runtime/src/security/bubblewrap.rs` and `crates/zeroclaw-runtime/src/security/firejail.rs`. Reviewed the wrapping paths so hardening flags are only added when backend help advertises support, and Bubblewrap still does not add bare `--seccomp` without a profile fd.
- **If any command was intentionally skipped, why:** Local Linux Firejail compile/test was not run because this was a macOS runner and `firejail.rs` is Linux-gated. GitHub's Linux build/test checks are green for this PR head.

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? (`Yes`) This changes native sandbox capability handling by dropping additional capabilities when supported. It does not grant broader access; unsupported flags are skipped and logged once.
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`) Git commit metadata includes standard contributor author/co-author attribution; no real identities or personal data were added to diff, tests, fixtures, or docs.
- If any `Yes`, describe the risk and mitigation: The risk is backend-version compatibility: older Firejail or Bubblewrap versions may not support every hardening flag. The mitigation is help-text feature detection, once-per-process caching, and tests that prove unsupported flags are not appended.

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: exact upgrade steps for existing users: No upgrade steps. Existing sandbox configuration keeps selecting the backend as before; this PR only changes the backend arguments when supported.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <merge_commit_sha>`
- **Feature flags or config toggles:** No new toggle. Operators can switch away from the affected native sandbox backend using the existing sandbox backend configuration if a backend-specific launch issue appears before rollback.
- **Observable failure symptoms:** Commands wrapped by Firejail or Bubblewrap fail to launch, or logs include once-per-process incomplete-hardening warnings such as `firejail sandbox hardening support is incomplete` or `bubblewrap sandbox hardening support is incomplete`.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): Missing PR record; recovery candidate `798aa936` by @darrenzeng2025, tracked from #6074 / #4812.
- Scope materially carried forward: Native sandbox backend hardening for Firejail and Bubblewrap, adapted to the current crate layout and support-detection constraints. This slice carries forward supported capability/seccomp-style hardening intent, but does not port the older fail-closed `detect.rs` changes or the invalid bare Bubblewrap `--seccomp` argument.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`Yes`)
