### PR TITLE
fix(agent/history): saturate tool-result trim accounting to avoid underflow panic

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/history.rs
+++ b/crates/zeroclaw-runtime/src/agent/history.rs
@@ -261,7 +261,11 @@ pub fn fast_trim_tool_results(
         if msg.role == "tool" && msg.content.len() > trim_to {
             let original_len = msg.content.len();
             msg.content = truncate_tool_message(&msg.content, trim_to);
-            saved += original_len - msg.content.len();
+            // `truncate_tool_message` re-serializes tool-result JSON, which can
+            // yield a string longer than the original (e.g. key reordering or
+            // added escaping when the inner content was already short). Guard
+            // the difference so a non-shrinking rewrite can't underflow/panic.
+            saved += original_len.saturating_sub(msg.content.len());
         }
     }
     saved
@@ -611,6 +615,40 @@ mod tests {
         assert!(
             truncated.starts_with(marker),
             "expected head to retain full marker, got: {truncated}"
+        );
+    }
+
+    /// Regression: `fast_trim_tool_results` underflowed `original_len -
+    /// new_len` (panic in debug builds) when `truncate_tool_message` produced
+    /// a *longer* string than the original. This happens for a native
+    /// tool-result envelope whose inner content sits just above the trim
+    /// budget: truncating the inner string to `trim_to` and inserting the
+    /// "[... N characters truncated ...]" marker, then re-serializing the JSON
+    /// envelope, can yield more bytes than went in. The saving must saturate.
+    #[test]
+    fn fast_trim_tool_results_does_not_underflow_when_rewrite_grows() {
+        // Inner content just over the 2000-char trim budget so truncation adds
+        // the marker; wrapped in the native `{tool_call_id, content}` envelope
+        // so `truncate_tool_message` takes the JSON-preserving path.
+        let inner = "a".repeat(2010);
+        let content = serde_json::to_string(&serde_json::json!({
+            "tool_call_id": "call_underflow",
+            "content": inner,
+        }))
+        .unwrap();
+        assert!(content.len() > 2000, "envelope must exceed the trim budget");
+
+        let mut history = vec![zeroclaw_providers::ChatMessage {
+            role: "tool".to_string(),
+            content,
+        }];
+
+        // Must not panic; the rewrite grows, so nothing is saved.
+        let saved = fast_trim_tool_results(&mut history, 0);
+        assert_eq!(saved, 0, "a non-shrinking rewrite must report zero saved");
+        assert!(
+            history[0].content.contains("characters truncated"),
+            "the tool message should have been rewritten through truncation"
         );
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `fast_trim_tool_results` computed `saved += original_len - msg.content.len()`. `truncate_tool_message` re-serializes a native tool-result envelope (`{tool_call_id, content}`) and can return a string **longer** than the original, underflowing the subtraction and panicking in debug builds.
  - Growth happens when the inner content sits just above the 2000-char trim budget: truncation inserts the `"[... N characters truncated ...]"` marker and the re-serialized JSON envelope can exceed the original byte length.
  - Switched the accumulator to `saturating_sub` so a non-shrinking rewrite reports zero saved instead of panicking. Observed live with a long-context reasoning model whose tool results landed just over the trim threshold.
- **Scope boundary:** Only the saving-accounting arithmetic in `fast_trim_tool_results`. No change to truncation behavior, trim budget, or the JSON envelope format.
- **Blast radius:** Context-overflow recovery path only (`agent/history.rs`). No provider, config, or CLI surface affected.
- **Linked issue(s):** None (latent panic found while dogfooding; no existing tracker).
- **Labels:** `type: bug`, `risk: low`, `size: S`

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
# clean (no output)

cargo clippy -p zeroclaw-runtime --all-targets -- -D warnings
#   Checking zeroclaw-runtime v0.8.1 ...
#   Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 14s   (no warnings)

cargo test -p zeroclaw-runtime --lib agent::history
# test agent::history::tests::fast_trim_tool_results_does_not_underflow_when_rewrite_grows ... ok

cargo test -p zeroclaw-runtime --lib
# test result: FAILED. 2407 passed; 2 failed; 2 ignored
```

- **Commands run and tail output:** fmt clean; crate clippy clean; the new regression test passes.
- **Beyond CI — what did you manually verify?** The two failures in the full `--lib` run are **unrelated to this change** and environment-sensitive under concurrent machine load:
  - `cron::store::tests::remove_job_emits_structured_cron_delete_event` **passes in isolation**.
  - `control_plane::authority::tests::unstamped_boot_id_with_live_pid_is_not_reclaimed` asserts PID `999999` is non-live; it flakes when the host PID table is saturated (a separate benchmark was running). This PR does not touch `control_plane` or `cron`.
- **If any command was intentionally skipped, why:** Full-workspace clippy/test scoped to the touched crate (`zeroclaw-runtime`); the diff is a one-line arithmetic guard plus a unit test in `agent/history.rs`.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No` (test uses repeated ASCII placeholder text)

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk: `git revert <sha>` is the plan.