### PR TITLE
[Bug]: external coding tools resolve relative working_directory from daemon cwd (#7877)

### DIFF
--- a/crates/zeroclaw-tools/src/claude_code.rs
+++ b/crates/zeroclaw-tools/src/claude_code.rs
@@ -143,9 +143,19 @@ impl Tool for ClaudeCodeTool {
         // non-existent paths instead of falling back to the raw value, which
         // could bypass the workspace containment check via symlinks or
         // specially-crafted path components).
+        //
+        // Relative paths are resolved against workspace_dir (not the process
+        // cwd) so that "." or "src" always refers to the configured workspace.
         let work_dir = if let Some(wd) = args.get("working_directory").and_then(|v| v.as_str()) {
-            let wd_path = std::path::PathBuf::from(wd);
             let workspace = &self.security.workspace_dir;
+            // Join with workspace_dir if the path is relative; use it as-is if
+            // already absolute.  This matches the expected behaviour where a
+            // relative working_directory is workspace-relative.
+            let wd_path = if std::path::Path::new(wd).is_absolute() {
+                std::path::PathBuf::from(wd)
+            } else {
+                workspace.join(wd)
+            };
             let canonical_wd = match wd_path.canonicalize() {
                 Ok(p) => p,
                 Err(_) => {
@@ -441,6 +451,55 @@ mod tests {
                 .unwrap_or("")
                 .contains("outside the workspace")
         );
+    }
+
+    #[tokio::test]
+    async fn claude_code_relative_working_directory_resolves_against_workspace() {
+        // Create a real subdirectory inside the test workspace so canonicalize
+        // succeeds.  The fix ensures the path is joined with workspace_dir first,
+        // not resolved from the process cwd.
+        let workspace = std::env::temp_dir();
+        let subdir = workspace.join("claude-code-test-subdir");
+        std::fs::create_dir_all(&subdir).ok();
+
+        let security = Arc::new(SecurityPolicy {
+            autonomy: AutonomyLevel::Full,
+            workspace_dir: workspace.clone(),
+            ..SecurityPolicy::default()
+        });
+        let tool = ClaudeCodeTool::new(security, test_config());
+
+        // "relative" is resolved against workspace, not cwd — so
+        // workspace/relative exists (after we canonicalise it).
+        let result = tool
+            .execute(json!({
+                "prompt": "hello",
+                // subdirectory name that exists inside workspace
+                "working_directory": subdir.file_name().unwrap().to_str().unwrap()
+            }))
+            .await;
+        // We expect either success (tool ran) or an error about the binary
+        // not being found — NOT "does not exist or is not accessible", which
+        // would indicate it looked in the wrong place.
+        match result {
+            Ok(r) if !r.success => {
+                let err = r.error.as_deref().unwrap_or("");
+                // Binary-not-found is acceptable; path-not-found is the bug.
+                assert!(
+                    !err.contains("does not exist or is not accessible"),
+                    "relative working_directory was resolved against cwd instead of workspace: {err}"
+                );
+            }
+            Err(e) => {
+                // Execution error (binary not found) is fine; canonicalize failure
+                // would indicate the wrong base directory.
+                assert!(
+                    !e.to_string().contains("does not exist"),
+                    "relative working_directory was resolved against cwd instead of workspace"
+                );
+            }
+            _ => {}
+        }
     }
 
     #[test]

--- a/crates/zeroclaw-tools/src/claude_code_runner.rs
+++ b/crates/zeroclaw-tools/src/claude_code_runner.rs
@@ -140,9 +140,19 @@ impl Tool for ClaudeCodeRunnerTool {
         })?;
 
         // Validate working directory
+        //
+        // Relative paths are resolved against workspace_dir (not the process
+        // cwd) so that "." or "src" always refers to the configured workspace.
         let work_dir = if let Some(wd) = args.get("working_directory").and_then(|v| v.as_str()) {
-            let wd_path = std::path::PathBuf::from(wd);
             let workspace = &self.security.workspace_dir;
+            // Join with workspace_dir if the path is relative; use it as-is if
+            // already absolute.  This matches the expected behaviour where a
+            // relative working_directory is workspace-relative.
+            let wd_path = if std::path::Path::new(wd).is_absolute() {
+                std::path::PathBuf::from(wd)
+            } else {
+                workspace.join(wd)
+            };
             let canonical_wd = match wd_path.canonicalize() {
                 Ok(p) => p,
                 Err(_) => {
@@ -506,6 +516,51 @@ mod tests {
                 .unwrap_or("")
                 .contains("outside the workspace")
         );
+    }
+
+    #[tokio::test]
+    async fn relative_working_directory_resolves_against_workspace() {
+        // Verify that a relative path existing inside the workspace is accepted
+        // (i.e. it is resolved against workspace_dir, not cwd).
+        let workspace = std::env::temp_dir();
+        let subdir = workspace.join("claude-code-runner-test-subdir");
+        std::fs::create_dir_all(&subdir).ok();
+
+        let security = Arc::new(SecurityPolicy {
+            autonomy: AutonomyLevel::Full,
+            workspace_dir: workspace.clone(),
+            ..SecurityPolicy::default()
+        });
+        let tool = ClaudeCodeRunnerTool::new(
+            security,
+            test_config(),
+            "http://localhost:3000".into(),
+        );
+
+        let result = tool
+            .execute(json!({
+                "prompt": "hello",
+                "working_directory": subdir.file_name().unwrap().to_str().unwrap()
+            }))
+            .await;
+
+        match result {
+            Ok(r) if !r.success => {
+                let err = r.error.as_deref().unwrap_or("");
+                // tmux not found is acceptable; path-not-found indicates the bug.
+                assert!(
+                    !err.contains("does not exist or is not accessible"),
+                    "relative working_directory was resolved against cwd instead of workspace: {err}"
+                );
+            }
+            Err(e) => {
+                assert!(
+                    !e.to_string().contains("does not exist"),
+                    "relative working_directory was resolved against cwd instead of workspace"
+                );
+            }
+            _ => {}
+        }
     }
 
     #[test]

--- a/crates/zeroclaw-tools/src/codex_cli.rs
+++ b/crates/zeroclaw-tools/src/codex_cli.rs
@@ -91,9 +91,19 @@ impl Tool for CodexCliTool {
         // non-existent paths instead of falling back to the raw value, which
         // could bypass the workspace containment check via symlinks or
         // specially-crafted path components).
+        //
+        // Relative paths are resolved against workspace_dir (not the process
+        // cwd) so that "." or "src" always refers to the configured workspace.
         let work_dir = if let Some(wd) = args.get("working_directory").and_then(|v| v.as_str()) {
-            let wd_path = std::path::PathBuf::from(wd);
             let workspace = &self.security.workspace_dir;
+            // Join with workspace_dir if the path is relative; use it as-is if
+            // already absolute.  This matches the expected behaviour where a
+            // relative working_directory is workspace-relative.
+            let wd_path = if std::path::Path::new(wd).is_absolute() {
+                std::path::PathBuf::from(wd)
+            } else {
+                workspace.join(wd)
+            };
             let canonical_wd = match wd_path.canonicalize() {
                 Ok(p) => p,
                 Err(_) => {
@@ -336,6 +346,46 @@ mod tests {
                 .unwrap_or("")
                 .contains("outside the workspace")
         );
+    }
+
+    #[tokio::test]
+    async fn codex_cli_relative_working_directory_resolves_against_workspace() {
+        // Verify that a relative path existing inside the workspace is accepted
+        // (i.e. it is resolved against workspace_dir, not cwd).
+        let workspace = std::env::temp_dir();
+        let subdir = workspace.join("codex-cli-test-subdir");
+        std::fs::create_dir_all(&subdir).ok();
+
+        let security = Arc::new(SecurityPolicy {
+            autonomy: AutonomyLevel::Full,
+            workspace_dir: workspace.clone(),
+            ..SecurityPolicy::default()
+        });
+        let tool = CodexCliTool::new(security, test_config());
+
+        let result = tool
+            .execute(json!({
+                "prompt": "hello",
+                "working_directory": subdir.file_name().unwrap().to_str().unwrap()
+            }))
+            .await;
+
+        match result {
+            Ok(r) if !r.success => {
+                let err = r.error.as_deref().unwrap_or("");
+                assert!(
+                    !err.contains("does not exist or is not accessible"),
+                    "relative working_directory was resolved against cwd instead of workspace: {err}"
+                );
+            }
+            Err(e) => {
+                assert!(
+                    !e.to_string().contains("does not exist"),
+                    "relative working_directory was resolved against cwd instead of workspace"
+                );
+            }
+            _ => {}
+        }
     }
 
     #[test]

--- a/crates/zeroclaw-tools/src/gemini_cli.rs
+++ b/crates/zeroclaw-tools/src/gemini_cli.rs
@@ -91,9 +91,19 @@ impl Tool for GeminiCliTool {
         // non-existent paths instead of falling back to the raw value, which
         // could bypass the workspace containment check via symlinks or
         // specially-crafted path components).
+        //
+        // Relative paths are resolved against workspace_dir (not the process
+        // cwd) so that "." or "src" always refers to the configured workspace.
         let work_dir = if let Some(wd) = args.get("working_directory").and_then(|v| v.as_str()) {
-            let wd_path = std::path::PathBuf::from(wd);
             let workspace = &self.security.workspace_dir;
+            // Join with workspace_dir if the path is relative; use it as-is if
+            // already absolute.  This matches the expected behaviour where a
+            // relative working_directory is workspace-relative.
+            let wd_path = if std::path::Path::new(wd).is_absolute() {
+                std::path::PathBuf::from(wd)
+            } else {
+                workspace.join(wd)
+            };
             let canonical_wd = match wd_path.canonicalize() {
                 Ok(p) => p,
                 Err(_) => {
@@ -326,6 +336,46 @@ mod tests {
                 .unwrap_or("")
                 .contains("outside the workspace")
         );
+    }
+
+    #[tokio::test]
+    async fn gemini_cli_relative_working_directory_resolves_against_workspace() {
+        // Verify that a relative path existing inside the workspace is accepted
+        // (i.e. it is resolved against workspace_dir, not cwd).
+        let workspace = std::env::temp_dir();
+        let subdir = workspace.join("gemini-cli-test-subdir");
+        std::fs::create_dir_all(&subdir).ok();
+
+        let security = Arc::new(SecurityPolicy {
+            autonomy: AutonomyLevel::Full,
+            workspace_dir: workspace.clone(),
+            ..SecurityPolicy::default()
+        });
+        let tool = GeminiCliTool::new(security, test_config());
+
+        let result = tool
+            .execute(json!({
+                "prompt": "hello",
+                "working_directory": subdir.file_name().unwrap().to_str().unwrap()
+            }))
+            .await;
+
+        match result {
+            Ok(r) if !r.success => {
+                let err = r.error.as_deref().unwrap_or("");
+                assert!(
+                    !err.contains("does not exist or is not accessible"),
+                    "relative working_directory was resolved against cwd instead of workspace: {err}"
+                );
+            }
+            Err(e) => {
+                assert!(
+                    !e.to_string().contains("does not exist"),
+                    "relative working_directory was resolved against cwd instead of workspace"
+                );
+            }
+            _ => {}
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Automated build resolving the linked issue. Diff touches 4 file(s):
- `crates/zeroclaw-tools/src/claude_code.rs`
- `crates/zeroclaw-tools/src/claude_code_runner.rs`
- `crates/zeroclaw-tools/src/codex_cli.rs`
- `crates/zeroclaw-tools/src/gemini_cli.rs`

## Linked issue

Resolves zeroclaw-labs/zeroclaw#7877

`risk: low` · `size: S`

## Testing (required)

- **CI:** relies on the repository CI suite (build + tests) for this change.
- **Beyond CI — what did you manually verify?** Automated build; the staged diff was produced against the pinned base commit and passed through adversarial cross-family review (advisory) before submission.
- **What was NOT verified:** no additional manual runtime verification beyond CI.
- **If any command was intentionally skipped, why:** N/A.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No

## Adversarial review (advisory)

Automated cross-family review returned **needs-attention** (advisory, non-blocking). Reviewer summary:

> VERDICT: NEEDS-ATTENTION
> FINDINGS:
> - <crates/zeroclaw-tools/src/claude_code.rs:149> HIGH: After joining a relative `working_directory` with `workspace_dir` the code only calls `canonicalize()` and returns the path. It does **not** verify that the resulting canonical path is still inside `workspace_dir`. An attacker could use `..` components or a symlink inside the workspace to escape the sandbox. Add a containment check (e.g., ensure `canonical_wd.starts_with(&workspace)`).
> - <crates/zeroclaw-tools/src/claude_code_runner.rs:149> HIGH: Same missing containment check as above; the fix is duplicated across tools, increasing the risk of inconsistency. Centralise the logic and enforce the workspace boundary after canonicalization.
> - <crates/zeroclaw-tools/src/codex_cli.rs:149> HIGH: Same missing containment check; duplicated bug.
> - <crates/zeroclaw-tools/src/gemini_cli.rs:149> HIGH: Same missing containment check; duplicated bug.
> - <crates/zeroclaw-tools/src/claude_code.rs:466> MED: The async test creates a subdirectory directly under `std::env::temp_dir()` with a fixed name (`claude-code-test-subdir`). When tests run in parallel (e.g., CI), they may clash, causing flaky failures or rac

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No

## Rollback

Low-risk PR: `git revert <sha>` reverts this change.
