### PR TITLE
fix(channels/discord): render interactive components in streamed replies

### DIFF
--- a/crates/zeroclaw-channels/src/discord/mod.rs
+++ b/crates/zeroclaw-channels/src/discord/mod.rs
@@ -3755,7 +3755,24 @@ impl Channel for DiscordChannel {
         // streaming/draft reply renders embeds the same as a normal send.
         let (text_without_embeds, embeds, _embed_failures, _embeds_truncated) =
             prepare_outgoing_embeds(text, self.workspace_dir.as_deref());
-        let (cleaned_content, parsed_attachments) = parse_attachment_markers(&text_without_embeds);
+        // Interactive components next (same ordering as `send()`): the
+        // `[COMPONENTS:{json}]` body also contains `[`/`]`, so strip it before the
+        // attachment scanner runs. A streamed/draft reply must render components
+        // identically to a normal send. `send()` parsed them but `finalize_draft`
+        // did not, so any reply that streamed (stream_mode != Off) leaked the raw
+        // marker as plain text. Each interactive component carrying a `prompt` is
+        // registered in `pending_components` via `build_marker_components`, so a
+        // click dispatches the same as on the non-streaming path. The action rows
+        // ride the first finalized message below, mirroring embeds.
+        let (text_without_components, component_rows) =
+            parse_component_markers(&text_without_embeds);
+        let component_action_rows = if component_rows.is_empty() {
+            Vec::new()
+        } else {
+            self.build_marker_components(&component_rows)
+        };
+        let (cleaned_content, parsed_attachments) =
+            parse_attachment_markers(&text_without_components);
         let (mut local_files, remote_urls, failures) =
             classify_outgoing_attachments(&parsed_attachments, self.workspace_dir.as_deref());
         let body = with_inline_attachment_urls(&cleaned_content, &remote_urls);
@@ -3776,10 +3793,11 @@ impl Channel for DiscordChannel {
             let mut first_message_id: Option<String> = None;
             for (i, chunk) in chunks.iter().enumerate() {
                 let new_id = if i == 0 {
-                    // Embeds + files ride the first message.
+                    // Embeds + components + files ride the first message.
                     let payload = DiscordOutgoing {
                         content: Some(chunk.clone()),
                         embeds: embeds.clone(),
+                        components: component_action_rows.clone(),
                         ..Default::default()
                     };
                     send_discord_message_payload_with_files(
@@ -3813,10 +3831,11 @@ impl Channel for DiscordChannel {
             let mut first_message_id: Option<String> = None;
             for (i, chunk) in chunks.iter().enumerate() {
                 let new_id = if i == 0 {
-                    // Embeds ride the first message.
+                    // Embeds + components ride the first message.
                     let payload = DiscordOutgoing {
                         content: Some(chunk.clone()),
                         embeds: embeds.clone(),
+                        components: component_action_rows.clone(),
                         ..Default::default()
                     };
                     send_discord_message_payload(&client, &self.bot_token, recipient, &payload)
@@ -3836,13 +3855,16 @@ impl Channel for DiscordChannel {
             return Ok(());
         }
 
-        // Path 3: simple case — edit in-place (with any embeds); fall back to
-        // delete + POST on failure. The reaction target is the draft message_id
-        // when the edit lands; when the fallback fires it's the freshly posted
-        // message instead.
+        // Path 3: simple case, edit in-place (with any embeds + components); fall
+        // back to delete + POST on failure. The reaction target is the draft
+        // message_id when the edit lands; when the fallback fires it's the freshly
+        // posted message instead. Editing the draft to carry the action rows is
+        // what makes a streamed reply's components render (Discord accepts
+        // `components` on a message edit just as on a create).
         let payload = DiscordOutgoing {
             content: Some(content.clone()),
             embeds: embeds.clone(),
+            components: component_action_rows.clone(),
             ..Default::default()
         };
         let reaction_target = match edit_discord_message_payload(
@@ -4091,6 +4113,33 @@ mod tests {
         assert_eq!(
             payload.to_rest_json(),
             serde_json::json!({ "content": "Result", "embeds": [{ "title": "Report" }] })
+        );
+    }
+
+    #[test]
+    fn finalize_draft_payload_carries_components() {
+        // finalize_draft must lift `[COMPONENTS:...]` out of the final streamed text
+        // and attach the action rows to the first message, the same transformation
+        // send() does. Before this fix only send() parsed components, so any reply
+        // that streamed (stream_mode != Off) leaked the raw marker as plain text.
+        // Pin the transformation so the streaming path can't regress to
+        // content-only.
+        let raw = "Pick one [COMPONENTS:{\"rows\":[[{\"label\":\"Go\",\"style\":\"primary\",\"prompt\":\"go\"}]]}]";
+        let (content, rows) = parse_component_markers(raw);
+        assert_eq!(content.trim(), "Pick one");
+        assert_eq!(rows.len(), 1, "one action row parsed");
+        let mut reg = pending::PendingComponents::default();
+        let component_action_rows = build_component_rows("n", &rows, &mut reg);
+        assert_eq!(component_action_rows.len(), 1, "row rendered");
+        let payload = DiscordOutgoing {
+            content: Some(content.trim().to_string()),
+            components: component_action_rows,
+            ..Default::default()
+        };
+        let json = payload.to_rest_json();
+        assert!(
+            json.get("components").is_some(),
+            "finalize payload must carry the action rows; got {json}"
         );
     }
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `[COMPONENTS:{json}]` interactive components (buttons/selects/modals, added in #7965) only rendered on the non-streaming `send()` path. `finalize_draft()` - the draft-streaming finalize used whenever `stream_mode != Off` - lifted embeds and attachments out of the final text but never parsed components, so any reply that streamed leaked the raw marker as **plain text** instead of rendering interactive components.
  - Parse and strip the marker in `finalize_draft` using the same `embeds -> components -> attachments` ordering as `send()`, build the action rows via `build_marker_components` (registering each prompt in `pending_components` so a click dispatches), and attach `components:` to the first finalized message across all three paths (file attachments, chunked over-length, and the simple edit-in-place). Mirrors the existing embed handling exactly.
  - Stripping the component marker before `parse_attachment_markers` also removes a latent hazard: the attachment scanner splits on the first `]`, and a `[COMPONENTS:{...}]` body contains `]` - the same ordering rationale `send()` already documents.
  - Adds `finalize_draft_payload_carries_components` to pin the transformation.
- **Scope boundary:** Only `finalize_draft`. No change to `send()`, the component parser/registry, the `[COMPONENTS:]` marker format, or any other channel. Replies with no component marker are byte-identical to before.
- **Blast radius:** Discord channel egress for streamed replies. Non-component streamed replies are unaffected (`parse_component_markers` is a no-op and `to_rest_json` omits the empty `components` key).
- **Linked issue(s):** Related #7965 (this is a follow-up - #7965 wired component parsing into `send()` and the interaction path but missed the draft-streaming finalize path).
- **Labels:** Suggested for maintainer: `type: bug`, `scope: channels`, `risk: low`, `size: S`.

## Validation Evidence (required)

Toolchain pinned to CI's `1.93.0`.

```
cargo fmt --all -- --check            -> [PASS]
cargo clippy --all-targets +1.93.0    -> [PASS]   (-D warnings)
cargo test +1.93.0                    -> [PASS]
```

- **Commands run and tail output:** full pre-push battery `RESULT: PASS` (0 blocking). New test
  `finalize_draft_payload_carries_components` passes; existing
  `finalize_draft_builds_a_first_message_payload_carrying_embeds` still passes (5/5 in the finalize group).
- **Beyond CI - what did you manually verify?** Live-verified on a running daemon: with `discord.oracle`
  on `stream_mode = partial`, a bot reply containing the kitchen-sink marker (3 buttons + a select) now
  renders as real interactive components in the streamed message instead of raw text. Verified the change
  survived a clean integration merge intact (no rerere clobber).
- **If any command was intentionally skipped, why:** web and shell batteries skipped - no `web/`/TS or
  `.sh` changes (Rust-only diff, 1 file).


<img width="879" height="569" alt="image" src="https://github.com/user-attachments/assets/f375d9a2-689e-4b9f-ba7a-f4305b695fdf" />

<img width="701" height="661" alt="image" src="https://github.com/user-attachments/assets/da68be6a-28c1-4808-8ed5-198c0aa4f995" />

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No** (same Discord REST calls the path already made; one payload now carries `components`)
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility (required)

- Backward compatible? **Yes** - replies without a component marker are byte-identical (empty `components` is omitted from the payload).
- Config / env / CLI surface changed? **No** - internal method; the `[COMPONENTS:]` marker and feature are already documented from #7965, so no docs change is warranted.

## Rollback (required for medium/high-risk PRs)

Low-risk. `git revert e2deaed4a0` restores the prior behavior (streamed replies leak the marker as text, as before this PR).
