### PR TITLE
docs(channels): remove stale guild override wording

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -256,8 +256,8 @@ const CHANNEL_HOOK_MAX_OUTBOUND_CHARS: usize = 20_000;
 type ProviderCacheMap = Arc<Mutex<HashMap<String, Arc<dyn ModelProvider>>>>;
 type RouteSelectionMap = Arc<Mutex<HashMap<String, ChannelRouteSelection>>>;
 /// Session-only model overrides scoped above the per-sender [`RouteSelectionMap`].
-/// Keyed by a `scope_override_key` (prefixed `user::`/`guild::`/`agent::`), so all
-/// three tiers share one in-memory map. Never persisted — lost on restart by design.
+/// Keyed by a `scope_override_key` (prefixed `user::`/`agent::`), so both
+/// tiers share one in-memory map. Never persisted — lost on restart by design.
 type ScopedRouteMap = Arc<Mutex<HashMap<String, ChannelRouteSelection>>>;
 
 fn effective_channel_message_timeout_secs(configured: u64) -> u64 {
@@ -466,7 +466,7 @@ struct ChannelRuntimeContext {
     pending_new_sessions: PendingNewSessionSet,
     provider_cache: ProviderCacheMap,
     route_overrides: RouteSelectionMap,
-    /// Session-only `/model` overrides scoped by user/guild/agent (see
+    /// Session-only `/model` overrides scoped by user/agent (see
     /// [`ScopedRouteMap`]). Consulted above `route_overrides` in
     /// [`get_route_selection`]; never persisted.
     scope_overrides: ScopedRouteMap,


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Removes the stale `guild::` prefix from the `ScopedRouteMap` comment.
  - Updates the nearby runtime-context comment from `user/guild/agent` to `user/agent`.
  - Keeps the #7998 scoped `/model` override documentation aligned with the merged behavior: user and agent scopes only.
- **Scope boundary:** Comment-only cleanup. This does not change runtime behavior, command parsing, model override precedence, or release notes.
- **Blast radius:** None expected; the diff only changes Rust comments in the channel orchestrator.
- **Linked issue(s):** Related #7998
- **Labels:** `type: docs`, `risk: low`, `size: XS`, `channel`

## Validation Evidence (required)

- **Commands run and tail output:**

```bash
git diff --check
# passed with no output

scripts/check-pr-title.sh "docs(channels): remove stale guild override wording"
# passed with no output
```

- **Beyond CI — what did you manually verify?** Searched the repo for stale `guild::` and `user/guild/agent` scoped-override wording. No release-note entry for #7998 exists in `CHANGELOG-next.md`, so no release-note cleanup was needed.
- **If any command was intentionally skipped, why:** Cargo validation was skipped because this is a comment-only cleanup with no compiled behavior change.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: N/A

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PRs: `git revert <sha>` is the plan unless otherwise noted.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Scope materially carried forward: N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why (inspiration-only, no direct code/design carry-over): N/A
