### PR TITLE
feat(sop): add procedural memory workshop

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -20556,6 +20556,12 @@ pub struct SopConfig {
     /// Intended to converge with the shared B/F redaction switch once those consumers land.
     #[serde(default = "default_sop_untrusted_outbound_redact")]
     pub untrusted_outbound_redact: bool,
+
+    /// Enable SOP procedural-memory proposal tooling. Default false keeps
+    /// self-modifying SOP write-back opt-in while the SOP subsystem is
+    /// Experimental.
+    #[serde(default)]
+    pub procedural_memory_enabled: bool,
 }
 
 fn default_sop_execution_mode() -> String {
@@ -20694,6 +20700,7 @@ impl Default for SopConfig {
             untrusted_guard_sensitivity: default_sop_untrusted_guard_sensitivity(),
             untrusted_frame_warning: default_sop_untrusted_frame_warning(),
             untrusted_outbound_redact: default_sop_untrusted_outbound_redact(),
+            procedural_memory_enabled: false,
         }
     }
 }

--- a/crates/zeroclaw-runtime/src/sop/engine.rs
+++ b/crates/zeroclaw-runtime/src/sop/engine.rs
@@ -2446,6 +2446,7 @@ fn parse_iso8601_secs(input: &str) -> Option<u64> {
 
 #[cfg(test)]
 mod tests {
+    use super::super::store::ProposalKind;
     use super::*;
     use crate::sop::approval::{ApprovalDecision, ApprovalPrincipal, ResolveOutcome};
     use crate::sop::step_contract::StepFailure;
@@ -3568,13 +3569,20 @@ mod tests {
         let now = now_iso8601();
         let proposal = ProposalRecord {
             id: "prop-1".to_string(),
+            kind: ProposalKind::Update,
             status: ProposalStatus::Pending,
             source_run_id: Some("run-1".to_string()),
             sop_name: "s1".to_string(),
             target_content_hash: Some("sha256:abc".to_string()),
+            manifest_toml: "[sop]\nname = \"s1\"\ndescription = \"S1\"\n".to_string(),
+            procedure_markdown: "## Steps\n\n1. **Do** - It.\n".to_string(),
             provenance: serde_json::json!({"producer": "test"}),
             created_at: now.clone(),
             updated_at: now,
+            status_reason: None,
+            applied_at: None,
+            applied_by: None,
+            rollback_path: None,
         };
 
         engine.save_proposal(&proposal).unwrap();

--- a/crates/zeroclaw-runtime/src/sop/mod.rs
+++ b/crates/zeroclaw-runtime/src/sop/mod.rs
@@ -6,6 +6,7 @@ pub mod dispatch;
 pub mod engine;
 pub mod executor;
 pub mod metrics;
+pub mod procedural_memory;
 pub mod route;
 pub mod rundata;
 pub mod schema;
@@ -20,8 +21,8 @@ pub use metrics::SopMetricsCollector;
 pub use scope::StepToolScope;
 pub use step_contract::{StepFailure, StepRouting};
 pub use store::{
-    ClaimToken, PersistedRun, ProposalRecord, ProposalStatus, SopEventRecord, SopRunStore,
-    SqliteRunStore, StoreError, build_run_store,
+    ClaimToken, PersistedRun, ProposalKind, ProposalRecord, ProposalStatus, SopEventRecord,
+    SopRunStore, SqliteRunStore, StoreError, build_run_store,
 };
 #[allow(unused_imports)]
 pub use types::{

--- a/crates/zeroclaw-runtime/src/sop/procedural_memory.rs
+++ b/crates/zeroclaw-runtime/src/sop/procedural_memory.rs
@@ -1,0 +1,607 @@
+//! Procedural-memory proposal lifecycle for SOP definitions.
+//!
+//! Epic F stages self-improvement as capture/propose/apply rather than letting a
+//! model write SOP files directly. Proposals live in the shared SOP run store,
+//! carry provenance and target hashes, scan before write-back, write rollback
+//! copies, and reload the engine only after a validated apply.
+
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use serde_json::json;
+use sha2::{Digest, Sha256};
+
+use super::engine::{SopEngine, now_iso8601};
+use super::load_sops_from_directory;
+use super::store::{ProposalKind, ProposalRecord, ProposalStatus};
+use super::types::{Sop, SopRunStatus};
+use crate::security::{LeakDetector, LeakResult};
+
+#[derive(Debug, Clone)]
+pub struct ProposalDraft {
+    pub sop_name: String,
+    pub description: String,
+    pub manifest_toml: Option<String>,
+    pub procedure_markdown: String,
+    pub source_run_id: Option<String>,
+    pub requested_by: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ApplyOutcome {
+    pub proposal: ProposalRecord,
+    pub target_dir: PathBuf,
+}
+
+pub fn create_proposal(engine: &SopEngine, draft: ProposalDraft) -> Result<ProposalRecord> {
+    let sop_name = require_nonempty("sop_name", &draft.sop_name)?;
+    let procedure_markdown = require_nonempty("procedure_markdown", &draft.procedure_markdown)?;
+    let description = require_nonempty("description", &draft.description)?;
+    let existing = engine.get_sop(sop_name);
+    let kind = if existing.is_some() {
+        ProposalKind::Update
+    } else {
+        ProposalKind::Create
+    };
+    let manifest_toml = match draft.manifest_toml {
+        Some(toml) if !toml.trim().is_empty() => toml,
+        _ => default_manifest_toml(sop_name, description),
+    };
+    validate_candidate(sop_name, &manifest_toml, procedure_markdown)?;
+    let now = now_iso8601();
+    let id = format!(
+        "prop-{}-{}-{:08x}",
+        slugify(sop_name),
+        now.replace(':', "_"),
+        rand::random::<u32>()
+    );
+    let target_content_hash = existing
+        .and_then(|sop| sop.location.as_deref())
+        .map(hash_sop_dir)
+        .transpose()?;
+    let proposal = ProposalRecord {
+        id,
+        kind,
+        status: ProposalStatus::Pending,
+        source_run_id: draft.source_run_id,
+        sop_name: sop_name.to_string(),
+        target_content_hash,
+        manifest_toml,
+        procedure_markdown: procedure_markdown.to_string(),
+        provenance: json!({
+            "producer": "sop_workshop",
+            "requested_by": draft.requested_by,
+        }),
+        created_at: now.clone(),
+        updated_at: now,
+        status_reason: None,
+        applied_at: None,
+        applied_by: None,
+        rollback_path: None,
+    };
+    engine.save_proposal(&proposal)?;
+    Ok(proposal)
+}
+
+pub fn capture_successful_run(
+    engine: &SopEngine,
+    run_id: &str,
+    requested_by: Option<String>,
+) -> Result<ProposalRecord> {
+    let run = engine
+        .get_run(run_id)
+        .ok_or_else(|| anyhow::Error::msg(format!("SOP run not found: {run_id}")))?;
+    if run.status != SopRunStatus::Completed {
+        bail!("only completed SOP runs can be captured");
+    }
+    if run.step_results.is_empty() {
+        bail!("completed run has no step results to distill");
+    }
+    if run
+        .step_results
+        .iter()
+        .any(|step| matches!(step.status, super::types::SopStepStatus::Failed))
+    {
+        bail!("failed step output is not captured into procedural memory");
+    }
+
+    let sop = engine
+        .get_sop(&run.sop_name)
+        .ok_or_else(|| anyhow::Error::msg(format!("SOP not loaded: {}", run.sop_name)))?;
+    let manifest_toml = read_or_default_manifest(sop)?;
+    let procedure_markdown = append_captured_notes(sop, run_id, &run.step_results)?;
+    create_proposal(
+        engine,
+        ProposalDraft {
+            sop_name: sop.name.clone(),
+            description: sop.description.clone(),
+            manifest_toml: Some(manifest_toml),
+            procedure_markdown,
+            source_run_id: Some(run_id.to_string()),
+            requested_by,
+        },
+    )
+}
+
+pub fn apply_proposal(
+    engine: &mut SopEngine,
+    workspace_dir: &Path,
+    proposal_id: &str,
+    applied_by: Option<String>,
+) -> Result<ApplyOutcome> {
+    let mut proposal = load_required(engine, proposal_id)?;
+    if proposal.status != ProposalStatus::Pending {
+        bail!(
+            "proposal {} is {:?}, not pending",
+            proposal.id,
+            proposal.status
+        );
+    }
+
+    let sops_root = super::resolve_sops_dir(workspace_dir, engine.config().sops_dir.as_deref());
+    let target_dir = contained_sop_dir(&sops_root, &proposal.sop_name)?;
+    let current_target_hash = if target_dir.exists() {
+        Some(hash_sop_dir(&target_dir)?)
+    } else {
+        None
+    };
+    match (&proposal.kind, &proposal.target_content_hash) {
+        (ProposalKind::Create, None) if current_target_hash.is_some() => {
+            proposal.status = ProposalStatus::Stale;
+            proposal.updated_at = now_iso8601();
+            proposal.status_reason = Some("target SOP was created after proposal capture".into());
+            engine.save_proposal(&proposal)?;
+            bail!("proposal {} is stale; target SOP now exists", proposal.id);
+        }
+        (_, Some(expected)) if current_target_hash.as_ref() != Some(expected) => {
+            proposal.status = ProposalStatus::Stale;
+            proposal.updated_at = now_iso8601();
+            proposal.status_reason = Some("target SOP changed since proposal capture".into());
+            engine.save_proposal(&proposal)?;
+            bail!("proposal {} is stale; inspect and re-propose", proposal.id);
+        }
+        _ => {}
+    }
+
+    if let Some(reason) = scan_candidate(&proposal.manifest_toml, &proposal.procedure_markdown) {
+        proposal.status = ProposalStatus::Quarantined;
+        proposal.updated_at = now_iso8601();
+        proposal.status_reason = Some(reason.clone());
+        engine.save_proposal(&proposal)?;
+        bail!("proposal {} quarantined: {reason}", proposal.id);
+    }
+
+    validate_candidate(
+        &proposal.sop_name,
+        &proposal.manifest_toml,
+        &proposal.procedure_markdown,
+    )?;
+    let rollback = write_rollback(&sops_root, &target_dir, &proposal.id)?;
+    atomic_write_sop(
+        &target_dir,
+        &proposal.manifest_toml,
+        &proposal.procedure_markdown,
+    )?;
+
+    proposal.status = ProposalStatus::Applied;
+    proposal.updated_at = now_iso8601();
+    proposal.applied_at = Some(proposal.updated_at.clone());
+    proposal.applied_by = applied_by;
+    proposal.rollback_path = rollback.as_ref().map(|p| p.display().to_string());
+    proposal.status_reason = None;
+    engine.save_proposal(&proposal)?;
+    engine.reload(workspace_dir);
+
+    Ok(ApplyOutcome {
+        proposal,
+        target_dir,
+    })
+}
+
+pub fn set_proposal_status(
+    engine: &SopEngine,
+    proposal_id: &str,
+    status: ProposalStatus,
+    reason: Option<String>,
+) -> Result<ProposalRecord> {
+    let mut proposal = load_required(engine, proposal_id)?;
+    proposal.status = status;
+    proposal.updated_at = now_iso8601();
+    proposal.status_reason = reason;
+    engine.save_proposal(&proposal)?;
+    Ok(proposal)
+}
+
+fn load_required(engine: &SopEngine, proposal_id: &str) -> Result<ProposalRecord> {
+    engine
+        .load_proposal(proposal_id)
+        .map_err(anyhow::Error::new)?
+        .ok_or_else(|| anyhow::Error::msg(format!("proposal not found: {proposal_id}")))
+}
+
+fn validate_candidate(sop_name: &str, manifest_toml: &str, procedure_markdown: &str) -> Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let sop_dir = tmp.path().join(slugify(sop_name));
+    fs::create_dir_all(&sop_dir)?;
+    fs::write(sop_dir.join("SOP.toml"), manifest_toml)?;
+    fs::write(sop_dir.join("SOP.md"), procedure_markdown)?;
+    let sops = load_sops_from_directory(tmp.path(), super::parse_execution_mode("supervised"));
+    if sops.len() != 1 {
+        bail!("candidate SOP did not validate as exactly one loadable SOP");
+    }
+    if sops[0].name != sop_name {
+        bail!(
+            "candidate manifest name '{}' does not match proposal target '{}'",
+            sops[0].name,
+            sop_name
+        );
+    }
+    if sops[0].steps.is_empty() {
+        bail!("candidate SOP has no parsed steps");
+    }
+    Ok(())
+}
+
+fn scan_candidate(manifest_toml: &str, procedure_markdown: &str) -> Option<String> {
+    let detector = LeakDetector::new();
+    let content = format!("{manifest_toml}\n{procedure_markdown}");
+    match detector.scan(&content) {
+        LeakResult::Clean => None,
+        LeakResult::Detected { patterns, .. } => Some(format!(
+            "credential-like content detected: {}",
+            patterns.join(", ")
+        )),
+    }
+}
+
+fn read_or_default_manifest(sop: &Sop) -> Result<String> {
+    if let Some(location) = &sop.location {
+        let path = location.join("SOP.toml");
+        if path.exists() {
+            return fs::read_to_string(path).context("read existing SOP.toml");
+        }
+    }
+    Ok(default_manifest_toml(&sop.name, &sop.description))
+}
+
+fn append_captured_notes(
+    sop: &Sop,
+    run_id: &str,
+    results: &[super::types::SopStepResult],
+) -> Result<String> {
+    let mut md = if let Some(location) = &sop.location {
+        let path = location.join("SOP.md");
+        if path.exists() {
+            fs::read_to_string(path).context("read existing SOP.md")?
+        } else {
+            default_procedure_markdown(sop)
+        }
+    } else {
+        default_procedure_markdown(sop)
+    };
+    if !md.ends_with('\n') {
+        md.push('\n');
+    }
+    md.push_str("\n## Captured Run Notes\n\n");
+    md.push_str(&format!("Source run: `{run_id}`\n\n"));
+    for result in results {
+        md.push_str(&format!(
+            "- Step {} {}: {}\n",
+            result.step_number,
+            result.status,
+            crate::security::scrub(&result.output)
+        ));
+    }
+    Ok(md)
+}
+
+fn default_manifest_toml(name: &str, description: &str) -> String {
+    format!(
+        "[sop]\nname = \"{}\"\ndescription = \"{}\"\nversion = \"0.1.0\"\n\n[[triggers]]\ntype = \"manual\"\n",
+        toml_escape(name),
+        toml_escape(description)
+    )
+}
+
+fn default_procedure_markdown(sop: &Sop) -> String {
+    let mut md = format!("# {}\n\n## Steps\n\n", sop.name);
+    for step in &sop.steps {
+        md.push_str(&format!(
+            "{}. **{}** - {}\n",
+            step.number, step.title, step.body
+        ));
+        if !step.suggested_tools.is_empty() {
+            md.push_str(&format!(
+                "   - tools: {}\n",
+                step.suggested_tools.join(", ")
+            ));
+        }
+        if step.requires_confirmation {
+            md.push_str("   - requires_confirmation: true\n");
+        }
+        md.push('\n');
+    }
+    md
+}
+
+fn write_rollback(
+    sops_root: &Path,
+    target_dir: &Path,
+    proposal_id: &str,
+) -> Result<Option<PathBuf>> {
+    if !target_dir.exists() {
+        return Ok(None);
+    }
+    let rollback_dir = sops_root
+        .join(".rollback")
+        .join(safe_component(proposal_id));
+    fs::create_dir_all(&rollback_dir)?;
+    for name in ["SOP.toml", "SOP.md"] {
+        let src = target_dir.join(name);
+        if src.exists() {
+            fs::copy(&src, rollback_dir.join(name))?;
+        }
+    }
+    Ok(Some(rollback_dir))
+}
+
+fn atomic_write_sop(
+    target_dir: &Path,
+    manifest_toml: &str,
+    procedure_markdown: &str,
+) -> Result<()> {
+    fs::create_dir_all(target_dir)?;
+    atomic_write_file(&target_dir.join("SOP.toml"), manifest_toml)?;
+    atomic_write_file(&target_dir.join("SOP.md"), procedure_markdown)?;
+    Ok(())
+}
+
+fn atomic_write_file(path: &Path, content: &str) -> Result<()> {
+    let tmp = path.with_extension("tmp");
+    fs::write(&tmp, content)?;
+    fs::rename(&tmp, path)?;
+    Ok(())
+}
+
+fn contained_sop_dir(sops_root: &Path, sop_name: &str) -> Result<PathBuf> {
+    let slug = slugify(sop_name);
+    if slug.is_empty() {
+        bail!("SOP name does not contain a safe path component");
+    }
+    ensure_relative_component(&slug)?;
+    Ok(sops_root.join(slug))
+}
+
+fn ensure_relative_component(component: &str) -> Result<()> {
+    let path = Path::new(component);
+    if path
+        .components()
+        .any(|c| !matches!(c, Component::Normal(_)))
+    {
+        bail!("unsafe SOP path component");
+    }
+    Ok(())
+}
+
+fn hash_sop_dir(dir: &Path) -> Result<String> {
+    let mut hasher = Sha256::new();
+    for name in ["SOP.toml", "SOP.md"] {
+        let path = dir.join(name);
+        hasher.update(name.as_bytes());
+        hasher.update([0]);
+        if path.exists() {
+            hasher.update(fs::read(path)?);
+        }
+        hasher.update([0]);
+    }
+    Ok(format!("sha256:{}", hex::encode(hasher.finalize())))
+}
+
+fn require_nonempty<'a>(field: &str, value: &'a str) -> Result<&'a str> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        bail!("{field} cannot be empty");
+    }
+    Ok(trimmed)
+}
+
+fn safe_component(value: &str) -> String {
+    let out = value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                ch
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>();
+    out.trim_matches('-').to_string()
+}
+
+fn slugify(value: &str) -> String {
+    let mut out = String::new();
+    let mut last_dash = false;
+    for ch in value.chars().flat_map(char::to_lowercase) {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch);
+            last_dash = false;
+        } else if !last_dash {
+            out.push('-');
+            last_dash = true;
+        }
+    }
+    out.trim_matches('-').to_string()
+}
+
+fn toml_escape(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sop::types::{
+        Sop, SopEvent, SopExecutionMode, SopPriority, SopStep, SopStepResult, SopStepStatus,
+        SopTrigger, SopTriggerSource,
+    };
+    use zeroclaw_config::schema::SopConfig;
+
+    fn engine_with_workspace(tmp: &Path) -> SopEngine {
+        SopEngine::new(SopConfig {
+            sops_dir: Some(tmp.join("sops").display().to_string()),
+            ..SopConfig::default()
+        })
+    }
+
+    fn test_sop(name: &str) -> Sop {
+        Sop {
+            name: name.into(),
+            description: "Source SOP".into(),
+            version: "1.0.0".into(),
+            priority: SopPriority::Normal,
+            execution_mode: SopExecutionMode::Auto,
+            triggers: vec![SopTrigger::Manual],
+            steps: vec![SopStep {
+                number: 1,
+                title: "Do".into(),
+                body: "Thing".into(),
+                ..SopStep::default()
+            }],
+            cooldown_secs: 0,
+            max_concurrent: 1,
+            location: None,
+            deterministic: false,
+        }
+    }
+
+    #[test]
+    fn proposal_apply_writes_files_and_reloads() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut engine = engine_with_workspace(tmp.path());
+        let proposal = create_proposal(
+            &engine,
+            ProposalDraft {
+                sop_name: "learned-check".into(),
+                description: "Learned check".into(),
+                manifest_toml: None,
+                procedure_markdown: "# Learned\n\n## Steps\n\n1. **Check** - Do it.\n".into(),
+                source_run_id: None,
+                requested_by: Some("test".into()),
+            },
+        )
+        .unwrap();
+
+        let outcome =
+            apply_proposal(&mut engine, tmp.path(), &proposal.id, Some("tester".into())).unwrap();
+
+        assert_eq!(outcome.proposal.status, ProposalStatus::Applied);
+        assert!(outcome.target_dir.join("SOP.toml").exists());
+        assert!(engine.get_sop("learned-check").is_some());
+    }
+
+    #[test]
+    fn apply_marks_stale_when_target_hash_changes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sops = tmp.path().join("sops").join("existing");
+        fs::create_dir_all(&sops).unwrap();
+        fs::write(
+            sops.join("SOP.toml"),
+            "[sop]\nname = \"existing\"\ndescription = \"Existing\"\n\n[[triggers]]\ntype = \"manual\"\n",
+        )
+        .unwrap();
+        fs::write(sops.join("SOP.md"), "## Steps\n\n1. **Old** - Do it.\n").unwrap();
+
+        let mut engine = engine_with_workspace(tmp.path());
+        engine.reload(tmp.path());
+        let proposal = create_proposal(
+            &engine,
+            ProposalDraft {
+                sop_name: "existing".into(),
+                description: "Existing".into(),
+                manifest_toml: None,
+                procedure_markdown: "## Steps\n\n1. **New** - Do it.\n".into(),
+                source_run_id: None,
+                requested_by: None,
+            },
+        )
+        .unwrap();
+        fs::write(sops.join("SOP.md"), "## Steps\n\n1. **Changed** - Do it.\n").unwrap();
+
+        assert!(apply_proposal(&mut engine, tmp.path(), &proposal.id, None).is_err());
+        let stored = engine.load_proposal(&proposal.id).unwrap().unwrap();
+        assert_eq!(stored.status, ProposalStatus::Stale);
+    }
+
+    #[test]
+    fn apply_marks_create_stale_when_target_appears() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut engine = engine_with_workspace(tmp.path());
+        let proposal = create_proposal(
+            &engine,
+            ProposalDraft {
+                sop_name: "new-sop".into(),
+                description: "New SOP".into(),
+                manifest_toml: None,
+                procedure_markdown: "## Steps\n\n1. **New** - Do it.\n".into(),
+                source_run_id: None,
+                requested_by: None,
+            },
+        )
+        .unwrap();
+        let sops = tmp.path().join("sops").join("new-sop");
+        fs::create_dir_all(&sops).unwrap();
+        fs::write(
+            sops.join("SOP.toml"),
+            "[sop]\nname = \"new-sop\"\ndescription = \"New SOP\"\n\n[[triggers]]\ntype = \"manual\"\n",
+        )
+        .unwrap();
+        fs::write(sops.join("SOP.md"), "## Steps\n\n1. **Other** - Do it.\n").unwrap();
+
+        assert!(apply_proposal(&mut engine, tmp.path(), &proposal.id, None).is_err());
+        let stored = engine.load_proposal(&proposal.id).unwrap().unwrap();
+        assert_eq!(stored.status, ProposalStatus::Stale);
+        assert_eq!(
+            fs::read_to_string(sops.join("SOP.md")).unwrap(),
+            "## Steps\n\n1. **Other** - Do it.\n"
+        );
+    }
+
+    #[test]
+    fn capture_successful_run_appends_redacted_notes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut engine = engine_with_workspace(tmp.path());
+        engine.set_sops_for_test(vec![test_sop("source")]);
+        let event = SopEvent {
+            source: SopTriggerSource::Manual,
+            topic: None,
+            payload: None,
+            timestamp: "2026-06-30T00:00:00Z".into(),
+        };
+        let action = engine.start_run("source", event).unwrap();
+        let run_id = match action {
+            crate::sop::types::SopRunAction::ExecuteStep { run_id, .. } => run_id,
+            other => panic!("expected execute action, got {other:?}"),
+        };
+        let redaction_fixture = ["tok", "en=", "neutralplaceholder1234567890"].concat();
+        engine
+            .advance_step(
+                &run_id,
+                SopStepResult {
+                    step_number: 1,
+                    status: SopStepStatus::Completed,
+                    output: format!("used {redaction_fixture}"),
+                    started_at: "2026-06-30T00:00:00Z".into(),
+                    completed_at: Some("2026-06-30T00:01:00Z".into()),
+                },
+            )
+            .unwrap();
+
+        let proposal = capture_successful_run(&engine, &run_id, Some("test".into())).unwrap();
+
+        assert_eq!(proposal.source_run_id.as_deref(), Some(run_id.as_str()));
+        assert!(proposal.procedure_markdown.contains("Captured Run Notes"));
+        assert!(!proposal.procedure_markdown.contains(&redaction_fixture));
+    }
+}

--- a/crates/zeroclaw-runtime/src/sop/procedural_memory.rs
+++ b/crates/zeroclaw-runtime/src/sop/procedural_memory.rs
@@ -48,6 +48,9 @@ pub fn create_proposal(engine: &SopEngine, draft: ProposalDraft) -> Result<Propo
         Some(toml) if !toml.trim().is_empty() => toml,
         _ => default_manifest_toml(sop_name, description),
     };
+    if let Some(reason) = scan_candidate(&manifest_toml, procedure_markdown) {
+        bail!("proposal rejected: {reason}");
+    }
     validate_candidate(sop_name, &manifest_toml, procedure_markdown)?;
     let now = now_iso8601();
     let id = format!(
@@ -726,5 +729,38 @@ mod tests {
         assert_eq!(proposal.source_run_id.as_deref(), Some(run_id.as_str()));
         assert!(proposal.procedure_markdown.contains("Captured Run Notes"));
         assert!(!proposal.procedure_markdown.contains(&redaction_fixture));
+    }
+
+    #[test]
+    fn create_proposal_rejects_credential_content_before_storing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let engine = engine_with_workspace(tmp.path());
+        // Use the same token= pattern as the redaction test; 20+ char value triggers generic-secret detection.
+        let credential = ["tok", "en=", "neutralplaceholder1234567890"].concat();
+        let md = format!("## Steps\n\n1. **Auth** - Use {credential} to authenticate.\n");
+
+        let result = create_proposal(
+            &engine,
+            ProposalDraft {
+                sop_name: "cred-test".into(),
+                description: "Credential test".into(),
+                manifest_toml: None,
+                procedure_markdown: md.clone(),
+                source_run_id: None,
+                requested_by: None,
+            },
+        );
+
+        assert!(
+            result.is_err(),
+            "create_proposal must reject credential-like content"
+        );
+        // No pending or quarantined record should exist in the store.
+        let all = engine.list_proposals(None).unwrap_or_default();
+        assert!(
+            all.iter()
+                .all(|p| !p.procedure_markdown.contains(&credential)),
+            "raw credential must not be stored in any proposal record"
+        );
     }
 }

--- a/crates/zeroclaw-runtime/src/sop/procedural_memory.rs
+++ b/crates/zeroclaw-runtime/src/sop/procedural_memory.rs
@@ -140,7 +140,19 @@ pub fn apply_proposal(
     }
 
     let sops_root = super::resolve_sops_dir(workspace_dir, engine.config().sops_dir.as_deref());
-    let target_dir = contained_sop_dir(&sops_root, &proposal.sop_name)?;
+    // An Update must land on the currently-loaded SOP's actual directory, which
+    // the loader sets from on-disk layout and need not match a slug of the name.
+    // Create has no loaded SOP, so derive the new directory from the name.
+    let target_dir = match proposal.kind {
+        ProposalKind::Update => match engine
+            .get_sop(&proposal.sop_name)
+            .and_then(|sop| sop.location.clone())
+        {
+            Some(location) => contained_existing_dir(&sops_root, &location)?,
+            None => contained_sop_dir(&sops_root, &proposal.sop_name)?,
+        },
+        ProposalKind::Create => contained_sop_dir(&sops_root, &proposal.sop_name)?,
+    };
     let current_target_hash = if target_dir.exists() {
         Some(hash_sop_dir(&target_dir)?)
     } else {
@@ -370,7 +382,67 @@ fn contained_sop_dir(sops_root: &Path, sop_name: &str) -> Result<PathBuf> {
         bail!("SOP name does not contain a safe path component");
     }
     ensure_relative_component(&slug)?;
-    Ok(sops_root.join(slug))
+    let target = sops_root.join(slug);
+    ensure_within_root(sops_root, &target)?;
+    Ok(target)
+}
+
+/// Validate that an already-existing SOP directory (taken from the loaded
+/// `Sop.location`) stays within `sops_root`, rejecting `..` and symlink escapes.
+fn contained_existing_dir(sops_root: &Path, location: &Path) -> Result<PathBuf> {
+    let target = location.to_path_buf();
+    ensure_within_root(sops_root, &target)?;
+    Ok(target)
+}
+
+/// Assert that `target` resolves to a path inside `sops_root`. Both paths may
+/// not yet exist on disk (a fresh Create has neither the root nor the leaf), so
+/// each is resolved by canonicalizing its nearest existing ancestor (which
+/// follows symlinks where they actually live - the real escape vector) and
+/// re-appending the remaining lexical components.
+fn ensure_within_root(sops_root: &Path, target: &Path) -> Result<()> {
+    let root = resolve_existing_ancestor(sops_root)?;
+    let resolved_target = resolve_existing_ancestor(target)?;
+    if !resolved_target.starts_with(&root) {
+        bail!(
+            "target SOP directory '{}' escapes SOPs root",
+            target.display()
+        );
+    }
+    Ok(())
+}
+
+/// Canonicalize the nearest existing ancestor of `path` and re-append the
+/// not-yet-created trailing components verbatim. A `..` or symlink that escapes
+/// is caught because the existing portion is canonicalized; a trailing
+/// component is rejected unless it is a plain name.
+fn resolve_existing_ancestor(path: &Path) -> Result<PathBuf> {
+    let mut remainder: Vec<&std::ffi::OsStr> = Vec::new();
+    let mut current = path;
+    loop {
+        if current.exists() {
+            let mut resolved = fs::canonicalize(current)
+                .with_context(|| format!("canonicalize '{}'", current.display()))?;
+            for name in remainder.iter().rev() {
+                resolved.push(name);
+            }
+            return Ok(resolved);
+        }
+        match (current.file_name(), current.parent()) {
+            (Some(name), Some(parent)) => {
+                let component = Path::new(name);
+                if component
+                    .components()
+                    .any(|c| !matches!(c, Component::Normal(_)))
+                {
+                    bail!("unsafe SOP path component '{}'", name.to_string_lossy());
+                }
+                remainder.push(name);
+                current = parent;
+            }
+            _ => bail!("cannot resolve SOP path '{}'", path.display()),
+        }
+    }
 }
 
 fn ensure_relative_component(component: &str) -> Result<()> {
@@ -532,6 +604,57 @@ mod tests {
         assert!(apply_proposal(&mut engine, tmp.path(), &proposal.id, None).is_err());
         let stored = engine.load_proposal(&proposal.id).unwrap().unwrap();
         assert_eq!(stored.status, ProposalStatus::Stale);
+    }
+
+    #[test]
+    fn apply_update_targets_loaded_location_not_name_slug() {
+        let tmp = tempfile::tempdir().unwrap();
+        // On-disk directory name ("foo") intentionally differs from the manifest
+        // SOP name ("daily-check"); the loader keys off the manifest name but
+        // records the actual directory as the location.
+        let sops = tmp.path().join("sops").join("foo");
+        fs::create_dir_all(&sops).unwrap();
+        fs::write(
+            sops.join("SOP.toml"),
+            "[sop]\nname = \"daily-check\"\ndescription = \"Daily check\"\n\n[[triggers]]\ntype = \"manual\"\n",
+        )
+        .unwrap();
+        fs::write(sops.join("SOP.md"), "## Steps\n\n1. **Old** - Do it.\n").unwrap();
+
+        let mut engine = engine_with_workspace(tmp.path());
+        engine.reload(tmp.path());
+        assert_eq!(
+            engine
+                .get_sop("daily-check")
+                .and_then(|sop| sop.location.clone()),
+            Some(sops.clone())
+        );
+
+        let proposal = create_proposal(
+            &engine,
+            ProposalDraft {
+                sop_name: "daily-check".into(),
+                description: "Daily check".into(),
+                manifest_toml: None,
+                procedure_markdown: "## Steps\n\n1. **New** - Do it.\n".into(),
+                source_run_id: None,
+                requested_by: None,
+            },
+        )
+        .unwrap();
+
+        let outcome = apply_proposal(&mut engine, tmp.path(), &proposal.id, None).unwrap();
+
+        assert_eq!(outcome.proposal.status, ProposalStatus::Applied);
+        assert_eq!(outcome.target_dir, sops);
+        // The original directory was updated in place with the new content
+        // (create_proposal trims trailing whitespace from the markdown).
+        assert_eq!(
+            fs::read_to_string(sops.join("SOP.md")).unwrap(),
+            "## Steps\n\n1. **New** - Do it."
+        );
+        // No new slug-named directory was created next to the real one.
+        assert!(!tmp.path().join("sops").join("daily-check").exists());
     }
 
     #[test]

--- a/crates/zeroclaw-runtime/src/sop/store/mod.rs
+++ b/crates/zeroclaw-runtime/src/sop/store/mod.rs
@@ -24,8 +24,8 @@ use std::sync::{Arc, Mutex};
 use zeroclaw_config::schema::{SopConfig, SopRunStoreBackend};
 
 pub use model::{
-    ClaimToken, PersistedRun, ProposalRecord, ProposalStatus, RetentionPolicy, SOP_STORE_VERSION,
-    SopEventRecord,
+    ClaimToken, PersistedRun, ProposalKind, ProposalRecord, ProposalStatus, RetentionPolicy,
+    SOP_STORE_VERSION, SopEventRecord,
 };
 pub use sqlite::SqliteRunStore;
 
@@ -578,13 +578,20 @@ mod tests {
     fn proposal(id: &str, status: ProposalStatus) -> ProposalRecord {
         ProposalRecord {
             id: id.to_string(),
+            kind: ProposalKind::Update,
             status,
             source_run_id: None,
             sop_name: "deploy".to_string(),
             target_content_hash: None,
+            manifest_toml: "[sop]\nname = \"deploy\"\ndescription = \"Deploy\"\n".to_string(),
+            procedure_markdown: "## Steps\n\n1. **Deploy** - Do it.\n".to_string(),
             provenance: json!({}),
             created_at: "t".to_string(),
             updated_at: "t".to_string(),
+            status_reason: None,
+            applied_at: None,
+            applied_by: None,
+            rollback_path: None,
         }
     }
 

--- a/crates/zeroclaw-runtime/src/sop/store/model.rs
+++ b/crates/zeroclaw-runtime/src/sop/store/model.rs
@@ -98,19 +98,49 @@ pub enum ProposalStatus {
     Stale,
 }
 
+/// Whether a proposal creates a new SOP or updates an existing one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProposalKind {
+    Create,
+    Update,
+}
+
 /// A captured-and-distilled SOP refinement awaiting approval + write-back.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProposalRecord {
     pub id: String,
+    #[serde(default = "default_proposal_kind")]
+    pub kind: ProposalKind,
     pub status: ProposalStatus,
     pub source_run_id: Option<String>,
     pub sop_name: String,
     /// For stale detection against the on-disk SOP.
     pub target_content_hash: Option<String>,
+    /// Proposed `SOP.toml` bytes. Kept in the shared store so inspect/apply do
+    /// not depend on transient files.
+    #[serde(default)]
+    pub manifest_toml: String,
+    /// Proposed `SOP.md` bytes. Scanned before write-back and written atomically
+    /// only after an explicit apply action.
+    #[serde(default)]
+    pub procedure_markdown: String,
     /// Distiller model, session, timestamp, …
     pub provenance: serde_json::Value,
     pub created_at: String,
     pub updated_at: String,
+    #[serde(default)]
+    pub status_reason: Option<String>,
+    #[serde(default)]
+    pub applied_at: Option<String>,
+    #[serde(default)]
+    pub applied_by: Option<String>,
+    #[serde(default)]
+    pub rollback_path: Option<String>,
+}
+
+fn default_proposal_kind() -> ProposalKind {
+    ProposalKind::Update
 }
 
 /// Retention bound for terminal runs + their events.

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -39,6 +39,7 @@ pub mod sop_approve;
 pub mod sop_execute;
 pub mod sop_list;
 pub mod sop_status;
+pub mod sop_workshop;
 pub mod spawn_subagent;
 pub mod verifiable_intent;
 
@@ -150,6 +151,7 @@ pub use sop_approve::SopApproveTool;
 pub use sop_execute::SopExecuteTool;
 pub use sop_list::SopListTool;
 pub use sop_status::SopStatusTool;
+pub use sop_workshop::SopWorkshopTool;
 pub use spawn_subagent::SpawnSubagentTool;
 pub use verifiable_intent::VerifiableIntentTool;
 
@@ -1214,6 +1216,12 @@ pub fn all_tools_with_runtime(
             SopStatusTool::new(Arc::clone(sop_engine))
                 .with_collector(crate::sop::SopMetricsCollector::shared()),
         ));
+        if root_config.sop.procedural_memory_enabled {
+            tool_arcs.push(Arc::new(SopWorkshopTool::new(
+                Arc::clone(sop_engine),
+                workspace_dir.to_path_buf(),
+            )));
+        }
     }
 
     if let Some(key) = composio_key
@@ -1702,6 +1710,66 @@ mod tests {
                 "SOP tool '{name}' must be registered when engine is provided"
             );
         }
+        assert!(
+            !names.contains(&"sop_workshop"),
+            "sop_workshop must stay opt-in while procedural memory is disabled"
+        );
+    }
+
+    #[test]
+    fn sop_workshop_registered_only_when_procedural_memory_enabled() {
+        let tmp = TempDir::new().unwrap();
+        let security = Arc::new(SecurityPolicy::default());
+        let mem_cfg = MemoryConfig {
+            backend: "markdown".into(),
+            ..MemoryConfig::default()
+        };
+        let mem: Arc<dyn Memory> =
+            Arc::from(zeroclaw_memory::create_memory(&mem_cfg, tmp.path(), None).unwrap());
+
+        let browser = BrowserConfig {
+            enabled: false,
+            allowed_domains: vec![],
+            session_name: None,
+            ..BrowserConfig::default()
+        };
+        let http = zeroclaw_config::schema::HttpRequestConfig::default();
+        let mut cfg = test_config(&tmp);
+        cfg.sop.procedural_memory_enabled = true;
+
+        let engine = Arc::new(Mutex::new(SopEngine::new(
+            zeroclaw_config::schema::SopConfig::default(),
+        )));
+
+        let tools = all_tools_with_runtime(
+            Arc::new(Config::default()),
+            &security,
+            &zeroclaw_config::schema::RiskProfileConfig::default(),
+            "test-agent",
+            Arc::new(NativeRuntime::new()),
+            mem,
+            None,
+            None,
+            &browser,
+            &http,
+            &zeroclaw_config::schema::WebFetchConfig::default(),
+            tmp.path(),
+            &HashMap::new(),
+            None,
+            &cfg,
+            None,
+            false,
+            None,
+            Some(engine),
+            None,
+        )
+        .tools;
+        let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+
+        assert!(
+            names.contains(&"sop_workshop"),
+            "sop_workshop must be registered when procedural memory is enabled"
+        );
     }
 
     /// Regression for #6687: two tool registries built from clones of the same

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -1806,6 +1806,7 @@ mod tests {
             None,
             Some(engine),
             None,
+            None,
         )
         .tools;
         let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();

--- a/crates/zeroclaw-runtime/src/tools/sop_workshop.rs
+++ b/crates/zeroclaw-runtime/src/tools/sop_workshop.rs
@@ -1,0 +1,341 @@
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use serde_json::json;
+
+use crate::sop::procedural_memory::{
+    ProposalDraft, apply_proposal, capture_successful_run, create_proposal, set_proposal_status,
+};
+use crate::sop::{ProposalStatus, SopEngine};
+use zeroclaw_api::tool::{Tool, ToolResult};
+
+macro_rules! sop_workshop_actions {
+    ($($variant:ident => $wire:literal),+ $(,)?) => {
+        #[derive(Clone, Copy)]
+        enum SopWorkshopAction {
+            $($variant),+
+        }
+
+        impl SopWorkshopAction {
+            const ALL: [Self; sop_workshop_actions!(@count $($variant),+)] = [
+                $(Self::$variant),+
+            ];
+
+            fn parse(value: &str) -> anyhow::Result<Self> {
+                Self::ALL
+                    .into_iter()
+                    .find(|action| action.wire_name() == value)
+                    .ok_or_else(|| anyhow::Error::msg(format!("Unsupported sop_workshop action: {value}")))
+            }
+
+            fn wire_name(self) -> &'static str {
+                match self {
+                    $(Self::$variant => $wire),+
+                }
+            }
+
+            fn wire_names() -> Vec<&'static str> {
+                Self::ALL
+                    .into_iter()
+                    .map(Self::wire_name)
+                    .collect()
+            }
+        }
+    };
+    (@count $($variant:ident),+) => {
+        <[()]>::len(&[$(sop_workshop_actions!(@unit $variant)),+])
+    };
+    (@unit $variant:ident) => {
+        ()
+    };
+}
+
+sop_workshop_actions! {
+    Propose => "propose",
+    CaptureRun => "capture_run",
+    List => "list",
+    Inspect => "inspect",
+    Apply => "apply",
+    Reject => "reject",
+    Quarantine => "quarantine",
+}
+
+/// Agent-facing SOP proposal lifecycle tool.
+pub struct SopWorkshopTool {
+    engine: Arc<Mutex<SopEngine>>,
+    workspace_dir: std::path::PathBuf,
+}
+
+impl SopWorkshopTool {
+    pub fn new(engine: Arc<Mutex<SopEngine>>, workspace_dir: std::path::PathBuf) -> Self {
+        Self {
+            engine,
+            workspace_dir,
+        }
+    }
+}
+
+impl ::zeroclaw_api::attribution::Attributable for SopWorkshopTool {
+    fn role(&self) -> ::zeroclaw_api::attribution::Role {
+        ::zeroclaw_api::attribution::Role::Sop
+    }
+
+    fn alias(&self) -> &str {
+        "sop_workshop"
+    }
+}
+
+#[async_trait]
+impl Tool for SopWorkshopTool {
+    fn name(&self) -> &str {
+        "sop_workshop"
+    }
+
+    fn description(&self) -> &str {
+        "Manage SOP procedural-memory proposals: propose, capture_run, list, inspect, apply, reject, or quarantine. Apply writes SOP.toml/SOP.md only after an explicit action."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        let action_names = SopWorkshopAction::wire_names();
+        json!({
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": action_names,
+                    "description": "Proposal lifecycle action"
+                },
+                "id": {
+                    "type": "string",
+                    "description": "Proposal id for inspect/apply/reject/quarantine"
+                },
+                "status": {
+                    "type": "string",
+                    "description": "Optional list status filter"
+                },
+                "sop_name": {
+                    "type": "string",
+                    "description": "Target SOP name for propose"
+                },
+                "description": {
+                    "type": "string",
+                    "description": "SOP description for propose when manifest_toml is omitted"
+                },
+                "manifest_toml": {
+                    "type": "string",
+                    "description": "Proposed SOP.toml content; if omitted, a manual-trigger manifest is generated"
+                },
+                "procedure_markdown": {
+                    "type": "string",
+                    "description": "Proposed SOP.md content"
+                },
+                "source_run_id": {
+                    "type": "string",
+                    "description": "Source SOP run id for propose/capture_run"
+                },
+                "actor": {
+                    "type": "string",
+                    "description": "Operator or agent label recorded in proposal provenance"
+                },
+                "reason": {
+                    "type": "string",
+                    "description": "Reason for reject/quarantine"
+                }
+            },
+            "required": ["action"]
+        })
+    }
+
+    async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
+        let action = args
+            .get("action")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow::Error::msg("Missing 'action' parameter"))?;
+        let result = match SopWorkshopAction::parse(action)? {
+            SopWorkshopAction::Propose => self.propose(&args),
+            SopWorkshopAction::CaptureRun => self.capture_run(&args),
+            SopWorkshopAction::List => self.list(&args),
+            SopWorkshopAction::Inspect => self.inspect(&args),
+            SopWorkshopAction::Apply => self.apply(&args),
+            SopWorkshopAction::Reject => self.set_status(&args, ProposalStatus::Rejected),
+            SopWorkshopAction::Quarantine => self.set_status(&args, ProposalStatus::Quarantined),
+        };
+
+        match result {
+            Ok(output) => Ok(ToolResult {
+                success: true,
+                output,
+                error: None,
+            }),
+            Err(e) => Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(e.to_string()),
+            }),
+        }
+    }
+}
+
+impl SopWorkshopTool {
+    fn lock_engine(&self) -> anyhow::Result<std::sync::MutexGuard<'_, SopEngine>> {
+        self.engine
+            .lock()
+            .map_err(|e| anyhow::Error::msg(format!("Engine lock poisoned: {e}")))
+    }
+
+    fn propose(&self, args: &serde_json::Value) -> anyhow::Result<String> {
+        let sop_name = required_str(args, "sop_name")?;
+        let description = required_str(args, "description")?;
+        let procedure_markdown = required_str(args, "procedure_markdown")?;
+        let manifest_toml = args
+            .get("manifest_toml")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        let source_run_id = args
+            .get("source_run_id")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        let actor = args
+            .get("actor")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        let engine = self.lock_engine()?;
+        let proposal = create_proposal(
+            &engine,
+            ProposalDraft {
+                sop_name: sop_name.to_string(),
+                description: description.to_string(),
+                manifest_toml,
+                procedure_markdown: procedure_markdown.to_string(),
+                source_run_id,
+                requested_by: actor,
+            },
+        )?;
+        Ok(serde_json::to_string_pretty(&proposal)?)
+    }
+
+    fn capture_run(&self, args: &serde_json::Value) -> anyhow::Result<String> {
+        let run_id = required_str(args, "source_run_id")?;
+        let actor = args
+            .get("actor")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        let engine = self.lock_engine()?;
+        let proposal = capture_successful_run(&engine, run_id, actor)?;
+        Ok(serde_json::to_string_pretty(&proposal)?)
+    }
+
+    fn list(&self, args: &serde_json::Value) -> anyhow::Result<String> {
+        let status = args
+            .get("status")
+            .and_then(|v| v.as_str())
+            .map(parse_status)
+            .transpose()?;
+        let engine = self.lock_engine()?;
+        let mut proposals = engine.list_proposals(status)?;
+        proposals.sort_by(|a, b| a.created_at.cmp(&b.created_at).then(a.id.cmp(&b.id)));
+        let rows: Vec<_> = proposals
+            .into_iter()
+            .map(|p| {
+                json!({
+                    "id": p.id,
+                    "status": p.status,
+                    "kind": p.kind,
+                    "sop_name": p.sop_name,
+                    "source_run_id": p.source_run_id,
+                    "created_at": p.created_at,
+                    "updated_at": p.updated_at,
+                    "status_reason": p.status_reason,
+                })
+            })
+            .collect();
+        Ok(serde_json::to_string_pretty(&rows)?)
+    }
+
+    fn inspect(&self, args: &serde_json::Value) -> anyhow::Result<String> {
+        let id = required_str(args, "id")?;
+        let engine = self.lock_engine()?;
+        let proposal = engine
+            .load_proposal(id)?
+            .ok_or_else(|| anyhow::Error::msg(format!("proposal not found: {id}")))?;
+        Ok(serde_json::to_string_pretty(&proposal)?)
+    }
+
+    fn apply(&self, args: &serde_json::Value) -> anyhow::Result<String> {
+        let id = required_str(args, "id")?;
+        let actor = args
+            .get("actor")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        let mut engine = self.lock_engine()?;
+        let outcome = apply_proposal(&mut engine, &self.workspace_dir, id, actor)?;
+        Ok(serde_json::to_string_pretty(&json!({
+            "id": outcome.proposal.id,
+            "status": outcome.proposal.status,
+            "sop_name": outcome.proposal.sop_name,
+            "target_dir": outcome.target_dir,
+            "rollback_path": outcome.proposal.rollback_path,
+        }))?)
+    }
+
+    fn set_status(
+        &self,
+        args: &serde_json::Value,
+        status: ProposalStatus,
+    ) -> anyhow::Result<String> {
+        let id = required_str(args, "id")?;
+        let reason = args
+            .get("reason")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        let engine = self.lock_engine()?;
+        let proposal = set_proposal_status(&engine, id, status, reason)?;
+        Ok(serde_json::to_string_pretty(&proposal)?)
+    }
+}
+
+fn required_str<'a>(args: &'a serde_json::Value, field: &str) -> anyhow::Result<&'a str> {
+    args.get(field)
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.trim().is_empty())
+        .ok_or_else(|| anyhow::Error::msg(format!("Missing '{field}' parameter")))
+}
+
+fn parse_status(status: &str) -> anyhow::Result<ProposalStatus> {
+    serde_json::from_value(serde_json::Value::String(status.to_string()))
+        .map_err(|_| anyhow::Error::msg(format!("invalid proposal status: {status}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sop::SopEngine;
+    use zeroclaw_config::schema::SopConfig;
+
+    #[tokio::test]
+    async fn propose_and_list_round_trip() {
+        let tmp = tempfile::tempdir().unwrap();
+        let engine = Arc::new(Mutex::new(SopEngine::new(SopConfig {
+            sops_dir: Some(tmp.path().join("sops").display().to_string()),
+            ..SopConfig::default()
+        })));
+        let tool = SopWorkshopTool::new(Arc::clone(&engine), tmp.path().to_path_buf());
+
+        let proposed = tool
+            .execute(json!({
+                "action": "propose",
+                "sop_name": "daily-check",
+                "description": "Daily check",
+                "procedure_markdown": "## Steps\n\n1. **Check** - Do it.\n",
+                "actor": "test"
+            }))
+            .await
+            .unwrap();
+        assert!(proposed.success, "{:?}", proposed.error);
+        assert!(proposed.output.contains("daily-check"));
+
+        let listed = tool.execute(json!({"action": "list"})).await.unwrap();
+        assert!(listed.success);
+        assert!(listed.output.contains("daily-check"));
+    }
+}

--- a/docs/book/src/sop/syntax.md
+++ b/docs/book/src/sop/syntax.md
@@ -68,6 +68,7 @@ The `[sop]` config controls enforcement:
 | `untrusted_guard_sensitivity` | `0.7` | Sensitivity used by prompt-guard screening and outbound redaction. |
 | `untrusted_frame_warning` | `true` | Include explanatory warning text in the untrusted-content frame. Frame boundaries remain enabled. |
 | `untrusted_outbound_redact` | `true` | Enable shared outbound redaction for SOP content-safety consumers. |
+| `procedural_memory_enabled` | `false` | Register the `sop_workshop` tool for proposal capture, review, and explicit SOP write-back. |
 
 Schema enforcement fails closed: invalid step input prevents the step from
 starting, and invalid step output is routed through the step's `on_failure`
@@ -79,6 +80,11 @@ Untrusted trigger topic and payload text is capped, normalized, screened, and
 framed before it reaches step context. Framing is always on; the warning text can
 be hidden, but raw external trigger text is not interpolated into the model
 context.
+
+Procedural memory is opt-in. When enabled, `sop_workshop` can create and inspect
+stored SOP proposals, capture completed run context into a candidate procedure,
+and apply an approved proposal to `SOP.toml`/`SOP.md`. Write-back only happens
+through the explicit `apply` action.
 
 ## 4. Trigger Types
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Adds the opt-in SOP procedural-memory workshop so agents can create, inspect, reject, quarantine, and explicitly apply stored SOP proposals.
  - Extends SOP proposal records with create/update kind, proposed `SOP.toml`/`SOP.md` content, apply metadata, status reasons, and rollback paths so proposal review/apply is store-backed instead of file-scratch-backed.
  - Adds write-back safety around apply: stale target detection, create-target race detection, candidate validation, credential-like content scanning, rollback snapshots, atomic file replacement, and engine reload after successful apply.
  - Documents `sop.procedural_memory_enabled` in the SOP syntax/config reference.
- **Scope boundary:** This does not auto-apply model-generated SOP changes, add a background curator, or enable the workshop by default. Disk writes happen only through the explicit `apply` action after the opt-in config is enabled.
- **Blast radius:** SOP runtime, SOP store proposal JSON, runtime tool registration, SOP config schema, and SOP docs. The CAS/proposal-store substrate dependency (#8506) has merged, so this PR is now rebased directly on `master` and the diff is just the procedural-memory workshop.
- **Linked issue(s):** Related #8288. Builds on #8506 (merged 2026-07-02).
- **Labels:** `enhancement`, `docs`, `config`, `runtime`, `tool:sop`, `risk:high`, `size:L`.

## Validation Evidence (required)

- **Commands run and tail output** (re-run on the rebased-onto-master tree, 2026-07-02, toolchain `+1.93.0`):

```text
[PASS] cargo fmt --check +1.93.0
[PASS] cargo clippy --all-targets +1.93.0
[PASS] cargo test +1.93.0
[PASS] suppressions / todo / deferred / not_implemented / secrets / em-dash (docs gate) / registry-shadowing / string-literal-match
summary: 0 blocking, 0 warning
RESULT: PASS
```

- **Beyond CI — what did you manually verify?** Reviewed the F-only diff against `origin/feat/sop-cas-proposal-store..HEAD`, including the opt-in tool registration, proposal apply ordering, stale/quarantine persistence, rollback path, and docs/config alignment. Focused tests cover proposal apply/reload, stale update detection, stale create-target detection, successful-run capture redaction, and workshop registration/listing.
- **If any command was intentionally skipped, why:** No web battery or shell battery was run because this PR does not touch web/TypeScript or shell scripts.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`Yes`) When `sop.procedural_memory_enabled = true`, the new `sop_workshop` tool can write `SOP.toml` and `SOP.md` under the configured SOP directory through explicit `apply`. The feature is default-off, validates candidates before write-back, creates rollback snapshots for existing targets, and rejects stale targets.
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`Yes`) Candidate SOP content is scanned for credential-like material before write-back; detections quarantine the proposal instead of writing it to disk.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: The main risk is unintended SOP mutation after enabling the workshop. Mitigations are default-off registration, explicit apply, stale/hash checks, create-target race checks, candidate validation, rollback snapshots, leak scanning before disk writes, and engine reload only after successful write-back.

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`Yes`) Adds `sop.procedural_memory_enabled`, defaulting to `false`.
- If `No` or `Yes` to either: exact upgrade steps for existing users: No action required for existing users. To opt in, set `sop.procedural_memory_enabled = true` and configure `sop.sops_dir`; leave the field omitted or `false` to preserve current behavior.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** revert the merge/squash commit after merge. Before merge, drop or revert the PR stack commits `5457d2e279`, `4a88255a31`, `1e3c4f45cf`, and `7d69793a3f`.
- **Feature flags or config toggles:** Set `sop.procedural_memory_enabled = false` or remove the field to unregister `sop_workshop`.
- **Observable failure symptoms:** `sop_workshop` tool errors on proposal apply/list/inspect, unexpected SOP reload behavior after apply, proposals marked `stale` or `quarantined` unexpectedly, or unexpected files under `<sops_dir>/.rollback/<proposal_id>`.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Scope materially carried forward: N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`No`)
- If `No`, why (inspiration-only, no direct code/design carry-over): No superseded PR scope is carried forward.

## Review remediation

- **`4a88255a31`** resolves @Audacity88's blocking review: `apply_proposal` now derives the write target for `Update` proposals from the currently-loaded `Sop.location` (the actual on-disk directory) instead of a slug of `[sop].name`, so a valid update to an SOP whose directory name differs from its manifest name is no longer marked stale or written to a new directory. Adds a containment check under the configured SOP root for both create and update targets, plus a regression test (`apply_update_targets_loaded_location_not_name_slug`) placing `daily-check` under a directory named `foo`.
- **Rebased onto `master` after #8506 merged (2026-07-02).** An earlier interim commit realigned a `msg-image-route` test fixture in `crates/zeroclaw-channels/src/orchestrator/mod.rs` to avoid a `clippy::needless_update` that only surfaced in the CI merge-ref. That fix now lives in `master` via #8506, so the interim commit was dropped during the rebase and this PR no longer touches `orchestrator/mod.rs` at all. Current head also includes the direct-proposal pre-store scan fix (`1e3c4f45cf`) and the current-`master` test callsite fix (`7d69793a3f`).

