### PR TITLE
fix(compatible): add tool name to native tool-result messages

### DIFF
--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -1219,6 +1219,10 @@ struct NativeMessage {
     tool_call_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tool_calls: Option<Vec<ToolCall>>,
+    /// Tool name for tool-role messages. Some providers (Groq) require this
+    /// field on native tool-result messages; without it they reject the request.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
     /// Raw reasoning content from thinking models; pass-through for model_providers
     /// that require it in assistant tool-call history messages.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2091,6 +2095,7 @@ impl OpenAiCompatibleModelProvider {
                         content,
                         tool_call_id: None,
                         tool_calls: Some(tool_calls),
+                        name: None,
                         reasoning_content,
                         reasoning,
                     };
@@ -2127,6 +2132,7 @@ impl OpenAiCompatibleModelProvider {
                         content,
                         tool_call_id: None,
                         tool_calls: None,
+                        name: None,
                         reasoning_content,
                         reasoning,
                     };
@@ -2162,11 +2168,17 @@ impl OpenAiCompatibleModelProvider {
                         .map(|value| MessageContent::Text(value.to_string()))
                         .or_else(|| Some(MessageContent::Text(message.content.clone())));
 
+                    let name = value
+                        .get("name")
+                        .and_then(serde_json::Value::as_str)
+                        .map(|s| s.to_string());
+
                     return NativeMessage {
                         role: "tool".to_string(),
                         content,
                         tool_call_id,
                         tool_calls: None,
+                        name,
                         reasoning_content: None,
                         reasoning: None,
                     };
@@ -2181,6 +2193,7 @@ impl OpenAiCompatibleModelProvider {
                     )),
                     tool_call_id: None,
                     tool_calls: None,
+                    name: None,
                     reasoning_content: None,
                     reasoning: None,
                 }
@@ -3526,6 +3539,7 @@ mod tests {
                 content: Some(MessageContent::Text("hello".to_string())),
                 tool_call_id: None,
                 tool_calls: None,
+                name: None,
                 reasoning_content: None,
                 reasoning: None,
             }],
@@ -5793,6 +5807,7 @@ mod tests {
             content: Some(MessageContent::Text("hi".to_string())),
             tool_call_id: None,
             tool_calls: None,
+            name: None,
             reasoning_content: None,
             reasoning: None,
         };
@@ -5807,6 +5822,7 @@ mod tests {
             content: Some(MessageContent::Text("hi".to_string())),
             tool_call_id: None,
             tool_calls: None,
+            name: None,
             reasoning_content: Some("thinking...".to_string()),
             reasoning: None,
         };


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Added `name: Option<String>` to the compatible-provider `NativeMessage` struct — Groq native tool calling rejects role-tool messages without a top-level `name` field, causing provider-side request errors.
  - The tool-role conversion path in `convert_messages_for_native` now extracts the tool name from the JSON payload and populates the field. Other message roles set `name: None`.
- **Scope boundary:** Only the compatible.rs `NativeMessage` struct and its conversion function. Does not touch the `openai.rs`, `azure_openai.rs`, or `openrouter.rs` `NativeMessage` structs (separate provider adapters, same pattern but out of scope for this fix).
- **Blast radius:** Low — `name` is `Option<String>` with `skip_serializing_if`, so `None` fields are omitted from serialized JSON (no change in wire format for providers that don't need it).
- **Linked issue(s):** Closes #7896.
- **Labels:** `provider:compatible`, `provider:groq`, `bug`, `risk:medium`, `size:S`

## Validation Evidence (required)

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` — clean (no output)
  - `cargo clippy --all-targets -- -D warnings` — `Finished dev profile` (no warnings)
  - `cargo test -p zeroclaw-providers -- compatible` — 192 passed
- **Beyond CI — what did you manually verify?**
  - Verified the `name` field is extracted from the tool-result JSON payload in the tool-role branch.
  - Verified `name: None` is set on all other `NativeMessage` constructors so serialization is unchanged for non-tool messages.
  - Verified `skip_serializing_if = "Option::is_none"` on the field ensures no wire-format change when `name` is absent.
- **If any command was intentionally skipped, why:** Full workspace `cargo test` skipped due to time; all compilation targets verified via `cargo check --all-targets`.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes` — `name` is `Option<String>`, new field omitted when `None`.
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: exact upgrade steps for existing users: No action needed.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <sha>`
- **Feature flags or config toggles:** `None`
- **Observable failure symptoms:** If the name extraction is incorrect, Groq native tool calls may still fail — but the field is now present in the request body, so the provider error should change from "missing name" to "wrong name", which is a tool-config issue, not a ZeroClaw bug.
