### PR TITLE
fix(channels): add missing ChannelMessage fields in orchestrator test

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -21203,6 +21203,7 @@ This is an example JSON object for profile settings."#;
                     mime_type: Some("image/png".to_string()),
                 }],
                 subject: None,
+                ..Default::default()
             },
             CancellationToken::new(),
         )


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `master` currently fails the **Test** and **Lint** CI jobs for every PR that recompiles it. Root cause is a semantic merge collision between two PRs that each passed CI in isolation:
    - **#8389** (`feat(channels): add passive WhatsApp group context`) added two **required** fields to `ChannelMessage`: `passive_context` and `conversation_scope`.
    - **#8468** (`fix(channels): preserve image bytes for a configured vision_model_provider`) added a test that constructs `ChannelMessage { .. }` listing every field **explicitly** — written before #8389, so it omits the two new fields.
  - Together on `master` the test no longer compiles:
    ```
    error[E0063]: missing fields `conversation_scope` and `passive_context`
      in initializer of `zeroclaw_api::channel::ChannelMessage`
      --> crates/zeroclaw-channels/src/orchestrator/mod.rs:21190
    ```
  - The regular `Check`/`Build` jobs don't compile `#[cfg(test)]` code, which is why the break passed the per-PR checks and landed on `master` — only `Test` (`cargo test --no-run`) and `Lint` (`clippy --all-targets`) build the test target.
  - Fix: add `..Default::default()` to that one constructor so the two new fields default to `false` / `Sender`, matching how the crate's other `ChannelMessage` literals already supply them. One line, test-only.
- **Scope boundary:** Touches a single test constructor in `crates/zeroclaw-channels/src/orchestrator/mod.rs`. No production code, no behavior change.
- **Blast radius:** Restores compilation of the `zeroclaw-channels` test target; unblocks `Test`/`Lint` for all open PRs. Nothing else.
- **Linked issue(s):** None. Unblocks CI on `master` (regression from #8389 × #8468).
- **Labels:** `bug`, `channel`, `risk:low`, `size:XS`

## Validation Evidence (required)

- **Commands run and tail output:**

```
$ cargo test -p zeroclaw-channels --no-run --locked
   Compiling zeroclaw-channels v0.8.2
    Finished `test` profile [unoptimized + debuginfo] target(s) in 1m 13s   # previously: error[E0063]

$ cargo test -p zeroclaw-channels --lib media_pipeline_preserves_image_bytes_when_vision_route_configured
running 1 test
test orchestrator::tests::media_pipeline_preserves_image_bytes_when_vision_route_configured ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1137 filtered out

$ cargo clippy -p zeroclaw-channels --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 43s   # no warnings

$ cargo fmt --all -- --check
FMT_OK (no diff)
```

Toolchain: `rustc 1.93.1 (01f6ddf75 2026-02-11)`. Branch is a single commit on current `master`.

- **Beyond CI — what did you manually verify?** Confirmed the failure reproduces on a clean `master` checkout, that this is the only constructor missing the fields (the test target now compiles to completion — the compiler had stopped at the first error), and that the previously-uncompilable test now passes at runtime. The added defaults (`passive_context: false`, `conversation_scope: Sender`) match the struct's `#[derive(Default)]` and the pre-#8389 behavior, so the test's intent is unchanged.
- **If any command was intentionally skipped, why:** Full-workspace `cargo test` not run end-to-end; the regression and fix are confined to one `zeroclaw-channels` test target, validated directly above.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility (required)

- Backward compatible? **Yes** — test-only, no API or behavior change.
- Config / env / CLI surface changed? **No**

## Rollback (required for medium/high-risk PRs)

Low-risk: `git revert <sha>` (single one-line commit).
