### PR TITLE
fix(docker): keep Node base policy in container TOML

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.7-labs
 
 # >>> generated:base-arg-node from dev/ci/container-base-images.toml by `cargo generate installers` - do not edit <<<
-ARG ZEROCLAW_BASE_NODE=node:26-bookworm-slim@sha256:4e2e85a824f938e41a61e9e819f0c7c11432f7d60f470b96214d3ead2f0dd63e
+ARG ZEROCLAW_BASE_NODE=node:24-bookworm-slim@sha256:c2d5ade763cacfb03fe9cb8e8af5d1be5041ff331921fa26a9b231ca3a4f780a
 # >>> end generated:base-arg-node <<<
 # >>> generated:base-arg-rust-slim from dev/ci/container-base-images.toml by `cargo generate installers` - do not edit <<<
 ARG ZEROCLAW_BASE_RUST_SLIM=rust:1.94-slim@sha256:cf09adf8c3ebaba10779e5c23ff7fe4df4cccdab8a91f199b0c142c53fef3e1a

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.7-labs
 
 # >>> generated:base-arg-node from dev/ci/container-base-images.toml by `cargo generate installers` - do not edit <<<
-ARG ZEROCLAW_BASE_NODE=node:26-bookworm-slim@sha256:4e2e85a824f938e41a61e9e819f0c7c11432f7d60f470b96214d3ead2f0dd63e
+ARG ZEROCLAW_BASE_NODE=node:24-bookworm-slim@sha256:c2d5ade763cacfb03fe9cb8e8af5d1be5041ff331921fa26a9b231ca3a4f780a
 # >>> end generated:base-arg-node <<<
 # >>> generated:base-arg-rust-bookworm from dev/ci/container-base-images.toml by `cargo generate installers` - do not edit <<<
 ARG ZEROCLAW_BASE_RUST_BOOKWORM=rust:1.94-bookworm@sha256:6ae102bdbf528294bc79ad6e1fae682f6f7c2a6e6621506ba959f9685b308a55

--- a/dev/ci/container-base-images.toml
+++ b/dev/ci/container-base-images.toml
@@ -1,9 +1,10 @@
 # Canonical container base-image pins for the generated container surfaces
 # (Dockerfile, Dockerfile.debian). Edit registry/repo/image_ref/tag here; `tag`
-# and `digest` are rewritten live by `cargo generate installers`. A row with
-# discover=true derives its tag from the repo root .nvmrc, then refreshes its
-# digest live from the registry. StageX pins in the Containerfile are
-# excluded on purpose: digest-only, reproducible-build intent, no tag to follow.
+# records the intended policy and `digest` is rewritten live by `cargo generate
+# installers`. A row with discover=true refreshes the digest for its declared
+# tag from the registry; Node discover rows must use a plain
+# <major>-bookworm-slim tag. StageX pins in the Containerfile are excluded on
+# purpose: digest-only, reproducible-build intent, no tag to follow.
 
 [[image]]
 zone = "base-arg-node"

--- a/dev/ci/container-base-images.toml
+++ b/dev/ci/container-base-images.toml
@@ -1,8 +1,8 @@
 # Canonical container base-image pins for the generated container surfaces
 # (Dockerfile, Dockerfile.debian). Edit registry/repo/image_ref/tag here; `tag`
 # and `digest` are rewritten live by `cargo generate installers`. A row with
-# discover=true resolves its tag live from the registry (node: highest
-# <major>-bookworm-slim on Docker Hub). StageX pins in the Containerfile are
+# discover=true derives its tag from the repo root .nvmrc, then refreshes its
+# digest live from the registry. StageX pins in the Containerfile are
 # excluded on purpose: digest-only, reproducible-build intent, no tag to follow.
 
 [[image]]
@@ -12,8 +12,8 @@ registry = "dockerhub"
 repo = "library/node"
 image_ref = "node"
 discover = true
-tag = "26-bookworm-slim"
-digest = "sha256:4e2e85a824f938e41a61e9e819f0c7c11432f7d60f470b96214d3ead2f0dd63e"
+tag = "24-bookworm-slim"
+digest = "sha256:c2d5ade763cacfb03fe9cb8e8af5d1be5041ff331921fa26a9b231ca3a4f780a"
 
 [[image]]
 zone = "base-arg-rust-slim"

--- a/xtask/src/generate/container_base.rs
+++ b/xtask/src/generate/container_base.rs
@@ -4,7 +4,6 @@ use std::path::Path;
 use std::time::Duration;
 
 const SOURCE: &str = "dev/ci/container-base-images.toml";
-const NODE_VERSION_SOURCE: &str = ".nvmrc";
 const NODE_SUITE: &str = "bookworm-slim";
 const INDEX_ACCEPT: &str = "application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json";
 
@@ -75,31 +74,6 @@ fn client() -> anyhow::Result<reqwest::blocking::Client> {
 #[derive(Deserialize)]
 struct Token {
     token: String,
-}
-
-fn node_tag_from_policy(root: &Path, zone: &str) -> anyhow::Result<String> {
-    let major =
-        node_major_policy(root).with_context(|| format!("{zone}: resolve Node major policy"))?;
-    Ok(format!("{major}-{NODE_SUITE}"))
-}
-
-fn node_major_policy(root: &Path) -> anyhow::Result<u32> {
-    let raw = std::fs::read_to_string(root.join(NODE_VERSION_SOURCE))
-        .with_context(|| format!("read {NODE_VERSION_SOURCE}"))?;
-    parse_node_major_policy(&raw)
-        .with_context(|| format!("{NODE_VERSION_SOURCE}: expected a non-zero Node major version"))
-}
-
-fn parse_node_major_policy(raw: &str) -> Option<u32> {
-    let version = raw.trim();
-    let version = version.strip_prefix('v').unwrap_or(version);
-    let major = version.split('.').next()?;
-    major
-        .chars()
-        .all(|c| c.is_ascii_digit())
-        .then(|| major.parse::<u32>().ok())
-        .flatten()
-        .filter(|major| *major > 0)
 }
 
 fn node_major_for_suite(tag: &str) -> Option<u32> {
@@ -197,13 +171,11 @@ pub fn refresh_source(root: &Path) -> anyhow::Result<()> {
     let client = client()?;
     let mut src = load(root)?;
     for img in &mut src.image {
-        let tag = if img.discover {
-            node_tag_from_policy(root, &img.zone)?
-        } else {
-            img.tag
-                .clone()
-                .with_context(|| format!("{}: non-discover row must set a tag", img.zone))?
-        };
+        let tag = img
+            .tag
+            .clone()
+            .with_context(|| format!("{}: row must set a tag", img.zone))?;
+        validate_node_tag_policy(img, &tag)?;
         let digest = resolve_digest(&client, img.registry, &img.repo, &tag)?;
         img.tag = Some(tag);
         img.digest = Some(digest);
@@ -215,10 +187,11 @@ pub fn refresh_source(root: &Path) -> anyhow::Result<()> {
 
 const SOURCE_HEADER: &str = "# Canonical container base-image pins for the generated container surfaces\n\
 # (Dockerfile, Dockerfile.debian). Edit registry/repo/image_ref/tag here; `tag`\n\
-# and `digest` are rewritten live by `cargo generate installers`. A row with\n\
-# discover=true derives its tag from the repo root .nvmrc, then refreshes its\n\
-# digest live from the registry. StageX pins in the Containerfile are\n\
-# excluded on purpose: digest-only, reproducible-build intent, no tag to follow.\n\n";
+# records the intended policy and `digest` is rewritten live by `cargo generate\n\
+# installers`. A row with discover=true refreshes the digest for its declared\n\
+# tag from the registry; Node discover rows must use a plain\n\
+# <major>-bookworm-slim tag. StageX pins in the Containerfile are excluded on\n\
+# purpose: digest-only, reproducible-build intent, no tag to follow.\n\n";
 
 fn render_source(src: &Source) -> anyhow::Result<String> {
     let body = toml::to_string_pretty(src).context("serialize source")?;
@@ -234,20 +207,20 @@ pub fn splice_zones(root: &Path, current: &str) -> anyhow::Result<String> {
         if !current.contains(&begin(&img.zone)) {
             continue;
         }
-        let (tag, digest) = resolved(root, img)?;
+        let (tag, digest) = resolved(img)?;
         out = splice(&out, &img.zone, &arg_line(img, tag, digest))?;
     }
     Ok(out)
 }
 
-fn resolved<'a>(root: &Path, img: &'a BaseImage) -> anyhow::Result<(&'a str, &'a str)> {
+fn resolved(img: &BaseImage) -> anyhow::Result<(&str, &str)> {
     let tag = img.tag.as_deref().with_context(|| {
         format!(
             "{}: TOML missing resolved tag; run `cargo generate installers`",
             img.zone
         )
     })?;
-    validate_node_tag_policy(root, img, tag)?;
+    validate_node_tag_policy(img, tag)?;
     let digest = img.digest.as_deref().with_context(|| {
         format!(
             "{}: TOML missing resolved digest; run `cargo generate installers`",
@@ -257,19 +230,12 @@ fn resolved<'a>(root: &Path, img: &'a BaseImage) -> anyhow::Result<(&'a str, &'a
     Ok((tag, digest))
 }
 
-fn validate_node_tag_policy(root: &Path, img: &BaseImage, tag: &str) -> anyhow::Result<()> {
+fn validate_node_tag_policy(img: &BaseImage, tag: &str) -> anyhow::Result<()> {
     if !img.discover {
         return Ok(());
     }
-    let expected = node_major_policy(root)?;
-    let actual = node_major_for_suite(tag)
+    node_major_for_suite(tag)
         .with_context(|| format!("{}: node tag {tag} is not <major>-{NODE_SUITE}", img.zone))?;
-    if actual != expected {
-        anyhow::bail!(
-            "{}: {NODE_VERSION_SOURCE} declares Node major {expected} but tag {tag} resolves to Node major {actual}",
-            img.zone
-        );
-    }
     Ok(())
 }
 
@@ -292,7 +258,7 @@ pub fn check(root: &Path, current: &str) -> anyhow::Result<Vec<String>> {
         if !declares {
             continue;
         }
-        let (tag, digest) = match resolved(root, img) {
+        let (tag, digest) = match resolved(img) {
             Ok(v) => v,
             Err(e) => {
                 drift.push(e.to_string());
@@ -344,10 +310,6 @@ digest = "sha256:{}"
         std::fs::write(dir.join("container-base-images.toml"), source).unwrap();
     }
 
-    fn write_nvmrc(root: &Path, major: u32) {
-        std::fs::write(root.join(".nvmrc"), major.to_string()).unwrap();
-    }
-
     fn fixed(zone: &str) -> BaseImage {
         BaseImage {
             zone: zone.to_string(),
@@ -397,7 +359,7 @@ digest = "sha256:{}"
     #[test]
     fn arg_line_round_trips_through_zone_body() {
         let img = fixed("base-arg-test");
-        let (tag, digest) = resolved(&root(), &img).unwrap();
+        let (tag, digest) = resolved(&img).unwrap();
         let line = arg_line(&img, tag, digest);
         let content = format!("{}\n{line}\n{}\n", begin(&img.zone), end(&img.zone));
         assert_eq!(zone_body(&content, &img.zone).unwrap(), line);
@@ -411,12 +373,11 @@ digest = "sha256:{}"
     }
 
     #[test]
-    fn splice_zones_rejects_node_tag_that_differs_from_nvmrc() {
+    fn splice_zones_rejects_non_plain_node_discover_tag() {
         let temp = tempfile::tempdir().unwrap();
-        write_nvmrc(temp.path(), 24);
-        write_source(temp.path(), &source_with_node_tag("27-bookworm-slim"));
+        write_source(temp.path(), &source_with_node_tag("24.1-bookworm-slim"));
         let content = format!(
-            "{}\nARG ZEROCLAW_BASE_NODE=node:27-bookworm-slim@sha256:{}\n{}\n",
+            "{}\nARG ZEROCLAW_BASE_NODE=node:24.1-bookworm-slim@sha256:{}\n{}\n",
             begin("base-arg-node"),
             "a".repeat(64),
             end("base-arg-node")
@@ -425,8 +386,9 @@ digest = "sha256:{}"
         let err = splice_zones(temp.path(), &content).unwrap_err();
 
         assert!(
-            err.to_string().contains(".nvmrc declares Node major 24"),
-            "expected .nvmrc mismatch error, got {err:#}"
+            err.to_string()
+                .contains("node tag 24.1-bookworm-slim is not <major>-bookworm-slim"),
+            "expected Node tag-shape error, got {err:#}"
         );
     }
 }

--- a/xtask/src/generate/container_base.rs
+++ b/xtask/src/generate/container_base.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use std::time::Duration;
 
 const SOURCE: &str = "dev/ci/container-base-images.toml";
+const NODE_VERSION_SOURCE: &str = ".nvmrc";
 const NODE_SUITE: &str = "bookworm-slim";
 const INDEX_ACCEPT: &str = "application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json";
 
@@ -76,44 +77,34 @@ struct Token {
     token: String,
 }
 
-#[derive(Deserialize)]
-struct TagPage {
-    results: Vec<TagEntry>,
-    next: Option<String>,
-}
-
-#[derive(Deserialize)]
-struct TagEntry {
-    name: String,
-}
-
-fn discover_node_tag(client: &reqwest::blocking::Client, repo: &str) -> anyhow::Result<String> {
-    let mut best: Option<u32> = None;
-    let mut url = Some(format!(
-        "https://hub.docker.com/v2/repositories/{repo}/tags?page_size=100&name={NODE_SUITE}"
-    ));
-    while let Some(next) = url.take() {
-        let page: TagPage = client
-            .get(&next)
-            .send()
-            .context("node tag list request")?
-            .error_for_status()
-            .context("node tag list status")?
-            .json()
-            .context("parse node tag list")?;
-        for t in &page.results {
-            if let Some(major) = node_major_for_suite(&t.name) {
-                best = Some(best.map_or(major, |b| b.max(major)));
-            }
-        }
-        url = page.next;
-    }
-    let major = best.context("registry returned no <major>-bookworm-slim node tag")?;
+fn node_tag_from_policy(root: &Path, zone: &str) -> anyhow::Result<String> {
+    let major =
+        node_major_policy(root).with_context(|| format!("{zone}: resolve Node major policy"))?;
     Ok(format!("{major}-{NODE_SUITE}"))
 }
 
+fn node_major_policy(root: &Path) -> anyhow::Result<u32> {
+    let raw = std::fs::read_to_string(root.join(NODE_VERSION_SOURCE))
+        .with_context(|| format!("read {NODE_VERSION_SOURCE}"))?;
+    parse_node_major_policy(&raw)
+        .with_context(|| format!("{NODE_VERSION_SOURCE}: expected a non-zero Node major version"))
+}
+
+fn parse_node_major_policy(raw: &str) -> Option<u32> {
+    let version = raw.trim();
+    let version = version.strip_prefix('v').unwrap_or(version);
+    let major = version.split('.').next()?;
+    major
+        .chars()
+        .all(|c| c.is_ascii_digit())
+        .then(|| major.parse::<u32>().ok())
+        .flatten()
+        .filter(|major| *major > 0)
+}
+
 fn node_major_for_suite(tag: &str) -> Option<u32> {
-    tag.strip_suffix(&format!("-{NODE_SUITE}"))
+    tag.strip_suffix(NODE_SUITE)
+        .and_then(|tag| tag.strip_suffix('-'))
         .filter(|m| !m.is_empty() && m.chars().all(|c| c.is_ascii_digit()))
         .and_then(|m| m.parse::<u32>().ok())
 }
@@ -207,7 +198,7 @@ pub fn refresh_source(root: &Path) -> anyhow::Result<()> {
     let mut src = load(root)?;
     for img in &mut src.image {
         let tag = if img.discover {
-            discover_node_tag(&client, &img.repo)?
+            node_tag_from_policy(root, &img.zone)?
         } else {
             img.tag
                 .clone()
@@ -225,8 +216,8 @@ pub fn refresh_source(root: &Path) -> anyhow::Result<()> {
 const SOURCE_HEADER: &str = "# Canonical container base-image pins for the generated container surfaces\n\
 # (Dockerfile, Dockerfile.debian). Edit registry/repo/image_ref/tag here; `tag`\n\
 # and `digest` are rewritten live by `cargo generate installers`. A row with\n\
-# discover=true resolves its tag live from the registry (node: highest\n\
-# <major>-bookworm-slim on Docker Hub). StageX pins in the Containerfile are\n\
+# discover=true derives its tag from the repo root .nvmrc, then refreshes its\n\
+# digest live from the registry. StageX pins in the Containerfile are\n\
 # excluded on purpose: digest-only, reproducible-build intent, no tag to follow.\n\n";
 
 fn render_source(src: &Source) -> anyhow::Result<String> {
@@ -243,19 +234,20 @@ pub fn splice_zones(root: &Path, current: &str) -> anyhow::Result<String> {
         if !current.contains(&begin(&img.zone)) {
             continue;
         }
-        let (tag, digest) = resolved(img)?;
+        let (tag, digest) = resolved(root, img)?;
         out = splice(&out, &img.zone, &arg_line(img, tag, digest))?;
     }
     Ok(out)
 }
 
-fn resolved(img: &BaseImage) -> anyhow::Result<(&str, &str)> {
+fn resolved<'a>(root: &Path, img: &'a BaseImage) -> anyhow::Result<(&'a str, &'a str)> {
     let tag = img.tag.as_deref().with_context(|| {
         format!(
             "{}: TOML missing resolved tag; run `cargo generate installers`",
             img.zone
         )
     })?;
+    validate_node_tag_policy(root, img, tag)?;
     let digest = img.digest.as_deref().with_context(|| {
         format!(
             "{}: TOML missing resolved digest; run `cargo generate installers`",
@@ -263,6 +255,22 @@ fn resolved(img: &BaseImage) -> anyhow::Result<(&str, &str)> {
         )
     })?;
     Ok((tag, digest))
+}
+
+fn validate_node_tag_policy(root: &Path, img: &BaseImage, tag: &str) -> anyhow::Result<()> {
+    if !img.discover {
+        return Ok(());
+    }
+    let expected = node_major_policy(root)?;
+    let actual = node_major_for_suite(tag)
+        .with_context(|| format!("{}: node tag {tag} is not <major>-{NODE_SUITE}", img.zone))?;
+    if actual != expected {
+        anyhow::bail!(
+            "{}: {NODE_VERSION_SOURCE} declares Node major {expected} but tag {tag} resolves to Node major {actual}",
+            img.zone
+        );
+    }
+    Ok(())
 }
 
 /// Network-free drift check: every declared ARG zone must match what the TOML
@@ -284,19 +292,13 @@ pub fn check(root: &Path, current: &str) -> anyhow::Result<Vec<String>> {
         if !declares {
             continue;
         }
-        let (tag, digest) = match resolved(img) {
+        let (tag, digest) = match resolved(root, img) {
             Ok(v) => v,
             Err(e) => {
                 drift.push(e.to_string());
                 continue;
             }
         };
-        if img.discover && node_major_for_suite(tag).is_none() {
-            drift.push(format!(
-                "{}: node tag {tag} is not <major>-{NODE_SUITE}",
-                img.zone
-            ));
-        }
         if !valid_digest(digest) {
             drift.push(format!("{}: malformed digest {digest}", img.zone));
         }
@@ -318,6 +320,32 @@ mod tests {
             .parent()
             .unwrap()
             .to_path_buf()
+    }
+
+    fn source_with_node_tag(tag: &str) -> String {
+        format!(
+            r#"[[image]]
+zone = "base-arg-node"
+arg = "ZEROCLAW_BASE_NODE"
+registry = "dockerhub"
+repo = "library/node"
+image_ref = "node"
+discover = true
+tag = "{tag}"
+digest = "sha256:{}"
+"#,
+            "a".repeat(64)
+        )
+    }
+
+    fn write_source(root: &Path, source: &str) {
+        let dir = root.join("dev/ci");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("container-base-images.toml"), source).unwrap();
+    }
+
+    fn write_nvmrc(root: &Path, major: u32) {
+        std::fs::write(root.join(".nvmrc"), major.to_string()).unwrap();
     }
 
     fn fixed(zone: &str) -> BaseImage {
@@ -369,7 +397,7 @@ mod tests {
     #[test]
     fn arg_line_round_trips_through_zone_body() {
         let img = fixed("base-arg-test");
-        let (tag, digest) = resolved(&img).unwrap();
+        let (tag, digest) = resolved(&root(), &img).unwrap();
         let line = arg_line(&img, tag, digest);
         let content = format!("{}\n{line}\n{}\n", begin(&img.zone), end(&img.zone));
         assert_eq!(zone_body(&content, &img.zone).unwrap(), line);
@@ -380,5 +408,25 @@ mod tests {
         let content = "FROM ${ZEROCLAW_BASE_RUST_SLIM} AS x\n";
         let drift = check(&root(), content).unwrap();
         assert!(drift.iter().any(|d| d.contains("base-arg-rust-slim")));
+    }
+
+    #[test]
+    fn splice_zones_rejects_node_tag_that_differs_from_nvmrc() {
+        let temp = tempfile::tempdir().unwrap();
+        write_nvmrc(temp.path(), 24);
+        write_source(temp.path(), &source_with_node_tag("27-bookworm-slim"));
+        let content = format!(
+            "{}\nARG ZEROCLAW_BASE_NODE=node:27-bookworm-slim@sha256:{}\n{}\n",
+            begin("base-arg-node"),
+            "a".repeat(64),
+            end("base-arg-node")
+        );
+
+        let err = splice_zones(temp.path(), &content).unwrap_err();
+
+        assert!(
+            err.to_string().contains(".nvmrc declares Node major 24"),
+            "expected .nvmrc mismatch error, got {err:#}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Node container-base discovery now refreshes the digest for the `tag` declared in `dev/ci/container-base-images.toml` instead of querying Docker Hub for the highest matching Node major. The TOML row remains the container-base policy source, so routine installer generation cannot silently move ZeroClaw to a new Node major.
- **What changed and why:** `cargo generate installers --check` stays network-free and validates discover-row Node tags as plain `<major>-bookworm-slim` tags before comparing generated Dockerfile zones against TOML.
- **What changed and why:** The generated Dockerfile surfaces and `dev/ci/container-base-images.toml` were refreshed to the declared `node:24-bookworm-slim` tag with the digest recorded in TOML.
- **Scope boundary:** This PR does not change `.nvmrc`, the long-term Node support policy, Docker build workflows, release/publish behavior, or non-Node base-image pins. It also does not add a second `major` field; the existing TOML `tag` is the container-base Node policy.
- **Blast radius:** Installer-generation and container base-image surfaces only: `xtask` generator logic, `dev/ci/container-base-images.toml`, `Dockerfile`, and `Dockerfile.debian`.
- **Linked issue(s):** Closes #8105.
- **Labels:** `enhancement`, `type: ci`, `risk: medium`, `size: S`, `dev`, `security:docker`.

## Validation Evidence (required)

- **Commands run and tail output:**

```text
$ cargo fmt -p xtask
(exit 0)

$ cargo test -p xtask container_base::tests
running 7 tests
test generate::container_base::tests::node_major_for_suite_rejects_non_plain_major ... ok
test generate::container_base::tests::node_major_for_suite_accepts_plain_major ... ok
test generate::container_base::tests::valid_digest_shape ... ok
test generate::container_base::tests::arg_line_round_trips_through_zone_body ... ok
test generate::container_base::tests::source_parses_and_node_is_discover ... ok
test generate::container_base::tests::check_flags_orphan_reference ... ok
test generate::container_base::tests::splice_zones_rejects_non_plain_node_discover_tag ... ok
test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 82 filtered out

$ cargo generate installers --check
ok: install-sh in sync
ok: setup-bat in sync
ok: containerfile in sync
ok: dockerfile in sync
ok: dockerfile-debian in sync
ok: pkgbuild in sync
ok: scoop in sync
ok: flake in sync
ok: docker-tags in sync

$ git diff --check
(no output; exit 0)
```

- **Beyond CI — what did you manually verify?** Verified the Node container-base policy is read from the TOML `tag`, generated Dockerfile zones still match the TOML tag+digest, and the generator no longer reads `.nvmrc` for container base-image policy.
- **If any command was intentionally skipped, why:** Workspace clippy and full workspace tests were not run. The touched Rust surface is the xtask container-base generator, and the focused xtask tests plus installer drift check cover the changed behavior.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No` (the generator still refreshes registry digests; this removes the Docker Hub tag-list major-selection policy from refresh)
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No` for user-facing runtime config, environment variables, and CLI. The maintainer-facing generator policy changed: the existing TOML `tag` now controls the Node major for the discover-row container base.
- If `No` or `Yes` to either: Existing users do not need upgrade steps. Maintainers changing the container-base Node major should update the TOML `tag`, then run `cargo generate installers` so the digest and generated Dockerfile zones refresh together.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <sha>` after merge, then rerun `cargo generate installers --check` to confirm generated surfaces return to the prior policy.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** `cargo generate installers --check` reports a Node tag-shape or generated-zone mismatch, or generated Dockerfiles unexpectedly pin a Node major that does not match the TOML tag.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Scope materially carried forward: N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why (inspiration-only, no direct code/design carry-over): N/A
