### PR TITLE
fix(web): show created storages across all badge-filtered config surfaces

### DIFF
--- a/web/src/components/sections/SectionNavigator.tsx
+++ b/web/src/components/sections/SectionNavigator.tsx
@@ -29,6 +29,7 @@ import {
 } from "../../lib/api";
 import { fuzzyFilter } from "../../lib/fuzzy";
 import { t } from "@/lib/i18n";
+import { badgeIsGood } from "./SectionPicker";
 
 // One selectable entity under a section. `url` is the entity's existing
 // form URL; `mapPath` is the dotted map path it lives under (used so the
@@ -123,17 +124,12 @@ export default function SectionNavigator({
       }
       if (section.shape === "typed_family_map") {
         // Configured/active provider or channel types under this section.
-        // Storage types badge as "created" (see storage_picker in
-        // api_sections.rs), so accept it alongside "configured"/"active" or
-        // configured storages render as "Nothing configured yet".
+        // Uses the shared `badgeIsGood` accept set so storage's "created" badge
+        // (see storage_picker in api_sections.rs) surfaces here alongside every
+        // other badge-filtered surface, from one source of truth.
         const picker = await getSectionPicker(section.key);
         const configuredTypes = picker.items
-          .filter(
-            (i) =>
-              i.badge === "configured" ||
-              i.badge === "active" ||
-              i.badge === "created",
-          )
+          .filter((i) => badgeIsGood(i.badge))
           .map((i) => i.key);
         const out: NavEntity[] = [];
         for (const type of configuredTypes) {

--- a/web/src/components/sections/SectionNavigator.tsx
+++ b/web/src/components/sections/SectionNavigator.tsx
@@ -123,9 +123,17 @@ export default function SectionNavigator({
       }
       if (section.shape === "typed_family_map") {
         // Configured/active provider or channel types under this section.
+        // Storage types badge as "created" (see storage_picker in
+        // api_sections.rs), so accept it alongside "configured"/"active" or
+        // configured storages render as "Nothing configured yet".
         const picker = await getSectionPicker(section.key);
         const configuredTypes = picker.items
-          .filter((i) => i.badge === "configured" || i.badge === "active")
+          .filter(
+            (i) =>
+              i.badge === "configured" ||
+              i.badge === "active" ||
+              i.badge === "created",
+          )
           .map((i) => i.key);
         const out: NavEntity[] = [];
         for (const type of configuredTypes) {

--- a/web/src/components/sections/SectionPicker.tsx
+++ b/web/src/components/sections/SectionPicker.tsx
@@ -213,7 +213,7 @@ export function badgeIsGood(badge: string | undefined): boolean {
 // Map a schema-driven badge string to a calm Badge tone. The badge text
 // itself is rendered verbatim — only the tint is chosen here, so no
 // section/option names are hardcoded.
-function badgeTone(badge: string): BadgeTone {
+export function badgeTone(badge: string): BadgeTone {
   if (badgeIsGood(badge)) return "ok";
   if (badge === "needs setup") return "warn";
   return "neutral";

--- a/web/src/components/sections/SectionPicker.tsx
+++ b/web/src/components/sections/SectionPicker.tsx
@@ -195,8 +195,19 @@ export default function SectionPicker({
   );
 }
 
-function badgeIsGood(badge: string | undefined): boolean {
-  return badge === "configured" || badge === "active" || badge === "set";
+// Shared "this option is configured/good" predicate, exported so every
+// badge-filtered surface (section nav, config item list, command-palette
+// search) reads one accept set instead of re-listing the literals. Storage
+// backends badge as "created" (see storage_picker in api_sections.rs); keeping
+// the set in one place means a badge rename can no longer half-land across
+// surfaces.
+export function badgeIsGood(badge: string | undefined): boolean {
+  return (
+    badge === "configured" ||
+    badge === "active" ||
+    badge === "set" ||
+    badge === "created"
+  );
 }
 
 // Map a schema-driven badge string to a calm Badge tone. The badge text

--- a/web/src/lib/configSearch.ts
+++ b/web/src/lib/configSearch.ts
@@ -17,6 +17,7 @@
 // empty list so the palette keeps showing its nav destinations.
 
 import { getMapKeys, getSectionPicker, getSections, type SectionInfo } from "./api";
+import { badgeIsGood } from "../components/sections/SectionPicker";
 
 /** A flat, jump-to-able config search target. */
 export interface ConfigSearchItem {
@@ -72,7 +73,7 @@ async function loadEntities(section: SectionInfo): Promise<ConfigSearchItem[]> {
     try {
       const picker = await getSectionPicker(section.key);
       configuredTypes = picker.items
-        .filter((i) => i.badge === "configured" || i.badge === "active")
+        .filter((i) => badgeIsGood(i.badge))
         .map((i) => i.key);
     } catch {
       return [];

--- a/web/src/pages/Config.tsx
+++ b/web/src/pages/Config.tsx
@@ -41,6 +41,7 @@ import SkillsBundleEditor from "../components/sections/SkillsBundleEditor";
 import ReloadDaemonButton from "../components/sections/ReloadDaemonButton";
 import SectionPicker, {
   badgeIsGood,
+  badgeTone,
 } from "../components/sections/SectionPicker";
 import SectionNavigator from "../components/sections/SectionNavigator";
 import AddEntityDialog from "../components/sections/AddEntityDialog";
@@ -1653,7 +1654,7 @@ function ConfiguredOnlyPicker({
           </div>
           <div className="flex items-center gap-2 flex-shrink-0">
             {item.badge && (
-              <Badge tone={item.badge === "active" ? "ok" : "neutral"}>
+              <Badge tone={badgeTone(item.badge)}>
                 {item.badge}
               </Badge>
             )}

--- a/web/src/pages/Config.tsx
+++ b/web/src/pages/Config.tsx
@@ -39,7 +39,9 @@ import FieldForm, {
 import PersonalityEditor from "../components/sections/PersonalityEditor";
 import SkillsBundleEditor from "../components/sections/SkillsBundleEditor";
 import ReloadDaemonButton from "../components/sections/ReloadDaemonButton";
-import SectionPicker from "../components/sections/SectionPicker";
+import SectionPicker, {
+  badgeIsGood,
+} from "../components/sections/SectionPicker";
 import SectionNavigator from "../components/sections/SectionNavigator";
 import AddEntityDialog from "../components/sections/AddEntityDialog";
 import SectionTabs, {
@@ -1579,9 +1581,7 @@ function ConfiguredOnlyPicker({
         .then((resp) => {
           if (cancelled) return;
           setItems(
-            resp.items.filter(
-              (i) => i.badge === "configured" || i.badge === "active",
-            ),
+            resp.items.filter((i) => badgeIsGood(i.badge)),
           );
         })
         .catch((e) => {


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:** The storage section picker badges configured backends
  as `"created"` (the backend `storage_picker` in `api_sections.rs` renames
  `"configured"` -> `"created"`), but the `SectionNavigator` `typed_family_map`
  child-loader only matched `"configured"`/`"active"`. So configured storage
  backends were dropped from the nav tree and the section rendered "Nothing
  configured yet". This extends the existing badge filter to also accept
  `"created"`, with a comment pointing at the backend rename.
- **Scope boundary:** Frontend only, one file, one filter predicate. No backend
  change — the `configured -> created` rename already shipped in `master`. Does
  not touch the picker primitives, the dashboard, or any other section shape.
- **Blast radius:** `SectionNavigator` nav-tree child enumeration for
  `typed_family_map` sections (providers, channels, storage). The change strictly
  widens which picker items pass the filter, so it cannot hide anything that
  previously showed; the only observable effect is configured storage backends
  now appearing as nav children.
- **Linked issue(s):** Supersedes #8022 (the storage-nav slice of that bundle).
  Related #8086, #8087 (the picker and dashboard-modal slices, already merged).
- **Labels:** suggested `type: bug`, `scope: web`, `risk: low`, `size: XS`
  (applied/snapshotted after creation if permitted).

## Validation Evidence (required)

No Rust changed, so the Rust battery is N/A; this is a web-only change.

```
# push-branch validate.sh --base upstream/master
[PASS] suppressions / todo / deferred / not_implemented / secrets
[PASS] em-dash (no docs changed) / artifacts / docs-coverage / no-attribution
[PASS] registry-shadowing
[SKIP] rust battery (no .rs changes)
[PASS] web check  (gen-api + tsc -b clean)
[SKIP] shell battery (no .sh changes)
summary: 0 blocking, 0 warning
RESULT: PASS

# cargo xtask web check
==> gen-api -> web/src/lib/api-generated.ts  (openapi-typescript 7.13.0)
==> npx tsc -b   (clean, no errors)

# vite build
✓ built in ~0.6s  (pre-existing chunk-size warnings only)
```

- **Commands run and tail output:** above (`validate.sh`, `cargo xtask web check`,
  `vite build`).
- **Beyond CI — what did you manually verify?** Confirmed the backend
  `storage_picker` rename (`configured -> created`) is present in `master` and is
  storage-specific, and that the existing nav filter excluded `"created"`. The
  original #8022 verified the end-to-end behavior (Storage section listing its
  configured backends) against a running daemon; this is the identical filter
  change extracted.
- **If any command was intentionally skipped, why:** Rust fmt/clippy/test skipped
  — no `.rs` files changed.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Display-only nav fix; no upgrade steps for existing users.

## Rollback (required for medium/high-risk PRs)

Low-risk: `git revert <sha>` is the plan.
