### PR TITLE
docs(mdbook): avoid stale placeholder warning translations

### DIFF
--- a/docs/book/src/agents/delegation.md
+++ b/docs/book/src/agents/delegation.md
@@ -119,9 +119,7 @@ This is a thin signal for the agent-loop spawn path. A dedicated "subagent start
 `delegate` enforces two gates in `crates/zeroclaw-runtime/src/tools/delegate.rs` before a target agent runs, in this order:
 
 1. **`delegation_policy.mode`**: the caller's risk profile must permit delegation. `[risk_profiles.<alias>].delegation_policy` is `{ mode = "forbidden" }` by default; set `mode = "allow"` to permit delegation at all. When forbidden, the refusal is:
-   ```text
-   delegation is forbidden by the caller's delegation_policy; set [risk_profiles.<caller_profile>].delegation_policy mode = "allow"
-   ```
+   `delegation is forbidden by the caller's delegation_policy; set [risk_profiles.<caller_profile>].delegation_policy mode = "allow"`
    This is editable in the gateway dashboard and zerocode at **Config → Risk profiles → `<profile>` → `delegation_policy.mode`** (a forbidden/allow select).
 
 2. **Reachability**: the target agent must be in the caller's reachable set, resolved by `Config::reachable_delegate_targets`. The reachable set is the union of two per-agent sources on `[agents.<caller>]`, minus the caller itself:
@@ -130,12 +128,14 @@ This is a thin signal for the agent-loop spawn path. A dedicated "subagent start
    - **explicit roster**: `delegates`, a possibly-empty list of agent aliases the caller may delegate to even across risk profiles.
 
    When the target is outside that set the refusal is:
-   ```text
+
+   ```plaintext
    delegate target "<target>" is not reachable from "<caller>"; add it to [agents.<caller>].delegates or share a risk profile with delegate_same_risk_profile enabled
    ```
 
    A same-profile target inherits the caller's session workspace boundary and shares its action/cost tracker. An explicit **cross-profile** target runs under its own resolved policy and must pass `ensure_no_escalation_beyond` the caller: a listed delegate that would widen privilege (broader autonomy, extra roots, higher budgets, etc.) is refused with:
-   ```text
+
+   ```plaintext
    delegate target "<target>" (risk profile "<target_profile>") would escalate beyond the caller (risk profile "<caller_profile>"): <violation>
    ```
 

--- a/docs/book/src/channels/nextcloud-talk.md
+++ b/docs/book/src/channels/nextcloud-talk.md
@@ -45,9 +45,7 @@ zeroclaw daemon
 Configure your Talk bot's webhook URL to point at the alias of the
 `[channels.nextcloud_talk.<alias>]` instance that should receive it:
 
-```
-https://<your-public-url>/nextcloud-talk/<alias>
-```
+`https://<your-public-url>/nextcloud-talk/<alias>`
 
 For example, `[channels.nextcloud_talk.work]` receives `POST /nextcloud-talk/work`.
 This per-alias routing (#6312) lets you run several Talk bots side by side and


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Replaced the short fragile placeholder examples in delegation and Nextcloud Talk docs with inline-code examples where inline rendering stays readable.
  - Kept the two long delegation refusal messages as display code blocks after draft-review layout feedback, using `plaintext` fences so the English source no longer matches the stale translated fenced-code msgids.
  - This avoids stale `.po` translations that dropped code fences and exposed `<target>`, `<caller>`, and URL placeholders as raw HTML during localized mdBook builds.
- **Scope boundary:** Source docs only. No `.po` catalog edits, generated reference changes, runtime changes, or translation-tool changes.
- **Blast radius:** Docs rendering for two English source pages and translated fallback behavior for changed strings.
- **Linked issue(s):** Related #7269
- **Labels:** docs, risk: low, size: S

## Validation Evidence (required)

- **Commands run and tail output:**

```text
$ git diff --check origin/master...HEAD
# no output

$ node - <<'NODE'
const fs = require('fs');
const delegation = fs.readFileSync('docs/book/src/agents/delegation.md', 'utf8');
const nextcloud = fs.readFileSync('docs/book/src/channels/nextcloud-talk.md', 'utf8');
const absent = [
  [nextcloud, '```\nhttps://<your-public-url>/nextcloud-talk/<alias>\n```'],
  [delegation, '```text\ndelegation is forbidden by the caller'],
  [delegation, '```text\ndelegate target "<target>" is not reachable'],
  [delegation, '```text\ndelegate target "<target>" (risk profile'],
];
const present = [
  /```plaintext\n\s*delegate target "<target>" is not reachable/,
  /```plaintext\n\s*delegate target "<target>" \(risk profile/,
];
let failed = false;
for (const [haystack, needle] of absent) {
  if (haystack.includes(needle)) {
    console.error(`still present: ${needle}`);
    failed = true;
  }
}
for (const needle of present) {
  if (!needle.test(delegation)) {
    console.error(`missing expected display block: ${needle}`);
    failed = true;
  }
}
if (failed) process.exit(1);
console.log('stale fenced placeholder msgids absent; long delegation refusals are plaintext blocks');
NODE
stale fenced placeholder msgids absent; long delegation refusals are plaintext blocks

$ env DOCS_FILES='docs/book/src/agents/delegation.md
docs/book/src/channels/nextcloud-talk.md' bash scripts/ci/docs_links_gate.sh
Collected 0 added link(s) from 2 docs file(s).
No added links detected in changed docs lines.

$ env npm_config_cache=tmp/npm-cache-docs DOCS_FILES='docs/book/src/agents/delegation.md
docs/book/src/channels/nextcloud-talk.md' bash scripts/ci/docs_quality_gate.sh
No prose em-dashes in changed docs files.
Linting docs files: docs/book/src/agents/delegation.md docs/book/src/channels/nextcloud-talk.md
markdownlint-cli2 v0.20.0 (markdownlint v0.40.0)
Finding: docs/book/src/agents/delegation.md docs/book/src/channels/nextcloud-talk.md !target/** !docs/book/src/SUMMARY.md
Linting: 2 file(s)
Summary: 0 error(s)

$ cd docs/book
$ env MDBOOK_BOOK__LANGUAGE=ja MDBOOK_OUTPUT__HTML__SEARCH__ENABLE=false MDBOOK_PREPROCESSOR__PEER_GROUPS__COMMAND='../../target/release/mdbook preprocess' mdbook build -d ../../tmp/mdbook-ja-check-public
INFO Book building has started
WARN unclosed HTML tag `<to>` found in `reference/cli.md` while exiting Item
WARN unclosed HTML tag `<to>` found in `reference/cli.md` while exiting Item
```

- **Beyond CI — what did you manually verify?** Checked the rendered Japanese mdBook output for the touched pages after the long delegation refusals were restored to display blocks. The two long delegation refusals render as `pre > code.language-plaintext` blocks, the Nextcloud placeholder URL renders as an inline `code` span, and the localized build no longer reports warnings for the touched `<target>`, `<caller>`, `<your-public-url>`, or `<alias>` placeholders. The remaining `<to>` warnings come from the separate generated CLI reference slice.
- **If any command was intentionally skipped, why:** Full `cargo mdbook build` was not run. This is a docs-source-only slice, and the targeted localized mdBook build covers the warning class this PR changes.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: N/A

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PR: `git revert <sha>`.
