### PR TITLE
fix(zerocode): detect daemon/TUI version mismatch during connect

### DIFF
--- a/apps/zerocode/src/client.rs
+++ b/apps/zerocode/src/client.rs
@@ -452,6 +452,17 @@ impl RpcClient {
             .unwrap_or("unknown")
             .to_string();
 
+        // Check for version mismatch between TUI and daemon.
+        // See issue #8186.
+        let client_version = env!("CARGO_PKG_VERSION");
+        if client_version != server_version {
+            return Err(anyhow::Error::msg(format!(
+                "Version mismatch: zerocode is v{} but the daemon is v{}. \
+                 Rebuild and restart the daemon from the same checkout as zerocode.",
+                client_version, server_version
+            )));
+        }
+
         let tui_id = resp.get("tui_id").and_then(Value::as_str).map(String::from);
         let tui_sig = resp
             .get("tui_sig")
@@ -600,6 +611,17 @@ impl RpcClient {
             .and_then(Value::as_str)
             .unwrap_or("unknown")
             .to_string();
+
+        // Check for version mismatch between TUI and daemon.
+        // See issue #8186.
+        let client_version = env!("CARGO_PKG_VERSION");
+        if client_version != server_version {
+            return Err(anyhow::Error::msg(format!(
+                "Version mismatch: zerocode is v{} but the daemon is v{}. \
+                 Rebuild and restart the daemon from the same checkout as zerocode.",
+                client_version, server_version
+            )));
+        }
 
         let tui_id = resp.get("tui_id").and_then(Value::as_str).map(String::from);
         let tui_sig = resp


### PR DESCRIPTION
## Summary

Add version mismatch detection between zerocode TUI client and daemon after the initialize RPC handshake.

**What changed and why:** When TUI and daemon versions differ, downstream RPC errors are misleading. This fix compares `CARGO_PKG_VERSION` with `server_version` immediately after initialize and returns a clear error message.

**Scope boundary:** Adds version check after initialize, no other logic changes.

**Blast radius:** Users running mismatched TUI/daemon versions will now get a clear error message instead of cryptic RPC failures.

**Linked issue(s):** Fixes #8186

**Labels:** type: bug, risk: low, size: M

## Validation Evidence

CI Run: https://github.com/zeroclaw-labs/zeroclaw/actions/runs/27997737251
- Lint: PASS
- Test: PASS
- All 18 Quality Gate checks: PASS

- **Commands run and tail output:** CI fully green
- **Beyond CI:** Verified error message is clear and actionable

## Security & Privacy Impact

- New permissions/file access? **No**
- External network calls? **No**
- Secrets changed? **No**
- PII in tests? **No**

## Compatibility

**Yes, backward compatible** - only adds error detection, no protocol changes.

## Rollback

Low-risk: `git revert <sha>` removes version check.