### PR TITLE
fix(tools): encode weather location path input

### DIFF
--- a/crates/zeroclaw-tools/src/weather_tool.rs
+++ b/crates/zeroclaw-tools/src/weather_tool.rs
@@ -140,8 +140,9 @@ impl WeatherTool {
 
     /// Build the wttr.in request URL for the given location.
     fn build_url(location: &str) -> String {
-        // Percent-encode spaces; wttr.in also accepts `+` but %20 is safer.
-        let encoded = location.trim().replace(' ', "+");
+        let encoded = urlencoding::encode(location.trim())
+            .replace("%20", "+")
+            .replace("%2C", ",");
         format!("{WTTR_BASE_URL}/{encoded}?format=j1")
     }
 
@@ -543,6 +544,24 @@ mod tests {
     fn build_url_zip_code() {
         let url = WeatherTool::build_url("74015");
         assert_eq!(url, "https://wttr.in/74015?format=j1");
+    }
+
+    #[test]
+    fn build_url_encodes_ampersand_in_location() {
+        let url = WeatherTool::build_url("A&B");
+        assert_eq!(url, "https://wttr.in/A%26B?format=j1");
+    }
+
+    #[test]
+    fn build_url_encodes_query_chars_in_location() {
+        let url = WeatherTool::build_url("Paris?format=3");
+        assert_eq!(url, "https://wttr.in/Paris%3Fformat%3D3?format=j1");
+    }
+
+    #[test]
+    fn build_url_encodes_non_ascii_location() {
+        let url = WeatherTool::build_url("北京");
+        assert_eq!(url, "https://wttr.in/%E5%8C%97%E4%BA%AC?format=j1");
     }
 
     // ── execute: parameter validation ─────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Percent-encode wttr.in location path input before appending the fixed JSON query string.
- Preserve existing behavior for normal city names, airport codes, zip codes, and GPS coordinates.

## Changes
- Reuse the existing `urlencoding` dependency in `WeatherTool::build_url`.
- Keep spaces as `+` and GPS coordinate commas as literal commas for wttr.in compatibility.
- Add regression coverage for `A&B`, `Paris?format=3`, and a non-ASCII location.

## Tests
- `cargo fmt --all -- --check`
- `cargo test -p zeroclaw-tools build_url --lib`
- `cargo clippy -p zeroclaw-tools --all-targets -- -D warnings`

## Risk
- Low. This is limited to URL construction for weather location input and does not add or duplicate state.