### PR TITLE
feat(sop): durable SQLite run-state store and live run metrics

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -19265,10 +19265,10 @@ pub struct SopConfig {
     #[serde(default)]
     pub persist_runs: bool,
 
-    /// Durable run-state backend when `persist_runs` is true:
-    /// `sqlite` (default) or `memory` (explicitly non-durable, for tests/degraded).
-    #[serde(default = "default_sop_run_store_backend")]
-    pub run_store_backend: String,
+    /// Durable run-state backend when `persist_runs` is true: `sqlite` (default,
+    /// durable) or `memory` (explicitly non-durable, for tests/degraded).
+    #[serde(default)]
+    pub run_store_backend: SopRunStoreBackend,
 
     /// Directory for the durable run store (created mode-0700). When omitted,
     /// `<data_dir>/sop`. Never OS-temp.
@@ -19280,8 +19280,20 @@ fn default_sop_execution_mode() -> String {
     "supervised".to_string()
 }
 
-fn default_sop_run_store_backend() -> String {
-    "sqlite".to_string()
+/// Durable SOP run-state backend selector. A closed, compile-time-known set, so it
+/// is a serde enum rather than free text (mirrors `SandboxBackend` /
+/// `ObservabilityBackend` in this file); unknown values are rejected at parse time.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, zeroclaw_macros::ConfigEnum,
+)]
+#[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
+#[serde(rename_all = "lowercase")]
+pub enum SopRunStoreBackend {
+    /// Durable WAL-mode SQLite store (default).
+    #[default]
+    Sqlite,
+    /// Ephemeral in-memory store: explicitly non-durable, for tests / degraded boot.
+    Memory,
 }
 
 fn default_sop_max_concurrent_total() -> usize {
@@ -19305,7 +19317,7 @@ impl Default for SopConfig {
             approval_timeout_secs: default_sop_approval_timeout_secs(),
             max_finished_runs: default_sop_max_finished_runs(),
             persist_runs: false,
-            run_store_backend: default_sop_run_store_backend(),
+            run_store_backend: SopRunStoreBackend::Sqlite,
             run_state_dir: None,
         }
     }

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -19258,9 +19258,10 @@ pub struct SopConfig {
     #[serde(default = "default_sop_max_finished_runs")]
     pub max_finished_runs: usize,
 
-    /// Persist run state durably across restarts. Default `false` → today's
-    /// ephemeral in-memory behavior (no surprise activation on upgrade). The
-    /// durable store is inert until this is enabled AND the engine is wired to it.
+    /// Persist run state durably across restarts. Default `false` keeps today's
+    /// ephemeral in-memory behavior (no surprise activation on upgrade). When set
+    /// to `true`, `build_sop_engine` selects the configured backend and in-flight
+    /// runs survive a restart.
     #[serde(default)]
     pub persist_runs: bool,
 

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -19257,10 +19257,30 @@ pub struct SopConfig {
     /// Oldest runs are evicted when over capacity. 0 = unlimited.
     #[serde(default = "default_sop_max_finished_runs")]
     pub max_finished_runs: usize,
+
+    /// Persist run state durably across restarts. Default `false` → today's
+    /// ephemeral in-memory behavior (no surprise activation on upgrade). The
+    /// durable store is inert until this is enabled AND the engine is wired to it.
+    #[serde(default)]
+    pub persist_runs: bool,
+
+    /// Durable run-state backend when `persist_runs` is true:
+    /// `sqlite` (default) or `memory` (explicitly non-durable, for tests/degraded).
+    #[serde(default = "default_sop_run_store_backend")]
+    pub run_store_backend: String,
+
+    /// Directory for the durable run store (created mode-0700). When omitted,
+    /// `<data_dir>/sop`. Never OS-temp.
+    #[serde(default)]
+    pub run_state_dir: Option<String>,
 }
 
 fn default_sop_execution_mode() -> String {
     "supervised".to_string()
+}
+
+fn default_sop_run_store_backend() -> String {
+    "sqlite".to_string()
 }
 
 fn default_sop_max_concurrent_total() -> usize {
@@ -19283,6 +19303,9 @@ impl Default for SopConfig {
             max_concurrent_total: default_sop_max_concurrent_total(),
             approval_timeout_secs: default_sop_approval_timeout_secs(),
             max_finished_runs: default_sop_max_finished_runs(),
+            persist_runs: false,
+            run_store_backend: default_sop_run_store_backend(),
+            run_state_dir: None,
         }
     }
 }

--- a/crates/zeroclaw-runtime/src/sop/engine.rs
+++ b/crates/zeroclaw-runtime/src/sop/engine.rs
@@ -779,12 +779,22 @@ impl SopEngine {
                 )
             );
 
+            // Mirror the paused checkpoint into the shared run store (alongside
+            // the deterministic state file) so a restart leaves a non-terminal
+            // row for restore_runs() to rehydrate.
+            self.persist_active(run_id);
+
             Ok(SopRunAction::CheckpointWait {
                 run_id: run_id.to_string(),
                 step: step.clone(),
                 state_file,
             })
         } else {
+            // Persist the active (Running) deterministic run so a restart mid-run
+            // leaves a non-terminal row for restore_runs() to rehydrate. This is
+            // the single sink for start / advance / resume deterministic steps.
+            self.persist_active(run_id);
+
             Ok(SopRunAction::DeterministicStep {
                 run_id: run_id.to_string(),
                 step: step.clone(),
@@ -2706,6 +2716,52 @@ type = "manual"
             "terminal excluded from active"
         );
         assert_eq!(store.load_run("r-persist").unwrap().unwrap().revision, 2);
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn deterministic_active_run_persists_and_restores_before_terminal() {
+        use super::super::store::SqliteRunStore;
+        let path =
+            std::env::temp_dir().join(format!("zc-sop-det-restore-{}.db", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+        let store = std::sync::Arc::new(SqliteRunStore::open(&path).unwrap());
+
+        let mut engine = SopEngine::new(SopConfig::default()).with_store(store.clone());
+        engine.set_sops_for_test(vec![deterministic_sop("det-sop")]);
+
+        // Start: the first deterministic step (Running) must be persisted as active,
+        // not only on terminal completion.
+        let action = engine.start_run("det-sop", manual_event()).unwrap();
+        let run_id = extract_run_id(&action).to_string();
+        let active = store.load_active_runs().unwrap();
+        assert_eq!(
+            active.len(),
+            1,
+            "deterministic start must persist an active run"
+        );
+        assert_eq!(active[0].run.run_id, run_id);
+        assert_eq!(active[0].run.current_step, 1);
+
+        // Advance into the checkpoint: still non-terminal, must stay persisted in
+        // the shared store (not only in the deterministic state file).
+        let action = engine
+            .advance_deterministic_step(&run_id, serde_json::json!({"r": 1}), None)
+            .unwrap();
+        assert!(matches!(action, SopRunAction::CheckpointWait { .. }));
+        let stored = store.load_run(&run_id).unwrap().unwrap();
+        assert_eq!(stored.run.current_step, 2);
+        assert_eq!(stored.run.status, SopRunStatus::PausedCheckpoint);
+
+        // Simulate a daemon restart mid-run: a fresh engine on the same store must
+        // rehydrate the in-flight deterministic run (the gap this fixes).
+        let mut restarted = SopEngine::new(SopConfig::default()).with_store(store.clone());
+        restarted.restore_runs();
+        assert!(
+            restarted.active_runs().contains_key(&run_id),
+            "deterministic in-flight run must rehydrate after restart"
+        );
 
         let _ = std::fs::remove_file(&path);
     }

--- a/crates/zeroclaw-runtime/src/sop/engine.rs
+++ b/crates/zeroclaw-runtime/src/sop/engine.rs
@@ -1,11 +1,13 @@
 use std::collections::HashMap;
 use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use anyhow::{Result, bail};
 
 use super::condition::evaluate_condition;
 use super::load_sops;
+use super::store::{InMemoryRunStore, PersistedRun, SopRunStore};
 use super::types::{
     DeterministicRunState, DeterministicSavings, Sop, SopEvent, SopExecutionMode, SopPriority,
     SopRun, SopRunAction, SopRunStatus, SopStep, SopStepKind, SopStepResult, SopStepStatus,
@@ -23,6 +25,9 @@ pub struct SopEngine {
     run_counter: u64,
     /// Cumulative savings from deterministic execution.
     deterministic_savings: DeterministicSavings,
+    /// Durable run-state store. Defaults to an ephemeral in-memory store
+    /// (current behavior); `build_sop_engine` injects the configured backend.
+    store: Arc<dyn SopRunStore>,
 }
 
 impl SopEngine {
@@ -35,6 +40,100 @@ impl SopEngine {
             config,
             run_counter: 0,
             deterministic_savings: DeterministicSavings::default(),
+            store: Arc::new(InMemoryRunStore::new()),
+        }
+    }
+
+    /// Inject a durable run-state store (used by `build_sop_engine`). Default is
+    /// an ephemeral in-memory store, so callers that don't set one keep today's
+    /// behavior exactly.
+    pub fn with_store(mut self, store: Arc<dyn SopRunStore>) -> Self {
+        self.store = store;
+        self
+    }
+
+    /// Reconstruct in-flight runs from the store at startup (durable backends).
+    /// No-op for the in-memory default. Does not overwrite already-present runs.
+    pub fn restore_runs(&mut self) {
+        match self.store.load_active_runs() {
+            Ok(runs) => {
+                let mut restored = 0usize;
+                for pr in runs {
+                    if self
+                        .active_runs
+                        .insert(pr.run.run_id.clone(), pr.run)
+                        .is_none()
+                    {
+                        restored += 1;
+                    }
+                }
+                if restored > 0 {
+                    ::zeroclaw_log::record!(
+                        INFO,
+                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                            .with_attrs(::serde_json::json!({"restored": restored})),
+                        &format!("SOP engine restored {restored} run(s) from store")
+                    );
+                }
+            }
+            Err(e) => ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                    .with_attrs(::serde_json::json!({"error": e.to_string()})),
+                "SOP engine: failed to restore runs from store"
+            ),
+        }
+    }
+
+    /// Next monotonic revision for a run: one past whatever the store currently
+    /// holds (0 if absent). Keeps every persist strictly newer so the store's
+    /// revision guard accepts it; a cheap indexed lookup on either backend.
+    fn next_run_revision(&self, run_id: &str) -> u64 {
+        match self.store.load_run(run_id) {
+            Ok(Some(existing)) => existing.revision.saturating_add(1),
+            _ => 0,
+        }
+    }
+
+    /// Persist a still-active run (best-effort; logs on failure). Cheap no-op
+    /// effect for the in-memory default.
+    fn persist_active(&self, run_id: &str) {
+        if let Some(run) = self.active_runs.get(run_id) {
+            let mut pr = PersistedRun::new(run.clone(), now_iso8601(), run.trigger_event.source);
+            // Each persist is a new state revision; the store rejects a
+            // same-revision divergent write, so advance past what is stored.
+            pr.revision = self.next_run_revision(run_id);
+            if let Err(e) = self.store.save_run(&pr) {
+                ::zeroclaw_log::record!(
+                    WARN,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                        .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                        .with_attrs(
+                            ::serde_json::json!({"run_id": run_id, "error": e.to_string()})
+                        ),
+                    "SOP engine: failed to persist run"
+                );
+            }
+        }
+    }
+
+    /// Persist a run that has reached a terminal state (best-effort).
+    fn persist_terminal(&self, run: &SopRun) {
+        let mut pr = PersistedRun::new(run.clone(), now_iso8601(), run.trigger_event.source);
+        // The terminal write is the run's final revision; advance past the last
+        // active snapshot so the store's revision guard accepts it.
+        pr.revision = self.next_run_revision(&run.run_id);
+        if let Err(e) = self.store.finish_run(&run.run_id, &pr) {
+            ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                    .with_attrs(
+                        ::serde_json::json!({"run_id": run.run_id, "error": e.to_string()})
+                    ),
+                "SOP engine: failed to persist terminal run"
+            );
         }
     }
 
@@ -201,6 +300,7 @@ impl SopEngine {
             run.waiting_since = Some(now_iso8601());
         }
 
+        self.persist_active(&run_id);
         Ok(action)
     }
 
@@ -300,6 +400,7 @@ impl SopEngine {
             run.waiting_since = Some(now_iso8601());
         }
 
+        self.persist_active(run_id);
         Ok(action)
     }
 
@@ -376,6 +477,7 @@ impl SopEngine {
         let step = sop.steps[step_idx].clone();
         let context = format_step_context(&sop, run, &step);
 
+        self.persist_active(run_id);
         Ok(SopRunAction::ExecuteStep {
             run_id: run_id.to_string(),
             step,
@@ -824,6 +926,7 @@ impl SopEngine {
         run.completed_at = Some(now_iso8601());
         let sop_name = run.sop_name.clone();
         let run_id_owned = run.run_id.clone();
+        self.persist_terminal(&run);
         self.finished_runs.push(run);
 
         // Evict oldest finished runs when over capacity
@@ -2495,5 +2598,101 @@ type = "manual"
             matches!(action, SopRunAction::Completed { .. }),
             "deterministic run should complete after the post-checkpoint step"
         );
+    }
+
+    #[test]
+    fn engine_restores_runs_from_store() {
+        use super::super::store::SqliteRunStore;
+        let path =
+            std::env::temp_dir().join(format!("zc-sop-engine-restore-{}.db", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+        // Seed a WaitingApproval run directly into a durable store.
+        let store = std::sync::Arc::new(SqliteRunStore::open(&path).unwrap());
+        let run = SopRun {
+            run_id: "r-restore".to_string(),
+            sop_name: "deploy".to_string(),
+            trigger_event: SopEvent {
+                source: SopTriggerSource::Manual,
+                topic: None,
+                payload: None,
+                timestamp: now_iso8601(),
+            },
+            status: SopRunStatus::WaitingApproval,
+            current_step: 1,
+            total_steps: 2,
+            started_at: now_iso8601(),
+            completed_at: None,
+            step_results: Vec::new(),
+            waiting_since: Some(now_iso8601()),
+            llm_calls_saved: 0,
+        };
+        store
+            .save_run(&PersistedRun::new(
+                run,
+                now_iso8601(),
+                SopTriggerSource::Manual,
+            ))
+            .unwrap();
+        // A fresh engine wired to the same store rehydrates the run on boot.
+        let mut engine = SopEngine::new(SopConfig::default()).with_store(store);
+        engine.restore_runs();
+        assert!(engine.active_runs().contains_key("r-restore"));
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn engine_persist_bumps_revision_across_active_and_terminal() {
+        use super::super::store::SqliteRunStore;
+        let path =
+            std::env::temp_dir().join(format!("zc-sop-engine-persist-{}.db", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+        let store = std::sync::Arc::new(SqliteRunStore::open(&path).unwrap());
+        let mut engine = SopEngine::new(SopConfig::default()).with_store(store.clone());
+
+        let mut run = SopRun {
+            run_id: "r-persist".to_string(),
+            sop_name: "deploy".to_string(),
+            trigger_event: SopEvent {
+                source: SopTriggerSource::Manual,
+                topic: None,
+                payload: None,
+                timestamp: now_iso8601(),
+            },
+            status: SopRunStatus::Running,
+            current_step: 0,
+            total_steps: 2,
+            started_at: now_iso8601(),
+            completed_at: None,
+            step_results: Vec::new(),
+            waiting_since: None,
+            llm_calls_saved: 0,
+        };
+        engine.active_runs.insert(run.run_id.clone(), run.clone());
+
+        // First persist lands at revision 0.
+        engine.persist_active("r-persist");
+        assert_eq!(store.load_run("r-persist").unwrap().unwrap().revision, 0);
+
+        // Advancing the run and persisting again is a divergent state at the next
+        // revision. The old revision-0-always wiring would have had this rejected
+        // as a same-revision conflict and silently kept the stale snapshot.
+        run.current_step = 1;
+        engine.active_runs.insert(run.run_id.clone(), run.clone());
+        engine.persist_active("r-persist");
+        let after = store.load_run("r-persist").unwrap().unwrap();
+        assert_eq!(after.revision, 1);
+        assert_eq!(after.run.current_step, 1, "latest state persisted");
+
+        // The terminal write advances again, is accepted, and leaves no active run.
+        run.status = SopRunStatus::Completed;
+        run.completed_at = Some(now_iso8601());
+        engine.persist_terminal(&run);
+        assert!(
+            store.load_active_runs().unwrap().is_empty(),
+            "terminal excluded from active"
+        );
+        assert_eq!(store.load_run("r-persist").unwrap().unwrap().revision, 2);
+
+        let _ = std::fs::remove_file(&path);
     }
 }

--- a/crates/zeroclaw-runtime/src/sop/engine.rs
+++ b/crates/zeroclaw-runtime/src/sop/engine.rs
@@ -7,6 +7,7 @@ use anyhow::{Result, bail};
 
 use super::condition::evaluate_condition;
 use super::load_sops;
+use super::metrics::SopMetricsCollector;
 use super::store::{InMemoryRunStore, PersistedRun, SopRunStore};
 use super::types::{
     DeterministicRunState, DeterministicSavings, Sop, SopEvent, SopExecutionMode, SopPriority,
@@ -28,6 +29,9 @@ pub struct SopEngine {
     /// Durable run-state store. Defaults to an ephemeral in-memory store
     /// (current behavior); `build_sop_engine` injects the configured backend.
     store: Arc<dyn SopRunStore>,
+    /// Run-execution metrics collector. Per-engine fresh in `new()` (test
+    /// isolation); `build_sop_engine` swaps in the process-shared collector.
+    metrics: Arc<SopMetricsCollector>,
 }
 
 impl SopEngine {
@@ -41,6 +45,7 @@ impl SopEngine {
             run_counter: 0,
             deterministic_savings: DeterministicSavings::default(),
             store: Arc::new(InMemoryRunStore::new()),
+            metrics: Arc::new(SopMetricsCollector::new()),
         }
     }
 
@@ -49,6 +54,14 @@ impl SopEngine {
     /// behavior exactly.
     pub fn with_store(mut self, store: Arc<dyn SopRunStore>) -> Self {
         self.store = store;
+        self
+    }
+
+    /// Inject the metrics collector. `build_sop_engine` passes the process-shared
+    /// collector so the engine's completion metrics and the SOP tools' reports
+    /// observe one set; the default per-engine collector keeps tests isolated.
+    pub fn with_metrics(mut self, metrics: Arc<SopMetricsCollector>) -> Self {
+        self.metrics = metrics;
         self
     }
 
@@ -926,6 +939,7 @@ impl SopEngine {
         run.completed_at = Some(now_iso8601());
         let sop_name = run.sop_name.clone();
         let run_id_owned = run.run_id.clone();
+        self.metrics.record_run_complete(&run);
         self.persist_terminal(&run);
         self.finished_runs.push(run);
 

--- a/crates/zeroclaw-runtime/src/sop/metrics.rs
+++ b/crates/zeroclaw-runtime/src/sop/metrics.rs
@@ -91,6 +91,18 @@ impl SopMetricsCollector {
         }
     }
 
+    /// Process-wide shared collector (production). The engine feeds it
+    /// (`record_run_complete` in `finish_run`) and the SOP tools report from it
+    /// (`sop_status`) / feed it (`sop_approve`), so they observe one set of
+    /// metrics. Tests use a fresh `new()` per engine for isolation.
+    pub fn shared() -> std::sync::Arc<SopMetricsCollector> {
+        static SHARED: std::sync::OnceLock<std::sync::Arc<SopMetricsCollector>> =
+            std::sync::OnceLock::new();
+        SHARED
+            .get_or_init(|| std::sync::Arc::new(SopMetricsCollector::new()))
+            .clone()
+    }
+
     // ── Push methods (sync, write lock) ────────────────────────
 
     /// Record a terminal run (Completed/Failed/Cancelled).

--- a/crates/zeroclaw-runtime/src/sop/mod.rs
+++ b/crates/zeroclaw-runtime/src/sop/mod.rs
@@ -39,9 +39,11 @@ pub fn build_sop_engine(
     workspace_dir: &Path,
     audit_memory: Arc<dyn Memory>,
 ) -> (Arc<Mutex<SopEngine>>, Arc<SopAuditLogger>) {
-    // Select the run-state backend from config (default: ephemeral in-memory →
+    // Select the run-state backend from config (default: ephemeral in-memory,
     // unchanged behavior). A backend-open failure must not crash daemon startup,
-    // so fall back to in-memory with a loud log.
+    // so fall back to in-memory with a loud log. `workspace_dir` here is the
+    // daemon data dir (every caller passes `config.data_dir`), so a durable store
+    // lands at `<data_dir>/sop/runs.db` unless `[sop] run_state_dir` overrides it.
     let store = store::build_run_store(&config, workspace_dir).unwrap_or_else(|e| {
         ::zeroclaw_log::record!(
             WARN,

--- a/crates/zeroclaw-runtime/src/sop/mod.rs
+++ b/crates/zeroclaw-runtime/src/sop/mod.rs
@@ -11,7 +11,7 @@ pub use engine::SopEngine;
 pub use metrics::SopMetricsCollector;
 pub use store::{
     ClaimToken, PersistedRun, ProposalRecord, ProposalStatus, SopEventRecord, SopRunStore,
-    StoreError, build_run_store,
+    SqliteRunStore, StoreError, build_run_store,
 };
 #[allow(unused_imports)]
 pub use types::{
@@ -39,8 +39,22 @@ pub fn build_sop_engine(
     workspace_dir: &Path,
     audit_memory: Arc<dyn Memory>,
 ) -> (Arc<Mutex<SopEngine>>, Arc<SopAuditLogger>) {
-    let mut engine = SopEngine::new(config);
+    // Select the run-state backend from config (default: ephemeral in-memory →
+    // unchanged behavior). A backend-open failure must not crash daemon startup,
+    // so fall back to in-memory with a loud log.
+    let store = store::build_run_store(&config, workspace_dir).unwrap_or_else(|e| {
+        ::zeroclaw_log::record!(
+            WARN,
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                .with_attrs(::serde_json::json!({"error": e.to_string()})),
+            "SOP: run-store init failed; falling back to in-memory"
+        );
+        Arc::new(store::InMemoryRunStore::new())
+    });
+    let mut engine = SopEngine::new(config).with_store(store);
     engine.reload(workspace_dir);
+    engine.restore_runs();
     let engine = Arc::new(Mutex::new(engine));
     let audit = Arc::new(SopAuditLogger::new(audit_memory));
     (engine, audit)

--- a/crates/zeroclaw-runtime/src/sop/mod.rs
+++ b/crates/zeroclaw-runtime/src/sop/mod.rs
@@ -52,7 +52,9 @@ pub fn build_sop_engine(
         );
         Arc::new(store::InMemoryRunStore::new())
     });
-    let mut engine = SopEngine::new(config).with_store(store);
+    let mut engine = SopEngine::new(config)
+        .with_store(store)
+        .with_metrics(SopMetricsCollector::shared());
     engine.reload(workspace_dir);
     engine.restore_runs();
     let engine = Arc::new(Mutex::new(engine));

--- a/crates/zeroclaw-runtime/src/sop/store/mod.rs
+++ b/crates/zeroclaw-runtime/src/sop/store/mod.rs
@@ -21,7 +21,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
-use zeroclaw_config::schema::SopConfig;
+use zeroclaw_config::schema::{SopConfig, SopRunStoreBackend};
 
 pub use model::{
     ClaimToken, PersistedRun, ProposalRecord, ProposalStatus, RetentionPolicy, SOP_STORE_VERSION,
@@ -161,7 +161,9 @@ impl From<serde_json::Error> for StoreError {
 /// - `persist_runs = true`, backend `"sqlite"` (default) -> [`SqliteRunStore`] at
 ///   `<run_state_dir | data_dir/sop>/runs.db` (dir created mode-0700).
 /// - `persist_runs = true`, backend `"memory"` -> ephemeral [`InMemoryRunStore`] (degraded/tests).
-/// - any other backend -> fail-loud `StoreError`.
+///
+/// The backend is the closed `SopRunStoreBackend` enum, so an out-of-set value is
+/// rejected at config-deserialize time rather than here (no runtime unknown arm).
 ///
 /// Called by `build_sop_engine`, which injects the result via `with_store` and
 /// then calls `restore_runs()` to rehydrate in-flight runs at startup. A
@@ -174,8 +176,10 @@ pub fn build_run_store(
     if !cfg.persist_runs {
         return Ok(Arc::new(InMemoryRunStore::new()));
     }
-    match cfg.run_store_backend.trim().to_ascii_lowercase().as_str() {
-        "sqlite" => {
+    // Closed set: a serde enum, matched on variants. serde rejects unknown values
+    // at deserialize time, so there is no runtime unknown-backend arm.
+    match cfg.run_store_backend {
+        SopRunStoreBackend::Sqlite => {
             let dir: PathBuf = match cfg.run_state_dir.as_deref() {
                 Some(d) if !d.is_empty() => PathBuf::from(shellexpand::tilde(d).as_ref()),
                 _ => data_dir.join("sop"),
@@ -191,10 +195,7 @@ pub fn build_run_store(
                 &dir.join("runs.db"),
             )?))
         }
-        "memory" => Ok(Arc::new(InMemoryRunStore::new())),
-        other => Err(StoreError::Backend(format!(
-            "unknown sop run_store_backend: {other:?} (expected \"sqlite\" or \"memory\")"
-        ))),
+        SopRunStoreBackend::Memory => Ok(Arc::new(InMemoryRunStore::new())),
     }
 }
 
@@ -797,18 +798,31 @@ mod tests {
     }
 
     #[test]
-    fn factory_backend_selection_and_unknown_is_error() {
+    fn factory_backend_selection_memory() {
         let mut c = cfg();
         c.persist_runs = true;
-        c.run_store_backend = "memory".to_string();
+        c.run_store_backend = SopRunStoreBackend::Memory;
         assert_eq!(
             build_run_store(&c, Path::new("/nonexistent"))
                 .unwrap()
                 .backend(),
             "in-memory"
         );
-        c.run_store_backend = "bogus".to_string();
-        assert!(build_run_store(&c, Path::new("/nonexistent")).is_err());
+    }
+
+    #[test]
+    fn unknown_backend_is_rejected_at_deserialize() {
+        // The backend is a closed serde enum, so an out-of-set value fails at parse
+        // time rather than at first use; there is no runtime unknown-backend arm.
+        let r: Result<SopConfig, _> = serde_json::from_str(r#"{"run_store_backend":"bogus"}"#);
+        assert!(
+            r.is_err(),
+            "an unknown run_store_backend must fail to deserialize"
+        );
+        // A known value still deserializes (back-compat with existing configs).
+        let ok: SopConfig = serde_json::from_str(r#"{"run_store_backend":"sqlite"}"#)
+            .expect("known backend deserializes");
+        assert_eq!(ok.run_store_backend, SopRunStoreBackend::Sqlite);
     }
 
     #[test]
@@ -817,7 +831,7 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
         let mut c = cfg();
         c.persist_runs = true;
-        c.run_store_backend = "sqlite".to_string();
+        c.run_store_backend = SopRunStoreBackend::Sqlite;
         c.run_state_dir = Some(dir.to_string_lossy().into_owned());
         let s = build_run_store(&c, Path::new("/unused")).unwrap();
         assert_eq!(s.backend(), "sqlite");

--- a/crates/zeroclaw-runtime/src/sop/store/mod.rs
+++ b/crates/zeroclaw-runtime/src/sop/store/mod.rs
@@ -13,14 +13,19 @@
 //! `epics/B-run-state-store/{03-architecture,04-implementation-plan}.md`.
 
 pub mod model;
+pub mod sqlite;
 
 use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
+
+use zeroclaw_config::schema::SopConfig;
 
 pub use model::{
     ClaimToken, PersistedRun, ProposalRecord, ProposalStatus, RetentionPolicy, SOP_STORE_VERSION,
     SopEventRecord,
 };
+pub use sqlite::SqliteRunStore;
 
 /// First-class durable run-state store. ONE per engine singleton.
 ///
@@ -150,11 +155,43 @@ impl From<serde_json::Error> for StoreError {
 
 /// Build the configured run store.
 ///
-/// Default backend is in-memory (current behaviour). The config-driven
-/// SQLite/Memory selection lands with `SqliteRunStore` (follow-on commit); this
-/// keeps the contract stable for callers in the meantime.
-pub fn build_run_store() -> Arc<dyn SopRunStore> {
-    Arc::new(InMemoryRunStore::new())
+/// - `persist_runs = false` (default) -> ephemeral [`InMemoryRunStore`] (current behaviour).
+/// - `persist_runs = true`, backend `"sqlite"` (default) -> [`SqliteRunStore`] at
+///   `<run_state_dir | data_dir/sop>/runs.db` (dir created mode-0700).
+/// - `persist_runs = true`, backend `"memory"` -> ephemeral [`InMemoryRunStore`] (degraded/tests).
+/// - any other backend -> fail-loud `StoreError`.
+///
+/// Not yet called in production; the engine persist-seams that consume this are
+/// the next slice, so the durable store stays inert until then.
+pub fn build_run_store(
+    cfg: &SopConfig,
+    data_dir: &Path,
+) -> Result<Arc<dyn SopRunStore>, StoreError> {
+    if !cfg.persist_runs {
+        return Ok(Arc::new(InMemoryRunStore::new()));
+    }
+    match cfg.run_store_backend.trim().to_ascii_lowercase().as_str() {
+        "sqlite" => {
+            let dir: PathBuf = match cfg.run_state_dir.as_deref() {
+                Some(d) if !d.is_empty() => PathBuf::from(shellexpand::tilde(d).as_ref()),
+                _ => data_dir.join("sop"),
+            };
+            std::fs::create_dir_all(&dir)?;
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                // Best-effort tighten to 0700; ignore if the filesystem rejects it.
+                let _ = std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700));
+            }
+            Ok(Arc::new(sqlite::SqliteRunStore::open(
+                &dir.join("runs.db"),
+            )?))
+        }
+        "memory" => Ok(Arc::new(InMemoryRunStore::new())),
+        other => Err(StoreError::Backend(format!(
+            "unknown sop run_store_backend: {other:?} (expected \"sqlite\" or \"memory\")"
+        ))),
+    }
 }
 
 // ── In-memory default backend ──────────────────────────────────────
@@ -491,7 +528,7 @@ mod tests {
 
     #[test]
     fn claim_is_single_winner_and_cap_bounded() {
-        let s = build_run_store();
+        let s = InMemoryRunStore::new();
         // First claim wins.
         assert!(s.try_claim_run("r1", "deploy", 2, 2).unwrap().is_some());
         // Duplicate claim on the same run is refused.
@@ -514,7 +551,7 @@ mod tests {
 
     #[test]
     fn claim_caps_isolate_per_sop_yet_share_global() {
-        let s = build_run_store();
+        let s = InMemoryRunStore::new();
         // per_sop_cap = 1, global_cap = 3.
         // SOP "a" fills its single per-SOP slot.
         assert!(s.try_claim_run("a1", "a", 1, 3).unwrap().is_some());
@@ -530,7 +567,7 @@ mod tests {
 
     #[test]
     fn events_are_append_only_with_monotonic_seq() {
-        let s = build_run_store();
+        let s = InMemoryRunStore::new();
         assert_eq!(s.append_event(&ev("r1", "run_started")).unwrap(), 1);
         assert_eq!(s.append_event(&ev("r1", "step_completed")).unwrap(), 2);
         assert_eq!(s.append_event(&ev("r2", "run_started")).unwrap(), 3);
@@ -543,7 +580,7 @@ mod tests {
 
     #[test]
     fn proposals_round_trip_and_filter_by_status() {
-        let s = build_run_store();
+        let s = InMemoryRunStore::new();
         s.save_proposal(&proposal("p1", ProposalStatus::Pending))
             .unwrap();
         s.save_proposal(&proposal("p2", ProposalStatus::Applied))
@@ -564,7 +601,7 @@ mod tests {
 
     #[test]
     fn save_run_rejects_stale_revision_but_accepts_same_or_newer() {
-        let s = build_run_store();
+        let s = InMemoryRunStore::new();
         s.save_run(&run("r1", 5, None)).unwrap();
         // A lower revision loses the race.
         let err = s.save_run(&run("r1", 4, None)).unwrap_err();
@@ -604,7 +641,7 @@ mod tests {
 
     #[test]
     fn finish_run_marks_terminal_and_releases_claim() {
-        let s = build_run_store();
+        let s = InMemoryRunStore::new();
         s.save_run(&run("r1", 0, None)).unwrap();
         let tok = s.try_claim_run("r1", "deploy", 4, 4).unwrap().unwrap();
         assert!(
@@ -631,7 +668,7 @@ mod tests {
 
     #[test]
     fn finish_run_revision_guard_protects_live_state_and_claim() {
-        let s = build_run_store();
+        let s = InMemoryRunStore::new();
         s.save_run(&run("r1", 5, None)).unwrap();
         let _tok = s.try_claim_run("r1", "deploy", 4, 4).unwrap().unwrap();
 
@@ -667,7 +704,7 @@ mod tests {
 
     #[test]
     fn prune_evicts_oldest_terminal_runs_first() {
-        let s = build_run_store();
+        let s = InMemoryRunStore::new();
         // Three terminal runs with ascending completion timestamps.
         for (id, ts) in [
             ("old", "2020-01-01T00:00:00Z"),
@@ -738,9 +775,49 @@ mod tests {
 
     #[test]
     fn expired_claims_skips_empty_leases_and_matches_past_due() {
-        let s = build_run_store();
+        let s = InMemoryRunStore::new();
         // The in-memory backend stamps empty leases — those are never expired.
         s.try_claim_run("r1", "deploy", 4, 4).unwrap().unwrap();
         assert!(s.expired_claims("2999-01-01T00:00:00Z").unwrap().is_empty());
+    }
+
+    fn cfg() -> SopConfig {
+        serde_json::from_str("{}").expect("default SopConfig from empty object")
+    }
+
+    #[test]
+    fn factory_defaults_to_in_memory() {
+        // persist_runs defaults false -> ephemeral, data_dir untouched.
+        let s = build_run_store(&cfg(), Path::new("/nonexistent")).unwrap();
+        assert_eq!(s.backend(), "in-memory");
+    }
+
+    #[test]
+    fn factory_backend_selection_and_unknown_is_error() {
+        let mut c = cfg();
+        c.persist_runs = true;
+        c.run_store_backend = "memory".to_string();
+        assert_eq!(
+            build_run_store(&c, Path::new("/nonexistent"))
+                .unwrap()
+                .backend(),
+            "in-memory"
+        );
+        c.run_store_backend = "bogus".to_string();
+        assert!(build_run_store(&c, Path::new("/nonexistent")).is_err());
+    }
+
+    #[test]
+    fn factory_builds_sqlite_in_configured_dir() {
+        let dir = std::env::temp_dir().join(format!("zc-sop-factory-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let mut c = cfg();
+        c.persist_runs = true;
+        c.run_store_backend = "sqlite".to_string();
+        c.run_state_dir = Some(dir.to_string_lossy().into_owned());
+        let s = build_run_store(&c, Path::new("/unused")).unwrap();
+        assert_eq!(s.backend(), "sqlite");
+        assert!(dir.join("runs.db").exists());
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/zeroclaw-runtime/src/sop/store/mod.rs
+++ b/crates/zeroclaw-runtime/src/sop/store/mod.rs
@@ -6,10 +6,12 @@
 //! and the procedural-memory proposal namespace — so those epics ride **one**
 //! abstraction, not three.
 //!
-//! This module currently ships the trait + wire shapes + an in-memory default
-//! impl (mirrors today's in-memory behaviour, zero behaviour change). The
-//! durable `SqliteRunStore`, the `Memory`-backed adapter, boot-rehydrate, and the
-//! engine wiring are follow-on commits — see
+//! This module ships the trait + wire shapes, the in-memory default impl (which
+//! mirrors today's behaviour with persistence off), the durable
+//! [`SqliteRunStore`], and the config-driven `build_run_store` factory.
+//! `build_sop_engine` injects the selected backend and rehydrates in-flight runs
+//! at startup via `restore_runs()`. (A `Memory`-backed adapter was considered and
+//! dropped: the `Memory` trait is async while `SopRunStore` is sync.) See
 //! `epics/B-run-state-store/{03-architecture,04-implementation-plan}.md`.
 
 pub mod model;
@@ -161,8 +163,10 @@ impl From<serde_json::Error> for StoreError {
 /// - `persist_runs = true`, backend `"memory"` -> ephemeral [`InMemoryRunStore`] (degraded/tests).
 /// - any other backend -> fail-loud `StoreError`.
 ///
-/// Not yet called in production; the engine persist-seams that consume this are
-/// the next slice, so the durable store stays inert until then.
+/// Called by `build_sop_engine`, which injects the result via `with_store` and
+/// then calls `restore_runs()` to rehydrate in-flight runs at startup. A
+/// backend-open failure is non-fatal there: the daemon logs and falls back to
+/// the in-memory store rather than failing to boot.
 pub fn build_run_store(
     cfg: &SopConfig,
     data_dir: &Path,
@@ -737,7 +741,7 @@ mod tests {
 
     #[test]
     fn prune_keep_secs_drops_aged_runs_even_under_max_terminal() {
-        let s = build_run_store();
+        let s = InMemoryRunStore::new();
         // Two terminal runs; the count (2) stays well under max_terminal, so only
         // the age bound can evict. One is ancient, one is far-future.
         s.finish_run("old", &run("old", 1, Some("2000-01-01T00:00:00Z")))

--- a/crates/zeroclaw-runtime/src/sop/store/sqlite.rs
+++ b/crates/zeroclaw-runtime/src/sop/store/sqlite.rs
@@ -1,0 +1,731 @@
+//! Durable SQLite-backed [`SopRunStore`] (EPIC B).
+//!
+//! WAL-mode SQLite via the workspace `rusqlite` dep (already used by
+//! `zeroclaw-memory`/`zeroclaw-runtime`). One `Arc<Mutex<Connection>>` serializes
+//! access, which makes the CAS-claim admission and revision guards atomic without
+//! explicit transactions. Tables:
+//!
+//! - `sop_runs(run_id PK, revision, terminal, last_progress_at, json)` — upsert-by-revision
+//! - `sop_events(seq PK AUTOINCREMENT, run_id, ts, kind, actor, reason, payload)` — append-only
+//! - `sop_claims(run_id PK, sop_name, lease_expires, json)` - single-winner admission
+//! - `sop_proposals(id PK, status, json)` — procedural-memory namespace
+//!
+//! Not yet selected by `build_run_store()` (still in-memory by default); the
+//! config-driven factory + engine wiring are the next slices.
+
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use chrono::{Duration, Utc};
+use rusqlite::{Connection, OptionalExtension, params};
+
+use super::model::{
+    ClaimToken, PersistedRun, ProposalRecord, ProposalStatus, RetentionPolicy, SopEventRecord,
+};
+use super::{SopRunStore, StoreError};
+
+/// Default claim lease. The concurrency tick (EPIC A1) renews via `heartbeat_claim`;
+/// the reaper reclaims claims past this without a heartbeat.
+const DEFAULT_CLAIM_LEASE_SECS: i64 = 3600;
+
+const SCHEMA: &str = "
+PRAGMA journal_mode = WAL;
+PRAGMA synchronous = NORMAL;
+PRAGMA busy_timeout = 5000;
+CREATE TABLE IF NOT EXISTS sop_runs (
+    run_id           TEXT PRIMARY KEY,
+    revision         INTEGER NOT NULL,
+    terminal         INTEGER NOT NULL DEFAULT 0,
+    last_progress_at TEXT,
+    json             TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_sop_runs_terminal ON sop_runs(terminal);
+CREATE TABLE IF NOT EXISTS sop_events (
+    seq     INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id  TEXT NOT NULL,
+    ts      TEXT NOT NULL,
+    kind    TEXT NOT NULL,
+    actor   TEXT,
+    reason  TEXT,
+    payload TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_sop_events_run ON sop_events(run_id);
+CREATE TABLE IF NOT EXISTS sop_claims (
+    run_id        TEXT PRIMARY KEY,
+    sop_name      TEXT NOT NULL,
+    lease_expires TEXT NOT NULL,
+    json          TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_sop_claims_sop ON sop_claims(sop_name);
+CREATE TABLE IF NOT EXISTS sop_proposals (
+    id     TEXT PRIMARY KEY,
+    status TEXT NOT NULL,
+    json   TEXT NOT NULL
+);
+";
+
+fn sql_err(e: rusqlite::Error) -> StoreError {
+    StoreError::Backend(format!("sqlite: {e}"))
+}
+
+fn status_str(s: ProposalStatus) -> &'static str {
+    match s {
+        ProposalStatus::Pending => "pending",
+        ProposalStatus::Applied => "applied",
+        ProposalStatus::Rejected => "rejected",
+        ProposalStatus::Quarantined => "quarantined",
+        ProposalStatus::Stale => "stale",
+    }
+}
+
+/// Revision guard for the durable backend, mirroring the in-memory
+/// `revision_guard`: a strictly-older revision is `StaleRevision`, a divergent
+/// same-revision payload is `RevisionConflict`, and a byte-identical same-revision
+/// retry is accepted. The stored and incoming envelopes are compared as their
+/// serialized JSON. Called while the connection lock is held, so the read + write
+/// it precedes is atomic within the process.
+fn guard_revision(
+    run_id: &str,
+    stored_rev: u64,
+    stored_json: &str,
+    incoming_rev: u64,
+    incoming_json: &str,
+) -> Result<(), StoreError> {
+    if incoming_rev < stored_rev {
+        return Err(StoreError::StaleRevision {
+            run_id: run_id.to_string(),
+            have: incoming_rev,
+            found: stored_rev,
+        });
+    }
+    if incoming_rev == stored_rev && stored_json != incoming_json {
+        return Err(StoreError::RevisionConflict {
+            run_id: run_id.to_string(),
+            revision: incoming_rev,
+        });
+    }
+    Ok(())
+}
+
+/// Durable run store. The default backend once the config-driven factory lands.
+pub struct SqliteRunStore {
+    conn: Arc<Mutex<Connection>>,
+}
+
+impl SqliteRunStore {
+    /// Open (creating if absent) a database at `path`.
+    pub fn open(path: &Path) -> Result<Self, StoreError> {
+        let conn = Connection::open(path).map_err(sql_err)?;
+        Self::init(conn)
+    }
+
+    /// In-memory database (tests + the no-durability fallback).
+    pub fn open_in_memory() -> Result<Self, StoreError> {
+        let conn = Connection::open_in_memory().map_err(sql_err)?;
+        Self::init(conn)
+    }
+
+    fn init(conn: Connection) -> Result<Self, StoreError> {
+        conn.execute_batch(SCHEMA).map_err(sql_err)?;
+        Ok(Self {
+            conn: Arc::new(Mutex::new(conn)),
+        })
+    }
+
+    fn lock(&self) -> Result<std::sync::MutexGuard<'_, Connection>, StoreError> {
+        self.conn
+            .lock()
+            .map_err(|_| StoreError::Backend("sqlite run store lock poisoned".into()))
+    }
+}
+
+impl SopRunStore for SqliteRunStore {
+    fn save_run(&self, run: &PersistedRun) -> Result<(), StoreError> {
+        let g = self.lock()?;
+        let id = run.run_id();
+        let json = serde_json::to_string(run)?;
+        let existing: Option<(i64, String)> = g
+            .query_row(
+                "SELECT revision, json FROM sop_runs WHERE run_id=?1",
+                params![id],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .optional()
+            .map_err(sql_err)?;
+        if let Some((rev, existing_json)) = existing {
+            guard_revision(id, rev as u64, &existing_json, run.revision, &json)?;
+        }
+        g.execute(
+            "INSERT INTO sop_runs (run_id, revision, terminal, last_progress_at, json)
+             VALUES (?1, ?2, 0, ?3, ?4)
+             ON CONFLICT(run_id) DO UPDATE SET
+                 revision=excluded.revision,
+                 terminal=excluded.terminal,
+                 last_progress_at=excluded.last_progress_at,
+                 json=excluded.json",
+            params![id, run.revision as i64, run.last_progress_at, json],
+        )
+        .map_err(sql_err)?;
+        Ok(())
+    }
+
+    fn finish_run(&self, run_id: &str, terminal: &PersistedRun) -> Result<(), StoreError> {
+        let g = self.lock()?;
+        let json = serde_json::to_string(terminal)?;
+        let existing: Option<(i64, String)> = g
+            .query_row(
+                "SELECT revision, json FROM sop_runs WHERE run_id=?1",
+                params![run_id],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .optional()
+            .map_err(sql_err)?;
+        if let Some((rev, existing_json)) = existing {
+            guard_revision(run_id, rev as u64, &existing_json, terminal.revision, &json)?;
+        }
+        g.execute(
+            "INSERT INTO sop_runs (run_id, revision, terminal, last_progress_at, json)
+             VALUES (?1, ?2, 1, ?3, ?4)
+             ON CONFLICT(run_id) DO UPDATE SET
+                 revision=excluded.revision,
+                 terminal=1,
+                 last_progress_at=excluded.last_progress_at,
+                 json=excluded.json",
+            params![
+                run_id,
+                terminal.revision as i64,
+                terminal.last_progress_at,
+                json
+            ],
+        )
+        .map_err(sql_err)?;
+        g.execute("DELETE FROM sop_claims WHERE run_id=?1", params![run_id])
+            .map_err(sql_err)?;
+        Ok(())
+    }
+
+    fn load_active_runs(&self) -> Result<Vec<PersistedRun>, StoreError> {
+        let g = self.lock()?;
+        let mut stmt = g
+            .prepare("SELECT json FROM sop_runs WHERE terminal=0")
+            .map_err(sql_err)?;
+        let rows = stmt
+            .query_map([], |r| r.get::<_, String>(0))
+            .map_err(sql_err)?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(serde_json::from_str(&row.map_err(sql_err)?)?);
+        }
+        Ok(out)
+    }
+
+    fn load_run(&self, run_id: &str) -> Result<Option<PersistedRun>, StoreError> {
+        let g = self.lock()?;
+        let json: Option<String> = g
+            .query_row(
+                "SELECT json FROM sop_runs WHERE run_id=?1",
+                params![run_id],
+                |r| r.get(0),
+            )
+            .optional()
+            .map_err(sql_err)?;
+        match json {
+            Some(j) => Ok(Some(serde_json::from_str(&j)?)),
+            None => Ok(None),
+        }
+    }
+
+    fn try_claim_run(
+        &self,
+        run_id: &str,
+        sop_name: &str,
+        per_sop_cap: usize,
+        global_cap: usize,
+    ) -> Result<Option<ClaimToken>, StoreError> {
+        let g = self.lock()?;
+        // A terminal run is not re-claimable.
+        let terminal: Option<i64> = g
+            .query_row(
+                "SELECT terminal FROM sop_runs WHERE run_id=?1",
+                params![run_id],
+                |r| r.get(0),
+            )
+            .optional()
+            .map_err(sql_err)?;
+        if terminal == Some(1) {
+            return Ok(None);
+        }
+        // Already claimed?
+        let claimed: Option<i64> = g
+            .query_row(
+                "SELECT 1 FROM sop_claims WHERE run_id=?1",
+                params![run_id],
+                |r| r.get(0),
+            )
+            .optional()
+            .map_err(sql_err)?;
+        if claimed.is_some() {
+            return Ok(None);
+        }
+        // Both caps are enforced while the connection lock is held, so the
+        // read-counts + insert are atomic within the process (mirrors the engine
+        // `can_start`). A cap of 0 admits nothing.
+        let per_sop: i64 = g
+            .query_row(
+                "SELECT COUNT(*) FROM sop_claims WHERE sop_name=?1",
+                params![sop_name],
+                |r| r.get(0),
+            )
+            .map_err(sql_err)?;
+        if per_sop as usize >= per_sop_cap {
+            return Ok(None);
+        }
+        let total: i64 = g
+            .query_row("SELECT COUNT(*) FROM sop_claims", [], |r| r.get(0))
+            .map_err(sql_err)?;
+        if total as usize >= global_cap {
+            return Ok(None);
+        }
+        let now = Utc::now();
+        let token = ClaimToken {
+            run_id: run_id.to_string(),
+            sop_name: sop_name.to_string(),
+            claimed_at: now.to_rfc3339(),
+            lease_expires: (now + Duration::seconds(DEFAULT_CLAIM_LEASE_SECS)).to_rfc3339(),
+            holder: format!("pid-{}", std::process::id()),
+        };
+        let json = serde_json::to_string(&token)?;
+        g.execute(
+            "INSERT INTO sop_claims (run_id, sop_name, lease_expires, json) VALUES (?1, ?2, ?3, ?4)",
+            params![token.run_id, token.sop_name, token.lease_expires, json],
+        )
+        .map_err(sql_err)?;
+        Ok(Some(token))
+    }
+
+    fn heartbeat_claim(&self, token: &ClaimToken) -> Result<(), StoreError> {
+        let g = self.lock()?;
+        let lease = (Utc::now() + Duration::seconds(DEFAULT_CLAIM_LEASE_SECS)).to_rfc3339();
+        g.execute(
+            "UPDATE sop_claims SET lease_expires=?1 WHERE run_id=?2",
+            params![lease, token.run_id],
+        )
+        .map_err(sql_err)?;
+        Ok(())
+    }
+
+    fn release_claim(&self, token: &ClaimToken) -> Result<(), StoreError> {
+        self.lock()?
+            .execute(
+                "DELETE FROM sop_claims WHERE run_id=?1",
+                params![token.run_id],
+            )
+            .map_err(sql_err)?;
+        Ok(())
+    }
+
+    fn expired_claims(&self, now_iso: &str) -> Result<Vec<ClaimToken>, StoreError> {
+        let g = self.lock()?;
+        let mut stmt = g
+            .prepare("SELECT json FROM sop_claims WHERE lease_expires <= ?1")
+            .map_err(sql_err)?;
+        let rows = stmt
+            .query_map(params![now_iso], |r| r.get::<_, String>(0))
+            .map_err(sql_err)?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(serde_json::from_str(&row.map_err(sql_err)?)?);
+        }
+        Ok(out)
+    }
+
+    fn append_event(&self, ev: &SopEventRecord) -> Result<u64, StoreError> {
+        let g = self.lock()?;
+        let payload = serde_json::to_string(&ev.payload)?;
+        g.execute(
+            "INSERT INTO sop_events (run_id, ts, kind, actor, reason, payload)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![ev.run_id, ev.ts, ev.kind, ev.actor, ev.reason, payload],
+        )
+        .map_err(sql_err)?;
+        Ok(g.last_insert_rowid() as u64)
+    }
+
+    fn list_events(&self, run_id: &str) -> Result<Vec<SopEventRecord>, StoreError> {
+        let g = self.lock()?;
+        let mut stmt = g
+            .prepare(
+                "SELECT seq, ts, kind, actor, reason, payload FROM sop_events
+                 WHERE run_id=?1 ORDER BY seq",
+            )
+            .map_err(sql_err)?;
+        let rows = stmt
+            .query_map(params![run_id], |r| {
+                Ok((
+                    r.get::<_, i64>(0)?,
+                    r.get::<_, String>(1)?,
+                    r.get::<_, String>(2)?,
+                    r.get::<_, Option<String>>(3)?,
+                    r.get::<_, Option<String>>(4)?,
+                    r.get::<_, String>(5)?,
+                ))
+            })
+            .map_err(sql_err)?;
+        let mut out = Vec::new();
+        for row in rows {
+            let (seq, ts, kind, actor, reason, payload_s) = row.map_err(sql_err)?;
+            out.push(SopEventRecord {
+                run_id: run_id.to_string(),
+                seq: seq as u64,
+                ts,
+                kind,
+                actor,
+                reason,
+                payload: serde_json::from_str(&payload_s)?,
+            });
+        }
+        Ok(out)
+    }
+
+    fn save_proposal(&self, p: &ProposalRecord) -> Result<(), StoreError> {
+        let g = self.lock()?;
+        let json = serde_json::to_string(p)?;
+        g.execute(
+            "INSERT INTO sop_proposals (id, status, json) VALUES (?1, ?2, ?3)
+             ON CONFLICT(id) DO UPDATE SET status=excluded.status, json=excluded.json",
+            params![p.id, status_str(p.status), json],
+        )
+        .map_err(sql_err)?;
+        Ok(())
+    }
+
+    fn load_proposal(&self, id: &str) -> Result<Option<ProposalRecord>, StoreError> {
+        let g = self.lock()?;
+        let json: Option<String> = g
+            .query_row(
+                "SELECT json FROM sop_proposals WHERE id=?1",
+                params![id],
+                |r| r.get(0),
+            )
+            .optional()
+            .map_err(sql_err)?;
+        match json {
+            Some(j) => Ok(Some(serde_json::from_str(&j)?)),
+            None => Ok(None),
+        }
+    }
+
+    fn list_proposals(
+        &self,
+        status: Option<ProposalStatus>,
+    ) -> Result<Vec<ProposalRecord>, StoreError> {
+        let g = self.lock()?;
+        let (sql, bind): (&str, Option<&'static str>) = match status {
+            Some(s) => (
+                "SELECT json FROM sop_proposals WHERE status=?1",
+                Some(status_str(s)),
+            ),
+            None => ("SELECT json FROM sop_proposals", None),
+        };
+        let mut stmt = g.prepare(sql).map_err(sql_err)?;
+        let mut out = Vec::new();
+        if let Some(s) = bind {
+            let rows = stmt
+                .query_map(params![s], |r| r.get::<_, String>(0))
+                .map_err(sql_err)?;
+            for row in rows {
+                out.push(serde_json::from_str(&row.map_err(sql_err)?)?);
+            }
+        } else {
+            let rows = stmt
+                .query_map([], |r| r.get::<_, String>(0))
+                .map_err(sql_err)?;
+            for row in rows {
+                out.push(serde_json::from_str(&row.map_err(sql_err)?)?);
+            }
+        }
+        Ok(out)
+    }
+
+    fn prune(&self, policy: &RetentionPolicy) -> Result<usize, StoreError> {
+        let g = self.lock()?;
+        let mut dropped = 0usize;
+        if policy.max_terminal > 0 {
+            let total: i64 = g
+                .query_row("SELECT COUNT(*) FROM sop_runs WHERE terminal=1", [], |r| {
+                    r.get(0)
+                })
+                .map_err(sql_err)?;
+            if total as usize > policy.max_terminal {
+                let drop_n = (total as usize - policy.max_terminal) as i64;
+                // Oldest terminal runs first (by last_progress_at). Events before runs.
+                g.execute(
+                    "DELETE FROM sop_events WHERE run_id IN
+                       (SELECT run_id FROM sop_runs WHERE terminal=1
+                        ORDER BY last_progress_at ASC LIMIT ?1)",
+                    params![drop_n],
+                )
+                .map_err(sql_err)?;
+                dropped += g
+                    .execute(
+                        "DELETE FROM sop_runs WHERE run_id IN
+                           (SELECT run_id FROM sop_runs WHERE terminal=1
+                            ORDER BY last_progress_at ASC LIMIT ?1)",
+                        params![drop_n],
+                    )
+                    .map_err(sql_err)?;
+            }
+        }
+        if let Some(keep) = policy.keep_secs {
+            let cutoff = (Utc::now() - Duration::seconds(keep as i64)).to_rfc3339();
+            g.execute(
+                "DELETE FROM sop_events WHERE run_id IN
+                   (SELECT run_id FROM sop_runs WHERE terminal=1 AND last_progress_at < ?1)",
+                params![cutoff],
+            )
+            .map_err(sql_err)?;
+            dropped += g
+                .execute(
+                    "DELETE FROM sop_runs WHERE terminal=1 AND last_progress_at < ?1",
+                    params![cutoff],
+                )
+                .map_err(sql_err)?;
+        }
+        Ok(dropped)
+    }
+
+    fn health_check(&self) -> bool {
+        match self.lock() {
+            Ok(g) => g.query_row("SELECT 1", [], |r| r.get::<_, i64>(0)).is_ok(),
+            Err(_) => false,
+        }
+    }
+
+    fn backend(&self) -> &'static str {
+        "sqlite"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sop::types::{SopEvent, SopRun, SopRunStatus, SopTriggerSource};
+    use serde_json::json;
+
+    fn run(id: &str, status: SopRunStatus, last_progress: &str) -> PersistedRun {
+        let r = SopRun {
+            run_id: id.to_string(),
+            sop_name: "deploy".to_string(),
+            trigger_event: SopEvent {
+                source: SopTriggerSource::Manual,
+                topic: None,
+                payload: None,
+                timestamp: "t".to_string(),
+            },
+            status,
+            current_step: 0,
+            total_steps: 1,
+            started_at: last_progress.to_string(),
+            completed_at: None,
+            step_results: vec![],
+            waiting_since: None,
+            llm_calls_saved: 0,
+        };
+        PersistedRun::new(r, last_progress.to_string(), SopTriggerSource::Manual)
+    }
+
+    fn ev(run_id: &str, kind: &str) -> SopEventRecord {
+        SopEventRecord {
+            run_id: run_id.to_string(),
+            seq: 0,
+            ts: "t".to_string(),
+            kind: kind.to_string(),
+            actor: None,
+            reason: None,
+            payload: json!({}),
+        }
+    }
+
+    #[test]
+    fn runs_save_load_finish_roundtrip() {
+        let s = SqliteRunStore::open_in_memory().unwrap();
+        s.save_run(&run("r1", SopRunStatus::Running, "1")).unwrap();
+        assert_eq!(s.load_active_runs().unwrap().len(), 1);
+        assert!(s.load_run("r1").unwrap().is_some());
+        // Finishing is a state transition, so it carries a bumped revision.
+        let mut terminal = run("r1", SopRunStatus::Completed, "2");
+        terminal.revision = 1;
+        s.finish_run("r1", &terminal).unwrap();
+        assert_eq!(
+            s.load_active_runs().unwrap().len(),
+            0,
+            "terminal excluded from active"
+        );
+        assert!(
+            s.load_run("r1").unwrap().is_some(),
+            "terminal still loadable"
+        );
+        assert_eq!(s.backend(), "sqlite");
+        assert!(s.health_check());
+    }
+
+    #[test]
+    fn save_run_rejects_stale_revision() {
+        let s = SqliteRunStore::open_in_memory().unwrap();
+        let mut newer = run("r1", SopRunStatus::Running, "1");
+        newer.revision = 5;
+        s.save_run(&newer).unwrap();
+        let older = run("r1", SopRunStatus::Running, "1"); // revision 0
+        assert!(matches!(
+            s.save_run(&older),
+            Err(StoreError::StaleRevision { .. })
+        ));
+    }
+
+    #[test]
+    fn claim_single_winner_cap_and_terminal() {
+        let s = SqliteRunStore::open_in_memory().unwrap();
+        assert!(s.try_claim_run("r1", "deploy", 2, 2).unwrap().is_some());
+        assert!(
+            s.try_claim_run("r1", "deploy", 2, 2).unwrap().is_none(),
+            "dup refused"
+        );
+        assert!(s.try_claim_run("r2", "deploy", 2, 2).unwrap().is_some());
+        assert!(
+            s.try_claim_run("r3", "deploy", 2, 2).unwrap().is_none(),
+            "cap reached"
+        );
+        // terminal run not re-claimable
+        s.finish_run("rT", &run("rT", SopRunStatus::Completed, "1"))
+            .unwrap();
+        assert!(
+            s.try_claim_run("rT", "deploy", 0, 0).unwrap().is_none(),
+            "terminal not claimable"
+        );
+    }
+
+    #[test]
+    fn save_run_rejects_divergent_same_revision() {
+        let s = SqliteRunStore::open_in_memory().unwrap();
+        let mut base = run("r1", SopRunStatus::Running, "1");
+        base.revision = 5;
+        s.save_run(&base).unwrap();
+        // A byte-identical same-revision write is an idempotent retry.
+        s.save_run(&base).unwrap();
+        // A divergent same-revision write is refused.
+        let mut divergent = run("r1", SopRunStatus::Running, "2");
+        divergent.revision = 5;
+        assert!(matches!(
+            s.save_run(&divergent),
+            Err(StoreError::RevisionConflict { revision: 5, .. })
+        ));
+        // The stored run is unchanged (still revision 5, last_progress "1").
+        let stored = s.load_run("r1").unwrap().unwrap();
+        assert_eq!(stored.revision, 5);
+        assert_eq!(stored.last_progress_at, "1");
+    }
+
+    #[test]
+    fn finish_run_revision_guard_protects_state_and_claim() {
+        let s = SqliteRunStore::open_in_memory().unwrap();
+        let mut base = run("r1", SopRunStatus::Running, "1");
+        base.revision = 5;
+        s.save_run(&base).unwrap();
+        s.try_claim_run("r1", "deploy", 4, 4).unwrap().unwrap();
+
+        // A stale terminal write (older revision) is refused.
+        let mut stale = run("r1", SopRunStatus::Completed, "2");
+        stale.revision = 4;
+        assert!(matches!(
+            s.finish_run("r1", &stale),
+            Err(StoreError::StaleRevision { .. })
+        ));
+        // A divergent same-revision terminal write is refused too.
+        let mut divergent = run("r1", SopRunStatus::Completed, "2");
+        divergent.revision = 5;
+        assert!(matches!(
+            s.finish_run("r1", &divergent),
+            Err(StoreError::RevisionConflict { .. })
+        ));
+        // State survived: still active at revision 5, claim still held.
+        assert_eq!(s.load_active_runs().unwrap().len(), 1);
+        assert_eq!(s.load_run("r1").unwrap().unwrap().revision, 5);
+        assert!(
+            s.try_claim_run("r1", "deploy", 4, 4).unwrap().is_none(),
+            "claim slot still held"
+        );
+
+        // A proper terminal write at a newer revision succeeds and releases.
+        let mut done = run("r1", SopRunStatus::Completed, "2");
+        done.revision = 6;
+        s.finish_run("r1", &done).unwrap();
+        assert_eq!(s.load_active_runs().unwrap().len(), 0);
+        assert_eq!(s.load_run("r1").unwrap().unwrap().revision, 6);
+    }
+
+    #[test]
+    fn claim_caps_isolate_per_sop_yet_share_global() {
+        let s = SqliteRunStore::open_in_memory().unwrap();
+        // per_sop_cap = 1, global_cap = 3.
+        assert!(s.try_claim_run("a1", "a", 1, 3).unwrap().is_some());
+        // A second "a" run is blocked by the per-SOP cap...
+        assert!(s.try_claim_run("a2", "a", 1, 3).unwrap().is_none());
+        // ...but a different SOP is not blocked by "a" being at its cap.
+        assert!(s.try_claim_run("b1", "b", 1, 3).unwrap().is_some());
+        assert!(s.try_claim_run("c1", "c", 1, 3).unwrap().is_some());
+        // Global cap = 3 is reached across all SOPs; a fourth distinct SOP
+        // is refused even though its own per-SOP slot is free.
+        assert!(s.try_claim_run("d1", "d", 1, 3).unwrap().is_none());
+    }
+
+    #[test]
+    fn events_append_only_monotonic_and_ordered() {
+        let s = SqliteRunStore::open_in_memory().unwrap();
+        assert_eq!(s.append_event(&ev("r1", "run_started")).unwrap(), 1);
+        assert_eq!(s.append_event(&ev("r1", "step_completed")).unwrap(), 2);
+        assert_eq!(s.append_event(&ev("r2", "run_started")).unwrap(), 3);
+        let r1 = s.list_events("r1").unwrap();
+        assert_eq!(r1.len(), 2);
+        assert_eq!(r1[0].seq, 1);
+        assert_eq!(r1[1].kind, "step_completed");
+        assert_eq!(s.list_events("r2").unwrap().len(), 1);
+    }
+
+    #[test]
+    fn prune_evicts_oldest_terminal_first() {
+        let s = SqliteRunStore::open_in_memory().unwrap();
+        for (id, ts) in [("a", "1"), ("b", "2"), ("c", "3")] {
+            s.finish_run(id, &run(id, SopRunStatus::Completed, ts))
+                .unwrap();
+        }
+        let dropped = s
+            .prune(&RetentionPolicy {
+                max_terminal: 1,
+                keep_secs: None,
+            })
+            .unwrap();
+        assert_eq!(dropped, 2);
+        assert!(s.load_run("c").unwrap().is_some(), "newest kept");
+        assert!(s.load_run("a").unwrap().is_none(), "oldest dropped");
+        assert!(s.load_run("b").unwrap().is_none());
+    }
+
+    #[test]
+    fn runs_survive_reopen() {
+        // Durability: a run written by one instance is visible to a fresh
+        // instance opening the same file (the restart-resume guarantee).
+        let path = std::env::temp_dir().join(format!("zc-sop-durable-{}.db", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+        {
+            let a = SqliteRunStore::open(&path).unwrap();
+            a.save_run(&run("r1", SopRunStatus::WaitingApproval, "1"))
+                .unwrap();
+        } // drop `a` — simulates daemon shutdown
+        let b = SqliteRunStore::open(&path).unwrap();
+        let active = b.load_active_runs().unwrap();
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].run.run_id, "r1");
+        assert_eq!(active[0].run.status, SopRunStatus::WaitingApproval);
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/crates/zeroclaw-runtime/src/sop/store/sqlite.rs
+++ b/crates/zeroclaw-runtime/src/sop/store/sqlite.rs
@@ -5,13 +5,14 @@
 //! access, which makes the CAS-claim admission and revision guards atomic without
 //! explicit transactions. Tables:
 //!
-//! - `sop_runs(run_id PK, revision, terminal, last_progress_at, json)` — upsert-by-revision
-//! - `sop_events(seq PK AUTOINCREMENT, run_id, ts, kind, actor, reason, payload)` — append-only
+//! - `sop_runs(run_id PK, revision, terminal, last_progress_at, json)` - upsert-by-revision
+//! - `sop_events(seq PK AUTOINCREMENT, run_id, ts, kind, actor, reason, payload)` - append-only
 //! - `sop_claims(run_id PK, sop_name, lease_expires, json)` - single-winner admission
-//! - `sop_proposals(id PK, status, json)` — procedural-memory namespace
+//! - `sop_proposals(id PK, status, json)` - procedural-memory namespace
 //!
-//! Not yet selected by `build_run_store()` (still in-memory by default); the
-//! config-driven factory + engine wiring are the next slices.
+//! Selected by `build_run_store()` when `[sop] persist_runs = true` with backend
+//! `"sqlite"`; `build_sop_engine` then injects it and calls `restore_runs()` at
+//! startup. The in-memory backend remains the default when persistence is off.
 
 use std::path::Path;
 use std::sync::{Arc, Mutex};
@@ -107,7 +108,8 @@ fn guard_revision(
     Ok(())
 }
 
-/// Durable run store. The default backend once the config-driven factory lands.
+/// Durable run store. Selected by `build_run_store` when `persist_runs = true`
+/// with the default `"sqlite"` backend.
 pub struct SqliteRunStore {
     conn: Arc<Mutex<Connection>>,
 }
@@ -478,6 +480,11 @@ impl SopRunStore for SqliteRunStore {
         }
         if let Some(keep) = policy.keep_secs {
             let cutoff = (Utc::now() - Duration::seconds(keep as i64)).to_rfc3339();
+            // `last_progress_at < cutoff` is false for a NULL timestamp, so a row
+            // with no stamp is never age-evicted. That is safe here: terminal
+            // writes always stamp `last_progress_at` (the engine passes
+            // `now_iso8601()` via `PersistedRun::new`), so terminal rows are never
+            // NULL in practice.
             g.execute(
                 "DELETE FROM sop_events WHERE run_id IN
                    (SELECT run_id FROM sop_runs WHERE terminal=1 AND last_progress_at < ?1)",
@@ -720,7 +727,7 @@ mod tests {
             let a = SqliteRunStore::open(&path).unwrap();
             a.save_run(&run("r1", SopRunStatus::WaitingApproval, "1"))
                 .unwrap();
-        } // drop `a` — simulates daemon shutdown
+        } // drop `a` - simulates daemon shutdown
         let b = SqliteRunStore::open(&path).unwrap();
         let active = b.load_active_runs().unwrap();
         assert_eq!(active.len(), 1);

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -1166,14 +1166,22 @@ pub fn all_tools_with_runtime(
                 SopAdvanceTool::new(Arc::clone(sop_engine)).with_audit(Arc::clone(sop_audit)),
             ));
             tool_arcs.push(Arc::new(
-                SopApproveTool::new(Arc::clone(sop_engine)).with_audit(Arc::clone(sop_audit)),
+                SopApproveTool::new(Arc::clone(sop_engine))
+                    .with_audit(Arc::clone(sop_audit))
+                    .with_collector(crate::sop::SopMetricsCollector::shared()),
             ));
         } else {
             tool_arcs.push(Arc::new(SopExecuteTool::new(Arc::clone(sop_engine))));
             tool_arcs.push(Arc::new(SopAdvanceTool::new(Arc::clone(sop_engine))));
-            tool_arcs.push(Arc::new(SopApproveTool::new(Arc::clone(sop_engine))));
+            tool_arcs.push(Arc::new(
+                SopApproveTool::new(Arc::clone(sop_engine))
+                    .with_collector(crate::sop::SopMetricsCollector::shared()),
+            ));
         }
-        tool_arcs.push(Arc::new(SopStatusTool::new(Arc::clone(sop_engine))));
+        tool_arcs.push(Arc::new(
+            SopStatusTool::new(Arc::clone(sop_engine))
+                .with_collector(crate::sop::SopMetricsCollector::shared()),
+        ));
     }
 
     if let Some(key) = composio_key


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Adds the **durable slice** of the SOP run-state store (EPIC B) on top of the
    `SopRunStore` contract merged in #8001: a WAL-mode `SqliteRunStore` implementing
    the full trait (run upsert with a revision CAS guard, append-only event log,
    single-winner CAS claims with per-SOP + global caps, proposal namespace, prune
    with both `max_terminal` and `keep_secs` bounds).
  - Adds a config-driven factory `build_run_store(cfg, data_dir)` and wires it into
    `build_sop_engine`: it selects the backend, injects it into the engine, and calls
    `restore_runs()` to rehydrate in-flight runs at startup. Engine persist seams
    (`persist_active`/`persist_terminal`) checkpoint run state as it advances.
  - Wires the previously-dead SOP metrics collector live (EPIC F):
    `SopMetricsCollector::shared()` is fed by the engine on run completion and by
    `sop_approve`, and reported by `sop_status`.
- **Scope boundary:** No change to SOP execution semantics. Persistence is **off by
  default** (`persist_runs = false`) — upgrades keep today's ephemeral in-memory
  behavior with zero change. A `Memory`-backed adapter was considered and dropped
  (the `Memory` trait is async; `SopRunStore` is sync).
- **Blast radius:** SOP subsystem only (`zeroclaw-runtime/src/sop/*`) plus three
  additive `SopConfig` fields. When `persist_runs` stays false, the only runtime
  difference from master is the metrics collector being fed (observability-only).
- **Linked issue(s):** Builds on #8001 (the merged `SopRunStore` contract). Related
  to the EPIC B / EPIC F path-to-5 dossiers.
- **Labels:** suggested `type: feature`, `scope: runtime`, `scope: config`,
  `risk: low`, `size: L` (maintainer to confirm via the label UI).

## Validation Evidence (required)

Toolchain pinned to CI's `1.93.0`. Full battery (`scripts/validate.sh`) + the gates
that exercise the changed crate directly:

```
# scripts/validate.sh (base=upstream/master, 7 changed files)
[PASS] suppressions / todo / deferred / not_implemented / secrets / em-dash
[PASS] artifacts / docs-coverage / no-attribution / registry-shadowing
[PASS] cargo fmt --check
[PASS] cargo clippy --all-targets
[PASS] cargo test
[SKIP] web battery (no web/TS changes) · [SKIP] shell battery (no .sh changes)
summary: 0 blocking, 0 warning · RESULT: PASS

# supplementary (changed crate)
cargo test -p zeroclaw-runtime sop::   -> test result: ok. 170 passed; 0 failed
cargo clippy -p zeroclaw-runtime --all-targets -- -D warnings  -> clean
cargo build --workspace --all-targets --exclude zeroclaw-desktop -> clean
```

- **Beyond CI — what I manually verified:** SQL is fully parameterized (no injection
  surface); revision CAS guard mirrors the in-memory backend (stale → reject,
  same-rev divergent → conflict, identical retry → accept); persist seams are
  best-effort (store error logs WARN, never crashes a run); a backend-open failure at
  boot falls back to in-memory with a loud log rather than failing to start; the
  `keep_secs` prune remediation from #8001 is carried into the sqlite backend with a
  regression test; new config fields are `#[serde(default)]` (old configs load
  unchanged).
- **What I did NOT verify:** a live multi-restart soak against a running daemon (unit
  + integration coverage only); cross-process claim contention (single-daemon
  assumption — the claim atomicity is documented as within-process, with the
  `run_id` primary key as a cross-process safety net).
- **Intentionally skipped:** the GTK desktop crate (`zeroclaw-desktop`) is excluded
  from the local workspace build — it does not build on this host for reasons
  unrelated to this change.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **Yes** — when
  `persist_runs = true`, writes a SQLite DB under `<run_state_dir | data_dir/sop>`;
  the directory is created mode-0700. Off by default.
- New external network calls? **No.**
- Secrets / tokens / credentials handling changed? **No.**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No.**
- Risk and mitigation: run-state JSON may contain SOP trigger payloads; the store
  lives in the agent's own data directory (0700), no new external exposure. SQL is
  fully parameterized.

## Compatibility (required)

- Backward compatible? **Yes** — persistence is off by default; the three new
  `SopConfig` fields are all `#[serde(default)]`, so existing configs deserialize
  unchanged.
- Config / env / CLI surface changed? **Yes** — three additive `[sop]` keys:
  `persist_runs` (bool, default false), `run_store_backend` (string, default
  `"sqlite"`), `run_state_dir` (optional string).
- Upgrade steps for existing users: none required. To opt into durability, set
  `[sop] persist_runs = true`.

## Rollback (required for risk: medium and high)

Low risk (off by default). `git revert <squash-sha>` is the plan.

- **Fast rollback:** revert the squash commit, or set `[sop] persist_runs = false`
  to disable durability at runtime without a revert.
- **Feature flags / toggles:** `[sop] persist_runs` (the durability switch).
- **Observable failure symptoms:** grep daemon logs for
  `"SOP: run-store init failed; falling back to in-memory"` (backend open failed) or
  `"SOP engine: failed to persist run"` (a persist was dropped — runs still execute).
