### PR TITLE
fix(config): warn when a2a.exposed_skills resolves no skills

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -16777,6 +16777,7 @@ impl Config {
         let mut warnings = Vec::new();
         self.collect_fallback_warnings(&mut warnings);
         self.collect_cross_provider_summary_model_warnings(&mut warnings);
+        self.collect_a2a_exposed_skills_warnings(&mut warnings);
         // `wire_api` is only honored by bring-your-own-endpoint families; on a
         // branded family with a fixed wire protocol it is silently ignored.
         // Surface that so an operator who sets it on, e.g., `mistral` learns it
@@ -16796,6 +16797,41 @@ impl Config {
             }
         }
         warnings
+    }
+
+    /// Surface the A2A `exposed_skills` filter that can never resolve a skill.
+    /// `exposed_skills` is a narrowing filter over the agent's resolved skill
+    /// set, which comes from `skill_bundles`. An agent that lists
+    /// `a2a.exposed_skills` but declares no `skill_bundles` advertises an empty
+    /// `skills: []` array on its agent card with no error, because every wanted
+    /// id is dropped for belonging to a bundle the agent does not declare. The
+    /// same silent emptiness happens when a wanted id names no skill in any
+    /// declared bundle, or when the owning bundle's include/exclude filter
+    /// excludes it; those need disk resolution, so this offline check covers the
+    /// common structural case: exposed skills with zero declared bundles.
+    fn collect_a2a_exposed_skills_warnings(
+        &self,
+        warnings: &mut Vec<crate::validation_warnings::ValidationWarning>,
+    ) {
+        for (agent_alias, agent) in &self.agents {
+            if agent.a2a.exposed_skills.is_empty() {
+                continue;
+            }
+            if !agent.skill_bundles.is_empty() {
+                continue;
+            }
+            warnings.push(crate::validation_warnings::ValidationWarning::new(
+                "a2a_exposed_skills_without_bundles",
+                format!(
+                    "agent `{agent_alias}` lists a2a.exposed_skills but declares no \
+                     skill_bundles, so its agent card advertises no skills (skills: []). \
+                     exposed_skills is a filter over the agent's resolved skill set; add \
+                     the owning bundle(s) to agents.{agent_alias}.skill_bundles so the \
+                     listed skills resolve."
+                ),
+                format!("agents.{agent_alias}.a2a.exposed_skills"),
+            ));
+        }
     }
 
     /// Surface the #7964 cross-provider shape on a legacy config that has NOT
@@ -29994,6 +30030,69 @@ allowed_users = []
             w.message.contains("beta -> custom.p2"),
             "message names beta + provider: {}",
             w.message
+        );
+    }
+
+    // exposed_skills set with no skill_bundles -> the agent card resolves no
+    // skills (skills: []) silently; the diagnostic fires and names the agent.
+    #[tokio::test]
+    async fn collect_warnings_flags_exposed_skills_without_bundles() {
+        let toml = r#"
+            [risk_profiles.default]
+            level = "supervised"
+
+            [agents.merchant]
+            enabled = true
+            risk_profile = "default"
+
+            [agents.merchant.a2a]
+            published = true
+            exposed_skills = ["ucp_discovery_get", "ucp_merchant_get"]
+        "#;
+        let cfg: Config = toml::from_str(toml).unwrap();
+        let warnings = cfg.collect_warnings();
+        let w = warnings
+            .iter()
+            .find(|w| w.code == "a2a_exposed_skills_without_bundles")
+            .expect("expected a2a_exposed_skills_without_bundles warning");
+        assert_eq!(w.path, "agents.merchant.a2a.exposed_skills");
+        assert!(
+            w.message.contains("merchant"),
+            "message names the agent: {}",
+            w.message
+        );
+        assert!(
+            w.message.contains("skill_bundles"),
+            "message points at skill_bundles: {}",
+            w.message
+        );
+    }
+
+    // exposed_skills set alongside at least one declared skill_bundle -> no
+    // structural diagnostic (disk resolution governs whether ids actually
+    // resolve; that is out of scope for this offline check).
+    #[tokio::test]
+    async fn collect_warnings_silent_for_exposed_skills_with_bundles() {
+        let toml = r#"
+            [risk_profiles.default]
+            level = "supervised"
+
+            [agents.merchant]
+            enabled = true
+            risk_profile = "default"
+            skill_bundles = ["commerce"]
+
+            [agents.merchant.a2a]
+            published = true
+            exposed_skills = ["ucp_discovery_get"]
+        "#;
+        let cfg: Config = toml::from_str(toml).unwrap();
+        let warnings = cfg.collect_warnings();
+        assert!(
+            !warnings
+                .iter()
+                .any(|w| w.code == "a2a_exposed_skills_without_bundles"),
+            "no exposed_skills warning when a bundle is declared: {warnings:?}"
         );
     }
 

--- a/docs/book/src/gateway/a2a-discovery.md
+++ b/docs/book/src/gateway/a2a-discovery.md
@@ -325,6 +325,14 @@ actually carries: it must live in one of the agent's skill bundles and its
 skill in a bundle the agent does not declare, is dropped silently rather than
 advertised.
 
+The most common cause of an empty `skills: []` array is setting
+`a2a.exposed_skills` on an agent that declares no `skill_bundles`.
+`exposed_skills` only narrows the agent's resolved skill set; it does not load
+skills on its own. With no bundle declared there is nothing for the filter to
+keep, so every name drops and the card advertises nothing. Add the owning
+bundle(s) to `agents.<alias>.skill_bundles`. Config validation surfaces this
+case as a startup warning (`a2a_exposed_skills_without_bundles`).
+
 ### What publishing actually exposes
 
 Read this before you publish. Once the server is enabled and an alias is


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - An agent that sets `a2a.exposed_skills` but declares no `skill_bundles` silently advertises an empty `skills: []` array on its agent card. `exposed_skills` is only a narrowing filter over the agent's resolved skill set (which comes from `skill_bundles`); with no bundle declared, every wanted id is dropped for belonging to a bundle the agent does not declare, and the card lists nothing with no error.
  - Added an offline `collect_warnings` diagnostic (`a2a_exposed_skills_without_bundles`) that fires for any agent with non-empty `exposed_skills` and empty `skill_bundles`, naming the agent and the field to fix. Matches the existing fail-loud-on-misconfiguration posture: config loads and validates, but would silently produce an empty card at runtime.
  - Documented the common cause in the A2A discovery troubleshooting section and referenced the warning code.
- **Scope boundary:** Does not change the gateway resolution logic in `a2a.rs` (working as designed); only adds a diagnostic and docs. Does not add disk-based resolution checks (the empty-bundle case is the common structural failure and is offline-checkable).
- **Blast radius:** `Config::collect_warnings` only; surfaced on CLI startup and the gateway prop/patch `warnings` field. No behavior change to card generation or task dispatch.
- **Linked issue(s):** none
- **Labels:** type:bug, risk:low, size:S

## Validation Evidence (required)

```
cargo fmt --all -- --check                          -> EXIT:0 (no output)
cargo clippy --all-targets -- -D warnings           -> Finished, clean
cargo test -p zeroclaw-config collect_warnings      -> 6 passed; 0 failed
cargo test -p zeroclaw-gateway a2a::                 -> 21 passed; 0 failed
```

- **Commands run and tail output:**
  - `cargo test -p zeroclaw-config collect_warnings`: `test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 963 filtered out`, including the two new tests `collect_warnings_flags_exposed_skills_without_bundles` and `collect_warnings_silent_for_exposed_skills_with_bundles`.
  - `cargo test -p zeroclaw-gateway a2a::`: `test result: ok. 21 passed; 0 failed` (existing `exposed_skills_*` resolution tests unaffected).
- **Beyond CI:** Traced the root cause through `exposed_skills()` in `a2a.rs` (the three-condition filter), confirmed the reported config hits condition 2 (`agent.skill_bundles` empty), so every wanted id drops. New tests assert the warning fires without bundles and stays silent once a bundle is declared.
- **If any command was intentionally skipped, why:** Full workspace `cargo test` not run; ran targeted config + gateway suites covering the change. Workspace clippy was run in full.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No (additive non-fatal warning; no schema field added)
- Upgrade steps: none. Affected operators add the owning bundle(s) to `agents.<alias>.skill_bundles` so listed `exposed_skills` resolve; the new warning points them at it.

## Rollback (required for medium/high-risk PRs)

Low-risk: `git revert <sha>` is the plan.