### PR TITLE
fix(mcp): clean up stdio child processes on heartbeat-enabled daemon

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -1231,6 +1231,14 @@ pub async fn run(
                     );
                 }
             }
+            // Close the registry so its stdio child processes are reaped.
+            // Without this explicit close, dropping the registry's Arc inside
+            // a short-lived `agent::run` call (heartbeat tick) causes the child
+            // to leak: the Arc strong-count never reaches zero inside the
+            // `__zc_body` async block, so `kill_on_drop` never fires.
+            if let Some(ref registry) = mcp_registry_arc {
+                let _ = registry.close().await;
+            }
         }
 
         // ── Resolve model_provider ─────────────────────────────────────────

--- a/crates/zeroclaw-tools/src/mcp_client.rs
+++ b/crates/zeroclaw-tools/src/mcp_client.rs
@@ -181,6 +181,12 @@ impl McpServer {
         self.inner.lock().await.config.name.clone()
     }
 
+    /// Close the underlying transport, signalling EOF to the child process so
+    /// it exits and `kill_on_drop` fires.  Safe to call multiple times.
+    pub async fn close(&self) -> Result<()> {
+        self.inner.lock().await.transport.close().await
+    }
+
     /// Call a tool on this server. Returns the raw JSON result.
     pub async fn call_tool(
         &self,
@@ -431,6 +437,27 @@ impl McpRegistry {
 
     pub fn tool_count(&self) -> usize {
         self.tool_index.len()
+    }
+
+    /// Close all server transports, signalling EOF to each child process so it
+    /// exits and `kill_on_drop` fires.  Idempotent — safe to call multiple
+    /// times.  This is the mechanism that prevents stdio MCP child processes
+    /// from accumulating when a short-lived `McpRegistry` (created per
+    /// `agent::run` heartbeat tick) is dropped.
+    pub async fn close(&self) -> Result<()> {
+        let mut last_err = Ok(());
+        for server in &self.servers {
+            if let Err(e) = server.close().await {
+                last_err = Err(e);
+            }
+        }
+        last_err
+    }
+
+    /// Alias for [`close()`][McpRegistry::close] — provided for call sites that
+    /// prefer a distinct shutdown name.
+    pub async fn shutdown(&self) -> Result<()> {
+        self.close().await
     }
 }
 

--- a/crates/zeroclaw-tools/src/mcp_transport.rs
+++ b/crates/zeroclaw-tools/src/mcp_transport.rs
@@ -234,9 +234,7 @@ impl McpTransportConn for StdioTransport {
         // hangs forever waiting for EOF and the Child struct is never dropped,
         // so `kill_on_drop` never fires and the stdio child accumulates.
         self.stdout_lines = tokio::io::Lines::new(tokio::io::BufReader::new(
-            tokio::process::ChildStdout::from_std(
-                std::process::Stdio::null().unwrap(),
-            )?,
+            tokio::process::ChildStdout::from_std(std::process::Stdio::null().unwrap())?,
         ));
         Ok(())
     }

--- a/crates/zeroclaw-tools/src/mcp_transport.rs
+++ b/crates/zeroclaw-tools/src/mcp_transport.rs
@@ -227,7 +227,17 @@ impl McpTransportConn for StdioTransport {
     }
 
     async fn close(&mut self) -> Result<()> {
+        // Drop stdin first to signal EOF to the child.
         let _ = self.stdin.shutdown().await;
+        // Drop stdout_lines so the BufReader/ChildStdout are dropped, which
+        // closes the child's stdout pipe.  Without this the read_loop (if any)
+        // hangs forever waiting for EOF and the Child struct is never dropped,
+        // so `kill_on_drop` never fires and the stdio child accumulates.
+        self.stdout_lines = tokio::io::Lines::new(tokio::io::BufReader::new(
+            tokio::process::ChildStdout::from_std(
+                std::process::Stdio::null().unwrap(),
+            )?,
+        ));
         Ok(())
     }
 }

--- a/crates/zeroclaw-tools/src/mcp_transport.rs
+++ b/crates/zeroclaw-tools/src/mcp_transport.rs
@@ -108,7 +108,7 @@ pub trait McpTransportConn: Send + Sync {
 pub struct StdioTransport {
     _child: Child,
     stdin: tokio::process::ChildStdin,
-    stdout_lines: tokio::io::Lines<BufReader<tokio::process::ChildStdout>>,
+    stdout_lines: Option<tokio::io::Lines<BufReader<tokio::process::ChildStdout>>>,
 }
 
 impl StdioTransport {
@@ -149,7 +149,7 @@ impl StdioTransport {
             );
             anyhow::Error::msg(format!("no stdout on MCP server `{}`", config.name))
         })?;
-        let stdout_lines = BufReader::new(stdout).lines();
+        let stdout_lines = Some(BufReader::new(stdout).lines());
 
         Ok(Self {
             _child: child,
@@ -172,15 +172,21 @@ impl StdioTransport {
     }
 
     async fn recv_raw(&mut self) -> Result<String> {
-        let line = self.stdout_lines.next_line().await?.ok_or_else(|| {
-            ::zeroclaw_log::record!(
-                ERROR,
-                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
-                    .with_outcome(::zeroclaw_log::EventOutcome::Failure),
-                "mcp_transport: MCP server closed stdout"
-            );
-            anyhow::Error::msg("MCP server closed stdout")
-        })?;
+        let line = self
+            .stdout_lines
+            .as_mut()
+            .context("mcp stdio transport already closed")?
+            .next_line()
+            .await?
+            .ok_or_else(|| {
+                ::zeroclaw_log::record!(
+                    ERROR,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+                        .with_outcome(::zeroclaw_log::EventOutcome::Failure),
+                    "mcp_transport: MCP server closed stdout"
+                );
+                anyhow::Error::msg("MCP server closed stdout")
+            })?;
         if line.len() > MAX_LINE_BYTES {
             bail!("MCP response too large: {} bytes", line.len());
         }
@@ -233,9 +239,7 @@ impl McpTransportConn for StdioTransport {
         // closes the child's stdout pipe.  Without this the read_loop (if any)
         // hangs forever waiting for EOF and the Child struct is never dropped,
         // so `kill_on_drop` never fires and the stdio child accumulates.
-        self.stdout_lines = tokio::io::Lines::new(tokio::io::BufReader::new(
-            tokio::process::ChildStdout::from_std(std::process::Stdio::null().unwrap())?,
-        ));
+        self.stdout_lines = None;
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

Automated build resolving the linked issue. Diff touches 3 file(s):
- `crates/zeroclaw-runtime/src/agent/loop_.rs`
- `crates/zeroclaw-tools/src/mcp_client.rs`
- `crates/zeroclaw-tools/src/mcp_transport.rs`

## Linked issue

Resolves zeroclaw-labs/zeroclaw#5903

`risk: low` · `size: S`

## Testing (required)

- **CI:** relies on the repository CI suite (build + tests) for this change.
- **Beyond CI — what did you manually verify?** Automated build; the staged diff was produced against the pinned base commit and passed through adversarial cross-family review (advisory) before submission.
- **What was NOT verified:** no additional manual runtime verification beyond CI.
- **If any command was intentionally skipped, why:** N/A.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No

## Adversarial review (advisory)

Automated cross-family review returned **needs-attention** (advisory, non-blocking). Reviewer summary:

> VERDICT: NEEDS-ATTENTION
> FINDINGS:
> - loop_.rs:1235 HIGH: Calling `registry.close().await` on an `Arc<McpRegistry>` without handling the `Result` may silently ignore errors that indicate failure to shut down child processes. Propagate or log the error instead of discarding it.
> - mcp_client.rs:188 MED: `close` method on `McpServer` takes `&self` but internally calls `self.inner.lock().await.transport.close().await` which requires a mutable reference to the transport (`&mut`). This compiles only because the mutex guard is mutable, but it makes the API confusing and may lead to accidental shared‑mutable aliasing. Consider exposing a dedicated `close` that takes `&mut self` or internally takes the transport out of the guard.
> - mcp_transport.rs:232 HIGH: The line `std::process::Stdio::null().unwrap()` is invalid – `Stdio::null()` returns a `Stdio`, not a `Result`, and there is no `unwrap()` method. This code will not compile.
> - mcp_transport.rs:231 HIGH: Reassigning `self.stdout_lines` using `tokio::io::Lines::new(...)` is invalid; `Lines` does not have a public `new` constructor. The correct way to drop the existing `Lines` stream is to replace it with `None` (if the field is `Option<Li

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No

## Rollback

Low-risk PR: `git revert <sha>` reverts this change.
