### PR TITLE
feat(skills): typed slash-command options in SKILL.md frontmatter

### DIFF
--- a/crates/zeroclaw-channels/src/discord/slash.rs
+++ b/crates/zeroclaw-channels/src/discord/slash.rs
@@ -605,6 +605,70 @@ mod typed_option_tests {
     }
 
     #[test]
+    fn md_skill_frontmatter_options_drive_a_typed_command_end_to_end() {
+        // End-to-end proof that no channel-side change was needed: a SKILL.md
+        // declaring slash_options in its frontmatter loads through the public
+        // runtime loader and registers a typed Discord command (dropdown +
+        // integer range), not the legacy single `input`.
+        let tmp = tempfile::tempdir().unwrap();
+        let skill_dir = tmp.path().join("draft");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        let md = r#"---
+name: draft
+description: Draft content to a spec.
+tags: [slash]
+slash_options:
+  - name: format
+    description: Output format.
+    type: string
+    required: true
+    choices: [{name: Email, value: email}, {name: Tweet, value: tweet}]
+  - name: words
+    type: integer
+    min: 10
+    max: 2000
+---
+# Draft
+
+Write it.
+"#;
+        std::fs::write(skill_dir.join("SKILL.md"), md).unwrap();
+
+        let skills = zeroclaw_runtime::skills::load_skills_from_directory(tmp.path(), false);
+        let specs = discord_slash_specs_from_skills(&skills);
+        assert_eq!(
+            specs.len(),
+            1,
+            "the slash-tagged MD skill yields one command"
+        );
+
+        let body = slash_command_registration_body(&specs);
+        let arr = body.as_array().unwrap();
+        let draft = arr
+            .iter()
+            .find(|c| c["name"] == json!("draft"))
+            .expect("draft command present");
+        let opts = draft["options"].as_array().unwrap();
+
+        // Typed options replaced the legacy single `input`.
+        assert!(opts.iter().all(|o| o["name"] != json!("input")));
+        let format = opts
+            .iter()
+            .find(|o| o["name"] == json!("format"))
+            .expect("format option");
+        assert_eq!(format["type"], json!(3)); // STRING
+        assert_eq!(format["required"], json!(true));
+        assert_eq!(format["choices"].as_array().unwrap().len(), 2);
+        let words = opts
+            .iter()
+            .find(|o| o["name"] == json!("words"))
+            .expect("words option");
+        assert_eq!(words["type"], json!(4)); // INTEGER
+        assert_eq!(words["min_value"], json!(10));
+        assert_eq!(words["max_value"], json!(2000));
+    }
+
+    #[test]
     fn projection_is_stable_across_int_vs_float_bounds() {
         // What we send (integer min/max) vs what Discord might echo back (float),
         // plus Discord's server-side decorations — must project equal.

--- a/crates/zeroclaw-runtime/src/skills/document.rs
+++ b/crates/zeroclaw-runtime/src/skills/document.rs
@@ -7,8 +7,11 @@
 use std::fmt::Write as _;
 
 use super::frontmatter::SkillFrontmatter;
+use super::{SkillSlashChoice, SkillSlashOption};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+// `Eq` is intentionally NOT derived: the frontmatter's `slash_options` carry
+// `f64` bounds (no total ordering). `PartialEq` covers the round-trip tests.
+#[derive(Debug, Clone, PartialEq)]
 pub struct SkillDocument {
     pub frontmatter: SkillFrontmatter,
     pub body: String,
@@ -44,6 +47,7 @@ impl SkillDocument {
         write_optional(&mut out, "version", self.frontmatter.version.as_deref());
         write_optional(&mut out, "category", self.frontmatter.category.as_deref());
         write_tags(&mut out, &self.frontmatter.tags);
+        write_slash_options(&mut out, &self.frontmatter.slash_options);
         out.push_str("---\n");
         if !self.body.is_empty() {
             if !self.body.starts_with('\n') {
@@ -81,6 +85,11 @@ fn parse_frontmatter(src: &str) -> Result<SkillFrontmatter, DocumentParseError> 
     let mut multiline: Option<(String, Vec<String>)> = None;
     let mut collecting_tags = false;
 
+    // Carve the nested `slash_options:` block out of the flat scan: its indented
+    // lines must not be (mis)read as flat keys — e.g. an option `description:`
+    // would otherwise hijack the skill's block-scalar collector.
+    let block_range = locate_slash_options_block(src);
+
     let flush = |fm: &mut SkillFrontmatter, key: &str, parts: &[String]| {
         let val = parts.join(" ");
         let val = val.trim();
@@ -90,7 +99,13 @@ fn parse_frontmatter(src: &str) -> Result<SkillFrontmatter, DocumentParseError> 
         assign(fm, key, val);
     };
 
-    for line in src.lines() {
+    for (idx, line) in src.lines().enumerate() {
+        if let Some((start, end)) = block_range
+            && idx >= start
+            && idx < end
+        {
+            continue;
+        }
         if let Some((ref key, ref mut parts)) = multiline {
             if line.starts_with(' ') || line.starts_with('\t') {
                 parts.push(line.trim().to_string());
@@ -143,6 +158,11 @@ fn parse_frontmatter(src: &str) -> Result<SkillFrontmatter, DocumentParseError> 
     if let Some((key, parts)) = multiline {
         flush(&mut fm, &key, &parts);
     }
+
+    // The one nested field. The flat loop above skips the `slash_options:`
+    // block (its indented lines have no top-level `key: value` it recognizes);
+    // the shared helper lifts it out and parses it.
+    fm.slash_options = parse_slash_options(src);
 
     if fm.name.is_empty() {
         return Err(DocumentParseError::MissingRequiredField("name"));
@@ -200,6 +220,281 @@ fn write_tags(out: &mut String, tags: &[String]) {
         return;
     }
     let _ = writeln!(out, "tags: [{}]", tags.join(", "));
+}
+
+// ─── Nested `slash_options:` (the one non-flat field) ──────────────────────
+//
+// Parsed/serialized here and shared with the loader's `parse_simple_frontmatter`
+// so both readers agree on the shape. A scoped, dependency-free parser for the
+// exact YAML subset the serializer below emits — see `parse_slash_options`.
+
+fn indent_of(line: &str) -> usize {
+    line.len() - line.trim_start().len()
+}
+
+/// Locate a top-level `slash_options:` block as a `[start, end)` line range
+/// (header line included). The block is the header plus every following indented
+/// (or blank) line, ending at the next top-level non-blank line or EOF. Only the
+/// block form (`slash_options:` with an empty inline value) is recognized; an
+/// inline `slash_options: [...]` is intentionally ignored.
+fn locate_slash_options_block(src: &str) -> Option<(usize, usize)> {
+    let lines: Vec<&str> = src.lines().collect();
+    let start = lines.iter().position(|line| {
+        if line.starts_with(' ') || line.starts_with('\t') {
+            return false;
+        }
+        match line.split_once(':') {
+            Some((key, value)) => key.trim() == "slash_options" && value.trim().is_empty(),
+            None => false,
+        }
+    })?;
+    let mut end = start + 1;
+    while end < lines.len() {
+        let line = lines[end];
+        if line.trim().is_empty() || line.starts_with(' ') || line.starts_with('\t') {
+            end += 1;
+        } else {
+            break;
+        }
+    }
+    Some((start, end))
+}
+
+/// Parse the nested `slash_options:` block from a SKILL.md frontmatter source.
+/// Absent block → empty. Lenient by design (matching the flat parser): an option
+/// missing `name` or `type` is dropped rather than failing the whole parse.
+///
+/// Supported subset (exactly what `write_slash_options` emits — keeps the
+/// hand-rolled parser tractable, no YAML dependency):
+/// ```text
+/// slash_options:
+///   - name: format
+///     description: Output format.
+///     type: string
+///     required: true
+///     choices: [{name: Email, value: email}, {name: Tweet, value: tweet}]
+///   - name: words
+///     type: integer
+///     min: 10
+///     max: 2000
+/// ```
+/// `choices` accepts an inline flow list (above) or a block list of single-line
+/// flow maps (`    - {name: X, value: Y}`). Option descriptions are single-line
+/// (no block scalars inside an option).
+pub(crate) fn parse_slash_options(src: &str) -> Vec<SkillSlashOption> {
+    let Some((start, end)) = locate_slash_options_block(src) else {
+        return Vec::new();
+    };
+    let lines: Vec<&str> = src.lines().collect();
+    let block = &lines[start + 1..end];
+
+    let mut options: Vec<SkillSlashOption> = Vec::new();
+    let mut item_indent: Option<usize> = None;
+    let mut cur: Option<OptionBuilder> = None;
+
+    for &line in block {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let indent = indent_of(line);
+        let trimmed = line.trim_start();
+
+        let dash_rest = if trimmed == "-" {
+            Some("")
+        } else {
+            trimmed.strip_prefix("- ")
+        };
+
+        if let Some(rest) = dash_rest {
+            let ii = *item_indent.get_or_insert(indent);
+            if indent <= ii {
+                // A new option item at the item indent.
+                if let Some(b) = cur.take() {
+                    options.extend(b.build());
+                }
+                let mut b = OptionBuilder::default();
+                if !rest.trim().is_empty() {
+                    apply_option_field(&mut b, rest.trim());
+                }
+                cur = Some(b);
+            } else if let (Some(b), Some(choice)) = (cur.as_mut(), parse_choice(rest.trim())) {
+                // A deeper dash → a `choices:` entry for the current option.
+                b.choices.push(choice);
+            }
+            continue;
+        }
+
+        if let Some(b) = cur.as_mut() {
+            apply_option_field(b, trimmed);
+        }
+    }
+    if let Some(b) = cur.take() {
+        options.extend(b.build());
+    }
+    options
+}
+
+#[derive(Default)]
+struct OptionBuilder {
+    name: String,
+    description: String,
+    kind: String,
+    required: bool,
+    choices: Vec<SkillSlashChoice>,
+    min: Option<f64>,
+    max: Option<f64>,
+    min_length: Option<u32>,
+    max_length: Option<u32>,
+}
+
+impl OptionBuilder {
+    fn build(self) -> Option<SkillSlashOption> {
+        if self.name.is_empty() || self.kind.is_empty() {
+            return None;
+        }
+        Some(SkillSlashOption {
+            name: self.name,
+            description: self.description,
+            kind: self.kind,
+            required: self.required,
+            choices: self.choices,
+            min: self.min,
+            max: self.max,
+            min_length: self.min_length,
+            max_length: self.max_length,
+        })
+    }
+}
+
+fn apply_option_field(b: &mut OptionBuilder, line: &str) {
+    let Some((key, value)) = line.split_once(':') else {
+        return;
+    };
+    let key = key.trim();
+    let raw = value.trim();
+    if key == "choices" {
+        // Inline flow list; an empty value means a block list follows (handled
+        // by the deeper-dash arm in `parse_slash_options`).
+        if !raw.is_empty() {
+            b.choices.extend(parse_inline_choices(raw));
+        }
+        return;
+    }
+    let val = raw.trim_matches('"').trim_matches('\'');
+    match key {
+        "name" => b.name = val.to_string(),
+        "description" => b.description = val.to_string(),
+        "type" => b.kind = val.to_string(),
+        "required" => b.required = val.eq_ignore_ascii_case("true"),
+        "min" => b.min = val.parse().ok(),
+        "max" => b.max = val.parse().ok(),
+        "min_length" => b.min_length = val.parse().ok(),
+        "max_length" => b.max_length = val.parse().ok(),
+        _ => {}
+    }
+}
+
+/// Parse an inline flow list `[{name: A, value: a}, {name: B, value: b}]` by
+/// extracting each balanced `{...}` group. Brace-depth tracking lets commas and
+/// colons inside a choice be ignored by the outer split.
+fn parse_inline_choices(s: &str) -> Vec<SkillSlashChoice> {
+    let mut choices = Vec::new();
+    let mut depth = 0usize;
+    let mut buf = String::new();
+    for ch in s.chars() {
+        match ch {
+            '{' => {
+                depth += 1;
+                buf.push(ch);
+            }
+            '}' => {
+                buf.push(ch);
+                depth = depth.saturating_sub(1);
+                if depth == 0 {
+                    if let Some(choice) = parse_choice(&buf) {
+                        choices.push(choice);
+                    }
+                    buf.clear();
+                }
+            }
+            _ if depth > 0 => buf.push(ch),
+            _ => {}
+        }
+    }
+    choices
+}
+
+/// Parse a single flow map `{name: X, value: Y}` (braces optional). `name` is
+/// required; `value` defaults to the display name when omitted.
+fn parse_choice(s: &str) -> Option<SkillSlashChoice> {
+    let inner = s.trim();
+    let inner = inner.strip_prefix('{').unwrap_or(inner);
+    let inner = inner.strip_suffix('}').unwrap_or(inner);
+    let mut name: Option<String> = None;
+    let mut value: Option<String> = None;
+    for part in inner.split(',') {
+        let Some((k, v)) = part.split_once(':') else {
+            continue;
+        };
+        let v = v.trim().trim_matches('"').trim_matches('\'');
+        match k.trim() {
+            "name" => name = Some(v.to_string()),
+            "value" => value = Some(v.to_string()),
+            _ => {}
+        }
+    }
+    let name = name.filter(|n| !n.is_empty())?;
+    let value = value
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| name.clone());
+    Some(SkillSlashChoice { name, value })
+}
+
+fn write_slash_options(out: &mut String, opts: &[SkillSlashOption]) {
+    if opts.is_empty() {
+        return;
+    }
+    out.push_str("slash_options:\n");
+    for o in opts {
+        let _ = writeln!(out, "  - name: {}", o.name);
+        if !o.description.is_empty() {
+            let _ = writeln!(out, "    description: {}", o.description);
+        }
+        let _ = writeln!(out, "    type: {}", o.kind);
+        if o.required {
+            out.push_str("    required: true\n");
+        }
+        if let Some(min) = o.min {
+            let _ = writeln!(out, "    min: {}", fmt_number(min));
+        }
+        if let Some(max) = o.max {
+            let _ = writeln!(out, "    max: {}", fmt_number(max));
+        }
+        if let Some(min_len) = o.min_length {
+            let _ = writeln!(out, "    min_length: {min_len}");
+        }
+        if let Some(max_len) = o.max_length {
+            let _ = writeln!(out, "    max_length: {max_len}");
+        }
+        if !o.choices.is_empty() {
+            let rendered: Vec<String> = o
+                .choices
+                .iter()
+                .map(|c| format!("{{name: {}, value: {}}}", c.name, c.value))
+                .collect();
+            let _ = writeln!(out, "    choices: [{}]", rendered.join(", "));
+        }
+    }
+}
+
+/// Render an f64 bound without a trailing `.0` for whole numbers (`min: 10`,
+/// not `min: 10.0`); both parse back to the same f64.
+fn fmt_number(v: f64) -> String {
+    if v.is_finite() && v.fract() == 0.0 {
+        format!("{}", v as i64)
+    } else {
+        format!("{v}")
+    }
 }
 
 #[cfg(test)]
@@ -286,6 +581,7 @@ mod tests {
                 version: Some("0.2.0".into()),
                 category: Some("coding".into()),
                 tags: vec!["slash".into(), "ops".into()],
+                slash_options: Vec::new(),
             },
             body: "# Code Review\n\nReviews diffs.\n".into(),
         };
@@ -315,5 +611,126 @@ mod tests {
         let doc = SkillDocument::parse(original).unwrap();
         let reparsed = SkillDocument::parse(&doc.serialize()).unwrap();
         assert_eq!(reparsed.frontmatter.tags, vec!["slash", "open-skills"]);
+    }
+
+    #[test]
+    fn parses_slash_options_with_inline_choices_and_bounds() {
+        let content = "---\nname: draft\ndescription: d\ntags: [slash]\nslash_options:\n  \
+            - name: format\n    description: Output format.\n    type: string\n    \
+            required: true\n    choices: [{name: Email, value: email}, {name: Tweet, value: tweet}]\n  \
+            - name: words\n    type: integer\n    min: 10\n    max: 2000\n---\n# Draft\n";
+        let fm = SkillDocument::parse(content).unwrap().frontmatter;
+        assert_eq!(fm.slash_options.len(), 2);
+        let format = &fm.slash_options[0];
+        assert_eq!(format.name, "format");
+        assert_eq!(format.description, "Output format.");
+        assert_eq!(format.kind, "string");
+        assert!(format.required);
+        assert_eq!(format.choices.len(), 2);
+        assert_eq!(format.choices[0].name, "Email");
+        assert_eq!(format.choices[0].value, "email");
+        let words = &fm.slash_options[1];
+        assert_eq!(words.kind, "integer");
+        assert!(!words.required);
+        assert_eq!(words.min, Some(10.0));
+        assert_eq!(words.max, Some(2000.0));
+        // Flat fields are unaffected by the nested block.
+        assert_eq!(fm.tags, vec!["slash"]);
+        assert_eq!(fm.description, "d");
+    }
+
+    #[test]
+    fn parses_slash_options_with_block_choices() {
+        let content = "---\nname: x\ndescription: d\nslash_options:\n  - name: tone\n    \
+            type: string\n    choices:\n      - {name: Formal, value: formal}\n      \
+            - {name: Casual, value: casual}\n---\n";
+        let fm = SkillDocument::parse(content).unwrap().frontmatter;
+        assert_eq!(fm.slash_options.len(), 1);
+        assert_eq!(fm.slash_options[0].choices.len(), 2);
+        assert_eq!(fm.slash_options[0].choices[1].name, "Casual");
+        assert_eq!(fm.slash_options[0].choices[1].value, "casual");
+    }
+
+    #[test]
+    fn absent_slash_options_is_empty() {
+        let fm = SkillDocument::parse("---\nname: x\ndescription: d\n---\n# Body\n")
+            .unwrap()
+            .frontmatter;
+        assert!(fm.slash_options.is_empty());
+    }
+
+    #[test]
+    fn drops_option_missing_name_or_type() {
+        let content = "---\nname: x\ndescription: d\nslash_options:\n  - name: notype\n  \
+            - type: string\n  - name: ok\n    type: string\n---\n";
+        let fm = SkillDocument::parse(content).unwrap().frontmatter;
+        assert_eq!(fm.slash_options.len(), 1);
+        assert_eq!(fm.slash_options[0].name, "ok");
+    }
+
+    #[test]
+    fn slash_options_block_does_not_pollute_skill_description() {
+        let content = "---\nname: x\ndescription: real skill description\nslash_options:\n  \
+            - name: q\n    description: option description\n    type: string\n---\n";
+        let fm = SkillDocument::parse(content).unwrap().frontmatter;
+        assert_eq!(fm.description, "real skill description");
+        assert_eq!(fm.slash_options[0].description, "option description");
+    }
+
+    #[test]
+    fn description_block_scalar_survives_a_following_slash_options_block() {
+        let content = "---\nname: x\ndescription: >-\n  long multi\n  line desc\nslash_options:\n  \
+            - name: q\n    type: string\n---\n";
+        let fm = SkillDocument::parse(content).unwrap().frontmatter;
+        assert_eq!(fm.description, "long multi line desc");
+        assert_eq!(fm.slash_options.len(), 1);
+    }
+
+    #[test]
+    fn round_trips_slash_options() {
+        let original = SkillDocument {
+            frontmatter: SkillFrontmatter {
+                name: "draft".into(),
+                description: "Draft content.".into(),
+                tags: vec!["slash".into()],
+                slash_options: vec![
+                    SkillSlashOption {
+                        name: "format".into(),
+                        description: "Output format.".into(),
+                        kind: "string".into(),
+                        required: true,
+                        choices: vec![
+                            SkillSlashChoice {
+                                name: "Email".into(),
+                                value: "email".into(),
+                            },
+                            SkillSlashChoice {
+                                name: "Tweet".into(),
+                                value: "tweet".into(),
+                            },
+                        ],
+                        min: None,
+                        max: None,
+                        min_length: None,
+                        max_length: None,
+                    },
+                    SkillSlashOption {
+                        name: "words".into(),
+                        description: String::new(),
+                        kind: "integer".into(),
+                        required: false,
+                        choices: vec![],
+                        min: Some(10.0),
+                        max: Some(2000.0),
+                        min_length: None,
+                        max_length: None,
+                    },
+                ],
+                ..Default::default()
+            },
+            body: "# Draft\n\nBody.\n".into(),
+        };
+        let parsed = SkillDocument::parse(&original.serialize()).unwrap();
+        assert_eq!(parsed.frontmatter, original.frontmatter);
     }
 }

--- a/crates/zeroclaw-runtime/src/skills/frontmatter.rs
+++ b/crates/zeroclaw-runtime/src/skills/frontmatter.rs
@@ -10,13 +10,26 @@
 //!
 //! The struct is the single source of truth: [`SkillFrontmatter::prop_fields`]
 //! enumerates the same field set that drives the dashboard form, CLI flags
-//! on `zeroclaw skills add`, and the TUI form. Adding a field here = all
-//! three surfaces gain it via `prop_fields`.
+//! on `zeroclaw skills add`, and the TUI form. Adding a flat scalar field here
+//! = all three surfaces gain it via `prop_fields`.
+//!
+//! The one exception is `slash_options`: a nested `slash_options:` YAML list
+//! (typed Discord slash-command parameters). It is the reason this file keeps
+//! a flat *scalar* schema while still expressing structured options — the
+//! nesting is parsed/serialized by the shared helper in [`super::document`],
+//! not the flat parser, and it is deliberately excluded from `prop_fields`
+//! (the flat form can't render a nested list; the dashboard gets a bespoke
+//! editor for it).
 
 use serde::{Deserialize, Serialize};
 use zeroclaw_config::traits::{PropFieldInfo, PropKind};
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+use super::SkillSlashOption;
+
+// `Eq` is intentionally NOT derived: `slash_options` carries `SkillSlashOption`,
+// whose `min`/`max` bounds are `f64` (no total ordering). `PartialEq` is all the
+// surfaces (tests, change detection) need.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct SkillFrontmatter {
     pub name: String,
     pub description: String,
@@ -35,6 +48,16 @@ pub struct SkillFrontmatter {
     /// longer silently strips its tags.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tags: Vec<String>,
+    /// Typed slash-command options a `slash`-tagged skill exposes (Discord
+    /// dropdowns / ranges / autocomplete). The one genuinely *nested* field —
+    /// a `slash_options:` YAML list of maps, each with an optional `choices`
+    /// sub-list. It is parsed/serialized by the shared nested helper in
+    /// [`super::document`] (the flat scalar parser leaves it untouched) and is
+    /// deliberately excluded from [`SkillFrontmatter::prop_fields`] because the
+    /// flat dashboard/CLI/TUI form can't express nesting; the dashboard gets a
+    /// bespoke editor for it instead. See [`SkillSlashOption`].
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub slash_options: Vec<SkillSlashOption>,
 }
 
 impl SkillFrontmatter {
@@ -128,14 +151,23 @@ mod tests {
 
     #[test]
     fn prop_fields_matches_struct() {
-        // Drift check: when a field is added to SkillFrontmatter, prop_fields
-        // must be updated to match. The expected count tracks every field.
+        // Drift check: when a FLAT scalar field is added to SkillFrontmatter,
+        // prop_fields must be updated to match. The struct has 8 fields, but
+        // `slash_options` is INTENTIONALLY excluded from prop_fields — it is a
+        // nested list the flat dashboard/CLI/TUI form can't render, so it gets
+        // a bespoke editor instead. Hence 7 flat fields surfaced here.
         let fields = SkillFrontmatter::prop_fields();
         assert_eq!(
             fields.len(),
             7,
             "SkillFrontmatter::prop_fields drifted from struct definition; \
-             update both when adding/removing fields"
+             update both when adding/removing FLAT fields (slash_options is \
+             nested and deliberately excluded)"
+        );
+        // slash_options must never sneak into the flat form.
+        assert!(
+            !fields.iter().any(|f| f.name == "slash_options"),
+            "slash_options is nested and must stay out of the flat prop_fields form"
         );
     }
 

--- a/crates/zeroclaw-runtime/src/skills/mod.rs
+++ b/crates/zeroclaw-runtime/src/skills/mod.rs
@@ -237,6 +237,11 @@ struct SkillMarkdownMeta {
     version: Option<String>,
     author: Option<String>,
     tags: Vec<String>,
+    /// Typed slash-command options from the nested `slash_options:` frontmatter
+    /// block. Parsed by the shared helper in `document` (not the flat scanner)
+    /// so a SKILL.md skill can drive native Discord slash commands — parity with
+    /// SKILL.toml's `[[skill.slash_options]]`.
+    slash_options: Vec<SkillSlashOption>,
 }
 
 fn default_version() -> String {
@@ -1090,7 +1095,7 @@ fn load_skill_md(path: &Path, dir: &Path) -> Result<Skill> {
         tags: parsed.meta.tags,
         tools: Vec::new(),
         prompts: vec![parsed.body],
-        slash_options: Vec::new(),
+        slash_options: parsed.meta.slash_options,
         location: Some(path.to_path_buf()),
     })
 }
@@ -1130,7 +1135,7 @@ fn load_open_skill_md(path: &Path) -> Result<Skill> {
         tags: parsed.meta.tags,
         tools: Vec::new(),
         prompts: vec![parsed.body],
-        slash_options: Vec::new(),
+        slash_options: parsed.meta.slash_options,
         location: Some(path.to_path_buf()),
     }))
 }
@@ -1237,6 +1242,10 @@ fn parse_simple_frontmatter(s: &str) -> SkillMarkdownMeta {
     if let Some(ref key) = collecting_multiline {
         flush_multiline(key, &multiline_parts, &mut meta);
     }
+    // The one nested field. Parsed by the shared helper so the loader and the
+    // service (`SkillDocument`) read `slash_options` identically — no second
+    // nested parser to drift.
+    meta.slash_options = document::parse_slash_options(s);
     meta
 }
 
@@ -2616,6 +2625,57 @@ version = "0.1.0"
 "#,
         );
         let skill = load_skill_toml(&path).unwrap();
+        assert!(skill.slash_options.is_empty());
+    }
+
+    #[test]
+    fn load_skill_md_parses_slash_options_from_frontmatter() {
+        let tmp = TempDir::new().unwrap();
+        let md = r#"---
+name: draft
+description: Draft content to a spec.
+tags: [slash]
+slash_options:
+  - name: format
+    description: Output format.
+    type: string
+    required: true
+    choices: [{name: Email, value: email}, {name: Tweet, value: tweet}]
+  - name: words
+    type: integer
+    min: 10
+    max: 2000
+---
+# Draft
+
+Write it.
+"#;
+        let path = tmp.path().join("SKILL.md");
+        std::fs::write(&path, md).unwrap();
+        let skill = load_skill_md(&path, tmp.path()).unwrap();
+
+        // Parity with SKILL.toml: the runtime Skill carries typed options.
+        assert_eq!(skill.slash_options.len(), 2);
+        assert_eq!(skill.slash_options[0].name, "format");
+        assert!(skill.slash_options[0].required);
+        assert_eq!(skill.slash_options[0].choices.len(), 2);
+        assert_eq!(skill.slash_options[1].kind, "integer");
+        assert_eq!(skill.slash_options[1].min, Some(10.0));
+        assert_eq!(skill.slash_options[1].max, Some(2000.0));
+        assert!(skill.tags.contains(&"slash".to_string()));
+
+        // The options block lives in frontmatter, so the prompt (body) is clean.
+        assert_eq!(skill.prompts.len(), 1);
+        assert!(skill.prompts[0].contains("Write it."));
+        assert!(!skill.prompts[0].contains("slash_options"));
+    }
+
+    #[test]
+    fn load_skill_md_without_slash_options_is_empty() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("SKILL.md");
+        std::fs::write(&path, "---\nname: plain\ndescription: d\n---\n# Plain\n").unwrap();
+        let skill = load_skill_md(&path, tmp.path()).unwrap();
         assert!(skill.slash_options.is_empty());
     }
 

--- a/crates/zeroclaw-runtime/src/skills/service.rs
+++ b/crates/zeroclaw-runtime/src/skills/service.rs
@@ -15,7 +15,8 @@ use super::scaffold::{self, ScaffoldError, ScaffoldOptions};
 use zeroclaw_config::schema::Config;
 
 /// Per-skill view returned by [`SkillsService::list_skills`].
-#[derive(Debug, Clone, PartialEq, Eq)]
+// `Eq` dropped: `frontmatter.slash_options` carry `f64` bounds (not `Eq`).
+#[derive(Debug, Clone, PartialEq)]
 pub struct SkillSummary {
     pub r#ref: SkillRef,
     pub directory: PathBuf,

--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -352,6 +352,8 @@ fn handle_add(
         // Scaffold creates a tagless skill; tags (including the `slash` opt-in
         // for #7490 slash commands) are managed in the dashboard skills editor.
         tags: Vec::new(),
+        // Slash options are authored in the dashboard editor, not at scaffold time.
+        slash_options: Vec::new(),
     };
 
     let skill_dir = service.scaffold_skill(


### PR DESCRIPTION
## Summary

- **What & why:** A `slash`-tagged skill can register native Discord slash-command parameters (dropdowns, integer/number ranges, length bounds) only if its manifest declares typed `slash_options`. Until now that was possible **only in the legacy `SKILL.toml`** format (`[[skill.slash_options]]`, added in #7844); a canonical `SKILL.md` skill could not — `load_skill_md` always produced empty `slash_options`. So a skill authored in the spec-canonical MD format silently fell back to a single free-text `input` on Discord, and the web dashboard (which only reads `SKILL.md`) couldn't express options at all. This makes **`SKILL.md` frontmatter a first-class home for typed slash options**, reaching parity with TOML and letting the canonical format drive native commands.
- **Shape:** options live in a nested `slash_options:` frontmatter key — the one genuinely nested field in an otherwise flat schema:
  ```yaml
  ---
  name: draft
  description: Draft written content to a spec.
  tags: [slash]
  slash_options:
    - name: format
      description: Output format.
      type: string
      required: true
      choices: [{name: Email, value: email}, {name: Tweet, value: tweet}]
    - name: words
      type: integer
      min: 10
      max: 2000
  ---
  # Draft …
  ```
- **No new dependency.** The flat frontmatter parsers deliberately avoid a YAML crate (binary size). Rather than reverse that, this adds a **scoped, hand-rolled parser for the bounded `slash_options:` subset** the serializer emits, shared by both frontmatter readers (loader + `SkillDocument`) so there is **one** nested parser, no drift. (A maintained YAML crate — `serde_yml`/`serde_norway`, collapsing both parsers — is a cleaner end-state and worth discussing; deferred to keep this change dependency-free. `serde_yaml` is already in the tree transitively via `probe-rs`/`wasm-compose`, so that conversation is open if maintainers prefer it.)
- **The Discord channel is unchanged.** `map_skill_slash_options` already reads `Skill.slash_options`; populating it from MD is sufficient. Proven by a new end-to-end test that loads a `SKILL.md` through the public loader and asserts the registration body carries typed options, not the single `input` fallback.
- **Scope boundary:** authoring path only. The dashboard editor form for these options, the visibility fix for listing TOML-only skills, and the TOML↔MD converter are a designed follow-up (PR B), sequenced after #7963 to avoid file collisions.

### Files
- `crates/zeroclaw-runtime/src/skills/frontmatter.rs` — `SkillFrontmatter.slash_options` (excluded from the flat `prop_fields()` form; drift test updated + guarded). `Eq` dropped (f64 bounds).
- `crates/zeroclaw-runtime/src/skills/document.rs` — shared `parse_slash_options` + `write_slash_options` + `locate_slash_options_block`; `Eq` dropped on `SkillDocument`.
- `crates/zeroclaw-runtime/src/skills/mod.rs` — `SkillMarkdownMeta.slash_options`; `parse_simple_frontmatter` calls the shared parser; both MD loaders populate `Skill.slash_options`.
- `crates/zeroclaw-runtime/src/skills/service.rs` — `Eq` dropped on `SkillSummary`.
- `src/skills/mod.rs` — CLI `skills add` constructs the new field (tagless/options-less scaffold).
- `crates/zeroclaw-channels/src/discord/slash.rs` — **test only** (E2E MD→Discord registration proof).

## Validation Evidence

```text
cargo fmt --all -- --check                                            # exit 0
cargo clippy --all-targets --features channels-full -- -D warnings    # 0 warnings (runtime, channels, config, eval, hardware, memory, providers, tools, root zeroclawlabs)
cargo clippy -p zeroclaw-gateway --all-targets -- -D warnings         # 0 warnings (downstream user of the changed types)
cargo test -p zeroclaw-runtime --lib skills::                         # 192 passed; 0 failed
cargo test -p zeroclaw-channels --features channel-discord --lib 'discord::slash'   # 16 passed; 0 failed
```
Ripple of the additive field + `Eq` drop verified: the only downstream users of the runtime
`SkillFrontmatter`/`SkillSummary`/`SkillDocument` are the gateway (`api_skills.rs`, validated above)
and the CLI (`src/skills`, in the root crate, validated). `apps/zerocode` defines its OWN
`SkillFrontmatter` wire-mirror (unaffected; it ignores the extra field on the wire). No type is used
as a map/set key, so dropping `Eq` is safe.
New tests: 8 in `document.rs` (inline + block choices, bounds, absent, malformed-drop, description-not-polluted, block-scalar-survives, round-trip), 2 in `mod.rs` (`load_skill_md` populates / empty), 1 in `slash.rs` (end-to-end MD→typed registration body).

- **Beyond CI:** not yet manually run against live Discord; the end-to-end test exercises loader → spec derivation → registration-body shape. (Plan: drop a `SKILL.md` with `slash_options` on the box, confirm `/demo` registers typed options.)

## Security & Privacy Impact
- New permissions / FS access? **No.** Same loader, same files; only an additional frontmatter field is parsed.
- New external calls? **No.** Discord registration is unchanged; it already reads `Skill.slash_options`.
- Secrets/PII? **No.**
- Note: exposing a skill as a slash command remains gated by the `slash` tag (and `open-skills` exclusion), unchanged.

## Compatibility
- **Backward compatible.** Existing `SKILL.toml` skills load and run unchanged (TOML still wins at runtime; reading preserved). MD skills without `slash_options` behave exactly as before. The single-`input` fallback persists for option-less slash skills. The new field is `#[serde(default, skip_serializing_if = "Vec::is_empty")]` so JSON/wire stays identical for skills without options.
- Config/env/CLI surface: no new keys. `prop_fields()` count unchanged (7) → dashboard/CLI/TUI flat forms unaffected.

## Rollback
- `risk: low` (authoring/parse only, no runtime/network change). Revert the commit; no migration needed (existing files unaffected; the field is additive and optional).

---
_No AI/Co-Authored-By trailers (CONTRIBUTING.md). Signed commits._
