### PR TITLE
[Tracker]: audit byte-limited string truncation for UTF-8 char-boundary safety. Work in th (#7828)

### DIFF
--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -858,17 +858,22 @@ pub fn scrub_secret_patterns(input: &str) -> String {
 }
 
 /// Sanitize API error text by scrubbing secrets and truncating length.
+/// Truncation operates on Unicode character count to respect the
+/// `MAX_API_ERROR_CHARS` limit, with a UTF-8 char-boundary-safe slice.
 pub fn sanitize_api_error(input: &str) -> String {
     let scrubbed = scrub_secret_patterns(input);
 
+    // Fast path: short enough as-is.
     if scrubbed.chars().count() <= MAX_API_ERROR_CHARS {
         return scrubbed;
     }
 
-    let mut end = MAX_API_ERROR_CHARS;
-    while end > 0 && !scrubbed.is_char_boundary(end) {
-        end -= 1;
-    }
+    // Truncate to MAX_API_ERROR_CHARS Unicode characters using char_indices
+    // so the byte slice is guaranteed to land on a valid char boundary.
+    let (end, _) = scrubbed
+        .char_indices()
+        .nth(MAX_API_ERROR_CHARS)
+        .unwrap_or((scrubbed.len(), '\0'));
 
     format!("{}...", &scrubbed[..end])
 }
@@ -1238,7 +1243,17 @@ fn create_model_provider_inner(
             && !has_custom_url
             && let Some(likely_model_provider) = check_api_key_prefix(provider_kind, key_value)
         {
-            let visible = &key_value[..key_value.len().min(8)];
+            // Walk back from byte 8 to a valid UTF-8 char boundary so that
+            // multi-byte characters in the prefix (extremely unlikely for API
+            // keys, but tracked in #7828) do not panic at the slice point.
+            let display_end = {
+                let mut i = key_value.len().min(8);
+                while i > 0 && !key_value.is_char_boundary(i) {
+                    i -= 1;
+                }
+                i
+            };
+            let visible = &key_value[..display_end];
             anyhow::bail!(
                 "API key prefix mismatch: key \"{visible}...\" looks like a \
                      {likely_model_provider} key, but model_provider \"{provider_kind}\" is selected. \
@@ -4264,5 +4279,173 @@ mod tests {
             result.is_ok(),
             "a deep acyclic chain must be depth-capped, never overflow or abort the build"
         );
+    }
+
+    // ── UTF-8 safe truncation tests ────────────────────────────────────
+    //
+    // Every byte-level truncation in the codebase must split on a UTF-8
+    // boundary so that no multi-byte character is cut in half.
+
+    #[test]
+    fn truncate_str_ascii() {
+        let s = "Hello, World!";
+        // Short enough — no truncation.
+        assert_eq!(truncate_str(s, 100), "Hello, World!");
+        // Exact boundary.
+        assert_eq!(truncate_str(s, 5), "Hello");
+        // Beyond end.
+        assert_eq!(truncate_str(s, 13), "Hello, World!");
+    }
+
+    #[test]
+    fn truncate_str_empty() {
+        assert_eq!(truncate_str("", 0), "");
+        assert_eq!(truncate_str("", 10), "");
+    }
+
+    #[test]
+    fn truncate_str_zero_max() {
+        assert_eq!(truncate_str("anything", 0), "");
+    }
+
+    #[test]
+    fn truncate_str_emoji_cut_before_multi_byte_boundary() {
+        // 🚀 is 4 bytes, 🌍 is 4 bytes.
+        // If we truncate to 5 bytes, naive code would cut inside 🚀.
+        // Safe truncation should end at byte 4 (just after 🚀).
+        assert_eq!(truncate_str("🚀🌍", 4), "🚀");
+        assert_eq!(truncate_str("🚀🌍", 5), "🚀");
+        assert_eq!(truncate_str("🚀🌍", 6), "🚀");
+        assert_eq!(truncate_str("🚀🌍", 7), "🚀");
+        assert_eq!(truncate_str("🚀🌍", 8), "🚀🌍");
+    }
+
+    #[test]
+    fn truncate_str_mixed_ascii_and_emoji() {
+        // "ab🚀cd" — 4-byte rocket between 2 ASCII chars on each side.
+        let s = "ab🚀cd";
+        assert_eq!(truncate_str(s, 2), "ab");
+        assert_eq!(truncate_str(s, 3), "ab");
+        assert_eq!(truncate_str(s, 6), "ab🚀");
+        assert_eq!(truncate_str(s, 7), "ab🚀c");
+        assert_eq!(truncate_str(s, 8), "ab🚀cd");
+    }
+
+    #[test]
+    fn truncate_str_multi_code_point_emoji() {
+        // A complex emoji sequence that is more than one codepoint.
+        // The woman-surfing sequence: U+1F3C4 U+200D U+2640 U+FE0F — 11 bytes total.
+        // Man-surfing: U+1F3C4 U+200D U+2642 U+FE0F — also 11 bytes.
+        let surfer = "\u{1f3c4}\u{200d}\u{2640}\u{fe0f}";
+        let s = format!("{surfer}{surfer}");
+        // Truncating to 11 bytes should yield exactly one surfer.
+        assert_eq!(truncate_str(&s, 11), surfer);
+        // Truncating to 10 bytes should yield nothing (no partial multi-byte).
+        assert_eq!(truncate_str(&s, 10), "");
+        // Full string at 22 bytes.
+        assert_eq!(truncate_str(&s, 22), s);
+    }
+
+    #[test]
+    fn truncate_str_3_byte_boundary() {
+        // "a\u{0800}b" — 3-byte char between ASCII.
+        // U+0800 (Samaritan letter alaf) encodes as 3 bytes: E0 A0 80.
+        let s = "a\u{0800}b";
+        assert_eq!(truncate_str(s, 1), "a");
+        assert_eq!(truncate_str(s, 2), "a");
+        assert_eq!(truncate_str(s, 4), "a\u{0800}");
+        assert_eq!(truncate_str(s, 5), "a\u{0800}b");
+    }
+
+    #[test]
+    fn truncate_str_all_continuation_bytes() {
+        // A 4-byte char. The continuation bytes (10xxxxxx) are valid
+        // ASCII-range octets in their own right. Safe truncation must
+        // scan backward for the leading byte rather than stopping at a
+        // lone continuation byte.
+        let s = "a\u{1f600}b"; // grinning face = 4 bytes
+        assert_eq!(truncate_str(s, 1), "a");
+        assert_eq!(truncate_str(s, 2), "a");
+        assert_eq!(truncate_str(s, 5), "a\u{1f600}");
+    }
+
+    #[test]
+    fn truncate_str_validates_no_utf8_replacement_characters() {
+        // Ensure no replacement character U+FFFD appears when truncation
+        // cuts at an awkward boundary. Iterate every truncation length
+        // for a mixed string.
+        let mixed = "Hi🚀🌍!";
+        for max in 0..=mixed.len() {
+            let t = truncate_str(mixed, max);
+            assert!(
+                t.len() <= max,
+                "length {len} exceeds max {max}: {t:?}",
+                len = t.len(),
+            );
+            assert!(
+                std::str::from_utf8(t.as_bytes()).is_ok(),
+                "truncated string is not valid UTF-8 at max={max}: {t:?}",
+            );
+            assert!(
+                !t.contains('\u{FFFD}'),
+                "truncated string contains replacement character at max={max}: {t:?}"
+            );
+            // Verify it's the longest possible prefix by checking that
+            // the next character boundary would exceed max.
+            if max < mixed.len() {
+                let next_boundary = t.len() + mixed[t.len()..].chars().next().unwrap().len();
+                assert!(
+                    next_boundary > max,
+                    "not longest prefix at max={max}: {t:?} vs mixed bytes {next_boundary}",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn truncate_str_cjk() {
+        // Each CJK character is 3 bytes.
+        let s = "中文测试";
+        assert_eq!(truncate_str(s, 3), "中");
+        assert_eq!(truncate_str(s, 5), "中");
+        assert_eq!(truncate_str(s, 6), "中文");
+        assert_eq!(truncate_str(s, 8), "中文");
+        assert_eq!(truncate_str(s, 9), "中文测");
+        assert_eq!(truncate_str(s, 12), "中文测试");
+    }
+
+    #[test]
+    fn truncate_str_surrogate_free() {
+        // Supplementary plane characters (emoji, rare CJK) are 4 bytes
+        // in UTF-8 and must not be split.
+        let s = "a\u{1f600}b\u{1f601}c"; // grin, grin-with-smiling-eyes
+        assert_eq!(truncate_str(s, 1), "a");
+        assert_eq!(truncate_str(s, 5), "a\u{1f600}");
+        assert_eq!(truncate_str(s, 6), "a\u{1f600}b");
+        assert_eq!(truncate_str(s, 10), "a\u{1f600}b\u{1f601}");
+        assert_eq!(truncate_str(s, 11), "a\u{1f600}b\u{1f601}c");
+    }
+
+    #[test]
+    fn truncate_str_zero_width_joiners() {
+        // Family emoji: man + ZWJ + woman + ZWJ + girl + ZWJ + boy
+        // Each ZWJ (U+200D) is 3 bytes.
+        let family = "\u{1f468}\u{200d}\u{1f469}\u{200d}\u{1f467}\u{200d}\u{1f466}";
+        assert_eq!(truncate_str(family, 0), "");
+        assert_eq!(truncate_str(family, 4), "");
+        assert_eq!(truncate_str(family, family.len()), family);
+        let t = truncate_str(family, 7);
+        // Should only contain whole characters, no replacement chars.
+        assert!(std::str::from_utf8(t.as_bytes()).is_ok());
+        assert!(!t.contains('\u{FFFD}'));
+    }
+
+    #[test]
+    fn truncate_model_name_tool_name_ascii() {
+        // Typical provider and tool names are ASCII — must remain unchanged.
+        for name in &["gpt-4o", "claude-sonnet-4-6", "web_search", "file_read"] {
+            assert_eq!(truncate_str(name, 64), *name);
+            assert_eq!(truncate_str(name, name.len()), *name);
+        }
     }
 }

--- a/plugins/image-gen-fal/src/lib.rs
+++ b/plugins/image-gen-fal/src/lib.rs
@@ -202,10 +202,17 @@ pub fn execute(input: String) -> FnResult<String> {
     };
 
     if resp.status >= 400 {
+        // Truncate error body at a UTF-8 char boundary to avoid panic on
+        // multi-byte content (see #7828).
+        let max_err_bytes = resp.body.len().min(500);
+        let trunc_end = (0..=max_err_bytes)
+            .rev()
+            .find(|&i| resp.body.is_char_boundary(i))
+            .unwrap_or(0);
         return Ok(serde_json::to_string(&ToolResult::failure(format!(
             "fal.ai API error ({}): {}",
             resp.status,
-            &resp.body[..resp.body.len().min(500)]
+            &resp.body[..trunc_end]
         )))?);
     }
 

--- a/tests/integration/memory_comparison.rs
+++ b/tests/integration/memory_comparison.rs
@@ -153,25 +153,38 @@ async fn compare_recall_quality() {
         println!("  Query: \"{query}\" — {desc}");
         println!("    SQLite:   {} results", sq_results.len());
         for r in &sq_results {
+            // Safely truncate at a UTF-8 char boundary to avoid panic with
+            // non-ASCII content (see #7828).
+            let preview = truncate_at_char_boundary(&r.content, 50);
             println!(
                 "      [{:.2}] {}: {}",
                 r.score.unwrap_or(0.0),
                 r.key,
-                &r.content[..r.content.len().min(50)]
+                preview
             );
         }
         println!("    Markdown: {} results", md_results.len());
         for r in &md_results {
+            let preview = truncate_at_char_boundary(&r.content, 50);
             println!(
                 "      [{:.2}] {}: {}",
                 r.score.unwrap_or(0.0),
                 r.key,
-                &r.content[..r.content.len().min(50)]
+                preview
             );
         }
         println!();
     }
 }
+
+/// Truncate `s` to at most `max` bytes, stepping back to a valid UTF-8
+/// char boundary so the returned slice never panics in `s[..i]`.
+fn truncate_at_char_boundary(s: &str, max: usize) -> &str {
+    let mut end = s.len().min(max);
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
 
 // ── Test 3: Recall speed at scale ──────────────────────────────
 


### PR DESCRIPTION
## Summary

Automated build resolving the linked issue. Diff touches 3 file(s):
- `crates/zeroclaw-providers/src/lib.rs`
- `plugins/image-gen-fal/src/lib.rs`
- `tests/integration/memory_comparison.rs`

## Linked issue

Resolves zeroclaw-labs/zeroclaw#7828

`risk: low` · `size: S`

## Testing (required)

- **CI:** relies on the repository CI suite (build + tests) for this change.
- **Beyond CI — what did you manually verify?** Automated build; the staged diff was produced against the pinned base commit and passed through adversarial cross-family review (advisory) before submission.
- **What was NOT verified:** no additional manual runtime verification beyond CI.
- **If any command was intentionally skipped, why:** N/A.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No

## Adversarial review (advisory)

Automated cross-family review returned **needs-attention** (advisory, non-blocking). Reviewer summary:

> VERDICT: NEEDS-ATTENTION
> FINDINGS:
> - lib.rs:862 HIGH: `sanitize_api_error` always appends `"..."` even when the input fits within `MAX_API_ERROR_CHARS`. This produces incorrect output and can exceed the intended length limit. Fix: only add the ellipsis when truncation actually occurs (i.e., when `end < scrubbed.len()`).
> - lib.rs:870 MED: The `char_indices().nth(MAX_API_ERROR_CHARS)` call walks to the *next* character after the limit, which is correct for slicing, but the fallback `unwrap_or((scrubbed.len(), '\0'))` returns the full length when the string is exactly `MAX_API_ERROR_CHARS` long, leading to the above bug. Consider using `nth(MAX_API_ERROR_CHARS - 1)` with proper handling for zero limit.
> - lib.rs:1245 MED: In `create_model_provider_inner`, the loop that walks back to a valid UTF‑8 boundary could theoretically loop forever if `key_value` is empty (though `min(8)` yields 0, the while condition `i > 0` prevents it). Still, an explicit early return for empty keys would be clearer.
> - plugins/image-gen-fal/src/lib.rs:215 MED: The truncation logic for error bodies scans backwards from `max_err_bytes` to find a char boundary. If `resp.body` is empty, `trunc_end` becomes 0 and t

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No

## Rollback

Low-risk PR: `git revert <sha>` reverts this change.
