### PR TITLE
fix(tools): normalize Windows workspace-prefixed paths

### DIFF
--- a/crates/zeroclaw-config/src/policy.rs
+++ b/crates/zeroclaw-config/src/policy.rs
@@ -631,6 +631,62 @@ fn rootless_path(path: &Path) -> Option<PathBuf> {
     }
 }
 
+struct NormalizedRootlessPath {
+    drive: Option<u8>,
+    text: String,
+}
+
+fn normalized_rootless_path_text(path: &Path) -> Option<NormalizedRootlessPath> {
+    let mut text = path.to_string_lossy().replace('\\', "/");
+
+    if let Some(rest) = text.strip_prefix("//?/UNC/") {
+        text = rest.to_string();
+    } else if let Some(rest) = text.strip_prefix("//?/") {
+        text = rest.to_string();
+    }
+
+    let mut drive = None;
+    let bytes = text.as_bytes();
+    if bytes.len() >= 2 && bytes[1] == b':' && bytes[0].is_ascii_alphabetic() {
+        drive = Some(bytes[0].to_ascii_lowercase());
+        text = text[2..].to_string();
+    }
+
+    let parts: Vec<&str> = text
+        .trim_start_matches('/')
+        .split('/')
+        .filter(|part| !part.is_empty() && *part != ".")
+        .collect();
+
+    if parts.is_empty() || parts.contains(&"..") {
+        None
+    } else {
+        Some(NormalizedRootlessPath {
+            drive,
+            text: parts.join("/"),
+        })
+    }
+}
+
+fn workspace_prefixed_relative_suffix(path: &Path, workspace_dir: &Path) -> Option<PathBuf> {
+    let path_text = normalized_rootless_path_text(path)?;
+    let workspace_text = normalized_rootless_path_text(workspace_dir)?;
+
+    if path_text.drive.is_some() && path_text.drive != workspace_text.drive {
+        return None;
+    }
+
+    if path_text.text == workspace_text.text {
+        return Some(PathBuf::new());
+    }
+
+    let prefix = format!("{}/", workspace_text.text);
+    path_text
+        .text
+        .strip_prefix(&prefix)
+        .map(|suffix| PathBuf::from(suffix.replace('/', std::path::MAIN_SEPARATOR_STR)))
+}
+
 // ── Shell Command Parsing Utilities ───────────────────────────────────────
 // These helpers implement a minimal quote-aware shell lexer. They exist
 // because security validation must reason about the *structure* of a
@@ -2104,6 +2160,14 @@ impl SecurityPolicy {
             expanded
         } else if let Some(workspace_hint) = rootless_path(&self.workspace_dir) {
             if let Ok(stripped) = expanded.strip_prefix(&workspace_hint) {
+                if stripped.as_os_str().is_empty() {
+                    self.workspace_dir.clone()
+                } else {
+                    self.workspace_dir.join(stripped)
+                }
+            } else if let Some(stripped) =
+                workspace_prefixed_relative_suffix(&expanded, &self.workspace_dir)
+            {
                 if stripped.as_os_str().is_empty() {
                     self.workspace_dir.clone()
                 } else {
@@ -4969,6 +5033,32 @@ mod tests {
             resolved,
             PathBuf::from("/zeroclaw-data/workspace/scripts/daily.py")
         );
+    }
+
+    #[test]
+    fn resolve_tool_path_normalizes_windows_workspace_prefixed_relative_paths() {
+        let workspace = PathBuf::from(r"C:\Users\me\.zeroclaw\agents\default\workspace");
+        let p = SecurityPolicy {
+            workspace_dir: workspace.clone(),
+            ..SecurityPolicy::default()
+        };
+        let resolved =
+            p.resolve_tool_path(r"Users\me\.zeroclaw\agents\default\workspace\nested\out.txt");
+
+        assert_eq!(resolved, workspace.join("nested").join("out.txt"));
+    }
+
+    #[test]
+    fn resolve_tool_path_does_not_normalize_mismatched_drive_prefixed_relative_paths() {
+        let workspace = PathBuf::from(r"C:\Users\me\.zeroclaw\agents\default\workspace");
+        let p = SecurityPolicy {
+            workspace_dir: workspace.clone(),
+            ..SecurityPolicy::default()
+        };
+        let resolved =
+            p.resolve_tool_path(r"D:Users\me\.zeroclaw\agents\default\workspace\nested\out.txt");
+
+        assert_ne!(resolved, workspace.join("nested").join("out.txt"));
     }
 
     #[test]

--- a/crates/zeroclaw-runtime/src/tools/file_read.rs
+++ b/crates/zeroclaw-runtime/src/tools/file_read.rs
@@ -51,23 +51,7 @@ impl FileReadTool {
             anyhow::bail!("Path not allowed by security policy: {path}");
         }
 
-        let p = std::path::Path::new(path);
-        if p.is_absolute() {
-            return Ok(p.to_path_buf());
-        }
-
-        let workspace_dir = &self.security.workspace_dir;
-        if let Ok(workspace_rootless) = workspace_dir.strip_prefix("/")
-            && let Ok(stripped) = p.strip_prefix(workspace_rootless)
-        {
-            return Ok(if stripped.as_os_str().is_empty() {
-                workspace_dir.clone()
-            } else {
-                workspace_dir.join(stripped)
-            });
-        }
-
-        Ok(workspace_dir.join(p))
+        Ok(self.security.resolve_tool_path(path))
     }
 }
 
@@ -487,6 +471,24 @@ mod tests {
         FileReadTool::new_with_persistence(security, false)
     }
 
+    fn workspace_prefixed_relative_path_for_test(
+        workspace: &std::path::Path,
+    ) -> std::path::PathBuf {
+        let mut relative = std::path::PathBuf::new();
+        for component in workspace.components() {
+            match component {
+                std::path::Component::Prefix(_)
+                | std::path::Component::RootDir
+                | std::path::Component::CurDir => {}
+                std::path::Component::ParentDir => {
+                    panic!("test workspace path must not contain parent components")
+                }
+                std::path::Component::Normal(part) => relative.push(part),
+            }
+        }
+        relative
+    }
+
     #[test]
     fn file_read_name() {
         let tool = test_tool(std::env::temp_dir());
@@ -803,6 +805,36 @@ mod tests {
         assert!(result.output.contains("1: deep content"));
 
         let _ = tokio::fs::remove_dir_all(&dir).await;
+    }
+
+    #[tokio::test]
+    async fn file_read_normalizes_workspace_prefixed_relative_path() {
+        let root = std::env::temp_dir().join("zeroclaw_test_file_read_workspace_prefixed");
+        let workspace = root.join("workspace");
+        let nested = workspace.join("nested");
+
+        let _ = tokio::fs::remove_dir_all(&root).await;
+        tokio::fs::create_dir_all(&nested).await.unwrap();
+        tokio::fs::write(nested.join("notes.txt"), "prefixed content")
+            .await
+            .unwrap();
+
+        let tool = test_tool(workspace.clone());
+        let workspace_prefixed =
+            workspace_prefixed_relative_path_for_test(&workspace).join("nested/notes.txt");
+        let result = tool
+            .execute(json!({"path": workspace_prefixed.to_string_lossy()}))
+            .await
+            .unwrap();
+
+        assert!(
+            result.success,
+            "workspace-prefixed file_read path should resolve, error: {:?}",
+            result.error
+        );
+        assert!(result.output.contains("1: prefixed content"));
+
+        let _ = tokio::fs::remove_dir_all(&root).await;
     }
 
     #[cfg(unix)]

--- a/crates/zeroclaw-tools/src/file_edit.rs
+++ b/crates/zeroclaw-tools/src/file_edit.rs
@@ -738,7 +738,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg(unix)]
     async fn file_edit_normalizes_workspace_prefixed_relative_path() {
         let root = std::env::temp_dir().join("zeroclaw_test_file_edit_workspace_prefixed");
         let workspace = root.join("workspace");
@@ -751,10 +750,9 @@ mod tests {
             .unwrap();
 
         let tool = test_tool(workspace.clone());
-        let workspace_prefixed = workspace
-            .strip_prefix(std::path::Path::new("/"))
-            .unwrap()
-            .join("nested/target.txt");
+        let workspace_prefixed =
+            crate::util_helpers::workspace_prefixed_relative_path_for_test(&workspace)
+                .join("nested/target.txt");
         let result = tool
             .execute(json!({
                 "path": workspace_prefixed.to_string_lossy(),

--- a/crates/zeroclaw-tools/src/file_write.rs
+++ b/crates/zeroclaw-tools/src/file_write.rs
@@ -363,7 +363,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg(unix)]
     async fn file_write_normalizes_workspace_prefixed_relative_path() {
         let root = std::env::temp_dir().join("zeroclaw_test_file_write_workspace_prefixed");
         let workspace = root.join("workspace");
@@ -371,10 +370,9 @@ mod tests {
         tokio::fs::create_dir_all(&workspace).await.unwrap();
 
         let tool = test_tool(workspace.clone());
-        let workspace_prefixed = workspace
-            .strip_prefix(std::path::Path::new("/"))
-            .unwrap()
-            .join("nested/out.txt");
+        let workspace_prefixed =
+            crate::util_helpers::workspace_prefixed_relative_path_for_test(&workspace)
+                .join("nested/out.txt");
         let result = tool
             .execute(json!({
                 "path": workspace_prefixed.to_string_lossy(),

--- a/crates/zeroclaw-tools/src/util_helpers.rs
+++ b/crates/zeroclaw-tools/src/util_helpers.rs
@@ -43,6 +43,25 @@ pub fn clean_verbatim_path(path: &std::path::Path) -> std::path::PathBuf {
 }
 
 #[cfg(test)]
+pub(crate) fn workspace_prefixed_relative_path_for_test(
+    workspace: &std::path::Path,
+) -> std::path::PathBuf {
+    let mut relative = std::path::PathBuf::new();
+    for component in workspace.components() {
+        match component {
+            std::path::Component::Prefix(_)
+            | std::path::Component::RootDir
+            | std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                panic!("test workspace path must not contain parent components")
+            }
+            std::path::Component::Normal(part) => relative.push(part),
+        }
+    }
+    relative
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Normalize workspace-prefixed relative paths that arrive with Windows separators so file tools resolve them inside the configured workspace instead of nesting the workspace prefix again.
  - Preserve the existing native rootless path fast path before falling back to string-normalized Windows-style matching.
  - Reject mismatched drive-prefixed relative paths instead of treating `D:...` as if it matched a `C:\...` workspace.
  - Route `file_read` through `SecurityPolicy::resolve_tool_path` so read/write/edit path semantics stay aligned.
- **Scope boundary:** This PR only covers the Windows workspace-prefixed file path semantics slice from #7462. It does not address the remaining console-encoding, updater, `content_search`, or `rg` Windows failures.
- **Blast radius:** File path resolution for `file_read`, file write/edit tools, and the shared security policy path resolver. No CLI, config schema, provider, network, or external integration surface changes.
- **Linked issue(s):** Related #7462.
- **Labels:** `bug`, `risk: high`, `size: S`, `config`, `runtime`, `tool`, `tool:file`.

## Validation Evidence (required)

- **Commands run and tail output:**

```bash
cargo test -p zeroclaw-config resolve_tool_path --lib
```

```text
running 6 tests
test policy::tests::resolve_tool_path_keeps_absolute ... ok
test policy::tests::resolve_tool_path_normalizes_workspace_prefixed_relative_paths ... ok
test policy::tests::resolve_tool_path_expands_tilde ... ok
test policy::tests::resolve_tool_path_does_not_normalize_mismatched_drive_prefixed_relative_paths ... ok
test policy::tests::resolve_tool_path_normalizes_windows_workspace_prefixed_relative_paths ... ok
test policy::tests::resolve_tool_path_joins_relative ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 932 filtered out
```

```bash
cargo test -p zeroclaw-runtime file_read_normalizes_workspace_prefixed_relative_path --lib
```

```text
running 1 test
test tools::file_read::tests::file_read_normalizes_workspace_prefixed_relative_path ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 2323 filtered out
```

```bash
cargo test -p zeroclaw-runtime file_read_nonexistent_consumes_rate_limit_budget --lib
```

```text
running 1 test
test tools::file_read::tests::file_read_nonexistent_consumes_rate_limit_budget ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 2323 filtered out
```

```bash
cargo test -p zeroclaw-tools workspace_prefixed --lib
```

```text
running 3 tests
test file_edit::tests::file_edit_normalizes_workspace_prefixed_relative_path ... ok
test file_write::tests::file_write_normalizes_workspace_prefixed_relative_path ... ok
test image_info::tests::wrapped_normalizes_workspace_prefixed_relative_path ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 1333 filtered out
```

```bash
cargo clippy -p zeroclaw-config -p zeroclaw-tools -p zeroclaw-runtime --lib -- -D warnings
```

```text
Finished `dev` profile [unoptimized + debuginfo] target(s)
```

```bash
cargo fmt -p zeroclaw-config -p zeroclaw-tools -p zeroclaw-runtime -- --check
git diff --check
```

```text
Both commands completed successfully.
```

- **Beyond CI — what did you manually verify?** Verified the Windows-style workspace-prefixed resolver case, the mismatched-drive regression, `file_read` alignment with the shared resolver, and failed-read rate-limit charging after the resolver change.
- **If any command was intentionally skipped, why:** Full workspace Cargo validation was not run locally because this is a narrow path-semantics fix with focused package coverage; broader CI should cover the full workspace matrix.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: No new permissions or data flows. The change narrows existing path resolution behavior to keep workspace-prefixed relative paths inside the existing workspace policy and avoids normalizing mismatched drive prefixes.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No upgrade steps required.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** Revert the PR commit.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Windows-style workspace-prefixed file paths may again resolve as nested workspace paths or fail with file resolution errors; mismatched drive-prefixed relative paths should not be normalized into the workspace.

## Supersede Attribution (required only when `Supersedes #` is used)

Not used.
