### PR TITLE
docs(squash-merge): document merge queue mode

### DIFF
--- a/.claude/skills/squash-merge/SKILL.md
+++ b/.claude/skills/squash-merge/SKILL.md
@@ -1,10 +1,12 @@
 # Skill: squash-merge
 
-Squash-merge a PR into `upstream/master` (zeroclaw-labs/zeroclaw) with fully preserved commit history in the squash message body. Use this skill when the user explicitly mentions squash-merging, merging a specific PR number, or landing a PR by number — e.g. "squash-merge #123", "merge PR 456", "land #789", "/squash-merge 123". Do **not** trigger on vague phrases like "ship it" or "merge it" without a PR number or clear upstream-merge context.
+Squash-merge or queue a PR into `upstream/master` (zeroclaw-labs/zeroclaw) with project-conventional squash metadata. Use this skill when the user explicitly mentions squash-merging, queueing, merging a specific PR number, or landing a PR by number — e.g. "squash-merge #123", "queue PR 456", "merge PR 456", "land #789", "/squash-merge 123". Do **not** trigger on vague phrases like "ship it" or "merge it" without a PR number or clear upstream-merge context.
 
 ## Why This Exists
 
-GitHub's default squash merge omits the PR number from the commit subject and formats the commit body inconsistently with project conventions. Direct-pushing a squash to master bypasses the PR merge mechanism entirely: the PR shows "Closed" instead of "Merged" (no purple badge, no linked issue auto-close, no merge commit association). This skill produces both: the purple **Merged** badge and a conventionally formatted squash commit with full commit history in the body.
+GitHub's default direct squash merge can omit the PR number from the commit subject or format the commit body inconsistently with project conventions. Direct-pushing a squash to master bypasses the PR merge mechanism entirely: the PR shows "Closed" instead of "Merged" (no purple badge, no linked issue auto-close, no merge commit association). This skill produces both: the purple **Merged** badge and a conventionally formatted squash commit.
+
+When merge queue is used, GitHub controls the final squash commit from repository settings and the PR's title/commit messages. In that mode, do not use direct `--subject` / `--body` flags; verify the generated metadata and enqueue the PR so GitHub tests the exact merge group before landing.
 
 ## Prerequisites
 
@@ -31,8 +33,8 @@ NUMBER=$(gh pr view <PR_NUMBER_OR_URL> --repo zeroclaw-labs/zeroclaw --json numb
 Then fetch PR metadata:
 
 ```bash
-gh pr view "$NUMBER" --repo zeroclaw-labs/zeroclaw \
-  --json number,title,headRefName,baseRefName,state,author,mergeable,reviewDecision
+PR_JSON=$(gh pr view "$NUMBER" --repo zeroclaw-labs/zeroclaw \
+  --json id,number,title,headRefName,headRefOid,baseRefName,state,author,mergeable,mergeStateStatus,reviewDecision,isDraft)
 ```
 
 Run pre-flight checks. **Stop at the first failure** and explain clearly:
@@ -42,6 +44,7 @@ Run pre-flight checks. **Stop at the first failure** and explain clearly:
 | PR is open | `state != "OPEN"` | "PR #$NUMBER is already `<state>`, nothing to merge." |
 | Targets master | `baseRefName != "master"` | "PR #$NUMBER targets `<base>`, not master. Confirm before proceeding." |
 | No merge conflicts | `mergeable == "CONFLICTING"` | "PR #$NUMBER has merge conflicts with master. The author must resolve them before this can merge." |
+| Not draft for queue mode | `isDraft == true` and queue mode is intended | "PR #$NUMBER is draft. Do not enqueue until it is ready for review." |
 
 Then fetch the review decision:
 
@@ -53,8 +56,38 @@ REVIEW_DECISION=$(gh pr view "$NUMBER" --repo zeroclaw-labs/zeroclaw \
 - `APPROVED` or `""` → proceed
 - `REVIEW_REQUIRED` → warn the user that no required review has been received, and ask if they want to proceed anyway
 - `CHANGES_REQUESTED` → stop: "PR #$NUMBER has a changes-requested review outstanding. The reviewer must approve or dismiss their review before this can merge."
+- Queue mode is stricter than direct mode: do not enqueue unless `reviewDecision == "APPROVED"`, `isDraft == false`, the PR is clean/mergeable, and required branch checks are green.
 
-### Step 2: Get Commit History
+### Step 2: Choose the Landing Mode
+
+Use one of these modes and say which one you are using before asking for final confirmation:
+
+- **Direct squash merge**: use when the user explicitly wants an immediate maintainer merge, merge queue is unavailable, or the PR cannot be queued. This mode prepares `gh pr merge --squash --subject ... --body ...`.
+- **Merge queue**: use only for open, non-draft, approved, clean/mergeable PRs with green required branch checks. This mode verifies the PR title, generated squash body source, and repository squash settings, then enqueues the PR for exact merge-group CI. Do not pass `--subject` or `--body` in queue mode.
+
+For merge queue mode, verify repository settings before continuing:
+
+```bash
+gh api repos/zeroclaw-labs/zeroclaw \
+  --jq '{allow_squash_merge, squash_merge_commit_title, squash_merge_commit_message}'
+```
+
+`allow_squash_merge` must be `true`. The title/message settings must generate a conventional squash subject from the PR title and a safe body from the configured body source. If the settings are unsafe for the intended PR, stop and use direct squash merge or fix the PR/repository metadata before queueing.
+
+Also verify required branch checks are green before queue mode:
+
+```bash
+gh pr checks "$NUMBER" --repo zeroclaw-labs/zeroclaw --required
+```
+
+### Step 3: Derive the Direct Squash Body or Queue Generated Metadata
+
+Direct squash merge and merge queue use different body sources:
+
+- Direct squash merge uses the `$COMMITS` body you pass to `gh pr merge --squash --body`.
+- Merge queue uses GitHub's repository settings and cannot be overridden with `--subject` / `--body`.
+
+For direct squash merge, get commit history:
 
 ```bash
 COMMITS=$(gh pr view "$NUMBER" --repo zeroclaw-labs/zeroclaw \
@@ -87,20 +120,43 @@ Leave `$COMMITS` empty if there is no commit body. A one-item bullet list adds n
 
 Note: commits from the API are in API order, which is typically chronological but not guaranteed for rebased histories. Use the `git log` fallback if ordering looks wrong.
 
-### Step 3: Derive the Squash Commit Subject
+For merge queue mode, derive and scan the exact generated body source based on `squash_merge_commit_message`:
 
-Before deriving the final merge command, sanitize `$COMMITS`: strip bot/AI
-`Co-authored-by` trailers and generated tool footers, while preserving human
-co-author trailers only when they credit incorporated contributor work under the
-superseding and privacy rules. Then verify the body before asking for merge
-confirmation:
+- `COMMIT_MESSAGES`: fetch every commit's `messageHeadline` and `messageBody`, then scan both. Do not scan headlines only; trailers can live in commit bodies.
+- `PR_BODY`: scan the current PR body.
+- `BLANK`: verify the generated body is empty.
+
+Example for the current ZeroClaw setting, `COMMIT_MESSAGES`:
 
 ```bash
-printf '%s\n' "$COMMITS" | rg -i '(^[[:space:]]*(Co-authored-by|Co-Authored-By):.*(Claude|Codex|ChatGPT|Copilot|GitHub Copilot|Gemini|\[bot\]|dependabot|github-actions|web-flow|blacksmith|noreply@(anthropic|openai)\.com)|^[[:space:]]*(Created with Claude Code|Generated with Claude Code)[[:space:]]*$)'
+QUEUE_BODY_SOURCE=$(gh pr view "$NUMBER" --repo zeroclaw-labs/zeroclaw \
+  --json commits \
+  --jq '[.commits[] | "\(.messageHeadline)\n\(.messageBody // "")"] | join("\n\n")')
 ```
 
-If this prints anything, stop and strip the remaining bot attribution or
-generated footer before continuing.
+### Step 4: Validate the Squash Metadata
+
+Before deriving the final direct merge command or queueing the PR, sanitize the body source that the chosen landing mode will actually use: `$COMMITS` for direct squash merge, or `$QUEUE_BODY_SOURCE` for merge queue. Strip bot/AI `Co-authored-by` trailers and generated tool footers, while preserving human co-author trailers only when they credit incorporated contributor work under the superseding and privacy rules. Set exactly one body source.
+
+For direct squash merge:
+
+```bash
+BODY_TO_CHECK="$COMMITS"
+```
+
+For merge queue:
+
+```bash
+BODY_TO_CHECK="$QUEUE_BODY_SOURCE"
+```
+
+Then verify it before asking for confirmation:
+
+```bash
+printf '%s\n' "$BODY_TO_CHECK" | rg -i '(^[[:space:]]*(Co-authored-by|Co-Authored-By):.*(Claude|Codex|ChatGPT|Copilot|GitHub Copilot|Gemini|\[bot\]|dependabot|github-actions|web-flow|blacksmith|noreply@(anthropic|openai)\.com)|^[[:space:]]*(Created with Claude Code|Generated with Claude Code)[[:space:]]*$)'
+```
+
+If this prints anything, stop. For direct squash merge, strip the remaining bot attribution or generated footer before continuing. For merge queue, fix the PR title/body/commit metadata or use another approved landing path, because queue mode cannot override the final squash body.
 
 ```bash
 PR_TITLE=$(gh pr view "$NUMBER" --repo zeroclaw-labs/zeroclaw --json title --jq '.title')
@@ -109,11 +165,13 @@ SUBJECT="${PR_TITLE} (#${NUMBER})"
 
 The title should follow conventional commit format, e.g. `feat(scope): description` or `fix: short message`. If it does not, flag it to the user and suggest a corrected title. Do not proceed until the subject is in conventional commit format.
 
-### Step 4: Confirm — MANDATORY, NO EXCEPTIONS
+For merge queue mode, also confirm that GitHub's generated squash subject will match project convention. With repository title setting `PR_TITLE`, the expected subject is `${PR_TITLE} (#${NUMBER})`. If the repository settings or PR title would produce a non-conventional subject, stop and fix the PR title/settings or use direct squash merge.
 
-**This step is non-negotiable.** A squash merge into `upstream/master` cannot be undone without a revert commit.
+### Step 5: Confirm — MANDATORY, NO EXCEPTIONS
 
-Present the following to the user with `$NUMBER`, `$SUBJECT`, and `$COMMITS` substituted with their actual values — never show variable names or placeholder text:
+**This step is non-negotiable.** A squash merge into `upstream/master`, whether direct or through merge queue, cannot be undone without a revert commit.
+
+For direct squash merge, present the following to the user with `$NUMBER`, `$SUBJECT`, and `$COMMITS` substituted with their actual values — never show variable names or placeholder text:
 
 ---
 
@@ -138,11 +196,25 @@ Run this command? (yes/no)
 
 ---
 
+For merge queue mode, first resolve the GraphQL PR id and head SHA, then present the exact queue command or GraphQL mutation plus the metadata that GitHub will use. The approval prompt must include the actual PR id, PR number, head SHA, generated squash subject, and generated squash body source. Do not show `$PULL_REQUEST_ID`, `$HEAD_SHA`, an abbreviated `PR_kw...`, `#1234`, or any other placeholder in the confirmation prompt. Include `expectedHeadOid` in the mutation so the approved head is the only head that can be queued.
+
+Show Dan:
+
+- PR number, title, and head SHA.
+- Queue mutation with actual `pullRequestId` and `expectedHeadOid`.
+- Squash subject from the PR title.
+- Squash body source from the repository setting, already scanned for bot/AI attribution.
+- Any linked issue or public tracker follow-through.
+
+Ask: `Run this queue command? (yes/no)`
+
 Do not infer consent from silence, prior approval of the commit message, or any earlier step. The user must respond with an unambiguous "yes" (or "y", "go", "do it") **in direct reply to this prompt**. Any other response — including silence, redirection, or "yes but first..." — means stop.
 
-### Step 5: Execute
+### Step 6: Execute
 
-Only after explicit confirmation in Step 4:
+Only after explicit confirmation in Step 5.
+
+For direct squash merge:
 
 ```bash
 gh pr merge "$NUMBER" --repo zeroclaw-labs/zeroclaw --squash \
@@ -150,9 +222,28 @@ gh pr merge "$NUMBER" --repo zeroclaw-labs/zeroclaw --squash \
   --body "$COMMITS"
 ```
 
+For merge queue mode, first resolve the GraphQL PR id and head SHA:
+
+```bash
+PULL_REQUEST_ID=$(gh pr view "$NUMBER" --repo zeroclaw-labs/zeroclaw --json id --jq '.id')
+HEAD_SHA=$(gh pr view "$NUMBER" --repo zeroclaw-labs/zeroclaw --json headRefOid --jq '.headRefOid')
+```
+
+Then enqueue and capture the queue entry id:
+
+```bash
+MERGE_QUEUE_ENTRY_ID=$(gh api graphql \
+  -f query='mutation($pullRequestId:ID!, $expectedHeadOid:GitObjectID!) { enqueuePullRequest(input:{pullRequestId:$pullRequestId, expectedHeadOid:$expectedHeadOid}) { mergeQueueEntry { id position state baseCommit { oid } headCommit { oid } pullRequest { number title url } } } }' \
+  -f pullRequestId="$PULL_REQUEST_ID" \
+  -f expectedHeadOid="$HEAD_SHA" \
+  --jq '.data.enqueuePullRequest.mergeQueueEntry.id')
+```
+
 If the command exits non-zero, stop and report the full error output verbatim. Do not retry or attempt to work around failures.
 
-### Step 6: Verify
+### Step 7: Verify
+
+For direct squash merge:
 
 ```bash
 gh pr view "$NUMBER" --repo zeroclaw-labs/zeroclaw \
@@ -164,17 +255,25 @@ If `state` is not `MERGED`, report the discrepancy and stop — do not assume su
 
 Report to the user: merge commit SHA and PR URL.
 
+For merge queue mode, verify the specific queue entry returned by the enqueue mutation. Do not rely on listing the first N queue entries when you have an entry id:
+
+```bash
+gh api graphql -f id="$MERGE_QUEUE_ENTRY_ID" \
+  -f query='query($id:ID!) { node(id:$id) { ... on MergeQueueEntry { id position state pullRequest { number title url } baseCommit { oid } headCommit { oid } } } }'
+```
+
+Report the PR number, queue position, queue state, base commit, and merge-group head commit. Inspect the merge-group checks for the queue `headCommit.oid` before treating the queue validation as green. Do not report the PR as merged until a later `gh pr view` confirms `state == "MERGED"`.
+
 **Never delete contributor branches.** Do not suggest, offer, or run any branch deletion command — not on the upstream remote, not on forks. Branch cleanup is the contributor's responsibility and is always a human decision.
 
 ## Rules
 
 - **Require a PR number or explicit squash-merge context before triggering** — do not invoke on vague phrases without a clear target.
 - **Never push squash commits directly to `upstream/master`** — always use `gh pr merge`. Direct push produces "Closed" not "Merged", breaks issue auto-close, and loses PR association.
-- **Never use `gh pr merge --squash` without `--subject` and `--body`** — the auto-generated message omits the PR number and uses inconsistent formatting.
-- **Never let GitHub auto-generate the squash message** — no web UI merge, no merge button clicks.
-- **Always strip bot/AI attribution from the squash body** before confirmation.
-  Preserve intentional human co-author trailers only under the superseding and
-  privacy rules.
+- **For direct merges, never use `gh pr merge --squash` without `--subject` and `--body`** — the auto-generated direct-merge message may omit the PR number or use inconsistent formatting.
+- **For direct merges, never let GitHub auto-generate the squash message** — no web UI merge, no merge button clicks for direct landing.
+- **For merge queue, verify generated metadata before enqueueing** — repository squash settings, PR title, and commit messages control the final squash commit.
+- **Always strip or reject bot/AI attribution from the squash body** before confirmation. Preserve intentional human co-author trailers only under the superseding and privacy rules.
 - **Always assign PR title and commit body to shell variables** — never interpolate untrusted content directly into quoted command arguments.
 - **Always run pre-flight checks** (merge conflicts, review decision) before confirming — do not skip them even if the user says "just merge it."
 - **Always confirm before merging, no exceptions** — show the user the exact expanded command with real values and require an explicit yes. Never infer consent.


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Updates `.claude/skills/squash-merge/SKILL.md` so the squash-merge skill has an explicit merge-queue landing mode instead of assuming every approved PR should be directly squash-merged.
  - Documents the distinction between direct squash merge metadata, which can be supplied with `--subject` / `--body`, and merge queue metadata, which GitHub derives from repository squash settings plus PR title/commit metadata.
  - Adds queue-mode checks for draft state, approval, mergeability, required checks, repository squash settings, expected head SHA, and bot/AI attribution in the body source that GitHub will actually use.
  - Clarifies verification after enqueueing: report queue entry state/base/head commits and do not describe a queued PR as merged until `gh pr view` confirms `state == "MERGED"`.
- **Scope boundary:** Documentation/skill workflow only. This does not change runtime code, CI configuration, repository merge settings, or GitHub branch protection.
- **Blast radius:** Maintainer workflow guidance for landing PRs. The main risk is process confusion if the instructions are wrong or too verbose; no product/runtime behavior changes.
- **Linked issue(s):** None.
- **Labels:** `docs`

## Validation Evidence (required)

Local validation is limited because the changed file is a Claude skill document outside the repo docs/book paths.

```bash
scripts/ci/docs_quality_gate.sh
```

Output:

```text
No docs files detected; skipping docs quality gate.
```

- **Commands run and tail output:** See output above.
- **Beyond CI — what did you manually verify?** Read the changed skill flow against the current repository squash settings: `allow_squash_merge=true`, `squash_merge_commit_title=PR_TITLE`, and `squash_merge_commit_message=COMMIT_MESSAGES`. Checked that the instructions require `expectedHeadOid` for queue enqueueing and distinguish queue verification from final merge verification. Direct squash-merge mode was not exercised in this pass; the direct-mode text is existing behavior kept as the fallback path.
- **If any command was intentionally skipped, why:** Rust fmt/clippy/tests were not run because this changes only `.claude/skills/squash-merge/SKILL.md`. The docs quality gate was run but skipped by path detection.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: Existing users do not need to take any upgrade action. Maintainers using the skill should follow the new mode selection step. Merge queue is the newly documented path for approved clean PRs that should be validated through merge-group CI. Direct squash merge remains the fallback path when queue mode is unavailable or explicitly desired, but it was not re-tested as part of this docs update.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PR. Rollback plan: `git revert cf4a15915a668ce2a24946dc862b961d4ef3342a`.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A

