### PR TITLE
test(config): cover comment writer end-to-end behavior

### DIFF
--- a/crates/zeroclaw-config/tests/comment_writer.rs
+++ b/crates/zeroclaw-config/tests/comment_writer.rs
@@ -58,7 +58,7 @@ async fn apply_comments_inserts_comment_above_target_key() {
          got line above: {:?}",
         lines[host_line_idx - 1]
     );
-    let _: toml::Value = result.trim().parse().expect("resulting TOML must parse");
+    let _: toml::Value = toml::from_str(result.trim()).expect("resulting TOML must parse");
     drop(dir);
 }
 
@@ -82,7 +82,7 @@ async fn apply_comments_updates_existing_comment_on_same_key() {
         result.contains("# updated description"),
         "new comment must appear; result:\n{result}"
     );
-    let parsed: toml::Value = result.trim().parse().expect("resulting TOML must parse");
+    let parsed: toml::Value = toml::from_str(result.trim()).expect("resulting TOML must parse");
     assert_eq!(
         parsed.get("host").and_then(toml::Value::as_str),
         Some("localhost")
@@ -127,7 +127,7 @@ async fn apply_comments_multiple_annotations_in_one_call() {
         lines[port_idx - 1]
     );
 
-    let parsed: toml::Value = result.trim().parse().expect("resulting TOML must parse");
+    let parsed: toml::Value = toml::from_str(result.trim()).expect("resulting TOML must parse");
     assert_eq!(
         parsed.get("host").and_then(toml::Value::as_str),
         Some("localhost")
@@ -176,7 +176,7 @@ async fn apply_comments_deep_dotted_traversal() {
         lines[api_key_idx - 1]
     );
 
-    let parsed: toml::Value = result.trim().parse().expect("resulting TOML must parse");
+    let parsed: toml::Value = toml::from_str(result.trim()).expect("resulting TOML must parse");
     let api_key_val = parsed
         .get("providers")
         .and_then(toml::Value::as_table)
@@ -211,7 +211,7 @@ async fn apply_comments_bad_intermediate_path_is_noop() {
         !result.contains("should not appear"),
         "comment must not appear for a bad intermediate path; result:\n{result}"
     );
-    let parsed: toml::Value = result.trim().parse().expect("resulting TOML must parse");
+    let parsed: toml::Value = toml::from_str(result.trim()).expect("resulting TOML must parse");
     assert_eq!(
         parsed.get("host").and_then(toml::Value::as_str),
         Some("localhost")
@@ -242,7 +242,7 @@ async fn apply_comments_nonexistent_key_is_noop() {
         !result.contains("ghost comment"),
         "comment must not appear for a nonexistent key; result:\n{result}"
     );
-    let parsed: toml::Value = result.trim().parse().expect("resulting TOML must parse");
+    let parsed: toml::Value = toml::from_str(result.trim()).expect("resulting TOML must parse");
     assert_eq!(
         parsed.get("host").and_then(toml::Value::as_str),
         Some("localhost")
@@ -317,7 +317,7 @@ async fn apply_comments_preserves_unrelated_content() {
         "blank line before [database] must be preserved"
     );
 
-    let parsed: toml::Value = result.trim().parse().expect("resulting TOML must parse");
+    let parsed: toml::Value = toml::from_str(result.trim()).expect("resulting TOML must parse");
     assert_eq!(
         parsed.get("host").and_then(toml::Value::as_str),
         Some("localhost")

--- a/crates/zeroclaw-config/tests/comment_writer.rs
+++ b/crates/zeroclaw-config/tests/comment_writer.rs
@@ -1,0 +1,346 @@
+//! End-to-end tests for `apply_comments()` — the async TOML comment-writing
+//! helper that decorates leaf keys by dotted path. Each test writes a config
+//! file to a temp directory, calls `apply_comments`, and asserts the on-disk
+//! result matches expectations.
+
+use std::path::{Path, PathBuf};
+
+use tempfile::tempdir;
+use zeroclaw_config::comment_writer::apply_comments;
+
+// ─────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────
+
+/// Write `content` to a temp file named `config.toml` and return the temp
+/// directory handle (must stay alive for the duration of the test) plus the
+/// file path.
+async fn write_temp_config(content: &str) -> (tempfile::TempDir, PathBuf) {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("config.toml");
+    tokio::fs::write(&path, content).await.unwrap();
+    (dir, path)
+}
+
+/// Read the content of a config file back from disk.
+async fn read_config(path: &Path) -> String {
+    tokio::fs::read_to_string(path).await.unwrap()
+}
+
+// ─────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn apply_comments_inserts_comment_above_target_key() {
+    let (dir, path) = write_temp_config("host = \"localhost\"\nport = 8080\n").await;
+
+    apply_comments(
+        &path,
+        &[(String::from("host"), String::from("the server hostname"))],
+    )
+    .await
+    .unwrap();
+
+    let result = read_config(&path).await;
+    let lines: Vec<&str> = result.lines().collect();
+    let host_line_idx = lines
+        .iter()
+        .position(|l| l.starts_with("host ="))
+        .expect("`host = ...` line must be present");
+    assert!(
+        host_line_idx > 0,
+        "comment line must exist above the host key"
+    );
+    assert!(
+        lines[host_line_idx - 1].contains("# the server hostname"),
+        "expected comment `# the server hostname` above `host = ...`; \
+         got line above: {:?}",
+        lines[host_line_idx - 1]
+    );
+    let _: toml::Value = result.trim().parse().expect("resulting TOML must parse");
+    drop(dir);
+}
+
+#[tokio::test]
+async fn apply_comments_updates_existing_comment_on_same_key() {
+    let (dir, path) = write_temp_config("# old comment\nhost = \"localhost\"\nport = 8080\n").await;
+
+    apply_comments(
+        &path,
+        &[(String::from("host"), String::from("updated description"))],
+    )
+    .await
+    .unwrap();
+
+    let result = read_config(&path).await;
+    assert!(
+        !result.contains("old comment"),
+        "old comment must be gone; result:\n{result}"
+    );
+    assert!(
+        result.contains("# updated description"),
+        "new comment must appear; result:\n{result}"
+    );
+    let parsed: toml::Value = result.trim().parse().expect("resulting TOML must parse");
+    assert_eq!(
+        parsed.get("host").and_then(toml::Value::as_str),
+        Some("localhost")
+    );
+    drop(dir);
+}
+
+#[tokio::test]
+async fn apply_comments_multiple_annotations_in_one_call() {
+    let (dir, path) = write_temp_config("host = \"localhost\"\nport = 8080\n").await;
+
+    apply_comments(
+        &path,
+        &[
+            (String::from("host"), String::from("server address")),
+            (String::from("port"), String::from("listen port")),
+        ],
+    )
+    .await
+    .unwrap();
+
+    let result = read_config(&path).await;
+    let lines: Vec<&str> = result.lines().collect();
+
+    let host_idx = lines
+        .iter()
+        .position(|l| l.starts_with("host ="))
+        .expect("host key present");
+    assert!(
+        host_idx > 0 && lines[host_idx - 1].contains("# server address"),
+        "comment above host key must be `# server address`; got {:?}",
+        lines[host_idx - 1]
+    );
+
+    let port_idx = lines
+        .iter()
+        .position(|l| l.starts_with("port ="))
+        .expect("port key present");
+    assert!(
+        port_idx > 0 && lines[port_idx - 1].contains("# listen port"),
+        "comment above port key must be `# listen port`; got {:?}",
+        lines[port_idx - 1]
+    );
+
+    let parsed: toml::Value = result.trim().parse().expect("resulting TOML must parse");
+    assert_eq!(
+        parsed.get("host").and_then(toml::Value::as_str),
+        Some("localhost")
+    );
+    assert_eq!(
+        parsed.get("port").and_then(toml::Value::as_integer),
+        Some(8080)
+    );
+    drop(dir);
+}
+
+#[tokio::test]
+async fn apply_comments_deep_dotted_traversal() {
+    // Use standard (non-dotted) table headers so that both toml_edit and
+    // toml::Value can parse the round-tripped output.
+    let (dir, path) = write_temp_config(
+        "[providers]\n\n\
+         [providers.models]\n\n\
+         [providers.models.anthropic]\n\n\
+         [providers.models.anthropic.default]\n\
+         api_key = \"sk-test\"\n\
+         model = \"claude-sonnet-4\"\n",
+    )
+    .await;
+
+    apply_comments(
+        &path,
+        &[(
+            String::from("providers.models.anthropic.default.api_key"),
+            String::from("Anthropic API key"),
+        )],
+    )
+    .await
+    .unwrap();
+
+    let result = read_config(&path).await;
+    let lines: Vec<&str> = result.lines().collect();
+
+    let api_key_idx = lines
+        .iter()
+        .position(|l| l.starts_with("api_key ="))
+        .expect("api_key key must be present");
+    assert!(
+        api_key_idx > 0 && lines[api_key_idx - 1].contains("# Anthropic API key"),
+        "comment must appear above `api_key = ...`; line above: {:?}",
+        lines[api_key_idx - 1]
+    );
+
+    let parsed: toml::Value = result.trim().parse().expect("resulting TOML must parse");
+    let api_key_val = parsed
+        .get("providers")
+        .and_then(toml::Value::as_table)
+        .and_then(|t| t.get("models"))
+        .and_then(toml::Value::as_table)
+        .and_then(|t| t.get("anthropic"))
+        .and_then(toml::Value::as_table)
+        .and_then(|t| t.get("default"))
+        .and_then(toml::Value::as_table)
+        .and_then(|t| t.get("api_key"))
+        .and_then(toml::Value::as_str);
+    assert_eq!(api_key_val, Some("sk-test"));
+    drop(dir);
+}
+
+#[tokio::test]
+async fn apply_comments_bad_intermediate_path_is_noop() {
+    // `host` is a string value, not a table. The dotted path `host.port`
+    // tries to traverse through a non-table intermediate, which should be
+    // silently skipped.
+    let (dir, path) = write_temp_config("host = \"localhost\"\nport = 8080\n").await;
+
+    apply_comments(
+        &path,
+        &[(String::from("host.port"), String::from("should not appear"))],
+    )
+    .await
+    .unwrap();
+
+    let result = read_config(&path).await;
+    assert!(
+        !result.contains("should not appear"),
+        "comment must not appear for a bad intermediate path; result:\n{result}"
+    );
+    let parsed: toml::Value = result.trim().parse().expect("resulting TOML must parse");
+    assert_eq!(
+        parsed.get("host").and_then(toml::Value::as_str),
+        Some("localhost")
+    );
+    assert_eq!(
+        parsed.get("port").and_then(toml::Value::as_integer),
+        Some(8080)
+    );
+    drop(dir);
+}
+
+#[tokio::test]
+async fn apply_comments_nonexistent_key_is_noop() {
+    let (dir, path) = write_temp_config("host = \"localhost\"\nport = 8080\n").await;
+
+    apply_comments(
+        &path,
+        &[(
+            String::from("does_not_exist"),
+            String::from("ghost comment"),
+        )],
+    )
+    .await
+    .unwrap();
+
+    let result = read_config(&path).await;
+    assert!(
+        !result.contains("ghost comment"),
+        "comment must not appear for a nonexistent key; result:\n{result}"
+    );
+    let parsed: toml::Value = result.trim().parse().expect("resulting TOML must parse");
+    assert_eq!(
+        parsed.get("host").and_then(toml::Value::as_str),
+        Some("localhost")
+    );
+    assert_eq!(
+        parsed.get("port").and_then(toml::Value::as_integer),
+        Some(8080)
+    );
+    drop(dir);
+}
+
+#[tokio::test]
+async fn apply_comments_unparseable_file_is_noop() {
+    let (dir, path) = write_temp_config("this is {{{ not valid TOML").await;
+    let original = read_config(&path).await;
+
+    let outcome =
+        apply_comments(&path, &[(String::from("host"), String::from("irrelevant"))]).await;
+
+    assert!(
+        outcome.is_ok(),
+        "apply_comments must return Ok(()) for an unparseable file"
+    );
+
+    let result = read_config(&path).await;
+    assert_eq!(
+        result, original,
+        "unparseable file content must remain exactly as-is"
+    );
+    drop(dir);
+}
+
+#[tokio::test]
+async fn apply_comments_preserves_unrelated_content() {
+    let (dir, path) = write_temp_config(
+        "# existing comment on host\n\
+         host = \"localhost\"\n\
+         port = 8080\n\n\
+         [database]\n\
+         # existing comment on url\n\
+         url = \"postgres://localhost/db\"\n\
+         max_connections = 10\n",
+    )
+    .await;
+
+    apply_comments(
+        &path,
+        &[(
+            String::from("database.url"),
+            String::from("database connection string"),
+        )],
+    )
+    .await
+    .unwrap();
+
+    let result = read_config(&path).await;
+
+    assert!(
+        !result.contains("existing comment on url"),
+        "old comment on database.url must be gone"
+    );
+    assert!(
+        result.contains("# database connection string"),
+        "new comment on database.url must appear"
+    );
+    assert!(
+        result.contains("# existing comment on host"),
+        "unrelated comment on host must be preserved"
+    );
+    assert!(
+        result.contains("\n\n[database]"),
+        "blank line before [database] must be preserved"
+    );
+
+    let parsed: toml::Value = result.trim().parse().expect("resulting TOML must parse");
+    assert_eq!(
+        parsed.get("host").and_then(toml::Value::as_str),
+        Some("localhost")
+    );
+    assert_eq!(
+        parsed.get("port").and_then(toml::Value::as_integer),
+        Some(8080)
+    );
+    assert_eq!(
+        parsed
+            .get("database")
+            .and_then(toml::Value::as_table)
+            .and_then(|t| t.get("url"))
+            .and_then(toml::Value::as_str),
+        Some("postgres://localhost/db")
+    );
+    assert_eq!(
+        parsed
+            .get("database")
+            .and_then(toml::Value::as_table)
+            .and_then(|t| t.get("max_connections"))
+            .and_then(toml::Value::as_integer),
+        Some(10)
+    );
+    drop(dir);
+}


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Adds 8 end-to-end tests for `apply_comments()` in `crates/zeroclaw-config/tests/comment_writer.rs` using a temp-file pattern.
  - Covers: comment insertion, comment update, multiple annotations, deep dotted traversal, bad intermediate path no-op, nonexistent key no-op, unparseable file no-op, and preservation of unrelated config content.
  - Fills the coverage gap identified in tracker #7685 where config comment-writer had only helper-level tests, lacking end-to-end temp-file coverage for file mutation behavior.
- **Scope boundary:** Only adds tests. No production code or Cargo.toml changes (dev-dependencies `tempfile` and `tokio::rt-multi-thread,macros` already present).
- **Blast radius:** Test-only change; no runtime, gateway, or config behavior impact.
- **Linked issue(s):** Closes #7691
- **Labels:** `config`, `tests`, `risk: medium`, `size: S`

## Validation Evidence

```bash
cargo test -p zeroclaw-config --test comment_writer
```

- **Commands run:** Test compile checked locally; full test run depends on CI.
- **Beyond CI — what did you manually verify?** Reviewed that each test exercises a distinct behavior path documented in the issue. Verified that `apply_comments` API signatures and no-op behaviors match the production code.
- **If any command was intentionally skipped, why:** No system linker locally; CI will run the full battery.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No** (test fixtures use placeholder values like `sk-test`, `postgres://localhost/db`)

## Compatibility

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**

## Rollback

Risk is medium (pins existing behavior in tests). Rollback: `git revert <sha>`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeroclaw-labs/codesmith/zeroclaw/pr/7766"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784189894&installation_id=140579446&pr_number=7766&repository=zeroclaw-labs%2Fzeroclaw&return_to=https%3A%2F%2Fgithub.com%2Fzeroclaw-labs%2Fzeroclaw%2Fpull%2F7766&signature=b971a0a53a3fe6bd1b109b1422c3735292a472178f66bdeb8fc7b1cbaf9a658e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->