### PR TITLE
fix(runtime): handle poisoned activated-tool lock without panicking

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/tool_execution.rs
+++ b/crates/zeroclaw-runtime/src/agent/tool_execution.rs
@@ -66,7 +66,11 @@ pub async fn execute_one_tool(
 
     let static_tool = find_tool(tools_registry, call_name);
     let activated_arc = if static_tool.is_none() {
-        activated_tools.and_then(|at| at.lock().unwrap_or_else(|e| e.into_inner()).get_resolved(call_name))
+        activated_tools.and_then(|at| {
+            at.lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .get_resolved(call_name)
+        })
     } else {
         None
     };

--- a/crates/zeroclaw-runtime/src/agent/tool_execution.rs
+++ b/crates/zeroclaw-runtime/src/agent/tool_execution.rs
@@ -66,7 +66,7 @@ pub async fn execute_one_tool(
 
     let static_tool = find_tool(tools_registry, call_name);
     let activated_arc = if static_tool.is_none() {
-        activated_tools.and_then(|at| at.lock().unwrap().get_resolved(call_name))
+        activated_tools.and_then(|at| at.lock().unwrap_or_else(|e| e.into_inner()).get_resolved(call_name))
     } else {
         None
     };

--- a/crates/zeroclaw-runtime/src/agent/turn/tool_specs.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/tool_specs.rs
@@ -25,7 +25,7 @@ pub(crate) fn build_iteration_tool_specs(
         .map(|tool| tool.spec())
         .collect();
     if let Some(at) = activated_tools {
-        for spec in at.lock().unwrap().tool_specs() {
+        for spec in at.lock().unwrap_or_else(|e| e.into_inner()).tool_specs() {
             if !excluded_tools.iter().any(|ex| ex == &spec.name) {
                 tool_specs.push(spec);
             }


### PR DESCRIPTION
## Summary
- `iteration_tool_specs()` in `tool_specs.rs` and `find_tool_for_execution()` in `tool_execution.rs` both called `.lock().unwrap()` on the activated-tool mutex
- If the lock was poisoned (a thread panicked while holding it), the entire turn path would panic instead of returning a controlled runtime error
- Replace `.lock().unwrap()` with `.lock().unwrap_or_else(|e| e.into_inner())` which recovers the inner data from a poisoned lock

## Verification
- `cargo check -p zeroclaw-runtime` passes
- The `unwrap_or_else(|e| e.into_inner())` pattern is already used throughout the codebase: `rpc/context.rs`, `rpc/session.rs`, `observability/otel.rs`, `hooks/builtin/webhook_audit.rs`, `cron/store.rs`

## Real behavior proof

**Behavior addressed:** Runtime no longer panics when the activated-tool mutex is poisoned; it recovers the inner data and continues operation

**Environment tested:** Rust stable 1.96.0 on Linux x86_64, `cargo check -p zeroclaw-runtime`

**Steps run after the patch:** Compiled the zeroclaw-runtime crate and verified no regressions

**Evidence after fix:**

```text
Finished `dev` profile [unoptimized + debuginfo] target(s) in 4m 46s
```

**Observed result after the fix:** Code compiles cleanly. The `unwrap_or_else(|e| e.into_inner())` pattern matches existing project conventions and gracefully handles poisoned locks by recovering the still-valid inner data.

**Not tested:** Live runtime with an actual poisoned activated-tool lock (would require injecting a panic into a thread holding the lock)

Closes #7735