### PR TITLE
feat(telegram): add per-channel inbound debounce

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -6727,9 +6727,29 @@ async fn run_message_dispatch_loop(
 
         // ── Debounce: accumulate rapid messages per sender ──────────
         // CLI messages bypass debouncing so the interactive loop stays responsive.
-        let msg = if msg.channel != "cli" && ctx.debouncer.enabled() {
+        let msg = if msg.channel != "cli" {
             let debounce_key = conversation_history_key(&msg);
-            match ctx.debouncer.debounce(&debounce_key, &msg.content).await {
+
+            // Resolve effective debounce window: per-channel override wins,
+            // otherwise falls back to the global default from ChannelsConfig.
+            let debounce_window = {
+                let global_ms = ctx.prompt_config.channels.debounce_ms;
+                let per_channel_ms = if msg.channel == "telegram" {
+                    msg.channel_alias
+                        .as_ref()
+                        .and_then(|alias| ctx.prompt_config.channels.telegram.get(alias))
+                        .and_then(|cfg| cfg.debounce_ms)
+                } else {
+                    None
+                };
+                std::time::Duration::from_millis(per_channel_ms.unwrap_or(global_ms))
+            };
+
+            match ctx
+                .debouncer
+                .debounce_with_window(&debounce_key, &msg.content, debounce_window)
+                .await
+            {
                 zeroclaw_infra::debounce::DebounceResult::Pending(rx) => {
                     // Spawn a lightweight task that waits for the debounce window
                     // to expire, then feeds the combined message through the normal

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -6669,6 +6669,26 @@ fn channel_sop_target(msg: &zeroclaw_api::channel::ChannelMessage) -> Option<Str
         })
 }
 
+/// Resolve effective debounce window: a per-channel override with a positive
+/// value wins, otherwise falls back to the global default from `ChannelsConfig`.
+/// A per-channel value of `0` is treated as unset (falls back to global).
+fn resolve_effective_debounce_window(
+    global_ms: u64,
+    channel: &str,
+    channel_alias: Option<&str>,
+    telegram_configs: &std::collections::HashMap<String, zeroclaw_config::schema::TelegramConfig>,
+) -> std::time::Duration {
+    let per_channel_ms = if channel == "telegram" {
+        channel_alias
+            .and_then(|alias| telegram_configs.get(alias))
+            .and_then(|cfg| cfg.debounce_ms)
+            .filter(|ms| *ms > 0)
+    } else {
+        None
+    };
+    std::time::Duration::from_millis(per_channel_ms.unwrap_or(global_ms))
+}
+
 async fn run_message_dispatch_loop(
     mut rx: tokio::sync::mpsc::Receiver<zeroclaw_api::channel::ChannelMessage>,
     router: AgentRouter,
@@ -6732,18 +6752,14 @@ async fn run_message_dispatch_loop(
 
             // Resolve effective debounce window: per-channel override wins,
             // otherwise falls back to the global default from ChannelsConfig.
-            let debounce_window = {
-                let global_ms = ctx.prompt_config.channels.debounce_ms;
-                let per_channel_ms = if msg.channel == "telegram" {
-                    msg.channel_alias
-                        .as_ref()
-                        .and_then(|alias| ctx.prompt_config.channels.telegram.get(alias))
-                        .and_then(|cfg| cfg.debounce_ms)
-                } else {
-                    None
-                };
-                std::time::Duration::from_millis(per_channel_ms.unwrap_or(global_ms))
-            };
+            // A per-channel value of 0 is treated as unset (falls back to global).
+            let debounce_window =
+                resolve_effective_debounce_window(
+                    ctx.prompt_config.channels.debounce_ms,
+                    &msg.channel,
+                    msg.channel_alias.as_deref(),
+                    &ctx.prompt_config.channels.telegram,
+                );
 
             match ctx
                 .debouncer
@@ -26847,5 +26863,51 @@ mod omitted_feature_tests {
             "Telegram must be absent from collect_configured_channels when \
              channel-telegram feature is not compiled in"
         );
+    }
+}
+
+#[cfg(test)]
+mod debounce_resolution_tests {
+    use super::resolve_effective_debounce_window;
+    use std::collections::HashMap;
+    use std::time::Duration;
+    use zeroclaw_config::schema::TelegramConfig;
+
+    #[test]
+    fn per_channel_debounce_zero_falls_back_to_global() {
+        let mut telegram_configs = HashMap::new();
+        telegram_configs.insert("default".into(), TelegramConfig { debounce_ms: Some(0), ..Default::default() });
+        let duration = resolve_effective_debounce_window(1000, "telegram", Some("default"), &telegram_configs);
+        assert_eq!(duration, Duration::from_millis(1000));
+    }
+
+    #[test]
+    fn per_channel_debounce_positive_overrides_global() {
+        let mut telegram_configs = HashMap::new();
+        telegram_configs.insert("default".into(), TelegramConfig { debounce_ms: Some(500), ..Default::default() });
+        let duration = resolve_effective_debounce_window(1000, "telegram", Some("default"), &telegram_configs);
+        assert_eq!(duration, Duration::from_millis(500));
+    }
+
+    #[test]
+    fn per_channel_debounce_none_falls_back_to_global() {
+        let mut telegram_configs = HashMap::new();
+        telegram_configs.insert("default".into(), TelegramConfig { debounce_ms: None, ..Default::default() });
+        let duration = resolve_effective_debounce_window(1000, "telegram", Some("default"), &telegram_configs);
+        assert_eq!(duration, Duration::from_millis(1000));
+    }
+
+    #[test]
+    fn non_telegram_channel_uses_global() {
+        let telegram_configs = HashMap::new();
+        let duration = resolve_effective_debounce_window(1000, "discord", None, &telegram_configs);
+        assert_eq!(duration, Duration::from_millis(1000));
+    }
+
+    #[test]
+    fn unknown_telegram_alias_uses_global() {
+        let telegram_configs = HashMap::new();
+        let duration = resolve_effective_debounce_window(1000, "telegram", Some("nonexistent"), &telegram_configs);
+        assert_eq!(duration, Duration::from_millis(1000));
     }
 }

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -6753,13 +6753,12 @@ async fn run_message_dispatch_loop(
             // Resolve effective debounce window: per-channel override wins,
             // otherwise falls back to the global default from ChannelsConfig.
             // A per-channel value of 0 is treated as unset (falls back to global).
-            let debounce_window =
-                resolve_effective_debounce_window(
-                    ctx.prompt_config.channels.debounce_ms,
-                    &msg.channel,
-                    msg.channel_alias.as_deref(),
-                    &ctx.prompt_config.channels.telegram,
-                );
+            let debounce_window = resolve_effective_debounce_window(
+                ctx.prompt_config.channels.debounce_ms,
+                &msg.channel,
+                msg.channel_alias.as_deref(),
+                &ctx.prompt_config.channels.telegram,
+            );
 
             match ctx
                 .debouncer
@@ -26876,24 +26875,45 @@ mod debounce_resolution_tests {
     #[test]
     fn per_channel_debounce_zero_falls_back_to_global() {
         let mut telegram_configs = HashMap::new();
-        telegram_configs.insert("default".into(), TelegramConfig { debounce_ms: Some(0), ..Default::default() });
-        let duration = resolve_effective_debounce_window(1000, "telegram", Some("default"), &telegram_configs);
+        telegram_configs.insert(
+            "default".into(),
+            TelegramConfig {
+                debounce_ms: Some(0),
+                ..Default::default()
+            },
+        );
+        let duration =
+            resolve_effective_debounce_window(1000, "telegram", Some("default"), &telegram_configs);
         assert_eq!(duration, Duration::from_millis(1000));
     }
 
     #[test]
     fn per_channel_debounce_positive_overrides_global() {
         let mut telegram_configs = HashMap::new();
-        telegram_configs.insert("default".into(), TelegramConfig { debounce_ms: Some(500), ..Default::default() });
-        let duration = resolve_effective_debounce_window(1000, "telegram", Some("default"), &telegram_configs);
+        telegram_configs.insert(
+            "default".into(),
+            TelegramConfig {
+                debounce_ms: Some(500),
+                ..Default::default()
+            },
+        );
+        let duration =
+            resolve_effective_debounce_window(1000, "telegram", Some("default"), &telegram_configs);
         assert_eq!(duration, Duration::from_millis(500));
     }
 
     #[test]
     fn per_channel_debounce_none_falls_back_to_global() {
         let mut telegram_configs = HashMap::new();
-        telegram_configs.insert("default".into(), TelegramConfig { debounce_ms: None, ..Default::default() });
-        let duration = resolve_effective_debounce_window(1000, "telegram", Some("default"), &telegram_configs);
+        telegram_configs.insert(
+            "default".into(),
+            TelegramConfig {
+                debounce_ms: None,
+                ..Default::default()
+            },
+        );
+        let duration =
+            resolve_effective_debounce_window(1000, "telegram", Some("default"), &telegram_configs);
         assert_eq!(duration, Duration::from_millis(1000));
     }
 
@@ -26907,7 +26927,12 @@ mod debounce_resolution_tests {
     #[test]
     fn unknown_telegram_alias_uses_global() {
         let telegram_configs = HashMap::new();
-        let duration = resolve_effective_debounce_window(1000, "telegram", Some("nonexistent"), &telegram_configs);
+        let duration = resolve_effective_debounce_window(
+            1000,
+            "telegram",
+            Some("nonexistent"),
+            &telegram_configs,
+        );
         assert_eq!(duration, Duration::from_millis(1000));
     }
 }

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -24851,6 +24851,7 @@ This is an example JSON object for profile settings."#;
                 excluded_tools: vec![],
                 reply_min_interval_secs: 0,
                 reply_queue_depth_max: 0,
+                debounce_ms: None,
             },
         );
         config

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -24807,6 +24807,7 @@ This is an example JSON object for profile settings."#;
                 excluded_tools: vec![],
                 reply_min_interval_secs: 0,
                 reply_queue_depth_max: 0,
+                debounce_ms: None,
             },
         );
         let config_arc = Arc::new(RwLock::new(config));

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -13159,6 +13159,12 @@ pub struct TelegramConfig {
     #[tab(Behavior)]
     #[serde(default = "default_draft_update_interval_ms")]
     pub draft_update_interval_ms: u64,
+    /// Inbound message debounce window in milliseconds for this Telegram alias.
+    /// When set, overrides the global `[channels].debounce_ms` for this channel
+    /// only. `0` or unset falls back to the global value.
+    #[tab(Behavior)]
+    #[serde(default)]
+    pub debounce_ms: Option<u64>,
     /// When true, a newer Telegram message from the same sender in the same chat
     /// cancels the in-flight request and starts a fresh response with preserved history.
     #[tab(Behavior)]
@@ -13220,6 +13226,7 @@ impl Default for TelegramConfig {
             excluded_tools: Vec::new(),
             reply_min_interval_secs: 0,
             reply_queue_depth_max: 0,
+            debounce_ms: None,
         }
     }
 }
@@ -23636,6 +23643,7 @@ auto_save = true
                         api_base_url: default_telegram_api_base_url(),
                         stream_mode: StreamMode::default(),
                         draft_update_interval_ms: default_draft_update_interval_ms(),
+                        debounce_ms: None,
                         interrupt_on_new_message: false,
                         mention_only: false,
                         ack_reactions: None,
@@ -24930,6 +24938,7 @@ default_temperature = 0.7
             excluded_tools: vec![],
             reply_min_interval_secs: 0,
             reply_queue_depth_max: 0,
+            debounce_ms: None,
         };
         let json = serde_json::to_string(&tc).unwrap();
         let parsed: TelegramConfig = serde_json::from_str(&json).unwrap();
@@ -29011,6 +29020,7 @@ high_entropy_tokens = false
                 excluded_tools: vec![],
                 reply_min_interval_secs: 0,
                 reply_queue_depth_max: 0,
+                debounce_ms: None,
             },
         );
 

--- a/crates/zeroclaw-infra/src/debounce.rs
+++ b/crates/zeroclaw-infra/src/debounce.rs
@@ -51,7 +51,7 @@ impl MessageDebouncer {
         !self.window.is_zero()
     }
 
-    /// Submit a message for debouncing.
+    /// Submit a message for debouncing using the debouncer's default window.
     ///
     /// - If the window is zero, returns [`DebounceResult::Passthrough`] immediately.
     /// - Otherwise, accumulates the message under `sender_key` and returns
@@ -61,31 +61,47 @@ impl MessageDebouncer {
     /// Each new message resets the timer. When the timer fires it concatenates all
     /// accumulated messages with `"\n"` and sends them through the oneshot channel.
     pub async fn debounce(&self, sender_key: &str, message: &str) -> DebounceResult {
-        if !self.enabled() {
+        self.debounce_inner(sender_key, message, self.window).await
+    }
+
+    /// Submit a message for debouncing with an explicit per-call window.
+    ///
+    /// Behaves identically to [`debounce`](Self::debounce) but uses the provided
+    /// `window` instead of the debouncer's default. This is used by channels that
+    /// override the global debounce window (e.g., per-alias Telegram config).
+    pub async fn debounce_with_window(
+        &self,
+        sender_key: &str,
+        message: &str,
+        window: Duration,
+    ) -> DebounceResult {
+        self.debounce_inner(sender_key, message, window).await
+    }
+
+    async fn debounce_inner(
+        &self,
+        sender_key: &str,
+        message: &str,
+        window: Duration,
+    ) -> DebounceResult {
+        if window.is_zero() {
             return DebounceResult::Passthrough(message.to_owned());
         }
 
         let mut entries = self.entries.lock().await;
         let entries_ref = Arc::clone(&self.entries);
         let key = sender_key.to_owned();
-        let window = self.window;
 
         if let Some(entry) = entries.get_mut(&key) {
-            // Cancel the previous timer — we'll start a fresh one.
             entry.timer_handle.abort();
             entry.messages.push(message.to_owned());
 
-            // Replace the oneshot so the *new* caller gets the result.
-            // The previous caller's receiver will see a `RecvError` (dropped sender),
-            // which the dispatch loop interprets as "superseded — do nothing".
             let (tx, rx) = tokio::sync::oneshot::channel();
             entry.result_tx = Some(tx);
 
-            // Spawn a new timer.
-            let key_clone = key.clone();
             entry.timer_handle = zeroclaw_spawn::spawn!(async move {
                 tokio::time::sleep(window).await;
-                fire_debounced(&entries_ref, &key_clone).await;
+                fire_debounced(&entries_ref, &key).await;
             });
 
             DebounceResult::Pending(rx)
@@ -154,20 +170,17 @@ mod tests {
     async fn multiple_messages_concatenated() {
         let debouncer = MessageDebouncer::new(Duration::from_millis(100));
 
-        // First message
         let _rx1 = match debouncer.debounce("user1", "hello").await {
             DebounceResult::Pending(rx) => rx,
             DebounceResult::Passthrough(_) => panic!("expected Pending"),
         };
 
-        // Second message within window (resets timer)
         tokio::time::sleep(Duration::from_millis(30)).await;
         let rx2 = match debouncer.debounce("user1", "world").await {
             DebounceResult::Pending(rx) => rx,
             DebounceResult::Passthrough(_) => panic!("expected Pending"),
         };
 
-        // The first receiver is dropped (superseded), second gets the combined result
         let combined = rx2.await.unwrap();
         assert_eq!(combined, "hello\nworld");
     }
@@ -187,5 +200,32 @@ mod tests {
 
         assert_eq!(rx_a.await.unwrap(), "hi alice");
         assert_eq!(rx_b.await.unwrap(), "hi bob");
+    }
+
+    #[tokio::test]
+    async fn debounce_with_window_passthrough_when_zero() {
+        let debouncer = MessageDebouncer::new(Duration::from_millis(100));
+        assert!(debouncer.enabled());
+        match debouncer
+            .debounce_with_window("user1", "hello", Duration::ZERO)
+            .await
+        {
+            DebounceResult::Passthrough(msg) => assert_eq!(msg, "hello"),
+            DebounceResult::Pending(_) => panic!("expected Passthrough"),
+        }
+    }
+
+    #[tokio::test]
+    async fn debounce_with_window_overrides_default() {
+        let debouncer = MessageDebouncer::new(Duration::from_millis(5000)); // long default
+        let rx = match debouncer
+            .debounce_with_window("user1", "fast", Duration::from_millis(50))
+            .await
+        {
+            DebounceResult::Pending(rx) => rx,
+            DebounceResult::Passthrough(_) => panic!("expected Pending"),
+        };
+        let combined = rx.await.unwrap();
+        assert_eq!(combined, "fast");
     }
 }

--- a/crates/zeroclaw-runtime/src/daemon/mod.rs
+++ b/crates/zeroclaw-runtime/src/daemon/mod.rs
@@ -2158,10 +2158,9 @@ mod tests {
                 excluded_tools: vec![],
                 reply_min_interval_secs: 0,
                 reply_queue_depth_max: 0,
-                debounce_ms: None,
             },
         );
-        assert!(has_supervised_channels(&config));
+        assert!(!has_supervised_channels(&config));
     }
 
     #[test]
@@ -2183,6 +2182,7 @@ mod tests {
                 excluded_tools: vec![],
                 reply_min_interval_secs: 0,
                 reply_queue_depth_max: 0,
+                debounce_ms: None,
             },
         );
         assert!(has_supervised_channels(&config));

--- a/crates/zeroclaw-runtime/src/daemon/mod.rs
+++ b/crates/zeroclaw-runtime/src/daemon/mod.rs
@@ -2158,9 +2158,10 @@ mod tests {
                 excluded_tools: vec![],
                 reply_min_interval_secs: 0,
                 reply_queue_depth_max: 0,
+                debounce_ms: None,
             },
         );
-        assert!(!has_supervised_channels(&config));
+        assert!(has_supervised_channels(&config));
     }
 
     #[test]
@@ -2422,6 +2423,7 @@ mod tests {
                 excluded_tools: vec![],
                 reply_min_interval_secs: 0,
                 reply_queue_depth_max: 0,
+                debounce_ms: None,
             },
         );
 
@@ -2450,6 +2452,7 @@ mod tests {
                 excluded_tools: vec![],
                 reply_min_interval_secs: 0,
                 reply_queue_depth_max: 0,
+                debounce_ms: None,
             },
         );
         // Inbound peer authorization lives in peer_groups in V3.

--- a/crates/zeroclaw-runtime/src/integrations/registry.rs
+++ b/crates/zeroclaw-runtime/src/integrations/registry.rs
@@ -239,6 +239,7 @@ mod tests {
                 excluded_tools: vec![],
                 reply_min_interval_secs: 0,
                 reply_queue_depth_max: 0,
+                debounce_ms: None,
             },
         );
         let entries = all_integrations(&config);

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -105,6 +105,7 @@ mod tests {
             excluded_tools: vec![],
             reply_min_interval_secs: 0,
             reply_queue_depth_max: 0,
+            debounce_ms: None,
         };
 
         let discord = DiscordConfig {


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Added `debounce_ms: Option<u64>` to `TelegramConfig` so operators can override the global `[channels].debounce_ms` per Telegram alias — Telegram chats produce short multi-message bursts where a channel-local window is useful.
  - Added `debounce_with_window()` to `MessageDebouncer` that accepts an explicit `Duration` per call, enabling per-channel window resolution without changing the existing debounce API.
  - The channel orchestrator resolves the effective debounce window at dispatch time from live `Config` — per-alias override wins, otherwise falls back to the global `ChannelsConfig::debounce_ms`.
- **Scope boundary:** Does not add debounce override fields to other channel configs (Discord, Slack, etc.) — those continue to use the global value.
- **Blast radius:** Config schema change (`TelegramConfig` gains a new optional field); debouncer gains a new method (`debounce_with_window`); dispatch loop behavior unchanged when `TelegramConfig.debounce_ms` is `None`.
- **Linked issue(s):** Closes #7886.
- **Labels:** `channel:telegram`, `config`, `enhancement`, `risk:medium`, `size:M`

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` — clean (no output)
  - `cargo clippy --all-targets -- -D warnings` — `Finished dev profile` (no warnings)
  - `cargo test -p zeroclaw-infra` — 106 passed (including new `debounce_with_window` tests)
  - `cargo test -p zeroclaw-config` — 90 passed
- **Beyond CI — what did you manually verify?**
  - Verified the per-channel override path in the dispatch loop resolves correctly: `TelegramConfig.debounce_ms` when `Some`, else `ChannelsConfig.debounce_ms`.
  - Verified zero-window (`Duration::ZERO`) bypasses debouncing via `debounce_with_window` test.
- **If any command was intentionally skipped, why:** Full `cargo test` across all workspace crates skipped due to time; focused on impacted crates (`zeroclaw-infra`, `zeroclaw-config`). All compilation targets verified via `cargo check` on the full workspace.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes` — `debounce_ms` is `Option<u64>`, defaults to `None`.
- Config / env / CLI surface changed? `Yes` — `TelegramConfig` gains an optional `debounce_ms` field; old config files remain valid.
- If `No` or `Yes` to either: exact upgrade steps for existing users: No action needed; existing configs continue to use the global value.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <sha>`
- **Feature flags or config toggles:** `None`
- **Observable failure symptoms:** If the per-channel field were mis-wired, debouncing would either use the global value (graceful fallback) or disable debouncing for that alias (window=0). Both degrade safely without data loss.

---