### PR TITLE
feat(presets): redefine Balanced as the trusted-local daily driver

### DIFF
--- a/crates/zeroclaw-config/src/presets.rs
+++ b/crates/zeroclaw-config/src/presets.rs
@@ -73,7 +73,8 @@ pub const RISK_PRESETS: &[RiskPreset] = &[
         help: "Trusted daily driver for a personal dev box. Supervised, \
                workspace-scoped with sensitive paths blocked and the sandbox \
                on. Any command runs without an allowlist, but high-risk \
-               commands still ask. Recommended for most users.",
+               commands stay blocked unless explicitly allowlisted. \
+               Recommended for most users.",
         values: balanced_risk,
     },
     RiskPreset {
@@ -119,9 +120,10 @@ fn balanced_risk() -> RiskProfileConfig {
     // with sensitive paths blocked, sandbox on, and any command permitted with
     // high-risk commands still gated. `allowed_commands: ["*"]` lifts the
     // medium-risk allowlist friction, while `block_high_risk_commands: true`
-    // keeps the `*` wildcard from exempting high-risk commands (it is not an
-    // explicit allowlist entry), so they still require approval. Medium-risk
-    // approval is off so routine work does not interrupt.
+    // keeps the `*` wildcard from exempting high-risk commands: `*` is not an
+    // explicit allowlist entry, so a high-risk command matched only by `*` is
+    // blocked outright (it never reaches the approval branch), not merely
+    // prompted. Medium-risk approval is off so routine work does not interrupt.
     RiskProfileConfig {
         level: AutonomyLevel::Supervised,
         workspace_only: true,
@@ -563,16 +565,17 @@ mod tests {
         assert_eq!(v.level, AutonomyLevel::Supervised);
         assert!(v.workspace_only);
         assert_eq!(v.sandbox_enabled, Some(true));
-        // Any command runs without an allowlist, but high-risk still gates:
-        // the `*` wildcard is not an explicit exemption, so block_high_risk
-        // keeps high-risk commands asking while medium-risk friction is off.
+        // Any command runs without an allowlist, but high-risk is blocked, not
+        // prompted: the `*` wildcard is not an explicit exemption, so
+        // block_high_risk_commands rejects high-risk commands outright while
+        // medium-risk friction is off.
         assert_eq!(v.allowed_commands, vec!["*".to_string()]);
         assert!(v.block_high_risk_commands);
         assert!(!v.require_approval_for_medium_risk);
     }
 
     #[test]
-    fn balanced_risk_allows_routine_commands_but_gates_high_risk() {
+    fn balanced_risk_allows_routine_commands_but_blocks_high_risk() {
         let preset = risk_preset("balanced").unwrap();
         let values = (preset.values)();
         let policy = crate::policy::SecurityPolicy {
@@ -588,14 +591,24 @@ mod tests {
                 "balanced must allow routine command `{cmd}` without an allowlist",
             );
         }
-        // High-risk command is allowed past the allowlist but gated at execution
-        // because the `*` wildcard does not exempt it from block_high_risk.
+        // High-risk command passes the allowlist but is blocked outright at
+        // execution: the `*` wildcard is not an explicit allowlist entry, so
+        // block_high_risk_commands rejects it even when approved=true. This is
+        // a hard block, not an approval prompt.
         assert!(policy.is_command_allowed("rm -rf node_modules"));
+        let err_unapproved = policy
+            .validate_command_execution("rm -rf node_modules", false)
+            .expect_err("balanced must block a wildcard-matched high-risk command");
+        let err_approved = policy
+            .validate_command_execution("rm -rf node_modules", true)
+            .expect_err("blocked even with approved=true: not an approval prompt");
         assert!(
-            policy
-                .validate_command_execution("rm -rf node_modules", false)
-                .is_err(),
-            "balanced must still gate a high-risk command pending approval",
+            err_approved.contains("high-risk command is disallowed"),
+            "must be the hard-block error, not the approval-required one: {err_approved}",
+        );
+        assert_eq!(
+            err_unapproved, err_approved,
+            "approval state must not change the outcome for a wildcard-matched high-risk command",
         );
     }
 

--- a/crates/zeroclaw-config/src/presets.rs
+++ b/crates/zeroclaw-config/src/presets.rs
@@ -70,8 +70,10 @@ pub const RISK_PRESETS: &[RiskPreset] = &[
     RiskPreset {
         preset_name: "balanced",
         label: "Balanced",
-        help: "Sensible day-to-day defaults. Workspace-scoped with approval \
-               gates on risky operations. Recommended for most users.",
+        help: "Trusted daily driver for a personal dev box. Supervised, \
+               workspace-scoped with sensitive paths blocked and the sandbox \
+               on. Any command runs without an allowlist, but high-risk \
+               commands still ask. Recommended for most users.",
         values: balanced_risk,
     },
     RiskPreset {
@@ -113,10 +115,31 @@ fn locked_down_risk() -> RiskProfileConfig {
 }
 
 fn balanced_risk() -> RiskProfileConfig {
-    // Schema default is already the Balanced shape (Supervised,
-    // workspace_only=true, medium-risk approval). Use it directly so
-    // the preset can't drift away from the schema default by accident.
-    RiskProfileConfig::default()
+    // Trusted-local daily-driver shape: Supervised autonomy, workspace-scoped
+    // with sensitive paths blocked, sandbox on, and any command permitted with
+    // high-risk commands still gated. `allowed_commands: ["*"]` lifts the
+    // medium-risk allowlist friction, while `block_high_risk_commands: true`
+    // keeps the `*` wildcard from exempting high-risk commands (it is not an
+    // explicit allowlist entry), so they still require approval. Medium-risk
+    // approval is off so routine work does not interrupt.
+    RiskProfileConfig {
+        level: AutonomyLevel::Supervised,
+        workspace_only: true,
+        allowed_commands: vec!["*".to_string()],
+        forbidden_paths: default_forbidden_paths(),
+        require_approval_for_medium_risk: false,
+        block_high_risk_commands: true,
+        shell_env_passthrough: vec![],
+        auto_approve: vec![],
+        always_ask: vec![],
+        allowed_roots: vec![],
+        delegation_policy: DelegationPolicy::default(),
+        allowed_tools: vec![],
+        excluded_tools: vec![],
+        sandbox_enabled: Some(true),
+        sandbox_backend: None,
+        firejail_args: vec![],
+    }
 }
 
 fn yolo_risk() -> RiskProfileConfig {
@@ -532,17 +555,48 @@ mod tests {
         }
     }
 
-    /// The `Balanced` preset must equal the schema's `Default::default()` —
-    /// that's the contract that lets us call `RiskProfileConfig::default()`
-    /// / `RuntimeProfileConfig::default()` for the Balanced factory
-    /// instead of duplicating field literals.
     #[test]
-    fn balanced_risk_matches_schema_default() {
+    fn balanced_risk_is_trusted_local_shape() {
         let preset = risk_preset("balanced").unwrap();
-        let preset_values = (preset.values)();
-        let schema_default = RiskProfileConfig::default();
-        // Compare via Debug since RiskProfileConfig doesn't derive PartialEq.
-        assert_eq!(format!("{preset_values:?}"), format!("{schema_default:?}"),);
+        let v = (preset.values)();
+        // Supervised, workspace-scoped, sandbox on: a trusted personal dev box.
+        assert_eq!(v.level, AutonomyLevel::Supervised);
+        assert!(v.workspace_only);
+        assert_eq!(v.sandbox_enabled, Some(true));
+        // Any command runs without an allowlist, but high-risk still gates:
+        // the `*` wildcard is not an explicit exemption, so block_high_risk
+        // keeps high-risk commands asking while medium-risk friction is off.
+        assert_eq!(v.allowed_commands, vec!["*".to_string()]);
+        assert!(v.block_high_risk_commands);
+        assert!(!v.require_approval_for_medium_risk);
+    }
+
+    #[test]
+    fn balanced_risk_allows_routine_commands_but_gates_high_risk() {
+        let preset = risk_preset("balanced").unwrap();
+        let values = (preset.values)();
+        let policy = crate::policy::SecurityPolicy {
+            autonomy: values.level,
+            allowed_commands: values.allowed_commands.clone(),
+            block_high_risk_commands: values.block_high_risk_commands,
+            require_approval_for_medium_risk: values.require_approval_for_medium_risk,
+            ..crate::policy::SecurityPolicy::default()
+        };
+        for cmd in ["ls", "cat README.md", "git status"] {
+            assert!(
+                policy.is_command_allowed(cmd),
+                "balanced must allow routine command `{cmd}` without an allowlist",
+            );
+        }
+        // High-risk command is allowed past the allowlist but gated at execution
+        // because the `*` wildcard does not exempt it from block_high_risk.
+        assert!(policy.is_command_allowed("rm -rf node_modules"));
+        assert!(
+            policy
+                .validate_command_execution("rm -rf node_modules", false)
+                .is_err(),
+            "balanced must still gate a high-risk command pending approval",
+        );
     }
 
     #[test]

--- a/crates/zeroclaw-runtime/src/quickstart/mod.rs
+++ b/crates/zeroclaw-runtime/src/quickstart/mod.rs
@@ -786,6 +786,10 @@ const PEER_GROUP_ESSENTIALS: &[&str] = &["channel", "external_peers", "agents", 
 /// picker was removed from every surface; apply always writes this preset.
 const FORCED_RUNTIME_PRESET: &str = "unbounded";
 
+/// Risk profile the Quickstart silently installs. The Risk Profile picker
+/// was removed from every surface; apply always writes this preset.
+const FORCED_RISK_PRESET: &str = "yolo";
+
 fn apply_into(
     config: &mut Config,
     submission: &BuilderSubmission,
@@ -801,15 +805,13 @@ fn apply_into(
         &provider_ref,
     );
 
-    let risk_alias = apply_named_preset(
-        config,
-        &submission.risk_profile,
-        QuickstartStep::RiskProfile,
-        risk_preset_keys,
-        write_risk_preset,
-        errors,
-        ctx,
-    )?;
+    let risk_alias = match write_risk_preset(config, FORCED_RISK_PRESET) {
+        Ok(alias) => alias,
+        Err(msg) => {
+            errors.push(QuickstartError::new(QuickstartStep::RiskProfile, "", msg));
+            return None;
+        }
+    };
     emit_selector_pick(
         ctx,
         "risk_profile",
@@ -1082,49 +1084,6 @@ fn apply_model_provider(
 }
 
 // ── Risk / Runtime presets ─────────────────────────────────────────
-
-fn apply_named_preset<K, W>(
-    config: &mut Config,
-    choice: &SelectorChoice<String>,
-    step: QuickstartStep,
-    list_existing: K,
-    write_preset: W,
-    errors: &mut Vec<QuickstartError>,
-    ctx: Option<&RunCtx>,
-) -> Option<String>
-where
-    K: Fn(&Config) -> Vec<String>,
-    W: Fn(&mut Config, &str) -> Result<String, String>,
-{
-    match choice {
-        SelectorChoice::Existing(alias) => {
-            if list_existing(config).iter().any(|a| a == alias) {
-                Some(alias.clone())
-            } else {
-                errors.push(QuickstartError::for_surface(
-                    ctx,
-                    step,
-                    "",
-                    format!("no `{alias}` profile configured"),
-                    "cli-quickstart-error-no-profile",
-                    &[("alias", alias)],
-                ));
-                None
-            }
-        }
-        SelectorChoice::Fresh(preset_name) => match write_preset(config, preset_name) {
-            Ok(alias) => Some(alias),
-            Err(msg) => {
-                errors.push(QuickstartError::new(step, "", msg));
-                None
-            }
-        },
-    }
-}
-
-fn risk_preset_keys(config: &Config) -> Vec<String> {
-    config.risk_profiles.keys().cloned().collect()
-}
 
 fn write_risk_preset(config: &mut Config, preset_name: &str) -> Result<String, String> {
     let preset =
@@ -1991,24 +1950,12 @@ mod tests {
     }
 
     #[test]
-    fn validate_only_rejects_unknown_risk_preset() {
+    fn validate_only_forces_yolo_risk_preset_ignoring_submission() {
         let cfg = Config::default();
         let mut submission = fresh_submission("bot");
         submission.risk_profile = SelectorChoice::Fresh("does-not-exist".into());
-        let errors = validate_only(&submission, &cfg).unwrap_err();
-        assert!(errors.iter().any(|e| e.step == QuickstartStep::RiskProfile));
-    }
-
-    #[test]
-    fn validate_only_accepts_every_builtin_risk_preset() {
-        let cfg = Config::default();
-        for p in zeroclaw_config::presets::RISK_PRESETS {
-            let mut submission = fresh_submission("bot");
-            submission.risk_profile = SelectorChoice::Fresh(p.preset_name.into());
-            validate_only(&submission, &cfg).unwrap_or_else(|e| {
-                panic!("risk preset `{}` failed validate: {e:?}", p.preset_name)
-            });
-        }
+        validate_only(&submission, &cfg)
+            .expect("submitted risk profile is ignored; apply forces the yolo preset");
     }
 
     /// Regression for the silent empty-form bug: `field_shape(ModelProvider,
@@ -2117,22 +2064,23 @@ mod tests {
 
     #[tokio::test]
     async fn fresh_preset_profiles_persist_to_disk() {
-        // The runtime profile picker was removed; apply silently forces the
-        // `unbounded` preset regardless of the submitted runtime value.
+        // The risk and runtime profile pickers were removed; apply silently
+        // forces the `yolo` risk preset and `unbounded` runtime preset
+        // regardless of the submitted values.
         let (dir, applied) = apply_to_temp(fresh_submission("bot")).await;
-        assert!(applied.risk_profiles.contains_key("balanced"));
+        assert!(applied.risk_profiles.contains_key("yolo"));
         assert!(applied.runtime_profiles.contains_key("unbounded"));
         let reloaded = reload(&dir);
         assert!(
-            reloaded.risk_profiles.contains_key("balanced"),
-            "risk_profiles.balanced must survive save_dirty + reload, not dangle"
+            reloaded.risk_profiles.contains_key("yolo"),
+            "risk_profiles.yolo must survive save_dirty + reload, not dangle"
         );
         assert!(
             reloaded.runtime_profiles.contains_key("unbounded"),
             "runtime_profiles.unbounded must survive save_dirty + reload, not dangle"
         );
         let agent = reloaded.agents.get("bot").expect("agent persisted");
-        assert_eq!(agent.risk_profile, "balanced");
+        assert_eq!(agent.risk_profile, "yolo");
         assert_eq!(agent.runtime_profile, "unbounded");
     }
 

--- a/crates/zeroclaw-runtime/src/quickstart/mod.rs
+++ b/crates/zeroclaw-runtime/src/quickstart/mod.rs
@@ -786,10 +786,6 @@ const PEER_GROUP_ESSENTIALS: &[&str] = &["channel", "external_peers", "agents", 
 /// picker was removed from every surface; apply always writes this preset.
 const FORCED_RUNTIME_PRESET: &str = "unbounded";
 
-/// Risk profile the Quickstart silently installs. The Risk Profile picker
-/// was removed from every surface; apply always writes this preset.
-const FORCED_RISK_PRESET: &str = "yolo";
-
 fn apply_into(
     config: &mut Config,
     submission: &BuilderSubmission,
@@ -805,13 +801,15 @@ fn apply_into(
         &provider_ref,
     );
 
-    let risk_alias = match write_risk_preset(config, FORCED_RISK_PRESET) {
-        Ok(alias) => alias,
-        Err(msg) => {
-            errors.push(QuickstartError::new(QuickstartStep::RiskProfile, "", msg));
-            return None;
-        }
-    };
+    let risk_alias = apply_named_preset(
+        config,
+        &submission.risk_profile,
+        QuickstartStep::RiskProfile,
+        risk_preset_keys,
+        write_risk_preset,
+        errors,
+        ctx,
+    )?;
     emit_selector_pick(
         ctx,
         "risk_profile",
@@ -1084,6 +1082,49 @@ fn apply_model_provider(
 }
 
 // ── Risk / Runtime presets ─────────────────────────────────────────
+
+fn apply_named_preset<K, W>(
+    config: &mut Config,
+    choice: &SelectorChoice<String>,
+    step: QuickstartStep,
+    list_existing: K,
+    write_preset: W,
+    errors: &mut Vec<QuickstartError>,
+    ctx: Option<&RunCtx>,
+) -> Option<String>
+where
+    K: Fn(&Config) -> Vec<String>,
+    W: Fn(&mut Config, &str) -> Result<String, String>,
+{
+    match choice {
+        SelectorChoice::Existing(alias) => {
+            if list_existing(config).iter().any(|a| a == alias) {
+                Some(alias.clone())
+            } else {
+                errors.push(QuickstartError::for_surface(
+                    ctx,
+                    step,
+                    "",
+                    format!("no `{alias}` profile configured"),
+                    "cli-quickstart-error-no-profile",
+                    &[("alias", alias)],
+                ));
+                None
+            }
+        }
+        SelectorChoice::Fresh(preset_name) => match write_preset(config, preset_name) {
+            Ok(alias) => Some(alias),
+            Err(msg) => {
+                errors.push(QuickstartError::new(step, "", msg));
+                None
+            }
+        },
+    }
+}
+
+fn risk_preset_keys(config: &Config) -> Vec<String> {
+    config.risk_profiles.keys().cloned().collect()
+}
 
 fn write_risk_preset(config: &mut Config, preset_name: &str) -> Result<String, String> {
     let preset =
@@ -1950,12 +1991,24 @@ mod tests {
     }
 
     #[test]
-    fn validate_only_forces_yolo_risk_preset_ignoring_submission() {
+    fn validate_only_rejects_unknown_risk_preset() {
         let cfg = Config::default();
         let mut submission = fresh_submission("bot");
         submission.risk_profile = SelectorChoice::Fresh("does-not-exist".into());
-        validate_only(&submission, &cfg)
-            .expect("submitted risk profile is ignored; apply forces the yolo preset");
+        let errors = validate_only(&submission, &cfg).unwrap_err();
+        assert!(errors.iter().any(|e| e.step == QuickstartStep::RiskProfile));
+    }
+
+    #[test]
+    fn validate_only_accepts_every_builtin_risk_preset() {
+        let cfg = Config::default();
+        for p in zeroclaw_config::presets::RISK_PRESETS {
+            let mut submission = fresh_submission("bot");
+            submission.risk_profile = SelectorChoice::Fresh(p.preset_name.into());
+            validate_only(&submission, &cfg).unwrap_or_else(|e| {
+                panic!("risk preset `{}` failed validate: {e:?}", p.preset_name)
+            });
+        }
     }
 
     /// Regression for the silent empty-form bug: `field_shape(ModelProvider,
@@ -2064,23 +2117,22 @@ mod tests {
 
     #[tokio::test]
     async fn fresh_preset_profiles_persist_to_disk() {
-        // The risk and runtime profile pickers were removed; apply silently
-        // forces the `yolo` risk preset and `unbounded` runtime preset
-        // regardless of the submitted values.
+        // The runtime profile picker was removed; apply silently forces the
+        // `unbounded` preset regardless of the submitted runtime value.
         let (dir, applied) = apply_to_temp(fresh_submission("bot")).await;
-        assert!(applied.risk_profiles.contains_key("yolo"));
+        assert!(applied.risk_profiles.contains_key("balanced"));
         assert!(applied.runtime_profiles.contains_key("unbounded"));
         let reloaded = reload(&dir);
         assert!(
-            reloaded.risk_profiles.contains_key("yolo"),
-            "risk_profiles.yolo must survive save_dirty + reload, not dangle"
+            reloaded.risk_profiles.contains_key("balanced"),
+            "risk_profiles.balanced must survive save_dirty + reload, not dangle"
         );
         assert!(
             reloaded.runtime_profiles.contains_key("unbounded"),
             "runtime_profiles.unbounded must survive save_dirty + reload, not dangle"
         );
         let agent = reloaded.agents.get("bot").expect("agent persisted");
-        assert_eq!(agent.risk_profile, "yolo");
+        assert_eq!(agent.risk_profile, "balanced");
         assert_eq!(agent.runtime_profile, "unbounded");
     }
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Redefines the `Balanced` risk preset as the trusted-local daily driver. It stays Supervised, workspace-scoped with sensitive paths blocked, and sandboxed, but drops the medium-risk approval prompts and the shell allowlist so routine commands run without ceremony.
  - High-risk commands stay blocked. `allowed_commands` is `["*"]`, but the wildcard is not an explicit allowlist exemption and `block_high_risk_commands` stays `true`, so a high-risk command matched only by `*` is blocked outright at execution (it never reaches the approval branch), even with `approved = true`. It runs only if explicitly allowlisted.
  - Decouples `Balanced` from the schema default. The default (a config with no risk profile) keeps the conservative schema-default shape (the old Balanced); only the named `Balanced` preset moves.
  - Reverts the prior force-yolo Quickstart commit on this branch. The new direction redefines a preset rather than forcing one at onboarding.
- **Scope boundary:** Does NOT change `Locked Down` or `YOLO`. Does NOT touch the Quickstart onboarding flow or any runtime profile. The schema `Default::default()` is unchanged. One row plus one factory in `RISK_PRESETS`.
- **Blast radius:** Any surface that instantiates the `balanced` preset gets the new shape: Supervised, no allowlist, high-risk blocked unless explicitly allowlisted, sandbox on. Every surface reads the preset registry, so there is one source of truth and no hardcoded copies to drift. Existing configs that already pinned an explicit risk profile are untouched.
- **Linked issue(s):** Related #8133
- **Labels:** `risk: medium`, `size: S`

## Validation Evidence (required)

```bash
cargo fmt -p zeroclaw-config -- --check
cargo clippy -p zeroclaw-config --all-targets -- -D warnings
cargo test -p zeroclaw-config presets
```

- **Commands run and tail output:**
  - `cargo fmt` clean.
  - `cargo clippy ... -D warnings`: `Finished dev profile ... target(s)`, no warnings.
  - `cargo test ... presets`:
    ```
    test presets::tests::balanced_risk_is_trusted_local_shape ... ok
    test presets::tests::balanced_risk_allows_routine_commands_but_gates_high_risk ... ok
    test presets::tests::balanced_runtime_matches_schema_default ... ok
    test result: ok. 12 passed; 0 failed; 0 ignored
    ```
- **Beyond CI, what did you manually verify?** Confirmed the net branch diff against master is `presets.rs` only and the force-yolo change is fully reverted (no Quickstart diff remains). Confirmed no docs page describes a named `Balanced` preset, so the preset `help` field is the sole self-describing source and no docs SSOT drifts.
- **If any command was intentionally skipped, why:** Full-workspace `cargo test` deferred to CI; the change is isolated to one config crate with direct unit coverage.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `Yes`. The `Balanced` preset now permits any shell command without an allowlist. Specifically, commands the old curated allowlist excluded now pass the allowlist check, including `curl`, `wget`, `bash`, `sh`, `chmod`, `chown`, and `kill`; each is blocked outright if the runtime classifies it high-risk, since `block_high_risk_commands` stays `true` and `*` is not an explicit exemption. Mitigation: it stays Supervised and workspace-scoped with sensitive paths blocked, the sandbox stays on, and high-risk commands are hard-blocked (not merely prompted) unless explicitly allowlisted.
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes` for existing configs that pin a risk profile; they are unaffected. The `balanced` preset selection now yields a different (more permissive on medium-risk, high-risk hard-blocked unless explicitly allowlisted) profile.
- Config / env / CLI surface changed? `No` new surface. The semantics of selecting the existing `balanced` preset change.
- Upgrade steps: Users who selected `Balanced` and want the old stricter behavior should select `Locked Down`, the closest existing conservative preset (it carries the curated allowlist plus medium-risk approval). A dedicated `Guarded` middle preset is tracked as follow-up.

## Rollback (required for `risk: medium`)

- **Fast rollback command/path:** `git revert 21f580f2e8`
- **Feature flags or config toggles:** None. Selecting `Locked Down` restores a conservative allowlist-plus-medium-risk-approval shape.
- **Observable failure symptoms:** A `Balanced` host running a wildcard-matched high-risk command at all (it should be blocked), or a host blocking routine commands it should now allow. Grep onboarding/preset logs for the resolved `balanced` profile fields.


