### PR TITLE
static_voice_peers caches config-derived voice peers on the channel handle (latent SSOT vi (#7795)

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -5706,6 +5706,42 @@ fn one_shot_channel_workspace_dir(config: &Config, channel_type: &str, alias: &s
     config.channel_workspace_dir(&format!("{channel_type}.{alias}"))
 }
 
+/// Build an on-demand resolver for voice-preference peers.
+///
+/// Returns a closure that reads `[peer_groups.*]` entries whose channel
+/// matches `channel_type` (or `"<channel_type>.<alias>"`) and whose
+/// `output_modality` is `Voice`. The resolver is called at each
+/// `is_voice_chat` check, ensuring no config state is cached on the
+/// channel handle (SSOT: AGENTS.md "ABSOLUTE RULE").
+fn voice_peer_resolver_for_channel(
+    config_arc: Arc<RwLock<Config>>,
+    channel_type: &'static str,
+    alias: &str,
+) -> Arc<dyn Fn() -> Vec<String> + Send + Sync> {
+    use zeroclaw_config::multi_agent::OutputModality;
+    let alias = alias.to_string();
+    Arc::new(move || {
+        let cfg = config_arc.read();
+        let mut out: Vec<String> = Vec::new();
+        let mut seen = std::collections::HashSet::new();
+        for group in cfg.peer_groups.values() {
+            let group_matches = match group.channel.split_once('.') {
+                Some((ty, al)) => ty == channel_type && al == alias,
+                None => group.channel == channel_type,
+            };
+            if group_matches && group.output_modality == OutputModality::Voice {
+                for peer in &group.external_peers {
+                    let username = peer.as_str().to_string();
+                    if seen.insert(username.clone()) {
+                        out.push(username);
+                    }
+                }
+            }
+        }
+        out
+    })
+}
+
 /// Build a single channel instance by config section name (e.g. "telegram").
 fn build_channel_by_id(
     config_arc: &Arc<RwLock<Config>>,
@@ -5742,7 +5778,11 @@ fn build_channel_by_id(
                 .with_streaming(tg.stream_mode, tg.draft_update_interval_ms)
                 .with_transcription(config.transcription.clone())
                 .with_tts(&config)
-                .with_voice_peer_prefs(&config, "telegram", alias)
+                .with_voice_peer_resolver(voice_peer_resolver_for_channel(
+                    config_arc.clone(),
+                    "telegram",
+                    &alias,
+                ))
                 .with_workspace_dir(workspace_dir)
                 .with_approval_timeout_secs(tg.approval_timeout_secs),
             ))
@@ -6752,7 +6792,11 @@ fn collect_configured_channels(
                     .with_streaming(tg.stream_mode, tg.draft_update_interval_ms)
                     .with_transcription(config.transcription.clone())
                     .with_tts(&config)
-                    .with_voice_peer_prefs(&config, "telegram", alias)
+                    .with_voice_peer_resolver(voice_peer_resolver_for_channel(
+                        config_arc.clone(),
+                        "telegram",
+                        &alias,
+                    ))
                     .with_workspace_dir(config.channel_workspace_dir(&format!("telegram.{alias}")))
                     .with_proxy_url(tg.proxy_url.clone())
                     .with_tool_command_specs(tool_specs.to_vec())

--- a/crates/zeroclaw-channels/src/telegram.rs
+++ b/crates/zeroclaw-channels/src/telegram.rs
@@ -548,8 +548,8 @@ pub struct TelegramChannel {
     voice_chats: Arc<std::sync::Mutex<std::collections::HashSet<String>>>,
     /// Peers that always receive voice replies, sourced from peer-group
     /// `output_modality = "voice"` config. Populated once at startup by
-    /// `with_voice_peer_prefs`; never mutated by session events.
-    static_voice_peers: Arc<std::sync::Mutex<std::collections::HashSet<String>>>,
+    /// `with_voice_peer_resolver`; never mutated by session events.
+    voice_peer_resolver: Arc<dyn Fn() -> Vec<String> + Send + Sync>,
     pending_voice:
         Arc<std::sync::Mutex<std::collections::HashMap<String, (String, std::time::Instant)>>>,
     /// Per-channel proxy URL override.
@@ -623,7 +623,7 @@ impl TelegramChannel {
             ack_reactions: true,
             tts_manager: None,
             voice_chats: Arc::new(std::sync::Mutex::new(std::collections::HashSet::new())),
-            static_voice_peers: Arc::new(std::sync::Mutex::new(std::collections::HashSet::new())),
+            voice_peer_resolver: Arc::new(|| vec![]),
             pending_voice: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             proxy_url: None,
             tool_command_specs: Vec::new(),
@@ -810,34 +810,17 @@ impl TelegramChannel {
         value.trim().trim_start_matches('@').to_string()
     }
 
-    /// Pre-seed static voice preferences from peer-group config.
+    /// Set a resolver for voice-preference peers sourced from peer-group config.
     ///
-    /// Iterates `[peer_groups.*]` entries that reference this channel and
-    /// carry `output_modality = "voice"`, then records every `external_peers`
-    /// entry in `static_voice_peers`. These peers always receive TTS replies —
-    /// including cron/proactive messages with no inbound voice note to mirror.
-    ///
-    /// Unlike the session `voice_chats` set, `static_voice_peers` is never
-    /// cleared by voice-send or text-message events.
-    pub fn with_voice_peer_prefs(
-        self,
-        config: &zeroclaw_config::schema::Config,
-        channel_type: &str,
-        alias: impl AsRef<str>,
+    /// The resolver is called at each `is_voice_chat` check (like `peer_resolver`),
+    /// ensuring no config-derived state is cached on the channel handle.
+    /// Peers returned by the resolver always receive TTS replies — including
+    /// cron/proactive messages with no inbound voice note to mirror.
+    pub fn with_voice_peer_resolver(
+        mut self,
+        resolver: Arc<dyn Fn() -> Vec<String> + Send + Sync>,
     ) -> Self {
-        use zeroclaw_config::multi_agent::OutputModality;
-        let alias = alias.as_ref();
-        let dotted = format!("{channel_type}.{alias}");
-        if let Ok(mut sp) = self.static_voice_peers.lock() {
-            for group in config.peer_groups.values() {
-                let matches = group.channel == channel_type || group.channel == dotted;
-                if matches && group.output_modality == OutputModality::Voice {
-                    for peer in &group.external_peers {
-                        sp.insert(peer.to_string());
-                    }
-                }
-            }
-        }
+        self.voice_peer_resolver = resolver;
         self
     }
 
@@ -1052,17 +1035,13 @@ impl TelegramChannel {
     /// Returns true if this recipient should receive a TTS voice reply —
     /// either because they triggered a voice-note session (`voice_chats`) or
     /// because their peer group has `output_modality = "voice"` in config
-    /// (`static_voice_peers`).
+    /// (resolved on demand via `voice_peer_resolver`).
     fn is_voice_chat(&self, recipient: &str) -> bool {
         self.voice_chats
             .lock()
             .map(|vs| vs.contains(recipient))
             .unwrap_or(false)
-            || self
-                .static_voice_peers
-                .lock()
-                .map(|sp| sp.contains(recipient))
-                .unwrap_or(false)
+            || (self.voice_peer_resolver)().contains(&recipient.to_string())
     }
 
     fn try_queue_voice_reply(&self, recipient: &str, content: &str, immediate: bool) {
@@ -4114,12 +4093,37 @@ mod tests {
     use super::*;
 
     #[test]
-    fn with_voice_peer_prefs_seeds_static_voice_peers_for_matching_groups_only() {
+    fn voice_peer_resolver_identifies_matching_groups_only() {
         use zeroclaw_config::multi_agent::{OutputModality, PeerGroupConfig, PeerUsername};
 
-        let mut config = zeroclaw_config::schema::Config::default();
-        // Voice group on this channel type — should be seeded.
-        config.peer_groups.insert(
+        let config = zeroclaw_config::schema::Config::default();
+        let config_arc = Arc::new(RwLock::new(config));
+
+        // Build an inline resolver that mimics voice_peer_resolver_for_channel.
+        let resolver: Arc<dyn Fn() -> Vec<String> + Send + Sync> = {
+            let cfg = config_arc.clone();
+            Arc::new(move || {
+                let cfg = cfg.read();
+                // With a default empty config the resolver returns nothing.
+                // Manually simulate the peers we want.
+                #[allow(clippy::vec_init_then_push)]
+                let mut out = Vec::new();
+                for (_name, group) in &cfg.peer_groups {
+                    let matches = group.channel == "telegram";
+                    if matches && group.output_modality == OutputModality::Voice {
+                        for peer in &group.external_peers {
+                            out.push(peer.as_str().to_string());
+                        }
+                    }
+                }
+                out
+            })
+        };
+
+        // Wire the resolver on a channel whose config HAS the groups.
+        let mut ch_config = zeroclaw_config::schema::Config::default();
+        // Voice group on this channel type — should be resolved.
+        ch_config.peer_groups.insert(
             "voicers".to_string(),
             PeerGroupConfig {
                 channel: "telegram".into(),
@@ -4129,7 +4133,7 @@ mod tests {
             },
         );
         // Voice group on a different channel — must NOT leak into telegram.
-        config.peer_groups.insert(
+        ch_config.peer_groups.insert(
             "other".to_string(),
             PeerGroupConfig {
                 channel: "signal".into(),
@@ -4139,7 +4143,7 @@ mod tests {
             },
         );
         // Mirror group on this channel — not a voice preference, skip.
-        config.peer_groups.insert(
+        ch_config.peer_groups.insert(
             "mirrorers".to_string(),
             PeerGroupConfig {
                 channel: "telegram".into(),
@@ -4149,37 +4153,65 @@ mod tests {
             },
         );
 
+        let ch_config_arc = Arc::new(RwLock::new(ch_config));
+        let resolver_with_data: Arc<dyn Fn() -> Vec<String> + Send + Sync> = {
+            let cfg = ch_config_arc.clone();
+            Arc::new(move || {
+                let cfg = cfg.read();
+                let mut out: Vec<String> = Vec::new();
+                let mut seen = std::collections::HashSet::new();
+                for group in cfg.peer_groups.values() {
+                    let group_matches = match group.channel.split_once('.') {
+                        Some((ty, al)) => ty == "telegram" && al == "default",
+                        None => group.channel == "telegram",
+                    };
+                    if group_matches && group.output_modality == OutputModality::Voice {
+                        for peer in &group.external_peers {
+                            let username = peer.as_str().to_string();
+                            if seen.insert(username.clone()) {
+                                out.push(username);
+                            }
+                        }
+                    }
+                }
+                out
+            })
+        };
+
         let ch = TelegramChannel::new(
             "fake-token".into(),
             "default",
             Arc::new(|| vec!["*".into()]),
             false,
         )
-        .with_voice_peer_prefs(&config, "telegram", "default");
+        .with_voice_peer_resolver(resolver_with_data);
 
-        // Peers go into static_voice_peers, not into the session voice_chats set.
-        let sp = ch.static_voice_peers.lock().unwrap();
-        assert!(sp.contains("@alice"), "voice peer should be in static set");
-        assert!(sp.contains("@bob"), "voice peer should be in static set");
         assert!(
-            !sp.contains("@carol"),
-            "peers on another channel must not be seeded"
+            ch.is_voice_chat("@alice"),
+            "voice peer should be resolved"
         );
         assert!(
-            !sp.contains("@dave"),
-            "mirror-modality peers must not be seeded"
+            ch.is_voice_chat("@bob"),
+            "voice peer should be resolved"
         );
-        drop(sp);
+        assert!(
+            !ch.is_voice_chat("@carol"),
+            "peers on another channel must not be resolved"
+        );
+        assert!(
+            !ch.is_voice_chat("@dave"),
+            "mirror-modality peers must not be resolved"
+        );
 
         let vc = ch.voice_chats.lock().unwrap();
         assert!(
             !vc.contains("@alice"),
-            "static peers must not pollute the session voice_chats set"
+            "voice peers must not pollute the session voice_chats set"
         );
     }
 
     #[test]
-    fn static_voice_peers_survive_session_voice_chats_removal() {
+    fn voice_peer_resolver_survives_session_voice_chats_removal() {
         use zeroclaw_config::multi_agent::{OutputModality, PeerGroupConfig, PeerUsername};
 
         let mut config = zeroclaw_config::schema::Config::default();
@@ -4193,22 +4225,47 @@ mod tests {
             },
         );
 
+        let config_arc = Arc::new(RwLock::new(config));
+        let resolver: Arc<dyn Fn() -> Vec<String> + Send + Sync> = {
+            let cfg = config_arc.clone();
+            Arc::new(move || {
+                let cfg = cfg.read();
+                let mut out: Vec<String> = Vec::new();
+                let mut seen = std::collections::HashSet::new();
+                for group in cfg.peer_groups.values() {
+                    let group_matches = match group.channel.split_once('.') {
+                        Some((ty, al)) => ty == "telegram" && al == "default",
+                        None => group.channel == "telegram",
+                    };
+                    if group_matches && group.output_modality == OutputModality::Voice {
+                        for peer in &group.external_peers {
+                            let username = peer.as_str().to_string();
+                            if seen.insert(username.clone()) {
+                                out.push(username);
+                            }
+                        }
+                    }
+                }
+                out
+            })
+        };
+
         let ch = TelegramChannel::new(
             "fake-token".into(),
             "default",
             Arc::new(|| vec!["*".into()]),
             false,
         )
-        .with_voice_peer_prefs(&config, "telegram", "default");
+        .with_voice_peer_resolver(resolver);
 
         // Simulate a voice-send removing @alice from voice_chats (even though
-        // she was never in it — this proves static peers are checked separately).
+        // she was never in it — this proves voice peers are checked separately).
         ch.voice_chats.lock().unwrap().remove("@alice");
 
-        // is_voice_chat must still return true via static_voice_peers.
+        // is_voice_chat must still return true via the voice peer resolver.
         assert!(
             ch.is_voice_chat("@alice"),
-            "static voice peer must remain active after voice_chats removal"
+            "voice peer must remain active after voice_chats removal"
         );
     }
 


### PR DESCRIPTION
## Summary

Automated build resolving the linked issue. Diff touches 2 file(s):
- `crates/zeroclaw-channels/src/orchestrator/mod.rs`
- `crates/zeroclaw-channels/src/telegram.rs`

## Linked issue

Resolves zeroclaw-labs/zeroclaw#7795

`risk: low` · `size: S`

## Testing (required)

- **CI:** relies on the repository CI suite (build + tests) for this change.
- **Beyond CI — what did you manually verify?** Automated build; the staged diff was produced against the pinned base commit and passed through adversarial cross-family review (advisory) before submission.
- **What was NOT verified:** no additional manual runtime verification beyond CI.
- **If any command was intentionally skipped, why:** N/A.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No

## Adversarial review (advisory)

Automated cross-family review returned **needs-attention** (advisory, non-blocking). Reviewer summary:

> VERDICT: NEEDS-ATTENTION
> FINDINGS:
> - **mod.rs:5715** HIGH: `let cfg = config_arc.read();` returns a `Result<RwLockReadGuard<Config>, PoisonError>`. The code treats it as a guard, causing a compile error. Fix by unwrapping or handling the error, e.g. `let cfg = config_arc.read().expect("RwLock poisoned")`.
> - **mod.rs:5715** HIGH: The closure captures `config_arc` but does not import `std::sync::RwLock` in this file (if not already imported). Ensure `use std::sync::RwLock;` is present.
> - **mod.rs:5722** MED: The resolver allocates a new `Vec<String>` on every call and also creates a new `HashSet` each time. While functionally correct, this may be a performance concern for high‑frequency `is_voice_chat` checks. Consider caching the set inside the closure with interior mutability if appropriate.
> - **telegram.rs:1052** MED: `self.voice_peer_resolver)().contains(&recipient.to_string())` creates a new `String` for each check, leading to unnecessary allocation. Use `contains(&recipient)` after converting the resolver output to `Vec<&str>` or store a `HashSet<String>` inside the resolver.
> - **telegram.rs:623** LOW: The default resolver `Arc::new(|| vec![])` returns an empty `Vec<String>` ea

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No

## Rollback

Low-risk PR: `git revert <sha>` reverts this change.
