### PR TITLE
feat(channels/discord): typed slash-command options + chunked interaction followups

### DIFF
--- a/crates/zeroclaw-channels/src/discord/interaction.rs
+++ b/crates/zeroclaw-channels/src/discord/interaction.rs
@@ -6,7 +6,7 @@
 
 use serde_json::json;
 
-use super::types::{DISCORD_MAX_MESSAGE_LENGTH, DiscordOutgoing};
+use super::types::DiscordOutgoing;
 
 /// Credentials needed to answer a deferred interaction later: the followup
 /// webhook is addressed by application id + interaction token.
@@ -100,34 +100,24 @@ pub(crate) async fn discord_reject_interaction(
     Ok(())
 }
 
-/// Deliver the agent's answer by editing the deferred interaction response
-/// (`PATCH /webhooks/{app_id}/{token}/messages/@original`). The token is valid
-/// for 15 minutes; no bot auth header is required for the followup webhook.
+/// Edit the deferred interaction's @original message
+/// (`PATCH {api_base}/webhooks/{app_id}/{token}/messages/@original`). The token
+/// is valid for 15 minutes; no bot auth header is required for the followup
+/// webhook. `content` must be within Discord's 2000-char limit — callers whose
+/// reply may exceed it chunk first and post the remainder via
+/// [`discord_post_interaction_followup`].
 pub(crate) async fn discord_edit_interaction_response(
     client: &reqwest::Client,
     app_id: &str,
     interaction_token: &str,
+    api_base: &str,
     content: &str,
 ) -> anyhow::Result<()> {
-    let url = format!(
-        "https://discord.com/api/v10/webhooks/{app_id}/{interaction_token}/messages/@original"
-    );
-    let trimmed: String = content.chars().take(DISCORD_MAX_MESSAGE_LENGTH).collect();
-    if trimmed.chars().count() < content.chars().count() {
-        ::zeroclaw_log::record!(
-            WARN,
-            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                .with_attrs(::serde_json::json!({
-                    "content_chars": content.chars().count(),
-                })),
-            "interaction reply truncated to Discord's 2000-char limit (chunked followups are a planned follow-up)"
-        );
-    }
+    let url = format!("{api_base}/webhooks/{app_id}/{interaction_token}/messages/@original");
     // without_url: transport errors embed the token-bearing URL.
     let resp = client
         .patch(&url)
-        .json(&DiscordOutgoing::text(trimmed).to_rest_json())
+        .json(&DiscordOutgoing::text(content).to_rest_json())
         .send()
         .await
         .map_err(reqwest::Error::without_url)?;
@@ -135,6 +125,31 @@ pub(crate) async fn discord_edit_interaction_response(
         let status = resp.status();
         let err = resp.text().await.unwrap_or_default();
         anyhow::bail!("interaction followup edit failed ({status}): {err}");
+    }
+    Ok(())
+}
+
+/// Post an additional interaction followup message
+/// (`POST {api_base}/webhooks/{app_id}/{token}`), used to deliver the answer
+/// chunks beyond the first when a reply exceeds Discord's 2000-char limit.
+pub(crate) async fn discord_post_interaction_followup(
+    client: &reqwest::Client,
+    app_id: &str,
+    interaction_token: &str,
+    api_base: &str,
+    content: &str,
+) -> anyhow::Result<()> {
+    let url = format!("{api_base}/webhooks/{app_id}/{interaction_token}");
+    let resp = client
+        .post(&url)
+        .json(&DiscordOutgoing::text(content).to_rest_json())
+        .send()
+        .await
+        .map_err(reqwest::Error::without_url)?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let err = resp.text().await.unwrap_or_default();
+        anyhow::bail!("interaction followup post failed ({status}): {err}");
     }
     Ok(())
 }

--- a/crates/zeroclaw-channels/src/discord/mod.rs
+++ b/crates/zeroclaw-channels/src/discord/mod.rs
@@ -2095,34 +2095,8 @@ impl Channel for DiscordChannel {
                                                 None => Vec::new(),
                                             };
                                             match specs.into_iter().find(|spec| spec.slug == command) {
-                                                Some(spec) if spec.options.is_empty() => {
-                                                    // Legacy single free-text `input` option.
-                                                    if input.is_empty() {
-                                                        None // known command, empty input
-                                                    } else {
-                                                        Some(format!(
-                                                            "Use the '{}' skill for this request: {input}",
-                                                            spec.skill_name
-                                                        ))
-                                                    }
-                                                }
                                                 Some(spec) => {
-                                                    // Typed options: fold the submitted name/value pairs
-                                                    // (extracted above) into the prompt (Discord enforces
-                                                    // the required ones).
-                                                    if submitted.is_empty() {
-                                                        None
-                                                    } else {
-                                                        let rendered = submitted
-                                                            .iter()
-                                                            .map(|(n, v)| format!("{n}: {v}"))
-                                                            .collect::<Vec<_>>()
-                                                            .join("\n");
-                                                        Some(format!(
-                                                            "Use the '{}' skill for this request:\n{rendered}",
-                                                            spec.skill_name
-                                                        ))
-                                                    }
+                                                    skill_command_prompt(&spec, &input, &submitted)
                                                 }
                                                 None => None, // stale or foreign command
                                             }

--- a/crates/zeroclaw-channels/src/discord/mod.rs
+++ b/crates/zeroclaw-channels/src/discord/mod.rs
@@ -21,6 +21,11 @@ pub use types::{DiscordSlashCommandResolver, DiscordSlashCommandSpec};
 // Contract types/codec/consts used throughout this module and its siblings.
 pub(crate) use types::*;
 
+// Contract tier: the typed slash-command option model the command spec carries.
+// Consumers (`types`, `slash`, dispatch) import `super::slash_options::…`
+// explicitly — no crate-wide re-export needed.
+mod slash_options;
+
 mod chunk;
 pub(crate) use chunk::*;
 
@@ -3235,6 +3240,7 @@ mod tests {
             skill_name: "deploy status".to_string(),
             slug: "deploy-status".to_string(),
             description: "Check deploy state".to_string(),
+            options: Vec::new(),
         }];
         let body = slash_command_registration_body(&specs);
         let commands = body.as_array().unwrap();

--- a/crates/zeroclaw-channels/src/discord/mod.rs
+++ b/crates/zeroclaw-channels/src/discord/mod.rs
@@ -725,6 +725,29 @@ const fn is_thread_channel_type(channel_type: u64) -> bool {
 /// is a safety bound so a hung request cannot stall the listener.
 const THREAD_LOOKUP_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Deliver a (deferred) interaction's answer, splitting it across Discord's
+/// 2000-char limit: the first chunk edits the @original deferred message and any
+/// remaining chunks are posted as followups. The chunking lives here in the
+/// wiring layer so `interaction` need not depend on `chunk` (preserving the
+/// no-impl-to-impl module boundary).
+async fn deliver_interaction_answer(
+    client: &reqwest::Client,
+    app_id: &str,
+    interaction_token: &str,
+    api_base: &str,
+    content: &str,
+) -> anyhow::Result<()> {
+    let chunks = split_message_for_discord(content);
+    let mut chunks = chunks.iter();
+    let first = chunks.next().map(String::as_str).unwrap_or("");
+    discord_edit_interaction_response(client, app_id, interaction_token, api_base, first).await?;
+    for chunk in chunks {
+        discord_post_interaction_followup(client, app_id, interaction_token, api_base, chunk)
+            .await?;
+    }
+    Ok(())
+}
+
 /// Pure channel-filter decision: does `msg_channel` pass the allowlist?
 ///
 /// A channel passes when:
@@ -1371,10 +1394,11 @@ impl Channel for DiscordChannel {
             }
             let content = crate::util::strip_tool_call_tags(&message.content);
             let client = self.http_client();
-            return discord_edit_interaction_response(
+            return deliver_interaction_answer(
                 &client,
                 &pending.app_id,
                 &pending.token,
+                DISCORD_API_BASE,
                 &content,
             )
             .await;
@@ -2079,7 +2103,7 @@ impl Channel for DiscordChannel {
                                             let msg = i18n::get_required_cli_string(
                                                 "channel-discord-interaction-unavailable",
                                             );
-                                            if let Err(e) = discord_edit_interaction_response(&client, &app_id, &interaction_token, &msg).await {
+                                            if let Err(e) = discord_edit_interaction_response(&client, &app_id, &interaction_token, DISCORD_API_BASE, &msg).await {
                                                 ::zeroclaw_log::record!(WARN, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_outcome(::zeroclaw_log::EventOutcome::Unknown).with_attrs(::serde_json::json!({"error": e.to_string()})), "discord interaction unavailable-notice failed");
                                             }
                                             pending.lock().remove(&interaction_id);
@@ -3019,6 +3043,60 @@ mod tests {
             ),
             Ok(())
         );
+    }
+
+    #[tokio::test]
+    async fn interaction_answer_over_2000_chars_chunks_into_edit_plus_followup() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+        let server = MockServer::start().await;
+        // The first chunk edits the deferred @original message.
+        Mock::given(method("PATCH"))
+            .and(path("/webhooks/app1/tok/messages/@original"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
+        // The remaining chunk is delivered as a followup POST (not truncated).
+        Mock::given(method("POST"))
+            .and(path("/webhooks/app1/tok"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = reqwest::Client::new();
+        // 3000 contiguous chars (no break point) → a 2000-char chunk + a 1000.
+        let content = "a".repeat(3000);
+        deliver_interaction_answer(&client, "app1", "tok", &server.uri(), &content)
+            .await
+            .unwrap();
+        // wiremock verifies the expect(1) counts when the server drops.
+    }
+
+    #[tokio::test]
+    async fn short_interaction_answer_only_edits_original() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/webhooks/app1/tok/messages/@original"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
+        // A short reply must not trigger any followup POST.
+        Mock::given(method("POST"))
+            .and(path("/webhooks/app1/tok"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let client = reqwest::Client::new();
+        deliver_interaction_answer(&client, "app1", "tok", &server.uri(), "short answer")
+            .await
+            .unwrap();
     }
 
     #[test]

--- a/crates/zeroclaw-channels/src/discord/mod.rs
+++ b/crates/zeroclaw-channels/src/discord/mod.rs
@@ -1940,6 +1940,9 @@ impl Channel for DiscordChannel {
                                 // routing happens in the spawned task.
                                 let prompt = interaction_string_option(d, "prompt");
                                 let input = interaction_string_option(d, "input");
+                                // Extract typed-option values here (owned) so the
+                                // spawned 'static task doesn't borrow `event`.
+                                let submitted = slash_options::extract_submitted_options(d);
                                 let interaction_guild = d
                                     .get("guild_id")
                                     .and_then(serde_json::Value::as_str)
@@ -2092,12 +2095,36 @@ impl Channel for DiscordChannel {
                                                 None => Vec::new(),
                                             };
                                             match specs.into_iter().find(|spec| spec.slug == command) {
-                                                Some(spec) if !input.is_empty() => Some(format!(
-                                                    "Use the '{}' skill for this request: {input}",
-                                                    spec.skill_name
-                                                )),
-                                                Some(_) => None, // known command, empty input
-                                                None => None,    // stale or foreign command
+                                                Some(spec) if spec.options.is_empty() => {
+                                                    // Legacy single free-text `input` option.
+                                                    if input.is_empty() {
+                                                        None // known command, empty input
+                                                    } else {
+                                                        Some(format!(
+                                                            "Use the '{}' skill for this request: {input}",
+                                                            spec.skill_name
+                                                        ))
+                                                    }
+                                                }
+                                                Some(spec) => {
+                                                    // Typed options: fold the submitted name/value pairs
+                                                    // (extracted above) into the prompt (Discord enforces
+                                                    // the required ones).
+                                                    if submitted.is_empty() {
+                                                        None
+                                                    } else {
+                                                        let rendered = submitted
+                                                            .iter()
+                                                            .map(|(n, v)| format!("{n}: {v}"))
+                                                            .collect::<Vec<_>>()
+                                                            .join("\n");
+                                                        Some(format!(
+                                                            "Use the '{}' skill for this request:\n{rendered}",
+                                                            spec.skill_name
+                                                        ))
+                                                    }
+                                                }
+                                                None => None, // stale or foreign command
                                             }
                                         };
                                         let Some(content) = content else {

--- a/crates/zeroclaw-channels/src/discord/mod.rs
+++ b/crates/zeroclaw-channels/src/discord/mod.rs
@@ -3154,6 +3154,7 @@ mod tests {
             tags: tags.iter().map(|t| (*t).to_string()).collect(),
             tools: vec![],
             prompts: vec![],
+            slash_options: Vec::new(),
             location: None,
         }
     }

--- a/crates/zeroclaw-channels/src/discord/slash.rs
+++ b/crates/zeroclaw-channels/src/discord/slash.rs
@@ -9,6 +9,7 @@
 
 use serde_json::json;
 
+use super::slash_options::{Choice, OptKind, OptionSpec};
 use super::types::{DiscordSlashCommandSpec, ReconcileOutcome};
 
 /// Discord caps an application at 100 global commands; stay under it with
@@ -99,9 +100,63 @@ pub fn discord_slash_specs_from_skills(
             skill_name,
             slug,
             description: description.chars().take(100).collect(),
+            options: map_skill_slash_options(skill),
         });
     }
     specs.sort_by(|a, b| a.slug.cmp(&b.slug));
+    map_options_cap(&mut specs);
+    specs
+}
+
+/// Map a skill's `[[skill.slash_options]]` declarations into Discord option
+/// specs. An option with an unknown `type` is dropped with a WARN rather than
+/// registering a bad type. Names are lower-cased and length-capped to Discord's
+/// option-name charset; required options are sorted first (Discord rejects a
+/// required option that follows an optional one).
+fn map_skill_slash_options(skill: &zeroclaw_runtime::skills::Skill) -> Vec<OptionSpec> {
+    let mut options = Vec::new();
+    for decl in &skill.slash_options {
+        let Some(kind) = OptKind::from_manifest(&decl.kind) else {
+            ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                    .with_attrs(::serde_json::json!({
+                        "skill": skill.name,
+                        "option": decl.name,
+                        "type": decl.kind,
+                    })),
+                "skipping skill slash option with unknown type"
+            );
+            continue;
+        };
+        options.push(OptionSpec {
+            name: decl.name.to_ascii_lowercase().chars().take(32).collect(),
+            description: decl.description.chars().take(100).collect(),
+            kind,
+            required: decl.required,
+            choices: decl
+                .choices
+                .iter()
+                .map(|c| Choice {
+                    name: c.name.clone(),
+                    value: c.value.clone(),
+                })
+                .collect(),
+            min: decl.min,
+            max: decl.max,
+            min_length: decl.min_length,
+            max_length: decl.max_length,
+        });
+    }
+    // Discord requires required options to precede optional ones; stable sort
+    // keeps declaration order within each group.
+    options.sort_by_key(|o| !o.required);
+    options
+}
+
+/// Apply the per-application command cap, logging the dropped slugs.
+fn map_options_cap(specs: &mut Vec<DiscordSlashCommandSpec>) {
     if specs.len() > MAX_SKILL_SLASH_COMMANDS {
         let dropped: Vec<&str> = specs[MAX_SKILL_SLASH_COMMANDS..]
             .iter()
@@ -116,7 +171,6 @@ pub fn discord_slash_specs_from_skills(
         );
         specs.truncate(MAX_SKILL_SLASH_COMMANDS);
     }
-    specs
 }
 
 /// The desired global-command set: `/ask` plus one command per skill spec,
@@ -138,16 +192,27 @@ pub(crate) fn slash_command_registration_body(
         }]
     })];
     for spec in specs {
-        commands.push(json!({
-            "name": spec.slug,
-            "description": spec.description,
-            "type": 1, // CHAT_INPUT
-            "options": [{
+        // A skill that declares no typed options keeps the legacy single
+        // required string `input` (backward-compatible + the ownership marker
+        // for reaping); one that declares options registers them instead.
+        let options: Vec<serde_json::Value> = if spec.options.is_empty() {
+            vec![json!({
                 "name": "input",
                 "description": SKILL_COMMAND_OPTION_DESCRIPTION,
                 "type": 3, // STRING
                 "required": true
-            }]
+            })]
+        } else {
+            spec.options
+                .iter()
+                .map(OptionSpec::to_registration_json)
+                .collect()
+        };
+        commands.push(json!({
+            "name": spec.slug,
+            "description": spec.description,
+            "type": 1, // CHAT_INPUT
+            "options": options,
         }));
     }
     serde_json::Value::Array(commands)
@@ -171,6 +236,13 @@ pub(crate) const SKILL_COMMAND_OPTION_DESCRIPTION: &str = "What to send to the s
 /// each other's commands as reap candidates (commands are
 /// application-global, desired sets are per-alias). Enable slash commands
 /// on at most one alias per bot application.
+///
+/// Limitation (typed options): this recognizes only the legacy single-`input`
+/// shape. A skill command that declares typed options has a different shape and
+/// is therefore NOT auto-reaped when its skill is uninstalled — it is still
+/// upserted/updated normally while installed. This is deliberately conservative
+/// (it never risks deleting a foreign command); durable reaping of typed
+/// commands (persisting the registered slug set) is a follow-on.
 pub(crate) fn is_skill_command_shape(cmd: &serde_json::Value) -> bool {
     let Some(opts) = cmd.get("options").and_then(|o| o.as_array()) else {
         return false;
@@ -186,9 +258,14 @@ pub(crate) fn is_skill_command_shape(cmd: &serde_json::Value) -> bool {
 }
 
 /// Comparable projection of a command for change detection: description plus
-/// (name, type, required, description) per option. Discord decorates listed
-/// commands with server-side fields (id, version, default_member_permissions,
-/// …) that must not defeat the comparison.
+/// per-option (name, type, required, description) and, for typed options, the
+/// (choices, min/max value, min/max length) constraints. Discord decorates
+/// listed commands with server-side fields (id, version,
+/// default_member_permissions, …) that must not defeat the comparison; the
+/// numeric constraints are normalised (numbers → f64, lengths → u64, choice
+/// values → number-or-string) so an int-vs-float representation difference
+/// between what we send and what Discord echoes back doesn't force a spurious
+/// re-registration.
 pub(crate) fn command_projection(cmd: &serde_json::Value) -> serde_json::Value {
     json!({
         "description": cmd.get("description").cloned().unwrap_or_default(),
@@ -203,12 +280,40 @@ pub(crate) fn command_projection(cmd: &serde_json::Value) -> serde_json::Value {
                             "type": o.get("type").cloned().unwrap_or_default(),
                             "required": o.get("required").cloned().unwrap_or(json!(false)),
                             "description": o.get("description").cloned().unwrap_or_default(),
+                            "choices": o
+                                .get("choices")
+                                .and_then(|c| c.as_array())
+                                .map(|cs| {
+                                    cs.iter()
+                                        .map(|c| {
+                                            json!({
+                                                "name": c.get("name").cloned().unwrap_or_default(),
+                                                "value": normalize_scalar(c.get("value")),
+                                            })
+                                        })
+                                        .collect::<Vec<_>>()
+                                })
+                                .unwrap_or_default(),
+                            "min_value": o.get("min_value").and_then(serde_json::Value::as_f64),
+                            "max_value": o.get("max_value").and_then(serde_json::Value::as_f64),
+                            "min_length": o.get("min_length").and_then(serde_json::Value::as_u64),
+                            "max_length": o.get("max_length").and_then(serde_json::Value::as_u64),
                         })
                     })
                     .collect::<Vec<_>>()
             })
             .unwrap_or_default(),
     })
+}
+
+/// Normalise a choice value for projection: a JSON number becomes an `f64`
+/// (so `10` and `10.0` compare equal), anything else is kept as-is.
+fn normalize_scalar(v: Option<&serde_json::Value>) -> serde_json::Value {
+    match v {
+        Some(serde_json::Value::Number(n)) => json!(n.as_f64()),
+        Some(other) => other.clone(),
+        None => serde_json::Value::Null,
+    }
 }
 
 /// Discord REST base; injectable in `reconcile_slash_commands` for tests.
@@ -368,4 +473,133 @@ pub(crate) async fn reconcile_slash_commands(
         );
     }
     Ok(ReconcileOutcome::Reconciled)
+}
+
+#[cfg(test)]
+mod typed_option_tests {
+    use super::super::slash_options::{OptKind, OptionSpec};
+    use super::*;
+
+    fn spec_with(options: Vec<OptionSpec>) -> DiscordSlashCommandSpec {
+        DiscordSlashCommandSpec {
+            skill_name: "s".to_string(),
+            slug: "s".to_string(),
+            description: "d".to_string(),
+            options,
+        }
+    }
+
+    fn opt(name: &str, kind: OptKind, required: bool) -> OptionSpec {
+        OptionSpec {
+            name: name.to_string(),
+            description: name.to_string(),
+            kind,
+            required,
+            choices: Vec::new(),
+            min: None,
+            max: None,
+            min_length: None,
+            max_length: None,
+        }
+    }
+
+    #[test]
+    fn no_options_falls_back_to_the_legacy_input() {
+        let body = slash_command_registration_body(&[spec_with(Vec::new())]);
+        let cmd = &body.as_array().unwrap()[1]; // [0] is /ask
+        let opts = cmd["options"].as_array().unwrap();
+        assert_eq!(opts.len(), 1);
+        assert_eq!(opts[0]["name"], json!("input"));
+        assert_eq!(opts[0]["type"], json!(3));
+        assert_eq!(
+            opts[0]["description"],
+            json!(SKILL_COMMAND_OPTION_DESCRIPTION)
+        );
+    }
+
+    #[test]
+    fn typed_options_replace_the_legacy_input() {
+        let mut limit = opt("limit", OptKind::Integer, false);
+        limit.min = Some(1.0);
+        limit.max = Some(50.0);
+        let mut query = opt("query", OptKind::String, true);
+        query.min_length = Some(1);
+        let body = slash_command_registration_body(&[spec_with(vec![query, limit])]);
+        let opts = body.as_array().unwrap()[1]["options"].as_array().unwrap();
+        assert_eq!(opts.len(), 2);
+        assert_eq!(opts[0]["name"], json!("query"));
+        assert_eq!(opts[0]["type"], json!(3));
+        assert_eq!(opts[0]["min_length"], json!(1));
+        assert_eq!(opts[1]["name"], json!("limit"));
+        assert_eq!(opts[1]["type"], json!(4));
+        assert_eq!(opts[1]["min_value"], json!(1));
+        assert_eq!(opts[1]["max_value"], json!(50));
+    }
+
+    #[test]
+    fn projection_is_stable_across_int_vs_float_bounds() {
+        // What we send (integer min/max) vs what Discord might echo back (float),
+        // plus Discord's server-side decorations — must project equal.
+        let sent = json!({ "description": "d", "options": [
+            { "name": "limit", "type": 4, "required": false, "description": "l", "min_value": 1, "max_value": 50 }
+        ]});
+        let echoed = json!({ "description": "d", "id": "9", "version": "v", "options": [
+            { "name": "limit", "type": 4, "required": false, "description": "l", "min_value": 1.0, "max_value": 50.0 }
+        ]});
+        assert_eq!(command_projection(&sent), command_projection(&echoed));
+    }
+
+    #[test]
+    fn map_drops_unknown_kinds_and_sorts_required_first() {
+        let skill = zeroclaw_runtime::skills::Skill {
+            name: "s".to_string(),
+            description: "d".to_string(),
+            version: "0".to_string(),
+            author: None,
+            tags: vec!["slash".to_string()],
+            tools: Vec::new(),
+            prompts: Vec::new(),
+            slash_options: vec![
+                zeroclaw_runtime::skills::SkillSlashOption {
+                    name: "opt".to_string(),
+                    description: "o".to_string(),
+                    kind: "string".to_string(),
+                    required: false,
+                    choices: Vec::new(),
+                    min: None,
+                    max: None,
+                    min_length: None,
+                    max_length: None,
+                },
+                zeroclaw_runtime::skills::SkillSlashOption {
+                    name: "Req".to_string(),
+                    description: "r".to_string(),
+                    kind: "integer".to_string(),
+                    required: true,
+                    choices: Vec::new(),
+                    min: None,
+                    max: None,
+                    min_length: None,
+                    max_length: None,
+                },
+                zeroclaw_runtime::skills::SkillSlashOption {
+                    name: "bad".to_string(),
+                    description: "b".to_string(),
+                    kind: "bogus".to_string(),
+                    required: false,
+                    choices: Vec::new(),
+                    min: None,
+                    max: None,
+                    min_length: None,
+                    max_length: None,
+                },
+            ],
+            location: None,
+        };
+        let mapped = map_skill_slash_options(&skill);
+        assert_eq!(mapped.len(), 2, "the unknown-kind option is dropped");
+        assert_eq!(mapped[0].name, "req", "required first + name lower-cased");
+        assert!(mapped[0].required);
+        assert_eq!(mapped[1].name, "opt");
+    }
 }

--- a/crates/zeroclaw-channels/src/discord/slash.rs
+++ b/crates/zeroclaw-channels/src/discord/slash.rs
@@ -109,42 +109,62 @@ pub fn discord_slash_specs_from_skills(
 }
 
 /// Map a skill's `[[skill.slash_options]]` declarations into Discord option
-/// specs. An option with an unknown `type` is dropped with a WARN rather than
-/// registering a bad type. Names are lower-cased and length-capped to Discord's
-/// option-name charset; required options are sorted first (Discord rejects a
-/// required option that follows an optional one).
+/// specs. Every authoring mistake is sanitised or dropped with a WARN rather
+/// than passed through to Discord, because an invalid registration body is
+/// rejected with a 400 and `reconcile_slash_commands` would then retry it on
+/// every READY (a re-registration loop). Specifically: an unknown `type` drops
+/// the option; the name is slugged to Discord's option-name charset (dropped if
+/// it slugs to empty) and de-duplicated within the command; numeric choices
+/// whose value doesn't parse to the option type are dropped; inverted `min`/
+/// `max` bounds are dropped. Required options are sorted first (Discord rejects
+/// a required option that follows an optional one).
 fn map_skill_slash_options(skill: &zeroclaw_runtime::skills::Skill) -> Vec<OptionSpec> {
     let mut options = Vec::new();
+    let mut seen = std::collections::HashSet::new();
     for decl in &skill.slash_options {
         let Some(kind) = OptKind::from_manifest(&decl.kind) else {
-            ::zeroclaw_log::record!(
-                WARN,
-                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                    .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                    .with_attrs(::serde_json::json!({
-                        "skill": skill.name,
-                        "option": decl.name,
-                        "type": decl.kind,
-                    })),
-                "skipping skill slash option with unknown type"
-            );
+            warn_drop_option(skill, &decl.name, "unknown type");
             continue;
         };
+        // Option names share the command-name charset; slug + de-dup so a name
+        // with spaces/punctuation/case can never 400 the whole command.
+        let name = discord_command_slug(&decl.name);
+        if name.is_empty() || !seen.insert(name.clone()) {
+            warn_drop_option(skill, &decl.name, "empty or duplicate option name");
+            continue;
+        }
+        // Drop choices whose value doesn't fit the option type (a string value
+        // on an int/number option is rejected by Discord).
+        let choices = decl
+            .choices
+            .iter()
+            .filter(|c| match kind {
+                OptKind::Integer => c.value.parse::<i64>().is_ok(),
+                OptKind::Number => c.value.parse::<f64>().is_ok(),
+                _ => true,
+            })
+            .map(|c| Choice {
+                name: c.name.clone(),
+                value: c.value.clone(),
+            })
+            .collect();
+        // Drop inverted numeric bounds rather than letting Discord 400 the command.
+        let (mut min, mut max) = (decl.min, decl.max);
+        if let (Some(lo), Some(hi)) = (min, max)
+            && lo > hi
+        {
+            warn_drop_option(skill, &decl.name, "min greater than max; dropping bounds");
+            min = None;
+            max = None;
+        }
         options.push(OptionSpec {
-            name: decl.name.to_ascii_lowercase().chars().take(32).collect(),
+            name,
             description: decl.description.chars().take(100).collect(),
             kind,
             required: decl.required,
-            choices: decl
-                .choices
-                .iter()
-                .map(|c| Choice {
-                    name: c.name.clone(),
-                    value: c.value.clone(),
-                })
-                .collect(),
-            min: decl.min,
-            max: decl.max,
+            choices,
+            min,
+            max,
             min_length: decl.min_length,
             max_length: decl.max_length,
         });
@@ -153,6 +173,54 @@ fn map_skill_slash_options(skill: &zeroclaw_runtime::skills::Skill) -> Vec<Optio
     // keeps declaration order within each group.
     options.sort_by_key(|o| !o.required);
     options
+}
+
+fn warn_drop_option(skill: &zeroclaw_runtime::skills::Skill, option: &str, reason: &str) {
+    ::zeroclaw_log::record!(
+        WARN,
+        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+            .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+            .with_attrs(::serde_json::json!({
+                "skill": skill.name,
+                "option": option,
+                "reason": reason,
+            })),
+        "dropping invalid skill slash option"
+    );
+}
+
+/// Build the agent prompt for a skill slash command: the legacy single `input`
+/// for an untyped command, or the submitted `name: value` lines for a typed
+/// one. Returns `None` only when an *untyped* command was invoked with empty
+/// input — a typed command, even an all-optional one invoked with no arguments,
+/// still invokes the skill (rendering an empty argument list).
+pub(crate) fn skill_command_prompt(
+    spec: &DiscordSlashCommandSpec,
+    input: &str,
+    submitted: &[(String, String)],
+) -> Option<String> {
+    if spec.options.is_empty() {
+        if input.is_empty() {
+            return None;
+        }
+        return Some(format!(
+            "Use the '{}' skill for this request: {input}",
+            spec.skill_name
+        ));
+    }
+    let rendered = submitted
+        .iter()
+        .map(|(name, value)| format!("{name}: {value}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    Some(if rendered.is_empty() {
+        format!("Use the '{}' skill for this request.", spec.skill_name)
+    } else {
+        format!(
+            "Use the '{}' skill for this request:\n{rendered}",
+            spec.skill_name
+        )
+    })
 }
 
 /// Apply the per-application command cap, logging the dropped slugs.
@@ -601,5 +669,100 @@ mod typed_option_tests {
         assert_eq!(mapped[0].name, "req", "required first + name lower-cased");
         assert!(mapped[0].required);
         assert_eq!(mapped[1].name, "opt");
+    }
+
+    fn sso(name: &str, kind: &str) -> zeroclaw_runtime::skills::SkillSlashOption {
+        zeroclaw_runtime::skills::SkillSlashOption {
+            name: name.to_string(),
+            description: "d".to_string(),
+            kind: kind.to_string(),
+            required: false,
+            choices: Vec::new(),
+            min: None,
+            max: None,
+            min_length: None,
+            max_length: None,
+        }
+    }
+
+    fn skill_with(
+        slash_options: Vec<zeroclaw_runtime::skills::SkillSlashOption>,
+    ) -> zeroclaw_runtime::skills::Skill {
+        zeroclaw_runtime::skills::Skill {
+            name: "s".to_string(),
+            description: "d".to_string(),
+            version: "0".to_string(),
+            author: None,
+            tags: vec!["slash".to_string()],
+            tools: Vec::new(),
+            prompts: Vec::new(),
+            slash_options,
+            location: None,
+        }
+    }
+
+    #[test]
+    fn map_slugs_option_names_and_dedups() {
+        let mapped = map_skill_slash_options(&skill_with(vec![
+            sso("My Option", "string"), // -> "my-option"
+            sso("dup", "string"),
+            sso("DUP", "string"), // slugs to "dup" -> dropped as duplicate
+        ]));
+        assert_eq!(mapped.len(), 2);
+        assert_eq!(mapped[0].name, "my-option");
+        assert_eq!(mapped[1].name, "dup");
+    }
+
+    #[test]
+    fn map_drops_a_nonparsing_numeric_choice() {
+        let mut o = sso("n", "integer");
+        o.choices = vec![
+            zeroclaw_runtime::skills::SkillSlashChoice {
+                name: "ok".to_string(),
+                value: "10".to_string(),
+            },
+            zeroclaw_runtime::skills::SkillSlashChoice {
+                name: "bad".to_string(),
+                value: "3.14".to_string(),
+            },
+        ];
+        let mapped = map_skill_slash_options(&skill_with(vec![o]));
+        assert_eq!(
+            mapped[0].choices.len(),
+            1,
+            "the non-integer choice is dropped"
+        );
+        assert_eq!(mapped[0].choices[0].value, "10");
+    }
+
+    #[test]
+    fn map_drops_inverted_bounds() {
+        let mut o = sso("n", "integer");
+        o.min = Some(50.0);
+        o.max = Some(1.0);
+        let mapped = map_skill_slash_options(&skill_with(vec![o]));
+        assert!(mapped[0].min.is_none() && mapped[0].max.is_none());
+    }
+
+    #[test]
+    fn prompt_legacy_typed_and_all_optional() {
+        let legacy = spec_with(Vec::new());
+        assert_eq!(skill_command_prompt(&legacy, "", &[]), None);
+        assert_eq!(
+            skill_command_prompt(&legacy, "do it", &[]).unwrap(),
+            "Use the 's' skill for this request: do it"
+        );
+
+        let typed = spec_with(vec![opt("q", OptKind::String, true)]);
+        // all-optional / no args STILL invokes the skill (the bug fix)
+        assert_eq!(
+            skill_command_prompt(&typed, "", &[]).unwrap(),
+            "Use the 's' skill for this request."
+        );
+        let submitted = vec![("q".to_string(), "rust".to_string())];
+        assert_eq!(
+            skill_command_prompt(&typed, "", &submitted).unwrap(),
+            "Use the 's' skill for this request:\nq: rust"
+        );
     }
 }

--- a/crates/zeroclaw-channels/src/discord/slash_options.rs
+++ b/crates/zeroclaw-channels/src/discord/slash_options.rs
@@ -148,6 +148,36 @@ fn number_value(v: f64, kind: OptKind) -> Value {
     }
 }
 
+/// Extract the values a user submitted for a slash command's options out of an
+/// INTERACTION_CREATE payload's `data.options[]`, as `(name, display)` pairs in
+/// the order Discord sent them. The value is stringified by JSON kind (string
+/// as-is; number/bool to text) for folding into the synthesized agent prompt.
+/// This generalises the single-`input` extractor for typed commands.
+pub fn extract_submitted_options(data: &Value) -> Vec<(String, String)> {
+    data.get("data")
+        .and_then(|d| d.get("options"))
+        .and_then(|o| o.as_array())
+        .map(|opts| {
+            opts.iter()
+                .filter_map(|o| {
+                    let name = o.get("name")?.as_str()?.to_string();
+                    let value = o.get("value").map(stringify_value).unwrap_or_default();
+                    Some((name, value))
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn stringify_value(v: &Value) -> String {
+    match v {
+        Value::String(s) => s.clone(),
+        Value::Bool(b) => b.to_string(),
+        Value::Number(n) => n.to_string(),
+        other => other.to_string(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -242,5 +272,34 @@ mod tests {
             value: "y".to_string(),
         }];
         assert!(u.to_registration_json().get("choices").is_none());
+    }
+
+    #[test]
+    fn extract_submitted_reads_typed_values_in_order_and_stringifies() {
+        let interaction = json!({
+            "type": 2,
+            "data": {
+                "name": "search",
+                "options": [
+                    { "name": "query", "type": 3, "value": "rust" },
+                    { "name": "limit", "type": 4, "value": 5 },
+                    { "name": "verbose", "type": 5, "value": true }
+                ]
+            }
+        });
+        assert_eq!(
+            extract_submitted_options(&interaction),
+            vec![
+                ("query".to_string(), "rust".to_string()),
+                ("limit".to_string(), "5".to_string()),
+                ("verbose".to_string(), "true".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn extract_submitted_is_empty_when_no_options() {
+        assert!(extract_submitted_options(&json!({ "data": { "name": "x" } })).is_empty());
+        assert!(extract_submitted_options(&json!({})).is_empty());
     }
 }

--- a/crates/zeroclaw-channels/src/discord/slash_options.rs
+++ b/crates/zeroclaw-channels/src/discord/slash_options.rs
@@ -1,0 +1,246 @@
+//! Typed slash-command option model (contract tier): the option shapes that
+//! flow from a skill's `[[skill.slash_options]]` manifest declaration into the
+//! Discord application-command registration body. Pure data plus the trivial
+//! serialization to Discord's option JSON — no IO, no runtime types. Imported
+//! by `types` (the command spec carries a `Vec<OptionSpec>`) and by `slash`
+//! (which maps skill declarations into these and builds the registration body);
+//! imports no sibling impl module, so the contract layer stays acyclic.
+
+use serde_json::{Map, Value, json};
+
+/// A Discord application-command option type this channel supports. The wire
+/// integer is Discord's `ApplicationCommandOptionType`. (Sub-commands/groups —
+/// types 1/2 — are intentionally out of scope here; flat options only.)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OptKind {
+    String,
+    Integer,
+    Number,
+    Boolean,
+    User,
+    Channel,
+    Role,
+    Mentionable,
+}
+
+impl OptKind {
+    /// Parse a skill-manifest `type` string. Unknown values return `None` (the
+    /// channel drops the option with a WARN rather than registering a bad type).
+    pub fn from_manifest(kind: &str) -> Option<Self> {
+        match kind.trim().to_ascii_lowercase().as_str() {
+            "string" | "str" | "text" => Some(Self::String),
+            "integer" | "int" => Some(Self::Integer),
+            "number" | "float" | "double" => Some(Self::Number),
+            "boolean" | "bool" => Some(Self::Boolean),
+            "user" => Some(Self::User),
+            "channel" => Some(Self::Channel),
+            "role" => Some(Self::Role),
+            "mentionable" => Some(Self::Mentionable),
+            _ => None,
+        }
+    }
+
+    /// Discord `ApplicationCommandOptionType` wire value.
+    pub fn wire_type(self) -> u8 {
+        match self {
+            Self::String => 3,
+            Self::Integer => 4,
+            Self::Boolean => 5,
+            Self::User => 6,
+            Self::Channel => 7,
+            Self::Role => 8,
+            Self::Mentionable => 9,
+            Self::Number => 10,
+        }
+    }
+
+    /// Choices and min/max bounds apply only to string/integer/number options.
+    fn is_scalar(self) -> bool {
+        matches!(self, Self::String | Self::Integer | Self::Number)
+    }
+}
+
+/// A predefined choice for a scalar option. `value` is held as text and coerced
+/// to the option's wire type when serialized (Discord requires integer/number
+/// choice values to be numeric).
+#[derive(Debug, Clone, PartialEq)]
+pub struct Choice {
+    pub name: String,
+    pub value: String,
+}
+
+/// A typed slash-command option in Discord's registration shape.
+#[derive(Debug, Clone, PartialEq)]
+pub struct OptionSpec {
+    pub name: String,
+    pub description: String,
+    pub kind: OptKind,
+    pub required: bool,
+    pub choices: Vec<Choice>,
+    pub min: Option<f64>,
+    pub max: Option<f64>,
+    pub min_length: Option<u32>,
+    pub max_length: Option<u32>,
+}
+
+impl OptionSpec {
+    /// Serialize to a Discord application-command option object. Choices and
+    /// bounds are emitted only for the kinds Discord accepts them on.
+    pub fn to_registration_json(&self) -> Value {
+        let mut obj = Map::new();
+        obj.insert("name".to_string(), json!(self.name));
+        obj.insert("description".to_string(), json!(self.description));
+        obj.insert("type".to_string(), json!(self.kind.wire_type()));
+        obj.insert("required".to_string(), json!(self.required));
+
+        if self.kind.is_scalar() && !self.choices.is_empty() {
+            let choices: Vec<Value> = self
+                .choices
+                .iter()
+                .map(|c| json!({ "name": c.name, "value": coerce_value(&c.value, self.kind) }))
+                .collect();
+            obj.insert("choices".to_string(), Value::Array(choices));
+        }
+
+        match self.kind {
+            OptKind::Integer | OptKind::Number => {
+                if let Some(min) = self.min {
+                    obj.insert("min_value".to_string(), number_value(min, self.kind));
+                }
+                if let Some(max) = self.max {
+                    obj.insert("max_value".to_string(), number_value(max, self.kind));
+                }
+            }
+            OptKind::String => {
+                if let Some(min) = self.min_length {
+                    obj.insert("min_length".to_string(), json!(min));
+                }
+                if let Some(max) = self.max_length {
+                    obj.insert("max_length".to_string(), json!(max));
+                }
+            }
+            _ => {}
+        }
+        Value::Object(obj)
+    }
+}
+
+/// Coerce a textual choice value to the option's wire type, falling back to the
+/// string form when it doesn't parse as the numeric type.
+fn coerce_value(value: &str, kind: OptKind) -> Value {
+    match kind {
+        OptKind::Integer => value
+            .parse::<i64>()
+            .map(|n| json!(n))
+            .unwrap_or_else(|_| json!(value)),
+        OptKind::Number => value
+            .parse::<f64>()
+            .map(|n| json!(n))
+            .unwrap_or_else(|_| json!(value)),
+        _ => json!(value),
+    }
+}
+
+fn number_value(v: f64, kind: OptKind) -> Value {
+    match kind {
+        OptKind::Integer => json!(v as i64),
+        _ => json!(v),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn opt(name: &str, kind: OptKind, required: bool) -> OptionSpec {
+        OptionSpec {
+            name: name.to_string(),
+            description: format!("{name} option"),
+            kind,
+            required,
+            choices: Vec::new(),
+            min: None,
+            max: None,
+            min_length: None,
+            max_length: None,
+        }
+    }
+
+    #[test]
+    fn manifest_kinds_map_to_wire_types() {
+        assert_eq!(OptKind::from_manifest("string").unwrap().wire_type(), 3);
+        assert_eq!(OptKind::from_manifest("INT").unwrap().wire_type(), 4);
+        assert_eq!(OptKind::from_manifest("boolean").unwrap().wire_type(), 5);
+        assert_eq!(OptKind::from_manifest("number").unwrap().wire_type(), 10);
+        assert_eq!(
+            OptKind::from_manifest("mentionable").unwrap().wire_type(),
+            9
+        );
+        assert!(OptKind::from_manifest("nonsense").is_none());
+    }
+
+    #[test]
+    fn a_plain_required_string_serializes_minimally() {
+        assert_eq!(
+            opt("input", OptKind::String, true).to_registration_json(),
+            json!({ "name": "input", "description": "input option", "type": 3, "required": true })
+        );
+    }
+
+    #[test]
+    fn integer_bounds_emit_numeric_min_max() {
+        let mut o = opt("limit", OptKind::Integer, false);
+        o.min = Some(1.0);
+        o.max = Some(50.0);
+        assert_eq!(
+            o.to_registration_json(),
+            json!({
+                "name": "limit", "description": "limit option", "type": 4, "required": false,
+                "min_value": 1, "max_value": 50
+            })
+        );
+    }
+
+    #[test]
+    fn string_length_bounds_emit_min_max_length() {
+        let mut o = opt("query", OptKind::String, true);
+        o.min_length = Some(2);
+        o.max_length = Some(200);
+        let j = o.to_registration_json();
+        assert_eq!(j["min_length"], json!(2));
+        assert_eq!(j["max_length"], json!(200));
+        assert!(j.get("min_value").is_none());
+    }
+
+    #[test]
+    fn choices_coerce_to_the_option_type_and_only_on_scalars() {
+        let mut s = opt("sort", OptKind::String, false);
+        s.choices = vec![Choice {
+            name: "Newest".to_string(),
+            value: "new".to_string(),
+        }];
+        assert_eq!(
+            s.to_registration_json()["choices"],
+            json!([{ "name": "Newest", "value": "new" }])
+        );
+
+        let mut i = opt("count", OptKind::Integer, false);
+        i.choices = vec![Choice {
+            name: "Ten".to_string(),
+            value: "10".to_string(),
+        }];
+        // integer choice value coerces to a JSON number
+        assert_eq!(
+            i.to_registration_json()["choices"],
+            json!([{ "name": "Ten", "value": 10 }])
+        );
+
+        // a non-scalar kind never emits choices even if some were set
+        let mut u = opt("who", OptKind::User, false);
+        u.choices = vec![Choice {
+            name: "x".to_string(),
+            value: "y".to_string(),
+        }];
+        assert!(u.to_registration_json().get("choices").is_none());
+    }
+}

--- a/crates/zeroclaw-channels/src/discord/slash_options.rs
+++ b/crates/zeroclaw-channels/src/discord/slash_options.rs
@@ -153,6 +153,10 @@ fn number_value(v: f64, kind: OptKind) -> Value {
 /// the order Discord sent them. The value is stringified by JSON kind (string
 /// as-is; number/bool to text) for folding into the synthesized agent prompt.
 /// This generalises the single-`input` extractor for typed commands.
+///
+/// Limitation: user/channel/role/mentionable options yield the raw snowflake id
+/// (Discord puts the resolved entity in `data.resolved`, which is not consulted
+/// here) — resolving ids to display names/mentions is a follow-on.
 pub fn extract_submitted_options(data: &Value) -> Vec<(String, String)> {
     data.get("data")
         .and_then(|d| d.get("options"))

--- a/crates/zeroclaw-channels/src/discord/types.rs
+++ b/crates/zeroclaw-channels/src/discord/types.rs
@@ -6,6 +6,8 @@
 
 use std::sync::Arc;
 
+use super::slash_options::OptionSpec;
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Outbound message envelope
 //
@@ -87,12 +89,16 @@ impl DiscordOutgoing {
 /// command name; `skill_name` is the skill's manifest name (sanitized of
 /// quotes and newlines at spec-build time, since it is interpolated into
 /// the synthesized agent prompt); `description` is truncated to Discord's
-/// 100-char limit.
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// 100-char limit; `options` are the typed command options (empty → the legacy
+/// single free-text `input`).
+///
+/// `Eq` is not derived: [`OptionSpec`] carries `f64` numeric bounds.
+#[derive(Debug, Clone, PartialEq)]
 pub struct DiscordSlashCommandSpec {
     pub skill_name: String,
     pub slug: String,
     pub description: String,
+    pub options: Vec<OptionSpec>,
 }
 
 /// Resolves the current skill-derived command set from canonical state at

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -15552,6 +15552,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 timeout_secs: None,
             }],
             prompts: vec!["Always run cargo test before final response.".into()],
+            slash_options: Vec::new(),
             location: None,
         }];
 
@@ -15593,6 +15594,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 timeout_secs: None,
             }],
             prompts: vec!["Always run cargo test before final response.".into()],
+            slash_options: Vec::new(),
             location: None,
         }];
 
@@ -15644,6 +15646,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 timeout_secs: None,
             }],
             prompts: vec!["Use <tool_call> and & keep output \"safe\"".into()],
+            slash_options: Vec::new(),
             location: None,
         }];
 

--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -6034,6 +6034,7 @@ mod tests {
                 })
                 .collect(),
             prompts: vec![],
+            slash_options: Vec::new(),
             location: None,
         }
     }
@@ -6122,6 +6123,7 @@ mod tests {
                 timeout_secs: None,
             }],
             prompts: vec![],
+            slash_options: Vec::new(),
             location: None,
         };
         tools::register_skill_tools_with_context(

--- a/crates/zeroclaw-runtime/src/agent/prompt.rs
+++ b/crates/zeroclaw-runtime/src/agent/prompt.rs
@@ -485,6 +485,7 @@ mod tests {
                 timeout_secs: None,
             }],
             prompts: vec!["Run smoke tests before deploy.".into()],
+            slash_options: Vec::new(),
             location: None,
         }];
 
@@ -532,6 +533,7 @@ mod tests {
                 timeout_secs: None,
             }],
             prompts: vec!["Run smoke tests before deploy.".into()],
+            slash_options: Vec::new(),
             location: Some(Path::new("/tmp/workspace/skills/deploy/SKILL.md").to_path_buf()),
         }];
 
@@ -612,6 +614,7 @@ mod tests {
                 timeout_secs: None,
             }],
             prompts: vec!["Use <tool_call> and & keep output \"safe\"".into()],
+            slash_options: Vec::new(),
             location: None,
         }];
         let ctx = PromptContext {

--- a/crates/zeroclaw-runtime/src/skills/cache.rs
+++ b/crates/zeroclaw-runtime/src/skills/cache.rs
@@ -250,6 +250,7 @@ mod tests {
                 tags: vec![],
                 tools: vec![],
                 prompts: vec![],
+                slash_options: vec![],
                 location: None,
             }]
         };

--- a/crates/zeroclaw-runtime/src/skills/mod.rs
+++ b/crates/zeroclaw-runtime/src/skills/mod.rs
@@ -67,8 +67,50 @@ pub struct Skill {
     pub tools: Vec<SkillTool>,
     #[serde(default)]
     pub prompts: Vec<String>,
+    /// Typed slash-command options a `slash`-tagged skill exposes (e.g. on
+    /// Discord). Empty for skills that take no structured input — slash channels
+    /// then fall back to a single free-text option. See [`SkillSlashOption`].
+    #[serde(default)]
+    pub slash_options: Vec<SkillSlashOption>,
     #[serde(skip)]
     pub location: Option<PathBuf>,
+}
+
+/// A typed option a `slash`-tagged skill exposes on its slash command. Shaped
+/// after the Discord Application Command Option model but channel-agnostic; a
+/// slash-capable channel maps `kind` to its wire option type. Declared in
+/// SKILL.toml under `[[skill.slash_options]]`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SkillSlashOption {
+    pub name: String,
+    pub description: String,
+    /// `string` | `integer` | `number` | `boolean` | `user` | `channel` |
+    /// `role` | `mentionable`. Unknown values are dropped by the channel.
+    #[serde(rename = "type")]
+    pub kind: String,
+    #[serde(default)]
+    pub required: bool,
+    /// Predefined choices (string/integer/number options only). The `value` is
+    /// kept as text and coerced to the option's type by the channel.
+    #[serde(default)]
+    pub choices: Vec<SkillSlashChoice>,
+    /// Inclusive bounds for integer/number options.
+    #[serde(default)]
+    pub min: Option<f64>,
+    #[serde(default)]
+    pub max: Option<f64>,
+    /// Length bounds for string options.
+    #[serde(default)]
+    pub min_length: Option<u32>,
+    #[serde(default)]
+    pub max_length: Option<u32>,
+}
+
+/// A predefined choice for a typed slash option.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SkillSlashChoice {
+    pub name: String,
+    pub value: String,
 }
 
 impl ::zeroclaw_api::attribution::Attributable for Skill {
@@ -143,6 +185,8 @@ struct SkillMeta {
     tags: Vec<String>,
     #[serde(default)]
     prompts: Vec<String>,
+    #[serde(default)]
+    slash_options: Vec<SkillSlashOption>,
 }
 
 /// Provenance metadata emitted by the SkillForge integrator (see
@@ -1019,6 +1063,7 @@ fn load_skill_toml(path: &Path) -> Result<Skill> {
         tags: manifest.skill.tags,
         tools: manifest.tools,
         prompts,
+        slash_options: manifest.skill.slash_options,
         location: Some(path.to_path_buf()),
     })
 }
@@ -1045,6 +1090,7 @@ fn load_skill_md(path: &Path, dir: &Path) -> Result<Skill> {
         tags: parsed.meta.tags,
         tools: Vec::new(),
         prompts: vec![parsed.body],
+        slash_options: Vec::new(),
         location: Some(path.to_path_buf()),
     })
 }
@@ -1084,6 +1130,7 @@ fn load_open_skill_md(path: &Path) -> Result<Skill> {
         tags: parsed.meta.tags,
         tools: Vec::new(),
         prompts: vec![parsed.body],
+        slash_options: Vec::new(),
         location: Some(path.to_path_buf()),
     }))
 }
@@ -2484,6 +2531,68 @@ prompts = ["If asked about XYZZY, respond YES"]
     }
 
     #[test]
+    fn typed_slash_options_are_parsed_from_the_skill_table() {
+        let tmp = TempDir::new().unwrap();
+        let path = write_manifest(
+            tmp.path(),
+            r#"
+[skill]
+name = "search"
+description = "Search the web"
+version = "0.1.0"
+tags = ["slash"]
+
+[[skill.slash_options]]
+name = "query"
+description = "The search query"
+type = "string"
+required = true
+max_length = 200
+
+[[skill.slash_options]]
+name = "sort"
+description = "Sort order"
+type = "string"
+choices = [
+    { name = "Newest", value = "new" },
+    { name = "Oldest", value = "old" },
+]
+"#,
+        );
+        let skill = load_skill_toml(&path).unwrap();
+        assert_eq!(skill.slash_options.len(), 2);
+
+        let query = &skill.slash_options[0];
+        assert_eq!(query.name, "query");
+        assert_eq!(query.kind, "string");
+        assert!(query.required);
+        assert_eq!(query.max_length, Some(200));
+
+        let sort = &skill.slash_options[1];
+        assert_eq!(sort.name, "sort");
+        assert!(!sort.required);
+        assert_eq!(sort.choices.len(), 2);
+        assert_eq!(sort.choices[0].name, "Newest");
+        assert_eq!(sort.choices[0].value, "new");
+    }
+
+    #[test]
+    fn skills_without_slash_options_default_to_empty() {
+        let tmp = TempDir::new().unwrap();
+        let path = write_manifest(
+            tmp.path(),
+            r#"
+[skill]
+name = "probe"
+description = "test"
+version = "0.1.0"
+"#,
+        );
+        let skill = load_skill_toml(&path).unwrap();
+        assert!(skill.slash_options.is_empty());
+    }
+
+    #[test]
     fn prompts_at_root_level_still_work() {
         let tmp = TempDir::new().unwrap();
         let path = write_manifest(
@@ -2869,6 +2978,7 @@ mod prompt_callable_name_tests {
             tags: Vec::new(),
             tools: vec![tool("run.lint", "shell")],
             prompts: Vec::new(),
+            slash_options: Vec::new(),
             location: None,
         };
 

--- a/crates/zeroclaw-runtime/src/skills/suggestions.rs
+++ b/crates/zeroclaw-runtime/src/skills/suggestions.rs
@@ -309,6 +309,7 @@ mod tests {
             tags: vec![],
             tools: vec![],
             prompts: vec![],
+            slash_options: Vec::new(),
             location: None,
         }
     }

--- a/crates/zeroclaw-runtime/src/tools/skill_tool.rs
+++ b/crates/zeroclaw-runtime/src/tools/skill_tool.rs
@@ -1075,6 +1075,7 @@ mod tests {
                 timeout_secs: None,
             }],
             prompts: vec![],
+            slash_options: Vec::new(),
             location: None,
         };
         crate::tools::register_skill_tools_with_context(


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - **Typed slash-command options.** A `slash`-tagged skill can now declare typed command options in its `SKILL.toml` under `[[skill.slash_options]]` — `string`/`integer`/`number`/`boolean`/`user`/`channel`/`role`/`mentionable`, with `choices`, `min`/`max`, and `min_length`/`max_length`. These register as real Discord application-command options, and the values the user submits are folded into the synthesized agent prompt (`name: value` lines). Previously every skill command had exactly one free-text `input` option; this lifts it to the full typed model OpenClaw/Hermes expose.
  - **Backward-compatible.** A skill that declares no options keeps the legacy single required `input` string (which also remains the ownership marker used for stale-command reaping). The manifest field defaults empty, so existing skills are unchanged.
  - **Input is validated, never trusted to Discord.** An authoring mistake in a manifest (an option name with spaces/punctuation, a non-numeric choice value on an integer option, inverted `min`/`max`, or duplicate names) would otherwise produce a registration body Discord rejects with `400`, and the reconcile would retry it on every READY — the same re-registration burst #7784 fixed. `map_skill_slash_options` slugs/de-dups names and drops bad choices/bounds with a WARN, so nothing invalid reaches Discord.
  - **Chunked interaction followups.** The deferred-reply path used to truncate any answer over Discord's 2000-char limit with a WARN (a flagged TODO). It now splits the answer with the shared chunker: the first chunk edits the `@original` deferred message and the rest are delivered as followup webhook POSTs, so long `/ask` answers arrive in full.
- **Scope boundary:** Flat typed options only — sub-commands/groups are a noted follow-on. **Not** in this PR: name/description localizations, guild-scoped deployment (both planned). User/channel/role/mentionable option values currently fold into the prompt as the raw snowflake id (resolving to a display name via `data.resolved` is a follow-on). No config/env/CLI flags added.
- **Blast radius:** The Discord channel's slash registration + reconcile projection + interaction dispatch + the followup path, plus a new optional `slash_options` field on the runtime `Skill`/`SkillMeta` manifest (additive, default empty; consumed only by the Discord channel).
- **Linked issue(s):** Part of #7831. (Builds on the modular refactor #7832, now merged.)
- **Design note for maintainers:** the `[[skill.slash_options]]` table is a **new user-facing `SKILL.toml` surface**. The Discord-side model + chunked followups are ordinary channel work in the lineage of #7489/#7490, but I'd value a sounding on the manifest schema shape (field names, where typed options live) before it sets precedent — happy to adjust.
- **Labels:** suggest `type: feature`, `risk: medium`, `size: M`, `channel:discord`, `skills` (maintainers apply).

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy -p zeroclaw-channels --features channel-discord --all-targets -- -D warnings
cargo test -p zeroclaw-channels --features channel-discord
cargo test -p zeroclaw-runtime slash_options
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` → clean (no diff)
  - `cargo clippy … --all-targets -- -D warnings` → `Finished dev profile …`; zero warnings
  - `cargo test -p zeroclaw-channels --features channel-discord` → `test result: ok. 950 passed; 0 failed; 1 ignored` (lib), integration bins `3 / 3 / 4 / 0 passed`, `0 failed`
  - `cargo test -p zeroclaw-runtime slash_options` → manifest-parse tests `ok. 2 passed; 0 failed`
- **Beyond CI — what did you manually verify?** Reconcile change-detection stability: the projection of a typed command normalises numeric bounds (int-vs-float) and choice values so a desired-vs-Discord echo difference doesn't force a spurious re-registration (a regression test pins int `1` vs float `1.0`). The registration-input validation (slug/dedup names, drop bad choices, drop inverted bounds) is test-pinned. An all-optional typed command invoked with no arguments still invokes the skill. An adversarial review pass confirmed the projection logic sound and surfaced the two issues above, both fixed.
- **If any command was intentionally skipped, why:** None.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No.**
- New external network calls? **No** — the same Discord REST surface; followups use the existing interaction webhook endpoint.
- Secrets / tokens / credentials handling changed? **No** — the interaction followup token handling is unchanged.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No.**
- If any `Yes`, describe the risk and mitigation: Slash-command option values are user-supplied and folded into the synthesized agent prompt — the same trust level as the existing `/ask` and skill `input` free text (already user-supplied since #7489/#7490); no new untrusted-input path.

## Compatibility (required)

- Backward compatible? **Yes** — skills with no declared options keep the legacy single `input`; the manifest field defaults empty; chunked followups only change behaviour for replies that previously got truncated past 2000 chars.
- Config / env / CLI surface changed? **Manifest only** — `SKILL.toml` gains an optional `[[skill.slash_options]]` table. Additive and default-none; existing manifests are unaffected. No config/env/CLI flags.
- If `No` or `Yes` to either: exact upgrade steps for existing users: None required; authors opt in by adding `[[skill.slash_options]]` to a `slash`-tagged skill.

## Rollback

Low-risk: `git revert <sha>` is the plan. Typed options are opt-in per skill and the chunked-followup change is confined to the deferred-reply path; reverting restores the single-`input` command shape and the prior truncation with no data or config implications.
