### PR TITLE
fix(ci): stop Kilo labeler matching shared provider files

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -349,12 +349,6 @@
           - "src/providers/kilocli.rs"
           - "crates/zeroclaw-providers/src/kilocli.rs"
 
-"provider:kilo":
-  - changed-files:
-      - any-glob-to-any-file:
-          - "crates/zeroclaw-providers/src/catalog.rs"
-          - "crates/zeroclaw-providers/src/factory.rs"
-
 "provider:ollama":
   - changed-files:
       - any-glob-to-any-file:

--- a/docs/book/src/maintainers/labels.md
+++ b/docs/book/src/maintainers/labels.md
@@ -145,6 +145,11 @@ Each channel gets a `channel:<name>` label in addition to the base `channel` lab
 
 ### Per-provider labels
 
+Provider-specific labels match dedicated provider source files. Shared registry
+or factory files should receive the base `provider` label only; maintainers can
+add a provider-specific label manually when a shared-file change is truly scoped
+to one provider.
+
 | Label | Matches |
 |---|---|
 | `provider:anthropic` | `anthropic.rs` |


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Removes the automatic `provider:kilo` path-labeler rule from shared provider registry and factory files.
  - Keeps shared provider registry/factory edits on the base `provider` label unless a maintainer manually adds a provider-specific label.
  - Documents that provider-specific labels should map to dedicated provider files, not shared registry/factory paths.
- **Scope boundary:** This does not change provider code, runtime behavior, label names, or the base `provider` path label.
- **Blast radius:** Future PRs that touch `crates/zeroclaw-providers/src/catalog.rs` or `crates/zeroclaw-providers/src/factory.rs` will no longer receive `provider:kilo` automatically.
- **Linked issue(s):** Related #7812. Related #8100.
- **Labels:** `type: ci`, `risk: low`, `size: XS`, `ci`, `docs`.

## Validation Evidence (required)

- **Commands run and tail output:**

```text
ruby -e 'require "yaml"; YAML.load_file(".github/labeler.yml"); puts "labeler yaml ok"'
labeler yaml ok

rg -n 'provider:kilo|crates/zeroclaw-providers/src/catalog.rs|crates/zeroclaw-providers/src/factory.rs' .github/labeler.yml docs/book/src/maintainers/labels.md
Result: no provider:kilo, catalog.rs, or factory.rs matches.

git diff --check
Result: passed.

DOCS_FILES=docs/book/src/maintainers/labels.md scripts/ci/docs_quality_gate.sh
No prose em-dashes in changed docs files.
Summary: 0 error(s)

scripts/check-pr-title.sh "fix(ci): stop Kilo labeler matching shared provider files"
Result: passed.
```

- **Beyond CI — what did you manually verify?** Confirmed #8100 received `provider:kilo` from the shared `factory.rs` path after #7812, proving the remaining Kilo rule still overmatched unrelated provider factory edits. Confirmed the docs table already omits a dedicated `provider:kilo` file mapping, so the docs update records the intended shared-file behavior.
- **If any command was intentionally skipped, why:** Rust validation was skipped because this PR only changes GitHub labeler metadata and maintainer documentation.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: N/A.

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: N/A.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PRs: `git revert <sha>` is the plan unless otherwise noted.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Scope materially carried forward: N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`Yes/No`): N/A
- If `No`, why (inspiration-only, no direct code/design carry-over): N/A
