### PR TITLE
fix(channels): preserve image bytes for a configured vision_model_provider

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -4328,7 +4328,8 @@ async fn process_channel_message_body(
 
     // ── Media pipeline: enrich inbound message with media annotations ──
     if ctx.media_pipeline.enabled && !msg.attachments.is_empty() {
-        let vision = ctx.model_provider.supports_vision();
+        let vision =
+            ctx.model_provider.supports_vision() || ctx.multimodal.vision_model_provider.is_some();
         // Build from legacy config; if that fails (e.g. no legacy api_key
         // but typed providers are configured), fall back to an empty shell
         // so with_typed_providers() can still populate the registry.
@@ -20834,6 +20835,121 @@ This is an example JSON object for profile settings."#;
     /// marker) sent through `process_channel_message` with a non-vision
     /// model_provider must produce a `"⚠️ Error: …does not support vision"` reply
     /// on the recording channel — no real Telegram or LLM API required.
+
+    #[tokio::test]
+    async fn media_pipeline_preserves_image_bytes_when_vision_route_configured() {
+        use wiremock::matchers::{body_string_contains, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let channel_impl = Arc::new(RecordingChannel::default());
+        let channel: Arc<dyn Channel> = channel_impl.clone();
+
+        let mut channels_by_name = HashMap::new();
+        channels_by_name.insert(channel.name().to_string(), channel);
+
+        let provider_impl = Arc::new(HistoryCaptureModelProvider::default());
+        let vision_server = MockServer::start().await;
+        let _vision_mock = Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(body_string_contains("data:image/png;base64,AQIDBA=="))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": "vision saw bytes"
+                        }
+                    }
+                ]
+            })))
+            .expect(1)
+            .mount_as_scoped(&vision_server)
+            .await;
+
+        let base_ctx = peer_prompt_test_context(
+            channels_by_name,
+            provider_impl.clone(),
+            Arc::new(zeroclaw_config::schema::Config::default()),
+            Arc::new(vec![]),
+        );
+        let runtime_ctx = Arc::new(ChannelRuntimeContext {
+            multimodal: zeroclaw_config::schema::MultimodalConfig {
+                vision_model_provider: Some(format!("custom:{}", vision_server.uri())),
+                vision_model: Some("test-vision-model".to_string()),
+                ..Default::default()
+            },
+            media_pipeline: zeroclaw_config::schema::MediaPipelineConfig {
+                enabled: true,
+                describe_images: true,
+                ..Default::default()
+            },
+            ..(*base_ctx).clone()
+        });
+
+        process_channel_message(
+            runtime_ctx,
+            zeroclaw_api::channel::ChannelMessage {
+                id: "msg-image-route".to_string(),
+                sender: "alice".to_string(),
+                reply_target: "chat-image-route".to_string(),
+                content: "please inspect this".to_string(),
+                channel: "test-channel".into(),
+                channel_alias: None,
+                timestamp: 1,
+                thread_ts: None,
+                interruption_scope_id: None,
+                attachments: vec![zeroclaw_api::media::MediaAttachment {
+                    file_name: "route.png".to_string(),
+                    data: vec![1, 2, 3, 4],
+                    mime_type: Some("image/png".to_string()),
+                }],
+                subject: None,
+            },
+            CancellationToken::new(),
+        )
+        .await;
+
+        {
+            let calls = provider_impl.calls.lock().unwrap();
+            assert!(
+                calls.is_empty(),
+                "default non-vision provider must not receive an image-bearing turn: {calls:?}"
+            );
+        }
+
+        let sent_messages = channel_impl.sent_messages.lock().await;
+        assert_eq!(
+            sent_messages.len(),
+            1,
+            "vision route should send exactly one assistant reply: {sent_messages:?}"
+        );
+        assert!(
+            sent_messages[0].contains("vision saw bytes"),
+            "reply should come from the mock vision provider: {sent_messages:?}"
+        );
+        drop(sent_messages);
+
+        let vision_requests = vision_server
+            .received_requests()
+            .await
+            .expect("mock server should record vision provider requests");
+        assert_eq!(
+            vision_requests.len(),
+            1,
+            "vision provider should receive exactly one request"
+        );
+        let vision_body: serde_json::Value = vision_requests[0]
+            .body_json()
+            .expect("vision provider request should be JSON");
+        assert_eq!(vision_body["model"], "test-vision-model");
+        assert!(
+            vision_body
+                .to_string()
+                .contains("data:image/png;base64,AQIDBA=="),
+            "vision provider request must contain the preserved attachment bytes: {vision_body}"
+        );
+    }
+
     #[tokio::test]
     async fn e2e_photo_attachment_rejected_by_non_vision_provider() {
         let channel_impl = Arc::new(RecordingChannel::default());


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - The media pipeline only embedded base64 image data when the *default* model provider reported vision support. When `[multimodal].vision_model_provider` routes images to a dedicated vision provider, the pipeline stripped the bytes to a filename ref **before** the vision route ran — so the vision provider never received the image.
  - Gate the media-pipeline vision flag on the configured vision route too, so the base64 data survives until the vision route dispatches it.
  - Add a wiremock regression proving the vision provider actually receives the preserved bytes.
- **Scope boundary:** Only the media-pipeline vision gate in `process_channel_message`. No change to routing/provider-selection logic, and no behavior change when no vision route is configured.
- **Blast radius:** `crates/zeroclaw-channels` inbound orchestrator path; affects only image-bearing messages when `[multimodal].vision_model_provider` is set and `[media_pipeline].enabled = true`.
- **Linked issue(s):** Closes #6841
- **Labels:** `bug`, `channel`, `config`, `provider`, `risk:medium`, `size:S`.

## Validation Evidence (required)

Full local ci-sim on aarch64 (pinned toolchain 1.93.0):

```
cargo +1.93.0 fmt --all -- --check                                                                         # clean
cargo +1.93.0 clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings  # clean
cargo +1.93.0 check --locked --features ci-all --all-targets                                                # ok
cargo +1.93.0 check --no-default-features                                                                    # ok
cargo +1.93.0 test --test architecture <persist-config-isolate / fluent-routing guards>                     # test result: ok. 1 passed (each)
cargo +1.93.0 nextest run --locked --workspace --exclude zeroclaw-desktop
#   Summary [50.782s] 10093 tests run: 10093 passed, 11 skipped
```

- **Commands run and tail output:** all six gates above ran clean; nextest tail `10093 tests run: 10093 passed, 11 skipped`.
- **Beyond CI — what did you manually verify?** Proved the new test is genuine fail-on-old/pass-on-new: with the fix reverted, `media_pipeline_preserves_image_bytes_when_vision_route_configured` **panics** (vision provider receives no bytes); with the fix it **passes**. Did NOT exercise a live external vision provider end-to-end — a localhost wiremock server stands in for the provider HTTP.
- **If any command was intentionally skipped, why:** none skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No** — the test uses a localhost wiremock server and a tiny synthetic base64 image (`AQIDBA==`).

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No** — consumes the existing `[multimodal].vision_model_provider` field.
- Upgrade steps: none.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <merge-sha>` — single-file change (`crates/zeroclaw-channels/src/orchestrator/mod.rs`), no migrations or data changes.
- **Feature flags or config toggles:** None. The new behavior is reached only when `[multimodal].vision_model_provider` is set and `[media_pipeline].enabled = true`; otherwise the path is unchanged.
- **Observable failure symptoms:** image-bearing messages with a configured vision route arriving at the provider as a filename ref (`[IMAGE:/path]`) instead of inline base64 — i.e. the vision provider "can't see" the image.
