### PR TITLE
ci(docs): run link gate in PR checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,6 +346,10 @@ jobs:
         env:
           BASE_SHA: ${{ steps.base.outputs.sha }}
         run: bash scripts/ci/docs_quality_gate.sh
+      - name: Docs link gate (added links)
+        env:
+          BASE_SHA: ${{ steps.base.outputs.sha }}
+        run: bash scripts/ci/docs_links_gate.sh
 
   zerocode-rpc-boundary:
     name: Zerocode RPC Boundary

--- a/docs/book/src/maintainers/ci-and-actions.md
+++ b/docs/book/src/maintainers/ci-and-actions.md
@@ -18,7 +18,7 @@ Composite job with multiple matrix legs:
 - **test**: `cargo nextest run --locked --workspace --exclude zeroclaw-desktop` on Linux
 - **security**: `cargo deny check`
 - **nix-eval**: evaluates the NixOS module assertions (`nixos-module-eval` flake check)
-- **docs-style**: markdown lint + em-dash prose check via `scripts/ci/docs_quality_gate.sh`
+- **docs-style**: markdown lint, em-dash prose check, and changed-line link gate via `scripts/ci/docs_quality_gate.sh` and `scripts/ci/docs_links_gate.sh`
 
 `fmt` runs first as the cheap serial gate. Every other job declares `needs: [fmt]` and fans out after formatting passes; `CI Required Gate` aggregates every result. Branch protection pins the composite gate job. A PR cannot merge until this is green. The `master` push run keeps the same quality signal while seeding trusted Rust caches for later PR runs.
 
@@ -168,7 +168,7 @@ Any PR that adds or changes a `uses:` action source must include an allowlist im
 - All third-party action refs must be pinned to a full commit SHA (per the allowlist policy above).
 - Keep `ci.yml`, `dev/ci.sh`, and `.githooks/pre-push` aligned, the same quality gates run locally and in CI.
 - Keep `scripts/ci/prepare_docker_context.sh`, `docker-image-pr.yml`, and the Docker job in `release-stable-manual.yml` aligned so PR validation exercises the same context shape the release workflow publishes.
-- The `docs-style` gate job runs `bash scripts/ci/docs_quality_gate.sh` (markdown lint + em-dash prose check). Run the same script locally before pushing docs changes.
+- The `docs-style` gate job runs `bash scripts/ci/docs_quality_gate.sh` (markdown lint + em-dash prose check) and `bash scripts/ci/docs_links_gate.sh` (changed-line link gate). Run both scripts locally before pushing docs changes.
 
 ## Emergency rollback
 

--- a/scripts/ci/collect_changed_links.py
+++ b/scripts/ci/collect_changed_links.py
@@ -89,17 +89,49 @@ def normalize_link_target(raw_target: str, source_path: str) -> str | None:
     if not path_without_fragment:
         return None
 
-    if path_without_fragment.startswith("/"):
-        resolved = path_without_fragment.lstrip("/")
-    else:
-        resolved = os.path.normpath(
-            os.path.join(os.path.dirname(source_path) or ".", path_without_fragment)
-        )
+    # Keep this changed-line gate aligned with the built-book link checker:
+    # site-absolute links and generated rustdoc API paths are assembled outside
+    # authored Markdown, so this script should not fail CI before mdBook builds.
+    if (
+        path_without_fragment.startswith("/")
+        or path_without_fragment.startswith("api/")
+        or "/api/" in path_without_fragment
+    ):
+        return None
+
+    resolved = os.path.normpath(
+        os.path.join(os.path.dirname(source_path) or ".", path_without_fragment)
+    )
 
     if not resolved or resolved == ".":
         return None
 
     return resolved
+
+
+def split_link_targets(targets: list[str]) -> tuple[list[str], list[str]]:
+    http_links: list[str] = []
+    local_links: list[str] = []
+    for target in targets:
+        if target.startswith(("http://", "https://")):
+            http_links.append(target)
+        else:
+            local_links.append(target)
+    return http_links, local_links
+
+
+def check_local_targets(local_links: list[str]) -> bool:
+    if local_links:
+        print(f"Checked {len(local_links)} local docs link target(s).")
+
+    missing_links = [target for target in local_links if not Path(target).exists()]
+    if not missing_links:
+        return True
+
+    print("Broken local docs link target(s):")
+    for target in missing_links:
+        print(f"  {target}")
+    return False
 
 
 def extract_links(text: str, source_path: str) -> list[str]:
@@ -141,14 +173,28 @@ def added_lines_for_file(base_sha: str, path: str) -> list[str]:
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Collect HTTP(S) links added in changed docs lines")
+    parser = argparse.ArgumentParser(description="Collect links added in changed docs lines")
     parser.add_argument("--base", default="", help="Base commit SHA")
     parser.add_argument(
         "--docs-files",
         default="",
         help="Newline-separated docs files list",
     )
-    parser.add_argument("--output", required=True, help="Output file for unique URLs")
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Output file for unique link targets",
+    )
+    parser.add_argument(
+        "--http-output",
+        default="",
+        help="Output file for unique HTTP(S) link targets",
+    )
+    parser.add_argument(
+        "--check-local-targets",
+        action="store_true",
+        help="Fail if any added source-relative docs link target is missing",
+    )
     args = parser.parse_args()
 
     base_sha = infer_base_sha(args.base)
@@ -160,17 +206,28 @@ def main() -> int:
         print("No docs files available for link collection.")
         return 0
 
-    unique_urls: list[str] = []
+    unique_links: list[str] = []
     seen: set[str] = set()
     for path in existing_files:
         for line in added_lines_for_file(base_sha, path):
             for link in extract_links(line, path):
                 if link not in seen:
                     seen.add(link)
-                    unique_urls.append(link)
+                    unique_links.append(link)
 
-    Path(args.output).write_text("\n".join(unique_urls) + ("\n" if unique_urls else ""), encoding="utf-8")
-    print(f"Collected {len(unique_urls)} added link(s) from {len(existing_files)} docs file(s).")
+    http_links, local_links = split_link_targets(unique_links)
+
+    Path(args.output).write_text(
+        "\n".join(unique_links) + ("\n" if unique_links else ""), encoding="utf-8"
+    )
+    if args.http_output:
+        Path(args.http_output).write_text(
+            "\n".join(http_links) + ("\n" if http_links else ""), encoding="utf-8"
+        )
+
+    print(f"Collected {len(unique_links)} added link(s) from {len(existing_files)} docs file(s).")
+    if args.check_local_targets and not check_local_targets(local_links):
+        return 1
     return 0
 
 

--- a/scripts/ci/docs_links_gate.sh
+++ b/scripts/ci/docs_links_gate.sh
@@ -6,23 +6,31 @@ BASE_SHA="${BASE_SHA:-}"
 DOCS_FILES_RAW="${DOCS_FILES:-}"
 
 LINKS_FILE="$(mktemp)"
-trap 'rm -f "$LINKS_FILE"' EXIT
+HTTP_LINKS_FILE="$(mktemp)"
+trap 'rm -f "$LINKS_FILE" "$HTTP_LINKS_FILE"' EXIT
 
 python3 ./scripts/ci/collect_changed_links.py \
     --base "$BASE_SHA" \
     --docs-files "$DOCS_FILES_RAW" \
-    --output "$LINKS_FILE"
+    --output "$LINKS_FILE" \
+    --http-output "$HTTP_LINKS_FILE" \
+    --check-local-targets
 
 if [ ! -s "$LINKS_FILE" ]; then
     echo "No added links detected in changed docs lines."
     exit 0
 fi
 
-if ! command -v lychee >/dev/null 2>&1; then
-    echo "lychee is required to run docs link gate locally."
-    echo "Install via: cargo install lychee"
-    exit 1
+if [ ! -s "$HTTP_LINKS_FILE" ]; then
+    echo "No added HTTP(S) links detected in changed docs lines."
+    exit 0
 fi
 
-echo "Checking added links with lychee (offline mode)..."
-lychee --offline --no-progress --format detailed "$LINKS_FILE"
+if ! command -v lychee >/dev/null 2>&1; then
+    echo "Added HTTP(S) links detected, but lychee is not installed; skipping optional HTTP(S) validation."
+    echo "Install via: cargo install lychee"
+    exit 0
+fi
+
+echo "Checking added HTTP(S) links with lychee (offline mode)..."
+lychee --offline --no-progress --format detailed "$HTTP_LINKS_FILE"


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Adds `scripts/ci/docs_links_gate.sh` to the required `docs-style` CI job so PRs exercise the changed-line docs link gate.
  - Extends `collect_changed_links.py` so it can split HTTP(S) targets from source-relative docs targets and fail on missing source-relative files.
  - Keeps HTTP(S) validation optional when `lychee` is not provisioned, which keeps the required docs job self-contained.
  - Updates the maintainer CI docs so `docs-style` lists both the quality gate and link gate.
- **Scope boundary:** This does not add a full-site crawler, install new CI tools, change release workflows, or run Rust validation.
- **Blast radius:** Required PR CI for docs changes. A bad link-gate result can block docs PRs until the source-relative link or script rule is fixed.
- **Linked issue(s):** Closes #8195
- **Labels:** `enhancement`, `risk: high`, `size: S`, `ci`, `docs`, `scripts`

## Validation Evidence (required)

- **Commands run and tail output:**

  ```bash
  PYTHONPYCACHEPREFIX=<tmp> python3 -m py_compile scripts/ci/collect_changed_links.py
  python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/ci.yml", encoding="utf-8")); print("ci.yml parses")'
  actionlint .github/workflows/ci.yml
  bash -n scripts/ci/docs_links_gate.sh
  shellcheck scripts/ci/docs_links_gate.sh
  git diff --check
  ```

  Tail output:

  ```text
  ci.yml parses
  ```

  ```bash
  scripts/ci/docs_links_gate.sh fixture checks
  ```

  Tail output:

  ```text
  == valid relative link ==
  Collected 1 added link(s) from 1 docs file(s).
  Checked 1 local docs link target(s).
  No added HTTP(S) links detected in changed docs lines.

  == broken relative link ==
  Collected 1 added link(s) from 1 docs file(s).
  Checked 1 local docs link target(s).
  Broken local docs link target(s):
    broken/missing.md
  broken status: 1

  == site-absolute generated API link ==
  Collected 0 added link(s) from 1 docs file(s).
  No added links detected in changed docs lines.

  == http link with lychee hidden from PATH ==
  Collected 1 added link(s) from 1 docs file(s).
  Added HTTP(S) links detected, but lychee is not installed; skipping optional HTTP(S) validation.
  Install via: cargo install lychee
  ```

  ```bash
  scripts/ci/docs_links_gate.sh committed-diff fixture checks
  ```

  Tail output:

  ```text
  == committed diff valid relative link ==
  Collected 1 added link(s) from 1 docs file(s).
  Checked 1 local docs link target(s).
  No added HTTP(S) links detected in changed docs lines.

  == committed diff broken relative link ==
  Collected 1 added link(s) from 1 docs file(s).
  Checked 1 local docs link target(s).
  Broken local docs link target(s):
    docs/missing.md
  broken diff status: 1
  ```

  ```bash
  scripts/ci/docs_links_gate.sh HTTP(S) fixture with lychee available
  ```

  Tail output:

  ```text
  Collected 1 added link(s) from 1 docs file(s).
  Checking added HTTP(S) links with lychee (offline mode)...
  Excluded.........1
  Errors...........0
  ```

- **Beyond CI — what did you manually verify?** Verified the gate accepts existing source-relative links, rejects missing source-relative links, skips site-absolute generated API links, does not require `lychee` in a CI-like PATH, and still uses `lychee --offline` when it is locally available.
- **If any command was intentionally skipped, why:** Full local `scripts/ci/docs_quality_gate.sh` markdownlint validation did not complete on this machine. The prose/em-dash portion passed, but the markdownlint step failed under the local Node 23/npm setup with an ESM/CJS package error; a Node 24 `npx` retry failed in npm before running the gate. GitHub `Docs Style` passed on head `7af0f31267`, covering the required CI docs gate.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: `N/A`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `Yes`
- If `No` or `Yes` to either: `collect_changed_links.py` now accepts optional `--http-output` and `--check-local-targets` helper flags. Existing `--output` callers still work; no user upgrade steps are required.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** Revert this PR, or remove the `Docs link gate (added links)` step from `.github/workflows/ci.yml` and restore the previous helper behavior.
- **Feature flags or config toggles:** `None`
- **Observable failure symptoms:** The required `Docs Style` job fails on docs PRs, with logs such as `Broken local docs link target(s):` or unexpected `docs_links_gate.sh` output.
