### PR TITLE
fix(tests): make process fixtures portable on Windows

### DIFF
--- a/crates/zeroclaw-api/src/runtime_traits.rs
+++ b/crates/zeroclaw-api/src/runtime_traits.rs
@@ -102,8 +102,18 @@ mod tests {
             command: &str,
             workspace_dir: &Path,
         ) -> anyhow::Result<tokio::process::Command> {
+            #[cfg(windows)]
+            let mut cmd = {
+                let mut cmd = tokio::process::Command::new("cmd");
+                cmd.args(["/C", "echo", command]);
+                cmd
+            };
+
+            #[cfg(not(windows))]
             let mut cmd = tokio::process::Command::new("echo");
+            #[cfg(not(windows))]
             cmd.arg(command);
+
             cmd.current_dir(workspace_dir);
             Ok(cmd)
         }

--- a/crates/zeroclaw-hardware/src/subprocess.rs
+++ b/crates/zeroclaw-hardware/src/subprocess.rs
@@ -432,23 +432,12 @@ mod tests {
         // `echo` prints its argument + newline and exits 0.
         let result_json = r#"{"success":true,"output":"ok","error":null}"#;
 
-        // Build a manifest pointing at `echo`.
+        // Build a manifest pointing at a tiny protocol helper.
         let m = make_manifest("echo_tool", vec![]);
 
-        // Construct an `echo` invocation as the binary with the JSON pre-set.
-        // We use `sh -c 'echo <json>'` because the SubprocessTool feeds the
-        // manifest binary with args on stdin — echo just ignores stdin.
-        let script = format!("echo '{}'", result_json);
-        let binary = PathBuf::from("sh");
-        // Override binary to `sh` and pass `-c` + script via a wrapper.
-        // Simpler: write a temp script.
         let dir = tempfile::tempdir().unwrap();
-        let script_path = dir.path().join("tool.sh");
-        std::fs::write(
-            &script_path,
-            format!("#!/bin/sh\ncat > /dev/null\necho '{}'\n", result_json),
-        )
-        .unwrap();
+        let script_path = protocol_helper_path(dir.path());
+        std::fs::write(&script_path, protocol_helper_script(result_json)).unwrap();
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
@@ -464,9 +453,26 @@ mod tests {
         assert!(result.success, "expected success=true, got: {:?}", result);
         assert_eq!(result.output, "ok");
         assert!(result.error.is_none());
+    }
 
-        let _ = script;
-        let _ = binary;
+    #[cfg(windows)]
+    fn protocol_helper_path(dir: &std::path::Path) -> PathBuf {
+        dir.join("tool.cmd")
+    }
+
+    #[cfg(not(windows))]
+    fn protocol_helper_path(dir: &std::path::Path) -> PathBuf {
+        dir.join("tool.sh")
+    }
+
+    #[cfg(windows)]
+    fn protocol_helper_script(result_json: &str) -> String {
+        format!("@echo off\r\nset /p _zc_args=\r\necho {result_json}\r\n")
+    }
+
+    #[cfg(not(windows))]
+    fn protocol_helper_script(result_json: &str) -> String {
+        format!("#!/bin/sh\ncat > /dev/null\necho '{}'\n", result_json)
     }
 
     /// A binary that hangs forever should be killed and return a timeout error.

--- a/crates/zeroclaw-providers/src/bedrock.rs
+++ b/crates/zeroclaw-providers/src/bedrock.rs
@@ -132,19 +132,16 @@ impl AwsCredentials {
             anyhow::Error::msg(format!("No credential_process in [{profile}]"))
         })?;
 
-        let output = std::process::Command::new("sh")
-            .args(["-c", &cmd])
-            .output()
-            .map_err(|e| {
-                ::zeroclaw_log::record!(
-                    ERROR,
-                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
-                        .with_outcome(::zeroclaw_log::EventOutcome::Failure)
-                        .with_attrs(::serde_json::json!({"error": format!("{}", e)})),
-                    "bedrock: failed to spawn credential_process"
-                );
-                anyhow::Error::msg(format!("Failed to run credential_process: {e}"))
-            })?;
+        let output = run_credential_process_command(&cmd).map_err(|e| {
+            ::zeroclaw_log::record!(
+                ERROR,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                    .with_attrs(::serde_json::json!({"error": format!("{}", e)})),
+                "bedrock: failed to spawn credential_process"
+            );
+            anyhow::Error::msg(format!("Failed to run credential_process: {e}"))
+        })?;
         anyhow::ensure!(
             output.status.success(),
             "credential_process exited with {}: {}",
@@ -348,6 +345,25 @@ impl AwsCredentials {
             None => false,
         }
     }
+}
+
+#[cfg(windows)]
+fn run_credential_process_command(cmd: &str) -> std::io::Result<std::process::Output> {
+    use std::os::windows::process::CommandExt;
+
+    const CREATE_NO_WINDOW: u32 = 0x08000000;
+
+    let mut command = std::process::Command::new("cmd.exe");
+    command
+        .raw_arg("/C")
+        .raw_arg(format!("\"{cmd}\""))
+        .creation_flags(CREATE_NO_WINDOW)
+        .output()
+}
+
+#[cfg(not(windows))]
+fn run_credential_process_command(cmd: &str) -> std::io::Result<std::process::Output> {
+    std::process::Command::new("sh").args(["-c", cmd]).output()
 }
 
 fn env_required(name: &str) -> anyhow::Result<String> {
@@ -2580,20 +2596,20 @@ credential_process=some-command
 
     #[test]
     fn from_credential_process_parses_json_output() {
-        // Verify config parsing + JSON shape by using `echo` as the command.
-        let config = "\
-[default]
-credential_process=echo '{\"Version\":1,\"AccessKeyId\":\"AKIA\",\"SecretAccessKey\":\"secret\",\"SessionToken\":\"tok\"}'
-region=ap-southeast-1
-";
-        let (cmd, region) = AwsCredentials::parse_aws_config(config, "default").unwrap();
-        assert!(cmd.starts_with("echo"));
+        let credential_json =
+            r#"{"Version":1,"AccessKeyId":"AKIA","SecretAccessKey":"secret","SessionToken":"tok"}"#;
+        #[cfg(windows)]
+        let credential_command = format!("echo {credential_json}");
+        #[cfg(not(windows))]
+        let credential_command = format!("printf '%s\\n' '{credential_json}'");
+        let config =
+            format!("[default]\ncredential_process={credential_command}\nregion=ap-southeast-1\n");
+
+        let (cmd, region) = AwsCredentials::parse_aws_config(&config, "default").unwrap();
+        assert_eq!(cmd, credential_command);
         assert_eq!(region.as_deref(), Some("ap-southeast-1"));
 
-        let output = std::process::Command::new("sh")
-            .args(["-c", &cmd])
-            .output()
-            .unwrap();
+        let output = run_credential_process_command(&cmd).unwrap();
         let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
         assert_eq!(json["AccessKeyId"].as_str(), Some("AKIA"));
         assert_eq!(json["SecretAccessKey"].as_str(), Some("secret"));

--- a/crates/zeroclaw-runtime/src/platform/traits.rs
+++ b/crates/zeroclaw-runtime/src/platform/traits.rs
@@ -36,8 +36,18 @@ mod tests {
             command: &str,
             workspace_dir: &Path,
         ) -> anyhow::Result<tokio::process::Command> {
+            #[cfg(windows)]
+            let mut cmd = {
+                let mut cmd = tokio::process::Command::new("cmd");
+                cmd.args(["/C", "echo", command]);
+                cmd
+            };
+
+            #[cfg(not(windows))]
             let mut cmd = tokio::process::Command::new("echo");
+            #[cfg(not(windows))]
             cmd.arg(command);
+
             cmd.current_dir(workspace_dir);
             Ok(cmd)
         }

--- a/crates/zeroclaw-runtime/src/skills/testing.rs
+++ b/crates/zeroclaw-runtime/src/skills/testing.rs
@@ -98,11 +98,7 @@ fn run_test_case(case: &TestCase, skill_dir: &Path, verbose: bool) -> Option<Tes
         println!("    running: {}", case.command);
     }
 
-    let result = Command::new("sh")
-        .arg("-c")
-        .arg(&case.command)
-        .current_dir(skill_dir)
-        .output();
+    let result = build_test_command(&case.command, skill_dir).output();
 
     let output = match result {
         Ok(o) => o,
@@ -146,6 +142,28 @@ fn run_test_case(case: &TestCase, skill_dir: &Path, verbose: bool) -> Option<Tes
             actual_output: combined.to_string(),
         })
     }
+}
+
+#[cfg(windows)]
+fn build_test_command(command: &str, skill_dir: &Path) -> Command {
+    use std::os::windows::process::CommandExt;
+
+    const CREATE_NO_WINDOW: u32 = 0x08000000;
+
+    let mut cmd = Command::new("cmd.exe");
+    cmd.raw_arg("/C")
+        .raw_arg(format!("\"{command}\""))
+        .current_dir(skill_dir)
+        .creation_flags(CREATE_NO_WINDOW);
+    cmd
+}
+
+#[cfg(not(windows))]
+fn build_test_command(command: &str, skill_dir: &Path) -> Command {
+    let mut cmd = Command::new("sh");
+    cmd.arg("-c").arg(command);
+    cmd.current_dir(skill_dir);
+    cmd
 }
 
 /// Test a single skill by parsing and running its TEST.sh.
@@ -407,12 +425,26 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let skill_dir = dir.path().join("exit-mismatch");
         fs::create_dir_all(&skill_dir).unwrap();
-        fs::write(skill_dir.join("TEST.sh"), "false | 0 | \n").unwrap();
+        fs::write(
+            skill_dir.join("TEST.sh"),
+            format!("{} | 0 | \n", failing_command()),
+        )
+        .unwrap();
 
         let result = test_skill(&skill_dir, "exit-mismatch", false).unwrap();
         assert_eq!(result.tests_run, 1);
         assert_eq!(result.tests_passed, 0);
         assert_eq!(result.failures[0].actual_exit, 1);
+    }
+
+    #[cfg(windows)]
+    fn failing_command() -> &'static str {
+        "exit /B 1"
+    }
+
+    #[cfg(not(windows))]
+    fn failing_command() -> &'static str {
+        "false"
     }
 
     #[test]

--- a/crates/zeroclaw-runtime/src/tools/shell.rs
+++ b/crates/zeroclaw-runtime/src/tools/shell.rs
@@ -588,6 +588,43 @@ mod tests {
         Arc::new(NativeRuntime::new())
     }
 
+    #[cfg(windows)]
+    fn stdin_reader_command() -> &'static str {
+        "more"
+    }
+
+    #[cfg(not(windows))]
+    fn stdin_reader_command() -> &'static str {
+        "cat"
+    }
+
+    #[cfg(windows)]
+    fn success_with_stderr_command() -> &'static str {
+        "echo out && echo warn 1>&2"
+    }
+
+    #[cfg(not(windows))]
+    fn success_with_stderr_command() -> &'static str {
+        "echo out; echo warn >&2"
+    }
+
+    #[cfg(windows)]
+    fn medium_risk_write_command() -> &'static str {
+        "copy /Y NUL zeroclaw_shell_approval_test"
+    }
+
+    #[cfg(not(windows))]
+    fn medium_risk_write_command() -> &'static str {
+        "touch zeroclaw_shell_approval_test"
+    }
+
+    fn medium_risk_write_base() -> &'static str {
+        medium_risk_write_command()
+            .split_whitespace()
+            .next()
+            .expect("medium-risk test command should have a base command")
+    }
+
     /// Returns the fully-wrapped shell tool as it is composed in production:
     /// RateLimited(PathGuarded(ShellTool)).  Tests that verify path-blocking or
     /// rate-limiting behaviour must use this helper so they exercise the wrappers.
@@ -632,17 +669,21 @@ mod tests {
         let security = Arc::new(SecurityPolicy {
             autonomy: AutonomyLevel::Supervised,
             workspace_dir: std::env::temp_dir(),
-            allowed_commands: vec!["cat".into()],
+            allowed_commands: vec![stdin_reader_command().into()],
             ..SecurityPolicy::default()
         });
         let tool = ShellTool::new(security, test_runtime());
-        let fut = tool.execute(json!({"command": "cat"}));
+        let fut = tool.execute(json!({"command": stdin_reader_command()}));
         let res = tokio::time::timeout(std::time::Duration::from_secs(10), fut).await;
         assert!(
             res.is_ok(),
             "a stdin-reading command hung — stdin is not null and may reach the terminal"
         );
-        assert!(res.unwrap().expect("cat should return a result").success);
+        assert!(
+            res.unwrap()
+                .expect("stdin reader should return a result")
+                .success
+        );
     }
 
     #[tokio::test]
@@ -774,7 +815,7 @@ mod tests {
         let tool = ShellTool::new(test_security(AutonomyLevel::Full), test_runtime())
             .with_persistent_writes(false);
         let result = tool
-            .execute(json!({"command": "echo out; echo warn >&2"}))
+            .execute(json!({"command": success_with_stderr_command()}))
             .await
             .expect("command should run");
         assert!(
@@ -1097,14 +1138,14 @@ mod tests {
     async fn shell_requires_approval_for_medium_risk_command() {
         let security = Arc::new(SecurityPolicy {
             autonomy: AutonomyLevel::Supervised,
-            allowed_commands: vec!["touch".into()],
+            allowed_commands: vec![medium_risk_write_base().into()],
             workspace_dir: std::env::temp_dir(),
             ..SecurityPolicy::default()
         });
 
         let tool = ShellTool::new(security.clone(), test_runtime());
         let denied = tool
-            .execute(json!({"command": "touch zeroclaw_shell_approval_test"}))
+            .execute(json!({"command": medium_risk_write_command()}))
             .await
             .expect("unapproved command should return a result");
         assert!(!denied.success);
@@ -1118,7 +1159,7 @@ mod tests {
 
         let allowed = tool
             .execute(json!({
-                "command": "touch zeroclaw_shell_approval_test",
+                "command": medium_risk_write_command(),
                 "approved": true
             }))
             .await

--- a/crates/zeroclaw-runtime/src/tunnel/custom.rs
+++ b/crates/zeroclaw-runtime/src/tunnel/custom.rs
@@ -167,7 +167,7 @@ mod tests {
 
     #[tokio::test]
     async fn start_without_pattern_returns_local_url() {
-        let tunnel = CustomTunnel::new("sleep 1".into(), None, None);
+        let tunnel = CustomTunnel::new(long_running_command(), None, None);
 
         let url = tunnel.start("127.0.0.1", 4455).await.unwrap();
         assert_eq!(url, "http://127.0.0.1:4455");
@@ -182,7 +182,7 @@ mod tests {
     #[tokio::test]
     async fn start_with_pattern_extracts_url() {
         let tunnel = CustomTunnel::new(
-            "echo https://public.example".into(),
+            echo_command("https://public.example"),
             None,
             Some("public.example".into()),
         );
@@ -201,7 +201,7 @@ mod tests {
     #[tokio::test]
     async fn start_replaces_host_and_port_placeholders() {
         let tunnel = CustomTunnel::new(
-            "echo http://{host}:{port}".into(),
+            echo_command("http://{host}:{port}"),
             None,
             Some("http://".into()),
         );
@@ -215,11 +215,31 @@ mod tests {
     #[tokio::test]
     async fn health_check_with_unreachable_health_url_returns_false() {
         let tunnel = CustomTunnel::new(
-            "sleep 1".into(),
+            long_running_command(),
             Some("http://127.0.0.1:9/healthz".into()),
             None,
         );
 
         assert!(!tunnel.health_check().await);
+    }
+
+    #[cfg(windows)]
+    fn long_running_command() -> String {
+        "cmd /C ping -n 2 127.0.0.1".into()
+    }
+
+    #[cfg(not(windows))]
+    fn long_running_command() -> String {
+        "sleep 1".into()
+    }
+
+    #[cfg(windows)]
+    fn echo_command(message: &str) -> String {
+        format!("cmd /C echo {message}")
+    }
+
+    #[cfg(not(windows))]
+    fn echo_command(message: &str) -> String {
+        format!("echo {message}")
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Replaces Unix-only test commands in runtime/API shell adapter tests with platform-aware fixtures so Windows does not try to execute standalone `echo`, `cat`, `touch`, `sleep`, or POSIX stderr redirection.
  - Runs skill `TEST.sh` commands through the platform shell, matching the native runtime's Windows `cmd.exe` quoting behavior so quoted command lines survive on Windows.
  - Routes Bedrock `credential_process` through the platform shell instead of hardcoding `sh -c`, preserving Windows support for AWS config credential helpers.
  - Gives custom tunnel and hardware subprocess tests Windows-compatible helper commands while keeping the production tunnel/subprocess behavior unchanged.
- **Scope boundary:** This PR only covers the shell/process fixture cluster from #7462. It does not address the remaining Windows path-semantics, console-encoding, updater, or `content_search`/`rg` failures, and it does not claim the full Windows suite is green.
- **Blast radius:** Mostly tests and fixtures. Non-test behavior touched is limited to Bedrock `credential_process` invocation and skill `TEST.sh` command execution. Both keep the same configured command sources and output parsing while using the platform shell on Windows instead of assuming Unix `sh`.
- **Linked issue(s):** Related #7462
- **Labels:** `bug`, `size: M`, `risk: high`, `provider`, `runtime`, `skills`, `tunnel`, `provider:bedrock`, `tool:shell`, `hardware`

## Validation Evidence (required)

- **Commands run and tail output:**
  - `cargo fmt -p zeroclaw-api -p zeroclaw-runtime -p zeroclaw-providers -p zeroclaw-hardware -- --check`
    - Passed.
  - `cargo test -p zeroclaw-api build_shell_command_executes --lib`
    - Passed: `1 passed; 0 failed; 51 filtered out`.
  - `cargo test -p zeroclaw-providers from_credential_process_parses_json_output --lib`
    - Passed: `1 passed; 0 failed; 1019 filtered out`.
  - `cargo test -p zeroclaw-runtime test_skill_exit_code_mismatch --lib`
    - Passed: `1 passed; 0 failed; 2298 filtered out`.
  - `cargo test -p zeroclaw-runtime shell_stdin_is_eof_not_the_terminal --lib`
    - Passed: `1 passed; 0 failed; 2298 filtered out`.
  - `cargo test -p zeroclaw-runtime shell_warns_on_ephemeral_success_with_stderr --lib`
    - Passed: `1 passed; 0 failed; 2298 filtered out`.
  - `cargo test -p zeroclaw-runtime shell_requires_approval_for_medium_risk_command --lib`
    - Passed: `1 passed; 0 failed; 2298 filtered out`.
  - `cargo test -p zeroclaw-runtime tunnel::custom::tests --lib`
    - Passed: `5 passed; 0 failed; 2294 filtered out`.
  - `rustc --crate-type lib --target x86_64-pc-windows-msvc --emit=metadata <minimal CommandExt verifier>`
    - Passed. This verifies the Windows-only `CommandExt::raw_arg` and `creation_flags` API shape used by the platform-shell helpers.
  - `cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings`
    - Passed as broad workspace-check validation at head `d5e207a5fd46f7fa83eb2dd986ec724ae013322e`; completed in 16m59s.
  - `cargo nextest run --locked --workspace --exclude zeroclaw-desktop`
    - Passed as broad CI-shaped test validation at head `d5e207a5fd46f7fa83eb2dd986ec724ae013322e`; the local timing record captured successful completion in 14m19s. The final nextest count summary was not captured, so this is recorded as a passed broad local run without a count total.
- **Beyond CI — what did you manually verify?**
  - Windows-native test run was not performed locally; the validation below is from a macOS host using cross-compilation checks where possible.
  - Reviewed the public PR diff snapshot; it contains one commit and the expected seven changed files.
  - Compared the new Windows shell helpers against the platform-shell shape covered by the standalone `CommandExt` verifier so `credential_process` and skill test execution use `cmd.exe`/`raw_arg`/`CREATE_NO_WINDOW` on Windows.
  - Confirmed broad local readiness validation now covers workspace clippy and CI-shaped nextest on the pushed head.
- **If any command was intentionally skipped, why:**
  - A narrow Windows-target `cargo check -p zeroclaw-providers --lib --target x86_64-pc-windows-msvc` was attempted, but it failed before reaching project code because `ring` could not find Windows C headers/toolchain support on this macOS host.
  - Earlier focused hardware subprocess test attempts were stopped under concurrent local Rust build contention. Later broad workspace nextest completed successfully on this PR head, so the earlier stopped focused run is no longer an open local readiness gap.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `Yes`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation:
  - Bedrock `credential_process` still reads the same AWS config command and parses the same stdout JSON. The change removes the Unix shell assumption and uses the platform shell on Windows; it does not log credential values, add new credential sources, or broaden where credentials are read from.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: exact upgrade steps for existing users:
  - No user action required.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert d5e207a5fd46f7fa83eb2dd986ec724ae013322e`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Windows test jobs still fail in the affected shell/process fixture cluster; Bedrock `credential_process` on Windows may fail to spawn or parse helper output.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Scope materially carried forward: N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why (inspiration-only, no direct code/design carry-over): No superseded PR scope is incorporated.
