### PR TITLE
fix(provider): trace native tool delivery decisions

### DIFF
--- a/crates/zeroclaw-log/src/lib.rs
+++ b/crates/zeroclaw-log/src/lib.rs
@@ -81,6 +81,15 @@ pub use writer::{init_from_config, record_event, runtime_trace_path};
 
 mod r#macro;
 
+/// Returns whether ZeroClaw DEBUG log events are enabled for the current
+/// subscriber. Use this before building expensive structured DEBUG attrs.
+pub fn debug_enabled() -> bool {
+    ::tracing::enabled!(
+        target: "zeroclaw_log_event",
+        ::tracing::Level::DEBUG
+    )
+}
+
 /// Test-only re-export of the writer-test mutex. Returns an opaque RAII
 /// guard so peer crates need not name `parking_lot`. Workspace crates
 /// that exercise the `record!` → `LogCaptureLayer` → broadcast hook

--- a/crates/zeroclaw-providers/src/anthropic.rs
+++ b/crates/zeroclaw-providers/src/anthropic.rs
@@ -1271,6 +1271,7 @@ impl ModelProvider for AnthropicModelProvider {
             .ok()
             .flatten();
         let native_tools = Self::convert_tools(request.tools);
+        let tools_count = native_tools.as_ref().map_or(0, Vec::len);
         let tool_choice = if native_tools.is_some() {
             tool_choice_override.map(|tc| serde_json::json!({ "type": tc }))
         } else {
@@ -1287,13 +1288,24 @@ impl ModelProvider for AnthropicModelProvider {
         let (effective_temperature, thinking_config, effective_max_tokens) =
             self.resolve_thinking(request.thinking, temperature, model);
 
-        ::zeroclaw_log::record!(
-            DEBUG,
-            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(
-                ::serde_json::json!({"max_tokens": effective_max_tokens, "model": model})
-            ),
-            "non-streaming API request"
-        );
+        if ::zeroclaw_log::debug_enabled() {
+            ::zeroclaw_log::record!(
+                DEBUG,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_attrs(::serde_json::json!({
+                        "provider": "anthropic",
+                        "alias": &self.alias,
+                        "request_api": "messages",
+                        "model": model,
+                        "stream": false,
+                        "max_tokens": effective_max_tokens,
+                        "tools_count": tools_count,
+                        "tool_choice": tool_choice.as_ref().and_then(|value| value.get("type")).and_then(|value| value.as_str()),
+                        "thinking_enabled": thinking_config.is_some(),
+                    })),
+                "anthropic provider request prepared"
+            );
+        }
         let native_request = NativeChatRequest {
             model: model.to_string(),
             max_tokens: effective_max_tokens,
@@ -1454,6 +1466,7 @@ impl ModelProvider for AnthropicModelProvider {
             .ok()
             .flatten();
         let native_tools = Self::convert_tools(request.tools);
+        let tools_count = native_tools.as_ref().map_or(0, Vec::len);
         let tool_choice = if native_tools.is_some() {
             tool_choice_override.map(|tc| serde_json::json!({ "type": tc }))
         } else {
@@ -1482,7 +1495,15 @@ impl ModelProvider for AnthropicModelProvider {
             ::zeroclaw_log::record!(
                 INFO,
                 ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                    .with_attrs(::serde_json::json!({"model": model})),
+                    .with_attrs(::serde_json::json!({
+                        "provider": "anthropic",
+                        "alias": &self.alias,
+                        "request_api": "messages",
+                        "model": model,
+                        "stream": false,
+                        "tools_count": tools_count,
+                        "tool_choice": tool_choice.as_ref().and_then(|value| value.get("type")).and_then(|value| value.as_str()),
+                    })),
                 "native thinking enabled; using non-streaming fallback to preserve signed thinking blocks"
             );
             let native_request = NativeChatRequest {
@@ -1574,13 +1595,24 @@ impl ModelProvider for AnthropicModelProvider {
             .boxed();
         }
 
-        ::zeroclaw_log::record!(
-            DEBUG,
-            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(
-                ::serde_json::json!({"max_tokens": effective_max_tokens, "model": model})
-            ),
-            "stream_chat request"
-        );
+        if ::zeroclaw_log::debug_enabled() {
+            ::zeroclaw_log::record!(
+                DEBUG,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_attrs(::serde_json::json!({
+                        "provider": "anthropic",
+                        "alias": &self.alias,
+                        "request_api": "messages",
+                        "model": model,
+                        "stream": true,
+                        "max_tokens": effective_max_tokens,
+                        "tools_count": tools_count,
+                        "tool_choice": tool_choice.as_ref().and_then(|value| value.get("type")).and_then(|value| value.as_str()),
+                        "thinking_enabled": false,
+                    })),
+                "anthropic streaming provider request prepared"
+            );
+        }
         let native_request = NativeChatRequest {
             model: model.to_string(),
             max_tokens: effective_max_tokens,

--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -2690,8 +2690,6 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
             self.strip_native_tool_messages(&effective_messages)
         };
 
-        // When wire_api = "responses", route all turns through the responses API.
-
         let tools = self.convert_tool_specs_for_model(request.tools, model);
         let native_request = self.build_native_tool_chat_request(
             &effective_messages,
@@ -2700,6 +2698,24 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
             temperature,
             !merge,
         );
+        let tools_count = native_request.tools.as_ref().map_or(0, Vec::len);
+        if ::zeroclaw_log::debug_enabled() {
+            ::zeroclaw_log::record!(
+                DEBUG,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Send)
+                    .with_attrs(::serde_json::json!({
+                        "provider": &self.name,
+                        "alias": &self.alias,
+                        "request_api": "chat_completions",
+                        "model": model,
+                        "stream": false,
+                        "native_tool_calling": self.native_tool_calling,
+                        "tools_count": tools_count,
+                        "tool_choice": native_request.tool_choice.as_deref(),
+                    })),
+                "compatible provider request prepared"
+            );
+        }
 
         let url = self.chat_completions_url();
         let response = match self
@@ -2813,6 +2829,24 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
             let effective_messages = Self::flatten_system_messages(&normalized, merge);
             let effective_messages = provider.strip_native_tool_messages(&effective_messages);
             let tools = provider.convert_tool_specs_for_model(tools_owned.as_deref(), &model);
+            let tools_count = tools.as_ref().map_or(0, Vec::len);
+            if ::zeroclaw_log::debug_enabled() {
+                ::zeroclaw_log::record!(
+                    DEBUG,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Send)
+                        .with_attrs(::serde_json::json!({
+                            "provider": &provider.name,
+                            "alias": &provider.alias,
+                            "request_api": "chat_completions",
+                            "model": &model,
+                            "stream": options_enabled,
+                            "native_tool_calling": provider.native_tool_calling,
+                            "tools_count": tools_count,
+                            "tool_choice": tools.as_ref().map(|_| "auto"),
+                        })),
+                    "compatible streaming provider request prepared"
+                );
+            }
 
             let payload_result = if has_tools {
                 serde_json::to_value(NativeChatRequest {

--- a/crates/zeroclaw-providers/src/openai.rs
+++ b/crates/zeroclaw-providers/src/openai.rs
@@ -484,6 +484,7 @@ impl ModelProvider for OpenAiModelProvider {
             temperature.map(|t| Self::adjust_temperature_for_model(model, t));
 
         let tools = Self::convert_tools(request.tools);
+        let tools_count = tools.as_ref().map_or(0, Vec::len);
         let native_request = NativeChatRequest {
             model: model.to_string(),
             messages: Self::convert_messages(request.messages),
@@ -492,6 +493,22 @@ impl ModelProvider for OpenAiModelProvider {
             tools,
             max_tokens: self.max_tokens,
         };
+        if ::zeroclaw_log::debug_enabled() {
+            ::zeroclaw_log::record!(
+                DEBUG,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Send)
+                    .with_attrs(::serde_json::json!({
+                        "provider": "openai",
+                        "alias": &self.alias,
+                        "request_api": "chat_completions",
+                        "model": model,
+                        "stream": false,
+                        "tools_count": tools_count,
+                        "tool_choice": native_request.tool_choice.as_deref(),
+                    })),
+                "openai provider request prepared"
+            );
+        }
 
         let response = self
             .http_client()
@@ -1018,7 +1035,25 @@ impl ModelProvider for OpenAiResponsesModelProvider {
             Some(instructions)
         };
         let tools = convert_tools(request.tools);
+        let tools_count = tools.as_ref().map_or(0, Vec::len);
         let req = self.build_request(instructions, input, tools, model, temperature, false);
+        if ::zeroclaw_log::debug_enabled() {
+            ::zeroclaw_log::record!(
+                DEBUG,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Send)
+                    .with_attrs(::serde_json::json!({
+                        "provider": "openai",
+                        "alias": &self.alias,
+                        "request_api": "responses",
+                        "model": model,
+                        "stream": false,
+                        "tools_count": tools_count,
+                        "tool_choice": req.tool_choice.as_deref(),
+                        "parallel_tool_calls": req.parallel_tool_calls,
+                    })),
+                "openai responses provider request prepared"
+            );
+        }
         let response = Client::new()
             .post(&self.responses_url)
             .header("Authorization", format!("Bearer {credential}"))
@@ -1064,6 +1099,7 @@ impl ModelProvider for OpenAiResponsesModelProvider {
         let reasoning_effort = self.reasoning_effort.clone();
         let max_tokens = self.max_tokens;
         let client = self.streaming_client();
+        let alias = ::zeroclaw_log::debug_enabled().then(|| self.alias.clone());
 
         let (tx, rx) = tokio::sync::mpsc::channel::<StreamResult<StreamEvent>>(100);
         let handle = ::zeroclaw_spawn::spawn!(async move {
@@ -1074,6 +1110,7 @@ impl ModelProvider for OpenAiResponsesModelProvider {
                 Some(instructions)
             };
             let tools = convert_tools(tools_owned.as_deref());
+            let tools_count = tools.as_ref().map_or(0, Vec::len);
             let has_tools = tools.is_some();
             let reasoning = reasoning_effort
                 .as_deref()
@@ -1092,6 +1129,23 @@ impl ModelProvider for OpenAiResponsesModelProvider {
                 max_output_tokens: max_tokens,
                 reasoning,
             };
+            if let Some(alias) = alias.as_deref() {
+                ::zeroclaw_log::record!(
+                    DEBUG,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Send)
+                        .with_attrs(::serde_json::json!({
+                            "provider": "openai",
+                            "alias": alias,
+                            "request_api": "responses",
+                            "model": &req.model,
+                            "stream": true,
+                            "tools_count": tools_count,
+                            "tool_choice": req.tool_choice.as_deref(),
+                            "parallel_tool_calls": req.parallel_tool_calls,
+                        })),
+                    "openai responses streaming provider request prepared"
+                );
+            }
 
             let request_builder = client
                 .post(&responses_url)

--- a/crates/zeroclaw-providers/src/openai_codex.rs
+++ b/crates/zeroclaw-providers/src/openai_codex.rs
@@ -1275,6 +1275,7 @@ impl OpenAiCodexModelProvider {
         let creds = self.resolve_credentials().await?;
         let normalized_model = normalize_model_id(model);
 
+        let tools_count = tools.as_ref().map_or(0, Vec::len);
         let has_tools = tools.is_some();
         let mut request = ResponsesRequest {
             model: normalized_model.to_string(),
@@ -1297,6 +1298,23 @@ impl OpenAiCodexModelProvider {
             tool_choice: has_tools.then(|| "auto".to_string()),
             parallel_tool_calls: has_tools.then_some(true),
         };
+        if ::zeroclaw_log::debug_enabled() {
+            ::zeroclaw_log::record!(
+                DEBUG,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Send)
+                    .with_attrs(::serde_json::json!({
+                        "provider": "openai_codex",
+                        "alias": &self.alias,
+                        "request_api": WIRE_API,
+                        "model": &request.model,
+                        "stream": true,
+                        "tools_count": tools_count,
+                        "tool_choice": request.tool_choice.as_deref(),
+                        "parallel_tool_calls": request.parallel_tool_calls,
+                    })),
+                "openai codex responses provider request prepared"
+            );
+        }
 
         let request_builder = self.responses_request_builder(
             &creds.bearer_token,
@@ -1503,6 +1521,7 @@ impl ModelProvider for OpenAiCodexModelProvider {
             let (instructions, input) = build_responses_input(&prepared.messages);
             let normalized_model = normalize_model_id(&model);
             let tools = convert_tools(tools.as_deref());
+            let tools_count = tools.as_ref().map_or(0, Vec::len);
             let has_tools = tools.is_some();
             let request = ResponsesRequest {
                 model: normalized_model.to_string(),
@@ -1525,6 +1544,23 @@ impl ModelProvider for OpenAiCodexModelProvider {
                 tool_choice: has_tools.then(|| "auto".to_string()),
                 parallel_tool_calls: has_tools.then_some(true),
             };
+            if ::zeroclaw_log::debug_enabled() {
+                ::zeroclaw_log::record!(
+                    DEBUG,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Send)
+                        .with_attrs(::serde_json::json!({
+                            "provider": "openai_codex",
+                            "alias": &provider.alias,
+                            "request_api": WIRE_API,
+                            "model": &request.model,
+                            "stream": true,
+                            "tools_count": tools_count,
+                            "tool_choice": request.tool_choice.as_deref(),
+                            "parallel_tool_calls": request.parallel_tool_calls,
+                        })),
+                    "openai codex responses streaming provider request prepared"
+                );
+            }
 
             let request_builder = provider
                 .responses_request_builder(

--- a/crates/zeroclaw-runtime/src/agent/turn/mod.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/mod.rs
@@ -296,17 +296,12 @@ pub async fn run_tool_call_loop(
             .into());
         }
 
-        let iteration_tool_specs = build_iteration_tool_specs(
+        let mut iteration_tool_specs = build_iteration_tool_specs(
             model_provider,
             tools_registry,
             excluded_tools,
             activated_tools,
         )?;
-        let IterationToolSpecs {
-            ref tool_specs,
-            use_native_tools,
-            ..
-        } = iteration_tool_specs;
 
         let (vision_model_provider_box, degrade_strip_images) =
             resolve_vision_provider(model_provider, history, multimodal_config, provider_name)?;
@@ -325,6 +320,12 @@ pub async fn run_tool_call_loop(
         } else {
             (model_provider, provider_name, model)
         };
+        iteration_tool_specs.refresh_native_tool_mode(active_model_provider);
+        let IterationToolSpecs {
+            ref tool_specs,
+            use_native_tools,
+            ..
+        } = iteration_tool_specs;
 
         let prepared_messages = prepare_messages_for_iteration(
             history,
@@ -353,10 +354,34 @@ pub async fn run_tool_call_loop(
         } else {
             None
         };
+        let request_tool_count = request_tools.map_or(0, <[crate::tools::ToolSpec]>::len);
+        let base_provider_supports_native_tools = model_provider.supports_native_tools();
+        let active_provider_supports_native_tools = active_model_provider.supports_native_tools();
+        let active_provider_supports_streaming = active_model_provider.supports_streaming();
+        let active_provider_supports_streaming_tool_events =
+            active_model_provider.supports_streaming_tool_events();
         let should_consume_provider_stream = (on_delta.is_some() || event_tx.is_some())
-            && model_provider.supports_streaming()
-            && (request_tools.is_none() || model_provider.supports_streaming_tool_events());
-        ::zeroclaw_log::record!(DEBUG, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(::serde_json::json!({"has_on_delta": on_delta.is_some(), "has_event_tx": event_tx.is_some(), "supports_streaming": model_provider.supports_streaming(), "should_consume_provider_stream": should_consume_provider_stream})), &format!("Streaming decision for iteration {}", iteration + 1));
+            && active_provider_supports_streaming
+            && (request_tools.is_none() || active_provider_supports_streaming_tool_events);
+        if ::zeroclaw_log::debug_enabled() {
+            ::zeroclaw_log::record!(
+                DEBUG,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_attrs(::serde_json::json!({
+                        "has_on_delta": on_delta.is_some(),
+                        "has_event_tx": event_tx.is_some(),
+                        "base_provider_supports_native_tools": base_provider_supports_native_tools,
+                        "active_provider_supports_native_tools": active_provider_supports_native_tools,
+                        "active_provider_supports_streaming": active_provider_supports_streaming,
+                        "active_provider_supports_streaming_tool_events": active_provider_supports_streaming_tool_events,
+                        "tool_specs_count": tool_specs.len(),
+                        "request_tools_count": request_tool_count,
+                        "use_native_tools": use_native_tools,
+                        "should_consume_provider_stream": should_consume_provider_stream,
+                    })),
+                &format!("native tool delivery decision for iteration {}", iteration + 1)
+            );
+        }
 
         let ProviderCallOutcome {
             chat_result,

--- a/crates/zeroclaw-runtime/src/agent/turn/tool_specs.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/tool_specs.rs
@@ -13,6 +13,13 @@ pub(crate) struct IterationToolSpecs {
     pub(crate) use_native_tools: bool,
 }
 
+impl IterationToolSpecs {
+    pub(crate) fn refresh_native_tool_mode(&mut self, model_provider: &dyn ModelProvider) {
+        self.use_native_tools =
+            model_provider.supports_native_tools() && !self.tool_specs.is_empty();
+    }
+}
+
 pub(crate) fn build_iteration_tool_specs(
     model_provider: &dyn ModelProvider,
     tools_registry: &[Box<dyn Tool>],
@@ -100,6 +107,38 @@ mod tests {
         }
     }
 
+    struct PromptToolsProvider;
+
+    #[async_trait]
+    impl ModelProvider for PromptToolsProvider {
+        fn capabilities(&self) -> ProviderCapabilities {
+            ProviderCapabilities {
+                native_tool_calling: false,
+                ..ProviderCapabilities::default()
+            }
+        }
+
+        async fn chat_with_system(
+            &self,
+            _system_prompt: Option<&str>,
+            _message: &str,
+            _model: &str,
+            _temperature: Option<f64>,
+        ) -> anyhow::Result<String> {
+            unreachable!("test provider should not execute chat")
+        }
+    }
+
+    impl zeroclaw_api::attribution::Attributable for PromptToolsProvider {
+        fn role(&self) -> Role {
+            Role::System
+        }
+
+        fn alias(&self) -> &str {
+            "test-prompt-tools-provider"
+        }
+    }
+
     struct CountingTool {
         name: String,
         invocations: Arc<AtomicUsize>,
@@ -183,6 +222,22 @@ mod tests {
                 .iter()
                 .any(|spec| spec.name == "docker-mcp__extract_text"),
             "recovered poisoned lock should still expose activated tool specs"
+        );
+    }
+
+    #[test]
+    fn iteration_tool_specs_recomputes_native_mode_for_active_provider() {
+        let invocations = Arc::new(AtomicUsize::new(0));
+        let tool = Box::new(CountingTool::new("read_file", invocations));
+        let mut specs = build_iteration_tool_specs(&NativeToolsProvider, &[tool], &[], None)
+            .expect("native provider with tools should build specs");
+        assert!(specs.use_native_tools);
+
+        specs.refresh_native_tool_mode(&PromptToolsProvider);
+
+        assert!(
+            !specs.use_native_tools,
+            "active provider must decide whether this turn uses native tool transport"
         );
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Adds DEBUG-level diagnostics at the runtime turn boundary for native tool delivery decisions, including provider capability booleans and tool counts.
  - Adds DEBUG-level diagnostics at OpenAI, OpenAI Responses, OpenAI Codex Responses, Anthropic, and OpenAI-compatible request-send boundaries so maintainers can see whether tools reached the provider request.
  - Recomputes native-tool transport mode after active provider selection, so vision-provider routing does not keep a stale native-tool decision from the base provider.
  - Uses the active provider for streaming capability checks in the same turn decision.
  - Guards structured DEBUG payload construction behind a log-level check to avoid building diagnostic JSON when DEBUG logs are disabled.
- **Scope boundary:** This PR does not change tool schemas, provider authentication, prompt-guided fallback parsing, MCP registration, or provider endpoint selection.
- **Blast radius:** Runtime turn orchestration and provider request construction for native-tool-capable OpenAI, Anthropic, OpenAI Codex, and OpenAI-compatible providers. Request payload contents stay unchanged except for the active-provider native-tool decision fix. One existing Anthropic native-thinking INFO fallback log now includes the same non-sensitive request metadata added to the DEBUG diagnostics.
- **Linked issue(s):** Related #7756.
- **Labels:** `bug`, `risk: high`, `size: M`, `agent`, `provider`, `runtime`, `provider:anthropic`, `provider:compatible`, `provider:openai`.

## Validation Evidence (required)

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` passed with no diff output.
  - `git diff --check` passed with no output.
  - `cargo check -p zeroclaw-log -p zeroclaw-providers -p zeroclaw-runtime --lib` passed: `Finished dev profile ... in 2m 47s`.
  - `cargo test -p zeroclaw-runtime turn_streamed_passes_tool_specs_to_provider --lib` passed: `1 passed; 0 failed; 2277 filtered out`.
  - `cargo test -p zeroclaw-runtime iteration_tool_specs_recomputes_native_mode_for_active_provider --lib` passed: `1 passed; 0 failed; 2277 filtered out`.
  - `cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings` passed: `Finished dev profile ... in 18m 08s`.
  - `cargo nextest run --locked --workspace --exclude zeroclaw-desktop` passed: `9130 tests run: 9130 passed, 11 skipped`.
- **Beyond CI — what did you manually verify?** Reviewed the provider diagnostics to confirm they log counts, booleans, provider alias/model, stream mode, and request API only. They do not log tool schemas, tool arguments, message text, credentials, or provider payload bodies.
- **If any command was intentionally skipped, why:** None.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: No new permission, network, credential, or PII surface is introduced. The new DEBUG diagnostics are deliberately limited to provider/request metadata and counts. The existing Anthropic native-thinking INFO fallback keeps its INFO level but now reports the same non-sensitive request metadata.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: Existing users do not need to change config, env vars, or CLI usage.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** Revert this PR commit.
- **Feature flags or config toggles:** None. The new diagnostics only emit when DEBUG logging is enabled. The existing Anthropic native-thinking fallback log remains INFO-level with non-sensitive metadata.
- **Observable failure symptoms:** Native-tool-capable turns may stop reporting expected provider request diagnostics, or routed multimodal turns may again omit native tools when the active provider differs from the base provider. Check DEBUG log events containing `native tool delivery decision` and provider request prepared messages.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Scope materially carried forward: N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why (inspiration-only, no direct code/design carry-over): No superseded PR scope is carried forward.
