### PR TITLE
fix(providers/copilot): gate tool_choice on non-empty tools

### DIFF
--- a/crates/zeroclaw-providers/src/copilot.rs
+++ b/crates/zeroclaw-providers/src/copilot.rs
@@ -388,11 +388,15 @@ impl CopilotModelProvider {
         let url = format!("{}/chat/completions", endpoint.trim_end_matches('/'));
 
         let native_tools = Self::convert_tools(tools);
+        let tool_choice = native_tools
+            .as_ref()
+            .is_some_and(|t| !t.is_empty())
+            .then(|| "auto".to_string());
         let request = ApiChatRequest {
             model: model.to_string(),
             messages,
             temperature,
-            tool_choice: native_tools.as_ref().map(|_| "auto".to_string()),
+            tool_choice,
             tools: native_tools,
         };
 
@@ -870,5 +874,38 @@ mod tests {
 
         let result = CopilotModelProvider::to_api_content("assistant", "sure").unwrap();
         assert!(matches!(result, ApiContent::Text(ref s) if s == "sure"));
+    }
+
+    #[test]
+    fn tool_choice_omitted_when_tools_empty() {
+        // Regression for #7862: vLLM 0.19+ returns HTTP 400 when an
+        // OpenAI-compat request body contains `tool_choice: "auto"` with an
+        // empty `tools` list ("When using tool_choice, tools must be set.").
+        // The Copilot provider's `send_chat_request` path must omit
+        // `tool_choice` whenever the converted tool list is `Some(vec![])`
+        // or `None`. (`convert_tools` itself wraps an empty input as
+        // `Some(vec![])` rather than `None`, so this gate is the only
+        // place the empty-list case is caught.)
+        //
+        // The serialized request shape is the observable contract: when
+        // `tools` is empty, the JSON body must NOT carry a `tool_choice`
+        // key (gated by `#[serde(skip_serializing_if = "Option::is_none")]`).
+        // Construct the request body inline with `static` lifetimes so we
+        // can exercise the wire-format path without going through the
+        // async `send_chat_request` (which would need a real GitHub
+        // token + network).
+        let tools: Option<Vec<NativeToolSpec<'static>>> = Some(vec![]);
+        let req = ApiChatRequest {
+            model: "claude-3.5".to_string(),
+            messages: vec![],
+            temperature: Some(0.0),
+            tool_choice: None, // gated: empty tools list ⇒ tool_choice omitted
+            tools,
+        };
+        let value: serde_json::Value = serde_json::to_value(&req).unwrap();
+        assert!(
+            value.get("tool_choice").is_none(),
+            "tool_choice must be omitted when tools is empty; got: {value}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- **What changed:** `copilot.rs:395` (in `send_chat_request`) now hoists the `tool_choice` computation to a local binding gated on `tools.is_some_and(|t| !t.is_empty())`.
- **Why:** vLLM 0.19+ returns HTTP 400 ("When using tool_choice, tools must be set") when an OpenAI-compat request body has `tool_choice: "auto"` alongside an empty `tools` list. Issue #7862.
- **Scope:** wire-format fix only. `copilot::convert_tools` (line 270) wraps an empty input as `Some(vec![])` (rather than coercing to `None` like some other providers), so the empty-list case is only caught by the gate at the request-build site.
- **Blast radius:** `zeroclaw-providers` crate only. No public API change. No new helper.

## Changes

- `copilot.rs:395`: hoist `tool_choice` to a local binding: `tools.as_ref().is_some_and(|t| !t.is_empty()).then(|| "auto".to_string())`.
- New `#[test] tool_choice_omitted_when_tools_empty` asserts that `ApiChatRequest` with `tools: Some(vec![])` and `tool_choice: None` serializes to JSON without the `tool_choice` key (gated by `#[serde(skip_serializing_if = "Option::is_none")]`).

## Tests

```text
$ cargo fmt --all -- --check
(no output — clean)

$ cargo clippy --locked -p zeroclaw-providers --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 48s
0 warnings.

$ cargo test --locked -p zeroclaw-providers --lib -- copilot::tests::tool_choice_omitted_when_tools_empty
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1028 filtered out
```

## Risk

Low. Wire-format fix gated on already-invalid input. The same `is_some_and(|t| !t.is_empty())` idiom is in `router.rs:641`, `reliable.rs:1565`, `compatible.rs:1910/2921`, and the sibling PRs `#8471` (compatible) / `#8473` (azure-openai).

Sibling PRs in the same #7862 series:
- PR #4 (`#8471`): `fix(providers/compatible): gate tool_choice on non-empty tools`
- PR #1 (`#8473`): `fix(providers/azure-openai): gate tool_choice on non-empty tools`
- PR #3: `fix(providers/openrouter): gate tool_choice on non-empty tools` (3 call sites)
- PR #5: `fix(providers/openai-codex): gate tool_choice on non-empty tools` (responses-wire path)

Refs: #7862