### PR TITLE
fix(ci): narrow Kilo provider path label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -353,7 +353,6 @@
   - changed-files:
       - any-glob-to-any-file:
           - "crates/zeroclaw-providers/src/catalog.rs"
-          - "crates/zeroclaw-config/src/schema.rs"
           - "crates/zeroclaw-providers/src/factory.rs"
 
 "provider:ollama":


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Removes the monolithic `crates/zeroclaw-config/src/schema.rs` path from the `provider:kilo` labeler rule.
  - Keeps the `provider:kilo` rule scoped to the existing provider catalog/factory labeler paths.
  - Prevents unrelated config-schema PRs like #7651 from picking up the Kilo provider label.
- **Scope boundary:** This does not change Kilo provider code, provider catalog behavior, or general `config`/`web` path labeling.
- **Blast radius:** Only the PR path labeler metadata for future path-label syncs changes.
- **Linked issue(s):** Related #7651.
- **Labels:** `risk: low`, `size: XS`, `ci`.

## Validation Evidence (required)

- **Commands run and tail output:**

```text
ruby -e 'require "yaml"; YAML.load_file(".github/labeler.yml"); puts "labeler yaml ok"'
labeler yaml ok

awk 'BEGIN{label=""} /^"provider:/{label=$0} /crates\/zeroclaw-config\/src\/schema.rs|crates\/zeroclaw-config\/src\/sections.rs/ {print label " -> " $0}' .github/labeler.yml
Result: no output.

git diff --check origin/master...HEAD
Result: passed.

scripts/check-pr-title.sh "fix(ci): narrow Kilo provider path label"
Result: passed.
```

- **Beyond CI - what did you manually verify?** Confirmed the `provider:kilo` stanza now contains only `crates/zeroclaw-providers/src/catalog.rs` and `crates/zeroclaw-providers/src/factory.rs`; it no longer matches broad config schema edits.
- **If any command was intentionally skipped, why:** Rust and web builds were skipped because this is a one-line GitHub labeler metadata change.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: None.

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: N/A.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PRs: `git revert <sha>` is the plan unless otherwise noted.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Scope materially carried forward: N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`Yes/No`): N/A
- If `No`, why (inspiration-only, no direct code/design carry-over): N/A
