### PR TITLE
feat(web): themed click-to-open config pickers (Select primitive)

### DIFF
--- a/web/src/components/sections/FieldForm.tsx
+++ b/web/src/components/sections/FieldForm.tsx
@@ -39,7 +39,7 @@ import {
 } from "lucide-react";
 import DirectoryPicker from "./DirectoryPicker";
 import ToolPicker from "@/components/ToolPicker";
-import { Badge, Button, ComboBox } from "@/components/ui";
+import { Badge, Button, ComboBox, Select } from "@/components/ui";
 import type { BadgeTone } from "@/components/ui";
 import { t } from "@/lib/i18n";
 import {
@@ -570,6 +570,9 @@ const AGENT_MULTI_ALIAS_FIELDS: Record<string, keyof AgentOptionsResponse> = {
   "skill_bundles": "skill_bundles",
   "knowledge_bundles": "knowledge_bundles",
   "mcp_bundles": "mcp_bundles",
+  // Delegates is a subset of the configured agents — give it the same themed
+  // multi-select (with agent suggestions) as the bundle fields, not free text.
+  delegates: "agents",
 };
 
 // Peer-groups carry the same alias-ref shape as agents do: a single
@@ -623,6 +626,31 @@ const LEAF_SINGLE_ALIAS_FIELDS: Record<string, keyof AgentOptionsResponse> = {
 function leafSingleAliasKind(path: string): keyof AgentOptionsResponse | null {
   const leaf = path.split(".").pop() ?? "";
   return LEAF_SINGLE_ALIAS_FIELDS[leaf] ?? null;
+}
+
+// `kind:"alias-ref"` fields carry a `<Type>Ref` type_hint naming the section
+// they reference. Map it to the `resolve-alias-source` query value (the backend
+// AliasSource variants). Used to DERIVE the source when the daemon emits the
+// kind but omits `alias_source` (older builds): the generic resolver still works
+// — covering provider refs (incl. tts/transcription/classifier) that have no
+// AgentOptionsResponse list, so they get a real dropdown, not a stuck spinner.
+const ALIAS_REF_TYPE_TO_SOURCE: Record<string, string> = {
+  ModelProviderRef: "model_providers",
+  TtsProviderRef: "tts_providers",
+  TranscriptionProviderRef: "transcription_providers",
+  RiskProfileRef: "risk_profiles",
+  RuntimeProfileRef: "runtime_profiles",
+  ChannelRef: "channels",
+};
+
+// The `resolve-alias-source` query value for an alias-ref entry: prefer the
+// daemon-declared `alias_source`; else derive it from the `<Type>Ref` type_hint.
+// Returns null for non-alias-ref entries or unmapped ref types.
+function aliasRefSource(entry: ListResponseEntry): string | null {
+  if (entry.kind !== "alias-ref") return null;
+  if (entry.alias_source) return entry.alias_source;
+  const m = entry.type_hint?.match(/(\w+Ref)\b/);
+  return (m && ALIAS_REF_TYPE_TO_SOURCE[m[1] ?? ""]) ?? null;
 }
 
 // Cross-section navigation map for agent alias-ref fields. Each entry
@@ -1406,8 +1434,7 @@ function FieldRow({
   // `aliasSource` is undefined and the effect is a no-op, leaving the maps
   // above to resolve refs. When the backend does declare it, the
   // `renderer === 'alias-ref'` branch takes precedence over those maps.
-  const aliasSource =
-    entry.kind === "alias-ref" ? entry.alias_source : undefined;
+  const aliasSource = aliasRefSource(entry);
   const [aliasValues, setAliasValues] = useState<string[] | null>(null);
   useEffect(() => {
     if (!aliasSource) return;
@@ -1423,6 +1450,20 @@ function FieldRow({
       cancelled = true;
     };
   }, [aliasSource]);
+
+  // Resolve the option list for an `alias-ref` field. Prefer the resolver values
+  // (keyed off `aliasSource`, which `aliasRefSource` derives from the type_hint
+  // when the daemon omits `alias_source`); else fall back to the agent/leaf alias
+  // map (`/api/config/agent-options`). `null` = no options yet.
+  const aliasRefOptions: string[] | null =
+    aliasValues ??
+    (agentSingleAliasKind && agentOptions
+      ? (agentOptions[agentSingleAliasKind] ?? [])
+      : null);
+  // Distinguish "actively resolving" (a source IS being fetched, show a spinner)
+  // from "unresolvable" (no source AND no fallback — render an empty, usable
+  // picker rather than a spinner that never finishes).
+  const aliasRefResolving = aliasSource !== null && aliasRefOptions === null;
 
   if (tombstoned) {
     return (
@@ -1525,43 +1566,51 @@ function FieldRow({
             onChange={(next) => onChange(next ? "true" : "false")}
           />
         ) : renderer === "select" ? (
-          <select
+          // Themed locked dropdown for enum variants (no browser-styled <option>
+          // list). The leading "—" is the empty/unset choice.
+          <Select
             id={entry.path}
             value={value}
-            onChange={(e) => onChange(e.target.value)}
-            className="input-electric w-full px-3 py-2 text-sm appearance-none cursor-pointer"
-          >
-            <option value="">—</option>
-            {(entry.enum_variants ?? []).map((v) => (
-              <option key={v} value={v}>
-                {v}
-              </option>
-            ))}
-          </select>
+            onChange={onChange}
+            aria-label={fieldShortLabel(entry)}
+            options={[
+              { value: "", label: "—" },
+              ...(entry.enum_variants ?? []).map((v) => ({
+                value: v,
+                label: v,
+              })),
+            ]}
+          />
         ) : renderer === "alias-ref" ? (
-          // Schema-driven alias-ref picker (zeroclaw-labs/zeroclaw#7594):
-          // a free-typeable input backed by a <datalist> of the live values
-          // resolved from `entry.alias_source`. Takes precedence over the
-          // per-section maps below; dormant until the backend emits this kind.
-          <>
+          // Schema-driven alias-ref picker (zeroclaw-labs/zeroclaw#7594): a
+          // themed, click-to-open ComboBox of the live values (resolved from
+          // `entry.alias_source`, with an agent-options fallback — see
+          // `aliasRefOptions`). Uses the same primitive as the model-field picker
+          // so it matches the rest of the page instead of a browser-styled native
+          // <select>. `openOnFocus` makes clicking the field open the list, since
+          // the configured aliases ARE the expected input. Free text is still
+          // accepted verbatim (and validated on save) so an existing or
+          // not-yet-created alias is never dropped. Precedes the per-section maps.
+          aliasRefResolving ? (
             <input
               id={entry.path}
-              list={`alias-${entry.path}`}
               value={value}
-              onChange={(e) => onChange(e.target.value)}
+              disabled
+              readOnly
               className="input-electric w-full px-3 py-2 text-sm"
-              placeholder={
-                aliasValues === null
-                  ? t("fieldform.alias_loading")
-                  : t("fieldform.alias_pick_or_type")
-              }
+              placeholder={t("fieldform.alias_loading")}
             />
-            <datalist id={`alias-${entry.path}`}>
-              {(aliasValues ?? []).map((v) => (
-                <option key={v} value={v} />
-              ))}
-            </datalist>
-          </>
+          ) : (
+            <ComboBox
+              id={entry.path}
+              value={value}
+              onChange={onChange}
+              options={aliasRefOptions ?? []}
+              openOnFocus
+              placeholder={t("fieldform.alias_pick_or_type")}
+              aria-label={fieldShortLabel(entry)}
+            />
+          )
         ) : isProviderModelField &&
           providerModels !== null &&
           providerModels.length > 0 ? (
@@ -1573,6 +1622,7 @@ function FieldRow({
             value={value}
             onChange={onChange}
             options={providerModels}
+            openOnFocus
             placeholder={t("fieldform.model_combo_placeholder")}
             emptyText={t("fieldform.model_combo_empty")}
             aria-label={t("fieldform.model_aria")}
@@ -1932,6 +1982,7 @@ function ArrayFieldEditor({
                       value={row}
                       onChange={(v) => setRow(i, v)}
                       options={suggestions}
+                      openOnFocus
                       placeholder={t("fieldform.value_combo_placeholder")}
                       emptyText={t("fieldform.value_combo_empty")}
                     />

--- a/web/src/components/ui/ComboBox.tsx
+++ b/web/src/components/ui/ComboBox.tsx
@@ -25,6 +25,13 @@ export interface ComboBoxProps {
   emptyText?: string;
   /** Extra classes for the root wrapper. */
   className?: string;
+  /**
+   * Open the list as soon as the input is focused/clicked (not just via the
+   * caret). Makes the field behave like a click-anywhere dropdown — handy when
+   * the options ARE the expected input (e.g. an alias picker) rather than rare
+   * suggestions over mostly-free text.
+   */
+  openOnFocus?: boolean;
   "aria-label"?: string;
 }
 
@@ -36,6 +43,7 @@ export function ComboBox({
   placeholder,
   emptyText = t("combobox.no_matches"),
   className = "",
+  openOnFocus = false,
   "aria-label": ariaLabel,
 }: ComboBoxProps) {
   const [open, setOpen] = useState(false);
@@ -136,6 +144,9 @@ export function ComboBox({
             setOpen(true);
           }}
           onKeyDown={onKeyDown}
+          onFocus={openOnFocus ? () => setOpen(true) : undefined}
+          // Re-open if the user clicks an already-focused input after closing it.
+          onClick={openOnFocus ? () => setOpen(true) : undefined}
           className="input-electric w-full px-3 py-2 pr-9 text-sm"
         />
         <button

--- a/web/src/components/ui/Select.tsx
+++ b/web/src/components/ui/Select.tsx
@@ -1,0 +1,167 @@
+// Operator Console — Select primitive.
+//
+// A themed, LOCKED dropdown for fixed value sets (e.g. enum variants). Unlike
+// ComboBox (free-text input + discoverable suggestions), the value is restricted
+// to the provided options — there is no typing. It exists so locked selects stop
+// rendering the browser's unstyled native `<option>` list (which ignores the
+// dark theme); this renders the same themed, keyboard-navigable listbox the
+// ComboBox uses. Click anywhere on the control opens it.
+
+import { useEffect, useId, useRef, useState } from "react";
+import { Check, ChevronsUpDown } from "lucide-react";
+
+export interface SelectOption {
+  value: string;
+  label: string;
+}
+
+export interface SelectProps {
+  /** Current value (must match an option's `value`, or be empty). */
+  value: string;
+  onChange: (value: string) => void;
+  options: SelectOption[];
+  id?: string;
+  /** Shown when no option is selected. */
+  placeholder?: string;
+  /** Extra classes for the root wrapper. */
+  className?: string;
+  "aria-label"?: string;
+}
+
+export function Select({
+  value,
+  onChange,
+  options,
+  id,
+  placeholder,
+  className = "",
+  "aria-label": ariaLabel,
+}: SelectProps) {
+  const [open, setOpen] = useState(false);
+  // Highlighted option index (keyboard navigation).
+  const [active, setActive] = useState(0);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const btnRef = useRef<HTMLButtonElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+  const reactId = useId();
+  const listboxId = `${id ?? reactId}-listbox`;
+
+  const selected = options.find((o) => o.value === value);
+
+  // On open, highlight the currently-selected option (or the first).
+  useEffect(() => {
+    if (!open) return;
+    const idx = options.findIndex((o) => o.value === value);
+    setActive(idx >= 0 ? idx : 0);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  // Close on outside click.
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [open]);
+
+  // Keep the highlighted option scrolled into view.
+  useEffect(() => {
+    if (!open) return;
+    listRef.current
+      ?.querySelector<HTMLElement>(`[data-idx="${active}"]`)
+      ?.scrollIntoView({ block: "nearest" });
+  }, [active, open]);
+
+  const choose = (v: string) => {
+    onChange(v);
+    setOpen(false);
+    btnRef.current?.focus();
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      if (!open) return setOpen(true);
+      setActive((a) => (options.length ? (a + 1) % options.length : 0));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      if (!open) return setOpen(true);
+      setActive((a) =>
+        options.length ? (a - 1 + options.length) % options.length : 0,
+      );
+    } else if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      if (!open) return setOpen(true);
+      const opt = options[active];
+      if (opt) choose(opt.value);
+    } else if (e.key === "Escape") {
+      if (open) {
+        e.preventDefault();
+        setOpen(false);
+      }
+    }
+  };
+
+  return (
+    <div ref={rootRef} className={`relative ${className}`}>
+      <button
+        ref={btnRef}
+        id={id}
+        type="button"
+        role="combobox"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-controls={listboxId}
+        aria-label={ariaLabel}
+        onClick={() => setOpen((o) => !o)}
+        onKeyDown={onKeyDown}
+        className="input-electric flex w-full cursor-pointer items-center justify-between gap-2 px-3 py-2 text-left text-sm"
+      >
+        <span className={selected ? "truncate" : "truncate text-pc-text-faint"}>
+          {selected ? selected.label : (placeholder ?? "")}
+        </span>
+        <ChevronsUpDown className="h-4 w-4 shrink-0 text-pc-text-muted" />
+      </button>
+      {open && (
+        <ul
+          ref={listRef}
+          id={listboxId}
+          role="listbox"
+          className="absolute z-30 mt-1 max-h-60 w-full overflow-y-auto rounded-[var(--radius-md)] border border-pc-border bg-pc-surface p-1 shadow-[var(--pc-shadow-md)]"
+        >
+          {options.map((o, i) => {
+            const sel = o.value === value;
+            const act = i === active;
+            return (
+              <li key={`${i}-${o.value}`}>
+                <button
+                  type="button"
+                  role="option"
+                  aria-selected={sel}
+                  data-idx={i}
+                  onMouseMove={() => setActive(i)}
+                  onClick={() => choose(o.value)}
+                  className={[
+                    "flex w-full items-center gap-2 rounded-[var(--radius-sm)] px-2.5 py-1.5 text-left text-sm transition-colors",
+                    act
+                      ? "bg-pc-accent/10 text-pc-text"
+                      : "text-pc-text-secondary hover:bg-pc-elevated/60",
+                  ].join(" ")}
+                >
+                  <Check
+                    className={`h-3.5 w-3.5 shrink-0 ${sel ? "text-pc-accent" : "opacity-0"}`}
+                  />
+                  <span className="truncate">{o.label}</span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/ui/index.ts
+++ b/web/src/components/ui/index.ts
@@ -21,3 +21,6 @@ export type { ConfirmDialogProps } from './ConfirmDialog';
 
 export { ComboBox } from './ComboBox';
 export type { ComboBoxProps } from './ComboBox';
+
+export { Select } from './Select';
+export type { SelectProps, SelectOption } from './Select';


### PR DESCRIPTION

_Split 1/3 of #8022. Independent base; #8022c (storage nav) stacks on this._

## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Adds a themed `Select` primitive (`web/src/components/ui/Select.tsx`): options-as-prop, no embedded value list, correct `role="combobox"/listbox/option"` ARIA, keyboard nav with wrap-around + scroll-into-view, outside-click close.
  - Adds an `openOnFocus` affordance to `ComboBox` so the list opens on focus/click (for fields where the options ARE the expected input, e.g. an alias picker).
  - Adopts both in `FieldForm` for enum and alias-ref fields in place of the native `<select>`.
- **Scope boundary:** Display-only. The daemon stays authoritative on save; no schema/`/api/config`/`validate_*` changes.
- **Known follow-up (registry):** the alias-ref picker prefers the daemon-declared `entry.alias_source` and falls back to a `<Type>Ref` type_hint derive table (`ALIAS_REF_TYPE_TO_SOURCE`) only when the daemon omits it. The backend currently stubs `alias_source: None`; removing the fallback is a follow-up once #7855 (`fix/7701-model-route-configurable`) populates `alias_source` backend-side. Tracked, not routed around.
- **Blast radius:** `web/` only (`ui/Select.tsx` new, `ui/ComboBox.tsx`, `ui/index.ts`, `sections/FieldForm.tsx`).

## Validation Evidence

```
$ cargo web check   # gen-api + npx tsc -b
EXIT=0  (clean)
```

- Split from #8022 by file; no behavior change versus that PR's picker work.

<img width="1110" height="292" alt="image" src="https://github.com/user-attachments/assets/db4fdd9e-b964-422d-83a1-6630439b7c94" />


## Security & Privacy Impact

- New permissions / network / secrets handling? **No.** Display-only UI; server remains source of truth on save.
- PII in diff/tests/fixtures? **No.**

## Compatibility

- Backward compatible? **Yes.** `openOnFocus` defaults to `false` (existing ComboBox callers unchanged). `Select` is additive.
- Config / env / CLI surface changed? **No.**

## Rollback (low risk)

`git revert <sha>`. No flags, no migration. Pure additive UI primitives.
