### PR TITLE
fix(config): gate Android shell import on non-Windows

### DIFF
--- a/crates/zeroclaw-config/src/platform/native.rs
+++ b/crates/zeroclaw-config/src/platform/native.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+#[cfg(not(target_os = "windows"))]
 use zeroclaw_api::platform::is_android;
 use zeroclaw_api::runtime_traits::RuntimeAdapter;
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Added a non-Windows cfg guard to the `is_android` import in the native runtime platform module so Windows clippy does not see it as unused when the only call site is compiled out.
- **Scope boundary:** This PR does not change shell command construction behavior, Android detection, runtime selection, or CI workflow definitions.
- **Blast radius:** Limited to compile-time import visibility in `zeroclaw-config`; runtime behavior is unchanged on all platforms.
- **Linked issue(s):** N/A
- **Related workflow failure:** Scheduled Cross-Platform Clippy on `master`: https://github.com/zeroclaw-labs/zeroclaw/actions/runs/27952378841
- **Labels:** `bug`, `risk: low`, `size: XS`, `config`.

## Validation Evidence (required)

```text
zc-cargo fmt --all -- --check
Result: passed.

zc-cargo clippy -p zeroclaw-config --all-targets --target x86_64-pc-windows-msvc -- -D warnings
Result: not completed locally. The macOS cross-target probe failed before reaching zeroclaw-config because the local C/MSVC environment cannot build ring for x86_64-pc-windows-msvc (`assert.h` not found, `VCINSTALLDIR=None`).

zc-cargo clippy -p zeroclaw-config --all-targets -- -D warnings
Result: inconclusive locally. The command reached zeroclaw-config but did not return after several minutes in the final clippy phase, so it was stopped rather than treated as passing.

GitHub PR Quality Gate
Result: passed, including Lint, Test, CI Required Gate, and Check x86_64-pc-windows-msvc.
```

- **Beyond CI — what did you manually verify?** Confirmed the failing scheduled job was Windows clippy rejecting `zeroclaw-config/src/platform/native.rs` for an unused `is_android` import, and confirmed the only use is inside `#[cfg(not(target_os = "windows"))]`.
- **If any command was intentionally skipped, why:** The scheduled Cross-Platform Clippy workflow was not rerun on this branch before this body update. The local macOS host also cannot complete the Windows MSVC clippy probe because dependency C build setup fails before reaching this crate.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No upgrade steps required.

## Rollback (required for `risk: medium` and `risk: high`)

Low risk: revert this PR commit.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Scope materially carried forward: N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why (inspiration-only, no direct code/design carry-over): No superseded PR or incorporated contributor work.
