### PR TITLE
ci(docker): build base Dockerfiles from source on container changes

### DIFF
--- a/.github/workflows/docker-image-pr.yml
+++ b/.github/workflows/docker-image-pr.yml
@@ -4,8 +4,11 @@ on:
   pull_request:
     branches: [master]
     paths:
+      - Dockerfile
+      - Dockerfile.debian
       - Dockerfile.ci
       - Dockerfile.debian.ci
+      - .dockerignore
       - .github/workflows/docker-image-pr.yml
       - .github/workflows/release-stable-manual.yml
       - scripts/ci/prepare_docker_context.sh
@@ -33,3 +36,34 @@ jobs:
 
       - name: Build Debian compatibility image
         run: docker build -f docker-ctx/Dockerfile.debian -t zeroclaw-pr-debian:smoke docker-ctx
+
+  source-images:
+    name: Dockerfile Source Build (no push)
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - dockerfile: Dockerfile
+            tag: zeroclaw-pr-source-default:build
+            cache-scope: docker-source-default
+          - dockerfile: Dockerfile.debian
+            tag: zeroclaw-pr-source-debian:build
+            cache-scope: docker-source-debian
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Build ${{ matrix.dockerfile }} from source
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: false
+          load: false
+          tags: ${{ matrix.tag }}
+          cache-from: type=gha,scope=${{ matrix.cache-scope }}
+          cache-to: type=gha,scope=${{ matrix.cache-scope }},mode=max


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** The Docker Image PR Check (`docker-image-pr.yml`) only triggered on the `.ci` variants and the prep script, and its smoke job builds those pre-built-binary images. Edits to the base `Dockerfile` / `Dockerfile.debian` (the full source-compiling images) triggered no container build at all. That gap let a stale `COPY --parents crates/aardvark-sys/build.rs ./` line ship on master and break every fresh build off upstream. This adds the base Dockerfiles + `.dockerignore` to the `paths:` filter and a `source-images` job that actually compiles both base Dockerfiles from the repo root via buildx with GHA layer caching.
- **Scope boundary:** Only `docker-image-pr.yml`. Does not change the Dockerfiles themselves, the `.ci` variants, the smoke job, the prep script, or any release/publish workflow.
- **Blast radius:** PR CI only. Adds a job that runs solely when container-type files change. No effect on the binary, runtime, or release pipeline.
- **Linked issue(s):** Related #8092 (the stale-COPY fix this guard would have caught).
- **Labels:** `risk: high` (touches `.github/workflows/**`), `size: XS`.

## Validation Evidence (required)

Workflow-only change; no Rust touched, so the cargo battery is N/A.

```
$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/docker-image-pr.yml')); print('OK')"
OK

$ git diff upstream/master --stat
 .github/workflows/docker-image-pr.yml | 34 ++++++++++++++++++++++++++++++++++
 1 file changed, 34 insertions(+)
```

Action pins (`docker/build-push-action@263435...` v6.18.0, `docker/setup-buildx-action@e468171...` v3.11.1) are already used elsewhere in `.github/workflows/`, confirmed consistent.

- **Beyond CI: what did you manually verify?** YAML parses; the two new job names are unique; `paths:` now includes `Dockerfile`, `Dockerfile.debian`, `.dockerignore`. The full ~60 min source compile was **not** run locally in this session and is not faked here. The honest end-to-end proof is the `source-images` job running on this very PR (the workflow change is itself in `paths:`), so CI will exercise it before merge.
- **If any command was intentionally skipped, why:** local 60 min cold container compile skipped: impractical to run interactively; CI on this PR is the real validator.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No` (job keeps `permissions: contents: read`; no push, `push: false load: false`)
- New external network calls? `No` (pulls base images same as existing build, no new endpoints)
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Upgrade steps: none. CI-only.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <sha>` of this commit; removes the `source-images` job and the expanded `paths:` filter.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** `source-images` job failing or timing out on PRs that touch container files. If the cold build exceeds 90 min, the job times out (visible as a red check on the PR). No effect on merged-image publishing, which runs in separate release workflows.
