### PR TITLE
test(self_test): add unit tests for security policy and tool registry checks

### DIFF
--- a/src/commands/self_test.rs
+++ b/src/commands/self_test.rs
@@ -437,7 +437,10 @@ async fn check_websocket_handshake(config: &crate::config::Config) -> CheckResul
 
 #[cfg(test)]
 mod tests {
-    use super::{format_probe_url, resolve_probe_host, web_dist_dir_expansion_reason_key};
+    use super::{
+        check_security_policy, check_tool_registry, format_probe_url, resolve_probe_host,
+        web_dist_dir_expansion_reason_key,
+    };
 
     #[test]
     fn web_dist_dir_with_tilde_resolves_to_tilde_reason_key() {
@@ -584,5 +587,21 @@ mod tests {
             format_probe_url("ws", "127.0.0.1", 42617, "/ws/chat"),
             "ws://127.0.0.1:42617/ws/chat"
         );
+    }
+
+    #[test]
+    fn check_security_policy_with_no_enabled_agents() {
+        let config = crate::config::Config::default();
+        let result = check_security_policy(&config);
+        assert!(!result.passed, "no enabled agents should fail");
+        assert_eq!(result.detail, "no enabled agents configured");
+    }
+
+    #[test]
+    fn check_tool_registry_with_no_enabled_agents() {
+        let config = crate::config::Config::default();
+        let result = check_tool_registry(&config);
+        assert!(!result.passed, "no enabled agents should fail");
+        assert_eq!(result.detail, "no enabled agents configured");
     }
 }


### PR DESCRIPTION
## Summary

Add test coverage for security policy and tool registry checks in the self-test command.

- `check_security_policy_with_no_enabled_agents`: verifies security check fails with empty agents
- `check_tool_registry_with_no_enabled_agents`: verifies tool registry check fails with empty agents

**What changed and why:** Added two tests that exercise the "no enabled agents" early-return failure branch in both production functions. Both tests use `Config::default()` which has no agents configured.

**Scope boundary:** Only adds new unit tests, no production code changes.

**Blast radius:** None - tests are isolated.

**Linked issue(s):** N/A

**Labels:** type: test, risk: low, size: XS

## Validation Evidence

Both tests pass under `cargo test`:
```bash
cargo test -p zerocode check_security_policy_with_no_enabled_agents
cargo test -p zerocode check_tool_registry_with_no_enabled_agents
```

- **Commands run and tail output:** All tests pass
- **Beyond CI:** Verified tests exercise the correct failure branches

## Security & Privacy Impact

- New permissions/file access? **No**
- External network calls? **No**
- Secrets changed? **No**
- PII in tests? **No**

## Compatibility

N/A - test-only change.

## Rollback

Low-risk: `git revert <sha>`.