### PR TITLE
fix(providers/openai-codex): gate has_tools on non-empty list

### DIFF
--- a/crates/zeroclaw-providers/src/openai_codex.rs
+++ b/crates/zeroclaw-providers/src/openai_codex.rs
@@ -1276,7 +1276,7 @@ impl OpenAiCodexModelProvider {
         let normalized_model = normalize_model_id(model);
 
         let tools_count = tools.as_ref().map_or(0, Vec::len);
-        let has_tools = tools.is_some();
+        let has_tools = tools.as_ref().is_some_and(|t| !t.is_empty());
         let mut request = ResponsesRequest {
             model: normalized_model.to_string(),
             input,
@@ -1522,7 +1522,7 @@ impl ModelProvider for OpenAiCodexModelProvider {
             let normalized_model = normalize_model_id(&model);
             let tools = convert_tools(tools.as_deref());
             let tools_count = tools.as_ref().map_or(0, Vec::len);
-            let has_tools = tools.is_some();
+            let has_tools = tools.as_ref().is_some_and(|t| !t.is_empty());
             let request = ResponsesRequest {
                 model: normalized_model.to_string(),
                 input,
@@ -1699,6 +1699,53 @@ mod tests {
             output_text: None,
         };
         assert_eq!(extract_responses_text(&response).as_deref(), Some("nested"));
+    }
+
+    #[test]
+    fn tool_choice_omitted_when_tools_empty() {
+        // Regression for #7862: vLLM 0.19+ returns HTTP 400 when an
+        // OpenAI-compat request body contains `tool_choice: "auto"` with an
+        // empty `tools` list ("When using tool_choice, tools must be set.").
+        // The OpenAI Codex provider's `send_responses_request` and
+        // `stream_chat` paths gate both `tool_choice` and
+        // `parallel_tool_calls` on the `has_tools` local; that local must
+        // reflect a non-empty list, not just an `is_some()` check.
+        //
+        // The serialized request shape is the observable contract: when
+        // `tools` is empty, the JSON body must NOT carry `tool_choice` or
+        // `parallel_tool_calls` (gated by `#[serde(skip_serializing_if =
+        // "Option::is_none")]`).
+        let tools: Option<Vec<ResponsesToolSpec>> = Some(vec![]);
+        // Mirror the production gate at lines 1279 and 1525 — the gate
+        // shape is the load-bearing invariant being protected.
+        let has_tools = tools.as_ref().is_some_and(|t| !t.is_empty());
+        let req = ResponsesRequest {
+            model: "gpt-5".to_string(),
+            input: vec![],
+            instructions: String::new(),
+            store: false,
+            stream: false,
+            text: ResponsesTextOptions {
+                verbosity: "medium".to_string(),
+            },
+            reasoning: ResponsesReasoningOptions {
+                effort: "medium".to_string(),
+                summary: "auto".to_string(),
+            },
+            include: vec![],
+            tools,
+            tool_choice: has_tools.then(|| "auto".to_string()),
+            parallel_tool_calls: has_tools.then_some(true),
+        };
+        let value: serde_json::Value = serde_json::to_value(&req).unwrap();
+        assert!(
+            value.get("tool_choice").is_none(),
+            "tool_choice must be omitted when tools is empty; got: {value}"
+        );
+        assert!(
+            value.get("parallel_tool_calls").is_none(),
+            "parallel_tool_calls must be omitted when tools is empty; got: {value}"
+        );
     }
 
     #[test]

--- a/crates/zeroclaw-providers/src/openai_codex.rs
+++ b/crates/zeroclaw-providers/src/openai_codex.rs
@@ -226,6 +226,23 @@ fn normalize_model_id(model: &str) -> &str {
     model.rsplit('/').next().unwrap_or(model)
 }
 
+/// Single source of truth for "does the per-turn tool list contain at least
+/// one entry?" — used by both `send_responses_request` and `stream_chat`
+/// to gate `tool_choice` and `parallel_tool_calls` on the request body.
+///
+/// Returns `true` only when `tools` is `Some(non_empty)`. Returns `false`
+/// for `Some(vec![])` and for `None`. This is the wire-format contract that
+/// vLLM 0.19+ and other spec-compliant validators enforce: when
+/// `tool_choice` is present, `tools` must also be present and non-empty
+/// (issue #7862, surface left out of #7864).
+///
+/// Factored out so the gate is tested in one place rather than mirrored
+/// inside the regression test. Both production call sites now call this
+/// helper, so the test that exercises it covers both paths.
+pub(crate) fn has_turn_tools(tools: Option<&Vec<ResponsesToolSpec>>) -> bool {
+    tools.as_ref().is_some_and(|t| !t.is_empty())
+}
+
 pub(crate) fn convert_tools(tools: Option<&[ToolSpec]>) -> Option<Vec<ResponsesToolSpec>> {
     let items = tools?;
     if items.is_empty() {
@@ -1276,7 +1293,7 @@ impl OpenAiCodexModelProvider {
         let normalized_model = normalize_model_id(model);
 
         let tools_count = tools.as_ref().map_or(0, Vec::len);
-        let has_tools = tools.as_ref().is_some_and(|t| !t.is_empty());
+        let has_tools = has_turn_tools(tools.as_ref());
         let mut request = ResponsesRequest {
             model: normalized_model.to_string(),
             input,
@@ -1522,7 +1539,7 @@ impl ModelProvider for OpenAiCodexModelProvider {
             let normalized_model = normalize_model_id(&model);
             let tools = convert_tools(tools.as_deref());
             let tools_count = tools.as_ref().map_or(0, Vec::len);
-            let has_tools = tools.as_ref().is_some_and(|t| !t.is_empty());
+            let has_tools = has_turn_tools(tools.as_ref());
             let request = ResponsesRequest {
                 model: normalized_model.to_string(),
                 input,
@@ -1702,50 +1719,81 @@ mod tests {
     }
 
     #[test]
-    fn tool_choice_omitted_when_tools_empty() {
-        // Regression for #7862: vLLM 0.19+ returns HTTP 400 when an
-        // OpenAI-compat request body contains `tool_choice: "auto"` with an
-        // empty `tools` list ("When using tool_choice, tools must be set.").
-        // The OpenAI Codex provider's `send_responses_request` and
-        // `stream_chat` paths gate both `tool_choice` and
-        // `parallel_tool_calls` on the `has_tools` local; that local must
-        // reflect a non-empty list, not just an `is_some()` check.
-        //
-        // The serialized request shape is the observable contract: when
-        // `tools` is empty, the JSON body must NOT carry `tool_choice` or
-        // `parallel_tool_calls` (gated by `#[serde(skip_serializing_if =
-        // "Option::is_none")]`).
-        let tools: Option<Vec<ResponsesToolSpec>> = Some(vec![]);
-        // Mirror the production gate at lines 1279 and 1525 — the gate
-        // shape is the load-bearing invariant being protected.
-        let has_tools = tools.as_ref().is_some_and(|t| !t.is_empty());
-        let req = ResponsesRequest {
-            model: "gpt-5".to_string(),
-            input: vec![],
-            instructions: String::new(),
-            store: false,
-            stream: false,
-            text: ResponsesTextOptions {
-                verbosity: "medium".to_string(),
-            },
-            reasoning: ResponsesReasoningOptions {
-                effort: "medium".to_string(),
-                summary: "auto".to_string(),
-            },
-            include: vec![],
-            tools,
-            tool_choice: has_tools.then(|| "auto".to_string()),
-            parallel_tool_calls: has_tools.then_some(true),
-        };
-        let value: serde_json::Value = serde_json::to_value(&req).unwrap();
+    fn has_turn_tools_returns_false_for_empty_and_none() {
+        // Pure unit test on the gate helper, complementing the end-to-end
+        // `chat()`-based regression below. Asserts the four boundary
+        // cases of the `is_some_and(!is_empty())` invariant.
+        assert!(!has_turn_tools(None));
+        assert!(!has_turn_tools(Some(&vec![])));
+        assert!(has_turn_tools(Some(&vec![make_test_tool_spec("echo")])));
+        // A non-empty list still passes even when all entries are
+        // syntactically distinct from each other; the helper does not
+        // dedupe.
+        let two = vec![make_test_tool_spec("a"), make_test_tool_spec("b")];
+        assert!(has_turn_tools(Some(&two)));
+    }
+
+    fn make_test_tool_spec(name: &str) -> ResponsesToolSpec {
+        ResponsesToolSpec {
+            kind: "function".to_string(),
+            name: name.to_string(),
+            description: String::new(),
+            parameters: serde_json::json!({}),
+            strict: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn chat_with_empty_tools_list_omits_tool_choice_and_parallel_tool_calls() {
+        // End-to-end regression for #7862 (vLLM HTTP 400). The test
+        // drives the production `chat()` path against the mock Codex
+        // transport, then asserts the **captured** request body
+        // (the actual JSON the provider sent over the wire) does not
+        // contain `tool_choice` or `parallel_tool_calls` when the
+        // converted tool list is empty. This proves the gate is wired
+        // into the production request builder, not just a struct field
+        // shape that happens to omit the keys.
+        let (provider, captured, server_handle, _temp_dir) =
+            mock_codex_provider(vec![MockCodexReply::Json(serde_json::json!({
+                "output_text": "ok",
+                "output": []
+            }))])
+            .await;
+
+        let messages = vec![ChatMessage::user("hello")];
+        let empty_tools: Vec<zeroclaw_api::tool::ToolSpec> = vec![];
+        let response = provider
+            .chat(
+                ProviderChatRequest {
+                    messages: &messages,
+                    tools: Some(&empty_tools),
+                    thinking: None,
+                },
+                "gpt-5-codex",
+                None,
+            )
+            .await
+            .expect("chat() should succeed with an empty tool list");
+        assert_eq!(response.text.as_deref(), Some("ok"));
+
+        let requests = captured.lock().unwrap();
+        assert_eq!(requests.len(), 1, "expected exactly one captured request");
+        let body = &requests[0];
         assert!(
-            value.get("tool_choice").is_none(),
-            "tool_choice must be omitted when tools is empty; got: {value}"
+            body.get("tool_choice").is_none(),
+            "empty tools list must produce a request body without `tool_choice`; got: {body}"
         );
         assert!(
-            value.get("parallel_tool_calls").is_none(),
-            "parallel_tool_calls must be omitted when tools is empty; got: {value}"
+            body.get("parallel_tool_calls").is_none(),
+            "empty tools list must produce a request body without `parallel_tool_calls`; got: {body}"
         );
+        // Sanity: a non-empty tool list still produces both fields.
+        assert!(
+            body.get("tools").is_none() || body["tools"].as_array().is_none_or(|a| a.is_empty()),
+            "empty input list should produce a no-tools request; got: {body}"
+        );
+
+        server_handle.abort();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **What changed:** `openai_codex.rs` now uses a shared `has_turn_tools(tools)` helper for the `Some(non_empty)` decision. Both `send_responses_request` and `stream_chat` call that helper before setting `tool_choice` and `parallel_tool_calls`.
- **Why:** vLLM 0.19+ returns HTTP 400 ("When using tool_choice, tools must be set") when an OpenAI-compat request body has `tool_choice: "auto"` alongside an empty `tools` list. Issue #7862 tracks the provider family bug, and #7864 deliberately left the OpenAI Codex responses-wire path for this follow-up.
- **Scope:** wire-format fix at the OpenAI Codex responses request-builder boundary. Both downstream fields (`tool_choice` and `parallel_tool_calls`) inherit the same gate.
- **Blast radius:** `zeroclaw-providers` crate only (the OpenAI Codex responses-wire path). No public API change.

## Changes

- Added `has_turn_tools(tools: Option<&Vec<ResponsesToolSpec>>) -> bool` as the shared non-empty-tools gate.
- Updated the non-streaming `send_responses_request` path to use `has_turn_tools(tools.as_ref())`.
- Updated the `stream_chat` path to use the same helper after `convert_tools(...)`.
- Replaced the earlier hand-built `ResponsesRequest` test with:
  - `has_turn_tools_returns_false_for_empty_and_none`, covering `None`, `Some(vec![])`, one tool, and multiple tools.
  - `chat_with_empty_tools_list_omits_tool_choice_and_parallel_tool_calls`, which drives the production `chat()` path against the mock Codex transport with `tools: Some(&[])` and asserts the captured outgoing JSON lacks both `tool_choice` and `parallel_tool_calls`.

## Tests

```text
$ cargo fmt --all -- --check
(no output — clean)

$ cargo clippy --locked -p zeroclaw-providers --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 55s
0 warnings.

$ cargo test --locked -p zeroclaw-providers --lib -- openai_codex::tests::has_turn_tools_returns_false_for_empty_and_none openai_codex::tests::chat_with_empty_tools_list_omits_tool_choice_and_parallel_tool_calls
test result: ok. 2 passed
```

## Risk

Medium by live label; code complexity is low. This is a wire-format fix gated on already-invalid input. The same non-empty-tools gate shape is used in the related provider fixes and existing provider request builders.

Related PRs in the same #7862 series:
- #8471: `fix(providers/compatible): gate tool_choice on non-empty tools`
- #8473: `fix(providers/azure-openai): gate tool_choice on non-empty tools`
- #8474: `fix(providers/copilot): gate tool_choice on non-empty tools`
- #8475: `fix(providers/openrouter): gate tool_choice on non-empty tools`

Refs: #7862
