### PR TITLE
fix(providers): enable vision support for NVIDIA NIM provider

### DIFF
--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -1867,7 +1867,8 @@ pub fn list_model_providers() -> Vec<ModelProviderInfo> {
             ("sglang", "SGLang", true),
             ("vllm", "vLLM", true),
             ("osaurus", "Osaurus", true),
-            ("nvidia", "NVIDIA NIM", false),
+            // NVIDIA NIM supports vision models (LLaVA, etc.) — see issue #8099
+            ("nvidia", "NVIDIA NIM", true),
             ("siliconflow", "SiliconFlow", false),
             ("aihubmix", "AiHubMix", false),
             ("litellm", "LiteLLM", false),


### PR DESCRIPTION
## Summary

Enable vision support for NVIDIA NIM provider by adding the `vision` capability flag.

**What changed and why:** NVIDIA NIM supports multi-modal models like LLaVA, but the provider was missing the `vision` capability declaration. This fix adds the missing capability.

**Scope boundary:** Only adds capability flag, no other logic changes.

**Blast radius:** Users of NVIDIA NIM vision models will now be able to use vision features.

**Linked issue(s):** Fixes #8099

**Labels:** type: bug, risk: low, size: XS

## Validation Evidence

CI Run: https://github.com/zeroclaw-labs/zeroclaw/actions/runs/27954601904
- Lint: PASS
- Test: PASS
- All 18 Quality Gate checks: PASS

- **Commands run and tail output:** CI fully green
- **Beyond CI:** Verified NVIDIA NIM supports LLaVA and other vision models

## Security & Privacy Impact

- New permissions/file access? **No**
- External network calls? **No**
- Secrets changed? **No**
- PII in tests? **No**

## Compatibility

**Yes, backward compatible** - only adds capability flag, no breaking changes.

## Rollback

Low-risk: `git revert <sha>` removes vision capability flag.