### PR TITLE
fix(cost): capture model cost for RPC/zerocode-TUI and standalone ACP turns (#5221)

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/acp_server.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/acp_server.rs
@@ -1237,6 +1237,19 @@ impl AcpServer {
         self.register_cancel_token(&session_id, cancel_token.clone())?;
         let (event_tx, mut event_rx) = tokio::sync::mpsc::channel::<TurnEvent>(100);
 
+        // Cost-tracking inputs, resolved before the spawn while `self.config`
+        // is in scope. `turn_streamed` reuses the outer cost scope set below;
+        // without it the turn falls back to a tracker-less `usage_only` context
+        // and model cost is silently dropped (#5221). Mirrors the gateway WS
+        // path. The process-global tracker is shared with the gateway/daemon.
+        let cost_tracker = zeroclaw_runtime::cost::CostTracker::get_or_init_global(
+            self.config.cost.clone(),
+            &self.config.data_dir,
+        );
+        let cost_pricing = std::sync::Arc::new(
+            zeroclaw_runtime::agent::cost::build_model_provider_pricing(&self.config),
+        );
+
         // Move the Arc into the spawned task and lock inside it.  The inner
         // Mutex stays locked for the duration of the turn, preventing
         // concurrent stop/reap from touching the agent mid-turn. The outer
@@ -1245,6 +1258,15 @@ impl AcpServer {
         let turn_handle = zeroclaw_spawn::spawn!(async move {
             let mut session = session_arc.lock().await;
             let (turn_alias, turn_provider, turn_model) = session.agent.attribution_fields();
+            // Stamp the resolved per-turn alias so `/api/cost?agent=<alias>`
+            // attributes this spend.
+            let cost_context = cost_tracker.map(|tracker| {
+                zeroclaw_runtime::agent::cost::ToolLoopCostTrackingContext::new(
+                    tracker,
+                    cost_pricing,
+                )
+                .with_agent_alias(&turn_alias)
+            });
             let span_session = session_id_for_task.clone();
             let result = {
                 use ::zeroclaw_log::Instrument as _;
@@ -1259,10 +1281,13 @@ impl AcpServer {
                 );
                 zeroclaw_runtime::agent::loop_::scope_session_key(
                     Some(session_id_for_task),
-                    session
-                        .agent
-                        .turn_streamed(&prompt, event_tx, Some(cancel_token))
-                        .instrument(span),
+                    zeroclaw_runtime::agent::cost::TOOL_LOOP_COST_TRACKING_CONTEXT.scope(
+                        cost_context,
+                        session
+                            .agent
+                            .turn_streamed(&prompt, event_tx, Some(cancel_token))
+                            .instrument(span),
+                    ),
                 )
                 .await
             };

--- a/crates/zeroclaw-runtime/src/daemon/mod.rs
+++ b/crates/zeroclaw-runtime/src/daemon/mod.rs
@@ -377,7 +377,13 @@ pub async fn run(
             sessions,
             session_backend,
             memory: rpc_memory,
-            cost_tracker: None, // TODO: wire when cost tracker is daemon-scoped
+            // Process-global tracker shared with the gateway and channel
+            // supervisor. Without this the RPC/zerocode-TUI turn path has no
+            // tracker to record into and model cost is silently dropped (#5221).
+            cost_tracker: crate::cost::CostTracker::get_or_init_global(
+                config.cost.clone(),
+                &config.data_dir,
+            ),
             event_tx: Some(event_tx.clone()),
             reload_tx: Some(reload_tx.clone()),
             approval_pending: std::sync::Arc::new(

--- a/crates/zeroclaw-runtime/src/rpc/dispatch.rs
+++ b/crates/zeroclaw-runtime/src/rpc/dispatch.rs
@@ -1403,6 +1403,19 @@ impl RpcDispatcher {
         let attribution_agent_alias = agent_alias.clone();
         let attribution_model_provider = model_provider.clone();
         let attribution_model = model.clone();
+        // Cost-tracking context for this turn. Built from the daemon-scoped
+        // tracker + the live pricing map and stamped with the agent alias so
+        // `execute_turn` can persist token usage and attribute spend. `None`
+        // when cost tracking is disabled (no tracker wired). See #5221.
+        let cost_context = self.ctx.cost_tracker.as_ref().map(|tracker| {
+            let cfg_guard = self.ctx.config.read();
+            let pricing = crate::agent::cost::build_model_provider_pricing(&cfg_guard);
+            crate::agent::cost::ToolLoopCostTrackingContext::new(
+                tracker.clone(),
+                std::sync::Arc::new(pricing),
+            )
+            .with_agent_alias(&attribution_agent_alias)
+        });
         let outcome = execute_turn(
             agent,
             prompt.clone(),
@@ -1414,6 +1427,7 @@ impl RpcDispatcher {
                 model,
                 channel: "rpc",
             },
+            cost_context,
             move |event| {
                 let rpc = rpc.clone();
                 let sid = sid_owned.clone();

--- a/crates/zeroclaw-runtime/src/rpc/turn.rs
+++ b/crates/zeroclaw-runtime/src/rpc/turn.rs
@@ -1,6 +1,7 @@
 //! Shared turn execution. Single source of truth for spawn-drain-cancel.
 
 use crate::agent::agent::{Agent, StreamedTurnError, StreamedTurnSuccess, TurnEvent};
+use crate::agent::cost::{TOOL_LOOP_COST_TRACKING_CONTEXT, ToolLoopCostTrackingContext};
 use crate::agent::loop_::is_tool_loop_cancelled;
 use std::sync::Arc;
 use tokio::sync::{Mutex, mpsc};
@@ -51,6 +52,7 @@ pub async fn execute_turn<F, Fut>(
     prompt: String,
     cancel: CancellationToken,
     attribution: TurnAttribution,
+    cost_context: Option<ToolLoopCostTrackingContext>,
     on_event: F,
 ) -> Result<TurnOutcome, TurnError>
 where
@@ -75,9 +77,25 @@ where
                 model = %attribution.model,
                 channel = %attribution.channel,
             );
-            guard
-                .turn_streamed_with_steering_state(&prompt, event_tx, Some(cancel_clone), None)
-                .instrument(span)
+            // Scope the cost-tracking context so this turn's per-call token
+            // usage is persisted and counted against budgets.
+            // `turn_streamed_with_steering_state` reuses this outer scope; with
+            // no scope set it falls back to a tracker-less `usage_only` context
+            // and model cost is silently dropped (#5221 regression). The scope
+            // must live INSIDE the spawned task — task-locals don't cross the
+            // spawn boundary.
+            TOOL_LOOP_COST_TRACKING_CONTEXT
+                .scope(
+                    cost_context,
+                    guard
+                        .turn_streamed_with_steering_state(
+                            &prompt,
+                            event_tx,
+                            Some(cancel_clone),
+                            None,
+                        )
+                        .instrument(span),
+                )
                 .await
         })
         .await
@@ -373,6 +391,149 @@ mod tests {
             matches!(outcome, Err(TurnError::AgentError(_))),
             "a genuine agent failure must surface as an error, not a silent \
              cancel"
+        );
+    }
+
+    /// Regression guard for #5221: a turn driven through `execute_turn` with a
+    /// real cost-tracking context must persist token usage to the tracker. The
+    /// RPC/zerocode-TUI path previously ran the turn without scoping the cost
+    /// context, so `turn_streamed_with_steering_state` fell back to a
+    /// tracker-less `usage_only` context and model cost was silently dropped.
+    #[tokio::test]
+    async fn execute_turn_scopes_cost_context_so_usage_is_persisted() {
+        use crate::agent::agent::Agent;
+        use crate::agent::dispatcher::NativeToolDispatcher;
+        use crate::cost::CostTracker;
+        use crate::observability::{NoopObserver, Observer};
+        use async_trait::async_trait;
+        use std::collections::HashMap;
+        use zeroclaw_api::attribution::{Attributable, ModelProviderKind, ProviderKind, Role};
+        use zeroclaw_api::model_provider::ModelProvider;
+        use zeroclaw_memory::Memory;
+        use zeroclaw_providers::ChatRequest;
+
+        // Minimal provider that returns a final answer carrying non-zero token
+        // usage on the non-streaming `chat` path (the default the engine takes
+        // when the provider does not advertise streaming).
+        struct UsageProvider;
+
+        #[async_trait]
+        impl ModelProvider for UsageProvider {
+            async fn chat_with_system(
+                &self,
+                _system_prompt: Option<&str>,
+                _message: &str,
+                _model: &str,
+                _temperature: Option<f64>,
+            ) -> anyhow::Result<String> {
+                Ok("ok".into())
+            }
+
+            async fn chat(
+                &self,
+                _request: ChatRequest<'_>,
+                _model: &str,
+                _temperature: Option<f64>,
+            ) -> anyhow::Result<zeroclaw_providers::ChatResponse> {
+                Ok(zeroclaw_providers::ChatResponse {
+                    text: Some("done".into()),
+                    tool_calls: vec![],
+                    usage: Some(zeroclaw_providers::traits::TokenUsage {
+                        input_tokens: Some(1_000),
+                        cached_input_tokens: None,
+                        output_tokens: Some(200),
+                    }),
+                    reasoning_content: None,
+                })
+            }
+        }
+
+        impl Attributable for UsageProvider {
+            fn role(&self) -> Role {
+                Role::Provider(ProviderKind::Model(ModelProviderKind::Custom))
+            }
+            fn alias(&self) -> &str {
+                "mock-provider"
+            }
+        }
+
+        let memory_cfg = zeroclaw_config::schema::MemoryConfig {
+            backend: "none".into(),
+            ..zeroclaw_config::schema::MemoryConfig::default()
+        };
+        let mem: Arc<dyn Memory> = Arc::from(
+            zeroclaw_memory::create_memory(&memory_cfg, std::path::Path::new("/tmp"), None)
+                .expect("memory creation should succeed"),
+        );
+        let workspace = tempfile::TempDir::new().expect("temp dir");
+        let tracker = Arc::new(
+            CostTracker::new(
+                zeroclaw_config::schema::CostConfig {
+                    enabled: true,
+                    track_per_agent: true,
+                    ..zeroclaw_config::schema::CostConfig::default()
+                },
+                workspace.path(),
+            )
+            .expect("cost tracker should initialize"),
+        );
+        let pricing = Arc::new(HashMap::from([(
+            "mock-provider".to_string(),
+            HashMap::from([
+                ("test-model.input".to_string(), 3.0),
+                ("test-model.output".to_string(), 15.0),
+            ]),
+        )]));
+        let cost_context = ToolLoopCostTrackingContext::new(Arc::clone(&tracker), pricing)
+            .with_agent_alias("rpc-agent");
+
+        let agent = Agent::builder()
+            .model_provider(Box::new(UsageProvider))
+            .tools(vec![])
+            .memory(mem)
+            .observer(Arc::from(NoopObserver {}) as Arc<dyn Observer>)
+            .tool_dispatcher(Box::new(NativeToolDispatcher))
+            .workspace_dir(std::path::PathBuf::from("/tmp"))
+            .model_name("test-model".into())
+            .model_provider_name("mock-provider".into())
+            .agent_alias("rpc-agent".into())
+            .build()
+            .expect("agent builder should succeed");
+
+        let outcome = execute_turn(
+            Arc::new(Mutex::new(agent)),
+            "hello".to_string(),
+            CancellationToken::new(),
+            TurnAttribution {
+                session_key: Some("s1".into()),
+                agent_alias: "rpc-agent".into(),
+                model_provider: "mock-provider".into(),
+                model: "test-model".into(),
+                channel: "rpc",
+            },
+            Some(cost_context),
+            noop,
+        )
+        .await
+        .expect("turn should complete");
+        assert!(
+            matches!(outcome, TurnOutcome::Completed { .. }),
+            "turn should complete normally"
+        );
+
+        let summary = tracker.get_summary().expect("cost summary");
+        assert_eq!(
+            summary.request_count, 1,
+            "execute_turn must scope the cost context so the turn's usage is \
+             persisted (#5221)"
+        );
+        assert_eq!(summary.total_tokens, 1_200);
+        let agent_summary = tracker
+            .get_summary_for_agent("rpc-agent")
+            .expect("agent-scoped summary");
+        assert_eq!(
+            agent_summary.request_count, 1,
+            "the agent alias must flow through to the persisted cost record"
         );
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:** Model cost was not captured for turns driven through the zerocode TUI / RPC socket or the standalone ACP server (issue 5221, reopened against v0.8.0-beta-2). Two root causes: (1) the RPC daemon never wired a cost tracker into `RpcContext` — a leftover `cost_tracker: None, // TODO` in `daemon/mod.rs`; and (2) the RPC and standalone-ACP turn drivers ran each turn without scoping `TOOL_LOOP_COST_TRACKING_CONTEXT`. With no outer scope, `Agent::turn_streamed_with_steering_state` falls back to the tracker-less `usage_only` context, so token usage was never persisted to `state/costs.jsonl` and budgets were not enforced.
- This wires the process-global `CostTracker` into the daemon (the same instance the gateway and channel supervisor already share) and scopes the cost context around the RPC turn (`execute_turn`, built at the dispatch layer from the tracker + live pricing map + agent alias) and the standalone ACP turn — mirroring the gateway WebSocket path, which already does exactly this. The contract that `turn_streamed*` *reuses* an outer scope is already covered by the existing `turn_streamed_reuses_outer_cost_tracking_context` test.
- **Scope boundary:** Does NOT change cron or the classic `zeroclaw agent` CLI (both already scope cost via `agent::loop_::run`). Does NOT change the gateway WS/webhook paths (already correct). Does NOT address `cost_usd = 0.0` records caused by a missing `[cost.rates]` pricing row or by streaming providers that omit a usage frame — those are a separate pricing/usage-population concern, not the capture bug fixed here.
- **Blast radius:** RPC/zerocode turn dispatch, standalone ACP turn dispatch, and daemon `RpcContext` construction. All three now record into the one shared process-global tracker; no new tracker instances are introduced.
- **Linked issue(s):** Closes #5221. Related #5484 (the original fix that regressed once the zerocode/RPC transport landed).
- **Labels:** `type: bug`, `risk: low`, `size: S`, scope `agent` / `channel`.

## Validation Evidence (required)

```bash
cargo fmt --all -- --check          # rc=0, no output
cargo clippy --all-targets -- -D warnings
cargo build --workspace --all-targets
cargo test -p zeroclaw-runtime --lib rpc::turn::tests
cargo test -p zeroclaw-runtime --lib turn_streamed_reuses_outer_cost_tracking_context
cargo test -p zeroclaw-channels --lib acp_server
```

- **Commands run and tail output:**

```
# clippy --all-targets -- -D warnings
    Checking zeroclaw-channels v0.8.0 (.../crates/zeroclaw-channels)
    Checking zeroclaw-eval v0.8.0 (.../crates/zeroclaw-eval)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 02s

# build --workspace --all-targets
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 4m 41s

# rpc::turn::tests (incl. new regression test)
running 5 tests
test rpc::turn::tests::execute_turn_scopes_cost_context_so_usage_is_persisted ... ok
test result: ok. 5 passed; 0 failed; 0 ignored; 2293 filtered out

# turn_streamed_reuses_outer_cost_tracking_context
test result: ok. 1 passed; 0 failed

# acp_server
test result: ok. 49 passed; 0 failed; 0 ignored; 905 filtered out
```

- **Beyond CI — what did you manually verify?** Ran a local daemon (scratch config, real `kilo.kilo_free` provider, `[cost] enabled = true`) and drove turns through both fixed paths, then inspected `state/costs.jsonl`:
  - RPC/zerocode turn → 2 cost records written, `agent_alias = "valid"`, `total_tokens` 2170 + 2194. (This file stayed empty before the change.)
  - Standalone `zeroclaw acp` turn → 2 records, `agent_alias = "acptest"`, `total_tokens` 1595 + 1618; the existing deny-with-edit approval behavior was unaffected.
  - `cost_usd` was `0.0` only because the throwaway config had no `[cost.rates]` entry for `kilo-auto/free` — token capture and per-agent attribution (the subject of this issue) are correct.
- **If any command was intentionally skipped, why:** Full `cargo test` (whole workspace) not run end-to-end; the change is confined to cost-context scoping, covered by the targeted runtime + channels suites above plus the live runs.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Upgrade steps: none. Existing deployments with `[cost] enabled = true` begin recording RPC/zerocode and standalone-ACP turns automatically; nothing to configure.

## Rollback

Low-risk: `git revert <sha>` is the plan. No feature flags or migrations involved.
