### PR TITLE
feat(sop): execute live SOP steps

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -6045,6 +6045,127 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn run_tool_call_loop_executes_queued_sop_steps_after_sop_execute() {
+        let turn_id = uuid::Uuid::new_v4().to_string();
+        let model_provider = ScriptedModelProvider::from_text_responses(vec![
+            r#"<tool_call>
+{"name":"sop_execute","arguments":{"name":"live-sop"}}
+</tool_call>"#,
+            "step one done",
+            "step two done",
+            "outer done",
+        ]);
+
+        let sop = crate::sop::Sop {
+            name: "live-sop".to_string(),
+            description: "live sop".to_string(),
+            version: "1".to_string(),
+            priority: crate::sop::SopPriority::Normal,
+            execution_mode: crate::sop::SopExecutionMode::Auto,
+            triggers: vec![crate::sop::SopTrigger::Manual],
+            steps: vec![
+                crate::sop::SopStep {
+                    number: 1,
+                    title: "First".to_string(),
+                    body: "Do the first step".to_string(),
+                    suggested_tools: Vec::new(),
+                    requires_confirmation: false,
+                    kind: crate::sop::SopStepKind::default(),
+                    schema: None,
+                },
+                crate::sop::SopStep {
+                    number: 2,
+                    title: "Second".to_string(),
+                    body: "Do the second step".to_string(),
+                    suggested_tools: Vec::new(),
+                    requires_confirmation: false,
+                    kind: crate::sop::SopStepKind::default(),
+                    schema: None,
+                },
+            ],
+            cooldown_secs: 0,
+            max_concurrent: 1,
+            location: None,
+            deterministic: false,
+        };
+        let mut engine = crate::sop::SopEngine::new(zeroclaw_config::schema::SopConfig::default());
+        engine.replace_sops_for_test(vec![sop]);
+        let engine = Arc::new(Mutex::new(engine));
+        let tools_registry: Vec<Box<dyn Tool>> = vec![Box::new(crate::tools::SopExecuteTool::new(
+            Arc::clone(&engine),
+        ))];
+
+        let mut history = vec![
+            ChatMessage::system("test-system"),
+            ChatMessage::user("start the live sop"),
+        ];
+        let observer = NoopObserver;
+
+        let result = run_tool_call_loop(ToolLoop {
+            exec: ResolvedAgentExecution {
+                model_access: ResolvedModelAccess {
+                    model_provider: &model_provider,
+                    provider_name: "mock-provider",
+                    model: "mock-model",
+                    temperature: Some(0.0),
+                },
+                tools_registry: &tools_registry,
+                observer: &observer,
+                silent: true,
+                approval: None,
+                multimodal_config: &zeroclaw_config::schema::MultimodalConfig::default(),
+                max_tool_iterations: 6,
+                hooks: None,
+                excluded_tools: &[],
+                dedup_exempt_tools: &[],
+                activated_tools: None,
+                model_switch_callback: None,
+                pacing: &zeroclaw_config::schema::PacingConfig::default(),
+                strict_tool_parsing: false,
+                parallel_tools: false,
+                max_tool_result_chars: 0,
+                context_token_budget: 0,
+                receipt_generator: None,
+                knobs: &LoopKnobs::default(),
+            },
+            history: &mut history,
+            channel_name: "agent",
+            channel_reply_target: None,
+            cancellation_token: None,
+            on_delta: None,
+            shared_budget: None,
+            channel: None,
+            collected_receipts: None,
+            event_tx: None,
+            steering: None,
+            new_messages_out: None,
+            image_cache: None,
+            ingress: IngressContext::internal(),
+            agent_alias: Some("test-agent"),
+            turn_id: &turn_id,
+        })
+        .await
+        .expect("live SOP execution should complete");
+
+        assert_eq!(result, "outer done");
+        let started = history
+            .iter()
+            .find_map(|msg| msg.content.strip_prefix("[Tool results]\n"))
+            .and_then(|content| content.split("SOP run started: ").nth(1))
+            .and_then(|rest| rest.lines().next())
+            .expect("sop_execute tool result should include a run id")
+            .to_string();
+        let engine = engine.lock().unwrap();
+        let run = engine
+            .get_run(&started)
+            .expect("run should remain queryable after completion");
+        assert_eq!(run.status, crate::sop::SopRunStatus::Completed);
+        assert_eq!(run.step_results.len(), 2);
+        assert_eq!(run.step_results[0].output, "step one done");
+        assert_eq!(run.step_results[1].output, "step two done");
+    }
+
     /// Regression: a native provider emitting multiple parallel tool calls
     /// in one turn must yield one role=tool message per call, each keyed to
     /// its own tool_call_id and output.

--- a/crates/zeroclaw-runtime/src/agent/turn/mod.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/mod.rs
@@ -837,33 +837,38 @@ pub async fn run_tool_call_loop(p: ToolLoop<'_>) -> Result<String> {
         )
         .await?;
 
-        let execution_result = if allow_parallel_execution && executable_calls.len() > 1 {
-            let meta = ctx.meta();
-            execute_tools_parallel(
-                &executable_calls,
-                tools_registry,
-                activated_tools,
-                &meta,
-                observer,
-                cancellation_token.as_ref(),
-                receipt_generator,
-                ctx.event_tx,
-            )
-            .await
-        } else {
-            let meta = ctx.meta();
-            execute_tools_sequential(
-                &executable_calls,
-                tools_registry,
-                activated_tools,
-                &meta,
-                observer,
-                cancellation_token.as_ref(),
-                receipt_generator,
-                ctx.event_tx,
-            )
-            .await
-        };
+        let live_sop_queue = crate::sop::executor::new_live_action_queue();
+        let execution_result =
+            crate::sop::executor::scope_live_action_queue(live_sop_queue.clone(), async {
+                if allow_parallel_execution && executable_calls.len() > 1 {
+                    let meta = ctx.meta();
+                    execute_tools_parallel(
+                        &executable_calls,
+                        tools_registry,
+                        activated_tools,
+                        &meta,
+                        observer,
+                        cancellation_token.as_ref(),
+                        receipt_generator,
+                        ctx.event_tx,
+                    )
+                    .await
+                } else {
+                    let meta = ctx.meta();
+                    execute_tools_sequential(
+                        &executable_calls,
+                        tools_registry,
+                        activated_tools,
+                        &meta,
+                        observer,
+                        cancellation_token.as_ref(),
+                        receipt_generator,
+                        ctx.event_tx,
+                    )
+                    .await
+                }
+            })
+            .await;
         let executed_slots = match execution_result {
             Ok(slots) => slots,
             Err(e) if is_tool_loop_cancelled(&e) => {
@@ -989,6 +994,48 @@ pub async fn run_tool_call_loop(p: ToolLoop<'_>) -> Result<String> {
         if cancelled_mid_batch {
             return Err(ToolLoopCancelled.into());
         }
+
+        let queued_sop_actions = crate::sop::executor::drain_live_actions(&live_sop_queue);
+        if !queued_sop_actions.is_empty() {
+            drive_live_sop_actions(
+                queued_sop_actions,
+                history,
+                model_provider,
+                provider_name,
+                model,
+                temperature,
+                tools_registry,
+                observer,
+                silent,
+                approval,
+                multimodal_config,
+                max_tool_iterations,
+                hooks,
+                excluded_tools,
+                dedup_exempt_tools,
+                activated_tools,
+                model_switch_callback.clone(),
+                pacing,
+                strict_tool_parsing,
+                parallel_tools,
+                max_tool_result_chars,
+                context_token_budget,
+                receipt_generator,
+                knobs,
+                channel_name,
+                channel_reply_target,
+                cancellation_token.clone(),
+                on_delta.clone(),
+                shared_budget.clone(),
+                channel,
+                collected_receipts,
+                event_tx.clone(),
+                new_messages_out.as_deref_mut(),
+                image_cache.as_deref_mut(),
+                agent_alias,
+            )
+            .await?;
+        }
     }
 
     finish_after_max_iterations(
@@ -1006,4 +1053,220 @@ pub async fn run_tool_call_loop(p: ToolLoop<'_>) -> Result<String> {
         new_messages_out,
     )
     .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn drive_live_sop_actions(
+    queued_actions: Vec<crate::sop::executor::QueuedSopAction>,
+    history: &mut Vec<ChatMessage>,
+    model_provider: &dyn ModelProvider,
+    provider_name: &str,
+    model: &str,
+    temperature: Option<f64>,
+    tools_registry: &[Box<dyn crate::tools::Tool>],
+    observer: &dyn crate::observability::Observer,
+    silent: bool,
+    approval: Option<&crate::approval::ApprovalManager>,
+    multimodal_config: &zeroclaw_config::schema::MultimodalConfig,
+    max_tool_iterations: usize,
+    hooks: Option<&crate::hooks::HookRunner>,
+    excluded_tools: &[String],
+    dedup_exempt_tools: &[String],
+    activated_tools: Option<&Arc<std::sync::Mutex<crate::tools::ActivatedToolSet>>>,
+    model_switch_callback: Option<ModelSwitchCallback>,
+    pacing: &zeroclaw_config::schema::PacingConfig,
+    strict_tool_parsing: bool,
+    parallel_tools: bool,
+    max_tool_result_chars: usize,
+    context_token_budget: usize,
+    receipt_generator: Option<&crate::agent::tool_receipts::ReceiptGenerator>,
+    knobs: &LoopKnobs,
+    channel_name: &str,
+    channel_reply_target: Option<&str>,
+    cancellation_token: Option<CancellationToken>,
+    on_delta: Option<tokio::sync::mpsc::Sender<StreamDelta>>,
+    shared_budget: Option<Arc<std::sync::atomic::AtomicUsize>>,
+    channel: Option<&dyn Channel>,
+    collected_receipts: Option<&std::sync::Mutex<Vec<String>>>,
+    event_tx: Option<tokio::sync::mpsc::Sender<TurnEvent>>,
+    mut new_messages_out: Option<&mut Vec<ChatMessage>>,
+    mut image_cache: Option<&mut zeroclaw_providers::multimodal::LocalImageCache>,
+    agent_alias: Option<&str>,
+) -> Result<()> {
+    let mut pending = std::collections::VecDeque::from(queued_actions);
+    while let Some(queued) = pending.pop_front() {
+        let mut action = queued.action;
+        loop {
+            match action {
+                crate::sop::SopRunAction::ExecuteStep {
+                    run_id,
+                    step,
+                    context,
+                } => {
+                    let started_at = crate::sop::engine::now_iso8601();
+                    let user_message = ChatMessage::user(context.clone());
+                    history.push(user_message.clone());
+                    if let Some(out) = new_messages_out.as_deref_mut() {
+                        out.push(user_message);
+                    }
+
+                    let mut sop_excluded_tools = excluded_tools.to_vec();
+                    for tool in ["sop_execute", "sop_advance", "sop_approve"] {
+                        if !sop_excluded_tools.iter().any(|existing| existing == tool) {
+                            sop_excluded_tools.push(tool.to_string());
+                        }
+                    }
+
+                    let nested_turn_id = format!("sop:{run_id}:step:{}", step.number);
+                    let step_output = Box::pin(run_tool_call_loop(ToolLoop {
+                        exec: ResolvedAgentExecution::resolve(
+                            ResolvedModelAccess {
+                                model_provider,
+                                provider_name,
+                                model,
+                                temperature,
+                            },
+                            ResolvedIo {
+                                tools_registry,
+                                observer,
+                                silent,
+                                approval,
+                                multimodal_config,
+                                hooks,
+                                activated_tools,
+                                model_switch_callback: model_switch_callback.clone(),
+                                receipt_generator,
+                            },
+                            ResolvedRuntimeKnobs {
+                                max_tool_iterations,
+                                excluded_tools: &sop_excluded_tools,
+                                dedup_exempt_tools,
+                                pacing,
+                                strict_tool_parsing,
+                                parallel_tools,
+                                max_tool_result_chars,
+                                context_token_budget,
+                                knobs,
+                            },
+                        ),
+                        history,
+                        channel_name,
+                        channel_reply_target,
+                        cancellation_token: cancellation_token.clone(),
+                        on_delta: on_delta.clone(),
+                        shared_budget: shared_budget.clone(),
+                        channel,
+                        collected_receipts,
+                        event_tx: event_tx.clone(),
+                        steering: None,
+                        new_messages_out: new_messages_out.as_deref_mut(),
+                        image_cache: image_cache.as_deref_mut(),
+                        ingress: IngressContext::internal(),
+                        agent_alias,
+                        turn_id: &nested_turn_id,
+                    }))
+                    .await;
+
+                    let completed_at = crate::sop::engine::now_iso8601();
+                    let step_result = match step_output {
+                        Ok(output) => crate::sop::SopStepResult {
+                            step_number: step.number,
+                            status: crate::sop::SopStepStatus::Completed,
+                            output,
+                            started_at,
+                            completed_at: Some(completed_at),
+                        },
+                        Err(e) => crate::sop::SopStepResult {
+                            step_number: step.number,
+                            status: crate::sop::SopStepStatus::Failed,
+                            output: e.to_string(),
+                            started_at,
+                            completed_at: Some(completed_at),
+                        },
+                    };
+
+                    let (next_action, finished_run) = crate::sop::executor::advance_sop_step(
+                        &queued.engine,
+                        &run_id,
+                        step_result.clone(),
+                    )?;
+                    crate::sop::executor::audit_sop_step(
+                        queued.audit.as_deref(),
+                        &run_id,
+                        &step_result,
+                        finished_run.as_ref(),
+                    )
+                    .await;
+                    action = next_action;
+                }
+                crate::sop::SopRunAction::WaitApproval { run_id, step, .. } => {
+                    ::zeroclaw_log::record!(
+                        INFO,
+                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                            .with_attrs(::serde_json::json!({
+                                "run_id": run_id,
+                                "step": step.number,
+                            })),
+                        "SOP live executor paused for approval"
+                    );
+                    break;
+                }
+                crate::sop::SopRunAction::DeterministicStep { run_id, step, .. } => {
+                    ::zeroclaw_log::record!(
+                        INFO,
+                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                            .with_attrs(::serde_json::json!({
+                                "run_id": run_id,
+                                "step": step.number,
+                            })),
+                        "SOP live executor yielded deterministic step"
+                    );
+                    break;
+                }
+                crate::sop::SopRunAction::CheckpointWait { run_id, step, .. } => {
+                    ::zeroclaw_log::record!(
+                        INFO,
+                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                            .with_attrs(::serde_json::json!({
+                                "run_id": run_id,
+                                "step": step.number,
+                            })),
+                        "SOP live executor paused at checkpoint"
+                    );
+                    break;
+                }
+                crate::sop::SopRunAction::Completed { run_id, sop_name } => {
+                    ::zeroclaw_log::record!(
+                        INFO,
+                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                            .with_attrs(::serde_json::json!({
+                                "run_id": run_id,
+                                "sop_name": sop_name,
+                            })),
+                        "SOP live executor completed run"
+                    );
+                    break;
+                }
+                crate::sop::SopRunAction::Failed {
+                    run_id,
+                    sop_name,
+                    reason,
+                } => {
+                    ::zeroclaw_log::record!(
+                        WARN,
+                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+                            .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                            .with_attrs(::serde_json::json!({
+                                "run_id": run_id,
+                                "sop_name": sop_name,
+                                "reason": reason,
+                            })),
+                        "SOP live executor failed run"
+                    );
+                    break;
+                }
+            }
+        }
+    }
+    Ok(())
 }

--- a/crates/zeroclaw-runtime/src/sop/engine.rs
+++ b/crates/zeroclaw-runtime/src/sop/engine.rs
@@ -169,6 +169,11 @@ impl SopEngine {
         &self.sops
     }
 
+    #[cfg(test)]
+    pub(crate) fn replace_sops_for_test(&mut self, sops: Vec<Sop>) {
+        self.sops = sops;
+    }
+
     /// Return all active (in-flight) runs.
     pub fn active_runs(&self) -> &HashMap<String, SopRun> {
         &self.active_runs

--- a/crates/zeroclaw-runtime/src/sop/executor.rs
+++ b/crates/zeroclaw-runtime/src/sop/executor.rs
@@ -1,0 +1,130 @@
+//! Live SOP action executor.
+//!
+//! The SOP engine is intentionally synchronous: it decides the next
+//! [`SopRunAction`] and owns run state, while callers perform side effects.
+//! This module is the bridge for live agent execution. It drives
+//! `ExecuteStep` actions through an async step runner, feeds the result back to
+//! the engine, and repeats until the run blocks or terminates.
+
+use std::collections::VecDeque;
+use std::future::Future;
+use std::sync::{Arc, Mutex};
+
+use anyhow::{Context, Result};
+
+use super::audit::SopAuditLogger;
+use super::engine::SopEngine;
+use super::metrics::SopMetricsCollector;
+use super::types::{SopRun, SopRunAction, SopStepResult};
+
+/// Live SOP action captured by SOP tools while they run inside an agent turn.
+#[derive(Clone)]
+pub(crate) struct QueuedSopAction {
+    pub engine: Arc<Mutex<SopEngine>>,
+    pub audit: Option<Arc<SopAuditLogger>>,
+    pub action: SopRunAction,
+}
+
+pub(crate) type LiveActionQueue = Arc<Mutex<VecDeque<QueuedSopAction>>>;
+
+tokio::task_local! {
+    static LIVE_SOP_ACTION_QUEUE: Option<LiveActionQueue>;
+}
+
+pub(crate) fn new_live_action_queue() -> LiveActionQueue {
+    Arc::new(Mutex::new(VecDeque::new()))
+}
+
+pub(crate) async fn scope_live_action_queue<T>(
+    queue: LiveActionQueue,
+    future: impl Future<Output = T>,
+) -> T {
+    LIVE_SOP_ACTION_QUEUE.scope(Some(queue), future).await
+}
+
+/// Queue a live action when the current tool call is running inside an agent
+/// turn. Only `ExecuteStep` actions are queued; all other variants are already
+/// terminal or blocked.
+pub(crate) fn enqueue_live_action(
+    engine: Arc<Mutex<SopEngine>>,
+    audit: Option<Arc<SopAuditLogger>>,
+    action: &SopRunAction,
+) {
+    if !matches!(action, SopRunAction::ExecuteStep { .. }) {
+        return;
+    }
+
+    let queued = QueuedSopAction {
+        engine,
+        audit,
+        action: action.clone(),
+    };
+    let _ = LIVE_SOP_ACTION_QUEUE.try_with(|queue| {
+        if let Some(queue) = queue
+            && let Ok(mut queue) = queue.lock()
+        {
+            queue.push_back(queued);
+        }
+    });
+}
+
+pub(crate) fn drain_live_actions(queue: &LiveActionQueue) -> Vec<QueuedSopAction> {
+    match queue.lock() {
+        Ok(mut queue) => queue.drain(..).collect(),
+        Err(poisoned) => poisoned.into_inner().drain(..).collect(),
+    }
+}
+
+pub(crate) fn advance_sop_step(
+    engine: &Arc<Mutex<SopEngine>>,
+    run_id: &str,
+    result: SopStepResult,
+) -> Result<(SopRunAction, Option<SopRun>)> {
+    let mut engine = engine
+        .lock()
+        .map_err(|e| anyhow::Error::msg(format!("SOP engine lock poisoned: {e}")))?;
+    let action = engine
+        .advance_step(run_id, result)
+        .with_context(|| format!("failed to advance SOP run {run_id}"))?;
+    let finished_run = match &action {
+        SopRunAction::Completed { run_id, .. } | SopRunAction::Failed { run_id, .. } => {
+            engine.get_run(run_id).cloned()
+        }
+        _ => None,
+    };
+    if let Some(ref run) = finished_run {
+        SopMetricsCollector::shared().record_run_complete(run);
+    }
+    Ok((action, finished_run))
+}
+
+pub(crate) async fn audit_sop_step(
+    audit: Option<&SopAuditLogger>,
+    run_id: &str,
+    result: &SopStepResult,
+    finished_run: Option<&SopRun>,
+) {
+    let Some(audit) = audit else {
+        return;
+    };
+    if let Err(e) = audit.log_step_result(run_id, result).await {
+        ::zeroclaw_log::record!(
+            WARN,
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                .with_attrs(::serde_json::json!({"error": e.to_string()})),
+            "SOP executor: audit log_step_result failed"
+        );
+    }
+    if let Some(run) = finished_run
+        && let Err(e) = audit.log_run_complete(run).await
+    {
+        ::zeroclaw_log::record!(
+            WARN,
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                .with_attrs(::serde_json::json!({"error": e.to_string()})),
+            "SOP executor: audit log_run_complete failed"
+        );
+    }
+}

--- a/crates/zeroclaw-runtime/src/sop/executor.rs
+++ b/crates/zeroclaw-runtime/src/sop/executor.rs
@@ -14,7 +14,6 @@ use anyhow::{Context, Result};
 
 use super::audit::SopAuditLogger;
 use super::engine::SopEngine;
-use super::metrics::SopMetricsCollector;
 use super::types::{SopRun, SopRunAction, SopStepResult};
 
 /// Live SOP action captured by SOP tools while they run inside an agent turn.
@@ -92,9 +91,6 @@ pub(crate) fn advance_sop_step(
         }
         _ => None,
     };
-    if let Some(ref run) = finished_run {
-        SopMetricsCollector::shared().record_run_complete(run);
-    }
     Ok((action, finished_run))
 }
 
@@ -125,6 +121,94 @@ pub(crate) async fn audit_sop_step(
                 .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
                 .with_attrs(::serde_json::json!({"error": e.to_string()})),
             "SOP executor: audit log_run_complete failed"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sop::metrics::SopMetricsCollector;
+    use crate::sop::types::{
+        Sop, SopEvent, SopExecutionMode, SopPriority, SopStep, SopStepKind, SopStepResult,
+        SopStepStatus, SopTrigger, SopTriggerSource,
+    };
+    use serde_json::json;
+    use zeroclaw_config::schema::SopConfig;
+
+    fn test_sop(name: &str) -> Sop {
+        Sop {
+            name: name.to_string(),
+            description: "Test SOP".to_string(),
+            version: "0.1.0".to_string(),
+            priority: SopPriority::Normal,
+            execution_mode: SopExecutionMode::Auto,
+            triggers: vec![SopTrigger::Manual],
+            steps: vec![SopStep {
+                number: 1,
+                title: "Step one".to_string(),
+                body: "Complete the step".to_string(),
+                suggested_tools: Vec::new(),
+                requires_confirmation: false,
+                kind: SopStepKind::Execute,
+                schema: None,
+            }],
+            cooldown_secs: 0,
+            max_concurrent: 1,
+            location: None,
+            deterministic: false,
+        }
+    }
+
+    fn manual_event() -> SopEvent {
+        SopEvent {
+            source: SopTriggerSource::Manual,
+            topic: None,
+            payload: None,
+            timestamp: "2026-06-28T00:00:00Z".to_string(),
+        }
+    }
+
+    fn extract_run_id(action: &SopRunAction) -> String {
+        match action {
+            SopRunAction::ExecuteStep { run_id, .. } => run_id.clone(),
+            other => panic!("expected ExecuteStep, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn live_executor_records_terminal_metrics_once() {
+        let collector = SopMetricsCollector::shared();
+        collector.reset_for_test();
+
+        let mut engine = SopEngine::new(SopConfig::default()).with_metrics(collector.clone());
+        engine.set_sops_for_test(vec![test_sop("live-once")]);
+        let action = engine.start_run("live-once", manual_event()).unwrap();
+        let run_id = extract_run_id(&action);
+        let engine = Arc::new(Mutex::new(engine));
+
+        let (action, finished_run) = advance_sop_step(
+            &engine,
+            &run_id,
+            SopStepResult {
+                step_number: 1,
+                status: SopStepStatus::Completed,
+                output: "ok".to_string(),
+                started_at: "2026-06-28T00:00:00Z".to_string(),
+                completed_at: Some("2026-06-28T00:00:01Z".to_string()),
+            },
+        )
+        .unwrap();
+
+        assert!(matches!(action, SopRunAction::Completed { .. }));
+        assert!(finished_run.is_some());
+        assert_eq!(
+            collector.get_metric_value("sop.runs_completed"),
+            Some(json!(1u64))
+        );
+        assert_eq!(
+            collector.get_metric_value("sop.live-once.runs_completed"),
+            Some(json!(1u64))
         );
     }
 }

--- a/crates/zeroclaw-runtime/src/sop/metrics.rs
+++ b/crates/zeroclaw-runtime/src/sop/metrics.rs
@@ -103,6 +103,12 @@ impl SopMetricsCollector {
             .clone()
     }
 
+    #[cfg(test)]
+    pub(crate) fn reset_for_test(&self) {
+        let mut state = self.inner.write().expect("metrics collector lock poisoned");
+        *state = CollectorState::default();
+    }
+
     // ── Push methods (sync, write lock) ────────────────────────
 
     /// Record a terminal run (Completed/Failed/Cancelled).

--- a/crates/zeroclaw-runtime/src/sop/mod.rs
+++ b/crates/zeroclaw-runtime/src/sop/mod.rs
@@ -3,6 +3,7 @@ pub mod audit;
 pub mod condition;
 pub mod dispatch;
 pub mod engine;
+pub mod executor;
 pub mod metrics;
 pub mod payload_safety;
 pub mod store;

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -1168,7 +1168,9 @@ pub fn all_tools_with_runtime(
             tool_arcs.push(Arc::new(
                 SopAdvanceTool::new(Arc::clone(sop_engine)).with_audit(Arc::clone(sop_audit)),
             ));
-            tool_arcs.push(Arc::new(SopApproveTool::new(Arc::clone(sop_engine))));
+            tool_arcs.push(Arc::new(
+                SopApproveTool::new(Arc::clone(sop_engine)).with_audit(Arc::clone(sop_audit)),
+            ));
         } else {
             tool_arcs.push(Arc::new(SopExecuteTool::new(Arc::clone(sop_engine))));
             tool_arcs.push(Arc::new(SopAdvanceTool::new(Arc::clone(sop_engine))));

--- a/crates/zeroclaw-runtime/src/tools/sop_advance.rs
+++ b/crates/zeroclaw-runtime/src/tools/sop_advance.rs
@@ -204,6 +204,14 @@ impl Tool for SopAdvanceTool {
             collector.record_run_complete(run);
         }
 
+        if let Ok(ref action) = action {
+            crate::sop::executor::enqueue_live_action(
+                Arc::clone(&self.engine),
+                self.audit.clone(),
+                action,
+            );
+        }
+
         match action {
             Ok(action) => {
                 let result_output = match action {

--- a/crates/zeroclaw-runtime/src/tools/sop_approve.rs
+++ b/crates/zeroclaw-runtime/src/tools/sop_approve.rs
@@ -3,14 +3,15 @@ use std::sync::{Arc, Mutex};
 use async_trait::async_trait;
 use serde_json::json;
 
-use crate::sop::SopEngine;
 use crate::sop::approval::{ApprovalDecision, ApprovalPrincipal, ResolveOutcome};
 use crate::sop::types::{SopRunAction, SopRunStatus};
+use crate::sop::{SopAuditLogger, SopEngine};
 use zeroclaw_api::tool::{Tool, ToolResult};
 
 /// Approve a pending SOP step that is waiting for operator approval.
 pub struct SopApproveTool {
     engine: Arc<Mutex<SopEngine>>,
+    audit: Option<Arc<SopAuditLogger>>,
     agent_alias: String,
 }
 
@@ -18,8 +19,14 @@ impl SopApproveTool {
     pub fn new(engine: Arc<Mutex<SopEngine>>) -> Self {
         Self {
             engine,
+            audit: None,
             agent_alias: "agent".to_string(),
         }
+    }
+
+    pub fn with_audit(mut self, audit: Arc<SopAuditLogger>) -> Self {
+        self.audit = Some(audit);
+        self
     }
 
     /// Set the agent alias recorded as the approval principal (default `"agent"`).
@@ -111,6 +118,11 @@ impl Tool for SopApproveTool {
 
         match result {
             Ok(ResolveOutcome::Resumed(action)) => {
+                crate::sop::executor::enqueue_live_action(
+                    Arc::clone(&self.engine),
+                    self.audit.clone(),
+                    &action,
+                );
                 let output = match action {
                     SopRunAction::ExecuteStep {
                         run_id, context, ..

--- a/crates/zeroclaw-runtime/src/tools/sop_execute.rs
+++ b/crates/zeroclaw-runtime/src/tools/sop_execute.rs
@@ -117,6 +117,14 @@ impl Tool for SopExecuteTool {
             );
         }
 
+        if let Ok(ref action) = action {
+            crate::sop::executor::enqueue_live_action(
+                Arc::clone(&self.engine),
+                self.audit.clone(),
+                action,
+            );
+        }
+
         match action {
             Ok(action) => {
                 let output = match action {


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Adds a live SOP action executor that captures `ExecuteStep` actions emitted by SOP tools during an agent turn.
  - Wires `sop_execute`, `sop_advance`, and audited `sop_approve` into a scoped live action queue so agent-started or agent-resumed SOPs continue automatically.
  - Drives queued SOP steps through `run_tool_call_loop` after the normal tool-result round, then advances/audits until completion, failure, approval gate, or checkpoint.
  - Adds a regression proving a two-step SOP started through `sop_execute` completes through the live agent loop.
- **Scope boundary:** This PR does not implement MQTT/cron triggered autonomy, the #6954 synthetic inbound primitive, or EPIC E per-step tool/I-O contracts. Triggered SOP dispatch remains the #6954/#6686 follow-up path.
- **Blast radius:** High-risk runtime path. The main behavioral surface is `run_tool_call_loop`; SOP tool behavior also changes for `sop_execute`, `sop_advance`, and `sop_approve` when they run inside a live agent turn.
- **Linked issue(s):** Related #8288.
- **Labels:** `enhancement`, `agent`, `runtime`, `agent:loop`, `tool:sop`, `risk:high`, `size:M`

## Validation Evidence

- **Commands run and tail output:**

```text
cargo +1.93.0 fmt --all -- --check
result: passed

cargo +1.93.0 clippy --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.67s

cargo +1.93.0 test
test result: ok. 245 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 299 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 188 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 158 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 0 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out
test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
Doc-tests zeroclaw
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

cargo +1.93.0 test -p zeroclaw-runtime run_tool_call_loop_executes_queued_sop_steps_after_sop_execute --lib
test result: ok. 1 passed; 0 failed

cargo +1.93.0 test -p zeroclaw-runtime sop --lib
test result: ok. 243 passed; 0 failed; 2255 filtered out

cargo +1.93.0 check -p zeroclaw-runtime --all-targets
Finished `dev` profile [unoptimized + debuginfo]

cargo +1.93.0 check --workspace --all-targets --exclude zeroclaw-desktop
Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.50s

cargo +1.93.0 check --no-default-features
Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.44s

git diff --check
result: passed
```

- **Beyond CI — what did you manually verify?** I reviewed the live executor call path and confirmed SOP tools enqueue only `ExecuteStep` actions while scoped inside an agent turn; `run_tool_call_loop` drains the queue after the normal tool-result round; nested SOP turns exclude SOP control tools to prevent double-driving; and the new regression covers a two-step live SOP completing through the agent loop.
- **If any command was intentionally skipped, why:** Web checks were skipped because no web/TS files changed. Shell checks were skipped because no `.sh` files changed. Docs checks were skipped because no docs changed and no new CLI/config/env/API route/default/user-facing docs surface was added.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? Yes. SOP tools that already start or resume SOP runs can now drive returned `ExecuteStep` actions through the existing agent tool loop. This does not add OS, filesystem, or network permission scope; it activates the already-modeled SOP execution path inside the existing turn loop.
- New external network calls? No.
- Secrets / tokens / credentials handling changed? No.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No.
- If any `Yes`, describe the risk and mitigation: A SOP started inside a live agent turn now performs nested model/tool turns instead of stopping at the first `ExecuteStep` instruction. Nested SOP step turns exclude `sop_execute`, `sop_advance`, and `sop_approve` to prevent self-advancing/double-driving; step errors are recorded as failed SOP step results and handed back to the engine.

## Compatibility

- Backward compatible? Yes.
- Config / env / CLI surface changed? No.
- If `No` or `Yes` to either: No upgrade steps.

## Rollback

- **Fast rollback command/path:** `git revert 6ad321297dd7799af409a19fa86f320a43bb9a5c`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** SOP runs started or resumed by an agent turn unexpectedly fail, repeat nested turns, or pause at the wrong gate. Check logs for `SOP live executor failed run`, `SOP live executor paused for approval`, `SOP executor: audit log_step_result failed`, and `SOP executor: audit log_run_complete failed`; watch SOP run-completion metrics for unexpected failed/completed transitions.

## Supersede Attribution

- Superseded PRs + authors: N/A.
- Scope materially carried forward: N/A.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? No.
- If `No`, why: No superseded PR or incorporated contributor work.
