### PR TITLE
fix(runtime): drop unconditional rumqttc dependency (#7888)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14570,7 +14570,6 @@ dependencies = [
  "regex",
  "reqwest 0.12.28",
  "ring",
- "rumqttc",
  "rusqlite",
  "rustls",
  "rustls-pemfile",

--- a/crates/zeroclaw-channels/Cargo.toml
+++ b/crates/zeroclaw-channels/Cargo.toml
@@ -19,7 +19,7 @@ zeroclaw-tool-call-parser.workspace = true
 zeroclaw-tools.workspace = true
 anyhow = "1.0"
 lru = "0.16"
-rumqttc = { version = "0.25", optional = true }
+rumqttc = { version = "0.25", optional = true, features = ["use-rustls-no-provider"] }
 lapin = { version = "2", optional = true, default-features = false, features = [
   "rustls",
 ] }

--- a/crates/zeroclaw-runtime/Cargo.toml
+++ b/crates/zeroclaw-runtime/Cargo.toml
@@ -43,7 +43,6 @@ parking_lot = "0.12"
 portable-atomic = "1"
 rand = "0.10"
 regex = "1.10"
-rumqttc = { version = "0.25", default-features = false, features = ["use-rustls-no-provider"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-webpki-roots-no-provider", "__rustls-ring", "blocking", "multipart", "stream", "socks"] }
 ring = "0.17"
 rusqlite = { version = "0.37", features = ["bundled"] }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `crates/zeroclaw-runtime/Cargo.toml` declared `rumqttc` as an unconditional dependency, but runtime has **zero direct use** of it — the only `rumqttc` API consumer is `crates/zeroclaw-channels/src/orchestrator/mqtt.rs`, already gated behind `channel-mqtt`. Removed it.
  - This made lean builds that omit `channel-mqtt` still pull the entire MQTT client stack, contradicting the selective-channel-build goal of #6866.
  - To keep the **effective feature set identical** for `channel-mqtt` builds (runtime previously contributed `use-rustls-no-provider` via feature unification), that feature was added to `zeroclaw-channels`' optional `rumqttc` dependency. The `ring` crypto provider is installed process-wide (`gateway/src/tls.rs`, `channels/src/irc.rs`), so `use-rustls-no-provider` remains the correct config.
- **Scope boundary:** Only the `rumqttc` dependency declaration in two manifests. No source code, no MQTT runtime behavior, no other channels/features touched.
- **Blast radius:** `channel-mqtt` builds (rumqttc now sourced solely via `zeroclaw-channels`); lean/`--no-default-features` builds (rumqttc no longer present). No effect on default builds.
- **Linked issue(s):** Closes #7888. Related #6866.
- **Labels:** `bug`, `risk: medium`, `dependencies`, `channel`, `runtime`, `channel:mqtt`

## Validation Evidence (required)

Dependency-graph proof (the meaningful signal for a manifest change), plus the full local CI battery at the pinned `1.93.0` toolchain.

```
# BEFORE was: rumqttc declared in runtime AND pulled into lean builds.
# AFTER:

$ cargo tree -i rumqttc --no-default-features
error: package ID specification `rumqttc` did not match any packages   # dropped from lean builds ✅

$ cargo tree -i rumqttc --features ci-all
rumqttc v0.25.1
└── zeroclaw-channels v0.8.1                                            # retained, via channels only ✅
    ├── zeroclaw-gateway v0.8.1
    ...
```

Full gate (mirrors `.github/workflows/ci.yml`, toolchain `1.93.0`):

```bash
cargo +1.93.0 fmt --all -- --check
cargo +1.93.0 clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
cargo +1.93.0 check --locked --features ci-all --all-targets
cargo +1.93.0 check --no-default-features
cargo +1.93.0 nextest run --locked --workspace --exclude zeroclaw-desktop
```

- **Commands run and tail output:** all gates GREEN. `Summary [74.1s] 9342 tests run: 9342 passed, 11 skipped`. Format clean; clippy `-D warnings` clean; both `Check` matrix variants pass with `--locked` (no `Cargo.lock` drift).
- **Beyond CI — what did you manually verify?** Confirmed via `cargo tree` that `rumqttc` is absent from the `--no-default-features` graph and present **only** through `zeroclaw-channels` under `ci-all` (which builds `channel-mqtt` → compiles the MQTT TLS path). Verified no `rumqttc` references remain anywhere under `crates/zeroclaw-runtime/` (src/tests/benches).
- **If any command was intentionally skipped, why:** Native session-backend feature sets (postgres/oracle/db2/mysql) need native client libs and are excluded by `ci-all`, matching CI.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes` — `channel-mqtt` builds get the identical effective `rumqttc` feature set; default builds unchanged.
- Config / env / CLI surface changed? `No`
- Upgrade steps: none.

## Rollback (required for `risk: medium`)

- **Fast rollback command/path:** `git revert <sha>` — pure manifest change, no migration.
- **Feature flags or config toggles:** `channel-mqtt` (unchanged; MQTT support continues to gate on it).
- **Observable failure symptoms:** an MQTT-enabled build failing to compile `zeroclaw-channels/src/orchestrator/mqtt.rs`, or a TLS handshake failure on `mqtts://` brokers (would indicate the rumqttc TLS feature set regressed).
