### PR TITLE
fix(cost): atomic ledger appends + recover concatenated records

### DIFF
--- a/crates/zeroclaw-config/src/cost/tracker.rs
+++ b/crates/zeroclaw-config/src/cost/tracker.rs
@@ -558,16 +558,38 @@ impl CostStorage {
             match serde_json::from_str::<CostRecord>(trimmed) {
                 Ok(record) => on_record(record),
                 Err(error) => {
-                    ::zeroclaw_log::record!(
-                        WARN,
-                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    // A single line that fails to parse may be two or more
+                    // records concatenated without a newline (a legacy
+                    // interleaved-write artifact from before the atomic-append
+                    // fix). Try to stream multiple records out of it before
+                    // giving up, so old corrupted ledgers still aggregate fully.
+                    let mut recovered = 0usize;
+                    let stream =
+                        serde_json::Deserializer::from_str(trimmed).into_iter::<CostRecord>();
+                    for value in stream {
+                        match value {
+                            Ok(record) => {
+                                on_record(record);
+                                recovered += 1;
+                            }
+                            Err(_) => break,
+                        }
+                    }
+                    if recovered == 0 {
+                        ::zeroclaw_log::record!(
+                            WARN,
+                            ::zeroclaw_log::Event::new(
+                                module_path!(),
+                                ::zeroclaw_log::Action::Note
+                            )
                             .with_outcome(::zeroclaw_log::EventOutcome::Unknown),
-                        &format!(
-                            "Skipping malformed cost record at {}:{}: {error}",
-                            self.path.display().to_string(),
-                            line_number + 1
-                        )
-                    );
+                            &format!(
+                                "Skipping malformed cost record at {}:{}: {error}",
+                                self.path.display().to_string(),
+                                line_number + 1
+                            )
+                        );
+                    }
                 }
             }
         }
@@ -626,7 +648,15 @@ impl CostStorage {
                 )
             })?;
 
-        writeln!(file, "{}", serde_json::to_string(&record)?).with_context(|| {
+        // Build the full line (record + newline) and emit it with a SINGLE
+        // `write_all`. `writeln!` can lower to multiple `write` syscalls (one for
+        // the body, one for the newline); under concurrent appenders that
+        // interleaves and produces concatenated JSON like `{..}{..}` on one
+        // line. One `write_all` on an O_APPEND fd keeps each record's bytes
+        // contiguous, so the reader always sees one record per line.
+        let mut line = serde_json::to_string(&record)?;
+        line.push('\n');
+        file.write_all(line.as_bytes()).with_context(|| {
             format!(
                 "Failed to write cost record to {}",
                 self.path.display().to_string()
@@ -733,6 +763,44 @@ mod tests {
             enabled: true,
             ..Default::default()
         }
+    }
+
+    /// Regression: a legacy ledger whose records were concatenated onto a
+    /// single line (the pre-atomic-append interleave bug) must still have all
+    /// of its records recovered by `for_each_record`, so historical cost data
+    /// keeps aggregating.
+    #[test]
+    fn recovers_concatenated_records_from_legacy_ledger() {
+        let tmp = TempDir::new().unwrap();
+        // Write two real, valid records through the normal (now-atomic) path.
+        let tracker = CostTracker::new(enabled_config(), tmp.path()).unwrap();
+        tracker
+            .record_usage(TokenUsage::new("test/model", 1000, 500, 0, 1.0, 2.0, 0.0))
+            .unwrap();
+        tracker
+            .record_usage(TokenUsage::new("test/model", 2000, 800, 0, 1.0, 2.0, 0.0))
+            .unwrap();
+
+        // Simulate the legacy interleaved-write artifact: collapse the two
+        // newline-separated records into one concatenated `{..}{..}` line.
+        let path = resolve_storage_path(tmp.path()).unwrap();
+        let joined: String = std::fs::read_to_string(&path)
+            .unwrap()
+            .lines()
+            .collect::<Vec<_>>()
+            .join("");
+        std::fs::write(&path, format!("{joined}\n")).unwrap();
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap().lines().count(),
+            1,
+            "ledger should now be a single concatenated line"
+        );
+
+        // A fresh storage over the corrupted ledger still recovers both records.
+        let storage = CostStorage::new(&path).unwrap();
+        let mut count = 0usize;
+        storage.for_each_record(|_| count += 1).unwrap();
+        assert_eq!(count, 2, "both concatenated records should be recovered");
     }
 
     #[test]

--- a/crates/zeroclaw-config/src/cost/tracker.rs
+++ b/crates/zeroclaw-config/src/cost/tracker.rs
@@ -582,12 +582,13 @@ impl CostStorage {
                                 module_path!(),
                                 ::zeroclaw_log::Action::Note
                             )
-                            .with_outcome(::zeroclaw_log::EventOutcome::Unknown),
-                            &format!(
-                                "Skipping malformed cost record at {}:{}: {error}",
-                                self.path.display().to_string(),
-                                line_number + 1
-                            )
+                            .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                            .with_attrs(::serde_json::json!({
+                                "path": self.path.display().to_string(),
+                                "line": line_number + 1,
+                                "error": error.to_string(),
+                            })),
+                            "skipping malformed cost record"
                         );
                     }
                 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** First split-out from #8380 (per @Audacity88's triage note — review the ledger fix on its own base). The cost ledger could **interleave records under concurrent appenders**: `writeln!` can lower to two `write` syscalls (body, then newline), so two appenders produce concatenated JSON like `{..}{..}` on one line — which the reader then dropped as malformed, losing cost data. This fixes both ends:
  - **Atomic append:** build the full `record + "\n"` and emit it with a single `write_all` on the `O_APPEND` fd, so each record's bytes stay contiguous (one record per line).
  - **Recovery:** on load, when a line fails to parse, stream multiple records out of it (`serde_json::Deserializer::into_iter`) so **legacy ledgers already corrupted with concatenated records still aggregate fully**.
- **Scope boundary:** Ledger correctness **only** — no pricing catalog, no `cost/org`/`cost/query` RPC, no zerocode Cost-tab UI. Those follow as separate PRs stacked on this base, per the split.
- **Blast radius:** `crates/zeroclaw-config/src/cost/tracker.rs` only (`CostStorage`). One file.
- **Linked issue(s):** Split out of #8380; `Supersedes #8380` in part. Carried forward from #8380's cost work (ledger portion).
- **Labels:** `bug`, `config`, `risk:medium`, `size:S`.

## Validation Evidence (required)

arm64 build host, toolchain 1.93.0:

```
$ cargo +1.93.0 build -p zeroclaw-config
    Finished `dev` profile target(s)

$ cargo +1.93.0 test -p zeroclaw-config --lib
test cost::tracker::tests::recovers_concatenated_records_from_legacy_ledger ... ok
test result: ok. 983 passed; 0 failed

$ cargo +1.93.0 fmt -p zeroclaw-config -- --check     # clean
$ cargo +1.93.0 clippy -p zeroclaw-config --all-targets -- -D warnings   # no warnings
```

- **Regression test added:** `recovers_concatenated_records_from_legacy_ledger` writes two real records through the (now-atomic) path, collapses them into one concatenated `{..}{..}` line to reproduce the legacy artifact, then asserts `for_each_record` recovers **both** — fails on old behavior (record dropped), passes on new.

## Security & Privacy Impact (required)

- New permissions / capabilities / fs scope? **No** (same ledger path/flags).
- New external network calls? **No.**
- Secrets/credentials handling changed? **No.**
- PII in diff/tests/fixtures? **No.**

## Compatibility (required)

- Backward compatible? **Yes** — recovery is purely additive; existing well-formed ledgers are unaffected, and previously-dropped concatenated records now aggregate.
- Config / env / CLI surface changed? **No.**

## Rollback

Low-risk: `git revert <sha>`.
