### PR TITLE
fix(telegram): bypass mention_only gate for replies to bot messages

### DIFF
--- a/crates/zeroclaw-channels/src/telegram.rs
+++ b/crates/zeroclaw-channels/src/telegram.rs
@@ -5721,6 +5721,160 @@ mod tests {
     }
 
     #[test]
+    fn parse_update_reply_to_bot_bypasses_mention_only_gate() {
+        let mention_only = true;
+        let ch = TelegramChannel::new(
+            "token".into(),
+            "telegram_test_alias",
+            Arc::new(|| vec!["*".into()]),
+            mention_only,
+        );
+        {
+            let mut cache = ch.bot_username.lock();
+            *cache = Some("mybot".to_string());
+        }
+        {
+            let mut cache = ch.bot_id.lock();
+            *cache = Some(42);
+        }
+
+        // Reply to the bot's own message — no mention needed.
+        let update = serde_json::json!({
+            "update_id": 20,
+            "message": {
+                "message_id": 55,
+                "text": "do this",
+                "from": { "id": 555, "username": "alice" },
+                "chat": { "id": -100_200_300, "type": "group" },
+                "reply_to_message": {
+                    "message_id": 50,
+                    "from": { "id": 42, "username": "mybot", "is_bot": true },
+                    "text": "original"
+                }
+            }
+        });
+
+        let parsed = ch
+            .parse_update_message(&update)
+            .expect("reply-to-bot should bypass mention_only gate");
+        assert_eq!(parsed.content, "do this");
+    }
+
+    #[test]
+    fn parse_update_reply_to_non_bot_still_dropped_in_mention_only() {
+        let mention_only = true;
+        let ch = TelegramChannel::new(
+            "token".into(),
+            "telegram_test_alias",
+            Arc::new(|| vec!["*".into()]),
+            mention_only,
+        );
+        {
+            let mut cache = ch.bot_username.lock();
+            *cache = Some("mybot".to_string());
+        }
+        {
+            let mut cache = ch.bot_id.lock();
+            *cache = Some(42);
+        }
+
+        // Reply to another user (not the bot) — still needs a mention.
+        let update = serde_json::json!({
+            "update_id": 21,
+            "message": {
+                "message_id": 56,
+                "text": "hello",
+                "from": { "id": 555, "username": "alice" },
+                "chat": { "id": -100_200_300, "type": "group" },
+                "reply_to_message": {
+                    "message_id": 51,
+                    "from": { "id": 99, "username": "charlie" },
+                    "text": "some message"
+                }
+            }
+        });
+
+        assert!(ch.parse_update_message(&update).is_none());
+    }
+
+    #[test]
+    fn parse_update_reply_bot_id_unresolved_falls_through_in_mention_only() {
+        let mention_only = true;
+        let ch = TelegramChannel::new(
+            "token".into(),
+            "telegram_test_alias",
+            Arc::new(|| vec!["*".into()]),
+            mention_only,
+        );
+        {
+            let mut cache = ch.bot_username.lock();
+            *cache = Some("mybot".to_string());
+        }
+        // bot_id stays None — unresolved.
+
+        // Reply to the bot's message, but bot_id is unresolved — falls through.
+        let update = serde_json::json!({
+            "update_id": 22,
+            "message": {
+                "message_id": 57,
+                "text": "hello",
+                "from": { "id": 555, "username": "alice" },
+                "chat": { "id": -100_200_300, "type": "group" },
+                "reply_to_message": {
+                    "message_id": 52,
+                    "from": { "id": 42, "username": "mybot", "is_bot": true },
+                    "text": "original"
+                }
+            }
+        });
+
+        assert!(ch.parse_update_message(&update).is_none());
+    }
+
+    #[test]
+    fn parse_update_reply_to_bot_bypasses_mention_only_gate_caption_path() {
+        let mention_only = true;
+        let ch = TelegramChannel::new(
+            "token".into(),
+            "telegram_test_alias",
+            Arc::new(|| vec!["*".into()]),
+            mention_only,
+        );
+        {
+            let mut cache = ch.bot_username.lock();
+            *cache = Some("mybot".to_string());
+        }
+        {
+            let mut cache = ch.bot_id.lock();
+            *cache = Some(42);
+        }
+
+        // Photo with a caption, replying to the bot — caption should pass.
+        let update = serde_json::json!({
+            "update_id": 23,
+            "message": {
+                "message_id": 58,
+                "caption": "enhance this",
+                "from": { "id": 555, "username": "alice" },
+                "chat": { "id": -100_200_300, "type": "group" },
+                "photo": [
+                    { "file_id": "abc", "width": 100, "height": 100 }
+                ],
+                "reply_to_message": {
+                    "message_id": 53,
+                    "from": { "id": 42, "username": "mybot", "is_bot": true },
+                    "text": "original photo"
+                }
+            }
+        });
+
+        let parsed = ch
+            .parse_update_message(&update)
+            .expect("reply-to-bot caption should bypass mention_only gate");
+        assert_eq!(parsed.content, "enhance this");
+    }
+
+    #[test]
     fn telegram_is_group_message_detects_groups() {
         let group_msg = serde_json::json!({
             "chat": { "type": "group" }

--- a/crates/zeroclaw-channels/src/telegram.rs
+++ b/crates/zeroclaw-channels/src/telegram.rs
@@ -536,6 +536,7 @@ pub struct TelegramChannel {
     last_draft_edit: Mutex<std::collections::HashMap<String, std::time::Instant>>,
     mention_only: bool,
     bot_username: Mutex<Option<String>>,
+    bot_id: Mutex<Option<i64>>,
     /// Base URL for the Telegram Bot API. Defaults to `https://api.telegram.org`.
     /// Override for local Bot API servers or testing.
     api_base: String,
@@ -614,6 +615,7 @@ impl TelegramChannel {
             typing_handle: Mutex::new(None),
             mention_only,
             bot_username: Mutex::new(None),
+            bot_id: Mutex::new(None),
             api_base: TELEGRAM_OFFICIAL_API_BASE_URL.to_string(),
             transcription: None,
             transcription_manager: None,
@@ -1251,11 +1253,17 @@ impl TelegramChannel {
         }
 
         let data: serde_json::Value = resp.json().await?;
-        let username = data
-            .get("result")
-            .and_then(|r| r.get("username"))
+        let result = data.get("result").context("missing result in getMe response")?;
+        let username = result
+            .get("username")
             .and_then(|u| u.as_str())
             .context("Bot username not found in response")?;
+
+        // Cache the bot's user ID for reply-to-self detection
+        if let Some(id) = result.get("id").and_then(|i| i.as_i64()) {
+            let mut cache = self.bot_id.lock();
+            *cache = Some(id);
+        }
 
         Ok(username.to_string())
     }
@@ -1353,6 +1361,17 @@ impl TelegramChannel {
             .unwrap_or(false)
     }
 
+    /// Check whether `message` is a reply to a message sent by the bot
+    /// itself. When true, the `mention_only` gate should be bypassed.
+    fn is_reply_to_bot(message: &serde_json::Value, bot_id: i64) -> bool {
+        message
+            .get("reply_to_message")
+            .and_then(|r| r.get("from"))
+            .and_then(|f| f.get("id"))
+            .and_then(|i| i.as_i64())
+            .is_some_and(|id| id == bot_id)
+    }
+
     /// Apply the `mention_only` gate to a non-text update (photo / document /
     /// voice) using its caption as the channel for the mention.
     ///
@@ -1382,6 +1401,17 @@ impl TelegramChannel {
         }
         let bot_username_guard = self.bot_username.lock();
         let bot_username = bot_username_guard.as_ref()?;
+
+        // If the user is replying directly to the bot's message, bypass the
+        // mention check — replies are an unambiguous signal of intent.
+        if let Some(caption) = caption {
+            if let Some(bot_id) = *self.bot_id.lock() {
+                if Self::is_reply_to_bot(message, bot_id) {
+                    return Some(Self::normalize_incoming_content(caption, bot_username));
+                }
+            }
+        }
+
         let caption = caption?;
         if !Self::contains_bot_mention(caption, bot_username) {
             return None;
@@ -2222,8 +2252,13 @@ Allowlist Telegram username (without '@') or numeric user ID.",
         if self.mention_only && is_group {
             let bot_username = self.bot_username.lock();
             if let Some(ref bot_username) = *bot_username {
+                // If the user is replying directly to the bot's message, bypass
+                // the mention check — replies are an unambiguous signal of intent.
                 if !Self::contains_bot_mention(text, bot_username) {
-                    return None;
+                    let bot_id = *self.bot_id.lock();
+                    if bot_id.is_none_or(|id| !Self::is_reply_to_bot(message, id)) {
+                        return None;
+                    }
                 }
             } else {
                 return None;

--- a/crates/zeroclaw-channels/src/telegram.rs
+++ b/crates/zeroclaw-channels/src/telegram.rs
@@ -1253,7 +1253,9 @@ impl TelegramChannel {
         }
 
         let data: serde_json::Value = resp.json().await?;
-        let result = data.get("result").context("missing result in getMe response")?;
+        let result = data
+            .get("result")
+            .context("missing result in getMe response")?;
         let username = result
             .get("username")
             .and_then(|u| u.as_str())
@@ -5875,10 +5877,7 @@ mod tests {
             "reply-to-bot caption should bypass mention_only gate"
         );
         let gated = result.unwrap();
-        assert!(
-            gated.is_some(),
-            "gate should return the normalized caption"
-        );
+        assert!(gated.is_some(), "gate should return the normalized caption");
         assert_eq!(gated.unwrap(), "enhance this");
     }
 

--- a/crates/zeroclaw-channels/src/telegram.rs
+++ b/crates/zeroclaw-channels/src/telegram.rs
@@ -1404,12 +1404,11 @@ impl TelegramChannel {
 
         // If the user is replying directly to the bot's message, bypass the
         // mention check — replies are an unambiguous signal of intent.
-        if let Some(caption) = caption {
-            if let Some(bot_id) = *self.bot_id.lock() {
-                if Self::is_reply_to_bot(message, bot_id) {
-                    return Some(Self::normalize_incoming_content(caption, bot_username));
-                }
-            }
+        if let Some(caption) = caption
+            && let Some(bot_id) = *self.bot_id.lock()
+            && Self::is_reply_to_bot(message, bot_id)
+        {
+            return Some(Self::normalize_incoming_content(caption, bot_username));
         }
 
         let caption = caption?;
@@ -5757,7 +5756,9 @@ mod tests {
         let parsed = ch
             .parse_update_message(&update)
             .expect("reply-to-bot should bypass mention_only gate");
-        assert_eq!(parsed.content, "do this");
+        // extract_reply_context prepends the quote; the gate returns the body,
+        // and the quote is re-added by the normal reply-handling path.
+        assert_eq!(parsed.content, "> @mybot:\n> original\n\ndo this");
     }
 
     #[test]
@@ -5850,28 +5851,35 @@ mod tests {
         }
 
         // Photo with a caption, replying to the bot — caption should pass.
-        let update = serde_json::json!({
-            "update_id": 23,
-            "message": {
-                "message_id": 58,
-                "caption": "enhance this",
-                "from": { "id": 555, "username": "alice" },
-                "chat": { "id": -100_200_300, "type": "group" },
-                "photo": [
-                    { "file_id": "abc", "width": 100, "height": 100 }
-                ],
-                "reply_to_message": {
-                    "message_id": 53,
-                    "from": { "id": 42, "username": "mybot", "is_bot": true },
-                    "text": "original photo"
-                }
+        // This exercises check_media_mention_gate directly because
+        // parse_update_message requires `message.text` and photo updates
+        // carry only `message.caption`.
+        let message = serde_json::json!({
+            "message_id": 58,
+            "caption": "enhance this",
+            "from": { "id": 555, "username": "alice" },
+            "chat": { "id": -100_200_300, "type": "group" },
+            "photo": [
+                { "file_id": "abc", "width": 100, "height": 100 }
+            ],
+            "reply_to_message": {
+                "message_id": 53,
+                "from": { "id": 42, "username": "mybot", "is_bot": true },
+                "text": "original photo"
             }
         });
 
-        let parsed = ch
-            .parse_update_message(&update)
-            .expect("reply-to-bot caption should bypass mention_only gate");
-        assert_eq!(parsed.content, "enhance this");
+        let result = ch.check_media_mention_gate(&message, Some("enhance this"));
+        assert!(
+            result.is_some(),
+            "reply-to-bot caption should bypass mention_only gate"
+        );
+        let gated = result.unwrap();
+        assert!(
+            gated.is_some(),
+            "gate should return the normalized caption"
+        );
+        assert_eq!(gated.unwrap(), "enhance this");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #5866 — When a group has `mention_only` enabled, replies directly to the bot's own messages are now recognized as an unambiguous signal of intent and bypass the mention check.

## Root cause

The `mention_only` gate required every message to contain a @botmention. When a user replied directly to the bot's message, the reply caption does not contain a mention, so the message was silently dropped even though the user clearly intended to talk to the bot.

## Fix

- Cache the bot's user ID from `getMe` response
- Add `is_reply_to_bot` helper that checks `reply_to_message.from.id` against the cached bot ID
- Apply the bypass in both the text message path and the caption path (photo/document/voice)

## Changes

- `crates/zeroclaw-channels/src/telegram.rs`: Cache bot_id, add reply-to-self detection, wire bypass into both text and caption mention checks

## Verification

Source-level verification: the `is_reply_to_bot` helper inspects the standard Telegram `reply_to_message` envelope which is present on all message types. Both call sites (text path and caption path) use the same helper in the same pattern: if the message is a reply to the bot, skip the mention check and normalize normally.