### PR TITLE
feat(web): themed, click-to-open config pickers + dashboard health fix-modal + storage nav fix

### DIFF
--- a/web/src/components/sections/FieldForm.tsx
+++ b/web/src/components/sections/FieldForm.tsx
@@ -39,7 +39,7 @@ import {
 } from "lucide-react";
 import DirectoryPicker from "./DirectoryPicker";
 import ToolPicker from "@/components/ToolPicker";
-import { Badge, Button, ComboBox } from "@/components/ui";
+import { Badge, Button, ComboBox, Select } from "@/components/ui";
 import type { BadgeTone } from "@/components/ui";
 import { t } from "@/lib/i18n";
 import {
@@ -570,6 +570,9 @@ const AGENT_MULTI_ALIAS_FIELDS: Record<string, keyof AgentOptionsResponse> = {
   "skill_bundles": "skill_bundles",
   "knowledge_bundles": "knowledge_bundles",
   "mcp_bundles": "mcp_bundles",
+  // Delegates is a subset of the configured agents — give it the same themed
+  // multi-select (with agent suggestions) as the bundle fields, not free text.
+  delegates: "agents",
 };
 
 // Peer-groups carry the same alias-ref shape as agents do: a single
@@ -623,6 +626,31 @@ const LEAF_SINGLE_ALIAS_FIELDS: Record<string, keyof AgentOptionsResponse> = {
 function leafSingleAliasKind(path: string): keyof AgentOptionsResponse | null {
   const leaf = path.split(".").pop() ?? "";
   return LEAF_SINGLE_ALIAS_FIELDS[leaf] ?? null;
+}
+
+// `kind:"alias-ref"` fields carry a `<Type>Ref` type_hint naming the section
+// they reference. Map it to the `resolve-alias-source` query value (the backend
+// AliasSource variants). Used to DERIVE the source when the daemon emits the
+// kind but omits `alias_source` (older builds): the generic resolver still works
+// — covering provider refs (incl. tts/transcription/classifier) that have no
+// AgentOptionsResponse list, so they get a real dropdown, not a stuck spinner.
+const ALIAS_REF_TYPE_TO_SOURCE: Record<string, string> = {
+  ModelProviderRef: "model_providers",
+  TtsProviderRef: "tts_providers",
+  TranscriptionProviderRef: "transcription_providers",
+  RiskProfileRef: "risk_profiles",
+  RuntimeProfileRef: "runtime_profiles",
+  ChannelRef: "channels",
+};
+
+// The `resolve-alias-source` query value for an alias-ref entry: prefer the
+// daemon-declared `alias_source`; else derive it from the `<Type>Ref` type_hint.
+// Returns null for non-alias-ref entries or unmapped ref types.
+function aliasRefSource(entry: ListResponseEntry): string | null {
+  if (entry.kind !== "alias-ref") return null;
+  if (entry.alias_source) return entry.alias_source;
+  const m = entry.type_hint?.match(/(\w+Ref)\b/);
+  return (m && ALIAS_REF_TYPE_TO_SOURCE[m[1] ?? ""]) ?? null;
 }
 
 // Cross-section navigation map for agent alias-ref fields. Each entry
@@ -1406,8 +1434,7 @@ function FieldRow({
   // `aliasSource` is undefined and the effect is a no-op, leaving the maps
   // above to resolve refs. When the backend does declare it, the
   // `renderer === 'alias-ref'` branch takes precedence over those maps.
-  const aliasSource =
-    entry.kind === "alias-ref" ? entry.alias_source : undefined;
+  const aliasSource = aliasRefSource(entry);
   const [aliasValues, setAliasValues] = useState<string[] | null>(null);
   useEffect(() => {
     if (!aliasSource) return;
@@ -1423,6 +1450,20 @@ function FieldRow({
       cancelled = true;
     };
   }, [aliasSource]);
+
+  // Resolve the option list for an `alias-ref` field. Prefer the resolver values
+  // (keyed off `aliasSource`, which `aliasRefSource` derives from the type_hint
+  // when the daemon omits `alias_source`); else fall back to the agent/leaf alias
+  // map (`/api/config/agent-options`). `null` = no options yet.
+  const aliasRefOptions: string[] | null =
+    aliasValues ??
+    (agentSingleAliasKind && agentOptions
+      ? (agentOptions[agentSingleAliasKind] ?? [])
+      : null);
+  // Distinguish "actively resolving" (a source IS being fetched, show a spinner)
+  // from "unresolvable" (no source AND no fallback — render an empty, usable
+  // picker rather than a spinner that never finishes).
+  const aliasRefResolving = aliasSource !== null && aliasRefOptions === null;
 
   if (tombstoned) {
     return (
@@ -1525,43 +1566,51 @@ function FieldRow({
             onChange={(next) => onChange(next ? "true" : "false")}
           />
         ) : renderer === "select" ? (
-          <select
+          // Themed locked dropdown for enum variants (no browser-styled <option>
+          // list). The leading "—" is the empty/unset choice.
+          <Select
             id={entry.path}
             value={value}
-            onChange={(e) => onChange(e.target.value)}
-            className="input-electric w-full px-3 py-2 text-sm appearance-none cursor-pointer"
-          >
-            <option value="">—</option>
-            {(entry.enum_variants ?? []).map((v) => (
-              <option key={v} value={v}>
-                {v}
-              </option>
-            ))}
-          </select>
+            onChange={onChange}
+            aria-label={fieldShortLabel(entry)}
+            options={[
+              { value: "", label: "—" },
+              ...(entry.enum_variants ?? []).map((v) => ({
+                value: v,
+                label: v,
+              })),
+            ]}
+          />
         ) : renderer === "alias-ref" ? (
-          // Schema-driven alias-ref picker (zeroclaw-labs/zeroclaw#7594):
-          // a free-typeable input backed by a <datalist> of the live values
-          // resolved from `entry.alias_source`. Takes precedence over the
-          // per-section maps below; dormant until the backend emits this kind.
-          <>
+          // Schema-driven alias-ref picker (zeroclaw-labs/zeroclaw#7594): a
+          // themed, click-to-open ComboBox of the live values (resolved from
+          // `entry.alias_source`, with an agent-options fallback — see
+          // `aliasRefOptions`). Uses the same primitive as the model-field picker
+          // so it matches the rest of the page instead of a browser-styled native
+          // <select>. `openOnFocus` makes clicking the field open the list, since
+          // the configured aliases ARE the expected input. Free text is still
+          // accepted verbatim (and validated on save) so an existing or
+          // not-yet-created alias is never dropped. Precedes the per-section maps.
+          aliasRefResolving ? (
             <input
               id={entry.path}
-              list={`alias-${entry.path}`}
               value={value}
-              onChange={(e) => onChange(e.target.value)}
+              disabled
+              readOnly
               className="input-electric w-full px-3 py-2 text-sm"
-              placeholder={
-                aliasValues === null
-                  ? t("fieldform.alias_loading")
-                  : t("fieldform.alias_pick_or_type")
-              }
+              placeholder={t("fieldform.alias_loading")}
             />
-            <datalist id={`alias-${entry.path}`}>
-              {(aliasValues ?? []).map((v) => (
-                <option key={v} value={v} />
-              ))}
-            </datalist>
-          </>
+          ) : (
+            <ComboBox
+              id={entry.path}
+              value={value}
+              onChange={onChange}
+              options={aliasRefOptions ?? []}
+              openOnFocus
+              placeholder={t("fieldform.alias_pick_or_type")}
+              aria-label={fieldShortLabel(entry)}
+            />
+          )
         ) : isProviderModelField &&
           providerModels !== null &&
           providerModels.length > 0 ? (
@@ -1573,6 +1622,7 @@ function FieldRow({
             value={value}
             onChange={onChange}
             options={providerModels}
+            openOnFocus
             placeholder={t("fieldform.model_combo_placeholder")}
             emptyText={t("fieldform.model_combo_empty")}
             aria-label={t("fieldform.model_aria")}
@@ -1932,6 +1982,7 @@ function ArrayFieldEditor({
                       value={row}
                       onChange={(v) => setRow(i, v)}
                       options={suggestions}
+                      openOnFocus
                       placeholder={t("fieldform.value_combo_placeholder")}
                       emptyText={t("fieldform.value_combo_empty")}
                     />

--- a/web/src/components/sections/SectionNavigator.tsx
+++ b/web/src/components/sections/SectionNavigator.tsx
@@ -124,8 +124,17 @@ export default function SectionNavigator({
       if (section.shape === "typed_family_map") {
         // Configured/active provider or channel types under this section.
         const picker = await getSectionPicker(section.key);
+        // A type has children when it has configured instances. The badge for
+        // that is normally "configured" (or "active"), but the Storage section
+        // renames "configured" → "created" backend-side (api_sections.rs), so it
+        // must be accepted too — else configured storages never list in the nav.
         const configuredTypes = picker.items
-          .filter((i) => i.badge === "configured" || i.badge === "active")
+          .filter(
+            (i) =>
+              i.badge === "configured" ||
+              i.badge === "active" ||
+              i.badge === "created",
+          )
           .map((i) => i.key);
         const out: NavEntity[] = [];
         for (const type of configuredTypes) {

--- a/web/src/components/ui/ComboBox.tsx
+++ b/web/src/components/ui/ComboBox.tsx
@@ -25,6 +25,13 @@ export interface ComboBoxProps {
   emptyText?: string;
   /** Extra classes for the root wrapper. */
   className?: string;
+  /**
+   * Open the list as soon as the input is focused/clicked (not just via the
+   * caret). Makes the field behave like a click-anywhere dropdown — handy when
+   * the options ARE the expected input (e.g. an alias picker) rather than rare
+   * suggestions over mostly-free text.
+   */
+  openOnFocus?: boolean;
   "aria-label"?: string;
 }
 
@@ -36,6 +43,7 @@ export function ComboBox({
   placeholder,
   emptyText = t("combobox.no_matches"),
   className = "",
+  openOnFocus = false,
   "aria-label": ariaLabel,
 }: ComboBoxProps) {
   const [open, setOpen] = useState(false);
@@ -136,6 +144,9 @@ export function ComboBox({
             setOpen(true);
           }}
           onKeyDown={onKeyDown}
+          onFocus={openOnFocus ? () => setOpen(true) : undefined}
+          // Re-open if the user clicks an already-focused input after closing it.
+          onClick={openOnFocus ? () => setOpen(true) : undefined}
           className="input-electric w-full px-3 py-2 pr-9 text-sm"
         />
         <button

--- a/web/src/components/ui/Select.tsx
+++ b/web/src/components/ui/Select.tsx
@@ -1,0 +1,167 @@
+// Operator Console — Select primitive.
+//
+// A themed, LOCKED dropdown for fixed value sets (e.g. enum variants). Unlike
+// ComboBox (free-text input + discoverable suggestions), the value is restricted
+// to the provided options — there is no typing. It exists so locked selects stop
+// rendering the browser's unstyled native `<option>` list (which ignores the
+// dark theme); this renders the same themed, keyboard-navigable listbox the
+// ComboBox uses. Click anywhere on the control opens it.
+
+import { useEffect, useId, useRef, useState } from "react";
+import { Check, ChevronsUpDown } from "lucide-react";
+
+export interface SelectOption {
+  value: string;
+  label: string;
+}
+
+export interface SelectProps {
+  /** Current value (must match an option's `value`, or be empty). */
+  value: string;
+  onChange: (value: string) => void;
+  options: SelectOption[];
+  id?: string;
+  /** Shown when no option is selected. */
+  placeholder?: string;
+  /** Extra classes for the root wrapper. */
+  className?: string;
+  "aria-label"?: string;
+}
+
+export function Select({
+  value,
+  onChange,
+  options,
+  id,
+  placeholder,
+  className = "",
+  "aria-label": ariaLabel,
+}: SelectProps) {
+  const [open, setOpen] = useState(false);
+  // Highlighted option index (keyboard navigation).
+  const [active, setActive] = useState(0);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const btnRef = useRef<HTMLButtonElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+  const reactId = useId();
+  const listboxId = `${id ?? reactId}-listbox`;
+
+  const selected = options.find((o) => o.value === value);
+
+  // On open, highlight the currently-selected option (or the first).
+  useEffect(() => {
+    if (!open) return;
+    const idx = options.findIndex((o) => o.value === value);
+    setActive(idx >= 0 ? idx : 0);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  // Close on outside click.
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [open]);
+
+  // Keep the highlighted option scrolled into view.
+  useEffect(() => {
+    if (!open) return;
+    listRef.current
+      ?.querySelector<HTMLElement>(`[data-idx="${active}"]`)
+      ?.scrollIntoView({ block: "nearest" });
+  }, [active, open]);
+
+  const choose = (v: string) => {
+    onChange(v);
+    setOpen(false);
+    btnRef.current?.focus();
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      if (!open) return setOpen(true);
+      setActive((a) => (options.length ? (a + 1) % options.length : 0));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      if (!open) return setOpen(true);
+      setActive((a) =>
+        options.length ? (a - 1 + options.length) % options.length : 0,
+      );
+    } else if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      if (!open) return setOpen(true);
+      const opt = options[active];
+      if (opt) choose(opt.value);
+    } else if (e.key === "Escape") {
+      if (open) {
+        e.preventDefault();
+        setOpen(false);
+      }
+    }
+  };
+
+  return (
+    <div ref={rootRef} className={`relative ${className}`}>
+      <button
+        ref={btnRef}
+        id={id}
+        type="button"
+        role="combobox"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-controls={listboxId}
+        aria-label={ariaLabel}
+        onClick={() => setOpen((o) => !o)}
+        onKeyDown={onKeyDown}
+        className="input-electric flex w-full cursor-pointer items-center justify-between gap-2 px-3 py-2 text-left text-sm"
+      >
+        <span className={selected ? "truncate" : "truncate text-pc-text-faint"}>
+          {selected ? selected.label : (placeholder ?? "")}
+        </span>
+        <ChevronsUpDown className="h-4 w-4 shrink-0 text-pc-text-muted" />
+      </button>
+      {open && (
+        <ul
+          ref={listRef}
+          id={listboxId}
+          role="listbox"
+          className="absolute z-30 mt-1 max-h-60 w-full overflow-y-auto rounded-[var(--radius-md)] border border-pc-border bg-pc-surface p-1 shadow-[var(--pc-shadow-md)]"
+        >
+          {options.map((o, i) => {
+            const sel = o.value === value;
+            const act = i === active;
+            return (
+              <li key={`${i}-${o.value}`}>
+                <button
+                  type="button"
+                  role="option"
+                  aria-selected={sel}
+                  data-idx={i}
+                  onMouseMove={() => setActive(i)}
+                  onClick={() => choose(o.value)}
+                  className={[
+                    "flex w-full items-center gap-2 rounded-[var(--radius-sm)] px-2.5 py-1.5 text-left text-sm transition-colors",
+                    act
+                      ? "bg-pc-accent/10 text-pc-text"
+                      : "text-pc-text-secondary hover:bg-pc-elevated/60",
+                  ].join(" ")}
+                >
+                  <Check
+                    className={`h-3.5 w-3.5 shrink-0 ${sel ? "text-pc-accent" : "opacity-0"}`}
+                  />
+                  <span className="truncate">{o.label}</span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/ui/index.ts
+++ b/web/src/components/ui/index.ts
@@ -21,3 +21,6 @@ export type { ConfirmDialogProps } from './ConfirmDialog';
 
 export { ComboBox } from './ComboBox';
 export type { ComboBoxProps } from './ComboBox';
+
+export { Select } from './Select';
+export type { SelectProps, SelectOption } from './Select';

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -581,6 +581,7 @@ const translations: Record<Locale, Record<string, string>> = {
     'cron.show_recent_runs': "Show this job's recent runs",
     'cron.timezone_placeholder': "e.g. America/New_York",
     'dashboard.cpu.label': "CPU",
+    'dashboard.fix': "Fix",
     'dashboard.last_ok_title': "last ok:",
     'dashboard.load_agents_error': "Failed to load agents",
     'dashboard.ok_prefix': "ok",

--- a/web/src/pages/Config.tsx
+++ b/web/src/pages/Config.tsx
@@ -45,7 +45,7 @@ import SectionTabs, {
 import CostRatesEditor, {
   type CostRatesCategory,
 } from "../components/sections/CostRatesEditor";
-import { Badge, Button, Card, PageHeader } from "@/components/ui";
+import { Badge, Button, Card, ComboBox, PageHeader } from "@/components/ui";
 import { t } from "@/lib/i18n";
 
 // Display order for the curated sidebar groups. Each `SectionInfo.group`
@@ -1079,7 +1079,9 @@ function AgentPeerGroupsTab({
   }, [agentAlias]);
 
   const addToGroup = async () => {
-    if (!pickerValue) return;
+    // The themed ComboBox accepts free text; only act on a real non-member group
+    // (the native <select> this replaced couldn't submit an arbitrary value).
+    if (!pickerValue || !nonMembers.includes(pickerValue)) return;
     setAdding(true);
     setError(null);
     try {
@@ -1158,27 +1160,23 @@ function AgentPeerGroupsTab({
         <span className="text-xs" style={{ color: "var(--pc-text-muted)" }}>
           {t("config.add_agent_to")}
         </span>
-        <select
+        <ComboBox
           value={pickerValue}
-          onChange={(e) => setPickerValue(e.target.value)}
-          disabled={adding || nonMembers.length === 0}
-          className="input-electric text-xs px-2 py-1 appearance-none cursor-pointer"
-        >
-          <option value="">
-            {nonMembers.length === 0
+          onChange={setPickerValue}
+          options={nonMembers}
+          openOnFocus
+          className="w-56"
+          aria-label={t("config.add_agent_to")}
+          placeholder={
+            nonMembers.length === 0
               ? t("config.no_other_groups")
-              : t("config.select_a_group")}
-          </option>
-          {nonMembers.map((g) => (
-            <option key={g} value={g}>
-              {g}
-            </option>
-          ))}
-        </select>
+              : t("config.select_a_group")
+          }
+        />
         <button
           type="button"
           onClick={addToGroup}
-          disabled={!pickerValue || adding}
+          disabled={!pickerValue || adding || !nonMembers.includes(pickerValue)}
           className="btn-electric text-xs px-3 py-1 rounded-lg disabled:opacity-50"
         >
           {adding ? t("config.adding") : t("config.add")}

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -24,6 +24,7 @@ import {
   Brain,
   Search,
   Monitor,
+  ArrowRight,
 } from "lucide-react";
 import type {
   StatusResponse,
@@ -50,8 +51,62 @@ import {
   getTuis,
 } from "@/lib/api";
 import { resolveModelToProviderType } from "@/lib/configuredModels";
+import DoctorFixModal from "@/components/DoctorFixModal";
 
 type CostWindow = "today" | "7d" | "30d" | "month" | "all";
+
+/**
+ * A component's `last_error` is sometimes a config path (e.g.
+ * `agents.cronos.model_provider`) — the field whose misconfiguration is crashing
+ * the supervisor. When we can parse a known config entity out of it, offer the
+ * same inline "fix in place" modal the Doctor page uses (edit the entity, save,
+ * no navigation). Returns null when nothing parseable is present (error shown as
+ * plain text). Mirrors Doctor's `remediationTarget`.
+ */
+function healthFixTarget(
+  err: string | null | undefined,
+): { prefix: string; entity: string; href: string } | null {
+  if (!err) return null;
+  // Anchor at the start (like Doctor's remediationTarget) so a config path is
+  // only matched when the error IS one (e.g. "agents.cronos.model_provider"),
+  // not when prose merely contains the word — "failed to load agents.json"
+  // must NOT yield a bogus Fix target for entity `agents.json`.
+  // agents.<alias>[.<field>] — edit the agent; deep-link the field's tab.
+  const agent = err.match(/^\s*agents\.([a-z0-9_-]+)(?:\.([a-z0-9_.-]+))?/i);
+  if (agent?.[1]) {
+    const alias = agent[1];
+    const field = agent[2] ?? "";
+    const tab = /provider$/i.test(field)
+      ? "?tab=providers"
+      : /^(risk|runtime)_profile/i.test(field)
+        ? "?tab=general"
+        : "";
+    return {
+      prefix: `agents.${alias}`,
+      entity: `agents.${alias}`,
+      href: `/config/agents/${encodeURIComponent(alias)}${tab}`,
+    };
+  }
+  // channels.<type>.<alias>
+  const chan = err.match(/^\s*channels\.([a-z0-9_-]+)\.([a-z0-9_-]+)/i);
+  if (chan?.[1] && chan[2]) {
+    return {
+      prefix: `channels.${chan[1]}.${chan[2]}`,
+      entity: `${chan[1]}.${chan[2]}`,
+      href: `/config/channels/${encodeURIComponent(chan[1])}/${encodeURIComponent(chan[2])}`,
+    };
+  }
+  // providers.models.<type>.<alias>
+  const prov = err.match(/^\s*providers\.models\.([a-z0-9_-]+)\.([a-z0-9_-]+)/i);
+  if (prov?.[1] && prov[2]) {
+    return {
+      prefix: `providers.models.${prov[1]}.${prov[2]}`,
+      entity: `${prov[1]}.${prov[2]}`,
+      href: `/config/providers.models/${encodeURIComponent(prov[1])}/${encodeURIComponent(prov[2])}`,
+    };
+  }
+  return null;
+}
 
 function costWindowBounds(window: CostWindow): { from?: Date; to?: Date } {
   const now = new Date();
@@ -376,6 +431,14 @@ function OverviewTab({
     0.001,
   );
 
+  // Component Health → "fix in place" modal target (set when an error row's
+  // last_error parses to a config entity). Same modal as the Doctor page.
+  const [healthFix, setHealthFix] = useState<{
+    prefix: string;
+    entity: string;
+    href: string;
+  } | null>(null);
+
   return (
     <>
       {/* Status Cards Grid */}
@@ -681,16 +744,33 @@ function OverviewTab({
                         </span>
                       </div>
                       {lastErr ? (
-                        <p
-                          className="text-[11px] mt-1 font-mono break-words"
-                          style={{ color: "var(--color-status-error)" }}
-                          title={lastErr}
-                        >
-                          ⚠{" "}
-                          {lastErr.length > 120
-                            ? lastErr.slice(0, 117) + "…"
-                            : lastErr}
-                        </p>
+                        (() => {
+                          const fix = healthFixTarget(lastErr);
+                          return (
+                            <div className="mt-1 flex items-start gap-2">
+                              <p
+                                className="flex-1 text-[11px] font-mono break-words"
+                                style={{ color: "var(--color-status-error)" }}
+                                title={lastErr}
+                              >
+                                ⚠{" "}
+                                {lastErr.length > 120
+                                  ? lastErr.slice(0, 117) + "…"
+                                  : lastErr}
+                              </p>
+                              {fix && (
+                                <button
+                                  type="button"
+                                  onClick={() => setHealthFix(fix)}
+                                  className="inline-flex h-6 flex-shrink-0 items-center gap-1 rounded-[var(--radius-md)] border border-pc-border bg-transparent px-2 text-[11px] font-medium text-pc-text-secondary transition-colors duration-150 hover:bg-[var(--pc-hover)] hover:text-pc-text hover:border-pc-border-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--pc-focus)] focus-visible:ring-offset-2 focus-visible:ring-offset-pc-base cursor-pointer"
+                                >
+                                  {t("dashboard.fix")}
+                                  <ArrowRight className="h-3 w-3" />
+                                </button>
+                              )}
+                            </div>
+                          );
+                        })()
                       ) : null}
                       <div
                         className="flex items-center gap-3 text-[11px] mt-0.5"
@@ -785,6 +865,16 @@ function OverviewTab({
           </div>
         </div>
       )}
+
+      {/* Component Health "fix in place" modal — same editor as the Doctor page.
+          Opens when an error row with a parseable config entity is actioned. */}
+      <DoctorFixModal
+        open={healthFix !== null}
+        prefix={healthFix?.prefix ?? ""}
+        entity={healthFix?.entity ?? ""}
+        href={healthFix?.href ?? ""}
+        onClose={() => setHealthFix(null)}
+      />
     </>
   );
 }

--- a/web/tsconfig.app.json
+++ b/web/tsconfig.app.json
@@ -22,8 +22,8 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedIndexedAccess": true,
 
-    /* Aliases */
-    "baseUrl": ".",
+    /* Aliases — `paths` resolves relative to this file; `baseUrl` not needed
+       (TS >=4.1) and Vite resolves `@` via its own resolve.alias. */
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
## Summary
The Operator Console config pages rendered several fields as browser-native
`<select>`s whose dropdown lists ignore the dark theme, and the schema-driven
`alias-ref` fields (risk/runtime profile, model/tts/transcription/classifier
provider) had degraded to a free-text box. This replaces them with the app's
themed, click-to-open pickers and fixes two adjacent issues found while testing.

## What changed
**Themed alias-ref pickers** (`web/src/components/sections/FieldForm.tsx`)
- `alias-ref` fields now render the themed `ComboBox` instead of a native `<select>`.
- Options resolve via `/api/config/resolve-alias-source`, deriving the `source`
  from the field's `<Type>Ref` type-hint (`ALIAS_REF_TYPE_TO_SOURCE`) when the
  daemon omits `alias_source`. This makes provider refs that have no
  `AgentOptionsResponse` list (tts / transcription / classifier) resolve real
  options. A new `aliasRefResolving` flag shows a spinner only while genuinely
  fetching — never a permanent one.
- `delegates` added to the agent multi-select map (themed agent picker, was free text).

**New locked `Select` primitive** (`web/src/components/ui/Select.tsx`, exported from `ui/index.ts`)
- Themed, keyboard-navigable, click-to-open dropdown for fixed value sets. Wired
  into the FieldForm `enum` branch (e.g. `memory.backend`) — the last native
  `<select>` users hit. (`bool` already used a themed switch.)

**Click-to-open** (`web/src/components/ui/ComboBox.tsx`)
- Opt-in `openOnFocus` prop so the alias, model-field, bundle, and peer-group
  pickers open on click, not just via the caret.

**Peer-groups picker** (`web/src/pages/Config.tsx`)
- "Add agent to group" native `<select>` → themed `ComboBox`; Add is gated on a
  real non-member group so the free-text input can't submit a bogus group.

**Dashboard Component Health → fix-in-place** (`web/src/pages/Dashboard.tsx`)
- Error rows whose `last_error` is a config path get a **Fix** button that opens
  the same `DoctorFixModal` the Doctor page uses. `healthFixTarget()` maps
  `agents.*` / `channels.*` / `providers.models.*` → `{prefix, entity, href}`,
  anchored at string start so prose errors don't yield bogus targets.

**Storage nav fix** (`web/src/components/sections/SectionNavigator.tsx`)
- The `typed_family_map` child-loader now accepts the `"created"` badge. The
  backend renames storage's `configured` badge → `created`
  (`crates/zeroclaw-gateway/src/api_sections.rs`), so configured storages
  previously showed "Nothing configured yet".

**Cleanup** (`web/tsconfig.app.json`)
- Drop redundant `baseUrl` (TS ≥4.1 resolves `paths` relative to the config;
  Vite resolves `@` via its own alias).

## Testing
- `tsc -b` clean; `vite build` clean.
- Verified end to end against a running daemon: alias pickers populate (incl.
  tts/transcription/classifier via `resolve-alias-source`), enum picker themed,
  the Storage section lists its configured backends, and the dashboard Fix button
  opens the modal for a flagged `agents.<alias>.<field>`.

## Notes / limitations
- `alias-ref` is **pick-or-type** (themed `ComboBox`), consistent with the
  existing bundle pickers; values are validated on save. Not a hard-locked select
  — happy to lock it if preferred.
- On daemons that predate `alias_source` AND lack `resolve-alias-source`, the
  derived-source fetch 404s and is caught (empty picker) — graceful, but emits one
  failing request per such field.
- `Select` shares listbox mechanics (outside-click, scroll-into-view, arrow nav)
  with `ComboBox` by copy; a shared hook is a reasonable follow-up (the
  locked-vs-free-text component split itself is intentional).
