### PR TITLE
fix(skills): parse skill review summary from tool history

### DIFF
--- a/crates/zeroclaw-runtime/src/skills/review.rs
+++ b/crates/zeroclaw-runtime/src/skills/review.rs
@@ -87,6 +87,7 @@ pub async fn maybe_run_skill_review(
     let review_input = build_review_input(&failed_slugs);
 
     let mut review_history = history;
+    let fork_start_len = review_history.len();
     review_history.push(ChatMessage::user(&review_input));
 
     let receipts: Mutex<Vec<String>> = Mutex::new(Vec::new());
@@ -135,7 +136,8 @@ pub async fn maybe_run_skill_review(
 
     match result {
         Ok(final_text) => {
-            let summary = summarize_actions(&receipts, &final_text);
+            let summary =
+                summarize_actions(&receipts, &review_history[fork_start_len..], &final_text);
             if !summary.is_empty() {
                 println!(
                     "{}",
@@ -199,7 +201,15 @@ fn count_tool_iterations(history: &[ChatMessage]) -> usize {
 
 /// Convert the review's tool receipts + final text into a one-line summary
 /// for the user. Returns "" if the fork did nothing notable.
-fn summarize_actions(receipts: &Mutex<Vec<String>>, final_text: &str) -> String {
+///
+/// `fork_history` must contain only messages produced by the review fork
+/// itself (not the parent turn), so that the fallback scan does not pick up
+/// tool results from the user's main turn.
+fn summarize_actions(
+    receipts: &Mutex<Vec<String>>,
+    fork_history: &[ChatMessage],
+    final_text: &str,
+) -> String {
     let receipts = receipts.lock().ok();
     let actions: Vec<String> = receipts
         .as_ref()
@@ -208,6 +218,18 @@ fn summarize_actions(receipts: &Mutex<Vec<String>>, final_text: &str) -> String 
 
     if !actions.is_empty() {
         return actions.join(" · ");
+    }
+
+    // The fork passes `collected_receipts` but `run_tool_call_loop` does not
+    // populate it without a receipt generator. Fall back to the tool-result
+    // messages produced by the review fork itself (not the parent turn).
+    let from_history: Vec<String> = fork_history
+        .iter()
+        .filter(|m| m.role == "tool")
+        .filter_map(|m| extract_action_summary(&m.content))
+        .collect();
+    if !from_history.is_empty() {
+        return from_history.join(" · ");
     }
 
     let trimmed = final_text.trim();
@@ -316,7 +338,7 @@ mod tests {
             "Patched skill 'deploy'.".to_string(),
             "Wrote references/staging.md for skill 'deploy'.".to_string(),
         ]);
-        let summary = summarize_actions(&receipts, "");
+        let summary = summarize_actions(&receipts, &[], "");
         assert!(summary.contains("patched deploy"));
         assert!(summary.contains("wrote file for deploy"));
     }
@@ -324,14 +346,14 @@ mod tests {
     #[test]
     fn summarize_actions_empty_for_nothing_to_save() {
         let receipts = Mutex::new(Vec::new());
-        let summary = summarize_actions(&receipts, "Nothing to save.");
+        let summary = summarize_actions(&receipts, &[], "Nothing to save.");
         assert_eq!(summary, "");
     }
 
     #[test]
     fn summarize_actions_empty_when_no_receipts_and_no_text() {
         let receipts = Mutex::new(Vec::new());
-        let summary = summarize_actions(&receipts, "");
+        let summary = summarize_actions(&receipts, &[], "");
         assert_eq!(summary, "");
     }
 
@@ -340,6 +362,7 @@ mod tests {
         let receipts = Mutex::new(Vec::new());
         let summary = summarize_actions(
             &receipts,
+            &[],
             "Noted that deploy needs DEPLOY_TOKEN.\nMore details below.",
         );
         assert!(summary.starts_with("Noted that deploy"));
@@ -350,10 +373,34 @@ mod tests {
         let receipts = Mutex::new(Vec::new());
         // 80+ chars of multi-byte content — must not panic on slicing.
         let text = "あ".repeat(50);
-        let summary = summarize_actions(&receipts, &text);
+        let summary = summarize_actions(&receipts, &[], &text);
         assert!(!summary.is_empty());
         // Verify it's valid UTF-8 (would have panicked if not).
         let _ = summary.chars().count();
+    }
+
+    #[test]
+    fn summarize_actions_reads_skill_manage_results_from_history() {
+        let receipts = Mutex::new(Vec::new());
+        let fork_history = vec![msg(
+            "tool",
+            "Patched skill 'file-lister' to provide a flat bullet list by default.",
+        )];
+        let summary = summarize_actions(&receipts, &fork_history, "ignored prose fallback");
+        assert_eq!(summary, "patched file-lister");
+    }
+
+    #[test]
+    fn summarize_actions_ignores_parent_turn_tool_messages() {
+        // A parent-turn tool message matching the action parser must not
+        // produce a false summary when the review fork itself did nothing.
+        let receipts = Mutex::new(Vec::new());
+        let fork_history: Vec<ChatMessage> = vec![]; // fork produced no tool messages
+        let summary = summarize_actions(&receipts, &fork_history, "Nothing to save.");
+        assert_eq!(
+            summary, "",
+            "parent-turn tool messages must not leak into the summary"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Skill review `summarize_actions` now falls back to parsing `tool`-role messages in `review_history` when `collected_receipts` is empty.
  - Fixes the cosmetic display bug where users saw an 80-char clip of LLM prose instead of `patched <slug>`.
- **Scope boundary:** Does not change skill_manage execution or receipt-generator wiring.
- **Blast radius:** Skill review fork summary line only.
- **Linked issue(s):** Closes #6644
- **Labels:** `bug`, `runtime`, `risk: low`, `size: XS`

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo test -p zeroclaw-runtime summarize_actions
```

- **Commands run and tail output:** `cargo fmt --all -- --check` passed locally. Full `cargo test` skipped — no system linker (`cc`) in environment; CI will run the battery.
- **Beyond CI — what did you manually verify?** Added unit test `summarize_actions_reads_skill_manage_results_from_history` covering the empty-receipt path.
- **If any command was intentionally skipped, why:** Missing `build-essential` / `cc` linker locally.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PR: `git revert <sha>`.

