### PR TITLE
fix(audit): drop stale RUSTSEC-2024-0370 ignore after Tauri desktop removal

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -33,7 +33,6 @@ ignore = [
     "RUSTSEC-2025-0098",  # unic-ucd-version unmaintained; tracking #8519
     "RUSTSEC-2025-0100",  # unic-ucd-ident unmaintained; tracking #8519
     # macro/font helpers unmaintained (transitive); tracking #8519
-    "RUSTSEC-2024-0370",  # proc-macro-error unmaintained; transitive macro helper; tracking #8519
     "RUSTSEC-2026-0173",  # proc-macro-error2 unmaintained; transitive macro helper; tracking #8519
     "RUSTSEC-2024-0388",  # derivative unmaintained; transitive derive helper; tracking #8519
     "RUSTSEC-2026-0192",  # ttf-parser unmaintained; via pdf-extract -> lopdf; tracking #8519


### PR DESCRIPTION
## Summary

PR #8544 removed the \`zeroclaw-desktop\` Tauri app, which was the only
workspace path pulling in the GTK3 gtk-rs bindings (and therefore
\`gtk3-macros\`). With that path gone, \`proc-macro-error\` is no longer
in the workspace \`Cargo.lock\`, so ignoring \`RUSTSEC-2024-0370\` is
unnecessary.

\`deny.toml\` already omits this entry; this change removes the drift
between \`.cargo/audit.toml\` and \`deny.toml\`. No functional code changes.

## Files changed

\`\`\`
.cargo/audit.toml | 1 -
1 file changed, 1 deletion(-)
\`\`\`

## Validation

- \`cargo audit --no-fetch\` on upstream/master: 0 vulnerabilities, 0 warnings
- \`cargo fmt --all -- --check\`: clean

## Related

- #8544 (removed the Tauri desktop app)
- #8519 (master audit-tracking issue)
