### PR TITLE
fix(tools): avoid manual Windows verbatim prefix slicing

### DIFF
--- a/crates/zeroclaw-tools/src/util_helpers.rs
+++ b/crates/zeroclaw-tools/src/util_helpers.rs
@@ -32,10 +32,10 @@ pub fn clean_verbatim_path(path: &std::path::Path) -> std::path::PathBuf {
     #[cfg(target_os = "windows")]
     {
         let path_str = path.to_string_lossy();
-        if path_str.starts_with(r"\\?\") {
+        if let Some(stripped) = path_str.strip_prefix(r"\\?\") {
             // Check if it's a local drive path (e.g. \\?\C:\...) by checking if the 6th char is ':'
             if path_str.chars().nth(5) == Some(':') {
-                return std::path::PathBuf::from(&path_str[4..]);
+                return std::path::PathBuf::from(stripped);
             }
         }
     }


### PR DESCRIPTION
## Summary

- **Why this PR exists:** The Windows Clippy job on `master` [failed](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/28370316111/job/84046174656) with `clippy::manual_strip` in `crates/zeroclaw-tools/src/util_helpers.rs`: `clean_verbatim_path()` checked `path_str.starts_with(r"\\?\")` and then manually sliced `&path_str[4..]`. This PR applies Clippy's suggested `strip_prefix()` shape while preserving the existing local-drive guard.
- **Base branch:** `master`
- **What changed and why:**
  - Replaces the Windows verbatim-path prefix check plus manual byte slice in `clean_verbatim_path()` with `strip_prefix()`.
  - Keeps the existing drive-letter guard, so `\\?\C:\...` is still stripped while `\\?\UNC\...` stays unchanged.
- **Scope boundary:** This PR only changes the Windows-only helper implementation in `zeroclaw-tools`; it does not change call sites or non-Windows behavior.
- **Blast radius:** Windows path-cleaning behavior in `zeroclaw-tools`. The existing focused helper tests cover drive-letter, normal, Unix-style, and driveless UNC inputs.
- **Linked issue(s):** None.
- **Labels:** `bug`, `tool`, `risk:high`, `size:XS`

## Validation Evidence (required)

- **Commands run and tail output:**

```text
cargo fmt --all -- --check
Result: passed

git diff --check
Result: passed with no output

scripts/check-pr-title.sh "fix(tools): avoid manual Windows verbatim prefix slicing"
Result: passed with no output
```

GitHub Actions also passed on this PR head:

```text
Format: passed
Lint: passed
Check x86_64-pc-windows-msvc: passed
Check (all features): passed
Test: passed
CI Required Gate: passed
```

- **Beyond CI — what did you manually verify?** Inspected `clean_verbatim_path()` and its existing tests. The patch only changes the Windows-only prefix removal path and preserves the same local-drive guard before returning a stripped path.
- **If any command was intentionally skipped, why:** The focused local Windows clippy command was not run before opening the draft because local Cargo was already under active Rust compile pressure from unrelated jobs. The equivalent GitHub Actions Windows check and Lint jobs have since passed on this PR head.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: `N/A`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: `N/A`

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <merge-sha>`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Windows path-cleaning behavior in `zeroclaw-tools` would revert to the previous manual-prefix-slice implementation.
