### PR TITLE
fix(providers): omit empty assistant tool-call content in OpenAI-compatible requests

### DIFF
--- a/crates/zeroclaw-providers/src/azure_openai.rs
+++ b/crates/zeroclaw-providers/src/azure_openai.rs
@@ -281,10 +281,7 @@ impl AzureOpenAiModelProvider {
                             },
                         })
                         .collect::<Vec<_>>();
-                    let content = value
-                        .get("content")
-                        .and_then(serde_json::Value::as_str)
-                        .map(ToString::to_string);
+                    let content = crate::request_payload::non_empty_string_field(&value, "content");
                     let reasoning_content = value
                         .get("reasoning_content")
                         .and_then(serde_json::Value::as_str)

--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -2093,10 +2093,8 @@ impl OpenAiCompatibleModelProvider {
                     last_assistant_tool_call_ids =
                         tool_calls.iter().filter_map(|tc| tc.id.clone()).collect();
 
-                    let content = value
-                        .get("content")
-                        .and_then(serde_json::Value::as_str)
-                        .map(|value| MessageContent::Text(value.to_string()));
+                    let content = crate::request_payload::non_empty_string_field(&value, "content")
+                        .map(MessageContent::Text);
 
                     // `reasoning` (OpenRouter / vLLM >= v0.16.0). Preserve
                     // whichever field name was originally received so the
@@ -5929,6 +5927,45 @@ mod tests {
             }
             other => panic!("expected text content from fallback, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn convert_messages_for_native_omits_empty_tool_call_content() {
+        let empty_history_json = serde_json::json!({
+            "content": "",
+            "tool_calls": [{
+                "id": "tc_1",
+                "name": "shell",
+                "arguments": "{\"cmd\":\"ls\"}"
+            }]
+        });
+        let non_empty_history_json = serde_json::json!({
+            "content": "I will check",
+            "tool_calls": [{
+                "id": "tc_2",
+                "name": "shell",
+                "arguments": "{\"cmd\":\"pwd\"}"
+            }]
+        });
+
+        let messages = vec![
+            ChatMessage::assistant(empty_history_json.to_string()),
+            ChatMessage::assistant(non_empty_history_json.to_string()),
+        ];
+        let provider = make_model_provider("test", "https://example.com", None);
+        let native = provider.convert_messages_for_native(&messages, true);
+        let empty_json = serde_json::to_value(&native[0]).unwrap();
+        let non_empty_json = serde_json::to_value(&native[1]).unwrap();
+
+        assert_eq!(empty_json.get("content"), None);
+        assert_ne!(
+            empty_json.get("content"),
+            Some(&serde_json::Value::String(String::new()))
+        );
+        assert_eq!(
+            non_empty_json.get("content"),
+            Some(&serde_json::json!("I will check"))
+        );
     }
 
     #[test]

--- a/crates/zeroclaw-providers/src/copilot.rs
+++ b/crates/zeroclaw-providers/src/copilot.rs
@@ -333,10 +333,8 @@ impl CopilotModelProvider {
                         })
                         .collect::<Vec<_>>();
 
-                    let content = value
-                        .get("content")
-                        .and_then(serde_json::Value::as_str)
-                        .map(|s| ApiContent::Text(s.to_string()));
+                    let content = crate::request_payload::non_empty_string_field(&value, "content")
+                        .map(ApiContent::Text);
 
                     return ApiMessage {
                         role: "assistant".to_string(),

--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -44,6 +44,9 @@ pub mod telnyx;
 pub mod traits;
 
 pub use dispatch::{ProviderDispatch, ProviderDispatchRef};
+
+mod request_payload;
+
 #[allow(unused_imports)]
 pub use traits::{
     ChatMessage, ChatRequest, ChatResponse, ConversationMessage, ModelProvider,

--- a/crates/zeroclaw-providers/src/openai.rs
+++ b/crates/zeroclaw-providers/src/openai.rs
@@ -304,10 +304,7 @@ impl OpenAiModelProvider {
                             },
                         })
                         .collect::<Vec<_>>();
-                    let content = value
-                        .get("content")
-                        .and_then(serde_json::Value::as_str)
-                        .map(ToString::to_string);
+                    let content = crate::request_payload::non_empty_string_field(&value, "content");
                     let reasoning_content = value
                         .get("reasoning_content")
                         .and_then(serde_json::Value::as_str)

--- a/crates/zeroclaw-providers/src/openrouter.rs
+++ b/crates/zeroclaw-providers/src/openrouter.rs
@@ -269,10 +269,8 @@ impl OpenRouterModelProvider {
                             },
                         })
                         .collect::<Vec<_>>();
-                    let content = value
-                        .get("content")
-                        .and_then(serde_json::Value::as_str)
-                        .map(|value| MessageContent::Text(value.to_string()));
+                    let content = crate::request_payload::non_empty_string_field(&value, "content")
+                        .map(MessageContent::Text);
                     let reasoning_content = value
                         .get("reasoning_content")
                         .and_then(serde_json::Value::as_str)

--- a/crates/zeroclaw-providers/src/request_payload.rs
+++ b/crates/zeroclaw-providers/src/request_payload.rs
@@ -1,0 +1,7 @@
+pub(crate) fn non_empty_string_field(value: &serde_json::Value, field: &str) -> Option<String> {
+    value
+        .get(field)
+        .and_then(serde_json::Value::as_str)
+        .filter(|content| !content.trim().is_empty())
+        .map(ToString::to_string)
+}


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - An assistant message carrying `tool_calls` serialized `content` as `""` (empty string). Per the OpenAI chat-completions spec such a message should omit `content` (or send `null`), not `""`.
  - Strict OpenAI-compatible backends reject `""`: NVIDIA NIM `llama-3.1-nemotron-ultra-253b` (via litellm) returns `400 string_too_short` ("String should have at least 1 character") and aborts the agentic turn mid-run.
  - Added a shared `non_empty_string_field` helper and applied it across the OpenAI-compatible providers so empty/whitespace tool-call content is omitted via `skip_serializing_if`.
- **Scope boundary:** Only the OUTGOING request payload for assistant tool-call messages. Does NOT change the `ChatMessage` session-store shape, non-empty content, or assistant messages without `tool_calls`.
- **Blast radius:** The OpenAI-compatible providers (`compatible`, `openai`, `azure_openai`, `openrouter`, `copilot`). No effect on persisted sessions or non-OpenAI providers.
- **Linked issue(s):** (none — surfaced during integration testing against a strict NIM backend)

## Validation Evidence (required)

```
$ cargo +1.93.0 fmt --all -- --check        # exit 0 (clean)
$ cargo +1.93.0 clippy -p zeroclaw-providers --all-targets -- -D warnings
    Finished `dev` profile ... (no warnings)
$ cargo +1.93.0 test -p zeroclaw-providers convert_messages_for_native_omits_empty_tool_call_content
running 1 test
test compatible::tests::convert_messages_for_native_omits_empty_tool_call_content ... ok
test result: ok. 1 passed; 0 failed; 0 ignored
```

- **Commands run and tail output:** above — `zeroclaw-providers` is fmt/clippy/check/test green, including the new regression test asserting empty tool-call content serializes as absent (not `""`) and non-empty content is unchanged.
- **Beyond CI — what did you manually verify?** Reproduced the original `400 string_too_short` against NVIDIA NIM nemotron-ultra with empty tool-call content; with this change the field is omitted and the turn proceeds. Verified the `ChatMessage` session-store shape is untouched and messages without `tool_calls` are unaffected.
- **If any command was intentionally skipped, why:** The full-workspace `nextest` run has 2 **pre-existing** failures in `zeroclaw-config` (`schema::tests::memory_config_pgvector_roundtrip`, `memory_config_pgvector_defaults_when_omitted`) that also fail on `master` without this change (verified on the base) — unrelated to this PR (which touches only `zeroclaw-providers`).

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Omitting empty content is OpenAI-spec-compliant and accepted by lenient backends that previously tolerated `""`; no upgrade steps needed.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PR: `git revert <sha>` is the plan.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A.

## i18n Follow-Through (required only when docs or user-facing wording change)

`N.A.` — no docs or user-facing wording changed.
