### PR TITLE
fix(memory): keep sqlite sessions out of hygiene archives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14428,6 +14428,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
+ "filetime",
  "parking_lot",
  "postgres",
  "regex",

--- a/crates/zeroclaw-memory/Cargo.toml
+++ b/crates/zeroclaw-memory/Cargo.toml
@@ -30,5 +30,6 @@ postgres = { version = "0.19", features = ["with-chrono-0_4"], optional = true }
 memory-postgres = ["dep:postgres", "zeroclaw-config/memory-postgres"]
 
 [dev-dependencies]
+filetime = "0.2"
 tempfile = "3.26"
 tokio = { version = "1.50", features = ["rt-multi-thread", "macros"] }

--- a/crates/zeroclaw-memory/src/hygiene.rs
+++ b/crates/zeroclaw-memory/src/hygiene.rs
@@ -239,6 +239,10 @@ fn archive_session_files(workspace_dir: &Path, archive_after_days: u32) -> Resul
             continue;
         };
 
+        if !is_legacy_session_artifact(filename) {
+            continue;
+        }
+
         let is_old = if let Some(date) = date_prefix(filename) {
             date < cutoff_date
         } else {
@@ -252,6 +256,12 @@ fn archive_session_files(workspace_dir: &Path, archive_after_days: u32) -> Resul
     }
 
     Ok(moved)
+}
+
+fn is_legacy_session_artifact(filename: &str) -> bool {
+    date_prefix(filename).is_some()
+        || filename.ends_with(".jsonl")
+        || filename.ends_with(".jsonl.migrated")
 }
 
 fn purge_memory_archives(workspace_dir: &Path, purge_after_days: u32) -> Result<u64> {
@@ -321,6 +331,10 @@ fn purge_session_archives(workspace_dir: &Path, purge_after_days: u32) -> Result
         let Some(filename) = path.file_name().and_then(|f| f.to_str()) else {
             continue;
         };
+
+        if !is_legacy_session_artifact(filename) {
+            continue;
+        }
 
         let is_old = if let Some(date) = date_prefix(filename) {
             date < cutoff_date
@@ -487,10 +501,19 @@ mod tests {
     use super::*;
     use crate::sqlite::SqliteMemory;
     use crate::traits::{Memory, MemoryCategory};
+    use filetime::{FileTime, set_file_mtime};
     use tempfile::TempDir;
 
     fn default_cfg() -> MemoryConfig {
         MemoryConfig::default()
+    }
+
+    fn set_old_mtime(path: &Path, days_old: i64) {
+        let old = FileTime::from_system_time(
+            (SystemTime::now() - StdDuration::from_secs(days_old as u64 * 24 * 60 * 60))
+                .max(SystemTime::UNIX_EPOCH),
+        );
+        set_file_mtime(path, old).unwrap();
     }
 
     #[test]
@@ -547,6 +570,92 @@ mod tests {
                 .exists(),
             "archived session file should exist"
         );
+    }
+
+    #[test]
+    fn keeps_sqlite_session_artifacts_out_of_archives() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path();
+        let sessions_dir = workspace.join("sessions");
+        fs::create_dir_all(&sessions_dir).unwrap();
+
+        let protected = ["sessions.db", "sessions.db-wal", "sessions.db-shm"];
+        for filename in protected {
+            let path = sessions_dir.join(filename);
+            fs::write(&path, "sqlite artifact").unwrap();
+            set_old_mtime(&path, 10);
+        }
+
+        run_if_due(&default_cfg(), workspace).unwrap();
+
+        for filename in protected {
+            assert!(
+                sessions_dir.join(filename).exists(),
+                "{filename} should remain in the hot sessions directory"
+            );
+            assert!(
+                !sessions_dir.join("archive").join(filename).exists(),
+                "{filename} must not be moved into the session archive"
+            );
+        }
+    }
+
+    #[test]
+    fn archives_old_legacy_jsonl_session_files() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path();
+        let sessions_dir = workspace.join("sessions");
+        fs::create_dir_all(&sessions_dir).unwrap();
+
+        let legacy_file = sessions_dir.join("legacy_session.jsonl");
+        fs::write(&legacy_file, "legacy session").unwrap();
+        set_old_mtime(&legacy_file, 10);
+
+        run_if_due(&default_cfg(), workspace).unwrap();
+
+        assert!(
+            !legacy_file.exists(),
+            "old legacy JSONL session file should be archived"
+        );
+        assert!(
+            sessions_dir
+                .join("archive")
+                .join("legacy_session.jsonl")
+                .exists(),
+            "archived legacy JSONL session file should exist"
+        );
+    }
+
+    #[test]
+    fn purges_old_legacy_session_archives_but_keeps_sqlite_artifacts() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path();
+        let archive_dir = workspace.join("sessions").join("archive");
+        fs::create_dir_all(&archive_dir).unwrap();
+
+        let protected = ["sessions.db", "sessions.db-wal", "sessions.db-shm"];
+        for filename in protected {
+            let path = archive_dir.join(filename);
+            fs::write(&path, "sqlite artifact").unwrap();
+            set_old_mtime(&path, 40);
+        }
+
+        let legacy_file = archive_dir.join("legacy_session.jsonl");
+        fs::write(&legacy_file, "legacy session").unwrap();
+        set_old_mtime(&legacy_file, 40);
+
+        run_if_due(&default_cfg(), workspace).unwrap();
+
+        assert!(
+            !legacy_file.exists(),
+            "old archived legacy session file should be purged"
+        );
+        for filename in protected {
+            assert!(
+                archive_dir.join(filename).exists(),
+                "{filename} should remain in the session archive"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Limit session hygiene archiving to legacy session artifacts instead of every old regular file in `workspace/sessions`.
  - Keep active SQLite session store files (`sessions.db`, `sessions.db-wal`, `sessions.db-shm`) in place even when their mtimes are older than the archive threshold.
  - Apply the same legacy-artifact filter when purging `workspace/sessions/archive`, so SQLite session store artifacts are not removed if they are already present there.
  - Add regression tests for preserving SQLite session artifacts and for continuing to archive/purge legacy JSONL session files.
- **Scope boundary:** This PR does not change the SQLite session schema, journal mode, session APIs, memory retention config, CLI behavior, or daemon lifecycle.
- **Blast radius:** Limited to memory hygiene file archival and purge behavior under `workspace/sessions`; memory rows, session database reads/writes, channel handling, and provider behavior are unchanged.
- **Linked issue(s):** None.
- **Labels:** Maintainer labels applied after review: `bug`, `dependencies`, `memory`, `risk:medium`, `size:S`.

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
```

Tail output:

```text
(no output; command exited 0)
```

```bash
cargo clippy --all-targets -- -D warnings
```

Tail output:

```text
Checking zeroclaw-channels v0.8.1 (/tmp/zc-session-hygiene-pr/crates/zeroclaw-channels)
Checking zeroclaw-eval v0.8.1 (/tmp/zc-session-hygiene-pr/crates/zeroclaw-eval)
Checking zeroclaw-gateway v0.8.1 (/tmp/zc-session-hygiene-pr/crates/zeroclaw-gateway)
Checking zeroclawlabs v0.8.1 (/tmp/zc-session-hygiene-pr)
Finished `dev` profile [unoptimized + debuginfo] target(s) in 22.66s
```

```bash
cargo test
```

Tail output:

```text
test result: ok. 158 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.09s

Running tests/test_live.rs (target/debug/deps/live-5ccbd5b383938c53)

running 7 tests
test live::gemini_fallback_oauth_refresh::gemini_warmup_refreshes_expired_oauth_token ... ignored, requires live Gemini OAuth credentials with refresh_token
test live::gemini_fallback_oauth_refresh::gemini_warmup_with_valid_credentials ... ignored, requires live Gemini OAuth credentials
test live::openai_codex_vision_e2e::openai_codex_second_vision_support ... ignored, requires live OpenAI Codex OAuth credentials (second profile)
test live::openai_codex_vision_e2e::provider_vision_support ... ignored, requires live model_provider OAuth credentials
test live::providers::e2e_live_openai_codex_multi_turn ... ignored, requires live OpenAI Codex OAuth credentials
test live::zai_jwt_auth::live_zai_jwt_auth_chat ... ignored, requires live ZAI_API_KEY
test live::zai_jwt_auth::live_zai_jwt_auth_multi_turn ... ignored, requires live ZAI_API_KEY

test result: ok. 0 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 0.00s

Running tests/test_system.rs (target/debug/deps/system-aabe82ccefd1f2a0)

running 9 tests
test system::multi_agent_e2e::peer_group_dotted_channel_refs_remain_alias_scoped_for_dispatch ... ok
test system::multi_agent_e2e::peer_group_routes_messages_only_within_resolved_peer_set ... ok
test system::multi_agent_e2e::legacy_install_upgrades_cleanly_with_backup ... ok
test system::full_stack::system_tool_execution_flow ... ok
test system::full_stack::system_simple_text_response ... ok
test system::full_stack::system_tool_arguments_passed_correctly ... ok
test system::full_stack::system_multi_turn_conversation ... ok
test system::full_stack::system_parallel_tool_execution ... ok
test system::multi_agent_e2e::two_sqlite_agents_on_one_install_have_isolated_memory ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.12s

Doc-tests zeroclaw

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

- **Commands run and tail output:** See above.
- **Beyond CI — what did you manually verify?** Verified the diff contains no filesystem-specific workaround text and that the new hygiene tests cover both archive and purge behavior for SQLite session artifacts versus legacy JSONL session files.
- **If any command was intentionally skipped, why:** None. Live credential tests remain ignored by the existing test suite unless credentials are supplied.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: Existing users do not need to change config or commands. Hygiene keeps active SQLite session store artifacts in place and still archives/purges recognized legacy session artifacts.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert 5da57a3bb04df90dd077a3f79ec6794d630292a6`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Legacy JSONL session files stop moving into `workspace/sessions/archive`, or old legacy session archives stop purging during hygiene; hygiene logs/report counts for archived or purged sessions stop matching expected legacy-file cleanup.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A
