### PR TITLE
fix(gateway): only print dashboard URL when web_dist_dir is available

### DIFF
--- a/crates/zeroclaw-gateway/src/lib.rs
+++ b/crates/zeroclaw-gateway/src/lib.rs
@@ -1561,7 +1561,11 @@ pub async fn run_gateway(
     if let Some(ref url) = tunnel_url {
         println!("  🌐 Public URL: {url}");
     }
-    println!("  🌐 Web Dashboard: http://{display_addr}{pfx}/");
+    if web_dist_dir.is_some() {
+        println!("  🌐 Web Dashboard: http://{display_addr}{pfx}/");
+    } else {
+        println!("  ⚠️  Web Dashboard: not available — build with `cargo web build`");
+    }
     if let Some(code) = pairing.pairing_code() {
         println!();
         println!("  🔐 PAIRING REQUIRED — use this one-time code:");


### PR DESCRIPTION
## Problem

When the Web dashboard is not found (no `web/dist`), the gateway still printed "🌐 Web Dashboard: http://..." at startup, misleading users into expecting a working dashboard.

## Root Cause

The startup banner unconditionally printed the dashboard URL regardless of whether `web_dist_dir` was resolved.

## Fix

Gate the dashboard URL behind `web_dist_dir.is_some()`. When the dashboard is not available, print a build instruction (`cargo web build`) instead.

Fixes #7529