### PR TITLE
fix(gateway): register devices on legacy /pair + backfill orphaned paired_tokens

### DIFF
--- a/crates/zeroclaw-gateway/src/api.rs
+++ b/crates/zeroclaw-gateway/src/api.rs
@@ -3502,6 +3502,101 @@ mod tests {
         h
     }
 
+    /// The backfill inserts a placeholder row for every paired-token hash that
+    /// has no device entry, skips hashes that already have one (without
+    /// clobbering their metadata), and is idempotent across restarts.
+    #[tokio::test]
+    async fn reconcile_backfills_orphan_token_hashes() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let registry = DeviceRegistry::new(tmp.path());
+
+        // A real, already-registered device with a name.
+        let known_hash = "a".repeat(64);
+        registry.register(
+            known_hash.clone(),
+            DeviceInfo {
+                id: "known".into(),
+                name: Some("My Laptop".into()),
+                device_type: Some("desktop".into()),
+                paired_at: Utc::now(),
+                last_seen: Utc::now(),
+                ip_address: None,
+                capabilities: None,
+            },
+        );
+
+        let orphan_a = "b".repeat(64);
+        let orphan_b = "c".repeat(64);
+        let inserted = registry
+            .reconcile_from_token_hashes(&[known_hash.clone(), orphan_a.clone(), orphan_b.clone()])
+            .unwrap();
+        assert_eq!(inserted, 2, "only the two orphan hashes should be inserted");
+        assert_eq!(registry.device_count(), 3);
+
+        // Existing metadata is preserved, not clobbered.
+        let known = registry
+            .list()
+            .into_iter()
+            .find(|d| d.id == "known")
+            .expect("known device still present");
+        assert_eq!(known.name.as_deref(), Some("My Laptop"));
+
+        // Re-running is a no-op (idempotent).
+        let again = registry
+            .reconcile_from_token_hashes(&[known_hash, orphan_a, orphan_b])
+            .unwrap();
+        assert_eq!(again, 0);
+        assert_eq!(registry.device_count(), 3);
+    }
+
+    /// Security-management contract: a token paired through the legacy `/pair`
+    /// route is an orphan (authenticates, but absent from the registry). After
+    /// backfill it is keyed by the SAME `token_hash` the auth gate uses, so the
+    /// revoke-by-device path (`revoke` → `PairingGuard::revoke_token_hash`)
+    /// invalidates exactly that bearer token.
+    #[tokio::test]
+    async fn backfilled_orphan_is_revocable_by_its_real_hash() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let data_dir = tmp.path().join("workspace");
+        std::fs::create_dir_all(&data_dir).unwrap();
+
+        let pairing = PairingGuard::new(true, &[]);
+        let code = pairing.pairing_code().unwrap();
+        let token = pairing
+            .try_pair(&code, "legacy-client")
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(pairing.is_authenticated(&token));
+
+        // Simulate the `/pair` orphan: token is paired but never registered.
+        let registry = DeviceRegistry::new(&data_dir);
+        assert_eq!(registry.device_count(), 0);
+
+        let inserted = registry
+            .reconcile_from_token_hashes(&pairing.tokens())
+            .unwrap();
+        assert_eq!(inserted, 1);
+
+        // The backfilled row is keyed by the auth hash, so revoke returns it and
+        // revoking that hash from the guard actually de-authenticates the token.
+        let device = registry
+            .list()
+            .into_iter()
+            .next()
+            .expect("one backfilled device");
+        let revoked_hash = registry
+            .revoke(&device.id)
+            .unwrap()
+            .expect("device existed");
+        assert_eq!(revoked_hash, PairingGuard::token_hash(&token));
+        assert!(pairing.revoke_token_hash(&revoked_hash));
+        assert!(
+            !pairing.is_authenticated(&token),
+            "token must not authenticate after revoke"
+        );
+    }
+
     /// Regression: `POST /api/devices/{id}/token/rotate` MUST invalidate the
     /// old bearer token. The pre-fix handler only issued a new pairing code
     /// and left the leaked token authenticating (GHSA-f385-f6h2-3gqj

--- a/crates/zeroclaw-gateway/src/api_pairing.rs
+++ b/crates/zeroclaw-gateway/src/api_pairing.rs
@@ -143,6 +143,65 @@ impl DeviceRegistry {
         self.cache.lock().insert(token_hash, info);
     }
 
+    /// Backfill placeholder rows for paired tokens that have no device entry.
+    ///
+    /// Bearer tokens paired through the legacy `/pair` route (`handle_pair`)
+    /// historically never called [`register`](Self::register), so their hashes
+    /// live in `gateway.paired_tokens` — the canonical credential set the auth
+    /// gate checks — with no matching device row. Such tokens fully
+    /// authenticate yet are invisible in `GET /api/devices` and cannot be
+    /// revoked from the management UI, which is a security-management gap.
+    ///
+    /// This reconciles the registry (metadata, keyed by `token_hash`) against
+    /// that canonical set on startup: every hash without a row gets a neutral
+    /// `"legacy"` placeholder so it surfaces and can be revoked like any other
+    /// device. The source of truth for *which* tokens are valid remains
+    /// `PairingGuard`/`gateway.paired_tokens` — this never invents a token,
+    /// only surfaces ones that already authenticate. `INSERT OR IGNORE` keeps a
+    /// real row from being clobbered. Returns the number of rows inserted.
+    pub fn reconcile_from_token_hashes(
+        &self,
+        token_hashes: &[String],
+    ) -> Result<usize, rusqlite::Error> {
+        let conn = self.open_db();
+        let mut cache = self.cache.lock();
+        let now = Utc::now();
+        let now_str = now.to_rfc3339();
+        let mut inserted = 0usize;
+        for token_hash in token_hashes {
+            if cache.contains_key(token_hash) {
+                continue;
+            }
+            let info = DeviceInfo {
+                id: uuid::Uuid::new_v4().to_string(),
+                name: None,
+                device_type: Some("legacy".to_string()),
+                paired_at: now,
+                last_seen: now,
+                ip_address: None,
+                capabilities: None,
+            };
+            let affected = conn.execute(
+                "INSERT OR IGNORE INTO devices (token_hash, id, name, device_type, paired_at, last_seen, ip_address, capabilities) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                rusqlite::params![
+                    token_hash,
+                    info.id,
+                    info.name,
+                    info.device_type,
+                    now_str,
+                    now_str,
+                    info.ip_address,
+                    None::<String>,
+                ],
+            )?;
+            if affected > 0 {
+                cache.insert(token_hash.clone(), info);
+                inserted += 1;
+            }
+        }
+        Ok(inserted)
+    }
+
     pub fn list(&self) -> Vec<DeviceInfo> {
         let conn = self.open_db();
         let mut stmt = conn

--- a/crates/zeroclaw-gateway/src/lib.rs
+++ b/crates/zeroclaw-gateway/src/lib.rs
@@ -1459,7 +1459,28 @@ pub async fn run_gateway(
 
     // Device registry and pairing store (only when pairing is required)
     let device_registry = if config.gateway.require_pairing {
-        Some(Arc::new(api_pairing::DeviceRegistry::new(&config.data_dir)))
+        let registry = Arc::new(api_pairing::DeviceRegistry::new(&config.data_dir));
+        // Reconcile the registry against the canonical paired-token set so that
+        // tokens paired via the legacy `/pair` route (and any other historical
+        // orphans) become visible and revocable in the management UI. The token
+        // set itself stays owned by `PairingGuard`/`gateway.paired_tokens`.
+        match registry.reconcile_from_token_hashes(&pairing.tokens()) {
+            Ok(0) => {}
+            Ok(n) => ::zeroclaw_log::record!(
+                INFO,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_attrs(::serde_json::json!({ "backfilled": n })),
+                "backfilled legacy paired token(s) into the device registry"
+            ),
+            Err(e) => ::zeroclaw_log::record!(
+                ERROR,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                    .with_attrs(::serde_json::json!({ "error": format!("{e}") })),
+                "device registry backfill from paired_tokens failed"
+            ),
+        }
+        Some(registry)
     } else {
         None
     };
@@ -2107,6 +2128,26 @@ async fn handle_pair(
                 ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note),
                 "new client paired successfully"
             );
+            // Register the device so a token paired via the legacy `/pair`
+            // route is listable and revocable from the management UI, exactly
+            // like `/api/pair` (`submit_pairing_enhanced`). Without this the
+            // token authenticates but has no device row, so the UI can neither
+            // see nor revoke it. The token itself is owned by `PairingGuard`
+            // and persisted below; this row is metadata keyed by its hash.
+            if let Some(ref registry) = state.device_registry {
+                registry.register(
+                    PairingGuard::token_hash(&token),
+                    api_pairing::DeviceInfo {
+                        id: uuid::Uuid::new_v4().to_string(),
+                        name: None,
+                        device_type: None,
+                        paired_at: chrono::Utc::now(),
+                        last_seen: chrono::Utc::now(),
+                        ip_address: Some(rate_key.clone()),
+                        capabilities: None,
+                    },
+                );
+            }
             if let Err(err) =
                 Box::pin(persist_pairing_tokens(state.config.clone(), &state.pairing)).await
             {


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - The legacy `POST /pair` handler (`handle_pair`) minted and persisted a bearer
    token but **never called `registry.register`**, so a device paired through it
    authenticates yet has **no `device_registry` row** — invisible in
    `GET /api/devices` and unrevocable from the management UI. `handle_pair` now
    registers the device, exactly like `POST /api/pair` (`submit_pairing_enhanced`).
  - **No startup reconciliation existed**, so tokens already paired via `/pair`
    (and any other historical orphans) stay invisible forever. Added
    `DeviceRegistry::reconcile_from_token_hashes`, called once at registry
    construction, which inserts a neutral `"legacy"` placeholder row for every
    `gateway.paired_tokens` hash lacking a device row. Idempotent;
    `INSERT OR IGNORE` never clobbers a real row.
  - Net effect: every active bearer token is now listable and revocable from the
    UI. This closes a **security-management gap (visibility/revocation)** — the
    auth gate itself was already sound (no access bypass; 401 without a valid
    token is unaffected).
- **Scope boundary:** No change to token generation, hashing, the on-disk
  `gateway.paired_tokens` format, or the auth gate. No change to the `devices`
  table schema. Does **not** touch the rotation/deletion revocation paths
  (`rotate_device_token`, `revoke_device`).
- **Blast radius:** `crates/zeroclaw-gateway` only. Behaviour changes: (1) `/pair`
  now writes a `devices.db` row on success; (2) on startup with
  `require_pairing = true`, the registry gains placeholder rows for any
  previously-orphaned paired tokens.
- **Linked issue(s):** Related #7243 (token-revocation follow-up, same subsystem),
  Related #6497 (registry bridge). No `Closes` — this is the
  registration/backfill counterpart to the merged revocation work, not a 1:1 fix
  for an existing issue.
- **Labels:** `bug`, `gateway`, `security:pairing`, `risk: high`, `size: S`

## Validation Evidence (required)

- **Commands run and tail output:**
  ```
  cargo fmt --all -- --check                → exit 0
  cargo clippy --all-targets -- -D warnings → exit 0 (no warnings)
  cargo test -p zeroclaw-gateway            → exit 0
    test result: ok. 265 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
    test api::tests::backfilled_orphan_is_revocable_by_its_real_hash ... ok
    test api::tests::reconcile_backfills_orphan_token_hashes ... ok
  ```
  (Run after rebasing onto current `master`.)
- **Beyond CI — what did you manually verify?** Two new tests assert the contract:
  (1) backfill inserts only orphan hashes, skips/preserves known rows, idempotent;
  (2) **security contract** — a `/pair`-style orphan, after backfill, is keyed by
  the same `token_hash` the auth gate uses, so `DeviceRegistry::revoke` →
  `PairingGuard::revoke_token_hash` actually de-authenticates the bearer token.
- **If any command was intentionally skipped, why:** Ran `cargo test -p
  zeroclaw-gateway` rather than full-workspace `cargo test` (change is gateway-only;
  workspace `clippy --all-targets` already compiled every target clean).

## Security & Privacy Impact (required)

- New permissions / capabilities / file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No** — token generation,
  hashing, and the `paired_tokens` store are untouched. The backfill only reads
  hashes already held in `PairingGuard` and writes *device metadata* rows keyed
  by those hashes. The credential set's source of truth remains `paired_tokens`.
- PII / real identities in diff? **No** — placeholder rows are `name = NULL`,
  `device_type = "legacy"`, `ip_address = NULL`.

## Compatibility (required)

- Backward compatible? **Yes** — additive; no schema migration, no config/CLI surface.
- Config / env / CLI surface changed? **No**
- Upgrade steps for existing users: none. On the next daemon restart with
  `require_pairing = true`, orphaned tokens are automatically backfilled into the
  registry.

## Rollback (required — risk: high)

- **Fast rollback command/path:** `git revert <sha>`. The change is additive and
  idempotent; reverting returns `/pair` to non-registering behaviour. Placeholder
  rows already created remain but are harmless (revocable like any device).
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** grep gateway logs for
  `device registry backfill from paired_tokens failed` (DB error on startup —
  logged, non-fatal) or `backfilled legacy paired token(s) into the device
  registry` (success, with a `backfilled` count attr). UI symptom of success:
  `GET /api/devices` lists devices that were previously absent.
