### PR TITLE
fix(discord): persist slash reconcile state + read shared stores from data_dir

### DIFF
--- a/crates/zeroclaw-channels/src/discord.rs
+++ b/crates/zeroclaw-channels/src/discord.rs
@@ -100,11 +100,6 @@ pub struct DiscordChannel {
     /// Resolves skill-derived commands to register alongside `/ask`.
     /// `None` (or an empty resolution) = `/ask` only.
     slash_command_resolver: Option<DiscordSlashCommandResolver>,
-    /// Fingerprint of the last *successfully* reconciled command set —
-    /// READYs with an unchanged set skip the REST round-trip; failures
-    /// reset it so the next READY retries instead of wedging. Arc'd
-    /// because reconciliation runs in a spawned task.
-    registered_commands_hash: Arc<Mutex<Option<u64>>>,
 }
 
 /// Credentials needed to answer a deferred interaction later: the followup
@@ -186,7 +181,6 @@ impl DiscordChannel {
             slash_commands: false,
             pending_interactions: Arc::new(Mutex::new(HashMap::new())),
             slash_command_resolver: None,
-            registered_commands_hash: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -1807,6 +1801,25 @@ fn command_projection(cmd: &serde_json::Value) -> serde_json::Value {
 /// Discord REST base; injectable in `reconcile_slash_commands` for tests.
 const DISCORD_API_BASE: &str = "https://discord.com/api/v10";
 
+/// Outcome of a slash-command reconcile pass.
+#[derive(Debug)]
+enum ReconcileOutcome {
+    /// The command set was reconciled (or was already current).
+    Reconciled,
+    /// Discord rate-limited the pass; the caller must persist this cooldown and
+    /// not retry until the given unix-seconds deadline.
+    RateLimited { until: i64 },
+}
+
+/// Turn a `429` response into a unix-seconds deadline before which no further
+/// reconcile should run, reading Discord's `retry_after` body / headers.
+async fn rate_limit_deadline(resp: reqwest::Response) -> i64 {
+    let now = crate::discord_slash_state::now_unix();
+    let headers = resp.headers().clone();
+    let body = resp.json::<serde_json::Value>().await.ok();
+    crate::discord_slash_state::retry_after_deadline(&headers, body.as_ref(), now)
+}
+
 /// Reconcile the application's global commands with the desired set:
 /// upsert each desired command (POST upserts by name) and delete stale
 /// skill-shaped commands left over from uninstalled skills. Commands
@@ -1826,7 +1839,7 @@ async fn reconcile_slash_commands(
     app_id: &str,
     desired: &serde_json::Value,
     api_base: &str,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<ReconcileOutcome> {
     let base = format!("{api_base}/applications/{app_id}/commands");
     let auth = format!("Bot {bot_token}");
     let Some(desired) = desired.as_array() else {
@@ -1848,6 +1861,11 @@ async fn reconcile_slash_commands(
         .send()
         .await
         .map_err(reqwest::Error::without_url)?;
+    if resp.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {
+        return Ok(ReconcileOutcome::RateLimited {
+            until: rate_limit_deadline(resp).await,
+        });
+    }
     if !resp.status().is_success() {
         anyhow::bail!("listing global commands failed ({})", resp.status());
     }
@@ -1912,6 +1930,19 @@ async fn reconcile_slash_commands(
             .send()
             .await
             .map_err(reqwest::Error::without_url)?;
+        if resp.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            // Stop on the first 429 and surface the cooldown rather than
+            // hammering the remaining upserts into the same rate limit.
+            let until = rate_limit_deadline(resp).await;
+            ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                    .with_attrs(::serde_json::json!({"command": name, "retry_after_until": until})),
+                "discord slash command reconcile rate-limited; backing off"
+            );
+            return Ok(ReconcileOutcome::RateLimited { until });
+        }
         if !resp.status().is_success() {
             let status = resp.status();
             let err = resp.text().await.unwrap_or_default();
@@ -1933,7 +1964,7 @@ async fn reconcile_slash_commands(
              reconcile not recorded, next READY retries"
         );
     }
-    Ok(())
+    Ok(ReconcileOutcome::Reconciled)
 }
 
 /// Acknowledge an interaction within Discord's 3-second window with a
@@ -2991,7 +3022,7 @@ impl Channel for DiscordChannel {
                                     let client = self.http_client();
                                     let bot_token = self.bot_token.clone();
                                     let resolver = self.slash_command_resolver.clone();
-                                    let hash_store = Arc::clone(&self.registered_commands_hash);
+                                    let workspace_dir = self.workspace_dir.clone();
                                     zeroclaw_spawn::spawn!(async move {
                                         let specs = match resolver {
                                             Some(resolve) => {
@@ -3017,21 +3048,38 @@ impl Channel for DiscordChannel {
                                             body.to_string().hash(&mut h);
                                             h.finish()
                                         };
-                                        // Skip only when the set matches the
-                                        // last *successful* reconcile —
-                                        // failures reset the fingerprint so
-                                        // the next READY retries.
-                                        if *hash_store.lock() == Some(fingerprint) {
+                                        use crate::discord_slash_state::SlashReconcileState;
+                                        let now = crate::discord_slash_state::now_unix();
+                                        let state =
+                                            SlashReconcileState::load(workspace_dir.as_deref(), &app_id);
+                                        // Honour a persisted rate-limit cooldown across restarts: a
+                                        // 429'd reconcile must not re-hammer Discord on the next READY.
+                                        if state.rate_limited(now) {
+                                            ::zeroclaw_log::record!(INFO, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(::serde_json::json!({"retry_after_until": state.retry_after_until})), "discord slash command reconcile in rate-limit cooldown; skipping");
+                                            return;
+                                        }
+                                        // Skip only when the set matches the last *successful*
+                                        // reconcile. The fingerprint is persisted, so an unchanged
+                                        // set is skipped after a restart too (no daily-budget churn).
+                                        if state.fingerprint == Some(fingerprint) {
                                             ::zeroclaw_log::record!(INFO, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(::serde_json::json!({"commands": specs.len() + 1})), "discord slash command set unchanged; skipping re-registration");
                                             return;
                                         }
                                         match reconcile_slash_commands(&client, &bot_token, &app_id, &body, DISCORD_API_BASE).await {
-                                            Ok(()) => {
-                                                *hash_store.lock() = Some(fingerprint);
+                                            Ok(ReconcileOutcome::Reconciled) => {
+                                                SlashReconcileState::record_success(workspace_dir.as_deref(), &app_id, fingerprint, now);
                                                 ::zeroclaw_log::record!(INFO, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(::serde_json::json!({"commands": specs.len() + 1})), "discord slash commands registered");
                                             }
+                                            Ok(ReconcileOutcome::RateLimited { until }) => {
+                                                // Persist the cooldown (keeping the prior fingerprint)
+                                                // so the next READY/restart waits it out.
+                                                SlashReconcileState::record_retry_after(workspace_dir.as_deref(), &app_id, &state, until);
+                                                ::zeroclaw_log::record!(WARN, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_outcome(::zeroclaw_log::EventOutcome::Unknown).with_attrs(::serde_json::json!({"retry_after_until": until})), "discord slash command reconcile rate-limited; cooldown persisted");
+                                            }
                                             Err(e) => {
-                                                *hash_store.lock() = None;
+                                                // Hard failure: leave persisted state untouched. The
+                                                // new fingerprint differs from the stored one, so the
+                                                // next READY retries without a forced reset.
                                                 ::zeroclaw_log::record!(WARN, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_outcome(::zeroclaw_log::EventOutcome::Unknown).with_attrs(::serde_json::json!({"error": e.to_string()})), "discord slash command registration failed");
                                             }
                                         }
@@ -4532,6 +4580,39 @@ mod tests {
         reconcile_slash_commands(&client, "tok", "app1", &desired, &server.uri())
             .await
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn reconcile_returns_rate_limited_on_post_429() {
+        // A 429 on an upsert must surface as RateLimited (with the body's
+        // retry_after deadline) so the caller persists a cooldown instead of
+        // re-hammering the daily command budget on the next READY.
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/applications/app1/commands"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/applications/app1/commands"))
+            .respond_with(
+                ResponseTemplate::new(429).set_body_json(serde_json::json!({"retry_after": 5.0})),
+            )
+            .mount(&server)
+            .await;
+
+        let client = reqwest::Client::new();
+        let desired = slash_command_registration_body(&[]); // /ask → one POST
+        let now = crate::discord_slash_state::now_unix();
+        let outcome = reconcile_slash_commands(&client, "tok", "app1", &desired, &server.uri())
+            .await
+            .unwrap();
+        match outcome {
+            ReconcileOutcome::RateLimited { until } => assert!(until >= now + 5),
+            ReconcileOutcome::Reconciled => panic!("expected RateLimited on a POST 429"),
+        }
     }
 
     #[test]

--- a/crates/zeroclaw-channels/src/discord_slash_state.rs
+++ b/crates/zeroclaw-channels/src/discord_slash_state.rs
@@ -1,0 +1,266 @@
+//! Persisted Discord slash-command reconcile state.
+//!
+//! The Discord channel reconciles its application's global slash commands with
+//! the desired (skill-derived) set on every gateway `READY`. Discord's daily
+//! command-create budget is finite, so re-running a full GET + per-command diff
+//! on every process start — and re-hammering after a rate-limit — risks the
+//! daily reconcile-429 burst.
+//!
+//! This module persists, per application id, the fingerprint of the last
+//! *successful* reconcile and any active `Retry-After` cooldown, so that a
+//! restart skips an unchanged set and honours a server-imposed back-off instead
+//! of immediately retrying. State lives at `<workspace_dir>/state/slash-commands.json`
+//! (the same `state/` convention the model cache uses); when no workspace dir is
+//! configured, persistence degrades to a no-op and the channel behaves as it did
+//! before — a full reconcile each start.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+const STATE_FILE: &str = "slash-commands.json";
+
+/// Persisted reconcile state for one Discord application.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct SlashReconcileState {
+    /// Application id this state belongs to. State recorded for a different
+    /// application (e.g. a swapped bot token) is ignored on load, degrading to
+    /// a full reconcile rather than trusting a stale fingerprint.
+    pub app_id: Option<String>,
+    /// Fingerprint of the last successfully reconciled command set.
+    pub fingerprint: Option<u64>,
+    /// Unix seconds of the last successful reconcile (diagnostic).
+    pub last_success_at: Option<i64>,
+    /// Unix-seconds deadline before which no reconcile should be attempted,
+    /// recorded from a `429` `Retry-After`. `None` once a reconcile succeeds.
+    pub retry_after_until: Option<i64>,
+}
+
+impl SlashReconcileState {
+    fn dir(workspace_dir: &Path) -> PathBuf {
+        workspace_dir.join("state")
+    }
+
+    fn path(workspace_dir: &Path) -> PathBuf {
+        Self::dir(workspace_dir).join(STATE_FILE)
+    }
+
+    /// Load persisted state for `app_id`. Returns the default (empty) state —
+    /// which forces a full reconcile — when no workspace dir is configured, the
+    /// file is absent or unreadable, or the recorded application id does not
+    /// match. Never fails; a corrupt or foreign file simply yields "no state".
+    pub fn load(workspace_dir: Option<&Path>, app_id: &str) -> Self {
+        let Some(ws) = workspace_dir else {
+            return Self::default();
+        };
+        let Ok(bytes) = std::fs::read(Self::path(ws)) else {
+            return Self::default();
+        };
+        match serde_json::from_slice::<Self>(&bytes) {
+            Ok(state) if state.app_id.as_deref() == Some(app_id) => state,
+            _ => Self::default(),
+        }
+    }
+
+    /// Record a successful reconcile: store the fingerprint, clear any
+    /// `Retry-After` cooldown. Best-effort — a write failure is logged at debug
+    /// and otherwise ignored (the in-process flow already succeeded).
+    pub fn record_success(workspace_dir: Option<&Path>, app_id: &str, fingerprint: u64, now: i64) {
+        Self {
+            app_id: Some(app_id.to_string()),
+            fingerprint: Some(fingerprint),
+            last_success_at: Some(now),
+            retry_after_until: None,
+        }
+        .write(workspace_dir);
+    }
+
+    /// Record a rate-limit cooldown observed during reconcile. The prior
+    /// fingerprint is preserved (the desired set did not change, only the
+    /// server asked us to wait), so the cooldown — not a forced re-diff — gates
+    /// the next attempt.
+    pub fn record_retry_after(workspace_dir: Option<&Path>, app_id: &str, prev: &Self, until: i64) {
+        Self {
+            app_id: Some(app_id.to_string()),
+            fingerprint: prev.fingerprint,
+            last_success_at: prev.last_success_at,
+            retry_after_until: Some(until),
+        }
+        .write(workspace_dir);
+    }
+
+    /// True when a recorded `Retry-After` cooldown is still in the future.
+    pub fn rate_limited(&self, now: i64) -> bool {
+        self.retry_after_until.is_some_and(|until| until > now)
+    }
+
+    fn write(&self, workspace_dir: Option<&Path>) {
+        let Some(ws) = workspace_dir else {
+            return;
+        };
+        let dir = Self::dir(ws);
+        if let Err(e) = std::fs::create_dir_all(&dir) {
+            ::zeroclaw_log::record!(
+                DEBUG,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_attrs(::serde_json::json!({"error": e.to_string()})),
+                "could not create slash-command state dir; reconcile state not persisted"
+            );
+            return;
+        }
+        // The state dir may hold per-channel material; keep it owner-only.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700));
+        }
+        let Ok(bytes) = serde_json::to_vec_pretty(self) else {
+            return;
+        };
+        // Write to a unique temp file then atomically rename, so overlapping
+        // READY tasks (a reconnect storm) can never observe a torn file — a
+        // half-written file would just load as "no state" and force a needless
+        // reconcile, the very churn this persistence removes.
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+        let tmp = dir.join(format!(
+            "{STATE_FILE}.{}.{}.tmp",
+            std::process::id(),
+            SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        if let Err(e) =
+            std::fs::write(&tmp, &bytes).and_then(|()| std::fs::rename(&tmp, Self::path(ws)))
+        {
+            let _ = std::fs::remove_file(&tmp);
+            ::zeroclaw_log::record!(
+                DEBUG,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_attrs(::serde_json::json!({"error": e.to_string()})),
+                "could not persist slash-command reconcile state"
+            );
+        }
+    }
+}
+
+/// Current unix time in seconds.
+pub fn now_unix() -> i64 {
+    chrono::Utc::now().timestamp()
+}
+
+/// Derive a `Retry-After` deadline (unix seconds) from a `429` response.
+///
+/// Discord returns the wait in the JSON body's `retry_after` (seconds, may be
+/// fractional); the `Retry-After` and `X-RateLimit-Reset-After` headers carry
+/// the same in seconds. We take the first present, in that order, round up, and
+/// floor at one second so a missing/zero value still yields a real cooldown.
+pub fn retry_after_deadline(
+    headers: &reqwest::header::HeaderMap,
+    body: Option<&serde_json::Value>,
+    now: i64,
+) -> i64 {
+    let secs = body
+        .and_then(|b| b.get("retry_after"))
+        .and_then(serde_json::Value::as_f64)
+        .or_else(|| header_secs(headers, "retry-after"))
+        .or_else(|| header_secs(headers, "x-ratelimit-reset-after"))
+        .unwrap_or(1.0);
+    now + (secs.ceil() as i64).max(1)
+}
+
+fn header_secs(headers: &reqwest::header::HeaderMap, name: &str) -> Option<f64> {
+    headers.get(name)?.to_str().ok()?.trim().parse::<f64>().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reqwest::header::HeaderMap;
+
+    #[test]
+    fn round_trip_persists_and_loads_for_matching_app() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ws = tmp.path();
+        SlashReconcileState::record_success(Some(ws), "app-1", 42, 1000);
+        let loaded = SlashReconcileState::load(Some(ws), "app-1");
+        assert_eq!(loaded.fingerprint, Some(42));
+        assert_eq!(loaded.last_success_at, Some(1000));
+        assert_eq!(loaded.retry_after_until, None);
+    }
+
+    #[test]
+    fn load_ignores_state_for_a_different_app() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ws = tmp.path();
+        SlashReconcileState::record_success(Some(ws), "app-1", 42, 1000);
+        // A different application id (swapped token) must not trust the file.
+        assert_eq!(
+            SlashReconcileState::load(Some(ws), "app-2"),
+            SlashReconcileState::default()
+        );
+    }
+
+    #[test]
+    fn missing_workspace_dir_is_a_noop_and_loads_default() {
+        // No panic, no persistence, full-reconcile default.
+        SlashReconcileState::record_success(None, "app-1", 42, 1000);
+        assert_eq!(
+            SlashReconcileState::load(None, "app-1"),
+            SlashReconcileState::default()
+        );
+    }
+
+    #[test]
+    fn retry_after_is_preserved_with_prior_fingerprint() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ws = tmp.path();
+        SlashReconcileState::record_success(Some(ws), "app-1", 7, 1000);
+        let prev = SlashReconcileState::load(Some(ws), "app-1");
+        SlashReconcileState::record_retry_after(Some(ws), "app-1", &prev, 2000);
+        let loaded = SlashReconcileState::load(Some(ws), "app-1");
+        assert_eq!(
+            loaded.fingerprint,
+            Some(7),
+            "fingerprint kept across back-off"
+        );
+        assert_eq!(loaded.retry_after_until, Some(2000));
+        assert!(loaded.rate_limited(1999));
+        assert!(!loaded.rate_limited(2000), "deadline is exclusive");
+        assert!(!loaded.rate_limited(2001));
+    }
+
+    #[test]
+    fn corrupt_file_loads_default() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ws = tmp.path();
+        std::fs::create_dir_all(ws.join("state")).unwrap();
+        std::fs::write(ws.join("state").join(STATE_FILE), b"not json").unwrap();
+        assert_eq!(
+            SlashReconcileState::load(Some(ws), "app-1"),
+            SlashReconcileState::default()
+        );
+    }
+
+    #[test]
+    fn retry_after_prefers_body_then_headers() {
+        let now = 1000;
+        // Body wins, fractional rounds up.
+        let body = serde_json::json!({"retry_after": 1.2});
+        assert_eq!(
+            retry_after_deadline(&HeaderMap::new(), Some(&body), now),
+            1002
+        );
+
+        // Header used when body absent.
+        let mut h = HeaderMap::new();
+        h.insert("retry-after", "3".parse().unwrap());
+        assert_eq!(retry_after_deadline(&h, None, now), 1003);
+
+        // X-RateLimit-Reset-After as last resort.
+        let mut h2 = HeaderMap::new();
+        h2.insert("x-ratelimit-reset-after", "2.5".parse().unwrap());
+        assert_eq!(retry_after_deadline(&h2, None, now), 1003);
+
+        // Nothing present → a minimum 1s cooldown, never zero.
+        assert_eq!(retry_after_deadline(&HeaderMap::new(), None, now), 1001);
+    }
+}

--- a/crates/zeroclaw-channels/src/lib.rs
+++ b/crates/zeroclaw-channels/src/lib.rs
@@ -33,6 +33,8 @@ pub mod clawdtalk;
 pub mod dingtalk;
 #[cfg(feature = "channel-discord")]
 pub mod discord;
+#[cfg(feature = "channel-discord")]
+pub mod discord_slash_state;
 #[cfg(feature = "channel-email")]
 pub mod email_channel;
 #[cfg(feature = "channel-email")]

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -612,7 +612,12 @@ pub fn all_tools_with_runtime(
     // bot/server set); the search tool reads from a shared archive DB
     // so it's enabled when at least one alias archives.
     if root_config.channels.discord.values().any(|d| d.archive) {
-        match zeroclaw_memory::SqliteMemory::new_named("sqlite", workspace_dir, "discord") {
+        // Read from the SHARED store (`config.data_dir`) the channel archive
+        // writer persists to (orchestrator builds `discord.db` under
+        // `&config.data_dir`), NOT the per-agent `workspace_dir` — otherwise the
+        // tool opens an empty DB and litters a stray `memory/discord.db` under
+        // every agent workspace.
+        match zeroclaw_memory::SqliteMemory::new_named("sqlite", &config.data_dir, "discord") {
             Ok(discord_mem) => {
                 tool_arcs.push(Arc::new(DiscordSearchTool::new(Arc::new(discord_mem))));
             }
@@ -1038,8 +1043,12 @@ pub fn all_tools_with_runtime(
     // created via /ws/chat was invisible to `sessions_list` /
     // `sessions_history`. Routing both call sites through the factory
     // closes that gap and honors the operator's configured backend.
+    // Read from the SHARED sessions store (`config.data_dir`) the gateway/daemon
+    // write to (they build the backend under `&config.data_dir`), NOT the
+    // per-agent `workspace_dir` — otherwise `sessions_list`/`sessions_history`
+    // miss real sessions and a stray `sessions/sessions.db` is created per agent.
     if let Ok(backend) =
-        zeroclaw_infra::make_session_backend(workspace_dir, &config.channels.session_backend)
+        zeroclaw_infra::make_session_backend(&config.data_dir, &config.channels.session_backend)
     {
         tool_arcs.push(Arc::new(SessionsCurrentTool::new(backend.clone())));
         tool_arcs.push(Arc::new(SessionsListTool::new(backend.clone())));
@@ -1653,6 +1662,99 @@ mod tests {
         // copying state.
         assert!(Arc::strong_count(&shared_engine) >= 3);
         assert!(Arc::strong_count(&shared_audit) >= 3);
+    }
+
+    /// Regression: `discord_search` and the `sessions_*` tools must open their
+    /// SQLite stores under the SHARED `config.data_dir` (where the channel
+    /// orchestrator / gateway WRITE them), not the per-agent `workspace_dir`.
+    /// Reading the per-agent dir made the tools see empty DBs and litter a
+    /// stray `memory/discord.db` + `sessions/sessions.db` into every agent
+    /// workspace. With `data_dir` and `workspace_dir` deliberately distinct,
+    /// nothing must be created under the workspace.
+    #[test]
+    fn shared_store_tools_open_data_dir_not_per_agent_workspace() {
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().join("data"); // shared store (writers' dir)
+        let workspace_dir = tmp.path().join("agent-ws"); // per-agent, intentionally distinct
+        std::fs::create_dir_all(&data_dir).unwrap();
+        std::fs::create_dir_all(&workspace_dir).unwrap();
+
+        let security = Arc::new(SecurityPolicy::default());
+        let mem_cfg = MemoryConfig {
+            backend: "markdown".into(),
+            ..MemoryConfig::default()
+        };
+        let mem: Arc<dyn Memory> =
+            Arc::from(zeroclaw_memory::create_memory(&mem_cfg, tmp.path(), None).unwrap());
+        let browser = BrowserConfig::default();
+        let http = zeroclaw_config::schema::HttpRequestConfig::default();
+        let web = zeroclaw_config::schema::WebFetchConfig::default();
+        let risk = zeroclaw_config::schema::RiskProfileConfig::default();
+
+        // root_config: shared data_dir + a Discord alias that archives (this is
+        // what gates discord_search registration).
+        let mut root_config = test_config(&tmp);
+        root_config.data_dir = data_dir.clone();
+        root_config.channels.discord.insert(
+            "oracle".to_string(),
+            zeroclaw_config::schema::DiscordConfig {
+                archive: true,
+                ..Default::default()
+            },
+        );
+
+        // `config` (arg 1) carries the canonical shared data_dir — exactly how
+        // the production callers pass it (a clone of the runtime config).
+        let config = Config {
+            data_dir: data_dir.clone(),
+            ..Config::default()
+        };
+
+        let tools = all_tools_with_runtime(
+            Arc::new(config),
+            &security,
+            &risk,
+            "test-agent",
+            Arc::new(NativeRuntime::new()),
+            mem,
+            None,
+            None,
+            &browser,
+            &http,
+            &web,
+            workspace_dir.as_path(), // DIFFERENT from data_dir
+            &HashMap::new(),
+            None,
+            &root_config,
+            None,
+            false,
+            None,
+            None,
+            None,
+        )
+        .tools;
+
+        let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+        assert!(
+            names.contains(&"discord_search"),
+            "discord_search must register when a Discord alias archives"
+        );
+        assert!(
+            names.iter().any(|n| n.starts_with("sessions")),
+            "session tools must register"
+        );
+
+        // The fix: both stores open under the shared data_dir, never the
+        // per-agent workspace. Pre-fix the readers created `memory/discord.db`
+        // and `sessions/sessions.db` under the workspace_dir.
+        assert!(
+            !workspace_dir.join("memory").exists(),
+            "discord_search must not open/create a store under the per-agent workspace_dir"
+        );
+        assert!(
+            !workspace_dir.join("sessions").exists(),
+            "session tools must not open/create a store under the per-agent workspace_dir"
+        );
     }
 
     /// Regression for #6687 blocker: a config with `sop.sops_dir` set but no


### PR DESCRIPTION
This PR bundles two related Discord/`data_dir` durability fixes.

---

# 1. Persist slash reconcile state across restarts

## Problem

The Discord channel reconciles its application's global slash commands with the
desired (skill-derived) set on every gateway `READY`. The fingerprint that lets
an unchanged set skip the REST round-trip was held only in memory
(`registered_commands_hash`), so:

- every process start re-ran a full `GET` + per-command diff against Discord's
  finite daily command-create budget, even when nothing changed; and
- a `429` mid-reconcile `bail!`ed and reset the fingerprint, so the next `READY`
  immediately re-hammered the same rate limit — a daily reconcile-429 burst.

## Change

Persist the reconcile state per application id at
`<workspace_dir>/state/slash-commands.json` (the `state/` convention the model
cache already uses), in a small new module `discord_slash_state`:

- **Skip an unchanged set across restarts**, not just within a process.
- **Honour `Retry-After` across restarts:** on a `429` (command list or upsert),
  record the deadline (body `retry_after`, else the `Retry-After` /
  `X-RateLimit-Reset-After` headers; ≥1s floor) and skip reconcile until it
  passes, instead of bailing and retrying on the next `READY`.

`reconcile_slash_commands` now returns a `ReconcileOutcome`
(`Reconciled` | `RateLimited { until }`) so a rate limit is a first-class
cooldown rather than a hard error. A genuine hard error leaves the persisted
state untouched, so the next `READY` still retries (the new fingerprint differs
from the stored one). The state file is written atomically (temp + rename) so an
overlapping reconcile during a reconnect storm can't observe a torn file.

### Compatibility / scope

- **No new config keys.** Rides the existing per-channel `state/` dir.
- **Degrades to a no-op** when no workspace dir is configured — behaviour
  unchanged there (a full reconcile each start, exactly as before).
- The persisted file holds only `{app_id, fingerprint, last_success_at,
  retry_after_until}` — no token or message content; the `state/` dir is 0700.
- A swapped bot token (different application id) is detected on load and forces a
  full reconcile rather than trusting a stale fingerprint.

---

# 2. Shared-store read-path fix (`discord_search` + `sessions_*`)

## Problem

`discord_search` and the `sessions_*` tools opened their SQLite stores under the
**per-agent `workspace_dir`**, but the writers persist them to the **shared
`config.data_dir`**:

- Discord archive — written at `crates/zeroclaw-channels/src/orchestrator/mod.rs`
  via `SqliteMemory::new_named("sqlite", &config.data_dir, "discord")`.
- Sessions — written via `make_session_backend(&config.data_dir, …)` in the
  daemon, orchestrator and gateway.

So the tools read an **empty/wrong DB** (`discord_search` returns nothing;
`sessions_list`/`sessions_history` miss real sessions) and litter stray empty
`memory/discord.db` + `sessions/sessions.db` files into every agent workspace.
This is the residual read-side instance of the `workspace_dir`↔`data_dir` family
(#7541 / #7121 / #7573) — those merges made `workspace_dir` reliably per-agent,
which surfaced it.

## Change

Point the two readers at the shared `config.data_dir` the writers use
(`crates/zeroclaw-runtime/src/tools/mod.rs`):

```rust
// discord_search
- SqliteMemory::new_named("sqlite", workspace_dir, "discord")
+ SqliteMemory::new_named("sqlite", &config.data_dir, "discord")

// sessions_*
- make_session_backend(workspace_dir, &config.channels.session_backend)
+ make_session_backend(&config.data_dir, &config.channels.session_backend)
```

`config: Arc<Config>` is already a parameter of `all_tools_with_runtime` and at
every production call site is the same runtime config whose `data_dir` the
writers use, so reads and writes now agree. Only these two *shared* stores
change; all other `workspace_dir` tool plumbing (git/file/linkedin/…) is
correctly per-agent and is left untouched. A regression test builds the tool
registry with `data_dir` ≠ `workspace_dir` and asserts neither store is created
under the per-agent workspace.

---

## Testing

- `discord_slash_state`: 6 unit tests (round-trip persist/load, app-id-mismatch →
  default, no-workspace no-op, retry-after preserves the prior fingerprint,
  corrupt file → default, `retry_after` body→header precedence).
- `reconcile_returns_rate_limited_on_post_429` (new) + the 3 pre-existing
  reconcile tests still pass (the `ReconcileOutcome` return is backward-compatible).
- `shared_store_tools_open_data_dir_not_per_agent_workspace` (new) — the
  read-path regression above.
- `cargo fmt` clean · `cargo clippy --all-targets -- -D warnings` clean ·
  `cargo test -p zeroclaw-channels --features channel-discord` /
  `cargo test -p zeroclaw-runtime` green.
