### PR TITLE
fix(runtime): resolve runtime profiles for direct turns

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -817,6 +817,17 @@ fn agent_provider_composite(
         .map(|(ty, alias, _)| format!("{ty}.{alias}"))
 }
 
+/// Return the owned agent config direct-turn setup needs, with runtime-profile
+/// values baked into `resolved`.
+fn resolved_agent_for_turn(
+    config: &zeroclaw_config::schema::Config,
+    agent_alias: &str,
+) -> Result<zeroclaw_config::schema::AliasedAgentConfig> {
+    config
+        .resolved_agent_config(agent_alias)
+        .with_context(|| format!("agents.{agent_alias} is not configured"))
+}
+
 /// Resolve (api_key, uri) for `provider_name`, preferring the alias-specific
 /// config when `provider_name` is a dotted `<family>.<alias>` reference.
 /// Falls back to `fallback` (the agent's configured provider) for bare family
@@ -857,10 +868,7 @@ pub async fn run(
     overrides: AgentRunOverrides,
 ) -> Result<String> {
     use ::zeroclaw_log::Instrument;
-    let agent = config
-        .agent(agent_alias)
-        .with_context(|| format!("agents.{agent_alias} is not configured"))?
-        .clone();
+    let agent = resolved_agent_for_turn(&config, agent_alias)?;
     crate::agent::thinking::validate_thinking_config(&agent.resolved.thinking);
     let risk_profile = config
         .risk_profile_for_agent(agent_alias)
@@ -900,14 +908,11 @@ pub async fn run(
         let agent_alias: &str = __zc_alias.as_str();
         // ── Effective per-agent runtime tunables ──────────────────────
         // Profile values (when set) override the agent's inline fields.
-        // See `Config::effective_*` helpers for precedence rules.
-        let _eff_max_tool_iterations = config.effective_max_tool_iterations(agent_alias);
-        let eff_max_history_messages = config.effective_max_history_messages(agent_alias);
-        let eff_max_context_tokens = config.effective_max_context_tokens(agent_alias);
-        let eff_compact_context = config.effective_compact_context(agent_alias);
-        let eff_max_system_prompt_chars = config.effective_max_system_prompt_chars(agent_alias);
-        let _eff_max_tool_result_chars = config.effective_max_tool_result_chars(agent_alias);
-        let _eff_tool_call_dedup_exempt = config.effective_tool_call_dedup_exempt(agent_alias);
+        // See `Config::resolved_agent_config` for precedence rules.
+        let eff_max_history_messages = agent.resolved.max_history_messages;
+        let eff_max_context_tokens = agent.resolved.max_context_tokens;
+        let eff_compact_context = agent.resolved.compact_context;
+        let eff_max_system_prompt_chars = agent.resolved.max_system_prompt_chars;
         let base_observer = observability::create_observer(&config.observability);
         let observer: Arc<dyn Observer> = Arc::from(base_observer);
         let runtime: Arc<dyn platform::RuntimeAdapter> =
@@ -2421,10 +2426,7 @@ pub async fn process_message(
     session_id: Option<&str>,
 ) -> Result<String> {
     use ::zeroclaw_log::Instrument;
-    let agent = config
-        .agent(agent_alias)
-        .with_context(|| format!("agents.{agent_alias} is not configured"))?
-        .clone();
+    let agent = resolved_agent_for_turn(&config, agent_alias)?;
     crate::agent::thinking::validate_thinking_config(&agent.resolved.thinking);
     let risk_profile = config
         .risk_profile_for_agent(agent_alias)
@@ -2469,14 +2471,9 @@ pub async fn process_message(
 
         // ── Effective per-agent runtime tunables ──────────────────────
         // Profile values (when set) override the agent's inline fields.
-        // See `Config::effective_*` helpers for precedence rules.
-        let _eff_max_tool_iterations = config.effective_max_tool_iterations(agent_alias);
-        let _eff_max_history_messages = config.effective_max_history_messages(agent_alias);
-        let _eff_max_context_tokens = config.effective_max_context_tokens(agent_alias);
-        let eff_compact_context = config.effective_compact_context(agent_alias);
-        let eff_max_system_prompt_chars = config.effective_max_system_prompt_chars(agent_alias);
-        let _eff_max_tool_result_chars = config.effective_max_tool_result_chars(agent_alias);
-        let _eff_tool_call_dedup_exempt = config.effective_tool_call_dedup_exempt(agent_alias);
+        // See `Config::resolved_agent_config` for precedence rules.
+        let eff_compact_context = agent.resolved.compact_context;
+        let eff_max_system_prompt_chars = agent.resolved.max_system_prompt_chars;
 
         let observer: Arc<dyn Observer> =
             Arc::from(observability::create_observer(&config.observability));
@@ -11300,6 +11297,37 @@ Let me check the result."#;
             Some("openai"),
             "bare family name would bypass the alias-aware factory path and drop \
              requires_openai_auth from the config, routing to the wrong provider"
+        );
+    }
+
+    #[test]
+    fn direct_turn_agent_config_resolves_runtime_profile_tunables() {
+        use zeroclaw_config::providers::RuntimeProfileRef;
+        use zeroclaw_config::schema::{AliasedAgentConfig, RuntimeProfileConfig};
+
+        let mut config = zeroclaw_config::schema::Config::default();
+        config.runtime_profiles.insert(
+            "long".to_string(),
+            RuntimeProfileConfig {
+                max_tool_iterations: 25,
+                ..Default::default()
+            },
+        );
+        config.agents.insert(
+            "default".to_string(),
+            AliasedAgentConfig {
+                runtime_profile: RuntimeProfileRef::new("long"),
+                ..Default::default()
+            },
+        );
+
+        let agent = super::resolved_agent_for_turn(&config, "default")
+            .expect("configured agent should resolve for direct turns");
+
+        assert_eq!(
+            agent.resolved.max_tool_iterations, 25,
+            "direct agent turns must honor runtime_profiles.*.max_tool_iterations \
+             instead of the skipped AliasedAgentConfig::resolved default"
         );
     }
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Resolve direct agent-turn configs through `Config::resolved_agent_config()` before entering the tool loop.
  - Keep direct `run()` and `process_message()` aligned with runtime-profile resolution instead of reading the skipped/default `AliasedAgentConfig::resolved` field.
  - Add a focused regression proving direct turns honor `runtime_profiles.*.max_tool_iterations` above the default.
- **Scope boundary:** This PR only fixes direct agent-turn runtime-profile resolution. It does not change channel orchestrator runtime-profile behavior, context-budget defaults, ZeroCode config editing UX, or session/help/keybinding UI.
- **Blast radius:** `zeroclaw-runtime` direct `run()` and `process_message()` agent loop setup. Channel runtime setup is intentionally out of scope.
- **Linked issue(s):** Fixes #7796.
- **Labels:** `bug`, `risk: high`, `size: XS`, `agent`, `runtime`

## Validation Evidence (required)

```text
cargo test -p zeroclaw-runtime direct_turn_agent_config_resolves_runtime_profile_tunables
Result: passed. 1 test passed; 0 failed; 2205 filtered out.

cargo fmt --all -- --check
Result: passed.

git diff --check
Result: passed.

cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
Result: passed.

cargo nextest run --locked --workspace --exclude zeroclaw-desktop
Result: passed. 8720 tests run; 8720 passed; 10 skipped.
```

- **Commands run and tail output:** See the command/result block above.
- **Beyond CI — what did you manually verify?** I inspected the direct-turn `run()` and `process_message()` call sites and confirmed both now use the same resolved-agent helper before validating thinking config and entering the tool loop.
- **If any command was intentionally skipped, why:** No required local validation command was intentionally skipped. I did not manually exercise a live provider turn.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: `N/A`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No upgrade steps are required.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert 4e5716924a4cc83c72f724c7598043f3587ec447` or use GitHub's Revert button for PR #7792 after merge.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Direct agent turns would again ignore runtime-profile values that are stored in `AliasedAgentConfig::resolved`, most visibly enforcing the default `max_tool_iterations = 10` despite a higher configured runtime-profile value.
