### PR TITLE
test: deterministic storage-reader timestamp and ordering regressions

### DIFF
--- a/crates/zeroclaw-infra/src/session_sqlite.rs
+++ b/crates/zeroclaw-infra/src/session_sqlite.rs
@@ -912,7 +912,29 @@ impl SessionBackend for SqliteSessionBackend {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::{DateTime, Duration, Utc};
     use tempfile::TempDir;
+
+    /// Insert a session with a specific created_at timestamp and return its key.
+    fn insert_session_with_time(backend: &SqliteSessionBackend, key: &str, ts: DateTime<Utc>) {
+        let conn = backend.conn.lock();
+        let ts_str = ts.to_rfc3339();
+        conn.execute(
+            "INSERT INTO sessions (session_key, role, content, created_at)
+            VALUES (?1, 'user', 'test', ?2)",
+            params![key, ts_str],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO session_metadata (session_key, created_at, last_activity, message_count)
+            VALUES (?1, ?2, ?2, 1)
+            ON CONFLICT(session_key) DO UPDATE SET
+                last_activity = excluded.last_activity,
+                message_count = message_count + 1",
+            params![key, ts_str],
+        )
+        .unwrap();
+    }
 
     #[test]
     fn round_trip_sqlite() {
@@ -1542,5 +1564,79 @@ mod tests {
         assert_eq!(single.name, from_list.name);
         assert_eq!(single.created_at, from_list.created_at);
         assert_eq!(single.last_activity, from_list.last_activity);
+    }
+    #[test]
+    fn load_with_timestamps_preserves_precision() {
+        let tmp = TempDir::new().unwrap();
+        let backend = SqliteSessionBackend::new(tmp.path()).unwrap();
+
+        // Use a non-round timestamp (millisecond precision)
+        let ts = Utc::now() - Duration::seconds(37) - Duration::milliseconds(123);
+        insert_session_with_time(&backend, "s1", ts);
+
+        let msgs = backend.load_with_timestamps("s1");
+        assert_eq!(msgs.len(), 1);
+        let loaded = msgs[0].created_at.unwrap();
+
+        // Should be within 1 second (SQLite stores RFC 3339 with sub-second)
+        assert!((loaded - ts).num_milliseconds().abs() < 1000);
+    }
+    #[test]
+    fn list_sessions_ordering_by_last_activity() {
+        let tmp = TempDir::new().unwrap();
+        let backend = SqliteSessionBackend::new(tmp.path()).unwrap();
+
+        let t1 = Utc::now() - Duration::hours(2);
+        let t2 = Utc::now() - Duration::hours(1);
+        let t3 = Utc::now();
+
+        insert_session_with_time(&backend, "old", t1);
+        insert_session_with_time(&backend, "mid", t2);
+        insert_session_with_time(&backend, "new", t3);
+
+        let sessions = backend.list_sessions_with_metadata();
+        assert_eq!(sessions.len(), 3);
+        assert_eq!(sessions[0].key, "new");
+        assert_eq!(sessions[1].key, "mid");
+        assert_eq!(sessions[2].key, "old");
+    }
+    #[test]
+    fn metadata_timestamps_use_utc_not_local() {
+        let tmp = TempDir::new().unwrap();
+        let backend = SqliteSessionBackend::new(tmp.path()).unwrap();
+
+        // Insert directly with a fixed UTC timestamp
+        let fixed = DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        insert_session_with_time(&backend, "utc_session", fixed);
+
+        let meta = backend.get_session_metadata("utc_session").unwrap();
+        assert_eq!(meta.created_at, fixed);
+        assert_eq!(meta.last_activity, fixed);
+    }
+    #[test]
+    fn sessions_with_missing_timestamp_fallback() {
+        let tmp = TempDir::new().unwrap();
+        let backend = SqliteSessionBackend::new(tmp.path()).unwrap();
+
+        // Manually insert with empty created_at to test fallback
+        let conn = backend.conn.lock();
+        conn.execute(
+            "INSERT INTO session_metadata (session_key, created_at, last_activity, message_count)
+            VALUES ('bad_ts', '', '', 0)",
+            [],
+        )
+        .unwrap();
+
+        let meta = backend.list_sessions_with_metadata();
+        assert_eq!(meta.len(), 1);
+        // Should fallback to Utc::now() rather than panic
+        assert!(
+            meta[0].created_at
+                > DateTime::parse_from_rfc3339("2000-01-01T00:00:00Z")
+                    .unwrap()
+                    .with_timezone(&Utc)
+        );
     }
 }

--- a/crates/zeroclaw-infra/src/session_store.rs
+++ b/crates/zeroclaw-infra/src/session_store.rs
@@ -544,4 +544,47 @@ mod tests {
         assert_eq!(meta.message_count, 2);
         assert!(meta.name.is_none());
     }
+    #[test]
+fn list_sessions_with_metadata_ordered_by_mtime_desc() {
+    let tmp = TempDir::new().unwrap();
+    let store = SessionStore::new(tmp.path()).unwrap();
+
+    // 人为制造不同时间的 session 文件
+    store
+        .append("old", &ChatMessage::user("old"))
+        .unwrap();
+
+    // 强制时间差
+    std::thread::sleep(std::time::Duration::from_millis(50));
+
+    store
+        .append("new", &ChatMessage::user("new"))
+        .unwrap();
+
+    let metas = store.list_sessions_with_metadata();
+    assert_eq!(metas.len(), 2);
+
+    // newest first
+    assert_eq!(metas[0].key, "new");
+    assert_eq!(metas[1].key, "old");
+
+    // strict ordering
+    assert!(metas[0].last_activity >= metas[1].last_activity);
+}
+#[test]
+fn list_sessions_with_metadata_stable_when_mtime_equal() {
+    let tmp = TempDir::new().unwrap();
+    let store = SessionStore::new(tmp.path()).unwrap();
+
+    // 两个 session 几乎同时写入，mtime 可能相同
+    store.append("a", &ChatMessage::user("a")).unwrap();
+    store.append("b", &ChatMessage::user("b")).unwrap();
+
+    let mut metas = store.list_sessions_with_metadata();
+    metas.sort_by_key(|m| m.key.clone());
+
+    assert_eq!(metas.len(), 2);
+    assert!(metas.iter().any(|m| m.key == "a"));
+    assert!(metas.iter().any(|m| m.key == "b"));
+}
 }

--- a/crates/zeroclaw-log/src/reader.rs
+++ b/crates/zeroclaw-log/src/reader.rs
@@ -270,7 +270,16 @@ mod tests {
         }
         event
     }
-
+    fn make_event_with_ts_and_id(ts: &str, id: &str, action: &str) -> LogEvent {
+        let mut event = LogEvent::new(
+            crate::event::Severity::Info,
+            action,
+            crate::event::EventCategory::Agent,
+        );
+        event.timestamp = ts.to_string();
+        event.id = id.to_string();
+        event
+    }
     #[test]
     fn empty_file_returns_at_end() {
         let tmp = tempfile::tempdir().unwrap();
@@ -401,5 +410,113 @@ mod tests {
         assert_eq!(older_page.events[1].message.as_deref(), Some("event-1"));
         assert_eq!(older_page.events[2].message.as_deref(), Some("event-0"));
         assert!(older_page.at_end);
+    }
+
+    #[test]
+    fn same_timestamp_pagination_no_duplicates() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("trace.jsonl");
+
+        let ts = "2026-01-01T00:00:00.000Z";
+        let events = vec![
+            make_event_with_ts_and_id(ts, "a", "act1"),
+            make_event_with_ts_and_id(ts, "b", "act2"),
+            make_event_with_ts_and_id(ts, "c", "act3"),
+            make_event_with_ts_and_id(ts, "d", "act4"),
+            make_event_with_ts_and_id(ts, "e", "act5"),
+        ];
+
+        write_jsonl(&path, &events);
+
+        let page1 = load_page(&path, &LogFilter::default(), 2).unwrap();
+        assert_eq!(page1.events.len(), 2);
+        let (cursor_ts, cursor_id) = page1.next_cursor.unwrap();
+
+        let older_filter = LogFilter {
+            until_ts: Some(cursor_ts),
+            until_id: Some(cursor_id),
+            ..Default::default()
+        };
+
+        let page2 = load_page(&path, &older_filter, 2).unwrap();
+        assert_eq!(page2.events.len(), 2);
+
+        // 不重复
+        let ids1: Vec<_> = page1.events.iter().map(|e| &e.id).collect();
+        let ids2: Vec<_> = page2.events.iter().map(|e| &e.id).collect();
+        for id in &ids1 {
+            assert!(!ids2.contains(id));
+        }
+    }
+    #[test]
+    fn same_timestamp_ordering_is_stable_by_id() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("trace.jsonl");
+
+        let ts = "2026-01-01T00:00:00.000Z";
+        let events = vec![
+            make_event_with_ts_and_id(ts, "z", "last"),
+            make_event_with_ts_and_id(ts, "m", "middle"),
+            make_event_with_ts_and_id(ts, "a", "first"),
+        ];
+
+        write_jsonl(&path, &events);
+
+        let page = load_page(&path, &LogFilter::default(), 10).unwrap();
+
+        // newest first ⇒ z, m, a
+        assert_eq!(page.events[0].id, "z");
+        assert_eq!(page.events[1].id, "m");
+        assert_eq!(page.events[2].id, "a");
+    }
+    #[test]
+    fn same_timestamp_last_page_reports_at_end() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("trace.jsonl");
+
+        let ts = "2026-01-01T00:00:00.000Z";
+        let events = vec![
+            make_event_with_ts_and_id(ts, "a", "x"),
+            make_event_with_ts_and_id(ts, "b", "y"),
+        ];
+
+        write_jsonl(&path, &events);
+
+        let page = load_page(&path, &LogFilter::default(), 10).unwrap();
+        assert!(page.at_end);
+    }
+    #[test]
+    fn mixed_timestamps_with_same_timestamp_boundary() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("trace.jsonl");
+
+        let events = vec![
+            make_event_with_ts_and_id("2026-01-01T00:00:02.000Z", "a", "new"),
+            make_event_with_ts_and_id("2026-01-01T00:00:01.000Z", "b", "mid"),
+            make_event_with_ts_and_id("2026-01-01T00:00:00.000Z", "c", "old1"),
+            make_event_with_ts_and_id("2026-01-01T00:00:00.000Z", "d", "old2"),
+        ];
+
+        write_jsonl(&path, &events);
+
+        let page1 = load_page(&path, &LogFilter::default(), 2).unwrap();
+        assert_eq!(page1.events[0].id, "a");
+        assert_eq!(page1.events[1].id, "b");
+
+        let (ts, id) = page1.next_cursor.unwrap();
+        let page2 = load_page(
+            &path,
+            &LogFilter {
+                until_ts: Some(ts),
+                until_id: Some(id),
+                ..Default::default()
+            },
+            2,
+        )
+        .unwrap();
+
+        assert_eq!(page2.events[0].id, "d");
+        assert_eq!(page2.events[1].id, "c");
+        assert!(page2.at_end);
     }
 }

--- a/crates/zeroclaw-memory/src/sqlite.rs
+++ b/crates/zeroclaw-memory/src/sqlite.rs
@@ -3750,4 +3750,131 @@ mod tests {
         let entry = mem.get("global").await.unwrap().expect("row should exist");
         assert!(entry.session_id.is_none());
     }
+    #[tokio::test]
+async fn recall_ordering_stable_when_timestamps_are_equal() {
+    let tmp = TempDir::new().unwrap();
+    let mem = SqliteMemory::new("test", tmp.path()).unwrap();
+
+    // 用固定时间戳写入多条记录（模拟同秒内的多次存储）
+    let fixed_ts = "2026-06-18T12:00:00Z";
+    for i in 0..5 {
+        mem.store(
+            &format!("key_{i}"),
+            &format!("content {i}"),
+            MemoryCategory::Core,
+            None,
+        )
+        .await
+        .unwrap();
+        // 手动覆盖 updated_at 使它们完全相同
+    }
+
+    // 强制把所有行的 updated_at 设为同一个值
+    {
+        let conn = mem.conn.lock();
+        conn.execute(
+            "UPDATE memories SET updated_at = ?1",
+            rusqlite::params![fixed_ts],
+        )
+        .unwrap();
+    }
+
+    // recall 不带关键词 → 按 updated_at DESC 排序，同时间戳内按插入顺序（id 排序）
+    let results = mem.recall("", 10, None, None, None).await.unwrap();
+    assert_eq!(results.len(), 5);
+
+    // 同时间戳时，排序应稳定（不 panic、不丢数据）
+    let keys: Vec<&str> = results.iter().map(|e| e.key.as_str()).collect();
+    assert!(
+        keys.contains(&"key_0")
+            && keys.contains(&"key_1")
+            && keys.contains(&"key_2")
+            && keys.contains(&"key_3")
+            && keys.contains(&"key_4"),
+        "All 5 records must be present when timestamps are equal"
+    );
+
+    // 再次查询，顺序应一致（稳定性）
+    let results2 = mem.recall("", 10, None, None, None).await.unwrap();
+    let keys2: Vec<&str> = results2.iter().map(|e| e.key.as_str()).collect();
+    assert_eq!(
+        keys, keys2,
+        "Ordering must be stable across repeated queries with equal timestamps"
+    );
+}
+#[tokio::test]
+async fn timestamp_roundtrip_preserves_utc_precision() {
+    let tmp = TempDir::new().unwrap();
+    let mem = SqliteMemory::new("test", tmp.path()).unwrap();
+
+    // 用不同精度和时区偏移的时间戳写入
+    let timestamps = [
+        "2026-01-01T00:00:00Z",          // 整秒
+        "2026-01-01T00:00:00.123Z",      // 毫秒
+        "2026-01-01T00:00:00.456789Z",   // 微秒
+        "2026-06-18T12:30:45.000Z",      // 另一个整秒
+    ];
+
+    for (i, ts) in timestamps.iter().enumerate() {
+        mem.store_with_metadata(
+            &format!("ts_{i}"),
+            &format!("timestamp test {i}"),
+            MemoryCategory::Core,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        // 覆盖为精确的时间戳字符串
+        let conn = mem.conn.lock();
+        conn.execute(
+            "UPDATE memories SET created_at = ?1, updated_at = ?1 WHERE key = ?2",
+            rusqlite::params![ts, format!("ts_{i}")],
+        )
+        .unwrap();
+    }
+
+    // 用 since/until 精确过滤
+    let results = mem
+        .recall(
+            "*",
+            10,
+            None,
+            Some("2026-01-01T00:00:00Z"),
+            Some("2026-01-01T00:00:01Z"),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        results.len(),
+        3,
+        "Should find exactly 3 entries within the time range"
+    );
+
+    // 验证每个结果的时间戳都 >= since 且 <= until
+    for entry in &results {
+        assert!(
+            entry.timestamp >= "2026-01-01T00:00:00Z"
+                && entry.timestamp <= "2026-01-01T00:00:01Z",
+            "Timestamp {} is outside the expected range",
+            entry.timestamp
+        );
+    }
+
+    // 用精确匹配查单个
+    let single = mem
+        .recall(
+            "*",
+            10,
+            None,
+            Some("2026-06-18T12:30:45Z"),
+            Some("2026-06-18T12:30:46Z"),
+        )
+        .await
+        .unwrap();
+    assert_eq!(single.len(), 1);
+    assert_eq!(single[0].key, "ts_3");
+}
 }


### PR DESCRIPTION
…ions

Add focused regression tests for memory, infra, and log edge cases identified in #7685 and requested in #7694.

Coverage added:
- log reader same-timestamp pagination stability
- SQLite timestamp loading and ordering
- session metadata ordering by last_activity
- boundary timestamp handling under shared timestamps

All tests use neutral fixtures and target read APIs only. No migrations, schema changes, or storage backend modifications.

Closes #7694

## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:** (2–5 bullets — the diff shows *what*, you explain *why*)
- **Scope boundary:** (what this PR explicitly does NOT change)
- **Blast radius:** (what other subsystems or consumers could be affected)
- **Linked issue(s):** Use plain text outside backticks. Use `Closes #`,
  `Fixes #`, or `Resolves #` only for issues this PR fully resolves. Use
  `Related #`, `Depends on #`, or `Supersedes #` for non-closing relationships.
- **Labels:** Snapshot the current GitHub labels after labels are applied, for
  example `type: docs`, `risk: low`, `size: S`, `docs`.

## Validation Evidence (required)

Local validation is the signal CI cannot replace. Run the full battery and paste literal output (tails, failures, warnings — not "all passed").

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

Docs-only changes: replace with markdown lint + link-integrity (`scripts/ci/docs_quality_gate.sh`). Bootstrap scripts: add `bash -n install.sh`.

- **Commands run and tail output:**
- **Beyond CI — what did you manually verify?** (scenarios, edge cases, what you did NOT verify)
- **If any command was intentionally skipped, why:**

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? (`Yes/No`)
- New external network calls? (`Yes/No`)
- Secrets / tokens / credentials handling changed? (`Yes/No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`Yes/No`)
- If any `Yes`, describe the risk and mitigation:

## Compatibility (required)

- Backward compatible? (`Yes/No`)
- Config / env / CLI surface changed? (`Yes/No`)
- If `No` or `Yes` to either: exact upgrade steps for existing users:

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PRs: `git revert <sha>` is the plan unless otherwise noted.

Medium/high-risk PRs must fill:

- **Fast rollback command/path:**
- **Feature flags or config toggles:** (or `None`)
- **Observable failure symptoms:** (what to grep logs for, which metric moves, which alert fires)

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line):
- Scope materially carried forward:
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`Yes/No`)
- If `No`, why (inspiration-only, no direct code/design carry-over):

---

**Labels** live in the GitHub label UI, not in the body. Maintainers and reviewers with label permissions set `risk:*`, `size:*`, and any missing manual labels via the sidebar. The PR path labeler only owns path/scope labels from `.github/labeler.yml`. Contributors without label permission can note obvious label mismatches in a comment.

**Do not add bot/AI attribution footers** such as `Co-authored-by: Claude ...`
or `Created with Claude Code` to the PR body or commit-message tail. Human
co-author trailers are appropriate only for incorporated contributor work under
the supersede-attribution section and privacy contract.

**Privacy contract** (`docs/book/src/contributing/privacy.md`) is a merge gate. Never commit real identities, secrets, personal emails, or PII in diff, tests, fixtures, or docs.
