### PR TITLE
chore(channel-matrix): upgrade Matrix Rust SDK to 0.18.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5661,9 +5661,9 @@ dependencies = [
 
 [[package]]
 name = "matrix-sdk"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bd53c36a55668a96eed57633a1347046271a9f9ce542a07f30e6a840e26f31f"
+checksum = "7083d580527511ac5d9369e03b9f2b20902e76949f1b3964051f978e4d3756ae"
 dependencies = [
  "anymap2",
  "aquamarine",
@@ -5722,9 +5722,9 @@ dependencies = [
 
 [[package]]
 name = "matrix-sdk-base"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a70b7aacc8429de35940f73ac1cff9679a764205f7c51d4e8f236b538442d79"
+checksum = "e09a917eb1f7643d9d9a06b2f131e2ceb39df6910a7b830dac18bfd6db37a1f5"
 dependencies = [
  "as_variant",
  "async-trait",
@@ -5749,9 +5749,9 @@ dependencies = [
 
 [[package]]
 name = "matrix-sdk-common"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697b45015c5b7128027fee8adf9f9f32a75a97ba8326bb9c7265fb90bcf2d766"
+checksum = "2b9d1e0fee0f090180ef9457034adc547e80de9e6e3eb2e63aaac68a8476f836"
 dependencies = [
  "eyeball-im",
  "futures-core",
@@ -5773,9 +5773,9 @@ dependencies = [
 
 [[package]]
 name = "matrix-sdk-crypto"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "948582d5461fa4066117e0a08828df16c3041d5f0c17aca679041fed30b4284a"
+checksum = "c54afd2a326f51c13a6ad44ec86315a688fffeb3f1e287fb343e0e1836a3bdaf"
 dependencies = [
  "aes 0.8.4",
  "aquamarine",
@@ -5814,9 +5814,9 @@ dependencies = [
 
 [[package]]
 name = "matrix-sdk-indexeddb"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6484e88308cfdf6deff13122a6b927c03936ec262d0fbb03bac7a0c73ae95c89"
+checksum = "fef37395fffb7c916f7109ab0d16d8ca599403dd8164d08c0d966176b66ede47"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5846,9 +5846,9 @@ dependencies = [
 
 [[package]]
 name = "matrix-sdk-sqlite"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d797f59498ea3db5341742fcf3765e3cf7418f6ddf667526b5ed12cb4aba6dc"
+checksum = "a49133429271005745f8d5a05362d2ba6567274777250236799927ca30dc0670"
 dependencies = [
  "as_variant",
  "async-trait",
@@ -5874,9 +5874,9 @@ dependencies = [
 
 [[package]]
 name = "matrix-sdk-store-encryption"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1728926a2bcdd33329c87c0da9d832d8eb610ecd4676ca5d38c108fab91b0102"
+checksum = "2f48f304e553fb6200b1d7d1f77a88fd182076d4b25624e9dbfa42d6a37de35e"
 dependencies = [
  "base64 0.22.1",
  "blake3",
@@ -8399,9 +8399,9 @@ dependencies = [
 
 [[package]]
 name = "ruma"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e420da038fd6529af5abffe21df50ba122e1b4a84db05c02ec05b5ab0a21a320"
+checksum = "ee4fe5bfacdb0e95e733da3b6c37d98edf46447a4a8e8dea824e0da266d8ad59"
 dependencies = [
  "assign",
  "js_int",
@@ -8415,9 +8415,9 @@ dependencies = [
 
 [[package]]
 name = "ruma-client-api"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a793e13cc9c354385e4f635b5eca581abe76169a9fafd8c530918f9b19f8d63"
+checksum = "bf7ca43a888ca569168d7e3901f4dd14a777b860bb19f4c08e35414162eb261c"
 dependencies = [
  "as_variant",
  "assign",
@@ -8438,9 +8438,9 @@ dependencies = [
 
 [[package]]
 name = "ruma-common"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b69b11cb6ccf0e27c3c44c50e2e4799337921c66d4e6a490c084f18c5b4481ec"
+checksum = "2c3b4f00112791b490acce57df1ce3eb3f88899b045bebcff8a29f75369640cc"
 dependencies = [
  "as_variant",
  "base64 0.22.1",
@@ -8472,9 +8472,9 @@ dependencies = [
 
 [[package]]
 name = "ruma-events"
-version = "0.33.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96e3c39ab1b692086d02513fe0c24400d864060880bbd2716cb5544f5923131"
+checksum = "85d2f90830fc131691349b96a69ff53444eb6c3e8dc7869c77961b43cfaf3344"
 dependencies = [
  "as_variant",
  "indexmap 2.14.0",
@@ -8494,9 +8494,9 @@ dependencies = [
 
 [[package]]
 name = "ruma-html"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1d81a7300e8623dbf5e6d73e700f0277fce6824849d77779ed997ec4e280b97"
+checksum = "48d33a944650f4bbd2188dd204d39dd87a9a1498f14b3a13252910c90ed7cd43"
 dependencies = [
  "as_variant",
  "html5ever 0.39.0",
@@ -8516,9 +8516,9 @@ dependencies = [
 
 [[package]]
 name = "ruma-macros"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac022103cd7829721476d3df79d16125be159e99527c8ddb27f125e7b674e5c"
+checksum = "c8cfb39eaa9b9fd389126ff941e060b496add5cbbfef559d80c46e571dda459c"
 dependencies = [
  "as_variant",
  "cfg-if",

--- a/crates/zeroclaw-channels/Cargo.toml
+++ b/crates/zeroclaw-channels/Cargo.toml
@@ -63,7 +63,7 @@ lettre = { version = "0.11.22", default-features = false, features = [
 ], optional = true }
 pulldown-cmark = { version = "0.13", optional = true }
 mail-parser = { version = "0.11.2", optional = true }
-matrix-sdk = { version = "0.17", optional = true, default-features = false, features = [
+matrix-sdk = { version = "0.18", optional = true, default-features = false, features = [
   "e2e-encryption",
   "markdown",
   "sqlite",


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Bumps the pinned `matrix-sdk` dependency in `zeroclaw-channels` from `0.17` to `0.18.0` and re-resolves `Cargo.lock`.
  - This pulls the upstream fix for the `Arc<ClientInner>` reference cycle that leaked ~1 MB Pss per `/admin/reload` (tracked in #6651, filed upstream as matrix-rust-sdk#6573). The 0.18.0 release notes call it out directly: "A cyclic reference of `Client` has been detected in `ThreadSubscriptionCatchup`, preventing `Client` to drop correctly. This is now fixed, removing a memory leak about `Client`." (matrix-rust-sdk#6594).
  - Pulls Ruma 0.16.0 (ruma-client-api 0.24, ruma-common 0.19, ruma-events 0.34, ruma-html 0.8, ruma-macros 0.19) and the matching matrix-sdk-base/common/crypto/sqlite/store-encryption 0.18 crates.
- **Scope boundary:** Dependency version bump plus the lockfile re-resolution it requires. No Matrix channel source changes. No behavior change beyond the upstream leak fix.
- **Blast radius:** The `channel-matrix` feature and its transitive Ruma graph. Other crates are unaffected; the lock delta is confined to the matrix-sdk/ruma subtree (52 lines, all version bumps).
- **Linked issue(s):** Fixes #6651
- **Upstream:** matrix-rust-sdk#6573 (reported the Arc cycle) was fixed by matrix-rust-sdk#6594, which ships in matrix-sdk 0.18.0. Issue: https://github.com/matrix-org/matrix-rust-sdk/issues/6573 — Fix: https://github.com/matrix-org/matrix-rust-sdk/pull/6594
- **Labels:** bug, dependencies, channel, channel:matrix, risk:medium, size:S

## Validation Evidence (required)

Run in a clean clone of `master` with the bump applied, full address space (the standard battery for the matrix feature).

`cargo update -p matrix-sdk --precise 0.18.0`:

```
    Updating matrix-sdk v0.17.0 -> v0.18.0
    Updating matrix-sdk-base v0.17.0 -> v0.18.0
    Updating matrix-sdk-common v0.17.0 -> v0.18.0
    Updating matrix-sdk-crypto v0.17.0 -> v0.18.0
    Updating matrix-sdk-indexeddb v0.17.0 -> v0.18.0
    Updating matrix-sdk-sqlite v0.17.0 -> v0.18.0
    Updating matrix-sdk-store-encryption v0.17.0 -> v0.18.0
    Updating ruma v0.15.1 -> v0.16.0
    Updating ruma-client-api v0.23.1 -> v0.24.0
    Updating ruma-common v0.18.0 -> v0.19.0
    Updating ruma-events v0.33.0 -> v0.34.0
    Updating ruma-html v0.7.0 -> v0.8.0
    Updating ruma-macros v0.18.0 -> v0.19.0
```

`cargo check -p zeroclaw-channels --features channel-matrix`:

```
    Checking ruma v0.16.0
    Checking matrix-sdk-crypto v0.18.0
    Checking matrix-sdk-base v0.18.0
    Checking matrix-sdk-sqlite v0.18.0
    Checking zeroclaw-channels v0.8.2 (/tmp/mtx-lock/crates/zeroclaw-channels)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 06s
```

`cargo fmt --all -- --check`: exit 0, no diff.

`cargo clippy -p zeroclaw-channels --features channel-matrix -- -D warnings`:

```
    Checking zeroclaw-channels v0.8.2 (/tmp/mtx-lock/crates/zeroclaw-channels)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 03s
```

- **Commands run and tail output:** above. Clean compile, no warnings, fmt clean.
- **Beyond CI — what did you manually verify?** Checked the 0.18.0 breaking changes against the Matrix channel source. The two breaking items (`RumaApiError` becoming a `UiaaResponse` alias with renamed `MatrixError`/`AuthResponse` variants, and `Pusher::set` gaining an `append: bool`) are on no path the channel uses, which is why no source change was required and the channel compiles unmodified. Did NOT run a live long-haul reload-leak reproduction against a homeserver in this PR; the leak fix is upstream's (matrix-rust-sdk#6594) and is what #6651 was blocked on.
- **If any command was intentionally skipped, why:** none skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: N/A.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: no upgrade steps for users. The matrix-sdk on-disk store format is compatible across this point bump; existing crypto/state stores load unchanged.

## Rollback (required for medium/high-risk PRs)

Low-risk. `git revert <sha>` restores the 0.17 pin and prior lock.
