### PR TITLE
fix(channel/matrix): persist thread history after first reply

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -543,11 +543,9 @@ pub fn conversation_history_key(msg: &zeroclaw_api::channel::ChannelMessage) -> 
     // after a restart; otherwise hydration loads sessions under the on-disk
     // (sanitized) name while lookup keeps producing the un-sanitized form.
     let thread_scope = match msg.thread_ts.as_deref() {
-        // Matrix root events can be self-anchored when `reply_in_thread`
-        // is enabled so outbound replies open a thread. That anchor is a
-        // delivery detail, not a conversation-history boundary; otherwise
-        // every top-level Matrix message becomes a fresh session.
-        Some(tid) if is_matrix_channel_name(&msg.channel) && tid == msg.id => None,
+        // Matrix thread_ts is a delivery anchor, not a topic boundary: root
+        // and follow-ups must share one sender+room session. See #7700.
+        Some(_) if is_matrix_channel_name(&msg.channel) => None,
         other => other,
     };
     let raw = match thread_scope {
@@ -15982,12 +15980,12 @@ BTC is currently around $65,000 based on latest tool output."#
     }
 
     #[test]
-    fn matrix_thread_conversation_history_key_uses_thread_root() {
-        let msg = zeroclaw_api::channel::ChannelMessage {
-            id: "$reply:server".into(),
+    fn matrix_thread_follow_up_shares_root_session_key() {
+        let root = zeroclaw_api::channel::ChannelMessage {
+            id: "$root:server".into(),
             sender: "@alice:server".into(),
             reply_target: "!room:server".into(),
-            content: "thread reply".into(),
+            content: "open the thread".into(),
             channel: "matrix".into(),
             channel_alias: None,
             timestamp: 1,
@@ -15996,10 +15994,19 @@ BTC is currently around $65,000 based on latest tool output."#
             attachments: vec![],
             subject: None,
         };
+        let follow_up = zeroclaw_api::channel::ChannelMessage {
+            id: "$reply:server".into(),
+            content: "thread reply".into(),
+            timestamp: 2,
+            thread_ts: Some("$root:server".into()),
+            interruption_scope_id: Some("$root:server".into()),
+            ..root.clone()
+        };
 
-        let key = conversation_history_key(&msg);
-        assert!(key.contains("_root_server"));
-        assert!(!key.contains("_reply_server"));
+        let root_key = conversation_history_key(&root);
+        assert_eq!(root_key, conversation_history_key(&follow_up));
+        assert!(!root_key.contains("$root:server"));
+        assert!(!root_key.contains("$reply:server"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **Closes:** #7700
- **What changed and why:**
  - A Matrix thread follow-up resolved to a different conversation-history session than the self-anchored root that opened the thread, so the agent saw an empty session on every turn after its first reply. `sessions_history` returned nothing for the thread-scoped session even though the session key was correctly scoped, exactly as reported.
  - Root cause is in `conversation_history_key` (`crates/zeroclaw-channels/src/orchestrator/mod.rs`). It stripped the thread anchor from the **root** turn (where `thread_ts == msg.id`) but kept it for **follow-ups** (where `thread_ts` is the root and `msg.id` is the new event). The result: the root keyed to `matrix_<room>_<sender>` while the follow-up keyed to `matrix_<room>_<root>_<sender>`. The two never matched, so the follow-up read an empty history.
  - On Matrix, `thread_ts` is always a delivery anchor (a self-anchored root, or the root a follow-up replies into), never a user-chosen topic boundary the way a Slack/forum thread is. The fix collapses the thread anchor for every Matrix message, so the root and all of its thread follow-ups share one `sender+room` session.
- **Scope boundary:** Only the Matrix branch of `conversation_history_key`. Non-Matrix forum channels keep per-thread (`thread_ts`) isolation unchanged. No changes to gating, outbound routing, streaming, or session-append plumbing.
- **Blast radius:** Matrix conversation-history session key derivation only.

## Validation Evidence

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p zeroclaw-channels --features channel-matrix --all-targets -- -D warnings` — clean
- `cargo test -p zeroclaw-channels --features channel-matrix matrix` — 133 passed, 0 failed
- New regression test `matrix_thread_follow_up_shares_root_session_key` asserts the root turn and a thread follow-up compute the **same** session key. The prior test that locked in the buggy behavior (`matrix_thread_conversation_history_key_uses_thread_root`) was replaced, since it encoded the divergence that caused this bug.

## Risk (required)

- New `unsafe`? No
- Tool/agent capability or access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No

## Compatibility (required)

- Backward compatible? Behaviorally yes for new conversations. Note: in-flight Matrix threads created before this change stored history under the old thread-scoped key; after upgrade those follow-ups resolve to the `sender+room` session and will not see that orphaned pre-upgrade history. New threads are unaffected.
- Config / env / CLI surface changed? No

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PR: `git revert e1cd4932d0`.
