### PR TITLE
fix(channels): enable model commands on WhatsApp Web

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -1335,7 +1335,14 @@ fn strip_tool_summary_prefix(text: &str) -> String {
 fn supports_runtime_model_switch(channel_name: &str) -> bool {
     matches!(
         channel_name,
-        "telegram" | "discord" | "matrix" | "slack" | "wecom_ws"
+        "telegram"
+            | "discord"
+            | "matrix"
+            | "slack"
+            | "wecom_ws"
+            | "whatsapp"
+            | "whatsapp-web"
+            | "whatsapp_web"
     )
 }
 
@@ -17850,6 +17857,20 @@ BTC is currently around $65,000 based on latest tool output."#
             parse_runtime_command("wecom_ws", "/model qwen-max"),
             Some(ChannelRuntimeCommand::SetModel("qwen-max".into()))
         );
+    }
+
+    #[test]
+    fn parse_runtime_command_allows_model_switch_for_whatsapp_web() {
+        for channel_name in &["whatsapp", "whatsapp-web", "whatsapp_web"] {
+            assert_eq!(
+                parse_runtime_command(channel_name, "/models openrouter"),
+                Some(ChannelRuntimeCommand::SetProvider("openrouter".into()))
+            );
+            assert_eq!(
+                parse_runtime_command(channel_name, "/model qwen-max"),
+                Some(ChannelRuntimeCommand::SetModel("qwen-max".into()))
+            );
+        }
     }
 
     fn scope_test_msg(


### PR DESCRIPTION
## Problem

WhatsApp Web channels (`whatsapp`, `whatsapp-web`, `whatsapp_web`) cannot use `/models`, `/model`, or `/config` runtime commands because `supports_runtime_model_switch()` did not include WhatsApp channel names.

## Root Cause

The `supports_runtime_model_switch()` function in the channel orchestrator gates slash-command parsing with a channel-name whitelist. WhatsApp Web aliases were missing from the match.

## Fix

Add `"whatsapp"`, `"whatsapp-web"`, and `"whatsapp_web"` to the `supports_runtime_model_switch()` match, plus a focused regression test that exercises `/models` and `/model` for all three aliases.

Fixes #8414