### PR TITLE
fix(runtime): drop dangling tool intent from cancelled ACP turns

### DIFF
--- a/crates/zeroclaw-runtime/src/rpc/dispatch.rs
+++ b/crates/zeroclaw-runtime/src/rpc/dispatch.rs
@@ -20,7 +20,7 @@ use zeroclaw_api::jsonrpc::{
     JSONRPC_VERSION, JsonRpcError, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse,
     RpcOutbound,
 };
-use zeroclaw_api::model_provider::ChatMessage;
+use zeroclaw_api::model_provider::{ChatMessage, ConversationMessage};
 
 /// Wire protocol version. Bump on breaking changes.
 pub const RPC_PROTOCOL_VERSION: u64 = 1;
@@ -324,6 +324,29 @@ fn model_provider_ref_from_provider_profile_prop(prop: &str) -> Option<String> {
     } else {
         Some(format!("{provider_type}.{provider_alias}"))
     }
+}
+
+/// Strip a trailing assistant tool intent that a cancel truncated before its
+/// results arrived. A cancelled turn persists whatever accumulated in history;
+/// if the cancel fired between the assistant emitting tool calls and the tool
+/// loop producing `ToolResults`, the slice ends on an `AssistantToolCalls`
+/// whose calls have no matching results. Persisting that teaches the next turn
+/// the work succeeded, so the model reports fabricated results. Returns the
+/// number of trailing messages removed.
+fn sanitize_cancelled_turn(messages: &mut Vec<ConversationMessage>) -> usize {
+    let before = messages.len();
+    while let Some(last) = messages.last() {
+        let dangling = match last {
+            ConversationMessage::AssistantToolCalls { tool_calls, .. } => !tool_calls.is_empty(),
+            _ => false,
+        };
+        if dangling {
+            messages.pop();
+        } else {
+            break;
+        }
+    }
+    before - messages.len()
 }
 
 /// Per-connection dispatcher. Shared state lives in [`RpcContext`].
@@ -1540,35 +1563,57 @@ impl RpcDispatcher {
                         outcome,
                         Ok(TurnOutcome::Completed { .. }) | Ok(TurnOutcome::Cancelled { .. })
                     )
-                    && let Some(new_msgs) = self
+                    && let Some(mut new_msgs) = self
                         .ctx
                         .sessions
                         .history_slice_from(sid, pre_history_len)
                         .await
-                    && !new_msgs.is_empty()
                 {
-                    let store = store.clone();
-                    let sid_owned = sid.to_string();
-                    let persisted = tokio::task::spawn_blocking(move || {
-                        store.append_turn(&sid_owned, &new_msgs)
-                    })
-                    .await;
-                    let error = match persisted {
-                        Ok(Ok(())) => None,
-                        Ok(Err(e)) => Some(e.to_string()),
-                        Err(join) => Some(join.to_string()),
-                    };
-                    if let Some(detail) = error {
-                        ::zeroclaw_log::record!(
-                            WARN,
-                            ::zeroclaw_log::Event::new(
-                                module_path!(),
-                                ::zeroclaw_log::Action::Note
-                            )
-                            .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                            .with_attrs(::serde_json::json!({"session_id": sid, "error": detail})),
-                            "Failed to persist ACP turn"
-                        );
+                    if matches!(outcome, Ok(TurnOutcome::Cancelled { .. })) {
+                        let dropped = sanitize_cancelled_turn(&mut new_msgs);
+                        if dropped > 0 {
+                            ::zeroclaw_log::record!(
+                                INFO,
+                                ::zeroclaw_log::Event::new(
+                                    module_path!(),
+                                    ::zeroclaw_log::Action::Note
+                                )
+                                .with_category(::zeroclaw_log::EventCategory::Agent)
+                                .with_outcome(::zeroclaw_log::EventOutcome::Success)
+                                .with_attrs(::serde_json::json!({
+                                    "session_id": sid,
+                                    "dropped_messages": dropped,
+                                })),
+                                "dropped dangling tool intent from cancelled turn before persisting"
+                            );
+                        }
+                    }
+                    if !new_msgs.is_empty() {
+                        let store = store.clone();
+                        let sid_owned = sid.to_string();
+                        let persisted = tokio::task::spawn_blocking(move || {
+                            store.append_turn(&sid_owned, &new_msgs)
+                        })
+                        .await;
+                        let error = match persisted {
+                            Ok(Ok(())) => None,
+                            Ok(Err(e)) => Some(e.to_string()),
+                            Err(join) => Some(join.to_string()),
+                        };
+                        if let Some(detail) = error {
+                            ::zeroclaw_log::record!(
+                                WARN,
+                                ::zeroclaw_log::Event::new(
+                                    module_path!(),
+                                    ::zeroclaw_log::Action::Note
+                                )
+                                .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                                .with_attrs(
+                                    ::serde_json::json!({"session_id": sid, "error": detail})
+                                ),
+                                "Failed to persist ACP turn"
+                            );
+                        }
                     }
                 }
             }
@@ -3606,6 +3651,56 @@ fn notification_for_turn_event(
 mod tests {
     use super::*;
     use serde_json::json;
+
+    use zeroclaw_api::model_provider::{ToolCall, ToolResultMessage};
+
+    fn assistant_tool_call(id: &str) -> ConversationMessage {
+        ConversationMessage::AssistantToolCalls {
+            text: Some("written to tmp/foo.md".into()),
+            tool_calls: vec![ToolCall {
+                id: id.into(),
+                name: "file_write".into(),
+                arguments: "{}".into(),
+                extra_content: None,
+            }],
+            reasoning_content: None,
+        }
+    }
+
+    #[test]
+    fn sanitize_drops_trailing_dangling_tool_call() {
+        let mut msgs = vec![
+            ConversationMessage::Chat(ChatMessage::user("do it")),
+            assistant_tool_call("toolu_1"),
+        ];
+        let dropped = sanitize_cancelled_turn(&mut msgs);
+        assert_eq!(dropped, 1);
+        assert_eq!(msgs.len(), 1);
+    }
+
+    #[test]
+    fn sanitize_keeps_resolved_tool_call() {
+        let mut msgs = vec![
+            assistant_tool_call("toolu_1"),
+            ConversationMessage::ToolResults(vec![ToolResultMessage {
+                tool_call_id: "toolu_1".into(),
+                content: "ok".into(),
+            }]),
+        ];
+        let dropped = sanitize_cancelled_turn(&mut msgs);
+        assert_eq!(dropped, 0);
+        assert_eq!(msgs.len(), 2);
+    }
+
+    #[test]
+    fn sanitize_keeps_plain_assistant_text() {
+        let mut msgs = vec![ConversationMessage::Chat(ChatMessage::assistant(
+            "just text",
+        ))];
+        let dropped = sanitize_cancelled_turn(&mut msgs);
+        assert_eq!(dropped, 0);
+        assert_eq!(msgs.len(), 1);
+    }
 
     fn parse(s: &str) -> Value {
         serde_json::from_str(s).unwrap()


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - The ACP/RPC dispatcher (`crates/zeroclaw-runtime/src/rpc/dispatch.rs`)
    persists a turn's accumulated history via `append_turn` on **both**
    `TurnOutcome::Completed` and `TurnOutcome::Cancelled`. When a cancel
    (`cancel_cause: client_rpc`) fires between the assistant emitting tool calls
    and the tool loop producing `ToolResults`, the persisted slice ends on an
    `AssistantToolCalls` whose calls have no matching results.
  - That dangling tool intent is written to ACP history as a clean turn. On the
    next turn the model rehydrates its own history, reads the unresolved tool
    call as completed work, and reports fabricated results (for example claiming
    a file was written when no `file_write` ever ran). Sessions with frequent
    client cancels compound this across turns.
  - Add `sanitize_cancelled_turn`: on `Cancelled`, strip trailing
    `AssistantToolCalls` groups with no matching results before `append_turn`,
    and attributed-log the count dropped. `Completed` turns are untouched.
- **Scope boundary:** Does not change the trim budgets, the channel-path
  `proactive_trim_turns` (that is #8050), `preflight_history_maintenance`,
  `context_compression`, or the `Chat`-mode session backend persistence. Only
  the ACP cancel persistence slice is sanitized; completed-turn persistence is
  unchanged.
- **Blast radius:** ACP/RPC inbound path only, cancel branch only. Completed
  turns persist exactly as before. The sanitizer mutates the transient history
  slice copy returned by `history_slice_from`, never the live agent history.
- **Linked issue(s):** Related #8050 (channel-path analogue; different layer,
  did not reach `dispatch.rs`). Related #6517.
- **Labels:** suggested `bug`, `runtime`, `risk: medium`, `size: S`.

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- **Commands run and tail output:**
  ```
  [PASS] cargo fmt --all -- --check          (exit 0, no diff)
  [PASS] cargo clippy --all-targets -D warnings  (Finished; 0 warnings, 0 errors)
  [PASS] cargo test -p zeroclaw-runtime
         test result: ok. 2346 passed; 0 failed; 2 ignored
  ```
  New unit tests in `rpc::dispatch::tests`:
  - `sanitize_drops_trailing_dangling_tool_call` (drops the unresolved intent)
  - `sanitize_keeps_resolved_tool_call` (tool call + matching results untouched)
  - `sanitize_keeps_plain_assistant_text` (plain assistant prose untouched)
- **Beyond CI — what did you manually verify?** Diagnosed a live broken session
  (`f84c05d`) by cross-referencing the runtime trace, the ACP session DB, and
  upstream/master source. Confirmed the DB held a `complete/success` assistant
  message claiming a file write with zero attached tool calls, and that the
  claimed file was absent from the session workspace. Confirmed the persistence
  site at `dispatch.rs` writes cancelled slices verbatim, and that #8050 only
  touched `zeroclaw-channels` so it could not address this path. Did not run a
  full end-to-end ACP cancel reproduction under load.
- **If any command was intentionally skipped, why:** Web/shell batteries skipped
  (no `.ts`/`.sh` changes).

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: no upgrade steps required. Existing persisted
  history is unchanged; only future cancelled turns are sanitized.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <sha>`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Renewed ACP fabrication after cancels (model
  claims tool results that never executed); grep logs for the new INFO note
  "dropped dangling tool intent from cancelled turn before persisting" to
  confirm the path is active. A regression in the other direction would drop
  legitimate trailing tool calls from a turn that was actually completing.
