### PR TITLE
fix(channels/feishu): route inbound messages to agent instead of LLM-only

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -18439,6 +18439,142 @@ This is an example JSON object for profile settings."#;
         );
     }
 
+    #[cfg(feature = "channel-lark")]
+    #[test]
+    fn collect_configured_channels_feishu_binding_reaches_tool_capable_agent_route() {
+        use zeroclaw_config::multi_agent::{AgentAlias, PeerGroupConfig, PeerUsername};
+
+        let mut config = Config::default();
+        config.channels.lark.insert(
+            "work".to_string(),
+            zeroclaw_config::schema::LarkConfig {
+                enabled: true,
+                app_id: "cli_feishu_app123".to_string(),
+                app_secret: "test-secret".to_string(),
+                use_feishu: true,
+                ack_reactions: Some(false),
+                ..Default::default()
+            },
+        );
+        config.agents.clear();
+        config.agents.insert(
+            "feishu-agent".to_string(),
+            zeroclaw_config::schema::AliasedAgentConfig {
+                enabled: true,
+                channels: vec!["feishu.work".into()],
+                ..Default::default()
+            },
+        );
+        config.peer_groups.insert(
+            "feishu_ops".to_string(),
+            PeerGroupConfig {
+                channel: "feishu.work".into(),
+                agents: vec![AgentAlias::new("feishu-agent")],
+                external_peers: vec![PeerUsername::new("@operator")],
+                ..Default::default()
+            },
+        );
+
+        let config_arc = Arc::new(RwLock::new(config.clone()));
+        let configured_channels = collect_configured_channels(&config_arc, "test", &[]);
+
+        let feishu = configured_channels
+            .iter()
+            .find(|entry| entry.alias.as_deref() == Some("work"))
+            .expect("feishu.work binding must be collected from [channels.lark.work]");
+        assert_eq!(feishu.display_name, "Feishu");
+        assert_eq!(feishu.channel.name(), "feishu");
+
+        let mut channels_by_name: HashMap<String, Arc<dyn Channel>> = HashMap::new();
+        let collected_channel_keys: Vec<String> = configured_channels
+            .iter()
+            .map(|entry| {
+                let key = composite_channel_key(entry.channel.name(), entry.alias.as_deref());
+                channels_by_name.insert(key.clone(), Arc::clone(&entry.channel));
+                key
+            })
+            .collect();
+        assert!(
+            collected_channel_keys
+                .iter()
+                .any(|key| key == "feishu.work"),
+            "startup collection must expose the Feishu alias key, got {collected_channel_keys:?}"
+        );
+
+        let enabled_agents = vec!["feishu-agent".to_string()];
+        let owners = build_owner_by_channel_key(&config, &enabled_agents, &collected_channel_keys);
+        assert_eq!(
+            owners.get("feishu.work").map(String::as_str),
+            Some("feishu-agent"),
+            "a feishu.<alias> agent binding must own the collected Feishu channel key"
+        );
+
+        let msg = channel_message("feishu", Some("work"));
+        assert!(
+            find_channel_for_message(&channels_by_name, &msg).is_some(),
+            "a Feishu inbound message must resolve to the collected live channel"
+        );
+
+        let tools_registry: Arc<Vec<Box<dyn Tool>>> = Arc::new(vec![Box::new(
+            zeroclaw_runtime::tools::SendMessageToPeerTool::new(
+                Arc::new(config.clone()),
+                "feishu-agent",
+            ),
+        )]);
+        let provider = Arc::new(HistoryCaptureModelProvider::default());
+        let base_ctx = (*peer_prompt_test_context(
+            channels_by_name,
+            provider,
+            Arc::new(config.clone()),
+            tools_registry,
+        ))
+        .clone();
+        let runtime_ctx = Arc::new(ChannelRuntimeContext {
+            agent_alias: Arc::new("feishu-agent".to_string()),
+            agent_cfg: Arc::new(
+                config
+                    .agents
+                    .get("feishu-agent")
+                    .expect("test config must include feishu-agent")
+                    .clone(),
+            ),
+            ..base_ctx
+        });
+
+        let mut by_agent: HashMap<String, Arc<ChannelRuntimeContext>> = HashMap::new();
+        by_agent.insert("feishu-agent".to_string(), Arc::clone(&runtime_ctx));
+        let router = AgentRouter::multi(by_agent, owners);
+
+        let resolved = router
+            .resolve(&msg)
+            .expect("Feishu inbound must route to the owning agent context");
+        assert!(Arc::ptr_eq(&resolved, &runtime_ctx));
+        // NB: intentionally NOT asserting tool availability on `resolved` — the tool was
+        // supplied by this test's `tools_registry`, so such a check would be tautological.
+        // The non-circular proof of #4873 is that the inbound Feishu message routes to the
+        // bound *agent* context (owned, above) scoped to the Feishu channel ref below —
+        // i.e. the agent path, not the LLM-only fallback.
+        assert_eq!(
+            peer_prompt_channel_ref(resolved.as_ref(), &msg).as_deref(),
+            Some("feishu.work")
+        );
+
+        let peer_map =
+            zeroclaw_runtime::tools::send_message_to_peer::render_sender_peer_map_for_channel(
+                resolved.prompt_config.as_ref(),
+                resolved.agent_alias.as_str(),
+                "feishu.work",
+            );
+        assert!(
+            peer_map.contains("Current-channel peer map for agent \"feishu-agent\""),
+            "Feishu agent path should render the same peer/tool context as other channels: {peer_map}"
+        );
+        assert!(
+            peer_map.contains("external peers: \"operator\""),
+            "Feishu peer map must be derived from the current Feishu channel ref: {peer_map}"
+        );
+    }
+
     #[cfg(feature = "channel-email")]
     #[test]
     fn collect_configured_channels_skips_unreferenced_email() {

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -139,6 +139,21 @@ use zeroclaw_runtime::util::truncate_with_ellipsis;
 
 type CronChannelRegistry = Arc<HashMap<String, Arc<dyn Channel>>>;
 
+#[cfg(feature = "channel-lark")]
+fn lark_effective_channel_type(config: &zeroclaw_config::schema::LarkConfig) -> &'static str {
+    if config.use_feishu { "feishu" } else { "lark" }
+}
+
+#[cfg(feature = "channel-lark")]
+fn lark_peer_resolver(
+    config_arc: &Arc<RwLock<Config>>,
+    alias: String,
+    channel_type: &'static str,
+) -> Arc<dyn Fn() -> Vec<String> + Send + Sync> {
+    let cfg_arc = Arc::clone(config_arc);
+    Arc::new(move || cfg_arc.read().channel_external_peers(channel_type, &alias))
+}
+
 /// Live channel registry consulted by `deliver_announcement` so cron sends reuse the
 /// authenticated channel instance (Matrix E2EE can't tolerate per-send session restore).
 /// Replaced wholesale by each `start_channels` call.
@@ -6266,11 +6281,8 @@ fn build_channel_by_id(
                     .get("default")
                     .context("Lark channel is not configured")?;
                 let alias = "default".to_string();
-                let peer_resolver: Arc<dyn Fn() -> Vec<String> + Send + Sync> = {
-                    let cfg_arc = config_arc.clone();
-                    let alias = alias.clone();
-                    Arc::new(move || cfg_arc.read().channel_external_peers("lark", &alias))
-                };
+                let peer_resolver =
+                    lark_peer_resolver(config_arc, alias.clone(), lark_effective_channel_type(lk));
                 Ok(Arc::new(
                     LarkChannel::from_config(lk, alias, peer_resolver)
                         .with_approval_timeout_secs(lk.approval_timeout_secs)
@@ -7860,11 +7872,8 @@ fn collect_configured_channels(
         if !lk.enabled {
             continue;
         }
-        let peer_resolver: Arc<dyn Fn() -> Vec<String> + Send + Sync> = {
-            let cfg_arc = config_arc.clone();
-            let alias = alias.clone();
-            Arc::new(move || cfg_arc.read().channel_external_peers("lark", &alias))
-        };
+        let peer_resolver =
+            lark_peer_resolver(config_arc, alias.clone(), lark_effective_channel_type(lk));
         let display_name = if lk.use_feishu { "Feishu" } else { "Lark" };
         channels.push(ConfiguredChannel {
             display_name,
@@ -9786,7 +9795,7 @@ pub async fn deliver_announcement(
                     )
                 );
             }
-            let peers = config.channel_external_peers("lark", alias);
+            let peers = config.channel_external_peers(lark_effective_channel_type(lk), alias);
             let peer_resolver: Arc<dyn Fn() -> Vec<String> + Send + Sync> =
                 Arc::new(move || peers.clone());
             let ch = LarkChannel::from_config(lk, alias, peer_resolver)
@@ -18437,6 +18446,93 @@ This is an example JSON object for profile settings."#;
                 .any(|entry| entry.display_name == "Mattermost"),
             "enabled channels should still load when no enabled agent declares channel bindings"
         );
+    }
+
+    #[cfg(feature = "channel-lark")]
+    #[tokio::test]
+    async fn collect_configured_channels_feishu_peer_group_passes_ingress_gate_before_routing() {
+        use zeroclaw_config::multi_agent::{AgentAlias, PeerGroupConfig, PeerUsername};
+
+        let mut config = Config::default();
+        config.channels.lark.insert(
+            "work".to_string(),
+            zeroclaw_config::schema::LarkConfig {
+                enabled: true,
+                app_id: "cli_feishu_app123".to_string(),
+                app_secret: "test-secret".to_string(),
+                use_feishu: true,
+                ack_reactions: Some(false),
+                ..Default::default()
+            },
+        );
+        config.agents.clear();
+        config.agents.insert(
+            "feishu-agent".to_string(),
+            zeroclaw_config::schema::AliasedAgentConfig {
+                enabled: true,
+                channels: vec!["feishu.work".into()],
+                ..Default::default()
+            },
+        );
+        config.peer_groups.insert(
+            "feishu_ops".to_string(),
+            PeerGroupConfig {
+                channel: "feishu.work".into(),
+                agents: vec![AgentAlias::new("feishu-agent")],
+                external_peers: vec![PeerUsername::new("ou_feishu_operator")],
+                ..Default::default()
+            },
+        );
+
+        let config_arc = Arc::new(RwLock::new(config));
+        let configured_channels = collect_configured_channels(&config_arc, "test", &[]);
+        let feishu = configured_channels
+            .iter()
+            .find(|entry| entry.alias.as_deref() == Some("work"))
+            .expect("feishu.work binding must be collected from [channels.lark.work]");
+        assert_eq!(feishu.display_name, "Feishu");
+        assert_eq!(feishu.channel.name(), "feishu");
+
+        let lk = config_arc
+            .read()
+            .channels
+            .lark
+            .get("work")
+            .expect("test config must include [channels.lark.work]")
+            .clone();
+        let peer_resolver = lark_peer_resolver(
+            &config_arc,
+            "work".to_string(),
+            lark_effective_channel_type(&lk),
+        );
+        let ch = LarkChannel::from_config(&lk, "work", peer_resolver);
+        let payload = serde_json::json!({
+            "header": { "event_type": "im.message.receive_v1" },
+            "event": {
+                "sender": {
+                    "sender_id": {
+                        "open_id": "ou_feishu_operator"
+                    }
+                },
+                "message": {
+                    "message_id": "om_feishu_ingress",
+                    "message_type": "text",
+                    "content": "{\"text\":\"Feishu ingress\"}",
+                    "chat_id": "oc_feishu_chat",
+                    "create_time": "1699999999000"
+                }
+            }
+        });
+
+        let msgs = ch.parse_event_payload(&payload).await;
+        assert_eq!(
+            msgs.len(),
+            1,
+            "Feishu peer group external_peers must authorize before routing"
+        );
+        assert_eq!(msgs[0].channel, "feishu");
+        assert_eq!(msgs[0].channel_alias.as_deref(), Some("work"));
+        assert_eq!(msgs[0].content, "Feishu ingress");
     }
 
     #[cfg(feature = "channel-lark")]

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -6257,7 +6257,7 @@ fn build_channel_by_id(
         "qq" => {
             anyhow::bail!("QQ channel requires the `channel-qq` feature");
         }
-        "lark" => {
+        "lark" | "feishu" => {
             #[cfg(feature = "channel-lark")]
             {
                 let lk = config
@@ -7852,7 +7852,9 @@ fn collect_configured_channels(
 
     #[cfg(feature = "channel-lark")]
     for (alias, lk) in &config.channels.lark {
-        if !active_channel_aliases.contains(&format!("lark.{alias}")) {
+        if !active_channel_aliases.contains(&format!("lark.{alias}"))
+            && !active_channel_aliases.contains(&format!("feishu.{alias}"))
+        {
             continue;
         }
         if !lk.enabled {


### PR DESCRIPTION
## Summary

Automated build resolving the linked issue. Diff touches 1 file(s):
- `crates/zeroclaw-channels/src/orchestrator/mod.rs`

## Linked issue

Resolves zeroclaw-labs/zeroclaw#4873

`risk: low` · `size: S`

## Testing (required)

- **CI:** relies on the repository CI suite (build + tests) for this change.
- **Beyond CI — what did you manually verify?** Automated build; the staged diff was produced against the pinned base commit and passed through adversarial cross-family review (advisory) before submission.
- **What was NOT verified:** no additional manual runtime verification beyond CI.
- **If any command was intentionally skipped, why:** N/A.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No

## Rollback

Low-risk PR: `git revert <sha>` reverts this change.

