### PR TITLE
fix(channels): preserve tool-result content when proactively trimming channel history

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -122,6 +122,7 @@ use zeroclaw_config::schema::Config;
 use zeroclaw_memory::{self, MEMORY_CONTEXT_CLOSE, MEMORY_CONTEXT_OPEN, Memory};
 use zeroclaw_providers::reliable::{scope_provider_fallback, take_last_provider_fallback};
 use zeroclaw_providers::{self, ChatMessage, ModelProvider, ProviderDispatch};
+use zeroclaw_runtime::agent::history::fast_trim_tool_results;
 use zeroclaw_runtime::agent::loop_::{
     LoopKnobs, ToolLoop, apply_policy_tool_filter, apply_text_tool_prompt_policy,
     build_tool_instructions_for_names, clear_model_switch_request, get_model_switch_state,
@@ -1831,13 +1832,35 @@ fn compact_sender_history(ctx: &ChannelRuntimeContext, sender_key: &str) -> bool
     true
 }
 
+/// Number of most-recent turns whose tool-result payloads are kept at full size
+/// when proactively trimming. The active exchange stays intact; only older
+/// tool results are shrunk to a bounded extract.
+const PROACTIVE_TRIM_PROTECT_LAST_N: usize = 4;
+
 /// Proactively trim conversation turns so that the total estimated character
-/// count stays within [`PROACTIVE_CONTEXT_BUDGET_CHARS`].  Drops the oldest
-/// turns first, but always preserves the most recent turn (the current user
-/// message).  Returns the number of turns dropped.
+/// count stays within [`PROACTIVE_CONTEXT_BUDGET_CHARS`].
+///
+/// Tool-result content is the bulk of an overflowing channel history, so before
+/// dropping any whole turns this first shrinks older `tool`-role payloads to a
+/// bounded head-extract in place (via [`fast_trim_tool_results`]). A trimmed
+/// tool result still tells the model what the tool returned; a *dropped* turn is
+/// gone entirely, which is what makes the bot "respond as if previous messages
+/// don't exist" (#6517). Only if the in-place extracts are still over budget are
+/// the oldest whole turns dropped, and the most recent turn (the current user
+/// message) is always preserved. Returns the number of whole turns dropped.
 fn proactive_trim_turns(turns: &mut Vec<ChatMessage>, budget: usize) -> usize {
     let total_chars: usize = turns.iter().map(|t| t.content.chars().count()).sum();
     if total_chars <= budget || turns.len() <= 1 {
+        return 0;
+    }
+
+    // Content-preserving pre-pass: shrink old tool-result payloads in place,
+    // keeping the messages and their tool-call pairing intact.
+    fast_trim_tool_results(turns, PROACTIVE_TRIM_PROTECT_LAST_N);
+
+    // Recompute after the in-place shrink — we may now fit with no turns dropped.
+    let total_chars: usize = turns.iter().map(|t| t.content.chars().count()).sum();
+    if total_chars <= budget {
         return 0;
     }
 
@@ -11402,6 +11425,50 @@ api_key = "anthropic-key"
         let dropped = proactive_trim_turns(&mut turns, 100);
         assert_eq!(dropped, 0, "single turn must never be dropped");
         assert_eq!(turns.len(), 1);
+    }
+
+    // #6517: large tool-result content is shrunk to a bounded extract in place
+    // before any whole turn is dropped, so the model keeps a record of what each
+    // tool returned instead of losing entire old turns ("responding as if
+    // previous messages don't exist").
+    #[test]
+    fn proactive_trim_shrinks_tool_results_before_dropping_turns() {
+        let mut turns: Vec<ChatMessage> = Vec::new();
+        for _ in 0..4 {
+            turns.push(ChatMessage::tool("x".repeat(5000)));
+        }
+        // Recent (protected) text turns; no tool payloads here.
+        turns.push(ChatMessage::user("u1".to_string()));
+        turns.push(ChatMessage::assistant("a1".to_string()));
+        turns.push(ChatMessage::user("u2".to_string()));
+        turns.push(ChatMessage::assistant("a2".to_string()));
+
+        let len_before = turns.len();
+        let total_before: usize = turns.iter().map(|t| t.content.chars().count()).sum();
+        let budget = 12_000;
+        assert!(total_before > budget, "test setup must start over budget");
+
+        let dropped = proactive_trim_turns(&mut turns, budget);
+
+        assert_eq!(
+            dropped, 0,
+            "in-place tool-result shrink should bring it under budget with no whole-turn drops"
+        );
+        assert_eq!(turns.len(), len_before, "no whole turn should be removed");
+        assert_eq!(
+            turns.iter().filter(|t| t.role == "tool").count(),
+            4,
+            "every tool turn must survive (shrunk, not dropped)"
+        );
+        assert!(
+            turns[0].content.chars().count() < 5000,
+            "an old tool result must be shrunk in place"
+        );
+        let total_after: usize = turns.iter().map(|t| t.content.chars().count()).sum();
+        assert!(
+            total_after <= budget,
+            "must be within budget after the in-place shrink: {total_after}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - `proactive_trim_turns` (the channel orchestrator's pre-loop overflow handler)
    dropped the oldest *whole* turns once history exceeded
    `PROACTIVE_CONTEXT_BUDGET_CHARS`, discarding their tool results entirely. On
    long channel conversations the model then responded as if earlier messages
    never happened (context drift / hallucination) - the channel reproduction of
    #6517.
  - Now it shrinks older `tool`-role payloads to a bounded in-place extract
    (`fast_trim_tool_results`, 2000-char floor) BEFORE dropping any whole turn,
    keeping the messages and their tool-call pairing intact, then recomputes the
    budget. Whole turns are only dropped if the extracts still do not fit; the
    most recent turns are protected from shrinking and the current turn is never
    dropped.
- **Scope boundary:** Does not change the trim budget itself (still the
  hardcoded `PROACTIVE_CONTEXT_BUDGET_CHARS`; making it config/provider-driven is
  a separate follow-up), the in-loop `preflight_history_maintenance` trim
  (covered by #8048), `strip_old_tool_context`, or `context_compression`. Uses
  the existing `fast_trim_tool_results` (master), not the escalating extract
  ladder from #8048, so this lands independently.
- **Blast radius:** Channel inbound path only (`proactive_trim_turns`, called per
  inbound message). Function signature and return semantics (whole turns dropped)
  unchanged; it now drops strictly fewer turns. It mutates the transient
  request-building copy `prior_turns` only - verified that copy is never persisted
  back to the session store (same pattern as the existing
  `strip_historical_image_payloads` in-place mutation).
- **Why here and not the in-loop trim:** `proactive_trim_turns` is the only
  overflow bound for the two provider calls the channel makes *before*
  `run_tool_call_loop` - the context-compressor summarizer call and the
  reply-intent classifier - which `preflight_history_maintenance` never sees. So
  this is the right layer for the channel fix, and content preservation now also
  benefits those pre-loop calls.
- **Linked issue(s):** Closes #8049. Related #6517.
- **Labels:** suggested `bug`, `channels`, `runtime`, `risk: medium`, `size: S`.

## Validation Evidence (required)

```bash
RUSTUP_TOOLCHAIN=1.93.0
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- **Commands run and tail output:**
  ```
  [PASS] cargo fmt --check
  [PASS] cargo clippy --all-targets
  [PASS] cargo test
  summary: 0 blocking, 0 warning
  RESULT: PASS
  ```
  Targeted: `cargo +1.93.0 test -p zeroclaw-channels --lib proactive_trim` = 4/4
  (3 pre-existing tests still green - they use user/assistant roles, so the new
  tool-result shrink is a no-op and prior drop behavior is preserved - plus 1 new
  `proactive_trim_shrinks_tool_results_before_dropping_turns`).
- **Beyond CI - what did you manually verify?** Traced that `proactive_trim_turns`
  is the binding trim for the channel/#6517 reproduction (its ~400k-char budget
  bites before the in-loop 128k path). Verified `prior_turns` is a transient
  request copy that is never persisted back, so in-place truncation cannot corrupt
  stored history.
- **If any command was intentionally skipped, why:** Web/shell batteries skipped
  (no `.ts`/`.sh` changes).

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: no upgrade steps required.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <sha>`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Grep logs for "Proactively trimmed
  conversation history" with high `dropped_turns` on long channel sessions, or
  renewed channel context drift / hallucination. A regression in the other
  direction would surface as `context_length_exceeded` (trim too weak).
