### PR TITLE
fix(providers): expose replay_assistant_reasoning and fall back tool_call_id (#8219)

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -708,6 +708,16 @@ pub struct ModelProviderConfig {
     ///   `chat_template_kwargs = { enable_thinking = false }`
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub chat_template_kwargs: Option<serde_json::Value>,
+    /// Whether stored assistant reasoning should be replayed on outbound
+    /// assistant history messages for OpenAI-compatible providers.
+    /// `Some(false)` strips `reasoning_content`/`reasoning` from outbound
+    /// history - use this when targeting a strict endpoint (e.g. Groq,
+    /// Mistral) that rejects reasoning fields on input. `None` (default)
+    /// preserves the provider's built-in behaviour. Generalises the
+    /// `groq`-factory shortcut added in #7616 to any OpenAI-compatible
+    /// `custom` endpoint pointed at a strict backend. See #8219.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub replay_assistant_reasoning: Option<bool>,
 }
 
 // ── Per-family model model_provider configs ────────────────────────────

--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -1679,6 +1679,12 @@ impl OpenAiCompatibleModelProvider {
         let targets_mistral_tool_call_contract = self.targets_mistral_tool_call_contract();
         let mut used_tool_call_ids = std::collections::HashSet::new();
         let mut tool_call_id_map = std::collections::HashMap::new();
+        // Tracks the normalized ids of the most recent assistant message's
+        // `tool_calls` in iteration order, used as a fallback when a
+        // subsequent role=tool message loses its `tool_call_id` field
+        // (regression observed on Groq `gpt-oss-120b` second-turn history
+        // reconstruction). See #8219.
+        let mut last_assistant_tool_call_ids: Vec<String> = Vec::new();
 
         messages
             .iter()
@@ -1689,6 +1695,7 @@ impl OpenAiCompatibleModelProvider {
                     && let Ok(parsed_calls) =
                         serde_json::from_value::<Vec<ProviderToolCall>>(tool_calls_value.clone())
                 {
+                    let mut normalized_ids = Vec::with_capacity(parsed_calls.len());
                     let tool_calls = parsed_calls
                         .into_iter()
                         .map(|tc| ToolCall {
@@ -1699,6 +1706,7 @@ impl OpenAiCompatibleModelProvider {
                                     &mut used_tool_call_ids,
                                 );
                                 tool_call_id_map.insert(tc.id, normalized_id.clone());
+                                normalized_ids.push(normalized_id.clone());
                                 normalized_id
                             }),
                             kind: Some("function".to_string()),
@@ -1714,6 +1722,8 @@ impl OpenAiCompatibleModelProvider {
                             extra_content: tc.extra_content,
                         })
                         .collect::<Vec<_>>();
+
+                    last_assistant_tool_call_ids = normalized_ids;
 
                     let content = value
                         .get("content")
@@ -1740,7 +1750,7 @@ impl OpenAiCompatibleModelProvider {
                 if message.role == "tool"
                     && let Ok(value) = serde_json::from_str::<serde_json::Value>(&message.content)
                 {
-                    let tool_call_id = value
+                    let mut tool_call_id = value
                         .get("tool_call_id")
                         .and_then(serde_json::Value::as_str)
                         .map(|raw_id| {
@@ -1754,6 +1764,19 @@ impl OpenAiCompatibleModelProvider {
                                 normalized_id
                             })
                         });
+                    // Some history reconstructions drop the `tool_call_id`
+                    // field on role=tool messages. Strict backends (e.g. Groq
+                    // on `gpt-oss-120b`) reject a `null` id with HTTP 400,
+                    // breaking the second turn of any multi-turn native
+                    // tool loop. Fall back to the first id from the most
+                    // recent assistant message's `tool_calls` so the role=tool
+                    // message always carries a non-null id when one is in
+                    // scope. See #8219.
+                    if tool_call_id.is_none()
+                        && let Some(fallback_id) = last_assistant_tool_call_ids.first().cloned()
+                    {
+                        tool_call_id = Some(fallback_id);
+                    }
                     let content = value
                         .get("content")
                         .and_then(serde_json::Value::as_str)

--- a/crates/zeroclaw-providers/src/factory.rs
+++ b/crates/zeroclaw-providers/src/factory.rs
@@ -147,6 +147,13 @@ pub fn apply_compat_options(
     if let Some(mt) = opts.provider_max_tokens {
         p = p.with_max_tokens(Some(mt));
     }
+    // Generalises the Groq-specific shortcut added in #7616 so any
+    // OpenAI-compatible `custom` endpoint pointed at a strict backend
+    // (Groq, Mistral, ...) can opt out of reasoning replay without
+    // a dedicated family factory. See #8219.
+    if opts.replay_assistant_reasoning == Some(false) {
+        p = p.without_assistant_reasoning_replay();
+    }
     Box::new(p)
 }
 

--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -628,6 +628,13 @@ pub struct ModelProviderRuntimeOptions {
     pub think: Option<bool>,
     /// Passed verbatim as `chat_template_kwargs` to the llamacpp provider.
     pub chat_template_kwargs: Option<serde_json::Value>,
+    /// When `Some(false)`, the OpenAI-compatible provider will strip stored
+    /// assistant `reasoning_content`/`reasoning` from outbound history.
+    /// `Some(true)` (or `None`) preserves the provider's default replay
+    /// behaviour. Lets operators targeting strict endpoints (e.g. Groq,
+    /// Mistral) via the generic `custom` provider opt out of reasoning
+    /// replay without depending on a family-specific shortcut. See #8219.
+    pub replay_assistant_reasoning: Option<bool>,
 }
 
 impl Default for ModelProviderRuntimeOptions {
@@ -649,6 +656,7 @@ impl Default for ModelProviderRuntimeOptions {
             wire_api: None,
             think: None,
             chat_template_kwargs: None,
+            replay_assistant_reasoning: None,
         }
     }
 }
@@ -708,6 +716,7 @@ pub fn model_provider_runtime_options_from_model_provider_entry(
         wire_api: entry.and_then(|e| e.wire_api.map(|w| w.as_str().to_string())),
         think: entry.and_then(|e| e.think),
         chat_template_kwargs: entry.and_then(|e| e.chat_template_kwargs.clone()),
+        replay_assistant_reasoning: entry.and_then(|e| e.replay_assistant_reasoning),
     }
 }
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Expose `replay_assistant_reasoning` on `ModelProviderConfig` so any chat-completions-style `custom` provider can disable assistant reasoning replay on outbound history, generalising the `groq`-factory shortcut added in #7616 to strict backends (Groq, Mistral, ...) reached through a generic compatible endpoint. Addresses the first half of #8219.
  - In `OpenAiCompatibleModelProvider::convert_messages_for_native`, when a `role=tool` history message lacks a `tool_call_id` field (some multi-turn reconstruction paths drop it), fall back to the first id from the most recent assistant message's `tool_calls` so the role=tool payload always carries a non-null id. Addresses the second half of #8219.
- **Scope boundary:** Does not change Groq factory defaults (still text-fallback unless `native_tools = true`). Does not touch any non-chat-completions path. Does not change parsing of streaming tool-call ids.
- **Blast radius:** Touches `ModelProviderConfig` (new optional field), `ModelProviderRuntimeOptions` (new optional field propagated through the same constructor used by every compat provider), `apply_compat_options` (one extra `if`-branch gated on a new flag), and the chat-completions native message converter (one new local fallback for the existing role=tool branch). Other compat families opt in by setting the new flag.
- **Linked issue(s):** Closes #8219
- **Labels:** `bug`, `risk: low`, `size: S`, `providers`

## Validation Evidence (required)

Local validation is the signal CI cannot replace. Run the full battery and paste literal output (tails, failures, warnings - not "all passed").

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

Docs-only changes: replace with markdown lint + link-integrity (`scripts/ci/docs_quality_gate.sh`). Bootstrap scripts: add `bash -n install.sh`.

- **Commands run and tail output:** `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` were not executed locally because the development environment in which this PR was authored does not have the Rust toolchain installed (`cargo`/`rustc` are unavailable). The change is mechanical: one new optional `bool` field added to `ModelProviderConfig` and `ModelProviderRuntimeOptions`, propagated through the existing `model_provider_runtime_options_from_model_provider_entry` constructor, consumed by a single `if`-branch in `apply_compat_options` that calls the existing `without_assistant_reasoning_replay()` builder introduced in #7616. The `compatible.rs` change extends `convert_messages_for_native` with one local `Vec<String>` and a fallback branch that reuses values already computed in the same closure; no new error paths or trait signatures.
- **Beyond CI - what did you manually verify?** Verified that the only call site of `without_assistant_reasoning_replay()` outside `apply_compat_options` is the Groq factory, which still controls its own behaviour; the new flag is a no-op for every family that does not set it. Verified that `convert_messages_for_native` already maintains the per-call normalized id list (via `tool_call_id_map`) and that the new fallback reads from a parallel local list populated in the same iteration, so the fallback is only consulted when the upstream message genuinely lacks the field (no behaviour change for well-formed history).
- **If any command was intentionally skipped, why:** No Rust toolchain (`cargo`/`rustc`) in the authoring environment. CI on `zeroclaw-labs/zeroclaw` will run the full battery on this branch once pushed.

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation:

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `Yes` - adds optional `replay_assistant_reasoning = true|false` field on every model_provider entry under `[providers.models.<family>.<alias>]`. Existing configs that do not set the field keep their current behaviour (the field defaults to `None`, which the provider treats as "honour built-in defaults"). The `groq` factory continues to default to off-replay for Groq regardless of this flag.
- If `No` or `Yes` to either: exact upgrade steps for existing users: No migration needed. Operators who wire a generic compatible `custom` provider at a strict endpoint (e.g. `uri = https://api.groq.com/...`) can now set `replay_assistant_reasoning = false` on that alias to stop receiving the `reasoning_content` 400.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PRs: `git revert <sha>` is the plan unless otherwise noted.

Medium/high-risk PRs must fill:

- **Fast rollback command/path:** `git revert <merge-sha>`
- **Feature flags or config toggles:** New optional `replay_assistant_reasoning` field - operators can keep it unset to retain prior behaviour. The `convert_messages_for_native` fallback only activates when `role=tool` lacks a `tool_call_id`; well-formed history is unaffected.
- **Observable failure symptoms:** None expected. If a future regression surfaces, symptoms would be either (a) a strict backend rejecting `reasoning_content` for an alias that previously worked - flip `replay_assistant_reasoning = false` - or (b) a role=tool payload again reaching a strict backend as `tool_call_id: null` - grep the request body for `tool_call_id\":null` immediately after an assistant `tool_calls` block.