### PR TITLE
docs(security): fix inaccurate tool-receipt chaining claim

### DIFF
--- a/docs/book/src/security/model.md
+++ b/docs/book/src/security/model.md
@@ -55,9 +55,9 @@ Docs: [Sandboxing](./sandboxing.md).
 
 ## Tool receipts
 
-Tool receipts provide HMAC evidence that a successful tool call and its result passed through the runtime. When receipts are enabled, successful tool outputs receive an HMAC-SHA256 receipt over the call and result, and the receipt is fed back into the conversation with the tool result.
+When tool receipts are enabled, every successful tool execution produces a signed receipt: an HMAC-SHA256 digest over the call and its result, keyed by an ephemeral per-daemon-process key. Receipts are independent: each one covers only the successful call it was computed for, so they are not chained, and tampering with one does not invalidate the others.
 
-Receipts help catch fabricated tool claims. They are not a chained or durable audit log today: receipt keys are ephemeral, receipts are not cross-signed with the conversation hash, and persistent receipt storage is still future work.
+Receipts are readable and greppable within a daemon session. They do not persist across daemon restarts (the key rotates on every start; a durable audit store is planned).
 
 Docs: [Tool receipts](./tool-receipts.md).
 

--- a/docs/book/src/security/overview.md
+++ b/docs/book/src/security/overview.md
@@ -7,4 +7,4 @@ Each agent runs under a risk profile and a runtime profile it references; see [A
 - [The security model](./model.md): the six enforcement layers, additional gates, failure behavior, and the default posture.
 - [Autonomy levels](./autonomy.md): the coarse-grained ReadOnly / Supervised / Full knob.
 - [Sandboxing](./sandboxing.md): OS-level isolation backends per platform.
-- [Tool receipts](./tool-receipts.md): HMAC evidence for successful tool results, passed back in-band with the conversation.
+- [Tool receipts](./tool-receipts.md): the signed HMAC-SHA256 proof that every successful tool call actually executed.


### PR DESCRIPTION
> **Maintainer's note** (Audacity88): I updated this PR body on behalf of @wangmiao0668000666 to reflect the current reviewed head and latest validation record. The branch still preserves the contributor commit `5085126` and its original authorship/committer attribution; authorship of the docs patch remains with the contributors. This edit only clarifies scope, validation, and merge metadata.

## Summary

Continuation of #8588. This corrects the security docs so tool receipts are described as enabled-only, successful-execution HMAC-SHA256 receipts. It removes the older implication that receipts are chained or durable audit records.

## What changed

- `docs/book/src/security/model.md`: describes tool receipts as enabled-only receipts for successful tool executions, with independent HMAC-SHA256 coverage over the call and result.
- `docs/book/src/security/overview.md`: aligns the one-line tool-receipts summary with the dedicated `tool-receipts.md` page.

## Validation

Contributor-reported focused docs gate on the current two-file scope:

```text
DOCS_FILES=$'docs/book/src/security/model.md\ndocs/book/src/security/overview.md' BASE_SHA=upstream/master bash scripts/ci/docs_quality_gate.sh
No prose em-dashes in changed docs files.
Linting docs files: docs/book/src/security/model.md docs/book/src/security/overview.md
Summary: 0 error(s)
```

## Related

- Continues #8588.
