### PR TITLE
refactor(log): extract JSONL write pipeline into testable helper

### DIFF
--- a/crates/zeroclaw-log/src/lib.rs
+++ b/crates/zeroclaw-log/src/lib.rs
@@ -77,7 +77,9 @@ pub use observer_bridge::{clear_observer_bridge, set_observer_bridge};
 pub use reader::{LogFilter, LogPage, current_log_path, find_event_by_id, load_page};
 pub use subscriber::{install_global_subscriber, try_install_capture_subscriber};
 pub use tool_io::{ToolIoCapture, capture_llm_request, capture_tool_input, capture_tool_output};
-pub use writer::{init_from_config, llm_request_payload_policy, record_event, runtime_trace_path};
+pub use writer::{
+    flush_for_test, init_from_config, llm_request_payload_policy, record_event, runtime_trace_path,
+};
 
 mod r#macro;
 

--- a/crates/zeroclaw-log/src/writer.rs
+++ b/crates/zeroclaw-log/src/writer.rs
@@ -68,6 +68,21 @@ pub fn runtime_trace_path() -> Option<PathBuf> {
     current_state().map(|s| s.policy.path.clone())
 }
 
+/// Synchronously wait for all pending log writes to land on disk.
+///
+/// **Currently a no-op** — `record_event` is still synchronous, so any
+/// `record!` call has already hit disk + fsync by the time the macro returns.
+/// A follow-up PR will move disk persistence to a background worker; this
+/// function will then become a real round-trip signal so test code can
+/// keep asserting on the file's contents immediately after `record_event`.
+///
+/// Callers must be in the `zeroclaw-log` crate's own test module (or any
+/// other test code that re-exports this function). Not part of the
+/// production runtime API.
+pub fn flush_for_test() -> Result<()> {
+    Ok(())
+}
+
 /// Resolved LLM-request-payload capture policy + the truncate cap, for the
 /// turn engine's `announce_llm_request`. `None` when no writer is installed
 /// (the policy defaults to `off`, so callers treat "no writer" as "off").
@@ -124,6 +139,21 @@ pub fn record_event(event: LogEvent) {
     }
 }
 
+/// Serialize one event as a single JSONL line (terminated with `\n`) to the
+/// provided buffered writer. Pure helper: does not open, flush, or fsync the
+/// file — the caller owns the [`BufWriter`] lifecycle.
+///
+/// Used by the production append path (`append_line`). The rolling trim path
+/// (`trim_to_last_entries`) writes the original JSONL bytes from the
+/// line-buffered reader directly, so it stays inline rather than going
+/// through this helper (re-serializing would risk non-byte-identical output
+/// for non-canonical input, e.g. reordered keys or whitespace).
+fn write_jsonl_line<W: Write + ?Sized>(writer: &mut W, value: &Value) -> Result<()> {
+    serde_json::to_writer(&mut *writer, value).context("serializing log line")?;
+    writer.write_all(b"\n").context("writing newline")?;
+    Ok(())
+}
+
 fn append_line(state: &Arc<WriterState>, value: &Value) -> Result<()> {
     let _guard = state.write_lock.lock();
 
@@ -153,8 +183,7 @@ fn append_line(state: &Arc<WriterState>, value: &Value) -> Result<()> {
         .open(&state.policy.path)
         .with_context(|| format!("opening log file {}", state.policy.path.display()))?;
     let mut writer = BufWriter::new(file);
-    serde_json::to_writer(&mut writer, value).context("serializing log line")?;
-    writer.write_all(b"\n").context("writing newline")?;
+    write_jsonl_line(&mut writer, value)?;
     writer.flush().context("flushing log line")?;
     let file = writer
         .into_inner()


### PR DESCRIPTION
## Summary

- **What changed:** Extract a small helper that owns the JSONL serialize + trailing-newline step in `crates/zeroclaw-log/src/writer.rs`, and add a `flush_for_test()` test-only API that is a no-op today.
- **Behavior change:** None. Zero observable change for production callers (`record!` macro and `record_event()`). Disk output is byte-identical and the sync semantics are unchanged.
- **Why this PR is its own thing:** It's the foundation for the follow-up PR that moves JSONL fsync off the async hot path via a `spawn_blocking` worker. Splitting it lets reviewers focus on the durability tradeoff of PR 2 without mixing in refactor noise.

## What's in this PR

1. **`write_jsonl_line<W: Write + ?Sized>(writer: &mut W, value: &Value) -> Result<()>`** (new, private helper)
   - Owns the `serde_json::to_writer(...)` + `write_all(b"\n")` pair.
   - Caller still owns the `BufWriter` lifecycle — open, flush, and `sync_data` all remain at the call site.
   - The rolling trim path (`trim_to_last_entries`) stays inline because it writes the original JSONL bytes from the line-buffered reader (re-serializing would risk non-byte-identical output for non-canonical input, e.g. reordered keys or whitespace from external tools).

2. **`pub fn flush_for_test() -> Result<()>`** (new, test-only API, re-exported from `lib.rs`)
   - Currently returns `Ok(())` because `record_event` is still synchronous.
   - A follow-up PR (PR 2) will make disk persistence asynchronous via a background worker; this function will then become a real round-trip signal so existing tests that assert on the log file immediately after `record_event` continue to pass.

## What's NOT in this PR

- No `spawn_blocking` worker.
- No change to `record_event` body.
- No change to `init_from_config`, `migrate::migrate_legacy_jsonl_in_place`, or the `record!` macro.
- No external-caller changes — every `record!` call site across the workspace is untouched.

## Validation

```text
$ cargo fmt --all -- --check
(no output — clean)

$ cargo clippy --locked -p zeroclaw-log --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.28s
0 warnings.

$ cargo test --locked -p zeroclaw-log --lib
test result: ok. 72 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

$ cargo build --locked
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 6m 52s
```

Diff: `+34 / -3` across 2 files. No new dependencies, no behavior change for existing production callers, and no CHANGELOG entry needed (refactor with no user-visible behavior change).

## Risk

Minimal. Pure refactor — identical byte output on disk, identical sync semantics, identical test surface. The two existing writer tests (`append_and_rolling_keeps_only_max_entries`, `disabled_storage_does_not_write_file`) pass unchanged, which is the regression guard.

## Follow-up

PR 2 (planned after this merges) will:
- Add a `tokio::task::spawn_blocking` worker that drains a bounded `mpsc::channel(1024)` of serialized `serde_json::Value`s.
- Change `record_event` to `try_send` and drop the write on overflow with a `tracing::warn!`.
- Replace per-record `sync_data()` with periodic `sync_all()` (every 100 records or 1 second, configurable).
- Implement `flush_for_test()` as a real `oneshot` round-trip so existing tests continue to pass without modification.

The durability tradeoff (process crash may lose up to N pending writes) will be documented in PR 2 and called out in the CHANGELOG.
