### PR TITLE
feat(slack): add thread history scope

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -601,9 +601,53 @@ fn channel_scope(msg: &zeroclaw_api::channel::ChannelMessage) -> String {
 }
 
 pub fn conversation_history_key(msg: &zeroclaw_api::channel::ChannelMessage) -> String {
+    conversation_history_key_with_slack_scope(
+        msg,
+        zeroclaw_config::schema::SlackThreadHistoryScope::Sender,
+    )
+}
+
+fn conversation_history_key_for_context(
+    ctx: &ChannelRuntimeContext,
+    msg: &zeroclaw_api::channel::ChannelMessage,
+) -> String {
+    let slack_scope = if msg.channel == "slack" {
+        msg.channel_alias
+            .as_deref()
+            .and_then(|alias| ctx.prompt_config.channels.slack.get(alias))
+            .map(|slack| slack.thread_history_scope)
+            .unwrap_or_default()
+    } else {
+        zeroclaw_config::schema::SlackThreadHistoryScope::Sender
+    };
+    conversation_history_key_with_slack_scope(msg, slack_scope)
+}
+
+fn conversation_history_key_with_slack_scope(
+    msg: &zeroclaw_api::channel::ChannelMessage,
+    slack_scope: zeroclaw_config::schema::SlackThreadHistoryScope,
+) -> String {
     let channel_scope = channel_scope(msg);
     if msg.channel == "wecom_ws" {
         return sanitize_session_key(&format!("{channel_scope}_{}", msg.reply_target));
+    }
+    if msg.channel == "slack" {
+        match slack_scope {
+            zeroclaw_config::schema::SlackThreadHistoryScope::Channel => {
+                return sanitize_session_key(&format!("{channel_scope}_{}", msg.reply_target));
+            }
+            zeroclaw_config::schema::SlackThreadHistoryScope::Thread
+                if msg.thread_ts.as_deref().is_some_and(|tid| !tid.is_empty()) =>
+            {
+                let tid = msg.thread_ts.as_deref().unwrap_or_default();
+                return sanitize_session_key(&format!(
+                    "{channel_scope}_{}_{tid}",
+                    msg.reply_target
+                ));
+            }
+            zeroclaw_config::schema::SlackThreadHistoryScope::Thread
+            | zeroclaw_config::schema::SlackThreadHistoryScope::Sender => {}
+        }
     }
     // reply_target gives per-channel isolation (distinct Discord/Slack
     // channels) and thread_ts gives per-topic isolation in forum groups.
@@ -2669,7 +2713,7 @@ fn build_scope_override_summary(
             scope_line(OverrideScope::Agent),
         )
     };
-    let sender_key = conversation_history_key(msg);
+    let sender_key = conversation_history_key_for_context(ctx, msg);
     let session = ctx
         .route_overrides
         .lock()
@@ -2699,7 +2743,7 @@ async fn handle_runtime_command_if_needed(
         return true;
     };
 
-    let sender_key = conversation_history_key(msg);
+    let sender_key = conversation_history_key_for_context(ctx, msg);
     let defaults_snapshot = runtime_defaults_snapshot(ctx);
     let mut current = get_route_selection(ctx, msg, &sender_key, &defaults_snapshot);
 
@@ -4385,7 +4429,7 @@ async fn process_channel_message_body(
         }
     }
 
-    let history_key = conversation_history_key(&msg);
+    let history_key = conversation_history_key_for_context(ctx.as_ref(), &msg);
     stamp_session_routing_context(ctx.as_ref(), &msg, &history_key);
     if msg.passive_context {
         record_passive_context(ctx.as_ref(), &msg, &history_key);
@@ -6013,7 +6057,7 @@ async fn run_message_dispatch_loop(
         // ── Debounce: accumulate rapid messages per sender ──────────
         // CLI messages bypass debouncing so the interactive loop stays responsive.
         let msg = if msg.channel != "cli" && ctx.debouncer.enabled() {
-            let debounce_key = conversation_history_key(&msg);
+            let debounce_key = conversation_history_key_for_context(ctx.as_ref(), &msg);
             match ctx.debouncer.debounce(&debounce_key, &msg.content).await {
                 zeroclaw_infra::debounce::DebounceResult::Pending(rx) => {
                     // Spawn a lightweight task that waits for the debounce window
@@ -17834,6 +17878,122 @@ BTC is currently around $65,000 based on latest tool output."#
             "wecom_ws_work_group--room-1"
         );
         assert_eq!(interruption_scope_key(&msg), "wecom_ws_work_group--room-1");
+    }
+
+    #[test]
+    fn slack_thread_history_scope_sender_preserves_sender_isolation() {
+        let first = zeroclaw_api::channel::ChannelMessage {
+            id: "slack_C123_1741234567.100001".into(),
+            sender: "U123".into(),
+            reply_target: "C123".into(),
+            content: "hello".into(),
+            channel: "slack".into(),
+            channel_alias: Some("support".into()),
+            timestamp: 1,
+            thread_ts: Some("1741234567.000001".into()),
+            interruption_scope_id: Some("1741234567.000001".into()),
+            attachments: vec![],
+            subject: None,
+            ..Default::default()
+        };
+        let second = zeroclaw_api::channel::ChannelMessage {
+            id: "slack_C123_1741234567.200002".into(),
+            sender: "U456".into(),
+            content: "same thread".into(),
+            timestamp: 2,
+            ..first.clone()
+        };
+
+        let first_key = conversation_history_key_with_slack_scope(
+            &first,
+            zeroclaw_config::schema::SlackThreadHistoryScope::Sender,
+        );
+        let second_key = conversation_history_key_with_slack_scope(
+            &second,
+            zeroclaw_config::schema::SlackThreadHistoryScope::Sender,
+        );
+
+        assert_ne!(first_key, second_key);
+        assert!(first_key.contains("U123"));
+        assert!(second_key.contains("U456"));
+    }
+
+    #[test]
+    fn slack_thread_history_scope_thread_shares_thread_across_senders() {
+        let first = zeroclaw_api::channel::ChannelMessage {
+            id: "slack_C123_1741234567.100001".into(),
+            sender: "U123".into(),
+            reply_target: "C123".into(),
+            content: "hello".into(),
+            channel: "slack".into(),
+            channel_alias: Some("support".into()),
+            timestamp: 1,
+            thread_ts: Some("1741234567.000001".into()),
+            interruption_scope_id: Some("1741234567.000001".into()),
+            attachments: vec![],
+            subject: None,
+            ..Default::default()
+        };
+        let second = zeroclaw_api::channel::ChannelMessage {
+            id: "slack_C123_1741234567.200002".into(),
+            sender: "U456".into(),
+            content: "same thread".into(),
+            timestamp: 2,
+            ..first.clone()
+        };
+
+        let first_key = conversation_history_key_with_slack_scope(
+            &first,
+            zeroclaw_config::schema::SlackThreadHistoryScope::Thread,
+        );
+        let second_key = conversation_history_key_with_slack_scope(
+            &second,
+            zeroclaw_config::schema::SlackThreadHistoryScope::Thread,
+        );
+
+        assert_eq!(first_key, second_key);
+        assert_eq!(first_key, "slack_support_C123_1741234567_000001");
+        assert!(!first_key.contains("U123"));
+        assert!(!first_key.contains("U456"));
+    }
+
+    #[test]
+    fn slack_thread_history_scope_channel_shares_channel_across_threads_and_senders() {
+        let first = zeroclaw_api::channel::ChannelMessage {
+            id: "slack_C123_1741234567.100001".into(),
+            sender: "U123".into(),
+            reply_target: "C123".into(),
+            content: "hello".into(),
+            channel: "slack".into(),
+            channel_alias: Some("support".into()),
+            timestamp: 1,
+            thread_ts: Some("1741234567.000001".into()),
+            interruption_scope_id: Some("1741234567.000001".into()),
+            attachments: vec![],
+            subject: None,
+            ..Default::default()
+        };
+        let second = zeroclaw_api::channel::ChannelMessage {
+            id: "slack_C123_1741234568.200002".into(),
+            sender: "U456".into(),
+            content: "different thread".into(),
+            timestamp: 2,
+            thread_ts: Some("1741234568.000001".into()),
+            interruption_scope_id: Some("1741234568.000001".into()),
+            ..first.clone()
+        };
+
+        let first_key = conversation_history_key_with_slack_scope(
+            &first,
+            zeroclaw_config::schema::SlackThreadHistoryScope::Channel,
+        );
+        let second_key = conversation_history_key_with_slack_scope(
+            &second,
+            zeroclaw_config::schema::SlackThreadHistoryScope::Channel,
+        );
+
+        assert_eq!(first_key, second_key);
+        assert_eq!(first_key, "slack_support_C123");
     }
 
     #[test]

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -12922,6 +12922,22 @@ impl ChannelConfig for DiscordConfig {
     }
 }
 
+/// Scope used for Slack channel conversation history.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default, zeroclaw_macros::ConfigEnum,
+)]
+#[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum SlackThreadHistoryScope {
+    /// Preserve the existing behavior: isolate history by Slack sender, channel, and thread.
+    #[default]
+    Sender,
+    /// Share history across all senders in the same Slack thread.
+    Thread,
+    /// Share history across all senders and threads in the same Slack channel.
+    Channel,
+}
+
 /// Slack bot channel configuration.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, Configurable)]
 #[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
@@ -12972,6 +12988,13 @@ pub struct SlackConfig {
     #[tab(Advanced)]
     #[serde(default)]
     pub thread_replies: Option<bool>,
+    /// Controls which Slack messages share conversation history.
+    /// `sender` keeps the historical ZeroClaw behavior (channel + thread + sender).
+    /// `thread` shares one history across everyone in the same Slack thread.
+    /// `channel` shares one history across the whole Slack channel.
+    #[tab(Advanced)]
+    #[serde(default)]
+    pub thread_history_scope: SlackThreadHistoryScope,
     /// When true, only respond to messages that @-mention the bot in groups.
     /// Direct messages remain allowed.
     #[tab(Behavior)]
@@ -24069,6 +24092,14 @@ allowed_users = ["U111"]
         assert_eq!(parsed.thread_replies, Some(false));
         assert!(!parsed.interrupt_on_new_message);
         assert!(!parsed.mention_only);
+        assert_eq!(parsed.thread_history_scope, SlackThreadHistoryScope::Sender);
+    }
+
+    #[test]
+    async fn slack_config_deserializes_thread_history_scope() {
+        let json = r#"{"bot_token":"xoxb-tok","thread_history_scope":"thread"}"#;
+        let parsed: SlackConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.thread_history_scope, SlackThreadHistoryScope::Thread);
     }
 
     #[test]
@@ -24106,6 +24137,20 @@ channel_ids = ["C123", "D456"]
         assert!(!parsed.interrupt_on_new_message);
         assert_eq!(parsed.thread_replies, None);
         assert!(!parsed.mention_only);
+        assert_eq!(parsed.thread_history_scope, SlackThreadHistoryScope::Sender);
+    }
+
+    #[test]
+    async fn slack_config_toml_with_thread_history_scope() {
+        let toml_str = r#"
+bot_token = "xoxb-tok"
+thread_history_scope = "channel"
+"#;
+        let parsed: SlackConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            parsed.thread_history_scope,
+            SlackThreadHistoryScope::Channel
+        );
     }
 
     #[test]

--- a/docs/book/src/channels/slack.md
+++ b/docs/book/src/channels/slack.md
@@ -92,6 +92,12 @@ secure.
 answers inside a thread if a message there @-mentions it, instead of replying to
 every message in a thread it's part of.
 
+`thread_history_scope` controls which Slack messages share one conversation
+history. The default `sender` preserves the historical behavior: a thread is
+split by sender. Set it to `thread` for support-style bots where everyone in
+the same Slack thread should share context, or `channel` to reuse one history
+across the whole Slack channel.
+
 ## Mentions and formatting
 
 - `mention_only`: when `true`, the bot only answers messages that @-mention it,


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Added `channels.slack.<alias>.thread_history_scope` so operators can choose sender-, thread-, or channel-wide Slack conversation history.
  - Kept the default as `sender` to preserve existing per-sender Slack thread behavior.
  - Resolved the Slack history key from live config at message-processing time, matching the repository source-of-truth rule.
  - Documented the new Slack thread context setting.
- **Scope boundary:** This PR does not change Slack message fetching, Slack API permissions, peer group authorization, mention gating, or any non-Slack channel behavior.
- **Blast radius:** Slack channel session/history routing, config schema parsing/schema export, and Slack channel documentation. Existing installs keep the old behavior unless they opt into `thread` or `channel`.
- **Linked issue(s):** None
- **Labels:** `enhancement`, `channel:slack`, `config`, `docs`, `risk:medium`, `size:S`

## Validation Evidence (required)

Local validation is the signal CI cannot replace. Run the full battery and paste literal output (tails, failures, warnings — not "all passed").

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

Docs-only changes: replace with markdown lint + link-integrity (`scripts/ci/docs_quality_gate.sh`). Bootstrap scripts: add `bash -n install.sh`.

- **Commands run and tail output:**

```bash
$ cargo fmt --check
# exited 0 with no output
```

```bash
$ cargo test -p zeroclaw-config slack_config_deserializes_thread_history_scope
running 1 test
test schema::tests::slack_config_deserializes_thread_history_scope ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1054 filtered out; finished in 0.00s
```

```bash
$ cargo test -p zeroclaw-channels slack_thread_history_scope_
running 3 tests
test orchestrator::tests::slack_thread_history_scope_channel_shares_channel_across_threads_and_senders ... ok
test orchestrator::tests::slack_thread_history_scope_thread_shares_thread_across_senders ... ok
test orchestrator::tests::slack_thread_history_scope_sender_preserves_sender_isolation ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 1161 filtered out; finished in 0.00s
```

- **Beyond CI — what did you manually verify?** Rebased onto current `upstream/master` and verified the branch contains one commit above base. Checked the config parser reports `thread_history_scope` as `SlackThreadHistoryScope`.
- **If any command was intentionally skipped, why:** Full `cargo clippy --all-targets -- -D warnings` and full `cargo test` were not run locally because this is a narrow Slack/config change and targeted crate tests cover the new behavior. CI should run the full workspace gate.

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: Not applicable.

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`Yes`)
- If `No` or `Yes` to either: Existing users do not need to change anything. To opt into shared Slack thread context, set `channels.slack.<alias>.thread_history_scope = "thread"`; use `"channel"` for one history across the channel or omit the field for the existing `"sender"` behavior.

## Rollback (required for medium/high-risk PRs)

Low-risk PRs: `git revert <sha>` is the plan unless otherwise noted.

Medium/high-risk PRs must fill:

- **Fast rollback command/path:** `git revert 7760e10466d8da38ade3430c196cb78050f76e9c`
- **Feature flags or config toggles:** Omit `channels.slack.<alias>.thread_history_scope` or set it to `"sender"` to restore historical per-sender Slack thread history without reverting.
- **Observable failure symptoms:** Slack conversations unexpectedly sharing or splitting context; look for unusual session history keys or Slack replies that reference another participant's prior thread message unexpectedly.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): Not applicable.
- Scope materially carried forward: Not applicable.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`No`)
- If `No`, why (inspiration-only, no direct code/design carry-over): No superseded PR or incorporated contributor work.
