### PR TITLE
fix(docs): hyperlink bare elicitation RFD URL in rustdoc comments

### DIFF
--- a/crates/zeroclaw-api/src/channel.rs
+++ b/crates/zeroclaw-api/src/channel.rs
@@ -510,7 +510,7 @@ pub trait Channel: Send + Sync + crate::attribution::Attributable {
     ///
     /// Free-form (no-choices) questions are not modeled by this method.
     /// Multiple-choice support landed via ACP `elicitation/create` (see
-    /// the ACP elicitation RFD: https://agentclientprotocol.com/rfds/elicitation);
+    /// the ACP elicitation RFD: <https://agentclientprotocol.com/rfds/elicitation>);
     /// free-form text is tracked under that spec's Phase 2.
     async fn request_choice(
         &self,
@@ -547,7 +547,7 @@ pub trait Channel: Send + Sync + crate::attribution::Attributable {
     ///
     /// Channels that can only handle structured choices (e.g. ACP in Phase 1
     /// of the elicitation rollout — see
-    /// the ACP elicitation RFD: https://agentclientprotocol.com/rfds/elicitation)
+    /// the ACP elicitation RFD: <https://agentclientprotocol.com/rfds/elicitation>)
     /// should return `false` so callers can fail fast with a useful error
     /// instead of timing out on `listen`. Free-form text support flips this
     /// to `true` in Phase 2.

--- a/crates/zeroclaw-api/src/elicitation.rs
+++ b/crates/zeroclaw-api/src/elicitation.rs
@@ -2,7 +2,7 @@
 //!
 //! Implements the subset of the ACP `elicitation/create` RFD that
 //! ZeroClaw uses for multiple-choice prompts. See the ACP elicitation
-//! RFD: https://agentclientprotocol.com/rfds/elicitation
+//! RFD: <https://agentclientprotocol.com/rfds/elicitation>
 //! for the design rationale.
 
 use serde::{Deserialize, Serialize};

--- a/crates/zeroclaw-channels/src/acp_channel.rs
+++ b/crates/zeroclaw-channels/src/acp_channel.rs
@@ -14,8 +14,7 @@
 //!   `elicitation.form` in `initialize.clientCapabilities`. Otherwise
 //!   it falls back to the legacy `session/request_permission` overload
 //!   for backward compatibility with clients that haven't yet shipped
-//!   the [elicitation RFD][rfd]
-//!   (https://agentclientprotocol.com/rfds/elicitation).
+//!   the [elicitation RFD][rfd].
 //! - `request_multi_choice` issues an `elicitation/create` request
 //!   with a `type: array` / `anyOf` schema. There is no legacy
 //!   fallback for multi-select — callers receive `Ok(None)` when the
@@ -71,7 +70,7 @@ pub struct AcpChannel {
     /// block. Drives the capability gate in `request_choice`: if
     /// `client_caps.form` is true we emit `elicitation/create`; otherwise
     /// we fall back to the legacy `session/request_permission` path.
-    /// See the ACP elicitation RFD: https://agentclientprotocol.com/rfds/elicitation.
+    /// See the ACP elicitation RFD: <https://agentclientprotocol.com/rfds/elicitation>.
     client_caps: ElicitationCapabilities,
 }
 

--- a/crates/zeroclaw-runtime/src/rpc/approval_channel.rs
+++ b/crates/zeroclaw-runtime/src/rpc/approval_channel.rs
@@ -9,7 +9,7 @@
 //! through the same `elicitation/create` outbound JSON-RPC method as
 //! `AcpChannel`, gated on the TUI advertising
 //! `clientCapabilities.elicitation.form` during `initialize`. See the ACP
-//! elicitation RFD: https://agentclientprotocol.com/rfds/elicitation
+//! elicitation RFD: <https://agentclientprotocol.com/rfds/elicitation>
 //! for the wire protocol.
 
 use std::sync::Arc;


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Wraps the bare `https://agentclientprotocol.com/rfds/elicitation` URL in 5 doc comments with `<…>` so `rustdoc` recognizes it as a hyperlink, eliminating 5 of the 7 "this URL is not a hyperlink" warnings currently emitted by `cargo doc` for `zeroclaw-api`, `zeroclaw-channels`, and `zeroclaw-runtime`.
  - Removes a stray broken inline link-reference tail `(https://agentclientprotocol.com/rfds/elicitation)` in `crates/zeroclaw-channels/src/acp_channel.rs` module docs. The `[elicitation RFD][rfd]` label on the previous line is already resolved by the file's existing `[rfd]: https://…` reference definition at line 42, so the inline tail was a redundant broken-ref-detector target that contributed 1 of the 7 warnings.
  - Net diff: 4 files, +6 / −7. No code, no config, no test, no schema changes.
  - Why: this is the smallest possible slice of #7269 `bug(docs): clean up docs build warning noise` — the ACP-elicitation URL hyperlink family is fully self-contained, has zero coupling to other warning classes in the tracker, and matches the `docs/risk:low` profile of the parent issue.
- **Scope boundary:**
  - Does **not** touch the 3 remaining `delegate.rs` `URL is not a hyperlink` warnings (lines 544–546) — those live in a private function's doc comment and only surface under `cargo doc --document-private-items`, which is outside the default CI path. They are filed as a separate slice if needed.
  - Does **not** touch any other warning class in #7269 (broken intra-doc links, private intra-doc links, redundant explicit links, mdBook HTML warnings, angle-bracket placeholders). PR #8470 already covers the angle-bracket placeholder slice; the rest remain on the parent tracker.
  - Does **not** change rendered HTML output behavior beyond making the URL clickable; the link target and label text are preserved verbatim.
- **Blast radius:** Documentation only. The only consumer of the changed text is `rustdoc`; the generated HTML now has 5 working `<a href=…>` links instead of 5 bare strings. No runtime, config, RPC, or API consumer is affected.
- **Linked issue(s):** Related #7269. This PR is a sub-slice of that tracker, not a full resolution — 5 of N warnings fixed, so the parent issue should remain open.
- **Labels:** `type:docs`, `risk:low`, `size:XS`, `docs`

## Validation Evidence (required)

- **Commands run and tail output:**
  - `cargo doc --workspace --no-deps --exclude zeroclaw-desktop --exclude xtask`
    - Before patch: `warning: this URL is not a hyperlink` × 7 across `crates/zeroclaw-channels/src/acp_channel.rs:18,74`, `crates/zeroclaw-runtime/src/rpc/approval_channel.rs:12`, `crates/zeroclaw-api/src/channel.rs:513,550`, `crates/zeroclaw-api/src/elicitation.rs:5`.
    - After patch: `Finished \`dev\` profile [unoptimized + debuginfo] target(s) in …` — 0 `URL is not a hyperlink` warnings emitted.
  - `cargo clippy -p zeroclaw-api -p zeroclaw-channels -p zeroclaw-runtime --all-targets --no-deps`
    - `Finished \`dev\` profile [unoptimized + debuginfo] target(s) in 4m 25s` — 0 warnings, 0 errors.
  - `cargo fmt -p zeroclaw-api -p zeroclaw-channels -p zeroclaw-runtime -- --check`
    - exit 0, no diff.
  - `cargo test -p zeroclaw-api --no-fail-fast`
    - `test result: ok. 1 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out` (doctest in `schema.rs`); remaining 2 doctests are `#[ignore]`d upstream and unrelated.
- **Beyond CI — what did you manually verify?** Visually confirmed each of the 6 sites with `git diff` against the parent commit: every replacement preserves the surrounding prose, link label, and target URL byte-for-byte. Verified the reference-definition indirection in `acp_channel.rs` (line 17 `[elicitation RFD][rfd]` is resolved by line 42 `[rfd]: https://…`) by re-rendering the module docs and confirming the link renders to the same target as before. Did **not** run `cargo test -p zeroclaw-channels` or `-p zeroclaw-runtime` — the changes are pure doc-comment text with no code path touched, so a doc-only cargo doc + clippy pass is sufficient evidence.
- **If any command was intentionally skipped, why:** `cargo test -p zeroclaw-channels` / `-p zeroclaw-runtime` skipped because the patch is a whitespace-and-punctuation change inside `///` and `//!` lines; the touched modules (`acp_channel.rs`, `approval_channel.rs`, `channel.rs`, `elicitation.rs`) have no test entry points that exercise their doc-comment prose. Skipped `cargo clippy --all-targets` (workspace-wide) due to the unrelated `glib-sys` build failure on the local Tauri toolchain (`Package 'glib-2.0' has version '2.56.4', required version is '>= 2.70'`); the three affected crates clippy clean individually, which is the relevant scope.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? `Yes` — doc-comment text only; no behavioral change, no public API surface touched (`Channel::request_choice`, `Channel::request_multi_choice`, `Channel::supports_free_form_ask`, `AcpChannel::client_caps`, and the `elicitation` module keep identical signatures).
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: exact upgrade steps for existing users: N/A

## Rollback (required for medium/high-risk PRs)

Low-risk PRs: `git revert <sha>` is the plan unless otherwise noted.

This PR is `risk:low`. The single rollback path is `git revert <sha>` of the merge commit, which restores the 7 rustdoc warnings. No feature flag, no config toggle, no migration step.

## Supersede Attribution (required only when `Supersedes #` is used)

Not applicable — this PR does not supersede any other PR.