### PR TITLE
ci(release): raise binary size hard limit to 64MB

### DIFF
--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -327,7 +327,7 @@ jobs:
         shell: bash
         run: bash scripts/ci/check_binary_size.sh "target/${{ matrix.target }}/release/${{ matrix.artifact }}" "${{ matrix.target }}"
         env:
-          BINARY_SIZE_HARD_LIMIT: "52428800" # 50MB — release builds include all optional features
+          BINARY_SIZE_HARD_LIMIT: "67108864" # 64MB — release builds include all optional features
 
       - name: Package (Unix)
         if: runner.os != 'Windows'


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** The v0.8.2 release build tripped the 50MB binary-size safeguard at 50.69MB (53154008 bytes) on `x86_64-unknown-linux-gnu`. Root-caused as organic source growth, not bloat or a feature regression, then raised `BINARY_SIZE_HARD_LIMIT` from 50MB to 64MB to restore headroom for the 0.8.x line.
  - The release feature set is unchanged since v0.7: Linux builds `default` features plus `channel-matrix`, `channel-lark`, `whatsapp-web`. No feature silently entered the default set.
  - `Cargo.lock` holds 1307 packages at both `v0.8.1` and `master` — zero net new dependencies across the cycle.
  - The 0.8.2 window added ~32k net lines of Rust (206 files, +39935/-7993), which is what pushed an all-features build just past the round 50MB number.
  - The release profile is already fully size-optimized (`opt-level=z`, `lto=fat`, `codegen-units=1`, `strip`, `panic=abort`), so there is no cheap compile-flag win left.
- **Scope boundary:** Only the `BINARY_SIZE_HARD_LIMIT` env value on the release size-check step changes. No build profile, feature set, dependency, or source change. The advisory warning thresholds in `scripts/ci/check_binary_size.sh` are untouched.
- **Blast radius:** Release pipeline only (`release-stable-manual.yml`). The non-release advisory size checks (default 20MB hard limit elsewhere) are unaffected.
- **Linked issue(s):** None.
- **Labels:** `ci`, `risk: low`, `size: XS`.

## Validation Evidence (required)

No Rust source changed, so the Rust battery is not the relevant signal for a CI-config one-liner. Validation focused on the workflow file and the guard arithmetic.

- **Commands run and tail output:**

```
$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-stable-manual.yml')); print('YAML OK')"
YAML OK

$ python3 -c "print('PASS' if 53154008 <= 67108864 else 'FAIL', '(headroom:', round((67108864-53154008)/1024/1024,1), 'MB)')"
PASS (headroom: 13.3 MB)
```

- **Beyond CI — what did you manually verify?** Confirmed via `git log -L` that the 50MB cap was last set at v0.7.0 (`30583e5514`) and has not moved since. Confirmed the failing target's exact build invocation (`cargo build --release --locked --features "channel-matrix,channel-lark,whatsapp-web"`, line 318) and that it inherits `[features].default`. Verified `default` did not grow (its most recent change removed `tui-onboarding`; `default-channels` is a 5-channel lean alias). Verified the lockfile package count is identical at v0.8.1 and master.
- **If any command was intentionally skipped, why:** `cargo fmt/clippy/test` skipped — the change is a single workflow env value with no Rust impact; running the Rust battery would validate nothing about this diff.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: none — internal CI threshold only, no user-facing surface.

## Rollback (required for medium/high-risk PRs)

Low-risk: `git revert <sha>`.