### PR TITLE
fix(ci): reconcile cargo-audit ignores with deny.toml to unblock master

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -18,4 +18,35 @@ ignore = [
 
     # ── Informational only (no tracking issue required) ────────────────────
     "RUSTSEC-2024-0384",  # instant unmaintained; informational advisory; transitive dep
+
+    # ── audit.toml/deny.toml drift reconcile + wasmtime CVEs; tracking #8519 ──
+    # cargo-audit reads the whole Cargo.lock, so it flags advisories cargo-deny
+    # (graph-aware) tolerates. Reconcile and remediate per #8519.
+    # wasmtime-wasi CVEs via zeroclaw-plugins; real fix is a wasmtime 43 -> 45.x
+    # bump (deferred). Tracking #8519.
+    "RUSTSEC-2026-0149",  # wasmtime-wasi WASI path_open(TRUNCATE) bypasses FilePerms::WRITE; via zeroclaw-plugins; needs wasmtime >= 44.0.2; bump deferred; tracking #8519
+    "RUSTSEC-2026-0182",  # wasmtime-wasi WASIp1 fd_renumber leak; via zeroclaw-plugins; needs wasmtime >= 44.0.3; bump deferred; tracking #8519
+    "RUSTSEC-2026-0188",  # wasmtime-wasi hard link/rename FilePerms bypass; via zeroclaw-plugins; needs wasmtime >= 45.0.3; bump deferred; tracking #8519
+    # GTK3 stack unmaintained via zeroclaw-desktop (tauri -> webkit2gtk); tracking #8519
+    "RUSTSEC-2024-0411",  # gdkwayland-sys unmaintained gtk-rs GTK3 bindings; tracking #8519
+    "RUSTSEC-2024-0412",  # gdk unmaintained gtk-rs GTK3 bindings; tracking #8519
+    "RUSTSEC-2024-0413",  # atk unmaintained gtk-rs GTK3 bindings; tracking #8519
+    "RUSTSEC-2024-0414",  # gdkx11-sys unmaintained gtk-rs GTK3 bindings; tracking #8519
+    "RUSTSEC-2024-0415",  # gtk unmaintained gtk-rs GTK3 bindings; tracking #8519
+    "RUSTSEC-2024-0416",  # atk-sys unmaintained gtk-rs GTK3 bindings; tracking #8519
+    "RUSTSEC-2024-0417",  # gdkx11 unmaintained gtk-rs GTK3 bindings; tracking #8519
+    "RUSTSEC-2024-0418",  # gdk-sys unmaintained gtk-rs GTK3 bindings; tracking #8519
+    "RUSTSEC-2024-0419",  # gtk3-macros unmaintained gtk-rs GTK3 bindings; tracking #8519
+    "RUSTSEC-2024-0420",  # gtk-sys unmaintained gtk-rs GTK3 bindings; tracking #8519
+    # unic-* unmaintained unicode tables (transitive); tracking #8519
+    "RUSTSEC-2025-0075",  # unic-char-range unmaintained; tracking #8519
+    "RUSTSEC-2025-0080",  # unic-common unmaintained; tracking #8519
+    "RUSTSEC-2025-0081",  # unic-char-property unmaintained; tracking #8519
+    "RUSTSEC-2025-0098",  # unic-ucd-version unmaintained; tracking #8519
+    "RUSTSEC-2025-0100",  # unic-ucd-ident unmaintained; tracking #8519
+    # macro/font helpers unmaintained (transitive); tracking #8519
+    "RUSTSEC-2024-0370",  # proc-macro-error unmaintained; transitive macro helper; tracking #8519
+    "RUSTSEC-2026-0173",  # proc-macro-error2 unmaintained; transitive macro helper; tracking #8519
+    "RUSTSEC-2024-0388",  # derivative unmaintained; transitive derive helper; tracking #8519
+    "RUSTSEC-2026-0192",  # ttf-parser unmaintained; via pdf-extract -> lopdf; tracking #8519
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -36,6 +36,33 @@ ignore = [
     # transitive via zeroclaw-desktop (tauri -> webkit2gtk); glib 0.18.5 is the
     # latest compatible version with the GTK3 stack; fix requires gtk-rs series bump
     { id = "RUSTSEC-2024-0429", reason = "glib VariantStrIter unsoundness; transitive via zeroclaw-desktop/tauri/webkit2gtk; no compatible fix in glib 0.18.x series" },
+    # audit.toml/deny.toml drift reconcile + wasmtime-wasi CVEs; tracking #8519.
+    # wasmtime-wasi CVEs via zeroclaw-plugins; real fix is a wasmtime 43 -> 45.x bump (deferred).
+    { id = "RUSTSEC-2026-0149", reason = "wasmtime-wasi WASI path_open(TRUNCATE) bypasses FilePerms::WRITE; via zeroclaw-plugins; needs wasmtime >= 44.0.2; bump deferred; tracking #8519" },
+    { id = "RUSTSEC-2026-0182", reason = "wasmtime-wasi WASIp1 fd_renumber leak; via zeroclaw-plugins; needs wasmtime >= 44.0.3; bump deferred; tracking #8519" },
+    { id = "RUSTSEC-2026-0188", reason = "wasmtime-wasi hard link/rename FilePerms bypass; via zeroclaw-plugins; needs wasmtime >= 45.0.3; bump deferred; tracking #8519" },
+    # GTK3 stack unmaintained via zeroclaw-desktop (tauri -> webkit2gtk); tracking #8519.
+    { id = "RUSTSEC-2024-0411", reason = "gdkwayland-sys unmaintained gtk-rs GTK3 bindings; tracking #8519" },
+    { id = "RUSTSEC-2024-0412", reason = "gdk unmaintained gtk-rs GTK3 bindings; tracking #8519" },
+    { id = "RUSTSEC-2024-0413", reason = "atk unmaintained gtk-rs GTK3 bindings; tracking #8519" },
+    { id = "RUSTSEC-2024-0414", reason = "gdkx11-sys unmaintained gtk-rs GTK3 bindings; tracking #8519" },
+    { id = "RUSTSEC-2024-0415", reason = "gtk unmaintained gtk-rs GTK3 bindings; tracking #8519" },
+    { id = "RUSTSEC-2024-0416", reason = "atk-sys unmaintained gtk-rs GTK3 bindings; tracking #8519" },
+    { id = "RUSTSEC-2024-0417", reason = "gdkx11 unmaintained gtk-rs GTK3 bindings; tracking #8519" },
+    { id = "RUSTSEC-2024-0418", reason = "gdk-sys unmaintained gtk-rs GTK3 bindings; tracking #8519" },
+    { id = "RUSTSEC-2024-0419", reason = "gtk3-macros unmaintained gtk-rs GTK3 bindings; tracking #8519" },
+    { id = "RUSTSEC-2024-0420", reason = "gtk-sys unmaintained gtk-rs GTK3 bindings; tracking #8519" },
+    # unic-* unmaintained unicode tables (transitive); tracking #8519.
+    { id = "RUSTSEC-2025-0075", reason = "unic-char-range unmaintained; tracking #8519" },
+    { id = "RUSTSEC-2025-0080", reason = "unic-common unmaintained; tracking #8519" },
+    { id = "RUSTSEC-2025-0081", reason = "unic-char-property unmaintained; tracking #8519" },
+    { id = "RUSTSEC-2025-0098", reason = "unic-ucd-version unmaintained; tracking #8519" },
+    { id = "RUSTSEC-2025-0100", reason = "unic-ucd-ident unmaintained; tracking #8519" },
+    # macro/font helpers unmaintained (transitive); tracking #8519.
+    { id = "RUSTSEC-2024-0370", reason = "proc-macro-error unmaintained; transitive macro helper; tracking #8519" },
+    { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 unmaintained; transitive macro helper; tracking #8519" },
+    { id = "RUSTSEC-2024-0388", reason = "derivative unmaintained; transitive derive helper; tracking #8519" },
+    { id = "RUSTSEC-2026-0192", reason = "ttf-parser unmaintained; via pdf-extract -> lopdf; tracking #8519" },
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - The `cargo audit` CI step (`.github/workflows/ci.yml`) reads the entire `Cargo.lock` and was failing master on 22 RustSec advisories not listed in `.cargo/audit.toml`, while `cargo deny check` (graph-aware, reads `deny.toml`) tolerated most of them. The two advisory tools had drifted out of sync.
  - Add all 22 advisories to both `.cargo/audit.toml` and `deny.toml`, each with a reason referencing tracking issue #8519 (milestone v0.8.4).
  - 3 of the 22 are real `wasmtime-wasi` CVEs (RUSTSEC-2026-0149 / -0182 / -0188) pulled in via `zeroclaw-plugins`. The genuine fix is a `wasmtime` 43 to 45.x stack bump, deferred to #8519; ignored here only to unblock the gate. Dependabot PR #8490 (bump to 44.0.2) is insufficient: -0182 needs >= 44.0.3 and -0188 needs >= 45.0.3.
  - The other 19 are unmaintained-crate advisories with no available fix (GTK3 stack via `zeroclaw-desktop`, `unic-*` unicode tables, `proc-macro-error`/`proc-macro-error2`, `derivative`, `ttf-parser` via `pdf-extract` to `lopdf`), all transitive.
- **Scope boundary:** Only the two advisory-ignore lists change. No dependency versions are bumped, no `Cargo.lock` change, no source code touched. The wasmtime version bump is explicitly NOT done here.
- **Blast radius:** CI Security gate only. The ignore entries suppress advisory failures in `cargo audit` and `cargo deny`; they do not alter runtime behavior or the dependency graph.
- **Linked issue(s):** Related #8519
- **Labels:** `type:ci`, `domain:ci`, `domain:security`, `risk:medium`, `size:S`

## Validation Evidence (required)

This is a config-only change to the advisory-ignore lists; the relevant gates are `cargo audit` and `cargo deny check`, both of which now pass.

```bash
cargo audit
cargo deny check
cargo fmt --all -- --check
```

- **Commands run and tail output:**
  - `cargo audit` -> `Scanning Cargo.lock for vulnerabilities (1229 crate dependencies)`, exit 0 (was exit 1 before this change).
  - `cargo deny check` -> `advisories ok, bans ok, licenses ok, sources ok`, exit 0.
  - `cargo fmt --all -- --check` -> exit 0.
  - Both TOML files parse cleanly (`tomllib.load`).
- **Beyond CI:** Reproduced the master `cargo audit` failure locally on a clean `upstream/master` checkout (8ac9565), enumerated the exact 22 failing advisory IDs, confirmed each is either a deferred-bump CVE or an unfixable unmaintained advisory, then verified the gate goes green after the change. Did NOT verify the wasmtime 45.x bump compiles; that is deferred to #8519.
- **If any command was intentionally skipped, why:** `cargo clippy` and `cargo test` are unaffected; the diff contains no Rust and no lockfile change.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: The 3 wasmtime-wasi CVEs are real `FilePerms` bypass/leak issues in the WASM plugin sandbox. They are suppressed in CI only, not fixed. Exposure is limited to the optional `plugins-wasm` feature. The real remediation (wasmtime 45.x) is tracked in #8519 with the patched-version constraints recorded.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: no upgrade steps; CI-config-only change.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert d34b33458f`
- **Feature flags or config toggles:** None. Reverting restores the prior ignore lists.
- **Observable failure symptoms:** The Security CI job fails on the `cargo audit` step with `error: 1 vulnerability found` or unmaintained-warning denials; grep CI logs for `RUSTSEC-2026-0188` or `RUSTSEC-2025-0080`.
