### PR TITLE
feat(skills): add runtime-profile prompt_injection_mode override

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -2085,7 +2085,7 @@ fn refreshed_new_session_system_prompt(ctx: &ChannelRuntimeContext) -> String {
         ),
         ctx.workspace_dir.as_ref(),
         ctx.prompt_config
-            .skills_prompt_mode_for_agent(ctx.agent_alias.as_str()),
+            .effective_skills_prompt_mode(ctx.agent_alias.as_str()),
     );
     replace_available_skills_section(ctx.system_prompt.as_str(), &refreshed_skills)
 }
@@ -9933,7 +9933,7 @@ pub async fn start_channels(
         ];
 
         if matches!(
-            config.skills_prompt_mode_for_agent(agent_alias),
+            config.effective_skills_prompt_mode(agent_alias),
             zeroclaw_config::schema::SkillsPromptInjectionMode::Compact
         ) {
             tool_descs.push((
@@ -10016,7 +10016,7 @@ pub async fn start_channels(
             bootstrap_max_chars,
             Some(&risk_profile),
             native_tools,
-            config.skills_prompt_mode_for_agent(agent_alias),
+            config.effective_skills_prompt_mode(agent_alias),
             agent.resolved.compact_context,
             agent.resolved.max_system_prompt_chars,
             true,

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -2084,7 +2084,8 @@ fn refreshed_new_session_system_prompt(ctx: &ChannelRuntimeContext) -> String {
             ctx.agent_alias.as_ref(),
         ),
         ctx.workspace_dir.as_ref(),
-        ctx.prompt_config.skills.prompt_injection_mode,
+        ctx.prompt_config
+            .skills_prompt_mode_for_agent(ctx.agent_alias.as_str()),
     );
     replace_available_skills_section(ctx.system_prompt.as_str(), &refreshed_skills)
 }
@@ -9932,7 +9933,7 @@ pub async fn start_channels(
         ];
 
         if matches!(
-            config.skills.prompt_injection_mode,
+            config.skills_prompt_mode_for_agent(agent_alias),
             zeroclaw_config::schema::SkillsPromptInjectionMode::Compact
         ) {
             tool_descs.push((
@@ -10015,7 +10016,7 @@ pub async fn start_channels(
             bootstrap_max_chars,
             Some(&risk_profile),
             native_tools,
-            config.skills.prompt_injection_mode,
+            config.skills_prompt_mode_for_agent(agent_alias),
             agent.resolved.compact_context,
             agent.resolved.max_system_prompt_chars,
             true,

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -3517,6 +3517,15 @@ pub struct AliasedAgentConfig {
     #[tab(Bundles)]
     #[serde(default)]
     pub skill_bundles: Vec<String>,
+    /// Per-agent override for how skills are injected into the system prompt.
+    /// `None` (the default) inherits the global `[skills] prompt_injection_mode`;
+    /// `full` or `compact` overrides it for this agent only. Resolved through
+    /// [`Config::skills_prompt_mode_for_agent`], the single point both the
+    /// system-prompt builder and the `read_skill` tool-registration gate
+    /// consult so they always agree on the effective mode.
+    #[tab(Bundles)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt_injection_mode: Option<SkillsPromptInjectionMode>,
     /// Knowledge bundle aliases. Additive: the agent loads every listed
     /// bundle.
     #[tab(Bundles)]
@@ -3680,6 +3689,7 @@ impl Default for AliasedAgentConfig {
             risk_profile: crate::providers::RiskProfileRef::default(),
             runtime_profile: crate::providers::RuntimeProfileRef::default(),
             skill_bundles: Vec::new(),
+            prompt_injection_mode: None,
             knowledge_bundles: Vec::new(),
             mcp_bundles: Vec::new(),
             acp_enable_mcp: false,
@@ -4072,6 +4082,23 @@ impl Config {
         }
         out.resolved = resolved;
         Some(out)
+    }
+
+    /// Resolve the effective skills prompt-injection mode for an agent: the
+    /// per-agent `[agents.<alias>] prompt_injection_mode` override when set,
+    /// otherwise the global `[skills] prompt_injection_mode`. Unknown aliases
+    /// also fall back to the global value.
+    ///
+    /// Centralizing the fallback here keeps the system-prompt builder and the
+    /// `read_skill` tool-registration gate in lockstep on one effective mode,
+    /// so a compact prompt is never paired with a missing `read_skill` tool
+    /// (or a full prompt with a spurious one).
+    #[must_use]
+    pub fn skills_prompt_mode_for_agent(&self, agent_alias: &str) -> SkillsPromptInjectionMode {
+        self.agents
+            .get(agent_alias)
+            .and_then(|agent| agent.prompt_injection_mode)
+            .unwrap_or(self.skills.prompt_injection_mode)
     }
 
     /// Resolve an agent's `model_provider` reference (`"<type>.<alias>"`) to
@@ -22105,6 +22132,75 @@ api_token = "Bearer test-token"
         );
         assert!(c.data_dir.to_string_lossy().contains("data"));
         assert!(c.config_path.to_string_lossy().contains("config.toml"));
+    }
+
+    #[test]
+    async fn skills_prompt_mode_for_agent_resolves_override_then_global() {
+        let mut config = Config::default();
+        config.skills.prompt_injection_mode = SkillsPromptInjectionMode::Full;
+        config.agents.insert(
+            "override".to_string(),
+            AliasedAgentConfig {
+                prompt_injection_mode: Some(SkillsPromptInjectionMode::Compact),
+                ..AliasedAgentConfig::default()
+            },
+        );
+        config
+            .agents
+            .insert("inherit".to_string(), AliasedAgentConfig::default());
+
+        // Per-agent override beats the global value.
+        assert_eq!(
+            config.skills_prompt_mode_for_agent("override"),
+            SkillsPromptInjectionMode::Compact
+        );
+        // No override → inherit the global value.
+        assert_eq!(
+            config.skills_prompt_mode_for_agent("inherit"),
+            SkillsPromptInjectionMode::Full
+        );
+        // Unknown alias also falls back to the global value.
+        assert_eq!(
+            config.skills_prompt_mode_for_agent("missing"),
+            SkillsPromptInjectionMode::Full
+        );
+
+        // Flipping the global moves only the inheriting/unknown agents; the
+        // explicit override is unaffected.
+        config.skills.prompt_injection_mode = SkillsPromptInjectionMode::Compact;
+        assert_eq!(
+            config.skills_prompt_mode_for_agent("inherit"),
+            SkillsPromptInjectionMode::Compact
+        );
+        assert_eq!(
+            config.skills_prompt_mode_for_agent("missing"),
+            SkillsPromptInjectionMode::Compact
+        );
+        assert_eq!(
+            config.skills_prompt_mode_for_agent("override"),
+            SkillsPromptInjectionMode::Compact
+        );
+    }
+
+    #[test]
+    async fn aliased_agent_prompt_injection_mode_deserializes() {
+        // Absent → None, so existing global-only configs keep inheriting the
+        // global mode (no migration).
+        let inherited: AliasedAgentConfig = toml::from_str("").unwrap();
+        assert_eq!(inherited.prompt_injection_mode, None);
+
+        // Explicit wire spellings parse to their variants.
+        let compact: AliasedAgentConfig =
+            toml::from_str("prompt_injection_mode = \"compact\"").unwrap();
+        assert_eq!(
+            compact.prompt_injection_mode,
+            Some(SkillsPromptInjectionMode::Compact)
+        );
+        let full: AliasedAgentConfig = toml::from_str("prompt_injection_mode = \"full\"").unwrap();
+        assert_eq!(
+            full.prompt_injection_mode,
+            Some(SkillsPromptInjectionMode::Full)
+        );
     }
 
     #[test]

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -3321,6 +3321,7 @@ pub struct ResolvedRuntime {
     pub max_tool_result_chars: usize,
     pub keep_tool_context_turns: usize,
     pub tool_receipts: ToolReceiptsConfig,
+    pub prompt_injection_mode: SkillsPromptInjectionMode,
 }
 
 impl ResolvedRuntime {
@@ -3359,6 +3360,7 @@ impl Default for ResolvedRuntime {
             max_tool_result_chars: default_max_tool_result_chars(),
             keep_tool_context_turns: default_keep_tool_context_turns(),
             tool_receipts: ToolReceiptsConfig::default(),
+            prompt_injection_mode: SkillsPromptInjectionMode::default(),
         }
     }
 }
@@ -3517,15 +3519,6 @@ pub struct AliasedAgentConfig {
     #[tab(Bundles)]
     #[serde(default)]
     pub skill_bundles: Vec<String>,
-    /// Per-agent override for how skills are injected into the system prompt.
-    /// `None` (the default) inherits the global `[skills] prompt_injection_mode`;
-    /// `full` or `compact` overrides it for this agent only. Resolved through
-    /// [`Config::skills_prompt_mode_for_agent`], the single point both the
-    /// system-prompt builder and the `read_skill` tool-registration gate
-    /// consult so they always agree on the effective mode.
-    #[tab(Bundles)]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub prompt_injection_mode: Option<SkillsPromptInjectionMode>,
     /// Knowledge bundle aliases. Additive: the agent loads every listed
     /// bundle.
     #[tab(Bundles)]
@@ -3689,7 +3682,6 @@ impl Default for AliasedAgentConfig {
             risk_profile: crate::providers::RiskProfileRef::default(),
             runtime_profile: crate::providers::RuntimeProfileRef::default(),
             skill_bundles: Vec::new(),
-            prompt_injection_mode: None,
             knowledge_bundles: Vec::new(),
             mcp_bundles: Vec::new(),
             acp_enable_mcp: false,
@@ -4068,6 +4060,7 @@ impl Config {
             max_system_prompt_chars: self.effective_max_system_prompt_chars(agent_alias),
             max_tool_result_chars: self.effective_max_tool_result_chars(agent_alias),
             keep_tool_context_turns: self.effective_keep_tool_context_turns(agent_alias),
+            prompt_injection_mode: self.effective_skills_prompt_mode(agent_alias),
             ..ResolvedRuntime::default()
         };
         if let Some(profile) = self.runtime_profile_for_agent(agent_alias) {
@@ -4085,19 +4078,20 @@ impl Config {
     }
 
     /// Resolve the effective skills prompt-injection mode for an agent: the
-    /// per-agent `[agents.<alias>] prompt_injection_mode` override when set,
-    /// otherwise the global `[skills] prompt_injection_mode`. Unknown aliases
-    /// also fall back to the global value.
+    /// agent's resolved runtime profile's `prompt_injection_mode` override when
+    /// set, otherwise the global `[skills] prompt_injection_mode`. Agents with
+    /// no runtime profile (or an unknown alias) fall back to the global value.
     ///
+    /// Keyed on the resolved runtime profile — the sanctioned surface for
+    /// per-agent runtime tunables (#6877) — so agent-inline knobs stay inert.
     /// Centralizing the fallback here keeps the system-prompt builder and the
     /// `read_skill` tool-registration gate in lockstep on one effective mode,
     /// so a compact prompt is never paired with a missing `read_skill` tool
     /// (or a full prompt with a spurious one).
     #[must_use]
-    pub fn skills_prompt_mode_for_agent(&self, agent_alias: &str) -> SkillsPromptInjectionMode {
-        self.agents
-            .get(agent_alias)
-            .and_then(|agent| agent.prompt_injection_mode)
+    pub fn effective_skills_prompt_mode(&self, agent_alias: &str) -> SkillsPromptInjectionMode {
+        self.runtime_profile_for_agent(agent_alias)
+            .and_then(|p| p.prompt_injection_mode)
             .unwrap_or(self.skills.prompt_injection_mode)
     }
 
@@ -11343,6 +11337,14 @@ pub struct RuntimeProfileConfig {
     /// Maximum memory entries injected per turn. `None` inherits global default (5).
     /// Set to `0` for unlimited.
     pub memory_recall_limit: Option<usize>,
+    /// How skills are injected into the system prompt for agents on this
+    /// profile. `None` inherits the global `[skills] prompt_injection_mode`;
+    /// `compact` inlines only compact skill metadata and registers the
+    /// `read_skill` tool, `full` inlines full skill instructions. Resolved
+    /// through [`Config::effective_skills_prompt_mode`], the single point both
+    /// the system-prompt builder and the `read_skill` tool-registration gate
+    /// consult so they always agree on the effective mode.
+    pub prompt_injection_mode: Option<SkillsPromptInjectionMode>,
     pub strict_tool_parsing: bool,
     #[nested]
     pub thinking: crate::scattered_types::ThinkingConfig,
@@ -11380,6 +11382,7 @@ impl Default for RuntimeProfileConfig {
             max_tool_result_chars: None,
             keep_tool_context_turns: None,
             memory_recall_limit: None,
+            prompt_injection_mode: None,
             strict_tool_parsing: false,
             thinking: crate::scattered_types::ThinkingConfig::default(),
             history_pruning: crate::scattered_types::HistoryPrunerConfig::default(),
@@ -22135,71 +22138,143 @@ api_token = "Bearer test-token"
     }
 
     #[test]
-    async fn skills_prompt_mode_for_agent_resolves_override_then_global() {
+    async fn runtime_profile_prompt_injection_mode_overrides_global() {
         let mut config = Config::default();
         config.skills.prompt_injection_mode = SkillsPromptInjectionMode::Full;
+        // A runtime profile that pins compact, and an agent pointing at it.
+        config.runtime_profiles.insert(
+            "compact_profile".to_string(),
+            RuntimeProfileConfig {
+                prompt_injection_mode: Some(SkillsPromptInjectionMode::Compact),
+                ..RuntimeProfileConfig::default()
+            },
+        );
+        // A runtime profile that leaves the mode unset (inherits global).
+        config
+            .runtime_profiles
+            .insert("unset_profile".to_string(), RuntimeProfileConfig::default());
         config.agents.insert(
             "override".to_string(),
             AliasedAgentConfig {
-                prompt_injection_mode: Some(SkillsPromptInjectionMode::Compact),
+                runtime_profile: "compact_profile".into(),
                 ..AliasedAgentConfig::default()
             },
         );
+        config.agents.insert(
+            "unset".to_string(),
+            AliasedAgentConfig {
+                runtime_profile: "unset_profile".into(),
+                ..AliasedAgentConfig::default()
+            },
+        );
+        // An agent with no runtime profile inherits the global.
         config
             .agents
             .insert("inherit".to_string(), AliasedAgentConfig::default());
 
-        // Per-agent override beats the global value.
+        // Profile override beats the global value.
         assert_eq!(
-            config.skills_prompt_mode_for_agent("override"),
+            config.effective_skills_prompt_mode("override"),
             SkillsPromptInjectionMode::Compact
         );
-        // No override → inherit the global value.
+        // Profile present but mode unset → inherit the global value.
         assert_eq!(
-            config.skills_prompt_mode_for_agent("inherit"),
+            config.effective_skills_prompt_mode("unset"),
+            SkillsPromptInjectionMode::Full
+        );
+        // No runtime profile → inherit the global value.
+        assert_eq!(
+            config.effective_skills_prompt_mode("inherit"),
             SkillsPromptInjectionMode::Full
         );
         // Unknown alias also falls back to the global value.
         assert_eq!(
-            config.skills_prompt_mode_for_agent("missing"),
+            config.effective_skills_prompt_mode("missing"),
             SkillsPromptInjectionMode::Full
         );
 
-        // Flipping the global moves only the inheriting/unknown agents; the
-        // explicit override is unaffected.
+        // Flipping the global moves only the inheriting/unset/unknown agents;
+        // the profile override is unaffected.
         config.skills.prompt_injection_mode = SkillsPromptInjectionMode::Compact;
         assert_eq!(
-            config.skills_prompt_mode_for_agent("inherit"),
+            config.effective_skills_prompt_mode("unset"),
             SkillsPromptInjectionMode::Compact
         );
         assert_eq!(
-            config.skills_prompt_mode_for_agent("missing"),
+            config.effective_skills_prompt_mode("inherit"),
             SkillsPromptInjectionMode::Compact
         );
         assert_eq!(
-            config.skills_prompt_mode_for_agent("override"),
+            config.effective_skills_prompt_mode("missing"),
+            SkillsPromptInjectionMode::Compact
+        );
+        assert_eq!(
+            config.effective_skills_prompt_mode("override"),
             SkillsPromptInjectionMode::Compact
         );
     }
 
     #[test]
-    async fn aliased_agent_prompt_injection_mode_deserializes() {
-        // Absent → None, so existing global-only configs keep inheriting the
-        // global mode (no migration).
-        let inherited: AliasedAgentConfig = toml::from_str("").unwrap();
+    async fn runtime_profile_prompt_injection_mode_deserializes() {
+        // Absent → None, so a profile that omits the key inherits the global
+        // mode (no migration for existing global-only configs).
+        let inherited: RuntimeProfileConfig = toml::from_str("").unwrap();
         assert_eq!(inherited.prompt_injection_mode, None);
 
         // Explicit wire spellings parse to their variants.
-        let compact: AliasedAgentConfig =
+        let compact: RuntimeProfileConfig =
             toml::from_str("prompt_injection_mode = \"compact\"").unwrap();
         assert_eq!(
             compact.prompt_injection_mode,
             Some(SkillsPromptInjectionMode::Compact)
         );
-        let full: AliasedAgentConfig = toml::from_str("prompt_injection_mode = \"full\"").unwrap();
+        let full: RuntimeProfileConfig =
+            toml::from_str("prompt_injection_mode = \"full\"").unwrap();
         assert_eq!(
             full.prompt_injection_mode,
             Some(SkillsPromptInjectionMode::Full)
+        );
+    }
+
+    #[test]
+    async fn resolved_agent_config_bakes_prompt_injection_mode_from_profile() {
+        // The documented invariant: a runtime_profile knob must be threaded
+        // through `resolved_agent_config` into `ResolvedRuntime`, consistent
+        // with the `effective_*` helper.
+        let raw = r#"
+[skills]
+prompt_injection_mode = "full"
+
+[runtime_profiles.fast]
+prompt_injection_mode = "compact"
+
+[agents.default]
+runtime_profile = "fast"
+
+[agents.plain]
+"#;
+        let parsed = parse_test_config(raw);
+
+        // Profiled agent: resolved value + effective helper both see compact.
+        let resolved = parsed
+            .resolved_agent_config("default")
+            .expect("agent default resolves");
+        assert_eq!(
+            resolved.resolved.prompt_injection_mode,
+            SkillsPromptInjectionMode::Compact
+        );
+        assert_eq!(
+            parsed.effective_skills_prompt_mode("default"),
+            SkillsPromptInjectionMode::Compact
+        );
+
+        // Profile-less agent: resolved value falls back to the global default.
+        let plain = parsed
+            .resolved_agent_config("plain")
+            .expect("agent plain resolves");
+        assert_eq!(
+            plain.resolved.prompt_injection_mode,
+            SkillsPromptInjectionMode::Full
         );
     }
 

--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -1819,7 +1819,7 @@ impl Agent {
             .route_model_by_hint(route_model_by_hint)
             .identity_config(agent_cfg.identity.clone())
             .skills(skills)
-            .skills_prompt_mode(config.skills_prompt_mode_for_agent(agent_alias))
+            .skills_prompt_mode(config.effective_skills_prompt_mode(agent_alias))
             .auto_save(config.memory.auto_save)
             .exclude_memory(exclude_memory)
             .security_summary(Some(security.prompt_summary()))

--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -1819,7 +1819,7 @@ impl Agent {
             .route_model_by_hint(route_model_by_hint)
             .identity_config(agent_cfg.identity.clone())
             .skills(skills)
-            .skills_prompt_mode(config.skills.prompt_injection_mode)
+            .skills_prompt_mode(config.skills_prompt_mode_for_agent(agent_alias))
             .auto_save(config.memory.auto_save)
             .exclude_memory(exclude_memory)
             .security_summary(Some(security.prompt_summary()))

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -1547,7 +1547,7 @@ pub async fn run(
             ),
         ];
         if matches!(
-            config.skills.prompt_injection_mode,
+            config.skills_prompt_mode_for_agent(agent_alias),
             zeroclaw_config::schema::SkillsPromptInjectionMode::Compact
         ) {
             tool_descs.push((
@@ -1668,7 +1668,7 @@ pub async fn run(
             &prompt_excluded_tools,
             activated_handle.as_ref(),
             agent.resolved.strict_tool_parsing,
-            config.skills.prompt_injection_mode,
+            config.skills_prompt_mode_for_agent(agent_alias),
             eff_compact_context,
             eff_max_system_prompt_chars,
             true,
@@ -1763,7 +1763,7 @@ pub async fn run(
                 &excluded_tools,
                 activated_handle.as_ref(),
                 agent.resolved.strict_tool_parsing,
-                config.skills.prompt_injection_mode,
+                config.skills_prompt_mode_for_agent(agent_alias),
                 eff_compact_context,
                 eff_max_system_prompt_chars,
                 true,
@@ -1879,7 +1879,7 @@ pub async fn run(
                         &excluded_tools,
                         activated_handle.as_ref(),
                         agent.resolved.strict_tool_parsing,
-                        config.skills.prompt_injection_mode,
+                        config.skills_prompt_mode_for_agent(agent_alias),
                         eff_compact_context,
                         eff_max_system_prompt_chars,
                         true,
@@ -2434,7 +2434,7 @@ pub async fn run(
                             &excluded_tools,
                             activated_handle.as_ref(),
                             agent.resolved.strict_tool_parsing,
-                            config.skills.prompt_injection_mode,
+                            config.skills_prompt_mode_for_agent(agent_alias),
                             eff_compact_context,
                             eff_max_system_prompt_chars,
                             true,
@@ -3041,7 +3041,7 @@ pub async fn process_message(
             ("image_info", "Read image metadata."),
         ];
         if matches!(
-            config.skills.prompt_injection_mode,
+            config.skills_prompt_mode_for_agent(agent_alias),
             zeroclaw_config::schema::SkillsPromptInjectionMode::Compact
         ) {
             tool_descs.push((
@@ -3156,7 +3156,7 @@ pub async fn process_message(
                 bootstrap_max_chars,
                 Some(&risk_profile),
                 native_tool_specs_present,
-                config.skills.prompt_injection_mode,
+                config.skills_prompt_mode_for_agent(agent_alias),
                 eff_compact_context,
                 eff_max_system_prompt_chars,
                 false,

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -1547,7 +1547,7 @@ pub async fn run(
             ),
         ];
         if matches!(
-            config.skills_prompt_mode_for_agent(agent_alias),
+            config.effective_skills_prompt_mode(agent_alias),
             zeroclaw_config::schema::SkillsPromptInjectionMode::Compact
         ) {
             tool_descs.push((
@@ -1668,7 +1668,7 @@ pub async fn run(
             &prompt_excluded_tools,
             activated_handle.as_ref(),
             agent.resolved.strict_tool_parsing,
-            config.skills_prompt_mode_for_agent(agent_alias),
+            config.effective_skills_prompt_mode(agent_alias),
             eff_compact_context,
             eff_max_system_prompt_chars,
             true,
@@ -1763,7 +1763,7 @@ pub async fn run(
                 &excluded_tools,
                 activated_handle.as_ref(),
                 agent.resolved.strict_tool_parsing,
-                config.skills_prompt_mode_for_agent(agent_alias),
+                config.effective_skills_prompt_mode(agent_alias),
                 eff_compact_context,
                 eff_max_system_prompt_chars,
                 true,
@@ -1879,7 +1879,7 @@ pub async fn run(
                         &excluded_tools,
                         activated_handle.as_ref(),
                         agent.resolved.strict_tool_parsing,
-                        config.skills_prompt_mode_for_agent(agent_alias),
+                        config.effective_skills_prompt_mode(agent_alias),
                         eff_compact_context,
                         eff_max_system_prompt_chars,
                         true,
@@ -2434,7 +2434,7 @@ pub async fn run(
                             &excluded_tools,
                             activated_handle.as_ref(),
                             agent.resolved.strict_tool_parsing,
-                            config.skills_prompt_mode_for_agent(agent_alias),
+                            config.effective_skills_prompt_mode(agent_alias),
                             eff_compact_context,
                             eff_max_system_prompt_chars,
                             true,
@@ -3041,7 +3041,7 @@ pub async fn process_message(
             ("image_info", "Read image metadata."),
         ];
         if matches!(
-            config.skills_prompt_mode_for_agent(agent_alias),
+            config.effective_skills_prompt_mode(agent_alias),
             zeroclaw_config::schema::SkillsPromptInjectionMode::Compact
         ) {
             tool_descs.push((
@@ -3156,7 +3156,7 @@ pub async fn process_message(
                 bootstrap_max_chars,
                 Some(&risk_profile),
                 native_tool_specs_present,
-                config.skills_prompt_mode_for_agent(agent_alias),
+                config.effective_skills_prompt_mode(agent_alias),
                 eff_compact_context,
                 eff_max_system_prompt_chars,
                 false,

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -1238,6 +1238,7 @@ pub async fn run(
         let eff_compact_context = agent.resolved.compact_context;
         let eff_max_system_prompt_chars = agent.resolved.max_system_prompt_chars;
         let eff_model_context_window = agent.resolved.model_context_window;
+        let eff_prompt_injection_mode = agent.resolved.prompt_injection_mode;
         let base_observer = observability::create_observer(&config.observability);
         let observer: Arc<dyn Observer> = Arc::from(base_observer);
         let turn_id = uuid::Uuid::new_v4().to_string();
@@ -1547,7 +1548,7 @@ pub async fn run(
             ),
         ];
         if matches!(
-            config.effective_skills_prompt_mode(agent_alias),
+            eff_prompt_injection_mode,
             zeroclaw_config::schema::SkillsPromptInjectionMode::Compact
         ) {
             tool_descs.push((
@@ -1668,7 +1669,7 @@ pub async fn run(
             &prompt_excluded_tools,
             activated_handle.as_ref(),
             agent.resolved.strict_tool_parsing,
-            config.effective_skills_prompt_mode(agent_alias),
+            eff_prompt_injection_mode,
             eff_compact_context,
             eff_max_system_prompt_chars,
             true,
@@ -1763,7 +1764,7 @@ pub async fn run(
                 &excluded_tools,
                 activated_handle.as_ref(),
                 agent.resolved.strict_tool_parsing,
-                config.effective_skills_prompt_mode(agent_alias),
+                eff_prompt_injection_mode,
                 eff_compact_context,
                 eff_max_system_prompt_chars,
                 true,
@@ -1879,7 +1880,7 @@ pub async fn run(
                         &excluded_tools,
                         activated_handle.as_ref(),
                         agent.resolved.strict_tool_parsing,
-                        config.effective_skills_prompt_mode(agent_alias),
+                        eff_prompt_injection_mode,
                         eff_compact_context,
                         eff_max_system_prompt_chars,
                         true,
@@ -2434,7 +2435,7 @@ pub async fn run(
                             &excluded_tools,
                             activated_handle.as_ref(),
                             agent.resolved.strict_tool_parsing,
-                            config.effective_skills_prompt_mode(agent_alias),
+                            eff_prompt_injection_mode,
                             eff_compact_context,
                             eff_max_system_prompt_chars,
                             true,
@@ -2839,6 +2840,7 @@ pub async fn process_message(
         // See `Config::resolved_agent_config` for precedence rules.
         let eff_compact_context = agent.resolved.compact_context;
         let eff_max_system_prompt_chars = agent.resolved.max_system_prompt_chars;
+        let eff_prompt_injection_mode = agent.resolved.prompt_injection_mode;
 
         let observer: Arc<dyn Observer> =
             Arc::from(observability::create_observer(&config.observability));
@@ -3041,7 +3043,7 @@ pub async fn process_message(
             ("image_info", "Read image metadata."),
         ];
         if matches!(
-            config.effective_skills_prompt_mode(agent_alias),
+            eff_prompt_injection_mode,
             zeroclaw_config::schema::SkillsPromptInjectionMode::Compact
         ) {
             tool_descs.push((
@@ -3156,7 +3158,7 @@ pub async fn process_message(
                 bootstrap_max_chars,
                 Some(&risk_profile),
                 native_tool_specs_present,
-                config.effective_skills_prompt_mode(agent_alias),
+                eff_prompt_injection_mode,
                 eff_compact_context,
                 eff_max_system_prompt_chars,
                 false,

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -762,7 +762,7 @@ pub fn all_tools_with_runtime(
     }
 
     if matches!(
-        root_config.skills.prompt_injection_mode,
+        root_config.skills_prompt_mode_for_agent(agent_alias),
         zeroclaw_config::schema::SkillsPromptInjectionMode::Compact
     ) {
         // ReadSkillTool now holds full config to support all skill sources:
@@ -2632,6 +2632,113 @@ mod tests {
         assert!(
             !subagent.iter().any(|n| n == ModelSwitchTool::NAME),
             "subagent must not be able to switch the inherited model"
+        );
+    }
+
+    #[test]
+    fn all_tools_registers_read_skill_for_compact_agent_override_over_global_full() {
+        let tmp = TempDir::new().unwrap();
+        let security = Arc::new(SecurityPolicy::default());
+        let mem_cfg = MemoryConfig {
+            backend: "markdown".into(),
+            ..MemoryConfig::default()
+        };
+        let mem: Arc<dyn Memory> =
+            Arc::from(zeroclaw_memory::create_memory(&mem_cfg, tmp.path(), None).unwrap());
+
+        let browser = BrowserConfig::default();
+        let http = zeroclaw_config::schema::HttpRequestConfig::default();
+        let mut cfg = test_config(&tmp);
+        // Global stays Full; the per-agent override flips this agent to Compact.
+        cfg.skills.prompt_injection_mode = zeroclaw_config::schema::SkillsPromptInjectionMode::Full;
+        cfg.agents.insert(
+            "test-agent".to_string(),
+            zeroclaw_config::schema::AliasedAgentConfig {
+                prompt_injection_mode: Some(
+                    zeroclaw_config::schema::SkillsPromptInjectionMode::Compact,
+                ),
+                ..Default::default()
+            },
+        );
+
+        let tools = all_tools(
+            Arc::new(cfg.clone()),
+            &security,
+            &zeroclaw_config::schema::RiskProfileConfig::default(),
+            "test-agent",
+            mem,
+            None,
+            None,
+            &browser,
+            &http,
+            &zeroclaw_config::schema::WebFetchConfig::default(),
+            tmp.path(),
+            &HashMap::new(),
+            None,
+            &cfg,
+            None,
+            false,
+            None,
+        )
+        .tools;
+        let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+        assert!(
+            names.contains(&"read_skill"),
+            "compact per-agent override should register read_skill even when global is full"
+        );
+    }
+
+    #[test]
+    fn all_tools_omits_read_skill_for_full_agent_override_over_global_compact() {
+        let tmp = TempDir::new().unwrap();
+        let security = Arc::new(SecurityPolicy::default());
+        let mem_cfg = MemoryConfig {
+            backend: "markdown".into(),
+            ..MemoryConfig::default()
+        };
+        let mem: Arc<dyn Memory> =
+            Arc::from(zeroclaw_memory::create_memory(&mem_cfg, tmp.path(), None).unwrap());
+
+        let browser = BrowserConfig::default();
+        let http = zeroclaw_config::schema::HttpRequestConfig::default();
+        let mut cfg = test_config(&tmp);
+        // Global is Compact; the per-agent override pins this agent to Full.
+        cfg.skills.prompt_injection_mode =
+            zeroclaw_config::schema::SkillsPromptInjectionMode::Compact;
+        cfg.agents.insert(
+            "test-agent".to_string(),
+            zeroclaw_config::schema::AliasedAgentConfig {
+                prompt_injection_mode: Some(
+                    zeroclaw_config::schema::SkillsPromptInjectionMode::Full,
+                ),
+                ..Default::default()
+            },
+        );
+
+        let tools = all_tools(
+            Arc::new(cfg.clone()),
+            &security,
+            &zeroclaw_config::schema::RiskProfileConfig::default(),
+            "test-agent",
+            mem,
+            None,
+            None,
+            &browser,
+            &http,
+            &zeroclaw_config::schema::WebFetchConfig::default(),
+            tmp.path(),
+            &HashMap::new(),
+            None,
+            &cfg,
+            None,
+            false,
+            None,
+        )
+        .tools;
+        let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+        assert!(
+            !names.contains(&"read_skill"),
+            "full per-agent override should omit read_skill even when global is compact"
         );
     }
 }

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -762,7 +762,7 @@ pub fn all_tools_with_runtime(
     }
 
     if matches!(
-        root_config.skills_prompt_mode_for_agent(agent_alias),
+        root_config.effective_skills_prompt_mode(agent_alias),
         zeroclaw_config::schema::SkillsPromptInjectionMode::Compact
     ) {
         // ReadSkillTool now holds full config to support all skill sources:
@@ -2649,14 +2649,22 @@ mod tests {
         let browser = BrowserConfig::default();
         let http = zeroclaw_config::schema::HttpRequestConfig::default();
         let mut cfg = test_config(&tmp);
-        // Global stays Full; the per-agent override flips this agent to Compact.
+        // Global stays Full; a runtime profile flips this agent to Compact and
+        // the agent selects it via `runtime_profile`.
         cfg.skills.prompt_injection_mode = zeroclaw_config::schema::SkillsPromptInjectionMode::Full;
-        cfg.agents.insert(
-            "test-agent".to_string(),
-            zeroclaw_config::schema::AliasedAgentConfig {
+        cfg.runtime_profiles.insert(
+            "compact_profile".to_string(),
+            zeroclaw_config::schema::RuntimeProfileConfig {
                 prompt_injection_mode: Some(
                     zeroclaw_config::schema::SkillsPromptInjectionMode::Compact,
                 ),
+                ..Default::default()
+            },
+        );
+        cfg.agents.insert(
+            "test-agent".to_string(),
+            zeroclaw_config::schema::AliasedAgentConfig {
+                runtime_profile: "compact_profile".into(),
                 ..Default::default()
             },
         );
@@ -2684,7 +2692,7 @@ mod tests {
         let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
         assert!(
             names.contains(&"read_skill"),
-            "compact per-agent override should register read_skill even when global is full"
+            "compact runtime-profile override should register read_skill even when global is full"
         );
     }
 
@@ -2702,15 +2710,23 @@ mod tests {
         let browser = BrowserConfig::default();
         let http = zeroclaw_config::schema::HttpRequestConfig::default();
         let mut cfg = test_config(&tmp);
-        // Global is Compact; the per-agent override pins this agent to Full.
+        // Global is Compact; a runtime profile pins this agent to Full and the
+        // agent selects it via `runtime_profile`.
         cfg.skills.prompt_injection_mode =
             zeroclaw_config::schema::SkillsPromptInjectionMode::Compact;
-        cfg.agents.insert(
-            "test-agent".to_string(),
-            zeroclaw_config::schema::AliasedAgentConfig {
+        cfg.runtime_profiles.insert(
+            "full_profile".to_string(),
+            zeroclaw_config::schema::RuntimeProfileConfig {
                 prompt_injection_mode: Some(
                     zeroclaw_config::schema::SkillsPromptInjectionMode::Full,
                 ),
+                ..Default::default()
+            },
+        );
+        cfg.agents.insert(
+            "test-agent".to_string(),
+            zeroclaw_config::schema::AliasedAgentConfig {
+                runtime_profile: "full_profile".into(),
                 ..Default::default()
             },
         );
@@ -2738,7 +2754,7 @@ mod tests {
         let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
         assert!(
             !names.contains(&"read_skill"),
-            "full per-agent override should omit read_skill even when global is compact"
+            "full runtime-profile override should omit read_skill even when global is compact"
         );
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `[skills] prompt_injection_mode` was global-only, so every agent in a multi-agent install had to share one mode. This adds an optional runtime-profile override, `[runtime_profiles.<alias>] prompt_injection_mode = "full" | "compact"`, so agents can select different skills prompt modes by selecting the appropriate runtime profile.
  - Resolution is centralized in `Config::effective_skills_prompt_mode(agent_alias)`: the agent's runtime profile override wins when set, otherwise the global `[skills] prompt_injection_mode` is used. The canonical config value remains in `Config`; the resolved runtime value is an execution snapshot, not a second source of truth.
  - `resolved_agent_config` bakes the effective mode into `ResolvedRuntime.prompt_injection_mode`, and the `run` / `process_message` turn paths consume that resolved snapshot alongside the adjacent `eff_*` runtime tunables. Setup paths that do not operate from `ResolvedRuntime` continue to resolve through `Config::effective_skills_prompt_mode`.
  - Prompt construction and `read_skill` tool registration still use one effective mode, so a Compact prompt is not paired with a missing `read_skill` tool and a Full prompt is not paired with a spurious one.
- **Scope boundary:** No change to the global default or its semantics. No new modes. No agent-inline `prompt_injection_mode` key. No gateway-specific changes.
- **Blast radius:** Skills system-prompt assembly and `read_skill` registration across the agent loop (`run` / `process_message`), the `Agent` builder, and channel orchestration. Agents whose runtime profiles do not set the override inherit the global value and behave as before.
- **Linked issue(s):** Closes #7749
- **Labels:** `enhancement`, `agent`, `channel`, `config`, `runtime`, `channel:core`, `risk:high`, `size:S`.

## Validation Evidence (required)

Run locally on the rebased branch with `rustc 1.95.0 (59807616e 2026-04-14)`:

```text
$ cargo fmt --all -- --check
# clean, exit 0

$ cargo test -p zeroclaw-config -p zeroclaw-runtime -p zeroclaw-channels -- --test-threads=1
# exit 0
# zeroclaw-config, zeroclaw-runtime, and zeroclaw-channels unit/integration/doc-test surfaces passed; expected ignored tests remained ignored.

$ cargo clippy --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 06s
# exit 0
```

- **Commands run and tail output:** see above. I also ran the non-serialized focused command, `cargo test -p zeroclaw-config -p zeroclaw-runtime -p zeroclaw-channels`, twice before the rebase; both runs reached the runtime tests and hit the pre-existing parallel flake `cron::store::tests::remove_job_emits_structured_cron_delete_event`. The same test passed in isolation with `cargo test -p zeroclaw-runtime cron::store::tests::remove_job_emits_structured_cron_delete_event -- --test-threads=1`, and the full focused suite passed when serialized.
- **Beyond CI - what did you manually verify?** Regression coverage now lives on the runtime-profile path: `runtime_profile_prompt_injection_mode_overrides_global`, `runtime_profile_prompt_injection_mode_deserializes`, and `resolved_agent_config_bakes_prompt_injection_mode_from_profile` cover config resolution/deserialization/resolved-runtime baking. Runtime coverage includes `all_tools_registers_read_skill_for_compact_agent_override_over_global_full` and `all_tools_omits_read_skill_for_full_agent_override_over_global_compact`, proving the `read_skill` gate follows the effective mode in both directions.
- **If any command was intentionally skipped, why:** `./dev/ci.sh all` was not run locally after this final review-fix commit because the targeted high-risk surface checks above passed and the PR's GitHub Quality Gate was already green before the final push. The final pushed commit should allow CI to re-run the required gate.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: N/A. `read_skill` registration is governed by the effective prompt mode, which still falls back to the global value and does not change tool access scope.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `Yes` - adds an optional `[runtime_profiles.<alias>] prompt_injection_mode` key (`"full"` | `"compact"`). It is additive and opt-in.
- If `No` or `Yes` to either: exact upgrade steps for existing users: None required. The field is `Option<SkillsPromptInjectionMode>`, defaults to absent, and absent values inherit the existing global `[skills] prompt_injection_mode`. Existing configs continue to round-trip and behave identically unless an operator explicitly sets a runtime-profile override.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert <squash-merge sha>` - single self-contained commit; no schema migration to unwind.
- **Feature flags or config toggles:** None. To disable the new behavior without reverting, remove `[runtime_profiles.<alias>] prompt_injection_mode` from the affected profile so it inherits the global `[skills] prompt_injection_mode` again.
- **Observable failure symptoms:** An agent whose runtime profile sets `prompt_injection_mode = "compact"` still inlines full skill bodies or lacks the `read_skill` tool; or a profile set to `"full"` still sees compact summaries or a spurious `read_skill`. Inspect the rendered `<available_skills>` section and whether `read_skill` is registered for that agent. The gate and prompt are driven by `Config::effective_skills_prompt_mode`, then consumed by `ResolvedRuntime.prompt_injection_mode` in the turn path.

