### PR TITLE
fix(tests): cover Windows path and shell portability

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -1162,7 +1162,7 @@ impl Agent {
             &security,
             risk_profile,
             agent_alias,
-            runtime,
+            runtime.clone(),
             memory.clone(),
             composio_key,
             composio_entity_id,
@@ -1404,11 +1404,12 @@ impl Agent {
             .cloned()
             .chain(mcp_elevation_arcs.iter().cloned())
             .collect();
-        tools::register_skill_tools_with_context(
+        tools::register_skill_tools_with_context_and_runtime(
             &mut tools,
             &skills,
             security.clone(),
             &skill_resolution_registry,
+            runtime,
         );
 
         let approval_manager = if approval_backchannel {

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -993,7 +993,7 @@ pub async fn run(
             &security,
             &risk_profile,
             agent_alias,
-            runtime,
+            runtime.clone(),
             mem.clone(),
             composio_key,
             composio_entity_id,
@@ -1339,11 +1339,12 @@ pub async fn run(
             .cloned()
             .chain(mcp_elevation_arcs.iter().cloned())
             .collect();
-        tools::register_skill_tools_with_context(
+        tools::register_skill_tools_with_context_and_runtime(
             &mut tools_registry,
             &skills,
             security.clone(),
             &skill_resolution_registry,
+            runtime,
         );
 
         let mut tool_descs: Vec<(&str, &str)> = vec![
@@ -2537,7 +2538,7 @@ pub async fn process_message(
             &security,
             &risk_profile,
             agent_alias,
-            runtime,
+            runtime.clone(),
             mem.clone(),
             composio_key,
             composio_entity_id,
@@ -2789,11 +2790,12 @@ pub async fn process_message(
             .cloned()
             .chain(mcp_elevation_arcs.iter().cloned())
             .collect();
-        tools::register_skill_tools_with_context(
+        tools::register_skill_tools_with_context_and_runtime(
             &mut tools_registry,
             &skills,
             security.clone(),
             &skill_resolution_registry,
+            runtime,
         );
 
         let mut tool_descs: Vec<(&str, &str)> = vec![

--- a/crates/zeroclaw-runtime/src/cron/scheduler.rs
+++ b/crates/zeroclaw-runtime/src/cron/scheduler.rs
@@ -1262,6 +1262,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(not(target_os = "windows"))]
     async fn run_job_command_success() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(&tmp).await;
@@ -1275,6 +1276,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(not(target_os = "windows"))]
     async fn run_job_command_failure() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(&tmp).await;
@@ -1288,6 +1290,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(not(target_os = "windows"))]
     async fn run_job_command_times_out() {
         let tmp = TempDir::new().unwrap();
         let mut config = test_config(&tmp).await;
@@ -1332,14 +1335,15 @@ mod tests {
             .entry(TEST_AGENT.into())
             .or_default()
             .allowed_commands = vec!["cat".into()];
-        let job = test_job("cat /etc/passwd");
+        let outside_path = absolute_path_outside_workspace();
+        let job = test_job(&format!("cat {outside_path}"));
         let security = test_security(&config);
 
         let (success, output) = run_job_command(&config, &security, &job).await;
         assert!(!success);
         assert!(output.contains("blocked by security policy"));
         assert!(output.contains("forbidden path argument"));
-        assert!(output.contains("/etc/passwd"));
+        assert!(output.contains(outside_path));
     }
 
     #[tokio::test]
@@ -1351,14 +1355,15 @@ mod tests {
             .entry(TEST_AGENT.into())
             .or_default()
             .allowed_commands = vec!["grep".into()];
-        let job = test_job("grep --file=/etc/passwd root ./src");
+        let outside_path = absolute_path_outside_workspace();
+        let job = test_job(&format!("grep --file={outside_path} root ./src"));
         let security = test_security(&config);
 
         let (success, output) = run_job_command(&config, &security, &job).await;
         assert!(!success);
         assert!(output.contains("blocked by security policy"));
         assert!(output.contains("forbidden path argument"));
-        assert!(output.contains("/etc/passwd"));
+        assert!(output.contains(outside_path));
     }
 
     #[tokio::test]
@@ -1370,17 +1375,19 @@ mod tests {
             .entry(TEST_AGENT.into())
             .or_default()
             .allowed_commands = vec!["grep".into()];
-        let job = test_job("grep -f/etc/passwd root ./src");
+        let outside_path = absolute_path_outside_workspace();
+        let job = test_job(&format!("grep -f{outside_path} root ./src"));
         let security = test_security(&config);
 
         let (success, output) = run_job_command(&config, &security, &job).await;
         assert!(!success);
         assert!(output.contains("blocked by security policy"));
         assert!(output.contains("forbidden path argument"));
-        assert!(output.contains("/etc/passwd"));
+        assert!(output.contains(outside_path));
     }
 
     #[tokio::test]
+    #[cfg(not(target_os = "windows"))]
     async fn run_job_command_blocks_tilde_user_path_argument() {
         let tmp = TempDir::new().unwrap();
         let mut config = test_config(&tmp).await;
@@ -1400,6 +1407,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(not(target_os = "windows"))]
     async fn run_job_command_blocks_input_redirection_path_bypass() {
         let tmp = TempDir::new().unwrap();
         let mut config = test_config(&tmp).await;
@@ -1453,7 +1461,18 @@ mod tests {
         assert!(output.contains("rate limit exceeded"));
     }
 
+    #[cfg(target_os = "windows")]
+    fn absolute_path_outside_workspace() -> &'static str {
+        r"C:\Windows\win.ini"
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    fn absolute_path_outside_workspace() -> &'static str {
+        "/etc/passwd"
+    }
+
     #[tokio::test]
+    #[cfg(not(target_os = "windows"))]
     async fn execute_job_with_retry_recovers_after_first_failure() {
         let tmp = TempDir::new().unwrap();
         let mut config = test_config(&tmp).await;
@@ -1486,6 +1505,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(not(target_os = "windows"))]
     async fn execute_job_with_retry_exhausts_attempts() {
         let tmp = TempDir::new().unwrap();
         let mut config = test_config(&tmp).await;

--- a/crates/zeroclaw-runtime/src/rpc/attachments.rs
+++ b/crates/zeroclaw-runtime/src/rpc/attachments.rs
@@ -149,7 +149,8 @@ pub async fn process_file_entry(
     let canonical = tokio::fs::canonicalize(&dest)
         .await
         .unwrap_or_else(|_| dest.clone());
-    let workspace_path = canonical.to_string_lossy().to_string();
+    let canonical_display = canonical.to_string_lossy();
+    let workspace_path = strip_windows_verbatim_prefix(&canonical_display).into_owned();
 
     // 6. Build marker.
     //
@@ -176,12 +177,9 @@ pub async fn process_file_entry(
     // and emit a WARN. Always use the workspace /uploads/ copy for clipboard.
     let kind = attachment_kind(&mime_type);
     let is_clipboard = matches!(entry.source, FileSource::Clipboard);
-    let display_path = if is_clipboard {
-        &workspace_path
-    } else {
-        original_path.as_deref().unwrap_or(&workspace_path)
-    };
     let marker = if kind == "IMAGE" {
+        let display_path =
+            image_marker_display_path(original_path.as_deref(), &workspace_path, is_clipboard);
         format!("[IMAGE:{display_path}]")
     } else {
         // Non-image: prose format with workspace path so the agent can
@@ -216,6 +214,30 @@ pub async fn process_file_entry(
 /// Sanitize a filename: strip path separators and null bytes.
 fn sanitize_filename(name: &str) -> String {
     name.replace(['/', '\\', '\0'], "_")
+}
+
+/// Strip the Windows verbatim (`\\?\`) prefix that `canonicalize` prepends so
+/// model-visible file markers contain ordinary local paths.
+fn strip_windows_verbatim_prefix(path: &str) -> std::borrow::Cow<'_, str> {
+    if let Some(rest) = path.strip_prefix(r"\\?\UNC\") {
+        return std::borrow::Cow::Owned(format!(r"\\{rest}"));
+    }
+    if let Some(rest) = path.strip_prefix(r"\\?\") {
+        return std::borrow::Cow::Borrowed(rest);
+    }
+    std::borrow::Cow::Borrowed(path)
+}
+
+fn image_marker_display_path<'a>(
+    original_path: Option<&'a str>,
+    workspace_path: &'a str,
+    is_clipboard: bool,
+) -> std::borrow::Cow<'a, str> {
+    if is_clipboard {
+        std::borrow::Cow::Borrowed(workspace_path)
+    } else {
+        strip_windows_verbatim_prefix(original_path.unwrap_or(workspace_path))
+    }
 }
 
 /// Derive MIME type from filename extension via `mime_guess`.
@@ -271,6 +293,38 @@ mod tests {
         assert_eq!(sanitize_filename("path/to/file.txt"), "path_to_file.txt");
         assert_eq!(sanitize_filename("back\\slash.txt"), "back_slash.txt");
         assert_eq!(sanitize_filename("null\0byte.txt"), "null_byte.txt");
+    }
+
+    #[test]
+    fn strip_windows_verbatim_prefix_keeps_markers_plain() {
+        assert_eq!(
+            strip_windows_verbatim_prefix(r"\\?\C:\Users\me\file.png"),
+            r"C:\Users\me\file.png"
+        );
+        assert_eq!(
+            strip_windows_verbatim_prefix(r"\\?\UNC\server\share\file.png"),
+            r"\\server\share\file.png"
+        );
+        assert_eq!(
+            strip_windows_verbatim_prefix("/tmp/file.png"),
+            "/tmp/file.png"
+        );
+    }
+
+    #[test]
+    fn path_mode_image_marker_display_path_strips_original_verbatim_prefix() {
+        let workspace_path = r"C:\Users\me\.zeroclaw\uploads\copy.png";
+        let display_path = image_marker_display_path(
+            Some(r"\\?\C:\Users\me\Pictures\source.png"),
+            workspace_path,
+            false,
+        );
+        let marker = format!("[IMAGE:{display_path}]");
+
+        assert_eq!(display_path, r"C:\Users\me\Pictures\source.png");
+        assert_eq!(marker, r"[IMAGE:C:\Users\me\Pictures\source.png]");
+        assert!(!marker.contains(r"\\?\"));
+        assert!(!workspace_path.contains(r"\\?\"));
     }
 
     #[test]

--- a/crates/zeroclaw-runtime/src/skills/mod.rs
+++ b/crates/zeroclaw-runtime/src/skills/mod.rs
@@ -1254,9 +1254,21 @@ fn resolve_skill_location(skill: &Skill, workspace_dir: &Path) -> PathBuf {
 fn render_skill_location(skill: &Skill, workspace_dir: &Path, prefer_relative: bool) -> String {
     let location = resolve_skill_location(skill, workspace_dir);
     if prefer_relative && let Ok(relative) = location.strip_prefix(workspace_dir) {
-        return relative.display().to_string();
+        return display_skill_location(relative);
     }
-    location.display().to_string()
+    display_skill_location(&location)
+}
+
+fn display_skill_location(path: &Path) -> String {
+    let rendered = path.display().to_string();
+    #[cfg(target_os = "windows")]
+    {
+        rendered.replace('\\', "/")
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        rendered
+    }
 }
 
 /// Build the "Available Skills" system prompt section with full skill instructions.
@@ -1457,15 +1469,30 @@ pub fn skills_to_tools_with_context(
     security: std::sync::Arc<crate::security::SecurityPolicy>,
     unfiltered_registry: &[std::sync::Arc<dyn zeroclaw_api::tool::Tool>],
 ) -> Vec<Box<dyn zeroclaw_api::tool::Tool>> {
+    skills_to_tools_with_context_and_runtime(
+        skills,
+        security,
+        unfiltered_registry,
+        std::sync::Arc::new(crate::platform::NativeRuntime::new()),
+    )
+}
+
+pub fn skills_to_tools_with_context_and_runtime(
+    skills: &[Skill],
+    security: std::sync::Arc<crate::security::SecurityPolicy>,
+    unfiltered_registry: &[std::sync::Arc<dyn zeroclaw_api::tool::Tool>],
+    runtime: std::sync::Arc<dyn crate::platform::RuntimeAdapter>,
+) -> Vec<Box<dyn zeroclaw_api::tool::Tool>> {
     let mut tools: Vec<Box<dyn zeroclaw_api::tool::Tool>> = Vec::new();
     for skill in skills {
         for tool in &skill.tools {
             match tool.kind.as_str() {
                 "shell" | "script" => {
-                    let inner = crate::skills::skill_tool::SkillShellTool::new(
+                    let inner = crate::skills::skill_tool::SkillShellTool::new_with_runtime(
                         &skill.name,
                         tool,
                         security.clone(),
+                        runtime.clone(),
                     );
                     tools.push(Box::new(zeroclaw_tools::wrappers::RateLimitedTool::new(
                         inner,

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -318,13 +318,33 @@ pub fn register_skill_tools_with_context(
     security: Arc<SecurityPolicy>,
     unfiltered_registry: &[Arc<dyn Tool>],
 ) {
+    register_skill_tools_with_context_and_runtime(
+        tools_registry,
+        skills,
+        security,
+        unfiltered_registry,
+        Arc::new(NativeRuntime::new()),
+    );
+}
+
+pub fn register_skill_tools_with_context_and_runtime(
+    tools_registry: &mut Vec<Box<dyn Tool>>,
+    skills: &[crate::skills::Skill],
+    security: Arc<SecurityPolicy>,
+    unfiltered_registry: &[Arc<dyn Tool>],
+    runtime: Arc<dyn RuntimeAdapter>,
+) {
     if skills.is_empty() {
         return;
     }
 
     let before = tools_registry.len();
-    let skill_tools =
-        crate::skills::skills_to_tools_with_context(skills, security, unfiltered_registry);
+    let skill_tools = crate::skills::skills_to_tools_with_context_and_runtime(
+        skills,
+        security,
+        unfiltered_registry,
+        runtime,
+    );
     let existing_names: std::collections::HashSet<String> = tools_registry
         .iter()
         .map(|t| t.name().to_string())

--- a/crates/zeroclaw-runtime/src/tools/shell.rs
+++ b/crates/zeroclaw-runtime/src/tools/shell.rs
@@ -814,7 +814,7 @@ mod tests {
     async fn shell_blocks_absolute_path_argument() {
         let tool = wrapped_shell(test_security(AutonomyLevel::Supervised));
         let result = tool
-            .execute(json!({"command": "cat /etc/passwd"}))
+            .execute(json!({"command": format!("cat {}", absolute_path_outside_workspace())}))
             .await
             .expect("absolute path argument should be blocked");
         assert!(!result.success);
@@ -831,7 +831,7 @@ mod tests {
     async fn shell_blocks_option_assignment_path_argument() {
         let tool = wrapped_shell(test_security(AutonomyLevel::Supervised));
         let result = tool
-            .execute(json!({"command": "grep --file=/etc/passwd root ./src"}))
+            .execute(json!({"command": format!("grep --file={} root ./src", absolute_path_outside_workspace())}))
             .await
             .expect("option-assigned forbidden path should be blocked");
         assert!(!result.success);
@@ -848,7 +848,7 @@ mod tests {
     async fn shell_blocks_short_option_attached_path_argument() {
         let tool = wrapped_shell(test_security(AutonomyLevel::Supervised));
         let result = tool
-            .execute(json!({"command": "grep -f/etc/passwd root ./src"}))
+            .execute(json!({"command": format!("grep -f{} root ./src", absolute_path_outside_workspace())}))
             .await
             .expect("short option attached forbidden path should be blocked");
         assert!(!result.success);
@@ -879,6 +879,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(not(target_os = "windows"))]
     async fn shell_blocks_input_redirection_path_bypass() {
         let tool = ShellTool::new(test_security(AutonomyLevel::Supervised), test_runtime());
         let result = tool
@@ -899,7 +900,7 @@ mod tests {
         Arc::new(SecurityPolicy {
             autonomy: AutonomyLevel::Supervised,
             workspace_dir: std::env::temp_dir(),
-            allowed_commands: vec!["env".into(), "echo".into()],
+            allowed_commands: vec![env_print_command().into(), "echo".into()],
             ..SecurityPolicy::default()
         })
     }
@@ -908,10 +909,64 @@ mod tests {
         Arc::new(SecurityPolicy {
             autonomy: AutonomyLevel::Supervised,
             workspace_dir: std::env::temp_dir(),
-            allowed_commands: vec!["env".into()],
+            allowed_commands: vec![env_print_command().into()],
             shell_env_passthrough: vars.iter().map(|v| (*v).to_string()).collect(),
             ..SecurityPolicy::default()
         })
+    }
+
+    #[cfg(target_os = "windows")]
+    fn env_print_command() -> &'static str {
+        "set"
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    fn env_print_command() -> &'static str {
+        "env"
+    }
+
+    #[cfg(target_os = "windows")]
+    fn home_env_key() -> &'static str {
+        "USERPROFILE"
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    fn home_env_key() -> &'static str {
+        "HOME"
+    }
+
+    #[cfg(target_os = "windows")]
+    fn absolute_path_outside_workspace() -> &'static str {
+        r"C:\Windows\win.ini"
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    fn absolute_path_outside_workspace() -> &'static str {
+        "/etc/passwd"
+    }
+
+    fn env_output_contains_key(output: &str, key: &str) -> bool {
+        output.lines().any(|line| {
+            line.split_once('=')
+                .is_some_and(|(name, _)| env_key_eq(name, key))
+        })
+    }
+
+    fn env_output_contains_assignment(output: &str, key: &str, value: &str) -> bool {
+        output.lines().any(|line| {
+            line.split_once('=')
+                .is_some_and(|(name, actual)| env_key_eq(name, key) && actual == value)
+        })
+    }
+
+    #[cfg(target_os = "windows")]
+    fn env_key_eq(actual: &str, expected: &str) -> bool {
+        actual.eq_ignore_ascii_case(expected)
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    fn env_key_eq(actual: &str, expected: &str) -> bool {
+        actual == expected
     }
 
     /// RAII guard that restores an environment variable to its original state on drop,
@@ -948,9 +1003,9 @@ mod tests {
 
         let tool = ShellTool::new(test_security_with_env_cmd(), test_runtime());
         let result = tool
-            .execute(json!({"command": "env"}))
+            .execute(json!({"command": env_print_command()}))
             .await
-            .expect("env command execution should succeed");
+            .expect("environment print command should succeed");
         assert!(result.success);
         assert!(
             !result.output.contains("sk-test-secret-12345"),
@@ -967,21 +1022,23 @@ mod tests {
         let tool = ShellTool::new(test_security_with_env_cmd(), test_runtime());
 
         let result = tool
-            .execute(json!({"command": "env"}))
+            .execute(json!({"command": env_print_command()}))
             .await
-            .expect("env command should succeed");
+            .expect("environment print command should succeed");
         assert!(result.success);
         assert!(
-            result.output.contains("HOME="),
-            "HOME should be available in shell environment"
+            env_output_contains_key(&result.output, home_env_key()),
+            "{} should be available in shell environment",
+            home_env_key()
         );
         assert!(
-            result.output.contains("PATH="),
+            env_output_contains_key(&result.output, "PATH"),
             "PATH should be available in shell environment"
         );
     }
 
     #[tokio::test]
+    #[cfg(not(target_os = "windows"))]
     async fn shell_blocks_plain_variable_expansion() {
         let tool = ShellTool::new(test_security_with_env_cmd(), test_runtime());
         let result = tool
@@ -1007,15 +1064,15 @@ mod tests {
         );
 
         let result = tool
-            .execute(json!({"command": "env"}))
+            .execute(json!({"command": env_print_command()}))
             .await
-            .expect("env command execution should succeed");
+            .expect("environment print command should succeed");
         assert!(result.success);
-        assert!(
-            result
-                .output
-                .contains("ZEROCLAW_TEST_PASSTHROUGH=db://unit-test")
-        );
+        assert!(env_output_contains_assignment(
+            &result.output,
+            "ZEROCLAW_TEST_PASSTHROUGH",
+            "db://unit-test"
+        ));
     }
 
     #[test]
@@ -1092,6 +1149,7 @@ mod tests {
     // ── Non-UTF8 binary output tests ────────────────────
 
     #[test]
+    #[cfg(not(target_os = "windows"))]
     fn decode_output_valid_utf8_roundtrips() {
         let input = "hello 世界 🌍".as_bytes();
         assert_eq!(super::decode_output(input), "hello 世界 🌍");
@@ -1308,13 +1366,13 @@ mod tests {
             }));
 
         let result = tool
-            .execute(json!({"command": "env"}))
+            .execute(json!({"command": env_print_command()}))
             .await
-            .expect("env command should succeed");
+            .expect("environment print command should succeed");
 
         assert!(result.success);
         assert!(
-            result.output.contains("ZC_TUI_TEST_VAR=tui_injected"),
+            env_output_contains_assignment(&result.output, "ZC_TUI_TEST_VAR", "tui_injected"),
             "tui_env var should appear in subprocess env, got:\n{}",
             result.output
         );
@@ -1326,9 +1384,9 @@ mod tests {
         let tool = ShellTool::new(test_security_with_env_cmd(), test_runtime());
 
         let result = tool
-            .execute(json!({"command": "env"}))
+            .execute(json!({"command": env_print_command()}))
             .await
-            .expect("env command should succeed");
+            .expect("environment print command should succeed");
 
         assert!(result.success);
         assert!(
@@ -1341,19 +1399,20 @@ mod tests {
     async fn shell_tui_env_overrides_safe_var() {
         // tui_env wins over the process-level value for a var that is also in SAFE_ENV_VARS.
         // This lets the TUI's PATH (e.g. with nix/brew) win over the daemon's PATH.
-        let _guard = EnvGuard::set("HOME", "/daemon-home");
+        let home_key = home_env_key();
+        let _guard = EnvGuard::set(home_key, "daemon-home");
 
         let tool =
             ShellTool::new(test_security_with_env_cmd(), test_runtime()).with_tui_env(Some({
                 let mut m = std::collections::HashMap::new();
-                m.insert("HOME".to_string(), "/tui-home".to_string());
+                m.insert(home_key.to_string(), "tui-home".to_string());
                 m
             }));
 
         let result = tool
-            .execute(json!({"command": "env"}))
+            .execute(json!({"command": env_print_command()}))
             .await
-            .expect("env command should succeed");
+            .expect("environment print command should succeed");
 
         assert!(
             result.success,
@@ -1361,13 +1420,13 @@ mod tests {
             result.output, result.error
         );
         assert!(
-            result.output.contains("HOME=/tui-home"),
-            "tui_env HOME should override daemon HOME, got:\n{}",
+            env_output_contains_assignment(&result.output, home_key, "tui-home"),
+            "tui_env {home_key} should override daemon {home_key}, got:\n{}",
             result.output
         );
         assert!(
-            !result.output.contains("HOME=/daemon-home"),
-            "daemon HOME must not leak through when tui_env overrides it, got:\n{}",
+            !env_output_contains_assignment(&result.output, home_key, "daemon-home"),
+            "daemon {home_key} must not leak through when tui_env overrides it, got:\n{}",
             result.output
         );
     }
@@ -1379,9 +1438,9 @@ mod tests {
         let tool = ShellTool::new(test_security_with_env_cmd(), test_runtime()).with_tui_env(None);
 
         let result = tool
-            .execute(json!({"command": "env"}))
+            .execute(json!({"command": env_print_command()}))
             .await
-            .expect("env command should succeed");
+            .expect("environment print command should succeed");
 
         assert!(result.success);
         assert!(
@@ -1409,13 +1468,13 @@ mod tests {
         );
 
         let result = tool
-            .execute(json!({"command": "env"}))
+            .execute(json!({"command": env_print_command()}))
             .await
-            .expect("env command should succeed");
+            .expect("environment print command should succeed");
 
         assert!(result.success);
         assert!(
-            result.output.contains("SSH_AUTH_SOCK=/tmp/fake.sock"),
+            env_output_contains_assignment(&result.output, "SSH_AUTH_SOCK", "/tmp/fake.sock"),
             "SSH_AUTH_SOCK from tui_env must reach subprocess"
         );
     }

--- a/crates/zeroclaw-runtime/src/tools/skill_tool.rs
+++ b/crates/zeroclaw-runtime/src/tools/skill_tool.rs
@@ -7,6 +7,7 @@
 //! convention and keeps names valid under OpenAI-compatible function-name
 //! rules (`^[a-zA-Z0-9_-]+$`), which reject `.`.
 
+use crate::platform::{NativeRuntime, RuntimeAdapter};
 use crate::security::SecurityPolicy;
 use async_trait::async_trait;
 use std::collections::HashMap;
@@ -20,6 +21,30 @@ use zeroclaw_api::tool::{Tool, ToolResult};
 const SKILL_SHELL_TIMEOUT_SECS: u64 = 60;
 /// Maximum output size in bytes (1 MB).
 const MAX_OUTPUT_BYTES: usize = 1_048_576;
+
+#[cfg(not(target_os = "windows"))]
+const SAFE_ENV_VARS: &[&str] = &[
+    "PATH", "HOME", "TERM", "LANG", "LC_ALL", "LC_CTYPE", "USER", "SHELL", "TMPDIR",
+];
+
+#[cfg(target_os = "windows")]
+const SAFE_ENV_VARS: &[&str] = &[
+    "PATH",
+    "PATHEXT",
+    "HOME",
+    "USERPROFILE",
+    "HOMEDRIVE",
+    "HOMEPATH",
+    "SYSTEMROOT",
+    "SYSTEMDRIVE",
+    "WINDIR",
+    "COMSPEC",
+    "TEMP",
+    "TMP",
+    "TERM",
+    "LANG",
+    "USERNAME",
+];
 
 /// Maximum provider function-name length. Anthropic's current client-tool
 /// contract is the strictest we rely on: `name` must match
@@ -100,6 +125,7 @@ pub struct SkillShellTool {
     command_template: String,
     args: HashMap<String, String>,
     security: Arc<SecurityPolicy>,
+    runtime: Arc<dyn RuntimeAdapter>,
     /// Resolved per-command timeout in seconds (manifest `timeout_secs`, or the
     /// `SKILL_SHELL_TIMEOUT_SECS` default), clamped to a minimum of 1.
     timeout_secs: u64,
@@ -115,12 +141,22 @@ impl SkillShellTool {
         tool: &crate::skills::SkillTool,
         security: Arc<SecurityPolicy>,
     ) -> Self {
+        Self::new_with_runtime(skill_name, tool, security, Arc::new(NativeRuntime::new()))
+    }
+
+    pub fn new_with_runtime(
+        skill_name: &str,
+        tool: &crate::skills::SkillTool,
+        security: Arc<SecurityPolicy>,
+        runtime: Arc<dyn RuntimeAdapter>,
+    ) -> Self {
         Self {
             tool_name: composed_tool_name(skill_name, &tool.name),
             tool_description: tool.description.clone(),
             command_template: tool.command.clone(),
             args: tool.args.clone(),
             security,
+            runtime,
             timeout_secs: tool.timeout_secs.unwrap_or(SKILL_SHELL_TIMEOUT_SECS).max(1),
         }
     }
@@ -206,16 +242,23 @@ impl Tool for SkillShellTool {
             });
         }
 
-        // Build and execute the command
-        let mut cmd = tokio::process::Command::new("sh");
-        cmd.arg("-c").arg(&command);
-        cmd.current_dir(&self.security.workspace_dir);
+        let mut cmd = match self
+            .runtime
+            .build_shell_command(&command, &self.security.workspace_dir)
+        {
+            Ok(cmd) => cmd,
+            Err(e) => {
+                return Ok(ToolResult {
+                    success: false,
+                    output: String::new(),
+                    error: Some(format!("Failed to build runtime command: {e}")),
+                });
+            }
+        };
         cmd.env_clear();
 
         // Only pass safe environment variables
-        for var in &[
-            "PATH", "HOME", "TERM", "LANG", "LC_ALL", "USER", "SHELL", "TMPDIR",
-        ] {
+        for var in SAFE_ENV_VARS {
             if let Ok(val) = std::env::var(var) {
                 cmd.env(var, val);
             }

--- a/crates/zeroclaw-tools/src/content_search.rs
+++ b/crates/zeroclaw-tools/src/content_search.rs
@@ -646,6 +646,16 @@ mod tests {
         })
     }
 
+    #[cfg(target_os = "windows")]
+    fn absolute_path_outside_workspace() -> &'static str {
+        r"C:\Windows"
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    fn absolute_path_outside_workspace() -> &'static str {
+        "/etc"
+    }
+
     fn create_test_files(dir: &TempDir) {
         std::fs::write(
             dir.path().join("hello.rs"),
@@ -854,7 +864,7 @@ mod tests {
     async fn content_search_rejects_absolute_path_outside_allowlist() {
         let tool = ContentSearchTool::new(test_security(std::env::temp_dir()));
         let result = tool
-            .execute(json!({"pattern": "test", "path": "/etc"}))
+            .execute(json!({"pattern": "test", "path": absolute_path_outside_workspace()}))
             .await
             .unwrap();
 

--- a/crates/zeroclaw-tools/src/file_edit.rs
+++ b/crates/zeroclaw-tools/src/file_edit.rs
@@ -319,6 +319,16 @@ mod tests {
         FileEditTool::new(security)
     }
 
+    #[cfg(target_os = "windows")]
+    fn absolute_path_outside_workspace() -> &'static str {
+        r"C:\Windows\win.ini"
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    fn absolute_path_outside_workspace() -> &'static str {
+        "/etc/passwd"
+    }
+
     /// Wraps `FileEditTool` with the production `PathGuardedTool` + `RateLimitedTool`
     /// stack, mirroring the registration in `zeroclaw-runtime::tools::mod`. Use this
     /// in tests that exercise path-allowlist or rate-limit behavior.
@@ -712,7 +722,7 @@ mod tests {
         let tool = wrapped_tool(std::env::temp_dir());
         let result = tool
             .execute(json!({
-                "path": "/etc/passwd",
+                "path": absolute_path_outside_workspace(),
                 "old_string": "root",
                 "new_string": "hacked"
             }))
@@ -728,6 +738,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(unix)]
     async fn file_edit_normalizes_workspace_prefixed_relative_path() {
         let root = std::env::temp_dir().join("zeroclaw_test_file_edit_workspace_prefixed");
         let workspace = root.join("workspace");

--- a/crates/zeroclaw-tools/src/file_write.rs
+++ b/crates/zeroclaw-tools/src/file_write.rs
@@ -292,6 +292,16 @@ mod tests {
         FileWriteTool::new_with_persistence(security, false)
     }
 
+    #[cfg(target_os = "windows")]
+    fn absolute_path_outside_workspace() -> &'static str {
+        r"C:\Windows\win.ini"
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    fn absolute_path_outside_workspace() -> &'static str {
+        "/etc/evil"
+    }
+
     #[test]
     fn file_write_name() {
         let tool = test_tool(std::env::temp_dir());
@@ -353,6 +363,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(unix)]
     async fn file_write_normalizes_workspace_prefixed_relative_path() {
         let root = std::env::temp_dir().join("zeroclaw_test_file_write_workspace_prefixed");
         let workspace = root.join("workspace");
@@ -431,7 +442,7 @@ mod tests {
     async fn file_write_blocks_absolute_path() {
         let tool = wrapped_tool(std::env::temp_dir());
         let result = tool
-            .execute(json!({"path": "/etc/evil", "content": "bad"}))
+            .execute(json!({"path": absolute_path_outside_workspace(), "content": "bad"}))
             .await
             .unwrap();
         assert!(!result.success);

--- a/crates/zeroclaw-tools/src/wrappers.rs
+++ b/crates/zeroclaw-tools/src/wrappers.rs
@@ -244,6 +244,16 @@ mod tests {
         })
     }
 
+    #[cfg(target_os = "windows")]
+    fn absolute_path_outside_workspace() -> &'static str {
+        r"C:\Windows\win.ini"
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    fn absolute_path_outside_workspace() -> &'static str {
+        "/etc/passwd"
+    }
+
     /// A minimal tool that records how many times `execute` was called.
     struct CountingTool {
         calls: Arc<AtomicUsize>,
@@ -346,7 +356,7 @@ mod tests {
         let (inner, counter) = CountingTool::new();
         let tool = PathGuardedTool::new(inner, policy(AutonomyLevel::Full));
         let result = tool
-            .execute(serde_json::json!({"command": "cat /etc/passwd"}))
+            .execute(serde_json::json!({"command": format!("cat {}", absolute_path_outside_workspace())}))
             .await
             .unwrap();
         assert!(!result.success);
@@ -381,7 +391,7 @@ mod tests {
                     .map(String::from)
             });
         let result = tool
-            .execute(serde_json::json!({"target": "/etc/shadow"}))
+            .execute(serde_json::json!({"target": absolute_path_outside_workspace()}))
             .await
             .unwrap();
         assert!(!result.success);
@@ -401,7 +411,7 @@ mod tests {
         let tool = RateLimitedTool::new(PathGuardedTool::new(inner, sec.clone()), sec);
 
         let blocked = tool
-            .execute(serde_json::json!({"path": "/etc/passwd"}))
+            .execute(serde_json::json!({"path": absolute_path_outside_workspace()}))
             .await
             .unwrap();
         assert!(!blocked.success);
@@ -482,7 +492,7 @@ mod tests {
         let tool = RateLimitedTool::new(PathGuardedTool::new(inner, sec.clone()), sec);
 
         let blocked = tool
-            .execute(serde_json::json!({"path": "/etc/passwd"}))
+            .execute(serde_json::json!({"path": absolute_path_outside_workspace()}))
             .await
             .unwrap();
         assert!(!blocked.success);


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Makes shell-tool environment tests use the platform's environment printer (`env` on Unix, `set` on Windows), Windows home variables, and case-insensitive environment-name checks so they do not fail on `cmd.exe` output.
  - Replaces Unix-only outside-workspace fixtures with platform-specific absolute paths in shell, cron, file write/edit, content search, and path-guard tests.
  - Keeps cron pre-spawn security-policy tests active on Windows while gating only the cases that need Unix shell syntax or `sh` execution.
  - Routes skill shell tools through the existing runtime shell adapter instead of hardcoding `sh`, so the same Windows `cmd.exe` path used by the built-in shell tool is covered.
  - Strips Windows verbatim path prefixes from RPC upload workspace paths and path-mode image markers, and renders model-visible skill locations with forward slashes on Windows.
- **Scope boundary:** This PR does not add Windows/macOS CI coverage, does not claim the full Windows test suite is green, and does not change config, CLI flags, approval policy, or filesystem access policy.
- **Blast radius:** Runtime shell/skill-tool execution, cron shell-command tests, RPC upload markers, model-visible skill location text, and path-guard test fixtures. The production behavior change is limited to using the existing runtime shell adapter for skill shell tools, surfacing a clear unsupported error for skill shell tools on WASM runtimes, and normalizing model-visible Windows paths.
- **Linked issue(s):** Related #7462. Related #7461.
- **Labels:** Snapshot after label application: `bug`, `risk: high`, `size: M`, `agent`, `cron`, `runtime`, `skills`, `tool`, `domain:ci`, `tool:file`, `tool:shell`.

## Validation Evidence (required)

- **Commands run and tail output:**

```text
cargo fmt -- --check
completed successfully with no formatting diff

git diff --check
completed successfully with no whitespace errors

cargo test -p zeroclaw-runtime tools::shell::tests --lib
test result: ok. 53 passed; 0 failed; 0 ignored; 0 measured; 2222 filtered out

cargo test -p zeroclaw-runtime tools::skill_tool::tests --lib
test result: ok. 31 passed; 0 failed; 0 ignored; 0 measured; 2244 filtered out

cargo test -p zeroclaw-runtime rpc::attachments::tests --lib
test result: ok. 16 passed; 0 failed; 0 ignored; 0 measured; 2259 filtered out

cargo test -p zeroclaw-runtime cron::scheduler::tests::run_job_command --lib
test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 2264 filtered out

cargo test -p zeroclaw-runtime cron::scheduler::tests::execute_job_with_retry --lib
test result: ok. 2 passed; 0 failed

cargo test -p zeroclaw-tools file_ --lib
test result: ok. 109 passed; 0 failed

cargo test -p zeroclaw-tools content_search --lib
test result: ok. 23 passed; 0 failed

cargo test -p zeroclaw-tools path_guard --lib
test result: ok. 4 passed; 0 failed

cargo test -p zeroclaw-tools wrappers::tests --lib
test result: ok. 10 passed; 0 failed

cargo test -p zeroclaw-channels prompt_skills_compact_mode_omits_instructions_but_keeps_tools --lib
test result: ok. 1 passed; 0 failed
```

- **Beyond CI — what did you manually verify?** Reviewed the diff against current `origin/master`; the branch has one surviving commit and only the intended Windows/path/shell portability surface. I also checked the PR title with `scripts/check-pr-title.sh`.
- **If any command was intentionally skipped, why:** I did not run a Windows-native test pass from this machine, so Windows CI or a Windows maintainer run still needs to verify the targeted failures before release confidence. I also did not run full workspace clippy or full workspace nextest; the focused tests cover the changed clusters, and broader validation should run before maintainers treat this as release-ready.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: No `Yes` answers. The skill shell change keeps the existing command approval and forbidden-path checks, but uses the existing runtime shell adapter instead of a hardcoded Unix shell.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No upgrade steps required.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert 62bb96bc4961add5762d4002ac4b2ddc256c261a`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Windows tests continue failing in shell env/path fixtures, file/path guard outside-workspace fixtures, cron shell-command policy tests, RPC upload marker assertions, or skill shell execution. Runtime symptoms would include skill shell tools failing on Windows hosts without `sh`, image markers containing `\\?\` prefixes, or model-visible skill locations using backslash-heavy Windows paths.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Scope materially carried forward: N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why (inspiration-only, no direct code/design carry-over): No superseded PR or incorporated contributor work.
