### PR TITLE
fix(runtime): report cost_usd in AgentEnd and emit it for channel turns

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -5816,6 +5816,35 @@ async fn process_channel_message_body(
         }
     }
 
+    // Emit AgentEnd so downstream observability (langfuse, dashboard, per-turn
+    // cost reconciliation) can identify the turn boundary and pull `tokens_used`
+    // + `cost_usd` from the same cost tracking context that the tool-call loop
+    // ran under. Mirrors the loop_::run path. Inserted after every
+    // LlmExecutionResult branch rejoin so success / error / cancel / timeout
+    // paths all reach it exactly once.
+    let turn_usage = cost_tracking_context
+        .as_ref()
+        .map(|c| c.snapshot_turn_usage());
+    ctx.observer.record_event(&ObserverEvent::AgentEnd {
+        model_provider: route.model_provider.clone(),
+        model: route.model.clone(),
+        duration: started_at.elapsed(),
+        tokens_used: turn_usage.as_ref().and_then(|u| {
+            (u.input_tokens > 0 || u.output_tokens > 0).then_some(
+                zeroclaw_api::observability_traits::TurnTokenUsage {
+                    input_tokens: u.input_tokens,
+                    output_tokens: u.output_tokens,
+                },
+            )
+        }),
+        cost_usd: turn_usage
+            .as_ref()
+            .and_then(|u| (u.input_tokens > 0 || u.output_tokens > 0).then_some(u.cost_usd)),
+        channel: Some(msg.channel.clone()),
+        agent_alias: Some(ctx.agent_alias.as_ref().clone()),
+        turn_id: Some(msg.id.clone()),
+    });
+
     // Swap 👀 → ✅ (or ⚠️ on error) to signal processing is complete. Await the
     // spawned ack add first so the remove can never race ahead of it.
     if resolve_channel_ack_reactions(&ctx, &msg)
@@ -18725,6 +18754,266 @@ BTC is currently around $65,000 based on latest tool output."#
         assert!(calls[1][2].1.contains("response-1"));
         assert!(calls[1][3].1.starts_with('['));
         assert!(calls[1][3].1.contains("follow up"));
+    }
+
+    /// Captures observer events for assertion; no-op for metrics.
+    /// Lives in the test module alongside other test-only types.
+    struct CapturingObserver {
+        events: std::sync::Mutex<Vec<zeroclaw_runtime::observability::traits::ObserverEvent>>,
+    }
+
+    impl Default for CapturingObserver {
+        fn default() -> Self {
+            Self {
+                events: std::sync::Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    impl zeroclaw_runtime::observability::Observer for CapturingObserver {
+        fn record_event(&self, event: &zeroclaw_runtime::observability::traits::ObserverEvent) {
+            self.events
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .push(event.clone());
+        }
+        fn record_metric(&self, _metric: &zeroclaw_runtime::observability::traits::ObserverMetric) {
+        }
+        fn name(&self) -> &str {
+            "capturing"
+        }
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+        fn flush(&self) {}
+    }
+
+    /// Mock model provider that returns a `ChatResponse` with `usage`, so the
+    /// cost-tracking path exercises `record_tool_loop_cost_usage` → non-zero
+    /// `cost_usd` → `AgentEnd.cost_usd: Some(...)`.
+    struct UsageReportingModelProvider;
+
+    #[async_trait::async_trait]
+    impl ModelProvider for UsageReportingModelProvider {
+        async fn chat_with_system(
+            &self,
+            _system_prompt: Option<&str>,
+            _message: &str,
+            _model: &str,
+            _temperature: Option<f64>,
+        ) -> anyhow::Result<String> {
+            Ok("cost ok".to_string())
+        }
+
+        async fn chat(
+            &self,
+            _request: zeroclaw_api::model_provider::ChatRequest<'_>,
+            _model: &str,
+            _temperature: Option<f64>,
+        ) -> anyhow::Result<zeroclaw_api::model_provider::ChatResponse> {
+            Ok(zeroclaw_api::model_provider::ChatResponse {
+                text: Some("cost ok".to_string()),
+                tool_calls: vec![],
+                usage: Some(zeroclaw_api::model_provider::TokenUsage {
+                    input_tokens: Some(500),
+                    cached_input_tokens: None,
+                    output_tokens: Some(100),
+                }),
+                reasoning_content: None,
+            })
+        }
+    }
+
+    impl zeroclaw_api::attribution::Attributable for UsageReportingModelProvider {
+        fn role(&self) -> zeroclaw_api::attribution::Role {
+            zeroclaw_api::attribution::Role::Provider(
+                zeroclaw_api::attribution::ProviderKind::Model(
+                    zeroclaw_api::attribution::ModelProviderKind::Custom,
+                ),
+            )
+        }
+        fn alias(&self) -> &str {
+            "usage-provider"
+        }
+    }
+
+    #[tokio::test]
+    async fn process_channel_message_agent_end_reports_cost_usd_when_pricing_is_configured() {
+        let channel_impl = Arc::new(RecordingChannel::default());
+        let channel: Arc<dyn Channel> = channel_impl.clone();
+        let mut channels_by_name = HashMap::new();
+        channels_by_name.insert(channel.name().to_string(), channel);
+
+        let provider_impl = Arc::new(UsageReportingModelProvider);
+        let capturing = Arc::new(CapturingObserver::default());
+        let observer: Arc<dyn zeroclaw_runtime::observability::Observer> = capturing.clone();
+
+        let workspace = TempDir::new().unwrap();
+        let tracker = Arc::new(
+            zeroclaw_runtime::cost::CostTracker::new(
+                zeroclaw_config::schema::CostConfig {
+                    enabled: true,
+                    track_per_agent: true,
+                    ..zeroclaw_config::schema::CostConfig::default()
+                },
+                workspace.path(),
+            )
+            .expect("cost tracker should initialize"),
+        );
+        let pricing: HashMap<String, HashMap<String, f64>> = HashMap::from([(
+            "test-provider".to_string(),
+            HashMap::from([
+                ("test-model.input".to_string(), 3.0),
+                ("test-model.output".to_string(), 15.0),
+            ]),
+        )]);
+        let cost_tracking = Some(ChannelCostTrackingState {
+            tracker: Arc::clone(&tracker),
+            model_provider_pricing: Arc::new(pricing),
+            agent_alias: Arc::new("test-agent".to_string()),
+        });
+
+        let runtime_ctx = Arc::new(ChannelRuntimeContext {
+            channels_by_name: Arc::new(channels_by_name),
+            model_provider: provider_impl.clone(),
+            model_provider_ref: Arc::new("test-provider".to_string()),
+            agent_alias: Arc::new("test-agent".to_string()),
+            agent_cfg: Arc::new(zeroclaw_config::schema::AliasedAgentConfig::default()),
+            memory: Arc::new(NoopMemory),
+            memory_strategy: Arc::new(
+                zeroclaw_runtime::agent::memory_strategy::DefaultMemoryStrategy::with_config(
+                    Arc::new(NoopMemory),
+                    zeroclaw_config::schema::MemoryConfig::default(),
+                    std::path::PathBuf::new(),
+                ),
+            ),
+            tools_registry: Arc::new(vec![]),
+            observer,
+            system_prompt: Arc::new("test-system-prompt".to_string()),
+            model: Arc::new("test-model".to_string()),
+            temperature: Some(0.0),
+            auto_save_memory: false,
+            max_tool_iterations: 5,
+            min_relevance_score: 0.0,
+            conversation_histories: Arc::new(Mutex::new(lru::LruCache::new(
+                std::num::NonZeroUsize::new(MAX_CONVERSATION_SENDERS).unwrap(),
+            ))),
+            pending_new_sessions: Arc::new(Mutex::new(HashSet::new())),
+            provider_cache: Arc::new(Mutex::new(HashMap::new())),
+            route_overrides: Arc::new(Mutex::new(HashMap::new())),
+            thinking_overrides: Arc::new(Mutex::new(HashMap::new())),
+            scope_overrides: Arc::new(Mutex::new(HashMap::new())),
+            reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
+            provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
+            workspace_dir: Arc::new(std::env::temp_dir()),
+            prompt_config: Arc::new(zeroclaw_config::schema::Config::default()),
+            message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
+            interrupt_on_new_message: InterruptOnNewMessageConfig {
+                telegram: false,
+                slack: false,
+                discord: false,
+                mattermost: false,
+                matrix: false,
+                whatsapp: false,
+            },
+            multimodal: zeroclaw_config::schema::MultimodalConfig::default(),
+            media_pipeline: zeroclaw_config::schema::MediaPipelineConfig::default(),
+            transcription_config: zeroclaw_config::schema::TranscriptionConfig::default(),
+            agent_transcription_provider: String::new(),
+            hooks: None,
+            non_cli_excluded_tools: Arc::new(Vec::new()),
+            autonomy_level: AutonomyLevel::default(),
+            tool_call_dedup_exempt: Arc::new(Vec::new()),
+            model_routes: Arc::new(Vec::new()),
+            query_classification: zeroclaw_config::schema::QueryClassificationConfig::default(),
+            ack_reactions: false,
+            show_tool_calls: false,
+            session_store: None,
+            approval_manager: Arc::new(ApprovalManager::for_non_interactive(
+                &zeroclaw_config::schema::RiskProfileConfig::default(),
+            )),
+            activated_tools: None,
+            cost_tracking,
+            pacing: zeroclaw_config::schema::PacingConfig::default(),
+            max_tool_result_chars: 0,
+            context_token_budget: 0,
+            debouncer: Arc::new(zeroclaw_infra::debounce::MessageDebouncer::new(
+                std::time::Duration::ZERO,
+            )),
+            receipt_generator: None,
+            show_receipts_in_response: false,
+            last_applied_config_stamp: Arc::new(Mutex::new(None)),
+            runtime_defaults_override: Arc::new(Mutex::new(None)),
+            persist_locks: Arc::new(std::sync::Mutex::new(HashMap::new())),
+        });
+
+        process_channel_message(
+            runtime_ctx,
+            zeroclaw_api::channel::ChannelMessage {
+                id: "msg-cost-test".to_string(),
+                sender: "bob".to_string(),
+                reply_target: "chat-2".to_string(),
+                content: "hello cost".to_string(),
+                channel: "test-channel".into(),
+                channel_alias: None,
+                timestamp: 1,
+                thread_ts: None,
+                interruption_scope_id: None,
+                attachments: vec![],
+                subject: None,
+                passive_context: false,
+                conversation_scope: zeroclaw_api::channel::ChannelConversationScope::Sender,
+            },
+            CancellationToken::new(),
+        )
+        .await;
+
+        let events = capturing.events.lock().unwrap_or_else(|e| e.into_inner());
+        let (tokens, cost_usd) = events
+            .iter()
+            .find_map(|event| match event {
+                zeroclaw_runtime::observability::traits::ObserverEvent::AgentEnd {
+                    tokens_used,
+                    cost_usd,
+                    ..
+                } => Some((tokens_used.clone(), *cost_usd)),
+                _ => None,
+            })
+            .expect("AgentEnd must be recorded after channel message processing");
+
+        let tokens = tokens.expect("AgentEnd must carry tokens_used when usage is reported");
+        assert_eq!(
+            tokens.input_tokens, 500,
+            "input tokens must be reported on AgentEnd"
+        );
+        assert_eq!(
+            tokens.output_tokens, 100,
+            "output tokens must be reported on AgentEnd"
+        );
+
+        let cost = cost_usd.expect("AgentEnd must carry cost_usd when pricing is configured");
+        assert!(
+            cost > 0.0,
+            "cost_usd should be non-zero with configured pricing"
+        );
+
+        // Verify exact cost: input 500 * $3/1M + output 100 * $15/1M
+        let expected_cost = (500.0 * 3.0 + 100.0 * 15.0) / 1_000_000.0;
+        assert!(
+            (cost - expected_cost).abs() < 1e-12,
+            "cost_usd should match pricing calculation; expected {expected_cost}, got {cost}"
+        );
+
+        // Verify that the cost tracker also recorded the session usage.
+        let summary = tracker
+            .get_summary()
+            .expect("cost tracker should have a summary");
+        assert_eq!(summary.request_count, 1);
+        assert_eq!(summary.total_tokens, 600);
+        assert!(
+            summary.session_cost_usd > 0.0,
+            "session cost should be non-zero"
+        );
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -96,6 +96,7 @@ struct TurnGuard {
     channel_name: String,
     total_input_tokens: u64,
     total_output_tokens: u64,
+    total_cost_usd: f64,
     saw_usage: bool,
     done: bool,
 }
@@ -116,7 +117,7 @@ impl TurnGuard {
                     output_tokens: self.total_output_tokens,
                 },
             ),
-            cost_usd: None,
+            cost_usd: self.saw_usage.then_some(self.total_cost_usd),
             channel: Some(self.channel_name.clone()),
             agent_alias: self.agent_alias.clone(),
             turn_id: self.turn_id.clone(),
@@ -2225,6 +2226,7 @@ impl Agent {
             channel_name: self.channel_name.clone(),
             total_input_tokens: 0,
             total_output_tokens: 0,
+            total_cost_usd: 0.0,
             saw_usage: false,
             done: false,
         };
@@ -2354,6 +2356,7 @@ impl Agent {
             guard.total_output_tokens = usage.output_tokens;
             guard.saw_usage = true;
         }
+        guard.total_cost_usd = usage.cost_usd;
         // Replay the loop's transcript additions into the conversation
         // history BEFORE propagating any loop error: rounds that already
         // executed carry side effects (tools ran), and the pre-consolidation
@@ -2622,6 +2625,7 @@ impl Agent {
             channel_name: self.channel_name.clone(),
             total_input_tokens: 0,
             total_output_tokens: 0,
+            total_cost_usd: 0.0,
             saw_usage: false,
             done: false,
         };
@@ -2804,6 +2808,7 @@ impl Agent {
                 guard.total_output_tokens = usage.output_tokens;
                 guard.saw_usage = true;
             }
+            guard.total_cost_usd = usage.cost_usd;
 
             // Replay everything the loop appended this round into the
             // conversation history and the persistence capture.
@@ -7479,6 +7484,117 @@ mod tests {
         assert!(
             agent_summary.session_cost_usd > 0.0,
             "agent alias should flow through persisted turn usage"
+        );
+    }
+
+    #[tokio::test]
+    async fn turn_agent_end_reports_cost_usd_when_pricing_is_configured() {
+        use crate::agent::cost::{
+            TOOL_LOOP_COST_TRACKING_CONTEXT, TOOL_LOOP_TURN_USAGE, ToolLoopCostTrackingContext,
+            TurnUsage,
+        };
+        use crate::cost::CostTracker;
+        use std::collections::HashMap;
+
+        let memory_cfg = zeroclaw_config::schema::MemoryConfig {
+            backend: "none".into(),
+            ..zeroclaw_config::schema::MemoryConfig::default()
+        };
+        let mem: Arc<dyn Memory> = Arc::from(
+            zeroclaw_memory::create_memory(&memory_cfg, std::path::Path::new("/tmp"), None)
+                .expect("memory creation should succeed with valid config"),
+        );
+        let capturing = Arc::new(CapturingObserver::default());
+        let observer: Arc<dyn Observer> = capturing.clone();
+        let workspace = tempfile::TempDir::new().expect("temp dir");
+        let tracker = Arc::new(
+            CostTracker::new(
+                zeroclaw_config::schema::CostConfig {
+                    enabled: true,
+                    track_per_agent: true,
+                    ..zeroclaw_config::schema::CostConfig::default()
+                },
+                workspace.path(),
+            )
+            .expect("cost tracker should initialize"),
+        );
+        let pricing = Arc::new(HashMap::from([(
+            "mock-provider".to_string(),
+            HashMap::from([
+                ("test-model.input".to_string(), 3.0),
+                ("test-model.output".to_string(), 15.0),
+            ]),
+        )]));
+        let cost_context = ToolLoopCostTrackingContext::new(Arc::clone(&tracker), pricing)
+            .with_agent_alias("cost-agent");
+        let turn_usage = Arc::new(parking_lot::Mutex::new(TurnUsage::default()));
+
+        let mut agent = Agent::builder()
+            .model_provider(Box::new(MockModelProvider {
+                responses: Mutex::new(vec![zeroclaw_providers::ChatResponse {
+                    text: Some("cost ok".into()),
+                    tool_calls: vec![],
+                    usage: Some(zeroclaw_providers::traits::TokenUsage {
+                        input_tokens: Some(500),
+                        cached_input_tokens: None,
+                        output_tokens: Some(100),
+                    }),
+                    reasoning_content: None,
+                }]),
+            }))
+            .tools(vec![Box::new(MockTool)])
+            .memory(mem)
+            .observer(observer)
+            .tool_dispatcher(Box::new(NativeToolDispatcher))
+            .workspace_dir(std::path::PathBuf::from("/tmp"))
+            .model_name("test-model".into())
+            .model_provider_name("mock-provider".into())
+            .agent_alias("cost-agent".into())
+            .build()
+            .expect("agent builder should succeed with valid config");
+
+        let _response = TOOL_LOOP_TURN_USAGE
+            .scope(
+                Some(Arc::clone(&turn_usage)),
+                TOOL_LOOP_COST_TRACKING_CONTEXT.scope(Some(cost_context), agent.turn("hello")),
+            )
+            .await
+            .expect("turn should succeed");
+
+        let events = capturing.events.lock();
+        let (tokens, cost_usd) = events
+            .iter()
+            .find_map(|event| match event {
+                ObserverEvent::AgentEnd {
+                    tokens_used,
+                    cost_usd,
+                    ..
+                } => Some((tokens_used.clone(), *cost_usd)),
+                _ => None,
+            })
+            .expect("AgentEnd must be recorded");
+
+        let tokens = tokens.expect("AgentEnd must carry tokens_used when usage is recorded");
+        assert_eq!(
+            tokens.input_tokens, 500,
+            "input tokens must be reported on AgentEnd"
+        );
+        assert_eq!(
+            tokens.output_tokens, 100,
+            "output tokens must be reported on AgentEnd"
+        );
+
+        let cost = cost_usd.expect("AgentEnd must carry cost_usd when pricing is configured");
+        assert!(
+            cost > 0.0,
+            "cost_usd should be non-zero with configured pricing"
+        );
+
+        // Verify the cost matches expected: 500*3.0/1M + 100*15.0/1M
+        let expected_cost = (500.0 * 3.0 + 100.0 * 15.0) / 1_000_000.0;
+        assert!(
+            (cost - expected_cost).abs() < 1e-12,
+            "cost_usd should match pricing calculation; expected {expected_cost}, got {cost}"
         );
     }
 

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -2793,8 +2793,10 @@ pub async fn run(
         // reads the context's own accumulator, which holds the session-wide
         // totals. Without this the CLI `AgentEnd` reported `tokens_used: None`
         // even though usage was tracked.
-        let tokens_used = cost_tracking_context.as_ref().and_then(|ctx| {
-            let usage = ctx.snapshot_turn_usage();
+        let turn_usage = cost_tracking_context
+            .as_ref()
+            .map(|ctx| ctx.snapshot_turn_usage());
+        let tokens_used = turn_usage.as_ref().and_then(|usage| {
             (usage.input_tokens > 0 || usage.output_tokens > 0).then_some(
                 zeroclaw_api::observability_traits::TurnTokenUsage {
                     input_tokens: usage.input_tokens,
@@ -2802,12 +2804,15 @@ pub async fn run(
                 },
             )
         });
+        let cost_usd = turn_usage.as_ref().and_then(|usage| {
+            (usage.input_tokens > 0 || usage.output_tokens > 0).then_some(usage.cost_usd)
+        });
         observer.record_event(&ObserverEvent::AgentEnd {
             model_provider: provider_name.to_string(),
             model: model_name.to_string(),
             duration,
             tokens_used,
-            cost_usd: None,
+            cost_usd,
             channel: Some(channel_name.to_string()),
             agent_alias: Some(agent_alias.to_string()),
             turn_id: Some(turn_id),

--- a/crates/zeroclaw-runtime/src/agent/safety_net.rs
+++ b/crates/zeroclaw-runtime/src/agent/safety_net.rs
@@ -1113,14 +1113,18 @@ async fn safety_net_agent_turn_agent_end_reports_token_totals() {
         .expect("turn should succeed");
 
     let events = capture.events.lock();
-    let tokens = events
+    let (tokens, cost_usd) = events
         .iter()
         .find_map(|event| match event {
-            ObserverEvent::AgentEnd { tokens_used, .. } => Some(tokens_used.clone()),
+            ObserverEvent::AgentEnd {
+                tokens_used,
+                cost_usd,
+                ..
+            } => Some((tokens_used.clone(), *cost_usd)),
             _ => None,
         })
-        .expect("AgentEnd must be recorded")
-        .expect("AgentEnd must carry tokens_used");
+        .expect("AgentEnd must be recorded");
+    let tokens = tokens.expect("AgentEnd must carry tokens_used");
     assert_eq!(
         tokens.input_tokens, 18,
         "input tokens must sum across all loop iterations"
@@ -1128,6 +1132,10 @@ async fn safety_net_agent_turn_agent_end_reports_token_totals() {
     assert_eq!(
         tokens.output_tokens, 8,
         "output tokens must sum across all loop iterations"
+    );
+    assert!(
+        cost_usd.is_some_and(|c| c == 0.0),
+        "cost_usd should be 0.0 when pricing is not configured but usage was tracked"
     );
 }
 


### PR DESCRIPTION
AgentEnd events now carry `cost_usd` across all three turn paths (CLI via loop_::run, Agent via turn/turn_streamed, and Channel via process_channel_message) so downstream observability (Langfuse, dashboard, cost reconciliation) can identify turn boundaries and pull both `tokens_used` and `cost_usd` from the same cost-tracking context.

- loop_::run: derive cost_usd from turn_usage snapshot (was hardcoded None)
- agent::TurnGuard: track total_cost_usd and emit via saw_usage guard
- orchestrator: emit AgentEnd after channel message processing (was missing)
- safety_net test: assert cost_usd is Some(0.0) when pricing is absent
- Add tests verifying exact cost calculation with configured pricing

## Summary

- **Base branch:** `master`
- **Branch:** `fix/agent-end-channel-and-cost`
- **What changed and why:**
  - `loop_::run`: derive `cost_usd` from `turn_usage` snapshot — was hardcoded `None`, so CLI turns never reported cost.
  - `agent::TurnGuard`: track `total_cost_usd` and emit via `saw_usage` guard — `TurnGuard` had no cost field at all.
  - `orchestrator::process_channel_message`: emit `AgentEnd` after channel message processing — the event was entirely missing for all channel transports, preventing downstream observability from identifying turn boundaries or reconciling per-turn cost.
  - `safety_net` test: assert `cost_usd == Some(0.0)` when pricing is absent but usage was tracked — pins the zero-cost-for-untracked-pricing contract.
  - Two new tests verifying exact cost calculation `(500*3.0 + 100*15.0) / 1_000_000` with configured pricing.
- **Scope boundary:**
  - Does NOT fix `Agent::run_interactive()` — that path has never emitted observer events (`agent.start` / `llm.request` / `llm.response` / `agent.end`). 
  - Does NOT change the `AgentEnd` event schema or add new fields — only populates existing fields that were always `None`.
- **Blast radius:** Downstream consumers of `AgentEnd` (Langfuse, OpenTelemetry, log backend, dashboard, cost reconciliation tools) will start receiving `cost_usd` values and channel-path `AgentEnd` events they never received before. These are additive — no existing consumer should break.
- **Linked issue(s):** Related #8539
- **Labels:** `bug`, `agent`, `channel`, `runtime`, `risk:high`, `size:M`

## Validation Evidence

All three commands ran locally with zero errors.

### cargo fmt --all -- --check

```
(no output — all files are correctly formatted)
```

### cargo clippy --all-targets -- -D warnings

```
(no warnings or errors)
```

### cargo test (full suite)

```
test result: ok
```

### Targeted test: safety_net_agent_turn_agent_end_reports_token_totals

```
running 1 test
test agent::agent::safety_net::safety_net_agent_turn_agent_end_reports_token_totals ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 2688 filtered out; finished in 0.03s
```

### Targeted test: turn_agent_end_reports_cost_usd

```
running 1 test
test agent::agent::tests::turn_agent_end_reports_cost_usd_when_pricing_is_configured ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 2688 filtered out; finished in 0.03s
```

### Targeted test: process_channel_message_agent_end

```
running 1 test
test orchestrator::tests::process_channel_message_agent_end_reports_cost_usd_when_pricing_is_configured ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1160 filtered out; finished in 0.06s
```

- **Beyond CI — what did you manually verify?**
  - Verified that all three paths (CLI / Agent / Channel) now emit `AgentEnd` with non-`None` `cost_usd` when pricing is configured.
  - Verified that `cost_usd` remains `Some(0.0)` when pricing is absent but usage is tracked.
  - Verified that `saw_usage` guard correctly suppresses `cost_usd` (returns `None`) when no usage was recorded.
- **Not verified:** End-to-end with real Langfuse/OTel backend — CI and manual observer-level assertions cover the event emission; backend ingestion is a separate concern.

## Security & Privacy Impact

- **New permissions, capabilities, or file system access scope?** No
- **New external network calls?** No
- **Secrets / tokens / credentials handling changed?** No
- **PII, real identities, or personal data in diff, tests, fixtures, or docs?** No

## Compatibility

- **Backward compatible?** Yes — the `AgentEnd` event schema is unchanged; previously-`None` fields now have values, which is additive.
- **Config / env / CLI surface changed?** No

## Rollback

Low-risk, No feature flags or config toggles needed. Observable failure symptom if rollback is needed: `cost_usd` returns to `None` in AgentEnd events and channel-path AgentEnd events disappear from observer logs.
