### PR TITLE
fix(zerocode): detect daemon version mismatches

### DIFF
--- a/apps/zerocode/locales/en/zerocode.ftl
+++ b/apps/zerocode/locales/en/zerocode.ftl
@@ -23,6 +23,7 @@ zc-app-quit-prompt = Quit zerocode?
 zc-app-quit-explainer = The TUI closes. The daemon keeps running; reconnect anytime.
 zc-app-reload-status-signalled = Daemon reload signalled — reconnecting…
 zc-app-reload-confirm-row = { $confirm_chord } = reload   { $cancel_chord } = cancel
+zc-error-daemon-version-mismatch = Version mismatch: zerocode is { $client_version } but the daemon is { $server_version }. Rebuild and restart the daemon from the same checkout as zerocode.
 
 zc-zerocode-tab-theme = Theme
 zc-zerocode-tab-agent-theme = Agent Themes

--- a/apps/zerocode/locales/es/zerocode.ftl
+++ b/apps/zerocode/locales/es/zerocode.ftl
@@ -21,6 +21,7 @@ zc-app-quit-prompt = ¿Salir de zerocode?
 zc-app-quit-explainer = La TUI se cierra. El daemon sigue ejecutándose; reconéctate cuando quieras.
 zc-app-reload-status-signalled = Recarga del daemon señalizada — reconectando…
 zc-app-reload-confirm-row = { $confirm_chord } = recargar   { $cancel_chord } = cancelar
+zc-error-daemon-version-mismatch = Las versiones no coinciden: zerocode es { $client_version }, pero el daemon es { $server_version }. Vuelve a compilar y reinicia el daemon desde el mismo checkout que zerocode.
 zc-zerocode-tab-theme = Tema
 zc-zerocode-tab-agent-theme = Temas de agente
 zc-zerocode-tab-presets = Preajustes

--- a/apps/zerocode/locales/fr/zerocode.ftl
+++ b/apps/zerocode/locales/fr/zerocode.ftl
@@ -21,6 +21,7 @@ zc-app-quit-prompt = Quitter zerocode ?
 zc-app-quit-explainer = L'interface TUI se ferme. Le démon continue de fonctionner ; reconnectez-vous à tout moment.
 zc-app-reload-status-signalled = Rechargement du démon signalé — reconnexion…
 zc-app-reload-confirm-row = { $confirm_chord } = recharger   { $cancel_chord } = annuler
+zc-error-daemon-version-mismatch = Incompatibilité de version : zerocode est en { $client_version }, mais le démon est en { $server_version }. Recompilez et redémarrez le démon depuis le même checkout que zerocode.
 zc-zerocode-tab-theme = Thème
 zc-zerocode-tab-agent-theme = Thèmes d'agent
 zc-zerocode-tab-presets = Préréglages

--- a/apps/zerocode/locales/ja/zerocode.ftl
+++ b/apps/zerocode/locales/ja/zerocode.ftl
@@ -21,6 +21,7 @@ zc-app-quit-prompt = zerocodeを終了しますか？
 zc-app-quit-explainer = TUIが閉じます。デーモンは稼働し続け、いつでも再接続できます。
 zc-app-reload-status-signalled = デーモンの再読み込みを通知しました — 再接続中…
 zc-app-reload-confirm-row = { $confirm_chord } = 再読み込み   { $cancel_chord } = キャンセル
+zc-error-daemon-version-mismatch = バージョンが一致しません: zerocode は { $client_version } ですが、デーモンは { $server_version } です。同じチェックアウトからデーモンを再ビルドして再起動してください。
 zc-zerocode-tab-theme = テーマ
 zc-zerocode-tab-agent-theme = エージェントテーマ
 zc-zerocode-tab-presets = プリセット

--- a/apps/zerocode/locales/zh-CN/zerocode.ftl
+++ b/apps/zerocode/locales/zh-CN/zerocode.ftl
@@ -21,6 +21,7 @@ zc-app-quit-prompt = 退出 zerocode？
 zc-app-quit-explainer = TUI 关闭。守护进程继续运行；可随时重新连接。
 zc-app-reload-status-signalled = 已发出守护进程重新加载信号 — 正在重新连接…
 zc-app-reload-confirm-row = { $confirm_chord } = 重新加载   { $cancel_chord } = 取消
+zc-error-daemon-version-mismatch = 版本不匹配：zerocode 是 { $client_version }，但守护进程是 { $server_version }。请从同一个检出重新构建并重启守护进程。
 zc-zerocode-tab-theme = 主题
 zc-zerocode-tab-agent-theme = 代理主题
 zc-zerocode-tab-presets = 预设

--- a/apps/zerocode/src/client.rs
+++ b/apps/zerocode/src/client.rs
@@ -4,6 +4,7 @@
 //! Wraps [`RpcOutbound`] from `zeroclaw-api` — the same request/response
 //! plumbing the daemon uses for bidirectional calls.
 
+use std::fmt;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
@@ -330,6 +331,71 @@ pub enum ConnectionState {
     Disconnected { reason: String },
 }
 
+/// The TUI and daemon are built from the same package version and do not
+/// promise cross-version wire compatibility.
+#[derive(Debug)]
+pub struct DaemonVersionMismatch {
+    client_version: &'static str,
+    server_version: String,
+}
+
+impl DaemonVersionMismatch {
+    fn new(server_version: impl Into<String>) -> Self {
+        Self {
+            client_version: env!("CARGO_PKG_VERSION"),
+            server_version: server_version.into(),
+        }
+    }
+
+    pub fn client_version(&self) -> &'static str {
+        self.client_version
+    }
+
+    pub fn server_version(&self) -> &str {
+        &self.server_version
+    }
+}
+
+impl fmt::Display for DaemonVersionMismatch {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Version mismatch: zerocode is {} but the daemon is {}. \
+             Rebuild and restart the daemon from the same checkout as zerocode.",
+            self.client_version, self.server_version
+        )
+    }
+}
+
+impl std::error::Error for DaemonVersionMismatch {}
+
+#[derive(Debug)]
+struct InitializeResponse {
+    server_version: String,
+    tui_id: Option<String>,
+    tui_sig: Option<String>,
+}
+
+fn parse_initialize_response(resp: &Value) -> Result<InitializeResponse> {
+    let server_version = resp
+        .get("server_version")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown")
+        .to_string();
+    if server_version != env!("CARGO_PKG_VERSION") {
+        return Err(DaemonVersionMismatch::new(server_version).into());
+    }
+
+    Ok(InitializeResponse {
+        server_version,
+        tui_id: resp.get("tui_id").and_then(Value::as_str).map(String::from),
+        tui_sig: resp
+            .get("tui_sig")
+            .and_then(Value::as_str)
+            .map(String::from),
+    })
+}
+
 // ── Client ───────────────────────────────────────────────────────
 
 #[derive(Debug)]
@@ -441,22 +507,24 @@ impl RpcClient {
         // same machine and the socket paths / env values are meaningful.
         let env_map: std::collections::HashMap<String, String> = std::env::vars().collect();
         init_params["env"] = serde_json::to_value(env_map).unwrap_or_default();
-        let resp = rpc
-            .request(method::INITIALIZE, init_params)
-            .await
-            .map_err(|e| anyhow::Error::msg(format!("initialize: {} ({})", e.message, e.code)))?;
+        let resp = match rpc.request(method::INITIALIZE, init_params).await {
+            Ok(resp) => resp,
+            Err(e) => {
+                read_task.abort();
+                return Err(anyhow::Error::msg(format!(
+                    "initialize: {} ({})",
+                    e.message, e.code
+                )));
+            }
+        };
 
-        let server_version = resp
-            .get("server_version")
-            .and_then(Value::as_str)
-            .unwrap_or("unknown")
-            .to_string();
-
-        let tui_id = resp.get("tui_id").and_then(Value::as_str).map(String::from);
-        let tui_sig = resp
-            .get("tui_sig")
-            .and_then(Value::as_str)
-            .map(String::from);
+        let init = match parse_initialize_response(&resp) {
+            Ok(init) => init,
+            Err(e) => {
+                read_task.abort();
+                return Err(e);
+            }
+        };
 
         let bcast_rx = notif_tx.subscribe();
         let (update_tx, _update_rx) = mpsc::channel::<SessionUpdate>(64);
@@ -466,11 +534,11 @@ impl RpcClient {
             rpc,
             _read_task: read_task,
             _router_task: router_task,
-            server_version,
+            server_version: init.server_version,
             notifications_bcast: notif_tx,
             connection_state: conn_state,
-            tui_id,
-            tui_sig,
+            tui_id: init.tui_id,
+            tui_sig: init.tui_sig,
             transport: Transport::Local,
         })
     }
@@ -590,22 +658,24 @@ impl RpcClient {
         // them would be misleading at best and silently broken at worst.
         // Env pass-through is only meaningful on a local Unix-socket connection
         // (see `connect` above), where the TUI and daemon share the same filesystem.
-        let resp = rpc
-            .request(method::INITIALIZE, init_params)
-            .await
-            .map_err(|e| anyhow::Error::msg(format!("initialize: {} ({})", e.message, e.code)))?;
+        let resp = match rpc.request(method::INITIALIZE, init_params).await {
+            Ok(resp) => resp,
+            Err(e) => {
+                read_task.abort();
+                return Err(anyhow::Error::msg(format!(
+                    "initialize: {} ({})",
+                    e.message, e.code
+                )));
+            }
+        };
 
-        let server_version = resp
-            .get("server_version")
-            .and_then(Value::as_str)
-            .unwrap_or("unknown")
-            .to_string();
-
-        let tui_id = resp.get("tui_id").and_then(Value::as_str).map(String::from);
-        let tui_sig = resp
-            .get("tui_sig")
-            .and_then(Value::as_str)
-            .map(String::from);
+        let init = match parse_initialize_response(&resp) {
+            Ok(init) => init,
+            Err(e) => {
+                read_task.abort();
+                return Err(e);
+            }
+        };
 
         let bcast_rx = notif_tx.subscribe();
         let (update_tx, _update_rx) = mpsc::channel::<SessionUpdate>(64);
@@ -615,11 +685,11 @@ impl RpcClient {
             rpc,
             _read_task: read_task,
             _router_task: router_task,
-            server_version,
+            server_version: init.server_version,
             notifications_bcast: notif_tx,
             connection_state: conn_state,
-            tui_id,
-            tui_sig,
+            tui_id: init.tui_id,
+            tui_sig: init.tui_sig,
             transport: Transport::Wss,
         })
     }
@@ -1292,6 +1362,52 @@ pub struct ConfigListResult {
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct ConfigSetResult {}
+
+#[cfg(test)]
+mod initialize_version_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn initialize_response_accepts_matching_server_version() {
+        let parsed = parse_initialize_response(&json!({
+            "server_version": env!("CARGO_PKG_VERSION"),
+            "tui_id": "tui_1",
+            "tui_sig": "sig_1"
+        }))
+        .unwrap();
+
+        assert_eq!(parsed.server_version, env!("CARGO_PKG_VERSION"));
+        assert_eq!(parsed.tui_id.as_deref(), Some("tui_1"));
+        assert_eq!(parsed.tui_sig.as_deref(), Some("sig_1"));
+    }
+
+    #[test]
+    fn initialize_response_rejects_mismatched_server_version() {
+        let err = parse_initialize_response(&json!({
+            "server_version": "0.0.0-test"
+        }))
+        .unwrap_err();
+        let mismatch = err
+            .downcast_ref::<DaemonVersionMismatch>()
+            .expect("mismatched daemon version should be typed");
+
+        assert_eq!(mismatch.client_version(), env!("CARGO_PKG_VERSION"));
+        assert_eq!(mismatch.server_version(), "0.0.0-test");
+        assert!(err.to_string().contains("Version mismatch"));
+    }
+
+    #[test]
+    fn initialize_response_rejects_missing_server_version_as_unknown() {
+        let err = parse_initialize_response(&json!({})).unwrap_err();
+        let mismatch = err
+            .downcast_ref::<DaemonVersionMismatch>()
+            .expect("missing daemon version should be typed");
+
+        assert_eq!(mismatch.client_version(), env!("CARGO_PKG_VERSION"));
+        assert_eq!(mismatch.server_version(), "unknown");
+    }
+}
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/apps/zerocode/src/i18n.rs
+++ b/apps/zerocode/src/i18n.rs
@@ -223,6 +223,15 @@ mod tests {
         let map = format_ftl_messages(EN_FTL, "en");
         assert!(map.contains_key("zc-pane-dashboard"));
         assert!(map.contains_key("zc-pane-chat"));
+        let mismatch = format_ftl_message(
+            EN_FTL,
+            "en",
+            "zc-error-daemon-version-mismatch",
+            &[("client_version", "0.8.1"), ("server_version", "0.8.0")],
+        )
+        .unwrap();
+        assert!(mismatch.contains("0.8.1"));
+        assert!(mismatch.contains("0.8.0"));
     }
 
     #[test]

--- a/apps/zerocode/src/main.rs
+++ b/apps/zerocode/src/main.rs
@@ -147,10 +147,23 @@ async fn main() -> ExitCode {
     match run().await {
         Ok(()) => ExitCode::SUCCESS,
         Err(e) => {
-            eprintln!("zerocode: {e:#}");
+            eprintln!("zerocode: {}", format_startup_error(&e));
             ExitCode::FAILURE
         }
     }
+}
+
+fn format_startup_error(err: &anyhow::Error) -> String {
+    if let Some(mismatch) = err.downcast_ref::<client::DaemonVersionMismatch>() {
+        return i18n::t_args(
+            "zc-error-daemon-version-mismatch",
+            &[
+                ("client_version", mismatch.client_version()),
+                ("server_version", mismatch.server_version()),
+            ],
+        );
+    }
+    format!("{err:#}")
 }
 
 /// Install a panic hook that restores the terminal before printing the
@@ -276,6 +289,7 @@ async fn run() -> anyhow::Result<()> {
         ConnectTarget::LocalSocket(socket) => {
             match client::RpcClient::connect(socket, None, None).await {
                 Ok(c) => c,
+                Err(e) if is_daemon_version_mismatch(&e) => return Err(e),
                 Err(_) => {
                     let config_dir = client::resolve_config_dir(cli.config_dir.as_deref())?;
                     spawn_ephemeral_daemon(&config_dir)?;
@@ -409,9 +423,15 @@ async fn await_daemon_ready(socket: &std::path::Path) -> anyhow::Result<client::
         }
         match client::RpcClient::connect(socket, None, None).await {
             Ok(c) => return Ok(c),
+            Err(e) if is_daemon_version_mismatch(&e) => return Err(e),
             Err(_) => tokio::time::sleep(DAEMON_CONNECT_INTERVAL).await,
         }
     }
+}
+
+fn is_daemon_version_mismatch(err: &anyhow::Error) -> bool {
+    err.downcast_ref::<client::DaemonVersionMismatch>()
+        .is_some()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Validate the daemon `server_version` returned by `initialize` in zerocode local and WSS RPC clients, so mismatched or missing versions fail during connect instead of surfacing later as generic RPC timeouts.
  - Stop the local startup path from treating a version mismatch as an unavailable daemon, so zerocode does not spawn or wait on another daemon when the running daemon is simply from a different build.
  - Format the startup mismatch message through zerocode Fluent catalogs and abort spawned read tasks before returning handshake errors.
- **Scope boundary:** This PR does not change the already-running TUI reconnect screen if a daemon changes version after the TUI is open. It also does not change daemon protocol fields, config, or CLI flags.
- **Blast radius:** `zerocode` RPC connect/startup paths for local IPC and WSS, plus zerocode locale catalogs for the new startup error.
- **Linked issue(s):** Closes #8186
- **Labels:** `bug`, `risk: medium`, `size: S`, `zerocode`

## Validation Evidence (required)

- **Commands run and tail output:**
  - `zc-cargo fmt -p zerocode` — passed.
  - `zc-cargo test -p zerocode` — passed: `115 passed` in `src/lib.rs`; `360 passed` in `src/main.rs`; doc-tests ran with `0` tests.
  - `git diff --check` — passed.
- **Beyond CI — what did you manually verify?**
  - Added behavior tests for matching, mismatched, and missing `initialize.server_version`.
  - Added an i18n formatting assertion for the new argumented Fluent key.
- **If any command was intentionally skipped, why:**
  - Workspace clippy and CI-shaped workspace nextest were not run locally. This PR currently has focused zerocode validation; run broad validation before reviewer sign-off if maintainers want full medium-risk local evidence.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: `N/A`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: Matching zerocode/daemon builds behave as before. If users see the new mismatch error, rebuild and restart the daemon from the same checkout as zerocode.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <merge-commit>`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** `zerocode` exits at startup with the version-mismatch message, or fails to connect to a daemon that previously connected.
