### PR TITLE
fix(runtime): keep pruned tool markers out of live context

### DIFF
--- a/crates/zeroclaw-api/src/model_provider.rs
+++ b/crates/zeroclaw-api/src/model_provider.rs
@@ -24,6 +24,10 @@ pub struct ChatMessage {
     pub content: String,
 }
 
+pub const PRUNED_TOOL_EXCHANGE_SUMMARY_PREFIX: &str = "[Tool exchange:";
+pub const PRUNED_TOOL_EXCHANGE_SUMMARY_SUFFIX: &str = "results collapsed]";
+pub const PRUNED_CONTEXT_SEPARATOR: &str = "[context continues]";
+
 impl ChatMessage {
     pub fn system(content: impl Into<String>) -> Self {
         Self {
@@ -51,6 +55,28 @@ impl ChatMessage {
             role: "tool".into(),
             content: content.into(),
         }
+    }
+
+    pub fn pruned_tool_exchange_summary(tool_count: usize) -> String {
+        format!(
+            "{PRUNED_TOOL_EXCHANGE_SUMMARY_PREFIX} {tool_count} tool call(s) — {PRUNED_TOOL_EXCHANGE_SUMMARY_SUFFIX}"
+        )
+    }
+
+    pub fn pruned_context_separator() -> Self {
+        Self::user(PRUNED_CONTEXT_SEPARATOR)
+    }
+
+    pub fn is_pruned_tool_exchange_summary(&self) -> bool {
+        self.role == "assistant"
+            && self
+                .content
+                .starts_with(PRUNED_TOOL_EXCHANGE_SUMMARY_PREFIX)
+            && self.content.contains(PRUNED_TOOL_EXCHANGE_SUMMARY_SUFFIX)
+    }
+
+    pub fn is_pruned_context_separator(&self) -> bool {
+        self.role == "user" && self.content.trim() == PRUNED_CONTEXT_SEPARATOR
     }
 }
 

--- a/crates/zeroclaw-providers/src/anthropic.rs
+++ b/crates/zeroclaw-providers/src/anthropic.rs
@@ -1,3 +1,5 @@
+#[cfg(test)]
+use crate::traits::PRUNED_CONTEXT_SEPARATOR;
 use crate::traits::{
     ChatMessage, ChatRequest as ProviderChatRequest, ChatResponse as ProviderChatResponse,
     ModelProvider, ProviderCapabilities, StreamChunk, StreamError, StreamEvent, StreamOptions,
@@ -456,11 +458,28 @@ impl AnthropicModelProvider {
         })
     }
 
+    fn should_skip_internal_pruning_marker(messages: &[ChatMessage], index: usize) -> bool {
+        let Some(msg) = messages.get(index) else {
+            return false;
+        };
+        if msg.is_pruned_tool_exchange_summary() {
+            return true;
+        }
+        msg.is_pruned_context_separator()
+            && index
+                .checked_sub(1)
+                .and_then(|previous| messages.get(previous))
+                .is_some_and(ChatMessage::is_pruned_tool_exchange_summary)
+    }
+
     fn convert_messages(messages: &[ChatMessage]) -> (Option<SystemPrompt>, Vec<NativeMessage>) {
         let mut system_text = None;
         let mut native_messages = Vec::new();
 
-        for msg in messages {
+        for (index, msg) in messages.iter().enumerate() {
+            if Self::should_skip_internal_pruning_marker(messages, index) {
+                continue;
+            }
             match msg.role.as_str() {
                 "system" => {
                     if system_text.is_none() {
@@ -3220,5 +3239,156 @@ data: {\"type\":\"message_stop\"}\n\n";
                 window[0].role
             );
         }
+    }
+
+    #[test]
+    fn convert_messages_does_not_surface_context_separator_as_user_instruction() {
+        let messages = vec![
+            ChatMessage {
+                role: "system".to_string(),
+                content: "You are helpful.".to_string(),
+            },
+            ChatMessage {
+                role: "assistant".to_string(),
+                content: ChatMessage::pruned_tool_exchange_summary(1),
+            },
+            ChatMessage::pruned_context_separator(),
+            ChatMessage {
+                role: "assistant".to_string(),
+                content: serde_json::json!({
+                    "content": "",
+                    "tool_calls": [
+                        {"id": "live_1", "name": "file_read", "arguments": "{}"}
+                    ]
+                })
+                .to_string(),
+            },
+            ChatMessage {
+                role: "tool".to_string(),
+                content: serde_json::json!({
+                    "tool_call_id": "live_1",
+                    "content": "recent file content"
+                })
+                .to_string(),
+            },
+            ChatMessage {
+                role: "user".to_string(),
+                content: "Continue from the current state.".to_string(),
+            },
+        ];
+
+        let (_system, native_msgs) = AnthropicModelProvider::convert_messages(&messages);
+        let roles = native_msgs
+            .iter()
+            .map(|message| message.role.as_str())
+            .collect::<Vec<_>>();
+        let flattened_text = native_msgs
+            .iter()
+            .flat_map(|message| message.content.iter())
+            .filter_map(|block| match block {
+                NativeContentOut::Text { text, .. } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+
+        assert!(
+            roles.windows(2).all(|pair| pair[0] != pair[1]),
+            "converted request should preserve Anthropic role alternation: {roles:?}"
+        );
+        assert!(
+            !flattened_text.contains(&PRUNED_CONTEXT_SEPARATOR),
+            "synthetic role separator should not be delivered to Anthropic as user text: \
+             {flattened_text:?}"
+        );
+        assert!(
+            native_msgs.iter().any(|message| {
+                message.content.iter().any(
+                    |block| matches!(block, NativeContentOut::ToolUse { id, .. } if id == "live_1"),
+                )
+            }),
+            "live tool_use must survive pruning-marker filtering"
+        );
+        assert!(
+            native_msgs.iter().any(|message| {
+                message.content.iter().any(|block| {
+                    matches!(
+                        block,
+                        NativeContentOut::ToolResult {
+                            tool_use_id,
+                            content,
+                            ..
+                        } if tool_use_id == "live_1" && content == "recent file content"
+                    )
+                })
+            }),
+            "matching live tool_result must survive pruning-marker filtering"
+        );
+    }
+
+    #[test]
+    fn convert_messages_keeps_real_context_separator_between_assistants() {
+        let messages = vec![
+            ChatMessage {
+                role: "system".to_string(),
+                content: "You are helpful.".to_string(),
+            },
+            ChatMessage {
+                role: "assistant".to_string(),
+                content: "protected assistant one".to_string(),
+            },
+            ChatMessage::pruned_context_separator(),
+            ChatMessage {
+                role: "assistant".to_string(),
+                content: serde_json::json!({
+                    "content": "",
+                    "tool_calls": [
+                        {"id": "live_2", "name": "file_read", "arguments": "{}"}
+                    ]
+                })
+                .to_string(),
+            },
+            ChatMessage {
+                role: "tool".to_string(),
+                content: serde_json::json!({
+                    "tool_call_id": "live_2",
+                    "content": "recent file content"
+                })
+                .to_string(),
+            },
+            ChatMessage {
+                role: "user".to_string(),
+                content: "Continue from the current state.".to_string(),
+            },
+        ];
+
+        let (_system, native_msgs) = AnthropicModelProvider::convert_messages(&messages);
+        let roles = native_msgs
+            .iter()
+            .map(|message| message.role.as_str())
+            .collect::<Vec<_>>();
+
+        assert!(
+            roles.windows(2).all(|pair| pair[0] != pair[1]),
+            "context separator should keep Anthropic roles alternating: {roles:?}"
+        );
+        assert!(
+            native_msgs.iter().any(|message| {
+                message.content.iter().any(
+                    |block| matches!(block, NativeContentOut::ToolUse { id, .. } if id == "live_2"),
+                )
+            }),
+            "live tool_use must survive real context separator conversion"
+        );
+        assert!(
+            native_msgs.iter().any(|message| {
+                message.content.iter().any(|block| {
+                    matches!(
+                        block,
+                        NativeContentOut::ToolResult { tool_use_id, .. } if tool_use_id == "live_2"
+                    )
+                })
+            }),
+            "matching live tool_result must survive real context separator conversion"
+        );
     }
 }

--- a/crates/zeroclaw-runtime/src/agent/history_pruner.rs
+++ b/crates/zeroclaw-runtime/src/agent/history_pruner.rs
@@ -1,4 +1,6 @@
 use zeroclaw_api::model_provider::ChatMessage;
+#[cfg(test)]
+use zeroclaw_api::model_provider::{PRUNED_CONTEXT_SEPARATOR, PRUNED_TOOL_EXCHANGE_SUMMARY_PREFIX};
 
 pub use zeroclaw_config::scattered_types::HistoryPrunerConfig;
 
@@ -65,9 +67,7 @@ pub struct PrunedOrphans {
     pub orphan_tool_call_ids: Vec<String>,
 }
 
-fn is_tool_exchange_summary(content: &str) -> bool {
-    content.starts_with("[Tool exchange:") && content.contains("results collapsed]")
-}
+const MAX_SYNTHETIC_TOOL_SUMMARIES: usize = 3;
 
 fn assistant_tool_calls_have_immediate_results(
     messages: &[ChatMessage],
@@ -151,7 +151,7 @@ pub fn remove_orphaned_tool_messages(messages: &mut Vec<ChatMessage>) -> PrunedO
         if let Some(doomed_ids) = assistant_tool_call_ids
             && i > 0
             && messages[i - 1].role == "assistant"
-            && ((is_tool_exchange_summary(&messages[i - 1].content)
+            && ((messages[i - 1].is_pruned_tool_exchange_summary()
                 && !assistant_tool_calls_have_immediate_results(messages, i, &doomed_ids))
                 || assistant_is_unresolved_dispatch(messages, i - 1, i))
         {
@@ -292,11 +292,9 @@ pub fn prune_history(messages: &mut Vec<ChatMessage>, config: &HistoryPrunerConf
                     tool_count += 1;
                 }
                 if tool_count > 0 && !any_tool_protected {
-                    let summary =
-                        format!("[Tool exchange: {tool_count} tool call(s) — results collapsed]");
                     messages[i] = ChatMessage {
                         role: "assistant".to_string(),
-                        content: summary,
+                        content: ChatMessage::pruned_tool_exchange_summary(tool_count),
                     };
                     for _ in 0..tool_count {
                         messages.remove(i + 1);
@@ -366,15 +364,39 @@ pub fn prune_history(messages: &mut Vec<ChatMessage>, config: &HistoryPrunerConf
         }
     }
 
-    // Phase 3 – merge consecutive synthetic tool-exchange summaries. GLM/Z.AI
+    // Phase 3 – keep synthetic summaries from dominating long tool-heavy
+    // histories. A wall of assistant-authored "Tool exchange collapsed" text
+    // can make the next provider request look like the assistant already
+    // completed the task, even though these are only pruning placeholders.
+    // Cap before merging so one merged summary cannot hide dozens of old
+    // collapsed exchanges inside a single provider-visible message.
+    let mut summaries_to_drop = messages
+        .iter()
+        .filter(|message| message.is_pruned_tool_exchange_summary())
+        .count()
+        .saturating_sub(MAX_SYNTHETIC_TOOL_SUMMARIES);
+    if summaries_to_drop > 0 {
+        let before = messages.len();
+        messages.retain(|message| {
+            if summaries_to_drop > 0 && message.is_pruned_tool_exchange_summary() {
+                summaries_to_drop -= 1;
+                false
+            } else {
+                true
+            }
+        });
+        dropped_messages += before - messages.len();
+    }
+
+    // Phase 4 – merge consecutive synthetic tool-exchange summaries. GLM/Z.AI
     // reject adjacent assistant messages, but these summaries are safe to
     // combine because they are both pruner-generated placeholders.
     let mut i = 0;
     while i + 1 < messages.len() {
         if messages[i].role == "assistant"
             && messages[i + 1].role == "assistant"
-            && is_tool_exchange_summary(&messages[i].content)
-            && is_tool_exchange_summary(&messages[i + 1].content)
+            && messages[i].is_pruned_tool_exchange_summary()
+            && messages[i + 1].is_pruned_tool_exchange_summary()
         {
             let next = messages.remove(i + 1);
             messages[i].content = format!("{}\n\n{}", messages[i].content, next.content);
@@ -384,22 +406,29 @@ pub fn prune_history(messages: &mut Vec<ChatMessage>, config: &HistoryPrunerConf
         }
     }
 
-    // Phase 4 – remove orphaned tool messages left behind by phases 1-3.
+    // Phase 5 – remove orphaned tool messages left behind by phases 1-4.
     dropped_messages += remove_orphaned_tool_messages(messages).removed;
 
-    // Phase 5 – separate any remaining adjacent assistant messages. These can
+    // Phase 6 – separate any remaining adjacent assistant messages. These can
     // happen when a protected assistant(tool_calls) group follows a collapsed
-    // summary. Insert a tiny user boundary rather than dropping protected data.
+    // summary. Prefer dropping the synthetic placeholder over inventing a user
+    // turn; the live assistant/tool-call message carries real conversation
+    // state, while the summary is only a lossy pruning artifact.
     let mut i = 1;
     while i < messages.len() {
         if messages[i - 1].role == "assistant" && messages[i].role == "assistant" {
-            messages.insert(
-                i,
-                ChatMessage {
-                    role: "user".to_string(),
-                    content: "[context continues]".to_string(),
-                },
-            );
+            if messages[i - 1].is_pruned_tool_exchange_summary() {
+                messages.remove(i - 1);
+                dropped_messages += 1;
+                i = i.saturating_sub(1).max(1);
+                continue;
+            }
+            if messages[i].is_pruned_tool_exchange_summary() {
+                messages.remove(i);
+                dropped_messages += 1;
+                continue;
+            }
+            messages.insert(i, ChatMessage::pruned_context_separator());
             i += 2;
         } else {
             i += 1;
@@ -792,8 +821,8 @@ mod tests {
         assert!(
             messages
                 .iter()
-                .any(|m| m.role == "user" && m.content == "[context continues]"),
-            "Phase 5 should separate collapsed summary from live assistant"
+                .all(|m| m.content != PRUNED_CONTEXT_SEPARATOR),
+            "pruning should not invent a user turn to separate a synthetic summary"
         );
         assert!(
             messages
@@ -900,7 +929,7 @@ mod tests {
             messages.iter().map(|m| m.role.as_str()).collect::<Vec<_>>(),
             vec!["system", "assistant", "user", "assistant"]
         );
-        assert_eq!(messages[2].content, "[context continues]");
+        assert_eq!(messages[2].content, PRUNED_CONTEXT_SEPARATOR);
     }
 
     // -----------------------------------------------------------------------
@@ -1221,6 +1250,104 @@ mod tests {
             "a tool message protected by keep_recent must survive; \
              got roles {:?}",
             messages.iter().map(|m| m.role.as_str()).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn prune_keeps_synthetic_tool_summaries_from_dominating_long_history() {
+        let mut messages = vec![
+            msg("system", "sys"),
+            msg(
+                "user",
+                "Build the A2A implementation and keep working until it is done.",
+            ),
+        ];
+
+        for i in 0..40 {
+            messages.push(msg(
+                "assistant",
+                &format!(
+                    r#"{{"content":null,"tool_calls":[{{"id":"old_{i}","name":"file_read","arguments":"{{}}"}}]}}"#
+                ),
+            ));
+            messages.push(msg(
+                "tool",
+                &format!(
+                    r#"{{"tool_call_id":"old_{i}","content":"{}"}}"#,
+                    "old tool output ".repeat(120)
+                ),
+            ));
+            messages.push(msg("user", &format!("Continue with slice {i}.")));
+        }
+
+        messages.push(msg(
+            "assistant",
+            r#"{"content":null,"tool_calls":[{"id":"live","name":"file_read","arguments":"{}"}]}"#,
+        ));
+        messages.push(msg(
+            "tool",
+            r#"{"tool_call_id":"live","content":"recent result"}"#,
+        ));
+        messages.push(msg("user", "Continue from the current state."));
+
+        let config = HistoryPrunerConfig {
+            enabled: true,
+            max_tokens: 2_000,
+            keep_recent: 4,
+            collapse_tool_results: true,
+        };
+
+        prune_history(&mut messages, &config);
+
+        let synthetic_summaries = messages
+            .iter()
+            .filter(|m| m.is_pruned_tool_exchange_summary())
+            .count();
+        assert!(
+            synthetic_summaries <= 3,
+            "provider-visible history should not be dominated by synthetic tool summaries; \
+             found {synthetic_summaries} in roles {:?}",
+            messages.iter().map(|m| m.role.as_str()).collect::<Vec<_>>()
+        );
+        assert!(
+            messages
+                .iter()
+                .any(|m| m.role == "user" && m.content == "Continue from the current state."),
+            "the current user intent must survive pruning"
+        );
+    }
+
+    #[test]
+    fn prune_bounds_summary_lines_before_merging_adjacent_summaries() {
+        let mut messages = vec![msg("system", "sys")];
+        for i in 0..12 {
+            messages.push(ChatMessage::assistant(
+                ChatMessage::pruned_tool_exchange_summary(i + 1),
+            ));
+        }
+        messages.push(msg("user", "Continue from the current state."));
+
+        let config = HistoryPrunerConfig {
+            enabled: true,
+            max_tokens: 100_000,
+            keep_recent: 1,
+            collapse_tool_results: true,
+        };
+
+        prune_history(&mut messages, &config);
+
+        let summary_lines = messages
+            .iter()
+            .map(|m| {
+                m.content
+                    .matches(PRUNED_TOOL_EXCHANGE_SUMMARY_PREFIX)
+                    .count()
+            })
+            .sum::<usize>();
+        assert!(
+            summary_lines <= MAX_SYNTHETIC_TOOL_SUMMARIES,
+            "merged summaries should remain bounded; found {summary_lines} summary lines in \
+             {messages:?}"
         );
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Added shared `ChatMessage` helpers for history-pruner marker construction and detection, so runtime and provider code use one sentinel contract.
  - Capped old synthetic tool-exchange summaries before adjacent summaries merge, so long tool-heavy histories cannot send a wall of collapsed-summary text back to the model.
  - Changed pruning cleanup to drop synthetic summaries before live assistant/tool-call groups instead of inserting a fake user separator.
  - Made Anthropic conversion hide only the synthetic summary + separator pair, while preserving real separators that still protect Anthropic role alternation.
- **Scope boundary:** This PR does not change the history-pruner token budget, `keep_recent` policy, provider retry behavior, tool execution, or non-Anthropic provider conversion.
- **Blast radius:** Runtime history pruning and Anthropic request conversion. Other providers still receive the bounded synthetic summaries, but the shared marker helpers reduce drift if they need matching behavior later.
- **Linked issue(s):** None.
- **Labels:** `bug`, `risk: high`, `size: M`, `agent`, `runtime`, `provider`, `provider:anthropic`

## Relationship to #7684

#7684 and this PR are complementary. #7684 is display and observability work: it renames the history-pruner marker, renders that marker as a visible `history-pruner` ACP event, and surfaces client-RPC cancels. This PR changes provider-bound history behavior: it bounds synthetic pruning summaries, drops synthetic summaries next to live assistant/tool-call state instead of inventing a fake user turn, and filters the internal marker pair out of Anthropic requests while preserving real role separators.

If the two PRs are stacked, `crates/zeroclaw-runtime/src/agent/history_pruner.rs` has a small manual conflict. The intended resolution is to keep #7684's newer marker wording/constant as the canonical marker and keep this PR's cap, drop, and provider-filter behavior.

## Validation Evidence (required)

- **Commands run and tail output:**

```text
cargo test -p zeroclaw-runtime history_pruner -- --nocapture
Result: PASS — 30 passed; 0 failed; 0 ignored; 2177 filtered out

cargo test -p zeroclaw-providers convert_messages_ -- --nocapture
Result: PASS — 36 passed; 0 failed; 0 ignored; 930 filtered out

cargo fmt --all -- --check
Result: PASS

git diff --check
Result: PASS

zc-cargo-broad --lane workspace-check --batch pr-7775-pruned-tool-markers --crates zeroclaw-api,zeroclaw-runtime,zeroclaw-providers --prs 7775 clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
Result: PASS — finished in 7m20s

zc-cargo-broad --lane nextest --batch pr-7775-pruned-tool-markers --crates zeroclaw-api,zeroclaw-runtime,zeroclaw-providers --prs 7775 nextest run --locked --workspace --exclude zeroclaw-desktop
Result: PASS — 8723 passed; 0 failed; 10 skipped
```

- **Beyond CI — what did you manually verify?** I traced the pruner phases after local review: old synthetic summaries are capped before merge, synthetic summaries adjacent to live assistant/tool-call groups are dropped, and Anthropic only filters a context separator when it directly follows a synthetic summary. The new tests cover the suspected long tool-history shape, the merged-summary wall case, Anthropic role alternation, and live `tool_use` / `tool_result` survival.
- **If any command was intentionally skipped, why:** None. Focused runtime/provider regressions, formatting, diff whitespace, workspace clippy, and CI-shaped nextest all passed locally.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: N/A

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <merge-commit>`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Watch for resumed long-running turns losing useful old tool context, Anthropic request-conversion errors about adjacent roles or missing tool results, or unexpected absence/excess of `[Tool exchange: ... results collapsed]` text in provider-visible history.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Scope materially carried forward: N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why (inspiration-only, no direct code/design carry-over): No superseded PR scope was incorporated.

