### PR TITLE
feat(sop): add SopRunStore trait + in-memory backend (EPIC B scaffold)

### DIFF
--- a/crates/zeroclaw-runtime/src/sop/mod.rs
+++ b/crates/zeroclaw-runtime/src/sop/mod.rs
@@ -3,11 +3,16 @@ pub mod condition;
 pub mod dispatch;
 pub mod engine;
 pub mod metrics;
+pub mod store;
 pub mod types;
 
 pub use audit::SopAuditLogger;
 pub use engine::SopEngine;
 pub use metrics::SopMetricsCollector;
+pub use store::{
+    ClaimToken, PersistedRun, ProposalRecord, ProposalStatus, SopEventRecord, SopRunStore,
+    StoreError, build_run_store,
+};
 #[allow(unused_imports)]
 pub use types::{
     DeterministicRunState, DeterministicSavings, Sop, SopEvent, SopExecutionMode, SopPriority,

--- a/crates/zeroclaw-runtime/src/sop/store/mod.rs
+++ b/crates/zeroclaw-runtime/src/sop/store/mod.rs
@@ -30,10 +30,15 @@ pub use model::{
 /// listener, and the gateway approve surface.
 pub trait SopRunStore: Send + Sync {
     // ── run state (persistence-resume, state-machine) ──
-    /// Persist-before-mutate. Monotonic-revision-guarded; idempotent on revision.
+    /// Persist-before-mutate. Revision-guarded: a strictly-older revision is
+    /// rejected as `StaleRevision`; an equal revision is accepted only as a
+    /// byte-identical idempotent retry, else `RevisionConflict`; a newer
+    /// revision wins.
     fn save_run(&self, run: &PersistedRun) -> Result<(), StoreError>;
     /// Move a run to terminal state (kept as a terminal record, not deleted) and
-    /// release any live claim.
+    /// release any live claim. Revision-guarded exactly like `save_run`, so a
+    /// stale or divergent terminal write cannot clobber newer state or release a
+    /// live claim.
     fn finish_run(&self, run_id: &str, terminal: &PersistedRun) -> Result<(), StoreError>;
     /// Boot-rehydrate source: every non-terminal run (latest revision per id).
     fn load_active_runs(&self) -> Result<Vec<PersistedRun>, StoreError>;
@@ -41,13 +46,18 @@ pub trait SopRunStore: Send + Sync {
     fn load_run(&self, run_id: &str) -> Result<Option<PersistedRun>, StoreError>;
 
     // ── CAS claim primitive (concurrency-control) ──
-    /// Atomic single-winner admission. Returns `Some(token)` to exactly one
-    /// caller iff under `cap` and no live claim exists for `run_id`, else `None`.
+    /// Atomic single-winner admission honoring BOTH concurrency limits. Returns
+    /// `Some(token)` to exactly one caller iff no live claim exists for `run_id`,
+    /// the run is not terminal, the live claims for `sop_name` stay below
+    /// `per_sop_cap`, AND total live claims stay below `global_cap`. Both caps
+    /// are inclusive maxima counted under one lock (mirrors the engine
+    /// `can_start`); a cap of 0 admits nothing. Otherwise `None`.
     fn try_claim_run(
         &self,
         run_id: &str,
         sop_name: &str,
-        cap: usize,
+        per_sop_cap: usize,
+        global_cap: usize,
     ) -> Result<Option<ClaimToken>, StoreError>;
     /// Renew a claim's lease (tick liveness). No-op if the claim is gone.
     fn heartbeat_claim(&self, token: &ClaimToken) -> Result<(), StoreError>;
@@ -90,6 +100,13 @@ pub enum StoreError {
         have: u64,
         found: u64,
     },
+    /// A same-revision write whose content diverges from the stored run. The
+    /// caller must bump `revision` to record new state; only a byte-identical
+    /// retry at the same revision is accepted (idempotent).
+    RevisionConflict {
+        run_id: String,
+        revision: u64,
+    },
     /// A claim was lost to a concurrent winner (over-cap or already claimed).
     ClaimLost,
 }
@@ -107,6 +124,10 @@ impl std::fmt::Display for StoreError {
             } => write!(
                 f,
                 "sop store stale revision for run {run_id}: have {have}, found {found}"
+            ),
+            Self::RevisionConflict { run_id, revision } => write!(
+                f,
+                "sop store revision conflict for run {run_id}: divergent write at revision {revision}"
             ),
             Self::ClaimLost => write!(f, "sop store claim lost to a concurrent winner"),
         }
@@ -174,25 +195,47 @@ impl InMemoryRunStore {
     }
 }
 
+/// Revision guard shared by every write path: returns `Ok(())` only when
+/// `incoming` is safe to persist over `existing` (a first write, a strictly
+/// newer revision, or a byte-identical same-revision retry). A strictly older
+/// revision is `StaleRevision`; a divergent same-revision payload is
+/// `RevisionConflict`. Durable backends apply the same rule transactionally.
+fn revision_guard(
+    existing: Option<&PersistedRun>,
+    incoming: &PersistedRun,
+) -> Result<(), StoreError> {
+    let Some(existing) = existing else {
+        return Ok(());
+    };
+    if incoming.revision < existing.revision {
+        return Err(StoreError::StaleRevision {
+            run_id: incoming.run_id().to_string(),
+            have: incoming.revision,
+            found: existing.revision,
+        });
+    }
+    if incoming.revision == existing.revision
+        && serde_json::to_vec(existing)? != serde_json::to_vec(incoming)?
+    {
+        return Err(StoreError::RevisionConflict {
+            run_id: incoming.run_id().to_string(),
+            revision: incoming.revision,
+        });
+    }
+    Ok(())
+}
+
 impl SopRunStore for InMemoryRunStore {
     fn save_run(&self, run: &PersistedRun) -> Result<(), StoreError> {
         let mut g = self.lock()?;
-        let id = run.run_id().to_string();
-        if let Some(existing) = g.runs.get(&id)
-            && existing.revision > run.revision
-        {
-            return Err(StoreError::StaleRevision {
-                run_id: id,
-                have: run.revision,
-                found: existing.revision,
-            });
-        }
-        g.runs.insert(id, run.clone());
+        revision_guard(g.runs.get(run.run_id()), run)?;
+        g.runs.insert(run.run_id().to_string(), run.clone());
         Ok(())
     }
 
     fn finish_run(&self, run_id: &str, terminal: &PersistedRun) -> Result<(), StoreError> {
         let mut g = self.lock()?;
+        revision_guard(g.runs.get(run_id), terminal)?;
         g.runs.insert(run_id.to_string(), terminal.clone());
         g.terminal.insert(run_id.to_string());
         g.claims.remove(run_id);
@@ -216,7 +259,8 @@ impl SopRunStore for InMemoryRunStore {
         &self,
         run_id: &str,
         sop_name: &str,
-        cap: usize,
+        per_sop_cap: usize,
+        global_cap: usize,
     ) -> Result<Option<ClaimToken>, StoreError> {
         let mut g = self.lock()?;
         if g.claims.contains_key(run_id) {
@@ -226,7 +270,15 @@ impl SopRunStore for InMemoryRunStore {
         if g.terminal.contains(run_id) {
             return Ok(None);
         }
-        if cap != 0 && g.claims.len() >= cap {
+        // Both caps are enforced atomically under one lock, so neither limit can
+        // be crossed by a concurrent winner. Counts are over LIVE claims, which
+        // track admitted (active) runs 1:1 (mirrors the engine `can_start`).
+        // A cap of 0 admits nothing (matches the engine `>= max_concurrent`).
+        let active_for_sop = g.claims.values().filter(|c| c.sop_name == sop_name).count();
+        if active_for_sop >= per_sop_cap {
+            return Ok(None);
+        }
+        if g.claims.len() >= global_cap {
             return Ok(None);
         }
         // Timestamps are stamped by durable backends; the in-memory backend
@@ -409,13 +461,13 @@ mod tests {
     fn claim_is_single_winner_and_cap_bounded() {
         let s = build_run_store();
         // First claim wins.
-        assert!(s.try_claim_run("r1", "deploy", 2).unwrap().is_some());
+        assert!(s.try_claim_run("r1", "deploy", 2, 2).unwrap().is_some());
         // Duplicate claim on the same run is refused.
-        assert!(s.try_claim_run("r1", "deploy", 2).unwrap().is_none());
+        assert!(s.try_claim_run("r1", "deploy", 2, 2).unwrap().is_none());
         // Second distinct run claims (under cap).
-        assert!(s.try_claim_run("r2", "deploy", 2).unwrap().is_some());
+        assert!(s.try_claim_run("r2", "deploy", 2, 2).unwrap().is_some());
         // Third exceeds cap=2.
-        assert!(s.try_claim_run("r3", "deploy", 2).unwrap().is_none());
+        assert!(s.try_claim_run("r3", "deploy", 2, 2).unwrap().is_none());
         // Releasing frees a slot.
         let tok = ClaimToken {
             run_id: "r1".to_string(),
@@ -425,7 +477,23 @@ mod tests {
             holder: "in-memory".to_string(),
         };
         s.release_claim(&tok).unwrap();
-        assert!(s.try_claim_run("r3", "deploy", 2).unwrap().is_some());
+        assert!(s.try_claim_run("r3", "deploy", 2, 2).unwrap().is_some());
+    }
+
+    #[test]
+    fn claim_caps_isolate_per_sop_yet_share_global() {
+        let s = build_run_store();
+        // per_sop_cap = 1, global_cap = 3.
+        // SOP "a" fills its single per-SOP slot.
+        assert!(s.try_claim_run("a1", "a", 1, 3).unwrap().is_some());
+        // A second "a" run is blocked by the per-SOP cap...
+        assert!(s.try_claim_run("a2", "a", 1, 3).unwrap().is_none());
+        // ...but a DIFFERENT SOP is not blocked by "a" being at its cap.
+        assert!(s.try_claim_run("b1", "b", 1, 3).unwrap().is_some());
+        assert!(s.try_claim_run("c1", "c", 1, 3).unwrap().is_some());
+        // Global cap = 3 is now reached across all SOPs; a fourth distinct SOP
+        // is refused even though its own per-SOP slot is free.
+        assert!(s.try_claim_run("d1", "d", 1, 3).unwrap().is_none());
     }
 
     #[test]
@@ -478,8 +546,25 @@ mod tests {
         ));
         // The stored revision is unchanged after the rejected write.
         assert_eq!(s.load_run("r1").unwrap().unwrap().revision, 5);
-        // Same revision is idempotent (last-writer guard allows ==).
+        // A byte-identical same-revision write is an idempotent retry.
         s.save_run(&run("r1", 5, None)).unwrap();
+        // A DIVERGENT same-revision write is refused, not silently applied.
+        let err = s
+            .save_run(&run("r1", 5, Some("2020-06-06T00:00:00Z")))
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            StoreError::RevisionConflict { revision: 5, .. }
+        ));
+        // The divergent payload did not land: completed_at is still None.
+        assert!(
+            s.load_run("r1")
+                .unwrap()
+                .unwrap()
+                .run
+                .completed_at
+                .is_none()
+        );
         // A newer revision wins.
         s.save_run(&run("r1", 6, None)).unwrap();
         assert_eq!(s.load_run("r1").unwrap().unwrap().revision, 6);
@@ -489,7 +574,7 @@ mod tests {
     fn finish_run_marks_terminal_and_releases_claim() {
         let s = build_run_store();
         s.save_run(&run("r1", 0, None)).unwrap();
-        let tok = s.try_claim_run("r1", "deploy", 4).unwrap().unwrap();
+        let tok = s.try_claim_run("r1", "deploy", 4, 4).unwrap().unwrap();
         assert!(
             s.load_active_runs()
                 .unwrap()
@@ -505,11 +590,47 @@ mod tests {
         // ...but still loadable as a terminal record.
         assert_eq!(s.load_run("r1").unwrap().unwrap().revision, 1);
         // ...and its claim slot was freed.
-        assert!(s.try_claim_run("r1b", "deploy", 1).unwrap().is_some());
+        assert!(s.try_claim_run("r1b", "deploy", 1, 4).unwrap().is_some());
         // A terminal run is not re-claimable even after its claim was released.
-        assert!(s.try_claim_run("r1", "deploy", 4).unwrap().is_none());
+        assert!(s.try_claim_run("r1", "deploy", 4, 4).unwrap().is_none());
         // release_claim on the old token is a no-op (slot already freed).
         s.release_claim(&tok).unwrap();
+    }
+
+    #[test]
+    fn finish_run_revision_guard_protects_live_state_and_claim() {
+        let s = build_run_store();
+        s.save_run(&run("r1", 5, None)).unwrap();
+        let _tok = s.try_claim_run("r1", "deploy", 4, 4).unwrap().unwrap();
+
+        // A stale terminal write (older revision) is refused: it must not
+        // clobber newer state nor release the live claim.
+        let err = s
+            .finish_run("r1", &run("r1", 4, Some("2020-01-02T00:00:00Z")))
+            .unwrap_err();
+        assert!(matches!(err, StoreError::StaleRevision { .. }));
+        // A divergent same-revision terminal write is refused too.
+        let err = s
+            .finish_run("r1", &run("r1", 5, Some("2020-01-02T00:00:00Z")))
+            .unwrap_err();
+        assert!(matches!(err, StoreError::RevisionConflict { .. }));
+
+        // State survived: still active, still revision 5, claim still held
+        // (a fresh claim on the same run is refused because the slot is taken).
+        assert!(
+            s.load_active_runs()
+                .unwrap()
+                .iter()
+                .any(|r| r.run_id() == "r1")
+        );
+        assert_eq!(s.load_run("r1").unwrap().unwrap().revision, 5);
+        assert!(s.try_claim_run("r1", "deploy", 4, 4).unwrap().is_none());
+
+        // A proper terminal write at a newer revision succeeds and releases.
+        s.finish_run("r1", &run("r1", 6, Some("2020-01-02T00:00:00Z")))
+            .unwrap();
+        assert!(s.load_active_runs().unwrap().is_empty());
+        assert_eq!(s.load_run("r1").unwrap().unwrap().revision, 6);
     }
 
     #[test]
@@ -549,7 +670,7 @@ mod tests {
     fn expired_claims_skips_empty_leases_and_matches_past_due() {
         let s = build_run_store();
         // The in-memory backend stamps empty leases — those are never expired.
-        s.try_claim_run("r1", "deploy", 4).unwrap().unwrap();
+        s.try_claim_run("r1", "deploy", 4, 4).unwrap().unwrap();
         assert!(s.expired_claims("2999-01-01T00:00:00Z").unwrap().is_empty());
     }
 }

--- a/crates/zeroclaw-runtime/src/sop/store/mod.rs
+++ b/crates/zeroclaw-runtime/src/sop/store/mod.rs
@@ -350,40 +350,72 @@ impl SopRunStore for InMemoryRunStore {
     }
 
     fn prune(&self, policy: &RetentionPolicy) -> Result<usize, StoreError> {
-        if policy.max_terminal == 0 {
-            return Ok(0);
-        }
         let mut g = self.lock()?;
-        if g.terminal.len() <= policy.max_terminal {
-            return Ok(0);
-        }
-        // Evict OLDEST terminal runs first (by completion, then start time) —
-        // HashSet order is non-deterministic, so sort before truncating.
-        let mut terminal: Vec<(String, String)> = g
-            .terminal
-            .iter()
-            .map(|id| {
-                let ts = g
-                    .runs
-                    .get(id)
-                    .map(|r| {
-                        r.run
+        let mut dropped = 0usize;
+
+        // Age bound (`keep_secs`): drop terminal runs whose completion (or start,
+        // when completion is unset) time is older than the cutoff, independently
+        // of the count, so it also applies when `max_terminal` is unbounded (0).
+        // The cutoff is formatted to match `now_iso8601()` (trailing "Z") so the stored
+        // ISO-8601 UTC timestamps compare lexically.
+        if let Some(keep) = policy.keep_secs {
+            let cutoff = (chrono::Utc::now() - chrono::Duration::seconds(keep as i64))
+                .format("%Y-%m-%dT%H:%M:%SZ")
+                .to_string();
+            let expired: Vec<String> = g
+                .terminal
+                .iter()
+                .filter(|id| {
+                    g.runs.get(*id).is_some_and(|r| {
+                        let ts = r
+                            .run
                             .completed_at
-                            .clone()
-                            .unwrap_or_else(|| r.run.started_at.clone())
+                            .as_deref()
+                            .unwrap_or(r.run.started_at.as_str());
+                        ts < cutoff.as_str()
                     })
-                    .unwrap_or_default();
-                (id.clone(), ts)
-            })
-            .collect();
-        terminal.sort_by(|a, b| a.1.cmp(&b.1));
-        let drop_n = terminal.len() - policy.max_terminal;
-        for (id, _) in terminal.into_iter().take(drop_n) {
-            g.runs.remove(&id);
-            g.events.remove(&id);
-            g.terminal.remove(&id);
+                })
+                .cloned()
+                .collect();
+            for id in expired {
+                g.runs.remove(&id);
+                g.events.remove(&id);
+                g.terminal.remove(&id);
+                dropped += 1;
+            }
         }
-        Ok(drop_n)
+
+        // Count bound (`max_terminal`, 0 = unbounded): keep at most N terminal
+        // runs, evicting the OLDEST excess (by completion, then start time).
+        // HashSet order is non-deterministic, so sort before truncating.
+        if policy.max_terminal > 0 && g.terminal.len() > policy.max_terminal {
+            let mut terminal: Vec<(String, String)> = g
+                .terminal
+                .iter()
+                .map(|id| {
+                    let ts = g
+                        .runs
+                        .get(id)
+                        .map(|r| {
+                            r.run
+                                .completed_at
+                                .clone()
+                                .unwrap_or_else(|| r.run.started_at.clone())
+                        })
+                        .unwrap_or_default();
+                    (id.clone(), ts)
+                })
+                .collect();
+            terminal.sort_by(|a, b| a.1.cmp(&b.1));
+            let drop_n = terminal.len() - policy.max_terminal;
+            for (id, _) in terminal.into_iter().take(drop_n) {
+                g.runs.remove(&id);
+                g.events.remove(&id);
+                g.terminal.remove(&id);
+                dropped += 1;
+            }
+        }
+        Ok(dropped)
     }
 
     fn health_check(&self) -> bool {
@@ -663,6 +695,44 @@ mod tests {
             })
             .unwrap(),
             0
+        );
+    }
+
+    #[test]
+    fn prune_keep_secs_drops_aged_runs_even_under_max_terminal() {
+        let s = build_run_store();
+        // Two terminal runs; the count (2) stays well under max_terminal, so only
+        // the age bound can evict. One is ancient, one is far-future.
+        s.finish_run("old", &run("old", 1, Some("2000-01-01T00:00:00Z")))
+            .unwrap();
+        s.finish_run("fresh", &run("fresh", 1, Some("2099-01-01T00:00:00Z")))
+            .unwrap();
+        let dropped = s
+            .prune(&RetentionPolicy {
+                max_terminal: 100,
+                keep_secs: Some(1),
+            })
+            .unwrap();
+        assert_eq!(
+            dropped, 1,
+            "aged terminal run must be pruned by keep_secs despite count under cap"
+        );
+        assert!(s.load_run("old").unwrap().is_none(), "ancient run evicted");
+        assert!(
+            s.load_run("fresh").unwrap().is_some(),
+            "future-dated run retained"
+        );
+        // keep_secs also applies when max_terminal is unbounded (0).
+        s.finish_run("old2", &run("old2", 1, Some("2001-01-01T00:00:00Z")))
+            .unwrap();
+        assert_eq!(
+            s.prune(&RetentionPolicy {
+                max_terminal: 0,
+                keep_secs: Some(1),
+            })
+            .unwrap(),
+            1,
+            "keep_secs prunes even with unbounded max_terminal"
         );
     }
 

--- a/crates/zeroclaw-runtime/src/sop/store/mod.rs
+++ b/crates/zeroclaw-runtime/src/sop/store/mod.rs
@@ -1,0 +1,432 @@
+//! Durable SOP run-state store (EPIC B) — the keystone contract.
+//!
+//! A single [`SopRunStore`] is owned by the engine singleton (EPIC A). It is the
+//! one durable home for run state, the CAS-claim admission primitive
+//! (concurrency-control), the append-only event log (audit-trail / observability),
+//! and the procedural-memory proposal namespace — so those epics ride **one**
+//! abstraction, not three.
+//!
+//! This module currently ships the trait + wire shapes + an in-memory default
+//! impl (mirrors today's in-memory behaviour, zero behaviour change). The
+//! durable `SqliteRunStore`, the `Memory`-backed adapter, boot-rehydrate, and the
+//! engine wiring are follow-on commits — see
+//! `epics/B-run-state-store/{03-architecture,04-implementation-plan}.md`.
+
+pub mod model;
+
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex};
+
+pub use model::{
+    ClaimToken, PersistedRun, ProposalRecord, ProposalStatus, RetentionPolicy, SOP_STORE_VERSION,
+    SopEventRecord,
+};
+
+/// First-class durable run-state store. ONE per engine singleton.
+///
+/// All methods are sync and **fail-loud**: a store error is never silently
+/// swallowed (persistence is fail-closed). Implementations must be cheap to
+/// `Arc::clone` and safe to share across the daemon tick, agent tools, MQTT
+/// listener, and the gateway approve surface.
+pub trait SopRunStore: Send + Sync {
+    // ── run state (persistence-resume, state-machine) ──
+    /// Persist-before-mutate. Monotonic-revision-guarded; idempotent on revision.
+    fn save_run(&self, run: &PersistedRun) -> Result<(), StoreError>;
+    /// Move a run to terminal state (kept as a terminal record, not deleted) and
+    /// release any live claim.
+    fn finish_run(&self, run_id: &str, terminal: &PersistedRun) -> Result<(), StoreError>;
+    /// Boot-rehydrate source: every non-terminal run (latest revision per id).
+    fn load_active_runs(&self) -> Result<Vec<PersistedRun>, StoreError>;
+    /// Single run by id (latest revision), terminal or not.
+    fn load_run(&self, run_id: &str) -> Result<Option<PersistedRun>, StoreError>;
+
+    // ── CAS claim primitive (concurrency-control) ──
+    /// Atomic single-winner admission. Returns `Some(token)` to exactly one
+    /// caller iff under `cap` and no live claim exists for `run_id`, else `None`.
+    fn try_claim_run(
+        &self,
+        run_id: &str,
+        sop_name: &str,
+        cap: usize,
+    ) -> Result<Option<ClaimToken>, StoreError>;
+    /// Renew a claim's lease (tick liveness). No-op if the claim is gone.
+    fn heartbeat_claim(&self, token: &ClaimToken) -> Result<(), StoreError>;
+    /// Release a claim (finish/cancel), freeing the slot for admission.
+    fn release_claim(&self, token: &ClaimToken) -> Result<(), StoreError>;
+    /// Reaper source: claims whose lease expired at/<= `now_iso`.
+    fn expired_claims(&self, now_iso: &str) -> Result<Vec<ClaimToken>, StoreError>;
+
+    // ── append-only event log (audit-trail, observability) ──
+    /// Append-only, monotonic-seq, never-overwrite. Returns the assigned seq.
+    fn append_event(&self, ev: &SopEventRecord) -> Result<u64, StoreError>;
+    /// Ordered event history for a run.
+    fn list_events(&self, run_id: &str) -> Result<Vec<SopEventRecord>, StoreError>;
+
+    // ── proposal namespace (procedural-memory — strictly last consumer) ──
+    fn save_proposal(&self, p: &ProposalRecord) -> Result<(), StoreError>;
+    fn load_proposal(&self, id: &str) -> Result<Option<ProposalRecord>, StoreError>;
+    fn list_proposals(
+        &self,
+        status: Option<ProposalStatus>,
+    ) -> Result<Vec<ProposalRecord>, StoreError>;
+
+    // ── maintenance ──
+    /// Drop terminal runs beyond the retention policy. Returns the count dropped.
+    fn prune(&self, policy: &RetentionPolicy) -> Result<usize, StoreError>;
+    fn health_check(&self) -> bool;
+    /// Backend name (for logs + the "never a silent no-op" guard).
+    fn backend(&self) -> &'static str;
+}
+
+/// Errors a store may surface. Never swallowed by callers.
+#[derive(Debug)]
+pub enum StoreError {
+    Io(std::io::Error),
+    Serde(serde_json::Error),
+    Backend(String),
+    /// A save lost the revision race (a newer revision already persisted).
+    StaleRevision {
+        run_id: String,
+        have: u64,
+        found: u64,
+    },
+    /// A claim was lost to a concurrent winner (over-cap or already claimed).
+    ClaimLost,
+}
+
+impl std::fmt::Display for StoreError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(e) => write!(f, "sop store io error: {e}"),
+            Self::Serde(e) => write!(f, "sop store serde error: {e}"),
+            Self::Backend(m) => write!(f, "sop store backend error: {m}"),
+            Self::StaleRevision {
+                run_id,
+                have,
+                found,
+            } => write!(
+                f,
+                "sop store stale revision for run {run_id}: have {have}, found {found}"
+            ),
+            Self::ClaimLost => write!(f, "sop store claim lost to a concurrent winner"),
+        }
+    }
+}
+
+impl std::error::Error for StoreError {}
+
+impl From<std::io::Error> for StoreError {
+    fn from(e: std::io::Error) -> Self {
+        Self::Io(e)
+    }
+}
+
+impl From<serde_json::Error> for StoreError {
+    fn from(e: serde_json::Error) -> Self {
+        Self::Serde(e)
+    }
+}
+
+/// Build the configured run store.
+///
+/// Default backend is in-memory (current behaviour). The config-driven
+/// SQLite/Memory selection lands with `SqliteRunStore` (follow-on commit); this
+/// keeps the contract stable for callers in the meantime.
+pub fn build_run_store() -> Arc<dyn SopRunStore> {
+    Arc::new(InMemoryRunStore::new())
+}
+
+// ── In-memory default backend ──────────────────────────────────────
+
+#[derive(Default)]
+struct Inner {
+    runs: HashMap<String, PersistedRun>,
+    terminal: HashSet<String>,
+    events: HashMap<String, Vec<SopEventRecord>>,
+    claims: HashMap<String, ClaimToken>,
+    proposals: HashMap<String, ProposalRecord>,
+    seq: u64,
+}
+
+/// Process-local, non-durable store. Mirrors today's in-memory run maps; lost on
+/// restart. The compatibility default until `SqliteRunStore` lands.
+pub struct InMemoryRunStore {
+    inner: Mutex<Inner>,
+}
+
+impl Default for InMemoryRunStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl InMemoryRunStore {
+    pub fn new() -> Self {
+        Self {
+            inner: Mutex::new(Inner::default()),
+        }
+    }
+
+    fn lock(&self) -> Result<std::sync::MutexGuard<'_, Inner>, StoreError> {
+        self.inner
+            .lock()
+            .map_err(|_| StoreError::Backend("in-memory store lock poisoned".into()))
+    }
+}
+
+impl SopRunStore for InMemoryRunStore {
+    fn save_run(&self, run: &PersistedRun) -> Result<(), StoreError> {
+        let mut g = self.lock()?;
+        let id = run.run_id().to_string();
+        if let Some(existing) = g.runs.get(&id)
+            && existing.revision > run.revision
+        {
+            return Err(StoreError::StaleRevision {
+                run_id: id,
+                have: run.revision,
+                found: existing.revision,
+            });
+        }
+        g.runs.insert(id, run.clone());
+        Ok(())
+    }
+
+    fn finish_run(&self, run_id: &str, terminal: &PersistedRun) -> Result<(), StoreError> {
+        let mut g = self.lock()?;
+        g.runs.insert(run_id.to_string(), terminal.clone());
+        g.terminal.insert(run_id.to_string());
+        g.claims.remove(run_id);
+        Ok(())
+    }
+
+    fn load_active_runs(&self) -> Result<Vec<PersistedRun>, StoreError> {
+        let g = self.lock()?;
+        Ok(g.runs
+            .values()
+            .filter(|r| !g.terminal.contains(r.run_id()))
+            .cloned()
+            .collect())
+    }
+
+    fn load_run(&self, run_id: &str) -> Result<Option<PersistedRun>, StoreError> {
+        Ok(self.lock()?.runs.get(run_id).cloned())
+    }
+
+    fn try_claim_run(
+        &self,
+        run_id: &str,
+        sop_name: &str,
+        cap: usize,
+    ) -> Result<Option<ClaimToken>, StoreError> {
+        let mut g = self.lock()?;
+        if g.claims.contains_key(run_id) {
+            return Ok(None);
+        }
+        // A run that has already reached a terminal state is not re-claimable.
+        if g.terminal.contains(run_id) {
+            return Ok(None);
+        }
+        if cap != 0 && g.claims.len() >= cap {
+            return Ok(None);
+        }
+        // Timestamps are stamped by durable backends; the in-memory backend
+        // leaves them empty (the reaper skips empty leases — see `expired_claims`).
+        let token = ClaimToken {
+            run_id: run_id.to_string(),
+            sop_name: sop_name.to_string(),
+            claimed_at: String::new(),
+            lease_expires: String::new(),
+            holder: "in-memory".to_string(),
+        };
+        g.claims.insert(run_id.to_string(), token.clone());
+        Ok(Some(token))
+    }
+
+    fn heartbeat_claim(&self, _token: &ClaimToken) -> Result<(), StoreError> {
+        Ok(())
+    }
+
+    fn release_claim(&self, token: &ClaimToken) -> Result<(), StoreError> {
+        self.lock()?.claims.remove(&token.run_id);
+        Ok(())
+    }
+
+    fn expired_claims(&self, now_iso: &str) -> Result<Vec<ClaimToken>, StoreError> {
+        let g = self.lock()?;
+        Ok(g.claims
+            .values()
+            .filter(|c| !c.lease_expires.is_empty() && c.lease_expires.as_str() <= now_iso)
+            .cloned()
+            .collect())
+    }
+
+    fn append_event(&self, ev: &SopEventRecord) -> Result<u64, StoreError> {
+        let mut g = self.lock()?;
+        g.seq += 1;
+        let seq = g.seq;
+        let mut rec = ev.clone();
+        rec.seq = seq;
+        g.events.entry(ev.run_id.clone()).or_default().push(rec);
+        Ok(seq)
+    }
+
+    fn list_events(&self, run_id: &str) -> Result<Vec<SopEventRecord>, StoreError> {
+        let mut v = self.lock()?.events.get(run_id).cloned().unwrap_or_default();
+        v.sort_by_key(|e| e.seq);
+        Ok(v)
+    }
+
+    fn save_proposal(&self, p: &ProposalRecord) -> Result<(), StoreError> {
+        self.lock()?.proposals.insert(p.id.clone(), p.clone());
+        Ok(())
+    }
+
+    fn load_proposal(&self, id: &str) -> Result<Option<ProposalRecord>, StoreError> {
+        Ok(self.lock()?.proposals.get(id).cloned())
+    }
+
+    fn list_proposals(
+        &self,
+        status: Option<ProposalStatus>,
+    ) -> Result<Vec<ProposalRecord>, StoreError> {
+        let g = self.lock()?;
+        Ok(g.proposals
+            .values()
+            .filter(|p| status.is_none_or(|s| p.status == s))
+            .cloned()
+            .collect())
+    }
+
+    fn prune(&self, policy: &RetentionPolicy) -> Result<usize, StoreError> {
+        if policy.max_terminal == 0 {
+            return Ok(0);
+        }
+        let mut g = self.lock()?;
+        if g.terminal.len() <= policy.max_terminal {
+            return Ok(0);
+        }
+        // Evict OLDEST terminal runs first (by completion, then start time) —
+        // HashSet order is non-deterministic, so sort before truncating.
+        let mut terminal: Vec<(String, String)> = g
+            .terminal
+            .iter()
+            .map(|id| {
+                let ts = g
+                    .runs
+                    .get(id)
+                    .map(|r| {
+                        r.run
+                            .completed_at
+                            .clone()
+                            .unwrap_or_else(|| r.run.started_at.clone())
+                    })
+                    .unwrap_or_default();
+                (id.clone(), ts)
+            })
+            .collect();
+        terminal.sort_by(|a, b| a.1.cmp(&b.1));
+        let drop_n = terminal.len() - policy.max_terminal;
+        for (id, _) in terminal.into_iter().take(drop_n) {
+            g.runs.remove(&id);
+            g.events.remove(&id);
+            g.terminal.remove(&id);
+        }
+        Ok(drop_n)
+    }
+
+    fn health_check(&self) -> bool {
+        self.inner.lock().is_ok()
+    }
+
+    fn backend(&self) -> &'static str {
+        "in-memory"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn ev(run: &str, kind: &str) -> SopEventRecord {
+        SopEventRecord {
+            run_id: run.to_string(),
+            seq: 0,
+            ts: "t".to_string(),
+            kind: kind.to_string(),
+            actor: None,
+            reason: None,
+            payload: json!({}),
+        }
+    }
+
+    fn proposal(id: &str, status: ProposalStatus) -> ProposalRecord {
+        ProposalRecord {
+            id: id.to_string(),
+            status,
+            source_run_id: None,
+            sop_name: "deploy".to_string(),
+            target_content_hash: None,
+            provenance: json!({}),
+            created_at: "t".to_string(),
+            updated_at: "t".to_string(),
+        }
+    }
+
+    #[test]
+    fn claim_is_single_winner_and_cap_bounded() {
+        let s = build_run_store();
+        // First claim wins.
+        assert!(s.try_claim_run("r1", "deploy", 2).unwrap().is_some());
+        // Duplicate claim on the same run is refused.
+        assert!(s.try_claim_run("r1", "deploy", 2).unwrap().is_none());
+        // Second distinct run claims (under cap).
+        assert!(s.try_claim_run("r2", "deploy", 2).unwrap().is_some());
+        // Third exceeds cap=2.
+        assert!(s.try_claim_run("r3", "deploy", 2).unwrap().is_none());
+        // Releasing frees a slot.
+        let tok = ClaimToken {
+            run_id: "r1".to_string(),
+            sop_name: "deploy".to_string(),
+            claimed_at: String::new(),
+            lease_expires: String::new(),
+            holder: "in-memory".to_string(),
+        };
+        s.release_claim(&tok).unwrap();
+        assert!(s.try_claim_run("r3", "deploy", 2).unwrap().is_some());
+    }
+
+    #[test]
+    fn events_are_append_only_with_monotonic_seq() {
+        let s = build_run_store();
+        assert_eq!(s.append_event(&ev("r1", "run_started")).unwrap(), 1);
+        assert_eq!(s.append_event(&ev("r1", "step_completed")).unwrap(), 2);
+        assert_eq!(s.append_event(&ev("r2", "run_started")).unwrap(), 3);
+        let r1 = s.list_events("r1").unwrap();
+        assert_eq!(r1.len(), 2);
+        assert_eq!(r1[0].seq, 1);
+        assert_eq!(r1[1].kind, "step_completed");
+        assert_eq!(s.list_events("r2").unwrap().len(), 1);
+    }
+
+    #[test]
+    fn proposals_round_trip_and_filter_by_status() {
+        let s = build_run_store();
+        s.save_proposal(&proposal("p1", ProposalStatus::Pending))
+            .unwrap();
+        s.save_proposal(&proposal("p2", ProposalStatus::Applied))
+            .unwrap();
+        assert_eq!(
+            s.load_proposal("p1").unwrap().unwrap().status,
+            ProposalStatus::Pending
+        );
+        assert_eq!(s.list_proposals(None).unwrap().len(), 2);
+        assert_eq!(
+            s.list_proposals(Some(ProposalStatus::Applied))
+                .unwrap()
+                .len(),
+            1
+        );
+        assert_eq!(s.backend(), "in-memory");
+    }
+}

--- a/crates/zeroclaw-runtime/src/sop/store/mod.rs
+++ b/crates/zeroclaw-runtime/src/sop/store/mod.rs
@@ -346,7 +346,39 @@ impl SopRunStore for InMemoryRunStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::sop::types::{SopEvent, SopRun, SopRunStatus, SopTriggerSource};
     use serde_json::json;
+
+    /// Build a `PersistedRun` at a given revision and completion timestamp.
+    fn run(id: &str, revision: u64, completed_at: Option<&str>) -> PersistedRun {
+        let started_at = "2020-01-01T00:00:00Z".to_string();
+        let sop_run = SopRun {
+            run_id: id.to_string(),
+            sop_name: "deploy".to_string(),
+            trigger_event: SopEvent {
+                source: SopTriggerSource::Manual,
+                topic: None,
+                payload: None,
+                timestamp: started_at.clone(),
+            },
+            status: SopRunStatus::Running,
+            current_step: 0,
+            total_steps: 1,
+            started_at: started_at.clone(),
+            completed_at: completed_at.map(|s| s.to_string()),
+            step_results: Vec::new(),
+            waiting_since: None,
+            llm_calls_saved: 0,
+        };
+        PersistedRun {
+            version: SOP_STORE_VERSION,
+            revision,
+            run: sop_run,
+            last_progress_at: started_at,
+            redacted: false,
+            trigger_source: SopTriggerSource::Manual,
+        }
+    }
 
     fn ev(run: &str, kind: &str) -> SopEventRecord {
         SopEventRecord {
@@ -428,5 +460,96 @@ mod tests {
             1
         );
         assert_eq!(s.backend(), "in-memory");
+    }
+
+    #[test]
+    fn save_run_rejects_stale_revision_but_accepts_same_or_newer() {
+        let s = build_run_store();
+        s.save_run(&run("r1", 5, None)).unwrap();
+        // A lower revision loses the race.
+        let err = s.save_run(&run("r1", 4, None)).unwrap_err();
+        assert!(matches!(
+            err,
+            StoreError::StaleRevision {
+                have: 4,
+                found: 5,
+                ..
+            }
+        ));
+        // The stored revision is unchanged after the rejected write.
+        assert_eq!(s.load_run("r1").unwrap().unwrap().revision, 5);
+        // Same revision is idempotent (last-writer guard allows ==).
+        s.save_run(&run("r1", 5, None)).unwrap();
+        // A newer revision wins.
+        s.save_run(&run("r1", 6, None)).unwrap();
+        assert_eq!(s.load_run("r1").unwrap().unwrap().revision, 6);
+    }
+
+    #[test]
+    fn finish_run_marks_terminal_and_releases_claim() {
+        let s = build_run_store();
+        s.save_run(&run("r1", 0, None)).unwrap();
+        let tok = s.try_claim_run("r1", "deploy", 4).unwrap().unwrap();
+        assert!(
+            s.load_active_runs()
+                .unwrap()
+                .iter()
+                .any(|r| r.run_id() == "r1")
+        );
+
+        s.finish_run("r1", &run("r1", 1, Some("2020-01-02T00:00:00Z")))
+            .unwrap();
+
+        // No longer reported as active...
+        assert!(s.load_active_runs().unwrap().is_empty());
+        // ...but still loadable as a terminal record.
+        assert_eq!(s.load_run("r1").unwrap().unwrap().revision, 1);
+        // ...and its claim slot was freed.
+        assert!(s.try_claim_run("r1b", "deploy", 1).unwrap().is_some());
+        // A terminal run is not re-claimable even after its claim was released.
+        assert!(s.try_claim_run("r1", "deploy", 4).unwrap().is_none());
+        // release_claim on the old token is a no-op (slot already freed).
+        s.release_claim(&tok).unwrap();
+    }
+
+    #[test]
+    fn prune_evicts_oldest_terminal_runs_first() {
+        let s = build_run_store();
+        // Three terminal runs with ascending completion timestamps.
+        for (id, ts) in [
+            ("old", "2020-01-01T00:00:00Z"),
+            ("mid", "2020-02-01T00:00:00Z"),
+            ("new", "2020-03-01T00:00:00Z"),
+        ] {
+            s.finish_run(id, &run(id, 1, Some(ts))).unwrap();
+        }
+        let dropped = s
+            .prune(&RetentionPolicy {
+                max_terminal: 2,
+                keep_secs: None,
+            })
+            .unwrap();
+        assert_eq!(dropped, 1);
+        // The oldest was evicted; the two newest survive.
+        assert!(s.load_run("old").unwrap().is_none());
+        assert!(s.load_run("mid").unwrap().is_some());
+        assert!(s.load_run("new").unwrap().is_some());
+        // A no-op prune (under cap) drops nothing.
+        assert_eq!(
+            s.prune(&RetentionPolicy {
+                max_terminal: 100,
+                keep_secs: None,
+            })
+            .unwrap(),
+            0
+        );
+    }
+
+    #[test]
+    fn expired_claims_skips_empty_leases_and_matches_past_due() {
+        let s = build_run_store();
+        // The in-memory backend stamps empty leases — those are never expired.
+        s.try_claim_run("r1", "deploy", 4).unwrap().unwrap();
+        assert!(s.expired_claims("2999-01-01T00:00:00Z").unwrap().is_empty());
     }
 }

--- a/crates/zeroclaw-runtime/src/sop/store/model.rs
+++ b/crates/zeroclaw-runtime/src/sop/store/model.rs
@@ -1,0 +1,133 @@
+//! Durable run-state store — versioned wire shapes (EPIC B).
+//!
+//! [`SopRun`] is the runtime FSM state; for durability it is wrapped in a
+//! forward-compatible [`PersistedRun`] envelope (version + monotonic revision +
+//! stall timestamp + redaction marker). The CAS [`ClaimToken`], append-only
+//! [`SopEventRecord`], and procedural-memory [`ProposalRecord`] share the same
+//! store so concurrency-control, audit-trail, and procedural-memory ride one
+//! abstraction rather than three.
+//!
+//! Design: `epics/B-run-state-store/03-architecture.md` (SOP path-to-5).
+
+use serde::{Deserialize, Serialize};
+
+use crate::sop::types::{SopRun, SopTriggerSource};
+
+/// Bump when the persisted envelope layout changes incompatibly. Rehydrate
+/// skips + logs unknown major versions rather than panicking on boot.
+pub const SOP_STORE_VERSION: u32 = 1;
+
+/// Forward-compatible durable envelope around a [`SopRun`].
+///
+/// `SopRun` is not persisted directly: this envelope adds the durability
+/// metadata (`version`, monotonic `revision`, stall `last_progress_at`,
+/// `redacted` marker, `trigger_source`) the raw run lacks.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PersistedRun {
+    /// = [`SOP_STORE_VERSION`] at write time.
+    pub version: u32,
+    /// Monotonic per-run write counter; last-writer guard on rehydrate + CAS.
+    pub revision: u64,
+    /// The full run FSM state (every mode, not just deterministic).
+    pub run: SopRun,
+    /// ISO-8601; bumped on every transition. The reaper ages out stalled `Running`.
+    pub last_progress_at: String,
+    /// True once `step_results`/outputs have been run through the leak detector.
+    pub redacted: bool,
+    /// Origin of the run, for per-source caps + audit.
+    pub trigger_source: SopTriggerSource,
+}
+
+impl PersistedRun {
+    /// Wrap a run at the current store version with revision 0.
+    pub fn new(run: SopRun, last_progress_at: String, trigger_source: SopTriggerSource) -> Self {
+        Self {
+            version: SOP_STORE_VERSION,
+            revision: 0,
+            run,
+            last_progress_at,
+            redacted: false,
+            trigger_source,
+        }
+    }
+
+    /// The run id this envelope is keyed by.
+    pub fn run_id(&self) -> &str {
+        &self.run.run_id
+    }
+}
+
+/// CAS claim handle. Opaque to the engine; the store validates it. The single
+/// admission primitive A1's concurrency tick and C's out-of-band approver share.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClaimToken {
+    pub run_id: String,
+    pub sop_name: String,
+    pub claimed_at: String,
+    /// `now + claim_lease_secs`; the reaper reclaims claims past this.
+    pub lease_expires: String,
+    /// Process/instance nonce so a CAS winner is provably this process.
+    pub holder: String,
+}
+
+/// One append-only audit/observability event. Never overwritten (the primitive
+/// the keyed `Memory` backend lacks).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SopEventRecord {
+    pub run_id: String,
+    /// Monotonic ordinal assigned by the store.
+    pub seq: u64,
+    pub ts: String,
+    /// e.g. `run_started` | `step_completed` | `entered_waiting_approval` | …
+    pub kind: String,
+    /// Approver / actor identity (EPIC C threads this in).
+    pub actor: Option<String>,
+    pub reason: Option<String>,
+    /// Redacted before append.
+    pub payload: serde_json::Value,
+}
+
+/// Lifecycle of a procedural-memory proposal (EPIC F, strictly-last consumer).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProposalStatus {
+    Pending,
+    Applied,
+    Rejected,
+    Quarantined,
+    Stale,
+}
+
+/// A captured-and-distilled SOP refinement awaiting approval + write-back.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProposalRecord {
+    pub id: String,
+    pub status: ProposalStatus,
+    pub source_run_id: Option<String>,
+    pub sop_name: String,
+    /// For stale detection against the on-disk SOP.
+    pub target_content_hash: Option<String>,
+    /// Distiller model, session, timestamp, …
+    pub provenance: serde_json::Value,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// Retention bound for terminal runs + their events.
+#[derive(Debug, Clone)]
+pub struct RetentionPolicy {
+    /// Keep at most this many terminal runs (0 = unbounded — discouraged).
+    pub max_terminal: usize,
+    /// Drop terminal runs whose `completed_at` is older than this, if set.
+    pub keep_secs: Option<u64>,
+}
+
+impl Default for RetentionPolicy {
+    fn default() -> Self {
+        // Mirrors today's in-memory `max_finished_runs` default of 100.
+        Self {
+            max_terminal: 100,
+            keep_secs: None,
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Adds the durable run-state store contract that SOP
  durability/concurrency/observability work will build on. ONE abstraction
  (`SopRunStore`) for run-state persistence, CAS-claim admission, an append-only
  event log, and procedural-memory proposals, so those concerns ride a single
  store rather than three ad-hoc mechanisms. This is the contract-first first
  slice; it is additive and not yet wired into the engine, so there is no
  runtime behavior change.
- **Scope boundary:** New `crates/zeroclaw-runtime/src/sop/store/` module only
  (+5 lines of re-exports in `sop/mod.rs`). No engine call-site, config, or tool
  surface touched. Default backend is the existing in-memory behavior.
- **Blast radius:** `sop/store/model.rs` (wire shapes), `sop/store/mod.rs` (trait
  + `InMemoryRunStore` + `build_run_store()` + tests), `sop/mod.rs` (re-exports).
  Nothing consumes the store yet.
- **Linked issue(s):** Groundwork for durable SOP run state. Underpins the fixes
  for #6689 (audit persistence) and #6037-class concurrency claims, and the
  resume/rehydrate path. Does not close an issue on its own.
- **Labels:** `enhancement`, `runtime`, `size: L`, `risk: high` (auto-labeled:
  runtime scope. Additive + unwired, so no behavior changes despite the risk
  tier, but the contract is what the durable backend will be held to, so it is
  reviewed as load-bearing).

## What it adds

- `trait SopRunStore` - run state (save/finish/load/active), CAS claim primitive
  (try_claim/heartbeat/release/expired), append-only event log
  (append_event/list_events), proposal namespace, and maintenance (prune /
  health_check / backend).
- Versioned wire shapes: `PersistedRun` (envelope: version + monotonic revision
  + stall ts + redaction marker + trigger source), `ClaimToken`,
  `SopEventRecord`, `ProposalRecord`/`ProposalStatus`, `RetentionPolicy`,
  `SOP_STORE_VERSION`.
- `StoreError` (+ `Display`/`Error`/`From` conversions), including a distinct
  `RevisionConflict` for divergent same-revision writes.
- `InMemoryRunStore` default (mirrors today's in-memory run maps; lost on
  restart) + `build_run_store()` factory.

## Review remediation (addresses the CHANGES_REQUESTED review)

1. **Same-revision overwrite (blocking).** Both write paths are now revision-
   guarded by one shared `revision_guard`: a strictly-older revision is rejected
   `StaleRevision`; an equal revision is accepted only as a byte-identical
   idempotent retry, otherwise rejected `RevisionConflict`; a newer revision
   wins. `finish_run` runs the same guard before it flips terminal + releases the
   claim, so a stale or divergent terminal write can no longer clobber newer
   state or drop a live claim. Regressions added for divergent same-revision
   saves and for stale/divergent terminal writes (state + claim verified intact).
2. **CAS claim could not hold both concurrency limits (blocking).**
   `try_claim_run` now takes both `per_sop_cap` and `global_cap` and enforces
   them atomically under one lock: live claims for the SOP are counted by
   `sop_name` against the per-SOP cap, and total live claims against the global
   cap, mirroring the engine `can_start` (`sop.max_concurrent` and
   `config.max_concurrent_total`, both inclusive-max, 0 admits nothing). Added a
   two-SOP regression proving one SOP at its per-SOP cap does not block a
   different SOP while the shared global cap still applies.
3. **Body label/risk drift (warning).** This body now snapshots the live labels
   (`risk: high`, `size: L`) and fills the risk-high rollback + compatibility
   sections below.

## Not in this PR (follow-ons, per the EPIC B plan)

`SqliteRunStore` durable backend, the `Memory`-backed adapter, the config-driven
`build_run_store(cfg, data_dir, memory)` factory, boot `restore_runs()`
rehydrate, and the engine persist-seams (the behavior-changing slice that makes
runs actually durable). Each lands as its own reviewed commit.

## Validation Evidence (required)

```
$ cargo +1.93.0 fmt -p zeroclaw-runtime -- --check
(clean)

$ cargo +1.93.0 clippy -p zeroclaw-runtime --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 05s

$ cargo +1.93.0 test -p zeroclaw-runtime sop::store
running 9 tests
test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 2299 filtered out
```

- **Commands run and tail output:** above (fmt clean, clippy 0 warnings,
  9 store tests green).
- **Beyond CI - what was manually verified:** the new dual-cap claim semantics
  were checked against the live engine admission path
  (`sop/engine.rs` `can_start`, lines 92-123) so the store mirrors the existing
  per-SOP + global limits exactly (inclusive-max, 0 admits nothing). Did NOT
  exercise the store under real engine wiring (it is intentionally unwired in
  this PR) or under multi-process contention (the in-memory backend is
  single-process; the durable backend lands later).
- **If any command was intentionally skipped, why:** none skipped.

Tests cover: CAS single-winner + cap bound (+ terminal-run not re-claimable),
per-SOP isolation vs shared global cap, append-only monotonic seq + ordering,
proposal round-trip + status filter, revision guard on save (stale + divergent
same-revision), revision guard on finish (stale + divergent terminal protects
state and claim), and oldest-first prune.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No` (the `redacted` marker is
  a field shape only; no redaction logic runs in this PR)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes` (additive, unwired; default backend is the existing
  in-memory behavior)
- Config / env / CLI surface changed? `No`
- Upgrade steps for existing users: none.

## Rollback (required for `risk: high`)

- **Fast rollback command/path:** `git revert <merge-sha>`. The module is
  self-contained and has no consumers, so a revert is clean.
- **Feature flags or config toggles:** None (nothing is wired; the store is not
  constructed on any runtime path yet).
- **Observable failure symptoms:** None expected at runtime, since no code path
  constructs or calls the store. A compile-time regression would surface in CI
  `Build`/`Test`; there is no log line or metric to grep because the store is
  not yet exercised.
