### PR TITLE
test(gateway): cover A2A security gates

### DIFF
--- a/crates/zeroclaw-gateway/src/api.rs
+++ b/crates/zeroclaw-gateway/src/api.rs
@@ -4260,5 +4260,262 @@ mod tests {
                 .unwrap();
             assert_eq!(status_of(router, req).await, StatusCode::OK);
         }
+
+        /// Build a state with a2a disabled at runtime, but a still-paired
+        /// token. Discovery and task routes must 404 — the public card
+        /// surface is not a read-through-when-off fallback.
+        fn disabled_state() -> AppState {
+            let state = paired_state();
+            state.config.write().a2a.server.enabled = false;
+            state
+        }
+
+        /// Build a state with a second alias that exists but is not
+        /// published, so a request to the right URL still hits the
+        /// "agent not advertised" gate.
+        fn unpublished_alias_state() -> AppState {
+            let state = paired_state();
+            let mut cfg = state.config.write();
+            cfg.agents.insert(
+                "hidden".to_string(),
+                zeroclaw_config::schema::AliasedAgentConfig {
+                    a2a: zeroclaw_config::multi_agent::AgentA2aConfig {
+                        published: false,
+                        exposed_skills: Vec::new(),
+                    },
+                    ..Default::default()
+                },
+            );
+            cfg.agents.insert(
+                "offline".to_string(),
+                zeroclaw_config::schema::AliasedAgentConfig {
+                    enabled: false,
+                    ..Default::default()
+                },
+            );
+            drop(cfg);
+            state
+        }
+
+        fn task_body_for(method: &str) -> String {
+            // Shape is what `handle_alias_task` actually walks: `jsonrpc`
+            // is required (or BAD_REQUEST), `method` is required, and the
+            // params must contain at least one text part or the handler
+            // returns invalid-params. Use `message/send` so the params
+            // path is exercised end-to-end.
+            format!(
+                r#"{{"jsonrpc":"2.0","id":1,"method":"{method}","params":{{"message":{{"parts":[{{"kind":"text","text":"hi"}}]}}}}}}"#
+            )
+        }
+
+        // ── Task endpoint: auth ────────────────────────────────────
+
+        #[tokio::test]
+        async fn task_endpoint_rejects_wrong_bearer_token() {
+            // A wrong token must not be silently accepted — auth is
+            // the load-bearing line for the task endpoint (it runs a
+            // full agent turn), so the rejection must be 401, not a
+            // 200 with an embedded error.
+            let router = crate::a2a::a2a_task_route().with_state(paired_state());
+            let req = axum::http::Request::builder()
+                .method("POST")
+                .uri("/a2a/maker")
+                .header("content-type", "application/json")
+                .header("authorization", "Bearer not-the-real-token")
+                .body(axum::body::Body::from(task_body_for("message/send")))
+                .unwrap();
+            assert_eq!(status_of(router, req).await, StatusCode::UNAUTHORIZED);
+        }
+
+        // ── Task endpoint: gates ───────────────────────────────────
+
+        #[tokio::test]
+        async fn task_endpoint_404s_when_a2a_server_disabled() {
+            // Even with a valid token, an admin who flipped the
+            // server off must not have live task endpoints. The
+            // discovery surface shares the same gate, so the test
+            // also pins that contract.
+            let router = crate::a2a::a2a_task_route().with_state(disabled_state());
+            let req = axum::http::Request::builder()
+                .method("POST")
+                .uri("/a2a/maker")
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {TOKEN}"))
+                .body(axum::body::Body::from(task_body_for("message/send")))
+                .unwrap();
+            assert_eq!(status_of(router, req).await, StatusCode::NOT_FOUND);
+        }
+
+        #[tokio::test]
+        async fn task_endpoint_404s_for_unknown_agent_alias() {
+            // Auth + server enabled, but the alias isn't an agent at
+            // all — must look the same as "doesn't exist" to a
+            // probing peer, not 403/401/200.
+            let router = crate::a2a::a2a_task_route().with_state(paired_state());
+            let req = axum::http::Request::builder()
+                .method("POST")
+                .uri("/a2a/no-such-agent")
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {TOKEN}"))
+                .body(axum::body::Body::from(task_body_for("message/send")))
+                .unwrap();
+            assert_eq!(status_of(router, req).await, StatusCode::NOT_FOUND);
+        }
+
+        #[tokio::test]
+        async fn task_endpoint_404s_for_unpublished_agent() {
+            // Agent exists but `a2a.published = false` — admin did
+            // not opt it into the A2A surface. Same shape as
+            // "doesn't exist" to avoid leaking agent inventory.
+            let router = crate::a2a::a2a_task_route().with_state(unpublished_alias_state());
+            let req = axum::http::Request::builder()
+                .method("POST")
+                .uri("/a2a/hidden")
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {TOKEN}"))
+                .body(axum::body::Body::from(task_body_for("message/send")))
+                .unwrap();
+            assert_eq!(status_of(router, req).await, StatusCode::NOT_FOUND);
+        }
+
+        #[tokio::test]
+        async fn task_endpoint_404s_for_disabled_agent() {
+            // `enabled = false` short-circuits `published` — even an
+            // admin who forgot to flip the A2A flag can't reach a
+            // disabled agent through the task endpoint.
+            let router = crate::a2a::a2a_task_route().with_state(unpublished_alias_state());
+            let req = axum::http::Request::builder()
+                .method("POST")
+                .uri("/a2a/offline")
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {TOKEN}"))
+                .body(axum::body::Body::from(task_body_for("message/send")))
+                .unwrap();
+            assert_eq!(status_of(router, req).await, StatusCode::NOT_FOUND);
+        }
+
+        // ── Task endpoint: body validation ─────────────────────────
+
+        #[tokio::test]
+        async fn task_endpoint_rejects_malformed_json() {
+            // The handler wraps axum's JSON rejection into a
+            // JSON-RPC `-32700` parse error with HTTP 400. Without
+            // that, a peer that sends a half-encoded body could
+            // crash the turn or get an empty 5xx.
+            let router = crate::a2a::a2a_task_route().with_state(paired_state());
+            let req = axum::http::Request::builder()
+                .method("POST")
+                .uri("/a2a/maker")
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {TOKEN}"))
+                .body(axum::body::Body::from("{not-json"))
+                .unwrap();
+            assert_eq!(status_of(router, req).await, StatusCode::BAD_REQUEST);
+        }
+
+        #[tokio::test]
+        async fn task_endpoint_rejects_wrong_jsonrpc_version() {
+            // The A2A wire contract is JSON-RPC 2.0 only — anything
+            // else is a hard client bug, not a protocol version we
+            // want to negotiate. 400 with an explicit jsonrpc error
+            // code is the right answer.
+            let body = r#"{"jsonrpc":"1.0","id":1,"method":"message/send","params":{"message":{"parts":[{"kind":"text","text":"hi"}]}}}"#;
+            let router = crate::a2a::a2a_task_route().with_state(paired_state());
+            let req = axum::http::Request::builder()
+                .method("POST")
+                .uri("/a2a/maker")
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {TOKEN}"))
+                .body(axum::body::Body::from(body))
+                .unwrap();
+            assert_eq!(status_of(router, req).await, StatusCode::BAD_REQUEST);
+        }
+
+        #[tokio::test]
+        async fn task_endpoint_rejects_unsupported_method_with_method_not_found() {
+            // Per the file's `if req.method != "message/send"` branch,
+            // unknown methods return 200 + JSON-RPC `-32601`. The
+            // status must NOT be 4xx — peers parse the JSON-RPC body
+            // for the method-not-found detail, not HTTP status.
+            let router = crate::a2a::a2a_task_route().with_state(paired_state());
+            let req = axum::http::Request::builder()
+                .method("POST")
+                .uri("/a2a/maker")
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {TOKEN}"))
+                .body(axum::body::Body::from(task_body_for("tasks/cancel")))
+                .unwrap();
+            assert_eq!(status_of(router, req).await, StatusCode::OK);
+        }
+
+        #[tokio::test]
+        async fn task_endpoint_rejects_message_with_no_text_parts() {
+            // The handler joins text parts; a payload with no text
+            // parts (or all non-text) would dispatch an empty prompt
+            // to the agent. Reject before the turn runs.
+            let body = r#"{"jsonrpc":"2.0","id":1,"method":"message/send","params":{"message":{"parts":[{"kind":"file","text":""}]}}}"#;
+            let router = crate::a2a::a2a_task_route().with_state(paired_state());
+            let req = axum::http::Request::builder()
+                .method("POST")
+                .uri("/a2a/maker")
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {TOKEN}"))
+                .body(axum::body::Body::from(body))
+                .unwrap();
+            assert_eq!(status_of(router, req).await, StatusCode::OK);
+        }
+
+        // ── Card routes: disabled server ───────────────────────────
+
+        #[tokio::test]
+        async fn catalog_card_404s_when_a2a_server_disabled() {
+            // The catalog is the entry point peers hit first; it
+            // must follow the same gate as the task endpoint, or a
+            // peer could enumerate the agent inventory while the
+            // server is "off".
+            let router = crate::a2a::a2a_routes().with_state(disabled_state());
+            let req = axum::http::Request::builder()
+                .method("GET")
+                .uri("/.well-known/agents-card.json")
+                .body(axum::body::Body::empty())
+                .unwrap();
+            assert_eq!(status_of(router, req).await, StatusCode::NOT_FOUND);
+        }
+
+        #[tokio::test]
+        async fn alias_card_404s_when_a2a_server_disabled() {
+            let router = crate::a2a::a2a_routes().with_state(disabled_state());
+            let req = axum::http::Request::builder()
+                .method("GET")
+                .uri("/a2a/maker/.well-known/agent-card.json")
+                .body(axum::body::Body::empty())
+                .unwrap();
+            assert_eq!(status_of(router, req).await, StatusCode::NOT_FOUND);
+        }
+
+        #[tokio::test]
+        async fn alias_card_404s_for_unknown_alias() {
+            // The card is supposed to advertise the published
+            // surface; asking about a non-existent alias must
+            // 404, not 200 with an empty body.
+            let router = crate::a2a::a2a_routes().with_state(paired_state());
+            let req = axum::http::Request::builder()
+                .method("GET")
+                .uri("/a2a/no-such-agent/.well-known/agent-card.json")
+                .body(axum::body::Body::empty())
+                .unwrap();
+            assert_eq!(status_of(router, req).await, StatusCode::NOT_FOUND);
+        }
+
+        #[tokio::test]
+        async fn alias_card_404s_for_unpublished_agent() {
+            let router = crate::a2a::a2a_routes().with_state(unpublished_alias_state());
+            let req = axum::http::Request::builder()
+                .method("GET")
+                .uri("/a2a/hidden/.well-known/agent-card.json")
+                .body(axum::body::Body::empty())
+                .unwrap();
+            assert_eq!(status_of(router, req).await, StatusCode::NOT_FOUND);
+        }
     }
 }

--- a/crates/zeroclaw-runtime/src/rpc/locales.rs
+++ b/crates/zeroclaw-runtime/src/rpc/locales.rs
@@ -228,3 +228,177 @@ fn validate_locale(locale: &str) -> Result<String, JsonRpcError> {
     }
     Ok(locale.to_string())
 }
+
+#[cfg(test)]
+mod tests {
+    //! The locale validator is the only thing standing between a hostile
+    //! RPC payload and the raw GitHub URL we build from it. Any shape
+    //! relaxation here would let a caller drive the fetch to an
+    //! arbitrary host or path. Lock the boundaries down.
+
+    use super::*;
+    use serde_json::json;
+    use zeroclaw_api::jsonrpc::LocalesFetchRequest;
+
+    /// Pick a known locale from the embedded registry. Tests should
+    /// never hardcode `en` — if the registry is ever trimmed, the
+    /// tests catch it here instead of at the assertion site.
+    fn known_locale() -> String {
+        crate::i18n::available_locales()
+            .first()
+            .map(|o| o.code.clone())
+            .expect("embedded locale registry is non-empty")
+    }
+
+    #[test]
+    fn validate_locale_rejects_empty_string() {
+        let err = validate_locale("").unwrap_err();
+        assert_eq!(err.code, INVALID_PARAMS);
+        assert!(err.message.contains("invalid locale"));
+    }
+
+    #[test]
+    fn validate_locale_rejects_over_sixteen_chars() {
+        // 17 ASCII alphanumeric chars — well-formed syntax but past the
+        // 16-char cap that bounds downstream URL/path usage.
+        let too_long = "a".repeat(17);
+        let err = validate_locale(&too_long).unwrap_err();
+        assert_eq!(err.code, INVALID_PARAMS);
+    }
+
+    #[test]
+    fn validate_locale_rejects_path_separators_and_dots() {
+        // The shape check is what stops `../etc/passwd` and `foo/bar`
+        // from ever reaching the URL builder — every separator below
+        // must be rejected.
+        for bad in [
+            "en/../etc",
+            "en/../../x",
+            "../etc",
+            "en/US",
+            "en.us",
+            "en us",
+            "en\n",
+            "en\t",
+            "日本語",
+            "en!",
+        ] {
+            let err = match validate_locale(bad) {
+                Ok(_) => panic!("expected rejection for {bad:?}"),
+                Err(e) => e,
+            };
+            assert_eq!(err.code, INVALID_PARAMS, "wrong code for {bad:?}");
+        }
+    }
+
+    #[test]
+    fn validate_locale_rejects_well_formed_unknown_locale() {
+        // Syntactically valid but absent from the registry — must
+        // fail at the registry check, not the shape check.
+        let err = validate_locale("zz").unwrap_err();
+        assert_eq!(err.code, INVALID_PARAMS);
+        assert!(
+            err.message.contains("not in registry"),
+            "registry-miss error path: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn validate_locale_accepts_every_embedded_locale() {
+        // Each locale in the registry must round-trip through validate —
+        // adding a locale to `locales.toml` must never silently break
+        // fetch for it.
+        for opt in crate::i18n::available_locales() {
+            assert_eq!(
+                validate_locale(&opt.code).unwrap(),
+                opt.code,
+                "registry locale {:?} rejected",
+                opt.code
+            );
+        }
+    }
+
+    #[test]
+    fn handle_locales_list_returns_embedded_registry() {
+        let v = handle_locales_list(Some("tui-1")).unwrap();
+        let locales = v.get("locales").and_then(|x| x.as_array()).unwrap();
+        assert!(!locales.is_empty(), "registry should never be empty");
+        let first = &locales[0];
+        assert!(first.get("code").and_then(|c| c.as_str()).is_some());
+        assert!(
+            first.get("label").and_then(|c| c.as_str()).is_some(),
+            "label missing from entry: {first}"
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_locales_fetch_rejects_params_missing_locale_field() {
+        // Empty object can't deserialize into `LocalesFetchRequest`
+        // (locale is required, not defaulted) — must surface as
+        // INVALID_PARAMS, not INTERNAL_ERROR.
+        let err = handle_locales_fetch(&json!({}), Some("tui-1"))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code, INVALID_PARAMS);
+    }
+
+    #[tokio::test]
+    async fn handle_locales_fetch_rejects_invalid_locale_shape() {
+        let err = handle_locales_fetch(&json!({"locale": "en/../etc"}), Some("tui-1"))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code, INVALID_PARAMS);
+        assert!(
+            err.message.contains("invalid locale"),
+            "shape-rejection path: {}",
+            err.message
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_locales_fetch_rejects_unknown_locale() {
+        let err = handle_locales_fetch(&json!({"locale": "zz"}), Some("tui-1"))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code, INVALID_PARAMS);
+        assert!(
+            err.message.contains("not in registry"),
+            "registry-miss path: {}",
+            err.message
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_locales_fetch_rejects_unknown_catalog() {
+        // Valid locale, but the catalog isn't in the fixed
+        // `FTL_CATALOGS` table. Rejection must happen *before* the
+        // HTTP request — if it didn't, we'd be testing the network.
+        let err = handle_locales_fetch(
+            &json!({
+                "locale": known_locale(),
+                "catalog": ["definitely-not-a-real-catalog"]
+            }),
+            Some("tui-1"),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.code, INVALID_PARAMS);
+        assert!(
+            err.message.contains("unknown catalog"),
+            "expected catalog-rejection path, got: {}",
+            err.message
+        );
+    }
+
+    #[tokio::test]
+    async fn locales_fetch_request_deserializes_with_default_empty_catalog() {
+        // The handler relies on `catalog` defaulting to empty when
+        // the caller omits it — verify the type itself honors that,
+        // since `handle_locales_fetch` would otherwise fall through
+        // to the all-catalogs branch.
+        let req: LocalesFetchRequest =
+            serde_json::from_value(json!({"locale": known_locale()})).unwrap();
+        assert!(req.catalog.is_empty());
+    }
+}

--- a/crates/zeroclaw-runtime/src/rpc/types.rs
+++ b/crates/zeroclaw-runtime/src/rpc/types.rs
@@ -1536,3 +1536,257 @@ rpc_type! {
         pub recorded: bool,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    //! Lock the wire shape down to what callers actually depend on:
+    //! - `#[serde(rename_all = "snake_case")]` on enums renames *variants*
+    //!   (and fields, when present). Changing the case convention would
+    //!   break every JSON-RPC client silently — these tests catch that.
+    //! - `#[serde(tag = "kind", ...)]` on tagged enums (`Quickstart*Result`)
+    //!   decides whether the discriminant is adjacent or inline; drift
+    //!   here breaks the web quickstart surface that consumes them.
+    //! - `#[serde(default, skip_serializing_if = "Option::is_none")]` on
+    //!   request/result optionals must stay symmetric so the dispatcher
+    //!   never sends an explicit `null` that older clients can't parse.
+
+    use super::*;
+    use serde_json::{Value, json};
+
+    #[test]
+    fn chat_mode_serializes_as_snake_case() {
+        assert_eq!(serde_json::to_value(ChatMode::Chat).unwrap(), json!("chat"));
+        assert_eq!(serde_json::to_value(ChatMode::Acp).unwrap(), json!("acp"));
+    }
+
+    #[test]
+    fn chat_mode_deserializes_from_snake_case() {
+        assert_eq!(
+            serde_json::from_value::<ChatMode>(json!("chat")).unwrap(),
+            ChatMode::Chat
+        );
+        assert_eq!(
+            serde_json::from_value::<ChatMode>(json!("acp")).unwrap(),
+            ChatMode::Acp
+        );
+    }
+
+    #[test]
+    fn file_source_default_is_file() {
+        // `FileSource` does not derive `PartialEq`; assert via the wire
+        // spelling instead. Default is `File` per the `#[default]`
+        // attribute — drift here would change file-attach defaults for
+        // every caller.
+        assert_eq!(
+            serde_json::to_value(FileSource::default()).unwrap(),
+            json!("file")
+        );
+        assert_eq!(
+            serde_json::to_value(FileSource::File).unwrap(),
+            json!("file")
+        );
+        assert_eq!(
+            serde_json::to_value(FileSource::Clipboard).unwrap(),
+            json!("clipboard")
+        );
+    }
+
+    #[test]
+    fn turn_completion_outcome_round_trips_each_variant() {
+        for variant in [
+            TurnCompletionOutcome::Completed,
+            TurnCompletionOutcome::Cancelled,
+            TurnCompletionOutcome::Failed,
+        ] {
+            let s = serde_json::to_value(variant).unwrap();
+            let back: TurnCompletionOutcome = serde_json::from_value(s.clone()).unwrap();
+            assert_eq!(back, variant, "round-trip failed for {s:?}");
+        }
+        // Lock the wire spelling — older clients string-match on these.
+        assert_eq!(
+            serde_json::to_value(TurnCompletionOutcome::Completed).unwrap(),
+            json!("completed")
+        );
+    }
+
+    #[test]
+    fn session_update_event_uses_snake_case_variants() {
+        // Variants stay PascalCase → wire is snake_case, including the
+        // multi-word ones that historically drifted when serde flattened
+        // them. The discriminant lives under `"type"` (adjacent tagging)
+        // — a change here would break every TUI that subscribes.
+        let evt = SessionUpdateEvent::AgentMessageChunk {
+            session_id: "s".into(),
+            text: "t".into(),
+        };
+        let v = serde_json::to_value(evt).unwrap();
+        assert_eq!(v["type"], json!("agent_message_chunk"));
+        assert_eq!(v["session_id"], json!("s"));
+        assert_eq!(v["text"], json!("t"));
+
+        let evt = SessionUpdateEvent::ApprovalRequest {
+            session_id: "s".into(),
+            request_id: "r".into(),
+            tool_name: "shell".into(),
+            arguments_summary: "ls".into(),
+            timeout_secs: 30,
+        };
+        let v = serde_json::to_value(evt).unwrap();
+        assert_eq!(v["type"], json!("approval_request"));
+        assert!(v.get("tool_name").is_some(), "got: {v}");
+    }
+
+    #[test]
+    fn quickstart_validate_result_ok_variant_uses_kind_tag() {
+        let v = serde_json::to_value(QuickstartValidateResult::Ok).unwrap();
+        assert_eq!(v, json!({"kind": "ok"}));
+    }
+
+    #[test]
+    fn quickstart_validate_result_errors_variant_carries_payload() {
+        // Just smoke-test the field structure — `QuickstartError` is owned
+        // by `quickstart` and has its own coverage there.
+        let v =
+            serde_json::to_value(QuickstartValidateResult::Errors { errors: Vec::new() }).unwrap();
+        assert_eq!(v["kind"], json!("errors"));
+        assert!(v["errors"].is_array(), "got: {v}");
+    }
+
+    #[test]
+    fn quickstart_apply_result_applied_variant_carries_daemon_flag() {
+        // `daemon_restarted: false` is the test-harness contract — the web
+        // surface reads this to decide whether to tell the user to restart
+        // manually. Lock it. The variant is tagged (`"kind": "applied"`),
+        // and the agent payload is snake_case.
+        let v = serde_json::to_value(QuickstartApplyResult::Applied {
+            agent: AppliedAgent {
+                alias: "primary".into(),
+                model_provider: "anthropic.claude".into(),
+                risk_profile: "standard".into(),
+                runtime_profile: "default".into(),
+                channels: vec!["telegram.main".into()],
+                memory_backend: "sqlite".into(),
+            },
+            daemon_restarted: false,
+        })
+        .unwrap();
+        assert_eq!(v["kind"], json!("applied"));
+        assert_eq!(v["daemon_restarted"], json!(false));
+        assert_eq!(v["agent"]["alias"], json!("primary"));
+    }
+
+    #[test]
+    fn initialize_params_defaults_protocol_version_to_one() {
+        // Older clients omit `protocol_version`; the runtime must default
+        // to `1` so the handshake succeeds without an explicit version.
+        let p: InitializeParams = serde_json::from_value(json!({})).unwrap();
+        assert_eq!(p.protocol_version, 1);
+    }
+
+    #[test]
+    fn initialize_params_accepts_snake_case_field_names() {
+        let p: InitializeParams = serde_json::from_value(json!({
+            "protocol_version": 2,
+            "tui_id": "abc",
+            "tui_sig": "sig",
+            "env": {"PATH": "/bin"}
+        }))
+        .unwrap();
+        assert_eq!(p.protocol_version, 2);
+        assert_eq!(p.tui_id.as_deref(), Some("abc"));
+        assert_eq!(p.env.get("PATH").map(String::as_str), Some("/bin"));
+    }
+
+    #[test]
+    fn initialize_params_renames_client_capabilities_field() {
+        // The ACP elicitation RFD uses camelCase on the wire; the rename
+        // is a one-shot field-level override — losing it would silently
+        // break elicitation handshake for every TUI that speaks it.
+        let p: InitializeParams = serde_json::from_value(json!({
+            "clientCapabilities": {"elicitation": {"form": true}}
+        }))
+        .unwrap();
+        let caps = p.client_capabilities.expect("rename lost the field");
+        assert_eq!(caps["elicitation"]["form"], json!(true));
+    }
+
+    #[test]
+    fn file_entry_skips_none_optional_fields_in_output() {
+        // `skip_serializing_if = "Option::is_none"` is what keeps the
+        // wire format tight for older clients that don't understand the
+        // `data_b64` field. Symmetric with the deserialize side.
+        let entry = FileEntry {
+            path: Some("/tmp/x".into()),
+            data_b64: None,
+            filename: None,
+            mime_type: None,
+            source: FileSource::File,
+        };
+        let v = serde_json::to_value(entry).unwrap();
+        assert_eq!(v["path"], json!("/tmp/x"));
+        assert_eq!(v["source"], json!("file"));
+        assert!(
+            v.as_object().unwrap().get("data_b64").is_none(),
+            "None data_b64 leaked into wire: {v}"
+        );
+        assert!(
+            v.as_object().unwrap().get("filename").is_none(),
+            "None filename leaked into wire: {v}"
+        );
+    }
+
+    #[test]
+    fn file_entry_deserializes_when_only_path_is_present() {
+        // The contract is "path OR data_b64"; the schema must accept
+        // path-only entries without forcing the caller to send nulls.
+        let entry: FileEntry = serde_json::from_value(json!({"path": "/tmp/a"})).unwrap();
+        assert_eq!(entry.path.as_deref(), Some("/tmp/a"));
+        assert!(entry.data_b64.is_none());
+        assert_eq!(serde_json::to_value(entry.source).unwrap(), json!("file"));
+    }
+
+    #[test]
+    fn tui_list_entry_round_trip_preserves_all_fields() {
+        let entry = TuiListEntry {
+            tui_id: "tui-1".into(),
+            connected_at: "2026-06-29T10:00:00Z".into(),
+            connected_at_unix: 1_750_000_000,
+            peer_label: "desktop".into(),
+            transport: "wss".into(),
+        };
+        let v: Value = serde_json::to_value(&entry).unwrap();
+        let back: TuiListEntry = serde_json::from_value(v).unwrap();
+        assert_eq!(back.tui_id, entry.tui_id);
+        assert_eq!(back.connected_at_unix, entry.connected_at_unix);
+        assert_eq!(back.transport, entry.transport);
+    }
+
+    #[test]
+    fn quickstart_type_option_round_trip() {
+        let opt = QuickstartTypeOption {
+            kind: "anthropic".into(),
+            display_name: "Anthropic".into(),
+            local: false,
+        };
+        let v = serde_json::to_value(&opt).unwrap();
+        assert_eq!(v["kind"], json!("anthropic"));
+        assert_eq!(v["local"], json!(false));
+        let back: QuickstartTypeOption = serde_json::from_value(v).unwrap();
+        assert_eq!(back.kind, opt.kind);
+        assert_eq!(back.local, opt.local);
+    }
+
+    #[test]
+    fn quickstart_dismiss_params_deserializes_with_optional_last_step() {
+        // `last_step` is `#[serde(default)] Option<QuickstartStep>` — older
+        // dismiss payloads omit it. Must default to `None` without error.
+        let params: QuickstartDismissParams = serde_json::from_value(json!({
+            "run_id": "r1",
+            "surface": "tui"
+        }))
+        .unwrap();
+        assert_eq!(params.run_id, "r1");
+        assert_eq!(params.surface, Surface::Tui);
+        assert!(params.last_step.is_none());
+    }
+}


### PR DESCRIPTION
  ## Summary

  The `a2a_auth` test mod had four tests covering only the happy path of the catalog / alias cards plus "task endpoint rejects missing auth".
  The surrounding gates — wrong token, disabled server, unknown / unpublished / disabled alias, malformed body, wrong jsonrpc version,
  unsupported method, empty prompt — were all untested. PR #8274 added the auth layer without a regression test for any of the failure modes.

  ## Changes

  All in `crates/zeroclaw-gateway/src/api.rs`, inside `mod tests { mod a2a_auth { ... } }`.

  ### Task endpoint `POST /a2a/{alias}`

  - `task_endpoint_rejects_wrong_bearer_token` — 401
  - `task_endpoint_404s_when_a2a_server_disabled` — 404 with valid token
  - `task_endpoint_404s_for_unknown_agent_alias` — 404
  - `task_endpoint_404s_for_unpublished_agent` — 404 (alias exists, `a2a.published = false`)
  - `task_endpoint_404s_for_disabled_agent` — 404 (alias exists, `enabled = false`)
  - `task_endpoint_rejects_malformed_json` — 400 with JSON-RPC parse error
  - `task_endpoint_rejects_wrong_jsonrpc_version` — 400 (not `"2.0"`)
  - `task_endpoint_rejects_unsupported_method_with_method_not_found` — 200 + JSON-RPC `-32601`
  - `task_endpoint_rejects_message_with_no_text_parts` — 200 + JSON-RPC `-32602`

  ### Card routes

  - `catalog_card_404s_when_a2a_server_disabled` — 404 (catalog must follow the same gate as the task endpoint)
  - `alias_card_404s_when_a2a_server_disabled` — 404
  - `alias_card_404s_for_unknown_alias` — 404
  - `alias_card_404s_for_unpublished_agent` — 404

  ## Helpers

  - `disabled_state()` — flips `a2a.server.enabled = false` on a paired state.
  - `unpublished_alias_state()` — adds a `hidden` (unpublished) and `offline` (disabled) agent.
  - `task_body_for(method)` — minimal valid JSON-RPC envelope for `message/send` with a text part.

  ## Validation

  - `cargo fmt -p zeroclaw-gateway --check` — clean
  - `cargo clippy -p zeroclaw-gateway --lib --tests --no-deps --features=a2a -- -D warnings` — clean
  - `cargo test -p zeroclaw-gateway --lib --features=a2a a2a_auth` — **17 passed; 0 failed** (4 pre-existing + 13 new)

  ## Risk

  Low (test-only, no production code paths touched).

  ## Notes

  `api_browse` was also targeted in the original PR description but is held back until the `Router<AppState>` → `tower::Service` question is
  resolved; the runtime-level browse tests in `crates/zeroclaw-runtime/src/browse.rs` already cover path containment.
