### PR TITLE
docs(squash-merge): extend skill with CI check and issue→merge workflow

### DIFF
--- a/.claude/skills/squash-merge/SKILL.md
+++ b/.claude/skills/squash-merge/SKILL.md
@@ -1,6 +1,30 @@
 # Skill: squash-merge
 
-Squash-merge a PR into `upstream/master` (zeroclaw-labs/zeroclaw) with fully preserved commit history in the squash message body. Use this skill when the user explicitly mentions squash-merging, merging a specific PR number, or landing a PR by number — e.g. "squash-merge #123", "merge PR 456", "land #789", "/squash-merge 123". Do **not** trigger on vague phrases like "ship it" or "merge it" without a PR number or clear upstream-merge context.
+Squash-merge a PR into `zeroclaw-labs/zeroclaw` `master` with fully preserved commit history in the squash message body. Use this skill when the user explicitly mentions squash-merging, merging a specific PR number, landing a PR, or 合入 — e.g. "squash-merge #123", "merge PR 456", "land #789", "合入 #123", "/squash-merge 123". Do **not** trigger on vague phrases like "ship it" or "merge it" without a PR number or clear upstream-merge context.
+
+## Related Skills
+
+| Step | Skill | When |
+|---|---|---|
+| Pick / triage issues | `github-issue-triage` | Backlog sweep, label issues, close duplicates |
+| File a bug / feature | `github-issue` | No existing issue for the work |
+| Open / update PR | `github-pr` | Branch is ready; needs template body and validation evidence |
+| Review before merge | `github-pr-review-session` | Maintainer reviewing someone else's PR |
+| **Land into master** | **this skill** | PR is approved and CI is green |
+
+## End-to-End Contributor Workflow (issue → merge)
+
+When the user asks to fix an issue and get it merged, follow this sequence:
+
+1. **Read the issue** — `gh issue view <N>`; confirm it is still open and not already fixed on `master`.
+2. **Branch** — `git checkout -b fix/<short-description>` from up-to-date `master`.
+3. **Implement** — minimal diff; reference canonical state (see `AGENTS.md` no-duplicate-state rule).
+4. **Validate** — run `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (or docs gate if docs-only).
+5. **Open PR** — use the `github-pr` skill; body must include `Closes #<N>` when the PR fully resolves the issue.
+6. **Wait for CI** — before merge, confirm required checks pass (see Pre-merge CI check below).
+7. **Squash-merge** — use this skill with explicit user confirmation.
+
+Do not skip straight to merge if no PR exists yet.
 
 ## Why This Exists
 
@@ -53,6 +77,31 @@ REVIEW_DECISION=$(gh pr view "$NUMBER" --repo zeroclaw-labs/zeroclaw \
 - `APPROVED` or `""` → proceed
 - `REVIEW_REQUIRED` → warn the user that no required review has been received, and ask if they want to proceed anyway
 - `CHANGES_REQUESTED` → stop: "PR #$NUMBER has a changes-requested review outstanding. The reviewer must approve or dismiss their review before this can merge."
+
+### Step 1b: Pre-merge CI Check
+
+Before asking the user to confirm the merge, verify CI status:
+
+```bash
+gh pr checks "$NUMBER" --repo zeroclaw-labs/zeroclaw
+```
+
+Also fetch rollup for a machine-readable summary:
+
+```bash
+gh pr view "$NUMBER" --repo zeroclaw-labs/zeroclaw \
+  --json statusCheckRollup \
+  --jq '[.statusCheckRollup[]? | {name: .name, state: .state, conclusion: .conclusion}]'
+```
+
+| State | Action |
+|---|---|
+| All required checks `SUCCESS` | Proceed to Step 2 |
+| Any required check `FAILURE` / `CANCELLED` | Stop — report failing check names; do not merge |
+| Checks `PENDING` / `IN_PROGRESS` | Stop — tell user to wait for CI; offer to retry later |
+| No checks configured | Warn and ask user whether to proceed |
+
+Do not merge on red CI unless the user explicitly overrides after seeing the failure list.
 
 ### Step 2: Get Commit History
 
@@ -164,6 +213,10 @@ If `state` is not `MERGED`, report the discrepancy and stop — do not assume su
 
 Report to the user: merge commit SHA and PR URL.
 
+**Post-merge (optional, only if user asks):**
+- Fetch latest master: `git checkout master && git pull upstream master` (or `origin master` if no upstream remote)
+- Verify linked issue closed: `gh issue view <N> --json state --jq .state` (should be `CLOSED` when PR body used `Closes #N`)
+
 **Never delete contributor branches.** Do not suggest, offer, or run any branch deletion command — not on the upstream remote, not on forks. Branch cleanup is the contributor's responsibility and is always a human decision.
 
 ## Rules
@@ -176,7 +229,7 @@ Report to the user: merge commit SHA and PR URL.
   Preserve intentional human co-author trailers only under the superseding and
   privacy rules.
 - **Always assign PR title and commit body to shell variables** — never interpolate untrusted content directly into quoted command arguments.
-- **Always run pre-flight checks** (merge conflicts, review decision) before confirming — do not skip them even if the user says "just merge it."
+- **Always run pre-flight checks** (merge conflicts, review decision, CI status) before confirming — do not skip them even if the user says "just merge it."
 - **Always confirm before merging, no exceptions** — show the user the exact expanded command with real values and require an explicit yes. Never infer consent.
 - **If the merge command fails, stop and report verbatim** — do not retry or work around failures automatically.
 - **Never delete branches** — not on upstream, not on forks. Branch cleanup is always the contributor's decision. Never suggest a deletion command.


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Adds a pre-merge CI verification step to the `squash-merge` skill so merges never land on red CI.
  - Documents the full end-to-end contributor workflow: issue → branch → implement → validate → PR → CI → merge.
  - Adds a related-skills table and post-merge verification guidance.
- **Scope boundary:** Documentation-only change to `.claude/skills/squash-merge/SKILL.md`; no runtime code.
- **Blast radius:** Only affects the `squash-merge` slash-command behavior within Claude Code.
- **Labels:** `docs`, `risk: low`, `size: XS`

## Validation Evidence

```bash
# Documentation-only change; no compile/test impact.
cargo fmt --all -- --check  # skipped — no Rust changes
```

- **Commands run:** N/A (docs-only).
- **Beyond CI — what did you manually verify?** Reviewed rendered markdown in preview for correct table formatting and code block syntax.
- **If any command was intentionally skipped, why:** No Rust code changed.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**

## Rollback

Low-risk PR: `git revert <sha>`.

Related #7702 (split from PR #7727 per review feedback; #7702 will be closed by #7727)