### PR TITLE
ci(npm): add daily audit sweep

### DIFF
--- a/.github/workflows/daily-npm-audit.yml
+++ b/.github/workflows/daily-npm-audit.yml
@@ -1,0 +1,137 @@
+name: Daily npm Audit
+
+on:
+  schedule:
+    - cron: "23 9 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: daily-npm-audit
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  npm-audit:
+    name: npm Audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install web dependencies
+        working-directory: web
+        run: npm ci --ignore-scripts --no-audit --no-fund
+
+      - name: Run npm audit
+        id: audit
+        continue-on-error: true
+        working-directory: web
+        shell: bash
+        env:
+          AUDIT_OUTPUT: ${{ runner.temp }}/npm-audit-output.json
+          AUDIT_ERROR: ${{ runner.temp }}/npm-audit-error.txt
+        run: |
+          set +e
+          npm audit --audit-level=high --json > "$AUDIT_OUTPUT" 2> "$AUDIT_ERROR"
+          exit_code=$?
+          set -e
+
+          echo "audit_exit_code=$exit_code" >> "$GITHUB_OUTPUT"
+
+          node <<'NODE'
+          const fs = require('fs');
+          const output = process.env.AUDIT_OUTPUT;
+          const githubOutput = process.env.GITHUB_OUTPUT;
+          try {
+            const report = JSON.parse(fs.readFileSync(output, 'utf8'));
+            const counts = report.metadata?.vulnerabilities ?? {};
+            const highCritical = (counts.high ?? 0) + (counts.critical ?? 0);
+            fs.appendFileSync(githubOutput, `audit_parse_ok=true\nhigh_critical_count=${highCritical}\n`);
+          } catch (_) {
+            fs.appendFileSync(githubOutput, 'audit_parse_ok=false\nhigh_critical_count=0\n');
+          }
+          NODE
+
+          cat "$AUDIT_OUTPUT"
+          if [[ -s "$AUDIT_ERROR" ]]; then
+            cat "$AUDIT_ERROR" >&2
+          fi
+          exit "$exit_code"
+
+      - name: Open issue on npm audit findings
+        id: npm_audit_issue
+        if: steps.audit.outputs.high_critical_count != '0'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          issues_enabled=$(gh api "repos/$GITHUB_REPOSITORY" --jq '.has_issues')
+          if [[ "$issues_enabled" != "true" ]]; then
+            echo "issue_url=" >> "$GITHUB_OUTPUT"
+            echo "::notice::Repository issues are disabled; skipping npm audit issue creation."
+            exit 0
+          fi
+
+          existing_url=$(gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --label "security" \
+            --label "dependencies" \
+            --state open \
+            --search "npm audit failed in:title" \
+            --json url \
+            --jq '.[0].url // ""')
+
+          if [[ -n "$existing_url" ]]; then
+            echo "issue_url=$existing_url" >> "$GITHUB_OUTPUT"
+            echo "An open npm audit issue already exists: $existing_url"
+            exit 0
+          fi
+
+          audit_output=$(head -c 60000 "${{ runner.temp }}/npm-audit-output.json")
+
+          {
+            printf '## npm audit failed\n\n'
+            printf 'Workflow run: %s\n\n' "${RUN_URL}"
+            printf 'High/critical findings: %s\n\n' "${{ steps.audit.outputs.high_critical_count }}"
+            printf '```json\n%s\n```\n\n' "${audit_output}"
+            printf 'Review `web/package-lock.json` and update affected npm packages.\n'
+          } > "${{ runner.temp }}/issue-body.md"
+
+          issue_url=$(gh issue create \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "ci: npm audit failed — $(date -u +%Y-%m-%d)" \
+            --label "security" \
+            --label "dependencies" \
+            --label "risk:high" \
+            --body-file "${{ runner.temp }}/issue-body.md")
+          echo "issue_url=$issue_url" >> "$GITHUB_OUTPUT"
+
+      - name: Propagate npm audit failure
+        if: steps.audit.outputs.audit_exit_code != '0'
+        env:
+          ISSUE_URL: ${{ steps.npm_audit_issue.outputs.issue_url }}
+          AUDIT_PARSE_OK: ${{ steps.audit.outputs.audit_parse_ok }}
+          HIGH_CRITICAL_COUNT: ${{ steps.audit.outputs.high_critical_count }}
+        run: |
+          if [[ "$HIGH_CRITICAL_COUNT" != "0" ]]; then
+            if [[ -n "$ISSUE_URL" ]]; then
+              echo "::error::npm audit found high/critical vulnerabilities. See $ISSUE_URL for details."
+            else
+              echo "::error::npm audit found high/critical vulnerabilities. Repository issues are disabled or issue creation was skipped; inspect this workflow log for details."
+            fi
+          elif [[ "$AUDIT_PARSE_OK" != "true" ]]; then
+            echo "::error::npm audit failed before producing a parseable report; inspect this workflow log for details."
+          else
+            echo "::error::npm audit failed without high/critical findings; inspect this workflow log for details."
+          fi
+          exit 1

--- a/docs/book/src/maintainers/ci-and-actions.md
+++ b/docs/book/src/maintainers/ci-and-actions.md
@@ -26,6 +26,10 @@ Composite job with multiple matrix legs:
 
 Runs `cargo deny check advisories` daily at 09:00 UTC against the dependency tree. Opens an issue on findings. No action unless a vulnerability is reported.
 
+### Daily npm Audit (`daily-npm-audit.yml`)
+
+Runs `npm audit --audit-level=high` daily at 09:23 UTC against `web/package-lock.json`. Opens one deduplicated `security` + `dependencies` issue when high-severity npm advisories affect the committed web lockfile.
+
 ### PR Path Labeler (`pr-path-labeler.yml`)
 
 Auto-applies path and scope labels based on changed files. It runs on PR open, reopen, and every pushed update to the PR branch. Because `sync-labels: true` is enabled, labels defined in `.github/labeler.yml` are recalculated from the current PR file set.


### PR DESCRIPTION
## Summary

- **Base branch:** `master`.
- **What changed and why:**
  - Adds `.github/workflows/daily-npm-audit.yml`, a scheduled and manually dispatchable workflow for the missing #8057 `web/` npm advisory sweep.
  - Runs `npm ci --ignore-scripts --no-audit --no-fund` in `web/` before running `npm audit --audit-level=high --json`.
  - Parses the audit JSON and opens or links one deduplicated issue only when high/critical npm findings are present.
  - Documents the new workflow in `docs/book/src/maintainers/ci-and-actions.md`.
- **Scope boundary:** This PR does not add a PR gate, does not change `web/package.json` or `web/package-lock.json`, does not update npm dependencies, and does not change Rust code.
- **Blast radius:** New scheduled/manual GitHub Actions workflow plus maintainer CI documentation. The workflow can create `security` + `dependencies` issues when high/critical npm advisories are reported.
- **Linked issue(s):** Related #8057. This PR completes the daily `npm audit` slice, but #8057 should only be closed after the remaining active slices merge: #8157 and #8168. #8158 and #8176 are already merged.
- **Labels:** `ci`, `docs`, `dependencies`, `domain:ci`, `domain:security`, `risk:high`, `size:S`, `type:ci`.

## Validation Evidence (required)

- **Commands run and tail output:**

```bash
uv run --with pyyaml python - <<'PY'
from pathlib import Path
import yaml
path = Path('.github/workflows/daily-npm-audit.yml')
data = yaml.safe_load(path.read_text())
allowed = {'name','run-name','on','permissions','env','defaults','concurrency','jobs'}
keys = {'on' if key is True else str(key) for key in data}
extra = sorted(keys - allowed)
if extra:
    print('unexpected top-level keys:', ', '.join(extra))
    raise SystemExit(1)
print('.github/workflows/daily-npm-audit.yml: yaml ok')
print('.github/workflows/daily-npm-audit.yml: top-level keys ok')
PY
```

```text
.github/workflows/daily-npm-audit.yml: yaml ok
.github/workflows/daily-npm-audit.yml: top-level keys ok
```

```bash
git diff --check -- .github/workflows/daily-npm-audit.yml docs/book/src/maintainers/ci-and-actions.md
```

```text
(no output)
```

```bash
podman run --rm \
  --volume ./web:/workspace/web \
  --entrypoint npm 3d67fd2cebc7 \
  ci --prefix /workspace/web --ignore-scripts --no-audit --no-fund
```

```text
added 219 packages in 28s
```

```bash
podman run --rm \
  --volume ./web:/workspace/web \
  --entrypoint npm 3d67fd2cebc7 \
  audit --prefix /workspace/web --audit-level=high --json
```

```text
{
  "auditReportVersion": 2,
  "vulnerabilities": {},
  "metadata": {
    "vulnerabilities": {
      "info": 0,
      "low": 0,
      "moderate": 0,
      "high": 0,
      "critical": 0,
      "total": 0
    },
    "dependencies": {
      "prod": 151,
      "dev": 137,
      "optional": 76,
      "peer": 0,
      "peerOptional": 0,
      "total": 287
    }
  }
}
```

- **Beyond CI — what did you manually verify?**
  - Verified the container mounted the repo `web/` package by reading `name`, `version`, and `scripts` through `npm --prefix /workspace/web pkg get name version scripts`.
  - Verified `npm audit --audit-level=high --json` reports zero high/critical findings for the current lockfile.
  - Verified the workflow uses `npm ci --ignore-scripts` before audit so package lifecycle scripts are not executed during dependency installation.
  - Verified missing GitHub Actions outputs do not make `steps.audit.outputs.high_critical_count != '0'` evaluate true by testing with `@actions/expressions`.
- **If any command was intentionally skipped, why:** Full Rust `cargo fmt`, `cargo clippy`, and `cargo test` were skipped because this PR changes only GitHub Actions YAML and maintainer documentation. Host `npm` was unavailable, so npm validation was run in a local StageX Node container instead.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `Yes` — the workflow grants `issues: write` so scheduled npm advisory findings can open or link a tracking issue. Repository content access is limited to `contents: read`.
- New external network calls? `Yes` — `actions/setup-node` restores npm cache, `npm ci` installs packages from the npm registry, `npm audit` queries npm advisory data, and `gh` calls the GitHub API when findings require issue handling.
- Secrets / tokens / credentials handling changed? `No` — the workflow uses the automatic `GITHUB_TOKEN` only; no new repository secret is introduced.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`.
- If any `Yes`, describe the risk and mitigation: The workflow uses pinned GitHub Actions, `npm ci --ignore-scripts`, least required GitHub token permissions, deduplicated issue creation, and JSON parsing so npm/tooling failures do not create vulnerability issues unless high/critical findings are present.

## Compatibility (required)

- Backward compatible? `Yes`.
- Config / env / CLI surface changed? `No`.
- If `No` or `Yes` to either: Existing users do not need migration steps. This is scheduled repository-maintenance automation only.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <merge_commit_sha>` removes `.github/workflows/daily-npm-audit.yml` and the maintainer docs entry.
- **Feature flags or config toggles:** Disable the `Daily npm Audit` workflow in the GitHub Actions UI if an immediate stop is needed before revert.
- **Observable failure symptoms:** `Daily npm Audit` workflow fails during `npm ci`, `npm audit`, GitHub issue lookup/creation, or failure propagation; duplicate `ci: npm audit failed` issues are created; selected-actions policy blocks `actions/setup-node`.