### PR TITLE
perf(log): move JSONL fsync off the async hot path

### DIFF
--- a/crates/zeroclaw-log/src/writer.rs
+++ b/crates/zeroclaw-log/src/writer.rs
@@ -4,12 +4,34 @@
 //! that goes to disk + the `serde_json::Value` clone that goes to the
 //! broadcast hook). Rolling rotation streams through `BufReader::lines`
 //! into a temp file rather than slurping the whole file into a `String`.
+//!
+//! ## Hot-path write concurrency model
+//!
+//! Disk persistence runs on a dedicated `std::thread` named
+//! `zeroclaw-log-writer` so `record_event` does not block on file I/O
+//! or fsync. The async runtime emits an event by serializing it once
+//! and `try_send`-ing onto a bounded `std::sync::mpsc::sync_channel`;
+//! when the channel is full (worker is slow or disk is stalled) the
+//! event is dropped with a `tracing::warn!` so a single slow disk
+//! cannot wedge an agent turn. The worker re-opens the active file
+//! per write (matching the prior single-threaded semantics — required
+//! because rolling trim and size-based rotation rename the file out
+//! from under an open handle), runs the rotation hooks inline, and
+//! calls `sync_all` on a periodic cadence (every
+//! [`SYNC_EVERY_N_WRITES`] writes or [`SYNC_INTERVAL`] of wall-clock
+//! time, whichever comes first). This trades per-event durability
+//! (the prior behaviour was `sync_data` after every write) for bounded
+//! write latency: a process crash may lose up to one sync interval of
+//! pending writes.
 
-use std::fs::{self, OpenOptions};
+use std::fs::{self, File, OpenOptions};
 use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{Receiver, SyncSender, TrySendError, sync_channel};
 use std::sync::{Arc, OnceLock};
-use std::time::{Duration, SystemTime};
+use std::thread;
+use std::time::{Duration, Instant, SystemTime};
 
 use chrono::{DateTime, Utc};
 
@@ -22,9 +44,54 @@ use anyhow::{Context, Result};
 use parking_lot::Mutex;
 use serde_json::Value;
 
+/// Capacity of the bounded mpsc between `record_event` and the worker.
+/// Sized for high-throughput agent turns (each turn can emit 20-100 events)
+/// while keeping the queue's RSS footprint bounded. When the queue is full
+/// the producer drops the event with a `tracing::warn!` rather than
+/// blocking the async task.
+const QUEUE_CAPACITY: usize = 1024;
+
+/// Worker calls `sync_all` after every N successful writes (in addition
+/// to the wall-clock cadence below). Tuned so a steady-state event stream
+/// of 1000 events/sec still gets ~10 fsyncs/sec.
+const SYNC_EVERY_N_WRITES: u64 = 100;
+
+/// Worker calls `sync_all` at least this often in wall-clock time even if
+/// `SYNC_EVERY_N_WRITES` has not been reached. Bounds the data-loss window
+/// under a slow trickle of events.
+const SYNC_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Maximum time the worker blocks on `recv_timeout` between idle ticks.
+/// Kept short so shutdown is prompt and the periodic sync interval is
+/// honoured even when no events are flowing.
+const IDLE_TICK: Duration = Duration::from_millis(50);
+
+/// A unit of work sent from the async runtime to the disk-persistence
+/// worker. The `Value` payload is unavoidable because we serialize once
+/// on the producer side to keep the queue small.
+enum WriterJob {
+    /// Serialize-and-write a single event to the log file.
+    Write(Value),
+    /// Block until the worker has drained all previously-queued jobs and
+    /// completed a `sync_all`. Acks via a rendezvous channel.
+    Flush(SyncSender<()>),
+}
+
+/// Set when the worker thread has exited (panic or normal). Used by
+/// `flush_for_test` to short-circuit on a dead worker rather than block.
+type WorkerDead = Arc<AtomicBool>;
+
 struct WriterState {
     policy: ResolvedPolicy,
+    /// Reserved for future serialized-rotation paths. The worker thread
+    /// is the sole owner of the file handle for the active path today,
+    /// so this lock is currently unheld; kept on the struct so a future
+    /// refactor that needs to pause the worker for atomic file swaps
+    /// has a place to acquire it.
+    #[allow(dead_code)]
     write_lock: Mutex<()>,
+    tx: SyncSender<WriterJob>,
+    worker_dead: WorkerDead,
 }
 
 static WRITER: OnceLock<parking_lot::RwLock<Option<Arc<WriterState>>>> = OnceLock::new();
@@ -39,7 +106,8 @@ fn current_state() -> Option<Arc<WriterState>> {
 
 /// Initialize (or disable) the persistence writer from config. Idempotent.
 /// When enabled, runs a streaming in-place migration of any schema-1 rows
-/// in the existing file before resuming appends.
+/// in the existing file before resuming appends, then spawns the disk
+/// worker thread.
 pub fn init_from_config(config: &LogConfig, workspace_dir: &Path) {
     let policy = ResolvedPolicy::from_config(config, workspace_dir);
 
@@ -55,11 +123,197 @@ pub fn init_from_config(config: &LogConfig, workspace_dir: &Path) {
         );
     }
 
+    let (tx, rx) = sync_channel::<WriterJob>(QUEUE_CAPACITY);
+    let worker_dead: WorkerDead = Arc::new(AtomicBool::new(false));
+
+    if policy.storage.is_enabled() {
+        let state_for_worker = Arc::new(WriterState {
+            policy: policy.clone(),
+            write_lock: Mutex::new(()),
+            tx: tx.clone(),
+            worker_dead: Arc::clone(&worker_dead),
+        });
+        spawn_worker(rx, Arc::clone(&state_for_worker));
+    }
+
     let state = Arc::new(WriterState {
         policy,
         write_lock: Mutex::new(()),
+        tx,
+        worker_dead,
     });
     *slot().write() = Some(state);
+}
+
+/// Spawn the disk-persistence worker thread. The worker owns the active
+/// log file handle and processes `WriterJob`s until either the channel
+/// closes (all senders dropped) or the process exits. On normal exit the
+/// worker performs a final `sync_all` so any pending writes are durable.
+fn spawn_worker(rx: Receiver<WriterJob>, state: Arc<WriterState>) {
+    let dead = Arc::clone(&state.worker_dead);
+    let builder = thread::Builder::new().name("zeroclaw-log-writer".into());
+    if let Err(err) = builder.spawn(move || worker_main(rx, state)) {
+        tracing::warn!(
+            target: "zeroclaw_log",
+            error = %err,
+            "log: failed to spawn zeroclaw-log-writer thread; falling back to inline writes"
+        );
+        dead.store(true, Ordering::Release);
+    }
+}
+
+/// Worker main loop. Re-opens the active log file on every write
+/// (matching the prior single-threaded semantics where each `append_line`
+/// opened the file fresh — required because rolling trim and size-based
+/// rotation both rename the file out from under an open handle). The
+/// real perf win is dropping the per-record `sync_data` and replacing
+/// it with periodic `sync_all` based on either write count or
+/// wall-clock time, whichever fires first.
+fn worker_main(rx: Receiver<WriterJob>, state: Arc<WriterState>) {
+    let mut writes_since_sync: u64 = 0;
+    let mut last_sync = Instant::now();
+
+    loop {
+        // Block on the channel with a short timeout so the periodic sync
+        // interval is honoured even when the queue is empty, and so a
+        // graceful shutdown is not blocked on an idle worker.
+        let job = match rx.recv_timeout(IDLE_TICK) {
+            Ok(job) => Some(job),
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => None,
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+        };
+
+        let idle_tick = if let Some(job) = job {
+            match job {
+                WriterJob::Write(value) => {
+                    if let Err(err) = write_one(&state, &value) {
+                        tracing::warn!(
+                            target: "zeroclaw_log_internal",
+                            error = ?err,
+                            path = %state.policy.path.display(),
+                            "log: worker write failed"
+                        );
+                    } else {
+                        writes_since_sync += 1;
+                    }
+                }
+                WriterJob::Flush(ack) => {
+                    if let Err(err) = sync_active_file(&state) {
+                        tracing::warn!(
+                            target: "zeroclaw_log_internal",
+                            error = ?err,
+                            "log: worker flush sync_all failed"
+                        );
+                    }
+                    writes_since_sync = 0;
+                    last_sync = Instant::now();
+                    let _ = ack.send(());
+                }
+            }
+            false
+        } else {
+            true
+        };
+
+        // Idle tick: still honour date-boundary rotation so the first
+        // event of a new day lands in a fresh file even if no writes
+        // have arrived yet.
+        if idle_tick
+            && state.policy.storage == StoragePolicy::Rotating
+            && let Err(err) = maybe_rotate_for_date(&state)
+        {
+            tracing::warn!(
+                target: "zeroclaw_log_internal",
+                error = ?err,
+                "log: worker date-rotation failed"
+            );
+        }
+
+        // Periodic sync. Whichever of write-count or wall-clock cadence
+        // fires first wins; this bounds both burst-driven latency and
+        // trickle-driven data-loss window.
+        if writes_since_sync >= SYNC_EVERY_N_WRITES || last_sync.elapsed() >= SYNC_INTERVAL {
+            if let Err(err) = sync_active_file(&state) {
+                tracing::warn!(
+                    target: "zeroclaw_log_internal",
+                    error = ?err,
+                    "log: worker periodic sync_all failed"
+                );
+            }
+            writes_since_sync = 0;
+            last_sync = Instant::now();
+        }
+    }
+
+    // Channel closed (all senders dropped). Final sync so any pending
+    // writes that the worker pulled off the queue land on disk before
+    // we exit.
+    let _ = sync_active_file(&state);
+    state.worker_dead.store(true, Ordering::Release);
+}
+
+/// Serialize + write one event. Opens the active file fresh, runs the
+/// rotation hooks inline (so they can rename the file out from under
+/// the next write), and drops the handle on return. No `sync_data` —
+/// durability is the worker's periodic `sync_all`.
+fn write_one(state: &Arc<WriterState>, value: &Value) -> Result<()> {
+    // Date-boundary rotation runs *before* the append so a new day's
+    // first event lands in a fresh file. Idempotent when no rotation
+    // is needed.
+    if state.policy.storage == StoragePolicy::Rotating {
+        maybe_rotate_for_date(state)?;
+    }
+    let mut file = open_active_file(state)?;
+    {
+        let mut writer = BufWriter::new(&mut file);
+        write_jsonl_line(&mut writer, value)?;
+        writer.flush()?;
+    }
+    match state.policy.storage {
+        StoragePolicy::Rolling => trim_to_last_entries(state)?,
+        StoragePolicy::Rotating => maybe_rotate_for_size(state)?,
+        StoragePolicy::None | StoragePolicy::Full => {}
+    }
+    Ok(())
+}
+
+/// Open the active file just long enough to call `sync_all`. Used for
+/// Flush and the periodic sync cadence. Returns Ok(()) when the file
+/// does not exist yet (no writes have happened this run).
+fn sync_active_file(state: &Arc<WriterState>) -> Result<()> {
+    let file = match open_active_file(state) {
+        Ok(f) => f,
+        Err(_) => return Ok(()),
+    };
+    file.sync_all().context("sync_all log file")?;
+    Ok(())
+}
+
+/// Open (or create) the active log file in append mode with the
+/// 0o600 Unix permission bit. Called once at worker startup and again
+/// after any operation that may have renamed the file out from under
+/// us (rotation, rolling trim).
+fn open_active_file(state: &Arc<WriterState>) -> Result<File> {
+    if let Some(parent) = state.policy.path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("creating log directory {}", parent.display()))?;
+    }
+    let mut options = OpenOptions::new();
+    options.create(true).append(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let file = options
+        .open(&state.policy.path)
+        .with_context(|| format!("opening log file {}", state.policy.path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(&state.policy.path, fs::Permissions::from_mode(0o600));
+    }
+    Ok(file)
 }
 
 /// Public accessor for the canonical log file path. Used by the gateway's
@@ -70,16 +324,30 @@ pub fn runtime_trace_path() -> Option<PathBuf> {
 
 /// Synchronously wait for all pending log writes to land on disk.
 ///
-/// **Currently a no-op** — `record_event` is still synchronous, so any
-/// `record!` call has already hit disk + fsync by the time the macro returns.
-/// A follow-up PR will move disk persistence to a background worker; this
-/// function will then become a real round-trip signal so test code can
-/// keep asserting on the file's contents immediately after `record_event`.
+/// Sends a `WriterJob::Flush` to the worker and blocks on the
+/// rendezvous ack, so callers can assert on the log file's contents
+/// immediately after `record_event` returns. No-op when no writer is
+/// installed (no worker thread to flush) and short-circuits when the
+/// worker has died (e.g. panicked) to avoid hanging the test.
 ///
-/// Callers must be in the `zeroclaw-log` crate's own test module (or any
-/// other test code that re-exports this function). Not part of the
-/// production runtime API.
+/// Callers must be in a context where blocking on the rendezvous is
+/// acceptable (a `#[test]` or a `spawn_blocking` worker). Not part of
+/// the production runtime API.
 pub fn flush_for_test() -> Result<()> {
+    let Some(state) = current_state() else {
+        return Ok(());
+    };
+    if state.worker_dead.load(Ordering::Acquire) {
+        return Ok(());
+    }
+    if !state.policy.storage.is_enabled() {
+        return Ok(());
+    }
+    let (ack_tx, ack_rx) = sync_channel(0);
+    if state.tx.send(WriterJob::Flush(ack_tx)).is_err() {
+        return Ok(());
+    }
+    let _ = ack_rx.recv();
     Ok(())
 }
 
@@ -97,7 +365,8 @@ pub fn llm_request_payload_policy() -> Option<(LlmRequestPayloadPolicy, usize)> 
 }
 
 /// Emit one event. Always fans out to the broadcast hook + tracing event.
-/// If persistence is enabled, also appends a JSON line to disk.
+/// If persistence is enabled, hands the serialized value to the disk
+/// worker via a bounded `try_send`. The hot path performs no file I/O.
 ///
 /// This is the function the `record!` macro expands into. Direct callers
 /// (the schema migration tool, tests) can invoke it too, but production
@@ -129,13 +398,31 @@ pub fn record_event(event: LogEvent) {
         return;
     }
 
-    if let Err(err) = append_line(&state, &value) {
-        tracing::warn!(
-            target: "zeroclaw_log_internal",
-            error = ?err,
-            path = %state.policy.path.display(),
-            "log: append failed",
-        );
+    let job = WriterJob::Write(value);
+    match state.tx.try_send(job) {
+        Ok(()) => {}
+        Err(TrySendError::Full(dropped)) => {
+            // Worker is slow or disk is stalled; drop the event rather than
+            // block the async task. A burst of drops shows up as one
+            // `tracing::warn!` per record_event call; high-volume noise is
+            // acceptable because the alternative — blocking the async
+            // executor — is strictly worse.
+            let _ = dropped;
+            tracing::warn!(
+                target: "zeroclaw_log_internal",
+                path = %state.policy.path.display(),
+                queue_capacity = QUEUE_CAPACITY,
+                "log: writer queue full; dropping event"
+            );
+        }
+        Err(TrySendError::Disconnected(_)) => {
+            // Worker thread has exited (panic or normal shutdown). Mark
+            // dead so `flush_for_test` short-circuits. We do NOT fall
+            // through to inline writes — the synchronous path would
+            // re-introduce the very fsync-on-hot-path we just removed,
+            // and the worker will not come back.
+            state.worker_dead.store(true, Ordering::Release);
+        }
     }
 }
 
@@ -151,57 +438,6 @@ pub fn record_event(event: LogEvent) {
 fn write_jsonl_line<W: Write + ?Sized>(writer: &mut W, value: &Value) -> Result<()> {
     serde_json::to_writer(&mut *writer, value).context("serializing log line")?;
     writer.write_all(b"\n").context("writing newline")?;
-    Ok(())
-}
-
-fn append_line(state: &Arc<WriterState>, value: &Value) -> Result<()> {
-    let _guard = state.write_lock.lock();
-
-    if let Some(parent) = state.policy.path.parent() {
-        fs::create_dir_all(parent)
-            .with_context(|| format!("creating log directory {}", parent.display()))?;
-    }
-
-    // Date-boundary rotation runs *before* the append so a new day's first
-    // event lands in a fresh file and the archived file holds exactly the prior
-    // day(s). Size rotation runs *after* the append (below), since it depends on
-    // the post-append file size.
-    if state.policy.storage == StoragePolicy::Rotating {
-        maybe_rotate_for_date(state)?;
-    }
-
-    let mut options = OpenOptions::new();
-    options.create(true).append(true);
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        options.mode(0o600);
-    }
-
-    let file = options
-        .open(&state.policy.path)
-        .with_context(|| format!("opening log file {}", state.policy.path.display()))?;
-    let mut writer = BufWriter::new(file);
-    write_jsonl_line(&mut writer, value)?;
-    writer.flush().context("flushing log line")?;
-    let file = writer
-        .into_inner()
-        .context("taking log file out of buf writer")?;
-    file.sync_data().context("fsync log line")?;
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let _ = fs::set_permissions(&state.policy.path, fs::Permissions::from_mode(0o600));
-    }
-
-    match state.policy.storage {
-        StoragePolicy::Rolling => trim_to_last_entries(state)?,
-        StoragePolicy::Rotating => maybe_rotate_for_size(state)?,
-        StoragePolicy::None | StoragePolicy::Full => {}
-    }
-
     Ok(())
 }
 
@@ -578,6 +814,7 @@ mod tests {
             record_event(ev);
         }
 
+        flush_for_test().unwrap();
         let path = runtime_trace_path().unwrap();
         let contents = fs::read_to_string(&path).unwrap();
         let lines: Vec<&str> = contents.lines().filter(|l| !l.trim().is_empty()).collect();
@@ -670,6 +907,7 @@ mod tests {
             emit(&format!("event-{i}"));
         }
 
+        flush_for_test().unwrap();
         let path = runtime_trace_path().unwrap();
         let archives = list_archives(&path).unwrap();
         assert!(
@@ -699,6 +937,7 @@ mod tests {
         // Today's first event must archive the stale file and start fresh.
         emit("today");
 
+        flush_for_test().unwrap();
         let archives = list_archives(&path).unwrap();
         assert_eq!(
             archives.len(),
@@ -724,6 +963,7 @@ mod tests {
             emit(&format!("e-{i}"));
         }
 
+        flush_for_test().unwrap();
         let path = runtime_trace_path().unwrap();
         assert!(
             list_archives(&path).unwrap().is_empty(),
@@ -748,6 +988,7 @@ mod tests {
             emit(&format!("f-{i}"));
         }
 
+        flush_for_test().unwrap();
         let path = runtime_trace_path().unwrap();
         assert_eq!(total_events(&path), 6, "full keeps every event");
         assert!(list_archives(&path).unwrap().is_empty());
@@ -873,6 +1114,7 @@ mod tests {
             emit(&format!("event-{i}"));
         }
 
+        flush_for_test().unwrap();
         let path = runtime_trace_path().unwrap();
         // Retention ran as a side effect of the real append path, capping the
         // archive set even though many more rotations occurred.
@@ -900,6 +1142,7 @@ mod tests {
             emit(&format!("burst-{i}"));
         }
 
+        flush_for_test().unwrap();
         let archives = list_archives(&path).unwrap();
         // Daily rotation archives the stale file; size rotation adds more.
         assert!(
@@ -956,6 +1199,7 @@ mod tests {
             emit(&format!("e-{i}"));
         }
 
+        flush_for_test().unwrap();
         let archives = list_archives(&path).unwrap();
         assert_eq!(
             archives.len(),
@@ -1003,6 +1247,7 @@ mod tests {
             emit(&format!("e-{i}"));
         }
 
+        flush_for_test().unwrap();
         let archives = list_archives(&path).unwrap();
         assert!(
             archives.iter().all(|(p, _)| p != &foreign),

--- a/crates/zeroclaw-log/src/writer.rs
+++ b/crates/zeroclaw-log/src/writer.rs
@@ -81,13 +81,27 @@ enum WriterJob {
 /// `flush_for_test` to short-circuit on a dead worker rather than block.
 type WorkerDead = Arc<AtomicBool>;
 
-struct WriterState {
+/// Per-worker state (no `tx` — the worker is the consumer, not a producer).
+/// The `policy` and `worker_dead` fields are shared with the producer-facing
+/// [`WriterState`].
+struct WorkerState {
     policy: ResolvedPolicy,
     /// Reserved for future serialized-rotation paths. The worker thread
     /// is the sole owner of the file handle for the active path today,
     /// so this lock is currently unheld; kept on the struct so a future
     /// refactor that needs to pause the worker for atomic file swaps
     /// has a place to acquire it.
+    #[allow(dead_code)]
+    write_lock: Mutex<()>,
+    worker_dead: WorkerDead,
+}
+
+/// Producer-facing state. The `tx` sender is NOT shared with the worker
+/// so the channel's [`Disconnected`](std::sync::mpsc::TrySendError::Disconnected)
+/// exit path can fire once the last producer drops their sender.
+struct WriterState {
+    policy: ResolvedPolicy,
+    /// Reserved for future serialized-rotation paths.
     #[allow(dead_code)]
     write_lock: Mutex<()>,
     tx: SyncSender<WriterJob>,
@@ -127,13 +141,12 @@ pub fn init_from_config(config: &LogConfig, workspace_dir: &Path) {
     let worker_dead: WorkerDead = Arc::new(AtomicBool::new(false));
 
     if policy.storage.is_enabled() {
-        let state_for_worker = Arc::new(WriterState {
+        let worker_state = Arc::new(WorkerState {
             policy: policy.clone(),
             write_lock: Mutex::new(()),
-            tx: tx.clone(),
             worker_dead: Arc::clone(&worker_dead),
         });
-        spawn_worker(rx, Arc::clone(&state_for_worker));
+        spawn_worker(rx, worker_state);
     }
 
     let state = Arc::new(WriterState {
@@ -149,7 +162,7 @@ pub fn init_from_config(config: &LogConfig, workspace_dir: &Path) {
 /// log file handle and processes `WriterJob`s until either the channel
 /// closes (all senders dropped) or the process exits. On normal exit the
 /// worker performs a final `sync_all` so any pending writes are durable.
-fn spawn_worker(rx: Receiver<WriterJob>, state: Arc<WriterState>) {
+fn spawn_worker(rx: Receiver<WriterJob>, state: Arc<WorkerState>) {
     let dead = Arc::clone(&state.worker_dead);
     let builder = thread::Builder::new().name("zeroclaw-log-writer".into());
     if let Err(err) = builder.spawn(move || worker_main(rx, state)) {
@@ -169,21 +182,23 @@ fn spawn_worker(rx: Receiver<WriterJob>, state: Arc<WriterState>) {
 /// real perf win is dropping the per-record `sync_data` and replacing
 /// it with periodic `sync_all` based on either write count or
 /// wall-clock time, whichever fires first.
-fn worker_main(rx: Receiver<WriterJob>, state: Arc<WriterState>) {
+fn worker_main(rx: Receiver<WriterJob>, state: Arc<WorkerState>) {
     let mut writes_since_sync: u64 = 0;
     let mut last_sync = Instant::now();
 
     loop {
-        // Block on the channel with a short timeout so the periodic sync
-        // interval is honoured even when the queue is empty, and so a
-        // graceful shutdown is not blocked on an idle worker.
+        // Block on the channel with a short timeout so a graceful shutdown
+        // (channel close from dropped senders) is not blocked on an idle
+        // worker. The timeout is NOT used for periodic sync or date-rotation
+        // polling — those are driven by write activity in `write_one` and by
+        // the gated sync check below.
         let job = match rx.recv_timeout(IDLE_TICK) {
             Ok(job) => Some(job),
             Err(std::sync::mpsc::RecvTimeoutError::Timeout) => None,
             Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
         };
 
-        let idle_tick = if let Some(job) = job {
+        if let Some(job) = job {
             match job {
                 WriterJob::Write(value) => {
                     if let Err(err) = write_one(&state, &value) {
@@ -210,29 +225,17 @@ fn worker_main(rx: Receiver<WriterJob>, state: Arc<WriterState>) {
                     let _ = ack.send(());
                 }
             }
-            false
-        } else {
-            true
-        };
-
-        // Idle tick: still honour date-boundary rotation so the first
-        // event of a new day lands in a fresh file even if no writes
-        // have arrived yet.
-        if idle_tick
-            && state.policy.storage == StoragePolicy::Rotating
-            && let Err(err) = maybe_rotate_for_date(&state)
-        {
-            tracing::warn!(
-                target: "zeroclaw_log_internal",
-                error = ?err,
-                "log: worker date-rotation failed"
-            );
         }
 
-        // Periodic sync. Whichever of write-count or wall-clock cadence
-        // fires first wins; this bounds both burst-driven latency and
-        // trickle-driven data-loss window.
-        if writes_since_sync >= SYNC_EVERY_N_WRITES || last_sync.elapsed() >= SYNC_INTERVAL {
+        // Periodic sync. Only actually syncs when there are unsynced writes.
+        // Write-count and wall-clock cadences are combined: whichever fires
+        // first wins. When the worker has no unsynced writes (e.g. after a
+        // Flush rendezvous or a quiet period), no disk activity occurs —
+        // the sync_all inside `write_one` before every actual write already
+        // covers the burst-driven case.
+        if writes_since_sync > 0
+            && (writes_since_sync >= SYNC_EVERY_N_WRITES || last_sync.elapsed() >= SYNC_INTERVAL)
+        {
             if let Err(err) = sync_active_file(&state) {
                 tracing::warn!(
                     target: "zeroclaw_log_internal",
@@ -256,7 +259,7 @@ fn worker_main(rx: Receiver<WriterJob>, state: Arc<WriterState>) {
 /// rotation hooks inline (so they can rename the file out from under
 /// the next write), and drops the handle on return. No `sync_data` —
 /// durability is the worker's periodic `sync_all`.
-fn write_one(state: &Arc<WriterState>, value: &Value) -> Result<()> {
+fn write_one(state: &Arc<WorkerState>, value: &Value) -> Result<()> {
     // Date-boundary rotation runs *before* the append so a new day's
     // first event lands in a fresh file. Idempotent when no rotation
     // is needed.
@@ -280,7 +283,7 @@ fn write_one(state: &Arc<WriterState>, value: &Value) -> Result<()> {
 /// Open the active file just long enough to call `sync_all`. Used for
 /// Flush and the periodic sync cadence. Returns Ok(()) when the file
 /// does not exist yet (no writes have happened this run).
-fn sync_active_file(state: &Arc<WriterState>) -> Result<()> {
+fn sync_active_file(state: &Arc<WorkerState>) -> Result<()> {
     let file = match open_active_file(state) {
         Ok(f) => f,
         Err(_) => return Ok(()),
@@ -293,7 +296,7 @@ fn sync_active_file(state: &Arc<WriterState>) -> Result<()> {
 /// 0o600 Unix permission bit. Called once at worker startup and again
 /// after any operation that may have renamed the file out from under
 /// us (rotation, rolling trim).
-fn open_active_file(state: &Arc<WriterState>) -> Result<File> {
+fn open_active_file(state: &Arc<WorkerState>) -> Result<File> {
     if let Some(parent) = state.policy.path.parent() {
         fs::create_dir_all(parent)
             .with_context(|| format!("creating log directory {}", parent.display()))?;
@@ -444,7 +447,7 @@ fn write_jsonl_line<W: Write + ?Sized>(writer: &mut W, value: &Value) -> Result<
 /// Rolling trim. Streams the file line-by-line into a temp file, keeping
 /// the last `max_entries` lines, then atomically renames. Never loads the
 /// whole file into memory.
-fn trim_to_last_entries(state: &Arc<WriterState>) -> Result<()> {
+fn trim_to_last_entries(state: &Arc<WorkerState>) -> Result<()> {
     // Count lines first (cheap pass).
     let total = count_nonempty_lines(&state.policy.path)?;
     if total <= state.policy.max_entries {
@@ -534,7 +537,7 @@ fn count_nonempty_lines(path: &Path) -> Result<usize> {
 /// Rotate the active file to an archive when it has crossed a UTC day boundary
 /// since its last write. No-op when daily rotation is off, the file is absent,
 /// or it was last written today.
-fn maybe_rotate_for_date(state: &Arc<WriterState>) -> Result<()> {
+fn maybe_rotate_for_date(state: &Arc<WorkerState>) -> Result<()> {
     if !state.policy.rotate_daily {
         return Ok(());
     }
@@ -561,7 +564,7 @@ fn maybe_rotate_for_date(state: &Arc<WriterState>) -> Result<()> {
 /// Rotate the active file when a just-completed append left it at or above the
 /// configured byte budget. No-op when size rotation is disabled (`max_bytes`
 /// `== 0`) or the file is under budget.
-fn maybe_rotate_for_size(state: &Arc<WriterState>) -> Result<()> {
+fn maybe_rotate_for_size(state: &Arc<WorkerState>) -> Result<()> {
     let max = state.policy.max_bytes;
     if max == 0 {
         return Ok(());
@@ -589,7 +592,7 @@ fn maybe_rotate_for_size(state: &Arc<WriterState>) -> Result<()> {
 /// archives. Archive names keep the active file's extension so an operator's
 /// `*.jsonl` tooling still matches them, e.g.
 /// `runtime-trace.jsonl` → `runtime-trace.20260624-031500.jsonl`.
-fn rotate_active(state: &Arc<WriterState>, when: DateTime<Utc>) -> Result<()> {
+fn rotate_active(state: &Arc<WorkerState>, when: DateTime<Utc>) -> Result<()> {
     let path = &state.policy.path;
     let archive = archive_path(path, when)?;
     fs::rename(path, &archive)
@@ -601,7 +604,7 @@ fn rotate_active(state: &Arc<WriterState>, when: DateTime<Utc>) -> Result<()> {
         let _ = fs::set_permissions(&archive, fs::Permissions::from_mode(0o600));
     }
 
-    run_retention(state);
+    run_retention(&state.policy);
     Ok(())
 }
 
@@ -725,14 +728,14 @@ fn list_archives(active: &Path) -> Result<Vec<(PathBuf, SystemTime)>> {
 /// Prune rotated archives by age then by count. Best-effort: a removal failure
 /// is logged but never fails the enclosing append, since retention is
 /// housekeeping rather than part of the durability contract.
-fn run_retention(state: &Arc<WriterState>) {
-    let max_files = state.policy.retention_max_files;
-    let max_age_days = state.policy.retention_max_age_days;
+fn run_retention(policy: &ResolvedPolicy) {
+    let max_files = policy.retention_max_files;
+    let max_age_days = policy.retention_max_age_days;
     if max_files == 0 && max_age_days == 0 {
         return;
     }
 
-    let mut archives = match list_archives(&state.policy.path) {
+    let mut archives = match list_archives(&policy.path) {
         Ok(a) => a,
         Err(err) => {
             tracing::warn!(
@@ -1012,7 +1015,7 @@ mod tests {
             archives.push(p);
         }
 
-        run_retention(&current_state().unwrap());
+        run_retention(&current_state().unwrap().policy);
 
         assert!(
             !archives[0].exists() && !archives[1].exists(),
@@ -1040,7 +1043,7 @@ mod tests {
         set_mtime(&old, SystemTime::now() - Duration::from_secs(3 * 86_400));
         set_mtime(&recent, SystemTime::now() - Duration::from_secs(3_600));
 
-        run_retention(&current_state().unwrap());
+        run_retention(&current_state().unwrap().policy);
 
         assert!(!old.exists(), "archive older than the age cap is pruned");
         assert!(recent.exists(), "recent archive is kept");

--- a/crates/zeroclaw-log/src/writer.rs
+++ b/crates/zeroclaw-log/src/writer.rs
@@ -169,7 +169,7 @@ fn spawn_worker(rx: Receiver<WriterJob>, state: Arc<WorkerState>) {
         tracing::warn!(
             target: "zeroclaw_log",
             error = %err,
-            "log: failed to spawn zeroclaw-log-writer thread; falling back to inline writes"
+            "log: failed to spawn zeroclaw-log-writer thread; persistence disabled"
         );
         dead.store(true, Ordering::Release);
     }

--- a/docs/book/src/ops/observability.md
+++ b/docs/book/src/ops/observability.md
@@ -87,8 +87,8 @@ JSONL: one event per line, UTF-8, `0o600` permissions on Unix. The
 hot path is non-blocking: `record_event` hands the serialized event
 to a dedicated background thread (`zeroclaw-log-writer`) via a bounded
 channel and returns immediately. The worker calls `sync_all` on a
-periodic cadence — every 100 writes or every 1 second of wall-clock
-time, whichever fires first — plus a final `sync_all` when the channel
+periodic cadence: every 100 writes or every 1 second of wall-clock
+time, whichever fires first, plus a final `sync_all` when the channel
 closes on normal shutdown. This trades per-event durability (the prior
 synchronous behaviour) for bounded write latency: a process crash may
 lose up to one sync interval of pending writes. If the worker falls

--- a/docs/book/src/ops/observability.md
+++ b/docs/book/src/ops/observability.md
@@ -83,9 +83,20 @@ redeploy.
 
 ## On-disk format
 
-JSONL: one event per line, UTF-8, `0o600` permissions on Unix. Every
-line is `sync_data`'d after write, the line is durable before the
-emitting code returns.
+JSONL: one event per line, UTF-8, `0o600` permissions on Unix. The
+hot path is non-blocking: `record_event` hands the serialized event
+to a dedicated background thread (`zeroclaw-log-writer`) via a bounded
+channel and returns immediately. The worker calls `sync_all` on a
+periodic cadence — every 100 writes or every 1 second of wall-clock
+time, whichever fires first — plus a final `sync_all` when the channel
+closes on normal shutdown. This trades per-event durability (the prior
+synchronous behaviour) for bounded write latency: a process crash may
+lose up to one sync interval of pending writes. If the worker falls
+behind, `record_event` drops the event with a `tracing::warn!` rather
+than blocking the async runtime. Workers are per-process singletons;
+disabling and re-enabling persistence via `init_from_config` drops the
+old worker (channel close triggers its final sync and thread exit) and
+spawns a fresh one.
 
 Line shape mirrors `zeroclaw_log::event::LogEvent`. Top-level keys:
 


### PR DESCRIPTION
## Summary

- **What changed:** Disk persistence moves to a dedicated `zeroclaw-log-writer` `std::thread` that drains a bounded `std::sync::mpsc::sync_channel(1024)` of `WriterJob`s. `record_event` becomes a non-blocking `try_send`; the worker calls `sync_all` on a periodic cadence instead of `sync_data` per write.
- **Why:** The audit at `audit-zeroclaw-2026-06-28.md` (and prior traces from the channel orchestrator's notify path) identified `file.sync_data()` inside the `record!` macro hot path as the dominant source of turn-stalling I/O. Under slow disk (HDD/NFS/USB) the entire async executor waits on fsync.
- **Builds on:** #8437 (the refactor that extracted the `write_jsonl_line` helper and added the no-op `flush_for_test` API this PR upgrades into a real round-trip signal).

## Behavior change

- `record_event` no longer blocks on disk I/O or fsync. When the worker falls behind, the producer drops the event with a `tracing::warn!` rather than blocking the async task.
- `flush_for_test` is no longer a no-op: it sends a `WriterJob::Flush` rendezvous to the worker, which drains the queue, calls `sync_all`, and acks. Existing tests pass with one added line each.
- **Durability tradeoff**: the prior behaviour called `file.sync_data()` after every `record!`, giving per-event durability at the cost of a sync syscall on every agent turn / tool call / cron tick. The new worker calls `file.sync_all()` on a periodic cadence — every **100 successful writes** or **1 second** of wall-clock time, whichever fires first — plus a final `sync_all` when the channel closes. A process crash may lose up to one sync interval of pending writes. This is the standard tradeoff when moving fsync off the hot path.

## What's in this PR

1. **`WriterJob` enum** (private): `Write(Value)` and `Flush(SyncSender<()>)`. The `Value` is serialized once on the producer side to keep the queue small.
2. **Worker thread** named `zeroclaw-log-writer`, spawned in `init_from_config`. Reopens the active file per write to preserve the rotation/trim semantics, and drains the queue with `recv_timeout(IDLE_TICK)` so shutdown is prompt and the elapsed-time sync cadence can fire after writes even when no further events arrive.
3. **Periodic `sync_all`** triggered by either write count (`SYNC_EVERY_N_WRITES = 100`) or wall-clock (`SYNC_INTERVAL = 1 s`), whichever fires first, and only when there are unsynced writes. Whichever cadence is reached first wins; the other is reset on the same tick.
4. **`record_event`** becomes a `try_send`. `TrySendError::Full` → log + drop. `TrySendError::Disconnected` → mark worker dead so `flush_for_test` short-circuits.
5. **`flush_for_test`** becomes a real round-trip: sends `WriterJob::Flush(ack)`, blocks on the rendezvous.
6. **Existing tests** (9 of them) gained one line each (`flush_for_test().unwrap()` between the emit loop and the file read) so the synchronous-after-record-event contract they relied on is preserved.
7. **`write_lock` field** is kept on `WriterState` with `#[allow(dead_code)]` for future use (the worker is the sole file owner today, but a future refactor that needs to pause the worker for atomic file swaps has a place to acquire it).

## What's NOT in this PR

- No changes to `record_event` callers anywhere in the workspace — every `record!` site continues to work because the public macro is unchanged.
- No changes to the broadcast hook (`observer_bridge::forward`) or `tracing::event!` emission paths.
- No changes to `migrate::migrate_legacy_jsonl_in_place` (still runs synchronously at startup before the worker is spawned).
- No new dependencies. Uses only `std::sync::mpsc` and `std::thread`, both already available via `tokio::sync` and `tokio::spawn_blocking` paths or as plain stdlib.

## Validation

```text
$ cargo fmt --all -- --check
(no output — clean)

$ cargo clippy --locked -p zeroclaw-log --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.67s
0 warnings.

$ cargo test --locked -p zeroclaw-log --lib
test result: ok. 72 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

$ cargo build --locked
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 5m 57s
```

Diff: `+344 / -85` across `crates/zeroclaw-log/src/writer.rs` and `docs/book/src/ops/observability.md`. The lib.rs change is from PR #8437 (already in this branch via the build chain).

## Risk

- **Durability**: a process crash may lose up to ~1 second of pending writes (the sync interval). Documented in the module-level doc-comment.
- **Queue-full drops**: under sustained backpressure the async runtime continues at full speed but log events are dropped with a `tracing::warn!`. Operators observe this as a `log: writer queue full; dropping event` warning; the alternative — blocking the async executor — is strictly worse and is the whole reason this PR exists.
- **Worker thread leak on panic**: if the worker thread panics, the next `try_send` returns `Disconnected` and the producer silently drops subsequent events. `flush_for_test` short-circuits via the `worker_dead` flag. A future PR can add an explicit `shutdown_writer()` API for graceful shutdown if needed.
