### PR TITLE
test(config): cover ThinkingLevel parsing, as_str roundtrip, and budget token thresholds

### DIFF
--- a/crates/zeroclaw-config/src/scattered_types.rs
+++ b/crates/zeroclaw-config/src/scattered_types.rs
@@ -803,3 +803,94 @@ impl Default for VoiceCallConfig {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn thinking_level_from_str_canonical_aliases() {
+        let cases = [
+            ("off", ThinkingLevel::Off),
+            ("none", ThinkingLevel::Off),
+            ("minimal", ThinkingLevel::Minimal),
+            ("min", ThinkingLevel::Minimal),
+            ("low", ThinkingLevel::Low),
+            ("medium", ThinkingLevel::Medium),
+            ("med", ThinkingLevel::Medium),
+            ("default", ThinkingLevel::Medium),
+            ("high", ThinkingLevel::High),
+            ("max", ThinkingLevel::Max),
+            ("maximum", ThinkingLevel::Max),
+        ];
+        for (s, expected) in cases {
+            assert_eq!(
+                ThinkingLevel::from_str_insensitive(s),
+                Some(expected),
+                "input={s}"
+            );
+        }
+    }
+
+    #[test]
+    fn thinking_level_from_str_case_insensitive() {
+        assert_eq!(
+            ThinkingLevel::from_str_insensitive("OFF"),
+            Some(ThinkingLevel::Off)
+        );
+        assert_eq!(
+            ThinkingLevel::from_str_insensitive("HIGH"),
+            Some(ThinkingLevel::High)
+        );
+        assert_eq!(
+            ThinkingLevel::from_str_insensitive("MAX"),
+            Some(ThinkingLevel::Max)
+        );
+        assert_eq!(
+            ThinkingLevel::from_str_insensitive("Medium"),
+            Some(ThinkingLevel::Medium)
+        );
+    }
+
+    #[test]
+    fn thinking_level_from_str_unknown_returns_none() {
+        assert_eq!(ThinkingLevel::from_str_insensitive("unknown"), None);
+        assert_eq!(ThinkingLevel::from_str_insensitive(""), None);
+        assert_eq!(ThinkingLevel::from_str_insensitive("ultra"), None);
+        assert_eq!(ThinkingLevel::from_str_insensitive("123"), None);
+    }
+
+    #[test]
+    fn thinking_level_as_str_roundtrips() {
+        for level in [
+            ThinkingLevel::Off,
+            ThinkingLevel::Minimal,
+            ThinkingLevel::Low,
+            ThinkingLevel::Medium,
+            ThinkingLevel::High,
+            ThinkingLevel::Max,
+        ] {
+            let s = level.as_str();
+            assert_eq!(
+                ThinkingLevel::from_str_insensitive(s),
+                Some(level),
+                "roundtrip failed for {s}"
+            );
+        }
+    }
+
+    #[test]
+    fn thinking_level_budget_tokens_only_high_and_max() {
+        assert_eq!(ThinkingLevel::Off.default_budget_tokens(), None);
+        assert_eq!(ThinkingLevel::Minimal.default_budget_tokens(), None);
+        assert_eq!(ThinkingLevel::Low.default_budget_tokens(), None);
+        assert_eq!(ThinkingLevel::Medium.default_budget_tokens(), None);
+        assert_eq!(ThinkingLevel::High.default_budget_tokens(), Some(10_000));
+        assert_eq!(ThinkingLevel::Max.default_budget_tokens(), Some(50_000));
+    }
+
+    #[test]
+    fn thinking_level_default_is_medium() {
+        assert_eq!(ThinkingLevel::default(), ThinkingLevel::Medium);
+    }
+}


### PR DESCRIPTION
## Summary

- **Base**: `master`
- **What**: Adds `#[cfg(test)] mod tests` to `crates/zeroclaw-config/src/scattered_types.rs` covering `ThinkingLevel`'s three public methods: `from_str_insensitive`, `as_str`, and `default_budget_tokens`.
- **Scope**: Test-only — no production code changes.
- **Blast radius**: None; `#[cfg(test)]` block is stripped from release builds.
- **Linked issues**: None.
- **Labels**: `config`, `tests`, `risk:low`, `size:S`

Six tests:
1. `thinking_level_from_str_canonical_aliases` — all 11 accepted alias strings map to the correct variant
2. `thinking_level_from_str_case_insensitive` — uppercase inputs fold correctly
3. `thinking_level_from_str_unknown_returns_none` — rejects empty string, garbage inputs
4. `thinking_level_as_str_roundtrips` — every variant's `as_str()` is accepted back by `from_str_insensitive`
5. `thinking_level_budget_tokens_only_high_and_max` — `Off/Minimal/Low/Medium` → `None`; `High` → `Some(10_000)`; `Max` → `Some(50_000)`
6. `thinking_level_default_is_medium` — `Default` impl yields `ThinkingLevel::Medium`

## Validation Evidence

```
test scattered_types::tests::thinking_level_as_str_roundtrips ... ok
test scattered_types::tests::thinking_level_budget_tokens_only_high_and_max ... ok
test scattered_types::tests::thinking_level_default_is_medium ... ok
test scattered_types::tests::thinking_level_from_str_canonical_aliases ... ok
test scattered_types::tests::thinking_level_from_str_case_insensitive ... ok
test scattered_types::tests::thinking_level_from_str_unknown_returns_none ... ok
test result: ok. 992 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.59s
```

`cargo clippy -p zeroclaw-config --tests -- -D warnings`: Finished, no errors.

## Security & Privacy Impact

- Introduces new user-facing API or data collection? **No**
- Modifies auth, permissions, or access control? **No**
- Stores or transmits sensitive data? **No**
- Could regress privacy-preserving behaviour? **No**

## Compatibility

Backward compatible — test-only addition, no public API changes.

## Rollback

Revert the appended `#[cfg(test)] mod tests` block in `scattered_types.rs`.
