### PR TITLE
fix(runtime): route native tool narration to stderr

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -3057,6 +3057,90 @@ mod tests {
         }
     }
 
+    #[test]
+    fn direct_agent_turn_does_not_write_intermediate_native_text_to_stdout() {
+        let current_exe = std::env::current_exe().expect("current test binary path");
+        let output = std::process::Command::new(current_exe)
+            .args([
+                "direct_agent_turn_stdout_boundary_helper_4721",
+                "--ignored",
+                "--nocapture",
+            ])
+            .output()
+            .expect("helper test process should run");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        assert!(
+            output.status.success(),
+            "helper failed with status {:?}\nstdout:\n{}\nstderr:\n{}",
+            output.status.code(),
+            stdout,
+            stderr
+        );
+        assert!(
+            !stdout.contains("intermediate native narration"),
+            "intermediate native narration leaked to stdout:\n{stdout}"
+        );
+        assert!(
+            stderr.contains("intermediate native narration"),
+            "intermediate native narration was not routed to stderr:\n{stderr}"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "subprocess helper for stdout/stderr boundary regression"]
+    async fn direct_agent_turn_stdout_boundary_helper_4721() {
+        let memory_cfg = zeroclaw_config::schema::MemoryConfig {
+            backend: "none".into(),
+            ..zeroclaw_config::schema::MemoryConfig::default()
+        };
+        let mem: Arc<dyn Memory> = Arc::from(
+            zeroclaw_memory::create_memory(&memory_cfg, std::path::Path::new("/tmp"), None)
+                .expect("memory creation should succeed with valid config"),
+        );
+
+        let model_provider = Box::new(MockModelProvider {
+            responses: Mutex::new(vec![
+                zeroclaw_providers::ChatResponse {
+                    text: Some("intermediate native narration".into()),
+                    tool_calls: vec![zeroclaw_providers::ToolCall {
+                        id: "tc1".into(),
+                        name: "echo".into(),
+                        arguments: "{}".into(),
+                        extra_content: None,
+                    }],
+                    usage: None,
+                    reasoning_content: None,
+                },
+                zeroclaw_providers::ChatResponse {
+                    text: Some("final answer".into()),
+                    tool_calls: vec![],
+                    usage: None,
+                    reasoning_content: None,
+                },
+            ]),
+        });
+
+        let observer: Arc<dyn Observer> = Arc::from(crate::observability::NoopObserver {});
+        let mut agent = Agent::builder()
+            .model_provider(model_provider)
+            .tools(vec![Box::new(MockTool)])
+            .memory(mem)
+            .observer(observer)
+            .tool_dispatcher(Box::new(NativeToolDispatcher))
+            .workspace_dir(std::path::PathBuf::from("/tmp"))
+            .build()
+            .expect("agent builder should succeed with valid config");
+
+        let answer = agent
+            .turn("run the tool")
+            .await
+            .expect("turn should finish");
+        assert_eq!(answer, "final answer");
+    }
+
     struct FailingModelProvider;
 
     #[async_trait]

--- a/crates/zeroclaw-runtime/src/agent/turn/mod.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/mod.rs
@@ -597,8 +597,8 @@ pub async fn run_tool_call_loop(
                 let _ = tx.send(StreamDelta::Text(narration)).await;
             }
             if !silent {
-                print!("{display_text}");
-                let _ = std::io::stdout().flush();
+                eprint!("{display_text}");
+                let _ = std::io::stderr().flush();
             }
         }
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Moved non-silent native-tool intermediate narration emitted during `Agent::turn` from stdout to stderr. Added a subprocess-boundary regression that proves native-tool intermediate narration is absent from process stdout and present on stderr. Preserved deliberate stdout surfaces for final command output, interactive final answers, and stdout protocol streams.
- **Scope boundary:** This PR does not reroute user-facing command output, ACP stdout protocol traffic, interactive prompts/final responses, doctor/service/status output, or the broader CLI stdout audit.
- **Blast radius:** Runtime native-tool turn narration only. Stdout consumers should stop seeing this intermediate text, while stderr still receives it for operator visibility. The PR is labeled `risk: high` because it touches runtime process-output routing.
- **Related issues/PRs:** Related #4721, #4727, #5958, #6944.
- **Labels:** `bug`, `risk: high`, `size: S`, `runtime`, `runtime:core`, `agent`

## Validation Evidence (required)

- **Commands run and tail output:** Local validation:

```text
cargo fmt --all -- --check
result: passed

cargo test -p zeroclaw-runtime direct_agent_
result: passed
summary: 2 passed; 0 failed; 1 ignored helper

cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
result: passed
tail: Finished `dev` profile ... in 19m35s

cargo nextest run --locked --workspace --exclude zeroclaw-desktop
result: passed
summary: 8720 tests run: 8720 passed, 11 skipped

git diff --check
result: passed
```

- **Beyond CI — what did you manually verify?** The regression runs the current test binary as a subprocess and checks the process boundary: intermediate native-tool narration is not in stdout and is present in stderr. Source review kept final command output, interactive final answers, and stdout protocol streams unchanged.
- **If any command was intentionally skipped, why:** None.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- If `No` or `Yes` to either: No upgrade steps. The change only moves native-tool intermediate narration from stdout to stderr.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <merge-commit>`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Missing native-tool intermediate narration in stderr, intermediate native-tool text reappearing in stdout, or downstream stdout parsers receiving narration before final output.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A
