### PR TITLE
perf(web-search): cache strip_tags regex in a LazyLock static

### DIFF
--- a/crates/zeroclaw-tools/src/web_search_tool.rs
+++ b/crates/zeroclaw-tools/src/web_search_tool.rs
@@ -3,6 +3,7 @@ use async_trait::async_trait;
 use regex::Regex;
 use serde_json::json;
 use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
 use std::time::Duration;
 use zeroclaw_api::tool::{Tool, ToolResult};
 
@@ -844,8 +845,9 @@ fn contains_ascii_case_insensitive(haystack: &str, needle: &str) -> bool {
 }
 
 fn strip_tags(content: &str) -> String {
-    let re = Regex::new(r"<[^>]+>").unwrap();
-    re.replace_all(content, "").to_string()
+    static RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"<[^>]+>").expect("strip_tags regex must compile"));
+    RE.replace_all(content, "").to_string()
 }
 
 #[async_trait]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** `strip_tags()` compiled a new `Regex` on every invocation and used `.unwrap()` — a panic risk if the pattern were ever edited incorrectly. Replace with a `LazyLock<Regex>` static: compile once at first use, reuse thereafter, and use `.expect()` with a message for clarity.
- **Scope boundary:** Only `strip_tags()` in `web_search_tool.rs`.
- **Blast radius:** Web search tool HTML-stripping path only.
- **Labels:** `bug`, `tool`, `tool:web`, `risk:medium`, `size:XS`

## Validation Evidence

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test -p zeroclaw-tools
```

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility

- Backward compatible? **Yes** — identical semantics, same return value.
- Config / env / CLI surface changed? **No**

## Rollback

Low-risk PR: `git revert <sha>` is the plan.
