### PR TITLE
docs(setup): mention Linux uninstall script

### DIFF
--- a/docs/book/src/setup/linux.md
+++ b/docs/book/src/setup/linux.md
@@ -176,6 +176,18 @@ zeroclaw service restart
 
 ## Uninstall
 
+If you installed with the bootstrap script, use the same script to uninstall:
+
+<div class="os-tabs-src">
+
+#### sh
+
+```sh
+./install.sh --uninstall
+```
+
+</div>
+
 Stop and remove the service:
 
 <div class="os-tabs-src">


### PR DESCRIPTION
## Summary

Document the Linux bootstrap uninstall command in the setup guide.

## Changes

- Add `./install.sh --uninstall` to the Linux uninstall section.
- Keep the existing manual service, binary, and workspace cleanup steps for non-bootstrap or manual cleanup paths.

## Tests

- `./scripts/ci/docs_quality_gate.sh`
- `git diff --check origin/master...HEAD`
- `bash -n install.sh`
- Manual changed-line link scan: no added links detected

`./scripts/ci/docs_links_gate.sh` could not run on the validation host because its default `python3` is 3.6.8 and the repository script requires Python 3.7+ syntax. This change adds no links, so the link-integrity path is empty.

## Risk

Low. Documentation-only change that points users to an existing installer flag.