### PR TITLE
fix(runtime): refresh system prompt on tool dispatcher swap

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -878,6 +878,19 @@ impl Agent {
 
     pub fn set_tool_dispatcher(&mut self, tool_dispatcher: Box<dyn ToolDispatcher>) {
         self.tool_dispatcher = tool_dispatcher;
+        self.refresh_system_prompt();
+    }
+
+    fn refresh_system_prompt(&mut self) {
+        let Some(ConversationMessage::Chat(first)) = self.history.first() else {
+            return;
+        };
+        if first.role != "system" {
+            return;
+        }
+        if let Ok(sys) = self.build_system_prompt() {
+            self.history[0] = ConversationMessage::Chat(ChatMessage::system(sys));
+        }
     }
 
     /// Return the names of all registered tools.  Test-only — avoids
@@ -3911,6 +3924,53 @@ mod tests {
             matches!(&history[2], ConversationMessage::Chat(m) if m.role == "assistant" && m.content == "hi there")
         );
         assert_eq!(history.len(), 3);
+    }
+
+    #[test]
+    fn set_tool_dispatcher_refreshes_existing_system_prompt() {
+        use zeroclaw_api::model_provider::{ChatMessage, ConversationMessage};
+
+        let model_provider = Box::new(MockModelProvider {
+            responses: Mutex::new(vec![]),
+        });
+        let memory_cfg = zeroclaw_config::schema::MemoryConfig {
+            backend: "none".into(),
+            ..zeroclaw_config::schema::MemoryConfig::default()
+        };
+        let mem: Arc<dyn Memory> = Arc::from(
+            zeroclaw_memory::create_memory(&memory_cfg, std::path::Path::new("/tmp"), None)
+                .expect("memory creation should succeed with valid config"),
+        );
+        let observer: Arc<dyn Observer> = Arc::from(crate::observability::NoopObserver {});
+        let mut agent = Agent::builder()
+            .model_provider(model_provider)
+            .tools(vec![Box::new(MockTool)])
+            .memory(mem)
+            .observer(observer)
+            .tool_dispatcher(Box::new(XmlToolDispatcher))
+            .workspace_dir(std::path::PathBuf::from("/tmp"))
+            .build()
+            .expect("agent builder should succeed with valid config");
+
+        agent.seed_history(&[ChatMessage::user("hello")]);
+        let before = match agent.history().first() {
+            Some(ConversationMessage::Chat(m)) if m.role == "system" => m.content.clone(),
+            other => panic!("expected a system prompt first, got {other:?}"),
+        };
+        assert!(
+            before.contains("Tool Use Protocol"),
+            "xml dispatcher system prompt should carry the xml tool protocol"
+        );
+
+        agent.set_tool_dispatcher(Box::new(NativeToolDispatcher));
+        let after = match agent.history().first() {
+            Some(ConversationMessage::Chat(m)) if m.role == "system" => m.content.clone(),
+            other => panic!("expected a system prompt first, got {other:?}"),
+        };
+        assert!(
+            !after.contains("Tool Use Protocol"),
+            "native dispatcher system prompt must not carry the xml tool protocol after swap"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `Agent::set_tool_dispatcher` swapped the dispatcher without refreshing an existing system prompt, so a mid-session swap left stale tool instructions at the head of history while the runtime dispatched through the new tool surface.
  - Added `Agent::refresh_system_prompt`, called from `set_tool_dispatcher`, which rebuilds the leading system message in place only when the first history entry is a system message. If history has no system prompt yet, nothing is added.
- **Scope boundary:** Does not change dispatcher selection, the system prompt content model, history trimming, or any non-system history entry. The refresh is a no-op when no system prompt is present.
- **Blast radius:** Every caller of `set_tool_dispatcher` (production dispatcher swaps and test helpers). Behavior is unchanged for agents that never swap dispatchers mid-session.
- **Linked issue(s):** Closes #7742
- **Labels:** type: bug, risk: low, size: S, runtime, agent

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy -p zeroclaw-runtime --all-targets -- -D warnings
cargo test -p zeroclaw-runtime set_tool_dispatcher_refreshes
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` clean, no diff.
  - `cargo clippy -p zeroclaw-runtime --all-targets -- -D warnings` finished, no warnings.
  - `cargo test -p zeroclaw-runtime set_tool_dispatcher_refreshes` 1 passed; 0 failed.
- **Beyond CI - what did you manually verify?** Confirmed the two dispatchers differ in their prompt instructions (`XmlToolDispatcher` emits the `## Tool Use Protocol` block, `NativeToolDispatcher` emits none), and the new test seeds an xml-built system prompt, swaps to native, and asserts the leading system message no longer carries the xml protocol. Verified the refresh is a no-op when history is empty (no system message inserted).
- **If any command was intentionally skipped, why:** Workspace-wide `cargo test` not run; the change is localized to `zeroclaw-runtime`.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- If `No` or `Yes` to either: no upgrade steps; behavior only changes for mid-session dispatcher swaps, which previously left a stale prompt.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk: `git revert <sha>` is the plan.
