### PR TITLE
fix(channels/discord): authorize autocomplete in parent-allowlisted threads

### DIFF
--- a/crates/zeroclaw-channels/src/discord/mod.rs
+++ b/crates/zeroclaw-channels/src/discord/mod.rs
@@ -1748,6 +1748,27 @@ async fn discord_thread_parent(
     result
 }
 
+/// Cache-only variant of [`discord_thread_parent`]: returns the cached parent
+/// id for `channel_id` if a prior [`discord_thread_parent`] call already
+/// populated the cache, otherwise `None`. It performs **no** Discord REST call,
+/// so it is safe on the per-keystroke autocomplete (type-4) path where an
+/// authenticated round-trip would violate the side-effect-free requirement.
+///
+/// A miss (`channel_id` never looked up, or looked up and found to be a
+/// non-thread) yields `None`, which keeps channel authorization fail-closed:
+/// the thread can only pass an allowlist via a known, already-cached parent.
+async fn discord_thread_parent_cached(
+    thread_channels: &Arc<AsyncMutex<HashMap<String, Option<String>>>>,
+    channel_id: &str,
+) -> Option<String> {
+    thread_channels
+        .lock()
+        .await
+        .get(channel_id)
+        .cloned()
+        .flatten()
+}
+
 // Discord gateway intent bits (API v10) — the ones zeroclaw consumes or
 // exposes as opt-ins. https://discord.com/developers/docs/events/gateway#gateway-intents
 const INTENT_GUILDS: u64 = 1 << 0;
@@ -3037,6 +3058,7 @@ impl Channel for DiscordChannel {
                                     let guild_filter = guild_filter.clone();
                                     let channel_filter = channel_filter.clone();
                                     let resolver = self.slash_command_resolver.clone();
+                                    let thread_channels = self.thread_channels.clone();
 
                                     zeroclaw_spawn::spawn!(async move {
                                         // Fail-closed authz, side-effect-free:
@@ -3046,12 +3068,22 @@ impl Channel for DiscordChannel {
                                         // don't make here). On denial OR no
                                         // matches we answer an empty choice set.
                                         //
-                                        // No thread-parent REST lookup: it is an
-                                        // authenticated round-trip per keystroke
-                                        // and would defeat the side-effect-free
-                                        // requirement, so a channel-filtered
-                                        // thread simply yields no completions
-                                        // (fail-closed) rather than probing.
+                                        // Thread-parent resolution is CACHE-ONLY:
+                                        // a parent populated by an earlier normal
+                                        // message in this thread lets a
+                                        // parent-allowlisted thread authorize
+                                        // autocomplete consistently with the
+                                        // message path (#6829). It reads the shared
+                                        // cache only — NO Discord REST call — so the
+                                        // per-keystroke path stays side-effect-free;
+                                        // an uncached thread still yields no
+                                        // completions (fail-closed) rather than
+                                        // probing.
+                                        let thread_parent = discord_thread_parent_cached(
+                                            &thread_channels,
+                                            &interaction_channel,
+                                        )
+                                        .await;
                                         let authorized = interaction_gate(
                                             &peers,
                                             &guild_filter,
@@ -3059,7 +3091,7 @@ impl Channel for DiscordChannel {
                                             &user_id,
                                             interaction_guild.as_deref(),
                                             &interaction_channel,
-                                            None,
+                                            thread_parent.as_deref(),
                                         )
                                         .is_ok();
 
@@ -7742,6 +7774,116 @@ mod tests {
         assert!(
             interaction_gate(&[], &[], &[], "u1", None, "c1", None).is_err(),
             "empty peer list denies"
+        );
+    }
+
+    #[tokio::test]
+    async fn thread_parent_cached_reads_cache_without_rest() {
+        // Cache-only lookup: a thread whose parent was resolved by an earlier
+        // message returns that parent; a channel cached as a non-thread, or one
+        // never looked up, returns None. No client/token is reachable here, so a
+        // non-None result can only have come from the cache (never a REST probe).
+        let cache: Arc<AsyncMutex<HashMap<String, Option<String>>>> =
+            Arc::new(AsyncMutex::new(HashMap::new()));
+        {
+            let mut c = cache.lock().await;
+            c.insert("thread1".to_string(), Some("parentA".to_string()));
+            c.insert("plain1".to_string(), None);
+        }
+        assert_eq!(
+            discord_thread_parent_cached(&cache, "thread1").await,
+            Some("parentA".to_string()),
+            "cached thread resolves to its parent"
+        );
+        assert_eq!(
+            discord_thread_parent_cached(&cache, "plain1").await,
+            None,
+            "channel cached as a non-thread has no parent"
+        );
+        assert_eq!(
+            discord_thread_parent_cached(&cache, "never_seen").await,
+            None,
+            "uncached channel yields None (fail-closed)"
+        );
+    }
+
+    #[tokio::test]
+    async fn autocomplete_authorizes_parent_allowlisted_thread_only_when_cached() {
+        // Regression for #8103: the type-4 arm resolves the thread parent from
+        // the shared cache (no REST) and passes it to `interaction_gate`, so a
+        // thread under an allowlisted parent authorizes autocomplete exactly as
+        // the message path does (#6829) — but only once the parent is cached.
+        // This reproduces the arm's authz step: cache-only parent → gate.
+        let peers = s(&["*"]);
+        let channel_filter = s(&["parentA"]); // allowlist the PARENT only
+        let cache: Arc<AsyncMutex<HashMap<String, Option<String>>>> =
+            Arc::new(AsyncMutex::new(HashMap::new()));
+        cache
+            .lock()
+            .await
+            .insert("thread_cached".to_string(), Some("parentA".to_string()));
+
+        // Thread whose parent is cached + allowlisted → autocomplete authorized.
+        let parent = discord_thread_parent_cached(&cache, "thread_cached").await;
+        assert!(
+            interaction_gate(
+                &peers,
+                &[],
+                &channel_filter,
+                "u1",
+                Some("g1"),
+                "thread_cached",
+                parent.as_deref(),
+            )
+            .is_ok(),
+            "cached allowlisted parent authorizes autocomplete in the thread"
+        );
+
+        // Same allowlist, thread NOT yet cached → no parent → fail-closed,
+        // matching the pre-fix behavior and avoiding a per-keystroke REST probe.
+        let parent = discord_thread_parent_cached(&cache, "thread_uncached").await;
+        assert!(
+            interaction_gate(
+                &peers,
+                &[],
+                &channel_filter,
+                "u1",
+                Some("g1"),
+                "thread_uncached",
+                parent.as_deref(),
+            )
+            .is_err(),
+            "uncached thread stays fail-closed"
+        );
+    }
+
+    #[test]
+    fn autocomplete_arm_resolves_cached_thread_parent_before_gate() {
+        // Source-level regression for #8103: within the type-4 arm, the parent
+        // is resolved from the cache (`discord_thread_parent_cached`) and that
+        // value (`thread_parent.as_deref()`) — not `None` — is passed to
+        // `interaction_gate`, with resolution preceding the gate. Reverting the
+        // arm to pass `None` removes `thread_parent.as_deref()` and fails this.
+        let src = include_str!("mod.rs");
+        let arm4 = src
+            .find("} else if itype == 4 {")
+            .expect("type-4 arm present");
+        let end = src[arm4..]
+            .find("// MESSAGE_UPDATE / MESSAGE_DELETE / MESSAGE_DELETE_BULK")
+            .map(|i| arm4 + i)
+            .expect("type-4 arm end boundary present");
+        let region = &src[arm4..end];
+        let cached = region
+            .find("discord_thread_parent_cached(")
+            .expect("type-4 arm resolves the cached thread parent");
+        let gate = region.find("interaction_gate(").expect("type-4 arm gates");
+        assert!(
+            cached < gate,
+            "cached thread-parent resolution must precede the gate"
+        );
+        assert!(
+            region.contains("thread_parent.as_deref()"),
+            "the resolved cached parent (not None) is passed to interaction_gate"
         );
     }
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Discord slash-command autocomplete (type-4 `APPLICATION_COMMAND_AUTOCOMPLETE`) gated the interaction with `interaction_gate(..., thread_parent = None)`. The normal message paths resolve the thread parent and pass it to `channel_passes_filter`, so a thread under an allowlisted parent is authorized — autocomplete was not, so it **failed closed to an empty choice set** in the very thread the same user can otherwise post messages in.
  - Added `discord_thread_parent_cached()` — a **cache-only (no REST)** read of the existing `thread_channels` cache — and wired it into the type-4 arm so a parent populated by an earlier message authorizes autocomplete consistently with the message path (#6829).
  - Cache-only by design: the per-keystroke autocomplete path stays side-effect-free (**no** unbounded Discord REST probe per keystroke); an uncached thread still fails closed.
- **Scope boundary:** Only the Discord type-4 autocomplete authorization path. Does **not** change `interaction_gate` / `channel_passes_filter` semantics, the message/component/modal arms, the REST `discord_thread_parent` lookup, or any non-Discord channel. Adds no REST call to the autocomplete path.
- **Blast radius:** Discord channels configured with `channel_ids` + slash commands. The only behavior change: autocomplete returns choices (instead of empty) inside a thread whose parent is allowlisted **and already cached**. No other channel/provider/runtime path touched.
- **Linked issue(s):** Closes #8103. Related #6829 (thread-parent handling on the message path).
- **Labels:** `bug`, `risk: medium`, `size: S`, `channel`, `channel:discord`, `priority:p2`, `status:accepted` (snapshot — I can't set `risk:` / `size:`; maintainer to confirm).

## Validation Evidence (required)

Full battery run locally on this branch (rustc 1.96.0, macOS; `CARGO_INCREMENTAL=0` per repo machine guidance).

```
$ cargo fmt --all -- --check
(clean — exit 0, no diff)

$ CARGO_INCREMENTAL=0 cargo clippy --all-targets -- -D warnings
    Checking zeroclaw-channels v0.8.1 (.../crates/zeroclaw-channels)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 31s
(no warnings)

$ CARGO_INCREMENTAL=0 cargo nextest run --locked --workspace --exclude zeroclaw-desktop
    Summary [  66.828s] 9385 tests run: 9385 passed, 11 skipped

$ cargo nextest run -p zeroclaw-channels autocomplete thread_parent interaction_gate channel_passes
    Summary [   0.277s] 14 tests run: 14 passed, 1074 skipped
```

- **Commands run and tail output:** as above.
- **Beyond CI — what did you manually verify?**
  - **Mutation check:** reverted the arm to pass `None` (the original bug) → the source-assertion test `autocomplete_arm_resolves_cached_thread_parent_before_gate` **FAILS** (`type-4 arm resolves the cached thread parent` panic); restored → all pass. The regression test genuinely guards the fix.
  - Traced consumers of the changed arm: `discord_thread_parent_cached` is new (no other callers); `interaction_gate` / `channel_passes_filter` are unchanged and now receive a real parent instead of `None`, exercising their existing, already-tested parent rule. The autocomplete answer remains a single type-8 callback (`autocomplete_answer_posts_a_single_type8_callback_and_nothing_else` still passes).
  - Confirmed cache-only semantics in a unit test where no client/token is reachable, so a non-`None` result can only come from the cache (never a REST probe).
  - **Not verified:** a live Discord round-trip (no live workspace). The fix relies on the existing, separately-tested `thread_channels` cache populated by the message path.
- **If any command was intentionally skipped, why:** none skipped. Used `cargo nextest` (project standard per `contributing/how-to.md`) in place of `cargo test`.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No.**
- New external network calls? **No** — explicitly cache-only; adds no Discord REST call (autocomplete path stays side-effect-free).
- Secrets / tokens / credentials handling changed? **No.**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No** (synthetic ids only: `parentA`, `thread_cached`, `u1`).
- **If any `Yes`, describe the risk and mitigation:** This change *loosens* one authorization decision, so for the record: autocomplete is now authorized only for a user who already passes the peer allowlist **and** is in a thread whose parent channel is explicitly in `channel_ids` — exactly the authorization the normal message path already grants in that thread via the same `channel_passes_filter` parent rule (#6829). It grants nothing beyond what the user can already do by posting a message there. Cached parents come only from successful Discord lookups (not user-spoofable), and uncached threads stay fail-closed. Net: a consistency fix, not privilege escalation.

## Compatibility (required)

- Backward compatible? **Yes.**
- Config / env / CLI surface changed? **No.**
- **Upgrade steps:** None. Existing `channel_ids` configs are unaffected; the only observable difference is that slash-option autocomplete inside a parent-allowlisted thread now returns choices once that thread's parent is cached (previously empty).

## Rollback (required for `risk: medium`)

- **Fast rollback command/path:** `git revert <merge-sha>` — single self-contained commit (`3fd572149`), reverts cleanly to the prior fail-closed behavior.
- **Feature flags or config toggles:** None (no toggle introduced). An operator who wants autocomplete in a specific thread without this change can list the thread id directly in `channel_ids` (the always-supported direct-match path).
- **Observable failure symptoms:** unexpected autocomplete choices appearing inside Discord threads, or autocomplete latency/429 pressure. Grep logs for `discord autocomplete answer failed`. Because the path issues no new REST call, no new rate-limit pressure is expected; 429s on the autocomplete path would be an unexpected rollback signal.