### PR TITLE
feat(observability): categorize and verb-tag agent-loop log events

### DIFF
--- a/crates/zeroclaw-api/src/attribution.rs
+++ b/crates/zeroclaw-api/src/attribution.rs
@@ -385,13 +385,10 @@ impl Role {
             Self::Channel(_) => "channel",
             Self::Tool(_) => "tool",
             Self::Cron(_) => "cron",
-            Self::Provider(ProviderKind::Model(_)) => "model_provider",
-            Self::Provider(ProviderKind::Tts(_)) => "tts_provider",
-            Self::Provider(ProviderKind::Transcription(_)) => "transcription_provider",
-            Self::Provider(ProviderKind::Tunnel(_)) => "tunnel_provider",
+            Self::Provider(_) => "provider",
             Self::Memory(_) => "memory",
             Self::Session => "session",
-            Self::Sop => "sop",
+            Self::Sop => "system",
             Self::PeerGroup | Self::Skill | Self::Mcp | Self::System => "system",
         }
     }

--- a/crates/zeroclaw-runtime/src/agent/context_compressor.rs
+++ b/crates/zeroclaw-runtime/src/agent/context_compressor.rs
@@ -239,7 +239,8 @@ impl ContextCompressor {
         if chars_saved > 0 {
             ::zeroclaw_log::record!(
                 INFO,
-                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Delete)
+                    .with_category(::zeroclaw_log::EventCategory::Agent)
                     .with_attrs(::serde_json::json!({"chars_saved": chars_saved})),
                 "Fast-trim saved chars from old tool results"
             );
@@ -296,7 +297,8 @@ impl ContextCompressor {
 
         ::zeroclaw_log::record!(
             INFO,
-            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Retry)
+                .with_category(::zeroclaw_log::EventCategory::Agent)
                 .with_attrs(::serde_json::json!({"context_window": self.context_window})),
             "Context limit adjusted, re-compressing"
         );
@@ -379,8 +381,9 @@ impl ContextCompressor {
             Ok(Err(e)) => {
                 ::zeroclaw_log::record!(
                     WARN,
-                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                        .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+                        .with_category(::zeroclaw_log::EventCategory::Agent)
+                        .with_outcome(::zeroclaw_log::EventOutcome::Failure)
                         .with_attrs(::serde_json::json!({"error": format!("{}", e)})),
                     "Summarization LLM call failed, using transcript truncation"
                 );
@@ -389,8 +392,9 @@ impl ContextCompressor {
             Err(_) => {
                 ::zeroclaw_log::record!(
                     WARN,
-                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                        .with_outcome(::zeroclaw_log::EventOutcome::Unknown),
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Timeout)
+                        .with_category(::zeroclaw_log::EventCategory::Agent)
+                        .with_outcome(::zeroclaw_log::EventOutcome::Failure),
                     &format!(
                         "Summarization timed out after {}s, using transcript truncation",
                         self.config.timeout_secs
@@ -417,7 +421,8 @@ impl ContextCompressor {
                 Ok(_) => {
                     ::zeroclaw_log::record!(
                         DEBUG,
-                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Save)
+                            .with_category(::zeroclaw_log::EventCategory::Agent)
                             .with_attrs(::serde_json::json!({"message_count": message_count})),
                         "Saved compression summary to memory before discarding messages"
                     );
@@ -425,7 +430,9 @@ impl ContextCompressor {
                 Err(e) => {
                     ::zeroclaw_log::record!(
                         DEBUG,
-                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+                            .with_category(::zeroclaw_log::EventCategory::Agent)
+                            .with_outcome(::zeroclaw_log::EventOutcome::Failure)
                             .with_attrs(::serde_json::json!({"error": format!("{}", e)})),
                         "Failed to save compression summary to memory"
                     );
@@ -450,8 +457,9 @@ impl ContextCompressor {
 
         ::zeroclaw_log::record!(
             WARN,
-            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Complete)
+                .with_category(::zeroclaw_log::EventCategory::Agent)
+                .with_outcome(::zeroclaw_log::EventOutcome::Success)
                 .with_attrs(::serde_json::json!({
                     "messages_summarized": message_count,
                     "summary_chars": summary.len(),

--- a/crates/zeroclaw-runtime/src/agent/cost.rs
+++ b/crates/zeroclaw-runtime/src/agent/cost.rs
@@ -315,7 +315,7 @@ pub fn record_tool_loop_cost_usage(
         && let Err(error) =
             tracker.record_usage_with_agent(cost_usage.clone(), ctx.agent_alias.as_deref())
     {
-        ::zeroclaw_log::record!(WARN, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_outcome(::zeroclaw_log::EventOutcome::Unknown).with_attrs(::serde_json::json!({"model_provider": model_provider_name, "model": model, "error": format!("{}", error)})), "Failed to record cost tracking usage: ");
+        ::zeroclaw_log::record!(WARN, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_category(::zeroclaw_log::EventCategory::Provider).with_outcome(::zeroclaw_log::EventOutcome::Unknown).with_attrs(::serde_json::json!({"model_provider": model_provider_name, "model": model, "error": format!("{}", error)})), "Failed to record cost tracking usage: ");
     }
 
     Some((cost_usage.total_tokens, cost_usage.cost_usd))
@@ -350,6 +350,7 @@ fn warn_once_missing_pricing(model_provider: &str, model: &str) {
         ::zeroclaw_log::record!(
             WARN,
             ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                .with_category(::zeroclaw_log::EventCategory::Provider)
                 .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
                 .with_attrs(
                     ::serde_json::json!({"model_provider": model_provider, "model": model})
@@ -364,9 +365,11 @@ fn warn_once_missing_pricing(model_provider: &str, model: &str) {
     } else {
         ::zeroclaw_log::record!(
             DEBUG,
-            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(
-                ::serde_json::json!({"model_provider": model_provider, "model": model})
-            ),
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                .with_category(::zeroclaw_log::EventCategory::Provider)
+                .with_attrs(
+                    ::serde_json::json!({"model_provider": model_provider, "model": model})
+                ),
             "Cost tracking recorded token usage with zero pricing (no pricing entry found)"
         );
     }

--- a/crates/zeroclaw-runtime/src/agent/dispatcher.rs
+++ b/crates/zeroclaw-runtime/src/agent/dispatcher.rs
@@ -75,6 +75,7 @@ impl XmlToolDispatcher {
                                 module_path!(),
                                 ::zeroclaw_log::Action::Note
                             )
+                            .with_category(::zeroclaw_log::EventCategory::Agent)
                             .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
                             .with_attrs(::serde_json::json!({"error": format!("{}", e)})),
                             "Malformed <tool_call> JSON"
@@ -195,7 +196,7 @@ impl ToolDispatcher for NativeToolDispatcher {
             .map(|tc| ParsedToolCall {
                 name: tc.name.clone(),
                 arguments: serde_json::from_str(&tc.arguments).unwrap_or_else(|e| {
-                    ::zeroclaw_log::record!(WARN, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_outcome(::zeroclaw_log::EventOutcome::Unknown).with_attrs(::serde_json::json!({"tool": tc.name, "error": format!("{}", e)})), "Failed to parse native tool call arguments as JSON; defaulting to empty object");
+                    ::zeroclaw_log::record!(WARN, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_category(::zeroclaw_log::EventCategory::Tool).with_outcome(::zeroclaw_log::EventOutcome::Unknown).with_attrs(::serde_json::json!({"tool": tc.name, "error": format!("{}", e)})), "Failed to parse native tool call arguments as JSON; defaulting to empty object");
                     Value::Object(serde_json::Map::new())
                 }),
                 tool_call_id: Some(tc.id.clone()),

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -265,14 +265,14 @@ pub(crate) fn filter_channel_builtin_tools(
     if tools_registry.len() != before_filter {
         ::zeroclaw_log::record!(
             INFO,
-            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(
-                ::serde_json::json!({
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Load)
+                .with_category(::zeroclaw_log::EventCategory::Agent)
+                .with_attrs(::serde_json::json!({
                     "before": before_filter,
                     "retained": tools_registry.len(),
                     "policy_allowed": security.allowed_tools.as_ref().map(|v| v.len()),
                     "policy_excluded": security.excluded_tools.as_ref().map(|v| v.len()),
-                })
-            ),
+                })),
             "Applied capability-based tool access filter (process_message)"
         );
     }
@@ -972,7 +972,8 @@ pub async fn run(
         };
         ::zeroclaw_log::record!(
             INFO,
-            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Load)
+                .with_category(::zeroclaw_log::EventCategory::Memory)
                 .with_attrs(::serde_json::json!({"backend": mem.name()})),
             "Memory initialized"
         );
@@ -981,7 +982,8 @@ pub async fn run(
         if !peripheral_overrides.is_empty() {
             ::zeroclaw_log::record!(
                 INFO,
-                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Load)
+                    .with_category(::zeroclaw_log::EventCategory::Agent)
                     .with_attrs(::serde_json::json!({"peripherals": peripheral_overrides})),
                 "Peripheral overrides from CLI (config boards take precedence)"
             );
@@ -1049,7 +1051,8 @@ pub async fn run(
         if count > 0 {
             ::zeroclaw_log::record!(
                 INFO,
-                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Register)
+                    .with_category(::zeroclaw_log::EventCategory::Channel)
                     .with_attrs(::serde_json::json!({"count": count})),
                 &format!("Registered {} channel(s) for CLI agent", count),
             );
@@ -1063,7 +1066,8 @@ pub async fn run(
         if !peripheral_tools.is_empty() {
             ::zeroclaw_log::record!(
                 INFO,
-                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Load)
+                    .with_category(::zeroclaw_log::EventCategory::Tool)
                     .with_attrs(::serde_json::json!({"count": peripheral_tools.len()})),
                 "Peripheral tools added"
             );
@@ -1085,7 +1089,8 @@ pub async fn run(
         if tools_registry.len() != before_filter {
             ::zeroclaw_log::record!(
                 INFO,
-                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Load)
+                    .with_category(::zeroclaw_log::EventCategory::Agent)
                     .with_attrs(::serde_json::json!({
                         "before": before_filter,
                         "retained": tools_registry.len(),
@@ -1115,7 +1120,8 @@ pub async fn run(
         if config.mcp.enabled && !config.mcp.servers.is_empty() {
             ::zeroclaw_log::record!(
                 INFO,
-                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note),
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Load)
+                    .with_category(::zeroclaw_log::EventCategory::Tool),
                 &format!(
                     "Initializing MCP client — {} server(s) configured",
                     config.mcp.servers.len()
@@ -1137,8 +1143,9 @@ pub async fn run(
                             INFO,
                             ::zeroclaw_log::Event::new(
                                 module_path!(),
-                                ::zeroclaw_log::Action::Note
-                            ),
+                                ::zeroclaw_log::Action::Load
+                            )
+                            .with_category(::zeroclaw_log::EventCategory::Tool),
                             &format!(
                                 "MCP deferred: {} tool stub(s) from {} server(s)",
                                 deferred_set.len(),
@@ -1214,8 +1221,9 @@ pub async fn run(
                             INFO,
                             ::zeroclaw_log::Event::new(
                                 module_path!(),
-                                ::zeroclaw_log::Action::Note
-                            ),
+                                ::zeroclaw_log::Action::Register
+                            )
+                            .with_category(::zeroclaw_log::EventCategory::Tool),
                             &format!(
                                 "MCP: {} tool(s) registered from {} server(s), {} skipped by policy",
                                 registered,
@@ -1229,6 +1237,7 @@ pub async fn run(
                     ::zeroclaw_log::record!(
                         ERROR,
                         ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+                            .with_category(::zeroclaw_log::EventCategory::Agent)
                             .with_outcome(::zeroclaw_log::EventOutcome::Failure)
                             .with_attrs(::serde_json::json!({"error": format!("{}", e)})),
                         "MCP registry failed to initialize"
@@ -1246,6 +1255,7 @@ pub async fn run(
                 ::zeroclaw_log::record!(
                     ERROR,
                     ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+                        .with_category(::zeroclaw_log::EventCategory::Agent)
                         .with_outcome(::zeroclaw_log::EventOutcome::Failure)
                         .with_attrs(::serde_json::json!({"agent_alias": agent_alias})),
                     "agent loop refused: agent.model_provider unresolved and no --provider override"
@@ -1326,7 +1336,8 @@ pub async fn run(
         if let Some(ref rag) = hardware_rag {
             ::zeroclaw_log::record!(
                 INFO,
-                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Load)
+                    .with_category(::zeroclaw_log::EventCategory::Agent)
                     .with_attrs(::serde_json::json!({"chunks": rag.len()})),
                 "Hardware RAG loaded"
             );
@@ -1583,6 +1594,7 @@ pub async fn run(
                                 module_path!(),
                                 ::zeroclaw_log::Action::Note
                             )
+                            .with_category(::zeroclaw_log::EventCategory::Agent)
                             .with_attrs(::serde_json::json!({"thinking_level": level})),
                             "Thinking directive parsed from message"
                         );
@@ -1764,8 +1776,9 @@ pub async fn run(
                                 INFO,
                                 ::zeroclaw_log::Event::new(
                                     module_path!(),
-                                    ::zeroclaw_log::Action::Note
-                                ),
+                                    ::zeroclaw_log::Action::Migrate
+                                )
+                                .with_category(::zeroclaw_log::EventCategory::Provider),
                                 &format!(
                                     "Model switch requested, switching from {} {} to {} {}",
                                     provider_name, model_name, new_model_provider, new_model
@@ -1830,8 +1843,9 @@ pub async fn run(
                                 INFO,
                                 ::zeroclaw_log::Event::new(
                                     module_path!(),
-                                    ::zeroclaw_log::Action::Note
+                                    ::zeroclaw_log::Action::Register
                                 )
+                                .with_category(::zeroclaw_log::EventCategory::Agent)
                                 .with_attrs(::serde_json::json!({"slug": slug})),
                                 "Auto-created skill from execution"
                             );
@@ -1841,8 +1855,9 @@ pub async fn run(
                                 DEBUG,
                                 ::zeroclaw_log::Event::new(
                                     module_path!(),
-                                    ::zeroclaw_log::Action::Note
-                                ),
+                                    ::zeroclaw_log::Action::Skip
+                                )
+                                .with_category(::zeroclaw_log::EventCategory::Agent),
                                 "Skill creation skipped (duplicate or disabled)"
                             );
                         }
@@ -1850,9 +1865,10 @@ pub async fn run(
                             WARN,
                             ::zeroclaw_log::Event::new(
                                 module_path!(),
-                                ::zeroclaw_log::Action::Note
+                                ::zeroclaw_log::Action::Fail
                             )
-                            .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                            .with_category(::zeroclaw_log::EventCategory::Agent)
+                            .with_outcome(::zeroclaw_log::EventOutcome::Failure)
                             .with_attrs(::serde_json::json!({"error": format!("{}", e)})),
                             "Skill creation failed"
                         ),
@@ -2014,6 +2030,7 @@ pub async fn run(
                                     module_path!(),
                                     ::zeroclaw_log::Action::Note
                                 )
+                                .with_category(::zeroclaw_log::EventCategory::Agent)
                                 .with_attrs(::serde_json::json!({"thinking_level": level})),
                                 "Thinking directive parsed"
                             );
@@ -2248,8 +2265,9 @@ pub async fn run(
                                     INFO,
                                     ::zeroclaw_log::Event::new(
                                         module_path!(),
-                                        ::zeroclaw_log::Action::Note
-                                    ),
+                                        ::zeroclaw_log::Action::Migrate
+                                    )
+                                    .with_category(::zeroclaw_log::EventCategory::Provider),
                                     &format!(
                                         "Model switch requested, switching from {} {} to {} {}",
                                         provider_name, model_name, new_model_provider, new_model
@@ -2301,9 +2319,9 @@ pub async fn run(
                                     WARN,
                                     ::zeroclaw_log::Event::new(
                                         module_path!(),
-                                        ::zeroclaw_log::Action::Note
+                                        ::zeroclaw_log::Action::Retry
                                     )
-                                    .with_outcome(::zeroclaw_log::EventOutcome::Unknown),
+                                    .with_category(::zeroclaw_log::EventCategory::Agent),
                                     "Context overflow in interactive loop, attempting recovery"
                                 );
                                 let mut compressor =
@@ -2328,8 +2346,10 @@ pub async fn run(
                                             INFO,
                                             ::zeroclaw_log::Event::new(
                                                 module_path!(),
-                                                ::zeroclaw_log::Action::Note
-                                            ),
+                                                ::zeroclaw_log::Action::Retry
+                                            )
+                                            .with_category(::zeroclaw_log::EventCategory::Agent)
+                                            .with_outcome(::zeroclaw_log::EventOutcome::Success),
                                             "Context recovered via compression, retrying turn"
                                         );
                                         continue;
@@ -2339,14 +2359,15 @@ pub async fn run(
                                             WARN,
                                             ::zeroclaw_log::Event::new(
                                                 module_path!(),
-                                                ::zeroclaw_log::Action::Note
+                                                ::zeroclaw_log::Action::Fail
                                             )
-                                            .with_outcome(::zeroclaw_log::EventOutcome::Unknown),
+                                            .with_category(::zeroclaw_log::EventCategory::Agent)
+                                            .with_outcome(::zeroclaw_log::EventOutcome::Failure),
                                             "Compression ran but couldn't reduce enough"
                                         );
                                     }
                                     Err(compress_err) => {
-                                        ::zeroclaw_log::record!(WARN, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_outcome(::zeroclaw_log::EventOutcome::Unknown).with_attrs(::serde_json::json!({"error": format!("{}", compress_err)})), "Compression failed during recovery");
+                                        ::zeroclaw_log::record!(WARN, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail).with_category(::zeroclaw_log::EventCategory::Agent).with_outcome(::zeroclaw_log::EventOutcome::Failure).with_attrs(::serde_json::json!({"error": format!("{}", compress_err)})), "Compression failed during recovery");
                                     }
                                 }
                             }
@@ -2392,7 +2413,7 @@ pub async fn run(
                         .await
                     {
                         Ok(result) if result.compressed => {
-                            ::zeroclaw_log::record!(INFO, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(::serde_json::json!({"passes": result.passes_used, "before": result.tokens_before, "after": result.tokens_after})), "Context compression complete");
+                            ::zeroclaw_log::record!(INFO, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Complete).with_category(::zeroclaw_log::EventCategory::Agent).with_outcome(::zeroclaw_log::EventOutcome::Success).with_attrs(::serde_json::json!({"passes": result.passes_used, "before": result.tokens_before, "after": result.tokens_after})), "Context compression complete");
                         }
                         Ok(_) => {} // No compression needed
                         Err(e) => {
@@ -2400,9 +2421,10 @@ pub async fn run(
                                 WARN,
                                 ::zeroclaw_log::Event::new(
                                     module_path!(),
-                                    ::zeroclaw_log::Action::Note
+                                    ::zeroclaw_log::Action::Fail
                                 )
-                                .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                                .with_category(::zeroclaw_log::EventCategory::Agent)
+                                .with_outcome(::zeroclaw_log::EventOutcome::Failure)
                                 .with_attrs(::serde_json::json!({"error": format!("{}", e)})),
                                 "Context compression failed, falling back to history trim"
                             );
@@ -2602,7 +2624,8 @@ pub async fn process_message(
         if count > 0 {
             ::zeroclaw_log::record!(
                 INFO,
-                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Register)
+                    .with_category(::zeroclaw_log::EventCategory::Channel)
                     .with_attrs(::serde_json::json!({"count": count})),
                 &format!("Registered {} channel(s) for process_message agent", count),
             );
@@ -2635,7 +2658,8 @@ pub async fn process_message(
         if config.mcp.enabled && !config.mcp.servers.is_empty() {
             ::zeroclaw_log::record!(
                 INFO,
-                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note),
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Load)
+                    .with_category(::zeroclaw_log::EventCategory::Tool),
                 &format!(
                     "Initializing MCP client — {} server(s) configured",
                     config.mcp.servers.len()
@@ -2655,8 +2679,9 @@ pub async fn process_message(
                             INFO,
                             ::zeroclaw_log::Event::new(
                                 module_path!(),
-                                ::zeroclaw_log::Action::Note
-                            ),
+                                ::zeroclaw_log::Action::Load
+                            )
+                            .with_category(::zeroclaw_log::EventCategory::Tool),
                             &format!(
                                 "MCP deferred: {} tool stub(s) from {} server(s)",
                                 deferred_set.len(),
@@ -2730,8 +2755,9 @@ pub async fn process_message(
                             INFO,
                             ::zeroclaw_log::Event::new(
                                 module_path!(),
-                                ::zeroclaw_log::Action::Note
-                            ),
+                                ::zeroclaw_log::Action::Register
+                            )
+                            .with_category(::zeroclaw_log::EventCategory::Tool),
                             &format!(
                                 "MCP: {} tool(s) registered from {} server(s), {} skipped by policy",
                                 registered,
@@ -2745,6 +2771,7 @@ pub async fn process_message(
                     ::zeroclaw_log::record!(
                         ERROR,
                         ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+                            .with_category(::zeroclaw_log::EventCategory::Agent)
                             .with_outcome(::zeroclaw_log::EventOutcome::Failure)
                             .with_attrs(::serde_json::json!({"error": format!("{}", e)})),
                         "MCP registry failed to initialize"
@@ -2964,6 +2991,7 @@ pub async fn process_message(
                     ::zeroclaw_log::record!(
                         INFO,
                         ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                            .with_category(::zeroclaw_log::EventCategory::Agent)
                             .with_attrs(::serde_json::json!({"thinking_level": level})),
                         "Thinking directive parsed from message"
                     );

--- a/crates/zeroclaw-runtime/src/agent/thinking.rs
+++ b/crates/zeroclaw-runtime/src/agent/thinking.rs
@@ -130,6 +130,7 @@ pub fn apply_thinking_level_with_config(
             ::zeroclaw_log::record!(
                 WARN,
                 ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_category(::zeroclaw_log::EventCategory::Agent)
                     .with_attrs(::serde_json::json!({
                         "requested": budget,
                         "clamped": clamped,
@@ -188,6 +189,7 @@ pub fn resolve_thinking_from_message(
             ::zeroclaw_log::record!(
                 INFO,
                 ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_category(::zeroclaw_log::EventCategory::Agent)
                     .with_attrs(::serde_json::json!({"thinking_level": format!("{level:?}")})),
                 "Thinking directive parsed from message"
             );

--- a/crates/zeroclaw-runtime/src/agent/tool_execution.rs
+++ b/crates/zeroclaw-runtime/src/agent/tool_execution.rs
@@ -83,6 +83,7 @@ pub async fn execute_one_tool(
                                 module_path!(),
                                 ::zeroclaw_log::Action::Note
                             )
+                            .with_category(::zeroclaw_log::EventCategory::Tool)
                             .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
                             .with_attrs(::serde_json::json!({
                                 "tool": call_name,

--- a/crates/zeroclaw-runtime/src/agent/turn/approval_gate.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/approval_gate.rs
@@ -61,9 +61,10 @@ pub(crate) async fn gate_tool_approval(
                             WARN,
                             ::zeroclaw_log::Event::new(
                                 module_path!(),
-                                ::zeroclaw_log::Action::Note
+                                ::zeroclaw_log::Action::Fail
                             )
-                            .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                            .with_category(::zeroclaw_log::EventCategory::Tool)
+                            .with_outcome(::zeroclaw_log::EventOutcome::Failure)
                             .with_attrs(::serde_json::json!({"error": format!("{}", e)})),
                             "Channel approval request failed"
                         );
@@ -108,6 +109,7 @@ pub(crate) async fn gate_tool_approval(
             ::zeroclaw_log::record!(
                 WARN,
                 ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Reject)
+                    .with_category(::zeroclaw_log::EventCategory::Tool)
                     .with_outcome(::zeroclaw_log::EventOutcome::Failure)
                     .with_attrs(::serde_json::json!({
                         "model": ctx.model,
@@ -147,7 +149,8 @@ pub(crate) async fn gate_tool_approval(
             }
             ::zeroclaw_log::record!(
                 INFO,
-                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Approve)
+                    .with_category(::zeroclaw_log::EventCategory::Tool)
                     .with_outcome(::zeroclaw_log::EventOutcome::Success)
                     .with_attrs(::serde_json::json!({
                         "model": ctx.model,

--- a/crates/zeroclaw-runtime/src/agent/turn/call_prep.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/call_prep.rs
@@ -50,11 +50,12 @@ pub(crate) async fn prepare_tool_calls(
                 .await
             {
                 crate::hooks::HookResult::Cancel(reason) => {
-                    ::zeroclaw_log::record!(INFO, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(::serde_json::json!({"tool": call.name, "reason": reason.to_string()})), "tool call cancelled by hook");
+                    ::zeroclaw_log::record!(INFO, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Cancel).with_category(::zeroclaw_log::EventCategory::Tool).with_attrs(::serde_json::json!({"tool": call.name, "reason": reason.to_string()})), "tool call cancelled by hook");
                     let cancelled = format!("Cancelled by hook: {reason}");
                     ::zeroclaw_log::record!(
                         WARN,
                         ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Cancel)
+                            .with_category(::zeroclaw_log::EventCategory::Tool)
                             .with_outcome(::zeroclaw_log::EventOutcome::Failure)
                             .with_attrs(::serde_json::json!({
                                 "model": ctx.model,
@@ -140,6 +141,7 @@ pub(crate) async fn prepare_tool_calls(
             ::zeroclaw_log::record!(
                 INFO,
                 ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Skip)
+                    .with_category(::zeroclaw_log::EventCategory::Tool)
                     .with_outcome(::zeroclaw_log::EventOutcome::Failure)
                     .with_attrs(::serde_json::json!({
                         "model": ctx.model,
@@ -176,15 +178,15 @@ pub(crate) async fn prepare_tool_calls(
 
         ::zeroclaw_log::record!(
             INFO,
-            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Start).with_attrs(
-                ::serde_json::json!({
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Start)
+                .with_category(::zeroclaw_log::EventCategory::Tool)
+                .with_attrs(::serde_json::json!({
                     "model": ctx.model,
                     "iteration": iteration + 1,
                     "tool": tool_name.clone(),
                     "arguments": scrub_credentials(&tool_args.to_string()),
                     "trace_id": ctx.turn_id,
-                })
-            ),
+                })),
             "tool_call_start"
         );
 
@@ -212,6 +214,7 @@ pub(crate) async fn prepare_tool_calls(
             ::zeroclaw_log::record!(
                 DEBUG,
                 ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_category(::zeroclaw_log::EventCategory::Tool)
                     .with_attrs(::serde_json::json!({"tool": tool_name})),
                 "Sending progress start to draft"
             );

--- a/crates/zeroclaw-runtime/src/agent/turn/context_recovery.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/context_recovery.rs
@@ -39,6 +39,7 @@ pub(crate) fn record_llm_failure(
     ::zeroclaw_log::record!(
         WARN,
         ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+            .with_category(::zeroclaw_log::EventCategory::Provider)
             .with_outcome(::zeroclaw_log::EventOutcome::Failure)
             .with_duration(u64::try_from(llm_started_at.elapsed().as_millis()).unwrap_or(u64::MAX))
             .with_attrs(::serde_json::json!({
@@ -64,8 +65,8 @@ pub(crate) fn try_recover_context_overflow(
     if zeroclaw_providers::reliable::is_context_window_exceeded(e) {
         ::zeroclaw_log::record!(
             WARN,
-            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Retry)
+                .with_category(::zeroclaw_log::EventCategory::Agent)
                 .with_attrs(::serde_json::json!({"iteration": iteration + 1})),
             "Context window exceeded, attempting in-loop recovery"
         );
@@ -75,7 +76,8 @@ pub(crate) fn try_recover_context_overflow(
         if chars_saved > 0 {
             ::zeroclaw_log::record!(
                 INFO,
-                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Retry)
+                    .with_category(::zeroclaw_log::EventCategory::Agent)
                     .with_attrs(::serde_json::json!({"chars_saved": chars_saved})),
                 "Context recovery: trimmed old tool results, retrying"
             );
@@ -87,7 +89,8 @@ pub(crate) fn try_recover_context_overflow(
         if dropped > 0 {
             ::zeroclaw_log::record!(
                 INFO,
-                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Retry)
+                    .with_category(::zeroclaw_log::EventCategory::Agent)
                     .with_attrs(::serde_json::json!({"dropped": dropped})),
                 "Context recovery: dropped old messages, retrying"
             );
@@ -98,6 +101,7 @@ pub(crate) fn try_recover_context_overflow(
         ::zeroclaw_log::record!(
             ERROR,
             ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+                .with_category(::zeroclaw_log::EventCategory::Agent)
                 .with_outcome(::zeroclaw_log::EventOutcome::Failure),
             "Context overflow unrecoverable: no trimmable messages"
         );

--- a/crates/zeroclaw-runtime/src/agent/turn/history_window.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/history_window.rs
@@ -15,12 +15,13 @@ pub(crate) fn preflight_history_maintenance(
     if context_token_budget > 0 {
         let estimated = estimate_history_tokens(history);
         if estimated > context_token_budget {
-            ::zeroclaw_log::record!(INFO, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(::serde_json::json!({"estimated": estimated, "budget": context_token_budget, "iteration": iteration + 1})), "Preemptive context trim: estimated tokens exceed budget");
+            ::zeroclaw_log::record!(INFO, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Delete).with_category(::zeroclaw_log::EventCategory::Agent).with_attrs(::serde_json::json!({"estimated": estimated, "budget": context_token_budget, "iteration": iteration + 1})), "Preemptive context trim: estimated tokens exceed budget");
             let chars_saved = fast_trim_tool_results(history, 4);
             if chars_saved > 0 {
                 ::zeroclaw_log::record!(
                     INFO,
-                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Delete)
+                        .with_category(::zeroclaw_log::EventCategory::Agent)
                         .with_attrs(::serde_json::json!({"chars_saved": chars_saved})),
                     "Preemptive fast-trim applied"
                 );
@@ -38,7 +39,7 @@ pub(crate) fn preflight_history_maintenance(
                     },
                 );
                 if stats.dropped_messages > 0 || stats.collapsed_pairs > 0 {
-                    ::zeroclaw_log::record!(INFO, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(::serde_json::json!({"collapsed": stats.collapsed_pairs, "dropped": stats.dropped_messages})), "Preemptive history prune applied");
+                    ::zeroclaw_log::record!(INFO, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Delete).with_category(::zeroclaw_log::EventCategory::Agent).with_attrs(::serde_json::json!({"collapsed": stats.collapsed_pairs, "dropped": stats.dropped_messages})), "Preemptive history prune applied");
                 }
             }
         }
@@ -52,7 +53,8 @@ pub(crate) fn preflight_history_maintenance(
     if !pruned_in_loop.is_empty() {
         ::zeroclaw_log::record!(
             WARN,
-            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Delete)
+                .with_category(::zeroclaw_log::EventCategory::Agent)
                 .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
                 .with_attrs(::serde_json::json!({
                     "removed": pruned_in_loop.removed,

--- a/crates/zeroclaw-runtime/src/agent/turn/max_iter.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/max_iter.rs
@@ -34,6 +34,7 @@ pub(crate) async fn finish_after_max_iterations(
     ::zeroclaw_log::record!(
         WARN,
         ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+            .with_category(::zeroclaw_log::EventCategory::Agent)
             .with_outcome(::zeroclaw_log::EventOutcome::Failure)
             .with_attrs(::serde_json::json!({
                 "model": model,
@@ -53,6 +54,7 @@ pub(crate) async fn finish_after_max_iterations(
     ::zeroclaw_log::record!(
         WARN,
         ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+            .with_category(::zeroclaw_log::EventCategory::Agent)
             .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
             .with_attrs(::serde_json::json!({"max_iterations": max_iterations})),
         "Max iterations reached, requesting final summary"
@@ -131,6 +133,7 @@ pub(crate) async fn finish_after_max_iterations(
             ::zeroclaw_log::record!(
                 ERROR,
                 ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+                    .with_category(::zeroclaw_log::EventCategory::Provider)
                     .with_outcome(::zeroclaw_log::EventOutcome::Failure)
                     .with_attrs(::serde_json::json!({
                         "model": model,

--- a/crates/zeroclaw-runtime/src/agent/turn/mod.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/mod.rs
@@ -378,10 +378,11 @@ pub async fn run_tool_call_loop(p: ToolLoop<'_>) -> Result<String> {
             if remaining == 0 {
                 ::zeroclaw_log::record!(
                     WARN,
-                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                        .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Reject)
+                        .with_category(::zeroclaw_log::EventCategory::Agent)
+                        .with_outcome(::zeroclaw_log::EventOutcome::Failure)
                         .with_attrs(::serde_json::json!({"iteration": iteration})),
-                    "Shared iteration budget exhausted at iteration "
+                    "Shared iteration budget exhausted at iteration"
                 );
                 break;
             }
@@ -398,7 +399,8 @@ pub async fn run_tool_call_loop(p: ToolLoop<'_>) -> Result<String> {
         {
             ::zeroclaw_log::record!(
                 INFO,
-                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note),
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Migrate)
+                    .with_category(::zeroclaw_log::EventCategory::Provider),
                 &format!(
                     "Model switch detected: {} {} -> {} {}",
                     provider_name, model, new_model_provider, new_model
@@ -482,6 +484,7 @@ pub async fn run_tool_call_loop(p: ToolLoop<'_>) -> Result<String> {
             ::zeroclaw_log::record!(
                 DEBUG,
                 ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_category(::zeroclaw_log::EventCategory::Agent)
                     .with_attrs(::serde_json::json!({
                         "has_on_delta": on_delta.is_some(),
                         "has_event_tx": event_tx.is_some(),
@@ -609,6 +612,7 @@ pub async fn run_tool_call_loop(p: ToolLoop<'_>) -> Result<String> {
             ::zeroclaw_log::record!(
                 WARN,
                 ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+                    .with_category(::zeroclaw_log::EventCategory::Provider)
                     .with_outcome(::zeroclaw_log::EventOutcome::Failure)
                     .with_attrs(serde_json::json!({
                         "channel": channel_name,
@@ -622,6 +626,7 @@ pub async fn run_tool_call_loop(p: ToolLoop<'_>) -> Result<String> {
             ::zeroclaw_log::record!(
                 DEBUG,
                 ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_category(::zeroclaw_log::EventCategory::Provider)
                     .with_attrs(serde_json::json!({
                     "iteration": iteration + 1,
                     "retry": malformed_tool_protocol_retries,
@@ -682,6 +687,7 @@ pub async fn run_tool_call_loop(p: ToolLoop<'_>) -> Result<String> {
             ::zeroclaw_log::record!(
                 INFO,
                 ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Complete)
+                    .with_category(::zeroclaw_log::EventCategory::Agent)
                     .with_outcome(::zeroclaw_log::EventOutcome::Success)
                     .with_attrs(::serde_json::json!({
                         "model": model,

--- a/crates/zeroclaw-runtime/src/agent/turn/parse_response.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/parse_response.rs
@@ -212,6 +212,7 @@ pub(crate) async fn interpret_chat_response(
         ::zeroclaw_log::record!(
             WARN,
             ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+                .with_category(::zeroclaw_log::EventCategory::Tool)
                 .with_outcome(::zeroclaw_log::EventOutcome::Failure)
                 .with_attrs(::serde_json::json!({
                     "model": ctx.model,
@@ -227,6 +228,7 @@ pub(crate) async fn interpret_chat_response(
     ::zeroclaw_log::record!(
         INFO,
         ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Receive)
+            .with_category(::zeroclaw_log::EventCategory::Provider)
             .with_outcome(::zeroclaw_log::EventOutcome::Success)
             .with_duration(u64::try_from(llm_started_at.elapsed().as_millis()).unwrap_or(u64::MAX))
             .with_attrs(::serde_json::json!({

--- a/crates/zeroclaw-runtime/src/agent/turn/post_exec.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/post_exec.rs
@@ -33,6 +33,7 @@ pub(crate) async fn record_executed_outcomes(
         ::zeroclaw_log::record!(
             INFO,
             ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Complete)
+                .with_category(::zeroclaw_log::EventCategory::Tool)
                 .with_outcome(if outcome.success {
                     ::zeroclaw_log::EventOutcome::Success
                 } else {
@@ -74,6 +75,7 @@ pub(crate) async fn record_executed_outcomes(
             ::zeroclaw_log::record!(
                 DEBUG,
                 ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_category(::zeroclaw_log::EventCategory::Tool)
                     .with_attrs(::serde_json::json!({"tool": call.name, "secs": secs})),
                 "Sending progress complete to draft"
             );

--- a/crates/zeroclaw-runtime/src/agent/turn/provider_call.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/provider_call.rs
@@ -70,14 +70,14 @@ pub(crate) async fn announce_llm_request(
         let _provider_guard = ::zeroclaw_log::attribution_span!(active_model_provider).entered();
         ::zeroclaw_log::record!(
             INFO,
-            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Send).with_attrs(
-                ::serde_json::json!({
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Send)
+                .with_category(::zeroclaw_log::EventCategory::Provider)
+                .with_attrs(::serde_json::json!({
                     "iteration": iteration + 1,
                     "messages_count": history.len(),
                     "model": active_model,
                     "trace_id": ctx.turn_id,
-                })
-            ),
+                })),
             "llm_request"
         );
     }
@@ -103,6 +103,7 @@ pub(crate) fn enforce_tool_loop_budget() -> Result<()> {
         ::zeroclaw_log::record!(
             WARN,
             ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Reject)
+                .with_category(::zeroclaw_log::EventCategory::Provider)
                 .with_outcome(::zeroclaw_log::EventOutcome::Failure)
                 .with_attrs(::serde_json::json!({
                     "current_usd": current_usd,
@@ -186,6 +187,7 @@ pub(crate) async fn call_provider(
                 ::zeroclaw_log::record!(
                     WARN,
                     ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+                        .with_category(::zeroclaw_log::EventCategory::Provider)
                         .with_outcome(::zeroclaw_log::EventOutcome::Failure)
                         .with_attrs(::serde_json::json!({
                             "model": active_model,

--- a/crates/zeroclaw-runtime/src/agent/turn/results_collect.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/results_collect.rs
@@ -69,6 +69,7 @@ pub(crate) fn collect_tool_results(
                     ::zeroclaw_log::record!(
                         WARN,
                         ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                            .with_category(::zeroclaw_log::EventCategory::Tool)
                             .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
                             .with_attrs(
                                 ::serde_json::json!({"tool": tool_name, "msg": msg.to_string()})
@@ -80,8 +81,9 @@ pub(crate) fn collect_tool_results(
                 crate::agent::loop_detector::LoopDetectionResult::Block(ref msg) => {
                     ::zeroclaw_log::record!(
                         WARN,
-                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                            .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Reject)
+                            .with_category(::zeroclaw_log::EventCategory::Tool)
+                            .with_outcome(::zeroclaw_log::EventOutcome::Failure)
                             .with_attrs(
                                 ::serde_json::json!({"tool": tool_name, "msg": msg.to_string()})
                             ),
@@ -98,6 +100,7 @@ pub(crate) fn collect_tool_results(
                     ::zeroclaw_log::record!(
                         WARN,
                         ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+                            .with_category(::zeroclaw_log::EventCategory::Tool)
                             .with_outcome(::zeroclaw_log::EventOutcome::Failure)
                             .with_attrs(::serde_json::json!({
                                 "model": model,
@@ -119,6 +122,7 @@ pub(crate) fn collect_tool_results(
             ::zeroclaw_log::record!(
                 DEBUG,
                 ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_category(::zeroclaw_log::EventCategory::Tool)
                     .with_attrs(::serde_json::json!({"tool": tool_name, "receipt": receipt})),
                 "Tool receipt generated"
             );
@@ -188,6 +192,7 @@ pub(crate) fn check_identical_output_abort(
             ::zeroclaw_log::record!(
                 WARN,
                 ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+                    .with_category(::zeroclaw_log::EventCategory::Tool)
                     .with_outcome(::zeroclaw_log::EventOutcome::Failure)
                     .with_attrs(::serde_json::json!({
                         "model": model,

--- a/crates/zeroclaw-runtime/src/agent/turn/stream_consume.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/stream_consume.rs
@@ -104,6 +104,7 @@ pub(crate) async fn consume_provider_streaming_response(
                 ::zeroclaw_log::record!(
                     WARN,
                     ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+                        .with_category(::zeroclaw_log::EventCategory::Provider)
                         .with_outcome(::zeroclaw_log::EventOutcome::Failure)
                         .with_attrs(::serde_json::json!({"error": format!("{}", err)})),
                     "model_provider stream emitted an error event"

--- a/crates/zeroclaw-runtime/src/agent/turn/tool_specs.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/tool_specs.rs
@@ -39,6 +39,7 @@ pub(crate) fn build_iteration_tool_specs(
                 ::zeroclaw_log::record!(
                     WARN,
                     ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                        .with_category(::zeroclaw_log::EventCategory::Tool)
                         .with_outcome(::zeroclaw_log::EventOutcome::Unknown),
                     "activated-tool lock poisoned while assembling iteration tool specs; recovering guard for read"
                 );

--- a/crates/zeroclaw-runtime/src/agent/turn/vision_route.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/vision_route.rs
@@ -39,6 +39,7 @@ pub(crate) fn resolve_vision_provider(
                 ::zeroclaw_log::record!(
                     ERROR,
                     ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+                        .with_category(::zeroclaw_log::EventCategory::Provider)
                         .with_outcome(::zeroclaw_log::EventOutcome::Failure)
                         .with_attrs(::serde_json::json!({
                             "vision_provider": vp,
@@ -92,6 +93,7 @@ pub(crate) fn resolve_vision_provider(
             ::zeroclaw_log::record!(
                 WARN,
                 ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_category(::zeroclaw_log::EventCategory::Provider)
                     .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
                     .with_attrs(::serde_json::json!({
                         "model_provider": provider_name,


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** The gateway's `?category=` and action-based log filters were effectively blind to agent-loop events: nearly every `record!` in the loop + turn engine emitted `Action::Note` with no `EventCategory`. This stamps an explicit category and a real action verb on every in-scope site so the durable trace is sliceable by subsystem and action.
  - 92 in-scope `record!` sites (agent loop + turn engine) now carry an explicit `EventCategory` (88 newly categorized; 4 in `tool_execution.rs` were already correct).
  - `Action::Note` is replaced by a discriminating verb where meaningful (Load/Register/Migrate/Retry/Reject/Skip/Save/Fail/Timeout/Complete/Cancel/Approve/Delete); ~9 genuinely-diagnostic trace sites intentionally stay `Note`.
  - Category rule: **Provider** = the LLM round-trip + its cost/budget/stream envelope; **Tool** = tool-call lifecycle + result collection; **Memory** = memory ops; **Agent** = loop orchestration (setup, model-switch decision, context compression, history trims, thinking).
  - **Companion fix** (`crates/zeroclaw-api/src/attribution.rs`): `Role::default_category()` returned `"model_provider"`/`"tts_provider"`/etc. and `"sop"` — none of which `EventCategory::parse` can match, so provider/SOP attribution spans silently fell to `Internal` (hidden by `hide_internal`). The Provider arms now return `"provider"` and Sop returns `"system"`. This rescues `llm_request` (which previously resolved to hidden Internal) and is repo-wide for all provider spans. `composite_prefix()` and on-disk attribution field names are unchanged.
- **Scope boundary:** Only the agent loop + turn engine are in scope (92 sites). The other ~2,519 workspace `record!` sites are a deferred follow-up; many already inherit a correct category from their entry-point attribution span (and the companion fix improves that inheritance). No new `Action`/`EventCategory` enum variants. `vision_route` maps to Provider (there is no Vision category).
- **Blast radius:** `zeroclaw-runtime` (the edited sites) and `zeroclaw-api` (the global `default_category()` behavior — every provider attribution span across the workspace now resolves to the `provider` category instead of hidden Internal). Behavior change is intended and observable: `llm_request` rows become visible under `?category=provider`.
- **Linked issue(s):** none (internal observability; part of the observability-gap effort).

## Validation Evidence (required)

```
$ cargo +1.93.0 fmt --all -- --check
clean (exit 0)

$ cargo +1.93.0 clippy -p zeroclaw-runtime -p zeroclaw-api --all-targets -- -D warnings
Finished (exit 0, no warnings)   # a typo'd Action/EventCategory variant would fail to compile here

$ cargo +1.93.0 test -p zeroclaw-runtime turn::      -> 16 passed; 0 failed
$ cargo +1.93.0 test -p zeroclaw-runtime agent::     -> 569 passed; 0 failed
$ cargo +1.93.0 test -p zeroclaw-api                 -> 53 passed; 0 failed
$ cargo +1.93.0 test -p zeroclaw-log                 -> 39 passed; 0 failed
```

- **Beyond CI — what I manually verified:** Confirmed `EventCategory::parse("provider")` is `Some` while `parse("model_provider")` is `None` (the bug the companion fixes), via a temporary test that was reverted. Spot-checked the highest-value assignments: `llm_request`/`llm_response` -> Provider, `history_window` trims -> Delete+Agent, tool lifecycle -> Tool. ASCII-only added lines; no `#[allow(dead_code)]`.
- **Not verified here (environmental):** `cargo build --workspace --all-targets` fails only in `robot-kit`/`aardvark-sys` (missing GTK system libs `gdk-3.0`/`gio-2.0` on this box) — no Cargo.toml or those crates touched. The relevant crates (`runtime`, `api`, `gateway`, `channels`, `log`) build clean `--all-targets`.
- **Live leg (run separately):** after a turn, `?category=provider` returns BOTH `llm_request` and `llm_response`; `?category=tool` returns the tool lifecycle; `?category=agent` the loop lifecycle; confirm `hide_internal` no longer swallows `llm_request`.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility (required)

- Backward compatible? **Yes** — only populating existing `event.category` / `event.action` fields with existing enum variants; no schema or enum change. One intended behavior change: `llm_request` (and other provider spans) move from hidden `Internal` to visible `Provider`.
- Config / env / CLI surface changed? **No**

## Rollback (required for medium/high risk)

Low risk: `git revert <sha>`. Pure field-population + one string-literal companion; no migration, no flags.
