### PR TITLE
test(tools): cover truncate_with_ellipsis

### DIFF
--- a/crates/zeroclaw-tools/src/util_helpers.rs
+++ b/crates/zeroclaw-tools/src/util_helpers.rs
@@ -107,4 +107,29 @@ mod tests {
         // Should remain unchanged since there's no drive letter at position 5
         assert_eq!(cleaned.to_string_lossy(), r"\\?\UNC\server\share");
     }
+
+    #[test]
+    fn truncate_with_ellipsis_keeps_short_or_exact_strings() {
+        assert_eq!(truncate_with_ellipsis("hello", 10), "hello");
+        // Exactly at the char budget is not truncated.
+        assert_eq!(truncate_with_ellipsis("hello", 5), "hello");
+        assert_eq!(truncate_with_ellipsis("", 3), "");
+    }
+
+    #[test]
+    fn truncate_with_ellipsis_truncates_and_appends() {
+        assert_eq!(truncate_with_ellipsis("hello world", 5), "hello...");
+    }
+
+    #[test]
+    fn truncate_with_ellipsis_trims_trailing_space_before_ellipsis() {
+        // The kept slice "ab " is trimmed before the ellipsis is appended.
+        assert_eq!(truncate_with_ellipsis("ab cd", 3), "ab...");
+    }
+
+    #[test]
+    fn truncate_with_ellipsis_counts_unicode_chars_not_bytes() {
+        // "héllo" cut after 2 chars keeps "hé" (3 bytes), not 2 bytes.
+        assert_eq!(truncate_with_ellipsis("héllo", 2), "hé...");
+    }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Adds unit coverage for `truncate_with_ellipsis` in `util_helpers.rs`, which previously had no tests. The suite pins current behavior so a regression is caught.
- **Scope boundary:** Test-only — adds a `#[cfg(test)]` module; no production code behavior changed.
- **Blast radius:** None — no runtime, API, config, or CLI surface touched.
- **Linked issue(s):** None.
- **Labels:** `tool`, `tests`, `risk:low`, `size:XS`

## Validation Evidence (required)

- **Commands run and tail output:**

```text
$ cargo test -p zeroclaw-tools util_helpers
test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured

$ cargo clippy -p zeroclaw-tools --tests
Finished `dev` profile [unoptimized + debuginfo] target(s)
```

  CI Quality Gate is green on this PR (18/18 checks).
- **Beyond CI — what did you manually verify?** Each assertion was derived by hand from the current source; the tests fail if the documented behavior regresses.
- **If any command was intentionally skipped, why:** `cargo test` / `cargo clippy` were scoped to the touched crate (`-p zeroclaw-tools`) since this is a single-crate test-only change; CI runs the full-workspace battery (fmt + clippy + test).

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**

## Rollback

Low-risk: `git revert <sha>` is the plan.

