### PR TITLE
fix(skills): correct "ClawhHub" typo in skill installer messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,7 +139,7 @@ indicatif = "0.18"
 # Temp files (update pipeline rollback)
 tempfile = "3.26"
 
-# Zip extraction for ClawhHub / OpenClaw registry installers
+# Zip extraction for ClawHub / OpenClaw registry installers
 zip = { version = "8.1", default-features = false, features = ["deflate-flate2"] }
 
 # Error handling

--- a/crates/zeroclaw-runtime/src/skills/mod.rs
+++ b/crates/zeroclaw-runtime/src/skills/mod.rs
@@ -41,7 +41,7 @@ const OPEN_SKILLS_REPO_URL: &str = "https://github.com/besoeasy/open-skills";
 const OPEN_SKILLS_SYNC_MARKER: &str = ".zeroclaw-open-skills-sync";
 const OPEN_SKILLS_SYNC_INTERVAL_SECS: u64 = 60 * 60 * 24 * 7;
 
-// ─── ClawhHub / OpenClaw registry installers ───────────────────────────────
+// ─── ClawHub / OpenClaw registry installers ───────────────────────────────
 const CLAWHUB_DOMAIN: &str = "clawhub.ai";
 const CLAWHUB_WWW_DOMAIN: &str = "www.clawhub.ai";
 const CLAWHUB_DOWNLOAD_API: &str = "https://clawhub.ai/api/v1/download";
@@ -1704,13 +1704,13 @@ fn clawhub_download_url(source: &str) -> Result<String> {
             .join("/");
 
         if path.is_empty() {
-            anyhow::bail!("could not extract slug from ClawhHub URL: {source}");
+            anyhow::bail!("could not extract slug from ClawHub URL: {source}");
         }
 
         return Ok(format!("{CLAWHUB_DOWNLOAD_API}?slug={path}"));
     }
 
-    anyhow::bail!("unrecognised ClawhHub source format: {source}")
+    anyhow::bail!("unrecognised ClawHub source format: {source}")
 }
 
 fn normalize_skill_name(s: &str) -> String {
@@ -2052,7 +2052,7 @@ pub async fn install_clawhub_skill_source(
     allow_scripts: bool,
 ) -> Result<(PathBuf, usize)> {
     let download_url = clawhub_download_url(source)
-        .with_context(|| format!("invalid ClawhHub source: {source}"))?;
+        .with_context(|| format!("invalid ClawHub source: {source}"))?;
     let skill_dir_name = clawhub_skill_dir_name(source)?;
     let installed_dir = skills_path.join(&skill_dir_name);
     if installed_dir.exists() {
@@ -2073,10 +2073,10 @@ pub async fn install_clawhub_skill_source(
         .with_context(|| format!("failed to fetch zip from {download_url}"))?;
 
     if resp.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {
-        anyhow::bail!("ClawhHub rate limit reached (HTTP 429). Wait a moment and retry.");
+        anyhow::bail!("ClawHub rate limit reached (HTTP 429). Wait a moment and retry.");
     }
     if !resp.status().is_success() {
-        anyhow::bail!("ClawhHub download failed (HTTP {})", resp.status());
+        anyhow::bail!("ClawHub download failed (HTTP {})", resp.status());
     }
 
     let bytes = resp.bytes().await?.to_vec();
@@ -2089,7 +2089,7 @@ pub async fn install_clawhub_skill_source(
         std::fs::write(
             installed_dir.join("SKILL.toml"),
             format!(
-                "[skill]\nname = \"{}\"\ndescription = \"ClawhHub installed skill\"\nversion = \"0.1.0\"\n",
+                "[skill]\nname = \"{}\"\ndescription = \"ClawHub installed skill\"\nversion = \"0.1.0\"\n",
                 skill_dir_name
             ),
         )?;


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** The ClawHub registry name was misspelled `ClawhHub` (extra `h`) in eight places. Corrected all of them to `ClawHub`. Four are user-facing CLI strings from the skill installer (download-failed, rate-limit, invalid-source, and unrecognised-format errors); one is the synthetic skill manifest `description`; the remaining two are source comments in `skills/mod.rs` and `Cargo.toml`.
- **Scope boundary:** Spelling only. No control flow, behavior, public API, config keys, or CLI flags change. The British spelling `unrecognised` is intentionally left as-is (not a typo).
- **Blast radius:** None functional. Anyone who scrapes or asserts on the literal error string `ClawhHub download failed` / `ClawhHub rate limit reached` would need to update to `ClawHub`; no such assertions exist in-tree.
- **Linked issue(s):** None.
- **Labels:** `bug`, `size: XS`, `risk: low`, `risk: manual`, `runtime`, `skills`.

## Validation Evidence (required)

```
$ rustc --version
rustc 1.93.1 (01f6ddf75 2026-02-11)

$ cargo fmt --all -- --check
(no output; exit 0)

$ cargo test -p zeroclaw-runtime clawhub
test skills::registry_tests::test_is_registry_source_rejects_clawhub ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 2360 filtered out
(exit 0)
```

- **Beyond CI — what did you manually verify?** Confirmed `git grep ClawhHub` returns zero matches after the change. Earlier exercised the `zeroclaw skills install clawhub:<slug>` path end-to-end against a locally built binary (a real install from clawhub.ai succeeds; the misspelling appeared in the error/success messages, which is how it was found).
- **If any command was intentionally skipped, why:** Full-workspace `cargo clippy --all-targets -- -D warnings` was not run to completion. Scoped clippy on the affected crate surfaces a pre-existing `clippy::manual_strip` error in `crates/zeroclaw-tools/src/util_helpers.rs:35` (Windows path handling), a file this PR does not touch — it exists identically on `master` and is unrelated to this change. This diff is a string-literal/comment edit with no logic change.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No` (error-message wording changes, but no flag, command, or config key changes)
- If `No` or `Yes` to either: No upgrade steps required.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk: `git revert <sha>` is the rollback plan.
