### PR TITLE
test(self_test): add memory roundtrip test

### DIFF
--- a/src/commands/self_test.rs
+++ b/src/commands/self_test.rs
@@ -585,4 +585,12 @@ mod tests {
             "ws://127.0.0.1:42617/ws/chat"
         );
     }
+
+    #[tokio::test]
+    async fn check_memory_roundtrip_with_default_config() {
+        let config = crate::config::Config::default();
+        let result = check_memory_roundtrip(&config).await;
+        // Memory roundtrip should succeed with default config
+        assert!(result.passed, "memory roundtrip should pass with default config");
+    }
 }


### PR DESCRIPTION
Add a test for the check_memory_roundtrip function to verify that the memory backend can successfully store and recall entries with the default configuration.