### PR TITLE
fix(agent): inject wss channel delivery defaults for cron_add on WebS…

### DIFF
--- a/crates/zeroclaw-gateway/src/ws.rs
+++ b/crates/zeroclaw-gateway/src/ws.rs
@@ -453,6 +453,10 @@ async fn handle_socket(
             }
         };
     agent.set_memory_session_id(Some(memory_session_id));
+    // Tag this agent with the WebSocket transport so cron_add can
+    // auto-inject delivery defaults back to this session.
+    agent.set_channel_name("wss");
+    agent.set_channel_reply_target(Some(session_key.clone()));
     if !stored_messages.is_empty() {
         agent.seed_history(&stored_messages);
     }

--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -202,6 +202,13 @@ pub struct Agent {
     /// at most once per session even though the multimodal pipeline re-walks
     /// the full conversation history on every turn and tool iteration.
     image_cache: zeroclaw_providers::multimodal::LocalImageCache,
+    /// Channel name for delivery-default injection in cron_add and other
+    /// channel-aware tools. Defaults to `"cli"` for non-channel paths.
+    channel_name: String,
+    /// Channel reply target (e.g. session key, Discord channel ID, Telegram
+    /// chat ID). Used by delivery-default injection when scheduling cron
+    /// jobs back to the current conversation.
+    channel_reply_target: Option<String>,
 }
 
 impl Drop for Agent {
@@ -317,6 +324,8 @@ pub struct AgentBuilder {
     approval_manager: Option<Arc<ApprovalManager>>,
     agent_alias: Option<String>,
     exclude_memory: bool,
+    channel_name: Option<String>,
+    channel_reply_target: Option<String>,
 }
 
 impl Default for AgentBuilder {
@@ -359,6 +368,8 @@ impl AgentBuilder {
             approval_manager: None,
             agent_alias: None,
             exclude_memory: false,
+            channel_name: None,
+            channel_reply_target: None,
         }
     }
 
@@ -544,6 +555,21 @@ impl AgentBuilder {
         self
     }
 
+    /// Set the channel name for delivery-default injection (e.g. `"wss"`,
+    /// `"discord"`, `"telegram"`). Defaults to `"cli"`.
+    pub fn channel_name(mut self, name: impl Into<String>) -> Self {
+        self.channel_name = Some(name.into());
+        self
+    }
+
+    /// Set the channel reply target (e.g. session key, Discord channel ID).
+    /// Used by delivery-default injection when scheduling cron jobs back to
+    /// the current conversation.
+    pub fn channel_reply_target(mut self, target: impl Into<String>) -> Self {
+        self.channel_reply_target = Some(target.into());
+        self
+    }
+
     pub fn build(self) -> Result<Agent> {
         let mut tools = self.tools.ok_or_else(|| {
             ::zeroclaw_log::record!(
@@ -685,6 +711,8 @@ impl AgentBuilder {
             agent_alias: self.agent_alias.unwrap_or_default(),
             channel_handles: AgentChannelHandles::default(),
             image_cache: zeroclaw_providers::multimodal::LocalImageCache::new(),
+            channel_name: self.channel_name.unwrap_or_else(|| "cli".into()),
+            channel_reply_target: self.channel_reply_target,
         })
     }
 }
@@ -878,6 +906,21 @@ impl Agent {
 
     pub fn set_tool_dispatcher(&mut self, tool_dispatcher: Box<dyn ToolDispatcher>) {
         self.tool_dispatcher = tool_dispatcher;
+    }
+
+    /// Set the channel name for delivery-default injection.
+    /// Used by WebSocket / gateway paths to identify the transport
+    /// (e.g. `"wss"`) so `cron_add` can auto-inject delivery config.
+    pub fn set_channel_name(&mut self, name: impl Into<String>) {
+        self.channel_name = name.into();
+    }
+
+    /// Set the channel reply target for delivery-default injection.
+    /// Used by WebSocket / gateway paths to pass the session key
+    /// (or Discord channel ID, Telegram chat ID, etc.) so `cron_add`
+    /// can auto-inject delivery config.
+    pub fn set_channel_reply_target(&mut self, target: Option<impl Into<String>>) {
+        self.channel_reply_target = target.map(Into::into);
     }
 
     /// Return the names of all registered tools.  Test-only — avoids
@@ -1969,8 +2012,8 @@ impl Agent {
                     temperature: self.temperature,
                     silent: false,
                     approval: self.approval_manager.as_deref(),
-                    channel_name: "cli",
-                    channel_reply_target: None,
+                    channel_name: &self.channel_name,
+                    channel_reply_target: self.channel_reply_target.as_deref(),
                     multimodal_config: &self.multimodal_config,
                     max_tool_iterations: self.config.resolved.max_tool_iterations,
                     cancellation_token: None,
@@ -2362,8 +2405,8 @@ impl Agent {
                         temperature: self.temperature,
                         silent: true,
                         approval: self.approval_manager.as_deref(),
-                        channel_name: "cli",
-                        channel_reply_target: None,
+                        channel_name: &self.channel_name,
+                        channel_reply_target: self.channel_reply_target.as_deref(),
                         multimodal_config: &self.multimodal_config,
                         max_tool_iterations: self.config.resolved.max_tool_iterations,
                         cancellation_token: cancel_token.clone(),

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -3178,6 +3178,31 @@ mod tests {
         );
     }
 
+    #[test]
+    fn cron_delivery_defaults_include_wss_channel() {
+        let mut args = serde_json::json!({
+            "job_type": "agent",
+            "prompt": "remind me later",
+            "schedule": { "kind": "cron", "expr": "0 18 * * *" }
+        });
+
+        maybe_inject_channel_delivery_defaults(
+            "cron_add",
+            &mut args,
+            "wss",
+            Some("gw_02e6dcba-a913-456e-9a6b-5e151ac83dcd"),
+        );
+
+        assert_eq!(
+            args["delivery"],
+            serde_json::json!({
+                "mode": "announce",
+                "channel": "wss",
+                "to": "gw_02e6dcba-a913-456e-9a6b-5e151ac83dcd",
+            })
+        );
+    }
+
     // ── truncate_tool_result tests ────────────────────────────────
 
     #[test]

--- a/crates/zeroclaw-runtime/src/agent/turn/delivery_defaults.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/delivery_defaults.rs
@@ -9,6 +9,7 @@ const AUTO_DELIVERY_DEFAULT_CHANNELS: &[&str] = &[
     "dingtalk",
     "lark",
     "feishu",
+    "wss",
 ];
 
 pub(crate) fn maybe_inject_channel_delivery_defaults(


### PR DESCRIPTION
fix #5862 
## Issue #5862 — Reproduction & Fix Report

---

### 1. Reproduction Confirmation

**On current master (v0.8.1), the original symptom has evolved:**

- **Before PR #5774** (v0.7.0): Model could **not see** `cron_add` at all; it fell back to the legacy `schedule` tool and claimed "only local shell cron is available."
- **After PR #5774** (current master): Model **can see** `cron_add` and attempts to call it, but the WebSocket (`wss`) path **lacks `delivery` auto-injection**, so the model either:
  1. Asks the user "where should I send the reminder?" (missing channel context)
  2. Creates the cron job but omits `delivery`, so the reminder has no destination when triggered

**Log evidence:**

```json
{"tool":"cron_add","arguments":{"approved":false,"job_type":"agent","name":"周报提醒","prompt":"...","schedule":{"expr":"0 18 * * *","kind":"cron","tz":"Asia/Shanghai"}}}
```

Notice **no `delivery` field** in the arguments. The model also tried `sessions_list` first to "find available channels" because it had no channel context.

---

### 2. Root Cause Analysis

**The issue is a missing `wss` entry in `AUTO_DELIVERY_DEFAULT_CHANNELS` combined with hard-coded `channel_name="cli"` in the WebSocket agent path.**

| Component | Problem | Impact |
|-----------|---------|--------|
| `delivery_defaults.rs` | `wss` not in `AUTO_DELIVERY_DEFAULT_CHANNELS` | `maybe_inject_channel_delivery_defaults` silently skips `cron_add` calls from WebSocket sessions |
| `agent.rs` | `turn` / `turn_streamed_with_steering_state` hard-code `channel_name: "cli"`, `channel_reply_target: None` | The loop has no session identity to inject as `delivery.to` |
| `ws.rs` | Does not pass `session_key` as `channel_reply_target` | The agent cannot auto-target the current WebSocket session |

---

### 3. Fix Plan

#### 3.1 Add per-session channel context to `Agent`

- Add `channel_name: String` and `channel_reply_target: Option<String>` to `Agent` struct
- Add `channel_name()` and `channel_reply_target()` setters on `AgentBuilder`
- Default `channel_name` to `"cli"` to preserve existing CLI/gateway behavior
- Modify `turn` and `turn_streamed_with_steering_state` to use `&self.channel_name` and `self.channel_reply_target.as_deref()` instead of hard-coded values

**Source of truth check:** `channel_name` and `channel_reply_target` are per-session runtime values, not config duplicates. They are set by the transport layer (gateway WS, channel orchestrator, CLI) at session start and consumed by the tool loop at call time. ✓

#### 3.2 Add `wss` to delivery-default whitelist

- Append `"wss"` to `AUTO_DELIVERY_DEFAULT_CHANNELS` in `delivery_defaults.rs`
- This allows `maybe_inject_channel_delivery_defaults` to inject `delivery={"mode":"announce","channel":"wss","to":"<session_key>"}` for `cron_add` calls from WebSocket sessions

#### 3.3 Wire gateway WS session to set channel context

- In `ws.rs`, after `agent.set_memory_session_id(...)`, call:
  - `agent.set_channel_name("wss")`
  - `agent.set_channel_reply_target(Some(session_key))`

---

### 4. Changes Detail

| File | Change | Lines |
|------|--------|-------|
| `crates/zeroclaw-runtime/src/agent/agent.rs` | Add `channel_name` and `channel_reply_target` fields to `Agent` and `AgentBuilder`; add setters; wire into `turn` / `turn_streamed_with_steering_state` | +45 |
| `crates/zeroclaw-runtime/src/agent/turn/delivery_defaults.rs` | Add `"wss"` to `AUTO_DELIVERY_DEFAULT_CHANNELS` | +1 |
| `crates/zeroclaw-gateway/src/ws.rs` | Call `set_channel_name("wss")` and `set_channel_reply_target(Some(session_key))` after agent init | +4 |
| `crates/zeroclaw-runtime/src/agent/loop_.rs` | Add regression test `cron_delivery_defaults_include_wss_channel` | +20 |

**Branch:** `fix/wss-cron-delivery-defaults-5862`
**Commit:** `70dfb9e9`

---

### 5. Test Points

- [x] `cargo fmt --all` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --package zeroclaw-runtime --lib agent::loop_::tests::cron_delivery_defaults` — all 3 tests pass (including new `wss` test)
- [x] Regression test `cron_delivery_defaults_include_wss_channel` verifies that `maybe_inject_channel_delivery_defaults` correctly injects `delivery` JSON when `channel_name="wss"` and `channel_reply_target="<session_key>"`
- [ ] **Manual end-to-end test on Web UI:** Send "帮我记录一个 cron：每天晚上 6 点，提醒我：该写周报了。" and verify the approval prompt shows `delivery` field auto-populated
- [ ] **Verify cron trigger:** Wait for the scheduled time (or manually trigger) and confirm the reminder message arrives back in the same WebSocket session

---

### 6. Next Steps

1. **Review & merge PR** — The fix is minimal, additive, and preserves all existing behavior for CLI (`"cli"`) and channel orchestrator paths.
2. **Close Issue #5862** after merge. The original symptom ("model does not know it can add cron") is resolved: on latest master the model sees `cron_add`, and after this PR it also gets correct `delivery` auto-injection on the WebSocket path.
3. **Future enhancement:** Consider extending `AUTO_DELIVERY_DEFAULT_CHANNELS` to other gateway transports (e.g. `acp` for the ACP server) if they also need cron delivery back to the originating session.

---

*Posted on behalf of reproduction & fix effort by @hanZeng-08.*
