### PR TITLE
feat(runtime): suggest cached extra registry skills

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -5363,8 +5363,9 @@ pub enum SkillsPromptInjectionMode {
 ///
 /// Reuses the same git-clone mechanism as the default `zeroclaw-skills`
 /// registry. Install a skill from it with `registry:<name>/<skill>`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum ExternalRegistryKind {
+    #[default]
     Git,
     Unsupported(String),
 }
@@ -5375,12 +5376,6 @@ impl ExternalRegistryKind {
             Self::Git => "git",
             Self::Unsupported(kind) => kind.as_str(),
         }
-    }
-}
-
-impl Default for ExternalRegistryKind {
-    fn default() -> Self {
-        Self::Git
     }
 }
 

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -5363,6 +5363,67 @@ pub enum SkillsPromptInjectionMode {
 ///
 /// Reuses the same git-clone mechanism as the default `zeroclaw-skills`
 /// registry. Install a skill from it with `registry:<name>/<skill>`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExternalRegistryKind {
+    Git,
+    Unsupported(String),
+}
+
+impl ExternalRegistryKind {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Git => "git",
+            Self::Unsupported(kind) => kind.as_str(),
+        }
+    }
+}
+
+impl Default for ExternalRegistryKind {
+    fn default() -> Self {
+        Self::Git
+    }
+}
+
+impl From<String> for ExternalRegistryKind {
+    fn from(kind: String) -> Self {
+        if kind == "git" {
+            Self::Git
+        } else {
+            Self::Unsupported(kind)
+        }
+    }
+}
+
+impl From<ExternalRegistryKind> for String {
+    fn from(kind: ExternalRegistryKind) -> Self {
+        kind.as_str().to_string()
+    }
+}
+
+impl std::fmt::Display for ExternalRegistryKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl Serialize for ExternalRegistryKind {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for ExternalRegistryKind {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(String::deserialize(deserializer)?.into())
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
 pub struct ExternalRegistry {
@@ -5372,8 +5433,9 @@ pub struct ExternalRegistry {
     pub url: String,
     /// Registry protocol. Only `"git"` is supported today; other protocols
     /// are reserved for a future additive release.
-    #[serde(default = "default_extra_registry_kind")]
-    pub kind: String,
+    #[serde(default)]
+    #[cfg_attr(feature = "schema-export", schemars(with = "String"))]
+    pub kind: ExternalRegistryKind,
     /// Whether this registry is eligible for installs. Default: `true`.
     #[serde(default = "default_true")]
     pub enabled: bool,
@@ -5391,10 +5453,6 @@ impl ExternalRegistry {
                 .bytes()
                 .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-' || b == b'_')
     }
-}
-
-fn default_extra_registry_kind() -> String {
-    "git".to_string()
 }
 
 /// Skills loading configuration (`[skills]` section).
@@ -17608,7 +17666,7 @@ impl Config {
                         reg.name
                     );
                 }
-                if reg.kind != "git" {
+                if reg.kind != ExternalRegistryKind::Git {
                     anyhow::bail!(
                         "skills.extra_registries[{}].kind must be 'git' (got '{}'); other protocols are not yet supported",
                         reg.name,
@@ -19928,7 +19986,7 @@ enabled = true
         ExternalRegistry {
             name: name.to_string(),
             url: url.to_string(),
-            kind: kind.to_string(),
+            kind: kind.to_string().into(),
             enabled: true,
         }
     }

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -1654,6 +1654,7 @@ pub async fn run(
                 &skills,
                 &runtime_capability_names,
                 &config.data_dir,
+                &config.skills.extra_registries,
                 config.skills.install_suggestions.enabled,
             ) {
                 final_output = suggestion;
@@ -2101,6 +2102,7 @@ pub async fn run(
                     &skills,
                     &runtime_capability_names,
                     &config.data_dir,
+                    &config.skills.extra_registries,
                     config.skills.install_suggestions.enabled,
                 ) {
                     final_output = suggestion;
@@ -3067,6 +3069,7 @@ pub async fn process_message(
             &skills,
             &runtime_capability_names,
             &config.data_dir,
+            &config.skills.extra_registries,
             config.skills.install_suggestions.enabled,
         ) {
             return Ok(suggestion);

--- a/crates/zeroclaw-runtime/src/skills/mod.rs
+++ b/crates/zeroclaw-runtime/src/skills/mod.rs
@@ -2393,7 +2393,7 @@ pub fn install_extra_registry_skill_source(
             }
         })?;
 
-    if registry.kind != "git" {
+    if registry.kind != zeroclaw_config::schema::ExternalRegistryKind::Git {
         anyhow::bail!(
             "registry '{registry_name}' uses unsupported kind '{}'; only 'git' is supported",
             registry.kind

--- a/crates/zeroclaw-runtime/src/skills/suggestions.rs
+++ b/crates/zeroclaw-runtime/src/skills/suggestions.rs
@@ -1,4 +1,4 @@
-use super::Skill;
+use super::{EXTRA_REGISTRY_DIR_PREFIX, SKILLS_REGISTRY_DIR_NAME, Skill};
 use serde::Deserialize;
 use std::collections::HashSet;
 use std::fs::File;
@@ -45,13 +45,14 @@ pub(crate) fn render_missing_skill_install_suggestion(
     installed_skills: &[Skill],
     installed_runtime_capabilities: &[&str],
     workspace_dir: &Path,
+    extra_registries: &[zeroclaw_config::schema::ExternalRegistry],
     enabled: bool,
 ) -> Option<String> {
     if !enabled || prompt.trim().is_empty() {
         return None;
     }
 
-    let catalog = load_cached_installable_skill_capabilities(workspace_dir);
+    let catalog = load_cached_installable_skill_capabilities(workspace_dir, extra_registries);
     suggest_missing_skill_install(
         prompt,
         installed_skills,
@@ -94,13 +95,46 @@ fn suggest_missing_skill_install(
 
 fn load_cached_installable_skill_capabilities(
     workspace_dir: &Path,
+    extra_registries: &[zeroclaw_config::schema::ExternalRegistry],
 ) -> Vec<InstallableSkillCapability> {
-    let skills_dir = workspace_dir.join("skills-registry").join("skills");
+    let mut capabilities = Vec::new();
+    let skills_dir = workspace_dir.join(SKILLS_REGISTRY_DIR_NAME).join("skills");
+    load_cached_registry_skill_capabilities(&skills_dir, None, &mut capabilities);
+
+    for registry in extra_registries
+        .iter()
+        .filter(|registry| registry.enabled && registry.kind == "git")
+    {
+        if !zeroclaw_config::schema::ExternalRegistry::is_valid_name(&registry.name) {
+            continue;
+        }
+        let skills_dir = workspace_dir
+            .join(format!("{}{}", EXTRA_REGISTRY_DIR_PREFIX, registry.name))
+            .join("skills");
+        load_cached_registry_skill_capabilities(
+            &skills_dir,
+            Some(&registry.name),
+            &mut capabilities,
+        );
+    }
+
+    capabilities.sort_by(|left, right| {
+        left.name
+            .cmp(&right.name)
+            .then_with(|| left.source.cmp(&right.source))
+    });
+    capabilities
+}
+
+fn load_cached_registry_skill_capabilities(
+    skills_dir: &Path,
+    registry_name: Option<&str>,
+    capabilities: &mut Vec<InstallableSkillCapability>,
+) {
     let Ok(entries) = std::fs::read_dir(skills_dir) else {
-        return Vec::new();
+        return;
     };
 
-    let mut capabilities = Vec::new();
     for entry in entries.flatten() {
         let skill_dir = entry.path();
         if !skill_dir.is_dir() {
@@ -115,22 +149,27 @@ fn load_cached_installable_skill_capabilities(
             continue;
         };
 
-        if let Some(capability) = load_skill_package_metadata(&skill_dir, &source) {
+        let skill_name = source;
+        let source = match registry_name {
+            Some(registry_name) => {
+                if !super::is_registry_source(&skill_name) {
+                    continue;
+                }
+                format!("registry:{registry_name}/{skill_name}")
+            }
+            None => skill_name.clone(),
+        };
+
+        if let Some(capability) = load_skill_package_metadata(&skill_dir, &source, &skill_name) {
             capabilities.push(capability);
         }
     }
-
-    capabilities.sort_by(|left, right| {
-        left.name
-            .cmp(&right.name)
-            .then_with(|| left.source.cmp(&right.source))
-    });
-    capabilities
 }
 
 fn load_skill_package_metadata(
     skill_dir: &Path,
     source: &str,
+    fallback_name: &str,
 ) -> Option<InstallableSkillCapability> {
     for manifest_name in ["SKILL.toml", "manifest.toml"] {
         let manifest_path = skill_dir.join(manifest_name);
@@ -141,7 +180,7 @@ fn load_skill_package_metadata(
 
     let markdown_path = skill_dir.join("SKILL.md");
     if markdown_path.exists() {
-        return load_markdown_skill_package_metadata(&markdown_path, source);
+        return load_markdown_skill_package_metadata(&markdown_path, source, fallback_name);
     }
 
     None
@@ -176,12 +215,13 @@ fn load_toml_skill_package_metadata(
 fn load_markdown_skill_package_metadata(
     markdown_path: &Path,
     source: &str,
+    fallback_name: &str,
 ) -> Option<InstallableSkillCapability> {
     let frontmatter = read_markdown_frontmatter(markdown_path)?;
     let meta = super::parse_simple_frontmatter(&frontmatter);
     let description = meta.description.unwrap_or_default();
     Some(InstallableSkillCapability {
-        name: meta.name.unwrap_or_else(|| source.to_string()),
+        name: meta.name.unwrap_or_else(|| fallback_name.to_string()),
         source: source.to_string(),
         description,
         aliases: Vec::new(),
@@ -324,6 +364,23 @@ mod tests {
         }
     }
 
+    fn extra_registry(name: &str, enabled: bool) -> zeroclaw_config::schema::ExternalRegistry {
+        extra_registry_with_kind(name, "git", enabled)
+    }
+
+    fn extra_registry_with_kind(
+        name: &str,
+        kind: &str,
+        enabled: bool,
+    ) -> zeroclaw_config::schema::ExternalRegistry {
+        zeroclaw_config::schema::ExternalRegistry {
+            name: name.to_string(),
+            url: format!("file:///tmp/{name}"),
+            kind: kind.to_string(),
+            enabled,
+        }
+    }
+
     #[test]
     fn installed_capability_proceeds_without_suggestion() {
         let installed = vec![installed_skill("calendar")];
@@ -445,6 +502,7 @@ mod tests {
             &[],
             &[],
             dir.path(),
+            &[],
             false,
         );
 
@@ -474,7 +532,7 @@ tags = ["scheduling"]
         )
         .unwrap();
 
-        let catalog = load_cached_installable_skill_capabilities(dir.path());
+        let catalog = load_cached_installable_skill_capabilities(dir.path(), &[]);
 
         assert_eq!(catalog.len(), 1);
         assert_eq!(catalog[0].name, "calendar");
@@ -494,6 +552,7 @@ tags = ["scheduling"]
             &[],
             &[],
             dir.path(),
+            &[],
             true,
         )
         .expect("cached registry metadata should render a suggestion");
@@ -519,7 +578,7 @@ aliases = ["release check"]
         )
         .unwrap();
 
-        let catalog = load_cached_installable_skill_capabilities(dir.path());
+        let catalog = load_cached_installable_skill_capabilities(dir.path(), &[]);
         let suggestion = suggest_missing_skill_install(
             "please run a release check before tagging",
             &[],
@@ -550,7 +609,7 @@ This body-only browser automation phrase must not be used for matching.
         )
         .unwrap();
 
-        let catalog = load_cached_installable_skill_capabilities(dir.path());
+        let catalog = load_cached_installable_skill_capabilities(dir.path(), &[]);
         let suggestion =
             suggest_missing_skill_install("please use screenshot helper here", &[], &[], &catalog);
         let body_only_match = suggest_missing_skill_install(
@@ -564,6 +623,114 @@ This body-only browser automation phrase must not be used for matching.
         assert_eq!(catalog[0].name, "screenshot-helper");
         assert!(suggestion.is_some());
         assert!(body_only_match.is_none());
+    }
+
+    #[test]
+    fn cached_registry_catalog_includes_enabled_extra_registries() {
+        let dir = tempfile::tempdir().unwrap();
+        let skill_dir = dir.path().join("extra-registry-acme/skills/team-calendar");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.toml"),
+            r#"
+[skill]
+name = "team-calendar"
+description = "Schedule meetings on the team calendar"
+aliases = ["team calendar"]
+"#,
+        )
+        .unwrap();
+
+        let catalog =
+            load_cached_installable_skill_capabilities(dir.path(), &[extra_registry("acme", true)]);
+        let suggestion = suggest_missing_skill_install(
+            "please use the team calendar to schedule this",
+            &[],
+            &[],
+            &catalog,
+        )
+        .expect("enabled cached extra registry metadata should suggest installation");
+
+        assert_eq!(catalog.len(), 1);
+        assert_eq!(catalog[0].name, "team-calendar");
+        assert_eq!(catalog[0].source, "registry:acme/team-calendar");
+        assert_eq!(suggestion.source, "registry:acme/team-calendar");
+        assert!(
+            suggestion
+                .render_user_message()
+                .contains("zeroclaw skills install registry:acme/team-calendar")
+        );
+    }
+
+    #[test]
+    fn cached_registry_catalog_skips_disabled_extra_registries() {
+        let dir = tempfile::tempdir().unwrap();
+        let skill_dir = dir.path().join("extra-registry-acme/skills/team-calendar");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            r#"---
+description: Team calendar scheduling
+---
+"#,
+        )
+        .unwrap();
+
+        let catalog = load_cached_installable_skill_capabilities(
+            dir.path(),
+            &[extra_registry("acme", false)],
+        );
+
+        assert!(catalog.is_empty());
+    }
+
+    #[test]
+    fn cached_registry_catalog_skips_non_git_extra_registries() {
+        let dir = tempfile::tempdir().unwrap();
+        let skill_dir = dir.path().join("extra-registry-acme/skills/team-calendar");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.toml"),
+            r#"
+[skill]
+name = "team-calendar"
+description = "Schedule meetings on the team calendar"
+aliases = ["team calendar"]
+"#,
+        )
+        .unwrap();
+
+        let catalog = load_cached_installable_skill_capabilities(
+            dir.path(),
+            &[extra_registry_with_kind("acme", "http", true)],
+        );
+
+        assert!(catalog.is_empty());
+    }
+
+    #[test]
+    fn cached_registry_catalog_skips_invalid_extra_registry_skill_sources() {
+        let dir = tempfile::tempdir().unwrap();
+        let skill_dir = dir.path().join("extra-registry-acme/skills/team.calendar");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.toml"),
+            r#"
+[skill]
+name = "team-calendar"
+description = "Schedule meetings on the team calendar"
+aliases = ["team calendar"]
+"#,
+        )
+        .unwrap();
+
+        let catalog =
+            load_cached_installable_skill_capabilities(dir.path(), &[extra_registry("acme", true)]);
+        let suggestion =
+            suggest_missing_skill_install("please use the team calendar", &[], &[], &catalog);
+
+        assert!(catalog.is_empty());
+        assert!(suggestion.is_none());
     }
 
     /// Regression: a capability in the raw registry but absent from the

--- a/crates/zeroclaw-runtime/src/skills/suggestions.rs
+++ b/crates/zeroclaw-runtime/src/skills/suggestions.rs
@@ -4,6 +4,7 @@ use std::collections::HashSet;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
+use zeroclaw_config::schema::ExternalRegistryKind;
 
 /// Server-side, post-submit install suggestions for cached skill registry metadata.
 ///
@@ -103,7 +104,7 @@ fn load_cached_installable_skill_capabilities(
 
     for registry in extra_registries
         .iter()
-        .filter(|registry| registry.enabled && registry.kind == "git")
+        .filter(|registry| registry.enabled && registry.kind == ExternalRegistryKind::Git)
     {
         if !zeroclaw_config::schema::ExternalRegistry::is_valid_name(&registry.name) {
             continue;
@@ -376,7 +377,7 @@ mod tests {
         zeroclaw_config::schema::ExternalRegistry {
             name: name.to_string(),
             url: format!("file:///tmp/{name}"),
-            kind: kind.to_string(),
+            kind: kind.to_string().into(),
             enabled,
         }
     }


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Missing-skill install suggestions now read enabled cached extra skill registries as well as the default cached `skills-registry`.
  - Extra-registry suggestions render install commands as `zeroclaw skills install registry:<name>/<skill>`, matching the install source added by #7827.
  - The catalog skips disabled extra registries, non-`git` registry kinds, invalid extra-registry names, and cached skill directories that do not match the installer source grammar.
  - Markdown skill metadata without a frontmatter `name` still displays the bare skill directory name instead of the full `registry:<name>/<skill>` source, keeping suggestion names concise while the install command includes the registry prefix.
- **Scope boundary:** This does not add live registry fetch/clone behavior, auto-install, plugin install suggestions, composer-time suggestions, skill-body matching, memory writes, or prompt mutation. The remaining plugin half of #6289 still needs plugin registry search/install-by-name before suggestion wiring can close it.
- **Blast radius:** Runtime missing-skill suggestion rendering for CLI one-shot, interactive CLI, and channel `process_message` paths. Agent-loop call sites now forward configured extra registries into the existing suggestion renderer, but this does not change agent orchestration, persona, tool execution, the install path, or the registry sync path.
- **Linked issue(s):** Related #6289, #7827
- **Labels:** `enhancement`, `risk: high`, `size: S`, `agent`, `config`, `runtime`, `skills`, `priority:p2`

## Validation Evidence (required)

- **Commands run and tail output:**

```text
cargo fmt -- --check
PASS

cargo test -p zeroclaw-runtime cached_registry_catalog --lib
PASS: 5 passed; 0 failed; 0 ignored; 2344 filtered out

cargo test -p zeroclaw-runtime skills::suggestions::tests --lib
PASS: 16 passed; 0 failed; 0 ignored; 2335 filtered out

cargo check -p zeroclaw-config --lib
PASS

cargo test -p zeroclaw-config extra_registry --lib
PASS: 6 passed; 0 failed; 0 ignored

cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
PASS

git diff --check
PASS

cargo nextest run --locked --workspace --exclude zeroclaw-desktop
PASS: 9439 passed; 11 skipped
```

- **Beyond CI — what did you manually verify?** Manual source review confirmed all three runtime suggestion call sites pass `config.skills.extra_registries`, and the extra-registry source text now reuses the installer grammar guard before rendering `registry:<name>/<skill>`. A manual CLI smoke with a synthetic cached extra registry produced the expected `registry:acme/team-calendar` install suggestion.
- **If any command was intentionally skipped, why:** None for the ready-state validation packet.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `Yes`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: Suggestions now read metadata from already-cached extra-registry skill directories under the existing ZeroClaw data directory. The path is limited to enabled git extra registries, validates registry and skill source names, reads metadata manifests/frontmatter only, and does not fetch, install, execute scripts, or read skill bodies. The runtime `kind == "git"` filter is defensive; current config validation already rejects other extra-registry kinds.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: exact upgrade steps for existing users: No upgrade required. Users only see extra-registry suggestions when they already have install suggestions enabled and an enabled git extra registry cached locally.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** Revert this PR. Operators can also disable the suggestion path with `skills.install_suggestions.enabled = false`.
- **Feature flags or config toggles:** `skills.install_suggestions.enabled = false`; disabling or removing an extra registry also prevents that registry from contributing suggestions.
- **Observable failure symptoms:** Unexpected "missing skill" suggestion text, a `zeroclaw skills install registry:<name>/<skill>` command for a skill the operator did not expect, or warning logs for malformed cached registry metadata.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): Not applicable.
- Scope materially carried forward: Not applicable.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why (inspiration-only, no direct code/design carry-over): This is a fresh narrow follow-up to #6289/#7827, with no superseded PR code carried forward.
