### PR TITLE
feat(runtime): wire before_llm_call hook into LLM call paths

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/turn/mod.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/mod.rs
@@ -296,6 +296,26 @@ pub async fn run_tool_call_loop(
             .into());
         }
 
+        // Modifying hook before LLM call (may rewrite messages/model or cancel).
+        // Runs before the framework's vision-provider routing and message
+        // preparation so user-defined strategies take priority over runtime
+        // fallbacks such as image-marker stripping.
+        let mut active_model = model.to_string();
+        if let Some(hooks) = hooks {
+            match hooks.run_before_llm_call(history, &mut active_model).await {
+                crate::hooks::HookResult::Continue(()) => {}
+                crate::hooks::HookResult::Cancel(reason) => {
+                    ::zeroclaw_log::record!(
+                        INFO,
+                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                            .with_attrs(::serde_json::json!({"reason": reason.to_string()})),
+                        "llm call cancelled by hook"
+                    );
+                    return Err(crate::agent::loop_::ToolLoopCancelled.into());
+                }
+            }
+        }
+
         let iteration_tool_specs = build_iteration_tool_specs(
             model_provider,
             tools_registry,
@@ -320,10 +340,13 @@ pub async fn run_tool_call_loop(
                 .vision_model_provider
                 .as_deref()
                 .unwrap_or(provider_name);
-            let vm = multimodal_config.vision_model.as_deref().unwrap_or(model);
+            let vm = multimodal_config
+                .vision_model
+                .as_deref()
+                .unwrap_or(&active_model);
             (vp_box.as_ref(), vp_name, vm)
         } else {
-            (model_provider, provider_name, model)
+            (model_provider, provider_name, &active_model)
         };
 
         let prepared_messages = prepare_messages_for_iteration(


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Wired the `before_llm_call` modifying hook into `run_tool_call_loop` in `crates/zeroclaw-runtime/src/agent/turn/mod.rs`.
  - The hook runs **before** the framework's vision-provider routing and per-iteration message preparation. This gives user-defined hooks priority over runtime fallbacks (e.g. image-marker stripping when no vision provider is configured), allowing plugins to rewrite messages, swap models, or cancel the call based on the original request state.
  - Cancellations abort the current tool-loop iteration via `ToolLoopCancelled`.
- **Scope boundary:** This PR only adds the call site for `before_llm_call`; it does not change the hook trait signature (already merged in #7667). No other hooks or agent entry points are modified.
- **Blast radius:** High by label classification because this touches runtime/agent LLM-call flow. The hook only fires when a `HookRunner` is attached (currently only embedded `Agent` paths pass one). When no hooks are registered, behavior is unchanged.
- **Linked issue(s):** Depends on #7667 (the mutable-borrow signature change for `before_llm_call`)
- **Labels:** `enhancement`, `size: XS`, `risk: high`, `agent`, `runtime`

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo check -p zeroclaw-runtime --all-targets
cargo test -p zeroclaw-runtime --lib hooks::runner::tests
cargo test -p zeroclaw-runtime --lib "agent::turn::vision_route::tests::prepare_messages_for_iteration_populates_and_reuses_image_cache" -- --exact
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check`: passed (no output after formatting)
  - `cargo clippy --all-targets -- -D warnings`: passed
  - `cargo check -p zeroclaw-runtime --all-targets`: passed
  - `cargo test -p zeroclaw-runtime --lib hooks::runner::tests`: `test result: ok. 4 passed; 0 failed`
  - `cargo test -p zeroclaw-runtime --lib "agent::turn::vision_route::tests::prepare_messages_for_iteration_populates_and_reuses_image_cache" -- --exact`: `test result: ok. 1 passed; 0 failed`
- **Beyond CI — what did you manually verify?** Confirmed the hook placement is before `resolve_vision_provider` and `prepare_messages_for_iteration`, so hook modifications take priority over framework vision fallback behavior.
- **If any command was intentionally skipped, why:** Full `cargo test` was not run locally because the repository’s full test suite is large and CI already covers it; targeted tests for the affected crate were run instead.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? (`Yes`)
  - The hook is opt-in; callers without a `HookRunner` see no behavior change.
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: exact upgrade steps for existing users: N/A

## Rollback (required for `risk: medium` and `risk: high`)

- Revert this PR (`git revert <merge-sha>`) to remove the `before_llm_call` invocation from the LLM turn loop.
- If a production regression needs immediate mitigation before revert lands, disable the affected `HookRunner` attachment path so `before_llm_call` is not invoked for embedded Agent calls.
- Re-run the targeted runtime hook/vision-provider tests and relevant CI after rollback.
