### PR TITLE
fix(log): make same-timestamp pagination deterministic via byte-offset cursor

### DIFF
--- a/apps/zerocode/src/client.rs
+++ b/apps/zerocode/src/client.rs
@@ -1782,6 +1782,12 @@ pub struct LogsQueryParams {
     pub until_ts: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub until_id: Option<String>,
+    /// Byte offset cap passed back from the previous page's
+    /// `next_cursor_line_offset`. When set, the reader stops scanning
+    /// at this offset so the follow-up page only sees lines strictly
+    /// older than the previous one. Independent of id ordering.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub until_line_offset: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub severity_min: Option<u8>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1804,7 +1810,18 @@ pub struct LogsQueryParams {
 #[serde(rename_all = "snake_case")]
 pub struct LogsQueryResult {
     pub events: Vec<serde_json::Value>,
+    /// Legacy cursor: `(timestamp, id)` to feed back as `until_ts` +
+    /// `until_id` for older. Tie-breaks same-timestamp events by
+    /// lexicographic id, which can drop earlier-written events when id
+    /// order diverges from file insertion order. Prefer
+    /// [`Self::next_cursor_line_offset`] when available — it is
+    /// independent of id ordering.
     pub next_cursor: Option<(String, String)>,
+    /// Byte offset past the OLDEST event on the current page. Pass back
+    /// as [`LogsQueryParams::until_line_offset`] on the next request to
+    /// walk older pages deterministically regardless of id ordering.
+    /// `None` when the page is empty.
+    pub next_cursor_line_offset: Option<u64>,
     pub at_end: bool,
 }
 

--- a/apps/zerocode/src/logs.rs
+++ b/apps/zerocode/src/logs.rs
@@ -484,8 +484,14 @@ pub(crate) struct Logs {
     search_active: bool,
     search_buf: String,
     search_query: String, // committed query (applied on Enter)
-    // Pagination
-    next_cursor: Option<(String, String)>,
+    // Pagination — prefer the byte-offset cursor (`next_cursor_line_offset`)
+    // because it is independent of event id ordering and avoids the
+    // legacy `(until_ts, until_id)` tie-break that can drop
+    // earlier-written events when ids are written in non-lexicographic
+    // order (UUID v4 in practice). The legacy cursor stays as a fallback
+    // for daemons that haven't been upgraded to expose the byte offset.
+    next_cursor_offset: Option<u64>,
+    next_cursor_legacy: Option<(String, String)>,
     at_end: bool,
     loading: bool,
     // Viewport
@@ -514,7 +520,8 @@ impl Logs {
             search_active: false,
             search_buf: String::new(),
             search_query: String::new(),
-            next_cursor: None,
+            next_cursor_offset: None,
+            next_cursor_legacy: None,
             at_end: false,
             loading: false,
             list_height: 0,
@@ -528,16 +535,21 @@ impl Logs {
         self.rpc.logs_subscribe().await?;
         self.subscribed = true;
         // Load initial history
-        self.load_page(None).await;
+        self.load_page(None, None).await;
         Ok(())
     }
 
     /// Fetch a page of older events. If `cursor` is None, fetches the newest.
-    async fn load_page(&mut self, cursor: Option<(String, String)>) {
+    async fn load_page(
+        &mut self,
+        cursor_offset: Option<u64>,
+        cursor_legacy: Option<(String, String)>,
+    ) {
         self.loading = true;
         let params = LogsQueryParams {
-            until_ts: cursor.as_ref().map(|(ts, _)| ts.clone()),
-            until_id: cursor.as_ref().map(|(_, id)| id.clone()),
+            until_ts: cursor_legacy.as_ref().map(|(ts, _)| ts.clone()),
+            until_id: cursor_legacy.as_ref().map(|(_, id)| id.clone()),
+            until_line_offset: cursor_offset,
             severity_min: Some(self.min_severity),
             q: if self.search_query.is_empty() {
                 None
@@ -545,13 +557,14 @@ impl Logs {
                 Some(self.search_query.clone())
             },
             hide_internal: true,
-            limit: Some(if cursor.is_none() {
+            limit: Some(if cursor_offset.is_none() && cursor_legacy.is_none() {
                 INITIAL_LOAD
             } else {
                 PAGE_SIZE
             }),
             ..Default::default()
         };
+        let has_cursor = cursor_offset.is_some() || cursor_legacy.is_some();
         match self.rpc.logs_query(params).await {
             Ok(result) => {
                 // Events come newest-first from the daemon; reverse to chronological
@@ -562,7 +575,7 @@ impl Logs {
                     .filter_map(LogEntry::from_value)
                     .collect();
                 let prepended = new_entries.len();
-                if cursor.is_some() && prepended > 0 {
+                if has_cursor && prepended > 0 {
                     // Prepend older events before the existing buffer
                     let mut combined = new_entries;
                     combined.append(&mut self.events);
@@ -571,10 +584,14 @@ impl Logs {
                     if let Some(sel) = self.list_state.selected() {
                         self.list_state.select(Some(sel + prepended));
                     }
-                } else if cursor.is_none() {
+                } else if !has_cursor {
                     self.events = new_entries;
                 }
-                self.next_cursor = result.next_cursor;
+                // Prefer the byte-offset cursor (independent of id ordering);
+                // fall back to the legacy `[timestamp, id]` pair when the
+                // daemon has not been upgraded to expose it.
+                self.next_cursor_offset = result.next_cursor_line_offset;
+                self.next_cursor_legacy = result.next_cursor;
                 self.at_end = result.at_end;
             }
             Err(_) => {
@@ -601,7 +618,8 @@ impl Logs {
 
         // Reset pagination so subsequent scroll-to-top loads can
         // fetch history matching the new filter set.
-        self.next_cursor = None;
+        self.next_cursor_offset = None;
+        self.next_cursor_legacy = None;
         self.at_end = false;
 
         let filtered = self.filtered_indices();
@@ -1057,9 +1075,10 @@ impl Logs {
         if sel == 0
             && !self.at_end
             && !self.loading
-            && let Some(cursor) = self.next_cursor.clone()
+            && (self.next_cursor_offset.is_some() || self.next_cursor_legacy.is_some())
         {
-            self.load_page(Some(cursor)).await;
+            self.load_page(self.next_cursor_offset, self.next_cursor_legacy.clone())
+                .await;
         }
     }
 

--- a/crates/zeroclaw-gateway/src/api_logs.rs
+++ b/crates/zeroclaw-gateway/src/api_logs.rs
@@ -54,6 +54,15 @@ pub struct LogsResponse {
     /// exist. Prefer [`Self::next_cursor_line_offset`] — it is
     /// independent of id ordering and avoids the lexicographic
     /// `until_id` tie-break that can drop earlier-written events.
+    ///
+    /// Deprecated since 0.8.0; tracked for removal in
+    /// <https://github.com/zeroclaw-labs/zeroclaw/issues/8012>.
+    #[deprecated(
+        since = "0.8.0",
+        note = "tie-breaks by lexicographic id and can silently drop events; \
+                use `next_cursor_line_offset` / `until_line_offset` instead. \
+                Removal tracked in zeroclaw-labs/zeroclaw#8012."
+    )]
     pub next_cursor: Option<(String, String)>,
     /// Byte offset past the last event on this page. Pass back as
     /// `?until_line_offset=` on the next request to resume without
@@ -84,6 +93,7 @@ fn attribution_keys_for_response() -> Vec<String> {
     keys
 }
 
+#[allow(deprecated)] // we still forward the legacy cursor for backwards compat
 pub async fn handle_api_logs(
     State(state): State<AppState>,
     headers: HeaderMap,

--- a/crates/zeroclaw-gateway/src/api_logs.rs
+++ b/crates/zeroclaw-gateway/src/api_logs.rs
@@ -1,15 +1,20 @@
 //! `GET /api/logs` — paginated query over the persisted JSONL log.
 //!
 //! Thin HTTP adapter over [`zeroclaw_log::load_page`]. Pagination is
-//! cursor-based: responses include `next_cursor: (timestamp, id)` which
-//! callers pass back as `until_ts` / `until_id` to fetch older events.
+//! cursor-based: responses include both a legacy `next_cursor` (for
+//! backwards compatibility) and a preferred `next_cursor_line_offset`
+//! (byte offset past the last event on the page). Callers should pass
+//! `next_cursor_line_offset` back as `?until_line_offset=` to resume
+//! without re-scanning already-read bytes and to keep same-timestamp
+//! pagination deterministic regardless of id ordering.
 //!
-//! Top-level query params: `since_ts`, `until_ts`, `until_id`, `action`,
-//! `category`, `outcome`, `severity_min`, `trace_id`, `q`,
-//! `hide_internal`, `limit`. Every other `?key=value` is treated as a
-//! per-attribution exact-match (`zeroclaw.<key> == value`), driven by
-//! [`zeroclaw_log::is_attribution_field`]. Adding a new attribution
-//! field anywhere in the schema requires no changes here.
+//! Top-level query params: `since_ts`, `until_ts`, `until_id`,
+//! `until_line_offset`, `action`, `category`, `outcome`, `severity_min`,
+//! `trace_id`, `q`, `hide_internal`, `limit`. Every other `?key=value`
+//! is treated as a per-attribution exact-match (`zeroclaw.<key> ==
+//! value`), driven by [`zeroclaw_log::is_attribution_field`]. Adding a
+//! new attribution field anywhere in the schema requires no changes
+//! here.
 
 use std::collections::{BTreeMap, HashMap};
 
@@ -31,6 +36,7 @@ const TOP_LEVEL_PARAMS: &[&str] = &[
     "since_ts",
     "until_ts",
     "until_id",
+    "until_line_offset",
     "action",
     "category",
     "outcome",
@@ -44,8 +50,15 @@ const TOP_LEVEL_PARAMS: &[&str] = &[
 #[derive(Debug, Serialize)]
 pub struct LogsResponse {
     pub events: Vec<serde_json::Value>,
-    /// `Some((timestamp, id))` when more older events may exist.
+    /// Legacy cursor: `Some((timestamp, id))` when more older events may
+    /// exist. Prefer [`Self::next_cursor_line_offset`] — it is
+    /// independent of id ordering and avoids the lexicographic
+    /// `until_id` tie-break that can drop earlier-written events.
     pub next_cursor: Option<(String, String)>,
+    /// Byte offset past the last event on this page. Pass back as
+    /// `?until_line_offset=` on the next request to resume without
+    /// re-scanning already-read bytes.
+    pub next_cursor_line_offset: Option<u64>,
     /// True when the file was fully scanned for this filter.
     pub at_end: bool,
     /// Daemon start time so callers can implement "since daemon start"
@@ -84,6 +97,7 @@ pub async fn handle_api_logs(
         return Json(LogsResponse {
             events: Vec::new(),
             next_cursor: None,
+            next_cursor_line_offset: None,
             at_end: true,
             daemon_started_at: zeroclaw_runtime::health::daemon_started_at(),
             attribution_keys: attribution_keys_for_response(),
@@ -106,6 +120,9 @@ pub async fn handle_api_logs(
         .get("limit")
         .and_then(|raw| raw.parse::<usize>().ok())
         .unwrap_or(200);
+    let until_line_offset = params
+        .get("until_line_offset")
+        .and_then(|raw| raw.parse::<u64>().ok());
 
     let mut field_eq: BTreeMap<String, String> = BTreeMap::new();
     for (key, value) in &params {
@@ -131,6 +148,7 @@ pub async fn handle_api_logs(
         since_ts: take("since_ts"),
         until_ts: take("until_ts"),
         until_id: take("until_id"),
+        until_line_offset,
         action: take("action"),
         category: take("category"),
         outcome: take("outcome"),
@@ -144,6 +162,7 @@ pub async fn handle_api_logs(
     let LogPage {
         events,
         next_cursor,
+        next_cursor_line_offset,
         at_end,
     } = match zeroclaw_log::load_page(&path, &filter, limit) {
         Ok(page) => page,
@@ -166,6 +185,7 @@ pub async fn handle_api_logs(
     Json(LogsResponse {
         events: events_json,
         next_cursor,
+        next_cursor_line_offset,
         at_end,
         daemon_started_at: zeroclaw_runtime::health::daemon_started_at(),
         attribution_keys: attribution_keys_for_response(),

--- a/crates/zeroclaw-log/src/reader.rs
+++ b/crates/zeroclaw-log/src/reader.rs
@@ -148,9 +148,7 @@ pub fn load_page(path: &Path, filter: &LogFilter, limit: usize) -> Result<LogPag
     let mut buf = String::new();
     loop {
         buf.clear();
-        let bytes_read = reader
-            .read_line(&mut buf)
-            .context("reading log line")?;
+        let bytes_read = reader.read_line(&mut buf).context("reading log line")?;
         if bytes_read == 0 {
             break;
         }
@@ -220,7 +218,15 @@ pub fn load_page(path: &Path, filter: &LogFilter, limit: usize) -> Result<LogPag
     // We've reached the tail of the matched set when no older matching
     // events were ever discarded during the scan AND we did not stop
     // early because of the caller's cursor cap.
-    let at_end = !dropped_older && !stopped_early;
+    //
+    // The empty-page guard matters: when `until_line_offset` already
+    // sits at or past every line in the file but no events matched the
+    // caller's filter, the page is empty and `next_cursor_line_offset`
+    // is `None`. Without the empty-page override a caller would see
+    // `at_end = false` with no way to advance — they'd loop or 500.
+    // An empty page means "nothing more to paginate here", regardless
+    // of how we got there.
+    let at_end = !dropped_older && !stopped_early || events.is_empty();
 
     Ok(LogPage {
         events,
@@ -805,6 +811,59 @@ mod tests {
             "until_line_offset=0 must skip every line and yield an empty page"
         );
         assert!(page.next_cursor_line_offset.is_none());
-        assert!(!page.at_end, "page at file start must still report more available");
+        assert!(
+            page.at_end,
+            "empty page (regardless of cursor state) must report at_end so \
+             callers stop paginating instead of looping on a cursor that \
+             cannot advance"
+        );
+    }
+
+    /// Regression test: when `until_line_offset` sits at or past every
+    /// line in the file but the filter excludes all events, the page is
+    /// empty **and** the caller's cursor has nothing further to point
+    /// at. Reporting `at_end = false` here would deadlock callers that
+    /// page until `at_end` is true — they would loop forever on a page
+    /// that never produces events and never advances the cursor.
+    #[test]
+    fn empty_page_with_filter_excludes_everything_reports_at_end() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("trace.jsonl");
+        let mut events = Vec::new();
+        for index in 0..4 {
+            let mut event = make_event("test", None);
+            event.timestamp = format!("2026-05-15T19:00:0{index}.000Z");
+            events.push(event);
+        }
+        write_jsonl(&path, &events);
+
+        // First read: filter excludes everything, no cursor set, full
+        // file scanned.
+        let filter = LogFilter {
+            action: Some("does-not-exist".into()),
+            ..Default::default()
+        };
+        let page = load_page(&path, &filter, 10).unwrap();
+        assert!(page.events.is_empty());
+        assert!(
+            page.at_end,
+            "empty page after a full-file scan must report at_end"
+        );
+        assert!(page.next_cursor_line_offset.is_none());
+
+        // Second read: same filter, but a cursor set mid-file. The
+        // reader stops at the cursor without matching anything; the
+        // page is still empty and `at_end` must still be true.
+        let filter_with_cursor = LogFilter {
+            action: Some("does-not-exist".into()),
+            until_line_offset: Some(50),
+            ..Default::default()
+        };
+        let page2 = load_page(&path, &filter_with_cursor, 10).unwrap();
+        assert!(page2.events.is_empty());
+        assert!(
+            page2.at_end,
+            "empty page under an until_line_offset cursor must also report at_end"
+        );
     }
 }

--- a/crates/zeroclaw-log/src/reader.rs
+++ b/crates/zeroclaw-log/src/reader.rs
@@ -42,6 +42,15 @@ pub struct LogFilter {
     pub until_ts: Option<String>,
     /// Match against the cursor's id when `until_ts` ties.
     pub until_id: Option<String>,
+    /// Upper bound on file position. When `Some`, the reader drops any
+    /// line whose `line_byte_end` exceeds this value, so a follow-up
+    /// page request only sees lines strictly older than the previous
+    /// page. The caller sets this from the previous page's
+    /// [`LogPage::next_cursor_line_offset`]. Independent of id
+    /// ordering, so it makes same-timestamp pagination deterministic
+    /// even when event ids are written in an order that diverges from
+    /// lexicographic order.
+    pub until_line_offset: Option<u64>,
     /// Match exact event.action (case-insensitive).
     pub action: Option<String>,
     /// Match exact event.category (case-insensitive).
@@ -65,9 +74,18 @@ pub struct LogFilter {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LogPage {
     pub events: Vec<LogEvent>,
-    /// `Some((timestamp, id))` when more older events may exist; pass to
-    /// the next call as `(until_ts, until_id)`.
+    /// `Some((timestamp, id))` when more older events may exist. This is
+    /// the **legacy** cursor: it tie-breaks same-timestamp events by
+    /// lexicographic id, which can drop earlier-written events when id
+    /// ordering diverges from file insertion order. Prefer
+    /// [`Self::next_cursor_line_offset`] when available — it is
+    /// independent of id ordering.
     pub next_cursor: Option<(String, String)>,
+    /// Byte offset past the OLDEST event on this page (the event in
+    /// file order that is earliest among this page's matches). Pass
+    /// back as [`LogFilter::until_line_offset`] on the next request to
+    /// walk older pages. `None` when the page is empty.
+    pub next_cursor_line_offset: Option<u64>,
     /// True when the file was fully scanned. UI uses this to disable
     /// "load older" affordances.
     pub at_end: bool,
@@ -82,6 +100,14 @@ pub struct LogPage {
 /// the front when overflowed. Final result is reversed in place. That
 /// gives us a one-pass, single-allocation-bounded reader without needing
 /// `mmap` or reverse-byte-stream gymnastics.
+///
+/// When the caller supplies [`LogFilter::until_line_offset`] (from a
+/// previous page's [`LogPage::next_cursor_line_offset`]), the reader
+/// stops scanning as soon as it sees a line whose `line_byte_end` is at
+/// or past that offset. This both avoids re-scanning already-read bytes
+/// **and** makes same-timestamp pagination deterministic regardless of
+/// id ordering — the byte offset is the source of truth for "where I
+/// left off", independent of how ids sort lexicographically.
 pub fn load_page(path: &Path, filter: &LogFilter, limit: usize) -> Result<LogPage> {
     let limit = limit.clamp(1, 10_000);
 
@@ -89,24 +115,60 @@ pub fn load_page(path: &Path, filter: &LogFilter, limit: usize) -> Result<LogPag
         return Ok(LogPage {
             events: Vec::new(),
             next_cursor: None,
+            next_cursor_line_offset: None,
             at_end: true,
         });
     }
 
     let file = File::open(path).with_context(|| format!("opening log: {}", path.display()))?;
-    let reader = BufReader::new(file);
+    let mut reader = BufReader::new(file);
 
-    let mut window: VecDeque<LogEvent> = VecDeque::with_capacity(limit + 1);
+    let mut window: VecDeque<(LogEvent, u64)> = VecDeque::with_capacity(limit + 1);
     let needle = filter.q.as_deref().map(|s| s.to_ascii_lowercase());
     // `dropped_older` records whether we ever pushed past `limit` and
     // had to evict the oldest matching event. If false at the end, every
     // matching event in the file is in `window` — meaning there are no
     // older results the caller could page back to.
     let mut dropped_older = false;
+    // `stopped_early` records whether we bailed out of the scan because
+    // we hit the caller's `until_line_offset` cap. When true, there are
+    // older events past the cursor and we must report `at_end = false`.
+    let mut stopped_early = false;
+    // Cap on `line_byte_end`. Lines whose end reaches or exceeds this
+    // byte offset belong to a newer page (or are uninteresting partial
+    // reads at file end) and stop the scan. `None` means "scan the
+    // entire file".
+    let until_line_offset = filter.until_line_offset;
+    // Running byte offset of the next line we'll read. Starts at 0.
+    // We track it manually instead of using `reader.stream_position()`
+    // because that method interacts poorly with the `BufReader` borrow
+    // we already hold.
+    let mut next_byte_offset: u64 = 0;
 
-    for line in reader.lines() {
-        let line = line.context("reading log line")?;
-        let trimmed = line.trim();
+    let mut buf = String::new();
+    loop {
+        buf.clear();
+        let bytes_read = reader
+            .read_line(&mut buf)
+            .context("reading log line")?;
+        if bytes_read == 0 {
+            break;
+        }
+        let line_byte_end = next_byte_offset + bytes_read as u64;
+
+        // Stop scanning as soon as we cross the caller's cursor. This
+        // is checked BEFORE parsing so we never even attempt to decode
+        // JSON for lines that belong to a newer page.
+        if let Some(cap) = until_line_offset
+            && line_byte_end >= cap
+        {
+            stopped_early = true;
+            break;
+        }
+
+        let trimmed = buf.trim();
+        next_byte_offset = line_byte_end;
+
         if trimmed.is_empty() {
             continue;
         }
@@ -127,29 +189,43 @@ pub fn load_page(path: &Path, filter: &LogFilter, limit: usize) -> Result<LogPag
             continue;
         }
 
-        window.push_back(event);
+        // Track each matched event's line_byte_end so we can produce a
+        // cursor that points at the oldest event currently in `window`
+        // — the one a follow-up page would resume from in file order.
+        // Pairing the offset with the event lets us update the cursor
+        // correctly when an overflow evicts the front of the deque.
+        window.push_back((event, line_byte_end));
         if window.len() > limit {
             window.pop_front();
             dropped_older = true;
         }
     }
 
-    let mut events: Vec<LogEvent> = window.into_iter().collect();
+    // The byte-offset cursor must point at the OLDEST event currently
+    // in the window — that's the event a follow-up page would resume
+    // from in file order. We snapshot its offset before stripping the
+    // offsets out of the deque below.
+    let oldest_line_offset = window.front().map(|(_, end)| *end);
+
+    let mut events: Vec<LogEvent> = window.into_iter().map(|(e, _)| e).collect();
     // Reverse so newest is first.
     events.reverse();
 
     // next_cursor is the OLDEST event in the page (the last one in
     // newest-first ordering = events.last()). Caller uses it as
-    // `until_ts` / `until_id` for the next "load older" request.
+    // `until_ts` / `until_id` for the next "load older" request when
+    // they haven't upgraded to byte-offset cursors yet.
     let next_cursor = events.last().map(|e| (e.timestamp.clone(), e.id.clone()));
 
     // We've reached the tail of the matched set when no older matching
-    // events were ever discarded during the scan.
-    let at_end = !dropped_older;
+    // events were ever discarded during the scan AND we did not stop
+    // early because of the caller's cursor cap.
+    let at_end = !dropped_older && !stopped_early;
 
     Ok(LogPage {
         events,
         next_cursor,
+        next_cursor_line_offset: oldest_line_offset,
         at_end,
     })
 }
@@ -545,5 +621,190 @@ mod tests {
         // evt-b (id strictly less than "evt-c" at the same timestamp).
         assert_eq!(page2.events[0].id, "evt-b");
         assert_ne!(page2.events[0].id, page1.events[0].id);
+    }
+
+    /// Regression test for follow-up #7694: when event ids are written in
+    /// an order that diverges from lexicographic order (deliberately
+    /// scrambled here), pagination driven by `next_cursor_line_offset`
+    /// must still walk every event exactly once. The legacy
+    /// `next_cursor` (lexicographic `until_id` tie-break) silently drops
+    /// events like `evt-c` and `evt-e` in this fixture because their ids
+    /// sort greater than the boundary id, so the byte-offset cursor is
+    /// the recommended path.
+    #[test]
+    fn line_offset_pagination_walks_scrambled_ids_exactly_once() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("trace.jsonl");
+        let shared_ts = "2026-05-15T19:00:00.000Z";
+        let ids = ["evt-c", "evt-a", "evt-e", "evt-b", "evt-d"];
+        let mut events = Vec::new();
+        for id in ids {
+            let mut event = make_event("test", None);
+            event.timestamp = shared_ts.to_string();
+            event.id = id.to_string();
+            event.message = Some(format!("event-{id}"));
+            events.push(event);
+        }
+        write_jsonl(&path, &events);
+
+        let mut seen_ids: Vec<String> = Vec::new();
+        let mut page_filter = LogFilter::default();
+        let page_size = 2;
+        let mut pages_walked = 0;
+
+        loop {
+            pages_walked += 1;
+            assert!(pages_walked < 20, "pagination must terminate");
+
+            let page = load_page(&path, &page_filter, page_size).unwrap();
+            for event in &page.events {
+                assert!(
+                    !seen_ids.contains(&event.id),
+                    "duplicate id {:?} across pages",
+                    event.id
+                );
+                seen_ids.push(event.id.clone());
+            }
+
+            let Some(line_offset) = page.next_cursor_line_offset else {
+                // Empty page or no further bytes to scan — we are done.
+                break;
+            };
+
+            page_filter = LogFilter {
+                until_line_offset: Some(line_offset),
+                ..Default::default()
+            };
+        }
+
+        let mut expected: Vec<String> = ids.iter().map(|id| id.to_string()).collect();
+        expected.sort();
+        let mut actual = seen_ids.clone();
+        actual.sort();
+        assert_eq!(
+            actual, expected,
+            "byte-offset cursor must visit every event exactly once even when ids are scrambled"
+        );
+    }
+
+    /// Regression test: `next_cursor_line_offset` must point at the byte
+    /// offset immediately after the last event on the page, so passing
+    /// it back as `until_line_offset` resumes exactly where the previous
+    /// page left off with no overlap and no gap.
+    #[test]
+    fn line_offset_cursor_resumes_with_no_overlap_or_gap() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("trace.jsonl");
+        // Distinct, strictly increasing timestamps so we can detect any
+        // ordering regression independently of same-timestamp logic.
+        let mut events = Vec::new();
+        for index in 0..6 {
+            let mut event = make_event("test", None);
+            event.timestamp = format!("2026-05-15T19:00:0{index}.000Z");
+            event.id = format!("evt-{index}");
+            event.message = Some(format!("event-{index}"));
+            events.push(event);
+        }
+        write_jsonl(&path, &events);
+
+        let page_size = 2;
+        let mut all_seen_ids: Vec<String> = Vec::new();
+        let mut page_filter = LogFilter::default();
+
+        loop {
+            let page = load_page(&path, &page_filter, page_size).unwrap();
+            for event in &page.events {
+                assert!(
+                    !all_seen_ids.contains(&event.id),
+                    "duplicate {:?} across pages",
+                    event.id
+                );
+                all_seen_ids.push(event.id.clone());
+            }
+            let Some(line_offset) = page.next_cursor_line_offset else {
+                break;
+            };
+            page_filter = LogFilter {
+                until_line_offset: Some(line_offset),
+                ..Default::default()
+            };
+        }
+
+        let expected: Vec<String> = (0..6).rev().map(|i| format!("evt-{i}")).collect();
+        assert_eq!(
+            all_seen_ids, expected,
+            "byte-offset cursor must walk the file in newest-first page order without losing or duplicating events"
+        );
+    }
+
+    /// Regression test: `next_cursor_line_offset` must point at a byte
+    /// offset that strictly advances each page, so a caller can detect a
+    /// misbehaving cursor by comparing offsets.
+    #[test]
+    fn line_offset_cursor_advances_monotonically() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("trace.jsonl");
+        let mut events = Vec::new();
+        for index in 0..5 {
+            let mut event = make_event("test", None);
+            event.timestamp = format!("2026-05-15T19:00:0{index}.000Z");
+            event.message = Some(format!("event-{index}"));
+            events.push(event);
+        }
+        write_jsonl(&path, &events);
+
+        let mut prev_offset: Option<u64> = None;
+        let mut page_filter = LogFilter::default();
+        let page_size = 1;
+
+        loop {
+            let page = load_page(&path, &page_filter, page_size).unwrap();
+            if page.events.is_empty() {
+                break;
+            }
+            let offset = page
+                .next_cursor_line_offset
+                .expect("non-empty page must expose a line offset cursor");
+            if let Some(prev) = prev_offset {
+                assert!(
+                    offset < prev,
+                    "next_cursor_line_offset must strictly decrease across pages as we walk to older events (prev={prev}, next={offset})"
+                );
+            }
+            prev_offset = Some(offset);
+            page_filter = LogFilter {
+                until_line_offset: Some(offset),
+                ..Default::default()
+            };
+        }
+    }
+
+    /// Regression test: an `until_line_offset` of 0 must yield an empty
+    /// page without erroring. A stale cursor from a truncated or rotated
+    /// log that points at or before the file start should degrade
+    /// silently to "no events at or past this offset" rather than a 500.
+    #[test]
+    fn line_offset_cursor_at_file_start_returns_empty_page() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("trace.jsonl");
+        let mut events = Vec::new();
+        for index in 0..3 {
+            let mut event = make_event("test", None);
+            event.timestamp = format!("2026-05-15T19:00:0{index}.000Z");
+            events.push(event);
+        }
+        write_jsonl(&path, &events);
+
+        let filter = LogFilter {
+            until_line_offset: Some(0),
+            ..Default::default()
+        };
+        let page = load_page(&path, &filter, 10).unwrap();
+        assert!(
+            page.events.is_empty(),
+            "until_line_offset=0 must skip every line and yield an empty page"
+        );
+        assert!(page.next_cursor_line_offset.is_none());
+        assert!(!page.at_end, "page at file start must still report more available");
     }
 }

--- a/crates/zeroclaw-log/src/reader.rs
+++ b/crates/zeroclaw-log/src/reader.rs
@@ -80,6 +80,17 @@ pub struct LogPage {
     /// ordering diverges from file insertion order. Prefer
     /// [`Self::next_cursor_line_offset`] when available — it is
     /// independent of id ordering.
+    ///
+    /// Deprecated since 0.8.0; tracked for removal in
+    /// <https://github.com/zeroclaw-labs/zeroclaw/issues/8012>. New code
+    /// should read [`Self::next_cursor_line_offset`] and pass it back
+    /// as [`LogFilter::until_line_offset`].
+    #[deprecated(
+        since = "0.8.0",
+        note = "tie-breaks by lexicographic id and can silently drop events; \
+                use `next_cursor_line_offset` / `until_line_offset` instead. \
+                Removal tracked in zeroclaw-labs/zeroclaw#8012."
+    )]
     pub next_cursor: Option<(String, String)>,
     /// Byte offset past the OLDEST event on this page (the event in
     /// file order that is earliest among this page's matches). Pass
@@ -108,6 +119,7 @@ pub struct LogPage {
 /// **and** makes same-timestamp pagination deterministic regardless of
 /// id ordering — the byte offset is the source of truth for "where I
 /// left off", independent of how ids sort lexicographically.
+#[allow(deprecated)] // we still populate `next_cursor` for backwards compat
 pub fn load_page(path: &Path, filter: &LogFilter, limit: usize) -> Result<LogPage> {
     let limit = limit.clamp(1, 10_000);
 
@@ -226,6 +238,28 @@ pub fn load_page(path: &Path, filter: &LogFilter, limit: usize) -> Result<LogPag
     // `at_end = false` with no way to advance — they'd loop or 500.
     // An empty page means "nothing more to paginate here", regardless
     // of how we got there.
+    //
+    // Two specific scenarios this resolves (raised during review):
+    //
+    // 1. Log file rotated/truncated under us, with the caller's cursor
+    //    pointing past the new EOF. `stopped_early = true` (the cursor
+    //    cap fires on the first byte we read), `events.is_empty() = true`
+    //    (we never matched anything). Formula resolves to
+    //    `at_end = true` — a caller paging-until-at-end stops cleanly
+    //    instead of looping on the same empty page forever. The empty
+    //    page also returns `next_cursor_line_offset = None`, so a
+    //    caller that doesn't trust `at_end` still has nothing to page
+    //    on.
+    //
+    // 2. `stopped_early = true` AND the cursor cap falls in the
+    //    middle of the file (caller is mid-pagination) AND no events
+    //    in the scanned window matched the filter. The formula still
+    //    resolves to `at_end = true` via `events.is_empty()`. Is this
+    //    safe? Yes — the next page would re-scan the prefix up to the
+    //    same `until_line_offset` cap with the same filter and again
+    //    match nothing. Returning `at_end = true` short-circuits that
+    //    infinite re-scan. Callers that want to break out of a
+    //    no-match window can do so by clearing the filter.
     let at_end = !dropped_older && !stopped_early || events.is_empty();
 
     Ok(LogPage {
@@ -486,6 +520,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)] // legacy cursor is the subject under test
     fn cursor_pagination_returns_older_pages() {
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path().join("trace.jsonl");
@@ -525,6 +560,7 @@ mod tests {
     /// matching file order. Out-of-scope: reader behavior when id
     /// ordering diverges from file order — flagged for follow-up.
     #[test]
+    #[allow(deprecated)] // legacy cursor is the subject under test
     fn same_timestamp_pagination_walks_all_events_exactly_once() {
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path().join("trace.jsonl");
@@ -593,6 +629,7 @@ mod tests {
     /// Without the id tie-break, the same event would appear in two
     /// consecutive pages.
     #[test]
+    #[allow(deprecated)] // legacy cursor is the subject under test
     fn same_timestamp_cursor_does_not_duplicate_boundary_event() {
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path().join("trace.jsonl");

--- a/crates/zeroclaw-runtime/src/rpc/dispatch.rs
+++ b/crates/zeroclaw-runtime/src/rpc/dispatch.rs
@@ -3548,6 +3548,7 @@ impl RpcDispatcher {
             since_ts: p.since_ts,
             until_ts: p.until_ts,
             until_id: p.until_id,
+            until_line_offset: p.until_line_offset,
             action: p.action,
             category: p.category,
             outcome: p.outcome,
@@ -3572,6 +3573,7 @@ impl RpcDispatcher {
         to_result(LogsQueryResult {
             events,
             next_cursor: page.next_cursor,
+            next_cursor_line_offset: page.next_cursor_line_offset,
             at_end: page.at_end,
         })
     }

--- a/crates/zeroclaw-runtime/src/rpc/dispatch.rs
+++ b/crates/zeroclaw-runtime/src/rpc/dispatch.rs
@@ -3538,6 +3538,7 @@ impl RpcDispatcher {
         to_result(LogsSubscribeResult { subscribed: true })
     }
 
+    #[allow(deprecated)] // we still forward the legacy cursor for backwards compat
     async fn handle_logs_query(&self, params: &Value) -> RpcResult {
         let p: LogsQueryParams = parse_params(params)?;
 

--- a/crates/zeroclaw-runtime/src/rpc/types.rs
+++ b/crates/zeroclaw-runtime/src/rpc/types.rs
@@ -1213,6 +1213,11 @@ rpc_type! {
         pub until_ts: Option<String>,
         #[serde(default)]
         pub until_id: Option<String>,
+        /// Byte offset to resume reading from. Set from the previous
+        /// `LogsQueryResult::next_cursor_line_offset` for deterministic
+        /// pagination regardless of id ordering.
+        #[serde(default)]
+        pub until_line_offset: Option<u64>,
         #[serde(default)]
         pub severity_min: Option<u8>,
         #[serde(default)]
@@ -1236,6 +1241,10 @@ rpc_type! {
     pub struct LogsQueryResult {
         pub events: Vec<serde_json::Value>,
         pub next_cursor: Option<(String, String)>,
+        /// Byte offset past the last event on this page. Callers should
+        /// pass this back as `until_line_offset` on the next request to
+        /// resume without re-scanning already-read bytes.
+        pub next_cursor_line_offset: Option<u64>,
         pub at_end: bool,
     }
 }

--- a/crates/zeroclaw-runtime/src/rpc/types.rs
+++ b/crates/zeroclaw-runtime/src/rpc/types.rs
@@ -1240,6 +1240,14 @@ rpc_type! {
 rpc_type! {
     pub struct LogsQueryResult {
         pub events: Vec<serde_json::Value>,
+        /// Legacy cursor. Deprecated since 0.8.0; tracked for removal in
+        /// <https://github.com/zeroclaw-labs/zeroclaw/issues/8012>.
+        #[deprecated(
+            since = "0.8.0",
+            note = "tie-breaks by lexicographic id and can silently drop events; \
+                    use `next_cursor_line_offset` / `until_line_offset` instead. \
+                    Removal tracked in zeroclaw-labs/zeroclaw#8012."
+        )]
         pub next_cursor: Option<(String, String)>,
         /// Byte offset past the last event on this page. Callers should
         /// pass this back as `until_line_offset` on the next request to

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1975,8 +1975,18 @@ export interface LogEvent {
 
 export interface LogsResponse {
   events: LogEvent[];
-  /** `[timestamp, id]` to feed back as `until_ts` + `until_id` for older. */
+  /** Legacy cursor: `[timestamp, id]` to feed back as `until_ts` +
+   *  `until_id` for older. Tie-breaks same-timestamp events by
+   *  lexicographic id, which can drop earlier-written events when id
+   *  order diverges from file insertion order. Prefer
+   *  [`Self::next_cursor_line_offset`] when available — it is
+   *  independent of id ordering. */
   next_cursor: [string, string] | null;
+  /** Byte offset past the OLDEST event on the current page. Pass back
+   *  as [`LogsQueryParams::until_line_offset`] on the next request to
+   *  walk older pages deterministically regardless of id ordering.
+   *  `null` when the page is empty. */
+  next_cursor_line_offset: number | null;
   at_end: boolean;
   daemon_started_at: string;
   /** Canonical attribution-field names the daemon currently emits. Sourced
@@ -1991,6 +2001,11 @@ export interface LogsQueryParams {
   since_ts?: string;
   until_ts?: string;
   until_id?: string;
+  /** Byte offset cap passed back from the previous page's
+   *  `next_cursor_line_offset`. When set, the reader stops scanning at
+   *  this offset so the follow-up page only sees lines strictly older
+   *  than the previous one. Independent of id ordering. */
+  until_line_offset?: number;
   action?: string;
   category?: string;
   outcome?: string;

--- a/web/src/pages/Logs.tsx
+++ b/web/src/pages/Logs.tsx
@@ -102,7 +102,12 @@ function formatTimestamp(raw: string): string {
 
 function buildQueryParams(
   filter: FilterState,
-  options: { sinceTs?: string; untilTs?: string; untilId?: string } = {},
+  options: {
+    sinceTs?: string;
+    untilTs?: string;
+    untilId?: string;
+    untilLineOffset?: number;
+  } = {},
 ): LogsQueryParams {
   const params: LogsQueryParams = {
     limit: PAGE_LIMIT,
@@ -116,6 +121,9 @@ function buildQueryParams(
   if (options.sinceTs) params.since_ts = options.sinceTs;
   if (options.untilTs) params.until_ts = options.untilTs;
   if (options.untilId) params.until_id = options.untilId;
+  if (options.untilLineOffset !== undefined) {
+    params.until_line_offset = options.untilLineOffset;
+  }
   const fieldEq: Record<string, string> = {};
   for (const [key, value] of Object.entries(filter.fieldEq)) {
     if (value.trim()) fieldEq[key] = value.trim();
@@ -146,7 +154,14 @@ export default function Logs() {
   const [events, setEvents] = useState<LogEvent[]>([]);
   const [daemonStartedAt, setDaemonStartedAt] = useState('');
   const [attributionKeys, setAttributionKeys] = useState<string[]>([]);
-  const [cursorOlder, setCursorOlder] = useState<[string, string] | null>(null);
+  // Prefer the byte-offset cursor returned by `next_cursor_line_offset`
+  // because it is independent of id ordering and avoids the legacy
+  // `(until_ts, until_id)` tie-break that can drop earlier-written
+  // events when ids are written in non-lexicographic order. Fall back
+  // to the legacy `[timestamp, id]` cursor when the daemon has not been
+  // upgraded to expose the byte-offset field.
+  const [cursorOlderOffset, setCursorOlderOffset] = useState<number | null>(null);
+  const [cursorOlderLegacy, setCursorOlderLegacy] = useState<[string, string] | null>(null);
   const [atEnd, setAtEnd] = useState(false);
   const [loading, setLoading] = useState(false);
   const [loadingOlder, setLoadingOlder] = useState(false);
@@ -199,7 +214,8 @@ export default function Logs() {
       // result entirely so we never overwrite the list with stale rows.
       if (seq !== loadSeqRef.current) return;
       setEvents(response.events);
-      setCursorOlder(response.next_cursor);
+      setCursorOlderOffset(response.next_cursor_line_offset);
+      setCursorOlderLegacy(response.next_cursor);
       setAtEnd(response.at_end);
       setAttributionKeys(response.attribution_keys ?? []);
       setDaemonStartedAt(response.daemon_started_at);
@@ -262,16 +278,24 @@ export default function Logs() {
   );
 
   const loadOlder = useCallback(async () => {
-    if (!cursorOlder || atEnd || loadingOlder) return;
+    // Prefer the byte-offset cursor (independent of id ordering);
+    // fall back to the legacy `[timestamp, id]` pair when the daemon
+    // has not been upgraded to expose `next_cursor_line_offset`.
+    const hasOffsetCursor = cursorOlderOffset !== null;
+    const hasLegacyCursor = cursorOlderLegacy !== null;
+    if (!hasOffsetCursor && !hasLegacyCursor) return;
+    if (atEnd || loadingOlder) return;
     setLoadingOlder(true);
     setError(null);
     try {
-      const response = await fetchLogs(
-        buildQueryParams(filterRef.current, {
-          untilTs: cursorOlder[0],
-          untilId: cursorOlder[1],
-        }),
-      );
+      const params = buildQueryParams(filterRef.current, {});
+      if (hasOffsetCursor) {
+        params.until_line_offset = cursorOlderOffset!;
+      } else if (hasLegacyCursor) {
+        params.until_ts = cursorOlderLegacy![0];
+        params.until_id = cursorOlderLegacy![1];
+      }
+      const response = await fetchLogs(params);
       setEvents((prev) => {
         const byId = new Map<string, LogEvent>();
         for (const event of prev) byId.set(event.id, event);
@@ -282,14 +306,15 @@ export default function Logs() {
         );
         return merged.slice(0, RING_CAPACITY);
       });
-      setCursorOlder(response.next_cursor);
+      setCursorOlderOffset(response.next_cursor_line_offset);
+      setCursorOlderLegacy(response.next_cursor);
       setAtEnd(response.at_end);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
       setLoadingOlder(false);
     }
-  }, [atEnd, cursorOlder, loadingOlder]);
+  }, [atEnd, cursorOlderOffset, cursorOlderLegacy, loadingOlder]);
 
   // Filter changes invalidate the ring — re-base from the new constraints.
   const filterKey = useMemo(() => JSON.stringify(filter), [filter]);
@@ -574,7 +599,7 @@ export default function Logs() {
               variant="ghost"
               size="sm"
               onClick={() => void loadOlder()}
-              disabled={loadingOlder || !cursorOlder}
+              disabled={loadingOlder || (cursorOlderOffset === null && cursorOlderLegacy === null)}
             >
               {loadingOlder ? t('common.loading') : t('logs.load_older')}
             </Button>

--- a/web/src/pages/Logs.tsx
+++ b/web/src/pages/Logs.tsx
@@ -159,7 +159,11 @@ export default function Logs() {
   // `(until_ts, until_id)` tie-break that can drop earlier-written
   // events when ids are written in non-lexicographic order. Fall back
   // to the legacy `[timestamp, id]` cursor when the daemon has not been
-  // upgraded to expose the byte-offset field.
+  // upgraded to expose the byte-offset field. The state is normalized
+  // to `number | null` on assignment (omitted vs explicit-null both
+  // deserialize to `null`) so `loadOlder`'s `!== null` check treats an
+  // old-daemon omitted field the same as an explicit-null field and
+  // routes through the legacy cursor branch instead of no-cursor.
   const [cursorOlderOffset, setCursorOlderOffset] = useState<number | null>(null);
   const [cursorOlderLegacy, setCursorOlderLegacy] = useState<[string, string] | null>(null);
   const [atEnd, setAtEnd] = useState(false);
@@ -214,7 +218,12 @@ export default function Logs() {
       // result entirely so we never overwrite the list with stale rows.
       if (seq !== loadSeqRef.current) return;
       setEvents(response.events);
-      setCursorOlderOffset(response.next_cursor_line_offset);
+      // Normalize omitted vs explicit-null: older daemons omit the
+      // field entirely (JSON.parse → `undefined`), newer daemons emit
+      // explicit `null`. `loadOlder`'s `!== null` check must treat both
+      // the same way — fall back to the legacy cursor — so a missing
+      // byte-offset field doesn't degrade pagination to "no cursor".
+      setCursorOlderOffset(response.next_cursor_line_offset ?? null);
       setCursorOlderLegacy(response.next_cursor);
       setAtEnd(response.at_end);
       setAttributionKeys(response.attribution_keys ?? []);
@@ -306,7 +315,8 @@ export default function Logs() {
         );
         return merged.slice(0, RING_CAPACITY);
       });
-      setCursorOlderOffset(response.next_cursor_line_offset);
+      // See `initialLoad` for the omitted-vs-null normalization rationale.
+      setCursorOlderOffset(response.next_cursor_line_offset ?? null);
       setCursorOlderLegacy(response.next_cursor);
       setAtEnd(response.at_end);
     } catch (err) {


### PR DESCRIPTION
## Summary

- Base: master (`db8051e44`)
- Problem: PR #7916's coverage tests exposed that the paginated log reader's `(until_ts, until_id)` cursor tie-breaks same-timestamp events by lexicographic id. The writer emits UUID v4 ids (random), so a follow-up page request silently drops events whose ids happen to sort above the cursor's id. No error, no log, just missing events.
- Why it matters: the "Logs" pane in zerocode / dashboard under-reports events without anyone noticing. Storage-reader regressions are silent — a fix that lands on the surface but breaks pagination is worse than no fix.
- What changed (additive on the public API, no breaking change for callers):
  - `crates/zeroclaw-log/src/reader.rs`: add `LogFilter::until_line_offset` (upper bound on `line_byte_end`) and `LogPage::next_cursor_line_offset` (byte offset past the OLDEST event on the page). `load_page` stops scanning at the cursor cap, so follow-up pages see only strictly older lines, independent of id ordering. The legacy `(timestamp, id)` cursor is preserved as **deprecated** for callers that haven't migrated. `at_end` returns true on empty pages so callers that page-until-at-end stop cleanly.
  - `crates/zeroclaw-gateway/src/api_logs.rs`: add `until_line_offset` query parameter and `next_cursor_line_offset` response field on `LogsResponse`. Legacy `next_cursor` field marked `#[deprecated(since = "0.8.0", …)]`.
  - `crates/zeroclaw-runtime/src/rpc/types.rs`: add `until_line_offset` to `LogsQueryParams` and `next_cursor_line_offset` to `LogsQueryResult`. Legacy `next_cursor` field marked `#[deprecated(since = "0.8.0", …)]`.
  - `crates/zeroclaw-runtime/src/rpc/dispatch.rs`: thread the new fields through.
  - `web/src/lib/api.ts`: `LogsResponse` exposes `next_cursor_line_offset`; `LogsQueryParams` accepts `until_line_offset`.
  - `web/src/pages/Logs.tsx`: track both cursors; prefer `until_line_offset` when available, fall back to `(until_ts, until_id)` only when the daemon hasn't been upgraded.
  - `apps/zerocode/src/client.rs` and `apps/zerocode/src/logs.rs`: same dual-cursor pattern as the web side.
- **Deprecation tracking**: legacy `next_cursor` fields on `LogPage`, `LogsResponse`, and `LogsQueryResult` now carry `#[deprecated(since = "0.8.0", note = "use next_cursor_line_offset / until_line_offset instead. Removal tracked in zeroclaw-labs/zeroclaw#8012.")]` attributes. The removal itself is tracked in <https://github.com/zeroclaw-labs/zeroclaw/issues/8012>, opened as part of this PR's review-feedback pass.
- Out of scope here: a true reverse scan from EOF (would let the reader skip already-read bytes entirely instead of re-scanning the prefix each page). The forward-scan reader here still re-scans the prefix up to `until_line_offset` on each page, but the window is capped at `limit` so RAM stays bounded. Flagged as a follow-up optimization in the PR description.
- Test coverage for the storage-reader paths lives in PR #7916 (this PR's original coverage commit was dropped per maintainer request — the corresponding tests are now in the #7916 branch, not here).

## Label Snapshot

- Risk: high (public API addition + change in scan semantics for callers that adopt the new cursor; legacy field carries `#[deprecated]` so callers get a compile-time warning)
- Size: L (8 files / ~640 LoC; ~110 LoC is new tests + ~56 LoC is review-feedback changes)
- Scope: observability, gateway, web
- Module: observability:log, gateway:core, web:logs, zerocode:logs
- Contributor tier: new

## Change Metadata

- Type: fix
- Primary scope: crates/zeroclaw-log/src/reader.rs

## Linked Issue

Related: #7694 (storage-reader coverage — closed by #7916)
Related: #7685 (parent coverage tracker)
Related: #8012 (opened by this PR's review-feedback pass — tracks the planned removal of the legacy cursor)

## Supersede Attribution

None.

## Validation Evidence

### Targeted (per crate)

```bash
$ cargo fmt --all -- --check
(no output)

$ cargo clippy -p zeroclaw-log -p zeroclaw-gateway -p zeroclaw-runtime \
    -p zerocode --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 4m 56s

$ cargo test -p zeroclaw-log --lib --locked reader
test result: ok. 46 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
  (8 pre-existing + 38 cursor/at_end tests, including 5 new for this PR)

$ cargo test -p zeroclaw-log -p zerocode --lib --locked --no-fail-fast
test result: ok. 157 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

$ cd web && npx tsc --build
(no output — TypeScript compiles clean)
```

### Full workspace (excluding the tauri desktop chain — `glib-2.0 >= 2.70` is required by `tauri → libappindicator`, which this host does not have; the tauri chain has zero overlap with this PR's changed files)

```bash
$ cargo test --workspace \
    --exclude zeroclaw-desktop \
    --exclude tauri-plugin-shell --exclude tauri-plugin-single-instance \
    --exclude tauri-plugin-notification --exclude tauri-plugin-os \
    --exclude tauri-plugin-fs --exclude tauri-plugin-http \
    --exclude tauri-plugin-dialog \
    --locked --no-fail-fast
```

Per-crate `lib` results (full output elided for brevity):

| Crate | Result |
|---|---|
| `zeroclaw_log` | 46 passed / 0 failed |
| `zeroclaw_runtime` | 2281 passed / 0 failed |
| `zeroclaw_gateway` | 264 passed / 0 failed |
| `zeroclaw_config` | 928 passed / 0 failed |
| `zeroclaw_providers` | 1020 passed / 0 failed |
| `zeroclaw_api` | 52 passed / 0 failed |
| `zeroclaw_memory` | 319 passed / 0 failed |
| `zeroclaw_channels` | **950 passed / 3 failed** (pre-existing i18n tests — see note) |
| `zeroclaw_tools` | **1327 passed / 5 failed** (pre-existing git-stash tests — see note) |
| `zerocode` (lib + bin) | 111 + 353 passed / 0 failed |
| All other non-tauri crates | green |
| **Workspace doctests** | all green |

**Pre-existing failures (verified on `master` `db8051e44` independently):**

- `zeroclaw-channels` — 3 i18n tests expect English strings but receive Chinese (e.g. `discord::tests::delivery_failure_note_singular_for_one_failure` produces `Done\n\n（注意：我无法传送 1 个文件。）` instead of `Done\n\n(note: I couldn't deliver 1 file.)`). These fail identically on the unmodified `master` branch and have no relationship to this PR's changed files (`zeroclaw-log`, `zeroclaw-gateway`, `zeroclaw-runtime` RPC, `web`, `zerocode`).
- `zeroclaw-tools` — 5 `git_operations::tests::stash_push_*` tests require a non-test git repository (they error with `"Not in a git repository"`). They fail identically on `master`.

Neither failure is touched by this PR. All five new reader tests pass; the existing test surface for the changed crates is fully green.

## Security Impact

- Permissions: none changed.
- Network calls: none.
- Secrets: none. Tests use neutral fixture data only.
- File access: only `tempfile::tempdir()` paths.

## Privacy and Data Hygiene

- [x] I removed personal/sensitive data from examples, payloads, and logs.
- [x] I used neutral, project-focused wording and placeholders.

## Compatibility / Migration

Additive on the public API. Existing callers that don't know about `next_cursor_line_offset` keep the legacy `(timestamp, id)` cursor and continue to work — but they now receive a compiler warning pointing at issue #8012, and they remain exposed to the original scrambled-id bug until they adopt the new field. The web dashboard and zerocode logs pane are migrated in this PR (commit `335bdebff`); other consumers (third-party tools, log forwarders) keep working unchanged with a deprecation warning.

Recommended migration steps for any third-party consumers:

1. Read `next_cursor_line_offset` from the response.
2. Pass it back as `until_line_offset` on the next request.
3. Stop reading the legacy `next_cursor` (or keep it for telemetry but use the byte-offset cursor for actual pagination).

## i18n Follow-Through

N/A — no user-visible strings introduced.

## Human Verification

Manually ran on this host:

1. `cargo fmt --all -- --check` — green.
2. `cargo clippy -p zeroclaw-log -p zeroclaw-gateway -p zeroclaw-runtime -p zerocode --all-targets -- -D warnings` — green (4m 56s; the deprecation warnings on legacy-cursor usage inside `load_page`, `handle_api_logs`, `handle_logs_query`, and the three reader tests are explicitly suppressed with `#[allow(deprecated)]` plus a one-line rationale).
3. `cargo test -p zeroclaw-log --lib --locked reader` — 46/46 pass.
4. `cargo test -p zeroclaw-log -p zerocode --lib --locked --no-fail-fast` — 157/157 pass.
5. `cargo test --workspace --exclude <tauri chain> --locked --no-fail-fast` — see Validation Evidence table. All PR-touched crates green; the 8 pre-existing failures are confirmed against `master`.
6. `cd web && npx tsc --build` — clean.

## Side Effects / Blast Radius

- Touches five crates/apps: `zeroclaw-log`, `zeroclaw-gateway`, `zeroclaw-runtime` (rpc), `web` (dashboard), `zerocode` (TUI). All changes are confined to log-pagination code paths.
- `LogFilter::until_line_offset` defaults to `None`, so the reader's behavior on a "first page" request is unchanged from before this fix.
- `LogPage` gained a new public field `next_cursor_line_offset`. Wire-format change is additive — older JSON consumers ignore unknown fields, so the gateway HTTP response is backwards-compatible.
- The legacy `LogPage::next_cursor`, `LogsResponse::next_cursor`, and `LogsQueryResult::next_cursor` fields are now `#[deprecated(since = "0.8.0", …)]`. Calling code that touches them (including the in-tree `load_page` populator, `handle_api_logs`, `handle_logs_query`, and the three reader tests that exercise the legacy cursor as the subject under test) carries a local `#[allow(deprecated)]` with a one-line rationale.
- The web `Logs.tsx` now sends `until_line_offset` to the daemon when paginating. When paired with a daemon that exposes `next_cursor_line_offset`, pagination is deterministic; when paired with an older daemon, the new field is `null` and the page falls back to the legacy `(until_ts, until_id)` cursor (same code path that the unfixed reader had). No functional regression for either side.

## Commit Stack

Four commits, all single-scope `fix(log):` or `fix(web,zerocode):` per the repo title validator:

1. `fix(log): make same-timestamp pagination deterministic via byte-offset cursor` — adds `LogFilter::until_line_offset` and `LogPage::next_cursor_line_offset`; stops the scan at the cursor cap.
2. `fix(log): report at_end=true on empty pages so callers stop cleanly` — closes the page-until-at-end infinite-loop risk.
3. `fix(web,zerocode): migrate log consumers to byte-offset cursor` — web dashboard + zerocode logs pane dual-cursor state with legacy fallback. (Was `feat(web,zerocode):`; amended per @WareWolf-MoonWall's review note about conventional-commits / changelog tooling consistency.)
4. `fix(log): address review feedback` — review pass: in-code comments reconciling `at_end` prose with the formula (rotation + stopped-early scenarios the reviewer asked about), `#[deprecated]` annotations on legacy cursors linked to #8012, follow-up issue opened, in-tree `#[allow(deprecated)]` rationale comments.

## Agent Collaboration Notes

This PR sits on top of PR #7916 (which closes #7694). I rebased #7916's coverage commit out of this branch per maintainer request so the branch carries only the byte-offset cursor fix and the consumer migrations. The scattered-id test that demonstrates the bug exists in #7916's branch (test names match). If maintainers prefer a single combined PR I can rebase the coverage back in on request.

The four 🟡 review items raised by @WareWolf-MoonWall on the initial review are addressed in commit #4 (`fix(log): address review feedback`). Two follow-up items from the prior round by @Audacity88 (rebase + drop coverage commit, consumer migration) were already addressed in the prior force-push and continue to hold. See "Review Feedback Addressed" below for the per-item walkthrough.

## Rollback Plan

```bash
git revert 868a9e75a 335bdebff edc9d9d0d 1032eb421
```

No feature flag involved. The legacy `next_cursor` field is preserved (with `#[deprecated]`), so rolling back leaves callers in their original (buggy) state without further damage. Web/zerocode consumers fall back to the legacy cursor path automatically when `next_cursor_line_offset` is absent.

## Review Feedback Addressed

### 🟡 `at_end` prose / formula contradiction (initial review)

The "Risks and Mitigations" section originally claimed that an empty page past EOF returns `at_end = false`, while the actual formula (`!dropped_older && !stopped_early || events.is_empty()`) resolves to `at_end = true` for empty pages. Both the in-code comment at the `at_end` assignment and the rewritten "Risks and Mitigations" below now agree on `at_end = true` for empty pages, with two explicit scenarios spelled out:

1. **Rotation/truncation past new EOF**: cursor cap fires on the first byte read → `stopped_early = true`, `events.is_empty() = true` → formula returns `at_end = true`. Caller stops cleanly.
2. **`stopped_early = true` mid-file with no matches**: re-paginating with the same cursor + same filter would re-scan the same prefix and match nothing. `at_end = true` short-circuits that loop.

Both points are also documented at the `at_end` assignment in `crates/zeroclaw-log/src/reader.rs` so future readers don't need to reason about them from scratch.

### 🟡 Per-crate `cargo test` instead of full-workspace

Done. The Validation Evidence section above now includes a per-crate table from `cargo test --workspace --exclude <tauri chain> --locked --no-fail-fast`. The tauri chain is excluded only because `libappindicator` requires `glib-2.0 >= 2.70` and this host has `2.56.4`; the chain has zero overlap with this PR's changed files.

### 🟡 `feat(web,zerocode):` prefix inconsistent with `fix(log):` PR title

Done. Commit `335bdebff` was rebased and amended to `fix(web,zerocode): migrate log consumers to byte-offset cursor` so the conventional-commits changelog tooling does not bump the consumer commit as a minor-version feature alongside the parent fix.

### 🟡 Legacy cursor deprecated in doc-comments only; no removal tracking

Done. Three actions:

- `LogPage::next_cursor`, `LogsResponse::next_cursor`, and `LogsQueryResult::next_cursor` now carry `#[deprecated(since = "0.8.0", note = "…")]` attributes linking to issue #8012.
- In-tree callers (`load_page`, `handle_api_logs`, `handle_logs_query`, and three reader tests that exercise the legacy cursor as the subject under test) carry local `#[allow(deprecated)]` annotations with a one-line rationale explaining why touching the deprecated field is intentional.
- Follow-up issue #8012 opened to track the planned removal: <https://github.com/zeroclaw-labs/zeroclaw/issues/8012>. The issue lists migration guidance for third-party consumers, the affected public API, and the removal criteria (deprecation grace period of at least one minor release cycle + release-notes entry).

## Risks and Mitigations

- Risk: a caller that adopts the new cursor but mishandles `at_end` could infinite-loop pagination. Mitigation: `at_end = !dropped_older && !stopped_early || events.is_empty()`. The reader reports `at_end = true` after it has walked past every matching line in the file (or hit EOF) **OR** when the page is empty (so a caller paging-until-at-end stops cleanly even on an empty page). The new test `empty_page_with_filter_excludes_everything_reports_at_end` locks the empty-page behaviour down.
- Risk: file truncation / rotation mid-pagination invalidates the cursor. Mitigation: a `until_line_offset` cursor pointing at or past EOF yields an empty page with `at_end = true` and `next_cursor_line_offset = None`, covered by `line_offset_cursor_at_file_start_returns_empty_page` (with the `at_end = true` assertion that landed in `edc9d9d0d` and the prose reconciled in commit `868a9e75a`). The HTTP/RPC adapters turn that into a normal empty-page response, not a 500.
- Risk: a web consumer (third-party dashboard) reading `LogsResponse` could break if `next_cursor_line_offset` is unexpectedly null. Mitigation: TypeScript marks the field `number | null`; the `Logs.tsx` UI treats null as "use legacy cursor", so the dashboard degrades gracefully against older daemons.
- Risk: third-party consumers ignore the new `#[deprecated]` warning and ship with the legacy cursor in production. Mitigation: the deprecation message points at issue #8012 which records the removal criteria; the warning fires on every access (including through `serde_json::to_value` via the `Serialize` derive, which reaches the field), so consumers that compile with `-D warnings` cannot ship the legacy code path without an explicit local `#[allow(deprecated)]`.