### PR TITLE
fix(self_test): correct comment numbering in run_full function

### DIFF
--- a/src/commands/self_test.rs
+++ b/src/commands/self_test.rs
@@ -66,13 +66,13 @@ pub async fn run_quick(config: &crate::config::Config) -> Result<Vec<CheckResult
 pub async fn run_full(config: &crate::config::Config) -> Result<Vec<CheckResult>> {
     let mut results = run_quick(config).await?;
 
-    // 9. Gateway health endpoint
+    // 10. Gateway health endpoint
     results.push(check_gateway_health(config).await);
 
-    // 10. Memory write/read round-trip
+    // 11. Memory write/read round-trip
     results.push(check_memory_roundtrip(config).await);
 
-    // 11. WebSocket handshake
+    // 12. WebSocket handshake
     #[cfg(feature = "gateway")]
     results.push(check_websocket_handshake(config).await);
 


### PR DESCRIPTION
## Summary

Correct comment numbering in the `run_full` function to accurately reflect the order of diagnostic checks.

**What changed and why:** Fixed overlapping comment numbers in `run_full` that conflicted with `run_quick`'s numbering. The three network checks appended by `run_full` are now correctly numbered as 10, 11, 12 instead of 9, 10, 11.

**Scope boundary:** Only changes comment numbering, no production code or test changes.

**Blast radius:** None - cosmetic fix only.

**Linked issue(s):** N/A

**Labels:** type: docs, risk: low, size: XS

## Validation Evidence

Full Quality Gate passed all 18 checks:
- CI Run: https://github.com/zeroclaw-labs/zeroclaw/actions/runs/27998334116
- All checks: Format, Lint, Build (x86_64, aarch64, Windows, 32-bit), Check (all/no features), Test, Security, Nix, Benchmarks, Installer Drift, Zerocode RPC, Docs Style

- **Commands run and tail output:** CI run SHA 27998334116 - all SUCCESS
- **Beyond CI:** Verified numbering sequence is now coherent: run_quick (1-9), run_full appends (10-12)

## Security & Privacy Impact

- New permissions/file access? **No**
- External network calls? **No**
- Secrets changed? **No**
- PII in tests? **No**
- Cosmetic change only

## Compatibility

**Yes, backward compatible** - no config/env/CLI surface changed. Comment-only fix.

## Rollback

Low-risk: `git revert fc1b91c is the plan`.