### PR TITLE
fix(runtime): gate Unix-only shell test helper

### DIFF
--- a/crates/zeroclaw-runtime/src/tools/shell.rs
+++ b/crates/zeroclaw-runtime/src/tools/shell.rs
@@ -636,6 +636,7 @@ mod tests {
         })
     }
 
+    #[cfg(unix)]
     fn unrestricted_shell_test_security() -> Arc<SecurityPolicy> {
         Arc::new(SecurityPolicy {
             autonomy: AutonomyLevel::Full,


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Gates the unrestricted shell-test security helper behind `#[cfg(unix)]`.
  - The helper is only used by Unix-only shell output tests, so Windows test builds otherwise see it as dead code under `-D warnings`.
  - Keeps the helper available to the Unix tests that need unrestricted shell commands.
- **Scope boundary:** This PR does not change shell tool behavior, command policy, security defaults, or production runtime code paths.
- **Blast radius:** Test-only compile surface in `zeroclaw-runtime`; Windows and Unix test-target linting are the affected surfaces.
- **Linked issue(s):** Related #8517
- **Labels:** `bug`, `runtime`, `tests`, `risk:medium`, `size:XS`

## Validation Evidence (required)

- **Commands run and tail output:**

```bash
cargo fmt --all -- --check
# Passed.
```

```bash
cargo clippy -p zeroclaw-runtime --all-targets --target x86_64-pc-windows-msvc --no-deps -- -D warnings
# Local macOS cross-target probe could not complete before crate linting:
# the build reached ring's C build script and failed because the local macOS
# environment does not provide the MSVC C header/toolchain surface needed for
# x86_64-pc-windows-msvc. The Windows GitHub runner is the required target proof.
```

- **Beyond CI — what did you manually verify?** Verified every caller of `unrestricted_shell_test_security()` in `shell.rs` is already under `#[cfg(unix)]`, so applying the same cfg to the helper removes the Windows dead-code surface without changing Unix test behavior.
- **If any command was intentionally skipped, why:** Host runtime Clippy was started but stopped after it became disproportionate for this one-line target-specific fix; the load-bearing validation is the actual Windows runner.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: `N/A`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: `N/A`

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <sha>`
- **Feature flags or config toggles:** `None`
- **Observable failure symptoms:** Windows test-target linting reports `unrestricted_shell_test_security` as dead code again.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): `N/A`
- Scope materially carried forward: `N/A`
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why (inspiration-only, no direct code/design carry-over): `N/A`
