### PR TITLE
fix(channels): initialize persist locks in cache-stability tests

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -18788,6 +18788,7 @@ BTC is currently around $65,000 based on latest tool output."#
             show_receipts_in_response: false,
             last_applied_config_stamp: Arc::new(Mutex::new(None)),
             runtime_defaults_override: Arc::new(Mutex::new(None)),
+            persist_locks: Arc::new(std::sync::Mutex::new(HashMap::new())),
         })
     }
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Adds the missing `persist_locks` field to the cache-stability test helper's `ChannelRuntimeContext` initializer.
  - Restores the `zeroclaw-channels` test build after the #7847 / #8174 same-file merge interaction left one test context on the older struct shape.
  - Matches the existing empty-lock-map initialization used by the other test contexts in `orchestrator/mod.rs`.
- **Scope boundary:** This PR only updates a test helper initializer. It does not change production channel runtime behavior, persistence locking semantics, prompt construction, or session storage.
- **Blast radius:** Limited to compiling and running `zeroclaw-channels` tests that construct this helper context.
- **Linked issue(s):** Related #7847, #8174, and #8403. This does not close a tracking issue.
- **Labels:** `bug`, `channel`, `risk:low`, `size:XS`

## Validation Evidence (required)

- **Commands run and tail output:**

```bash
git diff --check
```

Result: passed with no output.

GitHub Actions Quality Gate passed at head `f667f8aff4f87c2d0a7e961dc379bb8e2aa85a41`, including `Lint`, `Test`, `Build x86_64-unknown-linux-gnu`, and `CI Required Gate`.

- **Beyond CI — what did you manually verify?** I matched the master Quality Gate failure to the missing `persist_locks` field in this test helper, confirmed the surrounding `ChannelRuntimeContext` test initializers already use `Arc::new(std::sync::Mutex::new(HashMap::new()))`, and kept the patch to the single missing initializer.
- **If any command was intentionally skipped, why:** Local focused cargo validation was not completed because GitHub Actions had already covered the failing `Lint` and `Test` compile surfaces for this test-helper-only fix.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: N/A

## Rollback (required for medium/high-risk PRs)

Low-risk PRs: `git revert <sha>` is the plan unless otherwise noted.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Scope materially carried forward: N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`No`)
- If `No`, why (inspiration-only, no direct code/design carry-over): N/A
