### PR TITLE
test(channels): reject non-web WhatsApp cron delivery

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -9465,7 +9465,9 @@ pub async fn deliver_announcement(
                 .get(alias)
                 .ok_or_else(not_configured)?;
             if !wa.is_web_config() {
-                anyhow::bail!("WhatsApp channel send requires Web mode (session_path must be set)");
+                anyhow::bail!(
+                    "WhatsApp channel send requires Web mode (set session_path, pair_phone, or mode = personal)"
+                );
             }
             let peers = config.channel_external_peers("whatsapp", alias);
             let peer_resolver: Arc<dyn Fn() -> Vec<String> + Send + Sync> =
@@ -20564,6 +20566,42 @@ Done."#;
         assert!(
             msg.contains("[channels.whatsapp.default] not configured"),
             "whatsapp.default must report the real config table; got: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "whatsapp-web")]
+    async fn deliver_announcement_rejects_whatsapp_non_web_config_clearly() {
+        let mut config = zeroclaw_config::schema::Config::default();
+        config.channels.whatsapp.insert(
+            "default".to_string(),
+            zeroclaw_config::schema::WhatsAppConfig {
+                enabled: true,
+                access_token: Some("test-token".to_string()),
+                phone_number_id: Some("phone-number-id".to_string()),
+                verify_token: Some("verify-token".to_string()),
+                ..Default::default()
+            },
+        );
+
+        let err = deliver_announcement(&config, "whatsapp.default", "+15551234567", None, "hi")
+            .await
+            .expect_err("expected WhatsApp Cloud config to be rejected for cron delivery");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("WhatsApp channel send requires Web mode"),
+            "whatsapp.default must clearly explain the Web mode requirement; got: {msg}"
+        );
+        assert!(
+            msg.contains("session_path")
+                && msg.contains("pair_phone")
+                && msg.contains("mode = personal"),
+            "whatsapp.default must name the Web selectors accepted by cron delivery; got: {msg}"
+        );
+        assert!(
+            !msg.contains("unsupported delivery channel")
+                && !msg.contains("[channels.whatsapp.default] not configured"),
+            "whatsapp.default must reject the configured non-Web mode, not fall through; got: {msg}"
         );
     }
 


### PR DESCRIPTION
## Summary
- Add regression coverage for WhatsApp cron delivery when the configured WhatsApp channel is Cloud API mode rather than Web mode.

## Changes
- Keep the cron delivery branch on the WhatsApp arm for configured non-Web channels.
- Align the rejection message with the accepted Web selectors instead of only naming `session_path`.
- Assert the error does not fall through to unsupported-channel or not-configured paths.

## Tests
- `cargo fmt --all -- --check`
- `cargo test -p zeroclaw-channels deliver_announcement_rejects_whatsapp_non_web_config_clearly --features whatsapp-web -- --nocapture`
- `cargo clippy -p zeroclaw-channels --all-targets --features whatsapp-web -- -D warnings`

## Risk
- Low. Test-focused change with one clearer error string for an existing rejection path.