### PR TITLE
feat(cron): add shell_output_format config for raw stdout output

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -24793,8 +24793,6 @@ This is an example JSON object for profile settings."#;
                 }],
                 subject: None,
                 internal_sop_event: None,
-                passive_context: false,
-                conversation_scope: zeroclaw_api::channel::ChannelConversationScope::Sender,
             },
             CancellationToken::new(),
         )

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -24793,6 +24793,8 @@ This is an example JSON object for profile settings."#;
                 }],
                 subject: None,
                 internal_sop_event: None,
+                passive_context: false,
+                conversation_scope: zeroclaw_api::channel::ChannelConversationScope::Sender,
             },
             CancellationToken::new(),
         )

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -12597,6 +12597,14 @@ pub struct CronJobDecl {
     #[serde(default)]
     #[nested]
     pub delivery: Option<DeliveryConfigDecl>,
+    /// Output format for shell jobs: `"wrapped"` (default) or `"raw"`.
+    ///
+    /// - `"wrapped"` (default): returns stdout and stderr wrapped in a
+    ///   `status=... / stdout: / stderr:` envelope.
+    /// - `"raw"`: returns trimmed stdout on success; failures still include
+    ///   status and error context.
+    #[serde(default)]
+    pub shell_output_format: CronShellOutputFormat,
 }
 
 impl Default for CronJobDecl {
@@ -12613,8 +12621,21 @@ impl Default for CronJobDecl {
             uses_memory: true,
             session_target: None,
             delivery: None,
+            shell_output_format: CronShellOutputFormat::default(),
         }
     }
+}
+
+/// Output format for shell cron job stdout.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, zeroclaw_macros::ConfigEnum)]
+#[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum CronShellOutputFormat {
+    /// Wrapped format: `status=...\nstdout:\n...\nstderr:\n...` (default).
+    #[default]
+    Wrapped,
+    /// Raw stdout on success; failure context on error.
+    Raw,
 }
 
 /// Schedule variant for declarative cron jobs.

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -12601,8 +12601,11 @@ pub struct CronJobDecl {
     ///
     /// - `"wrapped"` (default): returns stdout and stderr wrapped in a
     ///   `status=... / stdout: / stderr:` envelope.
-    /// - `"raw"`: returns trimmed stdout on success; failures still include
-    ///   status and error context.
+    /// - `"raw"`: returns trimmed stdout when the process exits zero. A
+    ///   non-zero process exit still gets the wrapped status/stdout/stderr
+    ///   envelope for diagnosis. Failures that never reach a process exit —
+    ///   a security-policy denial, a shell setup/spawn failure, or a
+    ///   timeout — return a plain error string in either format.
     #[serde(default)]
     pub shell_output_format: CronShellOutputFormat,
 }
@@ -12634,7 +12637,9 @@ pub enum CronShellOutputFormat {
     /// Wrapped format: `status=...\nstdout:\n...\nstderr:\n...` (default).
     #[default]
     Wrapped,
-    /// Raw stdout on success; failure context on error.
+    /// Raw stdout on a zero process exit; wrapped status/stdout/stderr on a
+    /// non-zero exit; a plain error string for failures that never reach a
+    /// process exit (security denial, spawn/setup failure, timeout).
     Raw,
 }
 

--- a/crates/zeroclaw-gateway/src/api.rs
+++ b/crates/zeroclaw-gateway/src/api.rs
@@ -127,6 +127,11 @@ pub struct CronAddBody {
     pub delete_after_run: Option<bool>,
     /// If false, disable memory recall for this agent cron job (default: true).
     pub uses_memory: Option<bool>,
+    /// Shell output format for shell-type cron jobs. `"wrapped"` (default) or
+    /// `"raw"`. Only meaningful when `job_type` is `"shell"` (or inferred as
+    /// shell when no prompt is given). Ignored for agent jobs.
+    #[serde(default)]
+    pub shell_output_format: Option<zeroclaw_config::schema::CronShellOutputFormat>,
 }
 
 #[derive(Deserialize)]
@@ -148,6 +153,10 @@ pub struct CronPatchBody {
     pub enabled: Option<bool>,
     /// If false, disable memory recall for this agent cron job (default: true).
     pub uses_memory: Option<bool>,
+    /// Shell output format override. `"wrapped"` (default) or `"raw"`.
+    /// Only applied to shell-type jobs.
+    #[serde(default)]
+    pub shell_output_format: Option<zeroclaw_config::schema::CronShellOutputFormat>,
 }
 
 enum CronTimezonePatch {
@@ -419,6 +428,7 @@ pub async fn handle_api_cron_add(
         allowed_tools,
         delete_after_run,
         uses_memory,
+        shell_output_format,
     } = body;
 
     let config = state.config.read().clone();
@@ -496,7 +506,8 @@ pub async fn handle_api_cron_add(
             }
         };
 
-        zeroclaw_runtime::cron::add_shell_job_with_approval(
+        let fmt = shell_output_format.unwrap_or_default();
+        zeroclaw_runtime::cron::add_shell_job_with_approval_and_format(
             &config,
             &agent_alias,
             name,
@@ -504,6 +515,7 @@ pub async fn handle_api_cron_add(
             command,
             delivery,
             false,
+            fmt,
         )
     };
 
@@ -633,6 +645,7 @@ pub async fn handle_api_cron_patch(
         prompt,
         enabled,
         uses_memory,
+        shell_output_format,
     } = body;
     let timezone_patch = match parse_timezone_patch(tz, clear_tz) {
         Ok(patch) => patch,
@@ -708,6 +721,7 @@ pub async fn handle_api_cron_patch(
         prompt: patch_prompt,
         enabled,
         uses_memory,
+        shell_output_format,
         ..zeroclaw_runtime::cron::CronJobPatch::default()
     };
 

--- a/crates/zeroclaw-gateway/src/api.rs
+++ b/crates/zeroclaw-gateway/src/api.rs
@@ -462,6 +462,12 @@ pub async fn handle_api_cron_add(
         matches!(job_type.as_deref(), Some("agent")) || (job_type.is_none() && prompt.is_some());
 
     let result = if is_agent {
+        if shell_output_format.is_some() {
+            return bad_request(
+                "shell_output_format is not applicable to agent jobs; agent execution ignores it",
+            )
+            .into_response();
+        }
         let prompt = match prompt.as_deref() {
             Some(p) if !p.trim().is_empty() => p,
             _ => {
@@ -4108,7 +4114,7 @@ pub(crate) mod tests {
                 expr: "*/5 * * * *".to_string(),
                 tz: None,
             },
-            "echo hello",
+            "echo hello-raw-patch-run",
             None,
             true,
         )
@@ -4118,6 +4124,10 @@ pub(crate) mod tests {
             zeroclaw_config::schema::CronShellOutputFormat::Wrapped,
             "imperative jobs default to wrapped"
         );
+        // Imperative jobs get UUID ids; the scheduler resolves owning agent
+        // by reverse-lookup against `agent.cron_jobs`, same as
+        // `cron_api_run_executes_shell_job_and_records_run`.
+        link_job_to_test_agent(&state, &job.id);
 
         let response = handle_api_cron_patch(
             State(state.clone()),
@@ -4144,6 +4154,26 @@ pub(crate) mod tests {
             updated.shell_output_format,
             zeroclaw_config::schema::CronShellOutputFormat::Raw,
             "get_job must reflect the patched format for an imperative job"
+        );
+
+        // The regression this PATCH must actually prove: the persisted
+        // value is what execution reads, not just what get_job() reports.
+        // A job created wrapped, then PATCHed to raw, must run raw.
+        let run_response =
+            handle_api_cron_run(State(state.clone()), HeaderMap::new(), Path(job.id.clone()))
+                .await
+                .into_response();
+        assert_eq!(run_response.status(), StatusCode::OK);
+        let run_json = response_json(run_response).await;
+        assert_eq!(run_json["success"], true);
+        let output = run_json["output"].as_str().unwrap_or_default();
+        assert!(
+            output.contains("hello-raw-patch-run"),
+            "expected bare stdout in output, got: {output}"
+        );
+        assert!(
+            !output.contains("status="),
+            "a PATCH-to-raw job must run raw (bare stdout), not the wrapped status envelope; got: {output}"
         );
     }
 
@@ -4279,6 +4309,57 @@ pub(crate) mod tests {
                 .unwrap_or_default()
                 .contains("agent job"),
             "error should explain the field does not apply to agent jobs"
+        );
+    }
+
+    #[tokio::test]
+    async fn cron_api_add_rejects_shell_output_format_for_agent_job() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let config = zeroclaw_config::schema::Config {
+            data_dir: tmp.path().join("data"),
+            config_path: tmp.path().join("config.toml"),
+            ..zeroclaw_config::schema::Config::default()
+        };
+        std::fs::create_dir_all(&config.data_dir).unwrap();
+        let state = test_state(with_test_agent(config));
+
+        let response = handle_api_cron_add(
+            State(state.clone()),
+            HeaderMap::new(),
+            Json(
+                serde_json::from_value::<CronAddBody>(serde_json::json!({
+                    "name": "agent-format-job",
+                    "agent": "test-agent",
+                    "schedule": "*/5 * * * *",
+                    "job_type": "agent",
+                    "prompt": "do something",
+                    "shell_output_format": "raw"
+                }))
+                .expect("body should deserialize"),
+            ),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(
+            response.status(),
+            StatusCode::BAD_REQUEST,
+            "shell_output_format must be rejected at creation for agent jobs, matching the PATCH contract, \
+             instead of silently discarded"
+        );
+        let json = response_json(response).await;
+        assert!(
+            json["error"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("agent job"),
+            "error should explain the field does not apply to agent jobs"
+        );
+        assert!(
+            zeroclaw_runtime::cron::list_jobs(&state.config.read().clone())
+                .unwrap()
+                .is_empty(),
+            "a rejected create must not persist a job"
         );
     }
 

--- a/crates/zeroclaw-gateway/src/api.rs
+++ b/crates/zeroclaw-gateway/src/api.rs
@@ -4658,6 +4658,86 @@ pub(crate) mod tests {
         );
     }
 
+    /// Regression: a shell cron job created via the gateway API with
+    /// `shell_output_format = raw` must persist the format, return raw
+    /// stdout when triggered, and not wrap output in the status envelope.
+    #[tokio::test]
+    async fn cron_api_shell_raw_output_roundtrip() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let config = zeroclaw_config::schema::Config {
+            data_dir: tmp.path().join("data"),
+            config_path: tmp.path().join("config.toml"),
+            ..zeroclaw_config::schema::Config::default()
+        };
+        std::fs::create_dir_all(&config.data_dir).unwrap();
+        let state = test_state(with_test_agent(config));
+
+        // 1. Create a shell job with shell_output_format = raw via the API.
+        let add_response = handle_api_cron_add(
+            State(state.clone()),
+            HeaderMap::new(),
+            Json(
+                serde_json::from_value::<CronAddBody>(serde_json::json!({
+                    "name": "raw-echo",
+                    "agent": "test-agent",
+                    "schedule": "*/5 * * * *",
+                    "command": "echo hello-raw",
+                    "shell_output_format": "raw"
+                }))
+                .expect("body should deserialize"),
+            ),
+        )
+        .await
+        .into_response();
+        assert_eq!(add_response.status(), StatusCode::OK);
+        let add_json = response_json(add_response).await;
+        assert_eq!(add_json["status"], "ok");
+        let job_id = add_json["job"]["id"].as_str().expect("job id").to_string();
+
+        // 2. Read the job back via list and verify shell_output_format persisted.
+        let list_response = handle_api_cron_list(State(state.clone()), HeaderMap::new())
+            .await
+            .into_response();
+        let list_json = response_json(list_response).await;
+        let jobs = list_json["jobs"].as_array().expect("jobs array");
+        let listed = jobs
+            .iter()
+            .find(|j| j["id"].as_str() == Some(&job_id))
+            .expect("job in list");
+        assert_eq!(
+            listed["shell_output_format"].as_str(),
+            Some("raw"),
+            "shell_output_format must persist through the API store path"
+        );
+
+        // 3. Link to test-agent so the scheduler can resolve the owner.
+        link_job_to_test_agent(&state, &job_id);
+
+        // 4. Trigger the job manually and verify raw output.
+        let run_response =
+            handle_api_cron_run(State(state.clone()), HeaderMap::new(), Path(job_id.clone()))
+                .await
+                .into_response();
+        assert_eq!(run_response.status(), StatusCode::OK);
+        let run_json = response_json(run_response).await;
+        assert_eq!(run_json["status"], "ok", "job should succeed: {run_json}");
+        assert_eq!(run_json["success"], true);
+
+        let output = run_json["output"].as_str().expect("output string");
+        assert_eq!(
+            output, "hello-raw",
+            "raw mode must return trimmed stdout, not the wrapped envelope: {output}"
+        );
+        assert!(
+            !output.contains("status="),
+            "raw output must not contain the status envelope: {output}"
+        );
+        assert!(
+            !output.contains("stdout:"),
+            "raw output must not contain the stdout header: {output}"
+        );
+    }
+
     #[cfg(feature = "a2a")]
     mod a2a_auth {
         use super::*;

--- a/crates/zeroclaw-gateway/src/api.rs
+++ b/crates/zeroclaw-gateway/src/api.rs
@@ -129,7 +129,7 @@ pub struct CronAddBody {
     pub uses_memory: Option<bool>,
     /// Shell output format for shell-type cron jobs. `"wrapped"` (default) or
     /// `"raw"`. Only meaningful when `job_type` is `"shell"` (or inferred as
-    /// shell when no prompt is given). Ignored for agent jobs.
+    /// shell when no prompt is given). Rejected for agent jobs.
     #[serde(default)]
     pub shell_output_format: Option<zeroclaw_config::schema::CronShellOutputFormat>,
 }
@@ -677,10 +677,11 @@ pub async fn handle_api_cron_patch(
             .into_response();
         }
         if existing.source == "declarative" {
-            return bad_request(
-                "shell_output_format for a declarative job is set via config.toml, not the API; \
-                 the DB column is not read for declarative jobs and this PATCH would have no effect",
-            )
+            return bad_request(format!(
+                "shell_output_format for declarative job '{id}' is set via \
+                 cron.{id}.shell_output_format in config.toml, not the API; \
+                 the DB column is not read for declarative jobs and this PATCH would have no effect"
+            ))
             .into_response();
         }
     }
@@ -4235,12 +4236,14 @@ pub(crate) mod tests {
             "a declarative job's shell_output_format is owned by config.toml, not the API"
         );
         let json = response_json(response).await;
+        let error = json["error"].as_str().unwrap_or_default();
         assert!(
-            json["error"]
-                .as_str()
-                .unwrap_or_default()
-                .contains("declarative"),
+            error.contains("declarative"),
             "error should explain the field is config-owned for declarative jobs"
+        );
+        assert!(
+            error.contains("cron.decl-job.shell_output_format"),
+            "error should name the exact config key to edit instead: {error}"
         );
         let unchanged =
             zeroclaw_runtime::cron::get_job(&state.config.read().clone(), "decl-job").unwrap();

--- a/crates/zeroclaw-gateway/src/api.rs
+++ b/crates/zeroclaw-gateway/src/api.rs
@@ -663,6 +663,21 @@ pub async fn handle_api_cron_patch(
         }
     };
     let is_agent = matches!(existing.job_type, zeroclaw_runtime::cron::JobType::Agent);
+    if shell_output_format.is_some() {
+        if is_agent {
+            return bad_request(
+                "shell_output_format is not applicable to agent jobs; agent execution ignores it",
+            )
+            .into_response();
+        }
+        if existing.source == "declarative" {
+            return bad_request(
+                "shell_output_format for a declarative job is set via config.toml, not the API; \
+                 the DB column is not read for declarative jobs and this PATCH would have no effect",
+            )
+            .into_response();
+        }
+    }
     let setting_shell_command = !is_agent && (command.is_some() || prompt.is_some());
     if setting_shell_command && config.agent(&agent_alias).is_none() {
         return (
@@ -4073,6 +4088,198 @@ pub(crate) mod tests {
         let updated = zeroclaw_runtime::cron::get_job(&state.config.read().clone(), &id)
             .expect("updated job");
         assert_eq!(updated.prompt.as_deref(), Some("new prompt"));
+    }
+
+    #[tokio::test]
+    async fn cron_api_patch_updates_imperative_shell_output_format() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let config = zeroclaw_config::schema::Config {
+            data_dir: tmp.path().join("data"),
+            config_path: tmp.path().join("config.toml"),
+            ..zeroclaw_config::schema::Config::default()
+        };
+        std::fs::create_dir_all(&config.data_dir).unwrap();
+        let state = test_state(with_test_agent(config));
+        let job = zeroclaw_runtime::cron::add_shell_job_with_approval(
+            &state.config.read().clone(),
+            "test-agent",
+            Some("format-job".to_string()),
+            zeroclaw_runtime::cron::Schedule::Cron {
+                expr: "*/5 * * * *".to_string(),
+                tz: None,
+            },
+            "echo hello",
+            None,
+            true,
+        )
+        .expect("job added");
+        assert_eq!(
+            job.shell_output_format,
+            zeroclaw_config::schema::CronShellOutputFormat::Wrapped,
+            "imperative jobs default to wrapped"
+        );
+
+        let response = handle_api_cron_patch(
+            State(state.clone()),
+            HeaderMap::new(),
+            Path(job.id.clone()),
+            Json(
+                serde_json::from_value::<CronPatchBody>(
+                    serde_json::json!({ "shell_output_format": "raw" }),
+                )
+                .expect("body should deserialize"),
+            ),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "an imperative job's shell_output_format is a real, storable mutation"
+        );
+        let updated = zeroclaw_runtime::cron::get_job(&state.config.read().clone(), &job.id)
+            .expect("updated job");
+        assert_eq!(
+            updated.shell_output_format,
+            zeroclaw_config::schema::CronShellOutputFormat::Raw,
+            "get_job must reflect the patched format for an imperative job"
+        );
+    }
+
+    #[tokio::test]
+    async fn cron_api_patch_rejects_shell_output_format_for_declarative_job() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mut config = zeroclaw_config::schema::Config {
+            data_dir: tmp.path().join("data"),
+            config_path: tmp.path().join("config.toml"),
+            ..zeroclaw_config::schema::Config::default()
+        };
+        std::fs::create_dir_all(&config.data_dir).unwrap();
+        config = with_test_agent(config);
+        // `sync_declarative_jobs` only materializes a job for an agent that
+        // claims it via `cron_jobs`, exactly like `seed_claiming_agent` in
+        // cron::store's own tests.
+        config.agents.get_mut("test-agent").unwrap().cron_jobs = vec!["decl-job".to_string()];
+
+        let decl = zeroclaw_config::schema::CronJobDecl {
+            name: Some("decl-job".to_string()),
+            job_type: "shell".to_string(),
+            schedule: zeroclaw_config::schema::CronScheduleDecl::Cron {
+                expr: "0 2 * * *".to_string(),
+                tz: None,
+            },
+            command: Some("echo decl-output".to_string()),
+            prompt: None,
+            enabled: true,
+            model: None,
+            allowed_tools: None,
+            uses_memory: true,
+            session_target: None,
+            delivery: None,
+            shell_output_format: zeroclaw_config::schema::CronShellOutputFormat::Wrapped,
+        };
+        let mut decls = std::collections::HashMap::new();
+        decls.insert("decl-job".to_string(), decl.clone());
+        config.cron.insert("decl-job".to_string(), decl);
+        zeroclaw_runtime::cron::sync_declarative_jobs(&config, &decls).unwrap();
+        let state = test_state(config);
+
+        let response = handle_api_cron_patch(
+            State(state.clone()),
+            HeaderMap::new(),
+            Path("decl-job".to_string()),
+            Json(
+                serde_json::from_value::<CronPatchBody>(
+                    serde_json::json!({ "shell_output_format": "raw" }),
+                )
+                .expect("body should deserialize"),
+            ),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(
+            response.status(),
+            StatusCode::BAD_REQUEST,
+            "a declarative job's shell_output_format is owned by config.toml, not the API"
+        );
+        let json = response_json(response).await;
+        assert!(
+            json["error"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("declarative"),
+            "error should explain the field is config-owned for declarative jobs"
+        );
+        let unchanged =
+            zeroclaw_runtime::cron::get_job(&state.config.read().clone(), "decl-job").unwrap();
+        assert_eq!(
+            unchanged.shell_output_format,
+            zeroclaw_config::schema::CronShellOutputFormat::Wrapped,
+            "the rejected PATCH must not have changed the resolved format"
+        );
+    }
+
+    #[tokio::test]
+    async fn cron_api_patch_rejects_shell_output_format_for_agent_job() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let config = zeroclaw_config::schema::Config {
+            data_dir: tmp.path().join("data"),
+            config_path: tmp.path().join("config.toml"),
+            ..zeroclaw_config::schema::Config::default()
+        };
+        std::fs::create_dir_all(&config.data_dir).unwrap();
+        let state = test_state(with_test_agent(config));
+
+        let add_response = handle_api_cron_add(
+            State(state.clone()),
+            HeaderMap::new(),
+            Json(
+                serde_json::from_value::<CronAddBody>(serde_json::json!({
+                    "name": "agent-format-job",
+                    "agent": "test-agent",
+                    "schedule": "*/5 * * * *",
+                    "job_type": "agent",
+                    "prompt": "do something"
+                }))
+                .expect("body should deserialize"),
+            ),
+        )
+        .await
+        .into_response();
+        assert_eq!(add_response.status(), StatusCode::OK);
+        let id = zeroclaw_runtime::cron::list_jobs(&state.config.read().clone()).unwrap()[0]
+            .id
+            .clone();
+
+        let response = handle_api_cron_patch(
+            State(state.clone()),
+            HeaderMap::new(),
+            Path(id.clone()),
+            Json(
+                serde_json::from_value::<CronPatchBody>(
+                    serde_json::json!({ "shell_output_format": "raw" }),
+                )
+                .expect("body should deserialize"),
+            ),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(
+            response.status(),
+            StatusCode::BAD_REQUEST,
+            "shell_output_format is shell-only and must not be persisted for agent jobs"
+        );
+        let json = response_json(response).await;
+        assert!(
+            json["error"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("agent job"),
+            "error should explain the field does not apply to agent jobs"
+        );
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-runtime/src/cron/mod.rs
+++ b/crates/zeroclaw-runtime/src/cron/mod.rs
@@ -1,6 +1,6 @@
 use crate::security::SecurityPolicy;
 use anyhow::{Result, bail};
-use zeroclaw_config::schema::Config;
+use zeroclaw_config::schema::{Config, CronShellOutputFormat};
 
 mod schedule;
 mod store;
@@ -118,9 +118,40 @@ pub fn add_shell_job_with_approval(
     delivery: Option<DeliveryConfig>,
     approved: bool,
 ) -> Result<CronJob> {
+    add_shell_job_with_approval_and_format(
+        config,
+        agent_alias,
+        name,
+        schedule,
+        command,
+        delivery,
+        approved,
+        CronShellOutputFormat::default(),
+    )
+}
+
+/// Like `add_shell_job_with_approval` but with an explicit shell output format.
+pub fn add_shell_job_with_approval_and_format(
+    config: &Config,
+    agent_alias: &str,
+    name: Option<String>,
+    schedule: Schedule,
+    command: &str,
+    delivery: Option<DeliveryConfig>,
+    approved: bool,
+    shell_output_format: CronShellOutputFormat,
+) -> Result<CronJob> {
     validate_shell_command(config, agent_alias, command, approved)?;
     validate_delivery_config(delivery.as_ref())?;
-    store::add_shell_job(config, agent_alias, name, schedule, command, delivery)
+    store::add_shell_job_with_format(
+        config,
+        agent_alias,
+        name,
+        schedule,
+        command,
+        delivery,
+        shell_output_format,
+    )
 }
 
 /// Update a shell job's command with security validation.
@@ -173,7 +204,16 @@ pub fn add_shell_job(
     schedule: Schedule,
     command: &str,
 ) -> Result<CronJob> {
-    add_shell_job_with_approval(config, agent_alias, name, schedule, command, None, false)
+    add_shell_job_with_approval_and_format(
+        config,
+        agent_alias,
+        name,
+        schedule,
+        command,
+        None,
+        false,
+        CronShellOutputFormat::default(),
+    )
 }
 
 pub fn add_job(

--- a/crates/zeroclaw-runtime/src/cron/scheduler.rs
+++ b/crates/zeroclaw-runtime/src/cron/scheduler.rs
@@ -1133,13 +1133,14 @@ async fn run_job_command_with_timeout(
         );
     }
 
-    // Resolve the shell output format: declarative jobs read from config
-    // (the canonical source), imperative jobs use the stored field.
-    let output_format: &CronShellOutputFormat = config
-        .cron
-        .get(&job.id)
-        .map(|decl| &decl.shell_output_format)
-        .unwrap_or(&job.shell_output_format);
+    // `job.shell_output_format` is already the canonical value by the time
+    // it reaches here: due_jobs()/all_overdue_jobs() resolve declarative jobs
+    // from config and leave imperative jobs on their stored field (see
+    // resolve_declarative_shell_output_format in store.rs). Re-deriving it
+    // here from `config.cron.get(&job.id)` without checking `job.source`
+    // would let an unrelated same-ID declarative config entry silently
+    // override an imperative job's stored format.
+    let output_format = &job.shell_output_format;
 
     let child = match build_cron_shell_command(&job.command, &config.data_dir) {
         Ok(mut cmd) => match cmd.spawn() {
@@ -1466,20 +1467,12 @@ mod tests {
     #[cfg(not(target_os = "windows"))]
     async fn run_job_command_raw_output_success() {
         let tmp = TempDir::new().unwrap();
-        let mut config = test_config(&tmp).await;
-        // Insert a config-declared job with raw output format.
-        config.cron.insert(
-            "test-raw-job".into(),
-            zeroclaw_config::schema::CronJobDecl {
-                command: Some("echo raw-format-ok".into()),
-                shell_output_format: CronShellOutputFormat::Raw,
-                ..Default::default()
-            },
-        );
-        // The job id must match the config key for the format to be resolved.
+        let config = test_config(&tmp).await;
+        // The store layer resolves shell_output_format before handing the job
+        // to the scheduler (see resolve_declarative_shell_output_format), so
+        // the job's own field is already canonical by the time it gets here.
         let mut job = test_job("echo raw-format-ok");
-        job.id = "test-raw-job".into();
-        job.source = "declarative".into();
+        job.shell_output_format = CronShellOutputFormat::Raw;
         let security = test_security(&config);
 
         let (success, output) = run_job_command(&config, &security, &job).await;
@@ -1493,20 +1486,11 @@ mod tests {
     #[cfg(not(target_os = "windows"))]
     async fn run_job_command_raw_output_success_drops_stderr() {
         let tmp = TempDir::new().unwrap();
-        let mut config = test_config(&tmp).await;
+        let config = test_config(&tmp).await;
         // A zero-exit command that still writes to stderr (e.g. a tool's
         // progress/warning chatter) must not leak into raw-mode output.
-        config.cron.insert(
-            "test-raw-stderr".into(),
-            zeroclaw_config::schema::CronJobDecl {
-                command: Some("echo raw-stdout-ok; echo raw-stderr-noise >&2".into()),
-                shell_output_format: CronShellOutputFormat::Raw,
-                ..Default::default()
-            },
-        );
         let mut job = test_job("echo raw-stdout-ok; echo raw-stderr-noise >&2");
-        job.id = "test-raw-stderr".into();
-        job.source = "declarative".into();
+        job.shell_output_format = CronShellOutputFormat::Raw;
         let security = test_security(&config);
 
         let (success, output) = run_job_command(&config, &security, &job).await;
@@ -1521,18 +1505,9 @@ mod tests {
     #[cfg(not(target_os = "windows"))]
     async fn run_job_command_raw_output_failure_still_uses_wrapped() {
         let tmp = TempDir::new().unwrap();
-        let mut config = test_config(&tmp).await;
-        config.cron.insert(
-            "test-raw-fail".into(),
-            zeroclaw_config::schema::CronJobDecl {
-                command: Some("ls definitely_missing_file_raw_test".into()),
-                shell_output_format: CronShellOutputFormat::Raw,
-                ..Default::default()
-            },
-        );
+        let config = test_config(&tmp).await;
         let mut job = test_job("ls definitely_missing_file_raw_test");
-        job.id = "test-raw-fail".into();
-        job.source = "declarative".into();
+        job.shell_output_format = CronShellOutputFormat::Raw;
         let security = test_security(&config);
 
         let (success, output) = run_job_command(&config, &security, &job).await;
@@ -1541,6 +1516,37 @@ mod tests {
         // so operators can diagnose the failure.
         assert!(output.contains("status=exit status:"));
         assert!(output.contains("definitely_missing_file_raw_test"));
+    }
+
+    #[tokio::test]
+    #[cfg(not(target_os = "windows"))]
+    async fn run_job_command_imperative_job_ignores_same_id_declarative_config_entry() {
+        let tmp = TempDir::new().unwrap();
+        let mut config = test_config(&tmp).await;
+        // An unrelated declarative config entry happens to share the
+        // imperative job's ID and asks for raw output. Execution must go by
+        // the job's own (already-resolved) field, not re-derive from config
+        // by ID match, or the imperative job's stored format gets silently
+        // overridden.
+        config.cron.insert(
+            "test-job".into(),
+            zeroclaw_config::schema::CronJobDecl {
+                command: Some("echo collision-ok".into()),
+                shell_output_format: CronShellOutputFormat::Raw,
+                ..Default::default()
+            },
+        );
+        let mut job = test_job("echo collision-ok");
+        job.source = "imperative".into();
+        job.shell_output_format = CronShellOutputFormat::Wrapped;
+        let security = test_security(&config);
+
+        let (success, output) = run_job_command(&config, &security, &job).await;
+        assert!(success);
+        assert!(
+            output.contains("status="),
+            "imperative job's own Wrapped format must win over a same-ID declarative config entry: {output}"
+        );
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-runtime/src/cron/scheduler.rs
+++ b/crates/zeroclaw-runtime/src/cron/scheduler.rs
@@ -1154,9 +1154,7 @@ async fn run_job_command_with_timeout(
             let stdout = String::from_utf8_lossy(&output.stdout);
             let stderr = String::from_utf8_lossy(&output.stderr);
             let combined = match output_format {
-                CronShellOutputFormat::Raw if output.status.success() => {
-                    stdout.trim().to_string()
-                }
+                CronShellOutputFormat::Raw if output.status.success() => stdout.trim().to_string(),
                 _ => format!(
                     "status={}\nstdout:\n{}\nstderr:\n{}",
                     output.status,

--- a/crates/zeroclaw-runtime/src/cron/scheduler.rs
+++ b/crates/zeroclaw-runtime/src/cron/scheduler.rs
@@ -1154,6 +1154,12 @@ async fn run_job_command_with_timeout(
             let stdout = String::from_utf8_lossy(&output.stdout);
             let stderr = String::from_utf8_lossy(&output.stderr);
             let combined = match output_format {
+                // Raw mode on success returns bare stdout, by design — the
+                // point is to hand back exactly what a direct shell run
+                // would print on stdout, with no wrapper. stderr on a
+                // successful exit is intentionally dropped, not lost by
+                // accident; a failing exit still gets the full wrapped
+                // status/stdout/stderr envelope below for diagnosis.
                 CronShellOutputFormat::Raw if output.status.success() => stdout.trim().to_string(),
                 _ => format!(
                     "status={}\nstdout:\n{}\nstderr:\n{}",
@@ -1481,6 +1487,34 @@ mod tests {
         // Raw output should be just the command's trimmed stdout, no wrapper.
         assert_eq!(output, "raw-format-ok");
         assert!(!output.contains("status="));
+    }
+
+    #[tokio::test]
+    #[cfg(not(target_os = "windows"))]
+    async fn run_job_command_raw_output_success_drops_stderr() {
+        let tmp = TempDir::new().unwrap();
+        let mut config = test_config(&tmp).await;
+        // A zero-exit command that still writes to stderr (e.g. a tool's
+        // progress/warning chatter) must not leak into raw-mode output.
+        config.cron.insert(
+            "test-raw-stderr".into(),
+            zeroclaw_config::schema::CronJobDecl {
+                command: Some("echo raw-stdout-ok; echo raw-stderr-noise >&2".into()),
+                shell_output_format: CronShellOutputFormat::Raw,
+                ..Default::default()
+            },
+        );
+        let mut job = test_job("echo raw-stdout-ok; echo raw-stderr-noise >&2");
+        job.id = "test-raw-stderr".into();
+        job.source = "declarative".into();
+        let security = test_security(&config);
+
+        let (success, output) = run_job_command(&config, &security, &job).await;
+        assert!(success);
+        // Dropping stderr on a successful exit is intentional design, not
+        // an oversight — see the comment at the call site.
+        assert_eq!(output, "raw-stdout-ok");
+        assert!(!output.contains("raw-stderr-noise"));
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-runtime/src/cron/scheduler.rs
+++ b/crates/zeroclaw-runtime/src/cron/scheduler.rs
@@ -1133,13 +1133,13 @@ async fn run_job_command_with_timeout(
         );
     }
 
-    // Resolve the shell output format from config. Imperative jobs (created
-    // via CLI/API) are not in config.cron and default to Wrapped.
-    let output_format = config
+    // Resolve the shell output format: declarative jobs read from config
+    // (the canonical source), imperative jobs use the stored field.
+    let output_format: &CronShellOutputFormat = config
         .cron
         .get(&job.id)
         .map(|decl| &decl.shell_output_format)
-        .unwrap_or(&CronShellOutputFormat::Wrapped);
+        .unwrap_or(&job.shell_output_format);
 
     let child = match build_cron_shell_command(&job.command, &config.data_dir) {
         Ok(mut cmd) => match cmd.spawn() {
@@ -1309,6 +1309,7 @@ mod tests {
             allowed_tools: None,
             uses_memory: true,
             source: "imperative".into(),
+            shell_output_format: CronShellOutputFormat::default(),
             created_at: Utc::now(),
             next_run: Utc::now(),
             last_run: None,

--- a/crates/zeroclaw-runtime/src/cron/scheduler.rs
+++ b/crates/zeroclaw-runtime/src/cron/scheduler.rs
@@ -17,7 +17,7 @@ use tokio::process::Command;
 use tokio::time::{self, Duration};
 use tokio_util::sync::CancellationToken;
 use zeroclaw_config::schema::Config;
-use zeroclaw_config::schema::{CronJobDecl, CronScheduleDecl};
+use zeroclaw_config::schema::{CronJobDecl, CronScheduleDecl, CronShellOutputFormat};
 use zeroclaw_log::Instrument;
 
 const MIN_POLL_SECONDS: u64 = 5;
@@ -276,6 +276,7 @@ pub async fn run(
             uses_memory: true,
             session_target: None,
             delivery: None,
+            shell_output_format: CronShellOutputFormat::default(),
         };
         ::zeroclaw_log::record!(
             DEBUG,
@@ -1132,6 +1133,14 @@ async fn run_job_command_with_timeout(
         );
     }
 
+    // Resolve the shell output format from config. Imperative jobs (created
+    // via CLI/API) are not in config.cron and default to Wrapped.
+    let output_format = config
+        .cron
+        .get(&job.id)
+        .map(|decl| &decl.shell_output_format)
+        .unwrap_or(&CronShellOutputFormat::Wrapped);
+
     let child = match build_cron_shell_command(&job.command, &config.data_dir) {
         Ok(mut cmd) => match cmd.spawn() {
             Ok(child) => child,
@@ -1144,12 +1153,17 @@ async fn run_job_command_with_timeout(
         Ok(Ok(output)) => {
             let stdout = String::from_utf8_lossy(&output.stdout);
             let stderr = String::from_utf8_lossy(&output.stderr);
-            let combined = format!(
-                "status={}\nstdout:\n{}\nstderr:\n{}",
-                output.status,
-                stdout.trim(),
-                stderr.trim()
-            );
+            let combined = match output_format {
+                CronShellOutputFormat::Raw if output.status.success() => {
+                    stdout.trim().to_string()
+                }
+                _ => format!(
+                    "status={}\nstdout:\n{}\nstderr:\n{}",
+                    output.status,
+                    stdout.trim(),
+                    stderr.trim()
+                ),
+            };
             (output.status.success(), combined)
         }
         Ok(Err(e)) => (false, format!("spawn error: {e}")),
@@ -1441,6 +1455,59 @@ mod tests {
         assert!(success);
         assert!(output.contains("scheduler-ok"));
         assert!(output.contains("status=exit status: 0"));
+    }
+
+    #[tokio::test]
+    #[cfg(not(target_os = "windows"))]
+    async fn run_job_command_raw_output_success() {
+        let tmp = TempDir::new().unwrap();
+        let mut config = test_config(&tmp).await;
+        // Insert a config-declared job with raw output format.
+        config.cron.insert(
+            "test-raw-job".into(),
+            zeroclaw_config::schema::CronJobDecl {
+                command: Some("echo raw-format-ok".into()),
+                shell_output_format: CronShellOutputFormat::Raw,
+                ..Default::default()
+            },
+        );
+        // The job id must match the config key for the format to be resolved.
+        let mut job = test_job("echo raw-format-ok");
+        job.id = "test-raw-job".into();
+        job.source = "declarative".into();
+        let security = test_security(&config);
+
+        let (success, output) = run_job_command(&config, &security, &job).await;
+        assert!(success);
+        // Raw output should be just the command's trimmed stdout, no wrapper.
+        assert_eq!(output, "raw-format-ok");
+        assert!(!output.contains("status="));
+    }
+
+    #[tokio::test]
+    #[cfg(not(target_os = "windows"))]
+    async fn run_job_command_raw_output_failure_still_uses_wrapped() {
+        let tmp = TempDir::new().unwrap();
+        let mut config = test_config(&tmp).await;
+        config.cron.insert(
+            "test-raw-fail".into(),
+            zeroclaw_config::schema::CronJobDecl {
+                command: Some("ls definitely_missing_file_raw_test".into()),
+                shell_output_format: CronShellOutputFormat::Raw,
+                ..Default::default()
+            },
+        );
+        let mut job = test_job("ls definitely_missing_file_raw_test");
+        job.id = "test-raw-fail".into();
+        job.source = "declarative".into();
+        let security = test_security(&config);
+
+        let (success, output) = run_job_command(&config, &security, &job).await;
+        assert!(!success);
+        // On failure, raw mode should still include the wrapped format
+        // so operators can diagnose the failure.
+        assert!(output.contains("status=exit status:"));
+        assert!(output.contains("definitely_missing_file_raw_test"));
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-runtime/src/cron/scheduler.rs
+++ b/crates/zeroclaw-runtime/src/cron/scheduler.rs
@@ -499,6 +499,20 @@ async fn skip_missed_jobs_on_startup(config: &Config) {
 }
 
 pub async fn execute_job_now(config: &Config, job: &CronJob) -> (bool, String) {
+    // Reject orphaned declarative jobs: a declarative row whose canonical
+    // config declaration has been removed must not execute through any
+    // path (automatic polling or manual trigger).
+    if job.source == "declarative" && !super::store::is_valid_declarative_owner(config, &job.id) {
+        return (
+            false,
+            format!(
+                "cron job {id:?} is an orphaned declarative entry \
+                 (source = \"declarative\" but absent from live config); \
+                 cannot execute",
+                id = job.id
+            ),
+        );
+    }
     use zeroclaw_log::Instrument;
     let Some(agent_alias) = resolve_owning_agent(config, job) else {
         return (

--- a/crates/zeroclaw-runtime/src/cron/store.rs
+++ b/crates/zeroclaw-runtime/src/cron/store.rs
@@ -1080,6 +1080,10 @@ pub fn sync_declarative_jobs(
             let allowed_tools_json = encode_allowed_tools(decl.allowed_tools.as_ref())?;
             let command = decl.command.as_deref().unwrap_or("");
             let delete_after_run = matches!(decl.schedule, CronScheduleDecl::At { .. });
+            let shell_output_format_str = match decl.shell_output_format {
+                zeroclaw_config::schema::CronShellOutputFormat::Wrapped => "wrapped",
+                zeroclaw_config::schema::CronShellOutputFormat::Raw => "raw",
+            };
 
             // Check if job already exists.
             let exists: bool = conn
@@ -1107,8 +1111,8 @@ pub fn sync_declarative_jobs(
                              prompt = ?5, name = ?6, session_target = ?7, model = ?8,
                              enabled = ?9, delivery = ?10, delete_after_run = ?11,
                              allowed_tools = ?12, source = 'declarative', next_run = ?13,
-                             uses_memory = ?14
-                         WHERE id = ?15",
+                             uses_memory = ?14, shell_output_format = ?15
+                         WHERE id = ?16",
                         params![
                             expression,
                             command,
@@ -1124,6 +1128,7 @@ pub fn sync_declarative_jobs(
                             allowed_tools_json,
                             next_run.to_rfc3339(),
                             i32::from(decl.uses_memory),
+                            shell_output_format_str,
                             id,
                         ],
                     )
@@ -1135,8 +1140,8 @@ pub fn sync_declarative_jobs(
                              prompt = ?5, name = ?6, session_target = ?7, model = ?8,
                              enabled = ?9, delivery = ?10, delete_after_run = ?11,
                              allowed_tools = ?12, source = 'declarative',
-                             uses_memory = ?13
-                         WHERE id = ?14",
+                             uses_memory = ?13, shell_output_format = ?14
+                         WHERE id = ?15",
                         params![
                             expression,
                             command,
@@ -1151,6 +1156,7 @@ pub fn sync_declarative_jobs(
                             i32::from(delete_after_run),
                             allowed_tools_json,
                             i32::from(decl.uses_memory),
+                            shell_output_format_str,
                             id,
                         ],
                     )
@@ -1183,8 +1189,9 @@ pub fn sync_declarative_jobs(
                     "INSERT INTO cron_jobs (
                         id, expression, command, schedule, job_type, prompt, name,
                         session_target, model, enabled, delivery, delete_after_run,
-                        allowed_tools, source, uses_memory, agent_alias, created_at, next_run
-                     ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, 'declarative', ?14, ?15, ?16, ?17)",
+                        allowed_tools, source, uses_memory, agent_alias, created_at, next_run,
+                        shell_output_format
+                     ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, 'declarative', ?14, ?15, ?16, ?17, ?18)",
                     params![
                         id,
                         expression,
@@ -1203,6 +1210,7 @@ pub fn sync_declarative_jobs(
                         agent_alias,
                         now.to_rfc3339(),
                         next_run.to_rfc3339(),
+                        shell_output_format_str,
                     ],
                 )
                 .with_context(|| {
@@ -2860,6 +2868,57 @@ schedule = { kind = "every", every_ms = 300000 }
         assert!(
             err.to_string().contains("No cron job found"),
             "another agent's job must be unresolvable by name; got: {err}"
+        );
+    }
+
+    /// Regression: a declarative shell job with `shell_output_format = raw`
+    /// must report `shell_output_format = raw` through `get_job()`/`list_jobs()`,
+    /// matching the execution source of truth (config).
+    #[test]
+    fn sync_declarative_raw_shell_job_lists_with_raw_format() {
+        let tmp = TempDir::new().unwrap();
+        let mut config = test_config(&tmp);
+        seed_claiming_agent(&mut config, &["raw-decl"]);
+
+        let decls = decls_map(vec![(
+            "raw-decl".to_string(),
+            zeroclaw_config::schema::CronJobDecl {
+                name: Some("raw-decl".to_string()),
+                job_type: "shell".to_string(),
+                schedule: zeroclaw_config::schema::CronScheduleDecl::Cron {
+                    expr: "0 2 * * *".to_string(),
+                    tz: None,
+                },
+                command: Some("echo raw-decl-output".to_string()),
+                prompt: None,
+                enabled: true,
+                model: None,
+                allowed_tools: None,
+                uses_memory: true,
+                session_target: None,
+                delivery: None,
+                shell_output_format: zeroclaw_config::schema::CronShellOutputFormat::Raw,
+            },
+        )]);
+        sync_declarative_jobs(&config, &decls).unwrap();
+
+        let job = get_job(&config, "raw-decl").unwrap();
+        assert_eq!(
+            job.shell_output_format,
+            zeroclaw_config::schema::CronShellOutputFormat::Raw,
+            "get_job must return raw format for a declarative raw shell job"
+        );
+        assert_eq!(job.source, "declarative");
+
+        let jobs = list_jobs(&config).unwrap();
+        let listed = jobs
+            .iter()
+            .find(|j| j.id == "raw-decl")
+            .expect("job in list");
+        assert_eq!(
+            listed.shell_output_format,
+            zeroclaw_config::schema::CronShellOutputFormat::Raw,
+            "list_jobs must return raw format for a declarative raw shell job"
         );
     }
 }

--- a/crates/zeroclaw-runtime/src/cron/store.rs
+++ b/crates/zeroclaw-runtime/src/cron/store.rs
@@ -7,7 +7,7 @@ use chrono::{DateTime, Utc};
 use rusqlite::types::{FromSqlResult, ValueRef};
 use rusqlite::{Connection, OpenFlags, params};
 use uuid::Uuid;
-use zeroclaw_config::schema::Config;
+use zeroclaw_config::schema::{Config, CronShellOutputFormat};
 
 const MAX_CRON_OUTPUT_BYTES: usize = 16 * 1024;
 const TRUNCATED_OUTPUT_MARKER: &str = "\n...[truncated]";
@@ -61,6 +61,7 @@ pub fn add_job(
     add_shell_job(config, agent_alias, None, schedule, command, None)
 }
 
+#[cfg(test)]
 pub fn add_shell_job(
     config: &Config,
     agent_alias: &str,
@@ -68,6 +69,26 @@ pub fn add_shell_job(
     schedule: Schedule,
     command: &str,
     delivery: Option<DeliveryConfig>,
+) -> Result<CronJob> {
+    add_shell_job_with_format(
+        config,
+        agent_alias,
+        name,
+        schedule,
+        command,
+        delivery,
+        CronShellOutputFormat::default(),
+    )
+}
+
+pub fn add_shell_job_with_format(
+    config: &Config,
+    agent_alias: &str,
+    name: Option<String>,
+    schedule: Schedule,
+    command: &str,
+    delivery: Option<DeliveryConfig>,
+    shell_output_format: CronShellOutputFormat,
 ) -> Result<CronJob> {
     let now = Utc::now();
     validate_schedule(&schedule, now)?;
@@ -84,12 +105,17 @@ pub fn add_shell_job(
         anyhow::bail!("agent_alias is required; cron jobs must name an owning agent");
     }
 
+    let shell_output_format_str = match shell_output_format {
+        CronShellOutputFormat::Wrapped => "wrapped",
+        CronShellOutputFormat::Raw => "raw",
+    };
+
     with_initialized_connection(config, |conn| {
         conn.execute(
             "INSERT INTO cron_jobs (
                 id, expression, command, schedule, job_type, prompt, name, session_target, model,
-                enabled, delivery, delete_after_run, agent_alias, created_at, next_run
-             ) VALUES (?1, ?2, ?3, ?4, 'shell', NULL, ?5, 'isolated', NULL, 1, ?6, ?7, ?8, ?9, ?10)",
+                enabled, delivery, delete_after_run, agent_alias, created_at, next_run, shell_output_format
+             ) VALUES (?1, ?2, ?3, ?4, 'shell', NULL, ?5, 'isolated', NULL, 1, ?6, ?7, ?8, ?9, ?10, ?11)",
             params![
                 id,
                 expression,
@@ -101,6 +127,7 @@ pub fn add_shell_job(
                 agent_alias,
                 now.to_rfc3339(),
                 next_run.to_rfc3339(),
+                shell_output_format_str,
             ],
         )
         .context("Failed to insert cron shell job")?;
@@ -172,8 +199,8 @@ pub fn list_jobs(config: &Config) -> Result<Vec<CronJob>> {
     let Some(jobs) = with_read_connection(config, |conn| {
         let mut stmt = conn.prepare(
             "SELECT id, expression, command, schedule, job_type, prompt, name, session_target, model,
-                    enabled, delivery, delete_after_run, created_at, next_run, last_run, last_status, last_output,
-                    allowed_tools, source, uses_memory, agent_alias
+                     enabled, delivery, delete_after_run, created_at, next_run, last_run, last_status, last_output,
+                     allowed_tools, source, uses_memory, agent_alias, shell_output_format
              FROM cron_jobs ORDER BY next_run ASC",
         )?;
 
@@ -196,8 +223,8 @@ pub fn get_job(config: &Config, job_id: &str) -> Result<CronJob> {
     let Some(job) = with_read_connection(config, |conn| {
         let mut stmt = conn.prepare(
             "SELECT id, expression, command, schedule, job_type, prompt, name, session_target, model,
-                    enabled, delivery, delete_after_run, created_at, next_run, last_run, last_status, last_output,
-                    allowed_tools, source, uses_memory, agent_alias
+                     enabled, delivery, delete_after_run, created_at, next_run, last_run, last_status, last_output,
+                     allowed_tools, source, uses_memory, agent_alias, shell_output_format
              FROM cron_jobs WHERE id = ?1",
         )?;
 
@@ -269,8 +296,8 @@ pub fn list_jobs_by_agent(config: &Config, agent_alias: &str) -> Result<Vec<Cron
     let Some(jobs) = with_read_connection(config, |conn| {
         let mut stmt = conn.prepare(
             "SELECT id, expression, command, schedule, job_type, prompt, name, session_target, model,
-                    enabled, delivery, delete_after_run, created_at, next_run, last_run, last_status, last_output,
-                    allowed_tools, source, uses_memory, agent_alias
+                     enabled, delivery, delete_after_run, created_at, next_run, last_run, last_status, last_output,
+                     allowed_tools, source, uses_memory, agent_alias, shell_output_format
              FROM cron_jobs WHERE agent_alias = ?1 ORDER BY next_run ASC",
         )?;
         let rows = stmt.query_map(params![agent_alias], map_cron_job_row)?;
@@ -321,8 +348,8 @@ pub fn due_jobs(config: &Config, now: DateTime<Utc>) -> Result<Vec<CronJob>> {
     let Some(jobs) = with_read_connection(config, |conn| {
         let mut stmt = conn.prepare(
             "SELECT id, expression, command, schedule, job_type, prompt, name, session_target, model,
-                    enabled, delivery, delete_after_run, created_at, next_run, last_run, last_status, last_output,
-                    allowed_tools, source, uses_memory, agent_alias
+                     enabled, delivery, delete_after_run, created_at, next_run, last_run, last_status, last_output,
+                     allowed_tools, source, uses_memory, agent_alias, shell_output_format
              FROM cron_jobs
              WHERE enabled = 1 AND next_run <= ?1 AND locked_at IS NULL
              ORDER BY next_run ASC
@@ -357,8 +384,8 @@ pub fn all_overdue_jobs(config: &Config, now: DateTime<Utc>) -> Result<Vec<CronJ
     let Some(jobs) = with_read_connection(config, |conn| {
         let mut stmt = conn.prepare(
             "SELECT id, expression, command, schedule, job_type, prompt, name, session_target, model,
-                    enabled, delivery, delete_after_run, created_at, next_run, last_run, last_status, last_output,
-                    allowed_tools, source, uses_memory, agent_alias
+                     enabled, delivery, delete_after_run, created_at, next_run, last_run, last_status, last_output,
+                     allowed_tools, source, uses_memory, agent_alias, shell_output_format
              FROM cron_jobs
              WHERE enabled = 1 AND next_run <= ?1 AND locked_at IS NULL
              ORDER BY next_run ASC",
@@ -434,6 +461,9 @@ pub fn update_job(config: &Config, job_id: &str, patch: CronJobPatch) -> Result<
     if let Some(uses_memory) = patch.uses_memory {
         job.uses_memory = uses_memory;
     }
+    if let Some(shell_output_format) = patch.shell_output_format {
+        job.shell_output_format = shell_output_format;
+    }
 
     if schedule_changed {
         job.next_run = next_run_for_schedule(&job.schedule, Utc::now())?;
@@ -444,8 +474,8 @@ pub fn update_job(config: &Config, job_id: &str, patch: CronJobPatch) -> Result<
             "UPDATE cron_jobs
              SET expression = ?1, command = ?2, schedule = ?3, job_type = ?4, prompt = ?5, name = ?6,
                  session_target = ?7, model = ?8, enabled = ?9, delivery = ?10, delete_after_run = ?11,
-                 allowed_tools = ?12, next_run = ?13, uses_memory = ?14
-             WHERE id = ?15",
+                 allowed_tools = ?12, next_run = ?13, uses_memory = ?14, shell_output_format = ?15
+             WHERE id = ?16",
             params![
                 job.expression,
                 job.command,
@@ -461,6 +491,10 @@ pub fn update_job(config: &Config, job_id: &str, patch: CronJobPatch) -> Result<
                 encode_allowed_tools(job.allowed_tools.as_ref())?,
                 job.next_run.to_rfc3339(),
                 if job.uses_memory { 1 } else { 0 },
+                match job.shell_output_format {
+                    CronShellOutputFormat::Wrapped => "wrapped",
+                    CronShellOutputFormat::Raw => "raw",
+                },
                 job.id,
             ],
         )
@@ -882,6 +916,11 @@ fn map_cron_job_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<CronJob> {
     let source: Option<String> = row.get(18)?;
     let uses_memory: Option<i64> = row.get(19)?;
     let agent_alias: Option<String> = row.get(20)?;
+    let shell_output_format_raw: Option<String> = row.get(21)?;
+    let shell_output_format = shell_output_format_raw
+        .as_deref()
+        .and_then(|s| serde_json::from_str::<CronShellOutputFormat>(&format!("\"{s}\"")).ok())
+        .unwrap_or_default();
 
     Ok(CronJob {
         id: row.get(0)?,
@@ -901,6 +940,7 @@ fn map_cron_job_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<CronJob> {
         delete_after_run: row.get::<_, i64>(11)? != 0,
         source: source.unwrap_or_else(|| "imperative".to_string()),
         uses_memory: uses_memory != Some(0),
+        shell_output_format,
         created_at: parse_rfc3339(&created_at_raw).map_err(sql_conversion_error)?,
         next_run: parse_rfc3339(&next_run_raw).map_err(sql_conversion_error)?,
         last_run: match last_run_raw {
@@ -1476,6 +1516,11 @@ fn initialize_schema(conn: &Connection) -> Result<()> {
     // runs longer than the poll interval cannot be launched again while still in
     // flight (see `claim_job`/`release_job` and
     add_column_if_missing(conn, "locked_at", "TEXT")?;
+    add_column_if_missing(
+        conn,
+        "shell_output_format",
+        "TEXT NOT NULL DEFAULT 'wrapped'",
+    )?;
 
     Ok(())
 }
@@ -2701,6 +2746,7 @@ schedule = { kind = "every", every_ms = 300000 }
             allowed_tools: None,
             uses_memory: false,
             source: "imperative".to_string(),
+            shell_output_format: CronShellOutputFormat::default(),
             created_at: now,
             next_run: next_run_for_schedule(schedule, now).unwrap_or(now),
             last_run: None,

--- a/crates/zeroclaw-runtime/src/cron/store.rs
+++ b/crates/zeroclaw-runtime/src/cron/store.rs
@@ -947,10 +947,8 @@ fn map_cron_job_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<CronJob> {
     let uses_memory: Option<i64> = row.get(19)?;
     let agent_alias: Option<String> = row.get(20)?;
     let shell_output_format_raw: Option<String> = row.get(21)?;
-    let shell_output_format = shell_output_format_raw
-        .as_deref()
-        .and_then(|s| serde_json::from_str::<CronShellOutputFormat>(&format!("\"{s}\"")).ok())
-        .unwrap_or_default();
+    let shell_output_format = decode_shell_output_format(shell_output_format_raw.as_deref())
+        .map_err(sql_conversion_error)?;
 
     Ok(CronJob {
         id: row.get(0)?,
@@ -1029,6 +1027,18 @@ fn encode_allowed_tools(allowed_tools: Option<&Vec<String>>) -> Result<Option<St
         .map(serde_json::to_string)
         .transpose()
         .context("Failed to serialize cron allowed_tools")
+}
+
+fn decode_shell_output_format(raw: Option<&str>) -> Result<CronShellOutputFormat> {
+    let Some(raw) = raw else {
+        return Ok(CronShellOutputFormat::default());
+    };
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(CronShellOutputFormat::default());
+    }
+    serde_json::from_str(&format!("\"{trimmed}\""))
+        .with_context(|| format!("Unknown cron shell_output_format value: {trimmed}"))
 }
 
 fn decode_allowed_tools(raw: Option<&str>) -> Result<Option<Vec<String>>> {
@@ -2240,6 +2250,37 @@ mod tests {
         .unwrap();
 
         assert!(get_job(&config, "job-type-invalid").is_err());
+    }
+
+    #[test]
+    fn shell_output_format_from_sql_rejects_invalid_value() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(&tmp);
+        let now = Utc::now();
+
+        with_initialized_connection(&config, |conn| {
+            conn.execute(
+                "INSERT INTO cron_jobs (id, expression, command, schedule, job_type, created_at, next_run, shell_output_format)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                params![
+                    "shell-output-format-invalid",
+                    "*/5 * * * *",
+                    "echo ok",
+                    Option::<String>::None,
+                    "shell",
+                    now.to_rfc3339(),
+                    (now + ChronoDuration::minutes(5)).to_rfc3339(),
+                    "raw2",
+                ],
+            )?;
+            Ok(())
+        })
+        .unwrap();
+
+        assert!(
+            get_job(&config, "shell-output-format-invalid").is_err(),
+            "an unparseable persisted shell_output_format must surface an error, not silently become Wrapped"
+        );
     }
 
     #[test]

--- a/crates/zeroclaw-runtime/src/cron/store.rs
+++ b/crates/zeroclaw-runtime/src/cron/store.rs
@@ -2340,6 +2340,7 @@ mod tests {
                 uses_memory: true,
                 session_target: None,
                 delivery: None,
+                shell_output_format: Default::default(),
             },
         )
     }
@@ -2366,6 +2367,7 @@ mod tests {
                 uses_memory: true,
                 session_target: None,
                 delivery: None,
+                shell_output_format: Default::default(),
             },
         )
     }
@@ -2553,6 +2555,7 @@ mod tests {
             uses_memory: true,
             session_target: None,
             delivery: None,
+            shell_output_format: Default::default(),
         };
 
         let mut decls = std::collections::HashMap::new();

--- a/crates/zeroclaw-runtime/src/cron/store.rs
+++ b/crates/zeroclaw-runtime/src/cron/store.rs
@@ -2324,18 +2324,37 @@ mod tests {
         let db_path = cron_db(&config);
         std::fs::create_dir_all(db_path.parent().unwrap()).unwrap();
 
-        // Pre-create the DB with shell_output_format as nullable TEXT so that
-        // the normal migration path sees it already exists and leaves it as-is.
+        // Pre-create the DB with the complete legacy table shape (all columns
+        // that get_job() SELECTs) so SQLite can prepare the statement and
+        // map_cron_job_row() reaches decode_shell_output_format. The
+        // shell_output_format column is intentionally nullable so the normal
+        // migration path sees it already exists and leaves it as-is.
         {
             let conn = Connection::open(&db_path).unwrap();
             conn.execute_batch(
                 "CREATE TABLE IF NOT EXISTS cron_jobs (
-                    id               TEXT PRIMARY KEY,
-                    expression       TEXT NOT NULL,
-                    command          TEXT NOT NULL,
-                    created_at       TEXT NOT NULL,
-                    next_run         TEXT NOT NULL,
-                    shell_output_format TEXT
+                    id                   TEXT PRIMARY KEY,
+                    expression           TEXT NOT NULL,
+                    command              TEXT NOT NULL,
+                    schedule             TEXT,
+                    job_type             TEXT NOT NULL DEFAULT 'shell',
+                    prompt               TEXT,
+                    name                 TEXT,
+                    session_target       TEXT NOT NULL DEFAULT 'isolated',
+                    model                TEXT,
+                    enabled              INTEGER NOT NULL DEFAULT 1,
+                    delivery             TEXT,
+                    delete_after_run     INTEGER NOT NULL DEFAULT 0,
+                    allowed_tools        TEXT,
+                    created_at           TEXT NOT NULL,
+                    next_run             TEXT NOT NULL,
+                    last_run             TEXT,
+                    last_status          TEXT,
+                    last_output          TEXT,
+                    source               TEXT DEFAULT 'imperative',
+                    uses_memory          INTEGER NOT NULL DEFAULT 1,
+                    agent_alias          TEXT NOT NULL DEFAULT '',
+                    shell_output_format  TEXT
                 );",
             )
             .unwrap();
@@ -2354,9 +2373,13 @@ mod tests {
             .unwrap();
         }
 
+        let err = get_job(&config, "shell-output-format-null").expect_err(
+            "NULL shell_output_format must surface an error, not silently become Wrapped",
+        );
+        let msg = err.to_string();
         assert!(
-            get_job(&config, "shell-output-format-null").is_err(),
-            "NULL shell_output_format must surface an error, not silently become Wrapped"
+            msg.contains("NULL"),
+            "Error should identify the NULL shell_output_format column, got: {msg}"
         );
     }
 

--- a/crates/zeroclaw-runtime/src/cron/store.rs
+++ b/crates/zeroclaw-runtime/src/cron/store.rs
@@ -487,12 +487,24 @@ pub fn update_job(config: &Config, job_id: &str, patch: CronJobPatch) -> Result<
         job.uses_memory = uses_memory;
     }
     if let Some(shell_output_format) = patch.shell_output_format {
-        // Declarative jobs read this from `config.cron`, not the DB column
-        // (the API rejects this patch for them already; this is
-        // defense-in-depth for any other caller of `update_job`).
-        if job.source != "declarative" {
-            job.shell_output_format = shell_output_format;
+        // Config-owned (declarative) and non-shell (agent) jobs never store
+        // this field: the gateway API already rejects both cases, but this
+        // is the core boundary every caller of `update_job` goes through,
+        // so it must reject them too rather than silently ignoring or
+        // persisting a value execution never consumes.
+        if job.source == "declarative" {
+            anyhow::bail!(
+                "Cron job '{job_id}': shell_output_format is owned by config.toml for a \
+                 declarative job, not the database"
+            );
         }
+        if job.job_type != JobType::Shell {
+            let job_type: &str = job.job_type.into();
+            anyhow::bail!(
+                "Cron job '{job_id}': shell_output_format is shell-only and cannot be set on a '{job_type}' job"
+            );
+        }
+        job.shell_output_format = shell_output_format;
     }
 
     if schedule_changed {
@@ -1030,15 +1042,17 @@ fn encode_allowed_tools(allowed_tools: Option<&Vec<String>>) -> Result<Option<St
 }
 
 fn decode_shell_output_format(raw: Option<&str>) -> Result<CronShellOutputFormat> {
-    let Some(raw) = raw else {
-        return Ok(CronShellOutputFormat::default());
-    };
-    let trimmed = raw.trim();
-    if trimmed.is_empty() {
-        return Ok(CronShellOutputFormat::default());
+    // Exact match against the canonical `#[serde(rename_all = "snake_case")]`
+    // spellings, not a JSON-string round trip: wrapping arbitrary stored text
+    // in quotes and handing it to a JSON parser would let an escape sequence
+    // in the raw column (e.g. `raw`) decode as a different value than
+    // what was actually persisted.
+    match raw {
+        None => Ok(CronShellOutputFormat::default()),
+        Some("wrapped") => Ok(CronShellOutputFormat::Wrapped),
+        Some("raw") => Ok(CronShellOutputFormat::Raw),
+        Some(other) => anyhow::bail!("Unknown cron shell_output_format value: {other:?}"),
     }
-    serde_json::from_str(&format!("\"{trimmed}\""))
-        .with_context(|| format!("Unknown cron shell_output_format value: {trimmed}"))
 }
 
 fn decode_allowed_tools(raw: Option<&str>) -> Result<Option<Vec<String>>> {
@@ -1290,6 +1304,12 @@ fn validate_decl(id: &str, decl: &zeroclaw_config::schema::CronJobDecl) -> Resul
             if decl.prompt.as_deref().is_none_or(|p| p.trim().is_empty()) {
                 anyhow::bail!(
                     "Declarative cron job '{id}': agent job requires a non-empty 'prompt'"
+                );
+            }
+            if decl.shell_output_format != zeroclaw_config::schema::CronShellOutputFormat::default()
+            {
+                anyhow::bail!(
+                    "Declarative cron job '{id}': shell_output_format is shell-only and cannot be set on an agent job"
                 );
             }
         }
@@ -2258,29 +2278,37 @@ mod tests {
         let config = test_config(&tmp);
         let now = Utc::now();
 
-        with_initialized_connection(&config, |conn| {
-            conn.execute(
-                "INSERT INTO cron_jobs (id, expression, command, schedule, job_type, created_at, next_run, shell_output_format)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
-                params![
-                    "shell-output-format-invalid",
-                    "*/5 * * * *",
-                    "echo ok",
-                    Option::<String>::None,
-                    "shell",
-                    now.to_rfc3339(),
-                    (now + ChronoDuration::minutes(5)).to_rfc3339(),
-                    "raw2",
-                ],
-            )?;
-            Ok(())
-        })
-        .unwrap();
+        // "raw2": an ordinary unrecognized value. "": a present-but-empty
+        // column (distinct from the column being absent/NULL). "raw":
+        // an escaped spelling that a JSON-string round trip would have
+        // decoded as "raw" even though the persisted bytes are not the
+        // canonical value.
+        for (i, invalid) in ["raw2", "", "r\\u0061w"].into_iter().enumerate() {
+            let id = format!("shell-output-format-invalid-{i}");
+            with_initialized_connection(&config, |conn| {
+                conn.execute(
+                    "INSERT INTO cron_jobs (id, expression, command, schedule, job_type, created_at, next_run, shell_output_format)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                    params![
+                        id,
+                        "*/5 * * * *",
+                        "echo ok",
+                        Option::<String>::None,
+                        "shell",
+                        now.to_rfc3339(),
+                        (now + ChronoDuration::minutes(5)).to_rfc3339(),
+                        invalid,
+                    ],
+                )?;
+                Ok(())
+            })
+            .unwrap();
 
-        assert!(
-            get_job(&config, "shell-output-format-invalid").is_err(),
-            "an unparseable persisted shell_output_format must surface an error, not silently become Wrapped"
-        );
+            assert!(
+                get_job(&config, &id).is_err(),
+                "persisted shell_output_format {invalid:?} must surface an error, not silently become Wrapped"
+            );
+        }
     }
 
     #[test]
@@ -2642,6 +2670,28 @@ mod tests {
         let result = sync_declarative_jobs(&config, &decls);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("prompt"));
+    }
+
+    #[test]
+    fn sync_validates_agent_job_rejects_shell_output_format() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(&tmp);
+
+        let (id, mut decl) = make_agent_decl("bad-agent-format", "0 2 * * *", "do stuff");
+        decl.shell_output_format = zeroclaw_config::schema::CronShellOutputFormat::Raw;
+
+        let decls = decls_map(vec![(id, decl)]);
+        let result = sync_declarative_jobs(&config, &decls);
+        assert!(
+            result.is_err(),
+            "shell_output_format is shell-only and must be rejected on a declarative agent job"
+        );
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("shell_output_format")
+        );
     }
 
     #[test]
@@ -3077,6 +3127,87 @@ schedule = { kind = "every", every_ms = 300000 }
             overdue_job.shell_output_format,
             zeroclaw_config::schema::CronShellOutputFormat::Wrapped,
             "all_overdue_jobs must follow the current config value, not a stored snapshot"
+        );
+    }
+
+    #[test]
+    fn update_job_rejects_shell_output_format_for_declarative_job() {
+        let tmp = TempDir::new().unwrap();
+        let mut config = test_config(&tmp);
+        seed_claiming_agent(&mut config, &["decl-job"]);
+
+        let decl = zeroclaw_config::schema::CronJobDecl {
+            name: Some("decl-job".to_string()),
+            job_type: "shell".to_string(),
+            schedule: zeroclaw_config::schema::CronScheduleDecl::Cron {
+                expr: "0 2 * * *".to_string(),
+                tz: None,
+            },
+            command: Some("echo ok".to_string()),
+            prompt: None,
+            enabled: true,
+            model: None,
+            allowed_tools: None,
+            uses_memory: true,
+            session_target: None,
+            delivery: None,
+            shell_output_format: zeroclaw_config::schema::CronShellOutputFormat::Wrapped,
+        };
+        let decls = decls_map(vec![("decl-job".to_string(), decl.clone())]);
+        config.cron.insert("decl-job".to_string(), decl);
+        sync_declarative_jobs(&config, &decls).unwrap();
+
+        let err = update_job(
+            &config,
+            "decl-job",
+            CronJobPatch {
+                shell_output_format: Some(zeroclaw_config::schema::CronShellOutputFormat::Raw),
+                ..CronJobPatch::default()
+            },
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("config.toml"),
+            "the core update_job boundary must reject a config-owned mutation, not silently ignore it: {err}"
+        );
+    }
+
+    #[test]
+    fn update_job_rejects_shell_output_format_for_agent_job() {
+        let tmp = TempDir::new().unwrap();
+        let mut config = test_config(&tmp);
+        seed_claiming_agent(&mut config, &["default"]);
+
+        let job = add_agent_job(
+            &config,
+            "default",
+            Some("agent-job".into()),
+            Schedule::Cron {
+                expr: "*/5 * * * *".into(),
+                tz: None,
+            },
+            "summarize logs",
+            SessionTarget::Isolated,
+            None,
+            None,
+            false,
+            None,
+            true,
+        )
+        .unwrap();
+
+        let err = update_job(
+            &config,
+            &job.id,
+            CronJobPatch {
+                shell_output_format: Some(zeroclaw_config::schema::CronShellOutputFormat::Raw),
+                ..CronJobPatch::default()
+            },
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("shell-only"),
+            "the core update_job boundary must reject shell_output_format on a non-shell job: {err}"
         );
     }
 }

--- a/crates/zeroclaw-runtime/src/cron/store.rs
+++ b/crates/zeroclaw-runtime/src/cron/store.rs
@@ -222,7 +222,19 @@ pub fn list_jobs(config: &Config) -> Result<Vec<CronJob>> {
 }
 
 pub fn get_job(config: &Config, job_id: &str) -> Result<CronJob> {
-    let Some(mut job) = with_read_connection(config, |conn| {
+    let mut job = get_job_raw(config, job_id)?;
+    resolve_declarative_shell_output_format(config, &mut job);
+    Ok(job)
+}
+
+/// Raw DB row for a job, with no config overlay applied. `shell_output_format`
+/// on the returned job is exactly what's stored in the `cron_jobs` column —
+/// for a declarative job that is a stale/default value, not the canonical
+/// one from `config.cron`. Used by [`update_job`] so unrelated patches don't
+/// re-persist a config-resolved snapshot into a column declarative jobs
+/// don't own; every other caller should use [`get_job`] instead.
+fn get_job_raw(config: &Config, job_id: &str) -> Result<CronJob> {
+    let Some(job) = with_read_connection(config, |conn| {
         let mut stmt = conn.prepare(
             "SELECT id, expression, command, schedule, job_type, prompt, name, session_target, model,
                      enabled, delivery, delete_after_run, created_at, next_run, last_run, last_status, last_output,
@@ -240,8 +252,6 @@ pub fn get_job(config: &Config, job_id: &str) -> Result<CronJob> {
     else {
         anyhow::bail!("Cron job '{job_id}' not found")
     };
-
-    resolve_declarative_shell_output_format(config, &mut job);
     Ok(job)
 }
 
@@ -366,7 +376,10 @@ pub fn due_jobs(config: &Config, now: DateTime<Utc>) -> Result<Vec<CronJob>> {
         let mut jobs = Vec::new();
         for row in rows {
             match row {
-                Ok(job) => jobs.push(job),
+                Ok(mut job) => {
+                    resolve_declarative_shell_output_format(config, &mut job);
+                    jobs.push(job);
+                }
                 Err(e) => ::zeroclaw_log::record!(
                     WARN,
                     ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
@@ -401,7 +414,10 @@ pub fn all_overdue_jobs(config: &Config, now: DateTime<Utc>) -> Result<Vec<CronJ
         let mut jobs = Vec::new();
         for row in rows {
             match row {
-                Ok(job) => jobs.push(job),
+                Ok(mut job) => {
+                    resolve_declarative_shell_output_format(config, &mut job);
+                    jobs.push(job);
+                }
                 Err(e) => ::zeroclaw_log::record!(
                     WARN,
                     ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
@@ -421,7 +437,11 @@ pub fn all_overdue_jobs(config: &Config, now: DateTime<Utc>) -> Result<Vec<CronJ
 }
 
 pub fn update_job(config: &Config, job_id: &str, patch: CronJobPatch) -> Result<CronJob> {
-    let mut job = get_job(config, job_id)?;
+    // Start from the raw DB row, not the config-resolved `get_job()` view:
+    // for a declarative job, `shell_output_format` isn't DB-owned, so an
+    // unrelated patch (e.g. toggling `enabled`) must not re-persist the
+    // resolved config value into the column and recreate a second owner.
+    let mut job = get_job_raw(config, job_id)?;
     let mut schedule_changed = false;
 
     if let Some(schedule) = patch.schedule {
@@ -467,7 +487,12 @@ pub fn update_job(config: &Config, job_id: &str, patch: CronJobPatch) -> Result<
         job.uses_memory = uses_memory;
     }
     if let Some(shell_output_format) = patch.shell_output_format {
-        job.shell_output_format = shell_output_format;
+        // Declarative jobs read this from `config.cron`, not the DB column
+        // (the API rejects this patch for them already; this is
+        // defense-in-depth for any other caller of `update_job`).
+        if job.source != "declarative" {
+            job.shell_output_format = shell_output_format;
+        }
     }
 
     if schedule_changed {
@@ -2926,6 +2951,91 @@ schedule = { kind = "every", every_ms = 300000 }
             listed.shell_output_format,
             zeroclaw_config::schema::CronShellOutputFormat::Raw,
             "list_jobs must return raw format resolved from config for a declarative raw shell job"
+        );
+    }
+
+    /// Regression: an unrelated `update_job()` patch on a declarative job
+    /// must not persist a config-resolved snapshot of `shell_output_format`
+    /// into the DB column. After the update, a later config change must
+    /// still be reflected by `get_job()`, `due_jobs()`, and
+    /// `all_overdue_jobs()` — none of them may keep serving a value the
+    /// unrelated update happened to freeze at update time.
+    #[test]
+    fn update_job_unrelated_patch_does_not_snapshot_declarative_shell_output_format() {
+        let tmp = TempDir::new().unwrap();
+        let mut config = test_config(&tmp);
+        seed_claiming_agent(&mut config, &["raw-decl"]);
+
+        let mut decl = zeroclaw_config::schema::CronJobDecl {
+            name: Some("raw-decl".to_string()),
+            job_type: "shell".to_string(),
+            schedule: zeroclaw_config::schema::CronScheduleDecl::Cron {
+                expr: "0 2 * * *".to_string(),
+                tz: None,
+            },
+            command: Some("echo raw-decl-output".to_string()),
+            prompt: None,
+            enabled: true,
+            model: None,
+            allowed_tools: None,
+            uses_memory: true,
+            session_target: None,
+            delivery: None,
+            shell_output_format: zeroclaw_config::schema::CronShellOutputFormat::Raw,
+        };
+        let decls = decls_map(vec![("raw-decl".to_string(), decl.clone())]);
+        config.cron.insert("raw-decl".to_string(), decl.clone());
+        sync_declarative_jobs(&config, &decls).unwrap();
+
+        // Unrelated patch: only toggles `uses_memory`, never touches
+        // `shell_output_format`. Must not freeze the currently-resolved
+        // `Raw` value into the DB column.
+        update_job(
+            &config,
+            "raw-decl",
+            CronJobPatch {
+                uses_memory: Some(false),
+                ..CronJobPatch::default()
+            },
+        )
+        .unwrap();
+
+        // Config changes after the update — if the update had snapshotted
+        // `Raw` into the DB column, every read path below would still
+        // report `Raw` instead of following this change.
+        decl.shell_output_format = zeroclaw_config::schema::CronShellOutputFormat::Wrapped;
+        config.cron.insert("raw-decl".to_string(), decl);
+
+        let far_future = Utc::now() + ChronoDuration::days(365);
+
+        let job = get_job(&config, "raw-decl").unwrap();
+        assert_eq!(
+            job.shell_output_format,
+            zeroclaw_config::schema::CronShellOutputFormat::Wrapped,
+            "get_job must follow the current config value, not a value snapshotted by an unrelated update"
+        );
+        assert!(
+            !job.uses_memory,
+            "the unrelated patch must still have taken effect"
+        );
+
+        let due = due_jobs(&config, far_future).unwrap();
+        let due_job = due.iter().find(|j| j.id == "raw-decl").expect("job is due");
+        assert_eq!(
+            due_job.shell_output_format,
+            zeroclaw_config::schema::CronShellOutputFormat::Wrapped,
+            "due_jobs must follow the current config value, not a stored snapshot"
+        );
+
+        let overdue = all_overdue_jobs(&config, far_future).unwrap();
+        let overdue_job = overdue
+            .iter()
+            .find(|j| j.id == "raw-decl")
+            .expect("job is overdue");
+        assert_eq!(
+            overdue_job.shell_output_format,
+            zeroclaw_config::schema::CronShellOutputFormat::Wrapped,
+            "all_overdue_jobs must follow the current config value, not a stored snapshot"
         );
     }
 }

--- a/crates/zeroclaw-runtime/src/cron/store.rs
+++ b/crates/zeroclaw-runtime/src/cron/store.rs
@@ -1048,7 +1048,9 @@ fn decode_shell_output_format(raw: Option<&str>) -> Result<CronShellOutputFormat
     // in the raw column (e.g. `raw`) decode as a different value than
     // what was actually persisted.
     match raw {
-        None => Ok(CronShellOutputFormat::default()),
+        None => {
+            anyhow::bail!("cron shell_output_format column is NULL; schema requires TEXT NOT NULL")
+        }
         Some("wrapped") => Ok(CronShellOutputFormat::Wrapped),
         Some("raw") => Ok(CronShellOutputFormat::Raw),
         Some(other) => anyhow::bail!("Unknown cron shell_output_format value: {other:?}"),
@@ -2309,6 +2311,53 @@ mod tests {
                 "persisted shell_output_format {invalid:?} must surface an error, not silently become Wrapped"
             );
         }
+    }
+
+    #[test]
+    fn shell_output_format_from_sql_rejects_null() {
+        // Simulates a forward-compatible database where shell_output_format was
+        // added as a nullable column by a different schema version.
+        // add_column_if_missing skips the column if it already exists (regardless
+        // of type/nullability), so NULL can reach decode_shell_output_format.
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(&tmp);
+        let db_path = cron_db(&config);
+        std::fs::create_dir_all(db_path.parent().unwrap()).unwrap();
+
+        // Pre-create the DB with shell_output_format as nullable TEXT so that
+        // the normal migration path sees it already exists and leaves it as-is.
+        {
+            let conn = Connection::open(&db_path).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE IF NOT EXISTS cron_jobs (
+                    id               TEXT PRIMARY KEY,
+                    expression       TEXT NOT NULL,
+                    command          TEXT NOT NULL,
+                    created_at       TEXT NOT NULL,
+                    next_run         TEXT NOT NULL,
+                    shell_output_format TEXT
+                );",
+            )
+            .unwrap();
+            let now = Utc::now();
+            conn.execute(
+                "INSERT INTO cron_jobs (id, expression, command, created_at, next_run, shell_output_format)
+                 VALUES (?1, ?2, ?3, ?4, ?5, NULL)",
+                params![
+                    "shell-output-format-null",
+                    "*/5 * * * *",
+                    "echo ok",
+                    now.to_rfc3339(),
+                    (now + ChronoDuration::minutes(5)).to_rfc3339(),
+                ],
+            )
+            .unwrap();
+        }
+
+        assert!(
+            get_job(&config, "shell-output-format-null").is_err(),
+            "NULL shell_output_format must surface an error, not silently become Wrapped"
+        );
     }
 
     #[test]

--- a/crates/zeroclaw-runtime/src/cron/store.rs
+++ b/crates/zeroclaw-runtime/src/cron/store.rs
@@ -208,7 +208,9 @@ pub fn list_jobs(config: &Config) -> Result<Vec<CronJob>> {
 
         let mut jobs = Vec::new();
         for row in rows {
-            jobs.push(row?);
+            let mut job = row?;
+            resolve_declarative_shell_output_format(config, &mut job);
+            jobs.push(job);
         }
         Ok(jobs)
     })?
@@ -220,7 +222,7 @@ pub fn list_jobs(config: &Config) -> Result<Vec<CronJob>> {
 }
 
 pub fn get_job(config: &Config, job_id: &str) -> Result<CronJob> {
-    let Some(job) = with_read_connection(config, |conn| {
+    let Some(mut job) = with_read_connection(config, |conn| {
         let mut stmt = conn.prepare(
             "SELECT id, expression, command, schedule, job_type, prompt, name, session_target, model,
                      enabled, delivery, delete_after_run, created_at, next_run, last_run, last_status, last_output,
@@ -239,6 +241,7 @@ pub fn get_job(config: &Config, job_id: &str) -> Result<CronJob> {
         anyhow::bail!("Cron job '{job_id}' not found")
     };
 
+    resolve_declarative_shell_output_format(config, &mut job);
     Ok(job)
 }
 
@@ -303,7 +306,9 @@ pub fn list_jobs_by_agent(config: &Config, agent_alias: &str) -> Result<Vec<Cron
         let rows = stmt.query_map(params![agent_alias], map_cron_job_row)?;
         let mut jobs = Vec::new();
         for row in rows {
-            jobs.push(row?);
+            let mut job = row?;
+            resolve_declarative_shell_output_format(config, &mut job);
+            jobs.push(job);
         }
         Ok(jobs)
     })?
@@ -954,6 +959,16 @@ fn map_cron_job_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<CronJob> {
     })
 }
 
+/// For declarative jobs, resolve `shell_output_format` from the canonical
+/// config source instead of the DB column (which stays at the default).
+fn resolve_declarative_shell_output_format(config: &Config, job: &mut CronJob) {
+    if job.source == "declarative"
+        && let Some(decl) = config.cron.get(&job.id)
+    {
+        job.shell_output_format = decl.shell_output_format.clone();
+    }
+}
+
 fn decode_schedule(schedule_raw: Option<&str>, expression: &str) -> Result<Schedule> {
     if let Some(raw) = schedule_raw {
         let trimmed = raw.trim();
@@ -1080,10 +1095,6 @@ pub fn sync_declarative_jobs(
             let allowed_tools_json = encode_allowed_tools(decl.allowed_tools.as_ref())?;
             let command = decl.command.as_deref().unwrap_or("");
             let delete_after_run = matches!(decl.schedule, CronScheduleDecl::At { .. });
-            let shell_output_format_str = match decl.shell_output_format {
-                zeroclaw_config::schema::CronShellOutputFormat::Wrapped => "wrapped",
-                zeroclaw_config::schema::CronShellOutputFormat::Raw => "raw",
-            };
 
             // Check if job already exists.
             let exists: bool = conn
@@ -1111,8 +1122,8 @@ pub fn sync_declarative_jobs(
                              prompt = ?5, name = ?6, session_target = ?7, model = ?8,
                              enabled = ?9, delivery = ?10, delete_after_run = ?11,
                              allowed_tools = ?12, source = 'declarative', next_run = ?13,
-                             uses_memory = ?14, shell_output_format = ?15
-                         WHERE id = ?16",
+                             uses_memory = ?14
+                         WHERE id = ?15",
                         params![
                             expression,
                             command,
@@ -1128,7 +1139,6 @@ pub fn sync_declarative_jobs(
                             allowed_tools_json,
                             next_run.to_rfc3339(),
                             i32::from(decl.uses_memory),
-                            shell_output_format_str,
                             id,
                         ],
                     )
@@ -1140,8 +1150,8 @@ pub fn sync_declarative_jobs(
                              prompt = ?5, name = ?6, session_target = ?7, model = ?8,
                              enabled = ?9, delivery = ?10, delete_after_run = ?11,
                              allowed_tools = ?12, source = 'declarative',
-                             uses_memory = ?13, shell_output_format = ?14
-                         WHERE id = ?15",
+                             uses_memory = ?13
+                         WHERE id = ?14",
                         params![
                             expression,
                             command,
@@ -1156,7 +1166,6 @@ pub fn sync_declarative_jobs(
                             i32::from(delete_after_run),
                             allowed_tools_json,
                             i32::from(decl.uses_memory),
-                            shell_output_format_str,
                             id,
                         ],
                     )
@@ -1189,9 +1198,8 @@ pub fn sync_declarative_jobs(
                     "INSERT INTO cron_jobs (
                         id, expression, command, schedule, job_type, prompt, name,
                         session_target, model, enabled, delivery, delete_after_run,
-                        allowed_tools, source, uses_memory, agent_alias, created_at, next_run,
-                        shell_output_format
-                     ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, 'declarative', ?14, ?15, ?16, ?17, ?18)",
+                        allowed_tools, source, uses_memory, agent_alias, created_at, next_run
+                     ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, 'declarative', ?14, ?15, ?16, ?17)",
                     params![
                         id,
                         expression,
@@ -1210,7 +1218,6 @@ pub fn sync_declarative_jobs(
                         agent_alias,
                         now.to_rfc3339(),
                         next_run.to_rfc3339(),
-                        shell_output_format_str,
                     ],
                 )
                 .with_context(|| {
@@ -2873,40 +2880,40 @@ schedule = { kind = "every", every_ms = 300000 }
 
     /// Regression: a declarative shell job with `shell_output_format = raw`
     /// must report `shell_output_format = raw` through `get_job()`/`list_jobs()`,
-    /// matching the execution source of truth (config).
+    /// resolving from the config source of truth (not the DB column).
     #[test]
     fn sync_declarative_raw_shell_job_lists_with_raw_format() {
         let tmp = TempDir::new().unwrap();
         let mut config = test_config(&tmp);
         seed_claiming_agent(&mut config, &["raw-decl"]);
 
-        let decls = decls_map(vec![(
-            "raw-decl".to_string(),
-            zeroclaw_config::schema::CronJobDecl {
-                name: Some("raw-decl".to_string()),
-                job_type: "shell".to_string(),
-                schedule: zeroclaw_config::schema::CronScheduleDecl::Cron {
-                    expr: "0 2 * * *".to_string(),
-                    tz: None,
-                },
-                command: Some("echo raw-decl-output".to_string()),
-                prompt: None,
-                enabled: true,
-                model: None,
-                allowed_tools: None,
-                uses_memory: true,
-                session_target: None,
-                delivery: None,
-                shell_output_format: zeroclaw_config::schema::CronShellOutputFormat::Raw,
+        let decl = zeroclaw_config::schema::CronJobDecl {
+            name: Some("raw-decl".to_string()),
+            job_type: "shell".to_string(),
+            schedule: zeroclaw_config::schema::CronScheduleDecl::Cron {
+                expr: "0 2 * * *".to_string(),
+                tz: None,
             },
-        )]);
+            command: Some("echo raw-decl-output".to_string()),
+            prompt: None,
+            enabled: true,
+            model: None,
+            allowed_tools: None,
+            uses_memory: true,
+            session_target: None,
+            delivery: None,
+            shell_output_format: zeroclaw_config::schema::CronShellOutputFormat::Raw,
+        };
+        let decls = decls_map(vec![("raw-decl".to_string(), decl.clone())]);
+        // Populate config.cron so resolution finds the canonical source.
+        config.cron.insert("raw-decl".to_string(), decl);
         sync_declarative_jobs(&config, &decls).unwrap();
 
         let job = get_job(&config, "raw-decl").unwrap();
         assert_eq!(
             job.shell_output_format,
             zeroclaw_config::schema::CronShellOutputFormat::Raw,
-            "get_job must return raw format for a declarative raw shell job"
+            "get_job must return raw format resolved from config for a declarative raw shell job"
         );
         assert_eq!(job.source, "declarative");
 
@@ -2918,7 +2925,7 @@ schedule = { kind = "every", every_ms = 300000 }
         assert_eq!(
             listed.shell_output_format,
             zeroclaw_config::schema::CronShellOutputFormat::Raw,
-            "list_jobs must return raw format for a declarative raw shell job"
+            "list_jobs must return raw format resolved from config for a declarative raw shell job"
         );
     }
 }

--- a/crates/zeroclaw-runtime/src/cron/store.rs
+++ b/crates/zeroclaw-runtime/src/cron/store.rs
@@ -959,8 +959,16 @@ fn map_cron_job_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<CronJob> {
     let uses_memory: Option<i64> = row.get(19)?;
     let agent_alias: Option<String> = row.get(20)?;
     let shell_output_format_raw: Option<String> = row.get(21)?;
-    let shell_output_format = decode_shell_output_format(shell_output_format_raw.as_deref())
-        .map_err(sql_conversion_error)?;
+    // Declarative jobs never own this column — sync_declarative_jobs skips it
+    // and resolve_declarative_shell_output_format() overwrites from config.
+    // Decoding a NULL / corrupt / future shadow here would kill valid
+    // config-owned jobs before the overlay runs.
+    let shell_output_format = if source.as_deref() == Some("declarative") {
+        CronShellOutputFormat::default()
+    } else {
+        decode_shell_output_format(shell_output_format_raw.as_deref())
+            .map_err(sql_conversion_error)?
+    };
 
     Ok(CronJob {
         id: row.get(0)?,
@@ -2380,6 +2388,141 @@ mod tests {
         assert!(
             msg.contains("NULL"),
             "Error should identify the NULL shell_output_format column, got: {msg}"
+        );
+    }
+
+    /// Regression: a declarative job whose DB shadow for `shell_output_format`
+    /// is NULL or corrupt must still be visible through get_job / due_jobs /
+    /// all_overdue_jobs, with the canonical value resolved from config.
+    /// The strict decode must not kill valid config-owned jobs before the
+    /// declarative overlay runs.
+    #[test]
+    fn declarative_job_ignores_invalid_db_shadow_for_shell_output_format() {
+        let tmp = TempDir::new().unwrap();
+        let mut config = test_config(&tmp);
+
+        // Simulate a forward-compatible database where shell_output_format was
+        // added as a nullable column by a different schema version.
+        // add_column_if_missing skips the column if it already exists, so NULL
+        // or garbage can reach map_cron_job_row.
+        let db_path = cron_db(&config);
+        std::fs::create_dir_all(db_path.parent().unwrap()).unwrap();
+        {
+            let conn = Connection::open(&db_path).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE IF NOT EXISTS cron_jobs (
+                    id                   TEXT PRIMARY KEY,
+                    expression           TEXT NOT NULL,
+                    command              TEXT NOT NULL,
+                    schedule             TEXT,
+                    job_type             TEXT NOT NULL DEFAULT 'shell',
+                    prompt               TEXT,
+                    name                 TEXT,
+                    session_target       TEXT NOT NULL DEFAULT 'isolated',
+                    model                TEXT,
+                    enabled              INTEGER NOT NULL DEFAULT 1,
+                    delivery             TEXT,
+                    delete_after_run     INTEGER NOT NULL DEFAULT 0,
+                    allowed_tools        TEXT,
+                    created_at           TEXT NOT NULL,
+                    next_run             TEXT NOT NULL,
+                    last_run             TEXT,
+                    last_status          TEXT,
+                    last_output          TEXT,
+                    source               TEXT DEFAULT 'imperative',
+                    uses_memory          INTEGER NOT NULL DEFAULT 1,
+                    agent_alias          TEXT NOT NULL DEFAULT '',
+                    shell_output_format  TEXT
+                );",
+            )
+            .unwrap();
+
+            let now = Utc::now();
+            conn.execute(
+                "INSERT INTO cron_jobs (id, expression, command, created_at, next_run, source, enabled)
+                 VALUES (?1, ?2, ?3, ?4, ?5, 'declarative', 1)",
+                params![
+                    "raw-shadow",
+                    "0 2 * * *",
+                    "echo shadow",
+                    now.to_rfc3339(),
+                    (now + ChronoDuration::hours(1)).to_rfc3339(),
+                ],
+            )
+            .unwrap();
+        }
+
+        // config.cron owns the canonical shell_output_format for this job.
+        let decl = zeroclaw_config::schema::CronJobDecl {
+            name: Some("raw-shadow".to_string()),
+            job_type: "shell".to_string(),
+            schedule: zeroclaw_config::schema::CronScheduleDecl::Cron {
+                expr: "0 2 * * *".to_string(),
+                tz: None,
+            },
+            command: Some("echo shadow".to_string()),
+            prompt: None,
+            enabled: true,
+            model: None,
+            allowed_tools: None,
+            uses_memory: true,
+            session_target: None,
+            delivery: None,
+            shell_output_format: zeroclaw_config::schema::CronShellOutputFormat::Raw,
+        };
+        config.cron.insert("raw-shadow".to_string(), decl);
+
+        // --- NULL shadow ---
+        // DB column is NULL (from the nullable table above), config says Raw.
+        let job = get_job(&config, "raw-shadow").unwrap();
+        assert_eq!(
+            job.shell_output_format,
+            zeroclaw_config::schema::CronShellOutputFormat::Raw,
+            "get_job must resolve config value when DB shadow is NULL"
+        );
+        assert_eq!(job.source, "declarative");
+
+        // --- Garbage shadow ---
+        with_initialized_connection(&config, |conn| {
+            conn.execute(
+                "UPDATE cron_jobs SET shell_output_format = 'garbage' WHERE id = ?1",
+                params!["raw-shadow"],
+            )?;
+            Ok(())
+        })
+        .unwrap();
+        let job = get_job(&config, "raw-shadow").unwrap();
+        assert_eq!(
+            job.shell_output_format,
+            zeroclaw_config::schema::CronShellOutputFormat::Raw,
+            "get_job must resolve config value when DB shadow is garbage"
+        );
+
+        // --- due_jobs / all_overdue_jobs with NULL shadow ---
+        // Reset to NULL and force into the due window.
+        with_initialized_connection(&config, |conn| {
+            conn.execute(
+                "UPDATE cron_jobs SET shell_output_format = NULL, next_run = ?1 WHERE id = ?2",
+                params![
+                    (Utc::now() - ChronoDuration::hours(1)).to_rfc3339(),
+                    "raw-shadow"
+                ],
+            )?;
+            Ok(())
+        })
+        .unwrap();
+        let now = Utc::now();
+        let due = due_jobs(&config, now).unwrap();
+        assert!(
+            due.iter().any(|j| j.id == "raw-shadow"
+                && j.shell_output_format == zeroclaw_config::schema::CronShellOutputFormat::Raw),
+            "due_jobs must include declarative job despite NULL DB shadow"
+        );
+        let overdue = all_overdue_jobs(&config, now).unwrap();
+        assert!(
+            overdue.iter().any(|j| j.id == "raw-shadow"
+                && j.shell_output_format == zeroclaw_config::schema::CronShellOutputFormat::Raw),
+            "all_overdue_jobs must include declarative job despite NULL DB shadow"
         );
     }
 

--- a/crates/zeroclaw-runtime/src/cron/store.rs
+++ b/crates/zeroclaw-runtime/src/cron/store.rs
@@ -512,34 +512,68 @@ pub fn update_job(config: &Config, job_id: &str, patch: CronJobPatch) -> Result<
     }
 
     with_initialized_connection(config, |conn| {
-        conn.execute(
-            "UPDATE cron_jobs
-             SET expression = ?1, command = ?2, schedule = ?3, job_type = ?4, prompt = ?5, name = ?6,
-                 session_target = ?7, model = ?8, enabled = ?9, delivery = ?10, delete_after_run = ?11,
-                 allowed_tools = ?12, next_run = ?13, uses_memory = ?14, shell_output_format = ?15
-             WHERE id = ?16",
-            params![
-                job.expression,
-                job.command,
-                serde_json::to_string(&job.schedule)?,
-                <JobType as Into<&str>>::into(job.job_type).to_string(),
-                job.prompt,
-                job.name,
-                job.session_target.as_str(),
-                job.model,
-                if job.enabled { 1 } else { 0 },
-                serde_json::to_string(&job.delivery)?,
-                if job.delete_after_run { 1 } else { 0 },
-                encode_allowed_tools(job.allowed_tools.as_ref())?,
-                job.next_run.to_rfc3339(),
-                if job.uses_memory { 1 } else { 0 },
-                match job.shell_output_format {
-                    CronShellOutputFormat::Wrapped => "wrapped",
-                    CronShellOutputFormat::Raw => "raw",
-                },
-                job.id,
-            ],
-        )
+        // Declarative jobs don't own `shell_output_format` — the config is the
+        // canonical source, and `resolve_declarative_shell_output_format()` overlays
+        // it on every read. Writing the synthesized (Wrapped) value back into the
+        // column during an unrelated patch would overwrite whatever was stored
+        // there (NULL, garbage, or a future value) with a value the DB doesn't
+        // own. Omit the column from the UPDATE for declarative rows so the
+        // non-owned shadow stays untouched.
+        if job.source == "declarative" {
+            conn.execute(
+                "UPDATE cron_jobs
+                 SET expression = ?1, command = ?2, schedule = ?3, job_type = ?4, prompt = ?5, name = ?6,
+                     session_target = ?7, model = ?8, enabled = ?9, delivery = ?10, delete_after_run = ?11,
+                     allowed_tools = ?12, next_run = ?13, uses_memory = ?14
+                 WHERE id = ?15",
+                params![
+                    job.expression,
+                    job.command,
+                    serde_json::to_string(&job.schedule)?,
+                    <JobType as Into<&str>>::into(job.job_type).to_string(),
+                    job.prompt,
+                    job.name,
+                    job.session_target.as_str(),
+                    job.model,
+                    if job.enabled { 1 } else { 0 },
+                    serde_json::to_string(&job.delivery)?,
+                    if job.delete_after_run { 1 } else { 0 },
+                    encode_allowed_tools(job.allowed_tools.as_ref())?,
+                    job.next_run.to_rfc3339(),
+                    if job.uses_memory { 1 } else { 0 },
+                    job.id,
+                ],
+            )
+        } else {
+            conn.execute(
+                "UPDATE cron_jobs
+                 SET expression = ?1, command = ?2, schedule = ?3, job_type = ?4, prompt = ?5, name = ?6,
+                     session_target = ?7, model = ?8, enabled = ?9, delivery = ?10, delete_after_run = ?11,
+                     allowed_tools = ?12, next_run = ?13, uses_memory = ?14, shell_output_format = ?15
+                 WHERE id = ?16",
+                params![
+                    job.expression,
+                    job.command,
+                    serde_json::to_string(&job.schedule)?,
+                    <JobType as Into<&str>>::into(job.job_type).to_string(),
+                    job.prompt,
+                    job.name,
+                    job.session_target.as_str(),
+                    job.model,
+                    if job.enabled { 1 } else { 0 },
+                    serde_json::to_string(&job.delivery)?,
+                    if job.delete_after_run { 1 } else { 0 },
+                    encode_allowed_tools(job.allowed_tools.as_ref())?,
+                    job.next_run.to_rfc3339(),
+                    if job.uses_memory { 1 } else { 0 },
+                    match job.shell_output_format {
+                        CronShellOutputFormat::Wrapped => "wrapped",
+                        CronShellOutputFormat::Raw => "raw",
+                    },
+                    job.id,
+                ],
+            )
+        }
         .context("Failed to update cron job")?;
         Ok(())
     })?;
@@ -958,16 +992,17 @@ fn map_cron_job_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<CronJob> {
     let source: Option<String> = row.get(18)?;
     let uses_memory: Option<i64> = row.get(19)?;
     let agent_alias: Option<String> = row.get(20)?;
-    let shell_output_format_raw: Option<String> = row.get(21)?;
     // Declarative jobs never own this column — sync_declarative_jobs skips it
     // and resolve_declarative_shell_output_format() overwrites from config.
-    // Decoding a NULL / corrupt / future shadow here would kill valid
-    // config-owned jobs before the overlay runs.
+    // Skip reading column 21 entirely for declarative rows: the source
+    // ownership is already determined, and attempting a typed String read
+    // on a non-owned BLOB shadow would fail before the ownership branch
+    // can take effect.
     let shell_output_format = if source.as_deref() == Some("declarative") {
         CronShellOutputFormat::default()
     } else {
-        decode_shell_output_format(shell_output_format_raw.as_deref())
-            .map_err(sql_conversion_error)?
+        let raw: Option<String> = row.get(21)?;
+        decode_shell_output_format(raw.as_deref()).map_err(sql_conversion_error)?
     };
 
     Ok(CronJob {
@@ -2526,6 +2561,104 @@ mod tests {
         );
     }
 
+    /// Regression: SQLite permits a BLOB storage class in a TEXT-affinity
+    /// column. With `x'80'` in `shell_output_format`, a declarative row must
+    /// still be readable — the typed `row.get::<String>` for column 21 must
+    /// not run before the ownership branch can skip it.
+    #[test]
+    fn declarative_job_ignores_blob_db_shadow_for_shell_output_format() {
+        let tmp = TempDir::new().unwrap();
+        let mut config = test_config(&tmp);
+
+        let db_path = cron_db(&config);
+        std::fs::create_dir_all(db_path.parent().unwrap()).unwrap();
+        {
+            let conn = Connection::open(&db_path).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE IF NOT EXISTS cron_jobs (
+                    id                   TEXT PRIMARY KEY,
+                    expression           TEXT NOT NULL,
+                    command              TEXT NOT NULL,
+                    schedule             TEXT,
+                    job_type             TEXT NOT NULL DEFAULT 'shell',
+                    prompt               TEXT,
+                    name                 TEXT,
+                    session_target       TEXT NOT NULL DEFAULT 'isolated',
+                    model                TEXT,
+                    enabled              INTEGER NOT NULL DEFAULT 1,
+                    delivery             TEXT,
+                    delete_after_run     INTEGER NOT NULL DEFAULT 0,
+                    allowed_tools        TEXT,
+                    created_at           TEXT NOT NULL,
+                    next_run             TEXT NOT NULL,
+                    last_run             TEXT,
+                    last_status          TEXT,
+                    last_output          TEXT,
+                    source               TEXT DEFAULT 'imperative',
+                    uses_memory          INTEGER NOT NULL DEFAULT 1,
+                    agent_alias          TEXT NOT NULL DEFAULT '',
+                    shell_output_format  TEXT
+                );",
+            )
+            .unwrap();
+
+            let now = Utc::now();
+            // Insert a declarative row with a BLOB in shell_output_format.
+            // SQLite allows BLOB storage in TEXT-affinity columns.
+            // Set next_run in the past so the job is due for due_jobs().
+            conn.execute(
+                "INSERT INTO cron_jobs (id, expression, command, created_at, next_run, source, enabled, shell_output_format)
+                 VALUES (?1, ?2, ?3, ?4, ?5, 'declarative', 1, x'80')",
+                params![
+                    "blob-shadow",
+                    "0 2 * * *",
+                    "echo blob",
+                    now.to_rfc3339(),
+                    (now - ChronoDuration::hours(1)).to_rfc3339(),
+                ],
+            )
+            .unwrap();
+        }
+
+        let decl = zeroclaw_config::schema::CronJobDecl {
+            name: Some("blob-shadow".to_string()),
+            job_type: "shell".to_string(),
+            schedule: zeroclaw_config::schema::CronScheduleDecl::Cron {
+                expr: "0 2 * * *".to_string(),
+                tz: None,
+            },
+            command: Some("echo blob".to_string()),
+            prompt: None,
+            enabled: true,
+            model: None,
+            allowed_tools: None,
+            uses_memory: true,
+            session_target: None,
+            delivery: None,
+            shell_output_format: zeroclaw_config::schema::CronShellOutputFormat::Raw,
+        };
+        config.cron.insert("blob-shadow".to_string(), decl);
+
+        // get_job must succeed despite the BLOB shadow: the ownership branch
+        // skips reading column 21 for declarative rows entirely.
+        let job = get_job(&config, "blob-shadow").unwrap();
+        assert_eq!(
+            job.shell_output_format,
+            zeroclaw_config::schema::CronShellOutputFormat::Raw,
+            "get_job must resolve config value when DB shadow is a BLOB"
+        );
+        assert_eq!(job.source, "declarative");
+
+        // due_jobs must also succeed.
+        let now = Utc::now();
+        let due = due_jobs(&config, now).unwrap();
+        assert!(
+            due.iter().any(|j| j.id == "blob-shadow"
+                && j.shell_output_format == zeroclaw_config::schema::CronShellOutputFormat::Raw),
+            "due_jobs must include declarative job despite BLOB DB shadow"
+        );
+    }
+
     #[test]
     fn migration_falls_back_to_legacy_expression() {
         let tmp = TempDir::new().unwrap();
@@ -3293,9 +3426,29 @@ schedule = { kind = "every", every_ms = 300000 }
         config.cron.insert("raw-decl".to_string(), decl.clone());
         sync_declarative_jobs(&config, &decls).unwrap();
 
+        // Read the raw DB column value before the unrelated update.
+        // sync_declarative_jobs does not write shell_output_format, so the
+        // column stays at its DEFAULT ('wrapped').
+        let raw_before = with_read_connection(&config, |conn| {
+            let val: Option<String> = conn
+                .query_row(
+                    "SELECT shell_output_format FROM cron_jobs WHERE id = ?1",
+                    params!["raw-decl"],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            Ok(val)
+        })
+        .unwrap()
+        .expect("row exists");
+        assert_eq!(
+            raw_before.as_deref(),
+            Some("wrapped"),
+            "baseline: sync should not write shell_output_format for declarative jobs"
+        );
+
         // Unrelated patch: only toggles `uses_memory`, never touches
-        // `shell_output_format`. Must not freeze the currently-resolved
-        // `Raw` value into the DB column.
+        // `shell_output_format`. Must not overwrite the DB column.
         update_job(
             &config,
             "raw-decl",
@@ -3306,9 +3459,27 @@ schedule = { kind = "every", every_ms = 300000 }
         )
         .unwrap();
 
+        // Assert the raw SQLite column was NOT modified by the unrelated update.
+        let raw_after = with_read_connection(&config, |conn| {
+            let val: Option<String> = conn
+                .query_row(
+                    "SELECT shell_output_format FROM cron_jobs WHERE id = ?1",
+                    params!["raw-decl"],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            Ok(val)
+        })
+        .unwrap()
+        .expect("row exists");
+        assert_eq!(
+            raw_after, raw_before,
+            "unrelated update must not overwrite the non-owned shell_output_format column"
+        );
+
         // Config changes after the update — if the update had snapshotted
-        // `Raw` into the DB column, every read path below would still
-        // report `Raw` instead of following this change.
+        // a value into the DB column, every read path below would still
+        // report the old value instead of following this change.
         decl.shell_output_format = zeroclaw_config::schema::CronShellOutputFormat::Wrapped;
         config.cron.insert("raw-decl".to_string(), decl);
 

--- a/crates/zeroclaw-runtime/src/cron/store.rs
+++ b/crates/zeroclaw-runtime/src/cron/store.rs
@@ -358,26 +358,27 @@ pub fn rename_jobs_by_agent(config: &Config, from: &str, to: &str) -> Result<usi
 }
 
 pub fn due_jobs(config: &Config, now: DateTime<Utc>) -> Result<Vec<CronJob>> {
-    let lim = i64::try_from(config.scheduler.max_tasks.max(1))
-        .context("Scheduler max_tasks overflows i64")?;
+    let lim = config.scheduler.max_tasks.max(1);
     let Some(jobs) = with_read_connection(config, |conn| {
+        // Fetch all eligible rows without a SQL LIMIT: orphan filtering
+        // happens in Rust, and max_tasks is applied after filtering so
+        // that stale declarative rows cannot consume the live quota.
         let mut stmt = conn.prepare(
             "SELECT id, expression, command, schedule, job_type, prompt, name, session_target, model,
                      enabled, delivery, delete_after_run, created_at, next_run, last_run, last_status, last_output,
                      allowed_tools, source, uses_memory, agent_alias, shell_output_format
              FROM cron_jobs
              WHERE enabled = 1 AND next_run <= ?1 AND locked_at IS NULL
-             ORDER BY next_run ASC
-             LIMIT ?2",
+             ORDER BY next_run ASC",
         )?;
 
-        let rows = stmt.query_map(params![now.to_rfc3339(), lim], map_cron_job_row)?;
+        let rows = stmt.query_map(params![now.to_rfc3339()], map_cron_job_row)?;
 
         let mut jobs = Vec::new();
         for row in rows {
             match row {
                 Ok(mut job) => {
-                    if job.source == "declarative" && !config.cron.contains_key(&job.id) {
+                    if job.source == "declarative" && !is_valid_declarative_owner(config, &job.id) {
                         ::zeroclaw_log::record!(
                             WARN,
                             ::zeroclaw_log::Event::new(
@@ -408,7 +409,7 @@ pub fn due_jobs(config: &Config, now: DateTime<Utc>) -> Result<Vec<CronJob>> {
         return Ok(Vec::new());
     };
 
-    Ok(jobs)
+    Ok(jobs.into_iter().take(lim).collect())
 }
 
 pub fn all_overdue_jobs(config: &Config, now: DateTime<Utc>) -> Result<Vec<CronJob>> {
@@ -428,7 +429,7 @@ pub fn all_overdue_jobs(config: &Config, now: DateTime<Utc>) -> Result<Vec<CronJ
         for row in rows {
             match row {
                 Ok(mut job) => {
-                    if job.source == "declarative" && !config.cron.contains_key(&job.id) {
+                    if job.source == "declarative" && !is_valid_declarative_owner(config, &job.id) {
                         ::zeroclaw_log::record!(
                             WARN,
                             ::zeroclaw_log::Event::new(
@@ -1071,6 +1072,21 @@ fn resolve_declarative_shell_output_format(config: &Config, job: &mut CronJob) {
     {
         job.shell_output_format = decl.shell_output_format.clone();
     }
+}
+
+/// Returns `true` if a declarative job still has a live config owner.
+/// Covers both `config.cron` entries and derived declarations like
+/// `__builtin_backup` (from `config.backup.schedule_cron`).
+pub(crate) fn is_valid_declarative_owner(config: &Config, job_id: &str) -> bool {
+    if config.cron.contains_key(job_id) {
+        return true;
+    }
+    // __builtin_backup is derived from config.backup.schedule_cron and
+    // synced as source = 'declarative' by the scheduler startup path.
+    if job_id == "__builtin_backup" && config.backup.schedule_cron.is_some() {
+        return true;
+    }
+    false
 }
 
 fn decode_schedule(schedule_raw: Option<&str>, expression: &str) -> Result<Schedule> {

--- a/crates/zeroclaw-runtime/src/cron/store.rs
+++ b/crates/zeroclaw-runtime/src/cron/store.rs
@@ -377,6 +377,19 @@ pub fn due_jobs(config: &Config, now: DateTime<Utc>) -> Result<Vec<CronJob>> {
         for row in rows {
             match row {
                 Ok(mut job) => {
+                    if job.source == "declarative" && !config.cron.contains_key(&job.id) {
+                        ::zeroclaw_log::record!(
+                            WARN,
+                            ::zeroclaw_log::Event::new(
+                                module_path!(),
+                                ::zeroclaw_log::Action::Note
+                            )
+                            .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                            .with_attrs(::serde_json::json!({"job_id": job.id})),
+                            "Skipping orphaned declarative cron job not present in live config"
+                        );
+                        continue;
+                    }
                     resolve_declarative_shell_output_format(config, &mut job);
                     jobs.push(job);
                 }
@@ -415,6 +428,19 @@ pub fn all_overdue_jobs(config: &Config, now: DateTime<Utc>) -> Result<Vec<CronJ
         for row in rows {
             match row {
                 Ok(mut job) => {
+                    if job.source == "declarative" && !config.cron.contains_key(&job.id) {
+                        ::zeroclaw_log::record!(
+                            WARN,
+                            ::zeroclaw_log::Event::new(
+                                module_path!(),
+                                ::zeroclaw_log::Action::Note
+                            )
+                            .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                            .with_attrs(::serde_json::json!({"job_id": job.id})),
+                            "Skipping orphaned declarative cron job not present in live config"
+                        );
+                        continue;
+                    }
                     resolve_declarative_shell_output_format(config, &mut job);
                     jobs.push(job);
                 }
@@ -3428,7 +3454,18 @@ schedule = { kind = "every", every_ms = 300000 }
 
         // Read the raw DB column value before the unrelated update.
         // sync_declarative_jobs does not write shell_output_format, so the
-        // column stays at its DEFAULT ('wrapped').
+        // column stays at its DEFAULT ('wrapped'). Overwrite it with a
+        // distinct sentinel so the test can detect if the unrelated update
+        // writes the column back (which would indicate a snapshot defect).
+        with_read_connection(&config, |conn| {
+            conn.execute(
+                "UPDATE cron_jobs SET shell_output_format = 'future-format' WHERE id = ?1",
+                params!["raw-decl"],
+            )
+            .map_err(Into::into)
+        })
+        .unwrap();
+
         let raw_before = with_read_connection(&config, |conn| {
             let val: Option<String> = conn
                 .query_row(
@@ -3443,8 +3480,8 @@ schedule = { kind = "every", every_ms = 300000 }
         .expect("row exists");
         assert_eq!(
             raw_before.as_deref(),
-            Some("wrapped"),
-            "baseline: sync should not write shell_output_format for declarative jobs"
+            Some("future-format"),
+            "baseline: sentinel value must be set before unrelated update"
         );
 
         // Unrelated patch: only toggles `uses_memory`, never touches
@@ -3595,5 +3632,79 @@ schedule = { kind = "every", every_ms = 300000 }
             err.to_string().contains("shell-only"),
             "the core update_job boundary must reject shell_output_format on a non-shell job: {err}"
         );
+    }
+
+    /// Regression: an orphaned declarative row (source = 'declarative' but
+    /// absent from Config.cron) must be excluded from due_jobs and
+    /// all_overdue_jobs. This covers the case where sync_declarative_jobs
+    /// fails before stale-row cleanup (e.g. another invalid declaration
+    /// aborts validation), leaving a removed row in the DB that the
+    /// scheduler would otherwise still execute.
+    #[test]
+    fn due_jobs_excludes_orphaned_declarative_rows() {
+        let tmp = TempDir::new().unwrap();
+        let mut config = test_config(&tmp);
+        seed_claiming_agent(&mut config, &["orphan-decl"]);
+
+        let decl = zeroclaw_config::schema::CronJobDecl {
+            name: Some("orphan-decl".to_string()),
+            job_type: "shell".to_string(),
+            schedule: zeroclaw_config::schema::CronScheduleDecl::Cron {
+                expr: "0 2 * * *".to_string(),
+                tz: None,
+            },
+            command: Some("echo orphan".to_string()),
+            prompt: None,
+            enabled: true,
+            model: None,
+            allowed_tools: None,
+            uses_memory: true,
+            session_target: None,
+            delivery: None,
+            shell_output_format: zeroclaw_config::schema::CronShellOutputFormat::Wrapped,
+        };
+        let decls = decls_map(vec![("orphan-decl".to_string(), decl.clone())]);
+        config.cron.insert("orphan-decl".to_string(), decl.clone());
+        sync_declarative_jobs(&config, &decls).unwrap();
+
+        // Confirm the row is in the DB with source = 'declarative'.
+        let source_in_db = with_read_connection(&config, |conn| {
+            let val: Option<String> = conn
+                .query_row(
+                    "SELECT source FROM cron_jobs WHERE id = ?1",
+                    params!["orphan-decl"],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            Ok(val)
+        })
+        .unwrap()
+        .expect("row exists");
+        assert_eq!(source_in_db.as_deref(), Some("declarative"));
+
+        // Remove the declaration from config (simulating operator removal
+        // while sync is broken by a separate invalid declaration).
+        config.cron.remove("orphan-decl");
+
+        let far_future = Utc::now() + ChronoDuration::days(365);
+
+        // due_jobs must not return the orphaned row.
+        let due = due_jobs(&config, far_future).unwrap();
+        assert!(
+            due.iter().all(|j| j.id != "orphan-decl"),
+            "due_jobs must exclude orphaned declarative rows not in live config"
+        );
+
+        // all_overdue_jobs must not return it either.
+        let overdue = all_overdue_jobs(&config, far_future).unwrap();
+        assert!(
+            overdue.iter().all(|j| j.id != "orphan-decl"),
+            "all_overdue_jobs must exclude orphaned declarative rows not in live config"
+        );
+
+        // get_job still returns it (the row exists; the read path surfaces
+        // it for API/admin visibility, but execution won't pick it up).
+        let job = get_job(&config, "orphan-decl").unwrap();
+        assert_eq!(job.source, "declarative");
     }
 }

--- a/crates/zeroclaw-runtime/src/cron/types.rs
+++ b/crates/zeroclaw-runtime/src/cron/types.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use zeroclaw_config::schema::CronShellOutputFormat;
 
 pub fn deserialize_maybe_stringified<T: serde::de::DeserializeOwned>(
     v: &serde_json::Value,
@@ -159,6 +160,11 @@ pub struct CronJob {
     /// How the job was created: `"imperative"` (CLI/API) or `"declarative"` (config).
     #[serde(default = "default_source")]
     pub source: String,
+    /// Output format for shell jobs. `"wrapped"` (default) or `"raw"`.
+    /// Declarative jobs read this from `CronJobDecl.shell_output_format` in
+    /// the config; imperative jobs read it from the stored field in the DB.
+    #[serde(default)]
+    pub shell_output_format: CronShellOutputFormat,
     pub created_at: DateTime<Utc>,
     pub next_run: DateTime<Utc>,
     pub last_run: Option<DateTime<Utc>>,
@@ -190,6 +196,7 @@ pub struct CronJobPatch {
     pub delete_after_run: Option<bool>,
     pub allowed_tools: Option<Vec<String>>,
     pub uses_memory: Option<bool>,
+    pub shell_output_format: Option<CronShellOutputFormat>,
 }
 
 impl ::zeroclaw_api::attribution::Attributable for CronJob {


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Adds `shell_output_format` for shell cron jobs so operators can opt into trimmed raw stdout instead of the existing `status` / `stdout` / `stderr` envelope.
  - Keeps `wrapped` as the default for compatibility. A successful raw-mode process returns trimmed stdout; a non-zero exit retains the wrapped diagnostic envelope. Security denial, setup/spawn failure, and timeout continue to return a plain error string in either mode.
  - Uses `Config.cron[<id>].shell_output_format` as the canonical value for declarative jobs and the cron database column as the canonical value for imperative jobs. Execution now selects between those sources by `job.source`, not by whether a same-ID config entry happens to exist, so an imperative job can't have its stored format silently overridden by an unrelated declarative config entry sharing its ID.
  - Wires the option through the gateway HTTP add, list, patch, and manual-run paths. Unsupported agent-job and declarative-job HTTP mutations return `400` instead of reporting a successful no-op.
  - A persisted `shell_output_format` value that fails to parse (corrupt row, empty string, an escaped spelling, a NULL from a forward-schema nullable column, or a future/unknown value read by an older binary) now surfaces a decode error from `get_job`/`list_jobs`, matching how the adjacent `schedule`, `delivery`, `job_type`, and `allowed_tools` columns are already decoded. Decoding is an exact match on the two canonical `wrapped`/`raw` spellings rather than a JSON-string round trip, so a stored escape sequence can no longer decode as a different value than what was actually persisted.
  - `shell_output_format` is now rejected below the HTTP boundary too, not just at the gateway: a declarative agent job with a non-default value fails config sync, and `update_job` (the core function every caller goes through) rejects the field for a declarative job or a non-shell job instead of silently ignoring or persisting state execution never consumes.
  - Orphaned declarative rows (source = "declarative" but absent from live config) are excluded from all execution paths: `due_jobs()`, `all_overdue_jobs()`, and the manual executor (`execute_job_now()`). This covers the scenario where `sync_declarative_jobs()` fails before stale-row cleanup, leaving a removed command in the DB. The `__builtin_backup` derived declaration (from `config.backup.schedule_cron`) is treated as a valid owner. `due_jobs()` also now applies `max_tasks` truncation after orphan filtering so stale rows cannot consume the live scheduling quota.
- **Scope boundary:** This PR covers declarative config plus the gateway HTTP/store/runtime path. It does not add dashboard controls or parity for RPC `CronAddParams` / `CronPatchParams` and the agent-facing `cron_add` / `cron_update` schemas; those remaining surfaces stay tracked in open #8409.
- **Blast radius:** Cron config parsing, cron SQLite schema/read/write paths, shell-job output and stored history, and gateway cron HTTP DTOs. No permissions, command execution scope, or default output behavior changes.
- **Linked issue(s):** Addresses #8409. This is an API/config/runtime slice and does not fully resolve the issue.
- **Labels:** `enhancement`, `config`, `cron`, `gateway`, `runtime`, `principal contributor`, `risk:high`, `size:XL`

## Testing (required)

### How you can test

- **Reviewer testing requested?** N/A — focused scheduler, store, and gateway boundary regressions plus the required CI exercise the changed behavior directly.

### How I tested

- **CI checks relied on and why they cover this change:** The exact-head `Quality Gate` is green, including Format, Lint, cross-platform checks, all-features/no-default-features checks, Test, Security, and CI Required Gate. Semgrep is also green.
- **Known CI coverage gap, if any:** No timed-scheduler restart smoke was run; the focused tests cover synchronous formatting, persistence, canonical-source resolution, mutation rejection, orphan filtering, manual-execution rejection, and gateway add/list/patch/run behavior.
- **Commands run and tail output:**

```text
$ cargo test -p zeroclaw-runtime --lib cron::
test result: ok. 146 passed; 0 failed; 0 ignored

$ cargo test -p zeroclaw-gateway --lib cron_api
test result: ok. 23 passed; 0 failed; 0 ignored

$ cargo clippy -p zeroclaw-runtime -p zeroclaw-gateway -p zeroclaw-config --all-targets -- -D warnings
Not used as exact-head local evidence: Rust 1.97.1 reported lints in unchanged
rpc/dispatch.rs, skills/testing.rs, and sop/metrics.rs. The exact-head hosted
Lint job passed on the repository toolchain.

$ cargo fmt --all -- --check
clean
```

- **Beyond CI, what did you manually verify?** The focused gateway regression creates an imperative raw shell job, lists it to verify persistence, runs it, and checks that output is bare trimmed stdout. The PATCH regression changes an imperative job from wrapped to raw and proves execution consumes the stored value. Declarative regressions verify that unrelated database updates do not snapshot config-owned state and that get/list/due/overdue reads resolve the live config value. A scheduler regression (`run_job_command_imperative_job_ignores_same_id_declarative_config_entry`) reproduces the ownership-collision scenario from review: an imperative job stored as `Wrapped` plus a same-ID declarative config entry set to `Raw` still executes wrapped. A store regression (`shell_output_format_from_sql_rejects_invalid_value`) inserts an unrecognized value, an empty string, and an escaped spelling directly and proves `get_job` errors on all three instead of defaulting. A second store regression (`shell_output_format_from_sql_rejects_null`) pre-creates the column as nullable, inserts a NULL row, and proves `get_job` surfaces a decode error rather than silently returning Wrapped. Two more store regressions prove `update_job` rejects a `shell_output_format` patch for a declarative job and for an imperative agent job, and a sync regression proves a declarative agent job with a non-default `shell_output_format` fails validation. Agent and declarative HTTP mutation rejection is also covered. A new `due_jobs_excludes_orphaned_declarative_rows` regression proves that a declarative row absent from live config is excluded from both `due_jobs` and `all_overdue_jobs`. I did not launch a long-running scheduler or dashboard.
- **If any command was intentionally skipped, why:** No additional full-workspace run was required beyond the green exact-head required CI and the focused crate suites above.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- If any Yes, describe the risk and mitigation: **N/A**

## Compatibility (required)

- Backward compatible? **Yes** — existing and newly created jobs default to `wrapped`.
- Config / env / CLI surface changed? **Yes** — declarative cron entries gain optional `shell_output_format = "wrapped" | "raw"`, and the gateway cron add/patch DTOs gain the corresponding optional field.
- Rust/MSRV/toolchain floor changed? **No**
- Exact upgrade steps for existing users: None. Existing config and cron database rows continue to use `wrapped`. To opt in declaratively, set `cron.<alias>.shell_output_format = "raw"` and reload/restart through the normal config lifecycle. Imperative shell jobs can set the field through the gateway HTTP add or patch endpoint.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert the eventual squash-merge commit. The additive SQLite column may remain unused; the previous code ignores it.
- **Feature flags or config toggles:** For an immediate operator mitigation, set affected jobs back to `wrapped`. Declarative jobs use `cron.<alias>.shell_output_format = "wrapped"` followed by the normal reload/restart path; imperative shell jobs can be patched to `wrapped`.
- **Observable failure symptoms:** A raw job unexpectedly returns the `status` / `stdout` / `stderr` envelope, list/get reports a format inconsistent with execution, or a downstream consumer receives empty/incorrect content because it expected bare stdout.

## Supersede Attribution

N/A — this PR does not use `Supersedes #`.
