### PR TITLE
test(memory): cover jaccard dedup and conflict filtering edge cases

### DIFF
--- a/crates/zeroclaw-memory/src/conflict.rs
+++ b/crates/zeroclaw-memory/src/conflict.rs
@@ -175,4 +175,46 @@ mod tests {
         assert_eq!(conflicts.len(), 1);
         assert_eq!(conflicts[0], "1");
     }
+
+    #[test]
+    fn jaccard_deduplicates_repeated_words() {
+        // Token sets ignore repeats: {a, b} vs {a, b} are identical.
+        assert!((jaccard_similarity("a a b", "a b b") - 1.0).abs() < f64::EPSILON);
+        // {a, b} vs {a} -> intersection 1 / union 2.
+        assert!((jaccard_similarity("a a b", "a") - 0.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn find_text_conflicts_skips_superseded_and_identical() {
+        let entry = |id: &str, content: &str, superseded: Option<String>| MemoryEntry {
+            id: id.into(),
+            key: "k".into(),
+            content: content.into(),
+            category: MemoryCategory::Core,
+            timestamp: "now".into(),
+            session_id: None,
+            score: None,
+            namespace: "default".into(),
+            importance: Some(0.7),
+            superseded_by: superseded,
+            agent_alias: None,
+            agent_id: None,
+        };
+        let entries = vec![
+            entry("active", "User prefers Rust for systems work", None),
+            entry(
+                "old",
+                "User prefers Rust for systems work",
+                Some("x".into()),
+            ),
+        ];
+
+        // The already-superseded "old" entry is skipped; only "active" conflicts.
+        let conflicts = find_text_conflicts(&entries, "User now prefers Go for systems work", 0.3);
+        assert_eq!(conflicts, vec!["active".to_string()]);
+
+        // An identical new_content is an update, not a conflict.
+        let none = find_text_conflicts(&entries, "User prefers Rust for systems work", 0.3);
+        assert!(none.is_empty());
+    }
 }


### PR DESCRIPTION
## What

Extends the unit coverage of `crates/zeroclaw-memory/src/conflict.rs`. It already tested `jaccard_similarity` for identical/disjoint/partial/empty inputs and the basic `find_text_conflicts` category filter; this adds the set-semantics and filter edges.

## Why

`jaccard_similarity` backs the no-embeddings conflict path, and `find_text_conflicts` decides which Core memories get superseded — both have easy-to-break contracts:

- `jaccard_similarity` is **set**-based (`HashSet` of tokens), so repeated words are deduplicated — `"a a b"` vs `"a b b"` is `1.0`, not a multiset count. A regression to counting would change every similarity score;
- `find_text_conflicts` skips entries already marked `superseded_by`, and treats an identical `new_content` as an update rather than a conflict (so re-storing the same text doesn't supersede itself).

## Notes

Test-only; no behavior change. `cargo test -p zeroclaw-memory` and `cargo clippy -p zeroclaw-memory --tests` both pass.
