### PR TITLE
docs(windows-setup): fix dead quick-start link breaking docs build

### DIFF
--- a/docs/book/src/setup/windows.md
+++ b/docs/book/src/setup/windows.md
@@ -283,5 +283,5 @@ rmdir /s /q "%USERPROFILE%\.zeroclaw"
 ## Next
 
 - [Service management](./service.md)
-- [Quick start](../getting-started/quick-start.md)
+- [Quick start](../getting-started/quickstart.md)
 - [Operations → Overview](../ops/overview.md)


### PR DESCRIPTION
## What

Restores the hyphen-free filename in the Windows setup page's "Next" section:

```diff
- [Quick start](../getting-started/quick-start.md)
+ [Quick start](../getting-started/quickstart.md)
```

## Why

The docs build on `master` is failing the mdBook internal link check:

```
Error: internal link check failed; dead links found:
  setup/windows.html -> ../getting-started/quick-start.html
```

The target file is [`docs/book/src/getting-started/quickstart.md`](../blob/master/docs/book/src/getting-started/quickstart.md) — there is no `quick-start.md`. #6102 rewrote a previously-correct link (`quickstart.md` → `quick-start.md`) and introduced the dead reference. This is the only doc file that PR touched, and `git blame` on the line confirms commit `c6cf756567`.

## Scope

One-character fix (restore removed hyphen). No other files touched.