### PR TITLE
test(self_test): add config check test

### DIFF
--- a/src/commands/self_test.rs
+++ b/src/commands/self_test.rs
@@ -585,4 +585,13 @@ mod tests {
             "ws://127.0.0.1:42617/ws/chat"
         );
     }
+
+    #[test]
+    fn check_config_with_default_config() {
+        let config = crate::config::Config::default();
+        let result = check_config(&config);
+        // Default config should fail since no config file exists
+        assert!(!result.passed, "default config should not have a config file");
+        assert_eq!(result.detail, "config file not found (using defaults)");
+    }
 }


### PR DESCRIPTION
Add a test for the check_config function to verify that the default configuration correctly reports when no config file exists.