### PR TITLE
ci(workflows): add Trivy container scanning for PR and release images

### DIFF
--- a/.github/workflows/docker-image-pr.yml
+++ b/.github/workflows/docker-image-pr.yml
@@ -32,11 +32,40 @@ jobs:
       - name: Prepare Docker smoke context
         run: bash scripts/ci/prepare_docker_context.sh smoke docker-ctx
 
+      - name: Cache Trivy vulnerability database
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/.cache/trivy
+          key: trivy-db-${{ runner.os }}-${{ hashFiles('.github/workflows/docker-image-pr.yml') }}
+          restore-keys: |
+            trivy-db-${{ runner.os }}-
+
       - name: Build default image
         run: docker build -f docker-ctx/Dockerfile -t zeroclaw-pr-default:smoke docker-ctx
 
+      # Scans the CI smoke image, not the production source Dockerfile. Trivy is
+      # report-only during baseline rollout, so findings are logged but do not
+      # fail the PR workflow yet.
+      - name: Scan default image with Trivy
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          skip-dirs: /usr/share/zoneinfo
+          image-ref: zeroclaw-pr-default:smoke
+          format: table
+          exit-code: 0
+          severity: HIGH,CRITICAL
+
       - name: Build Debian compatibility image
         run: docker build -f docker-ctx/Dockerfile.debian -t zeroclaw-pr-debian:smoke docker-ctx
+
+      - name: Scan Debian image with Trivy
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          skip-dirs: /usr/share/zoneinfo
+          image-ref: zeroclaw-pr-debian:smoke
+          format: table
+          exit-code: 0
+          severity: HIGH,CRITICAL
 
   # Compiles the real source Dockerfiles (not the pre-built-binary `*.ci`
   # variants above). The default `Dockerfile` is built for both published

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,10 +22,8 @@ concurrency:
 
 permissions:
   contents: read
-  packages: write
-  # OIDC (`id-token: write`) is granted at the `publish` job level only — the
-  # `matrix` resolution job does not perform keyless signing and should not
-  # inherit OIDC minting.
+  # OIDC, package write, and security-events permissions are granted only to
+  # the jobs that need them.
 
 env:
   REGISTRY: ghcr.io
@@ -52,12 +50,11 @@ jobs:
     if: github.repository == 'zeroclaw-labs/zeroclaw'
     needs: [matrix]
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 60
     permissions:
       contents: read
       packages: write
       id-token: write   # required for keyless cosign OIDC signing of container images
-      security-events: write
     strategy:
       fail-fast: false
       matrix:
@@ -107,6 +104,27 @@ jobs:
           cosign sign --yes \
             "${{ env.REGISTRY }}/${{ env.IMAGE }}@${DIGEST}"
 
+  scan:
+    name: Scan ${{ matrix.stem }}
+    if: github.repository == 'zeroclaw-labs/zeroclaw'
+    needs: [matrix, publish]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.matrix.outputs.include) }}
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Scan pinned tag with Trivy
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
@@ -117,8 +135,35 @@ jobs:
           exit-code: 0
           severity: HIGH,CRITICAL
 
+      - name: Upload Trivy SARIF artifact
+        if: always() && hashFiles('trivy-results.sarif') != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: trivy-results-${{ matrix.stem }}
+          path: trivy-results.sarif
+          if-no-files-found: error
+          retention-days: 14
+
+  upload-sarif:
+    name: Upload SARIF ${{ matrix.stem }}
+    if: github.repository == 'zeroclaw-labs/zeroclaw'
+    needs: [matrix, scan]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.matrix.outputs.include) }}
+    steps:
+      - name: Download Trivy SARIF artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: trivy-results-${{ matrix.stem }}
+
       - name: Upload Trivy SARIF to GitHub Security tab
         uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
-        if: always() && hashFiles('trivy-results.sarif') != ''
         with:
           sarif_file: trivy-results.sarif

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,6 +5,10 @@ name: Docker Publish
 # dev/ci/docker-tags.toml; this workflow consumes it so published tags can never
 # drift from the spec. Each entry produces an immutable version-pinned tag
 # (Alpine-style `<stem>-v<version>`) and a floating tag (`<stem>`).
+#
+# Images are pushed with the canonical platform matrix first, signed by digest,
+# then the pinned tag is scanned in report-only mode (exit-code: 0). Enforcement
+# flips in a follow-up after the baseline is triaged.
 
 on:
   push:
@@ -45,13 +49,15 @@ jobs:
 
   publish:
     name: Build & push ${{ matrix.stem }}
+    if: github.repository == 'zeroclaw-labs/zeroclaw'
     needs: [matrix]
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     permissions:
       contents: read
       packages: write
       id-token: write   # required for keyless cosign OIDC signing of container images
+      security-events: write
     strategy:
       fail-fast: false
       matrix:
@@ -100,3 +106,19 @@ jobs:
         run: |
           cosign sign --yes \
             "${{ env.REGISTRY }}/${{ env.IMAGE }}@${DIGEST}"
+
+      - name: Scan pinned tag with Trivy
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          skip-dirs: /usr/share/zoneinfo
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ matrix.pinned_tag }}
+          format: sarif
+          output: trivy-results.sarif
+          exit-code: 0
+          severity: HIGH,CRITICAL
+
+      - name: Upload Trivy SARIF to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
+        if: always() && hashFiles('trivy-results.sarif') != ''
+        with:
+          sarif_file: trivy-results.sarif

--- a/docs/book/src/maintainers/ci-and-actions.md
+++ b/docs/book/src/maintainers/ci-and-actions.md
@@ -133,8 +133,8 @@ All third-party refs are pinned to a full commit SHA with a trailing version com
 | `actions/checkout` (`v6.0.2`) | Most workflows | Repository checkout |
 | `actions/cache` (`v4.2.3`, `v5.0.5`) | `docker-image-pr.yml`, `tweet-release.yml` | Generic dependency and Trivy database caching |
 | `actions/setup-node` (`v6.4.0`) | `release-stable-manual.yml`, `cross-platform-build-manual.yml` | Node toolchain for the web-dashboard build |
-| `actions/upload-artifact` (`v7.0.1`) | `release-stable-manual.yml`, `cross-platform-build-manual.yml` | Upload build artifacts |
-| `actions/download-artifact` (`v8.0.1`) | `release-stable-manual.yml`, `cross-platform-build-manual.yml` | Download build artifacts for packaging |
+| `actions/upload-artifact` (`v7.0.1`) | `release-stable-manual.yml`, `cross-platform-build-manual.yml`, `docker-publish.yml` | Upload build artifacts and Trivy SARIF handoff artifacts |
+| `actions/download-artifact` (`v8.0.1`) | `release-stable-manual.yml`, `cross-platform-build-manual.yml`, `docker-publish.yml` | Download build artifacts and Trivy SARIF handoff artifacts |
 | `actions/labeler` (`v6.1.0`) | `pr-path-labeler.yml` | Apply path/scope labels from `.github/labeler.yml` |
 | `dtolnay/rust-toolchain` (`stable`) | `ci.yml`, `release-stable-manual.yml`, `cross-platform-build-manual.yml`, `cross-platform-clippy.yml`, `daily-audit.yml`, `docs-deploy.yml` | Install Rust toolchain |
 | `Swatinem/rust-cache` (`v2.9.1`) | `ci.yml`, `release-stable-manual.yml`, `cross-platform-build-manual.yml`, `cross-platform-clippy.yml`, `docs-deploy.yml` | Cargo build/dependency caching |

--- a/docs/book/src/maintainers/ci-and-actions.md
+++ b/docs/book/src/maintainers/ci-and-actions.md
@@ -131,7 +131,7 @@ All third-party refs are pinned to a full commit SHA with a trailing version com
 | Action | Used in | Purpose |
 |---|---|---|
 | `actions/checkout` (`v6.0.2`) | Most workflows | Repository checkout |
-| `actions/cache` (`v5.0.5`) | `tweet-release.yml` | Generic dependency caching |
+| `actions/cache` (`v4.2.3`, `v5.0.5`) | `docker-image-pr.yml`, `tweet-release.yml` | Generic dependency and Trivy database caching |
 | `actions/setup-node` (`v6.4.0`) | `release-stable-manual.yml`, `cross-platform-build-manual.yml` | Node toolchain for the web-dashboard build |
 | `actions/upload-artifact` (`v7.0.1`) | `release-stable-manual.yml`, `cross-platform-build-manual.yml` | Upload build artifacts |
 | `actions/download-artifact` (`v8.0.1`) | `release-stable-manual.yml`, `cross-platform-build-manual.yml` | Download build artifacts for packaging |
@@ -144,6 +144,8 @@ All third-party refs are pinned to a full commit SHA with a trailing version com
 | `sigstore/cosign-installer` (`v3.8.1`) | `release-stable-manual.yml`, `docker-publish.yml` | Install cosign for keyless signing of release assets and container images |
 | `anchore/sbom-action` (`v0.17.9`) | `release-stable-manual.yml` | Generate SPDX + CycloneDX SBOMs for each release |
 | `slsa-framework/slsa-github-generator` (`v2.1.0`) | `release-stable-manual.yml` | Reusable workflow that produces SLSA L2 provenance for release artifacts |
+| `aquasecurity/trivy-action` (`v0.36.0`) | `docker-image-pr.yml`, `docker-publish.yml` | Report-only container vulnerability scanning |
+| `github/codeql-action/upload-sarif` (`v3.36.2`) | `docker-publish.yml` | Upload Trivy SARIF reports to the Security tab |
 
 The GitHub Release itself is created with `gh release create` inside the `publish` job, not a release action.
 
@@ -157,6 +159,8 @@ docker/*
 sigstore/cosign-installer@*
 anchore/sbom-action@*
 slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@*
+aquasecurity/trivy-action@*
+github/codeql-action/upload-sarif@*
 ```
 
 Export the current effective policy:


### PR DESCRIPTION
## Summary

- **Base branch:** `master`.
- **What changed and why:**
  - Adds report-only Trivy scans for Docker PR smoke images so container CVE findings are visible before release without blocking the current baseline rollout.
  - Adds report-only Trivy SARIF upload for release image tags so GitHub Security has a baseline/trend trail for published container images.
  - Preserves the current Docker source-image platform matrix and release `matrix.platforms` publish behavior after refreshing against current `master`.
  - Documents the selected-actions allowlist impact for Trivy, SARIF upload, and the new Trivy DB cache use.
- **Scope boundary:** Does not enforce container CVE failures yet (`exit-code: 0`), does not add a new workflow file, does not change Rust/Node code, does not change generated Docker tag data, and does not narrow published Docker platform coverage.
- **Blast radius:** GitHub Actions Docker PR/release workflows and maintainer CI documentation. Release workflow gains `security-events: write` for SARIF upload; PR workflow gains a Trivy DB cache step.
- **Linked issue(s):** Related #7675.
- **Labels:** `enhancement`, `ci`, `docs`, `domain:ci`, `domain:security`, `risk:high`, `size:S`, `type:ci`.

## Validation Evidence (required)

- **Commands run and tail output:**

```bash
git log --oneline origin/master..HEAD
```

```text
de1afa7c6f fix(ci): split trivy sarif upload
f75d74de07 ci(workflows): add Trivy container scanning for PR and release images
```

```bash
git diff --stat origin/master...HEAD
```

```text
 .github/workflows/docker-image-pr.yml       | 29 +++++++++++
 .github/workflows/docker-publish.yml        | 75 +++++++++++++++++++++++++++--
 docs/book/src/maintainers/ci-and-actions.md | 10 ++--
 3 files changed, 107 insertions(+), 7 deletions(-)
```

```bash
uv run --with pyyaml python - <<'PY'
from pathlib import Path
import yaml
for name in ['.github/workflows/docker-image-pr.yml', '.github/workflows/docker-publish.yml']:
    yaml.safe_load(Path(name).read_text())
    print(f'{name}: yaml ok')
PY
```

```text
.github/workflows/docker-image-pr.yml: yaml ok
.github/workflows/docker-publish.yml: yaml ok
```

```bash
git diff --check origin/master...HEAD
```

```text
(no output)
```

```bash
content search checks
```

```text
No conflict markers found.
No stale bad actions/cache SHA found.
No load: true release path found.
No old split docker push steps found.
```

- **Beyond CI — what did you manually verify?**
  - Verified `actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3` is used for the Trivy DB cache instead of the unresolvable typo SHA.
  - Verified the Docker PR source-image matrix still covers `Dockerfile` on `linux/amd64` and `linux/arm64`, plus `Dockerfile.debian` on `linux/amd64`.
  - Verified `docker-publish.yml` keeps `push: true` and `platforms: ${{ matrix.platforms }}`; the stale `load: true` single-platform publish path is not present.
  - Verified `docker-publish.yml` keeps the keyless cosign signing path, then splits report-only Trivy scanning and SARIF upload into separate jobs with narrower permissions.
  - Verified Trivy remains report-only with `exit-code: 0` in both workflows.
  - Verified allowlist docs include `actions/cache` for `docker-image-pr.yml`, `actions/upload-artifact` / `actions/download-artifact` for the SARIF handoff, `aquasecurity/trivy-action`, `github/codeql-action/upload-sarif`, and equivalent selected-actions patterns for the new action sources.
- **If any command was intentionally skipped, why:** Full Rust `cargo fmt`, `cargo clippy`, and `cargo test` were not run because this PR only changes GitHub Actions YAML and maintainer documentation. The Docker workflow itself was not simulated locally; GitHub Actions will validate the real Docker jobs after the rebased branch is pushed.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `Yes` — `docker-publish.yml` adds a separate `upload-sarif` job with `security-events: write` so SARIF output from Trivy can be uploaded to the GitHub Security tab. The `publish` job keeps GHCR write plus OIDC for signing, and the `scan` job only needs package read access.
- New external network calls? `Yes` — Trivy downloads vulnerability database data and scans image references; the PR workflow caches `~/.cache/trivy` with `actions/cache` to reduce repeat downloads.
- Secrets / tokens / credentials handling changed? `No` — the release workflow continues using the automatic `GITHUB_TOKEN`; no new repository secret is introduced.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`.
- If any `Yes`, describe the risk and mitigation: The new actions are pinned to full commit SHAs with version comments and documented in the selected-actions allowlist table/patterns. Scans are report-only during baseline rollout, so they surface findings without blocking releases until the baseline is triaged.

## Compatibility (required)

- Backward compatible? `Yes`.
- Config / env / CLI surface changed? `No`.
- If `No` or `Yes` to either: Existing users do not need migration steps. Published Docker platform coverage is preserved through `matrix.platforms`; this only adds report-only scanning and SARIF upload around existing Docker workflows.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <merge_commit_sha>` restores the Docker workflow and CI docs changes.
- **Feature flags or config toggles:** Disable `docker-image-pr.yml`/`docker-publish.yml` from GitHub Actions UI if an incident occurs before revert; otherwise revert the workflow changes.
- **Observable failure symptoms:** Docker Image PR Check fails before build/scan, release `docker-publish.yml` fails on Trivy scan, SARIF artifact handoff, or SARIF upload, missing SARIF file warnings, selected-actions policy blocks `aquasecurity/trivy-action`, `github/codeql-action/upload-sarif`, or the artifact handoff actions, or release image tags fail to publish.

#8057
