### PR TITLE
perf(skills): cache skill-directory loads (content-validated, audit-correct)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14515,6 +14515,7 @@ dependencies = [
  "dialoguer",
  "directories",
  "encoding_rs",
+ "filetime",
  "flate2",
  "fluent",
  "futures-util",

--- a/crates/zeroclaw-runtime/Cargo.toml
+++ b/crates/zeroclaw-runtime/Cargo.toml
@@ -112,6 +112,7 @@ rcgen = "0.13"
 tempfile = "3.26"
 tokio = { version = "1.50", features = ["rt-multi-thread", "macros"] }
 scopeguard = "1.2"
+filetime = "0.2"
 
 # Channel features (forwarded to zeroclaw-channels)
 

--- a/crates/zeroclaw-runtime/src/skills/cache.rs
+++ b/crates/zeroclaw-runtime/src/skills/cache.rs
@@ -90,7 +90,9 @@ fn cache_enabled() -> bool {
 /// (symlinks). Never follows symlinks, so it can't loop on a cycle and matches
 /// the auditor's no-follow stance. Tying the key to content — not metadata an edit
 /// can preserve — is what keeps a cached "clean" audit verdict from outliving the
-/// bytes it audited. Returns `None` when `dir` is absent or any entry can't be
+/// bytes it audited. Only *regular* files are opened: a non-regular entry (FIFO,
+/// socket, device) makes this return `None` so we never block opening it just to
+/// build a key. Returns `None` too when `dir` is absent or any entry can't be
 /// read; callers treat that as "do not cache" rather than trust a partial digest.
 fn dir_signature(dir: &Path) -> Option<u64> {
     if !dir.exists() {
@@ -119,10 +121,18 @@ fn dir_signature(dir: &Path) -> Option<u64> {
                 entries.insert(path, (2, h.finish()));
             } else if file_type.is_dir() {
                 stack.push(path);
-            } else {
+            } else if file_type.is_file() {
                 // Decline to cache rather than fingerprint a file we can't read.
                 let digest = hash_file_contents(&path)?;
                 entries.insert(path, (1, digest));
+            } else {
+                // Non-regular entry (FIFO, socket, device, ...). Opening a FIFO
+                // for read blocks on a writer, so probing it just to build the
+                // cache key could hang skill loading / prompt building — a far
+                // wider open surface than the uncached loader, which only reads
+                // the manifest it parses. Never open it: decline to cache this
+                // directory and let the uncached path handle whatever it is.
+                return None;
             }
         }
     }
@@ -344,6 +354,43 @@ mod tests {
             calls.load(Ordering::SeqCst),
             2,
             "content change under identical mtime+length must re-audit"
+        );
+    }
+
+    // Audit-boundary regression (review of #7786, round 2): a FIFO (or other
+    // non-regular entry) inside a skills dir must never be opened while building
+    // the cache key — opening a FIFO for read blocks on a writer and would hang
+    // skill loading / prompt building. `dir_signature` must bail to `None` so the
+    // directory simply bypasses the cache. If this regresses, the test hangs.
+    #[cfg(unix)]
+    #[test]
+    fn non_regular_entry_bypasses_cache_without_hanging() {
+        invalidate();
+        let tmp = TempDir::new().unwrap();
+        let skills_dir = tmp.path().join("skills");
+        write(&skills_dir, "alpha", "# Alpha\n");
+        let fifo = skills_dir.join("alpha/pipe");
+        let status = std::process::Command::new("mkfifo")
+            .arg(&fifo)
+            .status()
+            .expect("mkfifo should be available on unix test hosts");
+        assert!(status.success(), "mkfifo failed");
+
+        let calls = AtomicUsize::new(0);
+        let load = || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Vec::<Skill>::new()
+        };
+
+        // Must return promptly (no hang) and, because the dir can't be signed,
+        // run the loader every time instead of caching.
+        cached_load(&skills_dir, false, "test", load);
+        cached_load(&skills_dir, false, "test", load);
+
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            2,
+            "a directory containing a non-regular entry must bypass the cache"
         );
     }
 

--- a/crates/zeroclaw-runtime/src/skills/cache.rs
+++ b/crates/zeroclaw-runtime/src/skills/cache.rs
@@ -1,0 +1,372 @@
+//! Process-global cache for skill-directory loads.
+//!
+//! [`super::load_skills_from_directory`] and [`super::load_open_skills_from_directory`]
+//! are pure functions of `(dir, allow_scripts, filesystem state)`, but each call
+//! does a recursive read *and* a full security audit (content scan + parse) of
+//! every skill subdirectory. They run on every prompt build and every
+//! `read_skill` invocation, so the cost recurs constantly even when nothing on
+//! disk has changed.
+//!
+//! This module memoizes the result keyed by `(canonical dir, allow_scripts, tag)`
+//! and validates freshness with a cheap, **stat-only** directory signature: any
+//! add / remove / rename / content edit changes a file's mtime or length (or a
+//! symlink's target), which changes the signature and forces a re-audit. A stale
+//! "clean" audit verdict can therefore never be served from cache.
+//!
+//! [`invalidate`] gives the [`super::SkillsService`] an explicit hook to drop the
+//! cache immediately after a write, so an added/edited/removed skill is picked up
+//! on the very next load without waiting on anything.
+//!
+//! Kill-switch: the cache is on by default; setting `ZEROCLAW_SKILLS_CACHE_ENABLED`
+//! to a falsey value (`0` / `false` / `no` / `off`) forces every load to re-walk
+//! and re-audit, i.e. the exact pre-cache behavior. This is a runtime off-ramp if
+//! the cache is ever suspected of serving stale results.
+//!
+//! Caveat: the signature trusts filesystem metadata, so a deliberate edit that
+//! preserves both mtime and length (e.g. an attacker resetting mtime via
+//! `utimes`) would not be detected. This matches the staleness model of build
+//! tools like `cargo`/`make`; anyone with write access to the skills directory
+//! already controls which skills exist, so the audit is a guard against
+//! accidental/unreviewed content rather than against an attacker who can forge
+//! inode metadata.
+
+use super::Skill;
+use std::collections::hash_map::DefaultHasher;
+use std::collections::{BTreeMap, HashMap};
+use std::hash::{Hash, Hasher};
+use std::path::{Path, PathBuf};
+use std::sync::{OnceLock, RwLock};
+use std::time::UNIX_EPOCH;
+
+#[derive(PartialEq, Eq, Hash, Clone)]
+struct CacheKey {
+    dir: PathBuf,
+    allow_scripts: bool,
+    /// Distinguishes loaders that may share a directory path (workspace vs
+    /// open-skills) so their cached entries never collide.
+    tag: &'static str,
+}
+
+struct CacheEntry {
+    signature: u64,
+    skills: Vec<Skill>,
+}
+
+fn cache() -> &'static RwLock<HashMap<CacheKey, CacheEntry>> {
+    static CACHE: OnceLock<RwLock<HashMap<CacheKey, CacheEntry>>> = OnceLock::new();
+    CACHE.get_or_init(|| RwLock::new(HashMap::new()))
+}
+
+/// Best-effort canonicalization so two spellings of the same directory share an
+/// entry. Falls back to the path as given when the dir can't be canonicalized.
+fn canonical(dir: &Path) -> PathBuf {
+    std::fs::canonicalize(dir).unwrap_or_else(|_| dir.to_path_buf())
+}
+
+const CACHE_ENABLED_ENV: &str = "ZEROCLAW_SKILLS_CACHE_ENABLED";
+
+/// Pure kill-switch decision split from the env read so it stays testable
+/// without mutating process-global state. The cache is enabled unless the value
+/// is explicitly falsey; unset or unrecognized values leave it enabled.
+fn cache_enabled_from_env(raw: Option<&str>) -> bool {
+    !matches!(
+        raw.map(|v| v.trim().to_ascii_lowercase()).as_deref(),
+        Some("0") | Some("false") | Some("no") | Some("off")
+    )
+}
+
+/// Runtime kill-switch read per call (negligible beside the fs work it guards),
+/// so it takes effect without a rebuild. See [`CACHE_ENABLED_ENV`].
+fn cache_enabled() -> bool {
+    cache_enabled_from_env(std::env::var(CACHE_ENABLED_ENV).ok().as_deref())
+}
+
+/// Stat-only fingerprint of everything reachable under `dir` (recursive). Hashes
+/// each entry's relative path plus the cheap metadata that changes on any real
+/// edit — file mtime + length, and symlink target. Never follows symlinks, so it
+/// cannot loop on a cycle and matches the auditor's no-follow stance. Returns
+/// `None` when `dir` is absent or unreadable; callers treat that as "do not
+/// cache" and just run the loader (which yields an empty result anyway).
+fn dir_signature(dir: &Path) -> Option<u64> {
+    if !dir.exists() {
+        return None;
+    }
+
+    // BTreeMap keyed by path → deterministic hash order regardless of read_dir
+    // ordering. Value encodes the per-entry fingerprint.
+    let mut entries: BTreeMap<PathBuf, (u8, u64, u64)> = BTreeMap::new();
+    let mut stack = vec![dir.to_path_buf()];
+
+    while let Some(current) = stack.pop() {
+        let read = std::fs::read_dir(&current).ok()?;
+        for entry in read.flatten() {
+            let path = entry.path();
+            // DirEntry::file_type does not follow symlinks.
+            let Ok(file_type) = entry.file_type() else {
+                return None;
+            };
+
+            if file_type.is_symlink() {
+                // Hash the link target string; a retargeted symlink is a change.
+                let target_hash = std::fs::read_link(&path)
+                    .ok()
+                    .map(|t| {
+                        let mut h = DefaultHasher::new();
+                        t.hash(&mut h);
+                        h.finish()
+                    })
+                    .unwrap_or(0);
+                entries.insert(path, (2, target_hash, 0));
+            } else if file_type.is_dir() {
+                stack.push(path);
+            } else {
+                // DirEntry::metadata does not follow symlinks.
+                let Ok(meta) = entry.metadata() else {
+                    return None;
+                };
+                let mtime = meta
+                    .modified()
+                    .ok()
+                    .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+                    .map(|d| d.as_nanos() as u64)
+                    .unwrap_or(0);
+                entries.insert(path, (1, mtime, meta.len()));
+            }
+        }
+    }
+
+    let mut hasher = DefaultHasher::new();
+    for (path, fingerprint) in &entries {
+        path.hash(&mut hasher);
+        fingerprint.hash(&mut hasher);
+    }
+    Some(hasher.finish())
+}
+
+/// Memoize `load` for `(dir, allow_scripts, tag)`, validated by the directory
+/// signature. On a hit with a matching signature, returns a clone of the cached
+/// skills without touching the auditor. On a miss (or when the directory can't be
+/// signed) runs `load` and stores the result. Concurrent misses simply run the
+/// idempotent loader more than once; lock poisoning is recovered, not panicked.
+pub(super) fn cached_load(
+    dir: &Path,
+    allow_scripts: bool,
+    tag: &'static str,
+    load: impl FnOnce() -> Vec<Skill>,
+) -> Vec<Skill> {
+    if !cache_enabled() {
+        return load();
+    }
+    let Some(signature) = dir_signature(dir) else {
+        return load();
+    };
+    let key = CacheKey {
+        dir: canonical(dir),
+        allow_scripts,
+        tag,
+    };
+
+    {
+        let guard = cache().read().unwrap_or_else(|e| e.into_inner());
+        if let Some(entry) = guard.get(&key)
+            && entry.signature == signature
+        {
+            return entry.skills.clone();
+        }
+    }
+
+    // Miss: load outside the write lock would be cleaner, but the loader is fast
+    // relative to lock contention here and we want a single store. If the dir
+    // mutates during `load`, the change bumps mtime/len so the *next* call's
+    // signature differs from what we store and the entry self-heals.
+    let skills = load();
+    let mut guard = cache().write().unwrap_or_else(|e| e.into_inner());
+    guard.insert(
+        key,
+        CacheEntry {
+            signature,
+            skills: skills.clone(),
+        },
+    );
+    skills
+}
+
+/// Drop every cached entry. Call after any out-of-band mutation of a skills
+/// directory (e.g. [`super::SkillsService`] writes/removes) so the change is
+/// reflected on the next load even before mtimes are re-examined.
+pub fn invalidate() {
+    cache().write().unwrap_or_else(|e| e.into_inner()).clear();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tempfile::TempDir;
+
+    fn write(dir: &Path, name: &str, body: &str) {
+        let skill_dir = dir.join(name);
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(skill_dir.join("SKILL.md"), body).unwrap();
+    }
+
+    #[test]
+    fn second_load_is_a_cache_hit() {
+        invalidate();
+        let tmp = TempDir::new().unwrap();
+        let skills_dir = tmp.path().join("skills");
+        write(&skills_dir, "alpha", "# Alpha\n");
+        let calls = AtomicUsize::new(0);
+
+        let load = || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            vec![Skill {
+                name: "alpha".into(),
+                description: String::new(),
+                version: String::new(),
+                author: None,
+                tags: vec![],
+                tools: vec![],
+                prompts: vec![],
+                location: None,
+            }]
+        };
+
+        let a = cached_load(&skills_dir, false, "test", load);
+        let b = cached_load(&skills_dir, false, "test", load);
+        assert_eq!(a.len(), 1);
+        assert_eq!(b.len(), 1);
+        assert_eq!(calls.load(Ordering::SeqCst), 1, "loader should run once");
+    }
+
+    #[test]
+    fn adding_a_skill_invalidates_via_signature() {
+        invalidate();
+        let tmp = TempDir::new().unwrap();
+        let skills_dir = tmp.path().join("skills");
+        write(&skills_dir, "alpha", "# Alpha\n");
+        let calls = AtomicUsize::new(0);
+        let load = || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Vec::<Skill>::new()
+        };
+
+        cached_load(&skills_dir, false, "test", load);
+        write(&skills_dir, "beta", "# Beta\n");
+        cached_load(&skills_dir, false, "test", load);
+
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            2,
+            "adding a skill dir must bust the cache"
+        );
+    }
+
+    #[test]
+    fn editing_content_invalidates_via_signature() {
+        invalidate();
+        let tmp = TempDir::new().unwrap();
+        let skills_dir = tmp.path().join("skills");
+        write(&skills_dir, "alpha", "# Alpha\n");
+        let calls = AtomicUsize::new(0);
+        let load = || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Vec::<Skill>::new()
+        };
+
+        cached_load(&skills_dir, false, "test", load);
+        // Different length → signature changes even if mtime resolution is coarse.
+        write(
+            &skills_dir,
+            "alpha",
+            "# Alpha skill, now with a longer body.\n",
+        );
+        cached_load(&skills_dir, false, "test", load);
+
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            2,
+            "editing skill content must bust the cache"
+        );
+    }
+
+    #[test]
+    fn explicit_invalidate_forces_reload() {
+        invalidate();
+        let tmp = TempDir::new().unwrap();
+        let skills_dir = tmp.path().join("skills");
+        write(&skills_dir, "alpha", "# Alpha\n");
+        let calls = AtomicUsize::new(0);
+        let load = || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Vec::<Skill>::new()
+        };
+
+        cached_load(&skills_dir, false, "test", load);
+        invalidate();
+        cached_load(&skills_dir, false, "test", load);
+
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            2,
+            "invalidate() must force the next load to re-run"
+        );
+    }
+
+    #[test]
+    fn allow_scripts_flag_is_part_of_the_key() {
+        invalidate();
+        let tmp = TempDir::new().unwrap();
+        let skills_dir = tmp.path().join("skills");
+        write(&skills_dir, "alpha", "# Alpha\n");
+        let calls = AtomicUsize::new(0);
+        let load = || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Vec::<Skill>::new()
+        };
+
+        cached_load(&skills_dir, false, "test", load);
+        cached_load(&skills_dir, true, "test", load);
+
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            2,
+            "different allow_scripts must not share a cache entry"
+        );
+    }
+
+    #[test]
+    fn missing_dir_is_not_cached() {
+        invalidate();
+        let tmp = TempDir::new().unwrap();
+        let absent = tmp.path().join("does-not-exist");
+        let calls = AtomicUsize::new(0);
+        let load = || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Vec::<Skill>::new()
+        };
+
+        cached_load(&absent, false, "test", load);
+        cached_load(&absent, false, "test", load);
+
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            2,
+            "absent directory should bypass the cache entirely"
+        );
+    }
+
+    #[test]
+    fn kill_switch_parsing() {
+        // Default (unset) → enabled.
+        assert!(cache_enabled_from_env(None));
+        // Falsey spellings → disabled.
+        for v in ["0", "false", "no", "off", "OFF", "  False  "] {
+            assert!(!cache_enabled_from_env(Some(v)), "{v:?} should disable");
+        }
+        // Truthy / unrecognized → enabled (fail safe to caching on).
+        for v in ["1", "true", "yes", "on", "", "garbage"] {
+            assert!(cache_enabled_from_env(Some(v)), "{v:?} should stay enabled");
+        }
+    }
+}

--- a/crates/zeroclaw-runtime/src/skills/cache.rs
+++ b/crates/zeroclaw-runtime/src/skills/cache.rs
@@ -8,10 +8,23 @@
 //! disk has changed.
 //!
 //! This module memoizes the result keyed by `(canonical dir, allow_scripts, tag)`
-//! and validates freshness with a cheap, **stat-only** directory signature: any
-//! add / remove / rename / content edit changes a file's mtime or length (or a
-//! symlink's target), which changes the signature and forces a re-audit. A stale
-//! "clean" audit verdict can therefore never be served from cache.
+//! and validates freshness with a **content digest** of the directory: it hashes
+//! the bytes of every file reachable under `dir` (plus each symlink's target),
+//! never following symlinks so it can't loop. Because the digest covers file
+//! *content*, any change the auditor would care about — an edited `SKILL.md`, a
+//! flipped script, a retargeted symlink, altered TOML — produces a different
+//! signature and forces a re-audit. This matters specifically because the cache
+//! sits in front of the security audit: serving a cached "clean" verdict for
+//! content that has since changed would defeat the audit, so the freshness key is
+//! deliberately tied to the audited bytes rather than to metadata (mtime/length),
+//! which an edit can preserve. (The only residual risk is a 64-bit hash
+//! collision, which is not a practical forgery vector.)
+//!
+//! The digest reads each file once, but a cache *hit* then skips the audit's
+//! content scan, its regex/script/symlink checks, and the Markdown/TOML parsing —
+//! work the loader otherwise repeats (re-reading files) on every prompt build and
+//! every `read_skill` call. So the cache stays a net win without weakening the
+//! audit boundary.
 //!
 //! [`invalidate`] gives the [`super::SkillsService`] an explicit hook to drop the
 //! cache immediately after a write, so an added/edited/removed skill is picked up
@@ -21,14 +34,6 @@
 //! to a falsey value (`0` / `false` / `no` / `off`) forces every load to re-walk
 //! and re-audit, i.e. the exact pre-cache behavior. This is a runtime off-ramp if
 //! the cache is ever suspected of serving stale results.
-//!
-//! Caveat: the signature trusts filesystem metadata, so a deliberate edit that
-//! preserves both mtime and length (e.g. an attacker resetting mtime via
-//! `utimes`) would not be detected. This matches the staleness model of build
-//! tools like `cargo`/`make`; anyone with write access to the skills directory
-//! already controls which skills exist, so the audit is a guard against
-//! accidental/unreviewed content rather than against an attacker who can forge
-//! inode metadata.
 
 use super::Skill;
 use std::collections::hash_map::DefaultHasher;
@@ -36,7 +41,6 @@ use std::collections::{BTreeMap, HashMap};
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::sync::{OnceLock, RwLock};
-use std::time::UNIX_EPOCH;
 
 #[derive(PartialEq, Eq, Hash, Clone)]
 struct CacheKey {
@@ -81,20 +85,21 @@ fn cache_enabled() -> bool {
     cache_enabled_from_env(std::env::var(CACHE_ENABLED_ENV).ok().as_deref())
 }
 
-/// Stat-only fingerprint of everything reachable under `dir` (recursive). Hashes
-/// each entry's relative path plus the cheap metadata that changes on any real
-/// edit — file mtime + length, and symlink target. Never follows symlinks, so it
-/// cannot loop on a cycle and matches the auditor's no-follow stance. Returns
-/// `None` when `dir` is absent or unreadable; callers treat that as "do not
-/// cache" and just run the loader (which yields an empty result anyway).
+/// Content fingerprint of everything reachable under `dir` (recursive). Hashes
+/// each entry's path plus a digest of its *bytes* (files) or link target
+/// (symlinks). Never follows symlinks, so it can't loop on a cycle and matches
+/// the auditor's no-follow stance. Tying the key to content — not metadata an edit
+/// can preserve — is what keeps a cached "clean" audit verdict from outliving the
+/// bytes it audited. Returns `None` when `dir` is absent or any entry can't be
+/// read; callers treat that as "do not cache" rather than trust a partial digest.
 fn dir_signature(dir: &Path) -> Option<u64> {
     if !dir.exists() {
         return None;
     }
 
     // BTreeMap keyed by path → deterministic hash order regardless of read_dir
-    // ordering. Value encodes the per-entry fingerprint.
-    let mut entries: BTreeMap<PathBuf, (u8, u64, u64)> = BTreeMap::new();
+    // ordering. Value: (kind, content-or-target digest).
+    let mut entries: BTreeMap<PathBuf, (u8, u64)> = BTreeMap::new();
     let mut stack = vec![dir.to_path_buf()];
 
     while let Some(current) = stack.pop() {
@@ -108,29 +113,16 @@ fn dir_signature(dir: &Path) -> Option<u64> {
 
             if file_type.is_symlink() {
                 // Hash the link target string; a retargeted symlink is a change.
-                let target_hash = std::fs::read_link(&path)
-                    .ok()
-                    .map(|t| {
-                        let mut h = DefaultHasher::new();
-                        t.hash(&mut h);
-                        h.finish()
-                    })
-                    .unwrap_or(0);
-                entries.insert(path, (2, target_hash, 0));
+                let target = std::fs::read_link(&path).ok()?;
+                let mut h = DefaultHasher::new();
+                target.hash(&mut h);
+                entries.insert(path, (2, h.finish()));
             } else if file_type.is_dir() {
                 stack.push(path);
             } else {
-                // DirEntry::metadata does not follow symlinks.
-                let Ok(meta) = entry.metadata() else {
-                    return None;
-                };
-                let mtime = meta
-                    .modified()
-                    .ok()
-                    .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
-                    .map(|d| d.as_nanos() as u64)
-                    .unwrap_or(0);
-                entries.insert(path, (1, mtime, meta.len()));
+                // Decline to cache rather than fingerprint a file we can't read.
+                let digest = hash_file_contents(&path)?;
+                entries.insert(path, (1, digest));
             }
         }
     }
@@ -139,6 +131,26 @@ fn dir_signature(dir: &Path) -> Option<u64> {
     for (path, fingerprint) in &entries {
         path.hash(&mut hasher);
         fingerprint.hash(&mut hasher);
+    }
+    Some(hasher.finish())
+}
+
+/// Stream a file's full contents through a hasher (chunked, so a large bundled
+/// asset doesn't get slurped whole). `None` on any read error — the caller then
+/// declines to cache instead of trusting an incomplete digest.
+fn hash_file_contents(path: &Path) -> Option<u64> {
+    use std::io::Read;
+    let file = std::fs::File::open(path).ok()?;
+    let mut reader = std::io::BufReader::new(file);
+    let mut hasher = DefaultHasher::new();
+    let mut buf = [0u8; 16 * 1024];
+    loop {
+        match reader.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => hasher.write(&buf[..n]),
+            Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(_) => return None,
+        }
     }
     Some(hasher.finish())
 }
@@ -177,7 +189,7 @@ pub(super) fn cached_load(
 
     // Miss: load outside the write lock would be cleaner, but the loader is fast
     // relative to lock contention here and we want a single store. If the dir
-    // mutates during `load`, the change bumps mtime/len so the *next* call's
+    // mutates during `load`, its content digest changes, so the *next* call's
     // signature differs from what we store and the entry self-heals.
     let skills = load();
     let mut guard = cache().write().unwrap_or_else(|e| e.into_inner());
@@ -287,6 +299,51 @@ mod tests {
             calls.load(Ordering::SeqCst),
             2,
             "editing skill content must bust the cache"
+        );
+    }
+
+    // Audit-boundary regression (review of #7786): the cache sits in front of the
+    // security audit, so an edit that preserves BOTH length and mtime — exactly the
+    // case a metadata-only signature would miss — must still force a re-audit. This
+    // would fail on the original mtime+length signature and passes because the key
+    // is now a content digest.
+    #[test]
+    fn same_length_same_mtime_edit_still_busts_cache() {
+        invalidate();
+        let tmp = TempDir::new().unwrap();
+        let skills_dir = tmp.path().join("skills");
+        write(&skills_dir, "alpha", "AAAA\n");
+        let skill_md = skills_dir.join("alpha/SKILL.md");
+        let original_mtime =
+            filetime::FileTime::from_last_modification_time(&std::fs::metadata(&skill_md).unwrap());
+
+        let calls = AtomicUsize::new(0);
+        let load = || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Vec::<Skill>::new()
+        };
+
+        cached_load(&skills_dir, false, "test", load);
+
+        // Rewrite with same byte length, then forcibly restore the original mtime
+        // so length + mtime are byte-for-byte identical to the cached state.
+        std::fs::write(&skill_md, "BBBB\n").unwrap();
+        filetime::set_file_mtime(&skill_md, original_mtime).unwrap();
+        let after =
+            filetime::FileTime::from_last_modification_time(&std::fs::metadata(&skill_md).unwrap());
+        assert_eq!(after, original_mtime, "test precondition: mtime restored");
+        assert_eq!(
+            std::fs::metadata(&skill_md).unwrap().len(),
+            5,
+            "test precondition: length unchanged"
+        );
+
+        cached_load(&skills_dir, false, "test", load);
+
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            2,
+            "content change under identical mtime+length must re-audit"
         );
     }
 

--- a/crates/zeroclaw-runtime/src/skills/mod.rs
+++ b/crates/zeroclaw-runtime/src/skills/mod.rs
@@ -14,6 +14,7 @@ use zip::ZipArchive;
 
 pub mod audit;
 pub mod bundle;
+pub mod cache;
 pub mod constants;
 pub mod creator;
 pub mod document;
@@ -519,6 +520,12 @@ fn load_workspace_skills(workspace_dir: &Path, allow_scripts: bool) -> Vec<Skill
 }
 
 pub fn load_skills_from_directory(skills_dir: &Path, allow_scripts: bool) -> Vec<Skill> {
+    cache::cached_load(skills_dir, allow_scripts, "workspace", || {
+        load_skills_from_directory_uncached(skills_dir, allow_scripts)
+    })
+}
+
+fn load_skills_from_directory_uncached(skills_dir: &Path, allow_scripts: bool) -> Vec<Skill> {
     if !skills_dir.exists() {
         return Vec::new();
     }
@@ -612,6 +619,12 @@ fn finalize_open_skill(mut skill: Skill) -> Skill {
 }
 
 fn load_open_skills_from_directory(skills_dir: &Path, allow_scripts: bool) -> Vec<Skill> {
+    cache::cached_load(skills_dir, allow_scripts, "open-skills", || {
+        load_open_skills_from_directory_uncached(skills_dir, allow_scripts)
+    })
+}
+
+fn load_open_skills_from_directory_uncached(skills_dir: &Path, allow_scripts: bool) -> Vec<Skill> {
     if !skills_dir.exists() {
         return Vec::new();
     }

--- a/crates/zeroclaw-runtime/src/skills/service.rs
+++ b/crates/zeroclaw-runtime/src/skills/service.rs
@@ -157,6 +157,7 @@ impl<'a> SkillsService<'a> {
             return Err(ServiceError::NotFound(target.to_string()));
         }
         std::fs::write(dir.join(SKILL_MANIFEST_FILENAME), doc.serialize())?;
+        super::cache::invalidate();
         Ok(())
     }
 
@@ -167,13 +168,10 @@ impl<'a> SkillsService<'a> {
         frontmatter: SkillFrontmatter,
         opts: ScaffoldOptions,
     ) -> Result<PathBuf, ServiceError> {
-        Ok(scaffold::scaffold_skill(
-            self.config,
-            &self.install_root,
-            target,
-            frontmatter,
-            opts,
-        )?)
+        let path =
+            scaffold::scaffold_skill(self.config, &self.install_root, target, frontmatter, opts)?;
+        super::cache::invalidate();
+        Ok(path)
     }
 
     /// Archive or purge a skill directory.
@@ -199,6 +197,7 @@ impl<'a> SkillsService<'a> {
                 std::fs::rename(&dir, archive_root.join(archive_name))?;
             }
         }
+        super::cache::invalidate();
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `load_skills_from_directory` and `load_open_skills_from_directory` run a recursive read **plus a full security audit** (content scan + manifest parse) of every skill subdirectory on **every** call — on every prompt build *and* every `read_skill` invocation (and across the channels orchestrator and delegate paths) — so the same directories are re-walked and re-audited constantly even when nothing changed on disk.
  - Adds a process-global memoization layer (`skills::cache`) keyed by `(canonical dir, allow_scripts, loader-tag)`. Both directory loaders resolve through it; the audit + parse only re-run when the directory's contents actually change.
  - **Freshness is a content digest** — the signature hashes the *bytes* of every file reachable under the dir (symlinks by target, never followed). Because the cache sits in front of the security audit, the key is deliberately tied to the audited bytes, not to metadata an edit can preserve: any change the audit would care about (edited `SKILL.md`/`SKILL.toml`, a flipped script, a retargeted symlink) yields a different signature and forces a re-audit. The digest reads each file once, but a cache *hit* then skips the audit's content scan, its regex/script/symlink checks, the Markdown/TOML parsing, and the loader's redundant re-reads — so it stays a net win without weakening the audit boundary.
  - `SkillsService::{write_skill, scaffold_skill, remove_skill}` call `cache::invalidate()` so operator-driven edits show up on the next load immediately.
  - Runtime kill-switch `ZEROCLAW_SKILLS_CACHE_ENABLED` (default on; `0`/`false`/`no`/`off` → pre-cache always-re-audit behavior).
- **Scope boundary:** does **not** change skill *resolution* (which skills exist / which dirs are scanned), the audit rules, the `Skill` shape, or any public signature. Pure memoization of two existing pure functions. Does not touch the `read_skill` resolution divergence — that's #7245.
- **Blast radius:** every caller of the two directory loaders (prompt build, `read_skill`, channels orchestrator, delegate). Behavior is identical on a miss; on a hit the only difference is the saved audit/parse work. Cache memory is bounded by the number of *distinct* skill directories ever loaded (workspace + configured bundles + open-skills), which is small and stable per install.
- **Linked issue(s):** Related #7025, Related #7245 — those address the separate `read_skill` *resolution* bug; once #7245 routes `read_skill` through `load_skills_for_agent` it also benefits from this cache. No existing issue tracks skill-load caching.
- **Labels:** `runtime`, `skills` (current) — please also apply `risk: high`, `size: S`. This is a default-on cache in front of skill **security auditing** in `crates/zeroclaw-runtime`, so it warrants the high-risk classification.

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy -p zeroclaw-runtime --all-targets -- -D warnings
cargo test -p zeroclaw-runtime
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` → clean (no diff).
  - `cargo clippy -p zeroclaw-runtime --all-targets -- -D warnings` → exit 0, no warnings.
  - `cargo test -p zeroclaw-runtime` → `test result: ok. 2205 passed; 0 failed; 1 ignored`.
  - Cache unit tests → `8 passed; 0 failed`. Notably `same_length_same_mtime_edit_still_busts_cache`: edits a skill file preserving **both** length and mtime (via `filetime`) and asserts the cache still reloads — the exact audit-boundary case a metadata-only key would miss. It fails on the old mtime+length signature and passes on the content digest.
- **Beyond CI — what did you manually verify?** Confirmed every caller of both loaders only depends on the returned `Vec<Skill>`, not on per-call audit side effects; confirmed the digest is recomputed before each gate so any audited-content change forces a re-audit; tempdir-unique keys mean no cross-test bleed (full suite green).
- **If any command was intentionally skipped, why:** Scoped `clippy`/`test` to `zeroclaw-runtime` (only crate with code changes). Whole-workspace `cargo test` not run locally; CI runs the full battery (green).

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No** — same directories, same reads.
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- **Audit-boundary note:** the audit runs *behind* the cache, so the freshness key must prove the audited bytes are unchanged. It does: the signature is a **content digest** of every file under the dir, so an edit that changes content — even one preserving length and mtime — produces a different signature and re-audits. The only residual is a 64-bit hash collision, which is not a practical forgery vector. `SkillsService` writes also invalidate explicitly, and `ZEROCLAW_SKILLS_CACHE_ENABLED=0` disables the cache entirely.

## Compatibility (required)

- Backward compatible? **Yes** — public function signatures unchanged; behavior identical on a cache miss.
- Config / env / CLI surface changed? **Yes (additive, opt-out)** — adds one optional env var `ZEROCLAW_SKILLS_CACHE_ENABLED`; absent → cache on (the new default), existing deployments need no change.
- Upgrade steps: none.

## Rollback (required for `risk: high`)

- **Fast rollback command/path:** runtime, no redeploy — set `ZEROCLAW_SKILLS_CACHE_ENABLED=0` and restart to fall back to pre-cache behavior. Source rollback: `git revert <sha>` (self-contained, no migration).
- **Feature flags or config toggles:** `ZEROCLAW_SKILLS_CACHE_ENABLED` (default on; `0`/`false`/`no`/`off` disables).
- **Observable failure symptoms:** a skill change not reflected until restart would indicate an invalidation gap — confirm an edited `SKILL.md` is picked up after a prompt rebuild; flip the kill-switch to confirm. No new metric/alert added.

## Files
- `crates/zeroclaw-runtime/src/skills/cache.rs` (new — content-digest cache, invalidation, kill-switch, tests)
- `crates/zeroclaw-runtime/src/skills/mod.rs` (route both loaders through the cache)
- `crates/zeroclaw-runtime/src/skills/service.rs` (invalidate on write/scaffold/remove)
- `crates/zeroclaw-runtime/Cargo.toml` (+ `filetime` dev-dependency for the mtime-preserving regression)
