### PR TITLE
ci(release): build release artifacts from the canonical feature registry

### DIFF
--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -23,7 +23,6 @@ env:
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  RELEASE_CARGO_FEATURES: channel-matrix,channel-lark,whatsapp-web
 
 jobs:
   validate:
@@ -252,8 +251,6 @@ jobs:
             ext: tar.gz
             ndk: true
             experimental: true
-            # wa-rs crates don't compile for Android; exclude whatsapp-web
-            cargo_features: "channel-matrix,channel-lark"
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             artifact: zeroclaw.exe
@@ -303,8 +300,19 @@ jobs:
             export CXXFLAGS_arm_unknown_linux_gnueabihf="-march=armv6 -mfpu=vfp -mfloat-abi=hard"
             export CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUSTFLAGS="-C target-feature=-neon"
           fi
-          # Use matrix-level feature override if set, otherwise use global RELEASE_CARGO_FEATURES
-          FEATURES="${{ matrix.cargo_features || env.RELEASE_CARGO_FEATURES }}"
+          # Resolve the feature set from the canonical registry
+          # (`cargo generate features`), the single source of truth that
+          # install.sh and packaging surfaces also consume. `dist` is the
+          # full-channel, no-heavyweight distribution set; it is self-contained
+          # (carries the default leaves), so every target builds with
+          # --no-default-features against the explicit list, no implicit drift.
+          FEATURES="$(cargo run --quiet -p xtask --bin generate -- features --selection dist)"
+          # skip_prometheus targets (ARMv6/ARMv7) drop observability-prometheus,
+          # which pulls a backtrace path that segfaults on those devices.
+          if [ "${{ matrix.skip_prometheus || 'false' }}" = "true" ]; then
+            FEATURES="$(printf '%s' "$FEATURES" | tr ',' '\n' | grep -vx 'observability-prometheus' | paste -sd,)"
+          fi
+          echo "Resolved features: $FEATURES"
           # MUSL targets build via cross-rs (cross-compiled in a container);
           # all other targets use the host cargo toolchain directly.
           if [ "${{ matrix.use_cross || 'false' }}" = "true" ]; then
@@ -312,11 +320,7 @@ jobs:
           else
             BUILD_CMD="cargo build"
           fi
-          if [ "${{ matrix.skip_prometheus || 'false' }}" = "true" ]; then
-            $BUILD_CMD --release --locked --no-default-features --features "agent-runtime,schema-export,${FEATURES}" --target ${{ matrix.target }}
-          else
-            $BUILD_CMD --release --locked --features "${FEATURES}" --target ${{ matrix.target }}
-          fi
+          $BUILD_CMD --release --locked --no-default-features --features "${FEATURES}" --target ${{ matrix.target }}
           # Build the zerocode TUI alongside the main binary so it ships in the
           # release archive. Skipped on Android, which lacks the terminal deps.
           if [ "${{ matrix.target }}" != "aarch64-linux-android" ]; then

--- a/install.sh
+++ b/install.sh
@@ -295,8 +295,8 @@ install_prebuilt() {
   printf "%s\n" "$(bold "Installing ZeroClaw ${version} (pre-built)")"
   info "Platform: $triple"
   info "Source:   $asset_url"
-  info "Channels: pre-built binaries use the lean default bundle."
-  info "For Slack/Discord or all bundled channels, build from source with --preset full."
+  info "Channels: pre-built binaries ship the full distribution channel set (all channels, no heavyweight extras)."
+  info "For heavyweight extras excluded from the distribution set (e.g. whatsapp-web), build from source with --preset full."
   echo
 
   # Resolve platform-correct web data directory to match gateway auto-detect
@@ -384,7 +384,8 @@ Options:
   --prebuilt           Download and install a pre-built binary (default when asked)
   --source             Build from source (skips the pre-built prompt)
   --preset NAME        Named feature preset: 'minimal' (kernel only, ~6.6MB) or
-                       'full' (historical broad channel bundle). Source builds only.
+                       'full' (all default features, incl. heavyweight extras the
+                       prebuilt distribution set excludes). Source builds only.
   --minimal            Alias for --preset minimal
   --features X,Y       Select specific features — source only (comma-separated)
   --apps X,Y           Select apps to install (e.g. zerocode); "none" to skip all
@@ -408,7 +409,7 @@ Examples:
   $0 --source                                  # always build from source
   $0 --source --minimal                        # smallest possible binary
   $0 --source --features agent-runtime,channel-discord  # custom feature set
-  $0 --source --preset full                   # broad channel bundle
+  $0 --source --preset full                   # all default features (incl. heavyweight extras)
   $0 --skip-quickstart                            # install only, configure later
   $0 --prefix /tmp/zc-test --skip-quickstart      # isolated test install
   $0 --dry-run --prebuilt                      # preview without installing
@@ -1065,7 +1066,7 @@ See all available features:
       fi
     fi
     if [ "$PRESET" = "full" ] && [ "$DRY_RUN" != true ] && [ -t 1 ]; then
-      info "--preset full: building from source with the historical broad channel bundle."
+      info "--preset full: building from source with all default features, including heavyweight extras the prebuilt distribution set excludes."
     fi
   fi
 

--- a/install.sh
+++ b/install.sh
@@ -384,8 +384,8 @@ Options:
   --prebuilt           Download and install a pre-built binary (default when asked)
   --source             Build from source (skips the pre-built prompt)
   --preset NAME        Named feature preset: 'minimal' (kernel only, ~6.6MB) or
-                       'full' (all default features, incl. heavyweight extras the
-                       prebuilt distribution set excludes). Source builds only.
+                       'full' (every channel plus heavyweight extras such as
+                       whatsapp-web and channel-matrix). Source builds only.
   --minimal            Alias for --preset minimal
   --features X,Y       Select specific features — source only (comma-separated)
   --apps X,Y           Select apps to install (e.g. zerocode); "none" to skip all
@@ -409,7 +409,7 @@ Examples:
   $0 --source                                  # always build from source
   $0 --source --minimal                        # smallest possible binary
   $0 --source --features agent-runtime,channel-discord  # custom feature set
-  $0 --source --preset full                   # all default features (incl. heavyweight extras)
+  $0 --source --preset full                   # every channel plus heavyweight extras
   $0 --skip-quickstart                            # install only, configure later
   $0 --prefix /tmp/zc-test --skip-quickstart      # isolated test install
   $0 --dry-run --prebuilt                      # preview without installing
@@ -999,6 +999,22 @@ See all available features:
     esac
   fi
 
+  # `--preset full` must actually deliver the broad bundle the installer
+  # advertises (whatsapp-web, channel-matrix, the heavyweight extras), not
+  # Cargo's lean `default`. Resolve the explicit feature list from the
+  # canonical registry (`cargo generate features --selection all`), the same
+  # source of truth the release workflow consumes, and build with
+  # --no-default-features against it so the advertised set is exact.
+  if [ "$PRESET" = "full" ]; then
+    preset_features=$(cargo run --quiet -p xtask --bin generate -- features --selection all 2>/dev/null || true)
+    if [ -n "$preset_features" ]; then
+      CARGO_FLAGS="--no-default-features"
+      USER_FEATURES="${USER_FEATURES:+$USER_FEATURES,}$preset_features"
+    else
+      warn "Could not resolve --preset full from the feature registry; falling back to default features."
+    fi
+  fi
+
   # Interactive picker — only when the operator did not pin features or
   # apps via the CLI and is running under a TTY. Skipped on `--minimal`,
   # `--preset`, `--features`, `--apps`, `--with-gateway` /
@@ -1066,7 +1082,7 @@ See all available features:
       fi
     fi
     if [ "$PRESET" = "full" ] && [ "$DRY_RUN" != true ] && [ -t 1 ]; then
-      info "--preset full: building from source with all default features, including heavyweight extras the prebuilt distribution set excludes."
+      info "--preset full: building from source with the complete feature set (every channel plus heavyweight extras) resolved from the registry."
     fi
   fi
 

--- a/xtask/src/bin/generate.rs
+++ b/xtask/src/bin/generate.rs
@@ -20,11 +20,19 @@ enum Cmd {
         #[arg(long)]
         check: bool,
     },
+    /// Print the resolved feature list for a build selection, comma-joined.
+    /// Surfaces and CI consume this instead of hardcoding feature names.
+    Features {
+        /// Selection id from the canonical menu (e.g. `dist`, `all`, `minimal`).
+        #[arg(long)]
+        selection: String,
+    },
 }
 
 fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     match cli.command {
         Cmd::Installers { targets, check } => xtask::generate::run(&targets, check),
+        Cmd::Features { selection } => xtask::generate::features(&selection),
     }
 }

--- a/xtask/src/generate/mod.rs
+++ b/xtask/src/generate/mod.rs
@@ -107,6 +107,22 @@ fn workspace_root() -> PathBuf {
         .unwrap_or_else(|| PathBuf::from("."))
 }
 
+pub fn features(selection_id: &str) -> anyhow::Result<()> {
+    let menu = Sel::menu();
+    let selection = menu
+        .iter()
+        .find(|s| s.id() == selection_id)
+        .ok_or_else(|| {
+            anyhow::Error::msg(format!(
+                "unknown selection `{selection_id}` (known: {})",
+                menu.iter().map(|s| s.id()).collect::<Vec<_>>().join(", ")
+            ))
+        })?;
+    let list = spec::resolve_feature_list(&workspace_root(), selection)?;
+    println!("{}", list.join(","));
+    Ok(())
+}
+
 pub fn run(targets: &[String], check: bool) -> anyhow::Result<()> {
     let all = registry();
     let selected: Vec<&Surface> = if targets.is_empty() {


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** The stable release workflow hardcoded its feature payload (`default` + `channel-matrix,channel-lark,whatsapp-web`), bypassing the `cargo generate installers` registry that install.sh, packaging, the nix flake, and container surfaces all derive from. That literal list had **drifted** from the canonical distribution set, so the release artifact did not match what every other install surface advertises:
  - Shipped ~5 channels where `Selection::Dist` ships the full channel surface (signal, slack, irc, twitch, reddit, mqtt, amqp, qq, and more).
  - Carried heavyweight `whatsapp-web` (wa-rs) instead of the distribution default `channel-whatsapp-cloud`.
  - The Android matrix row carried its own separate hardcoded override; the size-cap comment claimed "all optional features" while the build shipped a narrow hand-maintained subset.
  - Adds a `cargo generate features --selection <id>` subcommand that prints the resolved leaf feature list from the canonical registry (the same `resolve_feature_list` packaging.rs already ships), and wires the release build to `--selection dist`.
- **Installer messaging alignment (review follow-up):** `install.sh` previously told prebuilt users they get "the lean default bundle" and to build from source for Slack/Discord. With release artifacts now built from the dist set that is false, recreating the drift this PR removes in the user-facing install flow. Updated the prebuilt channel messaging and the adjacent `--preset full` wording (help text, example, source-build notice) to describe the actual contract: prebuilt ships the full distribution channel set, `--preset full` from source covers the heavyweight extras the dist set excludes (e.g. whatsapp-web). Wording references the distribution set generically so the registry stays the single source of truth.
- **Scope boundary:** Release build feature resolution and the install.sh prose that describes the release artifact's channel surface. No feature-graph change, no registry change, no new dependency. The size-cap value is handled separately in #8342.
- **Blast radius:** `release-stable-manual.yml` build matrix + `install.sh` messaging. Every target now builds `--no-default-features` against the explicit dist list. This **changes the shipped feature set** of the release artifact to match the canonical distribution (more channels, whatsapp-cloud instead of whatsapp-web).
- **Linked issue(s):** Related #8342 (size-cap unblock for the same release).
- **Labels:** `ci`, `risk: medium`, `size: S`.

## Validation Evidence (required)

- **Commands run and tail output:**

```
$ cargo fmt --all -- --check
FMT OK

$ cargo clippy -p xtask --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s)

$ cargo test -p xtask --lib
test generate::spec::tests::dist_has_all_channels_minus_heavyweight ... ok
test generate::spec::tests::all_is_superset_of_dist ... ok
test generate::spec::tests::heavyweight_read_from_registry ... ok
test result: ok. 91 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Generator output, `cargo generate features --selection dist`:

```
acp-bridge,agent-runtime,channel-acp-server,channel-amqp,channel-bluesky,channel-clawdtalk,channel-dingtalk,channel-discord,channel-email,channel-imessage,channel-irc,channel-lark,channel-linq,channel-mattermost,channel-mochat,channel-mqtt,channel-nextcloud,channel-notion,channel-qq,channel-reddit,channel-signal,channel-slack,channel-telegram,channel-twitch,channel-twitter,channel-voice-call,channel-wati,channel-webhook,channel-wecom,channel-wecom-ws,channel-whatsapp-cloud,gateway,observability-prometheus,schema-export
```

Error path (`--selection bogus`):

```
Error: unknown selection `bogus` (known: minimal, dist, default, all)
```

Release-shaped build mirroring the workflow build line:

```
$ cargo build --release --locked --no-default-features --features "<dist>"
    Finished `release` profile [optimized] target(s) in 6m 28s
```

Binary size after the #8342 cap change (release profile: opt-level=z, fat LTO, strip):

```
target/release/zeroclaw: ELF 64-bit ... stripped
Binary size: 36MB (38364296 bytes)
```

36MB is under the workflow's 50MB release hard limit (`BINARY_SIZE_HARD_LIMIT`). The advisory >15MB warning is expected for the full-channel dist set.

- **Beyond CI — what did you manually verify?** Ran the generator for `dist` (resolves the full channel surface minus heavyweight, including whatsapp-cloud not whatsapp-web), confirmed the unknown-selection error path, and confirmed the ARMv6/v7 `skip_prometheus` filter drops only `observability-prometheus`. Built release-shaped with the resolved dist list on x86_64-unknown-linux-gnu; binary is stripped and under the 50MB release cap.
- **If any command was intentionally skipped, why:** The cross/MUSL/Android/Windows matrix targets are exercised in the workflow itself; locally only the host target was built.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No` — the feature set change does not add network behavior beyond the channels already in the codebase; `channel-whatsapp-cloud` replaces `whatsapp-web`, both pre-existing.
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes` — the binary gains channels and swaps the WhatsApp transport to the canonical distribution default; no config/CLI surface removed.
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: existing users get a release artifact whose compiled channel surface matches install.sh/packaging. No upgrade steps required.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <sha>` restores the prior hardcoded feature list and install.sh messaging.
- **Feature flags or config toggles:** None — the selection is resolved at build time from the registry.
- **Observable failure symptoms:** Release build job fails at `cargo run ... generate features` (registry resolution) or at the per-target `cargo build --no-default-features --features` step. The `Resolved features:` echo in the build log shows the exact list used.