### PR TITLE
fix(channels): fall back to env vars for OpenAI STT API key

### DIFF
--- a/crates/zeroclaw-channels/src/transcription.rs
+++ b/crates/zeroclaw-channels/src/transcription.rs
@@ -183,6 +183,33 @@ impl TranscriptionProvider for GroqProvider {
 
 // ── OpenAiWhisperProvider ───────────────────────────────────────
 
+/// Resolve the OpenAI STT API key from explicit config, then env vars.
+///
+/// Resolution order:
+/// 1. Non-empty `configured` value (from `[transcription.openai].api_key`)
+/// 2. `TRANSCRIPTION_API_KEY` env var
+/// 3. `OPENAI_API_KEY` env var
+fn resolve_openai_stt_api_key(configured: Option<&str>) -> Result<String> {
+    if let Some(value) = configured {
+        let value = value.trim();
+        if !value.is_empty() {
+            return Ok(value.to_string());
+        }
+    }
+    for var in ["TRANSCRIPTION_API_KEY", "OPENAI_API_KEY"] {
+        if let Ok(value) = std::env::var(var) {
+            let value = value.trim();
+            if !value.is_empty() {
+                return Ok(value.to_string());
+            }
+        }
+    }
+    anyhow::bail!(
+        "Missing OpenAI STT API key: set [transcription.openai].api_key, \
+         TRANSCRIPTION_API_KEY, or OPENAI_API_KEY"
+    )
+}
+
 /// OpenAI Whisper API transcription_provider.
 pub struct OpenAiWhisperProvider {
     alias: String,
@@ -191,17 +218,17 @@ pub struct OpenAiWhisperProvider {
 }
 
 impl OpenAiWhisperProvider {
+    /// Build from `OpenAiSttConfig`.
+    ///
+    /// Credential resolution order:
+    /// 1. `[transcription.openai].api_key` (explicit config)
+    /// 2. `TRANSCRIPTION_API_KEY` env var
+    /// 3. `OPENAI_API_KEY` env var
     pub fn from_config(
         alias: &str,
         config: &zeroclaw_config::schema::OpenAiSttConfig,
     ) -> Result<Self> {
-        let api_key = config
-            .api_key
-            .as_deref()
-            .map(str::trim)
-            .filter(|v| !v.is_empty())
-            .map(ToOwned::to_owned)
-            .context("Missing OpenAI STT API key: set [transcription.openai].api_key")?;
+        let api_key = resolve_openai_stt_api_key(config.api_key.as_deref())?;
 
         Ok(Self {
             alias: alias.to_string(),

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -5053,6 +5053,9 @@ pub struct ToolFilterGroup {
 #[prefix = "transcription.openai"]
 pub struct OpenAiSttConfig {
     /// OpenAI API key for Whisper transcription.
+    ///
+    /// When unset or empty at construction time, the provider falls back to
+    /// the `TRANSCRIPTION_API_KEY` env var, then `OPENAI_API_KEY`.
     #[serde(default)]
     #[secret]
     #[credential_class = "encrypted_secret"]


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - `OpenAiWhisperProvider::from_config()` only reads `[transcription.openai].api_key` from TOML and fails when absent, ignoring env vars. This forces operators to duplicate shared OpenAI credentials into agent-visible config even when `OPENAI_API_KEY` is already set in the environment.
  - Extracted `resolve_openai_stt_api_key()` helper with resolution order: explicit config → `TRANSCRIPTION_API_KEY` env → `OPENAI_API_KEY` env.
  - Updated `OpenAiSttConfig.api_key` doc comment to document the env fallback chain.
  - The resolution pattern follows the established `resolve_slack_token()` precedent (`crates/zeroclaw-config/src/schema.rs:12259–12272`).
- **Scope boundary:** This PR only touches OpenAI STT credential resolution. It does NOT change `GroqProvider`, `DeepgramProvider`, `AssemblyAiProvider`, `GoogleSttProvider`, or `LocalWhisperProvider` — each has its own credential contract. It does not alter config file parsing, secret encryption, or the schema-mirror env grammar (`ZEROCLAW_transcription__openai__api_key`) which already works.
- **Blast radius:** `crates/zeroclaw-channels/src/transcription.rs` — both legacy (`[transcription.openai]`) and typed (`[providers.transcription.openai.<alias>]`) config paths route through `from_config()`. Downstream: `TranscriptionManager` construction at startup.
- **Linked issue(s):** Fixes #7899
- **Labels:** `bug`, `risk: medium`, `size: XS`, `channel`, `config`, `provider`, `provider:openai`

## Validation Evidence (required)

Local validation is the signal CI cannot replace. Run the full battery and paste literal output (tails, failures, warnings — not "all passed").

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- **Commands run and tail output:**

  No Rust toolchain available in this environment — `cargo fmt`, `clippy`, and `cargo test` were not executed locally. CI will run the full battery.

  Source-level verification of the resolution logic:

  ```console
  $ rg -A12 "fn resolve_openai_stt_api_key" crates/zeroclaw-channels/src/transcription.rs
  fn resolve_openai_stt_api_key(configured: Option<&str>) -> Result<String> {
      if let Some(value) = configured {
          let value = value.trim();
          if !value.is_empty() {
              return Ok(value.to_string());
          }
      }
      for var in ["TRANSCRIPTION_API_KEY", "OPENAI_API_KEY"] {
          if let Ok(value) = std::env::var(var) {
              let value = value.trim();
              if !value.is_empty() {
                  return Ok(value.to_string());
              }
          }
      }
      anyhow::bail!(
          "Missing OpenAI STT API key: set [transcription.openai].api_key, \
           TRANSCRIPTION_API_KEY, or OPENAI_API_KEY"
      )
  }

  $ rg "resolve_openai_stt_api_key" crates/zeroclaw-channels/src/transcription.rs
  192:fn resolve_openai_stt_api_key(configured: Option<&str>) -> Result<String> {
  231:        let api_key = resolve_openai_stt_api_key(config.api_key.as_deref())?;

  $ rg "from_config.*openai" crates/zeroclaw-channels/src/transcription.rs
  836:            && let Ok(p) = OpenAiWhisperProvider::from_config("openai", openai_cfg)
  924:                            OpenAiWhisperProvider::from_config(alias, &openai_config)
  ```

  Both call sites (legacy L836 and typed L924) route through `from_config()` → `resolve_openai_stt_api_key()`.

  Credential resolution behavior matrix:

  | `config.api_key` | `TRANSCRIPTION_API_KEY` env | `OPENAI_API_KEY` env | Result |
  |---|---|---|---|
  | `Some("sk-…")` non-empty | any | any | uses `config.api_key` |
  | `Some("")` or `None` | `"sk-env1"` non-empty | any | uses `TRANSCRIPTION_API_KEY` |
  | `Some("")` or `None` | unset or empty | `"sk-env2"` non-empty | uses `OPENAI_API_KEY` |
  | `Some("")` or `None` | unset or empty | unset or empty | error: lists all 3 sources |

- **Beyond CI — what did you manually verify?**
  - Both call sites for `OpenAiWhisperProvider::from_config()` route through the new helper.
  - Resolution order (config > `TRANSCRIPTION_API_KEY` > `OPENAI_API_KEY`) matches `resolve_slack_token()` pattern character-for-character.
  - Empty-string values from config and env are treated as absent (`.trim()` → `.filter(|v| !v.is_empty())`).
  - Error message lists all three credential sources.
  - Diff is limited to 2 files, +37/−7 lines, no `Cargo.lock` changes.

- **If any command was intentionally skipped, why:** `cargo fmt`, `clippy`, and `cargo test` skipped — no Rust toolchain available. The resolution logic mirrors the established `resolve_slack_token()` precedent which is already exercised in CI.

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`) — same OpenAI API key, same usage; only the resolution source is expanded (config + 2 env vars). The key is sent to the same OpenAI Whisper endpoint via the existing `bearer_auth` path.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? (`Yes`) — existing configs with `[transcription.openai].api_key` continue to work identically.
- Config / env / CLI surface changed? (`Yes`) — two new env vars recognized: `TRANSCRIPTION_API_KEY` (STT-specific) and `OPENAI_API_KEY` (shared fallback). Both were already referenced in provider error messages in the codebase (`OPENAI_API_KEY` in `zeroclaw-providers/src/openai.rs`).
- If `No` or `Yes` to either: exact upgrade steps for existing users: No migration required. Operators who previously received "Missing OpenAI STT API key" and had `OPENAI_API_KEY` set in the environment will now succeed without any config change.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <sha>`
- **Feature flags or config toggles:** `None` — the env fallback is always active. Operators who want to prevent env-based credential resolution can explicitly set `[transcription.openai].api_key` in TOML (takes precedence over env vars).
- **Observable failure symptoms:** If the env-var resolution path somehow breaks, `TranscriptionManager::new()` or `from_config_for_agent()` will fail at construction with "Missing OpenAI STT API key: set [transcription.openai].api_key, TRANSCRIPTION_API_KEY, or OPENAI_API_KEY", and the agent's transcription capability will be unavailable. Search logs for `"Missing OpenAI STT API key"` or watch for `TranscriptionManager` construction failures in startup logs.
