### PR TITLE
docs(labels): document ACP channel label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -42,6 +42,19 @@
           - "src/channels/**"
           - "crates/zeroclaw-channels/src/**"
 
+"channel:acp":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/bin/zeroclaw-acp-bridge.rs"
+          - "docs/book/src/channels/acp.md"
+          - "apps/zerocode/src/acp.rs"
+          - "web/src/lib/acp.ts"
+          - "web/src/pages/AcpConsole.tsx"
+          - "crates/zeroclaw-channels/src/acp_channel.rs"
+          - "crates/zeroclaw-channels/src/orchestrator/acp_server.rs"
+          - "crates/zeroclaw-gateway/src/acp.rs"
+          - "crates/zeroclaw-infra/src/acp_session_store.rs"
+
 "channel:bluesky":
   - changed-files:
       - any-glob-to-any-file:

--- a/docs/book/src/maintainers/labels.md
+++ b/docs/book/src/maintainers/labels.md
@@ -115,10 +115,11 @@ Applied automatically by `pr-path-labeler.yml`. Globs live in `.github/labeler.y
 
 ### Per-channel labels
 
-Each channel gets a `channel:<name>` label in addition to the base `channel` label.
+Each channel gets a `channel:<name>` label in addition to the base `channel` label when the change touches channel crate paths. Cross-surface channel labels such as `channel:acp` may instead pair with the matching base surface label, such as `gateway`, `docs`, or app/web scope labels.
 
 | Label | Matches |
 |---|---|
+| `channel:acp` | `acp_channel.rs`, `acp_server.rs`, `zeroclaw-acp-bridge.rs`, `acp_session_store.rs`, `channels/acp.md`, selected ACP gateway/app/web entrypoints |
 | `channel:bluesky` | `bluesky.rs` |
 | `channel:clawdtalk` | `clawdtalk.rs` |
 | `channel:cli` | `cli.rs` |


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Adds `channel:acp` to `.github/labeler.yml` so ACP-specific PRs get the intentional ACP channel label.
  - Covers the direct ACP channel, bridge, gateway, app/web, infra, and docs entrypoints.
  - Updates the maintainer label guide to document `channel:acp` as a cross-surface channel label.
- **Scope boundary:** This PR does not create, delete, rename, or migrate any live GitHub labels. It does not change runtime behavior or stale/triage policy.
- **Blast radius:** PR path-label automation and maintainer label documentation only. Future PRs touching the listed ACP files may receive `channel:acp`.
- **Linked issue(s):** Related #6808
- **Labels:** `ci`, `docs`, `risk:low`, `size:XS`, `type:docs`

## Validation Evidence (required)

- **Commands run and tail output:**

```bash
scripts/ci/docs_quality_gate.sh
```

Output:

```text
No prose em-dashes in changed docs files.
Linting docs files: docs/book/src/maintainers/labels.md
markdownlint-cli2 v0.20.0 (markdownlint v0.40.0)
Finding: docs/book/src/maintainers/labels.md !target/** !docs/book/src/SUMMARY.md
Linting: 1 file(s)
Summary: 0 error(s)
```

```bash
git diff --check
```

Passed with no output.

```bash
ruby -e 'require "yaml"; YAML.load_file(ARGV[0]); puts "labeler yaml ok"' .github/labeler.yml
```

Output:

```text
labeler yaml ok
```

```bash
scripts/check-pr-title.sh "docs(labels): document ACP channel label"
```

Passed with no output.

```bash
ruby -e 'require "yaml"; labels = YAML.load_file(".github/labeler.yml"); paths = labels.fetch("channel:acp").first.fetch("changed-files").first.fetch("any-glob-to-any-file"); missing = paths.reject { |path| File.exist?(path) }; abort("missing: #{missing.join(", ")}") unless missing.empty?; puts "channel:acp paths ok: #{paths.length}"'
```

Output:

```text
channel:acp paths ok: 9
```

- **Beyond CI — what did you manually verify?** Verified that all added literal matcher paths exist.
- **If any command was intentionally skipped, why:** Rust validation was skipped because this is a docs/path-labeler change with no Rust behavior changes.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: `N/A`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: exact upgrade steps for existing users: `N/A`

## Rollback (required for medium/high-risk PRs)

Low-risk PR: `git revert <sha>` is the rollback plan.

## Supersede Attribution (required only when `Supersedes #` is used)

`N/A`
