### PR TITLE
fix(zeroclaw-runtime): drop unused unconditional rumqttc dependency (#7888)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14570,7 +14570,6 @@ dependencies = [
  "regex",
  "reqwest 0.12.28",
  "ring",
- "rumqttc",
  "rusqlite",
  "rustls",
  "rustls-pemfile",

--- a/crates/zeroclaw-runtime/Cargo.toml
+++ b/crates/zeroclaw-runtime/Cargo.toml
@@ -43,7 +43,6 @@ parking_lot = "0.12"
 portable-atomic = "1"
 rand = "0.10"
 regex = "1.10"
-rumqttc = { version = "0.25", default-features = false, features = ["use-rustls-no-provider"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-webpki-roots-no-provider", "__rustls-ring", "blocking", "multipart", "stream", "socks"] }
 ring = "0.17"
 rusqlite = { version = "0.37", features = ["bundled"] }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Remove the unconditional `rumqttc` dependency from `crates/zeroclaw-runtime/Cargo.toml` (and its resolved `Cargo.lock` entry). `zeroclaw-runtime` listed `rumqttc` directly but never used it — the only direct `rumqttc` API use in the tree is `crates/zeroclaw-channels/src/orchestrator/mqtt.rs`, which is feature-gated behind `channel-mqtt`.
  - Restores the selective-channel-build boundary introduced in #6866: builds that omit `channel-mqtt` should not pull the MQTT client stack, but the stray runtime dependency forced `rumqttc` into every build that includes `zeroclaw-runtime`.
- **Scope boundary:** Manifest-only. No source/code changes. `zeroclaw-channels` keeps its own `rumqttc = { optional = true }` and the `channel-mqtt = ["zeroclaw-channels/channel-mqtt"]` workspace feature cascade is untouched.
- **Blast radius:** Lean builds (no `channel-mqtt`) drop `rumqttc` and its transitive MQTT/TLS stack from the dependency graph. MQTT functionality is unaffected — it lives entirely in `zeroclaw-channels` behind `channel-mqtt`, which this PR does not modify.
- **Linked issue(s):** Resolves #7888
- **Labels:** `type: build`, `risk: low`, `size: S` (maintainer-set)

## Validation Evidence (required)

Manifest-only removal of an unused dependency. The decisive signal for this change is that `zeroclaw-runtime` source carries zero `rumqttc` references; CI runs the full `cargo` battery on the PR.

```bash
$ rg -n "rumqttc" crates/zeroclaw-runtime/src
# (no matches — runtime contains no rumqttc usage)

$ rg -n "rumqttc" crates/zeroclaw-channels/src/orchestrator/mqtt.rs | head -1
# rumqttc::... (the only direct API use; gated behind channel-mqtt — unchanged)

$ cargo fmt --all -- --check
# clean (exit 0)
```

- **Commands run and tail output:** `rg` usage scan (above) confirms the dependency was unused in runtime; `cargo fmt --all -- --check` is clean.
- **Beyond CI — what did you manually verify?** That the removed dependency has no source consumer in `zeroclaw-runtime`, and that the MQTT code path (`zeroclaw-channels`, `channel-mqtt`) retains its own `rumqttc` dependency, so no functionality is lost. Selective `--no-default-features` and full `clippy`/`test` builds are exercised by CI.
- **If any command was intentionally skipped, why:** Local full `cargo clippy`/`cargo test` not re-run for a manifest-only unused-dep removal — CI covers it, and the change cannot introduce a source compile error in runtime (no `rumqttc` symbols are referenced there).

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No (removes an MQTT client dependency from lean builds; adds nothing)
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No

## Compatibility (required)

- Backward compatible? Yes — no public API/CLI/config surface changes. MQTT remains available via the `channel-mqtt` feature.
- Config / env / CLI surface changed? No
- Upgrade steps for existing users: None. Builds that enable `channel-mqtt` are unchanged; lean builds simply no longer carry `rumqttc`.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PR: `git revert <sha>` restores the dependency line. No feature flags or data migration involved.

---

**Reviewer note (adversarial review false positive):** an automated cross-family review flagged a HIGH "removing `rumqttc` will break compilation if `use rumqttc::…` statements remain." This does not apply: `rg "rumqttc" crates/zeroclaw-runtime/src` returns zero matches, and issue #7888 itself documents that the only direct `rumqttc` API use is in `zeroclaw-channels`, not runtime. The MED notes about feature-gating and lockfile re-introduction are already satisfied — `zeroclaw-channels` owns the `optional = true` `rumqttc` + `channel-mqtt` gate, which this PR leaves intact.
