### PR TITLE
test(self_test): add sqlite check test

### DIFF
--- a/src/commands/self_test.rs
+++ b/src/commands/self_test.rs
@@ -585,4 +585,12 @@ mod tests {
             "ws://127.0.0.1:42617/ws/chat"
         );
     }
+
+    #[test]
+    fn check_sqlite_with_temp_directory() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let result = check_sqlite(temp_dir.path());
+        // SQLite should be able to create and open a new database file
+        assert!(result.passed, "sqlite check should pass with writable directory");
+    }
 }


### PR DESCRIPTION
Add a test for the check_sqlite function to verify that SQLite can open and query a database file in the workspace directory.