### PR TITLE
fix(install): detect Intel macOS prebuilt target

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -241,7 +241,13 @@ detect_target_triple() {
   arch=$(uname -m)
 
   case "$os" in
-  Darwin) echo "aarch64-apple-darwin" ;; # presume M-series
+  Darwin)
+    case "$arch" in
+    arm64 | aarch64) echo "aarch64-apple-darwin" ;;
+    x86_64) echo "x86_64-apple-darwin" ;;
+    *) echo "" ;;
+    esac
+    ;;
   Linux)
     libc=$(detect_libc)
     case "$arch" in


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** 
  - Detects the Darwin CPU architecture before selecting a prebuilt release target.
  - Maps Intel macOS (`x86_64`) to `x86_64-apple-darwin` instead of always assuming Apple Silicon.
  - Keeps Apple Silicon (`arm64` / `aarch64`) on `aarch64-apple-darwin`.
  - Leaves unknown Darwin architectures unsupported so the installer falls back to the source-build path.
- **Scope boundary:** This PR only changes `install.sh` target-triple detection. It does not change release packaging, Homebrew, PATH setup, source builds, feature selection, or quickstart behavior.
- **Blast radius:** Bootstrap installer prebuilt selection on macOS. Linux target mapping is unchanged. If the selected prebuilt asset is unavailable, the existing source-build fallback still applies.
- **Linked issue(s):** Depends on #8015. Related #8038.
- **Labels:** `bug`, `risk: medium`, `size: XS`

## Validation Evidence (required)

- **Commands run and tail output:**

```text
$ bash -n install.sh
# passed with no output

$ sh -n install.sh
# passed with no output

$ git diff --check origin/master...HEAD
# passed with no output

$ scripts/check-pr-title.sh "fix(install): detect Intel macOS prebuilt target"
# passed with no output

$ bash -c '...mock Darwin uname matrix...'
x86_64 -> x86_64-apple-darwin
arm64 -> aarch64-apple-darwin
aarch64 -> aarch64-apple-darwin
ppc ->

$ bash -c '...mock Linux uname matrix with detect_libc=gnu...'
x86_64 -> x86_64-unknown-linux-gnu
arm64 -> aarch64-unknown-linux-gnu
aarch64 -> aarch64-unknown-linux-gnu
armv7l -> armv7-unknown-linux-gnueabihf
armv6l -> arm-unknown-linux-gnueabihf
riscv64 ->
```

- **Beyond CI — what did you manually verify?** The mocked Darwin matrix verifies the changed macOS behavior directly: Intel macOS now selects the Intel release artifact name, Apple Silicon remains on the existing Apple Silicon artifact, and an unknown Darwin architecture still falls back instead of fabricating a target. The mocked Linux matrix confirms the existing Linux mappings were not changed by this patch.
- **If any command was intentionally skipped, why:** Rust `cargo fmt`, `cargo clippy`, and `cargo test` were skipped because this is a bootstrap script-only change with no Rust source changes. Full `shellcheck install.sh` is not cited as passing because the current installer has pre-existing baseline shellcheck findings outside this patch.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: `N/A`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No upgrade steps are required. Intel macOS installs will attempt the Intel prebuilt artifact after #8015 lands and a stable release publishes it; otherwise the existing source-build fallback remains in place.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** Revert this PR. On this branch, `git revert bccfd2218a576c7f89f126f855b72ece76936fa1`.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Intel macOS `install.sh --prebuilt` attempts to fetch the wrong or missing macOS release tarball before falling back to source build.
