### PR TITLE
feat(install): add zeroclaw to PATH automatically, with --no-modify-path opt-out

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -380,6 +380,8 @@ Options:
   --prefix PATH        Install everything under PATH (default: \$HOME)
                        Sets CARGO_HOME, RUSTUP_HOME, source checkout, config
   --dry-run            Show what would happen without building or installing
+  --no-modify-path     Don't add ZeroClaw to PATH in your shell profile; just
+                       print the line to add manually
   --skip-quickstart       Skip the post-install quickstart prompt
   --uninstall          Remove ZeroClaw binary and optionally config/data
   -h, --help           Show this help
@@ -442,6 +444,21 @@ do_uninstall() {
     else
       info "Config preserved at $config_dir (non-interactive — use rm -rf to remove)"
     fi
+  fi
+
+  # Strip the PATH marker block this installer may have added to the profile.
+  local profile
+  profile=$(detect_shell_profile)
+  if [ -f "$profile" ] && grep -q "# >>> zeroclaw >>>" "$profile" 2>/dev/null; then
+    local tmp_profile
+    tmp_profile=$(mktemp)
+    if sed '/# >>> zeroclaw >>>/,/# <<< zeroclaw <<</d' "$profile" >"$tmp_profile" 2>/dev/null &&
+      cat "$tmp_profile" >"$profile" 2>/dev/null; then
+      info "Removed PATH entry from $profile"
+    else
+      warn "Could not edit $profile — remove the zeroclaw PATH block manually"
+    fi
+    rm -f "$tmp_profile"
   fi
 
   # Check if another zeroclaw still lurks in PATH
@@ -692,6 +709,7 @@ SKIP_QUICKSTART=false
 LIST_FEATURES=false
 UNINSTALL=false
 DRY_RUN=false
+MODIFY_PATH=true # append PATH export to the shell profile; --no-modify-path opts out
 PREFIX="$HOME"
 INSTALL_MODE="" # ""=ask, "prebuilt"=force prebuilt, "source"=force source
 PRESET=""       # ""=unset, "minimal"=alias for --minimal, "full"=default-features
@@ -747,6 +765,7 @@ while [ $# -gt 0 ]; do
     PREFIX=$(echo "$1" | sed 's|/*$||')
     ;;
   --dry-run) DRY_RUN=true ;;
+  --no-modify-path) MODIFY_PATH=false ;;
   --skip-quickstart) SKIP_QUICKSTART=true ;;
   --prebuilt) INSTALL_MODE="prebuilt" ;;
   --source) INSTALL_MODE="source" ;;
@@ -1157,21 +1176,19 @@ fi # end source build block
 
 BIN="$CARGO_HOME/bin/zeroclaw"
 
-# ── PATH guidance ─────────────────────────────────────────────────
+# ── PATH setup ────────────────────────────────────────────────────
 
 PROFILE=$(detect_shell_profile)
 EXPORT_LINE=$(shell_export_syntax)
 
-SHOW_PATH_HELP=false
-if [ "$PREFIX" != "$HOME" ]; then
-  SHOW_PATH_HELP=true
-elif [ -f "$PROFILE" ] && ! grep -q "$CARGO_HOME/bin" "$PROFILE" 2>/dev/null; then
-  SHOW_PATH_HELP=true
-elif [ ! -f "$PROFILE" ]; then
-  SHOW_PATH_HELP=true
+# Is our bin dir already on PATH via the profile — either pre-existing or
+# from a prior run of this installer? If so there's nothing to do.
+PATH_ALREADY_SET=false
+if [ -f "$PROFILE" ] && grep -q "$CARGO_HOME/bin" "$PROFILE" 2>/dev/null; then
+  PATH_ALREADY_SET=true
 fi
 
-if [ "$SHOW_PATH_HELP" = true ]; then
+print_path_help() {
   echo
   printf "  %s (%s):\n" "$(bold "Add to your shell profile")" "$PROFILE"
   echo
@@ -1181,6 +1198,29 @@ if [ "$SHOW_PATH_HELP" = true ]; then
   echo
   printf "    source %s\n" "$PROFILE"
   echo
+}
+
+if [ "$PATH_ALREADY_SET" = true ]; then
+  : # already on PATH — nothing to do
+elif [ "$MODIFY_PATH" = true ] && [ "$PREFIX" = "$HOME" ]; then
+  # Auto-append to the profile, wrapped in a marker block so re-installs
+  # stay idempotent and an uninstall can strip it cleanly.
+  if [ "$DRY_RUN" = true ]; then
+    info "[dry-run] Would add $CARGO_HOME/bin to PATH in $PROFILE"
+  elif {
+    printf '\n# >>> zeroclaw >>>\n'
+    printf '%s\n' "$EXPORT_LINE"
+    printf '# <<< zeroclaw <<<\n'
+  } >>"$PROFILE" 2>/dev/null; then
+    info "Added $CARGO_HOME/bin to PATH in $PROFILE"
+    printf "    Reload your shell or run: source %s\n" "$PROFILE"
+  else
+    warn "Could not write to $PROFILE — add this line manually:"
+    print_path_help
+  fi
+else
+  # --no-modify-path, or a custom --prefix install we won't auto-edit for.
+  print_path_help
 fi
 
 # ── Quickstart prompt ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** The installer previously only *printed* a suggested PATH export line, leaving every user to hand-edit their shell profile before `zeroclaw` was runnable. This now appends the bin dir to the detected shell profile (`.zshrc` / `.bashrc` / `config.fish`) automatically, wrapped in a `# >>> zeroclaw >>>` marker block — matching the UX of rustup/nvm. The append is idempotent (skipped when the bin dir is already on PATH), `--no-modify-path` restores the old print-only behaviour, `--dry-run` reports what it *would* add without writing, and `do_uninstall` strips the marker block so removal is clean.
- **Scope boundary:** Only `install.sh` PATH handling and the matching uninstall strip. No change to the build, feature selection, prebuilt download, or quickstart flow. Does not touch how rustup itself is installed (`--no-modify-path` is still passed to rustup).
- **Blast radius:** Bootstrap/onboarding only. Affects what gets written to a user's shell rc file at install time. Custom `--prefix` installs are deliberately left print-only (we don't auto-edit a real profile for an isolated/test install).
- **Linked issue(s):** None.
- **Labels:** `enhancement`, `risk: low`, `size: XS`

## Validation Evidence (required)

Shell-only change — the Rust battery (`cargo fmt/clippy/test`) is N/A (no Rust touched). Per the template's bootstrap-script guidance:

```bash
$ bash -n install.sh && echo OK
OK
$ sh -n install.sh && echo OK
OK
```

- **Commands run and tail output:** `bash -n install.sh` and `sh -n install.sh` both pass (POSIX-clean). `shellcheck` not installed locally, so static lint was skipped there.
- **Beyond CI — what did you manually verify?** Ran the new logic end-to-end against a sandbox `$HOME`/profile:
  - `--dry-run --prebuilt` prints `Would add <bin> to PATH in <profile>` and writes **nothing** to the rc file.
  - Fresh install appends the `# >>> zeroclaw >>>` … `# <<< zeroclaw <<<` block while preserving pre-existing rc content.
  - Re-run: the `grep "$CARGO_HOME/bin"` guard hits, so no duplicate block is appended (idempotent).
  - `--uninstall` strips the marker block via `sed` (verified on BSD/macOS sed), restoring the original rc.
- **If any command was intentionally skipped, why:** Rust battery skipped — no Rust in the diff. `shellcheck` skipped — not installed on this machine; `bash -n`/`sh -n` cover syntax.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `Yes` — the installer now writes to the user's shell profile (`~/.zshrc` etc.) by default instead of only printing a suggestion. It is scoped to a single marked block, idempotent, opt-out via `--no-modify-path`, and announced on stdout. No write occurs in `--dry-run`.
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: Risk is an unexpected rc-file edit; mitigated by the marker block (clean re-install/uninstall), the `--no-modify-path` escape hatch, and print-only fallback for custom `--prefix` installs and when the write fails.

## Compatibility (required)

- Backward compatible? `Yes` — existing behaviour is reachable via `--no-modify-path`; profiles already containing the bin dir are left untouched.
- Config / env / CLI surface changed? `Yes` — adds one new flag, `--no-modify-path`, documented in `--help`. No existing flag changes.
- If `No` or `Yes` to either: No upgrade steps required. Users who prefer the old print-only behaviour pass `--no-modify-path`.

## Rollback (required for `risk: medium` and `risk: high`)

Low risk: `git revert <sha>` is the plan.
