### PR TITLE
fix(discord): resolve thread parent from cache in autocomplete gate

### DIFF
--- a/crates/zeroclaw-channels/src/discord/mod.rs
+++ b/crates/zeroclaw-channels/src/discord/mod.rs
@@ -3036,6 +3036,7 @@ impl Channel for DiscordChannel {
                                     let peers = (self.peer_resolver)();
                                     let guild_filter = guild_filter.clone();
                                     let channel_filter = channel_filter.clone();
+                                    let thread_channels = Arc::clone(&self.thread_channels);
                                     let resolver = self.slash_command_resolver.clone();
 
                                     zeroclaw_spawn::spawn!(async move {
@@ -3046,12 +3047,30 @@ impl Channel for DiscordChannel {
                                         // don't make here). On denial OR no
                                         // matches we answer an empty choice set.
                                         //
-                                        // No thread-parent REST lookup: it is an
-                                        // authenticated round-trip per keystroke
-                                        // and would defeat the side-effect-free
-                                        // requirement, so a channel-filtered
-                                        // thread simply yields no completions
-                                        // (fail-closed) rather than probing.
+                                        // Thread-parent authorization WITHOUT a
+                                        // REST round-trip: check the in-memory
+                                        // `thread_channels` cache (populated by
+                                        // the MESSAGE_CREATE and type-2 interaction
+                                        // arms). A cache miss means the thread
+                                        // hasn't been seen yet, so we fall back to
+                                        // fail-closed (None) rather than probing
+                                        // Discord — zero extra latency, zero
+                                        // authenticated calls per keystroke.
+                                        let cached_parent = if !channel_filter.is_empty()
+                                            && !interaction_channel.is_empty()
+                                            && !channel_filter
+                                                .iter()
+                                                .any(|c| c == &interaction_channel)
+                                        {
+                                            thread_channels
+                                                .lock()
+                                                .await
+                                                .get(&interaction_channel)
+                                                .cloned()
+                                                .flatten()
+                                        } else {
+                                            None
+                                        };
                                         let authorized = interaction_gate(
                                             &peers,
                                             &guild_filter,
@@ -3059,7 +3078,7 @@ impl Channel for DiscordChannel {
                                             &user_id,
                                             interaction_guild.as_deref(),
                                             &interaction_channel,
-                                            None,
+                                            cached_parent.as_deref(),
                                         )
                                         .is_ok();
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:** The type-4 (APPLICATION_COMMAND_AUTOCOMPLETE) interaction handler now checks the in-memory `thread_channels` cache for a resolved thread parent before calling `interaction_gate`. Previously it passed `None`, which caused autocomplete to fail closed in threads whose parent channel was allowlisted but whose thread id was not directly in `channel_ids`. This is a zero-latency, zero-REST probe — the cache is populated by the MESSAGE_CREATE and type-2 interaction arms on their normal code paths.
- **Scope boundary:** This PR does not add new REST lookups, does not change the message dispatch path, and does not alter the cache eviction policy. Cache misses still fall back to fail-closed (`None`), preserving the existing per-keystroke safety profile.
- **Blast radius:** Only the type-4 autocomplete arm of the Discord gateway listener. The `thread_channels` cache is shared across all interaction and message arms, but the autocomplete arm only reads it (it never writes), so there is no risk of cache-poisoning from keystrokes.
- **Linked issue(s):** Closes #8103
- **Labels:** `type: bug`, `risk: low`, `channel:discord`, `size: XS`

## Validation Evidence (required)

Cannot run the full Rust test suite in the current environment (Rust toolchain not installed).

- **Commands run and tail output:** N/A — environment limitation.
- **Beyond CI — what did you manually verify?** Reviewed the existing `autocomplete_authz_is_side_effect_free` unit test and confirmed the change is compatible (the test passes `None` for `parent_id`, and the changed code only supplies a non-`None` parent when the cache hits — on empty `channel_filter` it still passes `None`). The `interaction_arms_gate_before_take_after_the_doptions_merge` source-level test's string matches (`} else if itype == 4 {`) are unchanged.
- **If any command was intentionally skipped, why:** Rust toolchain not available in this environment; `cargo fmt`, `cargo clippy`, and `cargo test` were skipped for that reason.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: exact upgrade steps for existing users: N/A

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PR: `git revert <sha>` is the plan.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A
