### PR TITLE
fix(zerocode): enforce RPC-only boundary by dropping zeroclaw-providers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,6 +347,32 @@ jobs:
           BASE_SHA: ${{ steps.base.outputs.sha }}
         run: bash scripts/ci/docs_quality_gate.sh
 
+  zerocode-rpc-boundary:
+    name: Zerocode RPC Boundary
+    needs: [fmt]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Detect zerocode changes
+        id: changed
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base="$(git merge-base origin/master HEAD)"
+            if git diff --name-only "$base" HEAD | grep -q '^apps/zerocode/'; then
+              echo "run=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "run=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Guard zerocode RPC-only boundary
+        if: steps.changed.outputs.run == 'true'
+        run: bash scripts/ci/zerocode_no_zeroclaw_dep_gate.sh
+
   installer-drift:
     name: Installer Drift
     needs: [fmt]
@@ -368,7 +394,7 @@ jobs:
   gate:
     name: CI Required Gate
     if: always()
-    needs: [fmt, lint, build, check, check-32bit, bench, test, security, nix-eval, docs-style, installer-drift]
+    needs: [fmt, lint, build, check, check-32bit, bench, test, security, nix-eval, docs-style, installer-drift, zerocode-rpc-boundary]
     runs-on: ubuntu-latest
     steps:
       - name: Check results

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14809,7 +14809,6 @@ dependencies = [
  "unic-langid",
  "unicode-segmentation",
  "unicode-width 0.2.2",
- "zeroclaw-providers",
 ]
 
 [[package]]

--- a/apps/zerocode/Cargo.toml
+++ b/apps/zerocode/Cargo.toml
@@ -45,7 +45,6 @@ shellexpand = "3.1"
 directories = { workspace = true }
 fluent = "0.16"
 unic-langid = "0.9"
-zeroclaw-providers = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/apps/zerocode/src/quickstart_pane.rs
+++ b/apps/zerocode/src/quickstart_pane.rs
@@ -1955,9 +1955,7 @@ impl QuickstartPane {
         self.model_catalog_rx = Some(rx);
         tokio::spawn(async move {
             let models = match rpc.catalog_models(&type_key).await {
-                Ok(res) if res.live && !res.models.is_empty() => {
-                    sort_quickstart_models(&type_key, res.models)
-                }
+                Ok(res) if res.live && !res.models.is_empty() => Some(res.models),
                 _ => None,
             };
             let _ = tx.send(ModelCatalogFetchResult { type_key, models });
@@ -2307,10 +2305,6 @@ fn apply_model_catalog_to_rows(rows: &mut [FieldFormRow], model_catalog: Option<
 
 fn is_model_field(field: &QuickstartFieldDescriptor) -> bool {
     field.key.eq_ignore_ascii_case("model") || field.label.eq_ignore_ascii_case("model")
-}
-
-fn sort_quickstart_models(provider: &str, models: Vec<String>) -> Option<Vec<String>> {
-    zeroclaw_providers::catalog::sort_model_catalog_for_chat(provider, models)
 }
 
 fn build_field_form_rows(
@@ -3313,50 +3307,6 @@ mod tests {
             Some(["false".to_string(), "true".to_string()].as_slice())
         );
         assert_eq!(row.buf, "false");
-    }
-
-    #[test]
-    fn quickstart_model_sort_prefers_chat_and_coding_models() {
-        let sorted = sort_quickstart_models(
-            "openai",
-            vec![
-                "chatgpt-image-latest".into(),
-                "text-embedding-ada-002".into(),
-                "gpt-3.5-turbo".into(),
-                "gpt-5".into(),
-                "tts-1".into(),
-            ],
-        )
-        .expect("chat model catalog");
-
-        assert_eq!(sorted[0], "gpt-5");
-        assert!(!sorted.iter().any(|m| m == "chatgpt-image-latest"));
-        assert!(!sorted.iter().any(|m| m == "text-embedding-ada-002"));
-        assert!(!sorted.iter().any(|m| m == "tts-1"));
-
-        let sorted = sort_quickstart_models(
-            "openrouter",
-            vec![
-                "ai21/jamba-mini".into(),
-                "openai/gpt-4.1".into(),
-                "some/image-model".into(),
-                "anthropic/claude-sonnet-4".into(),
-            ],
-        )
-        .expect("chat model catalog");
-        assert_eq!(sorted[0], "anthropic/claude-sonnet-4");
-        assert_eq!(sorted[1], "openai/gpt-4.1");
-        assert!(!sorted.iter().any(|m| m == "some/image-model"));
-    }
-
-    #[test]
-    fn quickstart_model_sort_returns_none_when_only_non_chat_models_exist() {
-        let sorted = sort_quickstart_models(
-            "openai",
-            vec!["gpt-image-1.5".into(), "text-embedding-ada-002".into()],
-        );
-
-        assert!(sorted.is_none());
     }
 
     #[test]

--- a/scripts/ci/zerocode_no_zeroclaw_dep_gate.sh
+++ b/scripts/ci/zerocode_no_zeroclaw_dep_gate.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "==> zerocode gate: no zeroclaw-* crate dependency"
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+manifest="apps/zerocode/Cargo.toml"
+
+offending="$(
+    python3 - "$manifest" <<'PY'
+import sys
+import tomllib
+
+with open(sys.argv[1], "rb") as handle:
+    manifest = tomllib.load(handle)
+
+own_name = manifest.get("package", {}).get("name", "")
+
+dep_tables = []
+for key in ("dependencies", "dev-dependencies", "build-dependencies"):
+    table = manifest.get(key)
+    if isinstance(table, dict):
+        dep_tables.append(table)
+
+target = manifest.get("target")
+if isinstance(target, dict):
+    for cfg in target.values():
+        if not isinstance(cfg, dict):
+            continue
+        for key in ("dependencies", "dev-dependencies", "build-dependencies"):
+            table = cfg.get(key)
+            if isinstance(table, dict):
+                dep_tables.append(table)
+
+found = set()
+for table in dep_tables:
+    for name in table:
+        if name == own_name:
+            continue
+        if name.startswith("zeroclaw-") or name.startswith("zeroclaw_"):
+            found.add(name)
+
+for name in sorted(found):
+    print(name)
+PY
+)"
+
+if [ -n "$offending" ]; then
+    echo "::error file=${manifest}::zerocode must not depend on any zeroclaw-* crate; found:"
+    while IFS= read -r dep; do
+        echo "  - ${dep}"
+    done <<<"$offending"
+    echo "zerocode is an RPC-only surface: everything it knows must come over the wire, not by linking backend crates."
+    exit 1
+fi
+
+echo "zerocode gate passed: no zeroclaw-* dependencies."

--- a/scripts/ci/zerocode_no_zeroclaw_dep_gate.sh
+++ b/scripts/ci/zerocode_no_zeroclaw_dep_gate.sh
@@ -36,12 +36,25 @@ if isinstance(target, dict):
                 dep_tables.append(table)
 
 found = set()
+
+
+def flag(label):
+    if label.startswith("zeroclaw-") or label.startswith("zeroclaw_"):
+        found.add(label)
+
+
 for table in dep_tables:
-    for name in table:
+    for name, spec in table.items():
         if name == own_name:
             continue
-        if name.startswith("zeroclaw-") or name.startswith("zeroclaw_"):
-            found.add(name)
+        flag(name)
+        # Cargo renamed dependencies declare the real crate under `package`
+        # while the table key is an arbitrary local alias. Inspect both so a
+        # rename like `x = { package = "zeroclaw-providers" }` cannot slip past.
+        if isinstance(spec, dict):
+            package = spec.get("package")
+            if isinstance(package, str):
+                flag(package)
 
 for name in sorted(found):
     print(name)


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - zerocode is meant to be an RPC-only surface: everything the TUI knows must come over the wire, not by linking backend crates. It carried a direct `zeroclaw-providers` dependency that crossed that boundary.
  - The only use was re-sorting the model catalog client-side via `zeroclaw_providers::catalog::sort_model_catalog_for_chat` after fetching it from the daemon. That sort was redundant: the server handler `config/catalog-models` -> `quickstart::model_catalog` already chat-sorts the live path, and the pane only consumed the result when `res.live` was true. The client consumes the daemon-sorted models directly now.
  - Removed the local `sort_quickstart_models` shim and its two tests; they validated backend sorting that lives in and is tested by `zeroclaw-providers`.
  - Added a CI gate so the boundary cannot silently regress.
- **Scope boundary:** Does not touch `apps/tauri` (the desktop app legitimately links backend crates). Does not change any server-side sorting behavior or the wire contract; the daemon already returned chat-sorted models.
- **Blast radius:** zerocode model-catalog picker in Quickstart; the daemon-sorted ordering is unchanged, so the rendered list is identical. CI gains one gated job.
- **Linked issue(s):** No closing issue.
- **Labels:** `type: ci`, `ci`, `risk: low`, `size: XS`, `quickstart`

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy -p zerocode --all-targets -- -D warnings
cargo test -p zerocode --lib
bash scripts/ci/zerocode_no_zeroclaw_dep_gate.sh
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` -> clean, no output.
  - `cargo clippy -p zerocode --all-targets -- -D warnings` -> `Finished ... target(s)`, zero warnings.
  - `cargo test -p zerocode --lib` -> `test result: ok. 110 passed; 0 failed; 0 ignored`.
  - `bash scripts/ci/zerocode_no_zeroclaw_dep_gate.sh` -> `zerocode gate passed: no zeroclaw-* dependencies.`
  - `cargo tree -p zerocode -e normal,build | grep zeroclaw` -> only the crate itself; no `zeroclaw-*` deps.
- **Beyond CI, what did you manually verify?** Confirmed the guard fails when the dependency is re-added (`::error ... found: zeroclaw-providers`, exit 1) and passes once removed. Verified the live RPC path returns models already chat-sorted server-side, so removing the client sort preserves ordering.
- **If any command was intentionally skipped, why:** Full-workspace `cargo test` skipped in favor of `-p zerocode` plus the guard; the change is scoped to the zerocode crate and CI config.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- Upgrade steps: none. Rendered model list is unchanged.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk: `git revert <sha>` is the plan.