### PR TITLE
test(config): cover in-root path parent normalization

### DIFF
--- a/crates/zeroclaw-config/src/paths.rs
+++ b/crates/zeroclaw-config/src/paths.rs
@@ -85,4 +85,13 @@ mod tests {
             root.join("skills/coding"),
         );
     }
+
+    #[test]
+    fn dotdot_within_root_is_normalized() {
+        let root = Path::new("/tmp/install/shared");
+        assert_eq!(
+            resolve_under(root, "skills/../coding").unwrap(),
+            root.join("coding"),
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Adds a regression test (`dotdot_within_root_is_normalized`) covering that a path containing `..` that still resolves inside the root (e.g. `skills/../coding`) is allowed and lexically normalized to `root/coding` by `resolve_under`. Existing tests cover empty input, plain relative paths, `..` escapes, and double slashes, but not in-root `..` normalization. Test-only — no production code changes.
- **Scope boundary:** Test-only. No production code, schema, or behavior changes.
- **Blast radius:** None — adds one `#[test]` in `crates/zeroclaw-config/src/paths.rs`.
- **Linked issue(s):** None.

## Validation Evidence (required)

```
$ cargo test -p zeroclaw-config dotdot_within_root_is_normalized
test paths::tests::dotdot_within_root_is_normalized ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 968 filtered out; finished in 0.00s

$ cargo clippy -p zeroclaw-config --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 50.41s

$ cargo fmt -p zeroclaw-config -- --check
(no diff on the changed file)
```

- **Beyond CI — what did you manually verify?** Read `crates/zeroclaw-config/src/paths.rs` and confirmed the asserted behavior is the current public contract; the test uses real signatures and touches no production code. Pure-logic (no IO/network/time/global state).

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No

## Rollback

Low-risk, test-only: `git revert <sha>`.