### PR TITLE
feat(channels/qq): thread passive group replies via refer_msg

### DIFF
--- a/crates/zeroclaw-channels/src/qq.rs
+++ b/crates/zeroclaw-channels/src/qq.rs
@@ -947,7 +947,8 @@ impl QQChannel {
                     file_name.as_deref(),
                 )
                 .await?;
-            self.send_media_message(recipient, &file_info, in_reply_to).await?;
+            self.send_media_message(recipient, &file_info, in_reply_to)
+                .await?;
         } else {
             // Local file upload
             let path = Path::new(target);
@@ -1003,7 +1004,8 @@ impl QQChannel {
                     .await;
             }
 
-            self.send_media_message(recipient, &file_info, in_reply_to).await?;
+            self.send_media_message(recipient, &file_info, in_reply_to)
+                .await?;
         }
 
         Ok(())
@@ -1320,7 +1322,10 @@ impl Channel for QQChannel {
 
         // Send each media attachment
         for attachment in &attachments {
-            if let Err(e) = self.send_attachment(&message.recipient, attachment, None).await {
+            if let Err(e) = self
+                .send_attachment(&message.recipient, attachment, None)
+                .await
+            {
                 ::zeroclaw_log::record!(WARN, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_outcome(::zeroclaw_log::EventOutcome::Unknown).with_attrs(::serde_json::json!({"target": attachment.target, "error": format!("{}", e)})), "failed to send media attachment; falling back to text");
                 // Degrade to text fallback
                 let fallback = format!(

--- a/crates/zeroclaw-channels/src/qq.rs
+++ b/crates/zeroclaw-channels/src/qq.rs
@@ -1322,52 +1322,99 @@ impl ::zeroclaw_api::attribution::Attributable for QQChannel {
 }
 
 #[async_trait]
+trait QQOutboundSender {
+    async fn send_text_markdown(
+        &self,
+        recipient: &str,
+        content: &str,
+        in_reply_to: Option<&str>,
+    ) -> anyhow::Result<()>;
+
+    async fn send_attachment(
+        &self,
+        recipient: &str,
+        attachment: &QQMediaAttachment,
+        in_reply_to: Option<&str>,
+    ) -> anyhow::Result<()>;
+}
+
+#[async_trait]
+impl QQOutboundSender for QQChannel {
+    async fn send_text_markdown(
+        &self,
+        recipient: &str,
+        content: &str,
+        in_reply_to: Option<&str>,
+    ) -> anyhow::Result<()> {
+        QQChannel::send_text_markdown(self, recipient, content, in_reply_to).await
+    }
+
+    async fn send_attachment(
+        &self,
+        recipient: &str,
+        attachment: &QQMediaAttachment,
+        in_reply_to: Option<&str>,
+    ) -> anyhow::Result<()> {
+        QQChannel::send_attachment(self, recipient, attachment, in_reply_to).await
+    }
+}
+
+async fn send_qq_message_with_sender(
+    sender: &impl QQOutboundSender,
+    message: &SendMessage,
+) -> anyhow::Result<()> {
+    let (cleaned_text, attachments) = parse_qq_attachment_markers(&message.content);
+    let in_reply_to = message.in_reply_to.as_deref();
+
+    if attachments.is_empty() {
+        // No media markers — send as markdown (original path)
+        return sender
+            .send_text_markdown(&message.recipient, &message.content, in_reply_to)
+            .await;
+    }
+
+    // Send cleaned text first (if non-empty)
+    if !cleaned_text.is_empty() {
+        sender
+            .send_text_markdown(&message.recipient, &cleaned_text, in_reply_to)
+            .await?;
+    }
+
+    // Send each media attachment
+    for attachment in &attachments {
+        if let Err(e) = sender
+            .send_attachment(&message.recipient, attachment, in_reply_to)
+            .await
+        {
+            ::zeroclaw_log::record!(WARN, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_outcome(::zeroclaw_log::EventOutcome::Unknown).with_attrs(::serde_json::json!({"target": attachment.target, "error": format!("{}", e)})), "failed to send media attachment; falling back to text");
+            // Degrade to text fallback
+            let fallback = format!(
+                "{}: {}",
+                match attachment.kind {
+                    QQMediaFileType::Image => "Image",
+                    QQMediaFileType::Video => "Video",
+                    QQMediaFileType::Voice => "Voice",
+                    QQMediaFileType::File => "File",
+                },
+                attachment.target
+            );
+            sender
+                .send_text_markdown(&message.recipient, &fallback, in_reply_to)
+                .await?;
+        }
+    }
+
+    Ok(())
+}
+
+#[async_trait]
 impl Channel for QQChannel {
     fn name(&self) -> &str {
         "qq"
     }
 
     async fn send(&self, message: &SendMessage) -> anyhow::Result<()> {
-        let (cleaned_text, attachments) = parse_qq_attachment_markers(&message.content);
-        let in_reply_to = message.in_reply_to.as_deref();
-
-        if attachments.is_empty() {
-            // No media markers — send as markdown (original path)
-            return self
-                .send_text_markdown(&message.recipient, &message.content, in_reply_to)
-                .await;
-        }
-
-        // Send cleaned text first (if non-empty)
-        if !cleaned_text.is_empty() {
-            self.send_text_markdown(&message.recipient, &cleaned_text, in_reply_to)
-                .await?;
-        }
-
-        // Send each media attachment
-        for attachment in &attachments {
-            if let Err(e) = self
-                .send_attachment(&message.recipient, attachment, in_reply_to)
-                .await
-            {
-                ::zeroclaw_log::record!(WARN, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_outcome(::zeroclaw_log::EventOutcome::Unknown).with_attrs(::serde_json::json!({"target": attachment.target, "error": format!("{}", e)})), "failed to send media attachment; falling back to text");
-                // Degrade to text fallback
-                let fallback = format!(
-                    "{}: {}",
-                    match attachment.kind {
-                        QQMediaFileType::Image => "Image",
-                        QQMediaFileType::Video => "Video",
-                        QQMediaFileType::Voice => "Voice",
-                        QQMediaFileType::File => "File",
-                    },
-                    attachment.target
-                );
-                self.send_text_markdown(&message.recipient, &fallback, None)
-                    .await?;
-            }
-        }
-
-        Ok(())
+        send_qq_message_with_sender(self, message).await
     }
 
     #[allow(clippy::too_many_lines)]
@@ -2258,6 +2305,65 @@ allowed_users = ["user1"]
         assert_eq!(body["msg_type"], 2);
         assert_eq!(body["markdown"]["content"], "hello");
         assert!(body.get("refer_msg").is_none());
+    }
+
+    struct FailingAttachmentSender {
+        text_sends: tokio::sync::Mutex<Vec<(String, String, Option<String>)>>,
+    }
+
+    #[async_trait]
+    impl QQOutboundSender for FailingAttachmentSender {
+        async fn send_text_markdown(
+            &self,
+            recipient: &str,
+            content: &str,
+            in_reply_to: Option<&str>,
+        ) -> anyhow::Result<()> {
+            self.text_sends.lock().await.push((
+                recipient.to_string(),
+                content.to_string(),
+                in_reply_to.map(str::to_string),
+            ));
+            Ok(())
+        }
+
+        async fn send_attachment(
+            &self,
+            _recipient: &str,
+            attachment: &QQMediaAttachment,
+            in_reply_to: Option<&str>,
+        ) -> anyhow::Result<()> {
+            assert_eq!(attachment.kind, QQMediaFileType::Image);
+            assert_eq!(attachment.target, "https://cdn.example.com/fail.png");
+            assert_eq!(in_reply_to, Some("qq_msg_123"));
+            anyhow::bail!("simulated QQ attachment upload failure");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_attachment_fallback_send_preserves_in_reply_to() {
+        let sender = FailingAttachmentSender {
+            text_sends: tokio::sync::Mutex::new(Vec::new()),
+        };
+        let message = SendMessage {
+            content: "[IMAGE:https://cdn.example.com/fail.png]".to_string(),
+            recipient: "group:group_123".to_string(),
+            subject: None,
+            thread_ts: None,
+            cancellation_token: None,
+            attachments: vec![],
+            in_reply_to: Some("qq_msg_123".to_string()),
+        };
+
+        send_qq_message_with_sender(&sender, &message)
+            .await
+            .expect("fallback text send succeeds");
+
+        let text_sends = sender.text_sends.lock().await;
+        assert_eq!(text_sends.len(), 1);
+        assert_eq!(text_sends[0].0, "group:group_123");
+        assert_eq!(text_sends[0].1, "Image: https://cdn.example.com/fail.png");
+        assert_eq!(text_sends[0].2.as_deref(), Some("qq_msg_123"));
     }
 
     #[test]

--- a/crates/zeroclaw-channels/src/qq.rs
+++ b/crates/zeroclaw-channels/src/qq.rs
@@ -81,6 +81,56 @@ fn ensure_https(url: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
+fn build_media_message_body(
+    file_info: &str,
+    msg_seq: u32,
+    in_reply_to: Option<&str>,
+) -> serde_json::Value {
+    let mut body = json!({
+        "msg_type": 7,
+        "media": {
+            "file_info": file_info,
+        },
+        "msg_seq": msg_seq,
+    });
+
+    // Add refer_msg for passive replies (QQ threading/reply support)
+    if let Some(ref_msg_id) = in_reply_to {
+        body["refer_msg"] = json!({
+            "message_id": ref_msg_id,
+        });
+    }
+
+    body
+}
+
+fn build_markdown_message_body(
+    content: &str,
+    msg_seq: u32,
+    in_reply_to: Option<&str>,
+) -> serde_json::Value {
+    let mut body = json!({
+        "markdown": {
+            "content": content,
+        },
+        "msg_type": 2,
+        "msg_seq": msg_seq,
+    });
+
+    // Add refer_msg for passive replies (QQ threading/reply support)
+    if let Some(ref_msg_id) = in_reply_to {
+        body["refer_msg"] = json!({
+            "message_id": ref_msg_id,
+        });
+    }
+
+    body
+}
+
+fn channel_message_id_from(msg_id: &str) -> String {
+    msg_id.to_string()
+}
+
 /// Check whether a file extension is a natively supported QQ voice format.
 fn is_native_voice_ext(ext: &str) -> bool {
     matches!(ext.to_ascii_lowercase().as_str(), "wav" | "mp3" | "silk")
@@ -889,20 +939,7 @@ impl QQChannel {
         let url = format!("{QQ_API_BASE}/v2/{scope}/{id}/messages");
         ensure_https(&url)?;
 
-        let mut body = json!({
-            "msg_type": 7,
-            "media": {
-                "file_info": file_info,
-            },
-            "msg_seq": next_msg_seq(),
-        });
-
-        // Add refer_msg for passive replies (QQ threading/reply support)
-        if let Some(ref_msg_id) = in_reply_to {
-            body["refer_msg"] = json!({
-                "message_id": ref_msg_id,
-            });
-        }
+        let body = build_media_message_body(file_info, next_msg_seq(), in_reply_to);
 
         let resp = self
             .http_client()
@@ -1255,20 +1292,7 @@ impl QQChannel {
         let url = format!("{QQ_API_BASE}/v2/{scope}/{id}/messages");
         ensure_https(&url)?;
 
-        let mut body = json!({
-            "markdown": {
-                "content": content,
-            },
-            "msg_type": 2,
-            "msg_seq": next_msg_seq(),
-        });
-
-        // Add refer_msg for passive replies (QQ threading/reply support)
-        if let Some(ref_msg_id) = in_reply_to {
-            body["refer_msg"] = json!({
-                "message_id": ref_msg_id,
-            });
-        }
+        let body = build_markdown_message_body(content, next_msg_seq(), in_reply_to);
 
         let resp = self
             .http_client()
@@ -1323,7 +1347,7 @@ impl Channel for QQChannel {
         // Send each media attachment
         for attachment in &attachments {
             if let Err(e) = self
-                .send_attachment(&message.recipient, attachment, None)
+                .send_attachment(&message.recipient, attachment, in_reply_to)
                 .await
             {
                 ::zeroclaw_log::record!(WARN, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_outcome(::zeroclaw_log::EventOutcome::Unknown).with_attrs(::serde_json::json!({"target": attachment.target, "error": format!("{}", e)})), "failed to send media attachment; falling back to text");
@@ -1658,7 +1682,7 @@ impl Channel for QQChannel {
                             }
 
                             let channel_msg = ChannelMessage {
-                                id: msg_id.to_string(),
+                                id: channel_message_id_from(msg_id),
                                 sender: user_openid.to_string(),
                                 reply_target: chat_id,
                                 content: composed.content,
@@ -1730,7 +1754,7 @@ impl Channel for QQChannel {
                             }
 
                             let channel_msg = ChannelMessage {
-                                id: msg_id.to_string(),
+                                id: channel_message_id_from(msg_id),
                                 sender: author_id.to_string(),
                                 reply_target: chat_id,
                                 content: composed.content,
@@ -2199,15 +2223,48 @@ allowed_users = ["user1"]
     #[test]
     fn test_send_media_body_msg_type_7() {
         let file_info = "some_file_info_string";
-        let body = json!({
-            "msg_type": 7,
-            "media": {
-                "file_info": file_info,
-            },
-            "msg_seq": 1,
-        });
+        let body = build_media_message_body(file_info, 1, None);
         assert_eq!(body["msg_type"], 7);
         assert_eq!(body["media"]["file_info"], file_info);
+    }
+
+    #[test]
+    fn test_send_media_body_includes_refer_msg_when_replying() {
+        let body = build_media_message_body("some_file_info_string", 1, Some("qq_msg_123"));
+
+        assert_eq!(body["refer_msg"]["message_id"], "qq_msg_123");
+    }
+
+    #[test]
+    fn test_send_media_body_omits_refer_msg_without_reply() {
+        let body = build_media_message_body("some_file_info_string", 1, None);
+
+        assert!(body.get("refer_msg").is_none());
+    }
+
+    #[test]
+    fn test_send_markdown_body_includes_refer_msg_when_replying() {
+        let body = build_markdown_message_body("hello", 1, Some("qq_msg_123"));
+
+        assert_eq!(body["msg_type"], 2);
+        assert_eq!(body["markdown"]["content"], "hello");
+        assert_eq!(body["refer_msg"]["message_id"], "qq_msg_123");
+    }
+
+    #[test]
+    fn test_send_markdown_body_omits_refer_msg_without_reply() {
+        let body = build_markdown_message_body("hello", 1, None);
+
+        assert_eq!(body["msg_type"], 2);
+        assert_eq!(body["markdown"]["content"], "hello");
+        assert!(body.get("refer_msg").is_none());
+    }
+
+    #[test]
+    fn test_channel_message_id_uses_qq_msg_id() {
+        let qq_msg_id = "qq_msg_123";
+
+        assert_eq!(channel_message_id_from(qq_msg_id), qq_msg_id);
     }
 
     // --- compose_message_content tests (now async) ---

--- a/crates/zeroclaw-channels/src/qq.rs
+++ b/crates/zeroclaw-channels/src/qq.rs
@@ -877,20 +877,32 @@ impl QQChannel {
     }
 
     /// Send a media message (msg_type=7) with an already-uploaded file_info.
-    async fn send_media_message(&self, recipient: &str, file_info: &str) -> anyhow::Result<()> {
+    async fn send_media_message(
+        &self,
+        recipient: &str,
+        file_info: &str,
+        in_reply_to: Option<&str>,
+    ) -> anyhow::Result<()> {
         let token = self.get_token().await?;
         let (scope, id) = Self::resolve_recipient(recipient);
 
         let url = format!("{QQ_API_BASE}/v2/{scope}/{id}/messages");
         ensure_https(&url)?;
 
-        let body = json!({
+        let mut body = json!({
             "msg_type": 7,
             "media": {
                 "file_info": file_info,
             },
             "msg_seq": next_msg_seq(),
         });
+
+        // Add refer_msg for passive replies (QQ threading/reply support)
+        if let Some(ref_msg_id) = in_reply_to {
+            body["refer_msg"] = json!({
+                "message_id": ref_msg_id,
+            });
+        }
 
         let resp = self
             .http_client()
@@ -914,6 +926,7 @@ impl QQChannel {
         &self,
         recipient: &str,
         attachment: &QQMediaAttachment,
+        in_reply_to: Option<&str>,
     ) -> anyhow::Result<()> {
         let target = attachment.target.trim();
 
@@ -934,7 +947,7 @@ impl QQChannel {
                     file_name.as_deref(),
                 )
                 .await?;
-            self.send_media_message(recipient, &file_info).await?;
+            self.send_media_message(recipient, &file_info, in_reply_to).await?;
         } else {
             // Local file upload
             let path = Path::new(target);
@@ -968,7 +981,7 @@ impl QQChannel {
                         .with_attrs(::serde_json::json!({"target": target})),
                     "using cached upload for"
                 );
-                self.send_media_message(recipient, &cached_file_info)
+                self.send_media_message(recipient, &cached_file_info, in_reply_to)
                     .await?;
                 return Ok(());
             }
@@ -990,7 +1003,7 @@ impl QQChannel {
                     .await;
             }
 
-            self.send_media_message(recipient, &file_info).await?;
+            self.send_media_message(recipient, &file_info, in_reply_to).await?;
         }
 
         Ok(())
@@ -1228,20 +1241,32 @@ impl QQChannel {
     }
 
     /// Send a markdown text message (msg_type=2).
-    async fn send_text_markdown(&self, recipient: &str, content: &str) -> anyhow::Result<()> {
+    async fn send_text_markdown(
+        &self,
+        recipient: &str,
+        content: &str,
+        in_reply_to: Option<&str>,
+    ) -> anyhow::Result<()> {
         let token = self.get_token().await?;
         let (scope, id) = Self::resolve_recipient(recipient);
 
         let url = format!("{QQ_API_BASE}/v2/{scope}/{id}/messages");
         ensure_https(&url)?;
 
-        let body = json!({
+        let mut body = json!({
             "markdown": {
                 "content": content,
             },
             "msg_type": 2,
             "msg_seq": next_msg_seq(),
         });
+
+        // Add refer_msg for passive replies (QQ threading/reply support)
+        if let Some(ref_msg_id) = in_reply_to {
+            body["refer_msg"] = json!({
+                "message_id": ref_msg_id,
+            });
+        }
 
         let resp = self
             .http_client()
@@ -1278,23 +1303,24 @@ impl Channel for QQChannel {
 
     async fn send(&self, message: &SendMessage) -> anyhow::Result<()> {
         let (cleaned_text, attachments) = parse_qq_attachment_markers(&message.content);
+        let in_reply_to = message.in_reply_to.as_deref();
 
         if attachments.is_empty() {
             // No media markers — send as markdown (original path)
             return self
-                .send_text_markdown(&message.recipient, &message.content)
+                .send_text_markdown(&message.recipient, &message.content, in_reply_to)
                 .await;
         }
 
         // Send cleaned text first (if non-empty)
         if !cleaned_text.is_empty() {
-            self.send_text_markdown(&message.recipient, &cleaned_text)
+            self.send_text_markdown(&message.recipient, &cleaned_text, in_reply_to)
                 .await?;
         }
 
         // Send each media attachment
         for attachment in &attachments {
-            if let Err(e) = self.send_attachment(&message.recipient, attachment).await {
+            if let Err(e) = self.send_attachment(&message.recipient, attachment, None).await {
                 ::zeroclaw_log::record!(WARN, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_outcome(::zeroclaw_log::EventOutcome::Unknown).with_attrs(::serde_json::json!({"target": attachment.target, "error": format!("{}", e)})), "failed to send media attachment; falling back to text");
                 // Degrade to text fallback
                 let fallback = format!(
@@ -1307,7 +1333,7 @@ impl Channel for QQChannel {
                     },
                     attachment.target
                 );
-                self.send_text_markdown(&message.recipient, &fallback)
+                self.send_text_markdown(&message.recipient, &fallback, None)
                     .await?;
             }
         }
@@ -1574,14 +1600,17 @@ impl Channel for QQChannel {
 
                     match event_type {
                         "C2C_MESSAGE_CREATE" => {
+                            // Capture msg_id early so it can be used in the ChannelMessage id field
                             let msg_id = d.get("id").and_then(|i| i.as_str()).unwrap_or("");
                             if self.is_duplicate(msg_id).await {
                                 continue;
                             }
 
-                            let author_id = d.get("author").and_then(|a| a.get("id")).and_then(|i| i.as_str()).unwrap_or("unknown");
+                            let author_id =
+                                d.get("author").and_then(|a| a.get("id")).and_then(|i| i.as_str()).unwrap_or("unknown");
                             // For QQ, user_openid is the identifier
-                            let user_openid = d.get("author").and_then(|a| a.get("user_openid")).and_then(|u| u.as_str()).unwrap_or(author_id);
+                            let user_openid =
+                                d.get("author").and_then(|a| a.get("user_openid")).and_then(|u| u.as_str()).unwrap_or(author_id);
 
                             if !self.is_user_allowed(user_openid) {
                                 ::zeroclaw_log::record!(WARN, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_outcome(::zeroclaw_log::EventOutcome::Unknown).with_attrs(::serde_json::json!({"user_openid": user_openid})), "ignoring C2C message from unauthorized user");
@@ -1624,7 +1653,7 @@ impl Channel for QQChannel {
                             }
 
                             let channel_msg = ChannelMessage {
-                                id: Uuid::new_v4().to_string(),
+                                id: msg_id.to_string(),
                                 sender: user_openid.to_string(),
                                 reply_target: chat_id,
                                 content: composed.content,
@@ -1696,7 +1725,7 @@ impl Channel for QQChannel {
                             }
 
                             let channel_msg = ChannelMessage {
-                                id: Uuid::new_v4().to_string(),
+                                id: msg_id.to_string(),
                                 sender: author_id.to_string(),
                                 reply_target: chat_id,
                                 content: composed.content,


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** QQ group passive replies thread via `refer_msg` (in_reply_to). The code compiled and linted clean; it was committed unformatted and failed the `Format` gate. Applied `rustfmt`; no behavioral change.
- **Scope boundary:** QQ channel only.
- **Blast radius:** `zeroclaw-channels` qq path only.
- **Linked issue(s):** Resolves #7872

## Validation Evidence (required)

Validated against the **actual CI gate** (`ci-all`, toolchain `1.93.0`):

```
cargo +1.93.0 fmt --all -- --check                                                  -> PASS
cargo +1.93.0 check  --locked --features ci-all                                     -> PASS
cargo +1.93.0 clippy --workspace --exclude zeroclaw-desktop --all-targets \
      --features ci-all --locked -- -D warnings                                     -> PASS
cargo +1.93.0 test --test architecture (config-isolation + fluent)                  -> PASS
```
GitHub `Test` (full suite) + `CI Required Gate`: green.

## Security & Privacy Impact (required)

- New permissions / fs access? `No`
- New external network calls? `No`
- Secrets / credentials handling changed? `No`
- PII in diff/tests/fixtures/docs? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`

## Rollback (required for medium/high risk)

Low risk: `git revert <sha>`.
