### PR TITLE
fix(tools): gate execute_pipeline sub-tool execution with per-agent ToolAccessPolicy

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -9945,6 +9945,26 @@ fn build_owner_by_channel_key(
     owner_by_channel_key
 }
 
+/// Conditionally build a `PipelineTool` when the per-agent security
+/// policy allows `execute_pipeline`. Returns `None` when the raw
+/// config is missing, the tool is denied, or the pipeline has no tools.
+///
+/// This is the single production seam used by both `start_channels()`
+/// and the channel-path gate regression tests — removing the
+/// insertion block in `start_channels` removes the only call site, so
+/// tests that exercise this function fail alongside the production path.
+pub(crate) fn build_channel_pipeline_tool(
+    pipeline_raw: Option<&zeroclaw_runtime::tools::PipelineRaw>,
+    security: &SecurityPolicy,
+) -> Option<Box<dyn Tool>> {
+    let raw = pipeline_raw?;
+    if !security.is_tool_allowed("execute_pipeline") {
+        return None;
+    }
+    let policy = mcp_tool_access_policy(security, None);
+    zeroclaw_runtime::tools::build_pipeline_tool(raw, policy)
+}
+
 /// Start all configured channels and route messages to the agent
 #[allow(clippy::too_many_lines)]
 pub async fn start_channels(
@@ -10237,14 +10257,11 @@ pub async fn start_channels(
         }
 
         // ── Wire deferred PipelineTool with per-agent policy gate (channel path) ──
-        if let Some(ref raw) = all_tools_result_ch.pipeline_raw
-            && security.is_tool_allowed("execute_pipeline")
-        {
-            let policy =
-                zeroclaw_runtime::agent::loop_::mcp_tool_access_policy(security.as_ref(), None);
-            if let Some(pipe) = zeroclaw_runtime::tools::build_pipeline_tool(raw, policy) {
-                built_tools.push(pipe);
-            }
+        if let Some(pipe) = build_channel_pipeline_tool(
+            all_tools_result_ch.pipeline_raw.as_ref(),
+            security.as_ref(),
+        ) {
+            built_tools.push(pipe);
         }
 
         // Wire MCP tools into the per-agent registry before freezing —
@@ -26842,41 +26859,46 @@ mod omitted_feature_tests {
     // ── Pipeline gate (channel path) ───────────────────────────
     //
     // The channel path does not go through ScopedToolRegistry::assemble();
-    // it wires the deferred pipeline tool manually with its own top-level
-    // SecurityPolicy gate (start_channels, lines ~10075-10082). These tests
-    // exercise that manual path by building a minimal AllToolsResult with a
-    // PipelineRaw and applying the same gate check.
+    // gate via `build_channel_pipeline_tool`. These tests exercise the
+    // production seam by building a minimal PipelineRaw and calling the
+    // same helper used by `start_channels`.
 
-    /// Build a minimal `AllToolsResult` with a `PipelineRaw` and apply the
-    /// channel-path security gate, returning tool names.
+    /// Build a minimal `PipelineRaw` and call the channel-path production
+    /// seam `build_channel_pipeline_tool`, returning tool names.
     fn channel_pipeline_names(
         security: &std::sync::Arc<zeroclaw_runtime::security::SecurityPolicy>,
     ) -> Vec<String> {
         use std::sync::Arc;
         use zeroclaw_api::tool::ToolResult;
         use zeroclaw_config::schema::PipelineConfig;
-        use zeroclaw_runtime::tools::{Tool, PipelineRaw, build_pipeline_tool};
+        use zeroclaw_runtime::tools::{PipelineRaw, Tool};
 
         struct Stub(&'static str);
         impl ::zeroclaw_api::attribution::Attributable for Stub {
             fn role(&self) -> ::zeroclaw_api::attribution::Role {
                 ::zeroclaw_api::attribution::Role::Tool(
-                    ::zeroclaw_api::attribution::ToolKind::Plugin)
+                    ::zeroclaw_api::attribution::ToolKind::Plugin,
+                )
             }
-            fn alias(&self) -> &str { self.0 }
+            fn alias(&self) -> &str {
+                self.0
+            }
         }
         #[async_trait::async_trait]
         impl Tool for Stub {
-            fn name(&self) -> &str { self.0 }
-            fn description(&self) -> &str { "stub" }
-            fn parameters_schema(&self) -> serde_json::Value { serde_json::json!({}) }
-            async fn execute(
-                &self,
-                _args: serde_json::Value,
-            ) -> anyhow::Result<ToolResult> {
+            fn name(&self) -> &str {
+                self.0
+            }
+            fn description(&self) -> &str {
+                "stub"
+            }
+            fn parameters_schema(&self) -> serde_json::Value {
+                serde_json::json!({})
+            }
+            async fn execute(&self, _args: serde_json::Value) -> anyhow::Result<ToolResult> {
                 Ok(ToolResult {
                     success: true,
-                    output: "ok".to_string(),
+                    output: "ok".into(),
                     error: None,
                 })
             }
@@ -26884,16 +26906,15 @@ mod omitted_feature_tests {
 
         let mock_tool: Arc<dyn Tool> = Arc::new(Stub("shell"));
         let raw = PipelineRaw {
-            config: PipelineConfig { enabled: true, ..Default::default() },
+            config: PipelineConfig {
+                enabled: true,
+                ..Default::default()
+            },
             tool_arcs: vec![mock_tool],
         };
         let mut registry: Vec<Box<dyn Tool>> = Vec::new();
-        if security.is_tool_allowed("execute_pipeline") {
-            let policy =
-                zeroclaw_runtime::agent::loop_::mcp_tool_access_policy(security.as_ref(), None);
-            if let Some(pipe) = build_pipeline_tool(&raw, policy) {
-                registry.push(pipe);
-            }
+        if let Some(pipe) = super::build_channel_pipeline_tool(Some(&raw), security.as_ref()) {
+            registry.push(pipe);
         }
         registry.iter().map(|t| t.name().to_string()).collect()
     }

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -26838,4 +26838,86 @@ mod omitted_feature_tests {
              channel-telegram feature is not compiled in"
         );
     }
+
+    // ── Pipeline gate (channel path) ───────────────────────────
+    //
+    // The channel path does not go through ScopedToolRegistry::assemble();
+    // it wires the deferred pipeline tool manually with its own top-level
+    // SecurityPolicy gate (start_channels, lines ~10075-10082). These tests
+    // exercise that manual path by building a minimal AllToolsResult with a
+    // PipelineRaw and applying the same gate check.
+
+    /// Build a minimal `AllToolsResult` with a `PipelineRaw` and apply the
+    /// channel-path security gate, returning tool names.
+    fn channel_pipeline_names(
+        security: &std::sync::Arc<zeroclaw_runtime::security::SecurityPolicy>,
+    ) -> Vec<String> {
+        use std::sync::Arc;
+        use zeroclaw_api::tool::ToolResult;
+        use zeroclaw_config::schema::PipelineConfig;
+        use zeroclaw_runtime::tools::{Tool, PipelineRaw, build_pipeline_tool};
+
+        struct Stub(&'static str);
+        impl ::zeroclaw_api::attribution::Attributable for Stub {
+            fn role(&self) -> ::zeroclaw_api::attribution::Role {
+                ::zeroclaw_api::attribution::Role::Tool(
+                    ::zeroclaw_api::attribution::ToolKind::Plugin)
+            }
+            fn alias(&self) -> &str { self.0 }
+        }
+        #[async_trait::async_trait]
+        impl Tool for Stub {
+            fn name(&self) -> &str { self.0 }
+            fn description(&self) -> &str { "stub" }
+            fn parameters_schema(&self) -> serde_json::Value { serde_json::json!({}) }
+            async fn execute(
+                &self,
+                _args: serde_json::Value,
+            ) -> anyhow::Result<ToolResult> {
+                Ok(ToolResult {
+                    success: true,
+                    output: "ok".to_string(),
+                    error: None,
+                })
+            }
+        }
+
+        let mock_tool: Arc<dyn Tool> = Arc::new(Stub("shell"));
+        let raw = PipelineRaw {
+            config: PipelineConfig { enabled: true, ..Default::default() },
+            tool_arcs: vec![mock_tool],
+        };
+        let mut registry: Vec<Box<dyn Tool>> = Vec::new();
+        if security.is_tool_allowed("execute_pipeline") {
+            let policy =
+                zeroclaw_runtime::agent::loop_::mcp_tool_access_policy(security.as_ref(), None);
+            if let Some(pipe) = build_pipeline_tool(&raw, policy) {
+                registry.push(pipe);
+            }
+        }
+        registry.iter().map(|t| t.name().to_string()).collect()
+    }
+
+    #[test]
+    fn channel_pipeline_allowed_when_security_policy_admits() {
+        let security = std::sync::Arc::new(zeroclaw_runtime::security::SecurityPolicy::default());
+        let names = channel_pipeline_names(&security);
+        assert!(
+            names.contains(&"execute_pipeline".to_string()),
+            "channel path must include execute_pipeline when policy admits it, got {names:?}"
+        );
+    }
+
+    #[test]
+    fn channel_pipeline_denied_when_security_policy_excludes() {
+        let security = std::sync::Arc::new(zeroclaw_runtime::security::SecurityPolicy {
+            excluded_tools: Some(vec!["execute_pipeline".to_string()]),
+            ..Default::default()
+        });
+        let names = channel_pipeline_names(&security);
+        assert!(
+            !names.contains(&"execute_pipeline".to_string()),
+            "channel path must deny execute_pipeline when excluded_tools blocks it, got {names:?}"
+        );
+    }
 }

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -10236,6 +10236,17 @@ pub async fn start_channels(
             );
         }
 
+        // ── Wire deferred PipelineTool with per-agent policy gate (channel path) ──
+        if let Some(ref raw) = all_tools_result_ch.pipeline_raw
+            && security.is_tool_allowed("execute_pipeline")
+        {
+            let policy =
+                zeroclaw_runtime::agent::loop_::mcp_tool_access_policy(security.as_ref(), None);
+            if let Some(pipe) = zeroclaw_runtime::tools::build_pipeline_tool(raw, policy) {
+                built_tools.push(pipe);
+            }
+        }
+
         // Wire MCP tools into the per-agent registry before freezing —
         // non-fatal. When `mcp.deferred_loading` is enabled, MCP tools are
         // exposed via a `tool_search` built-in rather than added eagerly.

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -15792,15 +15792,17 @@ Let me check the result."#;
 
     // ── execute_pipeline top-level gate ───────────────────────────
     //
-    // Audacity88 review blocker: the deferred construction moved
-    // PipelineTool after apply_policy_tool_filter, so the top-level
-    // execute_pipeline tool name was never gated. The fix is a
-    // security.is_tool_allowed("execute_pipeline") check before
-    // build_pipeline_tool. These tests prove the gate works and fail
-    // when it is removed.
+    // The deferred construction moved PipelineTool after
+    // apply_policy_tool_filter, so the top-level execute_pipeline
+    // tool name must be gated by both the SecurityPolicy and the
+    // caller-supplied allowlist. These tests exercise
+    // ScopedToolRegistry::assemble() — the one production seam — so
+    // removing the gate from the assembly boundary fails these tests.
 
-    #[test]
-    fn execute_pipeline_denied_when_not_in_allowed_tools() {
+    async fn assemble_with_pipeline(
+        policy: TestPolicy,
+        caller_allowed: Option<&[String]>,
+    ) -> Vec<String> {
         let mut config = zeroclaw_config::schema::Config::default();
         config.pipeline.enabled = true;
         let security = Arc::new(TestPolicy {
@@ -15811,208 +15813,90 @@ Let me check the result."#;
         let mem: Arc<dyn zeroclaw_memory::Memory> =
             Arc::new(zeroclaw_memory::NoneMemory::new("test"));
 
+        let all = crate::tools::all_tools(
+            Arc::new(config.clone()),
+            &security,
+            &risk,
+            "test",
+            mem,
+            None,
+            None,
+            &config.browser,
+            &config.http_request,
+            &config.web_fetch,
+            &security.workspace_dir,
+            &config.agents,
+            None,
+            &config,
+            None,
+            false,
+            None,
+        );
+
+        let policy_arc = Arc::new(policy);
+        let out = crate::tools::scoped::ScopedToolRegistry::assemble(
+            crate::tools::scoped::ScopedAssembly {
+                config: &config,
+                agent_alias: "test",
+                security: &policy_arc,
+                built: all,
+                skills: &[],
+                runtime: Arc::new(crate::platform::NativeRuntime::new()),
+                caller_allowed,
+                connect_mcp: false,
+                connect_peripherals: false,
+                exclude_memory: false,
+                list_deferred_mcp_specs: false,
+                emit_assembly_logs: false,
+            },
+        )
+        .await;
+        out.registry.iter().map(|t| t.name().to_string()).collect()
+    }
+
+    #[tokio::test]
+    async fn execute_pipeline_denied_when_not_in_allowed_tools() {
         let policy = TestPolicy {
             allowed_tools: Some(vec!["file_read".into()]),
             ..TestPolicy::default()
         };
-
-        let all = crate::tools::all_tools(
-            Arc::new(config.clone()),
-            &security,
-            &risk,
-            "test",
-            mem,
-            None,
-            None,
-            &config.browser,
-            &config.http_request,
-            &config.web_fetch,
-            &security.workspace_dir,
-            &config.agents,
-            None,
-            &config,
-            None,
-            false,
-            None,
-        );
-
-        let mut registry = all.tools;
-        if let Some(ref raw) = all.pipeline_raw
-            && policy.is_tool_allowed("execute_pipeline")
-        {
-            let access = super::mcp_tool_access_policy(&policy, None);
-            if let Some(pipe) = crate::tools::build_pipeline_tool(raw, access) {
-                registry.push(pipe);
-            }
-        }
-
-        let names: Vec<&str> = registry.iter().map(|t| t.name()).collect();
+        let names = assemble_with_pipeline(policy, None).await;
         assert!(
-            !names.contains(&"execute_pipeline"),
+            !names.contains(&"execute_pipeline".to_string()),
             "execute_pipeline must be denied when not in allowed_tools, got {names:?}"
         );
     }
 
-    #[test]
-    fn execute_pipeline_denied_when_in_excluded_tools() {
-        let mut config = zeroclaw_config::schema::Config::default();
-        config.pipeline.enabled = true;
-        let security = Arc::new(TestPolicy {
-            workspace_dir: std::env::temp_dir(),
-            ..TestPolicy::default()
-        });
-        let risk = zeroclaw_config::schema::RiskProfileConfig::default();
-        let mem: Arc<dyn zeroclaw_memory::Memory> =
-            Arc::new(zeroclaw_memory::NoneMemory::new("test"));
-
+    #[tokio::test]
+    async fn execute_pipeline_denied_when_in_excluded_tools() {
         let policy = TestPolicy {
             excluded_tools: Some(vec!["execute_pipeline".into()]),
             ..TestPolicy::default()
         };
-
-        let all = crate::tools::all_tools(
-            Arc::new(config.clone()),
-            &security,
-            &risk,
-            "test",
-            mem,
-            None,
-            None,
-            &config.browser,
-            &config.http_request,
-            &config.web_fetch,
-            &security.workspace_dir,
-            &config.agents,
-            None,
-            &config,
-            None,
-            false,
-            None,
-        );
-
-        let mut registry = all.tools;
-        if let Some(ref raw) = all.pipeline_raw
-            && policy.is_tool_allowed("execute_pipeline")
-        {
-            let access = super::mcp_tool_access_policy(&policy, None);
-            if let Some(pipe) = crate::tools::build_pipeline_tool(raw, access) {
-                registry.push(pipe);
-            }
-        }
-
-        let names: Vec<&str> = registry.iter().map(|t| t.name()).collect();
+        let names = assemble_with_pipeline(policy, None).await;
         assert!(
-            !names.contains(&"execute_pipeline"),
+            !names.contains(&"execute_pipeline".to_string()),
             "execute_pipeline must be denied when in excluded_tools, got {names:?}"
         );
     }
 
-    #[test]
-    fn execute_pipeline_allowed_when_policy_admits_it() {
-        let mut config = zeroclaw_config::schema::Config::default();
-        config.pipeline.enabled = true;
-        let security = Arc::new(TestPolicy {
-            workspace_dir: std::env::temp_dir(),
-            ..TestPolicy::default()
-        });
-        let risk = zeroclaw_config::schema::RiskProfileConfig::default();
-        let mem: Arc<dyn zeroclaw_memory::Memory> =
-            Arc::new(zeroclaw_memory::NoneMemory::new("test"));
-
-        // Unrestricted policy must admit execute_pipeline when
-        // the pipeline config is enabled.
+    #[tokio::test]
+    async fn execute_pipeline_allowed_when_policy_admits_it() {
         let policy = TestPolicy::default();
-
-        let all = crate::tools::all_tools(
-            Arc::new(config.clone()),
-            &security,
-            &risk,
-            "test",
-            mem,
-            None,
-            None,
-            &config.browser,
-            &config.http_request,
-            &config.web_fetch,
-            &security.workspace_dir,
-            &config.agents,
-            None,
-            &config,
-            None,
-            false,
-            None,
-        );
-
-        let mut registry = all.tools;
-        if let Some(ref raw) = all.pipeline_raw
-            && policy.is_tool_allowed("execute_pipeline")
-        {
-            let access = super::mcp_tool_access_policy(&policy, None);
-            if let Some(pipe) = crate::tools::build_pipeline_tool(raw, access) {
-                registry.push(pipe);
-            }
-        }
-
-        let names: Vec<&str> = registry.iter().map(|t| t.name()).collect();
+        let names = assemble_with_pipeline(policy, None).await;
         assert!(
-            names.contains(&"execute_pipeline"),
+            names.contains(&"execute_pipeline".to_string()),
             "execute_pipeline must be present when policy admits it, got {names:?}"
         );
     }
 
-    #[test]
-    fn execute_pipeline_denied_when_caller_allowed_tools_omits_it() {
-        let mut config = zeroclaw_config::schema::Config::default();
-        config.pipeline.enabled = true;
-        let security = Arc::new(TestPolicy {
-            workspace_dir: std::env::temp_dir(),
-            ..TestPolicy::default()
-        });
-        let risk = zeroclaw_config::schema::RiskProfileConfig::default();
-        let mem: Arc<dyn zeroclaw_memory::Memory> =
-            Arc::new(zeroclaw_memory::NoneMemory::new("test"));
-
-        // SecurityPolicy admits execute_pipeline (unrestricted default),
-        // but the caller-supplied allowed_tools narrows to file_read only.
+    #[tokio::test]
+    async fn execute_pipeline_denied_when_caller_allowed_tools_omits_it() {
         let policy = TestPolicy::default();
-        let caller_allowed: Option<Vec<String>> = Some(vec!["file_read".into()]);
-
-        let all = crate::tools::all_tools(
-            Arc::new(config.clone()),
-            &security,
-            &risk,
-            "test",
-            mem,
-            None,
-            None,
-            &config.browser,
-            &config.http_request,
-            &config.web_fetch,
-            &security.workspace_dir,
-            &config.agents,
-            None,
-            &config,
-            None,
-            false,
-            None,
-        );
-
-        let mut registry = all.tools;
-        if let Some(ref raw) = all.pipeline_raw
-            && policy.is_tool_allowed("execute_pipeline")
-            && caller_allowed
-                .as_deref()
-                .is_none_or(|v| v.iter().any(|t| t == "execute_pipeline"))
-        {
-            let access = super::mcp_tool_access_policy(&policy, caller_allowed.as_deref());
-            if let Some(pipe) = crate::tools::build_pipeline_tool(raw, access) {
-                registry.push(pipe);
-            }
-        }
-
-        let names: Vec<&str> = registry.iter().map(|t| t.name()).collect();
+        let caller_allowed = vec!["file_read".to_string()];
+        let names = assemble_with_pipeline(policy, Some(&caller_allowed)).await;
         assert!(
-            !names.contains(&"execute_pipeline"),
+            !names.contains(&"execute_pipeline".to_string()),
             "execute_pipeline must be denied when caller allowed_tools omits it, got {names:?}"
         );
     }

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -15840,11 +15840,8 @@ Let me check the result."#;
         if let Some(ref raw) = all.pipeline_raw
             && policy.is_tool_allowed("execute_pipeline")
         {
-            let access =
-                super::mcp_tool_access_policy(&policy, None);
-            if let Some(pipe) =
-                crate::tools::build_pipeline_tool(raw, access)
-            {
+            let access = super::mcp_tool_access_policy(&policy, None);
+            if let Some(pipe) = crate::tools::build_pipeline_tool(raw, access) {
                 registry.push(pipe);
             }
         }
@@ -15897,11 +15894,8 @@ Let me check the result."#;
         if let Some(ref raw) = all.pipeline_raw
             && policy.is_tool_allowed("execute_pipeline")
         {
-            let access =
-                super::mcp_tool_access_policy(&policy, None);
-            if let Some(pipe) =
-                crate::tools::build_pipeline_tool(raw, access)
-            {
+            let access = super::mcp_tool_access_policy(&policy, None);
+            if let Some(pipe) = crate::tools::build_pipeline_tool(raw, access) {
                 registry.push(pipe);
             }
         }
@@ -15953,11 +15947,8 @@ Let me check the result."#;
         if let Some(ref raw) = all.pipeline_raw
             && policy.is_tool_allowed("execute_pipeline")
         {
-            let access =
-                super::mcp_tool_access_policy(&policy, None);
-            if let Some(pipe) =
-                crate::tools::build_pipeline_tool(raw, access)
-            {
+            let access = super::mcp_tool_access_policy(&policy, None);
+            if let Some(pipe) = crate::tools::build_pipeline_tool(raw, access) {
                 registry.push(pipe);
             }
         }
@@ -15966,6 +15957,63 @@ Let me check the result."#;
         assert!(
             names.contains(&"execute_pipeline"),
             "execute_pipeline must be present when policy admits it, got {names:?}"
+        );
+    }
+
+    #[test]
+    fn execute_pipeline_denied_when_caller_allowed_tools_omits_it() {
+        let mut config = zeroclaw_config::schema::Config::default();
+        config.pipeline.enabled = true;
+        let security = Arc::new(TestPolicy {
+            workspace_dir: std::env::temp_dir(),
+            ..TestPolicy::default()
+        });
+        let risk = zeroclaw_config::schema::RiskProfileConfig::default();
+        let mem: Arc<dyn zeroclaw_memory::Memory> =
+            Arc::new(zeroclaw_memory::NoneMemory::new("test"));
+
+        // SecurityPolicy admits execute_pipeline (unrestricted default),
+        // but the caller-supplied allowed_tools narrows to file_read only.
+        let policy = TestPolicy::default();
+        let caller_allowed: Option<Vec<String>> = Some(vec!["file_read".into()]);
+
+        let all = crate::tools::all_tools(
+            Arc::new(config.clone()),
+            &security,
+            &risk,
+            "test",
+            mem,
+            None,
+            None,
+            &config.browser,
+            &config.http_request,
+            &config.web_fetch,
+            &security.workspace_dir,
+            &config.agents,
+            None,
+            &config,
+            None,
+            false,
+            None,
+        );
+
+        let mut registry = all.tools;
+        if let Some(ref raw) = all.pipeline_raw
+            && policy.is_tool_allowed("execute_pipeline")
+            && caller_allowed
+                .as_deref()
+                .is_none_or(|v| v.iter().any(|t| t == "execute_pipeline"))
+        {
+            let access = super::mcp_tool_access_policy(&policy, caller_allowed.as_deref());
+            if let Some(pipe) = crate::tools::build_pipeline_tool(raw, access) {
+                registry.push(pipe);
+            }
+        }
+
+        let names: Vec<&str> = registry.iter().map(|t| t.name()).collect();
+        assert!(
+            !names.contains(&"execute_pipeline"),
+            "execute_pipeline must be denied when caller allowed_tools omits it, got {names:?}"
         );
     }
 }

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -15789,4 +15789,183 @@ Let me check the result."#;
             other => panic!("expected Line, got {other:?}"),
         }
     }
+
+    // ── execute_pipeline top-level gate ───────────────────────────
+    //
+    // Audacity88 review blocker: the deferred construction moved
+    // PipelineTool after apply_policy_tool_filter, so the top-level
+    // execute_pipeline tool name was never gated. The fix is a
+    // security.is_tool_allowed("execute_pipeline") check before
+    // build_pipeline_tool. These tests prove the gate works and fail
+    // when it is removed.
+
+    #[test]
+    fn execute_pipeline_denied_when_not_in_allowed_tools() {
+        let mut config = zeroclaw_config::schema::Config::default();
+        config.pipeline.enabled = true;
+        let security = Arc::new(TestPolicy {
+            workspace_dir: std::env::temp_dir(),
+            ..TestPolicy::default()
+        });
+        let risk = zeroclaw_config::schema::RiskProfileConfig::default();
+        let mem: Arc<dyn zeroclaw_memory::Memory> =
+            Arc::new(zeroclaw_memory::NoneMemory::new("test"));
+
+        let policy = TestPolicy {
+            allowed_tools: Some(vec!["file_read".into()]),
+            ..TestPolicy::default()
+        };
+
+        let all = crate::tools::all_tools(
+            Arc::new(config.clone()),
+            &security,
+            &risk,
+            "test",
+            mem,
+            None,
+            None,
+            &config.browser,
+            &config.http_request,
+            &config.web_fetch,
+            &security.workspace_dir,
+            &config.agents,
+            None,
+            &config,
+            None,
+            false,
+            None,
+        );
+
+        let mut registry = all.tools;
+        if let Some(ref raw) = all.pipeline_raw
+            && policy.is_tool_allowed("execute_pipeline")
+        {
+            let access =
+                super::mcp_tool_access_policy(&policy, None);
+            if let Some(pipe) =
+                crate::tools::build_pipeline_tool(raw, access)
+            {
+                registry.push(pipe);
+            }
+        }
+
+        let names: Vec<&str> = registry.iter().map(|t| t.name()).collect();
+        assert!(
+            !names.contains(&"execute_pipeline"),
+            "execute_pipeline must be denied when not in allowed_tools, got {names:?}"
+        );
+    }
+
+    #[test]
+    fn execute_pipeline_denied_when_in_excluded_tools() {
+        let mut config = zeroclaw_config::schema::Config::default();
+        config.pipeline.enabled = true;
+        let security = Arc::new(TestPolicy {
+            workspace_dir: std::env::temp_dir(),
+            ..TestPolicy::default()
+        });
+        let risk = zeroclaw_config::schema::RiskProfileConfig::default();
+        let mem: Arc<dyn zeroclaw_memory::Memory> =
+            Arc::new(zeroclaw_memory::NoneMemory::new("test"));
+
+        let policy = TestPolicy {
+            excluded_tools: Some(vec!["execute_pipeline".into()]),
+            ..TestPolicy::default()
+        };
+
+        let all = crate::tools::all_tools(
+            Arc::new(config.clone()),
+            &security,
+            &risk,
+            "test",
+            mem,
+            None,
+            None,
+            &config.browser,
+            &config.http_request,
+            &config.web_fetch,
+            &security.workspace_dir,
+            &config.agents,
+            None,
+            &config,
+            None,
+            false,
+            None,
+        );
+
+        let mut registry = all.tools;
+        if let Some(ref raw) = all.pipeline_raw
+            && policy.is_tool_allowed("execute_pipeline")
+        {
+            let access =
+                super::mcp_tool_access_policy(&policy, None);
+            if let Some(pipe) =
+                crate::tools::build_pipeline_tool(raw, access)
+            {
+                registry.push(pipe);
+            }
+        }
+
+        let names: Vec<&str> = registry.iter().map(|t| t.name()).collect();
+        assert!(
+            !names.contains(&"execute_pipeline"),
+            "execute_pipeline must be denied when in excluded_tools, got {names:?}"
+        );
+    }
+
+    #[test]
+    fn execute_pipeline_allowed_when_policy_admits_it() {
+        let mut config = zeroclaw_config::schema::Config::default();
+        config.pipeline.enabled = true;
+        let security = Arc::new(TestPolicy {
+            workspace_dir: std::env::temp_dir(),
+            ..TestPolicy::default()
+        });
+        let risk = zeroclaw_config::schema::RiskProfileConfig::default();
+        let mem: Arc<dyn zeroclaw_memory::Memory> =
+            Arc::new(zeroclaw_memory::NoneMemory::new("test"));
+
+        // Unrestricted policy must admit execute_pipeline when
+        // the pipeline config is enabled.
+        let policy = TestPolicy::default();
+
+        let all = crate::tools::all_tools(
+            Arc::new(config.clone()),
+            &security,
+            &risk,
+            "test",
+            mem,
+            None,
+            None,
+            &config.browser,
+            &config.http_request,
+            &config.web_fetch,
+            &security.workspace_dir,
+            &config.agents,
+            None,
+            &config,
+            None,
+            false,
+            None,
+        );
+
+        let mut registry = all.tools;
+        if let Some(ref raw) = all.pipeline_raw
+            && policy.is_tool_allowed("execute_pipeline")
+        {
+            let access =
+                super::mcp_tool_access_policy(&policy, None);
+            if let Some(pipe) =
+                crate::tools::build_pipeline_tool(raw, access)
+            {
+                registry.push(pipe);
+            }
+        }
+
+        let names: Vec<&str> = registry.iter().map(|t| t.name()).collect();
+        assert!(
+            names.contains(&"execute_pipeline"),
+            "execute_pipeline must be present when policy admits it, got {names:?}"
+        );
+    }
 }

--- a/crates/zeroclaw-runtime/src/agent/parity.rs
+++ b/crates/zeroclaw-runtime/src/agent/parity.rs
@@ -283,6 +283,7 @@ fn built_with(tools: Vec<Box<dyn Tool>>) -> AllToolsResult {
         escalate_handle: None,
         channel_room_handle: None,
         unfiltered_tool_arcs: Vec::new(),
+        pipeline_raw: None,
     }
 }
 

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -513,6 +513,11 @@ pub struct AllToolsResult {
     /// Pre-boxed Arcs of every tool (before policy filter). Used by
     /// skill-scoped builtin elevation to resolve targets at registration.
     pub unfiltered_tool_arcs: Vec<Arc<dyn Tool>>,
+    /// Shared slot that PipelineTool reads at execution time to apply the
+    /// per-agent `ToolAccessPolicy` gate. Set by the agent loop after
+    /// constructing the tool registry but before any turn runs.
+    pub pipeline_access_policy:
+        Option<Arc<std::sync::Mutex<Option<zeroclaw_tools::tool_search::ToolAccessPolicy>>>>,
 }
 
 /// Create full tool registry including memory tools and optional Composio
@@ -1401,6 +1406,7 @@ pub fn all_tools_with_runtime(
                     reaction_handle,
                     poll_handle: Some(poll_handle),
                     escalate_handle,
+                    pipeline_access_policy: None,
                 };
             }
 
@@ -1623,13 +1629,23 @@ pub fn all_tools_with_runtime(
     }
 
     // Pipeline tool (execute_pipeline) — multi-step tool chaining.
-    if root_config.pipeline.enabled {
+    // Shared mutable slot so the per-agent ToolAccessPolicy can be injected
+    // after registry construction. PipelineTool validates every step against
+    // both the global [pipeline].allowed_tools AND this per-agent gate.
+    let pipeline_access_policy: Option<
+        Arc<std::sync::Mutex<Option<zeroclaw_tools::tool_search::ToolAccessPolicy>>>,
+    > = if root_config.pipeline.enabled {
+        let policy = Arc::new(std::sync::Mutex::new(None));
         let pipeline_tools: Vec<Arc<dyn Tool>> = tool_arcs.clone();
         tool_arcs.push(Arc::new(PipelineTool::new(
             root_config.pipeline.clone(),
             pipeline_tools,
+            Arc::clone(&policy),
         )));
-    }
+        Some(policy)
+    } else {
+        None
+    };
 
     AllToolsResult {
         unfiltered_tool_arcs: tool_arcs.clone(),
@@ -1640,6 +1656,7 @@ pub fn all_tools_with_runtime(
         reaction_handle,
         poll_handle: Some(poll_handle),
         escalate_handle,
+        pipeline_access_policy,
     }
 }
 

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -497,6 +497,37 @@ pub const BUILTIN_TOOL_INTEGRATIONS: &[(&str, &str)] = &[
     ),
 ];
 
+/// Deferred pipeline construction data.
+///
+/// Collects the pieces needed to build a `PipelineTool` after the per-agent
+/// `ToolAccessPolicy` has been derived. Call [`build_pipeline_tool`] to
+/// produce the final `PipelineTool` with the policy gate baked in.
+pub struct PipelineRaw {
+    pub config: zeroclaw_config::schema::PipelineConfig,
+    /// Unfiltered tool Arcs (before policy filtering). The pipeline tool
+    /// gets a clone of this snapshot so it can resolve tools by name
+    /// regardless of top-level allowlist filtering.
+    pub tool_arcs: Vec<Arc<dyn Tool>>,
+}
+
+/// Build a `PipelineTool` from the raw deferred data and an optional
+/// per-agent `ToolAccessPolicy`.
+///
+/// Returns `None` when `raw.tool_arcs` is empty (nothing to pipeline).
+pub fn build_pipeline_tool(
+    raw: &PipelineRaw,
+    access_policy: Option<zeroclaw_tools::tool_search::ToolAccessPolicy>,
+) -> Option<Box<dyn Tool>> {
+    if raw.tool_arcs.is_empty() {
+        return None;
+    }
+    Some(Box::new(zeroclaw_tools::pipeline::PipelineTool::new(
+        raw.config.clone(),
+        raw.tool_arcs.clone(),
+        access_policy,
+    )))
+}
+
 /// Bundled return values from tool registry construction.
 ///
 /// Named struct to avoid an ever-growing positional tuple that's painful
@@ -510,14 +541,14 @@ pub struct AllToolsResult {
     pub reaction_handle: PerToolChannelHandle,
     pub poll_handle: Option<PerToolChannelHandle>,
     pub escalate_handle: Option<PerToolChannelHandle>,
-    /// Pre-boxed Arcs of every tool (before policy filter). Used by
-    /// skill-scoped builtin elevation to resolve targets at registration.
+    /// Pre-boxed Arcs of every tool (before policy filter and before
+    /// PipelineTool is added). PipelineTool construction is deferred to
+    /// the caller so the per-agent policy can be baked in immutably.
     pub unfiltered_tool_arcs: Vec<Arc<dyn Tool>>,
-    /// Shared slot that PipelineTool reads at execution time to apply the
-    /// per-agent `ToolAccessPolicy` gate. Set by the agent loop after
-    /// constructing the tool registry but before any turn runs.
-    pub pipeline_access_policy:
-        Option<Arc<std::sync::Mutex<Option<zeroclaw_tools::tool_search::ToolAccessPolicy>>>>,
+    /// Raw data for deferred PipelineTool construction. The caller derives
+    /// a `ToolAccessPolicy` from the agent's `SecurityPolicy` and then
+    /// calls `build_pipeline_tool()` to get a policy-gated pipeline tool.
+    pub pipeline_raw: Option<PipelineRaw>,
 }
 
 /// Create full tool registry including memory tools and optional Composio
@@ -1406,7 +1437,7 @@ pub fn all_tools_with_runtime(
                     reaction_handle,
                     poll_handle: Some(poll_handle),
                     escalate_handle,
-                    pipeline_access_policy: None,
+                    pipeline_raw: None,
                 };
             }
 
@@ -1628,21 +1659,15 @@ pub fn all_tools_with_runtime(
         }
     }
 
-    // Pipeline tool (execute_pipeline) — multi-step tool chaining.
-    // Shared mutable slot so the per-agent ToolAccessPolicy can be injected
-    // after registry construction. PipelineTool validates every step against
-    // both the global [pipeline].allowed_tools AND this per-agent gate.
-    let pipeline_access_policy: Option<
-        Arc<std::sync::Mutex<Option<zeroclaw_tools::tool_search::ToolAccessPolicy>>>,
-    > = if root_config.pipeline.enabled {
-        let policy = Arc::new(std::sync::Mutex::new(None));
-        let pipeline_tools: Vec<Arc<dyn Tool>> = tool_arcs.clone();
-        tool_arcs.push(Arc::new(PipelineTool::new(
-            root_config.pipeline.clone(),
-            pipeline_tools,
-            Arc::clone(&policy),
-        )));
-        Some(policy)
+    // Pipeline tool (execute_pipeline) — construction is deferred.
+    // The caller derives a ToolAccessPolicy from the agent's SecurityPolicy
+    // and calls build_pipeline_tool() to produce an immutable, policy-gated
+    // PipelineTool. No mutable slot; no stale/missing policy.
+    let pipeline_raw: Option<PipelineRaw> = if root_config.pipeline.enabled {
+        Some(PipelineRaw {
+            config: root_config.pipeline.clone(),
+            tool_arcs: tool_arcs.clone(),
+        })
     } else {
         None
     };
@@ -1656,7 +1681,7 @@ pub fn all_tools_with_runtime(
         reaction_handle,
         poll_handle: Some(poll_handle),
         escalate_handle,
-        pipeline_access_policy,
+        pipeline_raw,
     }
 }
 

--- a/crates/zeroclaw-runtime/src/tools/scoped.rs
+++ b/crates/zeroclaw-runtime/src/tools/scoped.rs
@@ -238,6 +238,7 @@ impl ScopedToolRegistry {
             escalate_handle,
             channel_room_handle,
             unfiltered_tool_arcs,
+            pipeline_raw,
         } = built;
 
         // 1. Peripherals. Loading CONNECTS hardware (serial opens are exclusive for
@@ -276,6 +277,21 @@ impl ScopedToolRegistry {
                     })),
                 "Applied capability-based tool access filter"
             );
+        }
+
+        // ── Wire deferred PipelineTool with per-agent policy gate ───
+        // PipelineTool construction is deferred so the per-agent
+        // ToolAccessPolicy is baked in immutably at construction time.
+        // The top-level `execute_pipeline` tool is gated on both the
+        // agent SecurityPolicy and the caller-supplied allowlist (if present).
+        if let Some(ref raw) = pipeline_raw
+            && security.is_tool_allowed("execute_pipeline")
+            && caller_allowed.is_none_or(|v| v.iter().any(|t| t == "execute_pipeline"))
+        {
+            let policy = mcp_tool_access_policy(security.as_ref(), caller_allowed);
+            if let Some(pipe) = crate::tools::build_pipeline_tool(raw, policy) {
+                tools_registry.push(pipe);
+            }
         }
 
         // 3. Documented divergence: ACP strips persistent memory tools.
@@ -635,6 +651,7 @@ mod tests {
             escalate_handle: None,
             channel_room_handle: None,
             unfiltered_tool_arcs: Vec::new(),
+            pipeline_raw: None,
         }
     }
 

--- a/crates/zeroclaw-tools/src/pipeline.rs
+++ b/crates/zeroclaw-tools/src/pipeline.rs
@@ -8,9 +8,11 @@ use anyhow::Result;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use zeroclaw_api::tool::{Tool, ToolOutput, ToolResult};
 use zeroclaw_config::schema::PipelineConfig;
+
+use crate::tool_search::ToolAccessPolicy;
 
 /// Errors specific to pipeline execution.
 #[derive(Debug, Clone, Serialize, thiserror::Error)]
@@ -74,16 +76,31 @@ pub struct PipelineTool {
     config: PipelineConfig,
     tools: Vec<Arc<dyn Tool>>,
     allowed_set: HashSet<String>,
+    tool_access_policy: Arc<Mutex<Option<ToolAccessPolicy>>>,
 }
 
 impl PipelineTool {
-    pub fn new(config: PipelineConfig, tools: Vec<Arc<dyn Tool>>) -> Self {
+    pub fn new(
+        config: PipelineConfig,
+        tools: Vec<Arc<dyn Tool>>,
+        tool_access_policy: Arc<Mutex<Option<ToolAccessPolicy>>>,
+    ) -> Self {
         let allowed_set: HashSet<String> = config.allowed_tools.iter().cloned().collect();
         Self {
             config,
             tools,
             allowed_set,
+            tool_access_policy,
         }
+    }
+
+    /// Set the per-agent tool access policy that gates sub-tool execution.
+    ///
+    /// Callers must invoke this after construction and before any pipeline
+    /// execution so that the per-agent `ToolAccessPolicy` is respected in
+    /// addition to the global `[pipeline].allowed_tools` config.
+    pub fn set_access_policy(&self, policy: ToolAccessPolicy) {
+        *self.tool_access_policy.lock().unwrap() = Some(policy);
     }
 
     /// Find a tool by name in the registry.
@@ -100,9 +117,16 @@ impl PipelineTool {
             return Err(PipelineError::TooManySteps(self.config.max_steps));
         }
 
-        // Check all tools are on the allowlist before executing any.
+        // Two-gate check: global pipeline allowlist AND per-agent access policy.
+        // The per-agent gate is a shared mutable slot set externally by loop_.rs
+        // after constructing the tool registry. When unset the gate is open.
+        let policy_guard = self.tool_access_policy.lock().unwrap();
         for step in &request.steps {
-            if !self.allowed_set.contains(&step.tool) {
+            if !self.allowed_set.contains(&step.tool)
+                || policy_guard
+                    .as_ref()
+                    .is_some_and(|p| !p.is_tool_allowed(&step.tool))
+            {
                 return Err(PipelineError::UnknownTool(step.tool.clone()));
             }
         }
@@ -537,7 +561,7 @@ mod tests {
             max_steps: 2,
             allowed_tools: vec!["shell".to_string()],
         };
-        let tool = PipelineTool::new(config, vec![]);
+        let tool = PipelineTool::new(config, vec![], Arc::new(Mutex::new(None)));
 
         let request = PipelineRequest {
             steps: vec![
@@ -569,7 +593,7 @@ mod tests {
             max_steps: 20,
             allowed_tools: vec!["shell".to_string()],
         };
-        let tool = PipelineTool::new(config, vec![]);
+        let tool = PipelineTool::new(config, vec![], Arc::new(Mutex::new(None)));
 
         let request = PipelineRequest {
             steps: vec![PipelineStep {
@@ -591,7 +615,7 @@ mod tests {
             max_steps: 20,
             allowed_tools: vec!["shell".to_string(), "file_read".to_string()],
         };
-        let tool = PipelineTool::new(config, vec![]);
+        let tool = PipelineTool::new(config, vec![], Arc::new(Mutex::new(None)));
 
         let request = PipelineRequest {
             steps: vec![
@@ -618,7 +642,7 @@ mod tests {
             max_steps: 20,
             allowed_tools: vec![],
         };
-        let tool = PipelineTool::new(config, vec![]);
+        let tool = PipelineTool::new(config, vec![], Arc::new(Mutex::new(None)));
 
         let request = PipelineRequest {
             steps: vec![],
@@ -702,7 +726,7 @@ mod tests {
                 output: "final answer".into(),
             }),
         ];
-        PipelineTool::new(config, tools)
+        PipelineTool::new(config, tools, Arc::new(Mutex::new(None)))
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-tools/src/pipeline.rs
+++ b/crates/zeroclaw-tools/src/pipeline.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use zeroclaw_api::tool::{Tool, ToolOutput, ToolResult};
 use zeroclaw_config::schema::PipelineConfig;
 
@@ -76,31 +76,25 @@ pub struct PipelineTool {
     config: PipelineConfig,
     tools: Vec<Arc<dyn Tool>>,
     allowed_set: HashSet<String>,
-    tool_access_policy: Arc<Mutex<Option<ToolAccessPolicy>>>,
+    /// Per-agent policy gate, baked in at construction. `None` only when
+    /// no SecurityPolicy gates are configured (all tools allowed, none
+    /// excluded); in that case `validate()` skips the per-agent check.
+    access_policy: Option<ToolAccessPolicy>,
 }
 
 impl PipelineTool {
     pub fn new(
         config: PipelineConfig,
         tools: Vec<Arc<dyn Tool>>,
-        tool_access_policy: Arc<Mutex<Option<ToolAccessPolicy>>>,
+        access_policy: Option<ToolAccessPolicy>,
     ) -> Self {
         let allowed_set: HashSet<String> = config.allowed_tools.iter().cloned().collect();
         Self {
             config,
             tools,
             allowed_set,
-            tool_access_policy,
+            access_policy,
         }
-    }
-
-    /// Set the per-agent tool access policy that gates sub-tool execution.
-    ///
-    /// Callers must invoke this after construction and before any pipeline
-    /// execution so that the per-agent `ToolAccessPolicy` is respected in
-    /// addition to the global `[pipeline].allowed_tools` config.
-    pub fn set_access_policy(&self, policy: ToolAccessPolicy) {
-        *self.tool_access_policy.lock().unwrap() = Some(policy);
     }
 
     /// Find a tool by name in the registry.
@@ -118,16 +112,15 @@ impl PipelineTool {
         }
 
         // Two-gate check: global pipeline allowlist AND per-agent access policy.
-        // The per-agent gate is a shared mutable slot set externally by loop_.rs
-        // after constructing the tool registry. When unset the gate is open.
-        let policy_guard = self.tool_access_policy.lock().unwrap();
+        // The per-agent policy is baked in at construction — no mutable slot.
         for step in &request.steps {
-            if !self.allowed_set.contains(&step.tool)
-                || policy_guard
-                    .as_ref()
-                    .is_some_and(|p| !p.is_tool_allowed(&step.tool))
-            {
+            if !self.allowed_set.contains(&step.tool) {
                 return Err(PipelineError::UnknownTool(step.tool.clone()));
+            }
+            if let Some(ref policy) = self.access_policy {
+                if !policy.is_tool_allowed(&step.tool) {
+                    return Err(PipelineError::UnknownTool(step.tool.clone()));
+                }
             }
         }
 
@@ -561,7 +554,7 @@ mod tests {
             max_steps: 2,
             allowed_tools: vec!["shell".to_string()],
         };
-        let tool = PipelineTool::new(config, vec![], Arc::new(Mutex::new(None)));
+        let tool = PipelineTool::new(config, vec![], None);
 
         let request = PipelineRequest {
             steps: vec![
@@ -593,7 +586,7 @@ mod tests {
             max_steps: 20,
             allowed_tools: vec!["shell".to_string()],
         };
-        let tool = PipelineTool::new(config, vec![], Arc::new(Mutex::new(None)));
+        let tool = PipelineTool::new(config, vec![], None);
 
         let request = PipelineRequest {
             steps: vec![PipelineStep {
@@ -615,7 +608,7 @@ mod tests {
             max_steps: 20,
             allowed_tools: vec!["shell".to_string(), "file_read".to_string()],
         };
-        let tool = PipelineTool::new(config, vec![], Arc::new(Mutex::new(None)));
+        let tool = PipelineTool::new(config, vec![], None);
 
         let request = PipelineRequest {
             steps: vec![
@@ -642,7 +635,7 @@ mod tests {
             max_steps: 20,
             allowed_tools: vec![],
         };
-        let tool = PipelineTool::new(config, vec![], Arc::new(Mutex::new(None)));
+        let tool = PipelineTool::new(config, vec![], None);
 
         let request = PipelineRequest {
             steps: vec![],
@@ -651,6 +644,73 @@ mod tests {
         };
 
         assert!(tool.validate(&request).is_ok());
+    }
+
+    // ── Per-agent policy gate ──────────────────────────────
+    //
+    // Regression for #7947: a tool present in [pipeline].allowed_tools
+    // must still be rejected when the calling agent's SecurityPolicy
+    // denies it. The per-agent policy is baked into PipelineTool at
+    // construction — no mutable slot.
+
+    #[test]
+    fn validate_per_agent_policy_denies_subtool() {
+        // Global pipeline allowlist admits shell.
+        let config = PipelineConfig {
+            enabled: true,
+            max_steps: 20,
+            allowed_tools: vec!["shell".to_string(), "file_read".to_string()],
+        };
+        // Per-agent policy only allows file_read — shell is denied.
+        let policy = ToolAccessPolicy {
+            allowed: Some(vec!["file_read".to_string()]),
+            ..ToolAccessPolicy::default()
+        };
+        let tool = PipelineTool::new(config, vec![], Some(policy));
+
+        let request = PipelineRequest {
+            steps: vec![PipelineStep {
+                tool: "shell".into(),
+                args: serde_json::json!({}),
+            }],
+            parallel: false,
+            result: PipelineResultMode::default(),
+        };
+
+        let err = tool.validate(&request).unwrap_err();
+        assert!(
+            matches!(err, PipelineError::UnknownTool(ref name) if name == "shell"),
+            "shell must be rejected by per-agent policy even though pipeline allowlist includes it, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn validate_per_agent_policy_allows_subtool() {
+        let config = PipelineConfig {
+            enabled: true,
+            max_steps: 20,
+            allowed_tools: vec!["shell".to_string(), "file_read".to_string()],
+        };
+        // Per-agent policy allows both.
+        let policy = ToolAccessPolicy {
+            allowed: Some(vec!["shell".to_string(), "file_read".to_string()]),
+            ..ToolAccessPolicy::default()
+        };
+        let tool = PipelineTool::new(config, vec![], Some(policy));
+
+        let request = PipelineRequest {
+            steps: vec![PipelineStep {
+                tool: "shell".into(),
+                args: serde_json::json!({}),
+            }],
+            parallel: false,
+            result: PipelineResultMode::default(),
+        };
+
+        assert!(
+            tool.validate(&request).is_ok(),
+            "shell must be allowed when both pipeline and per-agent policy admit it"
+        );
     }
 
     // ── Template resolution ────────────────────────────────
@@ -726,7 +786,7 @@ mod tests {
                 output: "final answer".into(),
             }),
         ];
-        PipelineTool::new(config, tools, Arc::new(Mutex::new(None)))
+        PipelineTool::new(config, tools, None)
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-tools/src/pipeline.rs
+++ b/crates/zeroclaw-tools/src/pipeline.rs
@@ -117,10 +117,10 @@ impl PipelineTool {
             if !self.allowed_set.contains(&step.tool) {
                 return Err(PipelineError::UnknownTool(step.tool.clone()));
             }
-            if let Some(ref policy) = self.access_policy {
-                if !policy.is_tool_allowed(&step.tool) {
-                    return Err(PipelineError::UnknownTool(step.tool.clone()));
-                }
+            if let Some(ref policy) = self.access_policy
+                && !policy.is_tool_allowed(&step.tool)
+            {
+                return Err(PipelineError::UnknownTool(step.tool.clone()));
             }
         }
 


### PR DESCRIPTION
## Problem

`execute_pipeline` sub-tool execution bypasses the per-agent `ToolAccessPolicy`. The pipeline tool carries an unfiltered internal registry built from the full tool set, so a tool denied by the agent's `allowed_tools` or `excluded_tools` can still be invoked as a pipeline step — a confused-deputy gap.

Issue: #7947

## Root Cause

Before this PR, `PipelineTool` was built eagerly inside `all_tools_with_runtime()` from the unfiltered tool set and pushed into `AllToolsResult.tools`. The top-level `apply_policy_tool_filter()` would drop `execute_pipeline` itself when denied, but once admitted, its internal `validate()` did not cross-check the per-agent policy — it only checked `[pipeline].allowed_tools`.

## Fix

### Deferred immutable construction

`PipelineTool` is no longer built inside `all_tools_with_runtime()`. Instead:

1. `AllToolsResult` exposes a `pipeline_raw: Option<PipelineRaw>` with the config and unfiltered tool arcs
2. Callers must gate on `SecurityPolicy.is_tool_allowed("execute_pipeline")` (and `caller_allowed` when present), then call `build_pipeline_tool(raw, policy)` to produce a `PipelineTool` with the per-agent `ToolAccessPolicy` baked in immutably at construction time — no mutable slot, no stale/missing policy
3. `PipelineTool::validate()` now requires each step to pass BOTH `[pipeline].allowed_tools` AND the caller's per-agent policy

### Wired consumers

- **`scoped::ScopedToolRegistry::assemble()`**: the single seam covering `run()`, `process_message()`, `Agent::from_config`, `independent_agentic_tools_for_target()`, and both gateway paths (seeded default + per-agent `/api/tools?agent=...`)
- **`orchestrator/mod.rs`**: the only consumer that does not route through `assemble()`, wired with the same `SecurityPolicy` gate

### Regression tests

- `execute_pipeline_denied_when_not_in_allowed_tools` — top-level gate: agent policy `allowed_tools = ["file_read"]` excludes `execute_pipeline`
- `execute_pipeline_denied_when_in_excluded_tools` — top-level gate: `excluded_tools = ["execute_pipeline"]`
- `execute_pipeline_allowed_when_policy_admits_it` — unrestricted policy admits the tool
- `execute_pipeline_denied_when_caller_allowed_tools_omits_it` — CLI `run()` path: caller `allowed_tools = ["file_read"]` even when SecurityPolicy is unrestricted

### Validation

```
test agent::loop_::tests::execute_pipeline_denied_when_not_in_allowed_tools ... ok
test agent::loop_::tests::execute_pipeline_denied_when_in_excluded_tools ... ok
test agent::loop_::tests::execute_pipeline_allowed_when_policy_admits_it ... ok
test agent::loop_::tests::execute_pipeline_denied_when_caller_allowed_tools_omits_it ... ok
test tools::scoped::tests::assemble_* ... ok (6 tests)
test agent::agent::parity::parity_l2_builtin_filter_semantic_parity ... ok

cargo clippy -- -D warnings: clean (zeroclaw-runtime, zeroclaw-channels, zeroclaw-gateway, zeroclaw-tools)
```

Fixes #7947