### PR TITLE
fix(providers): expose replay_assistant_reasoning config and fall back tool_call_id for role=tool

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -873,6 +873,17 @@ pub struct ModelProviderConfig {
     #[tab(Connection)]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tls_ca_cert_path: Option<String>,
+    /// Whether stored assistant reasoning should be replayed on outbound
+    /// assistant history messages for OpenAI-compatible providers.
+    /// `Some(false)` strips `reasoning_content`/`reasoning` from outbound
+    /// history — use this when targeting a strict endpoint (e.g. Groq,
+    /// Mistral) that rejects reasoning fields on input. `None` (default)
+    /// preserves the provider's built-in behaviour. Generalises the
+    /// `groq`-factory shortcut to any compatible `custom` endpoint pointed
+    /// at a strict backend. See #8219.
+    #[tab(Advanced)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub replay_assistant_reasoning: Option<bool>,
 }
 
 // ── Per-family model model_provider configs ────────────────────────────

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -876,7 +876,7 @@ pub struct ModelProviderConfig {
     /// Whether stored assistant reasoning should be replayed on outbound
     /// assistant history messages for OpenAI-compatible providers.
     /// `Some(false)` strips `reasoning_content`/`reasoning` from outbound
-    /// history — use this when targeting a strict endpoint (e.g. Groq,
+    /// history; use this when targeting a strict endpoint (e.g. Groq,
     /// Mistral) that rejects reasoning fields on input. `None` (default)
     /// preserves the provider's built-in behaviour. Generalises the
     /// `groq`-factory shortcut to any compatible `custom` endpoint pointed

--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -1990,6 +1990,12 @@ impl OpenAiCompatibleModelProvider {
         let targets_mistral_tool_call_contract = self.targets_mistral_tool_call_contract();
         let mut used_tool_call_ids = std::collections::HashSet::new();
         let mut tool_call_id_map = std::collections::HashMap::new();
+        // Tracks the normalized ids of the most recent assistant message's
+        // `tool_calls` in iteration order, used as a fallback when a
+        // subsequent role=tool message loses its `tool_call_id` field
+        // (regression observed on Groq `gpt-oss-120b` second-turn history
+        // reconstruction). See #8219.
+        let mut last_assistant_tool_call_ids: Vec<String> = Vec::new();
 
         messages
             .iter()
@@ -2000,6 +2006,7 @@ impl OpenAiCompatibleModelProvider {
                     && let Ok(parsed_calls) =
                         serde_json::from_value::<Vec<ProviderToolCall>>(tool_calls_value.clone())
                 {
+                    let mut normalized_ids = Vec::with_capacity(parsed_calls.len());
                     let tool_calls = parsed_calls
                         .into_iter()
                         .map(|tc| ToolCall {
@@ -2010,6 +2017,7 @@ impl OpenAiCompatibleModelProvider {
                                     &mut used_tool_call_ids,
                                 );
                                 tool_call_id_map.insert(tc.id, normalized_id.clone());
+                                normalized_ids.push(normalized_id.clone());
                                 normalized_id
                             }),
                             kind: Some("function".to_string()),
@@ -2025,6 +2033,8 @@ impl OpenAiCompatibleModelProvider {
                             extra_content: tc.extra_content,
                         })
                         .collect::<Vec<_>>();
+
+                    last_assistant_tool_call_ids = normalized_ids;
 
                     let content = value
                         .get("content")
@@ -2088,7 +2098,7 @@ impl OpenAiCompatibleModelProvider {
                 if message.role == "tool"
                     && let Ok(value) = serde_json::from_str::<serde_json::Value>(&message.content)
                 {
-                    let tool_call_id = value
+                    let mut tool_call_id = value
                         .get("tool_call_id")
                         .and_then(serde_json::Value::as_str)
                         .map(|raw_id| {
@@ -2102,6 +2112,18 @@ impl OpenAiCompatibleModelProvider {
                                 normalized_id
                             })
                         });
+                    // When history reconstruction drops the `tool_call_id`
+                    // field on role=tool messages, strict backends (e.g.
+                    // Groq `gpt-oss-120b`) reject a `null` id with HTTP
+                    // 400.  Fall back to the first id from the most recent
+                    // assistant `tool_calls` so the message always carries
+                    // a non-null id.  See #8219.
+                    if tool_call_id.is_none()
+                        && let Some(fallback_id) =
+                            last_assistant_tool_call_ids.first().cloned()
+                    {
+                        tool_call_id = Some(fallback_id);
+                    }
                     let content = value
                         .get("content")
                         .and_then(serde_json::Value::as_str)

--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -2119,8 +2119,7 @@ impl OpenAiCompatibleModelProvider {
                     // assistant `tool_calls` so the message always carries
                     // a non-null id.  See #8219.
                     if tool_call_id.is_none()
-                        && let Some(fallback_id) =
-                            last_assistant_tool_call_ids.first().cloned()
+                        && let Some(fallback_id) = last_assistant_tool_call_ids.first().cloned()
                     {
                         tool_call_id = Some(fallback_id);
                     }

--- a/crates/zeroclaw-providers/src/factory.rs
+++ b/crates/zeroclaw-providers/src/factory.rs
@@ -217,6 +217,13 @@ pub fn apply_compat_options(
             );
         }
     }
+    // Generalises the Groq-specific shortcut so any OpenAI-compatible
+    // `custom` endpoint pointed at a strict backend (Groq, Mistral, ...)
+    // can opt out of reasoning replay without a dedicated family factory.
+    // See #8219.
+    if opts.replay_assistant_reasoning == Some(false) {
+        p = p.without_assistant_reasoning_replay();
+    }
     Box::new(p)
 }
 

--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -637,6 +637,13 @@ pub struct ModelProviderRuntimeOptions {
     pub chat_template_kwargs: Option<serde_json::Value>,
     /// Path to a custom CA certificate file for TLS connections.
     pub tls_ca_cert_path: Option<String>,
+    /// When `Some(false)`, the OpenAI-compatible provider will strip stored
+    /// assistant `reasoning_content`/`reasoning` from outbound history.
+    /// `Some(true)` (or `None`) preserves the provider's default replay
+    /// behaviour. Lets operators targeting strict endpoints (e.g. Groq,
+    /// Mistral) via the generic `custom` provider opt out of reasoning
+    /// replay without depending on a family-specific shortcut. See #8219.
+    pub replay_assistant_reasoning: Option<bool>,
 }
 
 impl Default for ModelProviderRuntimeOptions {
@@ -660,6 +667,7 @@ impl Default for ModelProviderRuntimeOptions {
             think: None,
             chat_template_kwargs: None,
             tls_ca_cert_path: None,
+            replay_assistant_reasoning: None,
         }
     }
 }
@@ -729,6 +737,7 @@ pub fn model_provider_runtime_options_from_model_provider_entry(
         think: entry.and_then(|e| e.think),
         chat_template_kwargs: entry.and_then(|e| e.chat_template_kwargs.clone()),
         tls_ca_cert_path,
+        replay_assistant_reasoning: entry.and_then(|e| e.replay_assistant_reasoning),
     }
 }
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Exposed `replay_assistant_reasoning` as a config field on `ModelProviderConfig` so generic compatible `custom` endpoints pointed at strict backends (Groq, Mistral) can disable reasoning replay without a family-specific factory shortcut. Generalises the Groq-only fix from #7616.
  - When `convert_messages_for_native` serialises `role=tool` messages whose `tool_call_id` field was dropped during history reconstruction, it now falls back to the first id from the most recent assistant `tool_calls`. Prevents a `null` id reaching backends like Groq that reject `tool_call_id: null` with HTTP 400.
- **Scope boundary:** Does not change the Groq factory (already calls `without_assistant_reasoning_replay`). Does not alter any non-compat provider family.
- **Blast radius:** All compatible providers (custom, groq, deepseek, ...) inherit the new `replay_assistant_reasoning` config field (None = no-op). The tool-role fallback fires only when `tool_call_id` is absent and an assistant `tool_calls` record exists in the same message batch.
- **Linked issue(s):** `Closes #8219`
- **Labels:** `type: fix`, `risk: low`, `size: S`

## Validation Evidence (required)

Local validation is the signal CI cannot replace. Run the full battery and paste literal output (tails, failures, warnings -- not "all passed").

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- **Commands run and tail output:** Cargo toolchain not available in the local environment; relying on CI for fmt/clippy/test.
- **Beyond CI -- what did you manually verify?** Diff passes visual review: field additions are symmetric across config struct / runtime options struct / Default impl / constructor; the compatible.rs change follows the same pattern as the existing `tool_call_id_map` resolution.
- **If any command was intentionally skipped, why:** No local Rust installation.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)

## Compatibility (required)

- Backward compatible? (`Yes`) -- new field defaults to `None` (preserves existing behaviour).
- Config / env / CLI surface changed? (`Yes`) -- new optional config field `replay_assistant_reasoning` on `[providers.models.<family>.<alias>]`.
- If `No` or `Yes` to either: exact upgrade steps for existing users: No action needed. Operators targeting strict endpoints via `custom` can add `replay_assistant_reasoning = false` to their provider config.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PRs: `git revert <sha>` is the plan unless otherwise noted.

## Supersede Attribution (required only when `Supersedes #` is used)

Not applicable.
