### PR TITLE
fix(config): make the yolo preset fully unrestricted

### DIFF
--- a/crates/zeroclaw-config/src/presets.rs
+++ b/crates/zeroclaw-config/src/presets.rs
@@ -28,7 +28,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::autonomy::AutonomyLevel;
-use crate::autonomy::DelegationPolicy;
+use crate::autonomy::{DelegationMode, DelegationPolicy};
 use crate::policy::{default_allowed_commands, default_forbidden_paths};
 use crate::schema::{RiskProfileConfig, RuntimeProfileConfig};
 
@@ -135,7 +135,9 @@ fn balanced_risk() -> RiskProfileConfig {
         auto_approve: vec![],
         always_ask: vec![],
         allowed_roots: vec![],
-        delegation_policy: DelegationPolicy::default(),
+        delegation_policy: DelegationPolicy {
+            mode: DelegationMode::Allow,
+        },
         allowed_tools: vec![],
         excluded_tools: vec![],
         sandbox_enabled: Some(true),
@@ -159,10 +161,12 @@ fn yolo_risk() -> RiskProfileConfig {
         require_approval_for_medium_risk: false,
         block_high_risk_commands: false,
         shell_env_passthrough: vec![],
-        auto_approve: vec![],
+        auto_approve: vec!["*".to_string()],
         always_ask: vec![],
         allowed_roots: vec![],
-        delegation_policy: DelegationPolicy::default(),
+        delegation_policy: DelegationPolicy {
+            mode: DelegationMode::Allow,
+        },
         allowed_tools: vec![],
         excluded_tools: vec![],
         sandbox_enabled: Some(false),
@@ -665,6 +669,43 @@ mod tests {
             assert!(
                 policy.is_command_allowed(cmd),
                 "yolo profile must allow `{cmd}` — it grants full autonomy with no denylist",
+            );
+        }
+    }
+
+    /// Regression: the `yolo` preset must declare unrestricted intent.
+    #[test]
+    fn yolo_risk_auto_approves_everything_with_no_forbidden_paths() {
+        let preset = risk_preset("yolo").unwrap();
+        let values = (preset.values)();
+        assert_eq!(
+            values.auto_approve,
+            vec!["*".to_string()],
+            "yolo must auto-approve every tool via the `*` wildcard",
+        );
+        assert!(
+            values.forbidden_paths.is_empty(),
+            "yolo must have no forbidden paths",
+        );
+        assert!(
+            values.always_ask.is_empty(),
+            "yolo must never force an approval prompt",
+        );
+        assert!(
+            values.delegation_policy.permits(),
+            "yolo must permit delegation",
+        );
+    }
+
+    /// Regression: `yolo` and `balanced` both permit delegation.
+    #[test]
+    fn yolo_and_balanced_permit_delegation() {
+        for name in ["yolo", "balanced"] {
+            let preset = risk_preset(name).unwrap();
+            let values = (preset.values)();
+            assert!(
+                values.delegation_policy.permits(),
+                "{name} must permit delegation",
             );
         }
     }


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - The `yolo` risk preset declared `auto_approve: vec![]`, which reads as deny-by-default (auto-approve nothing) and contradicts the preset's stated full-autonomy intent. Set `auto_approve: vec!["*"]` so the profile explicitly auto-approves every tool, mirroring the existing `allowed_commands: vec!["*"]` wildcard.
  - Granted delegation on both the `yolo` and `balanced` presets by setting `delegation_policy` to `DelegationMode::Allow`; both previously inherited the default `Forbidden` mode.
  - `yolo` `forbidden_paths` was already empty (no path off-limits); left unchanged.
- **Scope boundary:** Only the `yolo` and `balanced` entries in `crates/zeroclaw-config/src/presets.rs`. No change to `locked_down`, to the approval engine, or to runtime presets.
- **Blast radius:** Any surface that reads a preset's `auto_approve` / `delegation_policy` (onboarding, config builder, doctor). `AutonomyLevel::Full` already bypassed the prompt at the approval layer, so runtime gating behavior of `yolo` is unchanged; this aligns the declared profile values with that intent. `balanced` now permits delegation where it previously did not.
- **Linked issue(s):** None.
- **Labels:** `type: bug`, `risk: low`, `size: S`

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy -p zeroclaw-config --all-targets -- -D warnings
cargo test -p zeroclaw-config --lib presets::
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` clean (no output).
  - `cargo clippy -p zeroclaw-config --all-targets -- -D warnings`: `Finished dev profile ... in 37.25s`, no warnings.
  - `cargo test -p zeroclaw-config --lib presets::`: `test result: ok. 14 passed; 0 failed; 0 ignored`.
- **Beyond CI — what did you manually verify?** Added two regression tests: one asserts `yolo` auto-approves everything (`*`), carries no forbidden paths, never forces a prompt, and permits delegation; another asserts both `yolo` and `balanced` permit delegation. Did NOT run the full workspace `cargo test` or workspace-wide clippy; scoped to the config crate the change touches.
- **If any command was intentionally skipped, why:** Workspace-wide clippy/test scoped down to `zeroclaw-config` since the diff is confined to that crate.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `Yes` — the `yolo` preset now declares `auto_approve: ["*"]` and both `yolo`/`balanced` permit delegation. `yolo` is the opt-in full-autonomy profile whose documented purpose is no gates; `balanced` delegation is limited to same-risk-profile peers at the call site.
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: `yolo` is explicitly the "machine you don't mind breaking" profile; the change makes the declared values match that intent. `balanced` delegation remains gated by shared-risk-profile reachability.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No` — preset values only; no schema, env, or CLI surface change.
- If `No` or `Yes` to either: existing configs are unaffected; the change only alters the values produced when a user selects the `yolo` or `balanced` preset.

## Rollback (required for medium/high-risk PRs)

Low-risk PR: `git revert <sha>` is the plan.