### PR TITLE
fix(config): extend ensure_no_escalation_beyond to cover allowed_tools and excluded_tools

### DIFF
--- a/crates/zeroclaw-config/src/policy.rs
+++ b/crates/zeroclaw-config/src/policy.rs
@@ -468,9 +468,18 @@ pub enum EscalationViolation {
     /// closed.
     BlockHighRiskCommandsDisabledByChild,
     /// Child flips `require_approval_for_medium_risk` from `true`
-    /// (parent) to `false`, bypassing the human-in-the-loop step the
-    /// parent required.
+    /// to `false`, bypassing the human-in-the-loop step the parent
+    /// required.
     RequireApprovalDisabledByChild,
+    /// Child's `allowed_tools` contains a tool the parent does not
+    /// allow, or child is unrestricted (`None`) while parent has a
+    /// restricted allowlist.
+    ToolNotInParent { tool: String },
+    /// Child drops an `excluded_tools` entry the parent enforces.
+    /// Superset semantics: the parent's excluded set must be a subset
+    /// of the child's, i.e. the child can ADD exclusions but never
+    /// DROP them.
+    ExcludedToolDroppedByChild { tool: String },
 }
 
 impl std::fmt::Display for EscalationViolation {
@@ -526,6 +535,14 @@ impl std::fmt::Display for EscalationViolation {
             Self::RequireApprovalDisabledByChild => write!(
                 f,
                 "subagent attempts to set require_approval_for_medium_risk=false but the parent enforces it"
+            ),
+            Self::ToolNotInParent { tool } => write!(
+                f,
+                "subagent allowed_tools entry {tool:?} is not present on the parent's allowed_tools"
+            ),
+            Self::ExcludedToolDroppedByChild { tool } => write!(
+                f,
+                "subagent drops excluded_tools entry {tool:?} that the parent enforces"
             ),
         }
     }
@@ -2354,6 +2371,41 @@ impl SecurityPolicy {
         }
         if parent.require_approval_for_medium_risk && !self.require_approval_for_medium_risk {
             return Err(EscalationViolation::RequireApprovalDisabledByChild);
+        }
+
+        // allowed_tools: if the parent has a restricted allowlist, the child
+        // must also be restricted and every child entry must be in the parent's
+        // list. A child `None` (unrestricted) when parent is `Some` is an
+        // escalation.
+        if let Some(ref parent_allowed) = parent.allowed_tools {
+            if self.allowed_tools.is_none() {
+                return Err(EscalationViolation::ToolNotInParent {
+                    tool: "(unrestricted)".to_string(),
+                });
+            }
+            if let Some(ref child_allowed) = self.allowed_tools {
+                for tool in child_allowed {
+                    if !parent_allowed.iter().any(|p| p == tool) {
+                        return Err(EscalationViolation::ToolNotInParent { tool: tool.clone() });
+                    }
+                }
+            }
+        }
+
+        // excluded_tools: superset semantics, same as forbidden_paths.
+        // The parent's excluded set must be a subset of the child's.
+        if let Some(ref parent_excluded) = parent.excluded_tools {
+            for tool in parent_excluded {
+                let child_has = self
+                    .excluded_tools
+                    .as_ref()
+                    .is_some_and(|c| c.iter().any(|ct| ct == tool));
+                if !child_has {
+                    return Err(EscalationViolation::ExcludedToolDroppedByChild {
+                        tool: tool.clone(),
+                    });
+                }
+            }
         }
 
         Ok(())
@@ -5401,6 +5453,91 @@ mod tests {
             .ensure_no_escalation_beyond(&parent)
             .expect_err("child flipping require_approval_for_medium_risk off must be rejected");
         assert_eq!(err, EscalationViolation::RequireApprovalDisabledByChild);
+    }
+
+    // ── allowed_tools / excluded_tools escalation checks ───────────────────
+
+    #[test]
+    fn ensure_no_escalation_rejects_child_allowed_tool_not_in_parent() {
+        let parent = SecurityPolicy {
+            allowed_tools: Some(vec!["file_read".into(), "delegate".into()]),
+            ..SecurityPolicy::default()
+        };
+        let child = SecurityPolicy {
+            allowed_tools: Some(vec!["file_read".into(), "shell".into()]),
+            ..SecurityPolicy::default()
+        };
+        let err = child
+            .ensure_no_escalation_beyond(&parent)
+            .expect_err("child tool not in parent allowlist must be rejected");
+        assert!(matches!(
+            err,
+            EscalationViolation::ToolNotInParent { ref tool } if tool == "shell"
+        ));
+    }
+
+    #[test]
+    fn ensure_no_escalation_rejects_unrestricted_child_when_parent_restricted() {
+        let parent = SecurityPolicy {
+            allowed_tools: Some(vec!["file_read".into()]),
+            ..SecurityPolicy::default()
+        };
+        let child = SecurityPolicy {
+            allowed_tools: None,
+            ..SecurityPolicy::default()
+        };
+        let err = child
+            .ensure_no_escalation_beyond(&parent)
+            .expect_err("unrestricted child under restricted parent must be rejected");
+        assert!(matches!(
+            err,
+            EscalationViolation::ToolNotInParent { ref tool } if tool == "(unrestricted)"
+        ));
+    }
+
+    #[test]
+    fn ensure_no_escalation_accepts_narrowed_allowed_tools() {
+        let parent = SecurityPolicy {
+            allowed_tools: Some(vec!["file_read".into(), "shell".into()]),
+            ..SecurityPolicy::default()
+        };
+        let child = SecurityPolicy {
+            allowed_tools: Some(vec!["file_read".into()]),
+            ..SecurityPolicy::default()
+        };
+        assert!(child.ensure_no_escalation_beyond(&parent).is_ok());
+    }
+
+    #[test]
+    fn ensure_no_escalation_rejects_child_dropping_parent_excluded_tool() {
+        let parent = SecurityPolicy {
+            excluded_tools: Some(vec!["shell".into()]),
+            ..SecurityPolicy::default()
+        };
+        let child = SecurityPolicy {
+            excluded_tools: None,
+            ..SecurityPolicy::default()
+        };
+        let err = child
+            .ensure_no_escalation_beyond(&parent)
+            .expect_err("child dropping parent's excluded tool must be rejected");
+        assert!(matches!(
+            err,
+            EscalationViolation::ExcludedToolDroppedByChild { ref tool } if tool == "shell"
+        ));
+    }
+
+    #[test]
+    fn ensure_no_escalation_accepts_child_with_stricter_excluded_tools() {
+        let parent = SecurityPolicy {
+            excluded_tools: Some(vec!["shell".into()]),
+            ..SecurityPolicy::default()
+        };
+        let child = SecurityPolicy {
+            excluded_tools: Some(vec!["shell".into(), "file_write".into()]),
+            ..SecurityPolicy::default()
+        };
+        assert!(child.ensure_no_escalation_beyond(&parent).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
Fixes: #8279

# PR Description for fix/8279-ensure-no-escalation-tools

## Summary

`SecurityPolicy::ensure_no_escalation_beyond` checked every escalation surface except `allowed_tools` and `excluded_tools`, leaving a gap where a child policy could silently broaden tool access beyond the parent ceiling.

- Add two new `EscalationViolation` variants: `ToolNotInParent` and `ExcludedToolDroppedByChild`.
- Extend `SecurityPolicy::ensure_no_escalation_beyond` to enforce:
  - **`allowed_tools` subset**: child must be a subset of parent. A child `None` (unrestricted) when parent is `Some` (restricted) is an escalation.
  - **`excluded_tools` superset**: child must be a superset of parent. A child dropping a parent's excluded entry is an escalation (same semantics as `forbidden_paths`).

This is Approach B (architectural hardening) for #8279. Approach A (runtime filter fix) is in `fix/8279-delegate-parent-tool-policy-filter`.

**Fixes**: #8279

---

## Validation Evidence

```bash
$ cargo test ensure_no_escalation -p zeroclaw-config -- --nocapture
running 21 tests
test policy::tests::ensure_no_escalation_accepts_child_with_stricter_excluded_tools ... ok
test policy::tests::ensure_no_escalation_accepts_narrowed_allowed_tools ... ok
test policy::tests::ensure_no_escalation_accepts_narrowed_child ... ok
test policy::tests::ensure_no_escalation_accepts_rw_root_downgraded_to_read_only_on_child ... ok
test policy::tests::ensure_no_escalation_accepts_subpath_narrowing_inside_parent_root ... ok
test policy::tests::ensure_no_escalation_rejects_child_allowed_tool_not_in_parent ... ok
test policy::tests::ensure_no_escalation_rejects_child_dropping_parent_excluded_tool ... ok
test policy::tests::ensure_no_escalation_rejects_disabled_block_high_risk_commands ... ok
test policy::tests::ensure_no_escalation_rejects_disabled_require_approval ... ok
test policy::tests::ensure_no_escalation_rejects_dropped_forbidden_path ... ok
test policy::tests::ensure_no_escalation_rejects_expanded_shell_env_passthrough ... ok
test policy::tests::ensure_no_escalation_rejects_higher_autonomy ... ok
test policy::tests::ensure_no_escalation_rejects_higher_max_actions ... ok
test policy::tests::ensure_no_escalation_rejects_higher_max_cost ... ok
test policy::tests::ensure_no_escalation_rejects_higher_shell_timeout ... ok
test policy::tests::ensure_no_escalation_rejects_new_command_not_in_parent ... ok
test policy::tests::ensure_no_escalation_rejects_new_read_only_root_not_in_parent ... ok
test policy::tests::ensure_no_escalation_rejects_new_rw_root_not_in_parent ... ok
test policy::tests::ensure_no_escalation_rejects_unrestricted_child_when_parent_restricted ... ok
test policy::tests::ensure_no_escalation_rejects_workspace_only_disabled_by_child ... ok
test policy::tests::ensure_no_escalation_accepts_identical_policy ... ok

test result: ok. 21 passed; 0 failed; 0 ignored; 0 measured; 951 filtered out

$ cargo fmt --all -- --check
# (clean, no output)

$ cargo clippy --all-targets -- -D warnings
# Finished clean — 0 warnings
```

---

## Security

- **Risk tier**: `high` (architectural hardening for S0 vulnerability).
- **Scope**: `SecurityPolicy::ensure_no_escalation_beyond` is the canonical cross-profile escalation check for all SubAgent spawn paths (`delegate`, `SubAgentOverrides`, `execute_pipeline`, etc.). Closing the `allowed_tools` / `excluded_tools` gap removes a confused-deputy bypass vector.
- **Not in this PR**: No runtime changes to `delegate` tool (Approach A handles that). No changes to `Provider` / `Channel` / `Tool` traits.

---

## Compatibility

| Scenario | Before | After | Impact |
|----------|--------|-------|--------|
| Parent `allowed_tools = Some(list)`, child `allowed_tools = None` | Accepted | Rejected with `ToolNotInParent` | Behavior change — this was the escalation bug |
| Parent `allowed_tools = Some([a, b])`, child `allowed_tools = Some([a, c])` | Accepted | Rejected with `ToolNotInParent` | Behavior change — this was the escalation bug |
| Parent `excluded_tools = Some([a])`, child `excluded_tools = None` | Accepted | Rejected with `ExcludedToolDroppedByChild` | Behavior change — this was the escalation bug |
| Parent `allowed_tools = None` (unrestricted) | Any child allowed | No change | No impact |
| Child is a strict subset / superset of parent | Accepted | Accepted | No change |

- **Breaking**: The `EscalationViolation` enum now has two new variants. Any code that `match`es exhaustively on `EscalationViolation` will need an update. This is a necessary change for the fix to be complete.
- **Rollback**: `git revert <merge-sha>`

---

## Regression Tests

| Test | Scenario |
|------|----------|
| `ensure_no_escalation_rejects_child_allowed_tool_not_in_parent` | Parent `["file_read", "delegate"]`, child `["file_read", "shell"]` → `ToolNotInParent("shell")` |
| `ensure_no_escalation_rejects_unrestricted_child_when_parent_restricted` | Parent `Some(["file_read"])`, child `None` → `ToolNotInParent("(unrestricted)")` |
| `ensure_no_escalation_accepts_narrowed_allowed_tools` | Parent `["file_read", "shell"]`, child `["file_read"]` → `Ok(())` |
| `ensure_no_escalation_rejects_child_dropping_parent_excluded_tool` | Parent `Some(["shell"])`, child `None` → `ExcludedToolDroppedByChild("shell")` |
| `ensure_no_escalation_accepts_child_with_stricter_excluded_tools` | Parent `Some(["shell"])`, child `Some(["shell", "file_write"])` → `Ok(())` |

---

## Rollback

`git revert <merge-sha>` — single-commit branch, revert removes the new `EscalationViolation` variants and the `ensure_no_escalation_beyond` check blocks.

---

## Related

- Approach A (runtime fix): `fix/8279-delegate-parent-tool-policy-filter`
- Fixes: #8279
- Related to: #7947 / PR #7960 (same confused-deputy class, different path)
