### PR TITLE
feat(providers)!: span attribution — route model provider calls through attribution dispatcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3547,6 +3547,7 @@ dependencies = [
  "toml 0.8.23",
  "xtask",
  "zeroclaw-api",
+ "zeroclaw-providers",
 ]
 
 [[package]]
@@ -14415,6 +14416,7 @@ dependencies = [
  "zeroclaw-api",
  "zeroclaw-config",
  "zeroclaw-log",
+ "zeroclaw-providers",
  "zeroclaw-spawn",
 ]
 

--- a/crates/zeroclaw-api/src/attribution.rs
+++ b/crates/zeroclaw-api/src/attribution.rs
@@ -194,7 +194,6 @@ pub enum ModelProviderKind {
     KiloCli,
     Kilo,
     Router,
-    Reliable,
     Moonshot,
     Qwen,
     Minimax,

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -121,7 +121,7 @@ use zeroclaw_api::session_keys::sanitize_session_key;
 use zeroclaw_config::schema::Config;
 use zeroclaw_memory::{self, MEMORY_CONTEXT_CLOSE, MEMORY_CONTEXT_OPEN, Memory};
 use zeroclaw_providers::reliable::{scope_provider_fallback, take_last_provider_fallback};
-use zeroclaw_providers::{self, ChatMessage, ModelProvider};
+use zeroclaw_providers::{self, ChatMessage, ModelProvider, ProviderDispatch};
 use zeroclaw_runtime::agent::loop_::{
     LoopKnobs, apply_policy_tool_filter, apply_text_tool_prompt_policy,
     build_tool_instructions_for_names, clear_model_switch_request, get_model_switch_state,
@@ -1450,7 +1450,10 @@ async fn maybe_apply_runtime_config_update(ctx: &ChannelRuntimeContext) -> Resul
     )?;
     let model_provider_instance: Arc<dyn ModelProvider> = Arc::from(model_provider_instance);
 
-    if let Err(err) = model_provider_instance.warmup().await {
+    if let Err(err) = ProviderDispatch::from_ref(&*model_provider_instance)
+        .warmup()
+        .await
+    {
         if zeroclaw_providers::reliable::is_non_retryable(&err) {
             ::zeroclaw_log::record!(WARN, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_outcome(::zeroclaw_log::EventOutcome::Unknown).with_attrs(::serde_json::json!({"model_provider": next_defaults.default_model_provider, "model": next_defaults.model, "err": err.to_string()})), "Rejecting config reload: model not available (non-retryable)");
             return Ok(());
@@ -2062,7 +2065,7 @@ async fn get_or_create_provider(
     .await?;
     let model_provider: Arc<dyn ModelProvider> = Arc::from(model_provider);
 
-    if let Err(err) = model_provider.warmup().await {
+    if let Err(err) = ProviderDispatch::from_ref(&*model_provider).warmup().await {
         ::zeroclaw_log::record!(
             WARN,
             ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
@@ -2804,7 +2807,7 @@ async fn classify_channel_reply_intent(
         let _ = writeln!(convo, "[{role}] {safe_content}");
     }
 
-    let response = model_provider
+    let response = ProviderDispatch::from_ref(model_provider)
         .chat_with_system(Some(system_prompt), &convo, model, temperature)
         .await?;
     Ok(parse_reply_intent(&response))
@@ -8406,7 +8409,7 @@ pub async fn start_channels(
             .await?,
         );
 
-        if let Err(e) = model_provider.warmup().await {
+        if let Err(e) = ProviderDispatch::from_ref(&*model_provider).warmup().await {
             ::zeroclaw_log::record!(
                 WARN,
                 ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)

--- a/crates/zeroclaw-log/src/broadcast.rs
+++ b/crates/zeroclaw-log/src/broadcast.rs
@@ -76,7 +76,8 @@ pub fn subscribe_or_install() -> broadcast::Receiver<Value> {
 /// hook must hold this so a parallel test cannot clear the hook mid-flight and
 /// drop another test's event. Lives at module scope (not inside `mod tests`)
 /// so sibling modules (e.g. `layer::e2e_tests`) acquire the SAME lock.
-#[cfg(test)]
+/// Always compiled (not gated behind `#[cfg(test)]`) so peer crates can
+/// borrow it via the `__private_test_hook_lock` helper in `lib.rs`.
 pub(crate) static HOOK_TEST_LOCK: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
 
 #[cfg(test)]

--- a/crates/zeroclaw-log/src/lib.rs
+++ b/crates/zeroclaw-log/src/lib.rs
@@ -80,3 +80,27 @@ pub use tool_io::{ToolIoCapture, capture_tool_input, capture_tool_output};
 pub use writer::{init_from_config, record_event, runtime_trace_path};
 
 mod r#macro;
+
+/// Test-only re-export of the writer-test mutex. Returns an opaque RAII
+/// guard so peer crates need not name `parking_lot`. Workspace crates
+/// that exercise the `record!` → `LogCaptureLayer` → broadcast hook
+/// path in `#[cfg(test)]` need to serialize against `writer::tests`
+/// and the broadcast tests; without this guard, a parallel
+/// `writer::tests` run can see this test's event land in its tempdir.
+#[doc(hidden)]
+#[must_use]
+pub fn __private_test_writer_lock() -> impl Drop {
+    crate::writer::WRITER_TEST_LOCK.lock()
+}
+
+/// Test-only re-export of the broadcast-hook mutex. Returns an opaque
+/// RAII guard. The broadcast module's own tests clear/install the
+/// global hook under this lock; peer crates exercising the hook
+/// must hold it for the duration of their assertions, otherwise a
+/// parallel `clear_broadcast_hook` drops the test's events and the
+/// search times out.
+#[doc(hidden)]
+#[must_use]
+pub fn __private_test_hook_lock() -> impl Drop {
+    crate::broadcast::HOOK_TEST_LOCK.lock()
+}

--- a/crates/zeroclaw-log/src/writer.rs
+++ b/crates/zeroclaw-log/src/writer.rs
@@ -236,8 +236,10 @@ fn count_nonempty_lines(path: &Path) -> Result<usize> {
 
 /// Shared test-time mutex for tests that mutate the global writer state.
 /// Re-exported `pub(crate)` so `macro::tests` etc. can serialize against
-/// the same lock as `writer::tests`.
-#[cfg(test)]
+/// the same lock as `writer::tests`. Always compiled (not gated behind
+/// `#[cfg(test)]`) so peer crates can borrow it via the
+/// `__private_test_writer_lock` helper in `lib.rs`. A `parking_lot::Mutex`
+/// static costs nothing at runtime when untouched.
 pub(crate) static WRITER_TEST_LOCK: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
 
 #[cfg(test)]

--- a/crates/zeroclaw-memory/Cargo.toml
+++ b/crates/zeroclaw-memory/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 [dependencies]
 zeroclaw-log.workspace = true
 zeroclaw-api.workspace = true
+zeroclaw-providers.workspace = true
 zeroclaw-spawn.workspace = true
 zeroclaw-config = { workspace = true, default-features = false }
 anyhow = "1.0"

--- a/crates/zeroclaw-memory/src/consolidation.rs
+++ b/crates/zeroclaw-memory/src/consolidation.rs
@@ -12,6 +12,7 @@ use crate::conflict;
 use crate::importance;
 use crate::traits::{Memory, MemoryCategory};
 use zeroclaw_api::model_provider::ModelProvider;
+use zeroclaw_providers::ProviderDispatch;
 
 /// Output of consolidation extraction.
 #[derive(Debug, serde::Deserialize)]
@@ -80,7 +81,7 @@ pub async fn consolidate_turn(
         turn_text.clone()
     };
 
-    let raw = model_provider
+    let raw = ProviderDispatch::from_ref(model_provider)
         .chat_with_system(
             Some(CONSOLIDATION_SYSTEM_PROMPT),
             &truncated,

--- a/crates/zeroclaw-providers/src/auth/gemini_oauth.rs
+++ b/crates/zeroclaw-providers/src/auth/gemini_oauth.rs
@@ -332,6 +332,17 @@ pub async fn poll_device_code_tokens(
 /// If the callback server can't receive the redirect (e.g., remote/headless environment),
 /// the user can paste the full callback URL or just the code.
 pub async fn receive_loopback_code(expected_state: &str, timeout: Duration) -> Result<String> {
+    ::zeroclaw_log::scope!(
+        model_provider_type: "gemini",
+        model_provider_alias: "oauth",
+        => async move {
+            receive_loopback_code_inner(expected_state, timeout).await
+        }
+    )
+    .await
+}
+
+async fn receive_loopback_code_inner(expected_state: &str, timeout: Duration) -> Result<String> {
     // Try to bind to the callback port
     let listener = match TcpListener::bind("127.0.0.1:1456").await {
         Ok(l) => l,

--- a/crates/zeroclaw-providers/src/auth/openai_oauth.rs
+++ b/crates/zeroclaw-providers/src/auth/openai_oauth.rs
@@ -226,6 +226,23 @@ pub async fn poll_device_code_tokens(
 }
 
 pub async fn receive_loopback_code(expected_state: &str, timeout: Duration) -> Result<String> {
+    // OAuth callback receiver has no concrete provider alias at this
+    // level (it's a low-level helper used during the OAuth dance,
+    // before the provider is constructed). Attribute with the provider
+    // type so on-disk events still slot under the right
+    // model_provider_type bucket. The "oauth" alias is a sentinel for
+    // "this happened during the OAuth dance".
+    ::zeroclaw_log::scope!(
+        model_provider_type: "openai",
+        model_provider_alias: "oauth",
+        => async move {
+            receive_loopback_code_inner(expected_state, timeout).await
+        }
+    )
+    .await
+}
+
+async fn receive_loopback_code_inner(expected_state: &str, timeout: Duration) -> Result<String> {
     let listener = TcpListener::bind("127.0.0.1:1455")
         .await
         .context("Failed to bind callback listener at 127.0.0.1:1455")?;
@@ -395,6 +412,21 @@ async fn parse_token_response(response: reqwest::Response) -> Result<TokenSet> {
 /// ZeroClaw's auth store. Replaces the `import_openai_codex_auth_profile`
 /// helper formerly in `src/main.rs`.
 pub async fn import_codex_auth_profile(
+    auth_service: &super::AuthService,
+    profile: &str,
+    import_path: &std::path::Path,
+) -> anyhow::Result<()> {
+    ::zeroclaw_log::scope!(
+        model_provider_type: "openai",
+        model_provider_alias: profile,
+        => async move {
+            import_codex_auth_profile_inner(auth_service, profile, import_path).await
+        }
+    )
+    .await
+}
+
+async fn import_codex_auth_profile_inner(
     auth_service: &super::AuthService,
     profile: &str,
     import_path: &std::path::Path,

--- a/crates/zeroclaw-providers/src/dispatch.rs
+++ b/crates/zeroclaw-providers/src/dispatch.rs
@@ -29,12 +29,37 @@ pub struct ProviderDispatch {
     inner: Arc<dyn ModelProvider>,
 }
 
+/// Borrowed-reference twin of [`ProviderDispatch`]. Use this at call
+/// sites that already hold a `&dyn ModelProvider` and shouldn't be
+/// forced to plumb `Arc<dyn ModelProvider>` through their signatures
+/// just to gain attribution. Same surface, same on-disk shape; the
+/// only difference is the storage discipline.
+///
+/// Streaming note: `stream_chat` on this borrowed variant is
+/// intentionally **not** provided. `stream_chat` returns a
+/// `BoxStream<'static, …>` that must outlive the dispatcher; only
+/// `Arc<dyn ModelProvider>` can satisfy that lifetime. Callers that
+/// stream must hold the provider as an `Arc` and use
+/// [`ProviderDispatch`].
+pub struct ProviderDispatchRef<'a> {
+    inner: &'a dyn ModelProvider,
+}
+
 impl ProviderDispatch {
     /// Wrap an `Arc<dyn ModelProvider>` so its method calls open
     /// `attribution_span!(&*inner)` automatically.
     #[must_use]
     pub fn new(inner: Arc<dyn ModelProvider>) -> Self {
         Self { inner }
+    }
+
+    /// Wrap a borrowed `&dyn ModelProvider`. Returns a
+    /// [`ProviderDispatchRef`] for ergonomic chaining at call sites
+    /// that don't hold an `Arc`. See [`ProviderDispatchRef`] for the
+    /// streaming caveat.
+    #[must_use]
+    pub fn from_ref(inner: &dyn ModelProvider) -> ProviderDispatchRef<'_> {
+        ProviderDispatchRef { inner }
     }
 
     /// Open `attribution_span!(&*self.inner)` + `scope!(model: model)`
@@ -220,6 +245,147 @@ impl ProviderDispatch {
         use zeroclaw_log::Instrument;
         let span = zeroclaw_log::attribution_span!(&*self.inner);
         self.inner.warmup().instrument(span).await
+    }
+}
+
+impl<'a> ProviderDispatchRef<'a> {
+    /// Open `attribution_span!(self.inner)` + `scope!(model: model)`
+    /// around the inner provider's `chat` call.
+    pub async fn chat(
+        &self,
+        request: ChatRequest<'_>,
+        model: &str,
+        temperature: Option<f64>,
+    ) -> anyhow::Result<ChatResponse> {
+        use zeroclaw_log::Instrument;
+        let span = zeroclaw_log::attribution_span!(self.inner);
+        async move {
+            zeroclaw_log::scope!(
+                model: model,
+                => self.inner.chat(request, model, temperature)
+            )
+            .await
+        }
+        .instrument(span)
+        .await
+    }
+
+    /// Wrap the inner provider's `simple_chat`. Dispatched through
+    /// `self.inner` so a concrete `simple_chat` override on the inner
+    /// provider is honored (rather than the trait default that
+    /// delegates to `chat_with_system`).
+    pub async fn simple_chat(
+        &self,
+        message: &str,
+        model: &str,
+        temperature: Option<f64>,
+    ) -> anyhow::Result<String> {
+        use zeroclaw_log::Instrument;
+        let span = zeroclaw_log::attribution_span!(self.inner);
+        async move {
+            zeroclaw_log::scope!(
+                model: model,
+                => self.inner.simple_chat(message, model, temperature)
+            )
+            .await
+        }
+        .instrument(span)
+        .await
+    }
+
+    /// Wrap the inner provider's `chat_with_system`.
+    pub async fn chat_with_system(
+        &self,
+        system_prompt: Option<&str>,
+        message: &str,
+        model: &str,
+        temperature: Option<f64>,
+    ) -> anyhow::Result<String> {
+        use zeroclaw_log::Instrument;
+        let span = zeroclaw_log::attribution_span!(self.inner);
+        async move {
+            zeroclaw_log::scope!(
+                model: model,
+                => self.inner.chat_with_system(system_prompt, message, model, temperature)
+            )
+            .await
+        }
+        .instrument(span)
+        .await
+    }
+
+    /// Wrap the inner provider's `chat_with_history`.
+    pub async fn chat_with_history(
+        &self,
+        messages: &[ChatMessage],
+        model: &str,
+        temperature: Option<f64>,
+    ) -> anyhow::Result<String> {
+        use zeroclaw_log::Instrument;
+        let span = zeroclaw_log::attribution_span!(self.inner);
+        async move {
+            zeroclaw_log::scope!(
+                model: model,
+                => self.inner.chat_with_history(messages, model, temperature)
+            )
+            .await
+        }
+        .instrument(span)
+        .await
+    }
+
+    /// Wrap the inner provider's `chat_with_tools`.
+    pub async fn chat_with_tools(
+        &self,
+        messages: &[ChatMessage],
+        tools: &[serde_json::Value],
+        model: &str,
+        temperature: Option<f64>,
+    ) -> anyhow::Result<ChatResponse> {
+        use zeroclaw_log::Instrument;
+        let span = zeroclaw_log::attribution_span!(self.inner);
+        async move {
+            zeroclaw_log::scope!(
+                model: model,
+                => self.inner.chat_with_tools(messages, tools, model, temperature)
+            )
+            .await
+        }
+        .instrument(span)
+        .await
+    }
+
+    /// Wrap the inner provider's `list_models`. No `model` parameter,
+    /// so attribution only.
+    pub async fn list_models(&self) -> anyhow::Result<Vec<String>> {
+        use zeroclaw_log::Instrument;
+        let span = zeroclaw_log::attribution_span!(self.inner);
+        self.inner.list_models().instrument(span).await
+    }
+
+    /// Wrap the inner provider's `list_models_with_pricing`.
+    pub async fn list_models_with_pricing(&self) -> anyhow::Result<Vec<ModelInfo>> {
+        use zeroclaw_log::Instrument;
+        let span = zeroclaw_log::attribution_span!(self.inner);
+        self.inner.list_models_with_pricing().instrument(span).await
+    }
+
+    /// Wrap the inner provider's `warmup`. No `model` parameter, so
+    /// attribution only.
+    pub async fn warmup(&self) -> anyhow::Result<()> {
+        use zeroclaw_log::Instrument;
+        let span = zeroclaw_log::attribution_span!(self.inner);
+        self.inner.warmup().instrument(span).await
+    }
+
+    /// Hand back the underlying borrowed provider reference. Useful
+    /// at call sites that need to forward the provider to a non-call
+    /// API (e.g. a helper that holds a `&dyn ModelProvider` for
+    /// non-attribution reasons such as a manual
+    /// `attribution_span!(provider).entered()` on a sibling event).
+    #[must_use]
+    pub fn inner(&self) -> &'a dyn ModelProvider {
+        self.inner
     }
 }
 
@@ -454,6 +620,69 @@ mod tests {
             }
         }
         assert!(found, "stream chunk record was not attributed");
+        zeroclaw_log::clear_broadcast_hook();
+    }
+
+    #[tokio::test]
+    async fn dispatch_ref_chat_attaches_inner_provider_attribution() {
+        let _writer_guard = zeroclaw_log::__private_test_writer_lock();
+        let _hook_guard = zeroclaw_log::__private_test_hook_lock();
+        zeroclaw_log::try_install_capture_subscriber();
+        let mut rx = zeroclaw_log::subscribe_or_install();
+        while rx.try_recv().is_ok() {}
+
+        // Hold the fake by ownership but pass &dyn to the borrowed
+        // dispatcher — exercises the call shape that the runtime's
+        // turn helpers use.
+        let fake = FakeAnthropic {
+            alias: "ref-alias".into(),
+        };
+        let dispatch = ProviderDispatch::from_ref(&fake as &dyn ModelProvider);
+        let request = ChatRequest {
+            messages: &[],
+            tools: None,
+            thinking: None,
+        };
+        let _ = dispatch.chat(request, "claude-sonnet-4-6", None).await;
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        let mut found = false;
+        while !found && std::time::Instant::now() < deadline {
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            let step = remaining.min(std::time::Duration::from_millis(50));
+            match tokio::time::timeout(step, rx.recv()).await {
+                Ok(Ok(value)) => {
+                    if value
+                        .get("message")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.contains("fake-anthropic chat called"))
+                        .unwrap_or(false)
+                    {
+                        let zc = value.get("zeroclaw").expect("zeroclaw block present");
+                        assert_eq!(
+                            zc.get("model_provider_alias").and_then(|v| v.as_str()),
+                            Some("ref-alias"),
+                        );
+                        assert_eq!(
+                            zc.get("model_provider_type").and_then(|v| v.as_str()),
+                            Some("anthropic"),
+                        );
+                        assert_eq!(
+                            zc.get("model").and_then(|v| v.as_str()),
+                            Some("claude-sonnet-4-6"),
+                        );
+                        found = true;
+                    }
+                }
+                Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => {}
+                Ok(Err(tokio::sync::broadcast::error::RecvError::Closed)) => break,
+                Err(_elapsed) => {}
+            }
+        }
+        assert!(
+            found,
+            "did not capture the fake-anthropic event via borrowed dispatcher",
+        );
         zeroclaw_log::clear_broadcast_hook();
     }
 }

--- a/crates/zeroclaw-providers/src/dispatch.rs
+++ b/crates/zeroclaw-providers/src/dispatch.rs
@@ -35,12 +35,10 @@ pub struct ProviderDispatch {
 /// just to gain attribution. Same surface, same on-disk shape; the
 /// only difference is the storage discipline.
 ///
-/// Streaming note: `stream_chat` on this borrowed variant is
-/// intentionally **not** provided. `stream_chat` returns a
-/// `BoxStream<'static, …>` that must outlive the dispatcher; only
-/// `Arc<dyn ModelProvider>` can satisfy that lifetime. Callers that
-/// stream must hold the provider as an `Arc` and use
-/// [`ProviderDispatch`].
+/// `stream_chat` is supported because the inner provider's
+/// `stream_chat` already returns a `BoxStream<'static, …>`; the
+/// returned stream owns its span guards (not borrowed from `self`),
+/// so the dispatcher's lifetime does not bound the stream.
 pub struct ProviderDispatchRef<'a> {
     inner: &'a dyn ModelProvider,
 }
@@ -55,8 +53,7 @@ impl ProviderDispatch {
 
     /// Wrap a borrowed `&dyn ModelProvider`. Returns a
     /// [`ProviderDispatchRef`] for ergonomic chaining at call sites
-    /// that don't hold an `Arc`. See [`ProviderDispatchRef`] for the
-    /// streaming caveat.
+    /// that don't hold an `Arc`.
     #[must_use]
     pub fn from_ref(inner: &dyn ModelProvider) -> ProviderDispatchRef<'_> {
         ProviderDispatchRef { inner }
@@ -268,6 +265,36 @@ impl<'a> ProviderDispatchRef<'a> {
         }
         .instrument(span)
         .await
+    }
+
+    /// Wrap the inner provider's `stream_chat`. Same span-parenting
+    /// trick as [`ProviderDispatch::stream_chat`]; the returned
+    /// `BoxStream<'static, …>` is independent of `self`'s lifetime
+    /// because the inner provider's `stream_chat` already returns
+    /// `'static` (the spans are owned by the closure, not borrowed
+    /// from `self`).
+    pub fn stream_chat(
+        &self,
+        request: ChatRequest<'_>,
+        model: &str,
+        temperature: Option<f64>,
+        options: StreamOptions,
+    ) -> stream::BoxStream<'static, StreamResult<StreamEvent>> {
+        let attribution = zeroclaw_log::attribution_span!(self.inner);
+        let _attribution_enter = attribution.enter();
+        let model_scope = zeroclaw_log::info_span!(
+            target: "zeroclaw_log_internal_scope",
+            "zeroclaw_scope",
+            model = %model,
+        );
+        let inner_stream = self.inner.stream_chat(request, model, temperature, options);
+        drop(_attribution_enter);
+        let mut inner_stream = inner_stream;
+        stream::poll_fn(move |cx| {
+            let _enter = model_scope.enter();
+            inner_stream.as_mut().poll_next(cx)
+        })
+        .boxed()
     }
 
     /// Wrap the inner provider's `simple_chat`. Dispatched through

--- a/crates/zeroclaw-providers/src/dispatch.rs
+++ b/crates/zeroclaw-providers/src/dispatch.rs
@@ -16,7 +16,10 @@
 
 use std::sync::Arc;
 
-use zeroclaw_api::model_provider::{ChatRequest, ChatResponse, ModelProvider};
+use futures_util::stream::{self, StreamExt as _};
+use zeroclaw_api::model_provider::{
+    ChatRequest, ChatResponse, ModelProvider, StreamEvent, StreamOptions, StreamResult,
+};
 
 /// Wraps a model provider so every call opens the correct
 /// `attribution_span!` automatically. See the module docs for the
@@ -59,14 +62,59 @@ impl ProviderDispatch {
         .instrument(span)
         .await
     }
+
+    /// Wrap the inner provider's `stream_chat` with
+    /// `attribution_span!` and a `scope!(model: …)`. Each `poll_next`
+    /// of the returned stream re-enters the `model_scope` span; the
+    /// attribution span is `model_scope`'s parent (set at construction
+    /// time while the attribution span was entered), so the layer's
+    /// leaf→root walk reaches the attribution contribution on every
+    /// per-chunk `record!` from inside the provider's stream body.
+    pub fn stream_chat(
+        &self,
+        request: ChatRequest<'_>,
+        model: &str,
+        temperature: Option<f64>,
+        options: StreamOptions,
+    ) -> stream::BoxStream<'static, StreamResult<StreamEvent>> {
+        let attribution = zeroclaw_log::attribution_span!(&*self.inner);
+        // Enter the attribution span synchronously so the model_scope
+        // info_span! constructs with attribution as its parent. Drop
+        // the guard before returning; the attribution span lives on
+        // via model_scope's parent pointer.
+        let _attribution_enter = attribution.enter();
+        let model_scope = zeroclaw_log::info_span!(
+            target: "zeroclaw_log_internal_scope",
+            "zeroclaw_scope",
+            model = %model,
+        );
+        let inner_stream = self.inner.stream_chat(request, model, temperature, options);
+        drop(_attribution_enter);
+        // Manually re-enter `model_scope` on every poll. `tracing`
+        // does not impl `Stream` for `Instrumented<S>` (only for
+        // `Future`s), so we use the `poll_fn` adapter to drive the
+        // inner stream while holding the scope guard for the duration
+        // of each poll. The guard never crosses an await — it is
+        // dropped before `poll_next` returns — so this stays `Send`.
+        let mut inner_stream = inner_stream;
+        stream::poll_fn(move |cx| {
+            let _enter = model_scope.enter();
+            inner_stream.as_mut().poll_next(cx)
+        })
+        .boxed()
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures_util::StreamExt;
     use std::sync::Arc;
     use zeroclaw_api::attribution::{Attributable, ModelProviderKind, ProviderKind, Role};
-    use zeroclaw_api::model_provider::{ChatRequest, ChatResponse, ModelProvider};
+    use zeroclaw_api::model_provider::{
+        ChatRequest, ChatResponse, ModelProvider, StreamChunk, StreamEvent, StreamOptions,
+        StreamResult,
+    };
 
     struct FakeAnthropic {
         alias: String,
@@ -172,6 +220,122 @@ mod tests {
             }
         }
         assert!(found, "did not capture the fake-anthropic event");
+        zeroclaw_log::clear_broadcast_hook();
+    }
+
+    struct StreamingFake {
+        alias: String,
+    }
+
+    impl Attributable for StreamingFake {
+        fn role(&self) -> Role {
+            Role::Provider(ProviderKind::Model(ModelProviderKind::Anthropic))
+        }
+        fn alias(&self) -> &str {
+            &self.alias
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ModelProvider for StreamingFake {
+        async fn chat_with_system(
+            &self,
+            _system_prompt: Option<&str>,
+            _message: &str,
+            _model: &str,
+            _temperature: Option<f64>,
+        ) -> anyhow::Result<String> {
+            anyhow::bail!("not used in stream test")
+        }
+
+        fn stream_chat(
+            &self,
+            _request: ChatRequest<'_>,
+            _model: &str,
+            _temperature: Option<f64>,
+            _options: StreamOptions,
+        ) -> futures_util::stream::BoxStream<'static, StreamResult<StreamEvent>> {
+            // Emit a record! from inside the stream body on each poll
+            // so the test can verify the span survives stream re-entry.
+            // We use `stream::iter` with eagerly-evaluated items;
+            // alternatively a manual stream could fire from inside
+            // `poll_next`. Either way the layer's scope walk must see
+            // the dispatcher-installed spans on the resulting event.
+            futures_util::stream::unfold(0u8, |state| async move {
+                match state {
+                    0 => {
+                        zeroclaw_log::record!(
+                            INFO,
+                            zeroclaw_log::Event::new(module_path!(), zeroclaw_log::Action::Note,),
+                            "streaming-fake chunk"
+                        );
+                        Some((Ok(StreamEvent::TextDelta(StreamChunk::delta("hi"))), 1u8))
+                    }
+                    1 => Some((Ok(StreamEvent::Final), 2u8)),
+                    _ => None,
+                }
+            })
+            .boxed()
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatch_stream_chunk_records_carry_attribution() {
+        let _writer_guard = zeroclaw_log::__private_test_writer_lock();
+        let _hook_guard = zeroclaw_log::__private_test_hook_lock();
+        zeroclaw_log::try_install_capture_subscriber();
+        let mut rx = zeroclaw_log::subscribe_or_install();
+        while rx.try_recv().is_ok() {}
+
+        let fake: Arc<dyn ModelProvider> = Arc::new(StreamingFake {
+            alias: "stream-alias".into(),
+        });
+        let dispatch = ProviderDispatch::new(fake);
+        let request = ChatRequest {
+            messages: &[],
+            tools: None,
+            thinking: None,
+        };
+        let mut stream =
+            dispatch.stream_chat(request, "claude-sonnet-4-6", None, StreamOptions::default());
+        while stream.next().await.is_some() {}
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        let mut found = false;
+        while !found && std::time::Instant::now() < deadline {
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            let step = remaining.min(std::time::Duration::from_millis(50));
+            match tokio::time::timeout(step, rx.recv()).await {
+                Ok(Ok(value)) => {
+                    if value
+                        .get("message")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.contains("streaming-fake chunk"))
+                        .unwrap_or(false)
+                    {
+                        let zc = value.get("zeroclaw").expect("zeroclaw block present");
+                        assert_eq!(
+                            zc.get("model_provider_alias").and_then(|v| v.as_str()),
+                            Some("stream-alias"),
+                            "stream chunk record not attributed; zc: {zc:?}",
+                        );
+                        assert_eq!(
+                            zc.get("model_provider_type").and_then(|v| v.as_str()),
+                            Some("anthropic"),
+                        );
+                        assert_eq!(
+                            zc.get("model").and_then(|v| v.as_str()),
+                            Some("claude-sonnet-4-6"),
+                        );
+                        found = true;
+                    }
+                }
+                Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => {}
+                Ok(Err(tokio::sync::broadcast::error::RecvError::Closed)) => break,
+                Err(_elapsed) => {}
+            }
+        }
+        assert!(found, "stream chunk record was not attributed");
         zeroclaw_log::clear_broadcast_hook();
     }
 }

--- a/crates/zeroclaw-providers/src/dispatch.rs
+++ b/crates/zeroclaw-providers/src/dispatch.rs
@@ -1,0 +1,150 @@
+//! `ProviderDispatch` — single source of truth for `attribution_span!`
+//! on the [`ModelProvider`] surface.
+//!
+//! Every direct call to a `ModelProvider` method in the workspace goes
+//! through this helper so the resulting `LogEvent` carries the inner
+//! provider's alias-bound attribution without the call site naming any
+//! of it. Each wrapping method opens
+//! `attribution_span!(&*self.inner)` (and, for the methods that take a
+//! model string, an additional `scope!(model: …)`) around the
+//! underlying call.
+//!
+//! Adding a new `ModelProvider` method: add the wrapping method here
+//! and extend the `scripts/ci/rust_quality_gate.sh` grep gate's
+//! protected method list. The dispatch module is the only place in the
+//! workspace that opens `attribution_span!` for a `ModelProvider`.
+
+use std::sync::Arc;
+
+use zeroclaw_api::model_provider::ModelProvider;
+
+/// Wraps a model provider so every call opens the correct
+/// `attribution_span!` automatically. See the module docs for the
+/// rationale and the CI gate that enforces routing through this type.
+pub struct ProviderDispatch {
+    inner: Arc<dyn ModelProvider>,
+}
+
+impl ProviderDispatch {
+    /// Wrap an `Arc<dyn ModelProvider>` so its method calls open
+    /// `attribution_span!(&*inner)` automatically.
+    #[must_use]
+    pub fn new(inner: Arc<dyn ModelProvider>) -> Self {
+        Self { inner }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use zeroclaw_api::attribution::{Attributable, ModelProviderKind, ProviderKind, Role};
+    use zeroclaw_api::model_provider::{ChatRequest, ChatResponse, ModelProvider};
+
+    struct FakeAnthropic {
+        alias: String,
+    }
+
+    impl Attributable for FakeAnthropic {
+        fn role(&self) -> Role {
+            Role::Provider(ProviderKind::Model(ModelProviderKind::Anthropic))
+        }
+        fn alias(&self) -> &str {
+            &self.alias
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ModelProvider for FakeAnthropic {
+        async fn chat_with_system(
+            &self,
+            _system_prompt: Option<&str>,
+            _message: &str,
+            _model: &str,
+            _temperature: Option<f64>,
+        ) -> anyhow::Result<String> {
+            Ok(String::new())
+        }
+
+        async fn chat(
+            &self,
+            _request: ChatRequest<'_>,
+            _model: &str,
+            _temperature: Option<f64>,
+        ) -> anyhow::Result<ChatResponse> {
+            zeroclaw_log::record!(
+                INFO,
+                zeroclaw_log::Event::new(module_path!(), zeroclaw_log::Action::Note),
+                "fake-anthropic chat called"
+            );
+            Ok(ChatResponse {
+                text: Some(String::new()),
+                tool_calls: Vec::new(),
+                usage: None,
+                reasoning_content: None,
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatch_chat_attaches_inner_provider_attribution() {
+        let _writer_guard = zeroclaw_log::__private_test_writer_lock();
+        let _hook_guard = zeroclaw_log::__private_test_hook_lock();
+        zeroclaw_log::try_install_capture_subscriber();
+        let mut rx = zeroclaw_log::subscribe_or_install();
+        while rx.try_recv().is_ok() {}
+
+        let fake: Arc<dyn ModelProvider> = Arc::new(FakeAnthropic {
+            alias: "test-alias".into(),
+        });
+        let dispatch = ProviderDispatch::new(fake);
+        let request = ChatRequest {
+            messages: &[],
+            tools: None,
+            thinking: None,
+        };
+        let _ = dispatch.chat(request, "claude-sonnet-4-6", None).await;
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        let mut found = false;
+        while !found && std::time::Instant::now() < deadline {
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            let step = remaining.min(std::time::Duration::from_millis(50));
+            match tokio::time::timeout(step, rx.recv()).await {
+                Ok(Ok(value)) => {
+                    if value
+                        .get("message")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.contains("fake-anthropic chat called"))
+                        .unwrap_or(false)
+                    {
+                        let zc = value.get("zeroclaw").expect("zeroclaw block present");
+                        assert_eq!(
+                            zc.get("model_provider").and_then(|v| v.as_str()),
+                            Some("anthropic.test-alias"),
+                            "expected composite model_provider; got: {zc:?}"
+                        );
+                        assert_eq!(
+                            zc.get("model_provider_type").and_then(|v| v.as_str()),
+                            Some("anthropic"),
+                        );
+                        assert_eq!(
+                            zc.get("model_provider_alias").and_then(|v| v.as_str()),
+                            Some("test-alias"),
+                        );
+                        assert_eq!(
+                            zc.get("model").and_then(|v| v.as_str()),
+                            Some("claude-sonnet-4-6"),
+                        );
+                        found = true;
+                    }
+                }
+                Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => {}
+                Ok(Err(tokio::sync::broadcast::error::RecvError::Closed)) => break,
+                Err(_elapsed) => {}
+            }
+        }
+        assert!(found, "did not capture the fake-anthropic event");
+        zeroclaw_log::clear_broadcast_hook();
+    }
+}

--- a/crates/zeroclaw-providers/src/dispatch.rs
+++ b/crates/zeroclaw-providers/src/dispatch.rs
@@ -18,7 +18,8 @@ use std::sync::Arc;
 
 use futures_util::stream::{self, StreamExt as _};
 use zeroclaw_api::model_provider::{
-    ChatRequest, ChatResponse, ModelProvider, StreamEvent, StreamOptions, StreamResult,
+    ChatMessage, ChatRequest, ChatResponse, ModelInfo, ModelProvider, StreamEvent, StreamOptions,
+    StreamResult,
 };
 
 /// Wraps a model provider so every call opens the correct
@@ -102,6 +103,112 @@ impl ProviderDispatch {
             inner_stream.as_mut().poll_next(cx)
         })
         .boxed()
+    }
+
+    /// Wrap the inner provider's `simple_chat`.
+    pub async fn simple_chat(
+        &self,
+        message: &str,
+        model: &str,
+        temperature: Option<f64>,
+    ) -> anyhow::Result<String> {
+        use zeroclaw_log::Instrument;
+        let span = zeroclaw_log::attribution_span!(&*self.inner);
+        async move {
+            zeroclaw_log::scope!(
+                model: model,
+                => self.inner.simple_chat(message, model, temperature)
+            )
+            .await
+        }
+        .instrument(span)
+        .await
+    }
+
+    /// Wrap the inner provider's `chat_with_system`.
+    pub async fn chat_with_system(
+        &self,
+        system_prompt: Option<&str>,
+        message: &str,
+        model: &str,
+        temperature: Option<f64>,
+    ) -> anyhow::Result<String> {
+        use zeroclaw_log::Instrument;
+        let span = zeroclaw_log::attribution_span!(&*self.inner);
+        async move {
+            zeroclaw_log::scope!(
+                model: model,
+                => self.inner.chat_with_system(system_prompt, message, model, temperature)
+            )
+            .await
+        }
+        .instrument(span)
+        .await
+    }
+
+    /// Wrap the inner provider's `chat_with_history`.
+    pub async fn chat_with_history(
+        &self,
+        messages: &[ChatMessage],
+        model: &str,
+        temperature: Option<f64>,
+    ) -> anyhow::Result<String> {
+        use zeroclaw_log::Instrument;
+        let span = zeroclaw_log::attribution_span!(&*self.inner);
+        async move {
+            zeroclaw_log::scope!(
+                model: model,
+                => self.inner.chat_with_history(messages, model, temperature)
+            )
+            .await
+        }
+        .instrument(span)
+        .await
+    }
+
+    /// Wrap the inner provider's `chat_with_tools`.
+    pub async fn chat_with_tools(
+        &self,
+        messages: &[ChatMessage],
+        tools: &[serde_json::Value],
+        model: &str,
+        temperature: Option<f64>,
+    ) -> anyhow::Result<ChatResponse> {
+        use zeroclaw_log::Instrument;
+        let span = zeroclaw_log::attribution_span!(&*self.inner);
+        async move {
+            zeroclaw_log::scope!(
+                model: model,
+                => self.inner.chat_with_tools(messages, tools, model, temperature)
+            )
+            .await
+        }
+        .instrument(span)
+        .await
+    }
+
+    /// Wrap the inner provider's `list_models`. No `model` parameter,
+    /// so attribution only — no `scope!(model: …)`.
+    pub async fn list_models(&self) -> anyhow::Result<Vec<String>> {
+        use zeroclaw_log::Instrument;
+        let span = zeroclaw_log::attribution_span!(&*self.inner);
+        self.inner.list_models().instrument(span).await
+    }
+
+    /// Wrap the inner provider's `list_models_with_pricing`. No `model`
+    /// parameter, so attribution only.
+    pub async fn list_models_with_pricing(&self) -> anyhow::Result<Vec<ModelInfo>> {
+        use zeroclaw_log::Instrument;
+        let span = zeroclaw_log::attribution_span!(&*self.inner);
+        self.inner.list_models_with_pricing().instrument(span).await
+    }
+
+    /// Wrap the inner provider's `warmup`. No `model` parameter, so
+    /// attribution only.
+    pub async fn warmup(&self) -> anyhow::Result<()> {
+        use zeroclaw_log::Instrument;
+        let span = zeroclaw_log::attribution_span!(&*self.inner);
+        self.inner.warmup().instrument(span).await
     }
 }
 

--- a/crates/zeroclaw-providers/src/dispatch.rs
+++ b/crates/zeroclaw-providers/src/dispatch.rs
@@ -16,7 +16,7 @@
 
 use std::sync::Arc;
 
-use zeroclaw_api::model_provider::ModelProvider;
+use zeroclaw_api::model_provider::{ChatRequest, ChatResponse, ModelProvider};
 
 /// Wraps a model provider so every call opens the correct
 /// `attribution_span!` automatically. See the module docs for the
@@ -31,6 +31,33 @@ impl ProviderDispatch {
     #[must_use]
     pub fn new(inner: Arc<dyn ModelProvider>) -> Self {
         Self { inner }
+    }
+
+    /// Open `attribution_span!(&*self.inner)` + `scope!(model: model)`
+    /// around the inner provider's `chat` call.
+    pub async fn chat(
+        &self,
+        request: ChatRequest<'_>,
+        model: &str,
+        temperature: Option<f64>,
+    ) -> anyhow::Result<ChatResponse> {
+        use zeroclaw_log::Instrument;
+        let span = zeroclaw_log::attribution_span!(&*self.inner);
+        // Enter the attribution span first so the scope! macro's
+        // info_span! constructs with the attribution span as its parent.
+        // Without this nesting, the attribution span and the scope
+        // span would be siblings (both children of the caller's span),
+        // and the layer's leaf→root walk from the scope span would
+        // skip the attribution contribution entirely.
+        async move {
+            zeroclaw_log::scope!(
+                model: model,
+                => self.inner.chat(request, model, temperature)
+            )
+            .await
+        }
+        .instrument(span)
+        .await
     }
 }
 

--- a/crates/zeroclaw-providers/src/dispatch.rs
+++ b/crates/zeroclaw-providers/src/dispatch.rs
@@ -105,7 +105,12 @@ impl ProviderDispatch {
         .boxed()
     }
 
-    /// Wrap the inner provider's `simple_chat`.
+    /// Wrap the inner provider's `simple_chat`. We dispatch through
+    /// `&*self.inner` because the `Arc<dyn ModelProvider>` blanket
+    /// impl does not forward `simple_chat`; routing via the blanket
+    /// would fall back to the trait default (which itself calls
+    /// `chat_with_system`), bypassing any concrete `simple_chat`
+    /// override on the inner provider.
     pub async fn simple_chat(
         &self,
         message: &str,
@@ -117,7 +122,7 @@ impl ProviderDispatch {
         async move {
             zeroclaw_log::scope!(
                 model: model,
-                => self.inner.simple_chat(message, model, temperature)
+                => (*self.inner).simple_chat(message, model, temperature)
             )
             .await
         }
@@ -188,19 +193,25 @@ impl ProviderDispatch {
     }
 
     /// Wrap the inner provider's `list_models`. No `model` parameter,
-    /// so attribution only — no `scope!(model: …)`.
+    /// so attribution only — no `scope!(model: …)`. We dispatch
+    /// through `&*self.inner` (instead of via the `Arc<dyn …>` blanket)
+    /// because the blanket impl does not forward `list_models` and
+    /// the trait default bails with "not supported".
     pub async fn list_models(&self) -> anyhow::Result<Vec<String>> {
         use zeroclaw_log::Instrument;
         let span = zeroclaw_log::attribution_span!(&*self.inner);
-        self.inner.list_models().instrument(span).await
+        (*self.inner).list_models().instrument(span).await
     }
 
-    /// Wrap the inner provider's `list_models_with_pricing`. No `model`
-    /// parameter, so attribution only.
+    /// Wrap the inner provider's `list_models_with_pricing`. Same
+    /// `&*self.inner` rationale as `list_models`.
     pub async fn list_models_with_pricing(&self) -> anyhow::Result<Vec<ModelInfo>> {
         use zeroclaw_log::Instrument;
         let span = zeroclaw_log::attribution_span!(&*self.inner);
-        self.inner.list_models_with_pricing().instrument(span).await
+        (*self.inner)
+            .list_models_with_pricing()
+            .instrument(span)
+            .await
     }
 
     /// Wrap the inner provider's `warmup`. No `model` parameter, so

--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -43,7 +43,7 @@ pub(crate) mod stream_guard;
 pub mod telnyx;
 pub mod traits;
 
-pub use dispatch::ProviderDispatch;
+pub use dispatch::{ProviderDispatch, ProviderDispatchRef};
 #[allow(unused_imports)]
 pub use traits::{
     ChatMessage, ChatRequest, ChatResponse, ConversationMessage, ModelProvider,

--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -23,6 +23,7 @@ pub mod bedrock;
 pub mod catalog;
 pub mod compatible;
 pub mod copilot;
+pub mod dispatch;
 pub mod factory;
 pub mod gemini;
 pub mod gemini_cli;
@@ -47,6 +48,7 @@ pub use traits::{
     ChatMessage, ChatRequest, ChatResponse, ConversationMessage, ModelProvider,
     ProviderCapabilityError, ToolCall, ToolResultMessage,
 };
+pub use dispatch::ProviderDispatch;
 
 use reliable::ReliableModelProvider;
 use serde::Deserialize;

--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -43,12 +43,12 @@ pub(crate) mod stream_guard;
 pub mod telnyx;
 pub mod traits;
 
+pub use dispatch::ProviderDispatch;
 #[allow(unused_imports)]
 pub use traits::{
     ChatMessage, ChatRequest, ChatResponse, ConversationMessage, ModelProvider,
     ProviderCapabilityError, ToolCall, ToolResultMessage,
 };
-pub use dispatch::ProviderDispatch;
 
 use reliable::ReliableModelProvider;
 use serde::Deserialize;

--- a/crates/zeroclaw-providers/src/model_pin.rs
+++ b/crates/zeroclaw-providers/src/model_pin.rs
@@ -1,4 +1,5 @@
 use super::ModelProvider;
+use super::dispatch::ProviderDispatch;
 use super::traits::{
     ChatMessage, ChatRequest, ChatResponse, StreamChunk, StreamEvent, StreamOptions, StreamResult,
 };
@@ -68,11 +69,11 @@ impl ModelProvider for ModelPinnedProvider {
     }
 
     async fn list_models(&self) -> anyhow::Result<Vec<String>> {
-        self.inner.list_models().await
+        ProviderDispatch::from_ref(&*self.inner).list_models().await
     }
 
     async fn warmup(&self) -> anyhow::Result<()> {
-        self.inner.warmup().await
+        ProviderDispatch::from_ref(&*self.inner).warmup().await
     }
 
     async fn chat_with_system(
@@ -82,7 +83,7 @@ impl ModelProvider for ModelPinnedProvider {
         _model: &str,
         temperature: Option<f64>,
     ) -> anyhow::Result<String> {
-        self.inner
+        ProviderDispatch::from_ref(&*self.inner)
             .chat_with_system(system_prompt, message, &self.pinned_model, temperature)
             .await
     }
@@ -93,7 +94,7 @@ impl ModelProvider for ModelPinnedProvider {
         _model: &str,
         temperature: Option<f64>,
     ) -> anyhow::Result<String> {
-        self.inner
+        ProviderDispatch::from_ref(&*self.inner)
             .chat_with_history(messages, &self.pinned_model, temperature)
             .await
     }
@@ -104,7 +105,7 @@ impl ModelProvider for ModelPinnedProvider {
         _model: &str,
         temperature: Option<f64>,
     ) -> anyhow::Result<ChatResponse> {
-        self.inner
+        ProviderDispatch::from_ref(&*self.inner)
             .chat(request, &self.pinned_model, temperature)
             .await
     }
@@ -116,7 +117,7 @@ impl ModelProvider for ModelPinnedProvider {
         _model: &str,
         temperature: Option<f64>,
     ) -> anyhow::Result<ChatResponse> {
-        self.inner
+        ProviderDispatch::from_ref(&*self.inner)
             .chat_with_tools(messages, tools, &self.pinned_model, temperature)
             .await
     }
@@ -129,6 +130,8 @@ impl ModelProvider for ModelPinnedProvider {
         temperature: Option<f64>,
         options: StreamOptions,
     ) -> BoxStream<'static, StreamResult<StreamChunk>> {
+        // stream_chat_with_system is not on ProviderDispatch's protected
+        // surface — the dispatcher only wraps stream_chat. Pass through.
         self.inner.stream_chat_with_system(
             system_prompt,
             message,
@@ -145,6 +148,7 @@ impl ModelProvider for ModelPinnedProvider {
         temperature: Option<f64>,
         options: StreamOptions,
     ) -> BoxStream<'static, StreamResult<StreamChunk>> {
+        // Same passthrough rationale as stream_chat_with_system.
         self.inner
             .stream_chat_with_history(messages, &self.pinned_model, temperature, options)
     }
@@ -156,8 +160,12 @@ impl ModelProvider for ModelPinnedProvider {
         temperature: Option<f64>,
         options: StreamOptions,
     ) -> BoxStream<'static, StreamResult<StreamEvent>> {
-        self.inner
-            .stream_chat(request, &self.pinned_model, temperature, options)
+        ProviderDispatch::from_ref(&*self.inner).stream_chat(
+            request,
+            &self.pinned_model,
+            temperature,
+            options,
+        )
     }
 }
 

--- a/crates/zeroclaw-providers/src/models_dev.rs
+++ b/crates/zeroclaw-providers/src/models_dev.rs
@@ -77,9 +77,23 @@ pub(crate) fn filter_models(catalog: &Catalog, provider_key: &str) -> Result<Vec
 ///
 /// First call fetches the catalog; subsequent calls hit the cache. The
 /// returned list is sorted for stable menu rendering.
+///
+/// Attribution: the models.dev catalog is a global, pre-authentication
+/// metadata source with no concrete `Attributable` thing of its own.
+/// We wrap the body with `scope!(model_provider_type: "models_dev",
+/// model_provider_alias: "catalog", …)` so the `filter_models` warning
+/// (and any future record! inside `fetch_catalog`) lands with the
+/// model_provider_type and model_provider_alias slots populated.
 pub async fn list_models_for(provider_key: &str) -> Result<Vec<String>> {
-    let catalog = CACHED_CATALOG.get_or_try_init(fetch_catalog).await?;
-    filter_models(catalog, provider_key)
+    ::zeroclaw_log::scope!(
+        model_provider_type: "models_dev",
+        model_provider_alias: "catalog",
+        => async move {
+            let catalog = CACHED_CATALOG.get_or_try_init(fetch_catalog).await?;
+            filter_models(catalog, provider_key)
+        }
+    )
+    .await
 }
 
 #[cfg(test)]

--- a/crates/zeroclaw-providers/src/reliable.rs
+++ b/crates/zeroclaw-providers/src/reliable.rs
@@ -1,4 +1,5 @@
 use super::ModelProvider;
+use super::dispatch::ProviderDispatch;
 use super::stream_guard::AbortOnDrop;
 use super::traits::{
     ChatMessage, ChatRequest, ChatResponse, StreamChunk, StreamEvent, StreamOptions, StreamResult,
@@ -749,7 +750,11 @@ impl ModelProvider for ReliableModelProvider {
                     .with_attrs(::serde_json::json!({"model_provider": name})),
                 "Warming up model_provider connection pool"
             );
-            if model_provider.warmup().await.is_err() {
+            if ProviderDispatch::from_ref(&**model_provider)
+                .warmup()
+                .await
+                .is_err()
+            {
                 ::zeroclaw_log::record!(
                     WARN,
                     ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
@@ -783,7 +788,7 @@ impl ModelProvider for ReliableModelProvider {
                 let mut last_diagnostic: Option<ProviderErrorDiagnostic> = None;
 
                 for attempt in 0..=self.max_retries {
-                    match model_provider
+                    match ProviderDispatch::from_ref(&**model_provider)
                         .chat_with_system(system_prompt, message, current_model, temperature)
                         .await
                     {
@@ -966,7 +971,7 @@ impl ModelProvider for ReliableModelProvider {
                 let mut last_diagnostic: Option<ProviderErrorDiagnostic> = None;
 
                 for attempt in 0..=self.max_retries {
-                    match model_provider
+                    match ProviderDispatch::from_ref(&**model_provider)
                         .chat_with_history(&effective_messages, current_model, temperature)
                         .await
                     {
@@ -1169,7 +1174,7 @@ impl ModelProvider for ReliableModelProvider {
                 let mut last_diagnostic: Option<ProviderErrorDiagnostic> = None;
 
                 for attempt in 0..=self.max_retries {
-                    match model_provider
+                    match ProviderDispatch::from_ref(&**model_provider)
                         .chat_with_tools(&effective_messages, tools, current_model, temperature)
                         .await
                     {
@@ -1363,7 +1368,10 @@ impl ModelProvider for ReliableModelProvider {
                         tools: request.tools,
                         thinking: request.thinking,
                     };
-                    match model_provider.chat(req, current_model, temperature).await {
+                    match ProviderDispatch::from_ref(&**model_provider)
+                        .chat(req, current_model, temperature)
+                        .await
+                    {
                         Ok(resp) => {
                             // Re-roll a transient empty completion instead of
                             // returning a blank turn (bounded by `max_retries`;
@@ -1579,7 +1587,12 @@ impl ModelProvider for ReliableModelProvider {
                 tools: request.tools,
                 thinking: request.thinking,
             };
-            let stream = model_provider.stream_chat(req, &current_model, temperature, options);
+            let stream = ProviderDispatch::from_ref(&**model_provider).stream_chat(
+                req,
+                &current_model,
+                temperature,
+                options,
+            );
             let (tx, rx) = tokio::sync::mpsc::channel::<StreamResult<StreamEvent>>(100);
 
             let handle = ::zeroclaw_spawn::spawn!(async move {

--- a/crates/zeroclaw-providers/src/reliable.rs
+++ b/crates/zeroclaw-providers/src/reliable.rs
@@ -4050,11 +4050,7 @@ mod tests {
         );
         // The wrapper must report the inner provider's role/alias,
         // not its own.
-        assert_eq!(
-            reliable.role(),
-            inner_role,
-            "wrapper must delegate role()",
-        );
+        assert_eq!(reliable.role(), inner_role, "wrapper must delegate role()",);
         assert_eq!(
             reliable.alias(),
             inner_alias,

--- a/crates/zeroclaw-providers/src/reliable.rs
+++ b/crates/zeroclaw-providers/src/reliable.rs
@@ -1737,14 +1737,26 @@ impl ModelProvider for ReliableModelProvider {
 
 impl ::zeroclaw_api::attribution::Attributable for ReliableModelProvider {
     fn role(&self) -> ::zeroclaw_api::attribution::Role {
-        ::zeroclaw_api::attribution::Role::Provider(
-            ::zeroclaw_api::attribution::ProviderKind::Model(
-                ::zeroclaw_api::attribution::ModelProviderKind::Reliable,
-            ),
-        )
+        // Delegate to the primary (first) inner provider so the on-disk
+        // model_provider_type reflects the concrete provider
+        // (`anthropic`, `openai`, …) rather than the wrapper kind.
+        // If the wrapper somehow held zero providers we fall back to
+        // the parent `System` role — log emissions in that degenerate
+        // state are not user-facing.
+        match self.model_providers.first() {
+            Some((_, p)) => ::zeroclaw_api::attribution::Attributable::role(&**p),
+            None => ::zeroclaw_api::attribution::Role::System,
+        }
     }
+
     fn alias(&self) -> &str {
-        &self.alias
+        // Delegate to the primary inner provider for the same reason
+        // as `role()`. Falls back to the wrapper's own configured alias
+        // when no inner provider is registered.
+        match self.model_providers.first() {
+            Some((_, p)) => ::zeroclaw_api::attribution::Attributable::alias(&**p),
+            None => &self.alias,
+        }
     }
 }
 
@@ -4013,5 +4025,83 @@ mod tests {
         );
 
         assert!(provider.supports_vision());
+    }
+
+    #[tokio::test]
+    async fn reliable_wrapper_exposes_inner_provider_attribution() {
+        use crate::ProviderDispatch;
+        use std::sync::Arc;
+        use zeroclaw_api::attribution::Attributable;
+
+        let inner_mock = MockModelProvider {
+            calls: Arc::new(AtomicUsize::new(0)),
+            fail_until_attempt: 0,
+            response: "ok",
+            error: "",
+        };
+        let inner_role = inner_mock.role();
+        let inner_alias = inner_mock.alias().to_string();
+
+        let reliable = ReliableModelProvider::new(
+            "wrapped-alias",
+            vec![("primary".into(), Box::new(inner_mock))],
+            0,
+            0,
+        );
+        // The wrapper must report the inner provider's role/alias,
+        // not its own.
+        assert_eq!(
+            reliable.role(),
+            inner_role,
+            "wrapper must delegate role()",
+        );
+        assert_eq!(
+            reliable.alias(),
+            inner_alias,
+            "wrapper must delegate alias()",
+        );
+
+        // End-to-end through ProviderDispatch: the captured event
+        // must report the inner provider's `model_provider_type`,
+        // never `reliable`.
+        let _writer_guard = zeroclaw_log::__private_test_writer_lock();
+        let _hook_guard = zeroclaw_log::__private_test_hook_lock();
+        zeroclaw_log::try_install_capture_subscriber();
+        let mut rx = zeroclaw_log::subscribe_or_install();
+        while rx.try_recv().is_ok() {}
+
+        let reliable: Arc<dyn ModelProvider> = Arc::new(reliable);
+        let dispatch = ProviderDispatch::new(reliable);
+        let req = ChatRequest {
+            messages: &[],
+            tools: None,
+            thinking: None,
+        };
+        let _ = dispatch.chat(req, "m", None).await;
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        let mut found_type: Option<String> = None;
+        while found_type.is_none() && std::time::Instant::now() < deadline {
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            let step = remaining.min(std::time::Duration::from_millis(50));
+            match tokio::time::timeout(step, rx.recv()).await {
+                Ok(Ok(value)) => {
+                    if let Some(zc) = value.get("zeroclaw")
+                        && let Some(t) = zc.get("model_provider_type").and_then(|v| v.as_str())
+                    {
+                        found_type = Some(t.to_string());
+                    }
+                }
+                Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => {}
+                Ok(Err(tokio::sync::broadcast::error::RecvError::Closed)) => break,
+                Err(_elapsed) => {}
+            }
+        }
+        assert_ne!(
+            found_type.as_deref(),
+            Some("reliable"),
+            "ReliableModelProvider must not surface as model_provider_type=reliable",
+        );
+        zeroclaw_log::clear_broadcast_hook();
     }
 }

--- a/crates/zeroclaw-providers/src/router.rs
+++ b/crates/zeroclaw-providers/src/router.rs
@@ -1,4 +1,5 @@
 use super::ModelProvider;
+use super::dispatch::ProviderDispatch;
 use super::traits::{
     ChatMessage, ChatRequest, ChatResponse, StreamChunk, StreamEvent, StreamOptions, StreamResult,
 };
@@ -244,7 +245,7 @@ impl ModelProvider for RouterModelProvider {
         // composite. Layer's `set_composite` splits it on emit.
         ::zeroclaw_log::record!(INFO, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(::serde_json::json!({"model_provider": provider_name.as_str(), "model": resolved_model.as_str()})), "router dispatching request");
 
-        model_provider
+        ProviderDispatch::from_ref(&**model_provider)
             .chat_with_system(system_prompt, message, &resolved_model, temperature)
             .await
     }
@@ -257,7 +258,7 @@ impl ModelProvider for RouterModelProvider {
     ) -> anyhow::Result<String> {
         let (provider_idx, resolved_model) = self.resolve(model);
         let (_, model_provider) = &self.model_providers[provider_idx];
-        model_provider
+        ProviderDispatch::from_ref(&**model_provider)
             .chat_with_history(messages, &resolved_model, temperature)
             .await
     }
@@ -270,7 +271,7 @@ impl ModelProvider for RouterModelProvider {
     ) -> anyhow::Result<ChatResponse> {
         let (provider_idx, resolved_model) = self.resolve(model);
         let (_, model_provider) = &self.model_providers[provider_idx];
-        model_provider
+        ProviderDispatch::from_ref(&**model_provider)
             .chat(request, &resolved_model, temperature)
             .await
     }
@@ -284,7 +285,7 @@ impl ModelProvider for RouterModelProvider {
     ) -> anyhow::Result<ChatResponse> {
         let (provider_idx, resolved_model) = self.resolve(model);
         let (_, model_provider) = &self.model_providers[provider_idx];
-        model_provider
+        ProviderDispatch::from_ref(&**model_provider)
             .chat_with_tools(messages, tools, &resolved_model, temperature)
             .await
     }
@@ -348,7 +349,12 @@ impl ModelProvider for RouterModelProvider {
     ) -> BoxStream<'static, StreamResult<StreamEvent>> {
         let (provider_idx, resolved_model) = self.resolve(model);
         let (_, model_provider) = &self.model_providers[provider_idx];
-        model_provider.stream_chat(request, &resolved_model, temperature, options)
+        ProviderDispatch::from_ref(&**model_provider).stream_chat(
+            request,
+            &resolved_model,
+            temperature,
+            options,
+        )
     }
 
     fn supports_vision(&self) -> bool {
@@ -366,7 +372,7 @@ impl ModelProvider for RouterModelProvider {
                     .with_attrs(::serde_json::json!({"model_provider": name})),
                 "Warming up routed model_provider"
             );
-            if let Err(e) = model_provider.warmup().await {
+            if let Err(e) = ProviderDispatch::from_ref(&**model_provider).warmup().await {
                 ::zeroclaw_log::record!(
                     WARN,
                     ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)

--- a/crates/zeroclaw-providers/tests/dispatch_integration.rs
+++ b/crates/zeroclaw-providers/tests/dispatch_integration.rs
@@ -1,0 +1,247 @@
+//! Integration test: every `ProviderDispatch` method routes through
+//! `attribution_span!(&*inner)`. Drives every wrapping method once and
+//! asserts every captured `LogEvent` carries the inner provider's
+//! `model_provider_type` / `model_provider_alias`.
+//!
+//! Locks in the contract that no future dispatcher addition can
+//! silently lose attribution.
+
+use std::sync::Arc;
+
+use futures_util::StreamExt;
+use zeroclaw_api::attribution::{Attributable, ModelProviderKind, ProviderKind, Role};
+use zeroclaw_api::model_provider::{
+    ChatMessage, ChatRequest, ChatResponse, ModelInfo, ModelProvider, StreamChunk, StreamEvent,
+    StreamOptions, StreamResult,
+};
+use zeroclaw_providers::ProviderDispatch;
+
+struct EverythingFake {
+    alias: String,
+}
+
+impl Attributable for EverythingFake {
+    fn role(&self) -> Role {
+        Role::Provider(ProviderKind::Model(ModelProviderKind::Anthropic))
+    }
+    fn alias(&self) -> &str {
+        &self.alias
+    }
+}
+
+#[async_trait::async_trait]
+impl ModelProvider for EverythingFake {
+    async fn chat(
+        &self,
+        _: ChatRequest<'_>,
+        _: &str,
+        _: Option<f64>,
+    ) -> anyhow::Result<ChatResponse> {
+        zeroclaw_log::record!(
+            INFO,
+            zeroclaw_log::Event::new(module_path!(), zeroclaw_log::Action::Note),
+            "EverythingFake chat"
+        );
+        Ok(ChatResponse {
+            text: Some(String::new()),
+            tool_calls: Vec::new(),
+            usage: None,
+            reasoning_content: None,
+        })
+    }
+
+    async fn simple_chat(&self, _: &str, _: &str, _: Option<f64>) -> anyhow::Result<String> {
+        zeroclaw_log::record!(
+            INFO,
+            zeroclaw_log::Event::new(module_path!(), zeroclaw_log::Action::Note),
+            "EverythingFake simple_chat"
+        );
+        Ok(String::new())
+    }
+
+    async fn chat_with_system(
+        &self,
+        _: Option<&str>,
+        _: &str,
+        _: &str,
+        _: Option<f64>,
+    ) -> anyhow::Result<String> {
+        zeroclaw_log::record!(
+            INFO,
+            zeroclaw_log::Event::new(module_path!(), zeroclaw_log::Action::Note),
+            "EverythingFake chat_with_system"
+        );
+        Ok(String::new())
+    }
+
+    async fn chat_with_history(
+        &self,
+        _: &[ChatMessage],
+        _: &str,
+        _: Option<f64>,
+    ) -> anyhow::Result<String> {
+        zeroclaw_log::record!(
+            INFO,
+            zeroclaw_log::Event::new(module_path!(), zeroclaw_log::Action::Note),
+            "EverythingFake chat_with_history"
+        );
+        Ok(String::new())
+    }
+
+    async fn chat_with_tools(
+        &self,
+        _: &[ChatMessage],
+        _: &[serde_json::Value],
+        _: &str,
+        _: Option<f64>,
+    ) -> anyhow::Result<ChatResponse> {
+        zeroclaw_log::record!(
+            INFO,
+            zeroclaw_log::Event::new(module_path!(), zeroclaw_log::Action::Note),
+            "EverythingFake chat_with_tools"
+        );
+        Ok(ChatResponse {
+            text: Some(String::new()),
+            tool_calls: Vec::new(),
+            usage: None,
+            reasoning_content: None,
+        })
+    }
+
+    async fn list_models(&self) -> anyhow::Result<Vec<String>> {
+        zeroclaw_log::record!(
+            INFO,
+            zeroclaw_log::Event::new(module_path!(), zeroclaw_log::Action::Note),
+            "EverythingFake list_models"
+        );
+        Ok(vec!["m".into()])
+    }
+
+    async fn list_models_with_pricing(&self) -> anyhow::Result<Vec<ModelInfo>> {
+        zeroclaw_log::record!(
+            INFO,
+            zeroclaw_log::Event::new(module_path!(), zeroclaw_log::Action::Note),
+            "EverythingFake list_models_with_pricing"
+        );
+        Ok(Vec::new())
+    }
+
+    async fn warmup(&self) -> anyhow::Result<()> {
+        zeroclaw_log::record!(
+            INFO,
+            zeroclaw_log::Event::new(module_path!(), zeroclaw_log::Action::Note),
+            "EverythingFake warmup"
+        );
+        Ok(())
+    }
+
+    fn stream_chat(
+        &self,
+        _: ChatRequest<'_>,
+        _: &str,
+        _: Option<f64>,
+        _: StreamOptions,
+    ) -> futures_util::stream::BoxStream<'static, StreamResult<StreamEvent>> {
+        futures_util::stream::unfold(0u8, |state| async move {
+            match state {
+                0 => {
+                    zeroclaw_log::record!(
+                        INFO,
+                        zeroclaw_log::Event::new(module_path!(), zeroclaw_log::Action::Note),
+                        "EverythingFake stream_chat chunk"
+                    );
+                    Some((Ok(StreamEvent::TextDelta(StreamChunk::delta("x"))), 1u8))
+                }
+                1 => Some((Ok(StreamEvent::Final), 2u8)),
+                _ => None,
+            }
+        })
+        .boxed()
+    }
+}
+
+#[tokio::test]
+async fn every_dispatcher_method_attributes() {
+    let _writer_guard = zeroclaw_log::__private_test_writer_lock();
+    let _hook_guard = zeroclaw_log::__private_test_hook_lock();
+    zeroclaw_log::try_install_capture_subscriber();
+    let mut rx = zeroclaw_log::subscribe_or_install();
+    while rx.try_recv().is_ok() {}
+
+    let fake: Arc<dyn ModelProvider> = Arc::new(EverythingFake {
+        alias: "integ".into(),
+    });
+    let d = ProviderDispatch::new(fake);
+    let req = ChatRequest {
+        messages: &[],
+        tools: None,
+        thinking: None,
+    };
+
+    d.chat(req, "m", None).await.unwrap();
+    d.simple_chat("hi", "m", None).await.unwrap();
+    d.chat_with_system(None, "hi", "m", None).await.unwrap();
+    d.chat_with_history(&[], "m", None).await.unwrap();
+    d.chat_with_tools(&[], &[], "m", None).await.unwrap();
+    d.list_models().await.unwrap();
+    d.list_models_with_pricing().await.unwrap();
+    d.warmup().await.unwrap();
+    let mut s = d.stream_chat(req, "m", None, StreamOptions::default());
+    while s.next().await.is_some() {}
+
+    let expected_messages = [
+        "EverythingFake chat",
+        "EverythingFake simple_chat",
+        "EverythingFake chat_with_system",
+        "EverythingFake chat_with_history",
+        "EverythingFake chat_with_tools",
+        "EverythingFake list_models",
+        "EverythingFake list_models_with_pricing",
+        "EverythingFake warmup",
+        "EverythingFake stream_chat chunk",
+    ];
+
+    let mut seen: std::collections::HashSet<String> = Default::default();
+    let mut all_received: Vec<String> = Vec::new();
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    while seen.len() < expected_messages.len() && std::time::Instant::now() < deadline {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        let step = remaining.min(std::time::Duration::from_millis(50));
+        match tokio::time::timeout(step, rx.recv()).await {
+            Ok(Ok(value)) => {
+                let Some(msg) = value.get("message").and_then(|v| v.as_str()) else {
+                    continue;
+                };
+                all_received.push(msg.to_string());
+                // Exact equality so e.g. "list_models" doesn't shadow
+                // "list_models_with_pricing" via substring containment.
+                let Some(expected) = expected_messages.iter().find(|e| msg == **e) else {
+                    continue;
+                };
+                let zc = value.get("zeroclaw").expect("zeroclaw block present");
+                assert_eq!(
+                    zc.get("model_provider_type").and_then(|v| v.as_str()),
+                    Some("anthropic"),
+                    "message {msg:?} missing model_provider_type attribution; zc: {zc:?}",
+                );
+                assert_eq!(
+                    zc.get("model_provider_alias").and_then(|v| v.as_str()),
+                    Some("integ"),
+                );
+                seen.insert((*expected).to_string());
+            }
+            Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => {}
+            Ok(Err(tokio::sync::broadcast::error::RecvError::Closed)) => break,
+            Err(_elapsed) => {}
+        }
+    }
+    let missing: Vec<_> = expected_messages
+        .iter()
+        .filter(|e| !seen.contains(**e))
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "missed messages: {missing:?}; all received: {all_received:?}; matched: {seen:?}"
+    );
+    zeroclaw_log::clear_broadcast_hook();
+}

--- a/crates/zeroclaw-runtime/src/agent/context_compressor.rs
+++ b/crates/zeroclaw-runtime/src/agent/context_compressor.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use zeroclaw_api::model_provider::{ChatMessage, ModelProvider};
 use zeroclaw_memory::traits::Memory;
+use zeroclaw_providers::ProviderDispatch;
 use zeroclaw_providers::multimodal;
 
 use crate::observability::{Observer, ObserverEvent};
@@ -362,9 +363,10 @@ impl ContextCompressor {
 
         // LLM summarization with safety timeout
         let timeout = Duration::from_secs(self.config.timeout_secs);
+        let dispatcher = ProviderDispatch::from_ref(model_provider);
         let summary_raw = match tokio::time::timeout(
             timeout,
-            model_provider.chat_with_system(
+            dispatcher.chat_with_system(
                 Some(SUMMARIZER_SYSTEM),
                 &user_prompt,
                 summary_model,

--- a/crates/zeroclaw-runtime/src/agent/turn/max_iter.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/max_iter.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use std::time::Duration;
 use tokio_util::sync::CancellationToken;
 use zeroclaw_config::schema::PacingConfig;
-use zeroclaw_providers::{ChatMessage, ModelProvider};
+use zeroclaw_providers::{ChatMessage, ModelProvider, ProviderDispatch};
 
 /// Graceful shutdown after the loop exhausts `max_iterations` (upstream loop
 /// body, max-iteration exit): log exhaustion, push a summary-request user
@@ -85,7 +85,8 @@ pub(crate) async fn finish_after_max_iterations(
                 .ok()
                 .flatten(),
         };
-        let summary_future = model_provider.chat(summary_request, model, temperature);
+        let dispatcher = ProviderDispatch::from_ref(model_provider);
+        let summary_future = dispatcher.chat(summary_request, model, temperature);
         match pacing.step_timeout_secs {
             Some(step_secs) if step_secs > 0 => {
                 let step_timeout = Duration::from_secs(step_secs);

--- a/crates/zeroclaw-runtime/src/agent/turn/provider_call.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/provider_call.rs
@@ -12,7 +12,7 @@ use crate::observability::ObserverEvent;
 use crate::tools::ToolSpec;
 use anyhow::Result;
 use std::time::{Duration, Instant};
-use zeroclaw_providers::{ChatMessage, ChatRequest, ChatResponse, ModelProvider};
+use zeroclaw_providers::{ChatMessage, ChatRequest, ChatResponse, ModelProvider, ProviderDispatch};
 
 /// Result of one provider call.
 ///
@@ -138,24 +138,20 @@ pub(crate) async fn call_provider(
     let mut streamed_protocol_suppressed = false;
 
     let chat_result = if should_consume_provider_stream {
-        use ::zeroclaw_log::Instrument;
-        let provider_span = ::zeroclaw_log::attribution_span!(active_model_provider);
-        let stream_future = ::zeroclaw_log::scope!(
-            model: active_model,
-            =>
-            consume_provider_streaming_response(
-                active_model_provider,
-                prepared_messages,
-                request_tools,
-                active_model,
-                ctx.temperature,
-                ctx.cancellation_token,
-                ctx.on_delta,
-                ctx.event_tx,
-                ctx.strict_tool_parsing,
-            )
-        )
-        .instrument(provider_span);
+        // Attribution is opened by ProviderDispatch::from_ref(...).stream_chat
+        // inside `consume_provider_streaming_response`; the caller does not
+        // wrap a second attribution_span! here.
+        let stream_future = consume_provider_streaming_response(
+            active_model_provider,
+            prepared_messages,
+            request_tools,
+            active_model,
+            ctx.temperature,
+            ctx.cancellation_token,
+            ctx.on_delta,
+            ctx.event_tx,
+            ctx.strict_tool_parsing,
+        );
         match stream_future.await {
             Ok(streamed) => {
                 streamed_live_deltas = streamed.forwarded_live_deltas;
@@ -200,25 +196,19 @@ pub(crate) async fn call_provider(
                     "llm_stream_fallback: provider stream failed, falling back to non-streaming chat"
                 );
                 {
-                    use ::zeroclaw_log::Instrument;
-                    let provider_span = ::zeroclaw_log::attribution_span!(active_model_provider);
-                    let chat_future = ::zeroclaw_log::scope!(
-                        model: active_model,
-                        =>
-                        active_model_provider.chat(
-                            ChatRequest {
-                                messages: prepared_messages,
-                                tools: request_tools,
-                                thinking: zeroclaw_api::NATIVE_THINKING_OVERRIDE
-                                    .try_with(Clone::clone)
-                                    .ok()
-                                    .flatten(),
-                            },
-                            active_model,
-                            ctx.temperature,
-                        )
-                    )
-                    .instrument(provider_span);
+                    let dispatcher = ProviderDispatch::from_ref(active_model_provider);
+                    let chat_future = dispatcher.chat(
+                        ChatRequest {
+                            messages: prepared_messages,
+                            tools: request_tools,
+                            thinking: zeroclaw_api::NATIVE_THINKING_OVERRIDE
+                                .try_with(Clone::clone)
+                                .ok()
+                                .flatten(),
+                        },
+                        active_model,
+                        ctx.temperature,
+                    );
                     if let Some(token) = ctx.cancellation_token {
                         tokio::select! {
                             () = token.cancelled() => Err(ToolLoopCancelled.into()),
@@ -233,25 +223,19 @@ pub(crate) async fn call_provider(
     } else {
         // Non-streaming path: wrap with optional per-step timeout from
         // pacing config to catch hung model responses.
-        use ::zeroclaw_log::Instrument;
-        let provider_span = ::zeroclaw_log::attribution_span!(active_model_provider);
-        let chat_future = ::zeroclaw_log::scope!(
-            model: active_model,
-            =>
-            active_model_provider.chat(
-                ChatRequest {
-                    messages: prepared_messages,
-                    tools: request_tools,
-                    thinking: zeroclaw_api::NATIVE_THINKING_OVERRIDE
-                        .try_with(Clone::clone)
-                        .ok()
-                        .flatten(),
-                },
-                active_model,
-                ctx.temperature,
-            )
-        )
-        .instrument(provider_span);
+        let dispatcher = ProviderDispatch::from_ref(active_model_provider);
+        let chat_future = dispatcher.chat(
+            ChatRequest {
+                messages: prepared_messages,
+                tools: request_tools,
+                thinking: zeroclaw_api::NATIVE_THINKING_OVERRIDE
+                    .try_with(Clone::clone)
+                    .ok()
+                    .flatten(),
+            },
+            active_model,
+            ctx.temperature,
+        );
 
         match ctx.pacing.step_timeout_secs {
             Some(step_secs) if step_secs > 0 => {

--- a/crates/zeroclaw-runtime/src/agent/turn/stream_consume.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/stream_consume.rs
@@ -9,7 +9,7 @@ use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 use zeroclaw_api::agent::TurnEvent;
 use zeroclaw_api::model_provider::StreamEvent;
-use zeroclaw_providers::{ChatMessage, ChatRequest, ModelProvider, ToolCall};
+use zeroclaw_providers::{ChatMessage, ChatRequest, ModelProvider, ProviderDispatch, ToolCall};
 
 #[derive(Debug, Default)]
 pub(crate) struct StreamedChatOutcome {
@@ -40,7 +40,7 @@ pub(crate) async fn consume_provider_streaming_response(
     event_tx: Option<&tokio::sync::mpsc::Sender<TurnEvent>>,
     strict_tool_parsing: bool,
 ) -> Result<StreamedChatOutcome> {
-    let mut provider_stream = model_provider.stream_chat(
+    let mut provider_stream = ProviderDispatch::from_ref(model_provider).stream_chat(
         ChatRequest {
             messages,
             tools: request_tools,

--- a/crates/zeroclaw-runtime/src/doctor/mod.rs
+++ b/crates/zeroclaw-runtime/src/doctor/mod.rs
@@ -96,7 +96,11 @@ async fn probe_models(config: &Config) -> Vec<DiagResult> {
 
     for provider_name in &targets {
         let result = match create_doctor_model_provider(config, provider_name) {
-            Ok(handle) => handle.list_models().await,
+            Ok(handle) => {
+                zeroclaw_providers::ProviderDispatch::from_ref(&*handle)
+                    .list_models()
+                    .await
+            }
             Err(e) => Err(e),
         };
         match result {
@@ -291,7 +295,11 @@ pub async fn run_models(
         println!("  [{}]", provider_name);
 
         let outcome = match create_doctor_model_provider(config, provider_name) {
-            Ok(handle) => handle.list_models().await,
+            Ok(handle) => {
+                zeroclaw_providers::ProviderDispatch::from_ref(&*handle)
+                    .list_models()
+                    .await
+            }
             Err(e) => Err(e),
         };
 

--- a/crates/zeroclaw-runtime/src/quickstart/mod.rs
+++ b/crates/zeroclaw-runtime/src/quickstart/mod.rs
@@ -1750,7 +1750,9 @@ pub async fn model_catalog(
     bool,
 ) {
     if let Ok(handle) = zeroclaw_providers::create_model_provider(model_provider, None)
-        && let Ok(models) = handle.list_models_with_pricing().await
+        && let Ok(models) = zeroclaw_providers::ProviderDispatch::from_ref(&*handle)
+            .list_models_with_pricing()
+            .await
         && !models.is_empty()
     {
         let raw_pricing: std::collections::HashMap<

--- a/crates/zeroclaw-runtime/src/tools/delegate.rs
+++ b/crates/zeroclaw-runtime/src/tools/delegate.rs
@@ -18,7 +18,7 @@ use zeroclaw_config::schema::{
 };
 use zeroclaw_log::Instrument as _;
 use zeroclaw_memory::Memory;
-use zeroclaw_providers::{self, ChatMessage, ModelProvider};
+use zeroclaw_providers::{self, ChatMessage, ModelProvider, ProviderDispatch};
 use zeroclaw_tools::memory_export::MemoryExportTool;
 use zeroclaw_tools::memory_forget::MemoryForgetTool;
 use zeroclaw_tools::memory_purge::MemoryPurgeTool;
@@ -949,9 +949,10 @@ impl DelegateTool {
         let timeout_secs = self
             .resolve_delegation_timeout(&agent_config.runtime_profile)
             .unwrap_or(self.delegate_config.timeout_secs);
+        let dispatcher = ProviderDispatch::from_ref(&*model_provider);
         let result = tokio::time::timeout(
             Duration::from_secs(timeout_secs),
-            model_provider.chat_with_system(system_prompt_ref, &full_prompt, &model, temperature),
+            dispatcher.chat_with_system(system_prompt_ref, &full_prompt, &model, temperature),
         )
         .await;
 

--- a/crates/zeroclaw-tools/src/llm_task.rs
+++ b/crates/zeroclaw-tools/src/llm_task.rs
@@ -11,6 +11,7 @@ use zeroclaw_api::model_provider::ModelProvider;
 use zeroclaw_api::tool::{Tool, ToolResult};
 use zeroclaw_config::policy::SecurityPolicy;
 use zeroclaw_config::policy::ToolOperation;
+use zeroclaw_providers::ProviderDispatch;
 
 /// Tool that runs a single prompt through an LLM and optionally validates
 /// the response against a JSON Schema. No tools are provided to the LLM —
@@ -163,7 +164,7 @@ impl Tool for LlmTaskTool {
         // Make the LLM call (no tools, no agent loop). `temperature` is
         // already Option<f64>; pass straight through. None omits the field
         // on the wire so the provider applies its own default.
-        let response = match model_provider
+        let response = match ProviderDispatch::from_ref(&*model_provider)
             .simple_chat(&effective_prompt, model, temperature)
             .await
         {

--- a/crates/zeroclaw-tools/src/model_routing_config.rs
+++ b/crates/zeroclaw-tools/src/model_routing_config.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use zeroclaw_api::tool::{Tool, ToolResult};
 use zeroclaw_config::policy::SecurityPolicy;
 use zeroclaw_config::schema::{ClassificationRule, Config, ModelRouteConfig};
+use zeroclaw_providers::ProviderDispatch;
 
 const DEFAULT_AGENT_MAX_DEPTH: u32 = 3;
 const DEFAULT_AGENT_MAX_ITERATIONS: usize = 10;
@@ -630,7 +631,7 @@ impl ModelRoutingConfigTool {
 
         // Greedy sampling: the ping is a liveness check, not a generation task.
         const PING_TEMPERATURE: f64 = 0.0;
-        model_provider
+        ProviderDispatch::from_ref(&*model_provider)
             .chat_with_system(
                 Some("Respond with OK."),
                 "ping",

--- a/scripts/ci/rust_quality_gate.sh
+++ b/scripts/ci/rust_quality_gate.sh
@@ -17,3 +17,166 @@ else
     echo "==> rust quality: cargo clippy --locked --all-targets -- -D clippy::correctness"
     cargo clippy --locked --all-targets -- -D clippy::correctness
 fi
+
+echo "==> rust quality: provider dispatch gate (no direct ModelProvider method calls outside ProviderDispatch)"
+
+# Methods covered by ProviderDispatch / ProviderDispatchRef. Adding a new
+# method to the dispatcher requires extending this list in lockstep with
+# the dispatch.rs file.
+PROTECTED_METHODS='\.(chat|stream_chat|simple_chat|chat_with_system|chat_with_history|chat_with_tools|list_models|list_models_with_pricing|warmup)\('
+
+# We allow:
+#   - dispatch.rs and its integration tests (the implementation + its
+#     dedicated test fakes).
+#   - Any code inside a `tests/` directory (`tests/live/` integration
+#     tests, `crates/*/tests/` integration tests).
+#   - Any line inside a `#[cfg(test)]` module: the gate uses the
+#     first `^#[cfg(test)]` line in each file as a boundary and drops
+#     matches at or below it.
+#   - `self.<method>(...)` self-calls (same Attributable instance;
+#     dispatcher wrap would be a redundant attribution layer).
+#   - `self.as_ref().<method>(...)` blanket-impl forwarders (used by
+#     `impl ModelProvider for Arc<T>` in zeroclaw-api — must call
+#     inner directly to avoid infinite recursion through the dispatcher).
+#   - Method calls that follow a ProviderDispatch construction within
+#     the prior 3 lines. The dispatcher's borrowed/owned variants
+#     produce the call shape `ProviderDispatch::from_ref(p).<method>(`
+#     or `ProviderDispatch::new(arc).<method>(` or
+#     `let dispatcher = ProviderDispatch::from_ref(...); dispatcher.<method>(`.
+#     When rustfmt wraps these onto separate lines, the `.method(` line
+#     loses the dispatcher token; we look at the surrounding context.
+
+set +e
+RG_OUTPUT=$(rg --vimgrep --type rust "$PROTECTED_METHODS" \
+    crates/ src/ xtask/ tools/ tests/ 2>/dev/null)
+RG_STATUS=$?
+set -e
+if [ "$RG_STATUS" -ne 0 ] && [ "$RG_STATUS" -ne 1 ]; then
+    echo "❌ ripgrep failed during dispatch gate (status $RG_STATUS)"
+    exit 1
+fi
+
+VIOLATIONS=$(printf '%s\n' "$RG_OUTPUT" | awk -F: '
+    BEGIN {
+        allowed["crates/zeroclaw-providers/src/dispatch.rs"] = 1
+        allowed["crates/zeroclaw-providers/tests/dispatch_integration.rs"] = 1
+    }
+    function read_file_lines(file,    cmd, raw_line, lineno) {
+        cmd = "cat " file " 2>/dev/null"
+        lineno = 1
+        while ((cmd | getline raw_line) > 0) {
+            file_lines[file, lineno] = raw_line
+            lineno++
+        }
+        close(cmd)
+        file_line_count[file] = lineno - 1
+        # Test boundary: first ^#[cfg(test)] line in the file.
+        test_boundary[file] = 999999999
+        for (i = 1; i <= file_line_count[file]; i++) {
+            if (file_lines[file, i] ~ /^#\[cfg\(test\)\]/) {
+                test_boundary[file] = i
+                break
+            }
+        }
+        file_loaded[file] = 1
+    }
+    function context_is_cfg_test_block(file, lineno,    i, ln) {
+        # Look back up to 200 lines for an indented `#[cfg(test)]`
+        # attribute followed by a `{` block start. If found and we are
+        # still inside the brace-balance window, treat the match as
+        # test code. (The 200-line window is a heuristic ceiling that
+        # covers realistic in-function #[cfg(test)] blocks while
+        # bounding cost; trait-method test stubs longer than that are
+        # rare in this codebase.)
+        for (i = lineno - 1; i >= lineno - 200 && i >= 1; i--) {
+            ln = file_lines[file, i]
+            if (ln ~ /^[[:space:]]+#\[cfg\(test\)\]/) {
+                # Found an indented cfg(test). Count braces between
+                # that line and the match line; if positive, we are
+                # still inside the cfg(test) block.
+                braces = 0
+                for (j = i + 1; j <= lineno; j++) {
+                    lnb = file_lines[file, j]
+                    n = gsub(/\{/, "{", lnb); braces += n
+                    n = gsub(/\}/, "}", lnb); braces -= n
+                }
+                if (braces > 0) return 1
+                # If braces are balanced or negative, the block closed
+                # before our match — keep looking back for an outer cfg.
+            }
+        }
+        return 0
+    }
+    function context_is_self_call(file, lineno,    i, ln) {
+        # Look back up to 3 lines for the receiver of this chained call.
+        # rustfmt commonly splits `self.method()` into `self\n.method()`
+        # — the gate must treat that as a self-call.
+        for (i = lineno - 1; i >= lineno - 3 && i >= 1; i--) {
+            ln = file_lines[file, i]
+            # Receiver is `self`, `self.as_ref()`, or any identifier
+            # ending in `self` (e.g. `(*self.inner)` is NOT a self-call
+            # but the inner is captured separately).
+            if (ln ~ /(^|[^a-zA-Z0-9_])self[ ]*$/) return 1
+            if (ln ~ /self\.as_ref\(\)[ ]*$/) return 1
+            # Non-empty non-whitespace continuation breaks the lookback —
+            # the previous line is a complete statement boundary.
+            if (ln ~ /[^[:space:]]/ && ln !~ /[\.\(\),][ ]*$/) return 0
+        }
+        return 0
+    }
+    function context_has_dispatcher(file, lineno,    start, i, ln) {
+        # Look back up to 5 lines for a ProviderDispatch construction
+        # or a dispatcher.<method> chain start.
+        start = lineno - 5
+        if (start < 1) start = 1
+        for (i = start; i <= lineno; i++) {
+            ln = file_lines[file, i]
+            if (ln ~ /ProviderDispatch::(new|from_ref)\(/) return 1
+            if (ln ~ /dispatcher[ ]*\.[a-z_]+\(/) return 1
+            if (ln ~ /dispatcher[ ]*$/) return 1
+        }
+        return 0
+    }
+    {
+        file = $1
+        line = $2
+        if (file == "") next
+        if (file in allowed) next
+        # Skip live/integration tests in /tests/ directories.
+        if (file ~ /(^|\/)tests?\//) next
+        if (!(file in file_loaded)) read_file_lines(file)
+        if (line + 0 >= test_boundary[file] + 0) next
+        # Drop matches inside indented #[cfg(test)] blocks (test
+        # helpers nested in production functions).
+        if (context_is_cfg_test_block(file, line + 0)) next
+        # Reconstruct content (rest of rg vimgrep after `file:line:col:`).
+        content = $4
+        for (i = 5; i <= NF; i++) content = content ":" $i
+        # Skip self-calls.
+        if (content ~ /self\.(chat|stream_chat|simple_chat|chat_with_system|chat_with_history|chat_with_tools|list_models|list_models_with_pricing|warmup)\(/) next
+        # Skip blanket Arc<T> forwarders.
+        if (content ~ /self\.as_ref\(\)\.(chat|stream_chat|simple_chat|chat_with_system|chat_with_history|chat_with_tools|list_models|list_models_with_pricing|warmup)\(/) next
+        # Skip rustfmt-split self.method() chains (receiver on prior line).
+        if (context_is_self_call(file, line + 0)) next
+        # Skip doc/comment lines.
+        if (content ~ /^[[:space:]]*\/\//) next
+        # Skip calls in the dispatcher-construction context.
+        if (context_has_dispatcher(file, line + 0)) next
+        print file ":" line ":" content
+    }
+')
+
+if [ -n "$VIOLATIONS" ]; then
+    echo "❌ Direct ModelProvider method calls found outside the dispatcher:"
+    echo "$VIOLATIONS"
+    echo
+    echo "Route the call through zeroclaw_providers::ProviderDispatch:"
+    echo "    ProviderDispatch::new(provider.clone()).<method>(...)        // Arc<dyn ModelProvider>"
+    echo "    ProviderDispatch::from_ref(&*provider).<method>(...)         // &dyn ModelProvider"
+    echo
+    echo "If this is a false positive (e.g. .chat() on a non-ModelProvider type),"
+    echo "extend the awk filter in scripts/ci/rust_quality_gate.sh."
+    exit 1
+fi
+
+echo "==> rust quality: provider dispatch gate clean"

--- a/src/main.rs
+++ b/src/main.rs
@@ -3280,9 +3280,10 @@ async fn main() -> Result<()> {
                     .unwrap_or("default");
                 match message {
                     Some(msg) => {
-                        let response = model_provider
-                            .simple_chat(&msg, model_name, Some(final_temperature))
-                            .await?;
+                        let response =
+                            zeroclaw_providers::ProviderDispatch::from_ref(&*model_provider)
+                                .simple_chat(&msg, model_name, Some(final_temperature))
+                                .await?;
                         println!("{response}");
                     }
                     None => {
@@ -3295,9 +3296,10 @@ async fn main() -> Result<()> {
                             if stdin.read_line(&mut line)? == 0 {
                                 break;
                             }
-                            let response = model_provider
-                                .simple_chat(line.trim(), model_name, Some(final_temperature))
-                                .await?;
+                            let response =
+                                zeroclaw_providers::ProviderDispatch::from_ref(&*model_provider)
+                                    .simple_chat(line.trim(), model_name, Some(final_temperature))
+                                    .await?;
                             println!("{response}");
                         }
                     }

--- a/tools/fill-translations/Cargo.toml
+++ b/tools/fill-translations/Cargo.toml
@@ -17,3 +17,4 @@ tokio = { version = "1.50", default-features = false, features = ["rt-multi-thre
 toml = "0.8"
 xtask = { path = "../../xtask" }
 zeroclaw-api = { workspace = true }
+zeroclaw-providers = { workspace = true }

--- a/tools/fill-translations/src/main.rs
+++ b/tools/fill-translations/src/main.rs
@@ -359,7 +359,7 @@ async fn translate_batch(
 
     let mut out = Vec::with_capacity(batch.len());
     for source in batch {
-        let content = provider
+        let content = zeroclaw_providers::ProviderDispatch::from_ref(provider)
             .chat_with_system(Some(&system), source, model, None)
             .await
             .map_err(|e| fail(e, String::new()))?;

--- a/xtask/src/cmd/fluent/fill.rs
+++ b/xtask/src/cmd/fluent/fill.rs
@@ -1,6 +1,7 @@
 use crate::util::*;
 use std::path::{Path, PathBuf};
 use zeroclaw_api::model_provider::ModelProvider;
+use zeroclaw_providers::ProviderDispatch;
 
 const DEFAULT_BATCH_SIZE: usize = 50;
 
@@ -152,7 +153,7 @@ fn call_api(
         .enable_all()
         .build()?;
     let content = rt.block_on(async {
-        provider
+        ProviderDispatch::from_ref(provider)
             .chat_with_system(Some(&system), &user_content, model, None)
             .await
     })?;


### PR DESCRIPTION
# Summary

**Base branch:** `master` (all contributions)

**What changed and why:**

- Added `ProviderDispatch` / `ProviderDispatchRef` as the single routed surface for protected `ModelProvider` calls, wrapping concrete provider attribution spans and model scopes around chat, streaming, model listing, and warmup operations.
- Migrated runtime agent turns, delegates, context compression, tools, memory consolidation, channel orchestration, CLI helpers, translation helpers, and provider wrappers to call through the dispatcher so emitted `LogEvent`s inherit concrete provider type/alias attribution.
- Fixed reliable-wrapper attribution by delegating `ReliableModelProvider` identity to the primary inner provider and removed the now-unreachable `ModelProviderKind::Reliable` enum variant.
- Added integration coverage for every dispatcher method plus a Rust quality-gate check that rejects direct production `ModelProvider` calls outside the dispatcher allowlist.
- Added attribution scopes for the `models_dev` catalog and record-emitting Gemini/OpenAI OAuth helper flows.

**Scope boundary:** This PR does not change provider selection, retry policy, model routing semantics, provider request/response payloads, or credential handling. Same-provider `self.*` fallback calls and live tests are intentionally not migrated through the dispatcher.

**Blast radius:** Provider observability/log attribution, runtime/provider/channel/tool/memory call paths that invoke model providers, CI quality gating, and the experimental `zeroclaw-api` model-provider enum surface.

**Linked issue(s):** None.

**Labels:** `enhancement`, `area: providers`, `area: observability`, `runtime`, `risk: high`, `size: XL`

---

# Validation Evidence (required)

Local validation is the signal CI cannot replace. Full battery run **after rebase onto current `master`** (resolving 72 commits of master churn with a single `CHANGELOG-next.md` conflict — see Compatibility section).

### `cargo fmt --all -- --check`

```
--- cargo fmt exit: 0 ---
```

### `cargo clippy --all-targets -- -D warnings`

```
    Checking zeroclaw-api v0.8.0 (...)
    Checking zeroclaw-providers v0.8.0 (...)
    Checking zeroclaw-tools v0.8.0 (...)
    Checking zeroclaw-runtime v0.8.0 (...)
    Checking zeroclaw-channels v0.8.0 (...)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 09s
--- cargo clippy exit: 0 ---
```

### `cargo test`

(The local nested-worktree `.cargo/config.toml` doubles `--default-theme=ayu` into rustdoc, so the doctest phase fails on a plain `cargo test`. Setting `RUSTDOCFLAGS` in the environment overrides the duplication and the doctest phase succeeds. This is a local-worktree config artifact unrelated to the PR.)

```
RUSTDOCFLAGS='--default-theme=ayu' cargo test

test result: ok. 159 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.14s

Running tests/test_live.rs
test result: ok. 0 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 0.00s
  (all 7 ignored — require live OAuth / API key credentials)

Running tests/test_system.rs
test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s

Doc-tests zeroclaw
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

--- RUSTDOCFLAGS='--default-theme=ayu' cargo test exit: 0 ---
```

### CI script changed by this PR

```
./scripts/ci/rust_quality_gate.sh --strict
==> rust quality: cargo fmt --all -- --check
==> rust quality: cargo clippy --locked --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.25s
==> rust quality: provider dispatch gate (no direct ModelProvider method calls outside ProviderDispatch)
==> rust quality: provider dispatch gate clean
--- ./scripts/ci/rust_quality_gate.sh --strict exit: 0 ---
```

**Beyond CI — what was manually verified:** Verified the direct-call guard against the post-rebase diff. Reviewed the rustdoc duplication root cause (local worktree config, not a code issue). Re-ran the full test battery after the rebase resolved the `CHANGELOG-next.md` conflict. Confirmed `git log upstream/master..HEAD -- CHANGELOG-next.md` is empty — this PR no longer touches the changelog.

**If any command was intentionally skipped, why:** None. The 7 live credential-gated tests remained ignored by their existing `#[ignore]`-equivalent annotations.

---

# Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

N/A.

---

# Compatibility (required)

- Backward compatible? **No** (one breaking change — see below)
- Config / env / CLI surface changed? **No**

**Breaking change (now reflected in the PR title with `!`):**

`ModelProviderKind::Reliable` was removed from the experimental `zeroclaw-api` enum because reliable attribution now delegates to the inner concrete provider. Downstream code that matched this variant exhaustively will fail to compile and must remove that arm (or match the concrete provider kind exposed by the wrapped provider). Code that did not match exhaustively is unaffected. `zeroclaw-api` is Experimental tier so this in-band closed-enum change is permitted under the API stability policy.

**Why no `CHANGELOG-next.md` entry:** Per maintainer guidance (`@singlerider`, `@WareWolf-MoonWall`), `CHANGELOG-next.md` is a release-coordination artifact and is not modified by feature PRs. The breaking-change note is captured here in the PR description and in the commit message of `b62d89886 feat(api)!: drop ModelProviderKind::Reliable`. The release process will pick it up from the commit log.

---

# Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <merge-sha>` for the squash merge commit.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:**
  - Missing or incorrect `zeroclaw.model_provider_type`, `zeroclaw.model_provider_alias`, or `model` fields in JSONL / log broadcast events.
  - CI failures from `scripts/ci/rust_quality_gate.sh` reporting direct `ModelProvider` calls.
  - Provider wrapper behavior regressions around reliable/router/model-pin chat, streaming, list-models, or warmup paths.

---

# Supersede Attribution

- Superseded PRs + authors: N/A.
- Scope materially carried forward: N/A.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? **No**
- If No, why (inspiration-only, no direct code/design carry-over): No superseded PR is referenced.

---

# Review-cycle changes (since first push)

Addressing review feedback from `@Audacity88`, `@singlerider`, and `@WareWolf-MoonWall`:

1. **PR title now carries `!`** — surfaces the breaking enum removal in the squash subject. (`@WareWolf-MoonWall` blocking item)
2. **`CHANGELOG-next.md` no longer modified by this PR** — entry removed; the breaking-change note lives in this PR description and the `feat(api)!:` commit. (`@singlerider` / `@WareWolf-MoonWall` blocking item)
3. **Rebased onto current `master`** — was 72 commits behind at the time of the rebase (up from the 62 originally flagged). Single `CHANGELOG-next.md` conflict resolved by taking master's content (matches blocking item #2). The merge commit `bb7feb0c2` is now absorbed into the linear rebase; branch is back to 15 clean commits. (`@Audacity88` / `@WareWolf-MoonWall` warning item)
4. **CHANGELOG/PR-body contradiction resolved** — the "No migration is needed" note is gone with the changelog removal; this PR description states the migration accurately. (`@WareWolf-MoonWall` warning item)

**Milestone placement** (`@WareWolf-MoonWall` ↔ `@singlerider`): awaiting maintainer call between v0.8.1 / v0.8.2 / v0.9.0 now that the two blocking items are resolved.
