### PR TITLE
feat(gateway): agent owned-state rename cascade + rename wiring (#7468)

### DIFF
--- a/crates/zeroclaw-api/src/memory_traits.rs
+++ b/crates/zeroclaw-api/src/memory_traits.rs
@@ -264,6 +264,18 @@ pub trait Memory: Send + Sync + crate::attribution::Attributable {
         Ok(Vec::new())
     }
 
+    /// Re-point every memory row from the `from` alias to the `to` alias,
+    /// returning the number of rows re-pointed. Called when an alias is renamed
+    /// (#7468). For the SQL backends (sqlite/postgres) memory rows ride the
+    /// agent's UUID, so this is a single `UPDATE agents SET alias` and the count
+    /// is the agents-row count (0 or 1); payload-keyed backends (qdrant) rewrite
+    /// the alias on every matching memory point and return that count.
+    /// Default: unsupported error; backends with per-agent storage override.
+    /// Markdown/none keep the default and the caller logs a warning.
+    async fn rename_agent(&self, _from: &str, _to: &str) -> anyhow::Result<usize> {
+        anyhow::bail!("rename_agent not supported by this memory backend")
+    }
+
     /// Count total memories
     async fn count(&self) -> anyhow::Result<usize>;
 

--- a/crates/zeroclaw-gateway/src/agent_owned_state.rs
+++ b/crates/zeroclaw-gateway/src/agent_owned_state.rs
@@ -196,3 +196,93 @@ pub async fn cascade_owned_state(
 
     report
 }
+
+/// What the agent-rename owned-state cascade re-pointed (#7468).
+#[derive(Debug, Default, Clone, serde::Serialize)]
+pub struct RenameStateReport {
+    pub memory_rows: usize,
+    pub cron_jobs: usize,
+    pub acp_sessions: usize,
+    pub sessions_repointed: usize,
+    /// Surfaced failures. Non-empty means part of the cascade did NOT complete —
+    /// those rows were not silently treated as re-pointed.
+    pub warnings: Vec<String>,
+}
+
+/// Re-point the agent's owned non-config **DB** state from `from` to `to`:
+/// memory rows (`agents.alias`), cron jobs, ACP sessions, and session-metadata
+/// attribution. The workspace directory is moved by the caller (mirroring how
+/// the delete handler archives the workspace, not `cascade_owned_state`).
+///
+/// Unlike delete this is **in-place** — no export/archive — and there is **no
+/// live-session refusal**: a live ACP session simply follows the rename.
+/// Best-effort + reported: a single store failing does not abort the others; the
+/// surface persists the renamed config last.
+pub async fn cascade_rename_agent(
+    config: &Config,
+    mem: &Arc<dyn Memory>,
+    session_backend: Option<&Arc<dyn SessionBackend>>,
+    from: &str,
+    to: &str,
+) -> RenameStateReport {
+    let mut warnings: Vec<String> = Vec::new();
+
+    let memory_rows = match mem.rename_agent(from, to).await {
+        Ok(n) => n,
+        Err(e) => {
+            warnings.push(format!("memory rename: {e}"));
+            0
+        }
+    };
+
+    let cron_jobs = match zeroclaw_runtime::cron::rename_jobs_by_agent(config, from, to) {
+        Ok(n) => n,
+        Err(e) => {
+            warnings.push(format!("cron rename: {e}"));
+            0
+        }
+    };
+
+    let acp_sessions = match AcpSessionStore::new(&config.data_dir) {
+        Ok(store) => match store.rename_sessions_by_agent(from, to) {
+            Ok(n) => n,
+            Err(e) => {
+                warnings.push(format!("acp rename: {e}"));
+                0
+            }
+        },
+        Err(e) => {
+            warnings.push(format!("acp store open: {e}"));
+            0
+        }
+    };
+
+    let sessions_repointed = match session_backend {
+        Some(b) => match b.rename_agent_attribution(from, to) {
+            Ok(n) => n,
+            Err(e) => {
+                warnings.push(format!("session attribution rename: {e}"));
+                0
+            }
+        },
+        None => 0,
+    };
+
+    if !warnings.is_empty() {
+        ::zeroclaw_log::record!(
+            WARN,
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                .with_attrs(::serde_json::json!({"from": from, "to": to, "warnings": warnings})),
+            "rename owned-state cascade completed with warnings (some state may not have been re-pointed)"
+        );
+    }
+
+    RenameStateReport {
+        memory_rows,
+        cron_jobs,
+        acp_sessions,
+        sessions_repointed,
+        warnings,
+    }
+}

--- a/crates/zeroclaw-gateway/src/api_config.rs
+++ b/crates/zeroclaw-gateway/src/api_config.rs
@@ -1455,6 +1455,44 @@ async fn rename_config_cascade(
 /// workspace dir, re-point owned DB state (memory/cron/acp/session), mark the
 /// touched paths dirty, persist. Mirrors `delete_agent_cascade` but in-place —
 /// no archive, no live-session refusal (a live ACP session follows the rename).
+/// Move the agent workspace dir for a rename. Returns `Some(warning)` when a
+/// move was attempted and FAILED — surfaced to the caller so a config/DB rename
+/// to `to` with the workspace stranded at `from` isn't reported as a clean
+/// success. Returns `None` on success or when there is nothing to move (a custom
+/// alias-independent path, or a source dir that doesn't exist).
+async fn move_renamed_workspace(
+    old_ws: &std::path::Path,
+    new_ws: &std::path::Path,
+) -> Option<String> {
+    if old_ws == new_ws || !old_ws.exists() {
+        return None;
+    }
+    if let Some(parent) = new_ws.parent() {
+        let _ = tokio::fs::create_dir_all(parent).await;
+    }
+    match tokio::fs::rename(old_ws, new_ws).await {
+        Ok(()) => None,
+        Err(err) => {
+            ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                    .with_attrs(::serde_json::json!({
+                        "old": old_ws.display().to_string(),
+                        "new": new_ws.display().to_string(),
+                        "err": err.to_string()
+                    })),
+                "agent rename: workspace move failed"
+            );
+            Some(format!(
+                "workspace move {} -> {} failed: {err}",
+                old_ws.display(),
+                new_ws.display()
+            ))
+        }
+    }
+}
+
 async fn rename_agent_cascade(
     state: &AppState,
     mut working: zeroclaw_config::schema::Config,
@@ -1478,27 +1516,14 @@ async fn rename_agent_cascade(
     // Move the workspace dir. For the default per-alias location this is
     // `<install>/agents/<from>/workspace` → `…/<to>/workspace`. A custom
     // workspace path is alias-independent, so `old_ws == new_ws` and we skip.
+    // A failed move is surfaced (like the owned-DB failures below), not just
+    // logged — otherwise config+DB point at `to` while the workspace is stranded
+    // at `from` and the caller sees a clean success.
     let new_ws = working.agent_workspace_dir(to);
-    let mut workspace_moved = false;
-    if old_ws != new_ws && old_ws.exists() {
-        if let Some(parent) = new_ws.parent() {
-            let _ = tokio::fs::create_dir_all(parent).await;
-        }
-        match tokio::fs::rename(&old_ws, &new_ws).await {
-            Ok(()) => workspace_moved = true,
-            Err(err) => {
-                ::zeroclaw_log::record!(
-                    WARN,
-                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                        .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                        .with_attrs(
-                            ::serde_json::json!({"from": from, "to": to, "err": err.to_string()})
-                        ),
-                    "agent rename: workspace move failed"
-                );
-            }
-        }
-    }
+    let move_warning = move_renamed_workspace(&old_ws, &new_ws).await;
+    let workspace_moved = old_ws != new_ws && old_ws.exists() && move_warning.is_none();
+    let mut warnings: Vec<String> = Vec::new();
+    warnings.extend(move_warning);
 
     // Re-point owned DB state (memory/cron/acp/session). Best-effort + reported.
     let owned = crate::agent_owned_state::cascade_rename_agent(
@@ -1509,21 +1534,24 @@ async fn rename_agent_cascade(
         to,
     )
     .await;
-    ::zeroclaw_log::record!(INFO, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(::serde_json::json!({"from": from, "to": to, "memory": owned.memory_rows, "cron": owned.cron_jobs, "acp": owned.acp_sessions, "sessions": owned.sessions_repointed, "workspace_moved": workspace_moved, "dirty_paths": report.dirty_paths.len(), "warnings": owned.warnings})), "agent renamed with owned-state cascade");
+    // Combine the workspace-move warning (if any) with the owned-store warnings
+    // so every partial failure reaches the caller, not just the server log.
+    warnings.extend(owned.warnings);
+    ::zeroclaw_log::record!(INFO, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(::serde_json::json!({"from": from, "to": to, "memory": owned.memory_rows, "cron": owned.cron_jobs, "acp": owned.acp_sessions, "sessions": owned.sessions_repointed, "workspace_moved": workspace_moved, "dirty_paths": report.dirty_paths.len(), "warnings": warnings})), "agent renamed with owned-state cascade");
 
     if let Err(e) = persist_and_swap(state, working).await {
         return error_response(e);
     }
-    // The config rename is complete and persisted. `owned.warnings` is non-empty
-    // only if an owned store (memory/cron/acp/session) did NOT follow — surface
-    // it to the caller (not just the server log) so the split can be remediated,
-    // rather than reporting a clean success.
+    // Config rename complete and persisted. `warnings` is non-empty only if a
+    // partial step (the workspace move, or an owned store) did NOT follow —
+    // surface it to the caller (not just the server log) so the split can be
+    // remediated, rather than reporting a clean success.
     axum::Json(RenameMapKeyResponse {
         path: body.path.clone(),
         from: from.clone(),
         to: to.clone(),
         renamed: true,
-        warnings: owned.warnings,
+        warnings,
     })
     .into_response()
 }
@@ -2272,6 +2300,34 @@ mod tests {
             custom,
             "after removal the custom workspace path defaults — resolve BEFORE the cascade"
         );
+    }
+
+    #[tokio::test]
+    async fn renamed_workspace_move_failure_is_surfaced() {
+        // A failed workspace move during rename must surface a warning (so the
+        // caller learns config/DB moved to `to` while the workspace is stranded
+        // at `from`), not be swallowed as a clean success.
+        let tmp = tempfile::tempdir().unwrap();
+        let old_ws = tmp.path().join("from-ws");
+        std::fs::create_dir_all(&old_ws).unwrap();
+        // Force the move to fail: new_ws's parent is a FILE, so create_dir_all
+        // and rename both fail.
+        let blocker = tmp.path().join("blocker");
+        std::fs::write(&blocker, b"x").unwrap();
+        let new_ws = blocker.join("to-ws");
+
+        let warning = move_renamed_workspace(&old_ws, &new_ws).await;
+        assert!(
+            warning.is_some(),
+            "a failed workspace move must surface a warning"
+        );
+        assert!(warning.unwrap().contains("workspace move"));
+        assert!(old_ws.exists(), "source dir stays put when the move fails");
+
+        // Nothing-to-move paths return None (no spurious warning).
+        assert!(move_renamed_workspace(&old_ws, &old_ws).await.is_none());
+        let missing = tmp.path().join("does-not-exist");
+        assert!(move_renamed_workspace(&missing, &new_ws).await.is_none());
     }
 
     #[test]

--- a/crates/zeroclaw-gateway/src/api_config.rs
+++ b/crates/zeroclaw-gateway/src/api_config.rs
@@ -1290,10 +1290,86 @@ pub struct RenameMapKeyResponse {
     pub from: String,
     pub to: String,
     pub renamed: bool,
+    /// Owned-state cascade warnings (agent rename only): a non-empty list means
+    /// the config rename succeeded but one or more owned stores (memory / cron /
+    /// acp / session) did **not** follow the rename, so they need operator
+    /// attention. Omitted from the JSON when empty (back-compat for the generic
+    /// and provider/channel rename paths, which have no owned state).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
+}
+
+/// Parse a rename `path` (the map-keyed *section*) into the typed
+/// [`AliasKind`](zeroclaw_config::alias_refs::AliasKind) whose rename needs the
+/// reference-rewrite cascade. Returns `None` for non-aliased sections (e.g.
+/// `mcp.servers`), which fall back to the generic key-swap rename.
+fn parse_alias_kind(path: &str) -> Option<zeroclaw_config::alias_refs::AliasKind> {
+    use zeroclaw_config::alias_refs::{AliasKind, ProviderCategory};
+    if path == "agents" {
+        return Some(AliasKind::Agent);
+    }
+    if let Some(rest) = path.strip_prefix("providers.") {
+        let (cat, family) = rest.split_once('.')?;
+        if family.is_empty() || family.contains('.') {
+            return None;
+        }
+        let category = match cat {
+            "models" => ProviderCategory::Models,
+            "tts" => ProviderCategory::Tts,
+            "transcription" => ProviderCategory::Transcription,
+            _ => return None,
+        };
+        return Some(AliasKind::Provider {
+            category,
+            family: family.to_string(),
+        });
+    }
+    if let Some(ty) = path.strip_prefix("channels.") {
+        if ty.is_empty() || ty.contains('.') {
+            return None;
+        }
+        return Some(AliasKind::Channel {
+            channel_type: ty.to_string(),
+        });
+    }
+    None
+}
+
+/// Map a [`RenameError`](zeroclaw_config::alias_refs::RenameError) to the HTTP
+/// error response (NotFound→404, InvalidName/Reserved→400, PostCondition→500).
+fn rename_error_response(
+    path: &str,
+    from: &str,
+    err: zeroclaw_config::alias_refs::RenameError,
+) -> Response {
+    use zeroclaw_config::alias_refs::RenameError;
+    let (code, msg) = match err {
+        RenameError::NotFound(p) => (
+            ConfigApiCode::PathNotFound,
+            format!("{p} is not configured"),
+        ),
+        RenameError::InvalidName(m) => (ConfigApiCode::ValidationFailed, m),
+        RenameError::Reserved(a) => (
+            ConfigApiCode::ValidationFailed,
+            format!("alias `{a}` is reserved and cannot be renamed"),
+        ),
+        RenameError::PostCondition(m) => (
+            ConfigApiCode::InternalError,
+            format!("rename cascade post-condition failed: {m}"),
+        ),
+    };
+    error_response(ConfigApiError::new(code, msg).with_path(format!("{path}.{from}")))
 }
 
 /// `POST /api/config/rename-map-key` — rename an alias within a map-keyed
 /// section, preserving the entry's value. Atomic: persists only on success.
+///
+/// Aliased sections (agents / providers / channels) route through
+/// `rename_with_cascade`, which rewrites every config reference to follow the new
+/// name (the generic key-swap alone would leave them dangling). Agent rename also
+/// re-points owned state (memory / cron / acp / session rows + the workspace
+/// dir). A missing source alias returns **404** for these. Non-aliased sections
+/// keep the generic key-swap behaviour.
 pub async fn handle_rename_map_key(
     State(state): State<AppState>,
     headers: HeaderMap,
@@ -1303,30 +1379,151 @@ pub async fn handle_rename_map_key(
         return e.into_response();
     }
 
-    let mut working = state.config.read().clone();
+    let working = state.config.read().clone();
 
-    let renamed = match working.rename_map_key(&body.path, &body.from, &body.to) {
-        Ok(b) => b,
-        Err(msg) => {
-            return error_response(
-                ConfigApiError::new(ConfigApiCode::ValidationFailed, msg).with_path(&body.path),
-            );
+    match parse_alias_kind(&body.path) {
+        Some(zeroclaw_config::alias_refs::AliasKind::Agent) => {
+            rename_agent_cascade(&state, working, &body).await
         }
-    };
+        Some(kind) => rename_config_cascade(&state, working, &kind, &body).await,
+        None => {
+            // Non-aliased section: the generic key-swap rename (unchanged).
+            let mut working = working;
+            let renamed = match working.rename_map_key(&body.path, &body.from, &body.to) {
+                Ok(b) => b,
+                Err(msg) => {
+                    return error_response(
+                        ConfigApiError::new(ConfigApiCode::ValidationFailed, msg)
+                            .with_path(&body.path),
+                    );
+                }
+            };
+            if renamed {
+                working.mark_dirty(&format!("{}.{}", body.path, body.from));
+                working.mark_dirty(&format!("{}.{}", body.path, body.to));
+                if let Err(e) = persist_and_swap(&state, working).await {
+                    return error_response(e);
+                }
+            }
+            axum::Json(RenameMapKeyResponse {
+                path: body.path,
+                from: body.from,
+                to: body.to,
+                renamed,
+                warnings: Vec::new(),
+            })
+            .into_response()
+        }
+    }
+}
 
-    if renamed {
-        working.mark_dirty(&format!("{}.{}", body.path, body.from));
-        working.mark_dirty(&format!("{}.{}", body.path, body.to));
-        if let Err(e) = persist_and_swap(&state, working).await {
-            return error_response(e);
+/// Config-only rename cascade for providers/channels (no owned state): rewrite
+/// references, mark every touched path dirty, persist.
+async fn rename_config_cascade(
+    state: &AppState,
+    mut working: zeroclaw_config::schema::Config,
+    kind: &zeroclaw_config::alias_refs::AliasKind,
+    body: &RenameMapKeyBody,
+) -> Response {
+    let report = match zeroclaw_config::alias_refs::rename_with_cascade(
+        &mut working,
+        kind,
+        &body.from,
+        &body.to,
+    ) {
+        Ok(r) => r,
+        Err(e) => return rename_error_response(&body.path, &body.from, e),
+    };
+    for path in &report.dirty_paths {
+        working.mark_dirty(path);
+    }
+    if let Err(e) = persist_and_swap(state, working).await {
+        return error_response(e);
+    }
+    ::zeroclaw_log::record!(INFO, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(::serde_json::json!({"path": body.path, "from": body.from, "to": body.to, "dirty_paths": report.dirty_paths.len()})), "alias renamed with config-ref cascade");
+    axum::Json(RenameMapKeyResponse {
+        path: body.path.clone(),
+        from: body.from.clone(),
+        to: body.to.clone(),
+        renamed: true,
+        warnings: Vec::new(),
+    })
+    .into_response()
+}
+
+/// Agent rename cascade: rewrite config refs (`rename_with_cascade`), move the
+/// workspace dir, re-point owned DB state (memory/cron/acp/session), mark the
+/// touched paths dirty, persist. Mirrors `delete_agent_cascade` but in-place —
+/// no archive, no live-session refusal (a live ACP session follows the rename).
+async fn rename_agent_cascade(
+    state: &AppState,
+    mut working: zeroclaw_config::schema::Config,
+    body: &RenameMapKeyBody,
+) -> Response {
+    use zeroclaw_config::alias_refs::{self, AliasKind};
+    let (from, to) = (&body.from, &body.to);
+
+    // Capture the OLD workspace path while the entry still lives under `from`
+    // (custom paths are read off the entry, which is about to move).
+    let old_ws = working.agent_workspace_dir(from);
+
+    let report = match alias_refs::rename_with_cascade(&mut working, &AliasKind::Agent, from, to) {
+        Ok(r) => r,
+        Err(e) => return rename_error_response(&body.path, from, e),
+    };
+    for path in &report.dirty_paths {
+        working.mark_dirty(path);
+    }
+
+    // Move the workspace dir. For the default per-alias location this is
+    // `<install>/agents/<from>/workspace` → `…/<to>/workspace`. A custom
+    // workspace path is alias-independent, so `old_ws == new_ws` and we skip.
+    let new_ws = working.agent_workspace_dir(to);
+    let mut workspace_moved = false;
+    if old_ws != new_ws && old_ws.exists() {
+        if let Some(parent) = new_ws.parent() {
+            let _ = tokio::fs::create_dir_all(parent).await;
+        }
+        match tokio::fs::rename(&old_ws, &new_ws).await {
+            Ok(()) => workspace_moved = true,
+            Err(err) => {
+                ::zeroclaw_log::record!(
+                    WARN,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                        .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                        .with_attrs(
+                            ::serde_json::json!({"from": from, "to": to, "err": err.to_string()})
+                        ),
+                    "agent rename: workspace move failed"
+                );
+            }
         }
     }
 
+    // Re-point owned DB state (memory/cron/acp/session). Best-effort + reported.
+    let owned = crate::agent_owned_state::cascade_rename_agent(
+        &working,
+        &state.mem,
+        state.session_backend.as_ref(),
+        from,
+        to,
+    )
+    .await;
+    ::zeroclaw_log::record!(INFO, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(::serde_json::json!({"from": from, "to": to, "memory": owned.memory_rows, "cron": owned.cron_jobs, "acp": owned.acp_sessions, "sessions": owned.sessions_repointed, "workspace_moved": workspace_moved, "dirty_paths": report.dirty_paths.len(), "warnings": owned.warnings})), "agent renamed with owned-state cascade");
+
+    if let Err(e) = persist_and_swap(state, working).await {
+        return error_response(e);
+    }
+    // The config rename is complete and persisted. `owned.warnings` is non-empty
+    // only if an owned store (memory/cron/acp/session) did NOT follow — surface
+    // it to the caller (not just the server log) so the split can be remediated,
+    // rather than reporting a clean success.
     axum::Json(RenameMapKeyResponse {
-        path: body.path,
-        from: body.from,
-        to: body.to,
-        renamed,
+        path: body.path.clone(),
+        from: from.clone(),
+        to: to.clone(),
+        renamed: true,
+        warnings: owned.warnings,
     })
     .into_response()
 }

--- a/crates/zeroclaw-infra/src/acp_session_store.rs
+++ b/crates/zeroclaw-infra/src/acp_session_store.rs
@@ -734,6 +734,21 @@ impl AcpSessionStore {
         Ok(rows)
     }
 
+    /// Re-point every ACP session (live or killed) from `from` to `to`,
+    /// returning the row count. The agent-rename cascade (#7468) keeps the
+    /// session and its transcript; only the owning alias moves. Unlike delete,
+    /// a live session (`killed_at IS NULL`) is no obstacle to rename.
+    pub fn rename_sessions_by_agent(&self, from: &str, to: &str) -> Result<usize> {
+        let conn = self.conn.lock();
+        let rows = conn
+            .execute(
+                "UPDATE acp_sessions SET agent_alias = ?2 WHERE agent_alias = ?1",
+                params![from, to],
+            )
+            .context("Failed to rename ACP session owner")?;
+        Ok(rows)
+    }
+
     /// Persist that an admin intentionally killed this ACP session. The
     /// transcript stays durable, but runtime rehydration must not revive it.
     pub fn mark_session_killed(&self, session_uuid: &str) -> Result<bool> {
@@ -1270,5 +1285,26 @@ mod tests {
         assert_eq!(store.delete_sessions_by_agent("alpha").unwrap(), 2);
         assert!(store.list_sessions_by_agent("alpha").unwrap().is_empty());
         assert_eq!(store.list_sessions_by_agent("beta").unwrap().len(), 1);
+    }
+
+    #[test]
+    fn rename_sessions_by_agent_repoints_live_and_killed() {
+        let (_tmp, store) = open_store();
+        store.create_session("a-live", "alpha", "/ws/a1").unwrap();
+        store.create_session("a-killed", "alpha", "/ws/a2").unwrap();
+        store.mark_session_killed("a-killed").unwrap();
+        store.create_session("b-live", "beta", "/ws/b1").unwrap();
+
+        // Rename re-points BOTH live and killed sessions; unlike delete, a live
+        // session is no obstacle.
+        assert_eq!(store.rename_sessions_by_agent("alpha", "gamma").unwrap(), 2);
+        assert!(store.list_sessions_by_agent("alpha").unwrap().is_empty());
+        assert_eq!(store.list_sessions_by_agent("gamma").unwrap().len(), 2);
+        // the live session followed the rename
+        assert_eq!(store.count_live_sessions_by_agent("gamma").unwrap(), 1);
+        // beta untouched
+        assert_eq!(store.list_sessions_by_agent("beta").unwrap().len(), 1);
+        // unknown source → 0
+        assert_eq!(store.rename_sessions_by_agent("ghost", "x").unwrap(), 0);
     }
 }

--- a/crates/zeroclaw-infra/src/session_backend.rs
+++ b/crates/zeroclaw-infra/src/session_backend.rs
@@ -177,6 +177,16 @@ pub trait SessionBackend: Send + Sync {
         Ok(0)
     }
 
+    /// Re-point session attribution (`agent_alias` `from` → `to`) on every
+    /// session owned by `from`, returning the number of rows updated. Used by
+    /// the agent-rename cascade (#7468): the conversation history is kept and
+    /// its attribution follows the renamed agent (contrast
+    /// [`Self::clear_agent_attribution`], which drops it on delete). No-op for
+    /// backends without per-agent metadata.
+    fn rename_agent_attribution(&self, _from: &str, _to: &str) -> std::io::Result<usize> {
+        Ok(0)
+    }
+
     /// Quick existence check used by the gateway to avoid resurrecting a
     /// session that the user just deleted (#7126). The default impl falls
     /// back to `get_session_metadata`; production backends should override

--- a/crates/zeroclaw-infra/src/session_sqlite.rs
+++ b/crates/zeroclaw-infra/src/session_sqlite.rs
@@ -541,6 +541,17 @@ impl SessionBackend for SqliteSessionBackend {
         Ok(rows)
     }
 
+    fn rename_agent_attribution(&self, from: &str, to: &str) -> std::io::Result<usize> {
+        let conn = self.conn.lock();
+        let rows = conn
+            .execute(
+                "UPDATE session_metadata SET agent_alias = ?2 WHERE agent_alias = ?1",
+                params![from, to],
+            )
+            .map_err(std::io::Error::other)?;
+        Ok(rows)
+    }
+
     /// Cheap existence probe used by the gateway to skip cancelled-append
     /// writes against a session the user just deleted (#7126). Mirrors the
     /// row that `delete_session` wipes — once the metadata row is gone the
@@ -1411,6 +1422,32 @@ mod tests {
         // Standalone getter also works.
         let alias = backend.get_session_agent_alias("s1").unwrap();
         assert_eq!(alias.as_deref(), Some("scout"));
+    }
+
+    #[test]
+    fn rename_agent_attribution_repoints_only_matching_sessions() {
+        let tmp = TempDir::new().unwrap();
+        let backend = SqliteSessionBackend::new(tmp.path()).unwrap();
+        backend.append("s1", &ChatMessage::user("hi")).unwrap();
+        backend.set_session_agent_alias("s1", "scout").unwrap();
+        backend.append("s2", &ChatMessage::user("yo")).unwrap();
+        backend.set_session_agent_alias("s2", "other").unwrap();
+
+        // Rename scout → ranger: the conversation history is kept and its
+        // attribution follows the renamed agent (contrast clear, which NULLs it).
+        let n = backend.rename_agent_attribution("scout", "ranger").unwrap();
+        assert_eq!(n, 1);
+        assert_eq!(
+            backend.get_session_agent_alias("s1").unwrap().as_deref(),
+            Some("ranger")
+        );
+        // unrelated session untouched
+        assert_eq!(
+            backend.get_session_agent_alias("s2").unwrap().as_deref(),
+            Some("other")
+        );
+        // unknown source → 0
+        assert_eq!(backend.rename_agent_attribution("ghost", "x").unwrap(), 0);
     }
 
     #[test]

--- a/crates/zeroclaw-memory/src/lucid.rs
+++ b/crates/zeroclaw-memory/src/lucid.rs
@@ -440,6 +440,12 @@ impl Memory for LucidMemory {
         self.local.export_agent(agent_alias).await
     }
 
+    async fn rename_agent(&self, from: &str, to: &str) -> anyhow::Result<usize> {
+        // The remote Lucid daemon has no agent_id concept; alias→UUID lives in
+        // the local SQLite mirror, so rename is a local update (mirrors purge).
+        self.local.rename_agent(from, to).await
+    }
+
     async fn count(&self) -> anyhow::Result<usize> {
         self.local.count().await
     }

--- a/crates/zeroclaw-memory/src/postgres.rs
+++ b/crates/zeroclaw-memory/src/postgres.rs
@@ -647,6 +647,49 @@ impl Memory for PostgresMemory {
         .await
     }
 
+    async fn rename_agent(&self, from: &str, to: &str) -> Result<usize> {
+        let client = self.client.get().clone();
+        let qualified_agents = self.qualified_agents.clone();
+        let qualified_table = self.qualified_table.clone();
+        let from = from.to_string();
+        let to = to.to_string();
+
+        run_on_os_thread(move || -> Result<usize> {
+            let mut client = client.lock();
+            // Memory rows ride `agent_id` (FK → agents.id); only the alias moves.
+            // Collision-safety (see the SQLite impl): `agents.alias` is UNIQUE and
+            // delete leaves an orphan agents row, so a bare UPDATE onto a
+            // previously-used-then-deleted `to` alias would violate the
+            // constraint. Run inside a transaction: refuse if `to` still owns
+            // memory rows (a real conflict), else drop the orphan `to` row first.
+            let mut tx = client.transaction()?;
+            let to_rows: i64 = tx
+                .query_one(
+                    &format!(
+                        "SELECT COUNT(*) FROM {qualified_table} WHERE agent_id = (SELECT id FROM {qualified_agents} WHERE alias = $1)"
+                    ),
+                    &[&to],
+                )?
+                .get(0);
+            if to_rows > 0 {
+                anyhow::bail!(
+                    "cannot rename agent memory to `{to}`: an existing memory store under that alias has {to_rows} row(s); refusing to merge"
+                );
+            }
+            tx.execute(
+                &format!("DELETE FROM {qualified_agents} WHERE alias = $1"),
+                &[&to],
+            )?;
+            let updated = tx.execute(
+                &format!("UPDATE {qualified_agents} SET alias = $2 WHERE alias = $1"),
+                &[&from, &to],
+            )?;
+            tx.commit()?;
+            usize::try_from(updated).context("PostgreSQL returned an oversized update count")
+        })
+        .await
+    }
+
     async fn count(&self) -> Result<usize> {
         let client = self.client.get().clone();
         let qualified_table = self.qualified_table.clone();

--- a/crates/zeroclaw-memory/src/qdrant.rs
+++ b/crates/zeroclaw-memory/src/qdrant.rs
@@ -807,6 +807,38 @@ impl Memory for QdrantMemory {
         self.list_for_agents(&[agent_alias], None, None).await
     }
 
+    async fn rename_agent(&self, from: &str, to: &str) -> Result<usize> {
+        // Qdrant keys memory points by the agent alias in the `agent_id`
+        // payload field (no UUID indirection), so rename rewrites that field on
+        // every matching point via set-payload-by-filter (mirrors the
+        // `session_id` migration path). Returns the count of points re-pointed.
+        self.ensure_initialized().await?;
+        let matches = self.list_for_agents(&[from], None, None).await?.len();
+        if matches == 0 {
+            return Ok(0);
+        }
+        let body = serde_json::json!({
+            "payload": { "agent_id": to },
+            "filter": Self::must_filter(&[("agent_id", from)]),
+        });
+        let resp = self
+            .request(
+                reqwest::Method::POST,
+                &format!("/collections/{}/points/payload", self.collection),
+            )
+            .query(&[("wait", "true")])
+            .json(&body)
+            .send()
+            .await
+            .context("failed to set payload during Qdrant agent rename")?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            anyhow::bail!("Qdrant set payload failed during agent rename ({status}): {text}");
+        }
+        Ok(matches)
+    }
+
     async fn count(&self) -> Result<usize> {
         self.ensure_initialized().await?;
 

--- a/crates/zeroclaw-memory/src/sqlite.rs
+++ b/crates/zeroclaw-memory/src/sqlite.rs
@@ -1242,6 +1242,48 @@ impl Memory for SqliteMemory {
         .await?
     }
 
+    async fn rename_agent(&self, from: &str, to: &str) -> anyhow::Result<usize> {
+        let conn = self.conn.clone();
+        let from = from.to_string();
+        let to = to.to_string();
+
+        tokio::task::spawn_blocking(move || -> anyhow::Result<usize> {
+            let conn = conn.lock();
+            // Memory rows ride `memories.agent_id` (FK → agents.id, a stable
+            // UUID); only the human `alias` column moves, so this is a single
+            // agents-row update. An unknown `from` matches nothing → Ok(0).
+            //
+            // Collision-safety: `agents.alias` is UNIQUE, and deleting an agent
+            // purges its memories but leaves the `agents` row behind (an orphan
+            // holding the alias). A bare UPDATE onto a previously-used-then-
+            // deleted `to` alias would hit the UNIQUE constraint and fail. We
+            // hold the connection lock across the whole sequence (single writer),
+            // so: refuse if `to` still has memory rows (a genuine conflict we
+            // won't silently merge), otherwise drop the orphan `to` row and
+            // proceed. (`COUNT(*)` over a NULL subselect when no `to` row exists
+            // is 0, so the common no-collision path falls straight through.)
+            let to_rows: i64 = conn.query_row(
+                "SELECT COUNT(*) FROM memories WHERE agent_id = (SELECT id FROM agents WHERE alias = ?1 LIMIT 1)",
+                params![to],
+                |row| row.get(0),
+            )?;
+            if to_rows > 0 {
+                anyhow::bail!(
+                    "cannot rename agent memory to `{to}`: an existing memory store under that alias has {to_rows} row(s); refusing to merge"
+                );
+            }
+            // Drop any orphan `to` agents row (verified above to own no memories).
+            conn.execute("DELETE FROM agents WHERE alias = ?1", params![to])?;
+            let affected = conn.execute(
+                "UPDATE agents SET alias = ?2 WHERE alias = ?1",
+                params![from, to],
+            )?;
+            #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+            Ok(affected)
+        })
+        .await?
+    }
+
     async fn count(&self) -> anyhow::Result<usize> {
         let conn = self.conn.clone();
 
@@ -1783,6 +1825,88 @@ mod tests {
         let purged_ghost = mem.purge_agent("ghost").await.unwrap();
         assert_eq!(purged_ghost, 0);
         assert_eq!(mem.count().await.unwrap(), 2);
+    }
+
+    #[tokio::test]
+    async fn sqlite_rename_agent_repoints_rows_under_new_alias() {
+        let (_tmp, mem) = temp_sqlite();
+        let alpha = mem.ensure_agent_uuid("alpha").await.unwrap();
+        for idx in 0..3 {
+            mem.store_with_agent(
+                &format!("alpha-{idx}"),
+                "alpha row",
+                MemoryCategory::Core,
+                None,
+                None,
+                None,
+                Some(&alpha),
+            )
+            .await
+            .unwrap();
+        }
+
+        // Rename alpha → beta: memory rows ride the UUID, so this updates exactly
+        // one `agents` row and the rows now resolve under the new alias.
+        let renamed = mem.rename_agent("alpha", "beta").await.unwrap();
+        assert_eq!(renamed, 1, "exactly one agents row re-aliased");
+
+        // The rows now resolve under `beta`, and `alpha` resolves to nothing.
+        assert_eq!(mem.export_agent("beta").await.unwrap().len(), 3);
+        assert_eq!(mem.export_agent("alpha").await.unwrap().len(), 0);
+        assert_eq!(mem.count().await.unwrap(), 3, "no rows lost on rename");
+
+        // Unknown source → nothing updated.
+        assert_eq!(mem.rename_agent("ghost", "phantom").await.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn sqlite_rename_agent_reclaims_orphan_and_refuses_live_collision() {
+        let (_tmp, mem) = temp_sqlite();
+        let alpha = mem.ensure_agent_uuid("alpha").await.unwrap();
+        mem.store_with_agent(
+            "a-0",
+            "alpha row",
+            MemoryCategory::Core,
+            None,
+            None,
+            None,
+            Some(&alpha),
+        )
+        .await
+        .unwrap();
+
+        // Simulate a prior delete of `beta`: its memories were purged but the
+        // agents row survives (delete never removes it) — an orphan in the
+        // UNIQUE alias slot. A bare UPDATE alpha→beta would hit the constraint.
+        let _beta = mem.ensure_agent_uuid("beta").await.unwrap();
+        assert_eq!(mem.purge_agent("beta").await.unwrap(), 0); // no memories anyway
+        // Rename succeeds: the orphan `beta` row is dropped, alpha→beta proceeds.
+        assert_eq!(mem.rename_agent("alpha", "beta").await.unwrap(), 1);
+        assert_eq!(mem.export_agent("beta").await.unwrap().len(), 1);
+        assert_eq!(mem.export_agent("alpha").await.unwrap().len(), 0);
+
+        // Now `beta` has a live memory. Renaming another agent ONTO it must
+        // refuse (we won't silently merge two agents' memories).
+        let gamma = mem.ensure_agent_uuid("gamma").await.unwrap();
+        mem.store_with_agent(
+            "g-0",
+            "gamma row",
+            MemoryCategory::Core,
+            None,
+            None,
+            None,
+            Some(&gamma),
+        )
+        .await
+        .unwrap();
+        let err = mem.rename_agent("gamma", "beta").await.unwrap_err();
+        assert!(
+            err.to_string().contains("refusing to merge"),
+            "expected merge-refusal, got: {err}"
+        );
+        // Nothing changed: both still resolve under their own aliases.
+        assert_eq!(mem.export_agent("beta").await.unwrap().len(), 1);
+        assert_eq!(mem.export_agent("gamma").await.unwrap().len(), 1);
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-runtime/src/cron/mod.rs
+++ b/crates/zeroclaw-runtime/src/cron/mod.rs
@@ -16,8 +16,8 @@ pub use schedule::{
 pub use store::{
     add_agent_job, all_overdue_jobs, due_jobs, get_job, list_jobs, list_jobs_by_agent, list_runs,
     record_last_run, record_last_run_with_status, record_run, remove_job, remove_jobs_by_agent,
-    reschedule_after_run, reschedule_after_run_with_status, skip_missed_run, sync_declarative_jobs,
-    update_job,
+    rename_jobs_by_agent, reschedule_after_run, reschedule_after_run_with_status, skip_missed_run,
+    sync_declarative_jobs, update_job,
 };
 pub use types::{
     CronJob, CronJobPatch, CronRun, DeliveryConfig, JobType, Schedule, SessionTarget,

--- a/crates/zeroclaw-runtime/src/cron/store.rs
+++ b/crates/zeroclaw-runtime/src/cron/store.rs
@@ -263,6 +263,21 @@ pub fn remove_jobs_by_agent(config: &Config, agent_alias: &str) -> Result<usize>
     Ok(changed)
 }
 
+/// Re-point every cron job owned by `from` to `to`, returning the row count.
+/// Called by the agent-rename cascade (#7468): the job keeps running, just
+/// under the renamed owner. `agent_alias` is plain TEXT (not a UUID), so this
+/// is a direct column update.
+pub fn rename_jobs_by_agent(config: &Config, from: &str, to: &str) -> Result<usize> {
+    let changed = with_initialized_connection(config, |conn| {
+        conn.execute(
+            "UPDATE cron_jobs SET agent_alias = ?2 WHERE agent_alias = ?1",
+            params![from, to],
+        )
+        .context("Failed to rename cron job owner")
+    })?;
+    Ok(changed)
+}
+
 pub fn due_jobs(config: &Config, now: DateTime<Utc>) -> Result<Vec<CronJob>> {
     let lim = i64::try_from(config.scheduler.max_tasks.max(1))
         .context("Scheduler max_tasks overflows i64")?;


### PR DESCRIPTION
> ### 📋 Stacked series — **7 of 8**
> Typed delete-with-cascade (#7175) + alias rename (#7468), sliced for review. **Opened as draft for CI; merge strictly in order.** While the PRs ahead are unmerged this diff is **cumulative** — it includes the un-merged slices below and collapses to its own delta once they land.
>
> **Sequence:** `1` #7785 ✅ · `2` #7830 ✅ · `3` #7837 · `4` #7838 · `5` #7839 · `6` #7840 · **`7` #7841 ← this PR** · `8` #7842

**This slice (own delta):** 12 files, **+620 / −18** (gateway + infra + runtime + memory). **Cumulative shown until #3–#6 merge:** 14 files, +2610 / −92.

## Summary
The surface half of rename (#7468): wires slice 6's `rename_with_cascade` into the gateway and re-points the agent's owned non-config state. Today `POST /api/config/rename-map-key` for an agent just swaps the config key — leaving every reference dangling and the agent's persisted state stranded under the old alias.

- **`handle_rename_map_key` routes by section:** agents → `rename_agent_cascade` (config rewrite + workspace move + owned-DB re-point + persist); providers/channels → `rename_config_cascade` (config rewrite + persist); non-aliased sections → the generic key-swap (unchanged). A missing source alias now returns **404** for aliased paths.
- **Persistence correctness (load-bearing):** `save_dirty` writes only *marked-dirty* paths, and the config-layer cascade never marks dirty — so the handler marks **every** path in `RenameReport.dirty_paths` (the renamed entry's old+new key + each rewritten referrer, at entry granularity) before persisting. `/verify` confirmed all 9 referrer sites rewritten in the on-disk file.
- **In-place, no archive; no live-session refusal** — a live ACP session simply follows the rename (contrast delete, which refuses).
- **Owned-state rename methods** (best-effort + reported): `Memory::rename_agent` (sqlite/postgres update the single `agents.alias` row — memory rides the UUID; lucid delegates; qdrant rewrites the `agent_id` payload), `cron::rename_jobs_by_agent`, `AcpSessionStore::rename_sessions_by_agent`, `SessionBackend::rename_agent_attribution`; a `cascade_rename_agent` coordinator runs them from `data_dir`.

## Review: 2 blockers found + fixed
1. **`rename_agent` UNIQUE(alias) collision silently orphaned memory.** Delete purges memories but leaves the `agents` row (the UNIQUE alias slot), so renaming onto a previously-used-then-deleted alias hit the constraint → the `Err` was swallowed as a best-effort warning while the config rename committed → **split-brain** returned as a clean 200. Fixed: `rename_agent` is now collision-safe — under the connection lock (a transaction for postgres) it refuses if the target alias still owns memory rows, else drops the orphan row and proceeds. + test (orphan-reclaim + live-collision-refusal).
2. **Owned-state warnings were dropped from the API response.** A partial owned-state failure returned `{renamed:true}` with the warning only in a server log. Fixed: `RenameMapKeyResponse.warnings` now carries `owned.warnings` (omitted when empty).

## Validation
`cargo clippy --workspace --all-targets` + `cargo fmt --all --check` **clean** at the stack tip (incl. postgres path). End-to-end `/verify` (real binary + live gateway): `rename victim→survivor` → 200, re-read the config FILE → all 9 referrer sites now `survivor`, `grep victim` → no matches; probes: rename non-existent → 404, no-op → 400. Full CI matrix runs on this draft.

## Security & Privacy
New fs op: the workspace dir move (operator-controlled `data_dir`). DB writes re-point `agent_alias`/`alias` columns. No new network/permissions/secrets. No PII in tests.
## Compatibility — backward compatible; agent rename now also rewrites refs + re-points owned state (a fix). New response field `warnings` is additive (omitted when empty).
## Rollback (risk: medium) — `git revert`; no migration; rename is idempotent/re-runnable.

## Deferred
- **RPC `config/map-key-rename`** still does the bare key-swap (a pre-existing gap); routing it through `rename_with_cascade` is a follow-up.
- **Markdown/none memory** keep the trait default (memory lives in the moved workspace) — a `rename_agent` bail surfaces as a warning.

Related #7468.
