### PR TITLE
chore(deps): unyank bitcoin crates in Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -942,15 +942,15 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitcoin-io"
-version = "0.1.100"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11301df0b06f22dea7bb1916403fdd88a371031e495c49b8f96931b28189e175"
+checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.14.100"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9901a56e133a1fc86eeb1113e2591f45f4682451ca893bff494d2f88918e3f"
+checksum = "4ed83caece3afc59919481b33b472e1432d1abc4641ed9100be142ef5110b406"
 dependencies = [
  "bitcoin-io",
  "hex-conservative",


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `bitcoin-io 0.1.100` and `bitcoin_hashes 0.14.100` were yanked from crates.io, emitting a yanked-package warning on every build that resolves the lockfile.
  - Both are transitive deps of the opt-in nostr channel (`nostr-sdk` -> `nostr` -> `bip39` / `bitcoin_hashes` -> `bitcoin-io`). They never compile in a default build.
  - Pinned each to the nearest non-yanked release in the same semver line: `bitcoin-io 0.1.100 -> 0.1.4`, `bitcoin_hashes 0.14.100 -> 0.14.2`.
- **Scope boundary:** Lockfile only. No `Cargo.toml` edits, no source changes, no feature-flag changes. The nostr channel and its public surface are untouched and remain opt-in behind `channel-nostr`.
- **Blast radius:** None for default builds (`cargo tree -e normal` shows zero crypto crates). Only the opt-in `channel-nostr` build path consumes these crates, and the pinned versions are API-compatible within the same minor line.
- **Linked issue(s):** None found. Searched open and closed issues/PRs for yanked/bitcoin/lockfile; no prior tracking item exists.
- **Labels:** `type: dependencies`, `risk: low`, `size: XS`, `dependencies`, `domain:deps`

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy --locked --all-targets
cargo build --locked
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` -> clean, no diff.
  - `cargo build --locked` -> `Finished dev profile [unoptimized + debuginfo] target(s)`. No yanked-package warnings.
  - `cargo clippy --locked --all-targets` -> `Finished dev profile`, no warnings.
  - `cargo tree -e normal | grep -i "nostr\|bitcoin\|bip39\|secp256k1"` -> no matches (default build carries zero crypto crates).
- **Beyond CI — what did you manually verify?** Confirmed the yanked warning is gone by resolving with `--locked`. Confirmed the bitcoin crates only enter the graph via the opt-in `channel-nostr` feature, so default and `channels-full` builds are unaffected. Did NOT build the `channel-nostr` feature in isolation.
- **If any command was intentionally skipped, why:** Full `cargo test` not run; the change is lockfile-only with no source delta, and build + clippy under `--locked` exercise lockfile validity.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Pinned versions are within the same minor line as the yanked releases; no upgrade steps required for existing users.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk: `git revert <sha>` restores the prior lockfile pins.