### PR TITLE
docs(labels): document line and memory backend labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -113,6 +113,12 @@
           - "src/channels/lark.rs"
           - "crates/zeroclaw-channels/src/lark.rs"
 
+"channel:line":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/zeroclaw-channels/src/line.rs"
+          - "docs/book/src/channels/line.md"
+
 "channel:linq":
   - changed-files:
       - any-glob-to-any-file:
@@ -279,6 +285,18 @@
       - any-glob-to-any-file:
           - "src/memory/**"
           - "crates/zeroclaw-memory/src/**"
+
+"memory:backend":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/memory/cli.rs"
+          - "crates/zeroclaw-memory/src/backend.rs"
+          - "crates/zeroclaw-memory/src/lucid.rs"
+          - "crates/zeroclaw-memory/src/markdown.rs"
+          - "crates/zeroclaw-memory/src/none.rs"
+          - "crates/zeroclaw-memory/src/postgres.rs"
+          - "crates/zeroclaw-memory/src/qdrant.rs"
+          - "crates/zeroclaw-memory/src/sqlite.rs"
 
 "security":
   - changed-files:

--- a/docs/book/src/maintainers/labels.md
+++ b/docs/book/src/maintainers/labels.md
@@ -130,6 +130,7 @@ Scoped path labels do not guarantee a same-prefix base label. Because `pr-path-l
 | `security:pairing` | pairing security, gateway pairing API, Tauri pairing command, and web pairing page |
 | `security:policy` | runtime security policy, IAM policy, and config policy files |
 | `security:secrets` | runtime and config secrets handling |
+| `memory:backend` | memory backend selection and storage implementation files |
 
 Do not apply legacy `observability: runtime_trace` to new issues or PRs. Use `observability:otel` when the work is about OpenTelemetry tracing, add base `observability` only when the issue or PR also matches that base surface, and decide any future runtime-trace-specific canonical label in a separate create/migrate packet.
 
@@ -151,6 +152,7 @@ Each channel gets a `channel:<name>` label in addition to the base `channel` lab
 | `channel:imessage` | `imessage.rs` |
 | `channel:irc` | `irc.rs` |
 | `channel:lark` | `lark.rs` |
+| `channel:line` | `line.rs`, `channels/line.md` |
 | `channel:linq` | `linq.rs` |
 | `channel:matrix` | `matrix.rs` |
 | `channel:mattermost` | `mattermost.rs` |


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Add `channel:line` to `.github/labeler.yml` for the existing LINE channel implementation and channel docs.
  - Add `memory:backend` to `.github/labeler.yml` for memory backend selection and concrete backend implementation files.
  - Document both retained labels in the maintainer label reference so the live label namespace and docs stay aligned after the #6808 cleanup packets.
- **Scope boundary:** This PR does not create, delete, rename, or migrate live GitHub labels. It also does not decide the held `channel:core`, `cron:scheduler`, or `memory:none` labels.
- **Blast radius:** Low. The only behavior change is PR path-labeling for future diffs touching the listed files.
- **Linked issue(s):** Related #6808
- **Labels:** `ci`, `docs`, `risk:low`, `size:XS`, `type:docs`

## Validation Evidence (required)

- **Commands run and tail output:**

```text
DOCS_FILES=docs/book/src/maintainers/labels.md BASE_SHA=origin/master bash scripts/ci/docs_links_gate.sh
Collected 0 added link(s) from 1 docs file(s).
No added links detected in changed docs lines.

DOCS_FILES=docs/book/src/maintainers/labels.md BASE_SHA=origin/master bash scripts/ci/docs_quality_gate.sh
No prose em-dashes in changed docs files.
Linting docs files: docs/book/src/maintainers/labels.md
markdownlint-cli2 v0.20.0 (markdownlint v0.40.0)
Linting: 1 file(s)
Summary: 0 error(s)

git diff --check
passed

ruby -e 'require "yaml"; YAML.load_file(".github/labeler.yml"); puts "labeler YAML ok"'
labeler YAML ok

scripts/check-pr-title.sh "docs(labels): document line and memory backend labels"
passed
```

- **Beyond CI — what did you manually verify?** Verified every new labeler path exists and checked recent equivalent label-docs PRs used the same `ci`, `docs`, `risk:low`, `size:XS`, and `type:docs` label shape.
- **If any command was intentionally skipped, why:** Rust validation was not run because this PR changes only maintainer docs and PR path-labeler metadata.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- If `No` or `Yes` to either: N/A

## Rollback (required for medium/high-risk PRs)

Low risk. Revert the PR if the labeler mapping is too broad or too narrow.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A
