### PR TITLE
fix(providers/compatible): gate tool_choice on non-empty tools

### DIFF
--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -1951,7 +1951,7 @@ impl OpenAiCompatibleModelProvider {
         allow_user_image_parts: bool,
     ) -> NativeChatRequest {
         let has_tool_entries = tools.as_ref().is_some_and(|tools| !tools.is_empty());
-        let tool_choice = tools.as_ref().map(|_| "auto".to_string());
+        let tool_choice = has_tool_entries.then(|| "auto".to_string());
 
         NativeChatRequest {
             model: model.to_string(),
@@ -3017,7 +3017,7 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
                         include_usage: true,
                     }),
                     tools: tools.clone(),
-                    tool_choice: tools.as_ref().map(|_| "auto".to_string()),
+                    tool_choice: has_tools.then(|| "auto".to_string()),
                     max_tokens: provider.max_tokens,
                     extra_body: provider.extra_body.clone(),
                 })
@@ -3539,6 +3539,42 @@ mod tests {
             Some(true),
             "tool-enabled streaming request must serialize stream_options.include_usage=true; \
              without it OpenAI-compatible providers omit the final usage event"
+        );
+    }
+
+    #[test]
+    fn tool_choice_omitted_when_tools_empty() {
+        // Regression for #7862: vLLM 0.19+ returns HTTP 400 when an
+        // OpenAI-compat request body contains `tool_choice: "auto"` with an
+        // empty `tools` list ("When using tool_choice, tools must be set.").
+        // `build_native_tool_chat_request` must omit `tool_choice` whenever
+        // the converted tool list is `Some(vec![])` or `None`.
+        let provider = make_model_provider("vllm-test", "https://example.com", None);
+        let req = provider.build_native_tool_chat_request(
+            &[],
+            Some(vec![]),
+            "llama-3.3-70b",
+            Some(0.0),
+            false,
+        );
+        let value: serde_json::Value = serde_json::to_value(&req).unwrap();
+        assert!(
+            value.get("tool_choice").is_none(),
+            "tool_choice must be omitted when tools is empty; got: {value}"
+        );
+        // Sanity: a non-empty tool list still produces tool_choice.
+        let req_with_tools = provider.build_native_tool_chat_request(
+            &[],
+            Some(vec![serde_json::json!({"name": "echo"})]),
+            "llama-3.3-70b",
+            Some(0.0),
+            false,
+        );
+        let value_with_tools: serde_json::Value = serde_json::to_value(&req_with_tools).unwrap();
+        assert_eq!(
+            value_with_tools.get("tool_choice").and_then(|v| v.as_str()),
+            Some("auto"),
+            "tool_choice must remain \"auto\" when tools is non-empty"
         );
     }
 


### PR DESCRIPTION
## Summary

- **What changed:** `compatible.rs:1954` (in `build_native_tool_chat_request`) and `compatible.rs:3020` (streaming payload path) now gate `tool_choice` on the already-existing `has_tool_entries` / `has_tools` locals — both of which correctly compute `tools.is_some_and(|t| !t.is_empty())` but were not being applied to `tool_choice`.
- **Why:** vLLM 0.19+ returns HTTP 400 ("When using tool_choice, tools must be set") when an OpenAI-compat request body has `tool_choice: "auto"` alongside an empty `tools` list. Issue #7862.
- **Scope:** wire-format fix only. `tool_choice` is now correctly omitted when the converted tool list is `Some(vec![])` or `None`. No behavior change for non-empty tool lists.
- **Blast radius:** `zeroclaw-providers` crate only. No public API change. No new helper (reuses `has_tool_entries` and `has_tools` locals that already exist in this file).

## Changes

- `compatible.rs:1954`: replace `tools.as_ref().map(|_| "auto".to_string())` with `has_tool_entries.then(|| "auto".to_string())` — `has_tool_entries` already exists at line 1953.
- `compatible.rs:3020`: replace `tools.as_ref().map(|_| "auto".to_string())` with `has_tools.then(|| "auto".to_string())` — `has_tools` already exists at line 2978.
- New `#[test] tool_choice_omitted_when_tools_empty` asserts that an empty `tools` list produces serialized JSON without the `tool_choice` key, and that a non-empty tool list still serializes `tool_choice: "auto"`.

## Tests

```text
$ cargo fmt --all -- --check
(no output — clean)

$ cargo clippy --locked -p zeroclaw-providers --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 06s
0 warnings.

$ cargo test --locked -p zeroclaw-providers --lib -- compatible::tests::tool_choice_omitted_when_tools_empty
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1028 filtered out

$ cargo test --locked -p zeroclaw-providers --lib -- compatible::
test result: ok. 189 passed; 0 failed; 0 ignored; 0 measured; 840 filtered out
```

## Risk

Low. Wire-format fix gated on already-invalid input (a tool list that is `Some(vec![])` cannot legitimately drive any tool call). The same `is_some_and(|t| !t.is_empty())` idiom is in `router.rs:641` and `reliable.rs:1565` — this PR aligns the two `compatible.rs` sites with that established pattern.

Sibling PRs in the same #7862 series (open in order):
- PR #1: `fix(providers/azure-openai): gate tool_choice on non-empty tools`
- PR #2: `fix(providers/copilot): gate tool_choice on non-empty tools`
- PR #3: `fix(providers/openrouter): gate tool_choice on non-empty tools` (3 call sites)
- PR #5: `fix(providers/openai-codex): gate tool_choice on non-empty tools` (responses-wire path)

Refs: #7862