### PR TITLE
fix(runtime): allow auto-approved tools on channels at non-Full autonomy

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -10399,7 +10399,7 @@ impl Default for WebhookAuditConfig {
 // contexts). Configs from older schema versions are folded into
 // `risk_profiles.default` by the migration in `schema/v2.rs`.
 
-fn default_auto_approve() -> Vec<String> {
+pub fn default_auto_approve() -> Vec<String> {
     vec![
         "file_read".into(),
         "memory_recall".into(),

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -282,10 +282,8 @@ pub(crate) fn filter_channel_builtin_tools(
     // operator-added auto_approve entries (e.g. shell) still require
     // explicit allowlisting via allowed_tools.
     if security.autonomy != AutonomyLevel::Full {
-        let safe_defaults: HashSet<&str> = zeroclaw_config::schema::default_auto_approve()
-            .iter()
-            .map(String::as_str)
-            .collect();
+        let defaults = zeroclaw_config::schema::default_auto_approve();
+        let safe_defaults: HashSet<&str> = defaults.iter().map(String::as_str).collect();
         tools_registry.retain(|t| {
             let name = t.name();
             if safe_defaults.contains(name) {
@@ -14221,7 +14219,7 @@ Let me check the result."#;
         // admitted by the policy itself.
         let policy = TestPolicy {
             allowed_tools: Some(vec!["shell".into()]),
-            autonomy: AutonomyLevel::Normal,
+            autonomy: AutonomyLevel::Supervised,
             ..TestPolicy::default()
         };
 
@@ -14287,7 +14285,7 @@ Let me check the result."#;
         let policy = TestPolicy {
             allowed_tools: Some(vec!["file_read".into()]),
             auto_approve: vec!["shell".into()],
-            autonomy: AutonomyLevel::Normal,
+            autonomy: AutonomyLevel::Supervised,
             ..TestPolicy::default()
         };
 

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -13987,7 +13987,6 @@ Let me check the result."#;
         );
     }
 
-<<<<<<< ours
     // ── Observer metadata regression tests ──
 
     #[derive(Default)]
@@ -14196,6 +14195,8 @@ Let me check the result."#;
 
         let events = capturing.events.lock();
         assert_all_events_share_turn_id(&events, Some("test-agent"), Some("cli"));
+    }
+
     // ── filter_channel_builtin_tools safe-default bypass ─────────
     //
     // At non-Full autonomy the known read-only defaults
@@ -14331,6 +14332,5 @@ Let me check the result."#;
             filtered.contains(&"file_read"),
             "file_read in allowed_tools must survive, got {filtered:?}"
         );
->>>>>>> theirs
     }
 }

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -274,7 +274,30 @@ pub(crate) fn filter_channel_builtin_tools(
     security: &zeroclaw_config::policy::SecurityPolicy,
 ) {
     let before_filter = tools_registry.len();
-    apply_policy_tool_filter(tools_registry, Some(security), None);
+
+    // At non-Full autonomy, auto-approved tools (web_search_tool,
+    // web_fetch, calculator, etc.) are always accessible on channels
+    // so the bot can fetch real-time information. Write/exec tools
+    // remain gated by the security policy.
+    if security.autonomy != AutonomyLevel::Full && !security.auto_approve.is_empty() {
+        let auto_set: HashSet<&str> =
+            security.auto_approve.iter().map(String::as_str).collect();
+        tools_registry.retain(|t| {
+            let name = t.name();
+            if auto_set.contains(name) {
+                // Auto-approved tool: bypass the allowed_tools allowlist
+                // but still respect the excluded_tools denylist.
+                return security
+                    .excluded_tools
+                    .as_ref()
+                    .is_none_or(|list| !list.iter().any(|ex| ex == name));
+            }
+            security.is_tool_allowed(name)
+        });
+    } else {
+        apply_policy_tool_filter(tools_registry, Some(security), None);
+    }
+
     if tools_registry.len() != before_filter {
         ::zeroclaw_log::record!(
             INFO,

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -275,18 +275,22 @@ pub(crate) fn filter_channel_builtin_tools(
 ) {
     let before_filter = tools_registry.len();
 
-    // At non-Full autonomy, auto-approved tools (web_search_tool,
-    // web_fetch, calculator, etc.) are always accessible on channels
-    // so the bot can fetch real-time information. Write/exec tools
-    // remain gated by the security policy.
-    if security.autonomy != AutonomyLevel::Full && !security.auto_approve.is_empty() {
-        let auto_set: HashSet<&str> =
-            security.auto_approve.iter().map(String::as_str).collect();
+    // At non-Full autonomy, the known default read-only auto-approve
+    // tools (web_search_tool, web_fetch, calculator, etc.) are always
+    // accessible on channels so the bot can fetch real-time information.
+    // Only the canonical builtin default set bypasses allowed_tools;
+    // operator-added auto_approve entries (e.g. shell) still require
+    // explicit allowlisting via allowed_tools.
+    if security.autonomy != AutonomyLevel::Full {
+        let safe_defaults: HashSet<&str> = zeroclaw_config::schema::default_auto_approve()
+            .iter()
+            .map(String::as_str)
+            .collect();
         tools_registry.retain(|t| {
             let name = t.name();
-            if auto_set.contains(name) {
-                // Auto-approved tool: bypass the allowed_tools allowlist
-                // but still respect the excluded_tools denylist.
+            if safe_defaults.contains(name) {
+                // Builtin read-only tool: admit past allowed_tools but
+                // still respect the excluded_tools denylist.
                 return security
                     .excluded_tools
                     .as_ref()
@@ -13985,6 +13989,7 @@ Let me check the result."#;
         );
     }
 
+<<<<<<< ours
     // ── Observer metadata regression tests ──
 
     #[derive(Default)]
@@ -14193,5 +14198,141 @@ Let me check the result."#;
 
         let events = capturing.events.lock();
         assert_all_events_share_turn_id(&events, Some("test-agent"), Some("cli"));
+    // ── filter_channel_builtin_tools safe-default bypass ─────────
+    //
+    // At non-Full autonomy the known read-only defaults
+    // (web_search_tool, web_fetch, calculator, etc.) bypass
+    // allowed_tools so the bot can always fetch real-time info.
+    // Operator-added auto_approve entries (e.g. shell) do NOT get
+    // the same bypass — they must be explicitly allowlisted.
+
+    #[test]
+    fn channel_safe_defaults_survive_restrictive_allowed_tools() {
+        let config = zeroclaw_config::schema::Config::default();
+        let security = Arc::new(TestPolicy {
+            workspace_dir: std::env::temp_dir(),
+            ..TestPolicy::default()
+        });
+        let risk = zeroclaw_config::schema::RiskProfileConfig::default();
+        let mem: Arc<dyn zeroclaw_memory::Memory> =
+            Arc::new(zeroclaw_memory::NoneMemory::new("test"));
+
+        // Restrict allowed_tools to shell only — nothing else is
+        // admitted by the policy itself.
+        let policy = TestPolicy {
+            allowed_tools: Some(vec!["shell".into()]),
+            autonomy: AutonomyLevel::Normal,
+            ..TestPolicy::default()
+        };
+
+        let mut registry = crate::tools::all_tools(
+            Arc::new(config.clone()),
+            &security,
+            &risk,
+            "test",
+            mem,
+            None,
+            None,
+            &config.browser,
+            &config.http_request,
+            &config.web_fetch,
+            &security.workspace_dir,
+            &config.agents,
+            None,
+            &config,
+            None,
+            false,
+            None,
+        )
+        .tools;
+
+        let before = tool_names(&registry);
+        assert!(
+            before.contains(&"web_search_tool"),
+            "precondition: web_search_tool in registry, got {before:?}"
+        );
+        assert!(
+            before.contains(&"shell"),
+            "precondition: shell in registry, got {before:?}"
+        );
+
+        super::filter_channel_builtin_tools(&mut registry, &policy);
+
+        let filtered = tool_names(&registry);
+        assert!(
+            filtered.contains(&"web_search_tool"),
+            "safe default web_search_tool must survive restrictive allowed_tools, got {filtered:?}"
+        );
+        assert!(
+            filtered.contains(&"shell"),
+            "shell in allowed_tools must survive, got {filtered:?}"
+        );
+    }
+
+    #[test]
+    fn channel_operator_auto_approve_gated_by_allowed_tools() {
+        let config = zeroclaw_config::schema::Config::default();
+        let security = Arc::new(TestPolicy {
+            workspace_dir: std::env::temp_dir(),
+            ..TestPolicy::default()
+        });
+        let risk = zeroclaw_config::schema::RiskProfileConfig::default();
+        let mem: Arc<dyn zeroclaw_memory::Memory> =
+            Arc::new(zeroclaw_memory::NoneMemory::new("test"));
+
+        // Operator added shell to auto_approve but allowed_tools
+        // only lists file_read. Under the safe-defaults gate,
+        // shell (NOT a canonical safe default) must still pass
+        // is_tool_allowed — which means it's dropped.
+        let policy = TestPolicy {
+            allowed_tools: Some(vec!["file_read".into()]),
+            auto_approve: vec!["shell".into()],
+            autonomy: AutonomyLevel::Normal,
+            ..TestPolicy::default()
+        };
+
+        let mut registry = crate::tools::all_tools(
+            Arc::new(config.clone()),
+            &security,
+            &risk,
+            "test",
+            mem,
+            None,
+            None,
+            &config.browser,
+            &config.http_request,
+            &config.web_fetch,
+            &security.workspace_dir,
+            &config.agents,
+            None,
+            &config,
+            None,
+            false,
+            None,
+        )
+        .tools;
+
+        let before = tool_names(&registry);
+        assert!(
+            before.contains(&"shell"),
+            "precondition: shell in registry, got {before:?}"
+        );
+        assert!(
+            before.contains(&"file_read"),
+            "precondition: file_read in registry, got {before:?}"
+        );
+
+        super::filter_channel_builtin_tools(&mut registry, &policy);
+
+        let filtered = tool_names(&registry);
+        assert!(
+            !filtered.contains(&"shell"),
+            "operator-added auto_approve shell must be dropped when not in allowed_tools, got {filtered:?}"
+        );
+        assert!(
+            filtered.contains(&"file_read"),
+            "file_read in allowed_tools must survive, got {filtered:?}"
+        );
+>>>>>>> theirs
     }
 }


### PR DESCRIPTION
**Maintainer note:** Updated before merge to reflect the current implementation and avoid re-closing #4083, which was already closed by #4094. The code diff remains the contributor's PR.

## Summary

Refs #4083 — At non-Full autonomy levels, the channel path (`process_message`) was applying the `SecurityPolicy` `allowed_tools` allowlist to all tools indiscriminately. When a user configured a restrictive `allowed_tools` list (e.g., `["shell", "file_read"]`), canonical read-only safe defaults like `web_search_tool`, `web_fetch`, and `calculator` could be silently dropped from the tool registry. Channel bots could not fetch real-time information even though those built-in defaults require no operator approval.

## Root cause

`filter_channel_builtin_tools` applied `SecurityPolicy::is_tool_allowed` uniformly to all tools, including canonical built-in read-only defaults that should stay available to channel bots at non-Full autonomy.

## Fix

Modified `filter_channel_builtin_tools` to add a bypass for the canonical built-in safe-default set at non-Full autonomy levels:
- Tools listed by `zeroclaw_config::schema::default_auto_approve()` (read-only defaults such as `web_search_tool`, `web_fetch`, `calculator`, etc.) bypass the `allowed_tools` allowlist
- These tools still respect the `excluded_tools` denylist
- Operator-added `security.auto_approve` entries do not get this bypass and still require explicit allowlisting through `allowed_tools`
- All other tools continue through the normal policy filtering
- At Full autonomy, behavior is completely unchanged

## Changes

- `crates/zeroclaw-config/src/schema.rs`: Expose the canonical `default_auto_approve()` registry helper for shared use
- `crates/zeroclaw-runtime/src/agent/loop_.rs`: Modified `filter_channel_builtin_tools` to preserve canonical safe defaults on non-Full channel turns while keeping `allowed_tools` as the hard cap for operator-added tools

## Safety

The fix uses the canonical built-in default set, not the operator-editable `security.auto_approve` list. Write/exec tools are not admitted by this bypass just because an operator adds them to `auto_approve`; they still go through `security.is_tool_allowed(name)` and must pass `allowed_tools` / `excluded_tools`.

Refs #4083
