### PR TITLE
fix(deps): bump anyhow for RUSTSEC-2026-0190

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,9 +260,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "anymap2"


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Updated the locked `anyhow` crate from `1.0.102` to `1.0.103`.
  - This resolves RustSec advisory `RUSTSEC-2026-0190`, which reports unsoundness in `anyhow::Error::downcast_mut()`.
  - The failure surfaced in the PR Quality Gate Security job while reviewing #8168, but the dependency advisory is independent of that Docker/Trivy workflow diff.
- **Scope boundary:** This PR does not change manifests, dependency policy, CI workflow definitions, Docker/Trivy scanning, or source code.
- **Blast radius:** Cargo dependency resolution only. All existing `anyhow = "1.0"` manifest constraints continue to accept the patched lockfile version.
- **Linked issue(s):** Related #8056. Related #8059. Related #8073. Unblocks the current Security check failure seen on #8168.
- **Labels:** `dependencies`, `type:dependencies`, `risk:medium`, `size:XS`

## Validation Evidence

- **Commands run and tail output:**

```text
$ cargo update -p anyhow --precise 1.0.103
    Updating crates.io index
    Updating anyhow v1.0.102 -> v1.0.103
note: pass `--verbose` to see 127 unchanged dependencies behind latest

$ cargo metadata --locked --format-version 1 --no-deps
metadata locked ok

$ cargo tree --locked -i anyhow
anyhow v1.0.103
...
```

```text
$ git diff --check
(no output)
```

- **Beyond CI - what did you manually verify?** Verified the diff is limited to the `Cargo.lock` `anyhow` package stanza and that the lockfile resolves `anyhow v1.0.103`.
- **If any command was intentionally skipped, why:** `cargo deny check` was attempted locally to match the CI Security job, but the local `cargo-deny` tool was not installed and three throwaway install attempts failed on crates.io transfer timeouts while fetching `cargo-deny` dependencies. CI should run the Security job with its normal tool-install step on this PR.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- If `No` or `Yes` to either: N/A

## Rollback

Low-risk rollback: revert the commit if the patched lockfile version causes unexpected dependency-resolution issues.

## Supersede Attribution

N/A
