### PR TITLE
fix(docker): drop stale aardvark-sys build.rs COPY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,10 +62,7 @@ COPY Cargo.toml Cargo.lock ./
 # Copy every workspace-member manifest in one glob — adding or removing a crate
 # no longer requires editing this file.  --parents preserves the
 # crates/<name>/Cargo.toml directory structure.
-# aardvark-sys has an implicit build script (build.rs at its crate root) that
-# Cargo must compile during the dependency pre-fetch step; copy it explicitly.
 COPY --parents crates/*/Cargo.toml ./
-COPY --parents crates/aardvark-sys/build.rs ./
 # apps/tauri: .dockerignore whitelists only Cargo.toml; src and build.rs are stubbed below.
 COPY apps/tauri/Cargo.toml apps/tauri/Cargo.toml
 # apps/zerocode: TUI app not shipped in the server image; copy only its manifest

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -69,10 +69,7 @@ COPY Cargo.toml Cargo.lock ./
 # Copy every workspace-member manifest in one glob — adding or removing a crate
 # no longer requires editing this file.  --parents preserves the
 # crates/<name>/Cargo.toml directory structure.
-# aardvark-sys has an implicit build script (build.rs at its crate root) that
-# Cargo must compile during the dependency pre-fetch step; copy it explicitly.
 COPY --parents crates/*/Cargo.toml ./
-COPY --parents crates/aardvark-sys/build.rs ./
 # apps/tauri: .dockerignore whitelists only Cargo.toml; src and build.rs are stubbed below.
 COPY apps/tauri/Cargo.toml apps/tauri/Cargo.toml
 # apps/zerocode: TUI app not shipped in the server image; copy only its manifest


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Commit c338e0949d (#8028) gated `aardvark-sys` behind the hardware feature and deleted `crates/aardvark-sys/build.rs` (libloading resolves the FFI symbols at runtime, so the build script became a no-op). Both `Dockerfile` and `Dockerfile.debian` still carried `COPY --parents crates/aardvark-sys/build.rs ./`, so a fresh build off `upstream/master` fails at the dependency pre-fetch step. Removed the dead COPY line and the now-stale comment block describing why the build script was copied.
- **Scope boundary:** Touches only the two Dockerfiles. No Rust, no CI workflow, no `.dockerignore`, no build logic beyond removing a file that no longer exists.
- **Blast radius:** Container image builds (`Dockerfile`, `Dockerfile.debian`) only. No effect on the binary, runtime, or any crate.
- **Linked issue(s):** None.
- **Labels:** `risk: low`, `size: XS`.

## Validation Evidence (required)

Dockerfile-only change; no Rust source touched, so the cargo battery is N/A. Verified the failure reproduces on a clean clone off `upstream/master` and that the referenced file is gone:

```
$ git ls-tree upstream/master crates/aardvark-sys/build.rs
(empty — file deleted by c338e0949d / #8028)

$ git diff upstream/master --stat
 Dockerfile        | 3 ---
 Dockerfile.debian | 3 ---
 2 files changed, 6 deletions(-)
```

Original build error this fixes:

```
[3/4] STEP 7/27: COPY --parents crates/aardvark-sys/build.rs ./
Error: building at STEP "COPY --parents crates/aardvark-sys/build.rs ./":
  copier: stat: "/crates/aardvark-sys/build.rs": no such file or directory
```

- **Commands run and tail output:** see above.
- **Beyond CI — what did you manually verify?** Confirmed `build.rs` is absent on `upstream/master`, confirmed both Dockerfiles were the only files referencing it, confirmed no `.dockerignore` or build step still depends on it.
- **If any command was intentionally skipped, why:** cargo fmt/clippy/test skipped — no Rust changed.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Upgrade steps: none.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk: `git revert <sha>` is the plan.