### PR TITLE
fix(providers): distinguish missing vs expired OpenAI Codex credentials

### DIFF
--- a/crates/zeroclaw-providers/src/openai_codex.rs
+++ b/crates/zeroclaw-providers/src/openai_codex.rs
@@ -1175,6 +1175,11 @@ impl OpenAiCodexModelProvider {
             Err(err) => return Err(err),
         };
 
+        // Distinguish "no credentials at all" from "credentials present but
+        // unusable" (expired / could not be refreshed) so the call-time error
+        // stops blaming a missing profile when the real fix is re-authentication.
+        let had_profile = profile.is_some();
+
         let account_id = profile.and_then(|p| p.account_id).or_else(|| {
             oauth_access_token
                 .as_deref()
@@ -1185,16 +1190,35 @@ impl OpenAiCodexModelProvider {
             oauth_access_token
         } else {
             Some(oauth_access_token.ok_or_else(|| {
-                ::zeroclaw_log::record!(
-                    ERROR,
-                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Reject)
-                        .with_outcome(::zeroclaw_log::EventOutcome::Failure)
-                        .with_attrs(::serde_json::json!({"missing": "oauth_access_token"})),
-                    "openai_codex: auth profile not found"
-                );
-                anyhow::Error::msg(
-                    "OpenAI Codex auth profile not found. Run `zeroclaw auth login --provider openai-codex`.",
-                )
+                if had_profile {
+                    ::zeroclaw_log::record!(
+                        ERROR,
+                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Reject)
+                            .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                            .with_attrs(::serde_json::json!({
+                                "missing": "oauth_access_token",
+                                "had_profile": true,
+                            })),
+                        "openai_codex: auth profile present but no usable access token"
+                    );
+                    anyhow::Error::msg(
+                        "OpenAI Codex credentials are present but expired or could not be refreshed. Re-run `zeroclaw auth login --provider openai-codex` to sign in again.",
+                    )
+                } else {
+                    ::zeroclaw_log::record!(
+                        ERROR,
+                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Reject)
+                            .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                            .with_attrs(::serde_json::json!({
+                                "missing": "oauth_access_token",
+                                "had_profile": false,
+                            })),
+                        "openai_codex: no auth profile found"
+                    );
+                    anyhow::Error::msg(
+                        "No OpenAI Codex credentials found. Run `zeroclaw auth login --provider openai-codex` to sign in.",
+                    )
+                }
             })?)
         };
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** The call-time OpenAI Codex credential resolver returned a single error — "OpenAI Codex auth profile not found" — for two distinct states: (a) no profile exists at all, and (b) a profile exists but its access token is expired and could not be refreshed. Case (b) misattributed a re-authentication problem to a missing profile, sending users into a login loop pointed at the wrong cause. The error now branches on whether a profile actually loaded: no profile → "No OpenAI Codex credentials found … sign in"; stale token → "credentials are present but expired or could not be refreshed … re-run … to sign in again".
- **Scope boundary:** Error/log message text only. No change to credential-resolution control flow, token refresh, or the custom-endpoint gateway-API-key path. No config, schema, or public API changes.
- **Blast radius:** Only the error surfaced when an OpenAI Codex (`requires_openai_auth`) slot cannot produce an access token. No other providers affected.
- **Linked issue(s):** none
- **Labels:** maintainer to set `risk:`/`size:` per template (suggest `risk: low`, `size: XS`).

## Validation Evidence (required)

- **Commands run and tail output** (scoped to the only crate touched, `zeroclaw-providers`):
  - `cargo fmt --all -- --check` → clean (whole repo)
  - `cargo clippy -p zeroclaw-providers --all-targets -- -D warnings` → `Finished` with no warnings
  - `cargo test -p zeroclaw-providers openai_codex` → `test result: ok. 38 passed; 0 failed; 0 ignored`
- **Beyond CI — what I manually verified:** confirmed `had_profile` is captured before `profile` is moved into the `account_id` computation; both branches retain the same `zeroclaw auth login --provider openai-codex` recovery command, only the framing differs; the added log attr is a boolean (`had_profile`), never a token value.
- **If any command was intentionally skipped, why:** full-workspace `cargo test` / `cargo clippy --all-targets` were scoped to `zeroclaw-providers` — localized, message-only change to one function. The required CI gate runs the full battery.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No` — only the wording of an existing "credential missing/expired" error; no credential value is read, logged, or stored. The structured log gains a boolean `had_profile`, not any token material.
- PII, real identities, or personal data? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No` — error/log string wording only.
- Upgrade steps: none.

## Rollback (required for medium/high)

Low risk: `git revert <sha>`.