### PR TITLE
test(hardware): cover serial path allowlist helpers

### DIFF
--- a/crates/zeroclaw-hardware/src/util.rs
+++ b/crates/zeroclaw-hardware/src/util.rs
@@ -50,3 +50,57 @@ pub fn serial_open_baud(path: &str, configured_baud: u32) -> u32 {
         configured_baud
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allows_known_serial_path_prefixes() {
+        for path in [
+            "/dev/ttyACM0",
+            "/dev/ttyUSB1",
+            "/dev/tty.usbmodem14201",
+            "/dev/cu.usbmodem14201",
+            "/dev/tty.usbserial-0001",
+            "/dev/cu.usbserial-0001",
+            "COM3",
+        ] {
+            assert!(is_serial_path_allowed(path), "{path} should be allowed");
+        }
+        // The bare prefix is a prefix of itself.
+        assert!(is_serial_path_allowed("COM"));
+    }
+
+    #[test]
+    fn rejects_paths_outside_the_allowlist() {
+        for path in [
+            "/dev/sda",
+            "/dev/ttyS0",
+            "/etc/passwd",
+            "ttyACM0", // missing /dev/ prefix
+            "/dev/ttyXYZ",
+            "",
+        ] {
+            assert!(!is_serial_path_allowed(path), "{path} should be rejected");
+        }
+    }
+
+    #[test]
+    fn allowlist_hint_lists_every_prefix_with_a_glob() {
+        let hint = serial_path_allowlist_hint();
+        assert!(hint.contains("/dev/ttyACM*"));
+        assert!(hint.contains("/dev/ttyUSB*"));
+        assert!(hint.contains("COM*"));
+        assert!(hint.contains(", "));
+    }
+
+    #[test]
+    fn non_simulated_paths_open_exclusively_at_configured_baud() {
+        // Real device paths are never the dev-sim path, regardless of the
+        // `dev-sim` feature, so they open exclusively at the configured baud.
+        assert!(!should_open_serial_nonexclusive("/dev/ttyACM0"));
+        assert_eq!(serial_open_baud("/dev/ttyACM0", 115_200), 115_200);
+        assert_eq!(serial_open_baud("COM3", 9_600), 9_600);
+    }
+}


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Adds unit coverage for the serial-path allowlist helpers in `util.rs`, which previously had no tests. The suite pins current behavior so a regression is caught.
- **Scope boundary:** Test-only — adds a `#[cfg(test)]` module; no production code behavior changed.
- **Blast radius:** None — no runtime, API, config, or CLI surface touched.
- **Linked issue(s):** None.
- **Labels:** `risk: low`, `size: S` (test-only; applied by maintainers/labeler).

## Validation Evidence (required)

- **Commands run and tail output:**

```text
$ cargo test -p zeroclaw-hardware util
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured

$ cargo clippy -p zeroclaw-hardware --tests
Finished `dev` profile [unoptimized + debuginfo] target(s)
```

  CI Quality Gate is green on this PR (18/18 checks).
- **Beyond CI — what did you manually verify?** Each assertion was derived by hand from the current source; the tests fail if the documented behavior regresses.
- **If any command was intentionally skipped, why:** `cargo test` / `cargo clippy` were scoped to the touched crate (`-p zeroclaw-hardware`) since this is a single-crate test-only change; CI runs the full-workspace battery (fmt + clippy + test).

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**

## Rollback

Low-risk: `git revert <sha>` is the plan.
