### PR TITLE
feat(xtask): drive container base pins from a canonical TOML

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
 # syntax=docker/dockerfile:1.7-labs
 
 # >>> generated:base-arg-node from dev/ci/container-base-images.toml by `cargo generate installers` - do not edit <<<
-ARG ZEROCLAW_BASE_NODE=node:24-bookworm-slim@sha256:2c87ef9bd3c6a3bd4b472b4bec2ce9d16354b0c574f736c476489d09f560a203
+ARG ZEROCLAW_BASE_NODE=node:26-bookworm-slim@sha256:4e2e85a824f938e41a61e9e819f0c7c11432f7d60f470b96214d3ead2f0dd63e
 # >>> end generated:base-arg-node <<<
 # >>> generated:base-arg-rust-slim from dev/ci/container-base-images.toml by `cargo generate installers` - do not edit <<<
-ARG ZEROCLAW_BASE_RUST_SLIM=rust:1.94-slim@sha256:da9dab7a6b8dd428e71718402e97207bb3e54167d37b5708616050b1e8f60ed6
+ARG ZEROCLAW_BASE_RUST_SLIM=rust:1.94-slim@sha256:cf09adf8c3ebaba10779e5c23ff7fe4df4cccdab8a91f199b0c142c53fef3e1a
 # >>> end generated:base-arg-rust-slim <<<
 # >>> generated:base-arg-debian from dev/ci/container-base-images.toml by `cargo generate installers` - do not edit <<<
-ARG ZEROCLAW_BASE_DEBIAN=debian:trixie-slim@sha256:f6e2cfac5cf956ea044b4bd75e6397b4372ad88fe00908045e9a0d21712ae3ba
+ARG ZEROCLAW_BASE_DEBIAN=debian:trixie-slim@sha256:4e401d95de7083948053197a9c3913343cd06b706bf15eb6a0c3ccd26f436a0e
 # >>> end generated:base-arg-debian <<<
 # >>> generated:base-arg-distroless from dev/ci/container-base-images.toml by `cargo generate installers` - do not edit <<<
-ARG ZEROCLAW_BASE_DISTROLESS=gcr.io/distroless/cc-debian13:nonroot@sha256:84fcd3c223b144b0cb6edc5ecc75641819842a9679a3a58fd6294bec47532bf7
+ARG ZEROCLAW_BASE_DISTROLESS=gcr.io/distroless/cc-debian13:nonroot@sha256:d3cda6e91129130d7229a1806b6a73d292ef245ab032da7851907798024cefba
 # >>> end generated:base-arg-distroless <<<
 
 # ── Stage 0: Frontend build ─────────────────────────────────────

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,22 @@
 # syntax=docker/dockerfile:1.7-labs
 
-# ── Stage 0: Frontend build ─────────────────────────────────────
-FROM node:24-bookworm-slim@sha256:2c87ef9bd3c6a3bd4b472b4bec2ce9d16354b0c574f736c476489d09f560a203 AS web-node
+# >>> generated:base-arg-node from dev/ci/container-base-images.toml by `cargo generate installers` - do not edit <<<
+ARG ZEROCLAW_BASE_NODE=node:24-bookworm-slim@sha256:2c87ef9bd3c6a3bd4b472b4bec2ce9d16354b0c574f736c476489d09f560a203
+# >>> end generated:base-arg-node <<<
+# >>> generated:base-arg-rust-slim from dev/ci/container-base-images.toml by `cargo generate installers` - do not edit <<<
+ARG ZEROCLAW_BASE_RUST_SLIM=rust:1.94-slim@sha256:da9dab7a6b8dd428e71718402e97207bb3e54167d37b5708616050b1e8f60ed6
+# >>> end generated:base-arg-rust-slim <<<
+# >>> generated:base-arg-debian from dev/ci/container-base-images.toml by `cargo generate installers` - do not edit <<<
+ARG ZEROCLAW_BASE_DEBIAN=debian:trixie-slim@sha256:f6e2cfac5cf956ea044b4bd75e6397b4372ad88fe00908045e9a0d21712ae3ba
+# >>> end generated:base-arg-debian <<<
+# >>> generated:base-arg-distroless from dev/ci/container-base-images.toml by `cargo generate installers` - do not edit <<<
+ARG ZEROCLAW_BASE_DISTROLESS=gcr.io/distroless/cc-debian13:nonroot@sha256:84fcd3c223b144b0cb6edc5ecc75641819842a9679a3a58fd6294bec47532bf7
+# >>> end generated:base-arg-distroless <<<
 
-FROM rust:1.94-slim@sha256:da9dab7a6b8dd428e71718402e97207bb3e54167d37b5708616050b1e8f60ed6 AS web-builder
+# ── Stage 0: Frontend build ─────────────────────────────────────
+FROM ${ZEROCLAW_BASE_NODE} AS web-node
+
+FROM ${ZEROCLAW_BASE_RUST_SLIM} AS web-builder
 WORKDIR /app
 COPY --from=web-node /usr/local/bin/node /usr/local/bin/node
 COPY --from=web-node /usr/local/lib/node_modules /usr/local/lib/node_modules
@@ -27,7 +40,7 @@ RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/regist
     cargo web build
 
 # ── Stage 1: Build ────────────────────────────────────────────
-FROM rust:1.94-slim@sha256:da9dab7a6b8dd428e71718402e97207bb3e54167d37b5708616050b1e8f60ed6 AS builder
+FROM ${ZEROCLAW_BASE_RUST_SLIM} AS builder
 
 WORKDIR /app
 # >>> generated:docker-features-arg by `cargo generate installers` - do not edit <<<
@@ -164,7 +177,7 @@ RUN mkdir -p /zeroclaw-data/.zeroclaw /zeroclaw-data/data && \
     chown -R 65534:65534 /zeroclaw-data
 
 # ── Stage 2: Development Runtime (Debian) ────────────────────
-FROM debian:trixie-slim@sha256:f6e2cfac5cf956ea044b4bd75e6397b4372ad88fe00908045e9a0d21712ae3ba AS dev
+FROM ${ZEROCLAW_BASE_DEBIAN} AS dev
 
 # Install essential runtime dependencies only (use docker-compose.override.yml for dev tools)
 RUN apt-get update && apt-get install -y \
@@ -207,7 +220,7 @@ ENTRYPOINT ["zeroclaw"]
 CMD ["daemon"]
 
 # ── Stage 3: Production Runtime (Distroless) ─────────────────
-FROM gcr.io/distroless/cc-debian13:nonroot@sha256:84fcd3c223b144b0cb6edc5ecc75641819842a9679a3a58fd6294bec47532bf7 AS release
+FROM ${ZEROCLAW_BASE_DISTROLESS} AS release
 
 COPY --from=builder /app/zeroclaw /usr/local/bin/zeroclaw
 COPY --from=builder /app/zerocode /usr/local/bin/zerocode

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,9 +1,16 @@
 # syntax=docker/dockerfile:1.7-labs
 
-# ── Stage 0: Frontend build ─────────────────────────────────────
-FROM node:24-bookworm-slim@sha256:2c87ef9bd3c6a3bd4b472b4bec2ce9d16354b0c574f736c476489d09f560a203 AS web-node
+# >>> generated:base-arg-node from dev/ci/container-base-images.toml by `cargo generate installers` - do not edit <<<
+ARG ZEROCLAW_BASE_NODE=node:24-bookworm-slim@sha256:2c87ef9bd3c6a3bd4b472b4bec2ce9d16354b0c574f736c476489d09f560a203
+# >>> end generated:base-arg-node <<<
+# >>> generated:base-arg-rust-bookworm from dev/ci/container-base-images.toml by `cargo generate installers` - do not edit <<<
+ARG ZEROCLAW_BASE_RUST_BOOKWORM=rust:1.94-bookworm@sha256:6ae102bdbf528294bc79ad6e1fae682f6f7c2a6e6621506ba959f9685b308a55
+# >>> end generated:base-arg-rust-bookworm <<<
 
-FROM rust:1.94-bookworm@sha256:6ae102bdbf528294bc79ad6e1fae682f6f7c2a6e6621506ba959f9685b308a55 AS web-builder
+# ── Stage 0: Frontend build ─────────────────────────────────────
+FROM ${ZEROCLAW_BASE_NODE} AS web-node
+
+FROM ${ZEROCLAW_BASE_RUST_BOOKWORM} AS web-builder
 WORKDIR /app
 COPY --from=web-node /usr/local/bin/node /usr/local/bin/node
 COPY --from=web-node /usr/local/lib/node_modules /usr/local/lib/node_modules
@@ -42,7 +49,7 @@ RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/regist
 #   docker compose -f docker-compose.yml -f docker-compose.debian.yml up
 
 # ── Stage 1: Build (match runtime glibc baseline) ───────────
-FROM rust:1.94-bookworm@sha256:6ae102bdbf528294bc79ad6e1fae682f6f7c2a6e6621506ba959f9685b308a55 AS builder
+FROM ${ZEROCLAW_BASE_RUST_BOOKWORM} AS builder
 
 WORKDIR /app
 # >>> generated:docker-features-arg by `cargo generate installers` - do not edit <<<

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.7-labs
 
 # >>> generated:base-arg-node from dev/ci/container-base-images.toml by `cargo generate installers` - do not edit <<<
-ARG ZEROCLAW_BASE_NODE=node:24-bookworm-slim@sha256:2c87ef9bd3c6a3bd4b472b4bec2ce9d16354b0c574f736c476489d09f560a203
+ARG ZEROCLAW_BASE_NODE=node:26-bookworm-slim@sha256:4e2e85a824f938e41a61e9e819f0c7c11432f7d60f470b96214d3ead2f0dd63e
 # >>> end generated:base-arg-node <<<
 # >>> generated:base-arg-rust-bookworm from dev/ci/container-base-images.toml by `cargo generate installers` - do not edit <<<
 ARG ZEROCLAW_BASE_RUST_BOOKWORM=rust:1.94-bookworm@sha256:6ae102bdbf528294bc79ad6e1fae682f6f7c2a6e6621506ba959f9685b308a55

--- a/dev/ci/container-base-images.toml
+++ b/dev/ci/container-base-images.toml
@@ -1,12 +1,9 @@
 # Canonical container base-image pins for the generated container surfaces
-# (Dockerfile, Dockerfile.debian). Source of truth: edit tag/registry/repo here.
-# `cargo generate installers` resolves the live digest from the registry, writes
-# tag+digest back into this file, and renders the generated ARG zones in the
-# surfaces from it.
-#
-# A row with no human-set `tag` is discovered live from the registry (node:
-# highest <major>-bookworm-slim on Docker Hub). StageX pins in the Containerfile
-# are excluded on purpose: digest-only, reproducible-build intent, no tag to follow.
+# (Dockerfile, Dockerfile.debian). Edit registry/repo/image_ref/tag here; `tag`
+# and `digest` are rewritten live by `cargo generate installers`. A row with
+# discover=true resolves its tag live from the registry (node: highest
+# <major>-bookworm-slim on Docker Hub). StageX pins in the Containerfile are
+# excluded on purpose: digest-only, reproducible-build intent, no tag to follow.
 
 [[image]]
 zone = "base-arg-node"
@@ -15,8 +12,8 @@ registry = "dockerhub"
 repo = "library/node"
 image_ref = "node"
 discover = true
-tag = "24-bookworm-slim"
-digest = "sha256:2c87ef9bd3c6a3bd4b472b4bec2ce9d16354b0c574f736c476489d09f560a203"
+tag = "26-bookworm-slim"
+digest = "sha256:4e2e85a824f938e41a61e9e819f0c7c11432f7d60f470b96214d3ead2f0dd63e"
 
 [[image]]
 zone = "base-arg-rust-slim"
@@ -25,7 +22,7 @@ registry = "dockerhub"
 repo = "library/rust"
 image_ref = "rust"
 tag = "1.94-slim"
-digest = "sha256:da9dab7a6b8dd428e71718402e97207bb3e54167d37b5708616050b1e8f60ed6"
+digest = "sha256:cf09adf8c3ebaba10779e5c23ff7fe4df4cccdab8a91f199b0c142c53fef3e1a"
 
 [[image]]
 zone = "base-arg-rust-bookworm"
@@ -43,7 +40,7 @@ registry = "dockerhub"
 repo = "library/debian"
 image_ref = "debian"
 tag = "trixie-slim"
-digest = "sha256:f6e2cfac5cf956ea044b4bd75e6397b4372ad88fe00908045e9a0d21712ae3ba"
+digest = "sha256:4e401d95de7083948053197a9c3913343cd06b706bf15eb6a0c3ccd26f436a0e"
 
 [[image]]
 zone = "base-arg-distroless"
@@ -52,4 +49,4 @@ registry = "gcr"
 repo = "distroless/cc-debian13"
 image_ref = "gcr.io/distroless/cc-debian13"
 tag = "nonroot"
-digest = "sha256:84fcd3c223b144b0cb6edc5ecc75641819842a9679a3a58fd6294bec47532bf7"
+digest = "sha256:d3cda6e91129130d7229a1806b6a73d292ef245ab032da7851907798024cefba"

--- a/dev/ci/container-base-images.toml
+++ b/dev/ci/container-base-images.toml
@@ -1,0 +1,55 @@
+# Canonical container base-image pins for the generated container surfaces
+# (Dockerfile, Dockerfile.debian). Source of truth: edit tag/registry/repo here.
+# `cargo generate installers` resolves the live digest from the registry, writes
+# tag+digest back into this file, and renders the generated ARG zones in the
+# surfaces from it.
+#
+# A row with no human-set `tag` is discovered live from the registry (node:
+# highest <major>-bookworm-slim on Docker Hub). StageX pins in the Containerfile
+# are excluded on purpose: digest-only, reproducible-build intent, no tag to follow.
+
+[[image]]
+zone = "base-arg-node"
+arg = "ZEROCLAW_BASE_NODE"
+registry = "dockerhub"
+repo = "library/node"
+image_ref = "node"
+discover = true
+tag = "24-bookworm-slim"
+digest = "sha256:2c87ef9bd3c6a3bd4b472b4bec2ce9d16354b0c574f736c476489d09f560a203"
+
+[[image]]
+zone = "base-arg-rust-slim"
+arg = "ZEROCLAW_BASE_RUST_SLIM"
+registry = "dockerhub"
+repo = "library/rust"
+image_ref = "rust"
+tag = "1.94-slim"
+digest = "sha256:da9dab7a6b8dd428e71718402e97207bb3e54167d37b5708616050b1e8f60ed6"
+
+[[image]]
+zone = "base-arg-rust-bookworm"
+arg = "ZEROCLAW_BASE_RUST_BOOKWORM"
+registry = "dockerhub"
+repo = "library/rust"
+image_ref = "rust"
+tag = "1.94-bookworm"
+digest = "sha256:6ae102bdbf528294bc79ad6e1fae682f6f7c2a6e6621506ba959f9685b308a55"
+
+[[image]]
+zone = "base-arg-debian"
+arg = "ZEROCLAW_BASE_DEBIAN"
+registry = "dockerhub"
+repo = "library/debian"
+image_ref = "debian"
+tag = "trixie-slim"
+digest = "sha256:f6e2cfac5cf956ea044b4bd75e6397b4372ad88fe00908045e9a0d21712ae3ba"
+
+[[image]]
+zone = "base-arg-distroless"
+arg = "ZEROCLAW_BASE_DISTROLESS"
+registry = "gcr"
+repo = "distroless/cc-debian13"
+image_ref = "gcr.io/distroless/cc-debian13"
+tag = "nonroot"
+digest = "sha256:84fcd3c223b144b0cb6edc5ecc75641819842a9679a3a58fd6294bec47532bf7"

--- a/xtask/src/generate/container_base.rs
+++ b/xtask/src/generate/container_base.rs
@@ -1,0 +1,376 @@
+use anyhow::Context;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use std::time::Duration;
+
+const SOURCE: &str = "dev/ci/container-base-images.toml";
+const NODE_SUITE: &str = "bookworm-slim";
+const INDEX_ACCEPT: &str = "application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json";
+
+#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum Registry {
+    DockerHub,
+    Gcr,
+}
+
+impl Registry {
+    fn host(self) -> &'static str {
+        match self {
+            Registry::DockerHub => "registry-1.docker.io",
+            Registry::Gcr => "gcr.io",
+        }
+    }
+
+    fn token_url(self, repo: &str) -> String {
+        match self {
+            Registry::DockerHub => format!(
+                "https://auth.docker.io/token?service=registry.docker.io&scope=repository:{repo}:pull"
+            ),
+            Registry::Gcr => {
+                format!("https://gcr.io/v2/token?service=gcr.io&scope=repository:{repo}:pull")
+            }
+        }
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+struct BaseImage {
+    zone: String,
+    arg: String,
+    registry: Registry,
+    repo: String,
+    image_ref: String,
+    #[serde(default, skip_serializing_if = "is_false")]
+    discover: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    tag: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    digest: Option<String>,
+}
+
+fn is_false(b: &bool) -> bool {
+    !*b
+}
+
+#[derive(Serialize, Deserialize)]
+struct Source {
+    image: Vec<BaseImage>,
+}
+
+fn load(root: &Path) -> anyhow::Result<Source> {
+    let raw =
+        std::fs::read_to_string(root.join(SOURCE)).with_context(|| format!("read {SOURCE}"))?;
+    toml::from_str(&raw).with_context(|| format!("parse {SOURCE}"))
+}
+
+fn client() -> anyhow::Result<reqwest::blocking::Client> {
+    reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()
+        .context("build http client")
+}
+
+#[derive(Deserialize)]
+struct Token {
+    token: String,
+}
+
+#[derive(Deserialize)]
+struct TagPage {
+    results: Vec<TagEntry>,
+    next: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct TagEntry {
+    name: String,
+}
+
+fn discover_node_tag(client: &reqwest::blocking::Client, repo: &str) -> anyhow::Result<String> {
+    let mut best: Option<u32> = None;
+    let mut url = Some(format!(
+        "https://hub.docker.com/v2/repositories/{repo}/tags?page_size=100&name={NODE_SUITE}"
+    ));
+    while let Some(next) = url.take() {
+        let page: TagPage = client
+            .get(&next)
+            .send()
+            .context("node tag list request")?
+            .error_for_status()
+            .context("node tag list status")?
+            .json()
+            .context("parse node tag list")?;
+        for t in &page.results {
+            if let Some(major) = node_major_for_suite(&t.name) {
+                best = Some(best.map_or(major, |b| b.max(major)));
+            }
+        }
+        url = page.next;
+    }
+    let major = best.context("registry returned no <major>-bookworm-slim node tag")?;
+    Ok(format!("{major}-{NODE_SUITE}"))
+}
+
+fn node_major_for_suite(tag: &str) -> Option<u32> {
+    tag.strip_suffix(&format!("-{NODE_SUITE}"))
+        .filter(|m| !m.is_empty() && m.chars().all(|c| c.is_ascii_digit()))
+        .and_then(|m| m.parse::<u32>().ok())
+}
+
+fn resolve_digest(
+    client: &reqwest::blocking::Client,
+    registry: Registry,
+    repo: &str,
+    tag: &str,
+) -> anyhow::Result<String> {
+    let token: Token = client
+        .get(registry.token_url(repo))
+        .send()
+        .with_context(|| format!("{repo}: registry auth request"))?
+        .error_for_status()
+        .with_context(|| format!("{repo}: registry auth status"))?
+        .json()
+        .with_context(|| format!("{repo}: parse registry token"))?;
+    let resp = client
+        .head(format!(
+            "https://{}/v2/{repo}/manifests/{tag}",
+            registry.host()
+        ))
+        .bearer_auth(&token.token)
+        .header(reqwest::header::ACCEPT, INDEX_ACCEPT)
+        .send()
+        .with_context(|| format!("{repo}:{tag}: manifest head request"))?
+        .error_for_status()
+        .with_context(|| format!("{repo}:{tag}: manifest head status"))?;
+    let digest = resp
+        .headers()
+        .get("docker-content-digest")
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_string)
+        .with_context(|| format!("{repo}:{tag}: registry returned no Docker-Content-Digest"))?;
+    if !valid_digest(&digest) {
+        anyhow::bail!("{repo}:{tag}: unexpected digest form: {digest}");
+    }
+    Ok(digest)
+}
+
+fn valid_digest(digest: &str) -> bool {
+    digest
+        .strip_prefix("sha256:")
+        .is_some_and(|hex| hex.len() == 64 && hex.chars().all(|c| c.is_ascii_hexdigit()))
+}
+
+fn arg_line(img: &BaseImage, tag: &str, digest: &str) -> String {
+    format!("ARG {}={}:{}@{}", img.arg, img.image_ref, tag, digest)
+}
+
+fn begin(zone: &str) -> String {
+    format!("# >>> generated:{zone} from {SOURCE} by `cargo generate installers` - do not edit <<<")
+}
+
+fn end(zone: &str) -> String {
+    format!("# >>> end generated:{zone} <<<")
+}
+
+fn zone_body(current: &str, zone: &str) -> Option<String> {
+    let b = begin(zone);
+    let e = end(zone);
+    let start = current.find(&b)? + b.len();
+    let rel = current[start..].find(&e)?;
+    Some(current[start..start + rel].trim().to_string())
+}
+
+fn splice(current: &str, zone: &str, body: &str) -> anyhow::Result<String> {
+    let b = begin(zone);
+    let e = end(zone);
+    let begin_at = current
+        .find(&b)
+        .with_context(|| format!("missing generated:{zone} BEGIN sentinel"))?;
+    let after_begin = begin_at + b.len();
+    let end_rel = current[after_begin..]
+        .find(&e)
+        .with_context(|| format!("missing generated:{zone} END sentinel"))?;
+    let end_at = after_begin + end_rel;
+    Ok(format!(
+        "{}\n{}\n{}",
+        &current[..after_begin],
+        body,
+        &current[end_at..]
+    ))
+}
+
+/// Resolve every row live and persist tag+digest back into the canonical TOML so
+/// it stays the single source the surfaces render from.
+pub fn refresh_source(root: &Path) -> anyhow::Result<()> {
+    let client = client()?;
+    let mut src = load(root)?;
+    for img in &mut src.image {
+        let tag = if img.discover {
+            discover_node_tag(&client, &img.repo)?
+        } else {
+            img.tag
+                .clone()
+                .with_context(|| format!("{}: non-discover row must set a tag", img.zone))?
+        };
+        let digest = resolve_digest(&client, img.registry, &img.repo, &tag)?;
+        img.tag = Some(tag);
+        img.digest = Some(digest);
+    }
+    let rendered = render_source(&src)?;
+    std::fs::write(root.join(SOURCE), rendered).with_context(|| format!("write {SOURCE}"))?;
+    Ok(())
+}
+
+fn render_source(src: &Source) -> anyhow::Result<String> {
+    toml::to_string_pretty(src).context("serialize source")
+}
+
+/// Splice the ARG zones each surface declares, sourced from the canonical TOML.
+/// Network-free: the TOML already carries the resolved tag+digest.
+pub fn splice_zones(root: &Path, current: &str) -> anyhow::Result<String> {
+    let src = load(root)?;
+    let mut out = current.to_string();
+    for img in &src.image {
+        if !current.contains(&begin(&img.zone)) {
+            continue;
+        }
+        let (tag, digest) = resolved(img)?;
+        out = splice(&out, &img.zone, &arg_line(img, tag, digest))?;
+    }
+    Ok(out)
+}
+
+fn resolved(img: &BaseImage) -> anyhow::Result<(&str, &str)> {
+    let tag = img.tag.as_deref().with_context(|| {
+        format!(
+            "{}: TOML missing resolved tag; run `cargo generate installers`",
+            img.zone
+        )
+    })?;
+    let digest = img.digest.as_deref().with_context(|| {
+        format!(
+            "{}: TOML missing resolved digest; run `cargo generate installers`",
+            img.zone
+        )
+    })?;
+    Ok((tag, digest))
+}
+
+/// Network-free drift check: every declared ARG zone must match what the TOML
+/// says, the TOML must carry a resolved tag+digest, and node's tag must be a
+/// plain-major LTS-suite tag. A `FROM ${ARG}` with no zone is flagged.
+pub fn check(root: &Path, current: &str) -> anyhow::Result<Vec<String>> {
+    let src = load(root)?;
+    let mut drift = Vec::new();
+    for img in &src.image {
+        let references = current.contains(&format!("${{{}}}", img.arg));
+        let declares = current.contains(&begin(&img.zone));
+        if references && !declares {
+            drift.push(format!(
+                "{} (FROM references ${} but zone is gone)",
+                img.zone, img.arg
+            ));
+            continue;
+        }
+        if !declares {
+            continue;
+        }
+        let (tag, digest) = match resolved(img) {
+            Ok(v) => v,
+            Err(e) => {
+                drift.push(e.to_string());
+                continue;
+            }
+        };
+        if img.discover && node_major_for_suite(tag).is_none() {
+            drift.push(format!(
+                "{}: node tag {tag} is not <major>-{NODE_SUITE}",
+                img.zone
+            ));
+        }
+        if !valid_digest(digest) {
+            drift.push(format!("{}: malformed digest {digest}", img.zone));
+        }
+        match zone_body(current, &img.zone) {
+            Some(body) if body == arg_line(img, tag, digest) => {}
+            _ => drift.push(img.zone.clone()),
+        }
+    }
+    Ok(drift)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn root() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .to_path_buf()
+    }
+
+    fn fixed(zone: &str) -> BaseImage {
+        BaseImage {
+            zone: zone.to_string(),
+            arg: "ZEROCLAW_TEST".to_string(),
+            registry: Registry::DockerHub,
+            repo: "library/rust".to_string(),
+            image_ref: "rust".to_string(),
+            discover: false,
+            tag: Some("1.94-slim".to_string()),
+            digest: Some(format!("sha256:{}", "a".repeat(64))),
+        }
+    }
+
+    #[test]
+    fn source_parses_and_node_is_discover() {
+        let src = load(&root()).unwrap();
+        let node = src
+            .image
+            .iter()
+            .find(|i| i.zone == "base-arg-node")
+            .unwrap();
+        assert!(node.discover, "node tag must be discovered live");
+        assert!(src.image.iter().any(|i| i.zone == "base-arg-rust-slim"));
+    }
+
+    #[test]
+    fn node_major_for_suite_accepts_plain_major() {
+        assert_eq!(node_major_for_suite("24-bookworm-slim"), Some(24));
+        assert_eq!(node_major_for_suite("26-bookworm-slim"), Some(26));
+    }
+
+    #[test]
+    fn node_major_for_suite_rejects_non_plain_major() {
+        assert_eq!(node_major_for_suite("24.1-bookworm-slim"), None);
+        assert_eq!(node_major_for_suite("lts-bookworm-slim"), None);
+        assert_eq!(node_major_for_suite("24-alpine"), None);
+        assert_eq!(node_major_for_suite("-bookworm-slim"), None);
+    }
+
+    #[test]
+    fn valid_digest_shape() {
+        assert!(valid_digest(&format!("sha256:{}", "a".repeat(64))));
+        assert!(!valid_digest(&format!("sha256:{}", "a".repeat(10))));
+        assert!(!valid_digest("md5:abc"));
+    }
+
+    #[test]
+    fn arg_line_round_trips_through_zone_body() {
+        let img = fixed("base-arg-test");
+        let (tag, digest) = resolved(&img).unwrap();
+        let line = arg_line(&img, tag, digest);
+        let content = format!("{}\n{line}\n{}\n", begin(&img.zone), end(&img.zone));
+        assert_eq!(zone_body(&content, &img.zone).unwrap(), line);
+    }
+
+    #[test]
+    fn check_flags_orphan_reference() {
+        let content = "FROM ${ZEROCLAW_BASE_RUST_SLIM} AS x\n";
+        let drift = check(&root(), content).unwrap();
+        assert!(drift.iter().any(|d| d.contains("base-arg-rust-slim")));
+    }
+}

--- a/xtask/src/generate/container_base.rs
+++ b/xtask/src/generate/container_base.rs
@@ -222,8 +222,16 @@ pub fn refresh_source(root: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
+const SOURCE_HEADER: &str = "# Canonical container base-image pins for the generated container surfaces\n\
+# (Dockerfile, Dockerfile.debian). Edit registry/repo/image_ref/tag here; `tag`\n\
+# and `digest` are rewritten live by `cargo generate installers`. A row with\n\
+# discover=true resolves its tag live from the registry (node: highest\n\
+# <major>-bookworm-slim on Docker Hub). StageX pins in the Containerfile are\n\
+# excluded on purpose: digest-only, reproducible-build intent, no tag to follow.\n\n";
+
 fn render_source(src: &Source) -> anyhow::Result<String> {
-    toml::to_string_pretty(src).context("serialize source")
+    let body = toml::to_string_pretty(src).context("serialize source")?;
+    Ok(format!("{SOURCE_HEADER}{body}"))
 }
 
 /// Splice the ARG zones each surface declares, sourced from the canonical TOML.

--- a/xtask/src/generate/mod.rs
+++ b/xtask/src/generate/mod.rs
@@ -5,6 +5,7 @@
 //! one table so adding one is data, not control flow.
 
 pub mod container;
+pub mod container_base;
 pub mod docker_tags;
 pub mod flake;
 pub mod install_sh;
@@ -83,7 +84,8 @@ fn registry() -> Vec<Surface> {
 /// heavyweight), build-time overridable via --build-arg.
 fn render_docker_arg(root: &Path, current: &str) -> anyhow::Result<String> {
     let body = container::render_features_arg(root, &Sel::Dist)?;
-    container::splice(current, "docker-features-arg", &body)
+    let spliced = container::splice(current, "docker-features-arg", &body)?;
+    container_base::splice_zones(root, &spliced)
 }
 
 /// Containerfile surface: standard image ships Dist (all channels, no
@@ -128,6 +130,10 @@ pub fn run(targets: &[String], check: bool) -> anyhow::Result<()> {
 
     let root = workspace_root();
     let mut drift = false;
+
+    if !check {
+        container_base::refresh_source(&root)?;
+    }
 
     for s in selected {
         let path = root.join(s.file);


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Container base-image pins were hand maintained inline in each Dockerfile, so a Docker Hub repush of `node:24-bookworm-slim` orphaned the by-digest pin and broke clean builds with `manifest unknown` (reported on Discord). rust/debian/distroless pins had silently drifted the same way.
  - Introduce `dev/ci/container-base-images.toml` as the single source of truth for every generated container surface. `cargo generate installers` resolves each pin live from the registry, writes the resolved tag and digest back into the TOML, and renders the generated `ARG` zones in the surfaces from it. The Dockerfiles now use `FROM ${ZEROCLAW_BASE_*}`.
  - Node is not pinned by hand and not derived from any local file. Its row carries `discover = true`; the tag is resolved live from Docker Hub as the highest `<major>-bookworm-slim`. Live regeneration moved it `24` -> `26-bookworm-slim` at the current digest (satisfies `web/package.json` node `>=24`).
  - The `--check` drift gate is network-free: it validates that each declared `ARG` zone matches the TOML and that the TOML carries a resolved tag and digest, with node's tag validated by shape (`<major>-bookworm-slim`).
- **Scope boundary:** Covers `Dockerfile` and `Dockerfile.debian` (the surfaces in the generate registry). `Dockerfile.ci` and `dev/ci/Dockerfile` are hand-maintained and out of scope. StageX pins in the `Containerfile` are intentionally left inline: digest-only, reproducible-build intent, no upstream tag to follow. No application code changes.
- **Blast radius:** Container build only. The generator's write path makes new network calls to the registry; the `--check` path used by CI does not.
- **Linked issue(s):** Related to the Discord `manifest unknown` report.
- **Labels:** `risk: low`, `type: ci`, `size: M`.

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy -p xtask --all-targets -- -D warnings
cargo test -p xtask container_base
cargo run -p xtask --bin generate -- installers dockerfile dockerfile-debian          # live
cargo run -p xtask --bin generate -- installers dockerfile dockerfile-debian --check   # offline
docker buildx build --target web-node -f Dockerfile .
docker buildx build --target web-node -f Dockerfile.debian .
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` -> clean (exit 0).
  - `cargo clippy -p xtask --all-targets -- -D warnings` -> clean (exit 0).
  - `cargo test -p xtask container_base` -> `test result: ok. 6 passed; 0 failed`. All tests are offline (finish in 0.00s; none make an HTTP call).
  - Live generate -> `wrote Dockerfile`, `wrote Dockerfile.debian`; node resolved `24` -> `26-bookworm-slim`, rust/debian/distroless digests refreshed to current registry values. Second run -> `unchanged` (idempotent).
  - `--check` -> `ok: dockerfile in sync`, `ok: dockerfile-debian in sync`, network-free (skips the registry refresh).
- **Beyond CI — what did you manually verify?** Live `docker buildx` (buildx 0.34.1, dockerd 29.5.2) against the generated pins:
  - `docker buildx build --target web-node -f Dockerfile .` -> **EXIT 0**. Log shows `load metadata for docker.io/library/node:26-bookworm-slim@sha256:4e2e85a8...` and `[web-node 1/1] FROM docker.io/library/node:26-bookworm-slim@sha256:4e2e85a8...` — the generated ARG/digest pulled and the stage built.
  - `docker buildx build --target web-node -f Dockerfile.debian .` -> **EXIT 0**, same node:26 pin resolved and built.
  - `docker manifest inspect` on the other four generated pins all resolve from the registry by digest: `rust:1.94-slim@sha256:cf09adf8...`, `rust:1.94-bookworm@sha256:6ae102bd...`, `debian:trixie-slim@sha256:4e401d95...`, `gcr.io/distroless/cc-debian13:nonroot@sha256:d3cda6e9...`.
  - Confirmed the canonical TOML header survives regeneration and that the TOML, both Dockerfiles, and the live registry all agree on node `26` at the same digest.
  - Not verified: a full release-stage build to completion (builder/release stages compile the entire workspace; out of scope for pin validation). `docker build --check` under the non-buildx daemon still rejects the pre-existing `--parents` labs flag (present on master); buildx honors the `1.7-labs` frontend and builds the node stage cleanly.
- **If any command was intentionally skipped, why:** Full-workspace `cargo test` not rerun here; the change is confined to `xtask` generation and two generated files, exercised by the xtask suite and the live/offline generate runs above.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `Yes` — the generator's write path resolves digests from Docker Hub and gcr.io (anonymous pull tokens, public images). The `--check` path used by CI makes no network call.
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No` — the `ZEROCLAW_BASE_*` build args remain overridable via `--build-arg`.
- Upgrade steps: none.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk: `git revert` the two commits restores the inline pins.
