### PR TITLE
test(eval): cover suite report aggregation and rendering

### DIFF
--- a/crates/zeroclaw-eval/src/report.rs
+++ b/crates/zeroclaw-eval/src/report.rs
@@ -109,3 +109,119 @@ impl SuiteReport {
         serde_json::to_string_pretty(&value).unwrap_or_else(|_| "{}".to_string())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn grade(check: &str, passed: bool, detail: &str) -> GradeResult {
+        GradeResult {
+            check: check.to_string(),
+            passed,
+            detail: detail.to_string(),
+        }
+    }
+
+    fn case(name: &str, grades: Vec<GradeResult>, error: Option<&str>) -> CaseReport {
+        CaseReport {
+            name: name.to_string(),
+            source: "fixture.json".to_string(),
+            grades,
+            error: error.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn case_passes_only_when_no_error_and_all_checks_pass() {
+        assert!(
+            case(
+                "a",
+                vec![grade("c1", true, ""), grade("c2", true, "")],
+                None
+            )
+            .passed()
+        );
+        // One failing check fails the case.
+        assert!(
+            !case(
+                "a",
+                vec![grade("c1", true, ""), grade("c2", false, "")],
+                None
+            )
+            .passed()
+        );
+        // A run error fails the case even when every check passed.
+        assert!(!case("a", vec![grade("c1", true, "")], Some("trace exhausted")).passed());
+        // No checks and no error passes vacuously.
+        assert!(case("a", vec![], None).passed());
+    }
+
+    #[test]
+    fn suite_counts_reflect_per_case_pass_fail() {
+        let suite = SuiteReport {
+            cases: vec![
+                case("ok", vec![grade("c", true, "")], None),
+                case("bad", vec![grade("c", false, "")], None),
+                case("err", vec![], Some("boom")),
+            ],
+        };
+        assert_eq!(suite.passed_count(), 1);
+        assert_eq!(suite.failed_count(), 2);
+        assert!(!suite.all_passed());
+    }
+
+    #[test]
+    fn empty_suite_passes_vacuously() {
+        let suite = SuiteReport { cases: vec![] };
+        assert_eq!(suite.passed_count(), 0);
+        assert_eq!(suite.failed_count(), 0);
+        assert!(suite.all_passed());
+    }
+
+    #[test]
+    fn render_table_marks_failures_and_lists_failing_checks() {
+        let suite = SuiteReport {
+            cases: vec![
+                case("ok", vec![grade("c", true, "")], None),
+                case(
+                    "bad",
+                    vec![grade("response_contains", false, "not found")],
+                    None,
+                ),
+            ],
+        };
+        let table = suite.render_table();
+        assert!(table.contains("✓ ok"));
+        assert!(table.contains("✗ bad"));
+        assert!(table.contains("response_contains: not found"));
+        assert!(table.contains("1/2 cases passed"));
+        assert!(table.contains("(1 failed)"));
+    }
+
+    #[test]
+    fn render_table_reports_run_errors() {
+        let suite = SuiteReport {
+            cases: vec![case("err", vec![], Some("trace exhausted"))],
+        };
+        let table = suite.render_table();
+        assert!(table.contains("run error: trace exhausted"));
+    }
+
+    #[test]
+    fn to_json_serializes_aggregate_and_cases() {
+        let suite = SuiteReport {
+            cases: vec![
+                case("ok", vec![grade("c", true, "")], None),
+                case("bad", vec![grade("c", false, "")], None),
+            ],
+        };
+        let json: serde_json::Value = serde_json::from_str(&suite.to_json()).unwrap();
+        assert_eq!(json["passed"].as_u64(), Some(1));
+        assert_eq!(json["failed"].as_u64(), Some(1));
+        assert_eq!(json["total"].as_u64(), Some(2));
+        assert_eq!(json["all_passed"].as_bool(), Some(false));
+        assert_eq!(json["cases"].as_array().unwrap().len(), 2);
+        assert_eq!(json["cases"][0]["name"].as_str(), Some("ok"));
+        assert_eq!(json["cases"][0]["passed"].as_bool(), Some(true));
+    }
+}


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Adds unit coverage for `CaseReport` / `SuiteReport` aggregation and rendering in `report.rs`, which previously had no tests. The suite pins current behavior so a regression is caught.
- **Scope boundary:** Test-only — adds a `#[cfg(test)]` module; no production code behavior changed.
- **Blast radius:** None — no runtime, API, config, or CLI surface touched.
- **Linked issue(s):** None.
- **Labels:** `risk: low`, `size: S` (test-only; applied by maintainers/labeler).

## Validation Evidence (required)

- **Commands run and tail output:**

```text
$ cargo test -p zeroclaw-eval report
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured

$ cargo clippy -p zeroclaw-eval --tests
Finished `dev` profile [unoptimized + debuginfo] target(s)
```

  CI Quality Gate is green on this PR (18/18 checks).
- **Beyond CI — what did you manually verify?** Each assertion was derived by hand from the current source; the tests fail if the documented behavior regresses.
- **If any command was intentionally skipped, why:** `cargo test` / `cargo clippy` were scoped to the touched crate (`-p zeroclaw-eval`) since this is a single-crate test-only change; CI runs the full-workspace battery (fmt + clippy + test).

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**

## Rollback

Low-risk: `git revert <sha>` is the plan.
