### PR TITLE
docs(security): fix inaccurate tool-receipt chaining claim

### DIFF
--- a/docs/book/src/security/model.md
+++ b/docs/book/src/security/model.md
@@ -55,9 +55,9 @@ Docs: [Sandboxing](./sandboxing.md).
 
 ## Tool receipts
 
-Every tool invocation, whether it executed, was blocked, or required approval, produces a signed receipt in a chain. Each receipt includes the hash of the previous one, so tampering with any receipt invalidates the rest.
+Every tool invocation, whether it executed, was blocked, or required approval, produces a signed receipt: an HMAC-SHA256 digest over the call and its result, keyed by an ephemeral per-daemon-process key. Receipts are independent: each one covers only the call it was computed for, so they are not chained, and tampering with one does not invalidate the others.
 
-Receipts are the source of truth for "what did the agent do yesterday". They're readable, greppable, and durable.
+Receipts are readable and greppable within a daemon session. They do not persist across daemon restarts (the key rotates on every start; a durable audit store is planned).
 
 Docs: [Tool receipts](./tool-receipts.md).
 

--- a/docs/book/src/security/overview.md
+++ b/docs/book/src/security/overview.md
@@ -7,4 +7,4 @@ Each agent runs under a risk profile and a runtime profile it references; see [A
 - [The security model](./model.md): the six enforcement layers, additional gates, failure behavior, and the default posture.
 - [Autonomy levels](./autonomy.md): the coarse-grained ReadOnly / Supervised / Full knob.
 - [Sandboxing](./sandboxing.md): OS-level isolation backends per platform.
-- [Tool receipts](./tool-receipts.md): the signed, chained audit log of every tool call.
+- [Tool receipts](./tool-receipts.md): the signed HMAC-SHA256 proof that every tool call actually executed.


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Three security-doc spots claimed tool receipts are "chained" (each receipt includes the hash of the previous one) and "durable". Both are inaccurate. The implementation (`crates/zeroclaw-runtime/src/agent/tool_receipts.rs`) signs each call independently over `tool_name | args | result | timestamp` with an ephemeral per-daemon key — there is no previous-hash field, so receipts are not chained. The authoritative `docs/book/src/security/tool-receipts.md` already states receipts are "not cross-signed ... the receipt only covers the call it was computed for," and `architecture/request-lifecycle.md` says they "are not chained." This PR brings `model.md` and `overview.md` in line with the implementation and the authoritative receipt page.
- **Scope boundary:** Prose-only. No code, no config, no behavior change. Touches exactly two files in `docs/book/src/security/`.
- **Blast radius:** None beyond readers of the security docs. No generated reference pages were hand-edited.
- **Linked issue(s):** None filed. Spotted during a docs read-through of the v0.8.2 release.
- **Labels:** `type:docs`, `risk:low`, `size:S`

## Validation Evidence (required)

Docs-only change; ran the docs markdown + link gates against the committed diff.

- **Commands run and tail output:**

```
$ bash scripts/ci/docs_quality_gate.sh
No prose em-dashes in changed docs files.
Linting docs files: docs/book/src/security/model.md docs/book/src/security/overview.md
markdownlint-cli2 v0.20.0 (markdownlint v0.40.0)
Summary: 0 error(s)

$ bash scripts/ci/docs_links_gate.sh
Collected 1 added link(s) from 2 docs file(s).
Checked 1 local docs link target(s).
No added HTTP(S) links detected in changed docs lines.
```

- **Beyond CI — what did I manually verify?**
  - Cross-checked the corrected claims against the implementation: `ReceiptGenerator::compute_hmac` (signs only `tool_name | args | result | timestamp`; no previous-receipt input) and `ReceiptScope` (a flat `Vec<String>` collector, no linking).
  - Confirmed consistency with the authoritative `security/tool-receipts.md` ("Not cross-signed ... only covers the call it was computed for"; ephemeral key rotated on restart; durable audit DB "Planned") and `architecture/request-lifecycle.md` ("not chained").
  - The v0.8.2 release notes list "HMAC tool receipts (#8009)" as wired through ACP/gateway WS/CLI turn paths — consistent with independent (non-chained) receipts.
- **If any command was intentionally skipped, why:** N/A. Docs-only; no `cargo fmt/clippy/test` surface changed.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility (required)

- Backward compatible? **Yes** (documentation only)
- Config / env / CLI surface changed? **No**

## Rollback

Low-risk: `git revert <sha>` is the plan.