### PR TITLE
chore(web): allow ZEROCLAW_GATEWAY_HOST env override in vite dev server

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -3,8 +3,9 @@ import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import path from "path";
 
+const gatewayHost = process.env.ZEROCLAW_GATEWAY_HOST ?? "127.0.0.1";
 const gatewayPort = process.env.ZEROCLAW_GATEWAY_PORT ?? "42617";
-const gatewayTarget = `http://127.0.0.1:${gatewayPort}`;
+const gatewayTarget = `http://${gatewayHost}:${gatewayPort}`;
 
 // Extra Host header values the dev server will accept, comma-separated, e.g.
 // ZEROCLAW_WEB_ALLOWED_HOSTS=my-box.internal,dev.example.com. Unset → Vite default.


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - The Vite dev server proxy target (`gatewayTarget`) was hardcoded to `127.0.0.1`, making it impossible to run the web dev server on a different machine from the gateway — for example, when developing over SSH from a laptop to a remote dev box, or running the gateway in a Docker container on a separate host.
  - This PR adds a `ZEROCLAW_GATEWAY_HOST` environment variable (defaults to `127.0.0.1` when unset) so operators can point the dev server at a different host without editing source code.
- **Scope boundary:** `web/vite.config.ts` only. No other files changed.
- **Blast radius:** None. Backward-compatible — the default value (`127.0.0.1`) is unchanged. Operators who do not set the env var see identical behavior.
- **Linked issue(s):** None.
- **Labels:** `area:web`, `risk:low`, `size:XS`, `type:chore`

## Validation Evidence (required)

```bash
# Default behavior unchanged — proxy target resolves to 127.0.0.1
$ ZEROCLAW_GATEWAY_PORT=42617 node -e "
  const host = process.env.ZEROCLAW_GATEWAY_HOST ?? \"127.0.0.1\";
  const port = process.env.ZEROCLAW_GATEWAY_PORT ?? \"42617\";
  console.log(\`http://\${host}:\${port}\`);
"
http://127.0.0.1:42617

# With override — proxy target resolves to the custom host
$ ZEROCLAW_GATEWAY_HOST=dev-box.internal ZEROCLAW_GATEWAY_PORT=42617 node -e "
  const host = process.env.ZEROCLAW_GATEWAY_HOST ?? \"127.0.0.1\";
  const port = process.env.ZEROCLAW_GATEWAY_PORT ?? \"42617\";
  console.log(\`http://\${host}:\${port}\`);
"
http://dev-box.internal:42617
```

- **Commands run and tail output:** `npm run dev` starts successfully with and without `ZEROCLAW_GATEWAY_HOST` set.
- **Beyond CI — what did you manually verify?** The Vite dev server proxy forwards API requests to the configured host. Verified with `ZEROCLAW_GATEWAY_HOST` set to a remote dev box IP — API calls (config fetch, session list) reach the correct gateway instance.
- **If any command was intentionally skipped, why:** `cargo fmt/clippy/test` — this PR touches `web/` only, no Rust source changed.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No** (the dev server already makes outbound proxy requests to the configured gateway target — this PR just makes the target host configurable)
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility (required)

- Backward compatible? **Yes** — default value is `127.0.0.1`, identical to the previous hardcoded string.
- Config / env / CLI surface changed? **No** — new optional env var added, no existing surfaces modified.

## Rollback

Low-risk PR. `git revert <sha>` is the plan.