### PR TITLE
test(config): cover postgres backend field-visibility exclusions

### DIFF
--- a/crates/zeroclaw-config/src/field_visibility.rs
+++ b/crates/zeroclaw-config/src/field_visibility.rs
@@ -125,6 +125,17 @@ mod tests {
     }
 
     #[test]
+    fn postgres_backend_hides_sqlite_and_qdrant_subsections() {
+        // postgres active → hide sqlite-only knobs and qdrant subsection,
+        // keep postgres subsection visible
+        let ex = memory_backend_excludes("postgres");
+        assert!(ex.contains(&"sqlite-open-timeout-secs"));
+        assert!(ex.contains(&"conversation-retention-days"));
+        assert!(ex.contains(&"qdrant."));
+        assert!(!ex.contains(&"postgres."));
+    }
+
+    #[test]
     fn path_matches_prefix_requires_segment_boundary() {
         // Exact match and children.
         assert!(path_matches_prefix("agents.aaa", "agents.aaa"));


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Adds a regression test (`postgres_backend_hides_sqlite_and_qdrant_subsections`) covering that `memory_backend_excludes("postgres")` hides the sqlite-only knobs (`sqlite-open-timeout-secs`, `conversation-retention-days`) and the `qdrant.` subsection while leaving the `postgres.` subsection visible. The existing `memory_excludes_hide_inactive_backends` test exercises the `sqlite` and `qdrant` active backends but omits the `postgres` case, leaving a gap in the three-backend exclusion matrix. Test-only — no production code changes.
- **Scope boundary:** Test-only. No production code, schema, or behavior changes.
- **Blast radius:** None — adds one `#[test]` in `crates/zeroclaw-config/src/field_visibility.rs`.
- **Linked issue(s):** None.

## Validation Evidence (required)

```
$ cargo test -p zeroclaw-config postgres_backend_hides_sqlite_and_qdrant_subsections
running 1 test
test field_visibility::tests::postgres_backend_hides_sqlite_and_qdrant_subsections ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 994 filtered out; finished in 0.00s

$ cargo clippy -p zeroclaw-config --all-targets -- -D warnings
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.17s

$ cargo fmt -p zeroclaw-config -- --check
(no diff on the changed file)
```

- **Beyond CI — what did you manually verify?** Read `crates/zeroclaw-config/src/field_visibility.rs` and confirmed that `memory_backend_excludes` contains three independent `if backend != "<backend>"` guards — one per backend — meaning the `postgres` case has distinct exclusions (sqlite knobs + qdrant subsection) that the existing tests do not cover. Pure-logic (no IO/network/time/global state).

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No

## Rollback

Low-risk, test-only: `git revert <sha>`.