### PR TITLE
fix(config): warn when sqlite memory requests vector search without an embedder

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -17136,6 +17136,7 @@ impl Config {
         self.collect_fallback_warnings(&mut warnings);
         self.collect_cross_provider_summary_model_warnings(&mut warnings);
         self.collect_a2a_exposed_skills_warnings(&mut warnings);
+        self.collect_memory_semantic_search_warnings(&mut warnings);
         // `wire_api` is only honored by bring-your-own-endpoint families; on a
         // branded family with a fixed wire protocol it is silently ignored.
         // Surface that so an operator who sets it on, e.g., `mistral` learns it
@@ -17155,6 +17156,100 @@ impl Config {
             }
         }
         warnings
+    }
+
+    /// Surface sqlite semantic/hybrid search with no effective embedder. The
+    /// runtime treats `NoopEmbedding` as dimensions 0 and silently skips the
+    /// vector path, so derive this from the canonical memory settings instead
+    /// of storing another effective-mode field.
+    fn collect_memory_semantic_search_warnings(
+        &self,
+        warnings: &mut Vec<crate::validation_warnings::ValidationWarning>,
+    ) {
+        if !Self::memory_backend_is_sqlite(&self.memory.backend) {
+            return;
+        }
+        if !matches!(
+            &self.memory.search_mode,
+            SearchMode::Embedding | SearchMode::Hybrid
+        ) {
+            return;
+        }
+        if self.memory_has_effective_embedder() {
+            return;
+        }
+
+        let search_mode = match &self.memory.search_mode {
+            SearchMode::Bm25 => "bm25",
+            SearchMode::Embedding => "embedding",
+            SearchMode::Hybrid => "hybrid",
+        };
+        warnings.push(crate::validation_warnings::ValidationWarning::new(
+            "memory_semantic_search_without_embedder",
+            format!(
+                "memory.search_mode is {search_mode:?} on sqlite memory, but no effective \
+                 embedding provider is configured; vector search is skipped and \
+                 recall falls back to keyword-only behavior. Configure \
+                 memory.embedding_provider or a valid memory.embedding_model \
+                 hint route, or set memory.search_mode = \"bm25\"."
+            ),
+            "memory.search_mode",
+        ));
+    }
+
+    fn memory_backend_is_sqlite(backend: &str) -> bool {
+        let trimmed = backend.trim();
+        let family = trimmed
+            .split_once('.')
+            .map_or(trimmed, |(family, _)| family)
+            .trim();
+        family.eq_ignore_ascii_case("sqlite")
+    }
+
+    fn memory_has_effective_embedder(&self) -> bool {
+        let fallback = || Self::memory_embedding_settings_have_effective_embedder(&self.memory);
+        let Some(hint) = self
+            .memory
+            .embedding_model
+            .strip_prefix("hint:")
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        else {
+            return fallback();
+        };
+
+        let Some(route) = self
+            .embedding_routes
+            .iter()
+            .find(|route| route.hint.trim() == hint)
+        else {
+            return fallback();
+        };
+
+        if Self::embedding_route_has_effective_embedder(route, self.memory.embedding_dimensions) {
+            return true;
+        }
+        fallback()
+    }
+
+    fn memory_embedding_settings_have_effective_embedder(memory: &MemoryConfig) -> bool {
+        let provider = memory.embedding_provider.trim();
+        !provider.is_empty()
+            && !provider.eq_ignore_ascii_case("none")
+            && memory.embedding_dimensions > 0
+    }
+
+    fn embedding_route_has_effective_embedder(
+        route: &EmbeddingRouteConfig,
+        fallback_dimensions: usize,
+    ) -> bool {
+        let provider = route.model_provider.trim();
+        let model = route.model.trim();
+        let dimensions = route.dimensions.unwrap_or(fallback_dimensions);
+        !provider.is_empty()
+            && !provider.eq_ignore_ascii_case("none")
+            && !model.is_empty()
+            && dimensions > 0
     }
 
     /// Surface the A2A `exposed_skills` filter that can never resolve a skill.
@@ -26744,6 +26839,7 @@ group_policy = "disabled"
     #[test]
     async fn collect_warnings_flags_wire_api_on_fixed_protocol_family() {
         let mut config = Config::default();
+        suppress_semantic_memory_warning(&mut config);
         // mistral has a fixed wire protocol and ignores wire_api.
         config
             .providers
@@ -30999,6 +31095,127 @@ allowed_users = []
         );
     }
 
+    const SEMANTIC_MEMORY_WARNING: &str = "memory_semantic_search_without_embedder";
+
+    fn warnings_with_code(
+        config: &Config,
+        code: &str,
+    ) -> Vec<crate::validation_warnings::ValidationWarning> {
+        config
+            .collect_warnings()
+            .into_iter()
+            .filter(|warning| warning.code == code)
+            .collect()
+    }
+
+    fn suppress_semantic_memory_warning(config: &mut Config) {
+        config.memory.search_mode = SearchMode::Bm25;
+    }
+
+    #[test]
+    async fn collect_warnings_flags_sqlite_hybrid_without_embedder() {
+        let config = Config::default();
+
+        let warnings = warnings_with_code(&config, SEMANTIC_MEMORY_WARNING);
+        assert_eq!(warnings.len(), 1);
+        let warning = &warnings[0];
+        assert_eq!(warning.path, "memory.search_mode");
+        assert!(
+            warning.message.contains("sqlite"),
+            "warning should name sqlite memory: {}",
+            warning.message
+        );
+        assert!(
+            warning.message.contains("keyword-only"),
+            "warning should describe the runtime degradation: {}",
+            warning.message
+        );
+    }
+
+    #[test]
+    async fn collect_warnings_flags_sqlite_embedding_without_embedder() {
+        let mut config = Config::default();
+        config.memory.search_mode = SearchMode::Embedding;
+
+        let warnings = warnings_with_code(&config, SEMANTIC_MEMORY_WARNING);
+        assert_eq!(warnings.len(), 1);
+        assert!(
+            warnings[0].message.contains("\"embedding\""),
+            "warning should name embedding search mode: {}",
+            warnings[0].message
+        );
+    }
+
+    #[test]
+    async fn collect_warnings_silent_for_valid_hint_embedding_route() {
+        let mut config = Config::default();
+        config.memory.embedding_model = "hint:semantic".to_string();
+        config.providers.models.openai.insert(
+            "default".to_string(),
+            OpenAIModelProviderConfig {
+                base: ModelProviderConfig {
+                    api_key: Some("k".to_string()),
+                    model: Some("gpt-4o".to_string()),
+                    ..Default::default()
+                },
+            },
+        );
+        config.embedding_routes.push(EmbeddingRouteConfig {
+            hint: "semantic".to_string(),
+            model_provider: "openai.default".to_string(),
+            model: "text-embedding-3-small".to_string(),
+            dimensions: Some(1536),
+            api_key: None,
+        });
+        config.validate().expect("hint route should validate");
+
+        assert!(
+            warnings_with_code(&config, SEMANTIC_MEMORY_WARNING).is_empty(),
+            "valid hint route must count as an effective embedder"
+        );
+    }
+
+    #[test]
+    async fn collect_warnings_flags_missing_hint_embedding_route() {
+        let mut config = Config::default();
+        config.memory.embedding_model = "hint:semantic".to_string();
+
+        let warnings = warnings_with_code(&config, SEMANTIC_MEMORY_WARNING);
+        assert_eq!(warnings.len(), 1);
+    }
+
+    #[test]
+    async fn collect_warnings_flags_invalid_hint_embedding_route() {
+        let mut config = Config::default();
+        config.memory.embedding_model = "hint:semantic".to_string();
+        config.embedding_routes.push(EmbeddingRouteConfig {
+            hint: "semantic".to_string(),
+            model_provider: "none".to_string(),
+            model: "text-embedding-3-small".to_string(),
+            dimensions: Some(1536),
+            api_key: None,
+        });
+
+        let warnings = warnings_with_code(&config, SEMANTIC_MEMORY_WARNING);
+        assert_eq!(warnings.len(), 1);
+    }
+
+    #[test]
+    async fn collect_warnings_silent_for_bm25_without_embedder() {
+        let mut config = Config::default();
+        config.memory.search_mode = SearchMode::Bm25;
+
+        assert!(warnings_with_code(&config, SEMANTIC_MEMORY_WARNING).is_empty());
+    }
+
+    #[test]
+    async fn collect_warnings_silent_for_non_sqlite_without_embedder() {
+        let mut config = Config::default();
+        config.memory.backend = "markdown.default".to_string();
+
+        assert!(warnings_with_code(&config, SEMANTIC_MEMORY_WARNING).is_empty());
+    }
+
     #[test]
     async fn config_validate_accepts_classifier_provider_pointing_at_existing_alias() {
         let toml = r#"
@@ -31083,6 +31300,7 @@ allowed_users = []
     #[test]
     async fn fallback_warns_on_dangling_ref() {
         let mut config = Config::default();
+        suppress_semantic_memory_warning(&mut config);
         config.providers.models.openai.insert(
             "primary".to_string(),
             provider_entry_with_fallback(&["openai.ghost"]),
@@ -31100,6 +31318,7 @@ allowed_users = []
     #[test]
     async fn fallback_no_warning_when_ref_resolves() {
         let mut config = Config::default();
+        suppress_semantic_memory_warning(&mut config);
         config.providers.models.openai.insert(
             "primary".to_string(),
             provider_entry_with_fallback(&["openai.backup"]),
@@ -31116,6 +31335,7 @@ allowed_users = []
     #[test]
     async fn fallback_warns_on_two_node_cycle() {
         let mut config = Config::default();
+        suppress_semantic_memory_warning(&mut config);
         config
             .providers
             .models
@@ -31141,6 +31361,7 @@ allowed_users = []
     #[test]
     async fn fallback_self_reference_is_a_cycle() {
         let mut config = Config::default();
+        suppress_semantic_memory_warning(&mut config);
         config.providers.models.openai.insert(
             "loop".to_string(),
             provider_entry_with_fallback(&["openai.loop"]),
@@ -31154,6 +31375,7 @@ allowed_users = []
     #[test]
     async fn fallback_empty_ref_is_skipped() {
         let mut config = Config::default();
+        suppress_semantic_memory_warning(&mut config);
         config
             .providers
             .models
@@ -31166,6 +31388,7 @@ allowed_users = []
     #[test]
     async fn fallback_warns_when_chain_exceeds_max_depth() {
         let mut config = Config::default();
+        suppress_semantic_memory_warning(&mut config);
         let n = crate::providers::MAX_FALLBACK_DEPTH + 2;
         for i in 0..n {
             let next = if i + 1 < n {
@@ -31195,6 +31418,7 @@ allowed_users = []
     #[test]
     async fn fallback_models_warns_on_empty_entry() {
         let mut config = Config::default();
+        suppress_semantic_memory_warning(&mut config);
         let mut entry = provider_entry_with_fallback(&[]);
         entry.base.fallback_models = vec!["".to_string()];
         config
@@ -31211,6 +31435,7 @@ allowed_users = []
     #[test]
     async fn fallback_models_warns_on_duplicate_of_primary() {
         let mut config = Config::default();
+        suppress_semantic_memory_warning(&mut config);
         let mut entry = provider_entry_with_fallback(&[]);
         entry.base.fallback_models = vec!["gpt-4o".to_string()];
         config
@@ -31227,6 +31452,7 @@ allowed_users = []
     #[test]
     async fn fallback_models_distinct_entries_do_not_warn() {
         let mut config = Config::default();
+        suppress_semantic_memory_warning(&mut config);
         let mut entry = provider_entry_with_fallback(&[]);
         entry.base.fallback_models = vec!["gpt-4o-mini".to_string()];
         config

--- a/crates/zeroclaw-config/src/validation_warnings.rs
+++ b/crates/zeroclaw-config/src/validation_warnings.rs
@@ -25,6 +25,8 @@ use serde::{Deserialize, Serialize};
 /// One non-fatal validation issue surfaced after a successful save.
 ///
 /// Stable codes (extend as new warnings are added):
+/// - `memory_semantic_search_without_embedder`: `memory.search_mode` requests
+///   vector search on sqlite memory, but no effective embedder is configured.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
 pub struct ValidationWarning {


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** `memory.backend` defaults to `sqlite` and `memory.search_mode` defaults to `Hybrid`, but `memory.embedding_provider` defaults to `none`. At runtime `none` resolves to `NoopEmbedding` (dimensions `0`), so the vector path is silently skipped and recall collapses to keyword/`LIKE`-fallback — with no warning, log, or `doctor` signal. This adds a non-fatal warning in `Config::collect_warnings()` (code `memory_semantic_search_without_embedder`) that fires when the memory backend family is sqlite, `search_mode` is `hybrid`/`embedding`, and no effective embedder is configured. The warning surfaces on stderr via `validate()`, through the gateway `PropResponse`/`PatchResponse`, and at `zeroclaw doctor`.
- **Scope boundary:** Warning-only — no behavior change. Does NOT change quickstart defaults, does NOT require an embedder, and does NOT derive an effective `bm25` mode at use time. No new config state is persisted; the check derives entirely from existing `[memory]` and `[[embedding_routes]]`. Scoped to the sqlite backend family (markdown/lucid/qdrant/pgvector are not warned).
- **Blast radius:** `Config::collect_warnings()` is consumed by `zeroclaw-config::validate()` (stderr), the gateway config API (`api_config.rs` prop/patch responses), and `zeroclaw doctor` (`doctor/mod.rs`). All three now emit one additional non-fatal warning for the default sqlite-without-embedder config. No runtime/recall behavior changes.
- **Linked issue(s):** Closes #8386
- **Labels:** `bug`, `config`, `risk:medium`, `size:S`

Detection rules (per maintainer guidance on the issue):
- sqlite family derived from `memory.backend` (not `resolve_active_storage()`), so a bare `backend = "sqlite"` with no `[storage.sqlite.*]` is covered;
- warns only for `search_mode ∈ {hybrid, embedding}`;
- a valid `hint:` embedding route counts as an effective embedder even when `embedding_provider` stays `none`.

Caveat (documented, matches the issue): the config-layer check treats a dotted catalog-ref route (e.g. `model_provider = "openai.default"`) as configured without resolving it against the catalog, so it can under-warn an unresolved dotted ref. The comprehensive runtime `dimensions() == 0` check is deferred as a follow-up (it lives in `zeroclaw-memory`, which #8382 is actively reworking).

## Validation Evidence (required)

- **Commands run and tail output:**

```
$ cargo fmt --all -- --check
(no output — exit 0)

$ cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
    Checking zeroclawlabs v0.8.2 (/…/zero-claw)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 7m 48s
(exit 0 — no warnings)

$ cargo nextest run --workspace --exclude zeroclaw-desktop --features ci-all
zeroclaw-config (changed crate):        1015 passed; 0 failed
zeroclaw-runtime  doctor (consumer):       34 passed; 0 failed
zeroclaw-gateway  api_config (consumer):   39 passed; 0 failed
```

Targeted `collect_warnings` suite (the 8 new tests + neighbors), all pass:

```
test schema::tests::collect_warnings_flags_sqlite_hybrid_without_embedder ... ok
test schema::tests::collect_warnings_flags_sqlite_embedding_without_embedder ... ok
test schema::tests::collect_warnings_silent_for_valid_hint_embedding_route ... ok
test schema::tests::collect_warnings_flags_missing_hint_embedding_route ... ok
test schema::tests::collect_warnings_flags_invalid_hint_embedding_route ... ok
test schema::tests::collect_warnings_silent_for_bm25_without_embedder ... ok
test schema::tests::collect_warnings_silent_for_non_sqlite_without_embedder ... ok
test result: ok. 13 passed; 0 failed
```

- **Beyond CI — what did you manually verify?** Audited every external assertion on `collect_warnings`/`.warnings` across the workspace to confirm the new default warning breaks no count/shape assertions (`dispatch.rs` `doctor_summary` uses hand-built `DiagResult`s; gateway delete-cascade `warnings` is an unrelated field). Verified default `embedding_dimensions = 1536` so a plain `embedding_provider = "openai"` does NOT false-positive. Confirmed the headline repro (default config = bare sqlite + hybrid + none) warns, and a valid `hint:` route stays silent.
- **If any command was intentionally skipped, why:** The full-workspace `nextest` run surfaced exactly **one** failure — `zeroclaw-channels matrix::tests::outbound_sandbox::rejects_absolute_outside_workspace` — which is a pre-existing **macOS-only** environment gap unrelated to this diff: the test hardcodes the Linux path `/etc/hostname` (see `crates/zeroclaw-channels/src/matrix.rs:5731`, comment "exists on every Linux host"), which is absent on macOS, so the disk-existence check fires before the workspace-bounds check. It passes on Linux CI. This PR touches only `zeroclaw-config`; `zeroclaw-channels` does not consume `collect_warnings`.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No** — no new/renamed config fields; this only adds a non-fatal diagnostic for an already-invalid-at-runtime combination. Existing configs load and validate exactly as before; affected configs now additionally print one warning.
- Upgrade steps for existing users: None. Operators who see the new warning can silence it by configuring `memory.embedding_provider` (or a valid `hint:` route) or setting `memory.search_mode = "bm25"`.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <sha>` — the change is a single self-contained method plus its tests in `zeroclaw-config`.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** A spurious warning with code `memory_semantic_search_without_embedder` appearing for a config that has a working embedder (false positive), or the warning failing to appear for the default sqlite+hybrid+none config (false negative). Grep logs / doctor output for the warning code.

