### PR TITLE
fix(gateway): make agent rename re-issue converge after post-persist partial failure (#7907)

### DIFF
--- a/crates/zeroclaw-gateway/src/api.rs
+++ b/crates/zeroclaw-gateway/src/api.rs
@@ -1910,6 +1910,11 @@ pub async fn handle_claude_code_hook(
     Json(serde_json::json!({ "ok": true }))
 }
 
+// Shared test helper: `api_config` tests reuse this AppState builder for the
+// agent rename/delete cascade handlers (#7907 regression coverage).
+#[cfg(test)]
+pub(crate) use tests::test_state;
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2075,7 +2080,7 @@ mod tests {
         config
     }
 
-    fn test_state(config: zeroclaw_config::schema::Config) -> AppState {
+    pub(crate) fn test_state(config: zeroclaw_config::schema::Config) -> AppState {
         AppState {
             config: Arc::new(RwLock::new(config)),
             model_provider: Arc::new(MockModelProvider),

--- a/crates/zeroclaw-gateway/src/api_config.rs
+++ b/crates/zeroclaw-gateway/src/api_config.rs
@@ -1562,22 +1562,44 @@ async fn rename_agent_cascade(
     for path in &report.dirty_paths {
         working.mark_dirty(path);
     }
+    // Compute the NEW workspace path off the rewritten config now, before
+    // `working` is moved into `persist_and_swap` below. Both paths are owned
+    // `PathBuf`s that outlive the move.
+    let new_ws = working.agent_workspace_dir(to);
+    let dirty_count = report.dirty_paths.len();
+
+    // Persist the config rename FIRST (#7907). Previously the workspace move and
+    // owned-state cascade ran *before* this durable write, so a persist failure
+    // after them left config still naming `from` while the workspace + owned
+    // stores had already moved to `to` — the inverse split-brain of what #7841
+    // fixed. Persisting first means an early failure here leaves config,
+    // workspace, and owned state all consistently on `from`: a clean abort
+    // (`persist_and_swap` reverts the on-disk file and never swaps `state.config`).
+    if let Err(e) = persist_and_swap(state, working).await {
+        return error_response(e);
+    }
+
+    // Config is now durably `to` and authoritative in `state.config`. Run the
+    // external side-effects against the committed config (read a short-lived
+    // clone — never hold the lock guard across an `.await`). Each side-effect is
+    // best-effort and surfaced as a warning; persist-first makes them all
+    // idempotently re-runnable from the corrected config (the workspace move
+    // early-returns once the source is gone; every owned-store op re-points by
+    // `WHERE agent_alias = from`), so re-issuing the same rename converges.
+    let cfg = state.config.read().clone();
 
     // Move the workspace dir. For the default per-alias location this is
     // `<install>/agents/<from>/workspace` → `…/<to>/workspace`. A custom
     // workspace path is alias-independent, so `old_ws == new_ws` and we skip.
-    // A failed move is surfaced (like the owned-DB failures below), not just
-    // logged — otherwise config+DB point at `to` while the workspace is stranded
-    // at `from` and the caller sees a clean success.
-    let new_ws = working.agent_workspace_dir(to);
+    let ws_existed = old_ws != new_ws && old_ws.exists();
     let move_warning = move_renamed_workspace(&old_ws, &new_ws).await;
-    let workspace_moved = old_ws != new_ws && old_ws.exists() && move_warning.is_none();
+    let workspace_moved = ws_existed && move_warning.is_none();
     let mut warnings: Vec<String> = Vec::new();
     warnings.extend(move_warning);
 
     // Re-point owned DB state (memory/cron/acp/session). Best-effort + reported.
     let owned = crate::agent_owned_state::cascade_rename_agent(
-        &working,
+        &cfg,
         &state.mem,
         state.session_backend.as_ref(),
         from,
@@ -1587,15 +1609,20 @@ async fn rename_agent_cascade(
     // Combine the workspace-move warning (if any) with the owned-store warnings
     // so every partial failure reaches the caller, not just the server log.
     warnings.extend(owned.warnings);
-    ::zeroclaw_log::record!(INFO, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(::serde_json::json!({"from": from, "to": to, "memory": owned.memory_rows, "cron": owned.cron_jobs, "acp": owned.acp_sessions, "sessions": owned.sessions_repointed, "workspace_moved": workspace_moved, "dirty_paths": report.dirty_paths.len(), "warnings": warnings})), "agent renamed with owned-state cascade");
 
-    if let Err(e) = persist_and_swap(state, working).await {
-        return error_response(e);
+    // The config rename committed. A non-empty `warnings` means a post-persist
+    // side-effect did not follow (config is `to`, some follower lags at `from`,
+    // re-runnable) — escalate to WARN so that degraded outcome is visible
+    // operationally instead of buried at INFO.
+    if warnings.is_empty() {
+        ::zeroclaw_log::record!(INFO, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(::serde_json::json!({"from": from, "to": to, "memory": owned.memory_rows, "cron": owned.cron_jobs, "acp": owned.acp_sessions, "sessions": owned.sessions_repointed, "workspace_moved": workspace_moved, "dirty_paths": dirty_count})), "agent renamed with owned-state cascade");
+    } else {
+        ::zeroclaw_log::record!(WARN, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(::serde_json::json!({"from": from, "to": to, "memory": owned.memory_rows, "cron": owned.cron_jobs, "acp": owned.acp_sessions, "sessions": owned.sessions_repointed, "workspace_moved": workspace_moved, "dirty_paths": dirty_count, "warnings": warnings})), "agent rename persisted but a post-persist side-effect did not follow; re-issue the rename to converge");
     }
-    // Config rename complete and persisted. `warnings` is non-empty only if a
-    // partial step (the workspace move, or an owned store) did NOT follow —
-    // surface it to the caller (not just the server log) so the split can be
-    // remediated, rather than reporting a clean success.
+
+    // Persisted rename. `warnings` carries any post-persist side-effect that did
+    // not follow, so the split can be remediated rather than reported as a clean
+    // success (207-style partial success).
     axum::Json(RenameMapKeyResponse {
         path: body.path.clone(),
         from: from.clone(),
@@ -2348,6 +2375,148 @@ mod tests {
         assert!(move_renamed_workspace(&old_ws, &old_ws).await.is_none());
         let missing = tmp.path().join("does-not-exist");
         assert!(move_renamed_workspace(&missing, &new_ws).await.is_none());
+    }
+
+    /// #7907: when config persistence FAILS, the agent rename must not have
+    /// moved any owned state. Pre-fix the workspace move + owned-state cascade
+    /// ran *before* `persist_and_swap`, so a persist failure left config naming
+    /// `from` while the workspace and owned stores had moved to `to` (the
+    /// inverse split-brain). Persist-first means an early failure leaves config,
+    /// workspace, and owned state all consistently on `from`.
+    #[tokio::test]
+    async fn agent_rename_leaves_owned_state_put_when_persist_fails() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Force config persistence to FAIL by making `config_path` itself a
+        // directory — save_dirty's atomic write can't replace a dir. Its parent
+        // (the install root) stays a real dir, so the agent-workspace creation
+        // and the cron seed below still work. data_dir is separate + writable.
+        let cfg_dir = tmp.path().join("config.toml");
+        std::fs::create_dir_all(&cfg_dir).unwrap();
+        let mut config = zeroclaw_config::schema::Config {
+            config_path: cfg_dir,
+            data_dir: tmp.path().join("data"),
+            ..Default::default()
+        };
+        std::fs::create_dir_all(&config.data_dir).unwrap();
+        // Agent under `from` with a resolvable risk_profile + an allowed cron
+        // command, so cron::add_job accepts a job tied to the agent.
+        let from_agent = zeroclaw_config::schema::AliasedAgentConfig {
+            risk_profile: "default".into(),
+            ..Default::default()
+        };
+        config.agents.insert("from".to_string(), from_agent);
+        config
+            .risk_profiles
+            .entry("default".into())
+            .or_default()
+            .allowed_commands = vec!["echo".into()];
+        config.runtime_profiles.entry("default".into()).or_default();
+
+        // Seed an owned-state row (a cron job) under `from` — the move-probe.
+        zeroclaw_runtime::cron::add_job(&config, "from", "* * * * *", "echo hi")
+            .expect("seed cron job");
+        assert_eq!(
+            zeroclaw_runtime::cron::list_jobs_by_agent(&config, "from")
+                .unwrap()
+                .len(),
+            1
+        );
+
+        let state = crate::api::test_state(config.clone());
+        let body = RenameMapKeyBody {
+            path: "agents".to_string(),
+            from: "from".to_string(),
+            to: "to".to_string(),
+        };
+        let resp = rename_agent_cascade(&state, config.clone(), &body).await;
+
+        // Persist failed -> error response, not a clean rename.
+        assert!(
+            !resp.status().is_success(),
+            "a failed config persist must surface an error"
+        );
+        // Owned state did NOT move: the cron job stays under `from`.
+        assert_eq!(
+            zeroclaw_runtime::cron::list_jobs_by_agent(&config, "from")
+                .unwrap()
+                .len(),
+            1,
+            "cron must stay under `from` when persist fails (no premature move)"
+        );
+        assert!(
+            zeroclaw_runtime::cron::list_jobs_by_agent(&config, "to")
+                .unwrap()
+                .is_empty(),
+            "cron must NOT have moved to `to` when persist fails"
+        );
+        // In-memory config was never swapped: still names `from`.
+        assert!(state.config.read().agents.contains_key("from"));
+        assert!(!state.config.read().agents.contains_key("to"));
+    }
+
+    /// #7907 happy path: when persist SUCCEEDS, owned state moves to `to` — so
+    /// the reorder didn't accidentally skip the side-effects.
+    #[tokio::test]
+    async fn agent_rename_moves_owned_state_after_successful_persist() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut config = zeroclaw_config::schema::Config {
+            config_path: tmp.path().join("config.toml"), // writable -> persist OK
+            data_dir: tmp.path().join("data"),
+            ..Default::default()
+        };
+        std::fs::create_dir_all(&config.data_dir).unwrap();
+        // Agent under `from` with a resolvable risk_profile + an allowed cron
+        // command, so cron::add_job accepts a job tied to the agent.
+        let from_agent = zeroclaw_config::schema::AliasedAgentConfig {
+            risk_profile: "default".into(),
+            ..Default::default()
+        };
+        config.agents.insert("from".to_string(), from_agent);
+        config
+            .risk_profiles
+            .entry("default".into())
+            .or_default()
+            .allowed_commands = vec!["echo".into()];
+        config.runtime_profiles.entry("default".into()).or_default();
+        // Create the agent's default workspace dir so the move has something to move.
+        let old_ws = config.agent_workspace_dir("from");
+        std::fs::create_dir_all(&old_ws).unwrap();
+        zeroclaw_runtime::cron::add_job(&config, "from", "* * * * *", "echo hi")
+            .expect("seed cron job");
+
+        let state = crate::api::test_state(config.clone());
+        let body = RenameMapKeyBody {
+            path: "agents".to_string(),
+            from: "from".to_string(),
+            to: "to".to_string(),
+        };
+        let resp = rename_agent_cascade(&state, config.clone(), &body).await;
+        assert!(resp.status().is_success(), "a clean rename returns success");
+
+        // Config swapped to `to`.
+        assert!(state.config.read().agents.contains_key("to"));
+        assert!(!state.config.read().agents.contains_key("from"));
+        // Cron re-pointed to `to` — the move happened, after a successful persist.
+        assert_eq!(
+            zeroclaw_runtime::cron::list_jobs_by_agent(&config, "to")
+                .unwrap()
+                .len(),
+            1,
+            "cron moves to `to` once persist succeeds"
+        );
+        assert!(
+            zeroclaw_runtime::cron::list_jobs_by_agent(&config, "from")
+                .unwrap()
+                .is_empty()
+        );
+        // Workspace moved to the new alias path.
+        assert!(
+            state.config.read().agent_workspace_dir("to").exists(),
+            "workspace moved to `to`"
+        );
+        assert!(!old_ws.exists(), "old workspace no longer present");
+        // (MockMemory.rename_agent is unsupported, so the response `warnings`
+        // carries that one known memory line — cron + workspace prove the move.)
     }
 
     #[test]

--- a/crates/zeroclaw-gateway/src/api_config.rs
+++ b/crates/zeroclaw-gateway/src/api_config.rs
@@ -1555,9 +1555,46 @@ async fn rename_agent_cascade(
     // (custom paths are read off the entry, which is about to move).
     let old_ws = working.agent_workspace_dir(from);
 
-    let report = match alias_refs::rename_with_cascade(&mut working, &AliasKind::Agent, from, to) {
-        Ok(r) => r,
-        Err(e) => return rename_error_response(&body.path, from, e),
+    // RESUME-AFTER-PARTIAL-FAILURE (#7907 review feedback): the prior
+    // persist-first fix left a partial-failure window where config is durably
+    // `to` while workspace / owned stores still lag at `from`. The handler's
+    // own WARN log told the operator to "re-issue the rename to converge" —
+    // but the API rejected that retry with `RenameError::NotFound` before any
+    // side-effect could run (the source alias is gone from the committed
+    // config). Detect that post-persist split-brain HERE, at the API entry,
+    // and short-circuit `rename_with_cascade` so the same request converges
+    // by running ONLY the side-effects. `working` is replaced with the
+    // post-swap config from `state.config` so the rest of the path (which
+    // reads `working.agent_workspace_dir(to)` etc.) sees a consistent view.
+    let mut resumed = false;
+    let report = if !working.agents.contains_key(from) && working.agents.contains_key(to) {
+        // RESUME-AFTER-PARTIAL-FAILURE (#7907 review feedback): the prior
+        // persist-first fix left a partial-failure window where config is
+        // durably `to` while workspace / owned stores still lag at `from`.
+        // The handler's own WARN log told the operator to "re-issue the
+        // rename to converge" — but the API rejected that retry because
+        // `rename_map_key` either NotFound-ed on `from` or InvalidName-ed
+        // on `to already exists`, before any side-effect could run. Detect
+        // that post-persist split-brain HERE, at the API entry, and
+        // short-circuit `rename_with_cascade` so the same request converges
+        // by running ONLY the side-effects. `working` is replaced with the
+        // post-swap config from `state.config` so the rest of the path
+        // (which reads `working.agent_workspace_dir(to)` etc.) sees a
+        // consistent view. `RenameReport` is empty because the in-memory
+        // rewrite already happened on the prior call.
+        working = state.config.read().clone();
+        resumed = true;
+        zeroclaw_config::alias_refs::RenameReport {
+            target_kind: zeroclaw_config::alias_refs::AliasKind::Agent,
+            old_alias: from.to_string(),
+            new_alias: to.to_string(),
+            dirty_paths: Vec::new(),
+        }
+    } else {
+        match alias_refs::rename_with_cascade(&mut working, &AliasKind::Agent, from, to) {
+            Ok(r) => r,
+            Err(e) => return rename_error_response(&body.path, from, e),
+        }
     };
     for path in &report.dirty_paths {
         working.mark_dirty(path);
@@ -1575,6 +1612,11 @@ async fn rename_agent_cascade(
     // fixed. Persisting first means an early failure here leaves config,
     // workspace, and owned state all consistently on `from`: a clean abort
     // (`persist_and_swap` reverts the on-disk file and never swaps `state.config`).
+    //
+    // On the resume path the config is already committed to `to` from the
+    // prior call, so `persist_and_swap` is a no-op write of the same state —
+    // we still call it for symmetry so the success/failure branch below
+    // doesn't need to special-case `resumed`.
     if let Err(e) = persist_and_swap(state, working).await {
         return error_response(e);
     }
@@ -1582,15 +1624,20 @@ async fn rename_agent_cascade(
     // Config is now durably `to` and authoritative in `state.config`. Run the
     // external side-effects against the committed config (read a short-lived
     // clone — never hold the lock guard across an `.await`). Each side-effect is
-    // best-effort and surfaced as a warning; persist-first makes them all
-    // idempotently re-runnable from the corrected config (the workspace move
-    // early-returns once the source is gone; every owned-store op re-points by
-    // `WHERE agent_alias = from`), so re-issuing the same rename converges.
+    // best-effort and surfaced as a warning. Re-issuing the same rename
+    // converges because the resume detection above skips `rename_with_cascade`
+    // and re-runs the side-effects against the corrected config (the workspace
+    // move early-returns once the source is gone; every owned-store op
+    // re-points by `WHERE agent_alias = from`).
     let cfg = state.config.read().clone();
 
     // Move the workspace dir. For the default per-alias location this is
     // `<install>/agents/<from>/workspace` → `…/<to>/workspace`. A custom
     // workspace path is alias-independent, so `old_ws == new_ws` and we skip.
+    // On the resume path `old_ws` was resolved from the original `working`
+    // BEFORE the resume short-circuit replaced it; if the prior call already
+    // moved the workspace, `old_ws.exists()` is false and this is a no-op
+    // (idempotent). Same for the owned-state cascade below.
     let ws_existed = old_ws != new_ws && old_ws.exists();
     let move_warning = move_renamed_workspace(&old_ws, &new_ws).await;
     let workspace_moved = ws_existed && move_warning.is_none();
@@ -1613,16 +1660,20 @@ async fn rename_agent_cascade(
     // The config rename committed. A non-empty `warnings` means a post-persist
     // side-effect did not follow (config is `to`, some follower lags at `from`,
     // re-runnable) — escalate to WARN so that degraded outcome is visible
-    // operationally instead of buried at INFO.
+    // operationally instead of buried at INFO. On the resume path the
+    // side-effects are intentionally re-run; the WARN reflects whether the
+    // resume was fully successful.
     if warnings.is_empty() {
-        ::zeroclaw_log::record!(INFO, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(::serde_json::json!({"from": from, "to": to, "memory": owned.memory_rows, "cron": owned.cron_jobs, "acp": owned.acp_sessions, "sessions": owned.sessions_repointed, "workspace_moved": workspace_moved, "dirty_paths": dirty_count})), "agent renamed with owned-state cascade");
+        ::zeroclaw_log::record!(INFO, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(::serde_json::json!({"from": from, "to": to, "memory": owned.memory_rows, "cron": owned.cron_jobs, "acp": owned.acp_sessions, "sessions": owned.sessions_repointed, "workspace_moved": workspace_moved, "dirty_paths": dirty_count, "resumed": resumed})), "agent renamed with owned-state cascade");
     } else {
-        ::zeroclaw_log::record!(WARN, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(::serde_json::json!({"from": from, "to": to, "memory": owned.memory_rows, "cron": owned.cron_jobs, "acp": owned.acp_sessions, "sessions": owned.sessions_repointed, "workspace_moved": workspace_moved, "dirty_paths": dirty_count, "warnings": warnings})), "agent rename persisted but a post-persist side-effect did not follow; re-issue the rename to converge");
+        ::zeroclaw_log::record!(WARN, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(::serde_json::json!({"from": from, "to": to, "memory": owned.memory_rows, "cron": owned.cron_jobs, "acp": owned.acp_sessions, "sessions": owned.sessions_repointed, "workspace_moved": workspace_moved, "dirty_paths": dirty_count, "resumed": resumed, "warnings": warnings})), "agent rename persisted but a post-persist side-effect did not follow; re-issue the rename to converge");
     }
 
     // Persisted rename. `warnings` carries any post-persist side-effect that did
     // not follow, so the split can be remediated rather than reported as a clean
-    // success (207-style partial success).
+    // success (207-style partial success). `renamed: true` reflects the config
+    // commit (which may have happened on a prior call) — `resumed` (logged)
+    // distinguishes the first-call vs resume-call paths.
     axum::Json(RenameMapKeyResponse {
         path: body.path.clone(),
         from: from.clone(),
@@ -2517,6 +2568,121 @@ mod tests {
         assert!(!old_ws.exists(), "old workspace no longer present");
         // (MockMemory.rename_agent is unsupported, so the response `warnings`
         // carries that one known memory line — cron + workspace prove the move.)
+    }
+
+    /// #7907 review feedback (Audacity88 / WareWolf-MoonWall / singlerider):
+    /// the prior persist-first fix left a partial-failure window where the
+    /// config rename was durable but a post-persist side-effect (workspace
+    /// move, owned-DB cascade) had not followed. The handler's own WARN log
+    /// told the operator to "re-issue the rename to converge" — but the API
+    /// rejected the retry with `RenameError::NotFound` because the source
+    /// alias is gone from the committed config. This test forces that exact
+    /// split-brain state (config durably `to`, workspace + cron still at
+    /// `from`) and proves the resume-aware path now converges the side-
+    /// effects on the second call.
+    #[tokio::test]
+    async fn agent_rename_reissue_converges_post_persist_partial_failure() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut config = zeroclaw_config::schema::Config {
+            config_path: tmp.path().join("config.toml"),
+            data_dir: tmp.path().join("data"),
+            ..Default::default()
+        };
+        std::fs::create_dir_all(&config.data_dir).unwrap();
+        // Agent under `from` with a resolvable risk_profile + an allowed cron
+        // command, so cron::add_job accepts a job tied to the agent.
+        let from_agent = zeroclaw_config::schema::AliasedAgentConfig {
+            risk_profile: "default".into(),
+            ..Default::default()
+        };
+        config.agents.insert("from".to_string(), from_agent);
+        config
+            .risk_profiles
+            .entry("default".into())
+            .or_default()
+            .allowed_commands = vec!["echo".into()];
+        config.runtime_profiles.entry("default".into()).or_default();
+        let old_ws = config.agent_workspace_dir("from");
+        std::fs::create_dir_all(&old_ws).unwrap();
+        zeroclaw_runtime::cron::add_job(&config, "from", "* * * * *", "echo hi")
+            .expect("seed cron job");
+
+        let state = crate::api::test_state(config.clone());
+        let body = RenameMapKeyBody {
+            path: "agents".to_string(),
+            from: "from".to_string(),
+            to: "to".to_string(),
+        };
+
+        // ── Simulate the post-persist split-brain: commit the config rename
+        // (so config durably says `to`) but DO NOT move the workspace or
+        // re-point the cron row. This is exactly the state a partially-failed
+        // first call would leave behind.
+        working_simulation_to(&mut config, "from", "to");
+        let persist_cfg = config.clone();
+        let _ = persist_and_swap(&state, persist_cfg).await;
+        // Sanity: config is now durably `to` and the source alias is gone.
+        assert!(state.config.read().agents.contains_key("to"));
+        assert!(!state.config.read().agents.contains_key("from"));
+        // Cron row and workspace are still at `from` (no side-effect ran).
+        assert_eq!(
+            zeroclaw_runtime::cron::list_jobs_by_agent(&config, "from")
+                .unwrap()
+                .len(),
+            1,
+            "precondition: cron row still at `from` (no side-effect ran)"
+        );
+        assert!(
+            old_ws.exists(),
+            "precondition: workspace still at `from` (no side-effect ran)"
+        );
+
+        // ── Re-issue the same rename. Pre-fix the API would 4xx with
+        // `RenameError::NotFound` at `rename_map_key`. The resume-aware
+        // path detects `from`-absent + `to`-present in the entry
+        // `working` and short-circuits straight to the side-effects.
+        let resp = rename_agent_cascade(&state, config.clone(), &body).await;
+        assert!(
+            resp.status().is_success(),
+            "re-issuing the same rename must converge (200 OK), not 4xx"
+        );
+
+        // ── Convergence assertions: workspace + cron now on `to`, nothing on
+        // `from`. The split-brain is healed by the second call.
+        assert!(
+            state.config.read().agent_workspace_dir("to").exists(),
+            "workspace converged to `to` on resume"
+        );
+        assert!(
+            !old_ws.exists(),
+            "old workspace no longer present after resume"
+        );
+        assert_eq!(
+            zeroclaw_runtime::cron::list_jobs_by_agent(&config, "to")
+                .unwrap()
+                .len(),
+            1,
+            "cron converged to `to` on resume"
+        );
+        assert!(
+            zeroclaw_runtime::cron::list_jobs_by_agent(&config, "from")
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    /// Helper: simulate the post-persist config-rename shape that
+    /// `rename_with_cascade` would leave on a partially-failed first call.
+    /// Re-runs the same in-memory rewrite + dirty-mark the production code
+    /// would have done, but stops short of moving the workspace or touching
+    /// owned-DB state — i.e. the split-brain we want to recover from.
+    fn working_simulation_to(working: &mut zeroclaw_config::schema::Config, from: &str, to: &str) {
+        use zeroclaw_config::alias_refs::{self, AliasKind};
+        let report = alias_refs::rename_with_cascade(working, &AliasKind::Agent, from, to)
+            .expect("simulation: in-memory rename succeeds");
+        for path in &report.dirty_paths {
+            working.mark_dirty(path);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Base: `master` (commit `74a806943`)
- Problem: PR #7940 (Nillth) fixed the rename split-brain by reordering persist-first. Reviewers (Audacity88 / WareWolf-MoonWall / singlerider) all flagged one residual blocker: the new WARN log told the operator to "re-issue the rename to converge", but the API rejected the retry with `RenameError::NotFound` (or `InvalidName "alias \`to\` already exists"`, depending on which side of the commit) before any side-effect could run. There was no working recovery path.
- Why: `rename_map_key` is the in-memory rewrite + dirty-marker that the persist-first contract relies on. When the source alias is already gone from the committed config (post-persist) OR the destination alias is already present (same state from the other side), the rewrite refuses. The handler then returns 4xx and the side-effects never run.
- What changed: at the API entry of `rename_agent_cascade`, detect the post-persist split-brain state (`from`-absent + `to`-present in `working.agents`). On that state, short-circuit `rename_with_cascade` with an empty `RenameReport`, adopt the committed config from `state.config`, and proceed straight to the side-effects (workspace move + `cascade_rename_agent`). The second call now converges the split-brain deterministically. `resumed: bool` is added to the WARN/INFO log attrs.
- Out of scope: the `MapKeyResponse::warnings` field on the delete path (PR #8017, #7941) is a sibling fix, separate PR.

## Label Snapshot
- Risk: medium
- Size: S
- Scope: gateway
- Module: config / agents
- Contributor tier: trusted (5+ PRs once this lands)

## Change Metadata
- Type: fix
- Primary scope: crates/zeroclaw-gateway/src/

## Linked Issue
Closes #7907
Related: #7941 (the delete-direction mirror; PR #8017 fixes it)

## Supersede Attribution
Built on top of Nillth's `b9bb21877` (cherry-picked into this branch, author amended to mine). Nillth's original commit remains the bulk of the work; this PR adds the resume-aware path + a third regression test that the reviewers asked for. If the maintainer prefers one combined PR, I can squash on request.

## Validation Evidence
```bash
$ cargo fmt --all -- --check
(no output — clean)
$ cargo clippy --locked -p zeroclaw-gateway --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 13.47s
$ cargo test --locked -p zeroclaw-gateway --lib
test result: ok. 266 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
$ cargo test --locked -p zeroclaw-gateway --lib api_config::tests::agent_rename
test api_config::tests::agent_rename_leaves_owned_state_put_when_persist_fails ... ok
test api_config::tests::agent_rename_reissue_converges_post_persist_partial_failure ... ok
test api_config::tests::agent_rename_moves_owned_state_after_successful_persist ... ok
test result: ok. 3 passed; 0 failed
```

## Real behavior proof

- **Behavior addressed**: a second `POST /api/config/rename-map-key` request with the same `from`/`to` after a post-persist partial failure must now (a) succeed (200 OK), not 4xx, and (b) converge the split-brain: the workspace and cron row move from `from` to `to` on the second call.
- **Real environment tested**: Linux x86_64, Rust 1.94, zeroclaw 0.8.1 / master @ `74a806943`.
- **Exact steps run after this patch**:
  - `cargo test --locked -p zeroclaw-gateway --lib api_config::tests::agent_rename` (3 tests, all green)
  - `cargo test --locked -p zeroclaw-gateway --lib` (full crate lib tests, 266 passed)
  - `cargo clippy --locked -p zeroclaw-gateway --all-targets -- -D warnings` (clean)
  - `cargo fmt --all -- --check` (clean)
- **Evidence after fix**:
  ```
  test api_config::tests::agent_rename_leaves_owned_state_put_when_persist_fails ... ok
  test api_config::tests::agent_rename_reissue_converges_post_persist_partial_failure ... ok
  test api_config::tests::agent_rename_moves_owned_state_after_successful_persist ... ok
  test result: ok. 3 passed; 0 failed
  ```
  The new test seeds the exact post-persist split-brain state that the reviewers described (config durably `to`, workspace + cron still at `from`), then re-issues the rename and asserts the second call (a) returns 200 OK, (b) moves the workspace to `to`, (c) re-points the cron row to `to`, (d) leaves `from` empty. Uses real `rusqlite` cron probes (not mocks).
- **Observed result after fix**: the second call converges the split-brain. The `resumed: true` attr in the INFO/WARN log line lets operators distinguish first-call from resume-call paths.
- **What was not tested**: the test suite does not exercise the actual HTTP handler endpoint — it calls the `rename_agent_cascade` function directly with a constructed `AppState`. The HTTP layer is a thin axum wrapper; the cascade logic the reviewers called out is fully covered.

## Security Impact
- Permissions: no new permission checks. `require_auth` upstream is unchanged.
- Network calls: none added.
- Secrets: none touched.
- File access: workspace move + owned-DB cascade are the same operations as before, just now also reachable via the resume path. The resume path does NOT skip these operations; it re-runs them against the committed config.

## Privacy and Data Hygiene
- No new data is written outside the existing workspace-rename + owned-DB-rename paths.
- The `resumed` boolean is logged at INFO (or WARN if any side-effect fails) — it does not surface in the response body, so it is not externally observable.

## Compatibility / Migration
- Response shape: unchanged. The handler still returns `RenameMapKeyResponse { path, from, to, renamed: true, warnings }` — the resume path sets `renamed: true` (the config IS renamed, just on a prior call) and an empty `warnings` once the side-effects converge. The new `resumed` attr is internal to the log line.
- API contract: the resume path returns 200 OK where the prior version would have returned 4xx. This is strictly an improvement (the operator's documented recovery path now actually works).
- Migration: none required for clients.

## i18n Follow-Through
No user-visible string changes.

## Human Verification
- Ran `cargo test --locked -p zeroclaw-gateway --lib` locally — 266 passed, 0 failed.
- Inspected the diff manually: the resume-detection block sits BEFORE the `rename_with_cascade` call. When triggered, it (a) replaces `working` with the post-swap config from `state.config`, (b) constructs an empty `RenameReport`, (c) sets `resumed = true`, and (d) skips the rewrite. The subsequent `persist_and_swap` is a no-op write of the same state. The side-effect block then runs unchanged.

## Side Effects / Blast Radius
- The `resumed` field is added to the JSON log attrs (not to the response). Operators scraping the JSON log lines will see a new key. The `tracing`/`zeroclaw_log` schemas allow this.
- The persist-and-swap call on the resume path is a no-op write of the same state. It is intentionally kept (instead of being short-circuited) so the success / failure branch downstream of `persist_and_swap` doesn't need to special-case `resumed`.

## Agent Collaboration Notes
- This PR is built on top of Nillth's `b9bb21877` (cherry-picked + author-amended). If the maintainer prefers a single combined PR (Nillth's reorder + this resume path + the regression test), I can squash on request — but I left them separate so the resume-path commit is clearly attributable to this PR.
- The `test_state` visibility change in `api.rs` (`pub(crate) use tests::test_state;` + `pub(crate) fn test_state`) was already part of Nillth's `b9bb21877` and is preserved in the parent commit. PR #8017 (#7941, delete cascade) also adds the same visibility change. If both PRs land, the second one's visibility change is a no-op (the symbol is already `pub(crate)`); rebase is trivial.

## Rollback Plan
- Revert the resume commit (`93bf326f9`). The parent commit (`6dd265a2e`, Nillth's reorder) and the prior `2eb0059ae` form the same state as the current PR #7940 — i.e. reverting this PR returns to "persist-first but no recovery path", which is the state PR #7940 is in today.
- No feature flag involved.

## Risks and Mitigations
- **Risk**: the resume detection could trigger on a *legitimate* rename where the operator created `to` in parallel (config has both `from` AND `to` via a different code path). Mitigation: the detection only triggers when `from` is absent. A normal "rename" request never has `from` absent in the input config; the only way to reach the detection is via a re-issue after a prior successful commit. Confirmed by reading all `working.agents.insert(...)` / `rename_map_key` call sites — none of them produce the `(from-absent, to-present)` shape from a fresh state.
- **Risk**: the resume path silently succeeds even if the operator wanted to re-issue a different rename (e.g. typos `to` in the second call). Mitigation: the second call's `to` is what the operator typed. The `renamed: true` response means "config is `to`" (true on both fresh and resume paths). The `resumed` log attr is the operator's signal that this was a convergence call, not a fresh rename.
- **Risk**: the resume path re-runs the owned-DB cascade on a store that has already been updated by a prior partial-failure call. Mitigation: `cascade_rename_agent` uses `WHERE agent_alias = from` re-points; if `from` has no rows (prior call succeeded), it is a no-op. Same for the workspace move (`if !old_ws.exists() { return None; }`). Both side-effects are idempotent against the split-brain state.
