### PR TITLE
fix(tools): drop unwrap from hardware_memory_read chip lookup

### DIFF
--- a/crates/zeroclaw-tools/src/hardware_memory_read.rs
+++ b/crates/zeroclaw-tools/src/hardware_memory_read.rs
@@ -20,6 +20,7 @@ impl HardwareMemoryReadTool {
         Self { boards }
     }
 
+    #[cfg(feature = "probe")]
     fn chip_for_board(board: &str) -> Option<&'static str> {
         match board {
             "nucleo-f401re" => Some("STM32F401RETx"),
@@ -71,25 +72,6 @@ impl Tool for HardwareMemoryReadTool {
             });
         }
 
-        let board = args
-            .get("board")
-            .and_then(|v| v.as_str())
-            .map(String::from)
-            .or_else(|| self.boards.first().cloned())
-            .unwrap_or_else(|| "nucleo-f401re".into());
-
-        let chip = Self::chip_for_board(&board);
-        if chip.is_none() {
-            return Ok(ToolResult {
-                success: false,
-                output: String::new(),
-                error: Some(format!(
-                    "Memory read only supports nucleo-f401re, nucleo-f411re. Got: {}",
-                    board
-                )),
-            });
-        }
-
         let address_str = args
             .get("address")
             .and_then(|v| v.as_str())
@@ -102,8 +84,31 @@ impl Tool for HardwareMemoryReadTool {
             .clamp(1, 256);
 
         #[cfg(feature = "probe")]
+        let board = args
+            .get("board")
+            .and_then(|v| v.as_str())
+            .map(String::from)
+            .or_else(|| self.boards.first().cloned())
+            .unwrap_or_else(|| "nucleo-f401re".into());
+
+        #[cfg(feature = "probe")]
+        let chip = match Self::chip_for_board(&board) {
+            Some(c) => c,
+            None => {
+                return Ok(ToolResult {
+                    success: false,
+                    output: String::new(),
+                    error: Some(format!(
+                        "Memory read only supports nucleo-f401re, nucleo-f411re. Got: {}",
+                        board
+                    )),
+                });
+            }
+        };
+
+        #[cfg(feature = "probe")]
         {
-            match probe_read_memory(chip.unwrap(), _address, _length) {
+            match probe_read_memory(chip, _address, _length) {
                 Ok(output) => {
                     return Ok(ToolResult {
                         success: true,


### PR DESCRIPTION
  ## Summary

  - **Base branch:** `master` (all contributions)                                                                                                                                             
  - **What changed and why:**
    - `chip_for_board(&board)` returns `Option<&'static str>`. The old code took the option, checked `is_none()` for an early `return`, then called `chip.unwrap()` twenty lines later inside 
  `#[cfg(feature = "probe")]`. The unwrap was reachable-but-safe — the compiler knew `chip` was still `None`-impossible — but the `is_none`/`unwrap` split was a maintenance trap: any future 
  edit between those two lines (reassigning `chip`, changing control flow) would silently convert the unwrap from "always-safe" to "may panic".                                             
    - Fold the chip resolution into the `probe` cfg block so `chip` is bound once via `match` and the compiler enforces non-`None`.                                                           
  - **Scope boundary:** Single source file. Logic is unchanged on the `probe`-enabled path.                                                                                                   
  - **Blast radius:** Only the `hardware_memory_read` tool. Other tools that use `chip_for_board` are unaffected (none share the helper today).                                               
  - **Behavioural delta:** When the `probe` feature is OFF, the tool used to first report "chip X is not supported" before falling through to the "build with --features probe" error. It now 
  always reports the "build with --features probe" message — which is the actionable fix anyway, since no chip is supported without probe-rs linked. The probe-on path is unchanged.          
  - **Linked issue(s):** None.                                                                                                                                                                
  - **Labels:** `type: fix`, `risk: low`, `size: S`, `tools`                                                                                                                                  
                                                                                                                                                                                            
  ## Validation Evidence                                                                                                                                                                      
                                                                                                                                                                                            
  - **Commands run and tail output:**                                                                                                                                                         
    - `cargo fmt -p zeroclaw-tools --check` → OK (silent)
    - `cargo clippy -p zeroclaw-tools --lib --tests --no-deps -- -D warnings` → Finished, no warnings                                                                                         
    - `cargo test -p zeroclaw-tools --lib hardware_memory` →                                                                                                                                
      ```                                                                                                                                                                                     
      running 2 tests                                                                                                                                                                       
      test hardware_memory_map::tests::static_map_arduino ... ok                                                                                                                            
      test hardware_memory_map::tests::static_map_nucleo ... ok

      test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 1360 filtered out; finished in 0.00s                                                                                        
      ```
  - **Skipped commands:** Full workspace `cargo test` / `cargo clippy --all-targets` — only `zeroclaw-tools` touched; incremental crate-scoped checks are sufficient.                         
  - **Not verified:** `cargo build --features probe,hardware` — the `probe` feature lives on the top-level `zeroclawlabs` package, not on `zeroclaw-tools`, so a `-p zeroclaw-tools` build    
  cannot exercise it. The probe-only branch is unchanged structurally (same `match probe_read_memory(chip, …)` call as before, just with `chip` no longer unwrapped) and the default build is 
  the path the rest of CI exercises.                                                                                                                                                          
                                                                                                                                                                                              
  ## Security & Privacy Impact                                                                                                                                                              
                                                                                                                                                                                            
  - New permissions, capabilities, or file system access scope? **No**                                                                                                                        
  - New external network calls? **No**
  - Secrets / tokens / credentials handling changed? **No**                                                                                                                                   
  - PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**                                                                                                        
                                                                                                                                                                                              
  ## Compatibility
                                                                                                                                                                                              
  - Backward compatible? **Yes** for users with `--features probe`; off that path the error wording is slightly less specific (see Behavioural delta above).                                  
  - Config / env / CLI surface changed? **No**                                                                                                                                              
                                                                                                                                                                                              
  ## Rollback                                                                                                                                                                                 
                                                                                                                                                                                            
  Low-risk PR. `git revert c55571456` is the plan. Restores the original `chip_for_board` / chip-check layout. 