### PR TITLE
fix(scoop): register zerocode.exe in manifest

### DIFF
--- a/dist/scoop/zeroclaw.json
+++ b/dist/scoop/zeroclaw.json
@@ -7,7 +7,7 @@
         "64bit": {
             "url": "https://github.com/zeroclaw-labs/zeroclaw/releases/download/v0.5.9/zeroclaw-x86_64-pc-windows-msvc.zip",
             "hash": "",
-            "bin": "zeroclaw.exe"
+            "bin": ["zeroclaw.exe", "zerocode.exe"]
         }
     },
     "checkver": {


### PR DESCRIPTION
Fixes #8275

## Summary

- **Base branch:** `master`
- **What changed and why:**
  - The Scoop manifest template (`dist/scoop/zeroclaw.json`) only listed `"zeroclaw.exe"` as a single string in the `bin` field.
  - `zerocode.exe` (the TUI config manager, a valid workspace binary defined in `apps/zerocode/Cargo.toml`) was never registered as a shim.
  - This meant `scoop install zeroclaw` did not place `zerocode` on PATH, even though the binary exists in `~\scoop\apps\zeroclaw\current\zerocode.exe`.
  - Updated `bin` field to an array: `["zeroclaw.exe", "zerocode.exe"]` so Scoop registers both shims.
- **Scope boundary:**
  - Does NOT change the release-time CI workflow (`pub-scoop.yml` already generates the correct manifest with both binaries).
  - Does NOT affect AUR PKGBUILD (`dist/aur/PKGBUILD:44`), `install.sh`, or Docker packaging — they already install/register `zerocode`.
  - Does NOT modify any Rust source code.
- **Blast radius:** Scoop manifest consumers only. No behavior change for the existing `zeroclaw` shim.
- **Linked issue(s):** Fixes #8275
- **Labels:** `type: bug`, `risk: low`, `size: XS`

## Validation Evidence (required)

### Local Validation

```bash
$ python3 -c "import json; data=json.load(open('dist/scoop/zeroclaw.json')); print(json.dumps(data['architecture']['64bit']['bin'], indent=2))"
[
  "zeroclaw.exe",
  "zerocode.exe"
]

$ python3 -c "
import json
data = json.load(open('dist/scoop/zeroclaw.json'))
bin_field = data['architecture']['64bit']['bin']
assert 'zeroclaw.exe' in bin_field, 'zeroclaw.exe missing!'
assert 'zerocode.exe' in bin_field, 'zerocode.exe missing!'
print('All assertions passed — both binaries registered in manifest.')
"
All assertions passed — both binaries registered in manifest.

$ python3 -m json.tool dist/scoop/zeroclaw.json > /dev/null && echo "JSON is valid"
JSON is valid
```

- **Commands run and tail output:**
  - `python3` script validates `bin` field is a valid array containing both executables
  - `python3 -m json.tool` confirms well-formed JSON
- **Beyond CI — what did I manually verify?**
  - Verified that `zerocode` is a valid workspace binary (`apps/zerocode/Cargo.toml` defines `[[bin]] name = "zerocode"`)
  - Verified that AUR PKGBUILD (`dist/aur/PKGBUILD:44`) and `install.sh` already install/register `zerocode` — Scoop was the only outlier
  - Verified that `pub-scoop.yml:106` already generates the correct manifest with both binaries; this PR only updates the local template
- **If any command was intentionally skipped, why:**
  - `cargo test` / `cargo clippy` were skipped because this PR only touches `dist/scoop/zeroclaw.json` (no `.rs` files)

### Negative control (before / after)

```bash
# Before fix (old manifest template)
$ python3 -c "import json; print(json.load(open('dist/scoop/zeroclaw.json'))['architecture']['64bit']['bin'])"
zeroclaw.exe

# After fix
$ python3 -c "import json; print(json.load(open('dist/scoop/zeroclaw.json'))['architecture']['64bit']['bin'])"
['zeroclaw.exe', 'zerocode.exe']
```

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- Scoop users who previously installed `zeroclaw` will need to run `scoop update zeroclaw` to receive the new `zerocode` shim. No other migration steps needed.

## Rollback (required for medium/high-risk PRs)

Low-risk PR. `git revert <sha>` is the plan.

- **Fast rollback command/path:** `git revert e99a9f3d`
- **Feature flags or config toggles:** `None`
- **Observable failure symptoms:** If Scoop rejects the manifest, `scoop install` would fail at parse time with a JSON validation error. No runtime symptoms.
