### PR TITLE
test(tools): cover node capability approval gating and group assembly

### DIFF
--- a/crates/zeroclaw-tools/src/node_capabilities.rs
+++ b/crates/zeroclaw-tools/src/node_capabilities.rs
@@ -263,4 +263,30 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn requires_approval_only_for_sensitive_prefixes() {
+        // Non-sensitive and unknown names never require approval.
+        assert!(!requires_approval("notification.notify"));
+        assert!(!requires_approval("unknown.capability"));
+        assert!(!requires_approval(""));
+        // The match is on the "camera."/"screen."/"location." prefix (with the
+        // trailing dot), so a bare word that merely starts the same misses.
+        assert!(!requires_approval("camerafoo"));
+        assert!(requires_approval("camera.snap"));
+        assert!(requires_approval("screen.capture"));
+        assert!(requires_approval("location.get"));
+    }
+
+    #[test]
+    fn all_standard_includes_every_capability_group() {
+        let caps = all_standard_capabilities();
+        let has = |name: &str| caps.iter().any(|c| c.name == name);
+        // One representative capability from each contributing group: camera,
+        // screen, location, and notifications (registered as "system.notify").
+        assert!(has("camera.snap"));
+        assert!(has("screen.capture"));
+        assert!(has("location.get"));
+        assert!(has("system.notify"));
+    }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Adds unit coverage for node capability approval gating and group assembly, which previously had no tests. The suite pins current behavior so a regression is caught.
- **Scope boundary:** Test-only — adds a `#[cfg(test)]` module; no production code behavior changed.
- **Blast radius:** None — no runtime, API, config, or CLI surface touched.
- **Linked issue(s):** None.
- **Labels:** `tool`, `tests`, `risk:low`, `size:XS` (test-only; applied by maintainers/labeler).

## Validation Evidence (required)

- **Commands run and tail output:**

```text
$ cargo test -p zeroclaw-tools node_capabilities
test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured

$ cargo clippy -p zeroclaw-tools --tests
Finished `dev` profile [unoptimized + debuginfo] target(s)
```

  CI Quality Gate is green on this PR (18/18 checks).
- **Beyond CI — what did you manually verify?** Each assertion was derived by hand from the current source; the tests fail if the documented behavior regresses.
- **If any command was intentionally skipped, why:** `cargo test` / `cargo clippy` were scoped to the touched crate (`-p zeroclaw-tools`) since this is a single-crate test-only change; CI runs the full-workspace battery (fmt + clippy + test).

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**

## Rollback

Low-risk: `git revert <sha>` is the plan.
