### PR TITLE
fix(channels): restore agent precheck controls

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -4859,37 +4859,111 @@ async fn process_channel_message_body(
         .as_ref()
         .map(|c| c.is_direct_message(&msg))
         .unwrap_or(false);
-    let classifier_intent = if should_bypass_reply_intent_precheck(&msg, direct_message) {
-        AssistantChannelOutcome::Reply(String::new())
-    } else {
-        let (classifier_provider_arc, classifier_model_owned, classifier_temperature): (
-            Arc<dyn ModelProvider>,
-            String,
-            Option<f64>,
-        ) = resolve_classifier_route(
-            ctx.as_ref(),
-            &ctx.agent_cfg.classifier_provider,
-            &runtime_defaults,
-        )
-        .await
-        .unwrap_or_else(|| {
-            (
-                Arc::clone(&active_model_provider),
-                route.model.clone(),
-                None,
-            )
-        });
+    let precheck = &ctx.agent_cfg.precheck;
+    let classifier_intent = ::zeroclaw_log::scope!(
+        category: "channel",
+        model_provider: route.model_provider.as_str(),
+        model: route.model.as_str(),
+        => async {
+            if should_bypass_reply_intent_precheck(&msg, direct_message) {
+                AssistantChannelOutcome::Reply(String::new())
+            } else if !precheck.enabled {
+                ::zeroclaw_log::record!(
+                    INFO,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Skip).with_attrs(
+                        ::serde_json::json!({
+                            "phase": "precheck",
+                            "reason": "disabled",
+                        })
+                    ),
+                    "reply-intent precheck skipped"
+                );
+                AssistantChannelOutcome::Reply(String::new())
+            } else {
+                let (classifier_provider_arc, classifier_model_owned, classifier_temperature): (
+                    Arc<dyn ModelProvider>,
+                    String,
+                    Option<f64>,
+                ) = resolve_classifier_route(
+                    ctx.as_ref(),
+                    &ctx.agent_cfg.classifier_provider,
+                    &runtime_defaults,
+                )
+                .await
+                .unwrap_or_else(|| {
+                    (
+                        Arc::clone(&active_model_provider),
+                        route.model.clone(),
+                        None,
+                    )
+                });
 
-        classify_channel_reply_intent(
-            classifier_provider_arc.as_ref(),
-            history[0].content.as_str(),
-            &history,
-            classifier_model_owned.as_str(),
-            classifier_temperature.or(runtime_defaults.defaults.temperature),
-        )
-        .await
-        .unwrap_or(AssistantChannelOutcome::Reply(String::new()))
-    };
+                let started = Instant::now();
+                let precheck_future = classify_channel_reply_intent(
+                    classifier_provider_arc.as_ref(),
+                    history[0].content.as_str(),
+                    &history,
+                    classifier_model_owned.as_str(),
+                    classifier_temperature.or(runtime_defaults.defaults.temperature),
+                );
+                match tokio::time::timeout(Duration::from_secs(precheck.timeout_secs), precheck_future)
+                    .await
+                {
+                    Ok(Ok(outcome)) => {
+                        ::zeroclaw_log::record!(
+                            INFO,
+                            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                                .with_duration(
+                                    u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
+                                )
+                                .with_attrs(::serde_json::json!({
+                                    "classifier_model": classifier_model_owned.as_str(),
+                                    "phase": "precheck",
+                                })),
+                            "reply-intent precheck completed"
+                        );
+                        outcome
+                    }
+                    Ok(Err(e)) => {
+                        let safe_err = zeroclaw_providers::sanitize_api_error(&e.to_string());
+                        ::zeroclaw_log::record!(
+                            WARN,
+                            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                                .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                                .with_duration(
+                                    u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
+                                )
+                                .with_attrs(::serde_json::json!({
+                                    "classifier_model": classifier_model_owned.as_str(),
+                                    "error": safe_err,
+                                    "phase": "precheck",
+                                })),
+                            "reply-intent precheck failed open"
+                        );
+                        AssistantChannelOutcome::Reply(String::new())
+                    }
+                    Err(_) => {
+                        ::zeroclaw_log::record!(
+                            WARN,
+                            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                                .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                                .with_duration(
+                                    u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
+                                )
+                                .with_attrs(::serde_json::json!({
+                                    "classifier_model": classifier_model_owned.as_str(),
+                                    "phase": "precheck",
+                                    "timeout_secs": precheck.timeout_secs,
+                                })),
+                            "reply-intent precheck timed out; failing open"
+                        );
+                        AssistantChannelOutcome::Reply(String::new())
+                    }
+                }
+            }
+        }
+    )
+    .await;
 
     // ACP sessions are direct user requests — there is no broadcast,
     // no peer context, no spam concern. The no-reply classifier is a
@@ -13945,6 +14019,7 @@ BTC is currently around $65,000 based on latest tool output."#
         precheck_calls: AtomicUsize,
         main_calls: AtomicUsize,
         models: std::sync::Mutex<Vec<String>>,
+        precheck_delay: Option<Duration>,
     }
 
     #[async_trait::async_trait]
@@ -13963,6 +14038,9 @@ BTC is currently around $65,000 based on latest tool output."#
 
             if message.starts_with("Decide whether the assistant should send any visible reply") {
                 self.precheck_calls.fetch_add(1, Ordering::SeqCst);
+                if let Some(delay) = self.precheck_delay {
+                    tokio::time::sleep(delay).await;
+                }
                 return Ok("NO_REPLY[INFO]: background chatter".to_string());
             }
 
@@ -15627,6 +15705,196 @@ BTC is currently around $65,000 based on latest tool output."#
         assert!(
             sent_messages.is_empty(),
             "provider returns NO_REPLY from precheck, so no visible reply should be sent"
+        );
+    }
+
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn process_channel_message_precheck_log_uses_span_attribution_not_attrs() {
+        let _writer_guard = zeroclaw_log::__private_test_writer_lock();
+        let _hook_guard = zeroclaw_log::__private_test_hook_lock();
+        zeroclaw_log::try_install_capture_subscriber();
+        let mut rx = zeroclaw_log::subscribe_or_install();
+        while rx.try_recv().is_ok() {}
+
+        let channel_impl = Arc::new(RecordingChannel::default());
+        let channel: Arc<dyn Channel> = channel_impl.clone();
+        let provider_impl = Arc::new(PrecheckProbeModelProvider::default());
+        let provider: Arc<dyn ModelProvider> = provider_impl;
+
+        let runtime_ctx = test_runtime_ctx_with_config_agent_and_provider_ref(
+            channel,
+            provider,
+            zeroclaw_config::schema::Config::default(),
+            zeroclaw_config::schema::AliasedAgentConfig::default(),
+            "custom.primary",
+            None,
+        );
+
+        process_channel_message(
+            runtime_ctx,
+            zeroclaw_api::channel::ChannelMessage {
+                id: "msg-precheck-log".to_string(),
+                sender: "alice".to_string(),
+                reply_target: "chat-precheck-log".to_string(),
+                content: "background chatter".to_string(),
+                channel: "test-channel".into(),
+                channel_alias: None,
+                timestamp: 5,
+                thread_ts: None,
+                interruption_scope_id: None,
+                attachments: vec![],
+                subject: None,
+                ..Default::default()
+            },
+            CancellationToken::new(),
+        )
+        .await;
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        let mut precheck_event = None;
+        while std::time::Instant::now() < deadline {
+            match tokio::time::timeout(std::time::Duration::from_millis(50), rx.recv()).await {
+                Ok(Ok(value)) => {
+                    if value
+                        .get("message")
+                        .and_then(|v| v.as_str())
+                        .is_some_and(|m| m == "reply-intent precheck completed")
+                    {
+                        precheck_event = Some(value);
+                        break;
+                    }
+                }
+                Ok(Err(_)) => break,
+                Err(_) => continue,
+            }
+        }
+
+        let value = precheck_event.expect("reply-intent precheck log should be emitted");
+        assert_eq!(
+            value["zeroclaw"]["agent_alias"], "test-agent",
+            "precheck record must inherit agent_alias from the channel turn span, got: {value}"
+        );
+        assert_eq!(
+            value["zeroclaw"]["model"], "test-model",
+            "precheck record must preserve primary model attribution, got: {value}"
+        );
+        assert_eq!(
+            value["attributes"]["classifier_model"], "test-model",
+            "classifier model must use a non-attribution attr key, got: {value}"
+        );
+        assert!(
+            value["attributes"].get("agent").is_none(),
+            "agent alias belongs in zeroclaw.agent_alias, not attributes.agent: {value}"
+        );
+        assert!(
+            value["attributes"].get("model").is_none(),
+            "classifier model must not shadow zeroclaw.model via attributes.model: {value}"
+        );
+    }
+
+    #[tokio::test]
+    async fn process_channel_message_skips_reply_intent_classifier_when_agent_precheck_disabled() {
+        let channel_impl = Arc::new(RecordingChannel::default());
+        let channel: Arc<dyn Channel> = channel_impl.clone();
+        let provider_impl = Arc::new(PrecheckProbeModelProvider::default());
+        let provider: Arc<dyn ModelProvider> = provider_impl.clone();
+        let agent_cfg = zeroclaw_config::schema::AliasedAgentConfig {
+            precheck: zeroclaw_config::scattered_types::ChannelPrecheckConfig {
+                enabled: false,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let runtime_ctx = test_runtime_ctx_with_config_agent_and_provider_ref(
+            channel,
+            provider,
+            zeroclaw_config::schema::Config::default(),
+            agent_cfg,
+            "test-provider",
+            None,
+        );
+
+        process_channel_message(
+            runtime_ctx,
+            zeroclaw_api::channel::ChannelMessage {
+                id: "msg-precheck-disabled".to_string(),
+                sender: "alice".to_string(),
+                reply_target: "chat-precheck-disabled".to_string(),
+                content: "background chatter".to_string(),
+                channel: "test-channel".into(),
+                channel_alias: None,
+                timestamp: 1,
+                thread_ts: None,
+                interruption_scope_id: None,
+                attachments: vec![],
+                subject: None,
+                ..Default::default()
+            },
+            CancellationToken::new(),
+        )
+        .await;
+
+        assert_eq!(provider_impl.precheck_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(provider_impl.main_calls.load(Ordering::SeqCst), 1);
+        let sent_messages = channel_impl.sent_messages.lock().await;
+        assert_eq!(
+            sent_messages.as_slice(),
+            ["chat-precheck-disabled:visible reply"]
+        );
+    }
+
+    #[tokio::test]
+    async fn process_channel_message_precheck_timeout_fails_open_to_reply() {
+        let channel_impl = Arc::new(RecordingChannel::default());
+        let channel: Arc<dyn Channel> = channel_impl.clone();
+        let provider_impl = Arc::new(PrecheckProbeModelProvider {
+            precheck_delay: Some(Duration::from_secs(2)),
+            ..Default::default()
+        });
+        let provider: Arc<dyn ModelProvider> = provider_impl.clone();
+        let agent_cfg = zeroclaw_config::schema::AliasedAgentConfig {
+            precheck: zeroclaw_config::scattered_types::ChannelPrecheckConfig {
+                timeout_secs: 1,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let runtime_ctx = test_runtime_ctx_with_config_agent_and_provider_ref(
+            channel,
+            provider,
+            zeroclaw_config::schema::Config::default(),
+            agent_cfg,
+            "test-provider",
+            None,
+        );
+
+        process_channel_message(
+            runtime_ctx,
+            zeroclaw_api::channel::ChannelMessage {
+                id: "msg-precheck-timeout".to_string(),
+                sender: "alice".to_string(),
+                reply_target: "chat-precheck-timeout".to_string(),
+                content: "background chatter".to_string(),
+                channel: "test-channel".into(),
+                channel_alias: None,
+                timestamp: 1,
+                thread_ts: None,
+                interruption_scope_id: None,
+                attachments: vec![],
+                subject: None,
+                ..Default::default()
+            },
+            CancellationToken::new(),
+        )
+        .await;
+
+        assert_eq!(provider_impl.precheck_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(provider_impl.main_calls.load(Ordering::SeqCst), 1);
+        let sent_messages = channel_impl.sent_messages.lock().await;
+        assert_eq!(
+            sent_messages.as_slice(),
+            ["chat-precheck-timeout:visible reply"]
         );
     }
 

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -3571,6 +3571,14 @@ pub struct AliasedAgentConfig {
     #[serde(default)]
     pub classifier_provider: crate::providers::ModelProviderRef,
 
+    /// Per-agent reply-intent precheck controls. The classifier call reads
+    /// this block at message time; model/provider selection stays on
+    /// `classifier_provider` so there is only one routing source of truth.
+    #[tab(Channels)]
+    #[serde(default)]
+    #[nested]
+    pub precheck: crate::scattered_types::ChannelPrecheckConfig,
+
     /// Per-agent override for the context-compression summarizer provider, as
     /// a `providers.models.<type>.<alias>` reference. Empty (Default) = inherit
     /// the runtime profile's `context_compression.summary_provider`, else the
@@ -3662,6 +3670,7 @@ impl Default for AliasedAgentConfig {
             tts_provider: crate::providers::TtsProviderRef::default(),
             transcription_provider: crate::providers::TranscriptionProviderRef::default(),
             classifier_provider: crate::providers::ModelProviderRef::default(),
+            precheck: crate::scattered_types::ChannelPrecheckConfig::default(),
             summary_provider: crate::providers::ModelProviderRef::default(),
             delegate_same_risk_profile: true,
             delegates: Vec::new(),
@@ -18144,6 +18153,15 @@ impl Config {
                 "channels.max_concurrent_per_channel must be greater than 0"
             );
         }
+        for (alias, agent) in &self.agents {
+            if agent.precheck.timeout_secs == 0 {
+                validation_bail!(
+                    InvalidNumericRange,
+                    format!("agents.{alias}.precheck.timeout_secs"),
+                    "agents.{alias}.precheck.timeout_secs must be greater than 0"
+                );
+            }
+        }
         // Heartbeat agent: when heartbeat is enabled, the agent field
         // must name a configured agent.
         if self.heartbeat.enabled {
@@ -23125,6 +23143,51 @@ reasoning_effort = "turbo"
         assert!(!cfg.resolved.parallel_tools);
         assert_eq!(cfg.resolved.tool_dispatcher, "auto");
         assert!(!cfg.resolved.strict_tool_parsing);
+        assert!(cfg.precheck.enabled);
+        assert_eq!(cfg.precheck.timeout_secs, 5);
+    }
+
+    #[test]
+    async fn agent_precheck_config_parses_from_agent_block() {
+        let raw = r#"
+[agents.default]
+model_provider = "custom.default"
+risk_profile = "default"
+runtime_profile = "default"
+
+[agents.default.precheck]
+enabled = false
+timeout_secs = 12
+"#;
+        let parsed = parse_test_config(raw);
+        let agent = parsed
+            .agents
+            .get("default")
+            .expect("[agents.default] parses into agents map");
+        assert!(!agent.precheck.enabled);
+        assert_eq!(agent.precheck.timeout_secs, 12);
+    }
+
+    #[test]
+    async fn validate_rejects_zero_agent_precheck_timeout() {
+        let raw = r#"
+[agents.default]
+model_provider = "custom.default"
+risk_profile = "default"
+runtime_profile = "default"
+
+[agents.default.precheck]
+timeout_secs = 0
+"#;
+        let parsed = parse_test_config(raw);
+        let error = parsed
+            .validate()
+            .expect_err("zero precheck timeout must be rejected");
+        assert!(
+            error
+                .to_string()
+                .contains("agents.default.precheck.timeout_secs")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Restores `[agents.<alias>.precheck]` parsing onto `AliasedAgentConfig` so per-agent precheck settings are no longer dropped before runtime.
  - Reconnects `precheck.enabled` in the channel reply-intent path so operators can skip the classifier for an agent and proceed directly to the main turn.
  - Wraps `classify_channel_reply_intent` with the configured `precheck.timeout_secs`, preserving the existing fail-open behavior on classifier errors and adding the same behavior on timeout.
  - Keeps model/provider selection on the existing `[agents.<alias>].classifier_provider` source of truth; this PR does not add a second precheck model-routing surface.
  - Keeps precheck log attribution in `zeroclaw.*` span/scope fields and records the classifier model under the non-attribution `classifier_model` attr.
  - Adds regression coverage for TOML parsing, zero-timeout validation, disabled-precheck skip, `classifier_provider` routing, timeout fail-open behavior, and precheck structured log field placement.
- **Scope boundary:** This PR does not change the reply-intent prompt, direct-message bypass logic, provider routing schema, gateway/API surfaces, storage, or channel-specific integrations.
- **Blast radius:** `zeroclaw-config` agent schema/validation, `zeroclaw-channels` reply-intent precheck execution, and the structured fields emitted by precheck log events. Existing configs retain the current behavior because precheck defaults to enabled with a 5-second timeout.
- **Linked issue(s):** Closes #6067. Related #6068, #6945, #7003.
- **Labels:** `enhancement`, `channel`, `config`, `risk:medium`, `size:S`.

## Validation Evidence (required)

Local validation was run from PR head `4652e33c843051ea44acc7c260820ca45acd752a`, rebased onto `upstream/master@1bb55531e3c7813a09034d1bb65cc055b568eb32`. Commands below are repository-relative.

```bash
cargo test -p zeroclaw-config precheck
# running 2 tests
# test schema::tests::agent_precheck_config_parses_from_agent_block ... ok
# test schema::tests::validate_rejects_zero_agent_precheck_timeout ... ok
# test result: ok. 2 passed; 0 failed; 0 ignored; 1060 filtered out

cargo test -p zeroclaw-channels precheck
# running 5 tests
# test orchestrator::tests::reply_intent_precheck_uses_structured_addressing_signal ... ok
# test orchestrator::tests::process_channel_message_uses_classifier_provider_for_precheck_model_selection ... ok
# test orchestrator::tests::process_channel_message_precheck_log_uses_span_attribution_not_attrs ... ok
# test orchestrator::tests::process_channel_message_skips_reply_intent_classifier_when_agent_precheck_disabled ... ok
# test orchestrator::tests::process_channel_message_precheck_timeout_fails_open_to_reply ... ok
# test result: ok. 5 passed; 0 failed; 0 ignored; 1169 filtered out

cargo test -p zeroclaw-channels --features channel-wecom-ws wecom_ws -- --nocapture
# running 57 tests
# test wecom_ws::tests::group_bot_mention_sets_structured_addressing_without_content_marker ... ok
# test wecom_ws::tests::single_chat_reply_target_is_direct_message ... ok
# test wecom_ws::tests::scope_uses_reply_target_for_single_chat_without_thread_fragmentation ... ok
# test wecom_ws::tests::channel_access_uses_live_runtime_policy ... ok
# test wecom_ws::tests::channel_bot_addressing_uses_live_runtime_policy ... ok
# test result: ok. 57 passed; 0 failed; 0 ignored; 1173 filtered out

cargo fmt --all -- --check
# exit 0

git diff --check
# exit 0

cargo clippy --all-targets -- -D warnings
# Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 29s

cargo test
# Finished `test` profile [unoptimized + debuginfo] target(s) in 1m 54s
# src/lib.rs: test result: ok. 245 passed; 0 failed
# src/main.rs: test result: ok. 300 passed; 0 failed
# component suite: test result: ok. 189 passed; 0 failed
# integration suite: test result: ok. 158 passed; 0 failed
# live suite: test result: ok. 0 passed; 0 failed; 7 ignored
# system suite: test result: ok. 9 passed; 0 failed
# Doc-tests zeroclaw: test result: ok. 0 passed; 0 failed
```

- **Commands run and tail output:** See command block above.
- **Beyond CI — what did you manually verify?** Searched open and closed upstream issues/PRs for `agent.default.precheck`, `[agents.<alias>.precheck]`, `ChannelPrecheckConfig`, `AliasedAgentConfig`, and `reply-intent precheck`. #6067 remains open and its latest completion check describes this exact missing enabled/timeout wiring. #7003 previously restored it, but current `master` no longer has `AliasedAgentConfig.precheck` or the precheck timeout/disabled branches. I also checked open PRs matching `precheck` and found no active PR covering this remaining scope. For the review follow-up, I verified the precheck log event now carries `zeroclaw.agent_alias`/`zeroclaw.model`, keeps event-local values under `attributes.classifier_model`/`attributes.phase`, and no longer emits `attributes.agent` or `attributes.model`. During the 2026-07-06 conflict refresh, I verified #8596 is merged into `master` and kept its structured addressing source of truth: the precheck bypass now uses `ChannelMessage::explicitly_addressed` via `should_bypass_reply_intent_precheck(&msg, direct_message)`, not the removed WeCom marker-text detection.
- **If any command was intentionally skipped, why:** None.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**.
- New external network calls? **No**. The existing reply-intent classifier call remains the only model call in this path; this PR restores per-agent controls for whether that call runs and how long it can block.
- Secrets / tokens / credentials handling changed? **No**.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**.
- If any `Yes`, describe the risk and mitigation: N/A.

## Compatibility (required)

- Backward compatible? **Yes**.
- Config / env / CLI surface changed? **Yes**, additive only.
- If `No` or `Yes` to either: Existing configs keep current behavior because `[agents.<alias>.precheck]` defaults to `enabled = true` and `timeout_secs = 5`. Operators can set `[agents.<alias>.precheck].enabled = false` to skip the classifier for one agent, or set `[agents.<alias>.precheck].timeout_secs` to bound classifier latency. Model/provider selection stays on `[agents.<alias>].classifier_provider`; no `precheck.model` migration is needed.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <sha>`.
- **Feature flags or config toggles:** Set `[agents.<alias>.precheck].enabled = false` to skip the classifier for one agent; omit the block to keep defaults.
- **Observable failure symptoms:** Unexpected `reply-intent precheck skipped`, `reply-intent precheck failed open`, or `reply-intent precheck timed out; failing open` logs; unexpected visible replies from channels where the classifier would previously have returned `NO_REPLY`; missing `zeroclaw.agent_alias` / `zeroclaw.model` or unexpected `attributes.agent` / `attributes.model` on precheck log events.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A.
- Scope materially carried forward: N/A.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? **No**.
- If `No`, why (inspiration-only, no direct code/design carry-over): This PR does not use `Supersedes #` and does not carry code from another contributor PR.
