### PR TITLE
fix(tools): default zero-minute polls

### DIFF
--- a/crates/zeroclaw-tools/src/poll.rs
+++ b/crates/zeroclaw-tools/src/poll.rs
@@ -98,6 +98,13 @@ fn validate_options(args: &serde_json::Value) -> Result<Vec<String>, String> {
     Ok(options)
 }
 
+fn duration_minutes_or_default(args: &serde_json::Value) -> u64 {
+    args.get("duration_minutes")
+        .and_then(|v| v.as_u64())
+        .filter(|duration| *duration > 0)
+        .unwrap_or(DEFAULT_DURATION_MINUTES)
+}
+
 /// Returns true for channel names that support native polls (Telegram, Discord).
 fn supports_native_poll(channel_name: &str) -> bool {
     let lower = channel_name.to_ascii_lowercase();
@@ -139,6 +146,7 @@ impl Tool for PollTool {
                 },
                 "duration_minutes": {
                     "type": "integer",
+                    "minimum": 1,
                     "description": "Poll duration in minutes (default: 60)"
                 },
                 "multi_select": {
@@ -192,10 +200,7 @@ impl Tool for PollTool {
             }
         };
 
-        let duration_minutes = args
-            .get("duration_minutes")
-            .and_then(|v| v.as_u64())
-            .unwrap_or(DEFAULT_DURATION_MINUTES);
+        let duration_minutes = duration_minutes_or_default(&args);
 
         let multi_select = args
             .get("multi_select")
@@ -420,6 +425,47 @@ mod tests {
     fn format_text_poll_multi_select_label() {
         let text = format_text_poll("Pick any", &["A".into(), "B".into()], 60, true);
         assert!(text.contains("multiple choices allowed"));
+    }
+
+    #[test]
+    fn duration_minutes_zero_uses_default() {
+        assert_eq!(
+            duration_minutes_or_default(&json!({ "duration_minutes": 0 })),
+            DEFAULT_DURATION_MINUTES
+        );
+        assert_eq!(
+            duration_minutes_or_default(&json!({ "duration_minutes": 15 })),
+            15
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_zero_duration_uses_default_in_sent_text_and_output() {
+        let security = Arc::new(SecurityPolicy::default());
+        let stub = Arc::new(StubChannel::new("slack"));
+        let sent = Arc::clone(&stub.sent);
+        let channel: Arc<dyn Channel> = stub;
+        let channels = make_channel_map(vec![channel]);
+        let tool = PollTool::new(security, channels);
+
+        let result = tool
+            .execute(json!({
+                "question": "Lunch?",
+                "options": ["Pizza", "Sushi"],
+                "channel": "slack",
+                "recipient": "general",
+                "duration_minutes": 0
+            }))
+            .await
+            .unwrap();
+
+        assert!(result.success, "error: {:?}", result.error);
+        assert!(result.output.contains("Duration: 60 min"));
+
+        let sent = sent.read();
+        assert_eq!(sent.len(), 1);
+        assert!(sent[0].contains("Poll closes in 60 min"));
+        assert!(!sent[0].contains("Poll closes in 0 min"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Prevent polls from being created with an effective zero-minute duration.

## Changes

- Treats `duration_minutes = 0` as the default poll duration.
- Advertises `duration_minutes` as a minimum-1 integer in the tool schema.
- Covers both the sent poll text and the returned tool output.

## Tests

- `cargo fmt --all -- --check`
- `cargo test -p zeroclaw-tools duration_minutes_zero_uses_default --lib`
- `cargo test -p zeroclaw-tools execute_zero_duration_uses_default_in_sent_text_and_output --lib`
- `cargo test -p zeroclaw-tools poll --lib`
- `cargo clippy -p zeroclaw-tools --all-targets -- -D warnings`

## Risk

Low. The change only affects zero or invalid duration inputs; positive durations continue to pass through unchanged.