### PR TITLE
fix(docs): clear rustdoc warnings surfaced by mdbook build

### DIFF
--- a/crates/zeroclaw-api/src/observability_traits.rs
+++ b/crates/zeroclaw-api/src/observability_traits.rs
@@ -149,7 +149,7 @@ pub enum ObserverEvent {
     /// Emitted after vector + keyword retrieval against the hardware
     /// datasheet index. Reports cardinalities only; carries an optional
     /// scrubbed-and-truncated query summary on the same terms as
-    /// [`MemoryRecall`]. Has no `success` field because the underlying
+    /// [`Self::MemoryRecall`]. Has no `success` field because the underlying
     /// `rag.retrieve` call is synchronous and infallible.
     RagRetrieve {
         query_summary: Option<String>,

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -3448,7 +3448,7 @@ pub struct ChannelAliasInfo {
 }
 
 impl Config {
-    /// Resolve the configured alias values valid for an [`AliasSource`].
+    /// Resolve the configured alias values valid for an [`crate::traits::AliasSource`].
     /// Two-tier sources return dotted `<type>.<alias>` keys; flat sources
     /// return bare alias keys. The single resolver every surface uses for
     /// `PropKind::AliasRef` pickers and validation.

--- a/crates/zeroclaw-runtime/src/agent/turn/stream_guard.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/stream_guard.rs
@@ -1,4 +1,4 @@
-//! Streaming-text guards: protocol-fragment buffering and <think> tag stripping.
+//! Streaming-text guards: protocol-fragment buffering and `<think>` tag stripping.
 
 use super::protocol_detect::{
     complete_json_fence_protocol_state, complete_non_protocol_json,


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** `cargo mdbook build` runs rustdoc as part of site assembly, and three doc warnings were failing a clean build. This clears all three so the build emits zero rustdoc warnings.
  - `zeroclaw-api`: unresolved intra-doc link `MemoryRecall` now targets the sibling enum variant via `Self::MemoryRecall`.
  - `zeroclaw-config`: unresolved intra-doc link `AliasSource` now uses the fully-qualified `crate::traits::AliasSource` path.
  - `zeroclaw-runtime`: unclosed HTML tag `think` in the `stream_guard.rs` module header is now backtick-wrapped so rustdoc reads it as code, not markup.
- **Scope boundary:** Documentation-comment fixes only. No runtime behavior, no API surface, no logic changes.
- **Blast radius:** None at runtime. Affects only generated rustdoc output and the mdbook build's warning state.
- **Linked issue(s):** None.
- **Labels:** `docs`, `risk: low`, `size: XS`.

## Validation Evidence (required)

This is a docs-comment-only change. The relevant gate is the doc build itself.

```bash
cargo mdbook build > /tmp/mdbook-build.log 2>&1
```

- **Commands run and tail output:**
  - `cargo mdbook build` exits `0`. Post-fix `grep -icE "warning|error"` on the build log returns `0`.
  - Tail: `==> Internal link check passed`, all locales (en/fr/ja/es/zh-CN) written, `==> Assembling site (rustdoc + locale redirect)`, `==> Done.`
  - Before the fix the same build surfaced exactly three rustdoc warnings: `unresolved link to MemoryRecall` (zeroclaw-api), `unresolved link to AliasSource` (zeroclaw-config), `unclosed HTML tag think` (zeroclaw-runtime).
- **Beyond CI — what did you manually verified?** Confirmed each of the three warnings is gone individually and that the full build log contains zero `warning`/`error` lines after the change. Did not run `cargo test`/`clippy` since no compiled code paths changed (doc comments only).
- **If any command was intentionally skipped, why:** `cargo clippy`/`cargo test` skipped — the change is limited to doc comments and a module-header doc string; no behavior is exercised by tests.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk: `git revert <sha>` is the plan.