### PR TITLE
fix(tests): make delivery_failure_note assertions locale-independent

### DIFF
--- a/crates/zeroclaw-channels/src/discord/mod.rs
+++ b/crates/zeroclaw-channels/src/discord/mod.rs
@@ -7005,9 +7005,17 @@ mod tests {
 
     #[test]
     fn delivery_failure_note_singular_for_one_failure() {
-        let note = delivery_failure_note(&[DiscordMarkerFailure::NotFound])
-            .expect("one failure should produce a note");
-        assert_eq!(note, "(note: I couldn't deliver 1 file.)");
+        let failures = [DiscordMarkerFailure::NotFound];
+        let note = delivery_failure_note(&failures).expect("one failure should produce a note");
+        // Locale-independent: count is always rendered as Arabic digits in
+        // every shipped locale's FTL template (`{$count}`). The literal
+        // English string used to live here but the assertion broke on any
+        // CI runner with a non-English `$LANG` (see PR #8488's blocker).
+        assert!(!note.is_empty(), "note must be non-empty");
+        assert!(
+            note.contains(failures.len().to_string().as_str()),
+            "note must contain the failure count"
+        );
         assert!(
             !note.contains("/workspace/missing.png"),
             "user-facing failure note must not echo local marker targets"
@@ -7016,13 +7024,19 @@ mod tests {
 
     #[test]
     fn delivery_failure_note_plural_redacts_targets() {
-        let note = delivery_failure_note(&[
+        let failures = [
             DiscordMarkerFailure::Refused,
             DiscordMarkerFailure::NotFound,
             DiscordMarkerFailure::Refused,
-        ])
-        .expect("multiple failures should produce a note");
-        assert_eq!(note, "(note: I couldn't deliver 3 files.)");
+        ];
+        let note =
+            delivery_failure_note(&failures).expect("multiple failures should produce a note");
+        // Locale-independent: see singular test for rationale.
+        assert!(!note.is_empty(), "note must be non-empty");
+        assert!(
+            note.contains(failures.len().to_string().as_str()),
+            "note must contain the failure count"
+        );
         assert!(
             !note.contains("a.png") && !note.contains("b.pdf") && !note.contains("c.mp4"),
             "user-facing failure note must not echo failed marker targets"
@@ -7038,7 +7052,14 @@ mod tests {
         let note = delivery_failure_note(&failures);
         let composed = compose_body_with_failure_note(&cleaned_content, note.as_deref());
 
-        assert_eq!(composed, "Done\n\n(note: I couldn't deliver 1 file.)");
+        // Locale-independent: the body must keep the original `Done` content,
+        // gain exactly one blank-line separator, and never echo the failed
+        // marker path. The previous literal English assertion was
+        // locale-dependent and broke on non-English CI runners.
+        assert!(
+            composed.starts_with("Done\n\n"),
+            "composed body must preserve original content with blank-line separator, got {composed:?}"
+        );
         assert!(
             !composed.contains("/workspace/missing.png"),
             "composed outbound body must not echo failed marker targets"

--- a/crates/zeroclaw-channels/src/whatsapp_web.rs
+++ b/crates/zeroclaw-channels/src/whatsapp_web.rs
@@ -2706,11 +2706,23 @@ mod tests {
     #[test]
     #[cfg(feature = "whatsapp-web")]
     fn delivery_failure_note_is_count_only() {
-        let note = whatsapp_delivery_failure_note(2).expect("note");
+        let count: usize = 2;
+        let note = whatsapp_delivery_failure_note(count).expect("note");
 
-        assert!(note.contains("2 WhatsApp media attachments"));
-        assert!(!note.contains("/"));
-        assert!(!note.contains("workspace"));
+        // Locale-independent: count is always rendered as Arabic digits in
+        // every shipped locale's FTL template (`{$count}`). The literal
+        // English phrase used to live here but the assertion would break
+        // on any CI runner with a non-English `$LANG`.
+        assert!(!note.is_empty(), "note must be non-empty");
+        assert!(
+            note.contains(count.to_string().as_str()),
+            "note must contain the failure count"
+        );
+        assert!(!note.contains("/"), "note must not contain path separators");
+        assert!(
+            !note.contains("workspace"),
+            "note must not echo local marker targets"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Three Discord tests hard-coded English expected values for
`delivery_failure_note`, which returns its content via
`i18n::get_required_cli_string_with_args`. The function is
locale-aware by design, so the assertions broke on any CI runner
with a non-English `$LANG` (PR #8488 surfaced this; the offending
tests were introduced in #6572).

Switch the assertions to structural checks that hold in every
shipped locale:

- the note is non-empty
- the note contains the failure count (Fluent `{$count}` always
  formats as Arabic digits, regardless of locale)
- the note does not echo the failed marker path

Also fix the matching latent bug in
`whatsapp_web::tests::delivery_failure_note_is_count_only`
(`#[cfg(feature = "whatsapp-web")]`): it asserted the literal
English phrase "2 WhatsApp media attachments", which would fail
in any non-English locale if the feature gate were ever enabled
on a non-English runner. Same structural fix.

## Why this works

`delivery_failure_note` uses `{$count}` interpolation in the
FTL catalog (e.g. `(note: I could not deliver {$count} WhatsApp
media attachment.)` for en, `（注意：我无法传送 {$count} 个
WhatsApp 媒体附件。）` for zh-CN, etc.). The count is always
serialized as Arabic digits regardless of the surrounding
locale, so asserting `note.contains(count.to_string())` is
locale-agnostic.

## What is NOT changed

- `.ftl` files — no user-facing copy changes.
- `delivery_failure_note` / `whatsapp_delivery_failure_note` /
  `compose_body_with_failure_note` implementations — only their
  test assertions change.
- The redaction invariant (note must not echo `/workspace/...`,
  `a.png`, `b.pdf`, `c.mp4`) is preserved verbatim.

## Files changed

```
crates/zeroclaw-channels/src/discord/mod.rs      | 37 ++++++++++++++++++++------
crates/zeroclaw-channels/src/whatsapp_web.rs     | 22 ++++++++++----
2 files changed, 46 insertions(+), 13 deletions(-)
```

## Validation

Local repro of the original failure:
- `LANG=zh_CN.UTF-8` (my sandbox default; same as the failing CI
  runner):
  - Before: 3 tests fail with
    `assertion `left == right` failed: left: "（注意：我无法传送
    1 个文件。）" right: "(note: I couldn't deliver 1 file.)"`
  - After: 4 tests pass (3 discord + 1 unchanged).
- `LANG=en_US.UTF-8`:
  - All 4 tests pass; no regression.
- `cargo test -p zeroclaw-channels --features whatsapp-web --lib
  delivery`: 8 tests pass (4 discord + 4 whatsapp-related,
  including the previously latent whatsapp test).

`cargo fmt --all -- --check`: clean.
`cargo test --locked`: not run on full workspace yet (CI will).

## Related

- #8488 (this unblocks the Test CI failure on that PR)
- #6572 (introduced the original locale-dependent assertions)