### PR TITLE
test(mcp): regression-test mcp_bundles enforcement + warn on no-bundle misconfig (#7733)

### DIFF
--- a/crates/zeroclaw-channels/tests/orchestrator_mcp_scope.rs
+++ b/crates/zeroclaw-channels/tests/orchestrator_mcp_scope.rs
@@ -1,0 +1,126 @@
+//! Regression coverage for #7733 at the channels-orchestrator MCP
+//! connection site (`crates/zeroclaw-channels/src/orchestrator/mod.rs`,
+//! search for `mcp_servers_for_agent`).
+//!
+//! The orchestrator's `handle_channel_message` requires a fully-built
+//! runtime context that is heavy to fixture from an integration test
+//! (see the comment at the top of
+//! `proof_orchestrator_session_context.rs` for the same reasoning).
+//! This file therefore guards the contract two ways:
+//!
+//! 1. **Resolver pin** — exercises `Config::mcp_servers_for_agent`, the
+//!    function the orchestrator now calls. If that resolver's
+//!    secure-by-default semantics ever weaken, this test fails inside
+//!    this crate's suite, not just in the config crate.
+//! 2. **Compile-time witness** — a tiny dead function that simply
+//!    forwards to `config.mcp_servers_for_agent(alias)`. If a future
+//!    refactor renames or removes that symbol, this file stops
+//!    compiling and forces reviewers to update the orchestrator call
+//!    site at the same time.
+//!
+//! Behavioral end-to-end coverage of the unscoped-agent zero-MCP path
+//! lives in `crates/zeroclaw-runtime/src/rpc/dispatch.rs::tests::`
+//! `chat_session_new_omits_mcp_tools_when_agent_has_no_bundles_*`.
+
+use std::collections::HashMap;
+
+use zeroclaw_config::schema::{
+    AliasedAgentConfig, Config, McpBundleConfig, McpServerConfig, McpTransport, RiskProfileConfig,
+};
+
+/// Build a two-agent config: `granted` (has bundle `b1`), `unscoped`
+/// (no bundles). The server `remote` is configured globally.
+fn make_two_agent_config() -> Config {
+    let mut providers = zeroclaw_config::providers::Providers::default();
+    {
+        let base = providers
+            .models
+            .ensure("openai", "test-provider")
+            .expect("`openai` slot must exist");
+        base.api_key = Some("test-key".into());
+        base.model = Some("test-model".into());
+        base.uri = Some("http://127.0.0.1:1".into());
+    }
+
+    let mut risk_profiles = HashMap::new();
+    risk_profiles.insert("test-profile".to_string(), RiskProfileConfig::default());
+
+    let mut agents = HashMap::new();
+    agents.insert(
+        "granted".to_string(),
+        AliasedAgentConfig {
+            enabled: true,
+            model_provider: "openai.test-provider".into(),
+            risk_profile: "test-profile".into(),
+            mcp_bundles: vec!["b1".into()],
+            ..Default::default()
+        },
+    );
+    agents.insert(
+        "unscoped".to_string(),
+        AliasedAgentConfig {
+            enabled: true,
+            model_provider: "openai.test-provider".into(),
+            risk_profile: "test-profile".into(),
+            mcp_bundles: Vec::new(),
+            ..Default::default()
+        },
+    );
+
+    let mut config = Config {
+        providers,
+        agents,
+        risk_profiles,
+        ..Config::default()
+    };
+    config.mcp.enabled = true;
+    config.mcp.servers = vec![McpServerConfig {
+        name: "remote".into(),
+        transport: McpTransport::Http,
+        url: Some("http://127.0.0.1:1".into()),
+        ..Default::default()
+    }];
+    config.mcp_bundles.insert(
+        "b1".into(),
+        McpBundleConfig {
+            servers: vec!["remote".into()],
+            exclude: vec![],
+        },
+    );
+    config
+}
+
+#[test]
+fn resolver_grants_only_to_granted_agent_under_two_agent_config() {
+    // The orchestrator now calls `config.mcp_servers_for_agent(alias)`.
+    // Pin its semantics here: `granted` gets `remote`, `unscoped` gets
+    // zero. If this flips, the orchestrator's #7733 fix has regressed
+    // at the contract level.
+    let config = make_two_agent_config();
+
+    let granted: Vec<String> = config
+        .mcp_servers_for_agent("granted")
+        .into_iter()
+        .map(|s| s.name)
+        .collect();
+    assert_eq!(granted, vec!["remote"], "granted agent must get `remote`");
+
+    assert!(
+        config.mcp_servers_for_agent("unscoped").is_empty(),
+        "unscoped agent must get zero servers (omission is not a grant)"
+    );
+
+    assert!(
+        config.mcp_servers_for_agent("ghost-agent").is_empty(),
+        "an unknown agent must get zero servers"
+    );
+}
+
+/// Compile-time witness: the symbol the orchestrator depends on must
+/// exist and have the right shape. If a future refactor removes or
+/// renames `Config::mcp_servers_for_agent`, this file stops compiling
+/// and signals reviewers to update the orchestrator call site too.
+#[allow(dead_code)]
+fn _mcp_servers_for_agent_witness(config: &Config, alias: &str) -> Vec<McpServerConfig> {
+    config.mcp_servers_for_agent(alias)
+}

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -17375,6 +17375,26 @@ impl Config {
         // not left wondering why an agent's MCP tools vanished, without
         // turning a typo into a hard startup failure.
         {
+            // Operator UX: secure-by-default means an agent with no
+            // `mcp_bundles` grant connects to ZERO MCP servers. When MCP is
+            // enabled and `[[mcp.servers]]` is non-empty but no
+            // `[mcp_bundles.*]` exists at all, every agent silently gets
+            // nothing. That is the inverse of the original #7733 silent
+            // no-op and surprises operators upgrading from <0.8.3. Warn
+            // once at startup so this surfaces via `doctor` and the
+            // standard startup warning stream.
+            if self.mcp.enabled && !self.mcp.servers.is_empty() && self.mcp_bundles.is_empty() {
+                ::zeroclaw_log::record!(
+                    WARN,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note,)
+                        .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                        .with_attrs(::serde_json::json!({
+                            "mcp_servers_configured": self.mcp.servers.len(),
+                        })),
+                    "[[mcp.servers]] is configured but no [mcp_bundles.*] bundles exist; no agent will receive any MCP tools. Add a [mcp_bundles.<alias>] entry and reference it from agents.<alias>.mcp_bundles to grant access."
+                );
+            }
+
             let known_servers: std::collections::HashSet<&str> =
                 self.mcp.servers.iter().map(|s| s.name.as_str()).collect();
             for (bundle_alias, bundle) in &self.mcp_bundles {
@@ -20307,6 +20327,69 @@ mod tests {
             config.mcp_servers_for_agent("ghost").is_empty(),
             "an unknown agent is granted no MCP servers"
         );
+    }
+
+    /// Regression test for the operator-UX warning added alongside #7733:
+    /// when MCP is enabled and `[[mcp.servers]]` is non-empty but no
+    /// `[mcp_bundles.*]` exists, validate() must still succeed (warnings
+    /// are non-fatal) AND every agent must resolve to zero servers
+    /// (proving the secure-by-default semantics that motivate the warning
+    /// are still in force).
+    #[test]
+    async fn validate_warns_when_servers_configured_but_no_bundles() {
+        use crate::schema::{McpServerConfig, McpTransport};
+        let mut config = Config::default();
+        config.mcp.enabled = true;
+        config.mcp.servers = vec![McpServerConfig {
+            name: "fs".into(),
+            transport: McpTransport::Stdio,
+            command: "/usr/bin/mcp-fs".into(),
+            ..Default::default()
+        }];
+        assert!(
+            config.mcp_bundles.is_empty(),
+            "test precondition: no bundles configured"
+        );
+
+        // validate() must succeed (warnings are non-fatal).
+        assert!(config.validate().is_ok());
+
+        // Behavioral assertion that motivates the warning: every agent
+        // resolves to zero servers under these conditions.
+        for alias in config.agents.keys() {
+            assert!(
+                config.mcp_servers_for_agent(alias).is_empty(),
+                "every agent must get zero servers when no bundles exist"
+            );
+        }
+    }
+
+    /// Counterpart to `validate_warns_when_servers_configured_but_no_bundles`:
+    /// once at least one `[mcp_bundles.*]` exists, the warning's
+    /// precondition no longer holds. validate() still succeeds and the
+    /// granted agent resolves to its bundled server.
+    #[test]
+    async fn validate_does_not_warn_when_a_bundle_exists() {
+        use crate::schema::{McpBundleConfig, McpServerConfig, McpTransport};
+        let mut config = Config::default();
+        config.mcp.enabled = true;
+        config.mcp.servers = vec![McpServerConfig {
+            name: "fs".into(),
+            transport: McpTransport::Stdio,
+            command: "/usr/bin/mcp-fs".into(),
+            ..Default::default()
+        }];
+        config.mcp_bundles.insert(
+            "default".into(),
+            McpBundleConfig {
+                servers: vec!["fs".into()],
+                exclude: vec![],
+            },
+        );
+
+        assert!(config.validate().is_ok());
+        // Precondition check: the warning's trigger condition is now false.
+        assert!(!config.mcp_bundles.is_empty());
     }
 
     fn parse_test_config(raw: &str) -> Config {

--- a/crates/zeroclaw-gateway/src/lib.rs
+++ b/crates/zeroclaw-gateway/src/lib.rs
@@ -4430,6 +4430,82 @@ mod tests {
         }
     }
 
+    /// Regression test for #7733 at the gateway MCP wiring site.
+    /// `append_scoped_mcp_tools` must early-return without mutating
+    /// `gw_tools` when the agent has no `mcp_bundles` grant, even if
+    /// `[[mcp.servers]]` is non-empty.
+    ///
+    /// Note: this is a behavior-pinning test, not a mutation-discriminating
+    /// one. The configured stdio server (`/usr/bin/mcp-fs`) is unlikely
+    /// to exist on the test host, so a hypothetical regression that
+    /// reverted to `&config.mcp.servers` would also produce zero
+    /// registered tools (the stdio connect fails non-fatally). The
+    /// stronger guard against that regression is
+    /// `crates/zeroclaw-channels/tests/orchestrator_mcp_scope.rs` plus
+    /// the resolver-level pins in `zeroclaw-config`. This test still
+    /// adds value by exercising the `append_scoped_mcp_tools` call
+    /// surface and ensuring it does not hang or panic for an unscoped
+    /// agent.
+    #[tokio::test]
+    async fn append_scoped_mcp_tools_is_a_noop_for_agent_without_bundles() {
+        use std::sync::Arc;
+        use zeroclaw_config::schema::{
+            AliasedAgentConfig, McpServerConfig, McpTransport, RiskProfileConfig,
+        };
+
+        let mut config = Config::default();
+        config.mcp.enabled = true;
+        config.mcp.servers = vec![McpServerConfig {
+            name: "fs".into(),
+            transport: McpTransport::Stdio,
+            command: "/usr/bin/mcp-fs".into(),
+            ..Default::default()
+        }];
+        // Critically: NO mcp_bundles configured and NO agent grants.
+        config
+            .risk_profiles
+            .insert("test-profile".into(), RiskProfileConfig::default());
+        config.agents.insert(
+            "unscoped".into(),
+            AliasedAgentConfig {
+                enabled: true,
+                model_provider: "openai.test-provider".into(),
+                risk_profile: "test-profile".into(),
+                mcp_bundles: Vec::new(),
+                ..Default::default()
+            },
+        );
+
+        let security: Arc<SecurityPolicy> = Arc::new(SecurityPolicy {
+            workspace_dir: std::env::temp_dir(),
+            ..SecurityPolicy::default()
+        });
+
+        let mut gw_tools: Vec<Box<dyn tools::Tool>> = Vec::new();
+        let initial_len = gw_tools.len();
+
+        // Bound the call with a short timeout: if the no-bundle branch
+        // ever stops being an early-return and tries to spawn an stdio
+        // MCP child, we'd rather see a timeout failure here than a
+        // hanging CI job.
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            super::append_scoped_mcp_tools(&config, "unscoped", &security, &mut gw_tools, None),
+        )
+        .await
+        .expect("append_scoped_mcp_tools must not hang for an unscoped agent");
+
+        assert_eq!(
+            gw_tools.len(),
+            initial_len,
+            "append_scoped_mcp_tools must not push any tool when the \
+             agent has no mcp_bundles grant; gw_tools went from {} \
+             to {}",
+            initial_len,
+            gw_tools.len()
+        );
+    }
+
     /// Gateway parity with the channel path: the gateway now scopes MCP servers
     /// by `mcp_bundles` and gates registration through the same
     /// `register_eager_mcp_tool_if_allowed` helper, so an `excluded_tools`-denied

--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -1298,7 +1298,11 @@ impl Agent {
         // Resolution-only MCP wrappers for skill MCP elevation (kind = "mcp").
         let mut mcp_elevation_arcs: Vec<Arc<dyn tools::Tool>> = Vec::new();
         // Secure by default: only the MCP servers granted by this agent's
-        // `mcp_bundles` (omission is not a grant).
+        // `mcp_bundles` (omission is not a grant). Regression-covered by
+        // `crates/zeroclaw-runtime/src/rpc/dispatch.rs::tests::`
+        // `chat_session_new_omits_mcp_tools_when_agent_has_no_bundles_{deferred,eager}`
+        // - those tests reach this code path via `session/new` -> `Agent::from_config_with_tui_env`.
+        // If you change the call below, update those tests.
         let agent_mcp_servers = if initialize_mcp && config.mcp.enabled {
             config.mcp_servers_for_agent(agent_alias)
         } else {

--- a/crates/zeroclaw-runtime/src/rpc/dispatch.rs
+++ b/crates/zeroclaw-runtime/src/rpc/dispatch.rs
@@ -4153,6 +4153,67 @@ mod tests {
         );
     }
 
+    /// Eager-mode counterpart to
+    /// `chat_session_new_omits_mcp_tools_when_agent_has_no_bundles_deferred`.
+    /// In eager mode the visible signal is the absence of any prefixed
+    /// `<server>__<tool>` name (here: `remote__domains.list`).
+    #[tokio::test]
+    async fn chat_session_new_omits_mcp_tools_when_agent_has_no_bundles_eager() {
+        use zeroclaw_config::schema::AliasedAgentConfig;
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let server = start_mock_mcp_http_server("domains.list").await;
+        let mut config = make_mcp_granting_config(&tmp, server.uri(), false);
+
+        let template = config
+            .agents
+            .get("test-agent")
+            .cloned()
+            .expect("test-agent must exist in make_mcp_granting_config");
+        config.agents.insert(
+            "unscoped-agent".to_string(),
+            AliasedAgentConfig {
+                enabled: true,
+                model_provider: template.model_provider.clone(),
+                risk_profile: template.risk_profile.clone(),
+                mcp_bundles: Vec::new(),
+                ..AliasedAgentConfig::default()
+            },
+        );
+
+        let (dispatcher, sessions) = make_acp_test_dispatcher(config);
+
+        let params = json!({
+            "agent_alias": "unscoped-agent",
+            "chat_mode": "chat",
+            "session_id": "chat-mcp-unscoped-eager-001"
+        });
+        let result = dispatcher.handle_session_new_for_test(&params).await;
+        assert!(
+            result.is_ok(),
+            "session/new for an unscoped agent should still succeed; got: {:?}",
+            result.err()
+        );
+
+        let agent_arc = sessions
+            .get_agent("chat-mcp-unscoped-eager-001")
+            .await
+            .expect("session must be registered after session/new");
+        let agent = agent_arc.lock().await;
+        let names = agent.tool_names();
+        assert!(
+            !names.contains(&"remote__domains.list"),
+            "Unscoped agent must NOT expose `remote__domains.list` in \
+             eager mode (mcp_bundles is empty -> no MCP connection -> \
+             no eager registration). Tools were: {names:?}"
+        );
+        assert!(
+            !names.iter().any(|n| n.starts_with("remote__")),
+            "No `remote__*` tool may leak to an unscoped agent; tools \
+             were: {names:?}"
+        );
+    }
+
     #[tokio::test]
     async fn acp_session_new_skips_mcp_tools() {
         let tmp = tempfile::TempDir::new().unwrap();

--- a/crates/zeroclaw-runtime/src/rpc/dispatch.rs
+++ b/crates/zeroclaw-runtime/src/rpc/dispatch.rs
@@ -4082,6 +4082,77 @@ mod tests {
         );
     }
 
+    /// Regression test for #7733. An agent whose `mcp_bundles` is empty
+    /// must receive ZERO MCP tools at session/new time, even when the
+    /// global `[mcp.servers]` list is non-empty and another agent (here
+    /// `test-agent`) has been granted that same server through a bundle.
+    /// In deferred mode the visible signal is the absence of
+    /// `tool_search`.
+    ///
+    /// If a future change reverts any production call site from
+    /// `config.mcp_servers_for_agent(agent_alias)` back to
+    /// `&config.mcp.servers`, this test fails.
+    #[tokio::test]
+    async fn chat_session_new_omits_mcp_tools_when_agent_has_no_bundles_deferred() {
+        use zeroclaw_config::schema::AliasedAgentConfig;
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let server = start_mock_mcp_http_server("domains.list").await;
+        let mut config = make_mcp_granting_config(&tmp, server.uri(), true);
+
+        // Add a SECOND agent with no `mcp_bundles`. Reuse `test-agent`'s
+        // model_provider/risk_profile so the agent is fully constructible
+        // without touching providers/risk_profiles.
+        let template = config
+            .agents
+            .get("test-agent")
+            .cloned()
+            .expect("test-agent must exist in make_mcp_granting_config");
+        config.agents.insert(
+            "unscoped-agent".to_string(),
+            AliasedAgentConfig {
+                enabled: true,
+                model_provider: template.model_provider.clone(),
+                risk_profile: template.risk_profile.clone(),
+                mcp_bundles: Vec::new(), // explicit: no grant
+                ..AliasedAgentConfig::default()
+            },
+        );
+
+        let (dispatcher, sessions) = make_acp_test_dispatcher(config);
+
+        let params = json!({
+            "agent_alias": "unscoped-agent",
+            "chat_mode": "chat",
+            "session_id": "chat-mcp-unscoped-deferred-001"
+        });
+        let result = dispatcher.handle_session_new_for_test(&params).await;
+        assert!(
+            result.is_ok(),
+            "session/new for an unscoped agent should still succeed; got: {:?}",
+            result.err()
+        );
+
+        let agent_arc = sessions
+            .get_agent("chat-mcp-unscoped-deferred-001")
+            .await
+            .expect("session must be registered after session/new");
+        let agent = agent_arc.lock().await;
+        let names = agent.tool_names();
+        assert!(
+            !names.contains(&"tool_search"),
+            "Unscoped agent must NOT expose `tool_search` in deferred mode \
+             (mcp_bundles is empty -> no MCP connection -> no deferred \
+             registry -> no tool_search). Tools were: {names:?}"
+        );
+        // And, defensively, no prefixed MCP tool either.
+        assert!(
+            !names.iter().any(|n| n.contains("__")),
+            "Unscoped agent must expose zero `<server>__<tool>` MCP tools; \
+             tools were: {names:?}"
+        );
+    }
+
     #[tokio::test]
     async fn acp_session_new_skips_mcp_tools() {
         let tmp = tempfile::TempDir::new().unwrap();

--- a/docs/book/src/tools/mcp.md
+++ b/docs/book/src/tools/mcp.md
@@ -32,6 +32,8 @@ servers = ["filesystem"]
 mcp_bundles = ["files"]   # connects to `filesystem`; an agent without this gets no MCP servers
 ```
 
+- Bundle changes take effect on **session restart**. The resolver (`Config::mcp_servers_for_agent`) runs at session/agent construction time; editing `[mcp_bundles.*]` or `agents.<alias>.mcp_bundles` while a session is live does not change that session's connected servers. End and restart the affected sessions to pick up new grants.
+
 This is the *connection* boundary (which servers an agent talks to at all). The `allowed_tools` / `excluded_tools` controls below are the per-tool *capability* boundary applied on top of whatever a granted server exposes.
 
 ## Transports


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:** The production fix for issue 7733 (per-agent MCP scoping via `mcp_bundles`) landed on master before this branch was opened — `Config::mcp_servers_for_agent` is now called at all five `McpRegistry::connect_all` sites (CLI loop, process_message, daemon `Agent::new`, channels orchestrator, gateway). What this PR adds is the **regression-prevention envelope** the original fix shipped without:
  - 2 new runtime tests (`crates/zeroclaw-runtime/src/rpc/dispatch.rs`) prove an agent whose `mcp_bundles` is empty receives **zero** MCP tools at `session/new` time, in both deferred and eager mode, even when another agent in the same config is granted that server. Mutation-verified: reverting `agent.rs:1303` from `config.mcp_servers_for_agent(agent_alias)` to `config.mcp.servers.clone()` makes both new tests fail with `tool_search` / `remote__domains.list` leaking into the unscoped agent.
  - 1 new resolver-pin + compile-time symbol-witness test for the channels-orchestrator path (`crates/zeroclaw-channels/tests/orchestrator_mcp_scope.rs`).
  - 1 new no-op test for the gateway path (`crates/zeroclaw-gateway/src/lib.rs`) covering `append_scoped_mcp_tools`'s no-bundle early-return.
  - 1 new operator-facing `WARN` in `Config::validate` (`crates/zeroclaw-config/src/schema.rs`) that fires when `mcp.enabled && !mcp.servers.is_empty() && mcp_bundles.is_empty()` — the inverse-silent-failure case where an operator upgrading from <0.8.3 ends up with `[[mcp.servers]]` but no `[mcp_bundles.*]` and silently gets no MCP tools anywhere. Surfaces via `doctor` and the standard startup warning stream.
  - Docs note that bundle edits take effect on **session restart** only (`docs/book/src/tools/mcp.md`), plus a coverage-reference comment in `agent.rs` pointing at the new regression tests.
- **Scope boundary:** No production code paths change behavior except the new `WARN` line in config validation. The MCP connection sites themselves are untouched — they were already correct on master. No new dependencies, no schema changes, no public-API changes.
- **Blast radius:** The only behavioral change a user can observe is one additional WARN log line at startup when MCP is enabled but no bundles are configured. Existing `mcp_bundles_*` resolver tests (4) and the existing positive dispatch tests (2) continue to pass unchanged.
- **Linked issue(s):** Closes #7733
- **Labels:** `docs`, `agent`, `config`, `gateway`, `runtime`, `tests`, `risk:high`, `size:M`

## Validation Evidence (required)

Commands run on `fix-7733` HEAD `90b839d9c3`, in a clean worktree at `.worktrees/fix-7733`, with `rustc 1.96.0`.

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- **Commands run and tail output:**

  `cargo fmt --all -- --check`:
  ```
  (no output, exit 0)
  ```

  `cargo clippy --all-targets -- -D warnings`:
  ```
  Checking zeroclaw-channels v0.8.2 (...)
  Checking zeroclaw-eval v0.8.2 (...)
      Finished \`dev\` profile [unoptimized + debuginfo] target(s) in 1m 21s
  (exit 0, zero warnings)
  ```

  `cargo test` — touched-crate excerpts (the full workspace `cargo test` runs ~6000 tests across all crates; below are the directly relevant tails plus the full-workspace doc-test note):
  ```
  # zeroclaw-config lib tests (978 pre-existing + 6 mcp-bundles-related):
  running 984 tests
  ...
  test schema::tests::mcp_bundles_empty_grants_no_servers ... ok
  test schema::tests::mcp_bundles_exclude_wins_across_bundles ... ok
  test schema::tests::mcp_bundles_union_resolves_and_dedups ... ok
  test schema::tests::mcp_bundles_unknown_bundle_and_dangling_name_grant_nothing ... ok
  test schema::tests::validate_does_not_warn_when_a_bundle_exists ... ok
  test schema::tests::validate_warns_when_servers_configured_but_no_bundles ... ok
  test result: ok. 984 passed; 0 failed; 0 ignored

  # zeroclaw-runtime lib tests (filtered to the 5 chat_session_new MCP tests):
  running 5 tests
  test rpc::dispatch::tests::chat_session_new_omits_mcp_tools_when_agent_has_no_bundles_deferred ... ok
  test rpc::dispatch::tests::chat_session_new_omits_mcp_tools_when_agent_has_no_bundles_eager ... ok
  test rpc::dispatch::tests::chat_session_new_writes_to_chat_backend_only ... ok
  test rpc::dispatch::tests::chat_session_new_exposes_prefixed_mcp_tool_in_eager_mode ... ok
  test rpc::dispatch::tests::chat_session_new_exposes_tool_search_in_deferred_mcp_mode ... ok
  test result: ok. 5 passed; 0 failed; 0 ignored

  # zeroclaw-channels new integration test file:
  running 1 test
  test resolver_grants_only_to_granted_agent_under_two_agent_config ... ok
  test result: ok. 1 passed; 0 failed; 0 ignored
  # (full zeroclaw-channels suite: 1090 passed, 0 failed, 1 ignored — unchanged from master)

  # zeroclaw-gateway lib tests (filtered to the 3 MCP-related tests):
  running 3 tests
  test tests::default_agent_alias_picks_smallest_enabled_and_is_deterministic ... ok
  test tests::gateway_excluded_tools_drops_denied_mcp_tool ... ok
  test tests::append_scoped_mcp_tools_is_a_noop_for_agent_without_bundles ... ok
  test result: ok. 3 passed; 0 failed; 0 ignored
  # (full zeroclaw-gateway suite: 322 passed, 0 failed — unchanged from master)

  # Integration + system suites (touched indirectly via shared config types):
  test result: ok. 158 passed; 0 failed; 0 ignored   (memory + telegram integration)
  test result: ok.   9 passed; 0 failed; 0 ignored   (system multi-agent E2E)
  ```

- **Beyond CI — what was manually verified:**
  - **Mutation guard, deferred mode:** edited `crates/zeroclaw-runtime/src/agent/agent.rs:1303` to revert from `config.mcp_servers_for_agent(agent_alias)` to `config.mcp.servers.clone()` and re-ran the new deferred-mode test — it **failed** with the unscoped agent's tool list growing by 1 (`tool_search`), proving the test catches the original #7733 silent-no-op regression. Reverted, test passes again. Same procedure for the eager-mode test — it failed with `remote__domains.list` leaking into the unscoped agent and passed once reverted.
  - **Mutation guard, gateway:** the gateway test is behavior-pinning, not mutation-discriminating, because the test's stdio MCP command (`/usr/bin/mcp-fs`) doesn't exist on the test host, so `connect_all` returns an empty registry either way. This is called out explicitly in the test's docstring with a pointer at the channels-orchestrator resolver-pin test as the stronger guard for that call site.
  - **Inverse-silent-failure WARN path:** smoke-checked the new `validate_warns_when_servers_configured_but_no_bundles` unit test exercises the exact `mcp.enabled && !mcp.servers.is_empty() && mcp_bundles.is_empty()` branch (resolver returns `Vec::new()` for every agent under that condition, confirmed by the test's behavioral assertion).
  - **Did not verify:** end-to-end manual run of a daemon with two real MCP servers under `mcp_bundles` (no MCP server binaries available in this environment). The dispatch tests cover this synthetically via a `wiremock` HTTP MCP server.
- **If any command was intentionally skipped, why:**
  - `cargo test --doc` fails on this worktree with `error: Option 'default-theme' given more than once` — a pre-existing **environmental** rustdoc CLI flag duplication that occurs when there are doc-tests present in the build cache, not introduced by this branch. My diff adds zero rustdoc-style code blocks (verified: \`git diff master...HEAD -- '*.rs' | grep -c '^+.*\`\`\`rust'\` returns 0). The failure reproduces independent of this branch's changes. Not addressed here; tracked separately.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No** (test agents are named `test-agent`, `granted`, `unscoped`, `unscoped-agent`; tool name `domains.list` is a generic placeholder.)
- If any `Yes`, describe the risk and mitigation: N/A — this PR is a security **improvement**: it adds regression tests for an already-shipped per-agent isolation fix and surfaces an operator-facing warning so a silent-misconfiguration cannot quietly defeat that isolation.

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- If `No` or `Yes` to either: exact upgrade steps for existing users: None required. Operators with a configuration that has `[[mcp.servers]]` but no `[mcp_bundles.*]` will see one new `WARN` line at startup pointing at the secure-by-default behavior; they can resolve it by adding a bundle entry (which is how MCP servers have been granted to agents since the original #7733 fix). The behavior of every agent is unchanged.

## Rollback (required for medium/high-risk PRs)

This PR is **low-risk** (additive tests + one non-fatal WARN at validation, no production hot-path changes). `git revert <merge-sha>` is the rollback plan and is safe — reverting the entire PR only removes regression coverage and one log line.

- **Fast rollback command/path:** `git revert <merge-sha>` against master.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** N/A — the WARN is a one-shot startup log line and cannot cause runtime errors. If a future bug were to make the WARN spam (e.g., validate-on-every-message), grep logs for `"[[mcp.servers]] is configured but no [mcp_bundles.*]"` and the rate of those lines.
