### PR TITLE
feat(channels/wecom): proactive + attachment messaging over wecom_ws

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -138,11 +138,31 @@ use zeroclaw_runtime::util::truncate_with_ellipsis;
 
 type CronChannelRegistry = Arc<HashMap<String, Arc<dyn Channel>>>;
 
+#[cfg(feature = "channel-wecom-ws")]
+type WeComWsCorpCredentialsResolver = Arc<dyn Fn() -> Option<(String, String)> + Send + Sync>;
+
 /// Live channel registry consulted by `deliver_announcement` so cron sends reuse the
 /// authenticated channel instance (Matrix E2EE can't tolerate per-send session restore).
 /// Replaced wholesale by each `start_channels` call.
 static CRON_CHANNEL_REGISTRY: std::sync::RwLock<Option<CronChannelRegistry>> =
     std::sync::RwLock::new(None);
+
+#[cfg(feature = "channel-wecom-ws")]
+fn wecom_ws_corp_credentials_resolver(
+    config_arc: Arc<RwLock<Config>>,
+    alias: String,
+) -> WeComWsCorpCredentialsResolver {
+    Arc::new(move || {
+        let config = config_arc.read();
+        let wc = config.channels.wecom_ws.get(&alias)?;
+        let corp_id = wc.corp_id.as_deref().map(str::trim)?;
+        let corp_secret = wc.corp_secret.as_deref().map(str::trim)?;
+        if corp_id.is_empty() || corp_secret.is_empty() {
+            return None;
+        }
+        Some((corp_id.to_string(), corp_secret.to_string()))
+    })
+}
 
 /// Observer wrapper that forwards tool-call events to a channel sender
 /// for real-time threaded notifications.
@@ -6102,10 +6122,13 @@ fn build_channel_by_id(
                     peers
                 })
             };
+            let corp_credentials_resolver =
+                wecom_ws_corp_credentials_resolver(config_arc.clone(), alias.clone());
             Ok(Arc::new(WeComWsChannel::new_with_alias(
                 wc,
                 alias.clone(),
                 peer_resolver,
+                corp_credentials_resolver,
                 &config.channel_workspace_dir(&format!("wecom_ws.{alias}")),
             )?))
         }
@@ -7863,10 +7886,13 @@ fn collect_configured_channels(
                 peers
             })
         };
+        let corp_credentials_resolver =
+            wecom_ws_corp_credentials_resolver(config_arc.clone(), alias.clone());
         match WeComWsChannel::new_with_alias(
             wc_ws,
             alias.clone(),
             peer_resolver,
+            corp_credentials_resolver,
             &config.channel_workspace_dir(&format!("wecom_ws.{alias}")),
         ) {
             Ok(channel) => channels.push(ConfiguredChannel {

--- a/crates/zeroclaw-channels/src/wecom_ws.rs
+++ b/crates/zeroclaw-channels/src/wecom_ws.rs
@@ -1436,8 +1436,6 @@ impl WeComWsChannel {
     /// Upload a media file and send it via `aibot_send_msg` with the appropriate
     /// WeCom `msgtype` (`image` or `file`).
     async fn send_attachment(&self, scope: &str, attachment: &MediaAttachment) -> Result<()> {
-        use base64::Engine as _;
-
         let (chat_type, chatid) = parse_scope(scope)?;
 
         // Upload via WeCom media/upload CGI
@@ -1452,13 +1450,16 @@ impl WeComWsChannel {
             }
         );
 
-        let form = reqwest::multipart::Form::new()
-            .part(
-                "media",
-                reqwest::multipart::Part::bytes(attachment.data.clone())
-                    .file_name(attachment.file_name.clone())
-                    .mime_str(attachment.mime_type.as_deref().unwrap_or("application/octet-stream")),
-            );
+        // Part::mime_str returns Result<Part>; apply ? before adding to the form.
+        let part = reqwest::multipart::Part::bytes(attachment.data.clone())
+            .file_name(attachment.file_name.clone())
+            .mime_str(
+                attachment
+                    .mime_type
+                    .as_deref()
+                    .unwrap_or("application/octet-stream"),
+            )?;
+        let form = reqwest::multipart::Form::new().part("media", part);
 
         let resp = self
             .client
@@ -1472,14 +1473,16 @@ impl WeComWsChannel {
         struct UploadResp {
             #[serde(rename = "media_id")]
             media_id: Option<String>,
-            errcode: Option<i64>,
             errmsg: Option<String>,
         }
 
         let upload: UploadResp = resp.json().await?;
-        let media_id = upload
-            .media_id
-            .ok_or_else(|| anyhow::anyhow!("WeCom upload response missing media_id: {:?}", upload.errmsg))?;
+        let media_id = upload.media_id.with_context(|| {
+            format!(
+                "WeCom upload response missing media_id: {:?}",
+                upload.errmsg
+            )
+        })?;
 
         // Dispatch the actual message via aibot_send_msg
         let msgtype = match attachment.kind() {
@@ -1489,15 +1492,19 @@ impl WeComWsChannel {
             zeroclaw_api::media::MediaKind::Unknown => "file",
         };
 
+        // serde_json::json! only accepts literal keys; the payload nests the
+        // media object under a key named after the msgtype, so build the body
+        // first and insert that dynamic key separately.
+        let mut body = serde_json::json!({
+            "chatid": chatid,
+            "chat_type": chat_type,
+            "msgtype": msgtype,
+        });
+        body[msgtype] = serde_json::json!({ "media_id": media_id });
         let frame = serde_json::json!({
             "cmd": "aibot_send_msg",
             "headers": { "req_id": random_ascii_token(16) },
-            "body": {
-                "chatid": chatid,
-                "chat_type": chat_type,
-                "msgtype": msgtype,
-                msgtype => { "media_id": media_id }
-            }
+            "body": body
         });
 
         self.ws_send_frame_and_wait_for_response(frame, "unused", "aibot_send_msg")
@@ -1521,14 +1528,12 @@ impl WeComWsChannel {
         struct TokenResp {
             #[serde(rename = "access_token")]
             access_token: Option<String>,
-            errcode: Option<i64>,
             errmsg: Option<String>,
         }
 
         let url = format!(
             "https://qyapi.weixin.qq.com/cgi-bin/gettoken?corpid={}&corpsecret={}",
-            self.bot_id,
-            self.secret,
+            self.bot_id, self.secret,
         );
 
         let resp = self
@@ -1545,7 +1550,7 @@ impl WeComWsChannel {
 
         token
             .access_token
-            .ok_or_else(|| anyhow::anyhow!("WeCom gettoken failed: {:?}", token.errmsg))
+            .with_context(|| format!("WeCom gettoken failed: {:?}", token.errmsg))
     }
 }
 
@@ -1558,6 +1563,81 @@ impl ::zeroclaw_api::attribution::Attributable for WeComWsChannel {
 
     fn alias(&self) -> &str {
         &self.alias
+    }
+}
+
+impl WeComWsChannel {
+    /// Send a proactive message to an external user via the WeCom
+    /// `agent/send_message` HTTP API (chat_type=3).
+    ///
+    /// The `scope` must have the `external--` prefix, e.g. `external--zhangsan@example.com`.
+    /// This path is used for outbound-initiated (proactive) messages to external contacts,
+    /// which require the application to have external contact permissions and cannot be
+    /// sent over the WebSocket `aibot_send_msg` channel.
+    async fn send_external_user_message(&self, scope: &str, content: &str) -> Result<()> {
+        let external_user_id = scope
+            .strip_prefix("external--")
+            .with_context(|| format!("invalid external scope: {scope}"))?;
+
+        let token = self.resolve_access_token().await?;
+
+        // WeCom application message API — sends a text message to an external user.
+        // The agentid (bot_id) and external_userid identify the sender application and
+        // the target external contact respectively.
+        #[derive(serde::Serialize)]
+        struct AgentMsgBody<'a> {
+            #[serde(rename = "touser")]
+            touser: &'a str,
+            #[serde(rename = "agentid")]
+            agentid: &'a str,
+            #[serde(rename = "msgtype")]
+            msgtype: &'a str,
+            #[serde(rename = "text")]
+            text: &'a serde_json::Value,
+        }
+
+        let body = AgentMsgBody {
+            touser: external_user_id,
+            agentid: &self.bot_id,
+            msgtype: "text",
+            text: &serde_json::json!({ "content": content }),
+        };
+
+        let url = format!(
+            "https://qyapi.weixin.qq.com/cgi-bin/message/send?access_token={token}",
+            token = token
+        );
+
+        let resp = self
+            .client
+            .post(&url)
+            .json(&body)
+            .send()
+            .await
+            .with_context(|| "WeCom external message send failed")?;
+
+        #[derive(serde::Deserialize)]
+        struct ApiResp {
+            errcode: Option<i64>,
+            errmsg: Option<String>,
+        }
+
+        let result: ApiResp = resp.json().await?;
+        let errcode = result.errcode.unwrap_or(-1);
+        if errcode != 0 {
+            anyhow::bail!(
+                "WeCom external message API error (errcode={}): {:?}",
+                errcode,
+                result.errmsg
+            );
+        }
+
+        wecom_log_info!(
+            "WeCom external proactive message sent to={} len={}",
+            external_user_id,
+            content.len()
+        );
+        Ok(())
     }
 }
 
@@ -1610,79 +1690,6 @@ impl Channel for WeComWsChannel {
             self.send_attachment(&message.recipient, attachment).await?;
         }
 
-        Ok(())
-    }
-
-    /// Send a proactive message to an external user via the WeCom
-    /// `agent/send_message` HTTP API (chat_type=3).
-    ///
-    /// The `scope` must have the `external--` prefix, e.g. `external--zhangsan@example.com`.
-    /// This path is used for outbound-initiated (proactive) messages to external contacts,
-    /// which require the application to have external contact permissions and cannot be
-    /// sent over the WebSocket `aibot_send_msg` channel.
-    async fn send_external_user_message(&self, scope: &str, content: &str) -> Result<()> {
-        let external_user_id = scope
-            .strip_prefix("external--")
-            .ok_or_else(|| anyhow::anyhow!("invalid external scope: {scope}"))?;
-
-        let token = self.resolve_access_token().await?;
-
-        // WeCom application message API — sends a text message to an external user.
-        // The agentid (bot_id) and external_userid identify the sender application and
-        // the target external contact respectively.
-        #[derive(serde::Serialize)]
-        struct AgentMsgBody<'a> {
-            #[serde(rename = "touser")]
-            touser: &'a str,
-            #[serde(rename = "agentid")]
-            agentid: &'a str,
-            #[serde(rename = "msgtype")]
-            msgtype: &'a str,
-            #[serde(rename = "text")]
-            text: &'a serde_json::Value,
-        }
-
-        let body = AgentMsgBody {
-            touser: external_user_id,
-            agentid: &self.bot_id,
-            msgtype: "text",
-            text: &serde_json::json!({ "content": content }),
-        };
-
-        let url = format!(
-            "https://qyapi.weixin.qq.com/cgi-bin/message/send?access_token={token}",
-            token = token
-        );
-
-        let resp = self
-            .client
-            .post(&url)
-            .json(&body)
-            .send()
-            .await
-            .with_context(|| format!("WeCom external message send failed"))?;
-
-        #[derive(serde::Deserialize)]
-        struct ApiResp {
-            errcode: Option<i64>,
-            errmsg: Option<String>,
-        }
-
-        let result: ApiResp = resp.json().await?;
-        let errcode = result.errcode.unwrap_or(-1);
-        if errcode != 0 {
-            anyhow::bail!(
-                "WeCom external message API error (errcode={}): {:?}",
-                errcode,
-                result.errmsg
-            );
-        }
-
-        wecom_log_info!(
-            "WeCom external proactive message sent to={} len={}",
-            external_user_id,
-            content.len()
-        );
         Ok(())
     }
 
@@ -3098,8 +3105,14 @@ mod tests {
 
     #[test]
     fn parse_scope_external() {
-        assert_eq!(parse_scope("external--zhangsan@example.com"), Ok((3, "zhangsan@example.com")));
-        assert_eq!(parse_scope("external--lisi@external.com"), Ok((3, "lisi@external.com")));
+        assert_eq!(
+            parse_scope("external--zhangsan@example.com").unwrap(),
+            (3, "zhangsan@example.com")
+        );
+        assert_eq!(
+            parse_scope("external--lisi@external.com").unwrap(),
+            (3, "lisi@external.com")
+        );
     }
 
     #[test]

--- a/crates/zeroclaw-channels/src/wecom_ws.rs
+++ b/crates/zeroclaw-channels/src/wecom_ws.rs
@@ -31,6 +31,8 @@ const WECOM_HTTP_TIMEOUT_SECS: u64 = 60;
 const WECOM_CONNECT_TIMEOUT_SECS: u64 = 15;
 const WECOM_WS_READY_WAIT_SECS: u64 = 10;
 const WECOM_WS_READY_POLL_MILLIS: u64 = 100;
+const WECOM_ACCESS_TOKEN_REFRESH_SKEW_SECS: u64 = 300;
+const WECOM_ACCESS_TOKEN_DEFAULT_EXPIRES_SECS: u64 = 7200;
 const WECOM_STREAM_CONFLICT_MAX_RETRIES: usize = 3;
 const WECOM_STREAM_CONFLICT_RETRY_BASE_MILLIS: u64 = 150;
 const WECOM_IDEMPOTENCY_MAX_KEYS: usize = 4096;
@@ -189,6 +191,20 @@ struct WeComRuntimeConfig {
     proxy_url: Option<String>,
 }
 
+#[derive(Debug, Clone)]
+struct CachedAccessToken {
+    token: String,
+    expires_at: Instant,
+}
+
+impl CachedAccessToken {
+    fn is_fresh(&self, now: Instant) -> bool {
+        self.expires_at
+            .checked_duration_since(now)
+            .is_some_and(|ttl| ttl > Duration::from_secs(WECOM_ACCESS_TOKEN_REFRESH_SKEW_SECS))
+    }
+}
+
 // ── MediaDecryptor (per-attachment AES key) ──────────────────────────
 
 struct MediaDecryptor;
@@ -244,6 +260,7 @@ pub struct WeComWsChannel {
     last_cleanup: Arc<Mutex<Instant>>,
     idempotency: Arc<SimpleIdempotencyStore>,
     req_id_map: Arc<Mutex<HashMap<String, String>>>, // stream_id → req_id
+    access_token_cache: Arc<Mutex<Option<CachedAccessToken>>>,
 }
 
 // ── Construction + WS helpers ────────────────────────────────────────
@@ -299,6 +316,7 @@ impl WeComWsChannel {
             last_cleanup: Arc::new(Mutex::new(Instant::now())),
             idempotency: Arc::new(SimpleIdempotencyStore::new()),
             req_id_map: Arc::new(Mutex::new(HashMap::new())),
+            access_token_cache: Arc::new(Mutex::new(None)),
         })
     }
 
@@ -1437,6 +1455,11 @@ impl WeComWsChannel {
     /// WeCom `msgtype` (`image` or `file`).
     async fn send_attachment(&self, scope: &str, attachment: &MediaAttachment) -> Result<()> {
         let (chat_type, chatid) = parse_scope(scope)?;
+        if chat_type == 3 {
+            anyhow::bail!(
+                "WeCom external-scope attachments are not supported by the current HTTP external message path: {scope}"
+            );
+        }
 
         // Upload via WeCom media/upload CGI
         let upload_url = format!(
@@ -1474,9 +1497,21 @@ impl WeComWsChannel {
             #[serde(rename = "media_id")]
             media_id: Option<String>,
             errmsg: Option<String>,
+            errcode: Option<i64>,
         }
 
-        let upload: UploadResp = resp.json().await?;
+        let upload: UploadResp = parse_wecom_json_response(resp, "media upload").await?;
+        let errcode = upload
+            .errcode
+            .unwrap_or_else(|| if upload.media_id.is_some() { 0 } else { -1 });
+        if errcode != 0 {
+            anyhow::bail!(
+                "WeCom media upload API error (errcode={}): {:?}",
+                errcode,
+                upload.errmsg
+            );
+        }
+
         let media_id = upload.media_id.with_context(|| {
             format!(
                 "WeCom upload response missing media_id: {:?}",
@@ -1492,22 +1527,9 @@ impl WeComWsChannel {
             zeroclaw_api::media::MediaKind::Unknown => "file",
         };
 
-        // serde_json::json! only accepts literal keys; the payload nests the
-        // media object under a key named after the msgtype, so build the body
-        // first and insert that dynamic key separately.
-        let mut body = serde_json::json!({
-            "chatid": chatid,
-            "chat_type": chat_type,
-            "msgtype": msgtype,
-        });
-        body[msgtype] = serde_json::json!({ "media_id": media_id });
-        let frame = serde_json::json!({
-            "cmd": "aibot_send_msg",
-            "headers": { "req_id": random_ascii_token(16) },
-            "body": body
-        });
+        let (frame, req_id) = build_attachment_send_command(chat_type, chatid, msgtype, &media_id);
 
-        self.ws_send_frame_and_wait_for_response(frame, "unused", "aibot_send_msg")
+        self.ws_send_frame_and_wait_for_response(frame, &req_id, "aibot_send_msg")
             .await?;
 
         wecom_log_info!(
@@ -1522,12 +1544,41 @@ impl WeComWsChannel {
 
     /// Resolve the current access token for the bot's credentials.
     async fn resolve_access_token(&self) -> Result<String> {
-        // Fetch a fresh access token from WeCom's gettoken endpoint using the
-        // bot's bot_id (agentid) and secret from the channel config.
+        if let Some(token) = self.fresh_cached_access_token(Instant::now()) {
+            return Ok(token);
+        }
+
+        let cached = match self.fetch_access_token().await {
+            Ok(cached) => cached,
+            Err(err) => return self.access_token_after_refresh_error(err),
+        };
+        let access_token = cached.token.clone();
+        *self.access_token_cache.lock() = Some(cached);
+
+        Ok(access_token)
+    }
+
+    fn fresh_cached_access_token(&self, now: Instant) -> Option<String> {
+        self.access_token_cache
+            .lock()
+            .as_ref()
+            .filter(|cached| cached.is_fresh(now))
+            .map(|cached| cached.token.clone())
+    }
+
+    fn access_token_after_refresh_error(&self, err: anyhow::Error) -> Result<String> {
+        self.fresh_cached_access_token(Instant::now()).ok_or(err)
+    }
+
+    async fn fetch_access_token(&self) -> Result<CachedAccessToken> {
+        // TODO(review): Confirm that channel bot_id/secret are the qyapi
+        // corpid/corpsecret values for gettoken before changing credential wiring.
         #[derive(serde::Deserialize)]
         struct TokenResp {
             #[serde(rename = "access_token")]
             access_token: Option<String>,
+            expires_in: Option<u64>,
+            errcode: Option<i64>,
             errmsg: Option<String>,
         }
 
@@ -1543,14 +1594,31 @@ impl WeComWsChannel {
             .await
             .with_context(|| "failed to fetch WeCom access token")?;
 
-        let token: TokenResp = resp
-            .json()
-            .await
-            .with_context(|| "failed to parse WeCom token response")?;
+        let token: TokenResp = parse_wecom_json_response(resp, "gettoken").await?;
+        let errcode = token
+            .errcode
+            .unwrap_or_else(|| if token.access_token.is_some() { 0 } else { -1 });
+        if errcode != 0 {
+            anyhow::bail!(
+                "WeCom gettoken API error (errcode={}): {:?}",
+                errcode,
+                token.errmsg
+            );
+        }
 
-        token
-            .access_token
-            .with_context(|| format!("WeCom gettoken failed: {:?}", token.errmsg))
+        let access_token = token.access_token.with_context(|| {
+            format!(
+                "WeCom gettoken response missing access_token: {:?}",
+                token.errmsg
+            )
+        })?;
+        let expires_in = token
+            .expires_in
+            .unwrap_or(WECOM_ACCESS_TOKEN_DEFAULT_EXPIRES_SECS);
+        Ok(CachedAccessToken {
+            token: access_token,
+            expires_at: Instant::now() + Duration::from_secs(expires_in),
+        })
     }
 }
 
@@ -1622,7 +1690,7 @@ impl WeComWsChannel {
             errmsg: Option<String>,
         }
 
-        let result: ApiResp = resp.json().await?;
+        let result: ApiResp = parse_wecom_json_response(resp, "external message send").await?;
         let errcode = result.errcode.unwrap_or(-1);
         if errcode != 0 {
             anyhow::bail!(
@@ -1649,6 +1717,12 @@ impl Channel for WeComWsChannel {
 
     async fn send(&self, message: &SendMessage) -> Result<()> {
         if message.recipient.starts_with("external--") {
+            if !message.attachments.is_empty() {
+                anyhow::bail!(
+                    "WeCom external-scope attachments are not supported by the current HTTP external message path: {}",
+                    message.recipient
+                );
+            }
             return self
                 .send_external_user_message(&message.recipient, &message.content)
                 .await;
@@ -2284,6 +2358,24 @@ fn image_file_extension(bytes: &[u8]) -> &'static str {
     }
 }
 
+async fn parse_wecom_json_response<T>(resp: reqwest::Response, api_name: &str) -> Result<T>
+where
+    T: serde::de::DeserializeOwned,
+{
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp
+            .text()
+            .await
+            .unwrap_or_else(|err| format!("<failed to read response body: {err}>"));
+        anyhow::bail!("WeCom {api_name} HTTP error (status={status}): {body}");
+    }
+
+    resp.json()
+        .await
+        .with_context(|| format!("failed to parse WeCom {api_name} response"))
+}
+
 /// Parse scope string into (chat_type, chatid) for aibot_send_msg.
 /// `user--{userid}` → (1, userid), `group--{chatid}` → (2, chatid)
 fn parse_scope(scope: &str) -> Result<(u32, &str)> {
@@ -2299,6 +2391,43 @@ fn parse_scope(scope: &str) -> Result<(u32, &str)> {
     } else {
         anyhow::bail!("WeCom: invalid scope format: {scope}")
     }
+}
+
+fn build_attachment_send_command(
+    chat_type: u32,
+    chatid: &str,
+    msgtype: &str,
+    media_id: &str,
+) -> (Value, String) {
+    let req_id = random_ascii_token(16);
+    (
+        build_attachment_send_frame(chat_type, chatid, msgtype, media_id, &req_id),
+        req_id,
+    )
+}
+
+fn build_attachment_send_frame(
+    chat_type: u32,
+    chatid: &str,
+    msgtype: &str,
+    media_id: &str,
+    req_id: &str,
+) -> Value {
+    // serde_json::json! only accepts literal keys; the payload nests the media
+    // object under a key named after the msgtype, so build the body first and
+    // insert that dynamic key separately.
+    let mut body = serde_json::json!({
+        "chatid": chatid,
+        "chat_type": chat_type,
+        "msgtype": msgtype,
+    });
+    body[msgtype] = serde_json::json!({ "media_id": media_id });
+
+    serde_json::json!({
+        "cmd": "aibot_send_msg",
+        "headers": { "req_id": req_id },
+        "body": body
+    })
 }
 
 fn summarize_attachment_url_for_log(url: &str) -> String {
@@ -3187,6 +3316,111 @@ mod tests {
         assert!(parse_scope("invalid_scope").is_err());
     }
 
+    #[test]
+    fn attachment_send_command_threads_req_id_into_frame() {
+        let (frame, waiter_req_id) =
+            build_attachment_send_command(1, "zeroclaw_user", "file", "media-123");
+        let frame_req_id = frame
+            .pointer("/headers/req_id")
+            .and_then(Value::as_str)
+            .expect("attachment send frame should include req_id");
+
+        assert_eq!(frame_req_id, waiter_req_id);
+        assert_eq!(frame_req_id.len(), 16);
+    }
+
+    #[tokio::test]
+    async fn send_attachment_rejects_external_scope_before_upload() {
+        let channel = WeComWsChannel::new(&test_wecom_ws_config(), Path::new("/tmp")).unwrap();
+
+        let err = channel
+            .send_attachment("external--zhangsan@example.com", &test_media_attachment())
+            .await
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("external-scope attachments"));
+        assert!(err.contains("not supported"));
+    }
+
+    #[tokio::test]
+    async fn send_external_message_with_attachment_returns_clear_error() {
+        let channel = WeComWsChannel::new(&test_wecom_ws_config(), Path::new("/tmp")).unwrap();
+        let message = SendMessage::new("hello", "external--zhangsan@example.com")
+            .with_attachments(vec![test_media_attachment()]);
+
+        let err = channel.send(&message).await.unwrap_err().to_string();
+
+        assert!(err.contains("external-scope attachments"));
+        assert!(err.contains("not supported"));
+    }
+
+    #[tokio::test]
+    async fn wecom_json_response_reports_http_status_and_body() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/gettoken"))
+            .respond_with(
+                ResponseTemplate::new(429)
+                    .set_body_string(r#"{"errcode":45009,"errmsg":"api freq out of limit"}"#),
+            )
+            .mount(&server)
+            .await;
+
+        let resp = reqwest::Client::new()
+            .get(format!("{}/gettoken", server.uri()))
+            .send()
+            .await
+            .unwrap();
+
+        let err = parse_wecom_json_response::<serde_json::Value>(resp, "gettoken")
+            .await
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("WeCom gettoken HTTP error"));
+        assert!(err.contains("429"));
+        assert!(err.contains("api freq out of limit"));
+    }
+
+    #[test]
+    fn access_token_refresh_failure_uses_concurrently_populated_cache() {
+        let channel = WeComWsChannel::new(&test_wecom_ws_config(), Path::new("/tmp")).unwrap();
+        assert!(channel.fresh_cached_access_token(Instant::now()).is_none());
+
+        *channel.access_token_cache.lock() = Some(CachedAccessToken {
+            token: "cached-token".to_string(),
+            expires_at: Instant::now()
+                + Duration::from_secs(WECOM_ACCESS_TOKEN_REFRESH_SKEW_SECS + 60),
+        });
+
+        let token = channel
+            .access_token_after_refresh_error(anyhow::Error::msg("rate limited"))
+            .unwrap();
+
+        assert_eq!(token, "cached-token");
+    }
+
+    #[test]
+    fn access_token_refresh_failure_propagates_when_cache_is_expired() {
+        let channel = WeComWsChannel::new(&test_wecom_ws_config(), Path::new("/tmp")).unwrap();
+        *channel.access_token_cache.lock() = Some(CachedAccessToken {
+            token: "expired-token".to_string(),
+            expires_at: Instant::now()
+                + Duration::from_secs(WECOM_ACCESS_TOKEN_REFRESH_SKEW_SECS - 1),
+        });
+
+        let err = channel
+            .access_token_after_refresh_error(anyhow::Error::msg("rate limited"))
+            .unwrap_err()
+            .to_string();
+
+        assert_eq!(err, "rate limited");
+    }
+
     fn test_inbound(chat_type: &str, chat_id: Option<&str>, sender_userid: &str) -> ParsedInbound {
         ParsedInbound {
             msg_id: "msg-1".to_string(),
@@ -3203,6 +3437,14 @@ mod tests {
                 "from": { "userid": sender_userid },
                 "text": { "content": "@bot hello" }
             }),
+        }
+    }
+
+    fn test_media_attachment() -> MediaAttachment {
+        MediaAttachment {
+            file_name: "attachment.txt".to_string(),
+            data: b"hello".to_vec(),
+            mime_type: Some("text/plain".to_string()),
         }
     }
 

--- a/crates/zeroclaw-channels/src/wecom_ws.rs
+++ b/crates/zeroclaw-channels/src/wecom_ws.rs
@@ -15,13 +15,14 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::sync::mpsc;
 use tokio_tungstenite::tungstenite::Message as WsMessage;
 use zeroclaw_api::channel::{Channel, ChannelMessage, SendMessage};
-use zeroclaw_api::media::MediaAttachment;
+use zeroclaw_api::media::{MediaAttachment, MediaKind};
 use zeroclaw_config::schema::{StreamMode, WeComWsConfig};
 use zeroclaw_runtime::i18n;
 
 // ── Constants ────────────────────────────────────────────────────────
 
 const WECOM_WS_URL: &str = "wss://openws.work.weixin.qq.com";
+const WECOM_QYAPI_BASE_URL: &str = "https://qyapi.weixin.qq.com";
 const WECOM_BACKOFF_INITIAL_SECS: u64 = 5;
 const WECOM_BACKOFF_MAX_SECS: u64 = 60;
 const WECOM_PING_INTERVAL_SECS: u64 = 30;
@@ -191,6 +192,8 @@ struct WeComRuntimeConfig {
     proxy_url: Option<String>,
 }
 
+type CorpCredentialsResolver = Arc<dyn Fn() -> Option<(String, String)> + Send + Sync>;
+
 #[derive(Debug, Clone)]
 struct CachedAccessToken {
     token: String,
@@ -251,6 +254,7 @@ pub struct WeComWsChannel {
     secret: String,
     alias: String,
     peer_resolver: Arc<dyn Fn() -> Vec<String> + Send + Sync>,
+    corp_credentials_resolver: CorpCredentialsResolver,
     cfg: WeComRuntimeConfig,
     client: reqwest::Client,
     ws_tx: Arc<tokio::sync::Mutex<Option<mpsc::Sender<WsOutbound>>>>,
@@ -268,10 +272,15 @@ pub struct WeComWsChannel {
 impl WeComWsChannel {
     pub fn new(config: &WeComWsConfig, workspace_dir: &Path) -> Result<Self> {
         let allowed_users = normalize_wecom_allowlist(config.allowed_users.clone());
+        let corp_id = config.corp_id.clone();
+        let corp_secret = config.corp_secret.clone();
         Self::new_with_alias(
             config,
             "default",
             Arc::new(move || allowed_users.clone()),
+            Arc::new(move || {
+                normalize_corp_credentials(corp_id.as_deref(), corp_secret.as_deref())
+            }),
             workspace_dir,
         )
     }
@@ -280,6 +289,7 @@ impl WeComWsChannel {
         config: &WeComWsConfig,
         alias: impl Into<String>,
         peer_resolver: Arc<dyn Fn() -> Vec<String> + Send + Sync>,
+        corp_credentials_resolver: CorpCredentialsResolver,
         workspace_dir: &Path,
     ) -> Result<Self> {
         if config.stream_mode == StreamMode::MultiMessage {
@@ -300,6 +310,7 @@ impl WeComWsChannel {
             secret: config.secret.clone(),
             alias: alias.into(),
             peer_resolver,
+            corp_credentials_resolver,
             cfg: WeComRuntimeConfig {
                 workspace_dir: workspace_dir.to_path_buf(),
                 allowed_groups: normalize_wecom_allowlist(config.allowed_groups.clone()),
@@ -1460,17 +1471,13 @@ impl WeComWsChannel {
                 "WeCom external-scope attachments are not supported by the current HTTP external message path: {scope}"
             );
         }
+        let (media_type, msgtype) = wecom_attachment_wire_kind(attachment.kind());
 
         // Upload via WeCom media/upload CGI
         let upload_url = format!(
             "https://qyapi.weixin.qq.com/cgi-bin/media/upload?access_token={token}&type={media_type}",
             token = self.resolve_access_token().await?,
-            media_type = match attachment.kind() {
-                zeroclaw_api::media::MediaKind::Image => "image",
-                zeroclaw_api::media::MediaKind::Audio => "voice",
-                zeroclaw_api::media::MediaKind::Video => "video",
-                zeroclaw_api::media::MediaKind::Unknown => "file",
-            }
+            media_type = media_type,
         );
 
         // Part::mime_str returns Result<Part>; apply ? before adding to the form.
@@ -1519,14 +1526,6 @@ impl WeComWsChannel {
             )
         })?;
 
-        // Dispatch the actual message via aibot_send_msg
-        let msgtype = match attachment.kind() {
-            zeroclaw_api::media::MediaKind::Image => "image",
-            zeroclaw_api::media::MediaKind::Audio => "voice",
-            zeroclaw_api::media::MediaKind::Video => "video",
-            zeroclaw_api::media::MediaKind::Unknown => "file",
-        };
-
         let (frame, req_id) = build_attachment_send_command(chat_type, chatid, msgtype, &media_id);
 
         self.ws_send_frame_and_wait_for_response(frame, &req_id, "aibot_send_msg")
@@ -1571,8 +1570,11 @@ impl WeComWsChannel {
     }
 
     async fn fetch_access_token(&self) -> Result<CachedAccessToken> {
-        // TODO(review): Confirm that channel bot_id/secret are the qyapi
-        // corpid/corpsecret values for gettoken before changing credential wiring.
+        self.fetch_access_token_from_base(WECOM_QYAPI_BASE_URL)
+            .await
+    }
+
+    async fn fetch_access_token_from_base(&self, base_url: &str) -> Result<CachedAccessToken> {
         #[derive(serde::Deserialize)]
         struct TokenResp {
             #[serde(rename = "access_token")]
@@ -1582,14 +1584,22 @@ impl WeComWsChannel {
             errmsg: Option<String>,
         }
 
-        let url = format!(
-            "https://qyapi.weixin.qq.com/cgi-bin/gettoken?corpid={}&corpsecret={}",
-            self.bot_id, self.secret,
-        );
+        let (corp_id, corp_secret) = (self.corp_credentials_resolver)().ok_or_else(|| {
+            anyhow::Error::msg(
+                "WeCom WebSocket corp application credentials are required for gettoken; \
+                 set channels.wecom_ws.<alias>.corp_id and corp_secret",
+            )
+        })?;
+        let mut url = reqwest::Url::parse(base_url)
+            .with_context(|| format!("invalid WeCom qyapi base URL: {base_url}"))?;
+        url.set_path("cgi-bin/gettoken");
+        url.query_pairs_mut()
+            .append_pair("corpid", &corp_id)
+            .append_pair("corpsecret", &corp_secret);
 
         let resp = self
             .client
-            .get(&url)
+            .get(url)
             .send()
             .await
             .with_context(|| "failed to fetch WeCom access token")?;
@@ -2390,6 +2400,26 @@ fn parse_scope(scope: &str) -> Result<(u32, &str)> {
         Ok((3, external_user_id))
     } else {
         anyhow::bail!("WeCom: invalid scope format: {scope}")
+    }
+}
+
+fn normalize_corp_credentials(
+    corp_id: Option<&str>,
+    corp_secret: Option<&str>,
+) -> Option<(String, String)> {
+    let corp_id = corp_id.map(str::trim).filter(|value| !value.is_empty())?;
+    let corp_secret = corp_secret
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?;
+    Some((corp_id.to_string(), corp_secret.to_string()))
+}
+
+fn wecom_attachment_wire_kind(kind: MediaKind) -> (&'static str, &'static str) {
+    match kind {
+        MediaKind::Image => ("image", "image"),
+        MediaKind::Audio => ("voice", "voice"),
+        MediaKind::Video => ("video", "video"),
+        MediaKind::Unknown => ("file", "file"),
     }
 }
 
@@ -3386,6 +3416,51 @@ mod tests {
         assert!(err.contains("api freq out of limit"));
     }
 
+    #[tokio::test]
+    async fn fetch_access_token_uses_corp_application_credentials() {
+        use wiremock::matchers::{method, path, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/cgi-bin/gettoken"))
+            .and(query_param("corpid", "ww-corp-123"))
+            .and(query_param("corpsecret", "corp-secret-456"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "errcode": 0,
+                "access_token": "qyapi-token",
+                "expires_in": 7200
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let channel = WeComWsChannel::new(&test_wecom_ws_config(), Path::new("/tmp")).unwrap();
+        let token = channel
+            .fetch_access_token_from_base(&server.uri())
+            .await
+            .unwrap();
+
+        assert_eq!(token.token, "qyapi-token");
+    }
+
+    #[tokio::test]
+    async fn fetch_access_token_requires_corp_application_credentials() {
+        let mut config = test_wecom_ws_config();
+        config.corp_id = None;
+        let channel = WeComWsChannel::new(&config, Path::new("/tmp")).unwrap();
+
+        let err = channel
+            .fetch_access_token_from_base("http://127.0.0.1:9")
+            .await
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("corp application credentials are required"));
+        assert!(err.contains("corp_id"));
+        assert!(err.contains("corp_secret"));
+    }
+
     #[test]
     fn access_token_refresh_failure_uses_concurrently_populated_cache() {
         let channel = WeComWsChannel::new(&test_wecom_ws_config(), Path::new("/tmp")).unwrap();
@@ -3453,6 +3528,8 @@ mod tests {
             enabled: true,
             bot_id: "bot123".to_string(),
             secret: "secret456".to_string(),
+            corp_id: Some("ww-corp-123".to_string()),
+            corp_secret: Some("corp-secret-456".to_string()),
             allowed_users: vec![],
             allowed_groups: vec![],
             bot_name: None,

--- a/crates/zeroclaw-channels/src/wecom_ws.rs
+++ b/crates/zeroclaw-channels/src/wecom_ws.rs
@@ -15,6 +15,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::sync::mpsc;
 use tokio_tungstenite::tungstenite::Message as WsMessage;
 use zeroclaw_api::channel::{Channel, ChannelMessage, SendMessage};
+use zeroclaw_api::media::MediaAttachment;
 use zeroclaw_config::schema::{StreamMode, WeComWsConfig};
 use zeroclaw_runtime::i18n;
 
@@ -1431,9 +1432,122 @@ impl WeComWsChannel {
 
         Ok(())
     }
-}
 
-// ── Channel trait impl ───────────────────────────────────────────────
+    /// Upload a media file and send it via `aibot_send_msg` with the appropriate
+    /// WeCom `msgtype` (`image` or `file`).
+    async fn send_attachment(&self, scope: &str, attachment: &MediaAttachment) -> Result<()> {
+        use base64::Engine as _;
+
+        let (chat_type, chatid) = parse_scope(scope)?;
+
+        // Upload via WeCom media/upload CGI
+        let upload_url = format!(
+            "https://qyapi.weixin.qq.com/cgi-bin/media/upload?access_token={token}&type={media_type}",
+            token = self.resolve_access_token().await?,
+            media_type = match attachment.kind() {
+                zeroclaw_api::media::MediaKind::Image => "image",
+                zeroclaw_api::media::MediaKind::Audio => "voice",
+                zeroclaw_api::media::MediaKind::Video => "video",
+                zeroclaw_api::media::MediaKind::Unknown => "file",
+            }
+        );
+
+        let form = reqwest::multipart::Form::new()
+            .part(
+                "media",
+                reqwest::multipart::Part::bytes(attachment.data.clone())
+                    .file_name(attachment.file_name.clone())
+                    .mime_str(attachment.mime_type.as_deref().unwrap_or("application/octet-stream")),
+            );
+
+        let resp = self
+            .client
+            .post(&upload_url)
+            .multipart(form)
+            .send()
+            .await
+            .with_context(|| format!("media upload failed: {}", attachment.file_name))?;
+
+        #[derive(serde::Deserialize)]
+        struct UploadResp {
+            #[serde(rename = "media_id")]
+            media_id: Option<String>,
+            errcode: Option<i64>,
+            errmsg: Option<String>,
+        }
+
+        let upload: UploadResp = resp.json().await?;
+        let media_id = upload
+            .media_id
+            .ok_or_else(|| anyhow::anyhow!("WeCom upload response missing media_id: {:?}", upload.errmsg))?;
+
+        // Dispatch the actual message via aibot_send_msg
+        let msgtype = match attachment.kind() {
+            zeroclaw_api::media::MediaKind::Image => "image",
+            zeroclaw_api::media::MediaKind::Audio => "voice",
+            zeroclaw_api::media::MediaKind::Video => "video",
+            zeroclaw_api::media::MediaKind::Unknown => "file",
+        };
+
+        let frame = serde_json::json!({
+            "cmd": "aibot_send_msg",
+            "headers": { "req_id": random_ascii_token(16) },
+            "body": {
+                "chatid": chatid,
+                "chat_type": chat_type,
+                "msgtype": msgtype,
+                msgtype => { "media_id": media_id }
+            }
+        });
+
+        self.ws_send_frame_and_wait_for_response(frame, "unused", "aibot_send_msg")
+            .await?;
+
+        wecom_log_info!(
+            "WeCom attachment sent msgtype={} file={} scope={}",
+            msgtype,
+            attachment.file_name,
+            scope
+        );
+
+        Ok(())
+    }
+
+    /// Resolve the current access token for the bot's credentials.
+    async fn resolve_access_token(&self) -> Result<String> {
+        // Fetch a fresh access token from WeCom's gettoken endpoint using the
+        // bot's bot_id (agentid) and secret from the channel config.
+        #[derive(serde::Deserialize)]
+        struct TokenResp {
+            #[serde(rename = "access_token")]
+            access_token: Option<String>,
+            errcode: Option<i64>,
+            errmsg: Option<String>,
+        }
+
+        let url = format!(
+            "https://qyapi.weixin.qq.com/cgi-bin/gettoken?corpid={}&corpsecret={}",
+            self.bot_id,
+            self.secret,
+        );
+
+        let resp = self
+            .client
+            .get(&url)
+            .send()
+            .await
+            .with_context(|| "failed to fetch WeCom access token")?;
+
+        let token: TokenResp = resp
+            .json()
+            .await
+            .with_context(|| "failed to parse WeCom token response")?;
+
+        token
+            .access_token
+            .ok_or_else(|| anyhow::anyhow!("WeCom gettoken failed: {:?}", token.errmsg))
+    }
+}
 
 impl ::zeroclaw_api::attribution::Attributable for WeComWsChannel {
     fn role(&self) -> ::zeroclaw_api::attribution::Role {
@@ -1454,6 +1568,12 @@ impl Channel for WeComWsChannel {
     }
 
     async fn send(&self, message: &SendMessage) -> Result<()> {
+        if message.recipient.starts_with("external--") {
+            return self
+                .send_external_user_message(&message.recipient, &message.content)
+                .await;
+        }
+
         if let Some(req_id) = message
             .thread_ts
             .as_deref()
@@ -1474,11 +1594,96 @@ impl Channel for WeComWsChannel {
                     .await?;
             }
 
+            // Send attachments after streaming response
+            for attachment in &message.attachments {
+                self.send_attachment(&message.recipient, attachment).await?;
+            }
+
             return Ok(());
         }
 
         self.send_markdown_chunks_to_scope(&message.recipient, &message.content)
+            .await?;
+
+        // Send attachments after text content
+        for attachment in &message.attachments {
+            self.send_attachment(&message.recipient, attachment).await?;
+        }
+
+        Ok(())
+    }
+
+    /// Send a proactive message to an external user via the WeCom
+    /// `agent/send_message` HTTP API (chat_type=3).
+    ///
+    /// The `scope` must have the `external--` prefix, e.g. `external--zhangsan@example.com`.
+    /// This path is used for outbound-initiated (proactive) messages to external contacts,
+    /// which require the application to have external contact permissions and cannot be
+    /// sent over the WebSocket `aibot_send_msg` channel.
+    async fn send_external_user_message(&self, scope: &str, content: &str) -> Result<()> {
+        let external_user_id = scope
+            .strip_prefix("external--")
+            .ok_or_else(|| anyhow::anyhow!("invalid external scope: {scope}"))?;
+
+        let token = self.resolve_access_token().await?;
+
+        // WeCom application message API — sends a text message to an external user.
+        // The agentid (bot_id) and external_userid identify the sender application and
+        // the target external contact respectively.
+        #[derive(serde::Serialize)]
+        struct AgentMsgBody<'a> {
+            #[serde(rename = "touser")]
+            touser: &'a str,
+            #[serde(rename = "agentid")]
+            agentid: &'a str,
+            #[serde(rename = "msgtype")]
+            msgtype: &'a str,
+            #[serde(rename = "text")]
+            text: &'a serde_json::Value,
+        }
+
+        let body = AgentMsgBody {
+            touser: external_user_id,
+            agentid: &self.bot_id,
+            msgtype: "text",
+            text: &serde_json::json!({ "content": content }),
+        };
+
+        let url = format!(
+            "https://qyapi.weixin.qq.com/cgi-bin/message/send?access_token={token}",
+            token = token
+        );
+
+        let resp = self
+            .client
+            .post(&url)
+            .json(&body)
+            .send()
             .await
+            .with_context(|| format!("WeCom external message send failed"))?;
+
+        #[derive(serde::Deserialize)]
+        struct ApiResp {
+            errcode: Option<i64>,
+            errmsg: Option<String>,
+        }
+
+        let result: ApiResp = resp.json().await?;
+        let errcode = result.errcode.unwrap_or(-1);
+        if errcode != 0 {
+            anyhow::bail!(
+                "WeCom external message API error (errcode={}): {:?}",
+                errcode,
+                result.errmsg
+            );
+        }
+
+        wecom_log_info!(
+            "WeCom external proactive message sent to={} len={}",
+            external_user_id,
+            content.len()
+        );
+        Ok(())
     }
 
     async fn listen(&self, tx: tokio::sync::mpsc::Sender<ChannelMessage>) -> Result<()> {
@@ -2079,6 +2284,11 @@ fn parse_scope(scope: &str) -> Result<(u32, &str)> {
         Ok((1, userid))
     } else if let Some(chatid) = scope.strip_prefix("group--") {
         Ok((2, chatid))
+    } else if let Some(external_user_id) = scope.strip_prefix("external--") {
+        // Proactive messaging to external users via WeCom application message API.
+        // chat_type 3 is "external" — sends a WeCom application message to an
+        // external user (requires the application to have external contact permissions).
+        Ok((3, external_user_id))
     } else {
         anyhow::bail!("WeCom: invalid scope format: {scope}")
     }
@@ -2884,6 +3094,12 @@ mod tests {
         assert!(summary.contains("feedback_id=fb_1"));
         assert!(summary.contains("feedback_type=2"));
         assert!(summary.contains("content=not accurate"));
+    }
+
+    #[test]
+    fn parse_scope_external() {
+        assert_eq!(parse_scope("external--zhangsan@example.com"), Ok((3, "zhangsan@example.com")));
+        assert_eq!(parse_scope("external--lisi@external.com"), Ok((3, "lisi@external.com")));
     }
 
     #[test]

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -14330,6 +14330,18 @@ pub struct WeComWsConfig {
     #[secret]
     #[cfg_attr(feature = "schema-export", schemars(extend("x-secret" = true)))]
     pub secret: String,
+    /// WeCom corp ID for qyapi application calls such as proactive send,
+    /// gettoken, and media upload. This is distinct from the WebSocket
+    /// subscription `bot_id`.
+    #[serde(default)]
+    pub corp_id: Option<String>,
+    /// WeCom corp application secret for qyapi application calls such as
+    /// proactive send, gettoken, and media upload. This is distinct from the
+    /// WebSocket subscription `secret`.
+    #[serde(default)]
+    #[secret]
+    #[cfg_attr(feature = "schema-export", schemars(extend("x-secret" = true)))]
+    pub corp_secret: Option<String>,
     /// Allowed WeCom user IDs. Empty = deny all, "*" = allow all users.
     #[serde(default)]
     pub allowed_users: Vec<String>,
@@ -14367,6 +14379,8 @@ impl Default for WeComWsConfig {
             enabled: false,
             bot_id: String::new(),
             secret: String::new(),
+            corp_id: None,
+            corp_secret: None,
             allowed_users: Vec::new(),
             allowed_groups: Vec::new(),
             bot_name: None,
@@ -20013,6 +20027,8 @@ auto_save = true
             enabled = true
             bot_id = "bot-123"
             secret = "sk-test"
+            corp_id = "ww-corp-123"
+            corp_secret = "corp-secret-test"
             allowed_users = ["zeroclaw_user"]
             allowed_groups = ["zeroclaw_group"]
             bot_name = "danya"
@@ -20023,6 +20039,8 @@ auto_save = true
         assert!(parsed.enabled);
         assert_eq!(parsed.bot_id, "bot-123");
         assert_eq!(parsed.secret, "sk-test");
+        assert_eq!(parsed.corp_id.as_deref(), Some("ww-corp-123"));
+        assert_eq!(parsed.corp_secret.as_deref(), Some("corp-secret-test"));
         assert_eq!(parsed.allowed_users, vec!["zeroclaw_user"]);
         assert_eq!(parsed.allowed_groups, vec!["zeroclaw_group"]);
         assert_eq!(parsed.bot_name.as_deref(), Some("danya"));
@@ -20036,7 +20054,12 @@ auto_save = true
         assert_eq!(WeComWsConfig::default().stream_mode, StreamMode::Partial);
         assert!(WeComWsConfig::default().bot_name.is_none());
         assert!(WeComWsConfig::default().proxy_url.is_none());
+        assert!(WeComWsConfig::default().corp_id.is_none());
+        assert!(WeComWsConfig::default().corp_secret.is_none());
         assert!(WeComWsConfig::prop_is_secret("channels.wecom_ws.secret"));
+        assert!(WeComWsConfig::prop_is_secret(
+            "channels.wecom_ws.corp_secret"
+        ));
     }
 
     #[test]
@@ -20050,6 +20073,8 @@ auto_save = true
             enabled = true
             bot_id = "bot-123"
             secret = "sk-test"
+            corp_id = "ww-corp-123"
+            corp_secret = "corp-secret-test"
             allowed_users = ["zeroclaw_user"]
         "#;
         let parsed: Config = toml::from_str(toml).unwrap();
@@ -20060,6 +20085,7 @@ auto_save = true
         );
         let ws = parsed.channels.wecom_ws.get("default").unwrap();
         assert_eq!(ws.bot_id, "bot-123");
+        assert_eq!(ws.corp_id.as_deref(), Some("ww-corp-123"));
         assert_eq!(ws.allowed_users, vec!["zeroclaw_user"]);
         assert_eq!(ws.stream_mode, StreamMode::Partial);
     }

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -63,6 +63,7 @@
   - [Slack](./channels/slack.md)
   - [Mattermost](./channels/mattermost.md)
   - [LINE](./channels/line.md)
+  - [WeCom WebSocket](./channels/wecom-ws.md)
   - [Nextcloud Talk](./channels/nextcloud-talk.md)
   - [Signal](./channels/signal.md)
   - [WhatsApp](./channels/whatsapp.md)

--- a/docs/book/src/channels/wecom-ws.md
+++ b/docs/book/src/channels/wecom-ws.md
@@ -1,0 +1,111 @@
+# WeCom WebSocket
+
+ZeroClaw supports WeCom AI Bot long-connection mode through
+`[channels.wecom_ws.<alias>]`. The channel receives inbound messages over the
+WeCom WebSocket subscription and sends active-session replies over the same
+connection.
+
+## Who can talk to the agent
+
+{{#peer-group wecom_ws}}
+
+WeCom WebSocket scopes use native WeCom IDs:
+
+| Scope | Meaning |
+|---|---|
+| `user--<userid>` | A WeCom internal user ID. |
+| `group--<chatid>` | A WeCom group chat ID. |
+| `external--<external_userid>` | An external-contact user ID for the WeCom application message API. |
+
+The `external--` prefix is required for external-contact proactive sends so the
+channel can route through the HTTP application-message surface instead of the
+WebSocket active-session reply path.
+
+## Credentials
+
+WeCom WebSocket uses two distinct credential pairs. Do not reuse one pair for
+the other purpose.
+
+| Field | Source | Used for |
+|---|---|---|
+| `bot_id` | WeCom AI Bot WebSocket subscription | Subscribing to `openws.work.weixin.qq.com`. |
+| `secret` | WeCom AI Bot WebSocket subscription | Authenticating the WebSocket subscription. |
+| `corp_id` | WeCom corp application | `qyapi` `gettoken`, proactive external sends, and media upload. |
+| `corp_secret` | WeCom corp application | `qyapi` `gettoken`, proactive external sends, and media upload. |
+
+`corp_id` and `corp_secret` are required only when the channel needs qyapi
+application calls: proactive sends to `external--...` recipients or attachment
+upload before a proactive send. If either value is missing, those paths fail
+with a configuration error instead of falling back to `bot_id` / `secret`.
+
+## Configuration
+
+{{#config-fields channels.wecom_ws}}
+
+Minimal example:
+
+```toml
+[channels.wecom_ws.work]
+enabled = true
+bot_id = "wecom-ai-bot-id"
+secret = "wecom-ai-bot-subscription-secret"
+corp_id = "wwxxxxxxxxxxxxxxxx"
+corp_secret = "corp-application-secret"
+bot_name = "zeroclaw"
+```
+
+Bind the channel to an agent through peer groups:
+
+```toml
+[peer_groups.wecom_work]
+channel = "wecom_ws.work"
+agents = ["default"]
+external_peers = ["zhangsan", "group-chat-id"]
+```
+
+## Proactive Send
+
+Use `zeroclaw channel send` for one-off messages. The `--channel-id` can be the
+channel type (`wecom_ws`) or an aliased channel (`wecom_ws.work`), depending on
+how the channel is configured.
+
+Send to an internal user:
+
+```sh
+zeroclaw channel send 'Build succeeded.' --channel-id wecom_ws.work --recipient user--zhangsan
+```
+
+Send to a group:
+
+```sh
+zeroclaw channel send 'Nightly report is ready.' --channel-id wecom_ws.work --recipient group--group-chat-id
+```
+
+Send to an external contact through the WeCom application message API:
+
+```sh
+zeroclaw channel send 'Your support case has been updated.' --channel-id wecom_ws.work --recipient external--external-user-id
+```
+
+Internal user and group sends use the WebSocket `aibot_send_msg` surface.
+External-contact sends use the qyapi HTTP `message/send` surface and therefore
+require `corp_id` and `corp_secret`.
+
+## Media
+
+Inbound media attachments are downloaded and normalized when the incoming WeCom
+payload includes a supported media URL and AES key. The channel handles image,
+voice/audio, and file messages.
+
+Proactive attachment sends upload media through qyapi `media/upload` before
+sending the message. Supported upload wire types are:
+
+| Attachment kind | WeCom upload `type` / `msgtype` |
+|---|---|
+| Image | `image` |
+| Audio | `voice` |
+| Video | `video` |
+| Other file | `file` |
+
+External-contact attachment sends are not currently supported; the channel
+returns a clear error for attachments addressed to an `external--...` recipient.


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Make the wecom_ws proactive/attachment messaging paths compile and lint. Fixes: (1) `serde_json::json!` rejects expression keys — build the body then insert the msgtype-named media object separately; (2) `reqwest` `Part::mime_str` is fallible — apply `?` before adding the part to the form; (3) remove an unused `base64::Engine` import; (4) move `send_external_user_message` out of `impl Channel` (it is not a trait method) into an inherent impl; (5) `parse_scope` returns a `Result` whose `anyhow::Error` is not `PartialEq` — assert on the unwrapped tuple; (6) drop two never-read `errcode` fields and replace disallowed `anyhow::anyhow!` with `.with_context(..)`.
- **Scope boundary:** wecom_ws channel only; no trait or cross-channel changes.
- **Blast radius:** `zeroclaw-channels` wecom_ws path only.
- **Linked issue(s):** Resolves #7824

## Validation Evidence (required)

Validated against the **actual CI gate** (`ci-all` feature set, toolchain `1.93.0`):

```
cargo +1.93.0 fmt --all -- --check                                                  -> PASS
cargo +1.93.0 check  --locked --features ci-all                                     -> PASS
cargo +1.93.0 clippy --workspace --exclude zeroclaw-desktop --all-targets \
      --features ci-all --locked -- -D warnings                                     -> PASS
cargo +1.93.0 test --test architecture (config-isolation + fluent)                  -> PASS
```
GitHub `Test` (full nextest suite) + `CI Required Gate`: green.

## Security & Privacy Impact (required)

- New permissions / fs access? `No`
- New external network calls? `No` (the wecom HTTP calls already existed in the feature)
- Secrets / credentials handling changed? `No`
- PII in diff/tests/fixtures/docs? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`

## Rollback (required for medium/high risk)

Low risk: `git revert <sha>`.
