### PR TITLE
docs(developing): define external integration boundary

### DIFF
--- a/docs/book/src/developing/first-party-extensions.md
+++ b/docs/book/src/developing/first-party-extensions.md
@@ -4,6 +4,27 @@ Use this page when adding or changing a built-in ZeroClaw provider, channel, too
 
 This page is not for out-of-process plugins. If the extension can live outside the core binary, start with [Plugin protocol](./plugin-protocol.md) or [MCP](../tools/mcp.md) before adding a first-party implementation.
 
+## Choose Built-In Or External
+
+Keep the core binary lean by choosing the narrowest durable home for each
+capability before adding or removing code. An external integration is not, by
+itself, a reason to delete a first-party tool; the boundary depends on the
+contract ZeroClaw must preserve for operators, agents, and existing configs.
+
+| Surface | Use when | Avoid when |
+|---|---|---|
+| Baseline built-in capability | The capability is part of the agent's baseline operating contract, needs tight autonomy/receipt integration, or must work before plugins, skills, or MCP servers are configured. | The behavior is just a wrapper around one vendor API, product, SaaS, or optional local program. |
+| Feature-gated first-party implementation | The implementation is first-party, security-sensitive, or needs Rust trait integration, but the dependency, platform, or binary-size cost should not affect minimal builds. New crates still need the architecture map, RFC, and stability-tier checks. | The feature flag would become a hidden compatibility trap or a second source of truth for config/state. |
+| WASM plugin | The capability should be installed, upgraded, permissioned, or distributed independently while still using ZeroClaw's plugin ABI and manifest permissions. | The current plugin ABI cannot express the needed security, lifecycle, or data contract. |
+| [Skill package](../tools/skills.md) | The value is mostly instructions, prompts, repeatable workflows, scripts, or CLI recipes that can run through existing tools. | The capability needs a new trusted runtime primitive, long-lived service, or direct config/schema ownership. |
+| MCP server | A local or remote service already exposes an appropriate Model Context Protocol surface, or the integration should remain outside the ZeroClaw process. | The project needs a stable first-party guarantee, offline default behavior, or a ZeroClaw-specific security model the server cannot provide. |
+| CLI-backed integration | A mature external CLI already owns authentication, API drift, and platform behavior, and ZeroClaw only needs to call it through existing shell/tool policy. | The CLI output is too unstable, requires broad ambient permissions, or would hide side effects from tool receipts and approval policy. |
+
+Use this as a decision checklist: document the required contract first,
+then choose a small migration candidate if code proof is needed. Do not start by
+removing tools or integrations until compatibility, config, security policy,
+operator visibility, and rollback are explicit.
+
 ## Choose The Smallest Surface
 
 Before writing code, decide which extension surface owns the behavior.

--- a/docs/book/src/tools/overview.md
+++ b/docs/book/src/tools/overview.md
@@ -6,6 +6,10 @@ Tools are not to be confused with `zeroclaw` CLI subcommands. CLI commands are f
 
 An agent gets its tools through the skill, knowledge, and MCP bundles it references; see [Agents](../agents/overview.md) for how bundles attach to an agent.
 
+Before adding a built-in tool or replacing one with an external integration,
+use the [first-party extension boundary](../developing/first-party-extensions.md#choose-built-in-or-external)
+to choose the smallest durable home.
+
 ## Built-in tools
 
 A minimal build ships with:


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Added a first-party extension boundary table for choosing between a baseline built-in capability, feature-gated first-party implementation, WASM plugin, skill package, MCP server, or CLI-backed integration.
  - Clarified that external integrations are not a blanket reason to remove built-in tools; compatibility, config, security policy, operator visibility, and rollback need to be explicit first.
  - Linked the tools overview to that boundary so future built-in-tool proposals see the rule before adding or removing tool code.
- **Scope boundary:** Documentation only. This PR does not remove tools, change feature defaults, add plugin behavior, change MCP behavior, or alter any runtime/tool registry code.
- **Blast radius:** Contributor and maintainer docs for extension/tool boundary decisions. No runtime, config, CLI, API, security-policy, or build behavior changes.
- **Linked issue(s):** Related #6165. Related #5574 and #7852.
- **Labels:** `type: docs`, `risk: low`, `size: XS`, `docs`, `domain:architecture`.

## Validation Evidence (required)

- **Commands run and tail output:**

```text
$ git diff --check -- docs/book/src/developing/first-party-extensions.md docs/book/src/tools/overview.md
Passed with no output.

$ BASE_SHA=$(git merge-base origin/master HEAD) DOCS_FILES='docs/book/src/developing/first-party-extensions.md
docs/book/src/tools/overview.md' scripts/ci/docs_links_gate.sh
Collected 2 added link(s) from 2 docs file(s).
Checking added links with lychee (offline mode)...
📝 Summary
---------------------
🔍 Total............0
🔗 Unique...........0
✅ Successful.......0
⏳ Timeouts.........0
🔀 Redirected.......0
👻 Excluded.........0
❓ Unknown..........0
🚫 Errors...........0
⛔ Unsupported......0

$ DOCS_FILES='docs/book/src/developing/first-party-extensions.md
docs/book/src/tools/overview.md' scripts/ci/docs_quality_gate.sh
No prose em-dashes in changed docs files.
Linting docs files: docs/book/src/developing/first-party-extensions.md docs/book/src/tools/overview.md
markdownlint-cli2 v0.20.0 (markdownlint v0.40.0)
Finding: docs/book/src/developing/first-party-extensions.md docs/book/src/tools/overview.md !target/** !docs/book/src/SUMMARY.md
Linting: 2 file(s)
Summary: 0 error(s)
```

- **Beyond CI - what did you manually verify?** Reviewed the docs diff to confirm it only adds the boundary table and cross-reference, with no runtime or generated-file changes. Confirmed the two added relative links resolve to `docs/book/src/tools/skills.md` and `docs/book/src/developing/first-party-extensions.md`.
- **If any command was intentionally skipped, why:** Rust build/test commands were skipped because this is a docs-only change.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: N/A.

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: N/A.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PR: revert the docs commit if the boundary language needs to be replaced.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A.
