### PR TITLE
fix(tests): make screenshot expectations platform-aware

### DIFF
--- a/crates/zeroclaw-tools/src/screenshot.rs
+++ b/crates/zeroclaw-tools/src/screenshot.rs
@@ -317,6 +317,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     fn screenshot_command_contains_output_path() {
         let cmd = ScreenshotTool::screenshot_command("/tmp/my_screenshot.png").unwrap();
         let joined = cmd.join(" ");
@@ -324,5 +325,11 @@ mod tests {
             joined.contains("/tmp/my_screenshot.png"),
             "Command should contain the output path"
         );
+    }
+
+    #[test]
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    fn screenshot_command_is_unsupported_on_other_platforms() {
+        assert!(ScreenshotTool::screenshot_command("screenshot.png").is_none());
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Limits the screenshot command output-path assertion to platforms where `ScreenshotTool::screenshot_command(...)` returns a supported command.
  - Adds an explicit unsupported-platform regression test that expects `screenshot_command(...)` to return `None`.
  - Removes the Windows failure mode where this unit test unwrapped `None` even though screenshots are not currently supported there.
- **Scope boundary:** This PR only covers the screenshot test/platform expectation gap from #7462. It does not add Windows screenshot support, change screenshot runtime behavior, or address the remaining updater, console-encoding, path-semantics, or CI-matrix work.
- **Blast radius:** Test-only change in `zeroclaw-tools` screenshot coverage. Runtime behavior is unchanged.
- **Linked issue(s):** Related #7462. Related #7461.
- **Labels:** `bug`, `risk: high`, `size: XS`, `tool`, `tool:browser`

## Validation Evidence (required)

- **Commands run and tail output:**

```text
cargo fmt -p zeroclaw-tools -- --check
result: passed

cargo test -p zeroclaw-tools screenshot --lib
running 7 tests
test screenshot::tests::screenshot_command_exists ... ok
test screenshot::tests::screenshot_command_contains_output_path ... ok
test screenshot::tests::screenshot_tool_name ... ok
test screenshot::tests::screenshot_tool_description ... ok
test screenshot::tests::screenshot_tool_spec ... ok
test screenshot::tests::screenshot_tool_schema ... ok
test screenshot::tests::screenshot_rejects_shell_injection_filename ... ok
test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 1330 filtered out

cargo clippy -p zeroclaw-tools --lib -- -D warnings
result: passed

git diff --check
result: passed
```

- **Beyond CI — what did you manually verify?** Confirmed the diff is limited to `crates/zeroclaw-tools/src/screenshot.rs` and that the new unsupported-platform expectation matches the existing `screenshot_command` implementation.
- **If any command was intentionally skipped, why:** Workspace-wide clippy and nextest were not run locally for this test-only XS slice; the focused `zeroclaw-tools` test and clippy coverage exercise the touched module.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: `N/A`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: `N/A`

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <merge-sha>`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Screenshot-focused unit tests fail on unsupported platforms, especially Windows, while runtime screenshot behavior remains unchanged.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): `N/A`
- Scope materially carried forward: `N/A`
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why (inspiration-only, no direct code/design carry-over): No superseded PR or contributor-authored code is carried forward.
