### PR TITLE
fix(scripts): use act's GoGitActionCache to resolve pinned non-tip action SHAs

### DIFF
--- a/scripts/dev/act-local.sh
+++ b/scripts/dev/act-local.sh
@@ -3,11 +3,19 @@
 #
 # Powers the release-runbook "Step 3 — Dry-run the release workflows
 # locally" instruction. Walks .github/workflows/, lets a maintainer pick
-# a job (or --all), pre-fetches pinned action SHAs that act's shallow
-# clone can't resolve, ensures .secrets exists, and threads
+# a job (or --all), ensures .secrets exists, and threads
 # --artifact-server-path plus a real GITHUB_TOKEN into every run. The
 # token is exported into the environment so act resolves it via
 # `-s GITHUB_TOKEN` (no token value lands in argv or process tables).
+#
+# Pinned action SHAs: workflows pin `uses:` to full 40-char commit SHAs,
+# and many of those commits are NOT ref tips (they're reachable only by
+# walking history, e.g. dtolnay/rust-toolchain@631a55b1...). act's
+# default on-disk action cache shells a shallow `git clone`/checkout that
+# can't resolve a non-tip SHA and dies with "reference not found". We run
+# act with its GoGitActionCache (--use-new-action-cache), which resolves
+# pinned non-tip SHAs correctly, plus --action-offline-mode so a cached
+# action is reused instead of re-fetched on every job in an --all sweep.
 #
 # --all enforces a hardcoded allowlist of dry-run-safe jobs. Anything
 # off the allowlist (publish, docker push, gh-pages deploys, external
@@ -30,7 +38,6 @@
 #   ./scripts/dev/act-local.sh --all                 # every dry-run-safe job (allowlist enforced)
 #   ./scripts/dev/act-local.sh --all --no-allowlist
 #                                                    # combined: also runs jobs not on the allowlist
-#   ./scripts/dev/act-local.sh --no-prefetch         # skip the SHA pre-fetch
 #   ./scripts/dev/act-local.sh --help
 
 set -eu
@@ -38,7 +45,6 @@ set -eu
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 ARTIFACT_DIR="${ACT_LOCAL_ARTIFACT_DIR:-/tmp/act-artifacts}"
 ACT_CACHE_DIR="${HOME}/.cache/act"
-PREFETCH=true
 NO_ALLOWLIST=false
 # Resolved at setup time. Prefers a standalone `act` on PATH, falls
 # back to `gh act` (the gh-act extension) — that's the install path
@@ -75,7 +81,7 @@ log()  { printf '==> %s\n' "$*" >&2; }
 die()  { printf 'error: %s\n' "$*" >&2; exit 1; }
 
 usage() {
-  sed -n '4,33p' "$0" | sed 's/^#//; s/^ //'
+  sed -n '4,41p' "$0" | sed 's/^#//; s/^ //'
   exit 0
 }
 
@@ -188,43 +194,6 @@ resolve_job() {
   esac
 }
 
-# ── Action SHA pre-fetch ───────────────────────────────────────────
-#
-# Extract every `uses: <owner>/<repo>@<sha>` line from the workflow
-# files, dedupe, and pre-clone each into ~/.cache/act/<owner>-<repo>@<sha>.
-# act's default shallow clone fails on arbitrary SHAs (we hit this live
-# with dtolnay/rust-toolchain@631a55b1...). Idempotent: pre-fetch is a
-# no-op when the cache dir already has action.yml.
-
-prefetch_actions() {
-  [ "$PREFETCH" = true ] || return 0
-
-  mkdir -p "$ACT_CACHE_DIR"
-  grep -hoE 'uses:[[:space:]]+[a-zA-Z0-9_./-]+@[a-f0-9]{40}' \
-    "$REPO_ROOT"/.github/workflows/*.yml \
-    | awk '{ print $2 }' \
-    | sort -u \
-    | while IFS=@ read -r action sha; do
-        slug=$(printf '%s' "$action" | tr '/' '-')
-        target="$ACT_CACHE_DIR/${slug}@${sha}"
-        if [ -f "$target/action.yml" ] || [ -f "$target/action.yaml" ]; then
-          continue
-        fi
-        short=$(printf '%s' "$sha" | cut -c1-7)
-        log "pre-fetch ${action}@${short}"
-        mkdir -p "$target"
-        (
-          cd "$target"
-          if [ ! -d .git ]; then
-            git init --quiet
-            git remote add origin "https://github.com/${action}.git"
-          fi
-          git fetch --quiet --depth 1 origin "$sha"
-          git checkout --quiet "$sha"
-        ) || die "pre-fetch failed for ${action}@${short}"
-      done
-}
-
 # ── Run a single job ───────────────────────────────────────────────
 
 cargo_toml_version() {
@@ -269,10 +238,19 @@ run_one() {
   fi
 
   # Build the act command via positional params (POSIX sh has no arrays).
+  # --use-new-action-cache selects act's GoGitActionCache, the only cache
+  # backend that resolves pinned non-tip action SHAs (the default on-disk
+  # cache shells a shallow clone and 400s on them). --action-offline-mode
+  # reuses an already-cached action instead of re-fetching it on every job
+  # of an --all sweep, and --action-cache-path keeps that cache in a
+  # predictable location.
   set -- workflow_dispatch \
          -j "$job" \
          -W "$workflow_file" \
          -s GITHUB_TOKEN \
+         --use-new-action-cache \
+         --action-offline-mode \
+         --action-cache-path "$ACT_CACHE_DIR" \
          --artifact-server-path "$ARTIFACT_DIR"
 
   if workflow_has_version_input "$workflow_file"; then
@@ -320,7 +298,6 @@ interactive_pick() {
   esac
   selected=$(printf '%s\n' "$pairs" | awk -v n="$choice" 'NR == n')
   [ -n "$selected" ] || die "no job at index $choice"
-  prefetch_actions
   run_one "$selected"
 }
 
@@ -337,9 +314,6 @@ main() {
     case "$1" in
       -h|--help)
         usage
-        ;;
-      --no-prefetch)
-        PREFETCH=false
         ;;
       --no-allowlist)
         NO_ALLOWLIST=true
@@ -368,16 +342,13 @@ main() {
       list_jobs
       ;;
     -a|--all)
-      prefetch_actions
       run_all
       ;;
     '')
-      prefetch_actions
       interactive_pick
       ;;
     *)
       pair=$(resolve_job "$action")
-      prefetch_actions
       run_one "$pair"
       ;;
   esac


### PR DESCRIPTION
## Summary

- **Base branch:** master (all contributions)
- **What changed and why:**
  - Replace the bespoke `prefetch_actions` git-clone loop in `scripts/dev/act-local.sh` with two act flags: `--use-new-action-cache` (selects act's GoGitActionCache, which resolves arbitrary commit SHAs — not just ref tips) and `--action-offline-mode` (reuses the cached checkout across an `--all` sweep instead of re-fetching). Cache path is pinned via `--action-cache-path "$HOME/.cache/act"` so behavior stays predictable.
  - Drop the `--no-prefetch` flag and the `PREFETCH` variable; they have no analog with the new cache backend.
  - Update the header comment block and `usage()` line range (`sed -n '4,33p'` → `sed -n '4,41p'`) to document the new SHA-resolution story.
- **Commit:** ab461f905fe05f4cdb1f77929bd5d77cb7d76448 (single commit; this PR is revertable as one unit).
- **Scope boundary:** Only `scripts/dev/act-local.sh`. No workflow files, no CI jobs, no Rust code, no runtime, no security policy, no docs outside the script's own header.
- **Blast radius:** Local-only developer tool. Affects maintainers who run `scripts/dev/act-local.sh` to dry-run release workflows (release runbook Step 3). No production code path, no CI step, no consumer of the script besides a human operator.
- **Linked issue(s):** None. This is a follow-up to the original `act-local.sh` introduction (88e9b07087, 0cf558bd60, a2988f0dff) — it fixes the pinned-SHA failure mode those commits left behind. Related to the release-runbook Step 3 instruction.
- **Supersedes:** https://github.com/zeroclaw-labs/zeroclaw/pull/8221.  This is a maintainer override/replacement of work originally done by @perlowja.

## Validation Evidence (required)

Shell-script-only change. The Rust battery (`cargo fmt` / `clippy` / `test`) has no signal on this diff and was intentionally skipped — see "intentionally skipped" below. The relevant local battery is `bash -n`, `shellcheck`, and `shfmt`, mirroring the spirit of the template's bootstrap-script clause.

```bash
bash -n scripts/dev/act-local.sh
shellcheck -s sh scripts/dev/act-local.sh
shfmt -d scripts/dev/act-local.sh
```

- **Commands run and tail output:**

  `bash -n scripts/dev/act-local.sh` — exit 0, no output. Parses cleanly.

  `shellcheck -s sh scripts/dev/act-local.sh` — exit 1, one **info-level** SC2086 finding:

  ```
  In scripts/dev/act-local.sh line 187:
          printf '  %s\n' $matches >&2
                          ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.
  ```

  Pre-existing on master (same warning at line 181 on master — the line number shifts only because this PR adds documentation comments above it). The `$matches` expansion is intentional word-splitting of newline-separated `<wf>:<job>` pairs for printing, and the tokens cannot contain shell metacharacters by construction (they come from workflow basenames and YAML job IDs). Not introduced by this PR; not fixed here to keep the diff focused.

  `shfmt -d scripts/dev/act-local.sh` — exit 1, 252 lines of style drift (case-arm indentation, redirect spacing, alignment). Pre-existing on master, which shows 308 lines of identical drift on the same file — this PR's net effect is a **reduction of 56 lines of shfmt drift** (purely as a side effect of deleting `prefetch_actions`). Not introduced by this PR; not addressed here because a reformat would balloon the diff and obscure the actual fix.

- **Beyond CI — what did you manually verify?**
  - Manually re-rendered the `usage()` output by running `sed -n '4,41p' scripts/dev/act-local.sh | sed 's/^#//; s/^ //'` against the new file; the new line range produces a clean help screen that includes the new pinned-SHA paragraph and stops cleanly before `set -eu`.
  - Visually confirmed the `act` invocation in `run_one` still threads `-s GITHUB_TOKEN`, `--artifact-server-path`, and (when applicable) the `version` input alongside the new cache flags. The token still resolves via the environment (no value in argv).
  - Ran `scripts/dev/act-local.sh` end-to-end on a workstation with Docker + act installed. act successfully resolved and cached the pinned non-tip action SHAs (including `dtolnay/rust-toolchain@631a55b1...`) via the GoGitActionCache backend, where the previous shallow-clone path died with "reference not found". Confirmed the fix works on the real failure mode this PR targets.

- **If any command was intentionally skipped, why:**
  - `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` — skipped. This PR touches zero Rust files (`git diff master...HEAD --stat`: `scripts/dev/act-local.sh | 69 +++++---`, single file). The Rust battery would still pass on master and provide no signal on a shell-script-only change. Running it here would be theater, not validation.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No.** The script already reads/writes `$HOME/.cache/act`; the new `--action-cache-path` flag points act at that same directory rather than letting act pick its default.
- New external network calls? **No net new endpoints.** Previously the script ran `git fetch` / `git clone` against `https://github.com/<owner>/<repo>.git` for each pinned action. Now act itself performs the equivalent fetch via its GoGitActionCache backend. Same hosts, same auth surface, fewer code paths under our control.
- Secrets / tokens / credentials handling changed? **No.** `GITHUB_TOKEN` still flows via `-s GITHUB_TOKEN` (environment-resolved, never argv). `.secrets` handling is unchanged.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No.**
- If any `Yes`, describe the risk and mitigation: N/A.

## Compatibility (required)

- Backward compatible? **No** for one narrow CLI surface: the `--no-prefetch` flag is removed. It has no analog with the new cache backend (there is nothing for the script to "not pre-fetch"). Anything else — interactive picker, `--list`, `--all`, `<wf>:<job>`, short-form job names, `--no-allowlist`, `--help` — is unchanged.
- Config / env / CLI surface changed? **Yes (small).** Removed: `--no-prefetch`. No new flags or env vars (`ACT_LOCAL_ARTIFACT_DIR` and `$HOME/.cache/act` continue to work as before).
- Upgrade steps for existing users:
  - If you have a personal alias or wrapper that passes `--no-prefetch`, drop the flag — it's now a no-op concept and the script will exit with `unknown flag: --no-prefetch`.
  - Nothing else to do. The first run will re-populate `$HOME/.cache/act` via act's own cache; subsequent runs reuse it offline.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PR. Single-commit revert: ab461f905fe05f4cdb1f77929bd5d77cb7d76448. Reverting restores the manual `prefetch_actions` loop and the `--no-prefetch` flag; no migration is needed because the script writes nothing outside `$HOME/.cache/act` and that cache is safe to coexist with either implementation.