### PR TITLE
test(log): cover legacy log action category mapping

### DIFF
--- a/crates/zeroclaw-log/src/migrate.rs
+++ b/crates/zeroclaw-log/src/migrate.rs
@@ -303,4 +303,30 @@ mod tests {
         let lines = read_all_lines(&path);
         assert!(lines.is_empty());
     }
+
+    #[test]
+    fn category_for_action_maps_every_known_action() {
+        assert_eq!(category_for_action("llm_request"), "agent");
+        assert_eq!(category_for_action("agent_start"), "agent");
+        assert_eq!(category_for_action("agent_end"), "agent");
+        assert_eq!(category_for_action("tool_call"), "tool");
+        assert_eq!(category_for_action("tool_call_start"), "tool");
+        assert_eq!(category_for_action("tool_call_result"), "tool");
+        assert_eq!(category_for_action("channel_message_inbound"), "channel");
+        assert_eq!(category_for_action("channel_send"), "channel");
+        assert_eq!(category_for_action("cron_run"), "cron");
+        assert_eq!(category_for_action("memory_store"), "memory");
+        assert_eq!(category_for_action("memory_recall"), "memory");
+        assert_eq!(category_for_action("memory_forget"), "memory");
+        assert_eq!(category_for_action("session_open"), "session");
+        assert_eq!(category_for_action("session_close"), "session");
+        assert_eq!(category_for_action("gateway_ws_turn"), "session");
+        assert_eq!(category_for_action("error"), "system");
+    }
+
+    #[test]
+    fn category_for_action_defaults_unknown_to_system() {
+        assert_eq!(category_for_action("totally_unknown"), "system");
+        assert_eq!(category_for_action(""), "system");
+    }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Adds unit coverage for the legacy log action -> category mapping in `migrate.rs`, which previously had no tests. The suite pins current behavior so a regression is caught.
- **Scope boundary:** Test-only — adds a `#[cfg(test)]` module; no production code behavior changed.
- **Blast radius:** None — no runtime, API, config, or CLI surface touched.
- **Linked issue(s):** None.
- **Labels:** `risk: low`, `size: S` (test-only; applied by maintainers/labeler).

## Validation Evidence (required)

- **Commands run and tail output:**

```text
$ cargo test -p zeroclaw-log migrate
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured

$ cargo clippy -p zeroclaw-log --tests
Finished `dev` profile [unoptimized + debuginfo] target(s)
```

  CI Quality Gate is green on this PR (18/18 checks).
- **Beyond CI — what did you manually verify?** Each assertion was derived by hand from the current source; the tests fail if the documented behavior regresses.
- **If any command was intentionally skipped, why:** `cargo test` / `cargo clippy` were scoped to the touched crate (`-p zeroclaw-log`) since this is a single-crate test-only change; CI runs the full-workspace battery (fmt + clippy + test).

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**

## Rollback

Low-risk: `git revert <sha>` is the plan.
