### PR TITLE
fix(zerocode): clear transcript highlight on input click

### DIFF
--- a/apps/zerocode/src/chat.rs
+++ b/apps/zerocode/src/chat.rs
@@ -946,8 +946,7 @@ impl Chat {
 
         // Any key press clears the mouse-click highlight — the user is done
         // with visual selection and is interacting via keyboard.
-        state.highlighted_entry = None;
-        state.mouse_down_entry = None;
+        state.clear_mouse_highlight();
 
         // ── Auto-exit browse mode on typing keys ─────────────────
         // If the user pressed a printable key that isn't a browse-mode
@@ -1657,6 +1656,7 @@ impl Chat {
         if let ChatPhase::Active(ref mut state) = self.phase {
             // Let the file explorer handle mouse events first when open.
             if state.input_bar.handle_mouse(mouse) {
+                state.clear_mouse_highlight();
                 return;
             }
 
@@ -4064,6 +4064,14 @@ impl ChatState {
         self.dirty = LinesDirty::Full;
     }
 
+    fn clear_mouse_highlight(&mut self) {
+        if self.highlighted_entry.is_some() || self.mouse_down_entry.is_some() {
+            self.highlighted_entry = None;
+            self.mouse_down_entry = None;
+            self.mark_dirty_full();
+        }
+    }
+
     // ── Browse-mode helpers ───────────────────────────────────────
 
     /// True when browse mode is active (cursor is set).
@@ -5605,6 +5613,55 @@ mod tests {
         } else {
             panic!("expected PickAgent phase");
         }
+    }
+
+    #[tokio::test]
+    async fn input_bar_click_clears_transcript_mouse_highlight() {
+        use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+        use ratatui::{Terminal, backend::TestBackend};
+
+        let (tx, _rx) = mpsc::channel::<String>(16);
+        let rpc = Arc::new(RpcOutbound::new(tx));
+        let client = Arc::new(RpcClient::with_rpc(Arc::clone(&rpc)));
+        let mut chat = Chat::new(client, PaneKind::Chat);
+        let mut state = state();
+        state
+            .entries
+            .push(ChatEntry::AgentMessage(Arc::<str>::from("hello")));
+        state.highlighted_entry = Some(0);
+        state.mouse_down_entry = Some(0);
+        state.mark_dirty_full();
+
+        let area = Rect::new(0, 0, 80, 20);
+        let backend = TestBackend::new(area.width, area.height);
+        let mut terminal = Terminal::new(backend).expect("test terminal");
+        terminal
+            .draw(|frame| {
+                render(frame, &mut state, area);
+            })
+            .expect("draw chat");
+
+        state.dirty = LinesDirty::Clean;
+        chat.phase = ChatPhase::Active(Box::new(state));
+
+        let click = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: 2,
+            row: area.height.saturating_sub(2),
+            modifiers: KeyModifiers::NONE,
+        };
+        chat.handle_mouse(click, area).await;
+
+        let ChatPhase::Active(state) = &chat.phase else {
+            panic!("expected active chat");
+        };
+        assert_eq!(state.highlighted_entry, None);
+        assert_eq!(state.mouse_down_entry, None);
+        assert_eq!(
+            state.dirty,
+            LinesDirty::Full,
+            "clearing the highlight must invalidate rendered transcript lines"
+        );
     }
 
     fn authoritative_rows(s: &ChatState, width: u16) -> u16 {


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Clear the transcript mouse-highlight state through a single `ChatState` helper so clearing also invalidates cached rendered transcript lines.
  - Clear that highlight when the input bar consumes a mouse click, restoring normal input focus after selecting a transcript message.
  - Add a regression test that renders the chat area, seeds a highlighted transcript entry, clicks the input bar, and asserts the highlight plus mouse-down state are cleared with a full redraw.
- **Scope boundary:** This PR only changes ZeroCode transcript/input mouse-highlight handling. It does not change browse-mode selection semantics, clipboard behavior, terminal-native selection, or input-bar editing behavior.
- **Blast radius:** `apps/zerocode/src/chat.rs`; affects ZeroCode TUI users who interact with transcript messages and the input bar by mouse.
- **Linked issue(s):** Closes #8385
- **Labels:** `bug`, `priority:p1`, `risk:medium`, `size:XS`, `zerocode`

## Validation Evidence (required)

- **Commands run and tail output:**

```bash
$ cargo fmt --all -- --check
# no output; exit 0
```

```bash
$ git diff --check
# no output; exit 0
```

```bash
$ env -u http_proxy -u https_proxy -u all_proxy -u ftp_proxy \
    -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u FTP_PROXY \
    -u no_proxy -u NO_PROXY \
    GIT_CONFIG_GLOBAL=/dev/null CARGO_HTTP_PROXY= \
    cargo test -p zerocode input_bar_click_clears_transcript_mouse_highlight -- --nocapture
warning: spurious network error (1 try remaining): [28] Timeout was reached (Operation timed out after 300128 milliseconds with 0 bytes received)
warning: spurious network error (1 try remaining): [28] Timeout was reached (Connection timed out after 300128 milliseconds)
error: failed to download from `https://static.crates.io/crates/anstyle/1.0.14/download`

Caused by:
  [28] Timeout was reached (Failed to connect to static.crates.io port 443 after 297120 ms: Could not connect to server)
```

- **Beyond CI — what did you manually verify?** Reviewed the mouse-event order in `Chat::handle_mouse`: input-bar mouse consumption now clears the existing transcript highlight before returning, while existing transcript blank-space clicks and browse-mode exits already invalidate rendered lines.
- **If any command was intentionally skipped, why:** `cargo clippy --all-targets -- -D warnings` and full `cargo test` were not run after the targeted `zerocode` regression test failed before compilation because Cargo could not download dependencies from `static.crates.io` in this environment.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: Not applicable.

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: No upgrade steps required.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert this PR.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** ZeroCode transcript clicks or input-bar clicks regress: selected transcript entries may remain highlighted, or clicking back into the input bar may not restore normal typing after a transcript mouse selection.
