### PR TITLE
fix(docs): silence mdbook placeholder warnings

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/history.rs
+++ b/crates/zeroclaw-runtime/src/agent/history.rs
@@ -249,7 +249,7 @@ fn is_path_listing_tool(tool_name: &str) -> bool {
 
 /// Provenance-aware wrapper around [`canonicalize_tool_result_media_markers`].
 ///
-/// Returns the output unchanged for path-listing tools ([`is_path_listing_tool`])
+/// Returns the output unchanged for path-listing tools (`is_path_listing_tool`)
 /// so their incidental image paths never become routable `[IMAGE:...]` markers;
 /// all other tools are canonicalized exactly as before.
 pub fn canonicalize_tool_result_media_markers_for(tool_name: &str, output: &str) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6625,8 +6625,9 @@ fn is_cli_placeholder_name(name: &str) -> bool {
 #[must_use]
 fn is_common_html_tag(name: &str) -> bool {
     const COMMON_HTML_TAGS: &[&str] = &[
-        "a", "abbr", "br", "code", "details", "div", "em", "img", "kbd", "li", "ol", "p", "samp",
-        "span", "strong", "summary", "table", "tbody", "td", "th", "thead", "tr", "ul", "var",
+        "a", "abbr", "br", "code", "details", "div", "em", "i", "img", "kbd", "li", "ol", "p",
+        "samp", "small", "span", "strong", "summary", "table", "tbody", "td", "th", "thead", "tr",
+        "ul", "var",
     ];
 
     let normalized = name.to_ascii_lowercase();
@@ -7930,11 +7931,11 @@ mod tests {
 
     #[test]
     fn markdown_help_does_not_escape_common_html_or_autolinks() {
-        let markdown = "Use <br> for HTML, see <https://example.com>, then pass <arg-name>.\n";
+        let markdown = "Use <br> and <small><i>HTML</i></small>, see <https://example.com>, then pass <arg-name>.\n";
 
         assert_eq!(
             escape_mdbook_placeholder_tags(markdown),
-            "Use <br> for HTML, see <https://example.com>, then pass `<arg-name>`.\n"
+            "Use <br> and <small><i>HTML</i></small>, see <https://example.com>, then pass `<arg-name>`.\n"
         );
     }
 

--- a/xtask/src/cmd/mdbook/peer_groups.rs
+++ b/xtask/src/cmd/mdbook/peer_groups.rs
@@ -262,19 +262,20 @@ fn render_secret_config(path: &str) -> String {
     // Dashboard deep-link path: dotted prefix minus `<alias>` and the field,
     // slash-joined (`channels.matrix.<alias>.password` -> `channels/matrix`).
     let section = dashboard_section(path);
+    let display_path = display_config_path(path);
     format!(
-        r#"> **`{path}` is a secret.** Stored encrypted, never in plain
+        r#"> **`{display_path}` is a secret.** Stored encrypted, never in plain
 > `config.toml`. Set it through one of these, which encrypt on write:
 
 <div class="os-tabs-src">
 
 #### Gateway dashboard
 
-Open [`/config/{section}`](http://127.0.0.1:42617/config/{section}) and set the `{path}` field there.
+Open [`/config/{section}`](http://127.0.0.1:42617/config/{section}) and set the `{display_path}` field there.
 
 #### zerocode
 
-In the **Config** pane, set the `{path}` field (input is masked).
+In the **Config** pane, set the `{display_path}` field (input is masked).
 
 #### zeroclaw config
 
@@ -352,6 +353,7 @@ fn render_thread_context(arg: &str) -> anyhow::Result<String> {
     let configure = match path {
         Some(p) => {
             let section = dashboard_section(p);
+            let display_path = display_config_path(p);
             format!(
                 r#"
 
@@ -361,11 +363,11 @@ Set the thread behavior on any surface:
 
 #### Gateway dashboard
 
-Open [`/config/{section}`](http://127.0.0.1:42617/config/{section}) and toggle the `{p}` field.
+Open [`/config/{section}`](http://127.0.0.1:42617/config/{section}) and toggle the `{display_path}` field.
 
 #### zerocode
 
-In the **Config** pane, set the `{p}` field.
+In the **Config** pane, set the `{display_path}` field.
 
 #### zeroclaw config
 
@@ -447,6 +449,7 @@ fn render_streaming(arg: &str) -> anyhow::Result<String> {
     let configure = match (path, mode) {
         (Some(p), m) if m == STREAM_MODE || m == STREAM_DRAFTS => {
             let section = dashboard_section(p);
+            let display_path = display_config_path(p);
             format!(
                 r#"
 
@@ -456,11 +459,11 @@ Set it on any surface:
 
 #### Gateway dashboard
 
-Open [`/config/{section}`](http://127.0.0.1:42617/config/{section}) and set the `{p}` field.
+Open [`/config/{section}`](http://127.0.0.1:42617/config/{section}) and set the `{display_path}` field.
 
 #### zerocode
 
-In the **Config** pane, set the `{p}` field.
+In the **Config** pane, set the `{display_path}` field.
 
 #### zeroclaw config
 
@@ -528,6 +531,10 @@ fn parse_kv_args(arg: &str) -> std::collections::HashMap<String, String> {
         map.insert(key, value);
     }
     map
+}
+
+fn display_config_path(path: &str) -> String {
+    path.replace('<', "&lt;").replace('>', "&gt;")
 }
 
 fn render_example(p: &PeerParams) -> String {
@@ -974,6 +981,38 @@ mod generated_prose_gate {
             }
         }
         false
+    }
+
+    #[test]
+    fn secret_config_escapes_alias_placeholder_in_rendered_markdown() {
+        let rendered = super::render_secret_config("channels.discord.<alias>.bot_token");
+
+        assert!(rendered.contains("`channels.discord.&lt;alias&gt;.bot_token`"));
+        assert!(rendered.contains("zeroclaw config set channels.discord.<alias>.bot_token"));
+        assert!(!rendered.contains("`channels.discord.<alias>.bot_token`"));
+    }
+
+    #[test]
+    fn config_explainers_escape_alias_placeholder_in_rendered_markdown() {
+        let thread = super::render_thread_context(
+            r#"channel="Matrix" prop="reply_in_thread" path="channels.matrix.<alias>.reply_in_thread""#,
+        )
+        .expect("thread context should render");
+        let streaming = super::render_streaming(
+            r#"channel="Slack" mode="stream_drafts" path="channels.slack.<alias>.stream_drafts""#,
+        )
+        .expect("streaming context should render");
+
+        assert!(thread.contains("`channels.matrix.&lt;alias&gt;.reply_in_thread`"));
+        assert!(
+            thread.contains("zeroclaw config set channels.matrix.<alias>.reply_in_thread true")
+        );
+        assert!(!thread.contains("`channels.matrix.<alias>.reply_in_thread`"));
+        assert!(streaming.contains("`channels.slack.&lt;alias&gt;.stream_drafts`"));
+        assert!(
+            streaming.contains("zeroclaw config set channels.slack.<alias>.stream_drafts <value>")
+        );
+        assert!(!streaming.contains("`channels.slack.<alias>.stream_drafts`"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Escapes generated `<alias>` config paths in mdBook prose so placeholder-looking paths do not become HTML warnings.
  - Keeps raw `zeroclaw config set ... <alias> ...` command examples copyable.
  - Preserves real `<small><i>...</i></small>` HTML in generated CLI reference markdown so `reference/cli.md` no longer emits unmatched closing-tag warnings.
  - Renders a private rustdoc helper name as code instead of an intra-doc link.
- **Scope boundary:** This does not change config schema, channel behavior, or the existing mdbook-mermaid version mismatch warning.
- **Blast radius:** Docs/reference generation output and rustdoc comments only.
- **Linked issue(s):** Related #7269
- **Labels:** `bug`, `core`, `agent`, `runtime`, `risk:low`, `size:XS`

## Validation Evidence (required)

- **Commands run and tail output:**

```text
zc-cargo fmt --all
result: passed

zc-cargo test -p xtask alias_placeholder
result: passed; 2 tests passed

zc-cargo test -p zeroclawlabs markdown_help_does_not_escape_common_html_or_autolinks
result: passed; targeted CLI markdown escaping test passed

zc-cargo mdbook build
result: passed; rustdoc generation completed, all locale books built, and internal link check passed
note: the existing mdbook-mermaid 0.5.0 vs mdbook 0.5.3 version warning still appears
```

- **Beyond CI — what did you manually verify?** The full docs build no longer emits the targeted rustdoc private-link warning, generated `<alias>` HTML warnings, or `</i>` / `</small>` closing-tag warnings.
- **If any command was intentionally skipped, why:** Full workspace clippy/test were not run because this is a low-risk docs-warning cleanup; focused tests plus the full docs build cover the changed behavior.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: None.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No upgrade steps required.

## Rollback (required for medium/high-risk PRs)

Low-risk PR. Revert this PR if needed.


