### PR TITLE
perf(channels): bound orchestrator notify channel + cap path/url body

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -150,9 +150,19 @@ static CRON_CHANNEL_REGISTRY: std::sync::RwLock<Option<CronChannelRegistry>> =
 /// for real-time threaded notifications.
 struct ChannelNotifyObserver {
     inner: Arc<dyn Observer>,
-    tx: tokio::sync::mpsc::UnboundedSender<String>,
+    tx: tokio::sync::mpsc::Sender<String>,
     tools_used: AtomicBool,
 }
+
+/// Maximum characters of a tool-argument detail included in a notify
+/// message. Caps the per-message body so a user-controlled `path` or
+/// `url` argument cannot inflate the mpsc payload or the platform
+/// channel post. Matches the size class of the other per-message caps
+/// already in use by the observer (200 / 200 / 120 chars) but raised to
+/// 4 KiB so realistic absolute paths (e.g. workspace-prefixed paths
+/// under `/var/lib/zeroclaw/workspaces/<uuid>/channels/...`) are not
+/// truncated in normal operation.
+const NOTIFY_DETAIL_MAX_CHARS: usize = 4096;
 
 impl Observer for ChannelNotifyObserver {
     fn record_event(&self, event: &ObserverEvent) {
@@ -169,9 +179,9 @@ impl Observer for ChannelNotifyObserver {
                         } else if let Some(q) = v.get("query").and_then(|c| c.as_str()) {
                             format!(": {}", truncate_with_ellipsis(q, 200))
                         } else if let Some(p) = v.get("path").and_then(|c| c.as_str()) {
-                            format!(": {p}")
+                            format!(": {}", truncate_with_ellipsis(p, NOTIFY_DETAIL_MAX_CHARS))
                         } else if let Some(u) = v.get("url").and_then(|c| c.as_str()) {
-                            format!(": {u}")
+                            format!(": {}", truncate_with_ellipsis(u, NOTIFY_DETAIL_MAX_CHARS))
                         } else {
                             let s = args.to_string();
                             format!(": {}", truncate_with_ellipsis(&s, 120))
@@ -183,7 +193,12 @@ impl Observer for ChannelNotifyObserver {
                 }
                 _ => String::new(),
             };
-            let _ = self.tx.send(format!("\u{1F527} `{tool}`{detail}"));
+            // Bounded channel: drop on full so a slow downstream
+            // channel (e.g. a stalled Discord / Slack API call) cannot
+            // wedge the observer hook. Live-typing notifications are
+            // best-effort UX; a dropped message degrades the indicator
+            // briefly but does not lose any real state.
+            let _ = self.tx.try_send(format!("\u{1F527} `{tool}`{detail}"));
         }
         self.inner.record_event(event);
     }
@@ -4936,7 +4951,10 @@ async fn process_channel_message_body(
     };
 
     // Wrap observer to forward tool events as live thread messages
-    let (notify_tx, mut notify_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+    // Bounded so a slow downstream channel cannot grow this queue
+    // without bound. See `ChannelNotifyObserver::record_event` for the
+    // drop-on-full contract.
+    let (notify_tx, mut notify_rx) = tokio::sync::mpsc::channel::<String>(128);
     let notify_observer: Arc<ChannelNotifyObserver> = Arc::new(ChannelNotifyObserver {
         inner: Arc::clone(&ctx.observer),
         tx: notify_tx,
@@ -17204,7 +17222,7 @@ BTC is currently around $65,000 based on latest tool output."#
 
     #[test]
     fn channel_notify_observer_truncates_utf8_arguments_safely() {
-        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<String>(128);
         let observer = ChannelNotifyObserver {
             inner: Arc::new(NoopObserver),
             tx,
@@ -17231,6 +17249,103 @@ BTC is currently around $65,000 based on latest tool output."#
         let emitted = rx.try_recv().expect("observer should emit notify message");
         assert!(emitted.contains("`file_write`"));
         assert!(emitted.is_char_boundary(emitted.len()));
+    }
+
+    /// Regression: the `path` argument branch must route through
+    /// `truncate_with_ellipsis` so a user-controlled path cannot inflate
+    /// the mpsc payload or the platform channel post. Previously the
+    /// branch was `format!(": {p}")` with no cap — a 10 MB path would
+    /// pass through verbatim. The cap constant is `NOTIFY_DETAIL_MAX_CHARS`
+    /// (4096); the ellipsis suffix is one character added by the helper.
+    #[test]
+    fn channel_notify_observer_caps_long_path_argument() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<String>(128);
+        let observer = ChannelNotifyObserver {
+            inner: Arc::new(NoopObserver),
+            tx,
+            tools_used: AtomicBool::new(false),
+        };
+
+        // 64 KiB path — 16x the per-message cap.
+        let long_path = "a".repeat(64 * 1024);
+        let payload = serde_json::json!({ "path": &long_path }).to_string();
+
+        observer.record_event(
+            &zeroclaw_runtime::observability::traits::ObserverEvent::ToolCallStart {
+                tool: "file_read".to_string(),
+                tool_call_id: None,
+                arguments: Some(payload),
+                channel: None,
+                agent_alias: None,
+                turn_id: None,
+            },
+        );
+
+        let emitted = rx.try_recv().expect("observer should emit notify message");
+        // The full input was 64 KiB; the emitted message must be capped
+        // to NOTIFY_DETAIL_MAX_CHARS + the literal prefix/suffix chars
+        // ("\u{1F527} `file_read`: " = 17 chars + "…" = 1 char).
+        let max_len = NOTIFY_DETAIL_MAX_CHARS + 17 + 1;
+        assert!(
+            emitted.chars().count() <= max_len,
+            "emitted notify message must be capped (got {} chars, max {})",
+            emitted.chars().count(),
+            max_len
+        );
+        assert!(
+            emitted.contains("`file_read`"),
+            "emitted message must still identify the tool"
+        );
+        assert!(
+            emitted.is_char_boundary(emitted.len()),
+            "truncation must preserve a valid char boundary"
+        );
+    }
+
+    /// Regression: the bounded mpsc must drop on full rather than
+    /// block. A slow downstream channel (e.g. a stalled Discord /
+    /// Slack API call) must not wedge the observer hook. With a
+    /// capacity-1 channel and two events pushed back-to-back without
+    /// draining, the second push must be silently dropped.
+    #[tokio::test]
+    async fn channel_notify_observer_drops_on_full_channel() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<String>(1);
+        let observer = ChannelNotifyObserver {
+            inner: Arc::new(NoopObserver),
+            tx,
+            tools_used: AtomicBool::new(false),
+        };
+
+        let mk_event = || zeroclaw_runtime::observability::traits::ObserverEvent::ToolCallStart {
+            tool: "file_read".to_string(),
+            tool_call_id: None,
+            arguments: Some(r#"{"path":"/a"}"#.to_string()),
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
+        };
+
+        // First push lands in the bounded buffer (capacity 1).
+        observer.record_event(&mk_event());
+        // Second push must drop: the consumer has not drained yet, so
+        // the buffer is full and `try_send` returns `Full`.
+        observer.record_event(&mk_event());
+
+        // Exactly one message arrived.
+        let first = rx
+            .recv()
+            .await
+            .expect("at least one notify should land before drop");
+        assert!(first.contains("`file_read`"));
+        // No second message; the channel is empty because the second
+        // push was dropped (not queued behind the first).
+        assert!(
+            rx.try_recv().is_err(),
+            "second push must be dropped when the channel is full"
+        );
+        // tools_used must reflect that both events were observed
+        // (the drop is on the notify side, not the observer side).
+        assert!(observer.tools_used.load(Ordering::Relaxed));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **What changed:** The `ChannelNotifyObserver` had two latent OOM vectors — an unbounded mpsc for tool-event notifications and two untruncated branches in the `path` / `url` argument formatters. Both are bounded in this PR.
- **Why:** Audit `audit-zeroclaw-2026-06-28.md` flagged the unbounded channel at `orchestrator/mod.rs:4570`; deeper reading of the observer impl at lines 157–189 surfaced the second risk (a user-controlled 10 MB path or URL passes through `format!(": {p}")` with no cap).
- **Behavior change:** None observable for well-behaved inputs. Under sustained backpressure (slow downstream channel + many tool calls), live-typing notifications may be dropped — the intended graceful-degradation contract documented on the producer push.

## Changes

### Producer side: cap the per-message body

The `path` and `url` branches in `ChannelNotifyObserver::record_event` at `crates/zeroclaw-channels/src/orchestrator/mod.rs:171–174` now route through `truncate_with_ellipsis`:

```rust
} else if let Some(p) = v.get("path").and_then(|c| c.as_str()) {
    format!(": {}", truncate_with_ellipsis(p, NOTIFY_DETAIL_MAX_CHARS))
} else if let Some(u) = v.get("url").and_then(|c| c.as_str()) {
    format!(": {}", truncate_with_ellipsis(u, NOTIFY_DETAIL_MAX_CHARS))
}
```

A new `const NOTIFY_DETAIL_MAX_CHARS: usize = 4096;` (4 KiB) keeps the cap visible at the call site. 4 KiB is large enough to cover any realistic absolute workspace-prefixed path (`/var/lib/zeroclaw/workspaces/<uuid>/channels/...`) and any reasonable URL, while bounding the worst case to a few KiB per notification. The other branches (`command` capped at 200, `query` capped at 200, generic capped at 120) are preserved unchanged.

### Consumer side: bound the queue

1. Struct field at `orchestrator/mod.rs:153`:
   `tx: tokio::sync::mpsc::UnboundedSender<String>` → `tx: tokio::sync::mpsc::Sender<String>`
2. Channel construction at `orchestrator/mod.rs:4954`:
   `unbounded_channel::<String>()` → `channel::<String>(128)`
3. Producer push at `orchestrator/mod.rs:186`:
   `self.tx.send(format!(...))` → `self.tx.try_send(format!(...))`

Capacity 128 matches the mid-range of the file's existing production mpsc channels (4–100 in production paths). Worst-case memory at 128 × 4 KiB is ~512 KiB, small relative to typical per-turn RSS.

### Tests

Two new regression tests pin the contracts; the existing UTF-8 truncation test is updated to construct a bounded channel to match the new field type.

- `channel_notify_observer_caps_long_path_argument` — feeds a 64 KiB `path` argument (16× the cap) and asserts the emitted string is bounded by `NOTIFY_DETAIL_MAX_CHARS + prefix + ellipsis`.
- `channel_notify_observer_drops_on_full_channel` — pushes two events into a capacity-1 channel without draining; asserts exactly one arrives and `tools_used` reflects both events were observed on the observer side (the drop is on the notify side, not the observer side).
- `channel_notify_observer_truncates_utf8_arguments_safely` (existing) — updated to construct a bounded `channel::<String>(128)` instead of an `unbounded_channel`. No test-logic change; the truncation-safety contract still holds.

## Public API impact

**None.** `ChannelNotifyObserver` is module-private (no `pub` modifier, no re-export from `lib.rs`). Only the internal field type changed. `zeroclaw-channels` is `Experimental` per `AGENTS.md`, so there is no stability concern regardless.

## Helper reuse

`truncate_with_ellipsis` and `floor_char_boundary` are reused unchanged from `crates/zeroclaw-channels/src/util.rs:2,13` — no new helpers, no new dependencies.

## Durability-of-UX tradeoff

Live-typing notifications are best-effort UX. A dropped message degrades the indicator briefly but does not lose any real state. We do not log on drop because the observer is in a hot path and a slow channel could generate thousands of drops per second; the existing observer-hook call sites in the file already follow the no-log-on-drop convention.

## Validation

```text
$ cargo fmt --all -- --check
(no output — clean)

$ cargo clippy --locked -p zeroclaw-channels --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 4m 28s
0 warnings.

$ cargo test --locked -p zeroclaw-channels --lib -- orchestrator::
test result: ok. 344 passed; 0 failed; 0 ignored; 0 measured; 777 filtered out

$ cargo test --locked -p zeroclaw-channels --lib -- channel_notify_observer
test result: ok. 3 passed (1 existing updated + 2 new)

$ cargo build --locked
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 5m 48s
```

Diff: `+121 / -6` in `crates/zeroclaw-channels/src/orchestrator/mod.rs` (single file). No new dependencies.

## Refs

- Audit at `audit-zeroclaw-2026-06-28.md`
- The two parallel fixes that landed before this one: PR #8437 (refactor: extract JSONL write helper), PR #8439 (perf: move JSONL fsync off hot path)