### PR TITLE
fix(tools): resolve relative working_directory against workspace root

### DIFF
--- a/crates/zeroclaw-tools/src/claude_code.rs
+++ b/crates/zeroclaw-tools/src/claude_code.rs
@@ -131,6 +131,13 @@ impl Tool for ClaudeCodeTool {
         // could bypass the workspace containment check via symlinks or
         // specially-crafted path components).
         let work_dir = if let Some(wd) = args.get("working_directory").and_then(|v| v.as_str()) {
+            if wd.trim().is_empty() {
+                return Ok(ToolResult {
+                    success: false,
+                    output: String::new(),
+                    error: Some("working_directory must not be empty".into()),
+                });
+            }
             let mut wd_path = std::path::PathBuf::from(wd);
             let workspace = &self.security.workspace_dir;
             // Resolve relative working_directory against the workspace

--- a/crates/zeroclaw-tools/src/claude_code.rs
+++ b/crates/zeroclaw-tools/src/claude_code.rs
@@ -131,8 +131,13 @@ impl Tool for ClaudeCodeTool {
         // could bypass the workspace containment check via symlinks or
         // specially-crafted path components).
         let work_dir = if let Some(wd) = args.get("working_directory").and_then(|v| v.as_str()) {
-            let wd_path = std::path::PathBuf::from(wd);
+            let mut wd_path = std::path::PathBuf::from(wd);
             let workspace = &self.security.workspace_dir;
+            // Resolve relative working_directory against the workspace
+            // root instead of the daemon's current directory (#7877).
+            if wd_path.is_relative() {
+                wd_path = workspace.join(&wd_path);
+            }
             let canonical_wd = match wd_path.canonicalize() {
                 Ok(p) => p,
                 Err(_) => {

--- a/crates/zeroclaw-tools/src/claude_code_runner.rs
+++ b/crates/zeroclaw-tools/src/claude_code_runner.rs
@@ -134,6 +134,13 @@ impl Tool for ClaudeCodeRunnerTool {
 
         // Validate working directory
         let work_dir = if let Some(wd) = args.get("working_directory").and_then(|v| v.as_str()) {
+            if wd.trim().is_empty() {
+                return Ok(ToolResult {
+                    success: false,
+                    output: String::new(),
+                    error: Some("working_directory must not be empty".into()),
+                });
+            }
             let mut wd_path = std::path::PathBuf::from(wd);
             let workspace = &self.security.workspace_dir;
             // Resolve relative working_directory against the workspace

--- a/crates/zeroclaw-tools/src/claude_code_runner.rs
+++ b/crates/zeroclaw-tools/src/claude_code_runner.rs
@@ -134,8 +134,13 @@ impl Tool for ClaudeCodeRunnerTool {
 
         // Validate working directory
         let work_dir = if let Some(wd) = args.get("working_directory").and_then(|v| v.as_str()) {
-            let wd_path = std::path::PathBuf::from(wd);
+            let mut wd_path = std::path::PathBuf::from(wd);
             let workspace = &self.security.workspace_dir;
+            // Resolve relative working_directory against the workspace
+            // root instead of the daemon's current directory (#7877).
+            if wd_path.is_relative() {
+                wd_path = workspace.join(&wd_path);
+            }
             let canonical_wd = match wd_path.canonicalize() {
                 Ok(p) => p,
                 Err(_) => {

--- a/crates/zeroclaw-tools/src/codex_cli.rs
+++ b/crates/zeroclaw-tools/src/codex_cli.rs
@@ -92,8 +92,13 @@ impl Tool for CodexCliTool {
         // could bypass the workspace containment check via symlinks or
         // specially-crafted path components).
         let work_dir = if let Some(wd) = args.get("working_directory").and_then(|v| v.as_str()) {
-            let wd_path = std::path::PathBuf::from(wd);
+            let mut wd_path = std::path::PathBuf::from(wd);
             let workspace = &self.security.workspace_dir;
+            // Resolve relative working_directory against the workspace
+            // root instead of the daemon's current directory (#7877).
+            if wd_path.is_relative() {
+                wd_path = workspace.join(&wd_path);
+            }
             let canonical_wd = match wd_path.canonicalize() {
                 Ok(p) => p,
                 Err(_) => {

--- a/crates/zeroclaw-tools/src/codex_cli.rs
+++ b/crates/zeroclaw-tools/src/codex_cli.rs
@@ -92,6 +92,13 @@ impl Tool for CodexCliTool {
         // could bypass the workspace containment check via symlinks or
         // specially-crafted path components).
         let work_dir = if let Some(wd) = args.get("working_directory").and_then(|v| v.as_str()) {
+            if wd.trim().is_empty() {
+                return Ok(ToolResult {
+                    success: false,
+                    output: String::new(),
+                    error: Some("working_directory must not be empty".into()),
+                });
+            }
             let mut wd_path = std::path::PathBuf::from(wd);
             let workspace = &self.security.workspace_dir;
             // Resolve relative working_directory against the workspace

--- a/crates/zeroclaw-tools/src/gemini_cli.rs
+++ b/crates/zeroclaw-tools/src/gemini_cli.rs
@@ -92,8 +92,13 @@ impl Tool for GeminiCliTool {
         // could bypass the workspace containment check via symlinks or
         // specially-crafted path components).
         let work_dir = if let Some(wd) = args.get("working_directory").and_then(|v| v.as_str()) {
-            let wd_path = std::path::PathBuf::from(wd);
+            let mut wd_path = std::path::PathBuf::from(wd);
             let workspace = &self.security.workspace_dir;
+            // Resolve relative working_directory against the workspace
+            // root instead of the daemon's current directory (#7877).
+            if wd_path.is_relative() {
+                wd_path = workspace.join(&wd_path);
+            }
             let canonical_wd = match wd_path.canonicalize() {
                 Ok(p) => p,
                 Err(_) => {

--- a/crates/zeroclaw-tools/src/gemini_cli.rs
+++ b/crates/zeroclaw-tools/src/gemini_cli.rs
@@ -92,6 +92,13 @@ impl Tool for GeminiCliTool {
         // could bypass the workspace containment check via symlinks or
         // specially-crafted path components).
         let work_dir = if let Some(wd) = args.get("working_directory").and_then(|v| v.as_str()) {
+            if wd.trim().is_empty() {
+                return Ok(ToolResult {
+                    success: false,
+                    output: String::new(),
+                    error: Some("working_directory must not be empty".into()),
+                });
+            }
             let mut wd_path = std::path::PathBuf::from(wd);
             let workspace = &self.security.workspace_dir;
             // Resolve relative working_directory against the workspace

--- a/crates/zeroclaw-tools/src/opencode_cli.rs
+++ b/crates/zeroclaw-tools/src/opencode_cli.rs
@@ -92,8 +92,20 @@ impl Tool for OpenCodeCliTool {
         // could bypass the workspace containment check via symlinks or
         // specially-crafted path components).
         let work_dir = if let Some(wd) = args.get("working_directory").and_then(|v| v.as_str()) {
-            let wd_path = std::path::PathBuf::from(wd);
+            if wd.trim().is_empty() {
+                return Ok(ToolResult {
+                    success: false,
+                    output: String::new(),
+                    error: Some("working_directory must not be empty".into()),
+                });
+            }
+            let mut wd_path = std::path::PathBuf::from(wd);
             let workspace = &self.security.workspace_dir;
+            // Resolve relative working_directory against the workspace
+            // root instead of the daemon's current directory (#7877).
+            if wd_path.is_relative() {
+                wd_path = workspace.join(&wd_path);
+            }
             let canonical_wd = match wd_path.canonicalize() {
                 Ok(p) => p,
                 Err(_) => {


### PR DESCRIPTION
## Summary

External coding tools (`claude_code`, `claude_code_runner`, `codex_cli`, `gemini_cli`) accepted a `working_directory` argument but resolved relative paths against the daemon's current directory instead of the configured workspace root. When the daemon was started outside the workspace (e.g. from `/`), relative paths like `"."` or `"src"` would fail with "does not exist" or be rejected as outside the workspace.

This patch adds an `is_relative()` check before canonicalization: if the `working_directory` is relative, it is joined with `security.workspace_dir` first, so the resulting path resolves correctly within the workspace boundary. Absolute paths keep their current behavior unchanged.

Additionally:
1. **Empty string rejection**: `PathBuf::from("").is_relative()` returns `true`, causing `workspace.join("")` → workspace itself, which is semantically ambiguous. All 5 coding tools now reject empty/whitespace-only `working_directory` values with a clear error message. Users should use `"."` or omit the argument to get workspace root.
2. **opencode_cli fix**: The initial PR covered 4 tools but missed `opencode_cli.rs`, which has the identical working_directory validation pattern and the same #7877 bug. Now patched.

Closes #7877

## Changes

- In each of the **five** coding tool implementations (4 original + `opencode_cli`), insert a relative-path guard before `canonicalize()`:
  - If the provided `working_directory` is relative, join it with `security.workspace_dir` first.
  - Absolute paths pass through unchanged.
- Add empty/whitespace rejection: if `working_directory` is empty or whitespace-only, return an error instead of silently resolving to workspace root.

## Affected files

- `crates/zeroclaw-tools/src/claude_code.rs`
- `crates/zeroclaw-tools/src/claude_code_runner.rs`
- `crates/zeroclaw-tools/src/codex_cli.rs`
- `crates/zeroclaw-tools/src/gemini_cli.rs`
- `crates/zeroclaw-tools/src/opencode_cli.rs` (newly fixed)

## Test plan

- [ ] Start the ZeroClaw daemon from a directory other than the configured workspace (e.g. `cd / && zeroclawd`).
- [ ] Enable an external coding tool (e.g. `codex_cli`).
- [ ] Invoke the tool with `working_directory = "."` — should resolve to the workspace root, not `/`.
- [ ] Invoke with `working_directory = "src"` — should resolve to `<workspace>/src`.
- [ ] Invoke with an absolute path — should behave identically to before this change.
- [ ] Verify that paths outside the workspace are still rejected by the containment check.
- [ ] Invoke with `working_directory = ""` — should return an error ("working_directory must not be empty").
- [ ] Repeat the above for `opencode_cli` (previously missed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
