### PR TITLE
docs(labels): document held scoped labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -492,6 +492,11 @@
           - "crates/zeroclaw-runtime/src/tools/cron_runs.rs"
           - "crates/zeroclaw-runtime/src/tools/cron_update.rs"
 
+"tool:delegate":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/zeroclaw-runtime/src/tools/delegate.rs"
+
 "tool:file":
   - changed-files:
       - any-glob-to-any-file:
@@ -611,6 +616,18 @@
       - any-glob-to-any-file:
           - "src/observability/**"
           - "crates/zeroclaw-runtime/src/observability/**"
+
+"observability:log":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/zeroclaw-log/src/**"
+          - "crates/zeroclaw-runtime/src/observability/log.rs"
+
+"observability:otel":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/zeroclaw-runtime/src/observability/otel.rs"
+          - "tests/component/otel_dependency_feature_regression.rs"
 
 "observability:prometheus":
   - changed-files:

--- a/docs/book/src/maintainers/labels.md
+++ b/docs/book/src/maintainers/labels.md
@@ -115,7 +115,9 @@ Applied automatically by `pr-path-labeler.yml`. Globs live in `.github/labeler.y
 
 ### Additional component labels
 
-Some base scopes have narrower path-owned labels for maintainer routing. These labels are synchronized by `.github/labeler.yml` when the PR diff touches the listed files.
+Some surfaces have narrower path-owned labels for maintainer routing. These labels are synchronized by `.github/labeler.yml` when the PR diff touches the listed files.
+
+Scoped path labels do not guarantee a same-prefix base label. Because `pr-path-labeler.yml` runs with `sync-labels: true`, maintainers should treat `.github/labeler.yml` as the source of truth for which base and scoped labels a PR receives.
 
 | Label | Matches |
 |---|---|
@@ -129,7 +131,7 @@ Some base scopes have narrower path-owned labels for maintainer routing. These l
 | `security:policy` | runtime security policy, IAM policy, and config policy files |
 | `security:secrets` | runtime and config secrets handling |
 
-Do not apply legacy `observability: runtime_trace` to new issues or PRs. Use base `observability` plus `observability:otel` when the work is about OpenTelemetry tracing, and decide any future runtime-trace-specific canonical label in a separate create/migrate packet.
+Do not apply legacy `observability: runtime_trace` to new issues or PRs. Use `observability:otel` when the work is about OpenTelemetry tracing, add base `observability` only when the issue or PR also matches that base surface, and decide any future runtime-trace-specific canonical label in a separate create/migrate packet.
 
 Gateway subarea labels such as `gateway: api`, `gateway: sse`, `gateway:local_bridge`, and `gateway:webhook_ingress` remain live migration holdbacks. New routing should use base `gateway` until a separate packet either creates canonical no-space/hyphenated sublabels and migrates refs, or collapses those labels into base `gateway`.
 

--- a/docs/book/src/maintainers/labels.md
+++ b/docs/book/src/maintainers/labels.md
@@ -119,6 +119,8 @@ Some base scopes have narrower path-owned labels for maintainer routing. These l
 
 | Label | Matches |
 |---|---|
+| `observability:log` | `crates/zeroclaw-log/src/**`, `crates/zeroclaw-runtime/src/observability/log.rs` |
+| `observability:otel` | `otel.rs`, OTel dependency feature regression coverage |
 | `observability:prometheus` | `prometheus.rs` |
 | `runtime:wasm` | runtime WASM platform and first-party WASM plugin host files |
 | `security:bubblewrap` | `bubblewrap.rs` |
@@ -126,6 +128,10 @@ Some base scopes have narrower path-owned labels for maintainer routing. These l
 | `security:pairing` | pairing security, gateway pairing API, Tauri pairing command, and web pairing page |
 | `security:policy` | runtime security policy, IAM policy, and config policy files |
 | `security:secrets` | runtime and config secrets handling |
+
+Do not apply legacy `observability: runtime_trace` to new issues or PRs. Use base `observability` plus `observability:otel` when the work is about OpenTelemetry tracing, and decide any future runtime-trace-specific canonical label in a separate create/migrate packet.
+
+Gateway subarea labels such as `gateway: api`, `gateway: sse`, `gateway:local_bridge`, and `gateway:webhook_ingress` remain live migration holdbacks. New routing should use base `gateway` until a separate packet either creates canonical no-space/hyphenated sublabels and migrates refs, or collapses those labels into base `gateway`.
 
 ### Per-channel labels
 
@@ -198,6 +204,7 @@ Tools are grouped by logical function rather than one label per file.
 | `tool:cloud` | `cloud_ops.rs`, `cloud_patterns.rs` |
 | `tool:composio` | `composio.rs` |
 | `tool:cron` | `src/tools/cron_add.rs`, `src/tools/cron_list.rs`, `src/tools/cron_remove.rs`, `src/tools/cron_run.rs`, `src/tools/cron_runs.rs`, `src/tools/cron_update.rs`, `crates/zeroclaw-runtime/src/tools/cron_add.rs`, `crates/zeroclaw-runtime/src/tools/cron_common.rs`, `crates/zeroclaw-runtime/src/tools/cron_list.rs`, `crates/zeroclaw-runtime/src/tools/cron_remove.rs`, `crates/zeroclaw-runtime/src/tools/cron_run.rs`, `crates/zeroclaw-runtime/src/tools/cron_runs.rs`, `crates/zeroclaw-runtime/src/tools/cron_update.rs` |
+| `tool:delegate` | `crates/zeroclaw-runtime/src/tools/delegate.rs` |
 | `tool:file` | `src/tools/file_edit.rs`, `src/tools/file_read.rs`, `src/tools/file_write.rs`, `src/tools/glob_search.rs`, `src/tools/content_search.rs`, `crates/zeroclaw-tools/src/file_edit.rs`, `crates/zeroclaw-runtime/src/tools/file_read.rs`, `crates/zeroclaw-tools/src/file_write.rs`, `crates/zeroclaw-tools/src/glob_search.rs`, `crates/zeroclaw-tools/src/content_search.rs` |
 | `tool:google-workspace` | `google_workspace.rs` |
 | `tool:mcp` | `mcp_client.rs`, `mcp_deferred.rs`, `mcp_protocol.rs`, `mcp_tool.rs`, `mcp_transport.rs` |
@@ -208,6 +215,8 @@ Tools are grouped by logical function rather than one label per file.
 | `tool:shell` | `src/tools/shell.rs`, `src/tools/node_tool.rs`, `src/tools/cli_discovery.rs`, `crates/zeroclaw-runtime/src/tools/shell.rs`, `crates/zeroclaw-gateway/src/node_tool.rs`, `crates/zeroclaw-tools/src/cli_discovery.rs` |
 | `tool:sop` | `src/tools/sop_advance.rs`, `src/tools/sop_approve.rs`, `src/tools/sop_execute.rs`, `src/tools/sop_list.rs`, `src/tools/sop_status.rs`, `crates/zeroclaw-runtime/src/tools/sop_advance.rs`, `crates/zeroclaw-runtime/src/tools/sop_approve.rs`, `crates/zeroclaw-runtime/src/tools/sop_execute.rs`, `crates/zeroclaw-runtime/src/tools/sop_list.rs`, `crates/zeroclaw-runtime/src/tools/sop_status.rs` |
 | `tool:web` | `web_fetch.rs`, `web_search_tool.rs`, `web_search_provider_routing.rs`, `http_request.rs` |
+
+`tool:schema` is a manual-only label for tool-schema serialization and cleaning issues. Do not add broad schema files to `.github/labeler.yml`; many schema files are shared config, provider, or API surfaces and would over-label unrelated changes.
 
 ## Size labels
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Adds path-labeler ownership for `observability:log`, `observability:otel`, and `tool:delegate` as the next narrow source-owned labeler/docs slice in the #6808 label cleanup.
  - Documents those labels in the maintainer labels guide.
  - Records holdback guidance for legacy `observability: runtime_trace`, gateway subarea labels, and manual-only `tool:schema` so they are not silently recreated or over-automated.
- **Scope boundary:** Does not create, delete, rename, or migrate any live GitHub labels. Does not resolve the remaining gateway/runtime-trace canonical spelling packet.
- **Blast radius:** Docs and PR path-labeler metadata only. Future PRs touching the listed source paths may receive the documented scoped labels.
- **Linked issue(s):** Related #6808
- **Labels:** `type:docs`, `risk:low`, `size:XS`, `docs`, `ci`

## Validation Evidence (required)

- **Commands run and tail output:**
  - `ruby -e 'require "yaml"; YAML.load_file(".github/labeler.yml"); puts "labeler yaml ok"'`
    - `labeler yaml ok`
  - `git diff --check`
    - passed with no output
  - `DOCS_FILES='docs/book/src/maintainers/labels.md' scripts/ci/docs_quality_gate.sh`
    - `Summary: 0 error(s)`
  - `DOCS_FILES='docs/book/src/maintainers/labels.md' scripts/ci/docs_links_gate.sh`
    - `Collected 0 added link(s) from 1 docs file(s).`
    - `No added links detected in changed docs lines.`
- **Beyond CI — what did you manually verify?** Compared the #6808 rollout context with the changed labeler/docs entries and kept this slice to narrow source-owned labels; broader gateway/runtime-trace/tool-schema decisions remain out of scope.
- **If any command was intentionally skipped, why:** Rust validation skipped; this is docs and labeler metadata only.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: N/A

## Rollback (required for medium/high-risk PRs)

Low-risk PR: `git revert <sha>`.
