### PR TITLE
fix(web): refresh model list on WebSocket reconnect after daemon reload

### DIFF
--- a/web/src/contexts/AgentContext.tsx
+++ b/web/src/contexts/AgentContext.tsx
@@ -129,6 +129,10 @@ export function AgentProvider({ agentAlias, children }: AgentProviderProps) {
   const switchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const wsVersionRef = useRef(0);
   const localMessageMutationVersionRef = useRef(0);
+  // Tracks whether this provider has already seen a successful connection.
+  // Used to trigger a model-info refresh on reconnect (e.g. after daemon
+  // reload) so the UI picks up newly-added providers from Quickstart (#8094).
+  const hasConnectedBefore = useRef(false);
 
   // Prime the model-provider catalog once so error formatting can resolve
   // display names from the backend registry rather than a local shadow list.
@@ -421,6 +425,14 @@ export function AgentProvider({ agentAlias, children }: AgentProviderProps) {
       if (version !== wsVersionRef.current) return;
       setConnected(true);
       setError(null);
+
+      // On reconnect (not the initial mount connection), refresh the model list
+      // so that providers added via Quickstart after a daemon reload are
+      // reflected in the UI without requiring a full page reset (#8094).
+      if (hasConnectedBefore.current) {
+        setModelInfoVersion((v) => v + 1);
+      }
+      hasConnectedBefore.current = true;
 
       // If we just reconnected after a model switch, apply the pending model now.
       if (pendingModelSwitchRef.current) {


### PR DESCRIPTION
fix #8094 
# Solution Design Details

## Bug Symptom

After adding an Anthropic provider key via Quickstart, the new provider appears on the Dashboard but not in the Chat window's model dropdown until a full page reset.

## Root Cause

1. Quickstart submission writes config and triggers `daemon reload`.
2. Daemon reload causes the Gateway to restart and the WebSocket to disconnect.
3. The WebSocket client has auto-reconnect logic (`scheduleReconnect`).
4. However, in `AgentContext.tsx`, the `ws.onOpen` callback only bumps `modelInfoVersion` (triggering `loadModelInfo`) during an **explicit model switch**.
5. On a plain reconnect (e.g., after daemon reload), `modelInfoVersion` does not change, so the `loadModelInfo` `useEffect` does not re-run, leaving the UI stale.

## Fix Strategy

Distinguish "initial connection" from "reconnect" inside `ws.onOpen`. Use a `hasConnectedBefore` ref. On reconnect, automatically increment `modelInfoVersion` so `loadModelInfo` re-fetches the latest provider/model list from the backend.

---

# Code Change Details

**File**: `web/src/contexts/AgentContext.tsx`

**Changes**:
- Added `hasConnectedBefore` ref, initialized to `false`.
- In `ws.onOpen` callback:
  - If `hasConnectedBefore.current === true` (reconnect), call `setModelInfoVersion(v => v + 1)`.
  - Then set `hasConnectedBefore.current = true`.
- Existing `pendingModelSwitchRef` logic remains untouched.

**Design Considerations**:
- Uses `useRef` instead of `useState` to avoid unnecessary re-renders.
- `hasConnectedBefore` does not need to be in the `useCallback` dependency array because refs are mutable containers read directly from the closure.

---

# Test Points

| Test Scenario | Expected Result |
|--------------|-----------------|
| First open of Chat page (initial connection) | `loadModelInfo` runs once, model list is correct |
| Quickstart adds new provider → daemon reload → WebSocket auto-reconnect | After reconnect, `modelInfoVersion` increments, `loadModelInfo` re-runs, new provider appears in the model dropdown |
| Manual model switch (switchModel) | Existing logic unaffected, pending model applied correctly |
| Network blip → auto-reconnect | Model list refreshes after reconnect, no errors |
| Switching between multiple agents | Each agent's `AgentProvider` is independent, no cross-contamination |

---

# Next Steps

- Perform full browser E2E validation (simulate Quickstart add provider → observe Chat model dropdown auto-refresh).
- Consider adding frontend automated tests (the `web/` directory currently has no test framework; evaluate Vitest + React Testing Library).
- Review whether other states (e.g., `availableModels`, `currentModel`) also need refresh on reconnect.
