### PR TITLE
feat(config): delete_with_cascade for channels (#7175)

### DIFF
--- a/crates/zeroclaw-api/src/memory_traits.rs
+++ b/crates/zeroclaw-api/src/memory_traits.rs
@@ -256,6 +256,14 @@ pub trait Memory: Send + Sync + crate::attribution::Attributable {
         anyhow::bail!("purge_agent not supported by this memory backend")
     }
 
+    /// Export every memory row attributed to `agent_alias`, for the agent-
+    /// deletion archive (export-then-delete, #7175). Pairs with
+    /// [`Self::purge_agent`]: the surface exports these rows to the archive,
+    /// then purges. Default: empty (backends without per-agent export).
+    async fn export_agent(&self, _agent_alias: &str) -> anyhow::Result<Vec<MemoryEntry>> {
+        Ok(Vec::new())
+    }
+
     /// Count total memories
     async fn count(&self) -> anyhow::Result<usize>;
 

--- a/crates/zeroclaw-config/src/alias_refs.rs
+++ b/crates/zeroclaw-config/src/alias_refs.rs
@@ -236,13 +236,13 @@ impl std::error::Error for CascadeError {}
 /// reference to the alias remains. `DryRun` computes the plan and mutates
 /// nothing. [`plan_delete`] is the read-only sibling.
 ///
-/// Implements the **model-provider** kind (`providers.models.<family>.<alias>`)
-/// and the **agent** kind (`agents.<alias>`). The agent arm cascades config
-/// references only; its owned non-config state (memory rows, workspace dir,
-/// cron/acp/session rows) is cascaded by the calling surface and is not yet
-/// reflected in `ImpactReport.owned_state`. TTS/transcription providers and
-/// channels return [`CascadeError::NotImplemented`] until their follow-up lands
-/// (#7175).
+/// Implements the **model-provider** (`providers.models.<family>.<alias>`),
+/// **agent** (`agents.<alias>`), and **channel** (`channels.<type>.<alias>`)
+/// kinds. The agent arm cascades config references only; its owned non-config
+/// state (memory rows, workspace dir, cron/acp/session rows) is cascaded by the
+/// calling surface and is not reflected in `ImpactReport.owned_state`.
+/// TTS/transcription providers return [`CascadeError::NotImplemented`] until
+/// their follow-up lands (#7175).
 pub fn delete_with_cascade(
     cfg: &mut Config,
     kind: &AliasKind,
@@ -258,9 +258,7 @@ pub fn delete_with_cascade(
             "TTS/transcription provider delete-with-cascade is not yet implemented".to_string(),
         )),
         AliasKind::Agent => delete_agent(cfg, alias, policy),
-        AliasKind::Channel { .. } => Err(CascadeError::NotImplemented(
-            "channel delete-with-cascade lands in a follow-up (#7175)".to_string(),
-        )),
+        AliasKind::Channel { channel_type } => delete_channel(cfg, channel_type, alias, policy),
     }
 }
 
@@ -428,6 +426,81 @@ fn scrub_agent_refs(cfg: &mut Config, alias: &str) {
     for group in cfg.peer_groups.values_mut() {
         group.agents.retain(|m| m.as_str() != alias); // raw
     }
+}
+
+fn delete_channel(
+    cfg: &mut Config,
+    channel_type: &str,
+    alias: &str,
+    policy: CascadePolicy,
+) -> Result<CascadeReport, CascadeError> {
+    let entry_path = format!("channels.{channel_type}.{alias}");
+    let section = format!("channels.{channel_type}");
+    let exists = cfg
+        .get_map_keys(&section)
+        .is_some_and(|keys| keys.iter().any(|k| k == alias));
+    if !exists {
+        return Err(CascadeError::NotFound(entry_path));
+    }
+
+    let kind = AliasKind::Channel {
+        channel_type: channel_type.to_string(),
+    };
+    let report = plan_delete(cfg, &kind, alias);
+
+    if policy == CascadePolicy::DryRun {
+        return Ok(CascadeReport {
+            plan: report,
+            applied: Vec::new(),
+            deleted_entry: None,
+        });
+    }
+    // HARD channel refs (see `collect_channel_refs`): a mandatory dotted
+    // `peer_groups.<g>.channel`, or a bare-type group member whose only
+    // `<type>.*` channel is the target (scrubbing it would orphan the member).
+    if !report.allowed {
+        return Err(CascadeError::Refused(Box::new(report)));
+    }
+
+    let applied = report.scrubs.clone();
+    let target = format!("{channel_type}.{alias}");
+    scrub_channel_refs(cfg, &target);
+    // Remove the `channels.<type>.<alias>` entry via the same generic map-key
+    // path the gateway/CLI use.
+    if let Err(e) = cfg.delete_map_key(&section, alias) {
+        return Err(CascadeError::PostCondition(format!(
+            "failed to remove {entry_path}: {e}"
+        )));
+    }
+
+    let remaining = find_all_references(cfg, &kind, alias);
+    if !remaining.is_empty() {
+        let paths: Vec<_> = remaining.iter().map(|s| s.path.as_str()).collect();
+        return Err(CascadeError::PostCondition(format!(
+            "{} dangling reference(s) to {target} remain: {}",
+            remaining.len(),
+            paths.join(", ")
+        )));
+    }
+
+    Ok(CascadeReport {
+        plan: report,
+        applied,
+        deleted_entry: Some(entry_path),
+    })
+}
+
+/// Mutating mirror of [`collect_channel_refs`]: drop the soft channel references
+/// to `target` (`"<type>.<alias>"`). `peer_groups.<g>.channel` is a HARD ref and
+/// is never scrubbed (a delete carrying one is refused before reaching here).
+/// Comparisons `.trim()` to mirror `find_all_references` and `validate()`.
+fn scrub_channel_refs(cfg: &mut Config, target: &str) {
+    for agent in cfg.agents.values_mut() {
+        agent.channels.retain(|ch| ch.trim() != target);
+    }
+    cfg.escalation
+        .alert_channels
+        .retain(|ch| ch.trim() != target);
 }
 
 // ── deterministic iteration over the alias-keyed maps ───────────────────────
@@ -1446,26 +1519,19 @@ mod tests {
 
     #[test]
     fn cascade_not_implemented_for_other_kinds() {
+        // Only TTS/transcription providers remain unimplemented now (model
+        // providers, agents, and channels are all wired).
         let mut cfg = empty_config();
-        assert!(matches!(
-            delete_with_cascade(
-                &mut cfg,
-                &AliasKind::Channel {
-                    channel_type: "discord".to_string()
-                },
-                "x",
-                CascadePolicy::RefuseOnHard,
-            ),
-            Err(CascadeError::NotImplemented(_))
-        ));
-        let tts = AliasKind::Provider {
-            category: ProviderCategory::Tts,
-            family: "elevenlabs".to_string(),
-        };
-        assert!(matches!(
-            delete_with_cascade(&mut cfg, &tts, "x", CascadePolicy::RefuseOnHard),
-            Err(CascadeError::NotImplemented(_))
-        ));
+        for category in [ProviderCategory::Tts, ProviderCategory::Transcription] {
+            let kind = AliasKind::Provider {
+                category,
+                family: "x".to_string(),
+            };
+            assert!(matches!(
+                delete_with_cascade(&mut cfg, &kind, "x", CascadePolicy::RefuseOnHard),
+                Err(CascadeError::NotImplemented(_))
+            ));
+        }
     }
 
     // ── delete_with_cascade (agents) ────────────────────────────────────────
@@ -1668,5 +1734,208 @@ mod tests {
         assert_eq!(report.deleted_entry.as_deref(), Some("agents.bot"));
         assert!(!cfg.agents.contains_key("bot"));
         assert!(find_all_references(&cfg, &AliasKind::Agent, "bot").is_empty());
+    }
+
+    // ── delete_with_cascade (channels) ──────────────────────────────────────
+
+    fn channel_kind() -> AliasKind {
+        AliasKind::Channel {
+            channel_type: "discord".to_string(),
+        }
+    }
+
+    fn has_channel(cfg: &Config, alias: &str) -> bool {
+        cfg.get_map_keys("channels.discord")
+            .unwrap_or_default()
+            .iter()
+            .any(|k| k == alias)
+    }
+
+    #[test]
+    fn cascade_channel_scrubs_soft_refs_and_removes_entry() {
+        let mut cfg = empty_config();
+        cfg.create_map_key("channels.discord", "main").unwrap();
+        cfg.agents.insert(
+            "ops".to_string(),
+            AliasedAgentConfig {
+                channels: vec!["discord.main".into()],
+                ..Default::default()
+            },
+        );
+        cfg.escalation
+            .alert_channels
+            .push("discord.main".to_string());
+
+        let report = delete_with_cascade(
+            &mut cfg,
+            &channel_kind(),
+            "main",
+            CascadePolicy::RefuseOnHard,
+        )
+        .expect("soft-only channel delete succeeds");
+        assert_eq!(report.applied.len(), 2, "agent channel + alert_channel");
+        assert_eq!(
+            report.deleted_entry.as_deref(),
+            Some("channels.discord.main")
+        );
+        assert!(!has_channel(&cfg, "main"));
+        assert!(cfg.agents["ops"].channels.is_empty());
+        assert!(cfg.escalation.alert_channels.is_empty());
+        assert!(find_all_references(&cfg, &channel_kind(), "main").is_empty());
+    }
+
+    #[test]
+    fn cascade_channel_refuses_on_hard_peer_group_ref() {
+        let mut cfg = empty_config();
+        cfg.create_map_key("channels.discord", "main").unwrap();
+        cfg.peer_groups.insert(
+            "crew".to_string(),
+            PeerGroupConfig {
+                channel: "discord.main".into(),
+                ..Default::default()
+            },
+        );
+        let err = delete_with_cascade(
+            &mut cfg,
+            &channel_kind(),
+            "main",
+            CascadePolicy::RefuseOnHard,
+        )
+        .unwrap_err();
+        match err {
+            CascadeError::Refused(report) => {
+                assert_eq!(report.blockers[0].path, "peer_groups.crew.channel");
+            }
+            other => panic!("expected Refused, got {other:?}"),
+        }
+        assert!(has_channel(&cfg, "main"), "no mutation on refuse");
+    }
+
+    #[test]
+    fn cascade_channel_dry_run_mutates_nothing() {
+        let mut cfg = empty_config();
+        cfg.create_map_key("channels.discord", "main").unwrap();
+        cfg.agents.insert(
+            "ops".to_string(),
+            AliasedAgentConfig {
+                channels: vec!["discord.main".into()],
+                ..Default::default()
+            },
+        );
+        let report =
+            delete_with_cascade(&mut cfg, &channel_kind(), "main", CascadePolicy::DryRun).unwrap();
+        assert!(report.deleted_entry.is_none());
+        assert_eq!(report.plan.scrubs.len(), 1);
+        assert!(has_channel(&cfg, "main"));
+        assert_eq!(cfg.agents["ops"].channels.len(), 1);
+    }
+
+    #[test]
+    fn cascade_channel_not_found() {
+        let mut cfg = empty_config();
+        let err = delete_with_cascade(
+            &mut cfg,
+            &channel_kind(),
+            "ghost",
+            CascadePolicy::RefuseOnHard,
+        )
+        .unwrap_err();
+        assert!(matches!(err, CascadeError::NotFound(_)));
+    }
+
+    #[test]
+    fn cascade_channel_refuses_orphaning_bare_group_member() {
+        // BARE-type group ("discord", not "discord.main"). validate()
+        // (schema.rs:17461-17478) requires each member to keep some `discord.*`
+        // channel. `ops`'s only discord channel is the one being deleted, so the
+        // delete must REFUSE — scrubbing it would yield a config validate() rejects.
+        let mut cfg = empty_config();
+        cfg.create_map_key("channels.discord", "main").unwrap();
+        cfg.agents.insert(
+            "ops".to_string(),
+            AliasedAgentConfig {
+                channels: vec!["discord.main".into()],
+                ..Default::default()
+            },
+        );
+        let mut group = PeerGroupConfig {
+            channel: "discord".into(), // bare type
+            ..Default::default()
+        };
+        group.agents.push(AgentAlias::new("ops"));
+        cfg.peer_groups.insert("crew".to_string(), group);
+
+        let err = delete_with_cascade(
+            &mut cfg,
+            &channel_kind(),
+            "main",
+            CascadePolicy::RefuseOnHard,
+        )
+        .unwrap_err();
+        match err {
+            CascadeError::Refused(report) => {
+                assert!(
+                    report
+                        .blockers
+                        .iter()
+                        .any(|b| b.path == "peer_groups.crew.agents[0]"),
+                    "bare-group member orphan must be a hard blocker, got {:?}",
+                    report.blockers
+                );
+            }
+            other => panic!("expected Refused, got {other:?}"),
+        }
+        assert!(has_channel(&cfg, "main"), "no mutation on refuse");
+        assert_eq!(
+            cfg.agents["ops"].channels.len(),
+            1,
+            "member channel not scrubbed on refuse"
+        );
+    }
+
+    #[test]
+    fn cascade_channel_proceeds_when_bare_group_member_keeps_another() {
+        // Same bare-type group, but `ops` also has `discord.backup`. Deleting
+        // `discord.main` leaves it with a surviving `discord.*`, so membership
+        // stays valid and the delete proceeds (scrubbing only the main ref).
+        let mut cfg = empty_config();
+        cfg.create_map_key("channels.discord", "main").unwrap();
+        cfg.create_map_key("channels.discord", "backup").unwrap();
+        cfg.agents.insert(
+            "ops".to_string(),
+            AliasedAgentConfig {
+                channels: vec!["discord.main".into(), "discord.backup".into()],
+                ..Default::default()
+            },
+        );
+        let mut group = PeerGroupConfig {
+            channel: "discord".into(), // bare type
+            ..Default::default()
+        };
+        group.agents.push(AgentAlias::new("ops"));
+        cfg.peer_groups.insert("crew".to_string(), group);
+
+        let report = delete_with_cascade(
+            &mut cfg,
+            &channel_kind(),
+            "main",
+            CascadePolicy::RefuseOnHard,
+        )
+        .expect("delete proceeds when a sibling channel keeps membership valid");
+        assert_eq!(
+            report.deleted_entry.as_deref(),
+            Some("channels.discord.main")
+        );
+        assert!(!has_channel(&cfg, "main"));
+        let remaining: Vec<&str> = cfg.agents["ops"]
+            .channels
+            .iter()
+            .map(|c| c.as_str())
+            .collect();
+        assert_eq!(
+            remaining,
+            vec!["discord.backup"],
+            "only the deleted channel is scrubbed; backup survives"
+        );
     }
 }

--- a/crates/zeroclaw-gateway/src/agent_owned_state.rs
+++ b/crates/zeroclaw-gateway/src/agent_owned_state.rs
@@ -1,0 +1,198 @@
+//! Agent-deletion **owned-state** cascade (#7175) — the non-config half of
+//! deleting an agent.
+//!
+//! Config references are scrubbed by
+//! `zeroclaw_config::alias_refs::delete_with_cascade`. This module handles the
+//! persisted state the *surface* owns (the infra stores `zeroclaw-config` can't
+//! depend on): memory rows, cron jobs, ACP sessions, and session-metadata
+//! attribution. Each store is opened from `config.data_dir` on demand.
+//!
+//! **Export-then-delete** (recoverable, per the agreed cascade policy): rows are
+//! written into the same `agents/_deleted/<alias>-<ts>/` archive as the
+//! workspace (under `cascade/`), then removed. Best-effort + reported — a single
+//! store failing does not abort the others (mirrors the existing
+//! archive+purge behaviour); the surface persists the config last.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::Context;
+use zeroclaw_api::memory_traits::Memory;
+use zeroclaw_config::schema::Config;
+use zeroclaw_infra::acp_session_store::AcpSessionStore;
+use zeroclaw_infra::session_backend::SessionBackend;
+
+/// Count of *live* (un-killed) ACP sessions owned by `alias`. Non-zero is a HARD
+/// blocker for deleting the agent. Returns `Err` if the ACP store exists but
+/// can't be opened/queried — the caller must **fail closed** (refuse the delete)
+/// rather than assume zero, since live sessions might exist undetected.
+/// (`AcpSessionStore::new` creates a missing DB empty, so a fresh system with no
+/// ACP usage returns `Ok(0)` and deletes proceed normally.)
+pub fn live_acp_session_count(config: &Config, alias: &str) -> anyhow::Result<usize> {
+    let store = AcpSessionStore::new(&config.data_dir)
+        .context("open ACP session store to verify live sessions")?;
+    store
+        .count_live_sessions_by_agent(alias)
+        .context("count live ACP sessions for agent")
+}
+
+/// What the owned-state cascade removed.
+#[derive(Debug, Default, Clone, serde::Serialize)]
+pub struct OwnedStateReport {
+    pub memory_purged: usize,
+    pub cron_removed: usize,
+    pub acp_removed: usize,
+    pub sessions_cleared: usize,
+    pub archived_to: Option<String>,
+    /// Surfaced failures (export / purge / delete errors). Non-empty means part
+    /// of the cascade did NOT complete — those rows were not silently treated as
+    /// removed. The handler logs these; nothing is masked as success.
+    pub warnings: Vec<String>,
+}
+
+async fn write_json(path: &Path, bytes: Vec<u8>) {
+    if let Err(err) = tokio::fs::write(path, bytes).await {
+        ::zeroclaw_log::record!(
+            WARN,
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                .with_attrs(::serde_json::json!({"path": path.display().to_string(), "err": err.to_string()})),
+            "owned-state cascade: failed to write archive file"
+        );
+    }
+}
+
+/// Export-then-delete the agent's owned non-config state into `archive_dir`
+/// (the `agents/_deleted/<alias>-<ts>/` the workspace was moved to), then return
+/// a report. Best-effort: each store is independent.
+///
+/// Precondition: the caller already refused if [`live_acp_session_count`] was
+/// non-zero, so only killed ACP sessions remain to delete here.
+pub async fn cascade_owned_state(
+    config: &Config,
+    mem: &Arc<dyn Memory>,
+    session_backend: Option<&Arc<dyn SessionBackend>>,
+    alias: &str,
+    archive_dir: &Path,
+) -> OwnedStateReport {
+    let cascade_dir = archive_dir.join("cascade");
+    let _ = tokio::fs::create_dir_all(&cascade_dir).await;
+    let mut warnings: Vec<String> = Vec::new();
+
+    // ── memory: export → archive → purge. Failures are SURFACED in `warnings`,
+    // not masked as 0 (markdown/none have no DB rows — their memory lives in the
+    // archived workspace — but a real backend error must stay visible). ────────
+    let mem_rows = match mem.export_agent(alias).await {
+        Ok(rows) => rows,
+        Err(e) => {
+            warnings.push(format!("memory export: {e}"));
+            Vec::new()
+        }
+    };
+    if let Ok(bytes) = serde_json::to_vec_pretty(&mem_rows) {
+        write_json(&cascade_dir.join("memory.json"), bytes).await;
+    }
+    let memory_purged = match mem.purge_agent(alias).await {
+        Ok(n) => n,
+        Err(e) => {
+            warnings.push(format!("memory purge: {e}"));
+            0
+        }
+    };
+
+    // ── cron: list → archive → remove (cron_runs cascade off job_id) ─────────
+    let cron_jobs = match zeroclaw_runtime::cron::list_jobs_by_agent(config, alias) {
+        Ok(jobs) => jobs,
+        Err(e) => {
+            warnings.push(format!("cron list: {e}"));
+            Vec::new()
+        }
+    };
+    if let Ok(bytes) = serde_json::to_vec_pretty(&cron_jobs) {
+        write_json(&cascade_dir.join("cron.json"), bytes).await;
+    }
+    let cron_removed = match zeroclaw_runtime::cron::remove_jobs_by_agent(config, alias) {
+        Ok(n) => n,
+        Err(e) => {
+            warnings.push(format!("cron remove: {e}"));
+            0
+        }
+    };
+
+    // ── acp: list → archive → delete (only killed sessions remain) ───────────
+    let mut acp_removed = 0;
+    match AcpSessionStore::new(&config.data_dir) {
+        Ok(store) => {
+            let sessions = store.list_sessions_by_agent(alias).unwrap_or_default();
+            // AcpSessionSummary isn't Serialize; hand-map the fields we keep.
+            let json: Vec<serde_json::Value> = sessions
+                .iter()
+                .map(|s| {
+                    serde_json::json!({
+                        "session_uuid": s.session_uuid,
+                        "agent_alias": s.agent_alias,
+                        "workspace_dir": s.workspace_dir,
+                        "token_count": s.token_count,
+                        "message_count": s.message_count,
+                        "created_at": s.created_at.to_rfc3339(),
+                        "last_activity": s.last_activity.to_rfc3339(),
+                    })
+                })
+                .collect();
+            if let Ok(bytes) = serde_json::to_vec_pretty(&json) {
+                write_json(&cascade_dir.join("acp.json"), bytes).await;
+            }
+            match store.delete_sessions_by_agent(alias) {
+                Ok(n) => acp_removed = n,
+                Err(e) => warnings.push(format!("acp delete: {e}")),
+            }
+        }
+        Err(e) => warnings.push(format!("acp store open: {e}")),
+    }
+
+    // ── session metadata: clear the stale agent attribution (keep the convo) ─
+    let sessions_cleared = match session_backend {
+        Some(b) => match b.clear_agent_attribution(alias) {
+            Ok(n) => n,
+            Err(e) => {
+                warnings.push(format!("session attribution clear: {e}"));
+                0
+            }
+        },
+        None => 0,
+    };
+
+    if !warnings.is_empty() {
+        ::zeroclaw_log::record!(
+            WARN,
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                .with_attrs(::serde_json::json!({"agent": alias, "warnings": warnings})),
+            "owned-state cascade completed with warnings (some state may not have been removed)"
+        );
+    }
+
+    let report = OwnedStateReport {
+        memory_purged,
+        cron_removed,
+        acp_removed,
+        sessions_cleared,
+        archived_to: Some(archive_dir.display().to_string()),
+        warnings,
+    };
+
+    // ── manifest: a self-describing record of the bundle ────────────────────
+    let manifest = serde_json::json!({
+        "alias": alias,
+        "memory_rows": report.memory_purged,
+        "cron_jobs": report.cron_removed,
+        "acp_sessions": report.acp_removed,
+        "sessions_cleared": report.sessions_cleared,
+        "warnings": report.warnings,
+    });
+    if let Ok(bytes) = serde_json::to_vec_pretty(&manifest) {
+        write_json(&archive_dir.join("manifest.json"), bytes).await;
+    }
+
+    report
+}

--- a/crates/zeroclaw-gateway/src/api_config.rs
+++ b/crates/zeroclaw-gateway/src/api_config.rs
@@ -1086,6 +1086,13 @@ async fn delete_agent_cascade(
         );
     }
 
+    // Resolve the workspace dir BEFORE the config cascade removes the agents
+    // entry: `agent_workspace_dir` only returns an operator-set custom
+    // `workspace.path` while the entry exists; after removal it silently falls
+    // back to the default `install_root/agents/<alias>/workspace`, so a
+    // custom-workspace agent's real dir would otherwise never be archived.
+    let workspace = working.agent_workspace_dir(alias);
+
     // Config cascade: scrub soft refs + remove the agents entry.
     let cascade = match alias_refs::delete_with_cascade(
         &mut working,
@@ -1107,8 +1114,8 @@ async fn delete_agent_cascade(
 
     // Archive into the shared graveyard `<data_dir>/agents/_deleted/<alias>-<ts>/`
     // (not inside the deleted agent's own dir), and give the owned-state exports
-    // a home there even if the agent had no workspace dir.
-    let workspace = working.agent_workspace_dir(alias);
+    // a home there even if the agent had no workspace dir. (`workspace` was
+    // resolved above, before the cascade removed the entry.)
     let ts = chrono::Utc::now().format("%Y%m%d%H%M%S");
     let archive_dir = working
         .data_dir
@@ -2032,6 +2039,41 @@ mod tests {
         assert_eq!(
             dirty_entry_for("providers.models.anthropic.default.fallback[0]"),
             "providers.models.anthropic.default"
+        );
+    }
+
+    #[test]
+    fn delete_cascade_resolves_custom_workspace_before_removing_entry() {
+        // Regression: `delete_agent_cascade` must resolve `agent_workspace_dir`
+        // BEFORE `delete_with_cascade` removes the agents entry. The method only
+        // returns an operator-set custom `workspace.path` while the entry exists;
+        // resolving it after removal silently yields the DEFAULT path, so a
+        // custom-workspace agent's real dir would never be archived.
+        let custom = std::path::PathBuf::from("/var/lib/zc-test/custom-victim-ws");
+        let mut cfg = zeroclaw_config::schema::Config::default();
+        cfg.agents.insert(
+            "victim".to_string(),
+            zeroclaw_config::schema::AliasedAgentConfig::default(),
+        );
+        cfg.agents.get_mut("victim").unwrap().workspace.path = Some(custom.clone());
+
+        // While the entry exists → the custom path (what the handler captures).
+        assert_eq!(cfg.agent_workspace_dir("victim"), custom);
+
+        // After the cascade removes the entry → it falls back to the DEFAULT
+        // path; that is exactly why resolution must happen before the cascade.
+        zeroclaw_config::alias_refs::delete_with_cascade(
+            &mut cfg,
+            &zeroclaw_config::alias_refs::AliasKind::Agent,
+            "victim",
+            zeroclaw_config::alias_refs::CascadePolicy::RefuseOnHard,
+        )
+        .expect("soft-only agent delete succeeds");
+        assert!(!cfg.agents.contains_key("victim"));
+        assert_ne!(
+            cfg.agent_workspace_dir("victim"),
+            custom,
+            "after removal the custom workspace path defaults — resolve BEFORE the cascade"
         );
     }
 

--- a/crates/zeroclaw-gateway/src/api_config.rs
+++ b/crates/zeroclaw-gateway/src/api_config.rs
@@ -997,7 +997,15 @@ pub async fn handle_delete_map_key(
     if let Err(e) = require_auth(&state, &headers) {
         return e.into_response();
     }
-    let mut working = state.config.read().clone();
+    let working = state.config.read().clone();
+    // Agent deletion is special: it must scrub config references (heartbeat,
+    // peer-groups, delegates, workspace.access, …) via `delete_with_cascade`
+    // and cascade owned non-config state (memory / cron / acp / session). The
+    // generic map-key delete below handles every other section unchanged.
+    if q.path == "agents" {
+        return delete_agent_cascade(&state, working, &q.key).await;
+    }
+    let mut working = working;
     let removed = match working.delete_map_key(&q.path, &q.key) {
         Ok(b) => b,
         Err(msg) => {
@@ -1007,45 +1015,6 @@ pub async fn handle_delete_map_key(
         }
     };
     if removed {
-        // Agent alias removal archives `agents/<alias>/workspace/` to
-        // `agents/_deleted/<alias>-<ts>/` rather than rm -rf. The
-        // workspace may contain operator notes, IDENTITY.md edits, etc.
-        // Memory database rows for the alias are also purged through
-        // the storage adapter so a future reuse of the same alias
-        // doesn't inherit stale rows.
-        if q.path == "agents" {
-            let workspace = working.agent_workspace_dir(&q.key);
-            if workspace.exists()
-                && let Some(parent) = workspace.parent()
-            {
-                let ts = chrono::Utc::now().format("%Y%m%d%H%M%S");
-                let archive_root = parent.join("_deleted");
-                let archive_dir = archive_root.join(format!("{}-{ts}", q.key));
-                if let Err(err) = tokio::fs::create_dir_all(&archive_root).await {
-                    ::zeroclaw_log::record!(WARN, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_outcome(::zeroclaw_log::EventOutcome::Unknown).with_attrs(::serde_json::json!({"agent": q.key, "archive": archive_root.display().to_string(), "err": err.to_string()})), "agent alias removed from config but archive dir creation failed");
-                } else if let Err(err) = tokio::fs::rename(&workspace, &archive_dir).await {
-                    ::zeroclaw_log::record!(WARN, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_outcome(::zeroclaw_log::EventOutcome::Unknown).with_attrs(::serde_json::json!({"agent": q.key, "from": workspace.display().to_string(), "to": archive_dir.display().to_string(), "err": err.to_string()})), "agent alias removed from config but workspace archive failed");
-                } else {
-                    ::zeroclaw_log::record!(INFO, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(::serde_json::json!({"agent": q.key, "archive": archive_dir.display().to_string()})), "agent workspace archived after alias removal");
-                }
-            }
-            match state.mem.purge_agent(&q.key).await {
-                Ok(rows) if rows > 0 => ::zeroclaw_log::record!(
-                    INFO,
-                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                        .with_attrs(::serde_json::json!({"agent": q.key, "rows": rows})),
-                    "agent memory rows purged after alias removal"
-                ),
-                Ok(_) => {}
-                Err(err) => ::zeroclaw_log::record!(
-                    WARN,
-                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                        .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                        .with_attrs(::serde_json::json!({"agent": q.key, "err": err.to_string()})),
-                    "purge_agent failed (backend may not support it)"
-                ),
-            }
-        }
         working.mark_dirty(&format!("{}.{}", q.path, q.key));
         if let Err(e) = persist_and_swap(&state, working).await {
             return error_response(e);
@@ -1057,6 +1026,180 @@ pub async fn handle_delete_map_key(
         created: false,
     })
     .into_response()
+}
+
+/// Agent-deletion cascade: refuse on HARD references (enabled `heartbeat.agent`
+/// or live ACP sessions), else scrub config refs + remove the entry via
+/// `delete_with_cascade`, archive the workspace, run the owned-state cascade
+/// (export-then-delete memory/cron/acp + clear session attribution), and persist.
+async fn delete_agent_cascade(
+    state: &AppState,
+    mut working: zeroclaw_config::schema::Config,
+    alias: &str,
+) -> Response {
+    use zeroclaw_config::alias_refs::{self, AliasKind, CascadePolicy};
+
+    if !working.agents.contains_key(alias) {
+        return error_response(
+            ConfigApiError::new(
+                ConfigApiCode::PathNotFound,
+                format!("agents.{alias} is not configured"),
+            )
+            .with_path("agents"),
+        );
+    }
+
+    // Refuse on HARD: config blockers (e.g. enabled heartbeat.agent) OR live ACP
+    // sessions (the operator must end those first). The ACP gate FAILS CLOSED:
+    // if the session store can't be read we refuse rather than risk orphaning
+    // live sessions.
+    let plan = alias_refs::plan_delete(&working, &AliasKind::Agent, alias);
+    let live_acp = match crate::agent_owned_state::live_acp_session_count(&working, alias) {
+        Ok(n) => n,
+        Err(e) => {
+            return error_response(
+                ConfigApiError::new(
+                    ConfigApiCode::ValidationFailed,
+                    format!(
+                        "cannot delete agent `{alias}`: could not verify live ACP sessions ({e}); refusing to avoid orphaning active sessions"
+                    ),
+                )
+                .with_path(format!("agents.{alias}")),
+            );
+        }
+    };
+    if !plan.allowed || live_acp > 0 {
+        let mut reasons: Vec<String> = plan
+            .blockers
+            .iter()
+            .map(|b| format!("{} (hard config reference)", b.path))
+            .collect();
+        if live_acp > 0 {
+            reasons.push(format!("{live_acp} live ACP session(s) — end them first"));
+        }
+        return error_response(
+            ConfigApiError::new(
+                ConfigApiCode::ValidationFailed,
+                format!("cannot delete agent `{alias}`: {}", reasons.join("; ")),
+            )
+            .with_path(format!("agents.{alias}")),
+        );
+    }
+
+    // Config cascade: scrub soft refs + remove the agents entry.
+    let cascade = match alias_refs::delete_with_cascade(
+        &mut working,
+        &AliasKind::Agent,
+        alias,
+        CascadePolicy::RefuseOnHard,
+    ) {
+        Ok(report) => report,
+        Err(e) => {
+            return error_response(
+                ConfigApiError::new(
+                    ConfigApiCode::ValidationFailed,
+                    format!("agent config cascade failed: {e}"),
+                )
+                .with_path(format!("agents.{alias}")),
+            );
+        }
+    };
+
+    // Archive into the shared graveyard `<data_dir>/agents/_deleted/<alias>-<ts>/`
+    // (not inside the deleted agent's own dir), and give the owned-state exports
+    // a home there even if the agent had no workspace dir.
+    let workspace = working.agent_workspace_dir(alias);
+    let ts = chrono::Utc::now().format("%Y%m%d%H%M%S");
+    let archive_dir = working
+        .data_dir
+        .join("agents")
+        .join("_deleted")
+        .join(format!("{alias}-{ts}"));
+    if let Err(err) = tokio::fs::create_dir_all(&archive_dir).await {
+        ::zeroclaw_log::record!(WARN, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_outcome(::zeroclaw_log::EventOutcome::Unknown).with_attrs(::serde_json::json!({"agent": alias, "archive": archive_dir.display().to_string(), "err": err.to_string()})), "agent delete: archive dir creation failed");
+    }
+    if workspace.exists() {
+        let dest = archive_dir.join("workspace");
+        if let Err(err) = tokio::fs::rename(&workspace, &dest).await {
+            ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                    .with_attrs(::serde_json::json!({"agent": alias, "err": err.to_string()})),
+                "agent delete: workspace archive failed"
+            );
+        }
+    }
+
+    // Owned-state cascade (export-then-delete memory/cron/acp + clear sessions).
+    let owned = crate::agent_owned_state::cascade_owned_state(
+        &working,
+        &state.mem,
+        state.session_backend.as_ref(),
+        alias,
+        &archive_dir,
+    )
+    .await;
+    ::zeroclaw_log::record!(INFO, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(::serde_json::json!({"agent": alias, "memory": owned.memory_purged, "cron": owned.cron_removed, "acp": owned.acp_removed, "sessions_cleared": owned.sessions_cleared, "archive": archive_dir.display().to_string()})), "agent deleted with owned-state cascade");
+
+    // Persist: mark EVERY entry the cascade touched dirty — the removed agent
+    // entry AND each other entry whose soft-ref was scrubbed. `save_dirty` writes
+    // only marked paths, so marking just `agents.<alias>` would leave a scrubbed
+    // referrer (another agent's `delegates`, a peer group's `agents`) correct in
+    // memory but STALE on disk, reappearing as a dangling reference on the next
+    // config reload (which `validate()` then rejects). Mirrors rename's
+    // `RenameReport.dirty_paths`.
+    for path in delete_cascade_dirty_paths(&cascade) {
+        working.mark_dirty(&path);
+    }
+    if let Err(e) = persist_and_swap(state, working).await {
+        return error_response(e);
+    }
+    axum::Json(MapKeyResponse {
+        path: "agents".to_string(),
+        key: alias.to_string(),
+        created: false,
+    })
+    .into_response()
+}
+
+/// Derive the entry/section config paths a delete cascade mutated, so the
+/// persisting surface can mark each dirty. Includes the removed entry
+/// (`deleted_entry`) and the entry of every scrubbed soft reference
+/// (`applied`). Mirrors how rename marks `RenameReport.dirty_paths`.
+fn delete_cascade_dirty_paths(report: &zeroclaw_config::alias_refs::CascadeReport) -> Vec<String> {
+    let mut paths: Vec<String> = report
+        .applied
+        .iter()
+        .map(|site| dirty_entry_for(&site.path))
+        .collect();
+    if let Some(entry) = &report.deleted_entry {
+        paths.push(entry.clone());
+    }
+    paths.sort();
+    paths.dedup();
+    paths
+}
+
+/// Truncate a `RefSite` dotted path to the entry/section path that
+/// `apply_dirty_path` re-serialises wholesale, so a nested change (a dropped
+/// vec element or a removed map key) persists with the whole entry rather than
+/// requiring a leaf-precise dirty path.
+fn dirty_entry_for(refsite_path: &str) -> String {
+    let segs: Vec<&str> = refsite_path.split('.').collect();
+    match segs.first().copied() {
+        // agents.<name>.* and peer_groups.<g>.* → the entry root.
+        Some("agents" | "peer_groups") if segs.len() >= 2 => format!("{}.{}", segs[0], segs[1]),
+        // providers.<cat>.<fam>.<alias>.* → the provider entry.
+        Some("providers") if segs.len() >= 4 => segs[..4].join("."),
+        // Scalars / whole-vector fields (heartbeat.agent, acp.default_agent,
+        // escalation.alert_channels[i], model_routes[i]…) → strip any index.
+        _ => refsite_path
+            .split('[')
+            .next()
+            .unwrap_or(refsite_path)
+            .to_string(),
+    }
 }
 
 /// `POST /api/config/map-key?path=<section>&key=<name>` — instantiate a new
@@ -1857,6 +2000,40 @@ mod tests {
     //
     // build_comment_prefix tests live in zeroclaw_config::comment_writer
     // — same reason.
+
+    #[test]
+    fn dirty_entry_for_truncates_ref_paths_to_persistable_entries() {
+        // agent / peer-group referrer sites → the entry root (whole subtree).
+        assert_eq!(dirty_entry_for("agents.lead.delegates[0]"), "agents.lead");
+        assert_eq!(
+            dirty_entry_for("agents.lead.workspace.access.bot"),
+            "agents.lead"
+        );
+        assert_eq!(
+            dirty_entry_for("agents.lead.workspace.read_memory_from[2]"),
+            "agents.lead"
+        );
+        assert_eq!(
+            dirty_entry_for("peer_groups.crew.agents[1]"),
+            "peer_groups.crew"
+        );
+        // scalars / whole-vector fields → the field/section, index stripped.
+        assert_eq!(dirty_entry_for("heartbeat.agent"), "heartbeat.agent");
+        assert_eq!(dirty_entry_for("acp.default_agent"), "acp.default_agent");
+        assert_eq!(
+            dirty_entry_for("escalation.alert_channels[3]"),
+            "escalation.alert_channels"
+        );
+        assert_eq!(
+            dirty_entry_for("model_routes[0].model_provider"),
+            "model_routes"
+        );
+        // provider entry → the 4-segment entry path.
+        assert_eq!(
+            dirty_entry_for("providers.models.anthropic.default.fallback[0]"),
+            "providers.models.anthropic.default"
+        );
+    }
 
     #[test]
     fn map_prop_error_classifies_unknown_property() {

--- a/crates/zeroclaw-gateway/src/lib.rs
+++ b/crates/zeroclaw-gateway/src/lib.rs
@@ -13,6 +13,7 @@
 //! - Header sanitization (handled by axum/hyper)
 
 pub mod acp;
+pub mod agent_owned_state;
 pub mod api;
 pub mod api_browse;
 pub mod api_config;

--- a/crates/zeroclaw-infra/src/acp_session_store.rs
+++ b/crates/zeroclaw-infra/src/acp_session_store.rs
@@ -646,6 +646,94 @@ impl AcpSessionStore {
         Ok(rows > 0)
     }
 
+    // ── per-agent cascade (agent deletion, #7175) ───────────────────────────
+
+    /// Count *live* ACP sessions for `agent_alias` — rows not yet killed
+    /// (`killed_at IS NULL`). A non-zero count is a HARD blocker for deleting the
+    /// agent: the operator must end the sessions first.
+    pub fn count_live_sessions_by_agent(&self, agent_alias: &str) -> Result<usize> {
+        let conn = self.conn.lock();
+        let n: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM acp_sessions WHERE agent_alias = ?1 AND killed_at IS NULL",
+                params![agent_alias],
+                |row| row.get(0),
+            )
+            .context("Failed to count live ACP sessions for agent")?;
+        Ok(n.max(0) as usize)
+    }
+
+    /// Summaries of every ACP session (live or killed) attributed to
+    /// `agent_alias`, for the export-then-delete archive.
+    pub fn list_sessions_by_agent(&self, agent_alias: &str) -> Result<Vec<AcpSessionSummary>> {
+        let conn = self.conn.lock();
+        let mut stmt = conn
+            .prepare(
+                "SELECT s.session_uuid,
+                        s.agent_alias,
+                        s.workspace_dir,
+                        s.token_count,
+                        s.created_at,
+                        s.last_activity,
+                        (SELECT COUNT(*) FROM acp_messages m WHERE m.session_id = s.id) AS message_count
+                 FROM acp_sessions s
+                 WHERE s.agent_alias = ?1
+                 ORDER BY s.last_activity DESC",
+            )
+            .context("Failed to prepare ACP per-agent session query")?;
+
+        let rows = stmt
+            .query_map(params![agent_alias], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, i64>(3)?,
+                    row.get::<_, String>(4)?,
+                    row.get::<_, String>(5)?,
+                    row.get::<_, i64>(6)?,
+                ))
+            })
+            .context("Failed to query ACP sessions for agent")?;
+
+        let mut out = Vec::new();
+        for row in rows {
+            let (
+                session_uuid,
+                agent_alias,
+                workspace_dir,
+                token_count,
+                created_s,
+                activity_s,
+                msg_count,
+            ) = row.context("Failed to read ACP session row")?;
+            out.push(AcpSessionSummary {
+                created_at: parse_ts(&created_s, "created_at", &session_uuid),
+                last_activity: parse_ts(&activity_s, "last_activity", &session_uuid),
+                session_uuid,
+                agent_alias,
+                workspace_dir,
+                token_count: token_count.max(0) as u64,
+                message_count: msg_count.max(0) as usize,
+            });
+        }
+        Ok(out)
+    }
+
+    /// Delete every ACP session (live or killed) for `agent_alias`, returning the
+    /// row count. Child tables (`acp_messages`/`acp_tool_calls`/`acp_session_events`)
+    /// cascade via their `ON DELETE CASCADE` FKs (`foreign_keys = ON`).
+    pub fn delete_sessions_by_agent(&self, agent_alias: &str) -> Result<usize> {
+        let conn = self.conn.lock();
+        let rows = conn
+            .execute(
+                "DELETE FROM acp_sessions WHERE agent_alias = ?1",
+                params![agent_alias],
+            )
+            .context("Failed to delete ACP sessions for agent")?;
+        Ok(rows)
+    }
+
     /// Persist that an admin intentionally killed this ACP session. The
     /// transcript stays durable, but runtime rehydration must not revive it.
     pub fn mark_session_killed(&self, session_uuid: &str) -> Result<bool> {
@@ -1160,5 +1248,27 @@ mod tests {
     fn list_sessions_empty_when_no_sessions() {
         let (_tmp, store) = open_store();
         assert!(store.list_sessions().unwrap().is_empty());
+    }
+
+    #[test]
+    fn per_agent_cascade_counts_live_and_deletes_only_that_agent() {
+        let (_tmp, store) = open_store();
+        store.create_session("a-live", "alpha", "/ws/a1").unwrap();
+        store.create_session("a-killed", "alpha", "/ws/a2").unwrap();
+        store.mark_session_killed("a-killed").unwrap();
+        store.create_session("b-live", "beta", "/ws/b1").unwrap();
+
+        // Only un-killed sessions count as live (the HARD-refuse signal).
+        assert_eq!(store.count_live_sessions_by_agent("alpha").unwrap(), 1);
+        assert_eq!(store.count_live_sessions_by_agent("beta").unwrap(), 1);
+        assert_eq!(store.count_live_sessions_by_agent("ghost").unwrap(), 0);
+
+        // list_by_agent returns all (live + killed) for export.
+        assert_eq!(store.list_sessions_by_agent("alpha").unwrap().len(), 2);
+
+        // delete_by_agent removes exactly that agent's sessions.
+        assert_eq!(store.delete_sessions_by_agent("alpha").unwrap(), 2);
+        assert!(store.list_sessions_by_agent("alpha").unwrap().is_empty());
+        assert_eq!(store.list_sessions_by_agent("beta").unwrap().len(), 1);
     }
 }

--- a/crates/zeroclaw-infra/src/session_backend.rs
+++ b/crates/zeroclaw-infra/src/session_backend.rs
@@ -168,6 +168,15 @@ pub trait SessionBackend: Send + Sync {
         Ok(false)
     }
 
+    /// Clear the agent attribution (`agent_alias` → NULL) on every session
+    /// owned by `agent_alias`, returning the number of rows updated. Used by the
+    /// agent-deletion cascade (#7175): the conversation history (a possibly
+    /// channel-shared session) is kept, only the stale agent attribution is
+    /// dropped. No-op for backends without per-agent metadata.
+    fn clear_agent_attribution(&self, _agent_alias: &str) -> std::io::Result<usize> {
+        Ok(0)
+    }
+
     /// Quick existence check used by the gateway to avoid resurrecting a
     /// session that the user just deleted (#7126). The default impl falls
     /// back to `get_session_metadata`; production backends should override

--- a/crates/zeroclaw-infra/src/session_sqlite.rs
+++ b/crates/zeroclaw-infra/src/session_sqlite.rs
@@ -530,6 +530,17 @@ impl SessionBackend for SqliteSessionBackend {
         Ok(true)
     }
 
+    fn clear_agent_attribution(&self, agent_alias: &str) -> std::io::Result<usize> {
+        let conn = self.conn.lock();
+        let rows = conn
+            .execute(
+                "UPDATE session_metadata SET agent_alias = NULL WHERE agent_alias = ?1",
+                params![agent_alias],
+            )
+            .map_err(std::io::Error::other)?;
+        Ok(rows)
+    }
+
     /// Cheap existence probe used by the gateway to skip cancelled-append
     /// writes against a session the user just deleted (#7126). Mirrors the
     /// row that `delete_session` wipes — once the metadata row is gone the

--- a/crates/zeroclaw-memory/src/lucid.rs
+++ b/crates/zeroclaw-memory/src/lucid.rs
@@ -432,6 +432,14 @@ impl Memory for LucidMemory {
             .await
     }
 
+    async fn purge_agent(&self, agent_alias: &str) -> anyhow::Result<usize> {
+        self.local.purge_agent(agent_alias).await
+    }
+
+    async fn export_agent(&self, agent_alias: &str) -> anyhow::Result<Vec<MemoryEntry>> {
+        self.local.export_agent(agent_alias).await
+    }
+
     async fn count(&self) -> anyhow::Result<usize> {
         self.local.count().await
     }

--- a/crates/zeroclaw-memory/src/postgres.rs
+++ b/crates/zeroclaw-memory/src/postgres.rs
@@ -605,6 +605,48 @@ impl Memory for PostgresMemory {
         .await
     }
 
+    async fn purge_agent(&self, agent_alias: &str) -> Result<usize> {
+        let client = self.client.get().clone();
+        let qualified_table = self.qualified_table.clone();
+        let qualified_agents = self.qualified_agents.clone();
+        let alias = agent_alias.to_string();
+
+        run_on_os_thread(move || -> Result<usize> {
+            let mut client = client.lock();
+            let stmt = format!(
+                "DELETE FROM {qualified_table} WHERE agent_id = (SELECT id FROM {qualified_agents} WHERE alias = $1)"
+            );
+            let deleted = client.execute(&stmt, &[&alias])?;
+            usize::try_from(deleted).context("PostgreSQL returned an oversized delete count")
+        })
+        .await
+    }
+
+    async fn export_agent(&self, agent_alias: &str) -> Result<Vec<MemoryEntry>> {
+        let client = self.client.get().clone();
+        let qualified_table = self.qualified_table.clone();
+        let qualified_agents = self.qualified_agents.clone();
+        let alias = agent_alias.to_string();
+
+        run_on_os_thread(move || -> Result<Vec<MemoryEntry>> {
+            let mut client = client.lock();
+            let stmt = format!(
+                "
+                SELECT m.id, m.key, m.content, m.category, m.created_at, m.session_id, a.alias AS agent_alias, m.agent_id
+                FROM {qualified_table} m
+                LEFT JOIN {qualified_agents} a ON a.id = m.agent_id
+                WHERE m.agent_id = (SELECT id FROM {qualified_agents} WHERE alias = $1)
+                ORDER BY m.created_at ASC
+                "
+            );
+            let rows = client.query(&stmt, &[&alias])?;
+            rows.iter()
+                .map(Self::row_to_entry)
+                .collect::<Result<Vec<MemoryEntry>>>()
+        })
+        .await
+    }
+
     async fn count(&self) -> Result<usize> {
         let client = self.client.get().clone();
         let qualified_table = self.qualified_table.clone();

--- a/crates/zeroclaw-memory/src/qdrant.rs
+++ b/crates/zeroclaw-memory/src/qdrant.rs
@@ -789,6 +789,24 @@ impl Memory for QdrantMemory {
         Ok(matches)
     }
 
+    async fn purge_agent(&self, agent_alias: &str) -> Result<usize> {
+        // Qdrant stores the agent alias in the `agent_id` payload field.
+        let matches = self
+            .list_for_agents(&[agent_alias], None, None)
+            .await?
+            .len();
+        if matches == 0 {
+            return Ok(0);
+        }
+        self.delete_points_matching(&[("agent_id", agent_alias)])
+            .await?;
+        Ok(matches)
+    }
+
+    async fn export_agent(&self, agent_alias: &str) -> Result<Vec<MemoryEntry>> {
+        self.list_for_agents(&[agent_alias], None, None).await
+    }
+
     async fn count(&self) -> Result<usize> {
         self.ensure_initialized().await?;
 

--- a/crates/zeroclaw-memory/src/sqlite.rs
+++ b/crates/zeroclaw-memory/src/sqlite.rs
@@ -1394,6 +1394,43 @@ impl Memory for SqliteMemory {
         .await?
     }
 
+    async fn export_agent(&self, agent_alias: &str) -> anyhow::Result<Vec<MemoryEntry>> {
+        let conn = self.conn.clone();
+        let agent_alias = agent_alias.to_string();
+
+        tokio::task::spawn_blocking(move || -> anyhow::Result<Vec<MemoryEntry>> {
+            let conn = conn.lock();
+            let mut stmt = conn.prepare(
+                "SELECT m.id, m.key, m.content, m.category, m.created_at, m.session_id, m.namespace, m.importance, m.superseded_by, a.alias, m.agent_id \
+                 FROM memories m LEFT JOIN agents a ON a.id = m.agent_id \
+                 WHERE m.agent_id = (SELECT id FROM agents WHERE alias = ?1 LIMIT 1) \
+                 ORDER BY m.created_at ASC",
+            )?;
+            let rows = stmt.query_map(params![agent_alias], |row| {
+                Ok(MemoryEntry {
+                    id: row.get(0)?,
+                    key: row.get(1)?,
+                    content: row.get(2)?,
+                    category: Self::str_to_category(&row.get::<_, String>(3)?),
+                    timestamp: row.get(4)?,
+                    session_id: row.get(5)?,
+                    score: None,
+                    namespace: row.get::<_, Option<String>>(6)?.unwrap_or_else(|| "default".into()),
+                    importance: row.get(7)?,
+                    superseded_by: row.get(8)?,
+                    agent_alias: row.get(9)?,
+                    agent_id: row.get(10)?,
+                })
+            })?;
+            let mut results = Vec::new();
+            for row in rows {
+                results.push(row?);
+            }
+            Ok(results)
+        })
+        .await?
+    }
+
     async fn recall_namespaced(
         &self,
         namespace: &str,
@@ -1746,6 +1783,45 @@ mod tests {
         let purged_ghost = mem.purge_agent("ghost").await.unwrap();
         assert_eq!(purged_ghost, 0);
         assert_eq!(mem.count().await.unwrap(), 2);
+    }
+
+    #[tokio::test]
+    async fn sqlite_export_agent_returns_only_that_agents_rows() {
+        let (_tmp, mem) = temp_sqlite();
+        let alpha = mem.ensure_agent_uuid("alpha").await.unwrap();
+        let rogue = mem.ensure_agent_uuid("rogue").await.unwrap();
+        for idx in 0..3 {
+            mem.store_with_agent(
+                &format!("alpha-{idx}"),
+                "alpha row",
+                MemoryCategory::Core,
+                None,
+                None,
+                None,
+                Some(&alpha),
+            )
+            .await
+            .unwrap();
+        }
+        mem.store_with_agent(
+            "rogue-0",
+            "rogue row",
+            MemoryCategory::Core,
+            None,
+            None,
+            None,
+            Some(&rogue),
+        )
+        .await
+        .unwrap();
+
+        let exported = mem.export_agent("alpha").await.unwrap();
+        assert_eq!(exported.len(), 3, "export only alpha's rows");
+        assert!(exported.iter().all(|e| e.key.starts_with("alpha-")));
+        assert_eq!(mem.export_agent("rogue").await.unwrap().len(), 1);
+        assert!(mem.export_agent("ghost").await.unwrap().is_empty());
+        // export does NOT delete.
+        assert_eq!(mem.count().await.unwrap(), 4);
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-runtime/src/cron/mod.rs
+++ b/crates/zeroclaw-runtime/src/cron/mod.rs
@@ -14,9 +14,10 @@ pub use schedule::{
 };
 #[allow(unused_imports)]
 pub use store::{
-    add_agent_job, all_overdue_jobs, due_jobs, get_job, list_jobs, list_runs, record_last_run,
-    record_last_run_with_status, record_run, remove_job, reschedule_after_run,
-    reschedule_after_run_with_status, skip_missed_run, sync_declarative_jobs, update_job,
+    add_agent_job, all_overdue_jobs, due_jobs, get_job, list_jobs, list_jobs_by_agent, list_runs,
+    record_last_run, record_last_run_with_status, record_run, remove_job, remove_jobs_by_agent,
+    reschedule_after_run, reschedule_after_run_with_status, skip_missed_run, sync_declarative_jobs,
+    update_job,
 };
 pub use types::{
     CronJob, CronJobPatch, CronRun, DeliveryConfig, JobType, Schedule, SessionTarget,

--- a/crates/zeroclaw-runtime/src/cron/store.rs
+++ b/crates/zeroclaw-runtime/src/cron/store.rs
@@ -226,6 +226,43 @@ pub fn remove_job(config: &Config, id: &str) -> Result<()> {
     Ok(())
 }
 
+/// Cron jobs owned by `agent_alias`, for the agent-deletion export-then-delete
+/// archive (#7175).
+pub fn list_jobs_by_agent(config: &Config, agent_alias: &str) -> Result<Vec<CronJob>> {
+    let Some(jobs) = with_read_connection(config, |conn| {
+        let mut stmt = conn.prepare(
+            "SELECT id, expression, command, schedule, job_type, prompt, name, session_target, model,
+                    enabled, delivery, delete_after_run, created_at, next_run, last_run, last_status, last_output,
+                    allowed_tools, source, uses_memory, agent_alias
+             FROM cron_jobs WHERE agent_alias = ?1 ORDER BY next_run ASC",
+        )?;
+        let rows = stmt.query_map(params![agent_alias], map_cron_job_row)?;
+        let mut jobs = Vec::new();
+        for row in rows {
+            jobs.push(row?);
+        }
+        Ok(jobs)
+    })?
+    else {
+        return Ok(Vec::new());
+    };
+    Ok(jobs)
+}
+
+/// Delete every cron job owned by `agent_alias`, returning the row count
+/// (`cron_runs` cascade via their `job_id` FK). A job whose owning agent is gone
+/// can never run, so the agent-deletion cascade removes it (#7175).
+pub fn remove_jobs_by_agent(config: &Config, agent_alias: &str) -> Result<usize> {
+    let changed = with_initialized_connection(config, |conn| {
+        conn.execute(
+            "DELETE FROM cron_jobs WHERE agent_alias = ?1",
+            params![agent_alias],
+        )
+        .context("Failed to delete cron jobs for agent")
+    })?;
+    Ok(changed)
+}
+
 pub fn due_jobs(config: &Config, now: DateTime<Utc>) -> Result<Vec<CronJob>> {
     let lim = i64::try_from(config.scheduler.max_tasks.max(1))
         .context("Scheduler max_tasks overflows i64")?;


### PR DESCRIPTION
> ### 📋 Stacked series — **5 of 8**
> Typed delete-with-cascade (#7175) + alias rename (#7468), sliced for review. **Opened as draft for CI; merge strictly in order.** While the PRs ahead are unmerged this diff is **cumulative** — it includes the un-merged slices below and collapses to its own delta once they land.
>
> **Sequence:** `1` #7785 ✅ · `2` #7830 ✅ · `3` #7837 · `4` #7838 · **`5` #7839 ← this PR** · `6` #7840 · `7` #7841 · `8` #7842

**This slice (own delta):** `crates/zeroclaw-config/src/alias_refs.rs` only — **+298 / −29**. **Cumulative shown until #3–#4 merge:** 14 files, +1294 / −76.

## Summary
Adds the **channel** arm of `delete_with_cascade`, completing the provider/agent/channel trio. For `channels.<type>.<alias>` it refuses on HARD refs, otherwise scrubs the SOFT refs, removes the entry via the same generic `delete_map_key("channels.<type>", alias)` the gateway/CLI use, and re-checks no dangling reference remains. `DryRun` mutates nothing.

- **SOFT (scrubbed):** every agent's `channels[]` and `escalation.alert_channels[]` entry naming the target (`retain`, trimmed to mirror `find_all_references` + `validate()`).
- **HARD (refused), two classes — both mirror `Config::validate()`:**
  1. a mandatory dotted `peer_groups.<g>.channel` naming the target;
  2. a member of a **bare-type** group (`channel = "discord"`) whose **only** `<type>.*` channel is the target — scrubbing it would leave that member without a required channel.
- **No owned non-config state:** channels have no memory/workspace/cron/session rows, so this is the *full* cascade for the kind — no surface-side half.

## Review: 1 blocker found + fixed
**Bare-type peer-group member orphaning.** `validate()` enforces *three* channel sites, not two: besides `agents.<X>.channels[]` (soft) and `peer_groups.<g>.channel` (hard), every member of a **bare-type** group must keep some `<type>.*` channel. The first cut enumerated only the first two — so deleting a member's only `discord.*` channel returned `Ok` but produced a config that `validate()` rejects. Fixed: `collect_channel_refs` now emits a HARD ref at `peer_groups.<g>.agents[i]` when scrubbing would orphan a bare-group member; the survivor test mirrors `validate()`'s untrimmed bare-membership comparison exactly. (This guard was subsequently lifted into the #7785 foundation during its review; retained here so the channel arm is self-contained.)

## Validation
`cargo clippy --workspace --all-targets` + `cargo fmt --all --check` **clean** at the stack tip. Channel test matrix: scrub-soft+remove · refuse-on-peer-group-channel · refuse-on-orphaning-bare-member · proceed-when-member-keeps-another · dry-run · not-found. Full CI runs on this draft. Pure library arm (no new surface) — exercised through the `handle_delete_map_key` route `/verify`'d in slice 4.

## Security & Privacy — no new fs/network/permissions/secrets; pure in-memory config mutation; synthetic-alias tests.
## Compatibility — backward compatible; adds a delete arm that previously returned `NotImplemented`. No surface change.
## Rollback (risk: low) — `git revert <sha>`; no migration; no persisted-state effect.

Related #7175.
