### PR TITLE
fix(providers): omit empty assistant tool-call content in OpenAI-compatible requests

### DIFF
--- a/crates/zeroclaw-providers/src/azure_openai.rs
+++ b/crates/zeroclaw-providers/src/azure_openai.rs
@@ -281,10 +281,7 @@ impl AzureOpenAiModelProvider {
                             },
                         })
                         .collect::<Vec<_>>();
-                    let content = value
-                        .get("content")
-                        .and_then(serde_json::Value::as_str)
-                        .map(ToString::to_string);
+                    let content = crate::request_payload::non_empty_string_field(&value, "content");
                     let reasoning_content = value
                         .get("reasoning_content")
                         .and_then(serde_json::Value::as_str)

--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -2093,10 +2093,8 @@ impl OpenAiCompatibleModelProvider {
                     last_assistant_tool_call_ids =
                         tool_calls.iter().filter_map(|tc| tc.id.clone()).collect();
 
-                    let content = value
-                        .get("content")
-                        .and_then(serde_json::Value::as_str)
-                        .map(|value| MessageContent::Text(value.to_string()));
+                    let content = crate::request_payload::non_empty_string_field(&value, "content")
+                        .map(MessageContent::Text);
 
                     // `reasoning` (OpenRouter / vLLM >= v0.16.0). Preserve
                     // whichever field name was originally received so the
@@ -5929,6 +5927,45 @@ mod tests {
             }
             other => panic!("expected text content from fallback, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn convert_messages_for_native_omits_empty_tool_call_content() {
+        let empty_history_json = serde_json::json!({
+            "content": "",
+            "tool_calls": [{
+                "id": "tc_1",
+                "name": "shell",
+                "arguments": "{\"cmd\":\"ls\"}"
+            }]
+        });
+        let non_empty_history_json = serde_json::json!({
+            "content": "I will check",
+            "tool_calls": [{
+                "id": "tc_2",
+                "name": "shell",
+                "arguments": "{\"cmd\":\"pwd\"}"
+            }]
+        });
+
+        let messages = vec![
+            ChatMessage::assistant(empty_history_json.to_string()),
+            ChatMessage::assistant(non_empty_history_json.to_string()),
+        ];
+        let provider = make_model_provider("test", "https://example.com", None);
+        let native = provider.convert_messages_for_native(&messages, true);
+        let empty_json = serde_json::to_value(&native[0]).unwrap();
+        let non_empty_json = serde_json::to_value(&native[1]).unwrap();
+
+        assert_eq!(empty_json.get("content"), None);
+        assert_ne!(
+            empty_json.get("content"),
+            Some(&serde_json::Value::String(String::new()))
+        );
+        assert_eq!(
+            non_empty_json.get("content"),
+            Some(&serde_json::json!("I will check"))
+        );
     }
 
     #[test]

--- a/crates/zeroclaw-providers/src/copilot.rs
+++ b/crates/zeroclaw-providers/src/copilot.rs
@@ -333,10 +333,8 @@ impl CopilotModelProvider {
                         })
                         .collect::<Vec<_>>();
 
-                    let content = value
-                        .get("content")
-                        .and_then(serde_json::Value::as_str)
-                        .map(|s| ApiContent::Text(s.to_string()));
+                    let content = crate::request_payload::non_empty_string_field(&value, "content")
+                        .map(ApiContent::Text);
 
                     return ApiMessage {
                         role: "assistant".to_string(),

--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -44,6 +44,9 @@ pub mod telnyx;
 pub mod traits;
 
 pub use dispatch::{ProviderDispatch, ProviderDispatchRef};
+
+mod request_payload;
+
 #[allow(unused_imports)]
 pub use traits::{
     ChatMessage, ChatRequest, ChatResponse, ConversationMessage, ModelProvider,

--- a/crates/zeroclaw-providers/src/openai.rs
+++ b/crates/zeroclaw-providers/src/openai.rs
@@ -304,10 +304,7 @@ impl OpenAiModelProvider {
                             },
                         })
                         .collect::<Vec<_>>();
-                    let content = value
-                        .get("content")
-                        .and_then(serde_json::Value::as_str)
-                        .map(ToString::to_string);
+                    let content = crate::request_payload::non_empty_string_field(&value, "content");
                     let reasoning_content = value
                         .get("reasoning_content")
                         .and_then(serde_json::Value::as_str)

--- a/crates/zeroclaw-providers/src/openrouter.rs
+++ b/crates/zeroclaw-providers/src/openrouter.rs
@@ -269,10 +269,8 @@ impl OpenRouterModelProvider {
                             },
                         })
                         .collect::<Vec<_>>();
-                    let content = value
-                        .get("content")
-                        .and_then(serde_json::Value::as_str)
-                        .map(|value| MessageContent::Text(value.to_string()));
+                    let content = crate::request_payload::non_empty_string_field(&value, "content")
+                        .map(MessageContent::Text);
                     let reasoning_content = value
                         .get("reasoning_content")
                         .and_then(serde_json::Value::as_str)

--- a/crates/zeroclaw-providers/src/request_payload.rs
+++ b/crates/zeroclaw-providers/src/request_payload.rs
@@ -1,0 +1,7 @@
+pub(crate) fn non_empty_string_field(value: &serde_json::Value, field: &str) -> Option<String> {
+    value
+        .get(field)
+        .and_then(serde_json::Value::as_str)
+        .filter(|content| !content.trim().is_empty())
+        .map(ToString::to_string)
+}


### PR DESCRIPTION
## Summary
Rebased + resubmitted (prior #8510/#8512 went stale against master). Omits empty assistant tool-call `content` in OpenAI-compatible provider requests — some endpoints reject an assistant message that carries tool_calls plus an empty string content.

## Validation Evidence
- `cargo +1.93.0 fmt --all -- --check` — clean
- `cargo +1.93.0 clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings` — Finished, no warnings
- `cargo +1.93.0 check --locked --features ci-all --all-targets` — clean (rebased on current master; the prior E0063 was pure staleness)

## Compatibility / Rollback
Behavior-only change in request serialization; revert the commit to roll back.