### PR TITLE
feat(cli): agents/providers/channels CRUD + skill-bundle cascade (#7468/#7175)

### DIFF
--- a/crates/zeroclaw-config/src/alias_refs.rs
+++ b/crates/zeroclaw-config/src/alias_refs.rs
@@ -954,6 +954,65 @@ fn rewrite_channel_refs(cfg: &mut Config, channel_type: &str, old: &str, new: &s
     dirty
 }
 
+// ── skill bundles (#7468/#7175) ─────────────────────────────────────────────
+// A skill bundle (`[skill_bundles.<alias>]`) has a single SOFT referrer
+// container: each agent's `skill_bundles: Vec<String>` list (validate() trims,
+// schema.rs ~17272). There is no HARD ref (an agent runs fine with an empty
+// bundle list), so bundles don't warrant an `AliasKind` variant — these three
+// standalone fns mirror the channel arm, flattened to the one container.
+
+/// Enumerate every agent that references skill bundle `alias` (TRIM-matched, as
+/// `Config::validate()` does). All refs are SOFT (droppable from the list).
+#[must_use]
+pub fn find_bundle_refs(cfg: &Config, alias: &str) -> Vec<RefSite> {
+    let mut sites = Vec::new();
+    for (name, agent) in sorted_agents(cfg) {
+        for (i, b) in agent.skill_bundles.iter().enumerate() {
+            if b.trim() == alias {
+                sites.push(RefSite::soft(
+                    format!("agents.{name}.skill_bundles[{i}]"),
+                    ScrubAction::DropFromVec { index: i },
+                    b.as_str(),
+                ));
+            }
+        }
+    }
+    sites
+}
+
+/// Mutating mirror of [`find_bundle_refs`] for delete: drop `alias` from every
+/// agent's `skill_bundles` list. Returns the touched `agents.<name>` dirty paths.
+pub fn scrub_bundle_refs(cfg: &mut Config, alias: &str) -> Vec<String> {
+    let mut dirty = Vec::new();
+    for (name, agent) in cfg.agents.iter_mut() {
+        let before = agent.skill_bundles.len();
+        agent.skill_bundles.retain(|b| b.trim() != alias);
+        if agent.skill_bundles.len() != before {
+            dirty.push(format!("agents.{name}"));
+        }
+    }
+    dirty
+}
+
+/// Mutating mirror for rename: rewrite every agent's `skill_bundles` entry
+/// naming `old` to name `new`. Returns the touched `agents.<name>` dirty paths.
+pub fn rewrite_bundle_refs(cfg: &mut Config, old: &str, new: &str) -> Vec<String> {
+    let mut dirty = Vec::new();
+    for (name, agent) in cfg.agents.iter_mut() {
+        let mut touched = false;
+        for b in agent.skill_bundles.iter_mut() {
+            if b.trim() == old {
+                *b = new.to_string();
+                touched = true;
+            }
+        }
+        if touched {
+            dirty.push(format!("agents.{name}"));
+        }
+    }
+    dirty
+}
+
 // ── deterministic iteration over the alias-keyed maps ───────────────────────
 // `Config::agents` / `peer_groups` are HashMaps; sort by key so RefSite order
 // is stable across runs (tests + dashboard binding depend on it).
@@ -2751,5 +2810,46 @@ mod tests {
             dirty.contains(&"heartbeat.agent".to_string()),
             "cleared heartbeat: {dirty:?}"
         );
+    }
+
+    #[test]
+    fn bundle_refs_find_scrub_rewrite() {
+        let mut cfg = empty_config();
+        cfg.agents.insert(
+            "a".to_string(),
+            AliasedAgentConfig {
+                skill_bundles: vec!["util".to_string(), "web".to_string()],
+                ..Default::default()
+            },
+        );
+        cfg.agents.insert(
+            "b".to_string(),
+            AliasedAgentConfig {
+                skill_bundles: vec![" util ".to_string()], // padded — validate trims
+                ..Default::default()
+            },
+        );
+
+        // find (trim-matched across both agents)
+        let sites = find_bundle_refs(&cfg, "util");
+        assert_eq!(sites.len(), 2, "{sites:?}");
+        assert!(sites.iter().all(|s| s.strength == RefStrength::Soft));
+
+        // rewrite util -> tools
+        let dirty = rewrite_bundle_refs(&mut cfg, "util", "tools");
+        assert_eq!(dirty.len(), 2);
+        assert_eq!(
+            cfg.agents["a"].skill_bundles,
+            vec!["tools".to_string(), "web".to_string()]
+        );
+        assert_eq!(cfg.agents["b"].skill_bundles, vec!["tools".to_string()]);
+        assert!(find_bundle_refs(&cfg, "util").is_empty());
+
+        // scrub tools from all agents
+        let dirty = scrub_bundle_refs(&mut cfg, "tools");
+        assert_eq!(dirty.len(), 2);
+        assert_eq!(cfg.agents["a"].skill_bundles, vec!["web".to_string()]);
+        assert!(cfg.agents["b"].skill_bundles.is_empty());
+        assert!(find_bundle_refs(&cfg, "tools").is_empty());
     }
 }

--- a/crates/zeroclaw-config/src/alias_refs.rs
+++ b/crates/zeroclaw-config/src/alias_refs.rs
@@ -190,6 +190,54 @@ pub struct CascadeReport {
     pub deleted_entry: Option<String>,
 }
 
+impl CascadeReport {
+    /// Every entry/section config path the delete mutated — the removed entry
+    /// plus the entry of each scrubbed soft reference. A persisting surface marks
+    /// **each** of these dirty before saving: `Config::save_dirty` writes only
+    /// marked paths, so a referrer scrubbed in another entry that isn't listed
+    /// here would be dropped in memory but left stale on disk (reappearing as a
+    /// dangling reference on the next reload). Symmetric with
+    /// [`RenameReport::dirty_paths`]; paths are at entry granularity (e.g.
+    /// `agents.lead`, `peer_groups.crew`, `heartbeat.agent`) so a marked path
+    /// re-serialises the whole changed subtree. Sorted + deduplicated.
+    #[must_use]
+    pub fn dirty_paths(&self) -> Vec<String> {
+        let mut paths: Vec<String> = self
+            .applied
+            .iter()
+            .map(|site| dirty_entry_for(&site.path))
+            .collect();
+        if let Some(entry) = &self.deleted_entry {
+            paths.push(entry.clone());
+        }
+        paths.sort();
+        paths.dedup();
+        paths
+    }
+}
+
+/// Truncate a [`RefSite`] dotted path to the entry/section path that an
+/// incremental save (`apply_dirty_path`) re-serialises wholesale, so a nested
+/// change (a dropped vec element or a removed/renamed map key) persists with the
+/// whole entry rather than needing a leaf-precise dirty path.
+#[must_use]
+pub fn dirty_entry_for(refsite_path: &str) -> String {
+    let segs: Vec<&str> = refsite_path.split('.').collect();
+    match segs.first().copied() {
+        // agents.<name>.* and peer_groups.<g>.* → the entry root.
+        Some("agents" | "peer_groups") if segs.len() >= 2 => format!("{}.{}", segs[0], segs[1]),
+        // providers.<cat>.<fam>.<alias>.* → the provider entry.
+        Some("providers") if segs.len() >= 4 => segs[..4].join("."),
+        // Scalars / whole-vector fields (heartbeat.agent, acp.default_agent,
+        // escalation.alert_channels[i], model_routes[i]…) → strip any index.
+        _ => refsite_path
+            .split('[')
+            .next()
+            .unwrap_or(refsite_path)
+            .to_string(),
+    }
+}
+
 /// Why a [`delete_with_cascade`] did not complete. `Refused` is an expected,
 /// renderable outcome (a hard reference blocks the delete), not a bug.
 #[derive(Debug)]
@@ -2635,5 +2683,73 @@ mod tests {
             "elevenlabs.studio"
         );
         assert!(find_all_references(&cfg, &kind, "default").is_empty());
+    }
+
+    #[test]
+    fn dirty_entry_for_truncates_ref_paths_to_persistable_entries() {
+        // agent / peer-group referrer sites → the entry root (whole subtree).
+        assert_eq!(dirty_entry_for("agents.lead.delegates[0]"), "agents.lead");
+        assert_eq!(
+            dirty_entry_for("agents.lead.workspace.access.bot"),
+            "agents.lead"
+        );
+        assert_eq!(
+            dirty_entry_for("peer_groups.crew.agents[1]"),
+            "peer_groups.crew"
+        );
+        // scalars / whole-vector fields → the field/section, index stripped.
+        assert_eq!(dirty_entry_for("heartbeat.agent"), "heartbeat.agent");
+        assert_eq!(dirty_entry_for("acp.default_agent"), "acp.default_agent");
+        assert_eq!(
+            dirty_entry_for("escalation.alert_channels[3]"),
+            "escalation.alert_channels"
+        );
+        assert_eq!(
+            dirty_entry_for("model_routes[0].model_provider"),
+            "model_routes"
+        );
+        // provider entry → the 4-segment entry path.
+        assert_eq!(
+            dirty_entry_for("providers.models.anthropic.default.fallback[0]"),
+            "providers.models.anthropic.default"
+        );
+    }
+
+    #[test]
+    fn cascade_report_dirty_paths_covers_scrubs_and_deleted_entry() {
+        // A delete that scrubbed two referrers in different entries + removed the
+        // entry must report all three dirty paths (deduped, sorted).
+        let mut cfg = empty_config();
+        cfg.heartbeat.enabled = false;
+        cfg.heartbeat.agent = "bot".to_string();
+        cfg.agents
+            .insert("bot".to_string(), AliasedAgentConfig::default());
+        cfg.agents.insert(
+            "lead".to_string(),
+            AliasedAgentConfig {
+                delegates: vec!["bot".to_string()],
+                ..Default::default()
+            },
+        );
+        let report = delete_with_cascade(
+            &mut cfg,
+            &AliasKind::Agent,
+            "bot",
+            CascadePolicy::RefuseOnHard,
+        )
+        .expect("delete succeeds");
+        let dirty = report.dirty_paths();
+        assert!(
+            dirty.contains(&"agents.bot".to_string()),
+            "removed entry: {dirty:?}"
+        );
+        assert!(
+            dirty.contains(&"agents.lead".to_string()),
+            "scrubbed delegate: {dirty:?}"
+        );
+        assert!(
+            dirty.contains(&"heartbeat.agent".to_string()),
+            "cleared heartbeat: {dirty:?}"
+        );
     }
 }

--- a/crates/zeroclaw-gateway/src/api_config.rs
+++ b/crates/zeroclaw-gateway/src/api_config.rs
@@ -1156,7 +1156,7 @@ async fn delete_agent_cascade(
     // memory but STALE on disk, reappearing as a dangling reference on the next
     // config reload (which `validate()` then rejects). Mirrors rename's
     // `RenameReport.dirty_paths`.
-    for path in delete_cascade_dirty_paths(&cascade) {
+    for path in cascade.dirty_paths() {
         working.mark_dirty(&path);
     }
     if let Err(e) = persist_and_swap(state, working).await {
@@ -1168,45 +1168,6 @@ async fn delete_agent_cascade(
         created: false,
     })
     .into_response()
-}
-
-/// Derive the entry/section config paths a delete cascade mutated, so the
-/// persisting surface can mark each dirty. Includes the removed entry
-/// (`deleted_entry`) and the entry of every scrubbed soft reference
-/// (`applied`). Mirrors how rename marks `RenameReport.dirty_paths`.
-fn delete_cascade_dirty_paths(report: &zeroclaw_config::alias_refs::CascadeReport) -> Vec<String> {
-    let mut paths: Vec<String> = report
-        .applied
-        .iter()
-        .map(|site| dirty_entry_for(&site.path))
-        .collect();
-    if let Some(entry) = &report.deleted_entry {
-        paths.push(entry.clone());
-    }
-    paths.sort();
-    paths.dedup();
-    paths
-}
-
-/// Truncate a `RefSite` dotted path to the entry/section path that
-/// `apply_dirty_path` re-serialises wholesale, so a nested change (a dropped
-/// vec element or a removed map key) persists with the whole entry rather than
-/// requiring a leaf-precise dirty path.
-fn dirty_entry_for(refsite_path: &str) -> String {
-    let segs: Vec<&str> = refsite_path.split('.').collect();
-    match segs.first().copied() {
-        // agents.<name>.* and peer_groups.<g>.* → the entry root.
-        Some("agents" | "peer_groups") if segs.len() >= 2 => format!("{}.{}", segs[0], segs[1]),
-        // providers.<cat>.<fam>.<alias>.* → the provider entry.
-        Some("providers") if segs.len() >= 4 => segs[..4].join("."),
-        // Scalars / whole-vector fields (heartbeat.agent, acp.default_agent,
-        // escalation.alert_channels[i], model_routes[i]…) → strip any index.
-        _ => refsite_path
-            .split('[')
-            .next()
-            .unwrap_or(refsite_path)
-            .to_string(),
-    }
 }
 
 /// `POST /api/config/map-key?path=<section>&key=<name>` — instantiate a new
@@ -2233,39 +2194,9 @@ mod tests {
     // build_comment_prefix tests live in zeroclaw_config::comment_writer
     // — same reason.
 
-    #[test]
-    fn dirty_entry_for_truncates_ref_paths_to_persistable_entries() {
-        // agent / peer-group referrer sites → the entry root (whole subtree).
-        assert_eq!(dirty_entry_for("agents.lead.delegates[0]"), "agents.lead");
-        assert_eq!(
-            dirty_entry_for("agents.lead.workspace.access.bot"),
-            "agents.lead"
-        );
-        assert_eq!(
-            dirty_entry_for("agents.lead.workspace.read_memory_from[2]"),
-            "agents.lead"
-        );
-        assert_eq!(
-            dirty_entry_for("peer_groups.crew.agents[1]"),
-            "peer_groups.crew"
-        );
-        // scalars / whole-vector fields → the field/section, index stripped.
-        assert_eq!(dirty_entry_for("heartbeat.agent"), "heartbeat.agent");
-        assert_eq!(dirty_entry_for("acp.default_agent"), "acp.default_agent");
-        assert_eq!(
-            dirty_entry_for("escalation.alert_channels[3]"),
-            "escalation.alert_channels"
-        );
-        assert_eq!(
-            dirty_entry_for("model_routes[0].model_provider"),
-            "model_routes"
-        );
-        // provider entry → the 4-segment entry path.
-        assert_eq!(
-            dirty_entry_for("providers.models.anthropic.default.fallback[0]"),
-            "providers.models.anthropic.default"
-        );
-    }
+    // dirty_entry_for / CascadeReport::dirty_paths tests live in
+    // zeroclaw_config::alias_refs — single source of truth (the gateway and CLI
+    // both consume the promoted helper).
 
     #[test]
     fn delete_cascade_resolves_custom_workspace_before_removing_entry() {

--- a/crates/zeroclaw-runtime/locales/en/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/en/cli.ftl
@@ -813,6 +813,7 @@ cli-alias-rename-postcondition = rename cascade post-condition failed: {$message
 cli-alias-unknown-provider-category = unknown provider category `{$category}` (expected models | tts | transcription)
 cli-alias-no-such-section = no such config section: {$section}
 cli-alias-live-acp-sessions = {$count} live ACP session(s) for `{$alias}` — end them first
+cli-alias-owned-state-unavailable = note: config references were updated, but the agent's owned state (memory rows, workspace dir, cron/acp/session rows) was NOT cascaded by this CLI yet — use the gateway API for the full owned-state cascade.
 cli-bundle-not-configured = skill bundle '{$alias}' is not configured
 cli-bundle-rename-failed = rename failed: {$error}
 

--- a/crates/zeroclaw-runtime/locales/en/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/en/cli.ftl
@@ -800,6 +800,21 @@ cli-alias-owned-cascaded = owned-state cascaded: memory {$memory} · cron {$cron
 cli-alias-owned-repointed = owned-state re-pointed: memory {$memory} · cron {$cron} · acp {$acp} · sessions {$sessions}
 cli-alias-warn-workspace-move = warning: workspace move failed: {$error}
 cli-alias-warn = warning: {$warning}
+cli-alias-deleted = deleted {$section}.{$alias} (scrubbed {$count} reference(s))
+cli-alias-delete-refused-header = refused: {$count} hard reference(s) block the delete:
+cli-alias-delete-refused-hint = delete refused — resolve the hard references first
+cli-alias-not-configured = {$path} is not configured
+cli-alias-delete-failed = delete failed: {$error}
+cli-alias-delete-reserved-default = the `default` agent is reserved and cannot be deleted
+cli-alias-renamed = renamed {$section}.{$from} → {$section}.{$to} (rewrote {$count} reference path(s))
+cli-alias-rename-invalid = invalid new alias: {$message}
+cli-alias-rename-reserved = alias `{$alias}` is reserved and cannot be renamed
+cli-alias-rename-postcondition = rename cascade post-condition failed: {$message}
+cli-alias-unknown-provider-category = unknown provider category `{$category}` (expected models | tts | transcription)
+cli-alias-no-such-section = no such config section: {$section}
+cli-alias-live-acp-sessions = {$count} live ACP session(s) for `{$alias}` — end them first
+cli-bundle-not-configured = skill bundle '{$alias}' is not configured
+cli-bundle-rename-failed = rename failed: {$error}
 
 # ── Skill-bundle CLI — zeroclaw skills bundle {add,remove,rename} (#7468 / #7175) ──
 cli-bundle-exists = skill bundle '{$alias}' already exists (no change)

--- a/crates/zeroclaw-runtime/locales/en/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/en/cli.ftl
@@ -785,3 +785,30 @@ turn-tool-interrupted-before-result = [interrupted by user before this tool prod
 # Safe reply delivered when the model repeatedly emits malformed internal
 # tool-call protocol and the turn gives up retrying.
 channel-runtime-malformed-tool-output = I generated an internal tool-call format error and could not complete this request. Please try again.
+
+# ── Alias CRUD CLI — zeroclaw {agents,providers,channels} {create,list,rename,delete} (#7468 / #7175) ──
+cli-alias-list-empty = (no entries under {$section})
+cli-alias-created = created {$section}.{$alias}
+cli-alias-exists = {$section}.{$alias} already exists (no change)
+cli-alias-impact-scrub-header = deleting {$section}.{$alias} would scrub {$count} reference(s):
+cli-alias-impact-blocked-header = deleting {$section}.{$alias} is BLOCKED by {$count} hard reference(s):
+cli-alias-impact-blocker = ✗ {$path} (hard reference)
+cli-alias-impact-scrub = • {$path} (would be scrubbed)
+cli-alias-no-changes = No changes made. Re-run with --yes to apply (or --dry-run to preview).
+cli-alias-warn-workspace-archive = warning: workspace archive failed: {$error}
+cli-alias-owned-cascaded = owned-state cascaded: memory {$memory} · cron {$cron} · acp {$acp} · sessions {$sessions} → {$archive}
+cli-alias-owned-repointed = owned-state re-pointed: memory {$memory} · cron {$cron} · acp {$acp} · sessions {$sessions}
+cli-alias-warn-workspace-move = warning: workspace move failed: {$error}
+cli-alias-warn = warning: {$warning}
+
+# ── Skill-bundle CLI — zeroclaw skills bundle {add,remove,rename} (#7468 / #7175) ──
+cli-bundle-exists = skill bundle '{$alias}' already exists (no change)
+cli-bundle-created = created skill_bundles.{$alias} (dir: {$dir})
+cli-bundle-created-warn = created skill_bundles.{$alias} (warning: dir resolve failed: {$error})
+cli-bundle-impact-header = deleting skill_bundles.{$alias} would strip it from {$count} agent reference(s):
+cli-bundle-no-changes = No changes made. Re-run with --yes to apply.
+cli-bundle-archived = archived bundle directory → {$path}
+cli-bundle-warn-archive = warning: bundle directory archive failed: {$error}
+cli-bundle-deleted = deleted skill_bundles.{$alias} (stripped from {$count} agent(s))
+cli-bundle-warn-move = warning: bundle directory move failed: {$error}
+cli-bundle-renamed = renamed skill_bundles.{$from} → skill_bundles.{$to}

--- a/src/alias_cli/mod.rs
+++ b/src/alias_cli/mod.rs
@@ -1,0 +1,405 @@
+//! CLI for alias CRUD — `zeroclaw {agents,providers,channels} {create,list,
+//! rename,delete}` (#7468 / #7175).
+//!
+//! Thin surface over the config-layer cascade in
+//! [`zeroclaw_config::alias_refs`]: `rename_with_cascade` / `delete_with_cascade`
+//! rewrite/scrub every reference and report the entry paths that changed; this
+//! module marks each dirty and persists via `Config::save_dirty` (which writes
+//! only marked paths). Plural groups (`agents`/`providers`/`channels`) are
+//! distinct from the singular `agent <alias>` run command, which is untouched.
+//!
+//! Providers and channels carry no owned non-config state, so their delete/
+//! rename is config-only. The agent owned-state cascade (memory / cron / acp /
+//! session rows + the workspace dir) is wired in a follow-up; until then agent
+//! delete/rename warn that owned state was not cascaded.
+
+use anyhow::{Context, Result, bail};
+use zeroclaw::{AgentsCommands, ChannelsCommands, ProvidersCommands};
+use zeroclaw_config::alias_refs::{
+    self, AliasKind, CascadeError, CascadePolicy, ProviderCategory, RenameError,
+};
+use zeroclaw_config::schema::Config;
+
+/// The agent alias reserved as the runtime fallback — protected from delete
+/// (rename is already guarded inside `rename_with_cascade`).
+const RESERVED_DEFAULT_AGENT: &str = "default";
+
+fn parse_provider_category(category: &str) -> Result<ProviderCategory> {
+    match category {
+        "models" => Ok(ProviderCategory::Models),
+        "tts" => Ok(ProviderCategory::Tts),
+        "transcription" => Ok(ProviderCategory::Transcription),
+        other => {
+            bail!("unknown provider category `{other}` (expected models | tts | transcription)")
+        }
+    }
+}
+
+/// The map-key section path for a kind (e.g. `agents`, `providers.models.anthropic`,
+/// `channels.discord`).
+fn section_path(kind: &AliasKind) -> String {
+    match kind {
+        AliasKind::Agent => "agents".to_string(),
+        AliasKind::Provider { category, family } => {
+            let cat = match category {
+                ProviderCategory::Models => "models",
+                ProviderCategory::Tts => "tts",
+                ProviderCategory::Transcription => "transcription",
+            };
+            format!("providers.{cat}.{family}")
+        }
+        AliasKind::Channel { channel_type } => format!("channels.{channel_type}"),
+    }
+}
+
+fn list_section(config: &Config, section: &str) -> Result<()> {
+    match config.get_map_keys(section) {
+        Some(mut keys) => {
+            keys.sort();
+            if keys.is_empty() {
+                println!("(no entries under {section})");
+            } else {
+                for k in keys {
+                    println!("{k}");
+                }
+            }
+        }
+        None => bail!("no such config section: {section}"),
+    }
+    Ok(())
+}
+
+fn create_entry(config: &mut Config, section: &str, alias: &str) -> Result<()> {
+    if config
+        .create_map_key(section, alias)
+        .map_err(anyhow::Error::msg)?
+    {
+        config.mark_dirty(&format!("{section}.{alias}"));
+        println!("created {section}.{alias}");
+    } else {
+        println!("{section}.{alias} already exists (no change)");
+    }
+    Ok(())
+}
+
+/// Print the dry-run impact (blockers + scrubs) for a delete.
+fn print_impact(kind: &AliasKind, alias: &str, config: &Config) {
+    let report = alias_refs::plan_delete(config, kind, alias);
+    if report.blockers.is_empty() {
+        println!(
+            "deleting {}.{alias} would scrub {} reference(s):",
+            section_path(kind),
+            report.scrubs.len()
+        );
+    } else {
+        println!(
+            "deleting {}.{alias} is BLOCKED by {} hard reference(s):",
+            section_path(kind),
+            report.blockers.len()
+        );
+        for b in &report.blockers {
+            println!("  ✗ {} (hard reference)", b.path);
+        }
+    }
+    for s in &report.scrubs {
+        println!("  • {} (would be scrubbed)", s.path);
+    }
+}
+
+/// Delete an aliased entry's config references (config-layer only).
+fn delete_config(
+    config: &mut Config,
+    kind: &AliasKind,
+    alias: &str,
+    dry_run: bool,
+    yes: bool,
+) -> Result<()> {
+    let section = section_path(kind);
+    if dry_run {
+        print_impact(kind, alias, config);
+        return Ok(());
+    }
+    if !yes {
+        print_impact(kind, alias, config);
+        println!("\nNo changes made. Re-run with --yes to apply (or --dry-run to preview).");
+        return Ok(());
+    }
+    match alias_refs::delete_with_cascade(config, kind, alias, CascadePolicy::RefuseOnHard) {
+        Ok(report) => {
+            for path in report.dirty_paths() {
+                config.mark_dirty(&path);
+            }
+            println!(
+                "deleted {section}.{alias} (scrubbed {} reference(s))",
+                report.applied.len()
+            );
+            Ok(())
+        }
+        Err(CascadeError::Refused(report)) => {
+            println!(
+                "refused: {} hard reference(s) block the delete:",
+                report.blockers.len()
+            );
+            for b in &report.blockers {
+                println!("  ✗ {}", b.path);
+            }
+            bail!("delete refused — resolve the hard references first");
+        }
+        Err(CascadeError::NotFound(p)) => bail!("{p} is not configured"),
+        Err(e) => bail!("delete failed: {e}"),
+    }
+}
+
+/// Rename an aliased entry's config references (config-layer only).
+fn rename_config(config: &mut Config, kind: &AliasKind, from: &str, to: &str) -> Result<()> {
+    match alias_refs::rename_with_cascade(config, kind, from, to) {
+        Ok(report) => {
+            for path in &report.dirty_paths {
+                config.mark_dirty(path);
+            }
+            println!(
+                "renamed {sec}.{from} → {sec}.{to} (rewrote {} reference path(s))",
+                report.dirty_paths.len(),
+                sec = section_path(kind)
+            );
+            Ok(())
+        }
+        Err(RenameError::NotFound(p)) => bail!("{p} is not configured"),
+        Err(RenameError::InvalidName(m)) => bail!("invalid new alias: {m}"),
+        Err(RenameError::Reserved(a)) => bail!("alias `{a}` is reserved and cannot be renamed"),
+        Err(RenameError::PostCondition(m)) => bail!("rename cascade post-condition failed: {m}"),
+    }
+}
+
+async fn save(config: &mut Config) -> Result<()> {
+    Box::pin(config.save_dirty())
+        .await
+        .context("failed to persist config")
+}
+
+// ── agents ──────────────────────────────────────────────────────────────────
+
+pub async fn handle_agents(cmd: AgentsCommands, config: &mut Config) -> Result<()> {
+    match cmd {
+        AgentsCommands::List => list_section(config, "agents"),
+        AgentsCommands::Create { alias } => {
+            create_entry(config, "agents", &alias)?;
+            save(config).await
+        }
+        AgentsCommands::Rename { from, to } => {
+            rename_config(config, &AliasKind::Agent, &from, &to)?;
+            warn_agent_owned_state();
+            save(config).await
+        }
+        AgentsCommands::Delete {
+            alias,
+            dry_run,
+            yes,
+        } => {
+            if alias == RESERVED_DEFAULT_AGENT {
+                bail!("the `default` agent is reserved and cannot be deleted");
+            }
+            delete_config(config, &AliasKind::Agent, &alias, dry_run, yes)?;
+            if yes && !dry_run {
+                warn_agent_owned_state();
+                save(config).await?;
+            }
+            Ok(())
+        }
+    }
+}
+
+fn warn_agent_owned_state() {
+    eprintln!(
+        "note: config references were updated, but the agent's owned state \
+         (memory rows, workspace dir, cron/acp/session rows) was NOT cascaded \
+         by this CLI yet — use the gateway API for the full owned-state cascade."
+    );
+}
+
+// ── providers ─────────────────────────────────────────────────────────────────
+
+pub async fn handle_providers(cmd: ProvidersCommands, config: &mut Config) -> Result<()> {
+    match cmd {
+        ProvidersCommands::List { category } => {
+            let cats = match category {
+                Some(c) => vec![parse_provider_category(&c)?],
+                None => vec![
+                    ProviderCategory::Models,
+                    ProviderCategory::Tts,
+                    ProviderCategory::Transcription,
+                ],
+            };
+            for cat in cats {
+                let cat_name = match cat {
+                    ProviderCategory::Models => "models",
+                    ProviderCategory::Tts => "tts",
+                    ProviderCategory::Transcription => "transcription",
+                };
+                // Enumerate families under this category, then their aliases.
+                if let Some(families) = config.get_map_keys(&format!("providers.{cat_name}")) {
+                    let mut families = families;
+                    families.sort();
+                    for family in families {
+                        if let Some(mut aliases) =
+                            config.get_map_keys(&format!("providers.{cat_name}.{family}"))
+                        {
+                            aliases.sort();
+                            for a in aliases {
+                                println!("{cat_name}.{family}.{a}");
+                            }
+                        }
+                    }
+                }
+            }
+            Ok(())
+        }
+        ProvidersCommands::Create {
+            category,
+            family,
+            alias,
+        } => {
+            let cat = parse_provider_category(&category)?;
+            let section = section_path(&AliasKind::Provider {
+                category: cat,
+                family,
+            });
+            create_entry(config, &section, &alias)?;
+            save(config).await
+        }
+        ProvidersCommands::Rename {
+            category,
+            family,
+            from,
+            to,
+        } => {
+            let category = parse_provider_category(&category)?;
+            rename_config(
+                config,
+                &AliasKind::Provider { category, family },
+                &from,
+                &to,
+            )?;
+            save(config).await
+        }
+        ProvidersCommands::Delete {
+            category,
+            family,
+            alias,
+            dry_run,
+            yes,
+        } => {
+            let category = parse_provider_category(&category)?;
+            let kind = AliasKind::Provider { category, family };
+            delete_config(config, &kind, &alias, dry_run, yes)?;
+            if yes && !dry_run {
+                save(config).await?;
+            }
+            Ok(())
+        }
+    }
+}
+
+// ── channels ─────────────────────────────────────────────────────────────────
+
+pub async fn handle_channels(cmd: ChannelsCommands, config: &mut Config) -> Result<()> {
+    match cmd {
+        ChannelsCommands::List { channel_type } => {
+            // `channels` is a struct of per-type maps, not one flat map, so with
+            // no filter we walk the canonical channel-type list.
+            let types: Vec<String> = match channel_type {
+                Some(t) => vec![t],
+                None => zeroclaw_config::schema::v2::V3_CHANNEL_TYPES
+                    .iter()
+                    .map(|s| (*s).to_string())
+                    .collect(),
+            };
+            let mut types = types;
+            types.sort();
+            for t in types {
+                if let Some(mut aliases) = config.get_map_keys(&format!("channels.{t}")) {
+                    aliases.sort();
+                    for a in aliases {
+                        println!("{t}.{a}");
+                    }
+                }
+            }
+            Ok(())
+        }
+        ChannelsCommands::Create {
+            channel_type,
+            alias,
+        } => {
+            create_entry(config, &format!("channels.{channel_type}"), &alias)?;
+            save(config).await
+        }
+        ChannelsCommands::Rename {
+            channel_type,
+            from,
+            to,
+        } => {
+            rename_config(config, &AliasKind::Channel { channel_type }, &from, &to)?;
+            save(config).await
+        }
+        ChannelsCommands::Delete {
+            channel_type,
+            alias,
+            dry_run,
+            yes,
+        } => {
+            let kind = AliasKind::Channel { channel_type };
+            delete_config(config, &kind, &alias, dry_run, yes)?;
+            if yes && !dry_run {
+                save(config).await?;
+            }
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_provider_category_maps_known_and_rejects_unknown() {
+        assert_eq!(
+            parse_provider_category("models").unwrap(),
+            ProviderCategory::Models
+        );
+        assert_eq!(
+            parse_provider_category("tts").unwrap(),
+            ProviderCategory::Tts
+        );
+        assert_eq!(
+            parse_provider_category("transcription").unwrap(),
+            ProviderCategory::Transcription
+        );
+        assert!(parse_provider_category("bogus").is_err());
+    }
+
+    #[test]
+    fn section_path_for_each_kind() {
+        assert_eq!(section_path(&AliasKind::Agent), "agents");
+        assert_eq!(
+            section_path(&AliasKind::Provider {
+                category: ProviderCategory::Models,
+                family: "anthropic".to_string(),
+            }),
+            "providers.models.anthropic"
+        );
+        assert_eq!(
+            section_path(&AliasKind::Provider {
+                category: ProviderCategory::Tts,
+                family: "elevenlabs".to_string(),
+            }),
+            "providers.tts.elevenlabs"
+        );
+        assert_eq!(
+            section_path(&AliasKind::Channel {
+                channel_type: "discord".to_string(),
+            }),
+            "channels.discord"
+        );
+    }
+}

--- a/src/alias_cli/mod.rs
+++ b/src/alias_cli/mod.rs
@@ -650,9 +650,13 @@ async fn agent_rename_owned_state(
 #[cfg(not(all(feature = "gateway", feature = "agent-runtime")))]
 fn warn_agent_owned_state() {
     eprintln!(
-        "note: config references were updated, but the agent's owned state \
-         (memory rows, workspace dir, cron/acp/session rows) was NOT cascaded \
-         by this CLI yet — use the gateway API for the full owned-state cascade."
+        "{}",
+        mt(
+            "cli-alias-owned-state-unavailable",
+            "note: config references were updated, but the agent's owned state \
+             (memory rows, workspace dir, cron/acp/session rows) was NOT cascaded \
+             by this CLI yet — use the gateway API for the full owned-state cascade."
+        )
     );
 }
 

--- a/src/alias_cli/mod.rs
+++ b/src/alias_cli/mod.rs
@@ -124,6 +124,13 @@ fn delete_config(
         println!("\nNo changes made. Re-run with --yes to apply (or --dry-run to preview).");
         return Ok(());
     }
+    apply_delete(config, kind, alias)
+}
+
+/// Apply the config-layer delete (scrub refs + remove entry) and mark the dirty
+/// paths. Bails on a hard-ref refusal or a missing alias. The caller persists.
+fn apply_delete(config: &mut Config, kind: &AliasKind, alias: &str) -> Result<()> {
+    let section = section_path(kind);
     match alias_refs::delete_with_cascade(config, kind, alias, CascadePolicy::RefuseOnHard) {
         Ok(report) => {
             for path in report.dirty_paths() {
@@ -187,8 +194,11 @@ pub async fn handle_agents(cmd: AgentsCommands, config: &mut Config) -> Result<(
             save(config).await
         }
         AgentsCommands::Rename { from, to } => {
+            // Capture the workspace path while the `from` entry still exists
+            // (custom paths are read off the entry, which the rename moves).
+            let old_ws = config.agent_workspace_dir(&from);
             rename_config(config, &AliasKind::Agent, &from, &to)?;
-            warn_agent_owned_state();
+            agent_rename_owned_state(config, &from, &to, &old_ws).await?;
             save(config).await
         }
         AgentsCommands::Delete {
@@ -199,16 +209,183 @@ pub async fn handle_agents(cmd: AgentsCommands, config: &mut Config) -> Result<(
             if alias == RESERVED_DEFAULT_AGENT {
                 bail!("the `default` agent is reserved and cannot be deleted");
             }
-            delete_config(config, &AliasKind::Agent, &alias, dry_run, yes)?;
-            if yes && !dry_run {
-                warn_agent_owned_state();
-                save(config).await?;
+            if dry_run {
+                print_impact(&AliasKind::Agent, &alias, config);
+                return Ok(());
             }
-            Ok(())
+            if !yes {
+                print_impact(&AliasKind::Agent, &alias, config);
+                println!(
+                    "\nNo changes made. Re-run with --yes to apply (or --dry-run to preview)."
+                );
+                return Ok(());
+            }
+            // Owned-state HARD gate (live ACP sessions) runs BEFORE the config
+            // cascade so a refusal mutates nothing.
+            agent_delete_precheck(config, &alias)?;
+            apply_delete(config, &AliasKind::Agent, &alias)?;
+            agent_delete_owned_state(config, &alias).await?;
+            save(config).await
         }
     }
 }
 
+// ── agent owned-state cascade (feature-gated) ─────────────────────────────────
+// Memory / cron / acp / session rows + the workspace dir live in infra crates
+// the gateway owns; the CLI opens them from `data_dir` and reuses the gateway's
+// cascade coordinators. A `--no-default-features` build (no gateway/runtime)
+// falls back to a config-only cascade + a warning.
+
+/// Memory + optional session-backend handles opened from `data_dir` for the
+/// owned-state cascade.
+#[cfg(all(feature = "gateway", feature = "agent-runtime"))]
+type OwnedStateHandles = (
+    std::sync::Arc<dyn zeroclaw_memory::Memory>,
+    Option<std::sync::Arc<dyn zeroclaw_infra::session_backend::SessionBackend>>,
+);
+
+#[cfg(all(feature = "gateway", feature = "agent-runtime"))]
+fn build_owned_state_handles(config: &Config) -> Result<OwnedStateHandles> {
+    use std::sync::Arc;
+    let mem: Arc<dyn zeroclaw_memory::Memory> = if config.agents.is_empty() {
+        Arc::new(zeroclaw_memory::NoneMemory::new("none"))
+    } else {
+        Arc::from(
+            zeroclaw_memory::create_memory_with_storage_and_routes(
+                &config.memory,
+                &config.embedding_routes,
+                config.resolve_active_storage(),
+                &config.data_dir,
+                None,
+            )
+            .context("open memory backend for the owned-state cascade")?,
+        )
+    };
+    let session_backend = if config.gateway.session_persistence {
+        Some(
+            zeroclaw_infra::make_session_backend(
+                &config.data_dir,
+                &config.channels.session_backend,
+            )
+            .context("open session backend for the owned-state cascade")?,
+        )
+    } else {
+        None
+    };
+    Ok((mem, session_backend))
+}
+
+#[cfg(all(feature = "gateway", feature = "agent-runtime"))]
+fn agent_delete_precheck(config: &Config, alias: &str) -> Result<()> {
+    // Fail closed: refuse if live ACP sessions exist, or if the store can't be
+    // read to verify (mirrors the gateway delete gate).
+    let live = crate::gateway::agent_owned_state::live_acp_session_count(config, alias)
+        .context("could not verify live ACP sessions")?;
+    if live > 0 {
+        bail!("{live} live ACP session(s) for `{alias}` — end them first");
+    }
+    Ok(())
+}
+
+#[cfg(not(all(feature = "gateway", feature = "agent-runtime")))]
+fn agent_delete_precheck(_config: &Config, _alias: &str) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(all(feature = "gateway", feature = "agent-runtime"))]
+async fn agent_delete_owned_state(config: &Config, alias: &str) -> Result<()> {
+    let (mem, session_backend) = build_owned_state_handles(config)?;
+    let ts = chrono::Utc::now().format("%Y%m%d%H%M%S");
+    let archive_dir = config
+        .data_dir
+        .join("agents")
+        .join("_deleted")
+        .join(format!("{alias}-{ts}"));
+    tokio::fs::create_dir_all(&archive_dir).await.ok();
+    // Archive the workspace dir alongside the owned-state exports.
+    let workspace = config.agent_workspace_dir(alias);
+    if workspace.exists() {
+        if let Err(e) = tokio::fs::rename(&workspace, archive_dir.join("workspace")).await {
+            eprintln!("warning: workspace archive failed: {e}");
+        }
+    }
+    let report = crate::gateway::agent_owned_state::cascade_owned_state(
+        config,
+        &mem,
+        session_backend.as_ref(),
+        alias,
+        &archive_dir,
+    )
+    .await;
+    println!(
+        "owned-state cascaded: memory {} · cron {} · acp {} · sessions {} → {}",
+        report.memory_purged,
+        report.cron_removed,
+        report.acp_removed,
+        report.sessions_cleared,
+        archive_dir.display()
+    );
+    for w in &report.warnings {
+        eprintln!("warning: {w}");
+    }
+    Ok(())
+}
+
+#[cfg(not(all(feature = "gateway", feature = "agent-runtime")))]
+async fn agent_delete_owned_state(_config: &Config, _alias: &str) -> Result<()> {
+    warn_agent_owned_state();
+    Ok(())
+}
+
+#[cfg(all(feature = "gateway", feature = "agent-runtime"))]
+async fn agent_rename_owned_state(
+    config: &Config,
+    from: &str,
+    to: &str,
+    old_ws: &std::path::Path,
+) -> Result<()> {
+    // Move the workspace dir (default per-alias location only; a custom path is
+    // alias-independent → old_ws == new_ws → skip).
+    let new_ws = config.agent_workspace_dir(to);
+    if old_ws != new_ws && old_ws.exists() {
+        if let Some(parent) = new_ws.parent() {
+            tokio::fs::create_dir_all(parent).await.ok();
+        }
+        if let Err(e) = tokio::fs::rename(old_ws, &new_ws).await {
+            eprintln!("warning: workspace move failed: {e}");
+        }
+    }
+    let (mem, session_backend) = build_owned_state_handles(config)?;
+    let report = crate::gateway::agent_owned_state::cascade_rename_agent(
+        config,
+        &mem,
+        session_backend.as_ref(),
+        from,
+        to,
+    )
+    .await;
+    println!(
+        "owned-state re-pointed: memory {} · cron {} · acp {} · sessions {}",
+        report.memory_rows, report.cron_jobs, report.acp_sessions, report.sessions_repointed
+    );
+    for w in &report.warnings {
+        eprintln!("warning: {w}");
+    }
+    Ok(())
+}
+
+#[cfg(not(all(feature = "gateway", feature = "agent-runtime")))]
+async fn agent_rename_owned_state(
+    _config: &Config,
+    _from: &str,
+    _to: &str,
+    _old_ws: &std::path::Path,
+) -> Result<()> {
+    warn_agent_owned_state();
+    Ok(())
+}
+
+#[cfg(not(all(feature = "gateway", feature = "agent-runtime")))]
 fn warn_agent_owned_state() {
     eprintln!(
         "note: config references were updated, but the agent's owned state \

--- a/src/alias_cli/mod.rs
+++ b/src/alias_cli/mod.rs
@@ -24,6 +24,34 @@ use zeroclaw_config::schema::Config;
 /// (rename is already guarded inside `rename_with_cascade`).
 const RESERVED_DEFAULT_AGENT: &str = "default";
 
+/// Resolve a `cli-*` Fluent key for alias-CRUD CLI output. Under `agent-runtime`
+/// (default + what CI/release build) this routes through Fluent; without it the
+/// runtime i18n crate is absent, so the English `fallback` is used.
+#[allow(unused_variables)]
+fn mt(key: &str, fallback: &str) -> String {
+    #[cfg(feature = "agent-runtime")]
+    {
+        zeroclaw_runtime::i18n::get_required_cli_string(key)
+    }
+    #[cfg(not(feature = "agent-runtime"))]
+    {
+        fallback.to_string() // i18n-exempt: English fallback when Fluent (agent-runtime) is disabled
+    }
+}
+
+/// `mt` with `{$name}` arguments.
+#[allow(unused_variables)]
+fn mta(key: &str, args: &[(&str, &str)], fallback: &str) -> String {
+    #[cfg(feature = "agent-runtime")]
+    {
+        zeroclaw_runtime::i18n::get_required_cli_string_with_args(key, args)
+    }
+    #[cfg(not(feature = "agent-runtime"))]
+    {
+        fallback.to_string() // i18n-exempt: English fallback when Fluent (agent-runtime) is disabled
+    }
+}
+
 fn parse_provider_category(category: &str) -> Result<ProviderCategory> {
     match category {
         "models" => Ok(ProviderCategory::Models),
@@ -57,7 +85,14 @@ fn list_section(config: &Config, section: &str) -> Result<()> {
         Some(mut keys) => {
             keys.sort();
             if keys.is_empty() {
-                println!("(no entries under {section})");
+                println!(
+                    "{}",
+                    mta(
+                        "cli-alias-list-empty",
+                        &[("section", section)],
+                        "(no entries under {$section})"
+                    )
+                );
             } else {
                 for k in keys {
                     println!("{k}");
@@ -75,9 +110,23 @@ fn create_entry(config: &mut Config, section: &str, alias: &str) -> Result<()> {
         .map_err(anyhow::Error::msg)?
     {
         config.mark_dirty(&format!("{section}.{alias}"));
-        println!("created {section}.{alias}");
+        println!(
+            "{}",
+            mta(
+                "cli-alias-created",
+                &[("section", section), ("alias", alias)],
+                "created {$section}.{$alias}"
+            )
+        );
     } else {
-        println!("{section}.{alias} already exists (no change)");
+        println!(
+            "{}",
+            mta(
+                "cli-alias-exists",
+                &[("section", section), ("alias", alias)],
+                "{$section}.{$alias} already exists (no change)"
+            )
+        );
     }
     Ok(())
 }
@@ -85,24 +134,55 @@ fn create_entry(config: &mut Config, section: &str, alias: &str) -> Result<()> {
 /// Print the dry-run impact (blockers + scrubs) for a delete.
 fn print_impact(kind: &AliasKind, alias: &str, config: &Config) {
     let report = alias_refs::plan_delete(config, kind, alias);
+    let section = section_path(kind);
     if report.blockers.is_empty() {
+        let count = report.scrubs.len().to_string();
         println!(
-            "deleting {}.{alias} would scrub {} reference(s):",
-            section_path(kind),
-            report.scrubs.len()
+            "{}",
+            mta(
+                "cli-alias-impact-scrub-header",
+                &[
+                    ("section", section.as_str()),
+                    ("alias", alias),
+                    ("count", count.as_str())
+                ],
+                "deleting {$section}.{$alias} would scrub {$count} reference(s):"
+            )
         );
     } else {
+        let count = report.blockers.len().to_string();
         println!(
-            "deleting {}.{alias} is BLOCKED by {} hard reference(s):",
-            section_path(kind),
-            report.blockers.len()
+            "{}",
+            mta(
+                "cli-alias-impact-blocked-header",
+                &[
+                    ("section", section.as_str()),
+                    ("alias", alias),
+                    ("count", count.as_str())
+                ],
+                "deleting {$section}.{$alias} is BLOCKED by {$count} hard reference(s):"
+            )
         );
         for b in &report.blockers {
-            println!("  ✗ {} (hard reference)", b.path);
+            println!(
+                "  {}",
+                mta(
+                    "cli-alias-impact-blocker",
+                    &[("path", b.path.as_str())],
+                    "✗ {$path} (hard reference)"
+                )
+            );
         }
     }
     for s in &report.scrubs {
-        println!("  • {} (would be scrubbed)", s.path);
+        println!(
+            "  {}",
+            mta(
+                "cli-alias-impact-scrub",
+                &[("path", s.path.as_str())],
+                "• {$path} (would be scrubbed)"
+            )
+        );
     }
 }
 
@@ -121,7 +201,13 @@ fn delete_config(
     }
     if !yes {
         print_impact(kind, alias, config);
-        println!("\nNo changes made. Re-run with --yes to apply (or --dry-run to preview).");
+        println!(
+            "\n{}",
+            mt(
+                "cli-alias-no-changes",
+                "No changes made. Re-run with --yes to apply (or --dry-run to preview)."
+            )
+        );
         return Ok(());
     }
     apply_delete(config, kind, alias)
@@ -306,7 +392,15 @@ async fn agent_delete_owned_state(config: &Config, alias: &str) -> Result<()> {
     let workspace = config.agent_workspace_dir(alias);
     if workspace.exists() {
         if let Err(e) = tokio::fs::rename(&workspace, archive_dir.join("workspace")).await {
-            eprintln!("warning: workspace archive failed: {e}");
+            let es = e.to_string();
+            eprintln!(
+                "{}",
+                mta(
+                    "cli-alias-warn-workspace-archive",
+                    &[("error", es.as_str())],
+                    "warning: workspace archive failed: {$error}"
+                )
+            );
         }
     }
     let report = crate::gateway::agent_owned_state::cascade_owned_state(
@@ -317,16 +411,34 @@ async fn agent_delete_owned_state(config: &Config, alias: &str) -> Result<()> {
         &archive_dir,
     )
     .await;
+    let memory = report.memory_purged.to_string();
+    let cron = report.cron_removed.to_string();
+    let acp = report.acp_removed.to_string();
+    let sessions = report.sessions_cleared.to_string();
+    let archive = archive_dir.display().to_string();
     println!(
-        "owned-state cascaded: memory {} · cron {} · acp {} · sessions {} → {}",
-        report.memory_purged,
-        report.cron_removed,
-        report.acp_removed,
-        report.sessions_cleared,
-        archive_dir.display()
+        "{}",
+        mta(
+            "cli-alias-owned-cascaded",
+            &[
+                ("memory", memory.as_str()),
+                ("cron", cron.as_str()),
+                ("acp", acp.as_str()),
+                ("sessions", sessions.as_str()),
+                ("archive", archive.as_str())
+            ],
+            "owned-state cascaded: memory {$memory} · cron {$cron} · acp {$acp} · sessions {$sessions} → {$archive}"
+        )
     );
     for w in &report.warnings {
-        eprintln!("warning: {w}");
+        eprintln!(
+            "{}",
+            mta(
+                "cli-alias-warn",
+                &[("warning", w.as_str())],
+                "warning: {$warning}"
+            )
+        );
     }
     Ok(())
 }
@@ -352,7 +464,15 @@ async fn agent_rename_owned_state(
             tokio::fs::create_dir_all(parent).await.ok();
         }
         if let Err(e) = tokio::fs::rename(old_ws, &new_ws).await {
-            eprintln!("warning: workspace move failed: {e}");
+            let es = e.to_string();
+            eprintln!(
+                "{}",
+                mta(
+                    "cli-alias-warn-workspace-move",
+                    &[("error", es.as_str())],
+                    "warning: workspace move failed: {$error}"
+                )
+            );
         }
     }
     let (mem, session_backend) = build_owned_state_handles(config)?;
@@ -364,12 +484,32 @@ async fn agent_rename_owned_state(
         to,
     )
     .await;
+    let memory = report.memory_rows.to_string();
+    let cron = report.cron_jobs.to_string();
+    let acp = report.acp_sessions.to_string();
+    let sessions = report.sessions_repointed.to_string();
     println!(
-        "owned-state re-pointed: memory {} · cron {} · acp {} · sessions {}",
-        report.memory_rows, report.cron_jobs, report.acp_sessions, report.sessions_repointed
+        "{}",
+        mta(
+            "cli-alias-owned-repointed",
+            &[
+                ("memory", memory.as_str()),
+                ("cron", cron.as_str()),
+                ("acp", acp.as_str()),
+                ("sessions", sessions.as_str())
+            ],
+            "owned-state re-pointed: memory {$memory} · cron {$cron} · acp {$acp} · sessions {$sessions}"
+        )
     );
     for w in &report.warnings {
-        eprintln!("warning: {w}");
+        eprintln!(
+            "{}",
+            mta(
+                "cli-alias-warn",
+                &[("warning", w.as_str())],
+                "warning: {$warning}"
+            )
+        );
     }
     Ok(())
 }

--- a/src/alias_cli/mod.rs
+++ b/src/alias_cli/mod.rs
@@ -57,9 +57,14 @@ fn parse_provider_category(category: &str) -> Result<ProviderCategory> {
         "models" => Ok(ProviderCategory::Models),
         "tts" => Ok(ProviderCategory::Tts),
         "transcription" => Ok(ProviderCategory::Transcription),
-        other => {
-            bail!("unknown provider category `{other}` (expected models | tts | transcription)")
-        }
+        other => bail!(
+            "{}",
+            mta(
+                "cli-alias-unknown-provider-category",
+                &[("category", other)],
+                "unknown provider category `{$category}` (expected models | tts | transcription)"
+            )
+        ),
     }
 }
 
@@ -99,7 +104,14 @@ fn list_section(config: &Config, section: &str) -> Result<()> {
                 }
             }
         }
-        None => bail!("no such config section: {section}"),
+        None => bail!(
+            "{}",
+            mta(
+                "cli-alias-no-such-section",
+                &[("section", section)],
+                "no such config section: {$section}"
+            )
+        ),
     }
     Ok(())
 }
@@ -222,24 +234,61 @@ fn apply_delete(config: &mut Config, kind: &AliasKind, alias: &str) -> Result<()
             for path in report.dirty_paths() {
                 config.mark_dirty(&path);
             }
+            let count = report.applied.len().to_string();
             println!(
-                "deleted {section}.{alias} (scrubbed {} reference(s))",
-                report.applied.len()
+                "{}",
+                mta(
+                    "cli-alias-deleted",
+                    &[
+                        ("section", section.as_str()),
+                        ("alias", alias),
+                        ("count", count.as_str())
+                    ],
+                    "deleted {$section}.{$alias} (scrubbed {$count} reference(s))"
+                )
             );
             Ok(())
         }
         Err(CascadeError::Refused(report)) => {
+            let count = report.blockers.len().to_string();
             println!(
-                "refused: {} hard reference(s) block the delete:",
-                report.blockers.len()
+                "{}",
+                mta(
+                    "cli-alias-delete-refused-header",
+                    &[("count", count.as_str())],
+                    "refused: {$count} hard reference(s) block the delete:"
+                )
             );
             for b in &report.blockers {
                 println!("  ✗ {}", b.path);
             }
-            bail!("delete refused — resolve the hard references first");
+            bail!(
+                "{}",
+                mt(
+                    "cli-alias-delete-refused-hint",
+                    "delete refused — resolve the hard references first"
+                )
+            );
         }
-        Err(CascadeError::NotFound(p)) => bail!("{p} is not configured"),
-        Err(e) => bail!("delete failed: {e}"),
+        Err(CascadeError::NotFound(p)) => bail!(
+            "{}",
+            mta(
+                "cli-alias-not-configured",
+                &[("path", p.as_str())],
+                "{$path} is not configured"
+            )
+        ),
+        Err(e) => {
+            let es = e.to_string();
+            bail!(
+                "{}",
+                mta(
+                    "cli-alias-delete-failed",
+                    &[("error", es.as_str())],
+                    "delete failed: {$error}"
+                )
+            )
+        }
     }
 }
 
@@ -250,17 +299,55 @@ fn rename_config(config: &mut Config, kind: &AliasKind, from: &str, to: &str) ->
             for path in &report.dirty_paths {
                 config.mark_dirty(path);
             }
+            let section = section_path(kind);
+            let count = report.dirty_paths.len().to_string();
             println!(
-                "renamed {sec}.{from} → {sec}.{to} (rewrote {} reference path(s))",
-                report.dirty_paths.len(),
-                sec = section_path(kind)
+                "{}",
+                mta(
+                    "cli-alias-renamed",
+                    &[
+                        ("section", section.as_str()),
+                        ("from", from),
+                        ("to", to),
+                        ("count", count.as_str())
+                    ],
+                    "renamed {$section}.{$from} → {$section}.{$to} (rewrote {$count} reference path(s))"
+                )
             );
             Ok(())
         }
-        Err(RenameError::NotFound(p)) => bail!("{p} is not configured"),
-        Err(RenameError::InvalidName(m)) => bail!("invalid new alias: {m}"),
-        Err(RenameError::Reserved(a)) => bail!("alias `{a}` is reserved and cannot be renamed"),
-        Err(RenameError::PostCondition(m)) => bail!("rename cascade post-condition failed: {m}"),
+        Err(RenameError::NotFound(p)) => bail!(
+            "{}",
+            mta(
+                "cli-alias-not-configured",
+                &[("path", p.as_str())],
+                "{$path} is not configured"
+            )
+        ),
+        Err(RenameError::InvalidName(m)) => bail!(
+            "{}",
+            mta(
+                "cli-alias-rename-invalid",
+                &[("message", m.as_str())],
+                "invalid new alias: {$message}"
+            )
+        ),
+        Err(RenameError::Reserved(a)) => bail!(
+            "{}",
+            mta(
+                "cli-alias-rename-reserved",
+                &[("alias", a.as_str())],
+                "alias `{$alias}` is reserved and cannot be renamed"
+            )
+        ),
+        Err(RenameError::PostCondition(m)) => bail!(
+            "{}",
+            mta(
+                "cli-alias-rename-postcondition",
+                &[("message", m.as_str())],
+                "rename cascade post-condition failed: {$message}"
+            )
+        ),
     }
 }
 
@@ -284,8 +371,11 @@ pub async fn handle_agents(cmd: AgentsCommands, config: &mut Config) -> Result<(
             // (custom paths are read off the entry, which the rename moves).
             let old_ws = config.agent_workspace_dir(&from);
             rename_config(config, &AliasKind::Agent, &from, &to)?;
-            agent_rename_owned_state(config, &from, &to, &old_ws).await?;
-            save(config).await
+            // Persist the config rename before the irreversible owned-state side
+            // effects (workspace move + DB re-point), so a later failure can't
+            // leave the config and owned state split.
+            save(config).await?;
+            agent_rename_owned_state(config, &from, &to, &old_ws).await
         }
         AgentsCommands::Delete {
             alias,
@@ -293,7 +383,13 @@ pub async fn handle_agents(cmd: AgentsCommands, config: &mut Config) -> Result<(
             yes,
         } => {
             if alias == RESERVED_DEFAULT_AGENT {
-                bail!("the `default` agent is reserved and cannot be deleted");
+                bail!(
+                    "{}",
+                    mt(
+                        "cli-alias-delete-reserved-default",
+                        "the `default` agent is reserved and cannot be deleted"
+                    )
+                );
             }
             if dry_run {
                 print_impact(&AliasKind::Agent, &alias, config);
@@ -302,16 +398,25 @@ pub async fn handle_agents(cmd: AgentsCommands, config: &mut Config) -> Result<(
             if !yes {
                 print_impact(&AliasKind::Agent, &alias, config);
                 println!(
-                    "\nNo changes made. Re-run with --yes to apply (or --dry-run to preview)."
+                    "\n{}",
+                    mt(
+                        "cli-alias-no-changes",
+                        "No changes made. Re-run with --yes to apply (or --dry-run to preview)."
+                    )
                 );
                 return Ok(());
             }
             // Owned-state HARD gate (live ACP sessions) runs BEFORE the config
             // cascade so a refusal mutates nothing.
             agent_delete_precheck(config, &alias)?;
+            // Resolve the workspace dir while the entry still exists (a custom
+            // `workspace.path` is read off it), then apply + PERSIST the config
+            // change before any irreversible owned-state side effects — so a
+            // later failure can't leave the config and owned state split.
+            let workspace = config.agent_workspace_dir(&alias);
             apply_delete(config, &AliasKind::Agent, &alias)?;
-            agent_delete_owned_state(config, &alias).await?;
-            save(config).await
+            save(config).await?;
+            agent_delete_owned_state(config, &alias, &workspace).await
         }
     }
 }
@@ -368,7 +473,15 @@ fn agent_delete_precheck(config: &Config, alias: &str) -> Result<()> {
     let live = crate::gateway::agent_owned_state::live_acp_session_count(config, alias)
         .context("could not verify live ACP sessions")?;
     if live > 0 {
-        bail!("{live} live ACP session(s) for `{alias}` — end them first");
+        let count = live.to_string();
+        bail!(
+            "{}",
+            mta(
+                "cli-alias-live-acp-sessions",
+                &[("count", count.as_str()), ("alias", alias)],
+                "{$count} live ACP session(s) for `{$alias}` — end them first"
+            )
+        );
     }
     Ok(())
 }
@@ -379,7 +492,11 @@ fn agent_delete_precheck(_config: &Config, _alias: &str) -> Result<()> {
 }
 
 #[cfg(all(feature = "gateway", feature = "agent-runtime"))]
-async fn agent_delete_owned_state(config: &Config, alias: &str) -> Result<()> {
+async fn agent_delete_owned_state(
+    config: &Config,
+    alias: &str,
+    workspace: &std::path::Path,
+) -> Result<()> {
     let (mem, session_backend) = build_owned_state_handles(config)?;
     let ts = chrono::Utc::now().format("%Y%m%d%H%M%S");
     let archive_dir = config
@@ -388,8 +505,9 @@ async fn agent_delete_owned_state(config: &Config, alias: &str) -> Result<()> {
         .join("_deleted")
         .join(format!("{alias}-{ts}"));
     tokio::fs::create_dir_all(&archive_dir).await.ok();
-    // Archive the workspace dir alongside the owned-state exports.
-    let workspace = config.agent_workspace_dir(alias);
+    // Archive the workspace dir alongside the owned-state exports. `workspace`
+    // was resolved by the caller before the config entry was removed, so a
+    // custom `workspace.path` is preserved (post-removal it would default).
     if workspace.exists() {
         if let Err(e) = tokio::fs::rename(&workspace, archive_dir.join("workspace")).await {
             let es = e.to_string();
@@ -444,7 +562,11 @@ async fn agent_delete_owned_state(config: &Config, alias: &str) -> Result<()> {
 }
 
 #[cfg(not(all(feature = "gateway", feature = "agent-runtime")))]
-async fn agent_delete_owned_state(_config: &Config, _alias: &str) -> Result<()> {
+async fn agent_delete_owned_state(
+    _config: &Config,
+    _alias: &str,
+    _workspace: &std::path::Path,
+) -> Result<()> {
     warn_agent_owned_state();
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -521,10 +521,21 @@ pub enum SkillBundleCommands {
         #[arg(long)]
         directory: Option<String>,
     },
-    /// Remove a configured skill bundle
+    /// Remove a configured skill bundle (archives its directory + strips it
+    /// from every agent's `skill_bundles` list)
     Remove {
         /// Bundle alias
         alias: String,
+        /// Skip the confirmation prompt
+        #[arg(long)]
+        yes: bool,
+    },
+    /// Rename a skill bundle (moves its directory + rewrites agent references)
+    Rename {
+        /// Current alias
+        from: String,
+        /// New alias
+        to: String,
     },
     /// Show metadata + skill list for a bundle
     Show {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -315,6 +315,109 @@ Examples:
     },
 }
 
+/// Alias CRUD for agents (`[agents.<alias>]`). Distinct from the `agent`
+/// run command. Rename/delete cascade config references; for agents they also
+/// re-point owned state (memory / cron / acp / session) and move the workspace.
+#[derive(Subcommand, Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum AgentsCommands {
+    /// List configured agent aliases
+    List,
+    /// Create a new agent alias with default config
+    Create {
+        /// New agent alias (lowercase alphanumeric + single underscore)
+        alias: String,
+    },
+    /// Rename an agent alias, rewriting every reference to it
+    Rename {
+        /// Current alias
+        from: String,
+        /// New alias
+        to: String,
+    },
+    /// Delete an agent alias, scrubbing references and cascading owned state
+    Delete {
+        /// Alias to delete
+        alias: String,
+        /// Show the impact (references that would be scrubbed) without deleting
+        #[arg(long)]
+        dry_run: bool,
+        /// Skip the confirmation prompt
+        #[arg(long)]
+        yes: bool,
+    },
+}
+
+/// Alias CRUD for providers (`[providers.<category>.<family>.<alias>]`).
+/// `category` is one of `models`, `tts`, `transcription`.
+#[derive(Subcommand, Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ProvidersCommands {
+    /// List provider aliases (optionally filtered by category)
+    List {
+        /// Category: models | tts | transcription
+        #[arg(long)]
+        category: Option<String>,
+    },
+    /// Create a new provider alias with default config
+    Create {
+        /// Category: models | tts | transcription
+        category: String,
+        /// Provider family (e.g. anthropic, openai, elevenlabs)
+        family: String,
+        /// New alias
+        alias: String,
+    },
+    /// Rename a provider alias, rewriting every reference
+    Rename {
+        category: String,
+        family: String,
+        from: String,
+        to: String,
+    },
+    /// Delete a provider alias, scrubbing references
+    Delete {
+        category: String,
+        family: String,
+        alias: String,
+        #[arg(long)]
+        dry_run: bool,
+        #[arg(long)]
+        yes: bool,
+    },
+}
+
+/// Alias CRUD for channels (`[channels.<type>.<alias>]`).
+#[derive(Subcommand, Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ChannelsCommands {
+    /// List channel aliases (optionally filtered by type)
+    List {
+        /// Channel type, e.g. discord, telegram
+        #[arg(long)]
+        channel_type: Option<String>,
+    },
+    /// Create a new channel alias with default config
+    Create {
+        /// Channel type (discord, telegram, slack, …)
+        channel_type: String,
+        /// New alias
+        alias: String,
+    },
+    /// Rename a channel alias, rewriting every reference
+    Rename {
+        channel_type: String,
+        from: String,
+        to: String,
+    },
+    /// Delete a channel alias, scrubbing references
+    Delete {
+        channel_type: String,
+        alias: String,
+        #[arg(long)]
+        dry_run: bool,
+        #[arg(long)]
+        yes: bool,
+    },
+}
+
 /// Skills management subcommands
 #[derive(Subcommand, Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum SkillCommands {

--- a/src/main.rs
+++ b/src/main.rs
@@ -231,6 +231,7 @@ fn pause_after_no_command_help() {
 
 #[cfg(feature = "agent-runtime")]
 mod agent;
+mod alias_cli;
 #[cfg(feature = "agent-runtime")]
 mod approval;
 #[cfg(feature = "agent-runtime")]
@@ -312,9 +313,9 @@ use config::Config;
 
 // Re-export so binary modules can use crate::<CommandEnum> while keeping a single source of truth.
 pub use zeroclaw::{
-    ChannelCommands, CronCommands, GatewayCommands, HardwareCommands, IntegrationCommands,
-    MigrateCommands, PeripheralCommands, ServiceCommands, SkillBundleCommands, SkillCommands,
-    SopCommands,
+    AgentsCommands, ChannelCommands, ChannelsCommands, CronCommands, GatewayCommands,
+    HardwareCommands, IntegrationCommands, MigrateCommands, PeripheralCommands, ProvidersCommands,
+    ServiceCommands, SkillBundleCommands, SkillCommands, SopCommands,
 };
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]
@@ -713,8 +714,15 @@ Examples:
         model_command: ModelCommands,
     },
 
-    /// List supported AI model_providers
-    Providers,
+    /// List supported AI model providers, or manage provider aliases.
+    ///
+    /// With no subcommand, prints the catalog of supported provider types. With
+    /// `create`/`list`/`rename`/`delete`, manages configured provider aliases
+    /// under `[providers.<category>.<family>.<alias>]`.
+    Providers {
+        #[command(subcommand)]
+        providers_command: Option<ProvidersCommands>,
+    },
 
     /// Manage channels (telegram, discord, slack)
     // i18n-exempt: clap derive help — framework requires a compile-time literal
@@ -735,6 +743,19 @@ Examples:
     Channel {
         #[command(subcommand)]
         channel_command: ChannelCommands,
+    },
+
+    /// Manage agent aliases (create/list/rename/delete). Distinct from `agent`,
+    /// which runs an agent.
+    Agents {
+        #[command(subcommand)]
+        agents_command: AgentsCommands,
+    },
+
+    /// Manage channel aliases (create/list/rename/delete)
+    Channels {
+        #[command(subcommand)]
+        channels_command: ChannelsCommands,
     },
 
     /// Browse 50+ integrations
@@ -4475,7 +4496,9 @@ async fn main() -> Result<()> {
             _ => doctor::run_models(&config, None, false, false).await,
         },
 
-        Commands::Providers => {
+        Commands::Providers {
+            providers_command: None,
+        } => {
             let model_providers = zeroclaw_providers::list_model_providers();
             let configured_types: std::collections::HashSet<&str> = config
                 .providers
@@ -4512,6 +4535,10 @@ async fn main() -> Result<()> {
             );
             Ok(())
         }
+
+        Commands::Providers {
+            providers_command: Some(providers_command),
+        } => Box::pin(alias_cli::handle_providers(providers_command, &mut config)).await,
 
         Commands::Service {
             service_command,
@@ -4572,6 +4599,13 @@ async fn main() -> Result<()> {
             ChannelCommands::Doctor => Box::pin(channels::doctor_channels(config)).await,
             other => Box::pin(channels::handle_command(other, &config)).await,
         },
+
+        Commands::Agents { agents_command } => {
+            Box::pin(alias_cli::handle_agents(agents_command, &mut config)).await
+        }
+        Commands::Channels { channels_command } => {
+            Box::pin(alias_cli::handle_channels(channels_command, &mut config)).await
+        }
 
         Commands::Integrations {
             integration_command,

--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -242,9 +242,14 @@ pub async fn handle_command(
         crate::SkillCommands::Bundle { bundle_command } => match bundle_command {
             crate::SkillBundleCommands::List => handle_bundle_list(config),
             crate::SkillBundleCommands::Add { alias, directory } => {
-                handle_bundle_add(alias, directory)
+                Box::pin(handle_bundle_add(config, alias, directory)).await
             }
-            crate::SkillBundleCommands::Remove { alias } => handle_bundle_remove(alias),
+            crate::SkillBundleCommands::Remove { alias, yes } => {
+                Box::pin(handle_bundle_remove(config, alias, yes)).await
+            }
+            crate::SkillBundleCommands::Rename { from, to } => {
+                Box::pin(handle_bundle_rename(config, from, to)).await
+            }
             crate::SkillBundleCommands::Show { alias } => handle_bundle_show(config, alias),
         },
         crate::SkillCommands::Test { name, verbose } => {
@@ -385,30 +390,147 @@ fn handle_edit(
     open_in_editor(&path)
 }
 
-fn handle_bundle_add(alias: String, directory: Option<String>) -> Result<()> {
-    // Bundle CRUD is config CRUD. Suggest the `zeroclaw config` invocations
-    // so the config writer stays single-sourced through api_config /
-    // handle_map_key rather than reaching it from here.
-    let directory_path = directory.unwrap_or_else(|| format!("shared/skills/{alias}"));
-    println!(
-        "{}",
-        zeroclaw_runtime::i18n::get_required_cli_string_with_args(
-            "cli-skills-bundle-add-prompt",
-            &[("alias", &alias), ("dir", &directory_path)],
-        )
-    );
-    Ok(())
+/// Create a skill bundle: insert the config entry, set a custom directory if
+/// given, materialize the resolved directory, and persist.
+async fn handle_bundle_add(
+    config: &crate::config::Config,
+    alias: String,
+    directory: Option<String>,
+) -> Result<()> {
+    let mut working = config.clone();
+    if !working
+        .create_map_key("skill_bundles", &alias)
+        .map_err(anyhow::Error::msg)?
+    {
+        println!("skill bundle '{alias}' already exists (no change)");
+        return Ok(());
+    }
+    if let Some(dir) = directory.as_ref()
+        && let Some(b) = working.skill_bundles.get_mut(&alias)
+    {
+        b.directory = Some(dir.clone());
+    }
+    working.mark_dirty(&format!("skill_bundles.{alias}"));
+    let install_root = working.install_root_dir();
+    match zeroclaw_config::skill_bundles::resolve_directory(&working, &install_root, &alias) {
+        Ok(dir) => {
+            tokio::fs::create_dir_all(&dir).await.ok();
+            println!("created skill_bundles.{alias} (dir: {})", dir.display());
+        }
+        Err(e) => println!("created skill_bundles.{alias} (warning: dir resolve failed: {e})"),
+    }
+    Box::pin(working.save_dirty())
+        .await
+        .context("failed to persist config")
 }
 
-fn handle_bundle_remove(alias: String) -> Result<()> {
+/// Delete a skill bundle: archive its directory, strip it from every agent's
+/// `skill_bundles` list, remove the config entry, and persist. Safe-by-default:
+/// without `--yes` it prints the impact and makes no change.
+async fn handle_bundle_remove(
+    config: &crate::config::Config,
+    alias: String,
+    yes: bool,
+) -> Result<()> {
+    let exists = config
+        .get_map_keys("skill_bundles")
+        .is_some_and(|k| k.contains(&alias));
+    if !exists {
+        anyhow::bail!("skill bundle '{alias}' is not configured");
+    }
+    let refs = zeroclaw_config::alias_refs::find_bundle_refs(config, &alias);
+    if !yes {
+        println!(
+            "deleting skill_bundles.{alias} would strip it from {} agent reference(s):",
+            refs.len()
+        );
+        for r in &refs {
+            println!("  • {}", r.path);
+        }
+        println!("\nNo changes made. Re-run with --yes to apply.");
+        return Ok(());
+    }
+    let mut working = config.clone();
+    // Archive the bundle directory under shared/skills/_deleted/ (the runtime
+    // skips that path, so the archived bundle isn't re-scanned as live skills).
+    let install_root = working.install_root_dir();
+    if let Ok(dir) =
+        zeroclaw_config::skill_bundles::resolve_directory(&working, &install_root, &alias)
+        && dir.exists()
+    {
+        let ts = chrono::Utc::now().format("%Y%m%d%H%M%S");
+        let archive = install_root
+            .join("shared")
+            .join("skills")
+            .join("_deleted")
+            .join(format!("{alias}-{ts}"));
+        if let Some(p) = archive.parent() {
+            tokio::fs::create_dir_all(p).await.ok();
+        }
+        match tokio::fs::rename(&dir, &archive).await {
+            Ok(()) => println!("archived bundle directory → {}", archive.display()),
+            Err(e) => eprintln!("warning: bundle directory archive failed: {e}"),
+        }
+    }
+    let mut dirty = zeroclaw_config::alias_refs::scrub_bundle_refs(&mut working, &alias);
+    working
+        .delete_map_key("skill_bundles", &alias)
+        .map_err(anyhow::Error::msg)?;
+    dirty.push(format!("skill_bundles.{alias}"));
+    for p in &dirty {
+        working.mark_dirty(p);
+    }
     println!(
-        "{}",
-        zeroclaw_runtime::i18n::get_required_cli_string_with_args(
-            "cli-skills-bundle-remove-prompt",
-            &[("alias", &alias)],
-        )
+        "deleted skill_bundles.{alias} (stripped from {} agent(s))",
+        refs.len()
     );
-    Ok(())
+    Box::pin(working.save_dirty())
+        .await
+        .context("failed to persist config")
+}
+
+/// Rename a skill bundle: rename the config entry, rewrite every agent's
+/// `skill_bundles` reference, move its directory, and persist.
+async fn handle_bundle_rename(
+    config: &crate::config::Config,
+    from: String,
+    to: String,
+) -> Result<()> {
+    let mut working = config.clone();
+    let install_root = working.install_root_dir();
+    // Resolve the OLD directory while the `from` entry still exists.
+    let old_dir =
+        zeroclaw_config::skill_bundles::resolve_directory(&working, &install_root, &from).ok();
+    match working.rename_map_key("skill_bundles", &from, &to) {
+        Ok(true) => {}
+        Ok(false) => anyhow::bail!("skill bundle '{from}' is not configured"),
+        Err(e) => anyhow::bail!("rename failed: {e}"),
+    }
+    let mut dirty = zeroclaw_config::alias_refs::rewrite_bundle_refs(&mut working, &from, &to);
+    dirty.push(format!("skill_bundles.{from}"));
+    dirty.push(format!("skill_bundles.{to}"));
+    // Move the directory (default per-alias path only; a custom path is
+    // alias-independent → old == new → skip).
+    let new_dir =
+        zeroclaw_config::skill_bundles::resolve_directory(&working, &install_root, &to).ok();
+    if let (Some(old), Some(new)) = (old_dir, new_dir)
+        && old != new
+        && old.exists()
+    {
+        if let Some(p) = new.parent() {
+            tokio::fs::create_dir_all(p).await.ok();
+        }
+        if let Err(e) = tokio::fs::rename(&old, &new).await {
+            eprintln!("warning: bundle directory move failed: {e}");
+        }
+    }
+    for p in &dirty {
+        working.mark_dirty(p);
+    }
+    println!("renamed skill_bundles.{from} → skill_bundles.{to}");
+    Box::pin(working.save_dirty())
+        .await
+        .context("failed to persist config")
 }
 
 fn print_bundle_include_exclude(include: &[String], exclude: &[String]) {

--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -5,6 +5,35 @@ use anyhow::{Context, Result};
 use std::path::PathBuf;
 use zeroclaw_runtime::i18n::{get_required_cli_string, get_required_cli_string_with_args};
 use zeroclaw_runtime::skills::{ScaffoldOptions, SkillFrontmatter, SkillsService};
+
+/// Resolve a `cli-*` Fluent key for skill-bundle CLI output. Under `agent-runtime`
+/// (default + what CI/release build) this routes through Fluent; without it the
+/// runtime i18n crate is absent, so the English `fallback` is used.
+#[allow(unused_variables)]
+fn mt(key: &str, fallback: &str) -> String {
+    #[cfg(feature = "agent-runtime")]
+    {
+        zeroclaw_runtime::i18n::get_required_cli_string(key)
+    }
+    #[cfg(not(feature = "agent-runtime"))]
+    {
+        fallback.to_string() // i18n-exempt: English fallback when Fluent (agent-runtime) is disabled
+    }
+}
+
+/// `mt` with `{$name}` arguments.
+#[allow(unused_variables)]
+fn mta(key: &str, args: &[(&str, &str)], fallback: &str) -> String {
+    #[cfg(feature = "agent-runtime")]
+    {
+        zeroclaw_runtime::i18n::get_required_cli_string_with_args(key, args)
+    }
+    #[cfg(not(feature = "agent-runtime"))]
+    {
+        fallback.to_string() // i18n-exempt: English fallback when Fluent (agent-runtime) is disabled
+    }
+}
+
 pub mod creator {
     #[allow(unused_imports)]
     pub use zeroclaw_runtime::skills::creator::*;
@@ -402,7 +431,14 @@ async fn handle_bundle_add(
         .create_map_key("skill_bundles", &alias)
         .map_err(anyhow::Error::msg)?
     {
-        println!("skill bundle '{alias}' already exists (no change)");
+        println!(
+            "{}",
+            mta(
+                "cli-bundle-exists",
+                &[("alias", alias.as_str())],
+                "skill bundle '{$alias}' already exists (no change)"
+            )
+        );
         return Ok(());
     }
     if let Some(dir) = directory.as_ref()
@@ -415,9 +451,27 @@ async fn handle_bundle_add(
     match zeroclaw_config::skill_bundles::resolve_directory(&working, &install_root, &alias) {
         Ok(dir) => {
             tokio::fs::create_dir_all(&dir).await.ok();
-            println!("created skill_bundles.{alias} (dir: {})", dir.display());
+            let d = dir.display().to_string();
+            println!(
+                "{}",
+                mta(
+                    "cli-bundle-created",
+                    &[("alias", alias.as_str()), ("dir", d.as_str())],
+                    "created skill_bundles.{$alias} (dir: {$dir})"
+                )
+            );
         }
-        Err(e) => println!("created skill_bundles.{alias} (warning: dir resolve failed: {e})"),
+        Err(e) => {
+            let es = e.to_string();
+            println!(
+                "{}",
+                mta(
+                    "cli-bundle-created-warn",
+                    &[("alias", alias.as_str()), ("error", es.as_str())],
+                    "created skill_bundles.{$alias} (warning: dir resolve failed: {$error})"
+                )
+            );
+        }
     }
     Box::pin(working.save_dirty())
         .await
@@ -440,14 +494,25 @@ async fn handle_bundle_remove(
     }
     let refs = zeroclaw_config::alias_refs::find_bundle_refs(config, &alias);
     if !yes {
+        let count = refs.len().to_string();
         println!(
-            "deleting skill_bundles.{alias} would strip it from {} agent reference(s):",
-            refs.len()
+            "{}",
+            mta(
+                "cli-bundle-impact-header",
+                &[("alias", alias.as_str()), ("count", count.as_str())],
+                "deleting skill_bundles.{$alias} would strip it from {$count} agent reference(s):"
+            )
         );
         for r in &refs {
             println!("  • {}", r.path);
         }
-        println!("\nNo changes made. Re-run with --yes to apply.");
+        println!(
+            "\n{}",
+            mt(
+                "cli-bundle-no-changes",
+                "No changes made. Re-run with --yes to apply."
+            )
+        );
         return Ok(());
     }
     let mut working = config.clone();
@@ -468,8 +533,28 @@ async fn handle_bundle_remove(
             tokio::fs::create_dir_all(p).await.ok();
         }
         match tokio::fs::rename(&dir, &archive).await {
-            Ok(()) => println!("archived bundle directory → {}", archive.display()),
-            Err(e) => eprintln!("warning: bundle directory archive failed: {e}"),
+            Ok(()) => {
+                let p = archive.display().to_string();
+                println!(
+                    "{}",
+                    mta(
+                        "cli-bundle-archived",
+                        &[("path", p.as_str())],
+                        "archived bundle directory → {$path}"
+                    )
+                );
+            }
+            Err(e) => {
+                let es = e.to_string();
+                eprintln!(
+                    "{}",
+                    mta(
+                        "cli-bundle-warn-archive",
+                        &[("error", es.as_str())],
+                        "warning: bundle directory archive failed: {$error}"
+                    )
+                );
+            }
         }
     }
     let mut dirty = zeroclaw_config::alias_refs::scrub_bundle_refs(&mut working, &alias);
@@ -480,9 +565,14 @@ async fn handle_bundle_remove(
     for p in &dirty {
         working.mark_dirty(p);
     }
+    let count = refs.len().to_string();
     println!(
-        "deleted skill_bundles.{alias} (stripped from {} agent(s))",
-        refs.len()
+        "{}",
+        mta(
+            "cli-bundle-deleted",
+            &[("alias", alias.as_str()), ("count", count.as_str())],
+            "deleted skill_bundles.{$alias} (stripped from {$count} agent(s))"
+        )
     );
     Box::pin(working.save_dirty())
         .await
@@ -521,13 +611,28 @@ async fn handle_bundle_rename(
             tokio::fs::create_dir_all(p).await.ok();
         }
         if let Err(e) = tokio::fs::rename(&old, &new).await {
-            eprintln!("warning: bundle directory move failed: {e}");
+            let es = e.to_string();
+            eprintln!(
+                "{}",
+                mta(
+                    "cli-bundle-warn-move",
+                    &[("error", es.as_str())],
+                    "warning: bundle directory move failed: {$error}"
+                )
+            );
         }
     }
     for p in &dirty {
         working.mark_dirty(p);
     }
-    println!("renamed skill_bundles.{from} → skill_bundles.{to}");
+    println!(
+        "{}",
+        mta(
+            "cli-bundle-renamed",
+            &[("from", from.as_str()), ("to", to.as_str())],
+            "renamed skill_bundles.{$from} → skill_bundles.{$to}"
+        )
+    );
     Box::pin(working.save_dirty())
         .await
         .context("failed to persist config")

--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -490,7 +490,14 @@ async fn handle_bundle_remove(
         .get_map_keys("skill_bundles")
         .is_some_and(|k| k.contains(&alias));
     if !exists {
-        anyhow::bail!("skill bundle '{alias}' is not configured");
+        anyhow::bail!(
+            "{}",
+            mta(
+                "cli-bundle-not-configured",
+                &[("alias", alias.as_str())],
+                "skill bundle '{$alias}' is not configured"
+            )
+        );
     }
     let refs = zeroclaw_config::alias_refs::find_bundle_refs(config, &alias);
     if !yes {
@@ -516,13 +523,32 @@ async fn handle_bundle_remove(
         return Ok(());
     }
     let mut working = config.clone();
-    // Archive the bundle directory under shared/skills/_deleted/ (the runtime
-    // skips that path, so the archived bundle isn't re-scanned as live skills).
     let install_root = working.install_root_dir();
-    if let Ok(dir) =
+    // Resolve the bundle directory while the entry still exists, so it can be
+    // archived AFTER the config change is durable.
+    let bundle_dir =
         zeroclaw_config::skill_bundles::resolve_directory(&working, &install_root, &alias)
-        && dir.exists()
-    {
+            .ok()
+            .filter(|d| d.exists());
+
+    // Mutate + PERSIST the config first, so a later archive failure can't leave
+    // the config pointing at a directory already moved to _deleted/.
+    let mut dirty = zeroclaw_config::alias_refs::scrub_bundle_refs(&mut working, &alias);
+    working
+        .delete_map_key("skill_bundles", &alias)
+        .map_err(anyhow::Error::msg)?;
+    dirty.push(format!("skill_bundles.{alias}"));
+    for p in &dirty {
+        working.mark_dirty(p);
+    }
+    Box::pin(working.save_dirty())
+        .await
+        .context("failed to persist config")?;
+
+    // Archive the bundle directory under shared/skills/_deleted/ (the runtime
+    // skips that path, so it isn't re-scanned as live skills) now that the
+    // config change is on disk.
+    if let Some(dir) = bundle_dir {
         let ts = chrono::Utc::now().format("%Y%m%d%H%M%S");
         let archive = install_root
             .join("shared")
@@ -557,14 +583,6 @@ async fn handle_bundle_remove(
             }
         }
     }
-    let mut dirty = zeroclaw_config::alias_refs::scrub_bundle_refs(&mut working, &alias);
-    working
-        .delete_map_key("skill_bundles", &alias)
-        .map_err(anyhow::Error::msg)?;
-    dirty.push(format!("skill_bundles.{alias}"));
-    for p in &dirty {
-        working.mark_dirty(p);
-    }
     let count = refs.len().to_string();
     println!(
         "{}",
@@ -574,9 +592,7 @@ async fn handle_bundle_remove(
             "deleted skill_bundles.{$alias} (stripped from {$count} agent(s))"
         )
     );
-    Box::pin(working.save_dirty())
-        .await
-        .context("failed to persist config")
+    Ok(())
 }
 
 /// Rename a skill bundle: rename the config entry, rewrite every agent's
@@ -593,16 +609,43 @@ async fn handle_bundle_rename(
         zeroclaw_config::skill_bundles::resolve_directory(&working, &install_root, &from).ok();
     match working.rename_map_key("skill_bundles", &from, &to) {
         Ok(true) => {}
-        Ok(false) => anyhow::bail!("skill bundle '{from}' is not configured"),
-        Err(e) => anyhow::bail!("rename failed: {e}"),
+        Ok(false) => anyhow::bail!(
+            "{}",
+            mta(
+                "cli-bundle-not-configured",
+                &[("alias", from.as_str())],
+                "skill bundle '{$alias}' is not configured"
+            )
+        ),
+        Err(e) => {
+            let es = e.to_string();
+            anyhow::bail!(
+                "{}",
+                mta(
+                    "cli-bundle-rename-failed",
+                    &[("error", es.as_str())],
+                    "rename failed: {$error}"
+                )
+            )
+        }
     }
     let mut dirty = zeroclaw_config::alias_refs::rewrite_bundle_refs(&mut working, &from, &to);
     dirty.push(format!("skill_bundles.{from}"));
     dirty.push(format!("skill_bundles.{to}"));
-    // Move the directory (default per-alias path only; a custom path is
-    // alias-independent → old == new → skip).
+    // Resolve the NEW directory (the entry now lives under `to`) for the move.
     let new_dir =
         zeroclaw_config::skill_bundles::resolve_directory(&working, &install_root, &to).ok();
+    for p in &dirty {
+        working.mark_dirty(p);
+    }
+    // PERSIST the config rename before moving the directory, so a later move
+    // failure can't leave the config naming `to` while the dir sits at `from`.
+    Box::pin(working.save_dirty())
+        .await
+        .context("failed to persist config")?;
+
+    // Move the directory (default per-alias path only; a custom path is
+    // alias-independent → old == new → skip).
     if let (Some(old), Some(new)) = (old_dir, new_dir)
         && old != new
         && old.exists()
@@ -622,9 +665,6 @@ async fn handle_bundle_rename(
             );
         }
     }
-    for p in &dirty {
-        working.mark_dirty(p);
-    }
     println!(
         "{}",
         mta(
@@ -633,9 +673,7 @@ async fn handle_bundle_rename(
             "renamed skill_bundles.{$from} → skill_bundles.{$to}"
         )
     );
-    Box::pin(working.save_dirty())
-        .await
-        .context("failed to persist config")
+    Ok(())
 }
 
 fn print_bundle_include_exclude(include: &[String], exclude: &[String]) {


### PR DESCRIPTION
> ### 📋 Stacked series — **8 of 8**
> Typed delete-with-cascade (#7175) + alias rename (#7468), sliced for review. **Opened as draft for CI; merge strictly in order.** This is the tail of the stack, so its diff is the **cumulative** feature until #3–#7 merge; it collapses to its own delta (the CLI + skill-bundle commits) once they land.
>
> **Sequence:** `1` #7785 ✅ · `2` #7830 ✅ · `3` #7837 · `4` #7838 · `5` #7839 · `6` #7840 · `7` #7841 · **`8` #7842 ← this PR**

**This slice (own delta):** 6 files, **+1101 / −102** — three commits: alias CRUD verbs, agent owned-state in the CLI, skill-bundle cascade. **Cumulative shown until #3–#7 merge:** 18 files, +3639 / −122.

## Summary
The user-facing surface for the whole feature — gives the config/gateway cascade primitives their first CLI callers.

- **`zeroclaw {agents,providers,channels} {create,list,rename,delete}`** — new **non-breaking plural** subcommand groups over the shared cascade. The existing `agent <alias>` (run) command is untouched; `providers` with no verb still prints the supported-provider catalog. Delete is **safe-by-default** (impact preview unless `--yes`).
- **`default`-agent CLI guard:** the gateway delete relies only on HARD refs (acp.default_agent / enabled heartbeat); a `default` agent with neither would be deletable, so the CLI adds an explicit refuse + test.
- **Agent owned-state cascade from the CLI** (feature-gated `#[cfg(all(feature="gateway",feature="agent-runtime"))]`, config-only fallback + warning when off): stores opened from `data_dir` (no live gateway) → live-ACP gate → `cascade_owned_state` on delete (archives workspace) / `cascade_rename_agent` on rename (moves workspace).
- **`skills bundle {add,remove,rename}` now cascade:** create makes the dir; delete archives `shared/skills/<a>/` → `skills/_deleted/<a>-<ts>/` and strips the bundle from every agent's `skill_bundles`; rename moves the dir and rewrites the references. Implemented as standalone `find/scrub/rewrite_bundle_refs` (a single SOFT container — no new `AliasKind` variant, which would churn every exhaustive match for no gain). Adds `SkillBundleCommands::Rename`.

## Anti-drift refactor (PR8a)
Promotes the gateway's private `delete_cascade_dirty_paths` + `dirty_entry_for` into `zeroclaw-config` as `CascadeReport::dirty_paths()` (symmetric with `RenameReport.dirty_paths`), so the gateway delete handler and the CLI share one source of truth instead of duplicating the dirty-path derivation.

## Validation
`cargo clippy --workspace --all-targets` + `cargo fmt --all --check` **clean** at this tip (the union of the whole stack, default features incl. gateway + agent-runtime). Smoke-tested each verb against a temp `data_dir`: rename persisted to disk; agent delete archived workspace to `_deleted/` + wrote the cascade manifest; bundle rename moved the dir + rewrote the agent ref; bundle delete archived the dir + stripped the ref. Full CI matrix runs on this draft.

## Security & Privacy
New fs writes are the same operator-controlled `data_dir` archives as the gateway path (workspace + skill-bundle dirs under `_deleted/`). No new network/permissions/secrets. No PII in tests.
## Compatibility — backward compatible; new subcommand groups are additive, existing commands untouched. `SkillBundleCommands::Rename` is new.
## Rollback (risk: medium) — `git revert <range>`; no migration; CLI-only surface.

Related #7468 · #7175.
