### PR TITLE
fix(install): detect Intel vs Apple Silicon for prebuilt target triple

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -241,7 +241,18 @@ detect_target_triple() {
   arch=$(uname -m)
 
   case "$os" in
-  Darwin) echo "aarch64-apple-darwin" ;; # presume M-series
+  Darwin)
+    # Apple Silicon reports arm64; Intel reports x86_64. A Rosetta-translated
+    # shell on Apple Silicon also reports x86_64 from `uname -m`, so consult
+    # `sysctl hw.optional.arm64` to recover the true CPU. Without this an Intel
+    # Mac (or an M-series Mac run under Rosetta) is handed the wrong-arch
+    # binary and hits "bad CPU type in executable".
+    if [ "$arch" = "arm64" ] || [ "$(sysctl -n hw.optional.arm64 2>/dev/null)" = "1" ]; then
+      echo "aarch64-apple-darwin"
+    else
+      echo "x86_64-apple-darwin"
+    fi
+    ;;
   Linux)
     libc=$(detect_libc)
     case "$arch" in
@@ -302,14 +313,11 @@ install_prebuilt() {
   tmp_dir=$(mktemp -d)
   trap 'rm -rf "$tmp_dir"' EXIT
 
-  curl -fSL --progress-bar "$asset_url" -o "$tmp_dir/$asset_name" ||
-    {
-      warn "Download failed — falling back to source build"
-      rm -rf "$tmp_dir"
-      return 1
-    }
-
-  # Verify checksum — all failure modes fall back to source rather than install unverified
+  # Fetch the checksum manifest first — it lists every published asset, so we
+  # can tell "no pre-built binary for this platform" (e.g. Intel macOS, which
+  # ships no release tarball) from a genuine download failure, and we never
+  # pull a tarball we couldn't verify anyway. All failure modes fall back to
+  # source rather than install unverified.
   if ! curl -fsSL "$sha256_url" -o "$tmp_dir/SHA256SUMS" 2>/dev/null; then
     warn "Could not fetch SHA256SUMS — falling back to source build"
     rm -rf "$tmp_dir"
@@ -318,10 +326,17 @@ install_prebuilt() {
 
   expected=$(grep "$asset_name" "$tmp_dir/SHA256SUMS" | awk '{print $1}')
   if [ -z "$expected" ]; then
-    warn "Asset not found in SHA256SUMS — falling back to source build"
+    warn "No pre-built binary published for $triple — falling back to source build"
     rm -rf "$tmp_dir"
     return 1
   fi
+
+  curl -fSL --progress-bar "$asset_url" -o "$tmp_dir/$asset_name" ||
+    {
+      warn "Download failed — falling back to source build"
+      rm -rf "$tmp_dir"
+      return 1
+    }
 
   if command -v sha256sum >/dev/null 2>&1; then
     actual=$(sha256sum "$tmp_dir/$asset_name" | awk '{print $1}')


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `detect_target_triple()` hardcoded `aarch64-apple-darwin` for every macOS host ("presume M-series"), so Intel Macs downloaded the arm64 release tarball and installed an unrunnable binary (`bad CPU type in executable`). It now detects the real CPU via `uname -m`.
  - Added a `sysctl hw.optional.arm64` fallback so an Apple Silicon Mac running under a Rosetta shell (where `uname -m` reports `x86_64`) still resolves to `aarch64` instead of being downgraded to an Intel build.
  - In the prebuilt path, fetch the `SHA256SUMS` manifest *before* downloading. When no asset exists for the detected triple (e.g. Intel macOS, which ships no CLI tarball today) the installer prints a clear "No pre-built binary published for `<triple>`" and falls back to a source build, instead of a doomed 404 download or a wrong-arch install.
- **Scope boundary:** Only `install.sh` macOS triple detection + prebuilt manifest ordering. Does **not** add an `x86_64-apple-darwin` release asset to CI (Intel still source-builds), and does not touch Linux/Windows detection or the `zeroclaw update` self-updater (already correct).
- **Blast radius:** Installer only. Apple Silicon native path is unchanged (verified). Intel macOS now source-builds via the existing fallback. The manifest-first reorder affects all platforms' prebuilt path but preserves checksum verification before install.
- **Linked issue(s):** Closes #8095
- **Labels:** `bug`, `risk: low`, `size: S`

## Validation Evidence (required)

Bootstrap-script change — ran script + installer-guard battery (Rust fmt/clippy/test battery N/A; no Rust sources changed).

- **Commands run and tail output:**

```
$ bash -n install.sh        # exit 0, no output
$ sh -n install.sh          # exit 0, no output
$ shellcheck -s sh install.sh
# Only pre-existing warnings (SC3043 'local' undefined, SC2144 glob -e, SC1091),
# all outside the changed lines; none introduced by this PR.
$ cargo test -p xtask install_sh
test generate::install_sh::tests::cargo_install_zone_has_dryrun_and_execute ... ok
test generate::install_sh::tests::render_file_is_idempotent_against_real_install_sh ... ok
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 86 filtered out
```

- **Beyond CI — what did you manually verify?** Exercised the triple-selection logic across all three Mac scenarios — native Apple Silicon (`arm64`->`aarch64-apple-darwin`), Intel (`x86_64` + no `hw.optional.arm64`->`x86_64-apple-darwin`), and Apple Silicon under Rosetta (`x86_64` + `hw.optional.arm64=1`->`aarch64-apple-darwin`). Ran `./install.sh --dry-run --prebuilt` on Apple Silicon: still resolves `aarch64-apple-darwin` (no regression). Confirmed via `release-stable-manual.yml` that no `x86_64-apple-darwin` CLI asset is published, so the Intel manifest-miss -> source-build fallback is the correct path.
- **NOT verified:** No physical Intel Mac available, so the Intel path was validated by logic simulation + release-manifest inspection rather than a live install; no real download/install performed (dry-run + unit tests only).
- **If any command was intentionally skipped, why:** `cargo fmt`/`clippy`/`test` full battery skipped — no Rust source changed (only `install.sh`); the relevant Rust coverage is the `xtask` installer-guard tests, which were run.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No** (same release URLs; only reordered the manifest fetch before the tarball download)
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No** (no flags added/changed; Apple Silicon behavior identical; Intel now gets the correct binary / source fallback)
- Upgrade steps: none.

## Rollback

Low risk — `git revert f86dce238a` restores prior behavior.
