### PR TITLE
perf(docs): publish rustdoc once, dedupe per-locale assets, drop print pages

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -267,6 +267,17 @@ jobs:
             mkdir -p "$TAG"
             rsync -a --delete "$TAG_SRC/" "$TAG/"
 
+            # Rustdoc is shared site-wide at '/api', owned by master (same rule
+            # as _shared). master rewrites it each deploy; a tag only seeds it
+            # when bootstrapping the first deploy, never regressing newer docs.
+            API_SRC="${GITHUB_WORKSPACE}/docs/book/book/api"
+            if [ -d "$API_SRC" ]; then
+              if [ "$TAG" = "master" ] || [ ! -d "api" ]; then
+                mkdir -p api
+                rsync -a --delete "$API_SRC/" "api/"
+              fi
+            fi
+
             # No stable/ tree: Stable is a pointer to a real version dir, never a
             # duplicate copy. The committed pointer (docs/book/stable-version.txt)
             # is published to the gh-pages root as stable-version.txt; gen-versions,

--- a/docs/book/book.toml
+++ b/docs/book/book.toml
@@ -25,6 +25,9 @@ enable = true
 limit-results = 30
 use-boolean-and = true
 
+[output.html.print]
+enable = false
+
 [output.html.fold]
 enable = true
 level = 0

--- a/docs/book/src/api.md
+++ b/docs/book/src/api.md
@@ -2,7 +2,7 @@
 
 Full rustdoc for every public type in the workspace, auto-generated from the `///` comments on each type, function, and module. Use this when you need to know the exact shape of a struct, the methods on a trait, or what a function returns: anything the generated reference exposes better than prose can.
 
-**[Open the rustdoc →](../api/zeroclaw/index.html)**
+**[Open the rustdoc →](/api/zeroclaw/index.html)**
 
 ## How to navigate it
 
@@ -15,18 +15,18 @@ Full rustdoc for every public type in the workspace, auto-generated from the `//
 
 | Crate | What it exposes |
 |---|---|
-| [`zeroclaw`](../api/zeroclaw/index.html) | Top-level umbrella with re-exports |
-| [`zeroclaw-api`](../api/zeroclaw_api/index.html) | Public traits: `Provider`, `Channel`, `Tool`, `StreamEvent` |
-| [`zeroclaw-config`](../api/zeroclaw_config/index.html) | Config schema, autonomy types, secrets |
-| [`zeroclaw-runtime`](../api/zeroclaw_runtime/index.html) | Agent loop, security, SOP, onboarding |
-| [`zeroclaw-providers`](../api/zeroclaw_providers/index.html) | Every LLM-provider implementation |
-| [`zeroclaw-channels`](../api/zeroclaw_channels/index.html) | Messaging integrations |
-| [`zeroclaw-gateway`](../api/zeroclaw_gateway/index.html) | HTTP/WebSocket gateway |
-| [`zeroclaw-tools`](../api/zeroclaw_tools/index.html) | Agent-callable tools |
-| [`zeroclaw-memory`](../api/zeroclaw_memory/index.html) | Conversation memory, embeddings |
-| [`zeroclaw-plugins`](../api/zeroclaw_plugins/index.html) | WASM plugin host |
-| [`zeroclaw-hardware`](../api/zeroclaw_hardware/index.html) | GPIO / I2C / SPI / USB |
-| [`zeroclaw-infra`](../api/zeroclaw_infra/index.html) | Tracing, metrics |
+| [`zeroclaw`](/api/zeroclaw/index.html) | Top-level umbrella with re-exports |
+| [`zeroclaw-api`](/api/zeroclaw_api/index.html) | Public traits: `Provider`, `Channel`, `Tool`, `StreamEvent` |
+| [`zeroclaw-config`](/api/zeroclaw_config/index.html) | Config schema, autonomy types, secrets |
+| [`zeroclaw-runtime`](/api/zeroclaw_runtime/index.html) | Agent loop, security, SOP, onboarding |
+| [`zeroclaw-providers`](/api/zeroclaw_providers/index.html) | Every LLM-provider implementation |
+| [`zeroclaw-channels`](/api/zeroclaw_channels/index.html) | Messaging integrations |
+| [`zeroclaw-gateway`](/api/zeroclaw_gateway/index.html) | HTTP/WebSocket gateway |
+| [`zeroclaw-tools`](/api/zeroclaw_tools/index.html) | Agent-callable tools |
+| [`zeroclaw-memory`](/api/zeroclaw_memory/index.html) | Conversation memory, embeddings |
+| [`zeroclaw-plugins`](/api/zeroclaw_plugins/index.html) | WASM plugin host |
+| [`zeroclaw-hardware`](/api/zeroclaw_hardware/index.html) | GPIO / I2C / SPI / USB |
+| [`zeroclaw-infra`](/api/zeroclaw_infra/index.html) | Tracing, metrics |
 
 See [Architecture → Crates](./architecture/crates.md) for a plain-English description of how the crates fit together.
 

--- a/xtask/src/cmd/mdbook/build.rs
+++ b/xtask/src/cmd/mdbook/build.rs
@@ -134,10 +134,51 @@ pub fn assemble(root: &std::path::Path, tag: Option<&str>) -> anyhow::Result<()>
 
 pub fn prune_rustdoc_source_view(api_dir: &Path) -> anyhow::Result<()> {
     let src_view = api_dir.join("src");
-    if src_view.exists() {
-        std::fs::remove_dir_all(&src_view)?;
+    if !src_view.exists() {
+        return Ok(());
     }
+    let mut stack = vec![api_dir.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        if dir == src_view {
+            continue;
+        }
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            match entry.file_type() {
+                Ok(ty) if ty.is_dir() => stack.push(path),
+                Ok(_) if path.extension().is_some_and(|e| e == "html") => {
+                    if let Ok(content) = std::fs::read_to_string(&path) {
+                        let stripped = strip_source_anchors(&content);
+                        if stripped != content {
+                            std::fs::write(&path, stripped)?;
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    std::fs::remove_dir_all(&src_view)?;
     Ok(())
+}
+
+pub fn strip_source_anchors(html: &str) -> String {
+    let needle = "<a class=\"src\"";
+    let mut out = String::with_capacity(html.len());
+    let mut rest = html;
+    while let Some(start) = rest.find(needle) {
+        let after = &rest[start..];
+        let Some(end) = after.find("</a>") else {
+            break;
+        };
+        out.push_str(&rest[..start]);
+        rest = &after[end + "</a>".len()..];
+    }
+    out.push_str(rest);
+    out
 }
 
 pub fn strip_chrome_hash(file_name: &str) -> Option<String> {
@@ -272,7 +313,7 @@ pub fn extract_shared_chrome(version_dir: &Path, shared_dir: &Path) -> anyhow::R
 
 #[cfg(test)]
 mod tests {
-    use super::strip_chrome_hash;
+    use super::{strip_chrome_hash, strip_source_anchors};
 
     #[test]
     fn strips_single_extension_hash() {
@@ -300,5 +341,27 @@ mod tests {
     fn ignores_non_hex_or_wrong_length() {
         assert_eq!(strip_chrome_hash("foo-1234567.js"), None);
         assert_eq!(strip_chrome_hash("foo-zzzzzzzz.js"), None);
+    }
+
+    #[test]
+    fn strips_rustdoc_source_anchor() {
+        let html = r#"<div><a class="src" href="../../src/zeroclaw_tools/x.rs.html#146-177">Source</a></div>"#;
+        assert_eq!(strip_source_anchors(html), "<div></div>");
+    }
+
+    #[test]
+    fn strips_multiple_source_anchors() {
+        let html = concat!(
+            r#"<a class="src" href="../src/a.rs.html#1">Source</a>"#,
+            "middle",
+            r#"<a class="src" href="../src/b.rs.html#2">Source</a>"#,
+        );
+        assert_eq!(strip_source_anchors(html), "middle");
+    }
+
+    #[test]
+    fn leaves_non_source_anchors_intact() {
+        let html = r#"<a href="../../src/foo">keep</a> and <a class="docblock">keep</a>"#;
+        assert_eq!(strip_source_anchors(html), html);
     }
 }

--- a/xtask/src/cmd/mdbook/build.rs
+++ b/xtask/src/cmd/mdbook/build.rs
@@ -113,9 +113,10 @@ pub fn assemble(root: &std::path::Path, tag: Option<&str>) -> anyhow::Result<()>
     println!("==> Assembling site (rustdoc + locale redirect)");
     let book = book_dir(root);
     let tag_dir = tag.unwrap_or(DEFAULT_TAG);
-    let api_dest = book.join("book").join(tag_dir).join("api");
+    let api_dest = book.join("book").join("api");
     let _ = std::fs::remove_dir_all(&api_dest);
     copy_dir_all(doc_dir(root), &api_dest)?;
+    prune_rustdoc_source_view(&api_dest)?;
 
     const INDEX_HTML: &str = "<!doctype html>\n<meta charset=\"utf-8\">\n<meta http-equiv=\"refresh\" content=\"0; url=./en/\">\n<link rel=\"canonical\" href=\"./en/\">\n<title>ZeroClaw Docs</title>\n";
     let out_dir = book.join("book").join(tag_dir);
@@ -129,6 +130,26 @@ pub fn assemble(root: &std::path::Path, tag: Option<&str>) -> anyhow::Result<()>
     let shared_dir = book.join("book").join("_shared");
     extract_shared_chrome(&version_dir, &shared_dir)?;
     Ok(())
+}
+
+pub fn prune_rustdoc_source_view(api_dir: &Path) -> anyhow::Result<()> {
+    let src_view = api_dir.join("src");
+    if src_view.exists() {
+        std::fs::remove_dir_all(&src_view)?;
+    }
+    Ok(())
+}
+
+pub fn strip_chrome_hash(file_name: &str) -> Option<String> {
+    let pos = file_name.rfind('-')?;
+    let rel_dot = file_name[pos + 1..].find('.')?;
+    let ext_pos = pos + 1 + rel_dot;
+    let hash = &file_name[pos + 1..ext_pos];
+    if hash.len() == 8 && hash.chars().all(|c| c.is_ascii_hexdigit()) {
+        Some(format!("{}{}", &file_name[..pos], &file_name[ext_pos..]))
+    } else {
+        None
+    }
 }
 
 pub fn extract_shared_chrome(version_dir: &Path, shared_dir: &Path) -> anyhow::Result<()> {
@@ -158,6 +179,7 @@ pub fn extract_shared_chrome(version_dir: &Path, shared_dir: &Path) -> anyhow::R
         "favicon",
         "theme/pc-themes",
         "theme/pc-enhance",
+        "mermaid",
     ];
 
     let walk_dir = |dir: &Path| -> Vec<std::path::PathBuf> {
@@ -186,21 +208,14 @@ pub fn extract_shared_chrome(version_dir: &Path, shared_dir: &Path) -> anyhow::R
                 continue;
             }
             let file_name = file.file_name().unwrap().to_string_lossy();
-            if let Some(pos) = file_name.rfind('-')
-                && let Some(ext_pos) = file_name.rfind('.')
-                && pos < ext_pos
-            {
-                let hash = &file_name[pos + 1..ext_pos];
-                if hash.len() == 8 && hash.chars().all(|c| c.is_ascii_hexdigit()) {
-                    let unhashed_name = format!("{}{}", &file_name[..pos], &file_name[ext_pos..]);
-                    let dest_rel = rel.parent().unwrap().join(unhashed_name);
-                    let dest = shared_dir.join(&dest_rel);
-                    std::fs::create_dir_all(dest.parent().unwrap())?;
-                    std::fs::copy(&file, &dest)?;
-                    let dest_rel_str = dest_rel.to_string_lossy().replace('\\', "/");
-                    // Store (locale-relative hashed path, unhashed shared-relative path).
-                    replacements.push((rel_str.clone(), dest_rel_str));
-                }
+            if let Some(unhashed_name) = strip_chrome_hash(&file_name) {
+                let dest_rel = rel.parent().unwrap().join(unhashed_name);
+                let dest = shared_dir.join(&dest_rel);
+                std::fs::create_dir_all(dest.parent().unwrap())?;
+                std::fs::copy(&file, &dest)?;
+                let dest_rel_str = dest_rel.to_string_lossy().replace('\\', "/");
+                // Store (locale-relative hashed path, unhashed shared-relative path).
+                replacements.push((rel_str.clone(), dest_rel_str));
             }
         }
     }
@@ -253,4 +268,37 @@ pub fn extract_shared_chrome(version_dir: &Path, shared_dir: &Path) -> anyhow::R
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::strip_chrome_hash;
+
+    #[test]
+    fn strips_single_extension_hash() {
+        assert_eq!(
+            strip_chrome_hash("custom-abc12345.css").as_deref(),
+            Some("custom.css")
+        );
+    }
+
+    #[test]
+    fn strips_compound_extension_hash() {
+        assert_eq!(
+            strip_chrome_hash("mermaid-193ae996.min.js").as_deref(),
+            Some("mermaid.min.js")
+        );
+    }
+
+    #[test]
+    fn ignores_unhashed_names() {
+        assert_eq!(strip_chrome_hash("mermaid-init.js"), None);
+        assert_eq!(strip_chrome_hash("chrome.css"), None);
+    }
+
+    #[test]
+    fn ignores_non_hex_or_wrong_length() {
+        assert_eq!(strip_chrome_hash("foo-1234567.js"), None);
+        assert_eq!(strip_chrome_hash("foo-zzzzzzzz.js"), None);
+    }
 }

--- a/xtask/src/cmd/mdbook/refs.rs
+++ b/xtask/src/cmd/mdbook/refs.rs
@@ -2,16 +2,16 @@ use crate::util::*;
 use std::path::Path;
 use std::process::Command;
 
-pub fn run(tag: Option<&str>) -> anyhow::Result<()> {
+pub fn run(_tag: Option<&str>) -> anyhow::Result<()> {
     let root = repo_root();
     require_tool("cargo", "https://rustup.rs")?;
     build_refs(&root)?;
     build_api(&root)?;
-    let tag_dir = tag.unwrap_or("master");
-    let api_dest = book_dir(&root).join("book").join(tag_dir).join("api");
-    std::fs::create_dir_all(book_dir(&root).join("book").join(tag_dir))?;
+    let api_dest = book_dir(&root).join("book").join("api");
+    std::fs::create_dir_all(book_dir(&root).join("book"))?;
     let _ = std::fs::remove_dir_all(&api_dest);
     copy_dir_all(doc_dir(&root), &api_dest)?;
+    crate::cmd::mdbook::build::prune_rustdoc_source_view(&api_dest)?;
     println!(
         "==> API reference: {}",
         api_dest.join("index.html").display()

--- a/xtask/src/cmd/mdbook/versions.rs
+++ b/xtask/src/cmd/mdbook/versions.rs
@@ -73,8 +73,7 @@ pub fn is_version_dir(name: &str) -> bool {
     name == "master" || parse_version(name).is_some()
 }
 
-/// Root-level directories that are not version dirs but must survive pruning.
-const ROOT_KEEP_DIRS: &[&str] = &["_shared", ".git"];
+const ROOT_KEEP_DIRS: &[&str] = &["_shared", "api", ".git"];
 
 /// Remove orphaned root *directories* left over from the pre-versioned docs
 /// layout (e.g. top-level `en/`, `fr/`, `api/`). Keeps the shared chrome dir


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - The gh-pages site copied the workspace rustdoc into every published version tree (`<tag>/api`), duplicated shared assets per locale, and emitted a whole-book `print.html` per locale. A full clone carried hundreds of MB many times over.
  - This publishes rustdoc once at the site root (`/api`), drops rustdoc's redundant `api/src/` source-view, dedupes `mermaid.min.js` into `_shared/`, and disables mdBook print output.
  - The shared-chrome hash detector mishandled compound extensions (`mermaid-193ae996.min.js`), so mermaid was never deduped; fixed and unit-tested via a new `strip_chrome_hash` helper.
- **Scope boundary:** Does not rewrite existing gh-pages or git history; does not change docs prose, the version selector UI, or full-text search. Old version trees already deployed keep their nested `api/` until rebuilt.
- **Blast radius:** docs-deploy workflow (gh-pages sync), `docs/book/book.toml`, the rustdoc bridge page (`docs/book/src/api.md` now links site-absolute `/api/...`), and the xtask mdbook build/refs/versions paths. No runtime, channel, provider, or gateway code touched.
- **Linked issue(s):** Related #7676
- **Labels:** `type: docs`, `risk: medium`, `size: M`, `docs`

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy -p xtask --all-targets -- -D warnings
cargo test -p xtask
./target/release/mdbook --tag master build
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check`: clean, exit 0.
  - `cargo clippy -p xtask --all-targets -- -D warnings`: `Finished dev profile`, exit 0, no warnings.
  - `cargo test -p xtask`: `test result: ok. 79 passed; 0 failed` plus the asset binary suite `5 passed`. Includes 4 new `strip_chrome_hash` tests (single/compound extension, unhashed, non-hex).
  - `mdbook --tag master build`: `==> Internal link check passed`, build exit 0.
- **Beyond CI, what I manually verified (real build of master):**
  - rustdoc lands once at `book/api` (212 MB); `book/master/api` no longer exists.
  - `print.html` count after build: 0.
  - Per-version tree dropped from 311 MB to 49 MB.
  - `book/master/en/api.html` links resolve to site-absolute `/api/zeroclaw/...`.
  - 0 per-locale `mermaid-*.min.js` copies remain; single `_shared/mermaid.min.js`, refs rewritten depth-aware to the shared copy.
  - 3-version site math: ~933 MB to ~360 MB (one shared 212 MB api + three 49 MB trees).
  - **Not verified locally:** the gh-pages force-push/prune path runs only on GitHub Actions; the workflow `apply_run_slice` api sync mirrors the existing `_shared` ownership rule and is exercised on first deploy.
- **If any command was intentionally skipped, why:** Full workspace `cargo test`/`clippy --all-targets` were scoped to `-p xtask`; the diff only touches xtask + docs + workflow, and the tmpfs build quota on this host cannot hold a full workspace debug + release build simultaneously. CI runs the full battery.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes` for readers: both old (`<tag>/api`) and new (`/api`) link forms resolve during the transition. Print-to-PDF via the browser print page is removed.
- Config / env / CLI surface changed? `No`
- Upgrade steps: none. First master deploy after merge writes the root `/api`; previously deployed tags keep working and shed their nested `api/` only when rebuilt.

## Rollback (required for risk: medium)

- **Fast rollback command/path:** `git revert <sha>` and redeploy docs; the next master deploy restores per-version `api/` and print pages.
- **Feature flags or config toggles:** `[output.html.print] enable` in `docs/book/book.toml` re-enables print pages.
- **Observable failure symptoms:** Broken API reference links on the docs site (`/api/...` 404), or the version selector losing the API link. Check the docs-deploy workflow log for the `api/` rsync step and confirm `/api/index.html` exists at the gh-pages root.
