### PR TITLE
fix(zerocode): improve quickstart provider reuse flow

### DIFF
--- a/apps/zerocode/locales/en/zerocode.ftl
+++ b/apps/zerocode/locales/en/zerocode.ftl
@@ -247,6 +247,11 @@ zc-quickstart-selector-agent = Agent
 zc-quickstart-selector-submit = Submit
 
 zc-quickstart-reuse-alias-help = Reuse this alias instead of creating a new one.
+zc-quickstart-existing-providers-heading = Existing providers
+zc-quickstart-existing-providers-show-more = [+ Show { $count } more existing providers]
+zc-quickstart-existing-providers-show-fewer = [- Show fewer existing providers]
+zc-quickstart-new-provider-heading = Create new provider
+zc-quickstart-provider-alias-exists = Alias `{ $alias }` already exists. Pick another alias or use the existing provider.
 
 zc-quickstart-risk-locked-down = Locked Down
 zc-quickstart-risk-locked-down-desc = Tight defaults. Workspace-only fs, approval on med/high risk.
@@ -297,6 +302,11 @@ zc-quickstart-status-first-error = { $where }{ $field }: { $message }{ $more }
 zc-quickstart-status-more-errors = { " " }(+{ $count } more)
 zc-quickstart-status-can-create = All required selectors ✓. Press `{ $chord }` to Create.
 zc-quickstart-status-hint = ↑/↓ to move, Enter to open. `{ $chord }` enables when all required selectors are ✓.
+zc-quickstart-missing-model-provider = Choose a model provider before creating.
+zc-quickstart-missing-risk-profile = Choose a risk profile before creating.
+zc-quickstart-missing-runtime-profile = Choose a runtime profile before creating.
+zc-quickstart-missing-memory = Choose a memory backend before creating.
+zc-quickstart-missing-agent = Name the agent before creating.
 
 zc-quickstart-channels-empty = No channels configured. An agent without channels still works via `zeroclaw agent <name>` from the CLI.
 zc-quickstart-channels-add = + Add channel

--- a/apps/zerocode/src/quickstart_pane.rs
+++ b/apps/zerocode/src/quickstart_pane.rs
@@ -3493,7 +3493,7 @@ mod tests {
         assert_eq!(labels[0], "openrouter.default");
         assert_eq!(labels[1], "openai.gpt5");
         assert!(
-            labels.iter().any(|label| *label == "OpenRouter"),
+            labels.contains(&"OpenRouter"),
             "create-new provider rows must remain visible"
         );
     }

--- a/apps/zerocode/src/quickstart_pane.rs
+++ b/apps/zerocode/src/quickstart_pane.rs
@@ -21,6 +21,7 @@ use std::sync::Arc;
 /// "bool value with length 7".
 const UNSET_DISPLAY: &str = "<unset>";
 const MODEL_CATALOG_MAX_ATTEMPTS: u8 = 2;
+const MODEL_PROVIDER_EXISTING_COLLAPSED_LIMIT: usize = 5;
 
 /// Upper bound on rendered secret-mask bullets. A pasted API key can be
 /// 100+ chars; one bullet per character wraps the masked value across
@@ -109,6 +110,18 @@ impl Selector {
         }
     }
 
+    fn from_step(step: QuickstartStep) -> Option<Self> {
+        match step {
+            QuickstartStep::ModelProvider => Some(Selector::ModelProvider),
+            QuickstartStep::RiskProfile => Some(Selector::RiskProfile),
+            QuickstartStep::RuntimeProfile => Some(Selector::RuntimeProfile),
+            QuickstartStep::Memory => Some(Selector::Memory),
+            QuickstartStep::Channels => Some(Selector::Channels),
+            QuickstartStep::PeerGroups => Some(Selector::PeerGroups),
+            QuickstartStep::Agent => Some(Selector::Agent),
+        }
+    }
+
     /// Localised title for the selector that owns a validation step, so
     /// a field error can name where the problem lives (e.g.
     /// `Model provider / alias: …`) instead of only a count.
@@ -152,11 +165,60 @@ fn retain_filled_selector_errors(
         .collect()
 }
 
-fn next_selector_index_after(sel: Selector) -> Option<usize> {
+fn first_incomplete_required_selector(form: &FormState) -> Option<Selector> {
+    Selector::ALL.iter().copied().find(|sel| {
+        !matches!(
+            sel,
+            Selector::Submit | Selector::Channels | Selector::PeerGroups
+        ) && !form.is_satisfied(*sel)
+    })
+}
+
+fn incomplete_submit_error(form: &FormState) -> Option<QuickstartError> {
+    let sel = first_incomplete_required_selector(form)?;
+    let message_key = match sel {
+        Selector::ModelProvider => "zc-quickstart-missing-model-provider",
+        Selector::RiskProfile => "zc-quickstart-missing-risk-profile",
+        Selector::RuntimeProfile => "zc-quickstart-missing-runtime-profile",
+        Selector::Memory => "zc-quickstart-missing-memory",
+        Selector::Agent => "zc-quickstart-missing-agent",
+        Selector::Channels | Selector::PeerGroups | Selector::Submit => return None,
+    };
+    Some(QuickstartError {
+        step: sel.step(),
+        field: String::new(),
+        message: crate::i18n::t(message_key),
+    })
+}
+
+fn errors_include_selector(errors: &[QuickstartError], sel: Selector) -> bool {
+    let step = sel.step();
+    errors.iter().any(|e| e.step == step)
+}
+
+fn next_selector_index_after(sel: Selector, form: &FormState) -> Option<usize> {
+    let current = Selector::ALL.iter().position(|s| *s == sel)?;
+    let next = (current + 1).min(Selector::ALL.len().saturating_sub(1));
+
     Selector::ALL
         .iter()
-        .position(|s| *s == sel)
-        .map(|idx| (idx + 1).min(Selector::ALL.len().saturating_sub(1)))
+        .enumerate()
+        .skip(next)
+        .find_map(|(idx, candidate)| {
+            if selector_needs_attention(*candidate, form) {
+                Some(idx)
+            } else {
+                None
+            }
+        })
+        .or(Some(next))
+}
+
+fn selector_needs_attention(sel: Selector, form: &FormState) -> bool {
+    match sel {
+        Selector::Submit => form.all_selectors_satisfied(),
+        _ => !form.is_satisfied(sel),
+    }
 }
 
 fn apply_model_catalog_result(form: &mut FieldFormModal, models: Option<Vec<String>>) {
@@ -180,7 +242,9 @@ fn opt(value: &str, label: impl Into<String>, help: impl Into<String>) -> Picker
         value: value.to_string(),
         label: label.into(),
         help: help.into(),
-        use_existing: false,
+        kind: PickerOptionKind::Choice {
+            use_existing: false,
+        },
     }
 }
 
@@ -189,7 +253,49 @@ fn existing_opt(alias: String) -> PickerOption {
         label: format!("Use existing: {alias}"),
         value: alias,
         help: crate::i18n::t("zc-quickstart-reuse-alias-help"),
-        use_existing: true,
+        kind: PickerOptionKind::Choice { use_existing: true },
+    }
+}
+
+fn existing_provider_opt(alias: String) -> PickerOption {
+    PickerOption {
+        label: alias.clone(),
+        value: alias,
+        help: crate::i18n::t("zc-quickstart-reuse-alias-help"),
+        kind: PickerOptionKind::Choice { use_existing: true },
+    }
+}
+
+fn header_opt(label: impl Into<String>) -> PickerOption {
+    PickerOption {
+        value: String::new(),
+        label: label.into(),
+        help: String::new(),
+        kind: PickerOptionKind::Header,
+    }
+}
+
+fn existing_provider_toggle_opt(hidden_count: usize, expanded: bool) -> PickerOption {
+    let label = if expanded {
+        format!(
+            "  {}",
+            crate::i18n::t("zc-quickstart-existing-providers-show-fewer")
+        )
+    } else {
+        let count = hidden_count.to_string();
+        format!(
+            "  {}",
+            crate::i18n::t_args(
+                "zc-quickstart-existing-providers-show-more",
+                &[("count", count.as_str())],
+            )
+        )
+    };
+    PickerOption {
+        value: String::new(),
+        label,
+        help: String::new(),
+        kind: PickerOptionKind::ExistingProviderToggle { expanded },
     }
 }
 
@@ -325,12 +431,7 @@ fn memory_options() -> Vec<PickerOption> {
                 .ok()
                 .and_then(|v| v.as_str().map(str::to_string))
                 .unwrap_or_else(|| format!("{kind:?}").to_lowercase());
-            PickerOption {
-                value: wire.clone(),
-                label: wire,
-                help: String::new(),
-                use_existing: false,
-            }
+            opt(&wire, wire.clone(), String::new())
         })
         .collect()
 }
@@ -355,9 +456,65 @@ fn provider_type_options(snapshot: Option<&QuickstartStateResult>) -> Vec<Picker
             } else {
                 crate::i18n::t("zc-quickstart-provider-cloud")
             },
-            use_existing: false,
+            kind: PickerOptionKind::Choice {
+                use_existing: false,
+            },
         })
         .collect()
+}
+
+fn ordered_existing_provider_refs(existing: &[String]) -> Vec<String> {
+    let mut refs: Vec<String> = existing.to_vec();
+    refs.sort_by(|a, b| {
+        let rank = |value: &str| {
+            if value == "openrouter.default" {
+                0
+            } else if value.ends_with(".default") {
+                1
+            } else {
+                2
+            }
+        };
+        rank(a).cmp(&rank(b)).then_with(|| a.cmp(b))
+    });
+    refs
+}
+
+fn model_provider_picker_options(
+    snapshot: Option<&QuickstartStateResult>,
+    existing_expanded: bool,
+) -> Vec<PickerOption> {
+    let Some(snap) = snapshot else {
+        return Vec::new();
+    };
+
+    let mut options = Vec::new();
+    let existing = ordered_existing_provider_refs(&snap.model_providers);
+    if !existing.is_empty() {
+        options.push(header_opt(crate::i18n::t(
+            "zc-quickstart-existing-providers-heading",
+        )));
+        let visible_count = if existing_expanded {
+            existing.len()
+        } else {
+            existing.len().min(MODEL_PROVIDER_EXISTING_COLLAPSED_LIMIT)
+        };
+        for alias in existing.iter().take(visible_count) {
+            options.push(existing_provider_opt(alias.clone()));
+        }
+        if existing.len() > MODEL_PROVIDER_EXISTING_COLLAPSED_LIMIT {
+            options.push(existing_provider_toggle_opt(
+                existing.len() - MODEL_PROVIDER_EXISTING_COLLAPSED_LIMIT,
+                existing_expanded,
+            ));
+        }
+    }
+
+    options.push(header_opt(crate::i18n::t(
+        "zc-quickstart-new-provider-heading",
+    )));
+    options.extend(provider_type_options(snapshot));
+    options
 }
 
 fn channel_type_options(snapshot: Option<&QuickstartStateResult>) -> Vec<PickerOption> {
@@ -373,7 +530,9 @@ fn channel_type_options(snapshot: Option<&QuickstartStateResult>) -> Vec<PickerO
             value: t.kind.clone(),
             label: t.display_name.clone(),
             help: format!("Configure a new {} channel.", t.display_name),
-            use_existing: false,
+            kind: PickerOptionKind::Choice {
+                use_existing: false,
+            },
         })
         .collect()
 }
@@ -493,6 +652,10 @@ impl FormState {
                 )
             })
             .all(|s| self.is_satisfied(*s))
+    }
+
+    fn selector_is_complete(&self, sel: Selector, errors: &[QuickstartError]) -> bool {
+        self.is_satisfied(sel) && !errors_include_selector(errors, sel)
     }
 
     fn summary(&self, sel: Selector) -> String {
@@ -849,6 +1012,13 @@ fn byte_index_at_char(s: &str, char_idx: usize) -> usize {
         .unwrap_or(s.len())
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PickerOptionKind {
+    Choice { use_existing: bool },
+    Header,
+    ExistingProviderToggle { expanded: bool },
+}
+
 #[derive(Clone)]
 struct PickerOption {
     /// Wire-side value written back into [`FormState`].
@@ -857,10 +1027,24 @@ struct PickerOption {
     label: String,
     /// One-line help / blurb.
     help: String,
-    /// `true` when this option points at an already-configured alias
-    /// (`SelectorChoice::Existing`). `false` for fresh presets / type
-    /// rows that build a `SelectorChoice::Fresh`.
-    use_existing: bool,
+    kind: PickerOptionKind,
+}
+
+impl PickerOption {
+    fn is_selectable(&self) -> bool {
+        !matches!(self.kind, PickerOptionKind::Header)
+    }
+
+    fn use_existing(&self) -> bool {
+        matches!(self.kind, PickerOptionKind::Choice { use_existing: true })
+    }
+
+    fn existing_provider_toggle_expanded(&self) -> Option<bool> {
+        match self.kind {
+            PickerOptionKind::ExistingProviderToggle { expanded } => Some(expanded),
+            _ => None,
+        }
+    }
 }
 
 pub struct QuickstartPane {
@@ -1019,6 +1203,8 @@ impl QuickstartPane {
                     if matches!(sel, Selector::Submit) {
                         if self.can_create() {
                             self.submit().await;
+                        } else {
+                            self.report_incomplete_submit();
                         }
                     } else {
                         self.open_modal_for(sel);
@@ -1029,6 +1215,8 @@ impl QuickstartPane {
             Some(QuickstartTabAction::Create) => {
                 if self.can_create() {
                     self.submit().await;
+                } else {
+                    self.report_incomplete_submit();
                 }
                 false
             }
@@ -1106,6 +1294,9 @@ impl QuickstartPane {
                         .enumerate()
                         .find(|(_, r)| in_rect(col, row, **r))
                     {
+                        if !self.modal_row_is_selectable(idx) {
+                            return;
+                        }
                         self.set_modal_cursor(idx);
                         // Synthesise the same Enter behaviour the
                         // keyboard takes.
@@ -1143,6 +1334,8 @@ impl QuickstartPane {
                         if matches!(sel, Selector::Submit) {
                             if self.can_create() {
                                 self.submit().await;
+                            } else {
+                                self.report_incomplete_submit();
                             }
                         } else {
                             self.open_modal_for(sel);
@@ -1168,13 +1361,16 @@ impl QuickstartPane {
             editor.scroll_lines(delta);
             return;
         }
+        if let Modal::Picker(p) = modal {
+            p.cursor = wrapped_selectable_option_index(&p.options, p.cursor, delta);
+            return;
+        }
         let (cur, len) = match modal {
-            Modal::Picker(p) => (&mut p.cursor, p.options.len()),
             Modal::FieldForm(f) => (&mut f.cursor, f.fields.len()),
             Modal::ChannelList(cl) => (&mut cl.cursor, self.modal_row_rects.len()),
             Modal::PeerGroupList(pl) => (&mut pl.cursor, self.modal_row_rects.len()),
             Modal::Agent(a) => (&mut a.cursor, self.modal_row_rects.len()),
-            Modal::TextInput(_) => return,
+            Modal::Picker(_) | Modal::TextInput(_) => return,
         };
         if len == 0 {
             return;
@@ -1191,7 +1387,7 @@ impl QuickstartPane {
         };
         match modal {
             Modal::Picker(p) => {
-                if idx < p.options.len() {
+                if p.options.get(idx).is_some_and(PickerOption::is_selectable) {
                     p.cursor = idx;
                 }
             }
@@ -1220,6 +1416,14 @@ impl QuickstartPane {
         }
     }
 
+    fn modal_row_is_selectable(&self, idx: usize) -> bool {
+        match self.active_modal.as_ref() {
+            Some(Modal::Picker(p)) => p.options.get(idx).is_some_and(PickerOption::is_selectable),
+            Some(Modal::TextInput(_)) | None => false,
+            _ => true,
+        }
+    }
+
     fn move_selection(&mut self, delta: i32) {
         let len = Selector::ALL.len() as i32;
         let current = self.list_state.selected().unwrap_or(0) as i32;
@@ -1228,8 +1432,31 @@ impl QuickstartPane {
     }
 
     fn advance_after_completed(&mut self, sel: Selector) {
-        if let Some(next) = next_selector_index_after(sel) {
+        if let Some(next) = next_selector_index_after(sel, &self.form) {
             self.list_state.select(Some(next));
+        }
+    }
+
+    fn keep_selector_selected(&mut self, sel: Selector) {
+        if let Some(idx) = Selector::ALL.iter().position(|candidate| *candidate == sel) {
+            self.list_state.select(Some(idx));
+        }
+    }
+
+    fn advance_after_validated(&mut self, sel: Selector) {
+        if errors_include_selector(&self.last_errors, sel) {
+            self.keep_selector_selected(sel);
+        } else {
+            self.advance_after_completed(sel);
+        }
+    }
+
+    fn report_incomplete_submit(&mut self) {
+        if let Some(error) = incomplete_submit_error(&self.form) {
+            if let Some(sel) = Selector::from_step(error.step) {
+                self.keep_selector_selected(sel);
+            }
+            self.last_errors = vec![error];
         }
     }
 
@@ -1261,18 +1488,13 @@ impl QuickstartPane {
                 }));
             }
             Selector::ModelProvider => {
-                let mut options: Vec<PickerOption> =
-                    provider_type_options(self.state_snapshot.as_ref());
-                if let Some(snap) = &self.state_snapshot {
-                    for alias in &snap.model_providers {
-                        options.push(existing_opt(alias.clone()));
-                    }
-                }
+                let options = model_provider_picker_options(self.state_snapshot.as_ref(), false);
+                let cursor = current_provider_picker_cursor(&options, &self.form);
                 self.active_modal = Some(Modal::Picker(PickerModal {
                     selector: sel,
                     purpose: PickerPurpose::ProviderType,
                     options,
-                    cursor: 0,
+                    cursor,
                 }));
             }
             Selector::Channels => {
@@ -1352,15 +1574,37 @@ impl QuickstartPane {
                 Some(QuickstartModalAction::Cancel) => {
                     self.active_modal = None;
                 }
-                Some(QuickstartModalAction::Up) if p.cursor > 0 => {
-                    p.cursor -= 1;
+                Some(QuickstartModalAction::Up) => {
+                    if let Some(next) = adjacent_selectable_option_index(&p.options, p.cursor, -1) {
+                        p.cursor = next;
+                    }
                 }
-                Some(QuickstartModalAction::Down) if p.cursor + 1 < p.options.len() => {
-                    p.cursor += 1;
+                Some(QuickstartModalAction::Down) => {
+                    if let Some(next) = adjacent_selectable_option_index(&p.options, p.cursor, 1) {
+                        p.cursor = next;
+                    }
                 }
                 Some(QuickstartModalAction::Confirm) => {
+                    if let Some(expanded) = p.options[p.cursor].existing_provider_toggle_expanded()
+                    {
+                        p.options =
+                            model_provider_picker_options(self.state_snapshot.as_ref(), !expanded);
+                        p.cursor = p
+                            .options
+                            .iter()
+                            .position(|option| {
+                                option.existing_provider_toggle_expanded() == Some(!expanded)
+                            })
+                            .unwrap_or_else(|| {
+                                nearest_selectable_option_index(&p.options, p.cursor)
+                            });
+                        return;
+                    }
+                    if !p.options[p.cursor].is_selectable() {
+                        return;
+                    }
                     let chosen = p.options[p.cursor].value.clone();
-                    let use_existing = p.options[p.cursor].use_existing;
+                    let use_existing = p.options[p.cursor].use_existing();
                     let selector = p.selector;
                     let purpose = p.purpose;
                     match (purpose, use_existing) {
@@ -1368,13 +1612,13 @@ impl QuickstartPane {
                             self.apply_picker_choice(selector, chosen, use_existing);
                             self.active_modal = None;
                             self.revalidate().await;
-                            self.advance_after_completed(selector);
+                            self.advance_after_validated(selector);
                         }
                         (PickerPurpose::ProviderType, true) => {
                             self.adopt_existing_provider(chosen);
                             self.active_modal = None;
                             self.revalidate().await;
-                            self.advance_after_completed(selector);
+                            self.advance_after_validated(selector);
                         }
                         (PickerPurpose::ProviderType, false) => {
                             self.active_modal = None;
@@ -1389,7 +1633,7 @@ impl QuickstartPane {
                             self.adopt_existing_channel(chosen);
                             self.active_modal = None;
                             self.revalidate().await;
-                            self.advance_after_completed(selector);
+                            self.advance_after_validated(selector);
                         }
                         (PickerPurpose::ChannelType, false) => {
                             self.active_modal = None;
@@ -1460,6 +1704,17 @@ impl QuickstartPane {
                     self.active_modal = None;
                 }
                 Some(QuickstartModalAction::NextField) | Some(QuickstartModalAction::Down) => {
+                    if let Some(error) =
+                        current_field_form_duplicate_error(self.state_snapshot.as_ref(), f)
+                    {
+                        self.last_errors = vec![error];
+                        return;
+                    }
+                    if current_field_form_row_is_model_provider_alias(f) {
+                        self.last_errors.retain(|e| {
+                            e.step != QuickstartStep::ModelProvider || e.field != "alias"
+                        });
+                    }
                     if f.cursor + 1 < f.fields.len() {
                         f.cursor += 1;
                     } else {
@@ -1475,6 +1730,17 @@ impl QuickstartPane {
                 }
                 Some(QuickstartModalAction::Confirm) => {
                     if f.cursor + 1 < f.fields.len() {
+                        if let Some(error) =
+                            current_field_form_duplicate_error(self.state_snapshot.as_ref(), f)
+                        {
+                            self.last_errors = vec![error];
+                            return;
+                        }
+                        if current_field_form_row_is_model_provider_alias(f) {
+                            self.last_errors.retain(|e| {
+                                e.step != QuickstartStep::ModelProvider || e.field != "alias"
+                            });
+                        }
                         f.cursor += 1;
                         return;
                     }
@@ -1491,9 +1757,11 @@ impl QuickstartPane {
                             Some(Modal::ChannelList(ChannelListModal { cursor: 0 }));
                     } else {
                         self.active_modal = None;
-                        self.advance_after_completed(selector);
                     }
                     self.revalidate().await;
+                    if !from_channel {
+                        self.advance_after_validated(selector);
+                    }
                 }
                 Some(QuickstartModalAction::Left) => {
                     let variants = f
@@ -1590,7 +1858,8 @@ impl QuickstartPane {
                             }));
                         } else if cl.cursor == drafts + 1 {
                             self.active_modal = None;
-                            self.advance_after_completed(Selector::Channels);
+                            self.revalidate().await;
+                            self.advance_after_validated(Selector::Channels);
                         }
                     }
                     _ => {}
@@ -1629,7 +1898,8 @@ impl QuickstartPane {
                             }
                         } else if pl.cursor == drafts + 1 {
                             self.active_modal = None;
-                            self.advance_after_completed(Selector::PeerGroups);
+                            self.revalidate().await;
+                            self.advance_after_validated(Selector::PeerGroups);
                         }
                     }
                     _ => {}
@@ -1676,7 +1946,7 @@ impl QuickstartPane {
                         self.commit_agent_modal();
                         self.active_modal = None;
                         self.revalidate().await;
-                        self.advance_after_completed(Selector::Agent);
+                        self.advance_after_validated(Selector::Agent);
                     }
                     Some(QuickstartModalAction::NextField) | Some(QuickstartModalAction::Down)
                         if a.cursor + 1 < row_count =>
@@ -1822,12 +2092,7 @@ impl QuickstartPane {
         refs.sort();
         refs.dedup();
         refs.into_iter()
-            .map(|r| PickerOption {
-                label: r.clone(),
-                value: r,
-                help: String::new(),
-                use_existing: false,
-            })
+            .map(|r| opt(&r, r.clone(), String::new()))
             .collect()
     }
 
@@ -1877,7 +2142,8 @@ impl QuickstartPane {
         // frozen modal while the catalog RPC runs. The row builder also
         // handles bool toggles, enum defaults, and the synthetic model
         // provider alias row.
-        let rows = build_field_form_rows(section, fields, None);
+        let mut rows = build_field_form_rows(section, fields, None);
+        restore_field_form_rows_from_form(section, &type_key, &mut rows, &self.form);
         let model_catalog_state = if is_model_provider {
             ModelCatalogState::Pending
         } else {
@@ -1980,6 +2246,18 @@ impl QuickstartPane {
                     message: format!("Required field `{k}` is empty"),
                 })
                 .collect();
+            return false;
+        }
+        if let Some(error) = model_provider_alias_duplicate_error(self.state_snapshot.as_ref(), f) {
+            let alias_idx = f
+                .fields
+                .iter()
+                .position(|row| row.descriptor.key == "alias")
+                .unwrap_or(0);
+            self.last_errors = vec![error];
+            if let Some(Modal::FieldForm(form)) = self.active_modal.as_mut() {
+                form.cursor = alias_idx;
+            }
             return false;
         }
         match f.selector {
@@ -2090,7 +2368,7 @@ impl QuickstartPane {
     }
 
     fn can_create(&self) -> bool {
-        self.form.all_selectors_satisfied() && !self.busy
+        self.form.all_selectors_satisfied() && self.last_errors.is_empty() && !self.busy
     }
 
     async fn submit(&mut self) {
@@ -2119,16 +2397,9 @@ impl QuickstartPane {
     }
 
     fn handle_apply_success(&mut self, agent: AppliedAgent, daemon_restarted: bool) {
-        // Arm the Stage-2 hand-off **before** any daemon reload can kick
-        // in. When reload is signalled the socket dies shortly after
-        // this returns, the TUI waits during the disconnect, and the
-        // next `app::run` pane rebuild consumes the pending reconnect
-        // chat handoff.
-        //
-        // Test/standalone daemons can report `daemon_restarted = false`.
-        // In that case no disconnect is coming, so freezing Quickstart
-        // behind `applied_alias` strands the user. Queue an immediate
-        // connected-client handoff instead.
+        // A real daemon reload must survive the old connection closing:
+        // use the immediate handoff only when the daemon reports that no
+        // reconnect is needed.
         self.applied_alias =
             queue_apply_handoff(&self.reconnect_state, agent.alias, daemon_restarted);
         self.last_errors.clear();
@@ -2146,7 +2417,7 @@ impl QuickstartPane {
         let items: Vec<ListItem> = Selector::ALL
             .iter()
             .map(|sel| {
-                let satisfied = self.form.is_satisfied(*sel);
+                let satisfied = self.form.selector_is_complete(*sel, &self.last_errors);
                 let glyph_style = if satisfied {
                     Style::default()
                         .fg(Color::Green)
@@ -2226,14 +2497,12 @@ impl QuickstartPane {
         } else {
             crate::i18n::t_args("zc-quickstart-status-hint", &[("chord", "c")])
         };
-        let style = if self.applied_alias.is_some() {
+        let style = if self.applied_alias.is_some() || can_create {
             Style::default()
                 .fg(Color::Green)
                 .add_modifier(Modifier::BOLD)
         } else if !self.last_errors.is_empty() {
             Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)
-        } else if can_create {
-            theme::accent_style()
         } else {
             theme::dim_style()
         };
@@ -2294,6 +2563,180 @@ fn apply_model_catalog_to_rows(rows: &mut [FieldFormRow], model_catalog: Option<
             row.descriptor.enum_variants = Some(models.to_vec());
             if !models.contains(&row.buf) {
                 row.buf = models[0].clone();
+            }
+        }
+    }
+}
+
+fn first_selectable_option_index(options: &[PickerOption]) -> usize {
+    options
+        .iter()
+        .position(PickerOption::is_selectable)
+        .unwrap_or(0)
+}
+
+fn nearest_selectable_option_index(options: &[PickerOption], preferred: usize) -> usize {
+    if options
+        .get(preferred)
+        .is_some_and(PickerOption::is_selectable)
+    {
+        return preferred;
+    }
+    options
+        .iter()
+        .enumerate()
+        .skip(preferred.saturating_add(1))
+        .find(|(_, option)| option.is_selectable())
+        .map(|(idx, _)| idx)
+        .or_else(|| {
+            options
+                .iter()
+                .enumerate()
+                .take(preferred)
+                .rev()
+                .find(|(_, option)| option.is_selectable())
+                .map(|(idx, _)| idx)
+        })
+        .unwrap_or(0)
+}
+
+fn adjacent_selectable_option_index(
+    options: &[PickerOption],
+    current: usize,
+    delta: i32,
+) -> Option<usize> {
+    if delta < 0 {
+        options
+            .iter()
+            .enumerate()
+            .take(current)
+            .rev()
+            .find(|(_, option)| option.is_selectable())
+            .map(|(idx, _)| idx)
+    } else {
+        options
+            .iter()
+            .enumerate()
+            .skip(current.saturating_add(1))
+            .find(|(_, option)| option.is_selectable())
+            .map(|(idx, _)| idx)
+    }
+}
+
+fn wrapped_selectable_option_index(options: &[PickerOption], current: usize, delta: i32) -> usize {
+    if options.is_empty() {
+        return 0;
+    }
+    let mut next = current.min(options.len().saturating_sub(1));
+    for _ in 0..options.len() {
+        next = (next as i32 + delta).rem_euclid(options.len() as i32) as usize;
+        if options[next].is_selectable() {
+            return next;
+        }
+    }
+    current.min(options.len().saturating_sub(1))
+}
+
+fn current_provider_picker_cursor(options: &[PickerOption], form: &FormState) -> usize {
+    if form.provider_type.is_empty() {
+        return first_selectable_option_index(options);
+    }
+
+    let target = if form.provider_mode == SelectorMode::Existing && !form.provider_alias.is_empty()
+    {
+        format!("{}.{}", form.provider_type, form.provider_alias)
+    } else {
+        form.provider_type.clone()
+    };
+
+    options
+        .iter()
+        .position(|o| o.value == target && o.is_selectable())
+        .unwrap_or_else(|| first_selectable_option_index(options))
+}
+
+fn model_provider_alias_value(form: &FieldFormModal) -> String {
+    form.fields
+        .iter()
+        .find(|row| row.descriptor.key == "alias")
+        .map(|row| row.buf.trim().to_string())
+        .filter(|alias| !alias.is_empty())
+        .unwrap_or_else(|| form.alias.clone())
+}
+
+fn model_provider_alias_duplicate_error(
+    snapshot: Option<&QuickstartStateResult>,
+    form: &FieldFormModal,
+) -> Option<QuickstartError> {
+    if form.selector != Selector::ModelProvider {
+        return None;
+    }
+    let alias = model_provider_alias_value(form);
+    if alias.trim().is_empty() {
+        return None;
+    }
+    let dotted = format!("{}.{}", form.type_key, alias.trim());
+    let exists = snapshot?
+        .model_providers
+        .iter()
+        .any(|existing| existing == &dotted);
+    if !exists {
+        return None;
+    }
+    Some(QuickstartError {
+        step: QuickstartStep::ModelProvider,
+        field: "alias".into(),
+        message: crate::i18n::t_args(
+            "zc-quickstart-provider-alias-exists",
+            &[("alias", dotted.as_str())],
+        ),
+    })
+}
+
+fn current_field_form_duplicate_error(
+    snapshot: Option<&QuickstartStateResult>,
+    form: &FieldFormModal,
+) -> Option<QuickstartError> {
+    let row = form.fields.get(form.cursor)?;
+    if row.descriptor.key != "alias" {
+        return None;
+    }
+    model_provider_alias_duplicate_error(snapshot, form)
+}
+
+fn current_field_form_row_is_model_provider_alias(form: &FieldFormModal) -> bool {
+    form.selector == Selector::ModelProvider
+        && form
+            .fields
+            .get(form.cursor)
+            .is_some_and(|row| row.descriptor.key == "alias")
+}
+
+fn restore_field_form_rows_from_form(
+    section: QuickstartFieldSection,
+    type_key: &str,
+    rows: &mut [FieldFormRow],
+    form: &FormState,
+) {
+    if !matches!(section, QuickstartFieldSection::ModelProvider)
+        || form.provider_type != type_key
+        || form.provider_mode != SelectorMode::Fresh
+    {
+        return;
+    }
+
+    for row in rows {
+        match row.descriptor.key.as_str() {
+            "alias" if !form.provider_alias.is_empty() => {
+                row.buf = form.provider_alias.clone();
+            }
+            "model" if !form.model.is_empty() => {
+                row.buf = form.model.clone();
+            }
+            key => {
+                if let Some(value) = form.provider_fields.get(key) {
+                    row.buf = value.clone();
+                }
             }
         }
     }
@@ -2997,6 +3440,126 @@ mod tests {
         f
     }
 
+    fn model_provider_snapshot(existing: Vec<&str>) -> QuickstartStateResult {
+        QuickstartStateResult {
+            quickstart_completed: false,
+            agents: Vec::new(),
+            risk_profiles: Vec::new(),
+            runtime_profiles: Vec::new(),
+            model_providers: existing.into_iter().map(str::to_string).collect(),
+            channels: Vec::new(),
+            unassigned_channels: Vec::new(),
+            storage: Vec::new(),
+            model_provider_types: vec![
+                crate::client::QuickstartTypeOption {
+                    kind: "openrouter".into(),
+                    display_name: "OpenRouter".into(),
+                    local: false,
+                },
+                crate::client::QuickstartTypeOption {
+                    kind: "anthropic".into(),
+                    display_name: "Anthropic".into(),
+                    local: false,
+                },
+                crate::client::QuickstartTypeOption {
+                    kind: "ollama".into(),
+                    display_name: "Ollama".into(),
+                    local: true,
+                },
+            ],
+            channel_types: Vec::new(),
+            risk_presets: Vec::new(),
+            runtime_presets: Vec::new(),
+            memory_kinds: Vec::new(),
+            personality_files: Vec::new(),
+        }
+    }
+
+    fn selectable_labels(options: &[PickerOption]) -> Vec<&str> {
+        options
+            .iter()
+            .filter(|option| option.is_selectable())
+            .map(|option| option.label.as_str())
+            .collect()
+    }
+
+    #[test]
+    fn model_provider_picker_groups_existing_first_without_hiding_new_provider() {
+        let snap = model_provider_snapshot(vec!["openrouter.default", "openai.gpt5"]);
+
+        let options = model_provider_picker_options(Some(&snap), false);
+        let labels = selectable_labels(&options);
+
+        assert_eq!(labels[0], "openrouter.default");
+        assert_eq!(labels[1], "openai.gpt5");
+        assert!(
+            labels.iter().any(|label| *label == "OpenRouter"),
+            "create-new provider rows must remain visible"
+        );
+    }
+
+    #[test]
+    fn model_provider_picker_collapses_existing_provider_overflow() {
+        let snap = model_provider_snapshot(vec![
+            "openrouter.default",
+            "openai.gpt5",
+            "anthropic.sonnet",
+            "anthropic.haiku",
+            "ollama.local",
+            "groq.default",
+            "xai.grok",
+        ]);
+
+        let collapsed = model_provider_picker_options(Some(&snap), false);
+        let collapsed_labels = selectable_labels(&collapsed);
+        assert!(collapsed_labels.contains(&"  [+ Show 2 more existing providers]"));
+        assert!(!collapsed_labels.contains(&"xai.grok"));
+
+        let expanded = model_provider_picker_options(Some(&snap), true);
+        let expanded_labels = selectable_labels(&expanded);
+        assert!(expanded_labels.contains(&"xai.grok"));
+        assert!(expanded_labels.contains(&"  [- Show fewer existing providers]"));
+        assert!(expanded_labels.contains(&"OpenRouter"));
+    }
+
+    #[test]
+    fn model_provider_alias_duplicate_is_caught_from_snapshot() {
+        let snap = model_provider_snapshot(vec!["openrouter.default"]);
+        let mut form = FieldFormModal {
+            selector: Selector::ModelProvider,
+            type_key: "openrouter".into(),
+            alias: "default".into(),
+            model_catalog_state: ModelCatalogState::NotApplicable,
+            model_catalog_attempts: 0,
+            fields: vec![model_provider_alias_row()],
+            cursor: 0,
+        };
+        form.fields[0].buf = "default".into();
+
+        let error = model_provider_alias_duplicate_error(Some(&snap), &form).expect("duplicate");
+
+        assert_eq!(error.step, QuickstartStep::ModelProvider);
+        assert_eq!(error.field, "alias");
+        assert!(error.message.contains("openrouter.default"));
+    }
+
+    #[test]
+    fn model_provider_alias_duplicate_check_allows_new_aliases() {
+        let snap = model_provider_snapshot(vec!["openrouter.default"]);
+        let mut form = FieldFormModal {
+            selector: Selector::ModelProvider,
+            type_key: "openrouter".into(),
+            alias: "default".into(),
+            model_catalog_state: ModelCatalogState::NotApplicable,
+            model_catalog_attempts: 0,
+            fields: vec![model_provider_alias_row()],
+            cursor: 0,
+        };
+        form.fields[0].buf = "work".into();
+
+        assert!(model_provider_alias_duplicate_error(Some(&snap), &form).is_none());
+    }
+
     #[test]
     fn submit_is_excluded_from_completeness() {
         // Regression: can_create walked Selector::ALL including Submit,
@@ -3018,6 +3581,20 @@ mod tests {
         let mut f = complete_form();
         f.agent_name.clear();
         assert!(!f.all_selectors_satisfied());
+    }
+
+    #[test]
+    fn incomplete_submit_reports_first_missing_required_selector() {
+        let mut f = complete_form();
+        f.channels.clear();
+        f.peer_groups.clear();
+        f.agent_name.clear();
+
+        let error = incomplete_submit_error(&f).expect("missing required selector");
+
+        assert_eq!(error.step, QuickstartStep::Agent);
+        assert_eq!(error.field, String::new());
+        assert!(error.message.contains("Name the agent"));
     }
 
     #[test]
@@ -3061,7 +3638,7 @@ mod tests {
     }
 
     #[test]
-    fn apply_handoff_starts_chat_and_preserves_reconnect_when_reload_was_signalled() {
+    fn apply_handoff_waits_for_reconnect_when_reload_was_signalled() {
         let state = std::sync::Arc::new(std::sync::Mutex::new(
             crate::app::CrossReconnectState::default(),
         ));
@@ -3189,6 +3766,75 @@ mod tests {
     }
 
     #[test]
+    fn model_provider_picker_reopens_on_current_provider() {
+        let options = vec![
+            opt("anthropic", "Anthropic", ""),
+            opt("openai", "OpenAI", ""),
+            existing_opt("openai.default".into()),
+        ];
+        let mut form = FormState::default_form();
+
+        form.provider_type = "openai".into();
+        form.provider_mode = SelectorMode::Fresh;
+        assert_eq!(current_provider_picker_cursor(&options, &form), 1);
+
+        form.provider_alias = "default".into();
+        form.provider_mode = SelectorMode::Existing;
+        assert_eq!(current_provider_picker_cursor(&options, &form), 2);
+    }
+
+    #[test]
+    fn model_provider_form_reopens_with_staged_values() {
+        let fields = vec![
+            QuickstartFieldDescriptor {
+                key: "model".into(),
+                label: "model".into(),
+                help: String::new(),
+                kind: crate::client::QuickstartFieldKind::String,
+                is_secret: false,
+                enum_variants: None,
+                required: true,
+                default: None,
+            },
+            QuickstartFieldDescriptor {
+                key: "api_key".into(),
+                label: "api_key".into(),
+                help: String::new(),
+                kind: crate::client::QuickstartFieldKind::String,
+                is_secret: true,
+                enum_variants: None,
+                required: false,
+                default: None,
+            },
+        ];
+        let mut form = FormState::default_form();
+        form.provider_type = "openai".into();
+        form.provider_alias = "work".into();
+        form.provider_mode = SelectorMode::Fresh;
+        form.model = "gpt-5".into();
+        form.provider_fields.insert(
+            "api_key".into(),
+            "sk-test-value-that-is-long-enough-to-wrap".into(),
+        );
+
+        let mut rows = build_field_form_rows(QuickstartFieldSection::ModelProvider, fields, None);
+        restore_field_form_rows_from_form(
+            QuickstartFieldSection::ModelProvider,
+            "openai",
+            &mut rows,
+            &form,
+        );
+
+        assert_eq!(rows[0].descriptor.key, "alias");
+        assert_eq!(rows[0].buf, "work");
+        assert_eq!(rows[1].descriptor.key, "model");
+        assert_eq!(rows[1].buf, "gpt-5");
+        assert_eq!(rows[2].descriptor.key, "api_key");
+        assert_eq!(rows[2].buf, "sk-test-value-that-is-long-enough-to-wrap");
+        assert!(masked_secret(&rows[2].buf).contains("(+"));
+    }
+
+    #[test]
     fn transient_model_catalog_miss_retries_before_manual_fallback() {
         let mut form = FieldFormModal {
             selector: Selector::ModelProvider,
@@ -3263,17 +3909,52 @@ mod tests {
 
     #[test]
     fn completed_selector_advances_to_next_row() {
-        assert_eq!(next_selector_index_after(Selector::ModelProvider), Some(1));
+        let form = FormState::default_form();
+        assert_eq!(
+            next_selector_index_after(Selector::ModelProvider, &form),
+            Some(1)
+        );
         assert_eq!(Selector::ALL[1], Selector::RiskProfile);
         let submit_index = Selector::ALL.len() - 1;
         assert_eq!(
-            next_selector_index_after(Selector::Agent),
+            next_selector_index_after(Selector::Agent, &complete_form()),
             Some(submit_index)
         );
         assert_eq!(Selector::ALL[submit_index], Selector::Submit);
         assert_eq!(
-            next_selector_index_after(Selector::Submit),
+            next_selector_index_after(Selector::Submit, &complete_form()),
             Some(submit_index)
+        );
+    }
+
+    #[test]
+    fn completed_selector_visits_optional_rows() {
+        let mut form = complete_form();
+        form.channels.clear();
+        form.peer_groups.clear();
+
+        assert_eq!(
+            next_selector_index_after(Selector::ModelProvider, &form).map(|idx| Selector::ALL[idx]),
+            Some(Selector::Channels)
+        );
+        assert_eq!(
+            next_selector_index_after(Selector::Channels, &form).map(|idx| Selector::ALL[idx]),
+            Some(Selector::PeerGroups)
+        );
+        assert_eq!(
+            next_selector_index_after(Selector::PeerGroups, &form).map(|idx| Selector::ALL[idx]),
+            Some(Selector::Submit)
+        );
+    }
+
+    #[test]
+    fn completed_selector_keeps_first_unfilled_required_row() {
+        let mut form = complete_form();
+        form.risk.clear();
+
+        assert_eq!(
+            next_selector_index_after(Selector::ModelProvider, &form).map(|idx| Selector::ALL[idx]),
+            Some(Selector::RiskProfile)
         );
     }
 
@@ -3371,6 +4052,20 @@ mod tests {
 
         let kept = retain_filled_selector_errors(&f, vec![err(QuickstartStep::ModelProvider)]);
         assert_eq!(kept.len(), 1, "filled-selector errors must be retained");
+    }
+
+    #[test]
+    fn selector_with_validation_error_does_not_render_complete() {
+        let mut f = FormState::default_form();
+        f.provider_type = "anthropic".into();
+        f.provider_alias = "default".into();
+        f.model = "claude-3-5-haiku-20241022".into();
+        assert!(f.is_satisfied(Selector::ModelProvider));
+
+        let errors = vec![err(QuickstartStep::ModelProvider)];
+
+        assert!(!f.selector_is_complete(Selector::ModelProvider, &errors));
+        assert!(errors_include_selector(&errors, Selector::ModelProvider));
     }
 
     #[test]

--- a/crates/zeroclaw-runtime/src/quickstart/mod.rs
+++ b/crates/zeroclaw-runtime/src/quickstart/mod.rs
@@ -1185,7 +1185,7 @@ fn apply_memory(
                     return None;
                 }
             };
-            if !section_has_alias(config, "storage", family, alias) {
+            if !storage_has_ref(config, reference) {
                 let path = format!("storage.{family}.{alias}");
                 errors.push(QuickstartError::for_surface(
                     ctx,
@@ -1744,6 +1744,12 @@ fn section_has_alias(config: &Config, prefix: &str, family: &str, alias: &str) -
     false
 }
 
+fn storage_has_ref(config: &Config, reference: &str) -> bool {
+    collect_aliased_refs(&config.storage)
+        .iter()
+        .any(|configured| configured == reference)
+}
+
 /// Live model catalog for a provider type. `(models, pricing, live)`:
 /// `live=true` means surfaces should render a picker; `live=false`
 /// means fall back to free text. Tries `ModelProvider::list_models_with_pricing()`
@@ -1873,6 +1879,56 @@ mod tests {
                 personality_file: None,
                 personality_files: vec![],
             },
+        }
+    }
+
+    #[test]
+    fn existing_postgres_memory_storage_ref_is_accepted() {
+        let mut cfg = Config::default();
+        cfg.storage.postgres.insert(
+            "default".into(),
+            zeroclaw_config::schema::PostgresStorageConfig::default(),
+        );
+        let choice = SelectorChoice::Existing("postgres.default".to_string());
+        let mut errors = Vec::new();
+
+        let applied = apply_memory(&mut cfg, &choice, &mut errors, None);
+
+        assert!(errors.is_empty(), "apply_memory errors: {errors:?}");
+        assert_eq!(applied.as_deref(), Some("postgres.default"));
+        assert_eq!(cfg.memory.backend, "postgres.default");
+    }
+
+    #[test]
+    fn memory_storage_refs_from_snapshot_are_accepted() {
+        let mut cfg = Config::default();
+        cfg.storage.postgres.insert(
+            "default".into(),
+            zeroclaw_config::schema::PostgresStorageConfig::default(),
+        );
+        let snapshot = snapshot_state(&cfg);
+
+        assert!(
+            snapshot
+                .storage
+                .iter()
+                .any(|ref_| ref_ == "postgres.default"),
+            "snapshot should expose configured postgres storage: {:?}",
+            snapshot.storage
+        );
+        for reference in snapshot.storage {
+            let mut candidate = cfg.clone();
+            let choice = SelectorChoice::Existing(reference.clone());
+            let mut errors = Vec::new();
+
+            let applied = apply_memory(&mut candidate, &choice, &mut errors, None);
+
+            assert!(
+                errors.is_empty(),
+                "snapshot storage ref {reference:?} should apply without errors: {errors:?}"
+            );
+            assert_eq!(applied.as_deref(), Some(reference.as_str()));
+            assert_eq!(candidate.memory.backend, reference);
         }
     }
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Put existing model providers at the top of the Quickstart provider picker so users can reuse configured aliases without discovering them at the bottom of a long provider list.
  - Collapse long existing-provider lists behind a show-more row while keeping the create-new provider section visible.
  - Keep fresh-provider alias collisions inside the alias form instead of closing the modal and showing only a generic apply failure.
  - When Submit is attempted before required fields are complete, select and report the first missing required selector.
  - Use the same schema-derived storage refs for the Quickstart memory snapshot and existing-memory apply path, including `postgres.default`.
- **Scope boundary:** This PR does not change agent alias normalization in #7637, Dashboard agent rename behavior, chat active-agent switching, or transcript highlight dismissal.
- **Blast radius:** ZeroCode Quickstart picker/form behavior and runtime Quickstart memory validation. It does not change daemon config schema or provider/channel registries.
- **Linked issue(s):** Related #7637
- **Labels:** `bug`, `quickstart`, `zerocode`, `runtime`, `risk:high`, `size:L`

## Validation Evidence (required)

- **Commands run and tail output:**

```text
focused local cargo wrapper: cargo fmt --all -- --check
Result: passed

focused local cargo wrapper: cargo test -p zerocode quickstart_pane::tests::
Result: passed
running 39 tests
test result: ok. 39 passed; 0 failed; 0 ignored; 0 measured; 395 filtered out

focused local cargo wrapper: cargo test -p zeroclaw-runtime memory_storage_refs_from_snapshot_are_accepted
Result: passed
running 1 test
test quickstart::tests::memory_storage_refs_from_snapshot_are_accepted ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 2642 filtered out

git diff --cached --check
Result: passed
```

- **Beyond CI — what did you manually verify?** Dan dogfooded the Quickstart provider-picker, duplicate-alias, incomplete-submit, and ready-to-create behavior from the combined stack and confirmed the Quickstart flow looks ready.
- **If any command was intentionally skipped, why:** Broad local `clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings` passed on this PR head. Broad local `nextest run --locked --workspace --exclude zeroclaw-desktop` was attempted and hit an unrelated `zeroclaw-providers` timeout assertion (`openai_factory_forwards_timeout_to_native_provider`); this PR does not touch provider timeout code. GitHub-visible checks are green.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: `N/A`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: `N/A`

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <merge-sha>`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Quickstart provider picker rows appear in the wrong order, duplicate alias selection closes the modal and fails at submit time, incomplete Submit does not identify the missing selector, or existing memory refs shown by Quickstart fail during apply.
