### PR TITLE
test(config): cover provider alias predicates

### DIFF
--- a/crates/zeroclaw-config/src/provider_aliases.rs
+++ b/crates/zeroclaw-config/src/provider_aliases.rs
@@ -138,3 +138,206 @@ pub fn canonical_china_provider_name(name: &str) -> Option<&'static str> {
 pub fn family_honors_wire_api(family: &str) -> bool {
     matches!(family, "openai" | "llamacpp" | "custom")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn glm_aliases_split_global_and_cn() {
+        for name in ["glm", "zhipu", "glm-global", "zhipu-global"] {
+            assert!(is_glm_global_alias(name), "{name} is a GLM global alias");
+            assert!(!is_glm_cn_alias(name), "{name} is not a GLM CN alias");
+            assert!(is_glm_alias(name));
+        }
+        for name in ["glm-cn", "zhipu-cn", "bigmodel"] {
+            assert!(is_glm_cn_alias(name), "{name} is a GLM CN alias");
+            assert!(
+                !is_glm_global_alias(name),
+                "{name} is not a GLM global alias"
+            );
+            assert!(is_glm_alias(name));
+        }
+        assert!(!is_glm_alias("gpt-4o"));
+    }
+
+    #[test]
+    fn zai_aliases_split_global_and_cn() {
+        for name in ["zai", "z.ai", "zai-global", "z.ai-global"] {
+            assert!(is_zai_global_alias(name));
+            assert!(is_zai_alias(name));
+        }
+        for name in ["zai-cn", "z.ai-cn"] {
+            assert!(is_zai_cn_alias(name));
+            assert!(is_zai_alias(name));
+        }
+        assert!(!is_zai_alias("openai"));
+    }
+
+    #[test]
+    fn minimax_aliases_split_intl_and_cn() {
+        for name in [
+            "minimax",
+            "minimax-intl",
+            "minimax-io",
+            "minimax-global",
+            "minimax-oauth",
+            "minimax-portal",
+            "minimax-oauth-global",
+            "minimax-portal-global",
+        ] {
+            assert!(is_minimax_intl_alias(name));
+            assert!(is_minimax_alias(name));
+        }
+        for name in [
+            "minimax-cn",
+            "minimaxi",
+            "minimax-oauth-cn",
+            "minimax-portal-cn",
+        ] {
+            assert!(is_minimax_cn_alias(name));
+            assert!(is_minimax_alias(name));
+        }
+        assert!(!is_minimax_alias("minimax-unknown"));
+    }
+
+    #[test]
+    fn moonshot_aliases_split_intl_and_cn() {
+        for name in [
+            "moonshot-intl",
+            "moonshot-global",
+            "kimi-intl",
+            "kimi-global",
+        ] {
+            assert!(is_moonshot_intl_alias(name));
+            assert!(is_moonshot_alias(name));
+        }
+        for name in ["moonshot", "kimi", "moonshot-cn", "kimi-cn"] {
+            assert!(is_moonshot_cn_alias(name));
+            assert!(is_moonshot_alias(name));
+        }
+        assert!(!is_moonshot_alias("gemini"));
+    }
+
+    #[test]
+    fn qwen_alias_family_is_union_without_bailian() {
+        assert!(is_qwen_cn_alias("qwen"));
+        assert!(is_qwen_cn_alias("dashscope"));
+        assert!(is_qwen_intl_alias("qwen-intl"));
+        assert!(is_qwen_intl_alias("dashscope-international"));
+        assert!(is_qwen_us_alias("qwen-us"));
+        assert!(is_qwen_oauth_alias("qwen-code"));
+        for name in [
+            "qwen",
+            "dashscope",
+            "qwen-intl",
+            "qwen-us",
+            "qwen-code",
+            "qwen_oauth",
+        ] {
+            assert!(is_qwen_alias(name));
+        }
+        // bailian is its own family and must not fold into qwen.
+        assert!(!is_qwen_alias("bailian"));
+        assert!(!is_qwen_alias("aliyun"));
+    }
+
+    #[test]
+    fn standalone_china_aliases_match() {
+        assert!(is_qianfan_alias("qianfan"));
+        assert!(is_qianfan_alias("baidu"));
+        assert!(is_doubao_alias("doubao"));
+        assert!(is_doubao_alias("volcengine"));
+        assert!(is_doubao_alias("ark"));
+        assert!(is_bailian_alias("bailian"));
+        assert!(is_bailian_alias("aliyun"));
+    }
+
+    #[test]
+    fn canonical_name_maps_each_china_family() {
+        let cases = [
+            ("qwen", "qwen"),
+            ("dashscope", "qwen"),
+            ("qwen-code", "qwen"),
+            ("glm", "glm"),
+            ("bigmodel", "glm"),
+            ("moonshot", "moonshot"),
+            ("kimi-global", "moonshot"),
+            ("minimax", "minimax"),
+            ("minimaxi", "minimax"),
+            ("zai", "zai"),
+            ("z.ai-cn", "zai"),
+            ("qianfan", "qianfan"),
+            ("baidu", "qianfan"),
+            ("doubao", "doubao"),
+            ("ark", "doubao"),
+            ("bailian", "bailian"),
+            ("aliyun", "bailian"),
+        ];
+        for (alias, canonical) in cases {
+            assert_eq!(
+                canonical_china_provider_name(alias),
+                Some(canonical),
+                "{alias} should canonicalize to {canonical}",
+            );
+        }
+        assert_eq!(canonical_china_provider_name("openai"), None);
+        assert_eq!(canonical_china_provider_name("anthropic"), None);
+        assert_eq!(canonical_china_provider_name(""), None);
+    }
+
+    #[test]
+    fn canonical_name_agrees_with_family_predicates() {
+        let samples = [
+            "qwen",
+            "dashscope-intl",
+            "glm",
+            "bigmodel",
+            "kimi",
+            "moonshot-global",
+            "minimax",
+            "minimax-cn",
+            "zai",
+            "z.ai-global",
+            "qianfan",
+            "baidu",
+            "doubao",
+            "volcengine",
+            "bailian",
+            "aliyun",
+        ];
+        for name in samples {
+            let canonical = canonical_china_provider_name(name)
+                .unwrap_or_else(|| panic!("{name} should be recognized as a China provider"));
+            match canonical {
+                "qwen" => assert!(is_qwen_alias(name)),
+                "glm" => assert!(is_glm_alias(name)),
+                "moonshot" => assert!(is_moonshot_alias(name)),
+                "minimax" => assert!(is_minimax_alias(name)),
+                "zai" => assert!(is_zai_alias(name)),
+                "qianfan" => assert!(is_qianfan_alias(name)),
+                "doubao" => assert!(is_doubao_alias(name)),
+                "bailian" => assert!(is_bailian_alias(name)),
+                other => panic!("unexpected canonical name {other} for {name}"),
+            }
+        }
+    }
+
+    #[test]
+    fn wire_api_honored_only_by_byo_endpoint_families() {
+        for family in ["openai", "llamacpp", "custom"] {
+            assert!(family_honors_wire_api(family), "{family} honors wire_api");
+        }
+        for family in [
+            "anthropic",
+            "qwen",
+            "glm",
+            "moonshot",
+            "gemini",
+            "minimax",
+            "",
+        ] {
+            assert!(!family_honors_wire_api(family), "{family} ignores wire_api");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Adds unit coverage for the China-provider alias predicates and `canonical_china_provider_name` in `provider_aliases.rs`, which previously had no tests. The suite pins current behavior so a regression is caught.
- **Scope boundary:** Test-only — adds a `#[cfg(test)]` module; no production code behavior changed.
- **Blast radius:** None — no runtime, API, config, or CLI surface touched.
- **Linked issue(s):** None.
- **Labels:** `risk: low`, `size: S` (test-only; applied by maintainers/labeler).

## Validation Evidence (required)

- **Commands run and tail output:**

```text
$ cargo test -p zeroclaw-config provider_aliases
test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured

$ cargo clippy -p zeroclaw-config --tests
Finished `dev` profile [unoptimized + debuginfo] target(s)
```

  CI Quality Gate is green on this PR (18/18 checks).
- **Beyond CI — what did you manually verify?** Each assertion was derived by hand from the current source; the tests fail if the documented behavior regresses.
- **If any command was intentionally skipped, why:** `cargo test` / `cargo clippy` were scoped to the touched crate (`-p zeroclaw-config`) since this is a single-crate test-only change; CI runs the full-workspace battery (fmt + clippy + test).

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**

## Rollback

Low-risk: `git revert <sha>` is the plan.
