### PR TITLE
docs(labels): document retained scoped labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -286,11 +286,49 @@
           - "src/security/**"
           - "crates/zeroclaw-runtime/src/security/**"
 
+"security:bubblewrap":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/zeroclaw-runtime/src/security/bubblewrap.rs"
+
+"security:docker":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/zeroclaw-runtime/src/security/docker.rs"
+
+"security:pairing":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/zeroclaw-runtime/src/security/pairing.rs"
+          - "crates/zeroclaw-gateway/src/api_pairing.rs"
+          - "apps/tauri/src/commands/pairing.rs"
+          - "web/src/pages/Pairing.tsx"
+
+"security:policy":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/zeroclaw-runtime/src/security/policy.rs"
+          - "crates/zeroclaw-runtime/src/security/iam_policy.rs"
+          - "crates/zeroclaw-config/src/policy.rs"
+
+"security:secrets":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/zeroclaw-runtime/src/security/secrets.rs"
+          - "crates/zeroclaw-config/src/secrets.rs"
+
 "runtime":
   - changed-files:
       - any-glob-to-any-file:
           - "src/runtime/**"
           - "crates/zeroclaw-runtime/src/**"
+
+"runtime:wasm":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/zeroclaw-runtime/src/platform/wasm.rs"
+          - "crates/zeroclaw-plugins/src/wasm_tool.rs"
+          - "crates/zeroclaw-plugins/src/wasm_channel.rs"
 
 "quickstart":
   - changed-files:
@@ -382,6 +420,11 @@
           - "src/providers/openrouter.rs"
           - "crates/zeroclaw-providers/src/openrouter.rs"
 
+"provider:reliable":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/zeroclaw-providers/src/reliable.rs"
+
 "provider:telnyx":
   - changed-files:
       - any-glob-to-any-file:
@@ -468,6 +511,12 @@
       - any-glob-to-any-file:
           - "src/tools/google_workspace.rs"
           - "crates/zeroclaw-tools/src/google_workspace.rs"
+
+"tool:pushover":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/tools/pushover.rs"
+          - "crates/zeroclaw-tools/src/pushover.rs"
 
 "tool:mcp":
   - changed-files:
@@ -562,6 +611,11 @@
       - any-glob-to-any-file:
           - "src/observability/**"
           - "crates/zeroclaw-runtime/src/observability/**"
+
+"observability:prometheus":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/zeroclaw-runtime/src/observability/prometheus.rs"
 
 "tests":
   - changed-files:

--- a/docs/book/src/maintainers/labels.md
+++ b/docs/book/src/maintainers/labels.md
@@ -113,6 +113,20 @@ Applied automatically by `pr-path-labeler.yml`. Globs live in `.github/labeler.y
 
 `ci` is scoped to GitHub automation/config files, not all `.github/**` paths. The root `.github/*.json` matcher is intentional for automation metadata (for example `.github/label-policy.json`), so files like `.github/assets/**`, `.github/ISSUE_TEMPLATE/**`, `.github/CODEOWNERS`, and `.github/pull_request_template.md` do not match `ci`.
 
+### Additional component labels
+
+Some base scopes have narrower path-owned labels for maintainer routing. These labels are synchronized by `.github/labeler.yml` when the PR diff touches the listed files.
+
+| Label | Matches |
+|---|---|
+| `observability:prometheus` | `prometheus.rs` |
+| `runtime:wasm` | runtime WASM platform and first-party WASM plugin host files |
+| `security:bubblewrap` | `bubblewrap.rs` |
+| `security:docker` | `docker.rs` |
+| `security:pairing` | pairing security, gateway pairing API, Tauri pairing command, and web pairing page |
+| `security:policy` | runtime security policy, IAM policy, and config policy files |
+| `security:secrets` | runtime and config secrets handling |
+
 ### Per-channel labels
 
 Each channel gets a `channel:<name>` label in addition to the base `channel` label when the change touches channel crate paths. Cross-surface channel labels such as `channel:acp` may instead pair with the matching base surface label, such as `gateway`, `docs`, or app/web scope labels.
@@ -169,7 +183,10 @@ to one provider.
 | `provider:ollama` | `ollama.rs` |
 | `provider:openai` | `openai.rs`, `openai_codex.rs` |
 | `provider:openrouter` | `openrouter.rs` |
+| `provider:reliable` | `reliable.rs` |
 | `provider:telnyx` | `telnyx.rs` |
+
+Some provider labels describe provider families that currently share the OpenAI-compatible provider implementation instead of a dedicated source file. Maintainers may apply these manually when an issue or PR is truly about that family: `provider:groq`, `provider:kimi`, `provider:minimax`, `provider:moonshot`, and `provider:qwen`. Do not add shared factory or compatible-provider files to these labeler rules; that would over-label unrelated shared changes.
 
 ### Per-tool-group labels
 
@@ -186,6 +203,7 @@ Tools are grouped by logical function rather than one label per file.
 | `tool:mcp` | `mcp_client.rs`, `mcp_deferred.rs`, `mcp_protocol.rs`, `mcp_tool.rs`, `mcp_transport.rs` |
 | `tool:memory` | `memory_forget.rs`, `memory_recall.rs`, `memory_store.rs` |
 | `tool:microsoft365` | `microsoft365/**` |
+| `tool:pushover` | `pushover.rs` |
 | `tool:security` | `src/tools/security_ops.rs`, `src/tools/verifiable_intent.rs`, `crates/zeroclaw-runtime/src/tools/security_ops.rs`, `crates/zeroclaw-runtime/src/tools/verifiable_intent.rs` |
 | `tool:shell` | `src/tools/shell.rs`, `src/tools/node_tool.rs`, `src/tools/cli_discovery.rs`, `crates/zeroclaw-runtime/src/tools/shell.rs`, `crates/zeroclaw-gateway/src/node_tool.rs`, `crates/zeroclaw-tools/src/cli_discovery.rs` |
 | `tool:sop` | `src/tools/sop_advance.rs`, `src/tools/sop_approve.rs`, `src/tools/sop_execute.rs`, `src/tools/sop_list.rs`, `src/tools/sop_status.rs`, `crates/zeroclaw-runtime/src/tools/sop_advance.rs`, `crates/zeroclaw-runtime/src/tools/sop_approve.rs`, `crates/zeroclaw-runtime/src/tools/sop_execute.rs`, `crates/zeroclaw-runtime/src/tools/sop_list.rs`, `crates/zeroclaw-runtime/src/tools/sop_status.rs` |


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Adds path-labeler ownership for retained scoped labels with stable file ownership: `observability:prometheus`, `provider:reliable`, `runtime:wasm`, `security:bubblewrap`, `security:docker`, `security:pairing`, `security:policy`, `security:secrets`, and `tool:pushover`.
  - Updates the maintainer label guide so those retained labels are documented as synchronized path labels.
  - Documents manual provider-family labels for OpenAI-compatible families that share implementation files, without adding noisy shared-file automation for them.
- **Scope boundary:** This PR does not create, delete, rename, or migrate live GitHub labels. It does not add automation for other remaining label-cleanup families tracked in #6808.
- **Blast radius:** PR label-routing metadata only. After merge, `pr-path-labeler.yml` can add or remove the newly documented path labels on future PR updates when matching files are touched.
- **Linked issue(s):** Related #6808
- **Labels:** `ci`, `docs`, `risk:low`, `size:XS`, `type:docs`

## Validation Evidence (required)

- **Commands run and tail output:**

```bash
ruby -ryaml -e 'YAML.load_file(".github/labeler.yml"); puts "labeler yaml ok"'
# labeler yaml ok

ruby -ryaml -e 'labels = YAML.load_file(".github/labeler.yml"); names = %w[observability:prometheus provider:reliable runtime:wasm security:bubblewrap security:docker security:pairing security:policy security:secrets tool:pushover]; missing = names.flat_map { |name| Array(labels.fetch(name)).flat_map { |rule| Array(rule.fetch("changed-files")).flat_map { |changed| Array(changed.fetch("any-glob-to-any-file")) } }.map { |path| [name, path] } }.reject { |_, path| File.exist?(path) }; abort missing.map { |name, path| "missing #{name}: #{path}" }.join("\n") unless missing.empty?; puts "all retained literal paths exist"'
# all retained literal paths exist

gh label list --repo zeroclaw-labs/zeroclaw --limit 1000 --json name --jq '.[] | .name' | grep -E '^(observability:prometheus|provider:reliable|runtime:wasm|security:bubblewrap|security:docker|security:pairing|security:policy|security:secrets|tool:pushover)$' | sort
# observability:prometheus
# provider:reliable
# runtime:wasm
# security:bubblewrap
# security:docker
# security:pairing
# security:policy
# security:secrets
# tool:pushover

git diff --check
# no output

DOCS_FILES=docs/book/src/maintainers/labels.md scripts/ci/docs_quality_gate.sh
# No prose em-dashes in changed docs files.
# Linting docs files: docs/book/src/maintainers/labels.md
# Summary: 0 error(s)

scripts/ci/docs_links_gate.sh
# No docs files available for link collection.
# No added links detected in changed docs lines.

scripts/check-pr-title.sh "docs(labels): document retained scoped labels"
# no output
```

- **Beyond CI — what did you manually verify?** Verified the retained label set is intentionally limited to labels with stable path ownership, and that other remaining label-cleanup families tracked in #6808 stay out of synchronized path-label automation.
- **If any command was intentionally skipped, why:** Rust build/test commands were skipped because this is a docs and labeler-config-only change with no Rust code path changes.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: None.

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: No user upgrade steps. The PR only changes maintainer label metadata and path-labeler coverage.

## Rollback (required for medium/high-risk PRs)

Low-risk PRs: `git revert <sha>` is the plan unless otherwise noted.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): None.
- Scope materially carried forward: None.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`No`)
- If `No`, why (inspiration-only, no direct code/design carry-over): No superseded contributor work is incorporated.
