### PR TITLE
fix(channels): carry WeCom reply scope as structured metadata

### DIFF
--- a/crates/zeroclaw-api/src/channel.rs
+++ b/crates/zeroclaw-api/src/channel.rs
@@ -76,6 +76,9 @@ pub struct ChannelMessage {
     /// When true, the orchestrator records this as context only and must not
     /// start an agent turn or emit visible channel side effects.
     pub passive_context: bool,
+    /// Channel adapter observed that this inbound message explicitly addressed
+    /// the bot through a platform-level signal such as an @mention.
+    pub explicitly_addressed: bool,
     /// Controls whether conversation history is sender-scoped or room-scoped.
     pub conversation_scope: ChannelConversationScope,
 }
@@ -628,6 +631,7 @@ mod tests {
         assert!(msg.attachments.is_empty());
         assert!(msg.subject.is_none());
         assert!(!msg.passive_context);
+        assert!(!msg.explicitly_addressed);
         assert_eq!(msg.conversation_scope, ChannelConversationScope::Sender);
     }
 

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -88,6 +88,8 @@ pub use crate::wechat::WeChatChannel;
 pub use crate::wecom::WeComChannel;
 #[cfg(feature = "channel-wecom-ws")]
 pub use crate::wecom_ws::WeComWsChannel;
+#[cfg(feature = "channel-wecom-ws")]
+use crate::wecom_ws::WeComWsRuntimePolicy;
 #[cfg(feature = "channel-whatsapp-cloud")]
 pub use crate::whatsapp::WhatsAppChannel;
 pub use zeroclaw_api::channel::{Channel, ChannelMessage, SendMessage};
@@ -6648,30 +6650,26 @@ fn build_channel_by_id(
                 config.channels.wecom_ws.get(&alias).with_context(|| {
                     format!("WeCom WebSocket channel '{alias}' is not configured")
                 })?;
-            let peer_resolver: Arc<dyn Fn() -> Vec<String> + Send + Sync> = {
+            let policy_resolver: Arc<dyn Fn() -> WeComWsRuntimePolicy + Send + Sync> = {
                 let cfg_arc = config_arc.clone();
                 let alias = alias.clone();
-                let configured_allowed_users = wc.allowed_users.clone();
+                let snapshot = wc.clone();
                 Arc::new(move || {
                     let config = cfg_arc.read();
-                    let mut peers = configured_allowed_users.clone();
-                    for peer in config.channel_external_peers("wecom-ws", &alias) {
-                        if !peers.contains(&peer) {
-                            peers.push(peer);
-                        }
+                    let mut external_peers = config.channel_external_peers("wecom-ws", &alias);
+                    external_peers.extend(config.channel_external_peers("wecom_ws", &alias));
+
+                    if let Some(wc_ws) = config.channels.wecom_ws.get(&alias) {
+                        WeComWsRuntimePolicy::from_config(wc_ws, external_peers)
+                    } else {
+                        WeComWsRuntimePolicy::from_config(&snapshot, external_peers)
                     }
-                    for peer in config.channel_external_peers("wecom_ws", &alias) {
-                        if !peers.contains(&peer) {
-                            peers.push(peer);
-                        }
-                    }
-                    peers
                 })
             };
             Ok(Arc::new(WeComWsChannel::new_with_alias(
                 wc,
                 alias.clone(),
-                peer_resolver,
+                policy_resolver,
                 &config.channel_workspace_dir(&format!("wecom_ws.{alias}")),
             )?))
         }
@@ -8537,30 +8535,26 @@ fn collect_configured_channels(
         if !wc_ws.enabled {
             continue;
         }
-        let peer_resolver: Arc<dyn Fn() -> Vec<String> + Send + Sync> = {
+        let policy_resolver: Arc<dyn Fn() -> WeComWsRuntimePolicy + Send + Sync> = {
             let cfg_arc = config_arc.clone();
             let alias = alias.clone();
-            let configured_allowed_users = wc_ws.allowed_users.clone();
+            let snapshot = wc_ws.clone();
             Arc::new(move || {
                 let config = cfg_arc.read();
-                let mut peers = configured_allowed_users.clone();
-                for peer in config.channel_external_peers("wecom-ws", &alias) {
-                    if !peers.contains(&peer) {
-                        peers.push(peer);
-                    }
+                let mut external_peers = config.channel_external_peers("wecom-ws", &alias);
+                external_peers.extend(config.channel_external_peers("wecom_ws", &alias));
+
+                if let Some(wc_ws) = config.channels.wecom_ws.get(&alias) {
+                    WeComWsRuntimePolicy::from_config(wc_ws, external_peers)
+                } else {
+                    WeComWsRuntimePolicy::from_config(&snapshot, external_peers)
                 }
-                for peer in config.channel_external_peers("wecom_ws", &alias) {
-                    if !peers.contains(&peer) {
-                        peers.push(peer);
-                    }
-                }
-                peers
             })
         };
         match WeComWsChannel::new_with_alias(
             wc_ws,
             alias.clone(),
-            peer_resolver,
+            policy_resolver,
             &config.channel_workspace_dir(&format!("wecom_ws.{alias}")),
         ) {
             Ok(channel) => channels.push(ConfiguredChannel {

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -602,9 +602,6 @@ fn channel_scope(msg: &zeroclaw_api::channel::ChannelMessage) -> String {
 
 pub fn conversation_history_key(msg: &zeroclaw_api::channel::ChannelMessage) -> String {
     let channel_scope = channel_scope(msg);
-    if msg.channel == "wecom_ws" {
-        return sanitize_session_key(&format!("{channel_scope}_{}", msg.reply_target));
-    }
     // reply_target gives per-channel isolation (distinct Discord/Slack
     // channels) and thread_ts gives per-topic isolation in forum groups.
     // Sanitize so the runtime HashMap key matches `SessionStore::list_sessions`
@@ -617,10 +614,7 @@ pub fn conversation_history_key(msg: &zeroclaw_api::channel::ChannelMessage) -> 
         other => other,
     };
     let raw = match (msg.conversation_scope, thread_scope) {
-        (zeroclaw_api::channel::ChannelConversationScope::ReplyTarget, Some(tid)) => {
-            format!("{channel_scope}_{}_{tid}", msg.reply_target)
-        }
-        (zeroclaw_api::channel::ChannelConversationScope::ReplyTarget, None) => {
+        (zeroclaw_api::channel::ChannelConversationScope::ReplyTarget, _) => {
             format!("{channel_scope}_{}", msg.reply_target)
         }
         (zeroclaw_api::channel::ChannelConversationScope::Sender, Some(tid)) => {
@@ -660,20 +654,20 @@ fn followup_thread_id(msg: &zeroclaw_api::channel::ChannelMessage) -> Option<Str
 }
 
 fn interruption_scope_key(msg: &zeroclaw_api::channel::ChannelMessage) -> String {
-    if msg.channel == "wecom_ws" && msg.reply_target.starts_with("group--") {
-        let channel_scope = match &msg.channel_alias {
-            Some(alias) => format!("{}.{}", msg.channel, alias),
-            None => msg.channel.clone(),
-        };
-        return sanitize_session_key(&format!("{channel_scope}_{}", msg.reply_target));
-    }
-
-    match &msg.interruption_scope_id {
-        Some(scope) => format!(
+    match (msg.conversation_scope, msg.interruption_scope_id.as_deref()) {
+        (zeroclaw_api::channel::ChannelConversationScope::ReplyTarget, Some(scope)) => {
+            sanitize_session_key(&format!("{}_{}", channel_scope(msg), scope))
+        }
+        (zeroclaw_api::channel::ChannelConversationScope::ReplyTarget, None) => {
+            sanitize_session_key(&format!("{}_{}", channel_scope(msg), msg.reply_target))
+        }
+        (zeroclaw_api::channel::ChannelConversationScope::Sender, Some(scope)) => format!(
             "{}_{}_{}_{}",
             msg.channel, msg.reply_target, msg.sender, scope
         ),
-        None => format!("{}_{}_{}", msg.channel, msg.reply_target, msg.sender),
+        (zeroclaw_api::channel::ChannelConversationScope::Sender, None) => {
+            format!("{}_{}_{}", msg.channel, msg.reply_target, msg.sender)
+        }
     }
 }
 
@@ -1346,9 +1340,11 @@ fn supports_runtime_model_switch(channel_name: &str) -> bool {
     )
 }
 
-fn is_explicitly_addressed_channel_message(channel_name: &str, content: &str) -> bool {
-    channel_name == "wecom_ws"
-        && content.contains("[WeCom group message addressed to this bot via @")
+fn should_bypass_reply_intent_precheck(
+    msg: &zeroclaw_api::channel::ChannelMessage,
+    direct_message: bool,
+) -> bool {
+    msg.explicitly_addressed || direct_message
 }
 
 fn is_matrix_channel_name(channel_name: &str) -> bool {
@@ -4775,13 +4771,11 @@ async fn process_channel_message_body(
     }
 
     // ── Reply-intent precheck ────────────────────────────────────────
-    let explicit_channel_address =
-        is_explicitly_addressed_channel_message(&msg.channel, &msg.content);
     let direct_message = target_channel
         .as_ref()
         .map(|c| c.is_direct_message(&msg))
         .unwrap_or(false);
-    let classifier_intent = if explicit_channel_address || direct_message {
+    let classifier_intent = if should_bypass_reply_intent_precheck(&msg, direct_message) {
         AssistantChannelOutcome::Reply(String::new())
     } else {
         let (classifier_provider_arc, classifier_model_owned, classifier_temperature): (
@@ -17840,7 +17834,7 @@ BTC is currently around $65,000 based on latest tool output."#
     }
 
     #[test]
-    fn wecom_ws_conversation_history_key_uses_reply_target_scope() {
+    fn reply_target_conversation_history_key_uses_room_scope() {
         let msg = zeroclaw_api::channel::ChannelMessage {
             id: "msg_wecom_ws".into(),
             sender: "zeroclaw_user".into(),
@@ -17850,9 +17844,10 @@ BTC is currently around $65,000 based on latest tool output."#
             channel_alias: Some("work".into()),
             timestamp: 1,
             thread_ts: Some("req-1".into()),
-            interruption_scope_id: None,
+            interruption_scope_id: Some("group--room-1".into()),
             attachments: vec![],
             subject: None,
+            conversation_scope: zeroclaw_api::channel::ChannelConversationScope::ReplyTarget,
 
             ..Default::default()
         };
@@ -18288,19 +18283,21 @@ BTC is currently around $65,000 based on latest tool output."#
     }
 
     #[test]
-    fn explicit_wecom_group_address_bypasses_reply_intent_precheck() {
-        assert!(is_explicitly_addressed_channel_message(
-            "wecom_ws",
-            "[WeCom group message addressed to this bot via @danya]\n@danya say hi"
-        ));
-        assert!(!is_explicitly_addressed_channel_message(
-            "wecom_ws",
-            "@danya say hi"
-        ));
-        assert!(!is_explicitly_addressed_channel_message(
-            "telegram",
-            "[WeCom group message addressed to this bot via @danya]\n@danya say hi"
-        ));
+    fn reply_intent_precheck_uses_structured_addressing_signal() {
+        let marker_only = zeroclaw_api::channel::ChannelMessage {
+            content: "[WeCom group message addressed to this bot via @danya]\n@danya say hi".into(),
+            channel: "wecom_ws".into(),
+            explicitly_addressed: false,
+            ..Default::default()
+        };
+        assert!(!should_bypass_reply_intent_precheck(&marker_only, false));
+        assert!(should_bypass_reply_intent_precheck(&marker_only, true));
+
+        let addressed = zeroclaw_api::channel::ChannelMessage {
+            explicitly_addressed: true,
+            ..marker_only
+        };
+        assert!(should_bypass_reply_intent_precheck(&addressed, false));
     }
 
     #[test]

--- a/crates/zeroclaw-channels/src/wecom_ws.rs
+++ b/crates/zeroclaw-channels/src/wecom_ws.rs
@@ -210,12 +210,40 @@ impl SimpleIdempotencyStore {
 #[derive(Clone)]
 struct WeComRuntimeConfig {
     workspace_dir: PathBuf,
-    allowed_groups: Vec<String>,
-    bot_name: Option<String>,
+    // Connection/resource settings are captured when the channel is built; config
+    // changes for these require a channel rebuild/reconnect to take effect.
     file_retention_days: u32,
     max_file_size_bytes: u64,
     stream_mode: StreamMode,
     proxy_url: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct WeComWsRuntimePolicy {
+    allowed_users: Vec<String>,
+    allowed_groups: Vec<String>,
+    bot_name: Option<String>,
+}
+
+impl WeComWsRuntimePolicy {
+    pub(crate) fn from_config(
+        config: &WeComWsConfig,
+        external_peers: impl IntoIterator<Item = String>,
+    ) -> Self {
+        let mut allowed_users = normalize_wecom_allowlist(config.allowed_users.clone());
+        for peer in external_peers {
+            let peer = normalize_wecom_identity(&peer);
+            if !peer.is_empty() && !allowed_users.contains(&peer) {
+                allowed_users.push(peer);
+            }
+        }
+
+        Self {
+            allowed_users,
+            allowed_groups: normalize_wecom_allowlist(config.allowed_groups.clone()),
+            bot_name: normalize_optional_wecom_identity(config.bot_name.as_deref()),
+        }
+    }
 }
 
 // ── MediaDecryptor (per-attachment AES key) ──────────────────────────
@@ -263,7 +291,7 @@ pub struct WeComWsChannel {
     bot_id: String,
     secret: String,
     alias: String,
-    peer_resolver: Arc<dyn Fn() -> Vec<String> + Send + Sync>,
+    policy_resolver: Arc<dyn Fn() -> WeComWsRuntimePolicy + Send + Sync>,
     cfg: WeComRuntimeConfig,
     client: reqwest::Client,
     ws_tx: Arc<tokio::sync::Mutex<Option<mpsc::Sender<WsOutbound>>>>,
@@ -279,19 +307,18 @@ pub struct WeComWsChannel {
 
 impl WeComWsChannel {
     pub fn new(config: &WeComWsConfig, workspace_dir: &Path) -> Result<Self> {
-        let allowed_users = normalize_wecom_allowlist(config.allowed_users.clone());
         Self::new_with_alias(
             config,
             "default",
-            Arc::new(move || allowed_users.clone()),
+            Self::static_policy_resolver(config),
             workspace_dir,
         )
     }
 
-    pub fn new_with_alias(
+    pub(crate) fn new_with_alias(
         config: &WeComWsConfig,
         alias: impl Into<String>,
-        peer_resolver: Arc<dyn Fn() -> Vec<String> + Send + Sync>,
+        policy_resolver: Arc<dyn Fn() -> WeComWsRuntimePolicy + Send + Sync>,
         workspace_dir: &Path,
     ) -> Result<Self> {
         if config.stream_mode == StreamMode::MultiMessage {
@@ -311,11 +338,9 @@ impl WeComWsChannel {
             bot_id: config.bot_id.clone(),
             secret: config.secret.clone(),
             alias: alias.into(),
-            peer_resolver,
+            policy_resolver,
             cfg: WeComRuntimeConfig {
                 workspace_dir: workspace_dir.to_path_buf(),
-                allowed_groups: normalize_wecom_allowlist(config.allowed_groups.clone()),
-                bot_name: normalize_optional_wecom_identity(config.bot_name.as_deref()),
                 file_retention_days: config.file_retention_days,
                 max_file_size_bytes: config.max_file_size_mb.saturating_mul(1024 * 1024),
                 stream_mode: config.stream_mode,
@@ -329,6 +354,13 @@ impl WeComWsChannel {
             idempotency: Arc::new(SimpleIdempotencyStore::new()),
             req_id_map: Arc::new(Mutex::new(HashMap::new())),
         })
+    }
+
+    fn static_policy_resolver(
+        config: &WeComWsConfig,
+    ) -> Arc<dyn Fn() -> WeComWsRuntimePolicy + Send + Sync> {
+        let policy = WeComWsRuntimePolicy::from_config(config, std::iter::empty());
+        Arc::new(move || policy.clone())
     }
 
     async fn wait_for_ws_sender(&self) -> Result<mpsc::Sender<WsOutbound>> {
@@ -457,8 +489,8 @@ impl WeComWsChannel {
     }
 
     fn access_decision(&self, inbound: &ParsedInbound) -> AccessDecision {
-        let allowed_users = normalize_wecom_allowlist((self.peer_resolver)());
-        evaluate_access_decision(&allowed_users, &self.cfg.allowed_groups, inbound)
+        let policy = (self.policy_resolver)();
+        evaluate_access_decision(&policy.allowed_users, &policy.allowed_groups, inbound)
     }
 
     fn compose_content_for_framework(&self, inbound: &ParsedInbound, normalized: &str) -> String {
@@ -466,7 +498,8 @@ impl WeComWsChannel {
     }
 
     fn message_explicitly_addresses_bot(&self, inbound: &ParsedInbound, normalized: &str) -> bool {
-        message_explicitly_addresses_bot(inbound, normalized, self.cfg.bot_name.as_deref())
+        let policy = (self.policy_resolver)();
+        message_explicitly_addresses_bot(inbound, normalized, policy.bot_name.as_deref())
     }
 
     async fn respond_access_denied(
@@ -3083,6 +3116,78 @@ mod tests {
             proxy_url: None,
             excluded_tools: vec![],
         }
+    }
+
+    #[test]
+    fn runtime_policy_normalizes_config_and_external_peers() {
+        let mut config = test_wecom_ws_config();
+        config.allowed_users = vec![" user-1 ".to_string(), "".to_string()];
+        config.allowed_groups = vec![" group-1 ".to_string()];
+        config.bot_name = Some(" danya ".to_string());
+
+        let policy = WeComWsRuntimePolicy::from_config(
+            &config,
+            vec![
+                "user-1".to_string(),
+                " external-1 ".to_string(),
+                "".to_string(),
+            ],
+        );
+
+        assert_eq!(
+            policy.allowed_users,
+            vec!["user-1".to_string(), "external-1".to_string()]
+        );
+        assert_eq!(policy.allowed_groups, vec!["group-1".to_string()]);
+        assert_eq!(policy.bot_name.as_deref(), Some("danya"));
+    }
+
+    #[test]
+    fn channel_access_uses_live_runtime_policy() {
+        let mut config = test_wecom_ws_config();
+        config.allowed_users = vec!["user-1".to_string()];
+        let policy = Arc::new(Mutex::new(WeComWsRuntimePolicy::from_config(
+            &config,
+            std::iter::empty(),
+        )));
+        let policy_resolver = {
+            let policy = policy.clone();
+            Arc::new(move || policy.lock().clone())
+        };
+        let channel =
+            WeComWsChannel::new_with_alias(&config, "primary", policy_resolver, Path::new("/tmp"))
+                .unwrap();
+        let inbound = test_inbound("group", Some("group-1"), "blocked-user");
+
+        assert_eq!(channel.access_decision(&inbound), AccessDecision::Denied);
+
+        policy.lock().allowed_groups = vec!["group-1".to_string()];
+
+        assert_eq!(channel.access_decision(&inbound), AccessDecision::Allowed);
+    }
+
+    #[test]
+    fn channel_bot_addressing_uses_live_runtime_policy() {
+        let mut config = test_wecom_ws_config();
+        config.bot_name = Some("danya".to_string());
+        let policy = Arc::new(Mutex::new(WeComWsRuntimePolicy::from_config(
+            &config,
+            std::iter::empty(),
+        )));
+        let policy_resolver = {
+            let policy = policy.clone();
+            Arc::new(move || policy.lock().clone())
+        };
+        let channel =
+            WeComWsChannel::new_with_alias(&config, "primary", policy_resolver, Path::new("/tmp"))
+                .unwrap();
+        let inbound = test_inbound("group", Some("group-1"), "user-1");
+
+        assert!(channel.message_explicitly_addresses_bot(&inbound, "@danya say hi"));
+
+        policy.lock().bot_name = Some("otherbot".to_string());
+
+        assert!(!channel.message_explicitly_addresses_bot(&inbound, "@danya say hi"));
     }
 
     #[test]

--- a/crates/zeroclaw-channels/src/wecom_ws.rs
+++ b/crates/zeroclaw-channels/src/wecom_ws.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::sync::mpsc;
 use tokio_tungstenite::tungstenite::Message as WsMessage;
-use zeroclaw_api::channel::{Channel, ChannelMessage, SendMessage};
+use zeroclaw_api::channel::{Channel, ChannelConversationScope, ChannelMessage, SendMessage};
 use zeroclaw_config::schema::{StreamMode, WeComWsConfig};
 use zeroclaw_runtime::i18n;
 
@@ -116,7 +116,37 @@ struct ParsedInbound {
 
 #[derive(Debug, Clone)]
 struct ScopeDecision {
-    conversation_scope: String,
+    reply_target: String,
+    conversation_scope: ChannelConversationScope,
+    interruption_scope_id: Option<String>,
+}
+
+impl ScopeDecision {
+    fn channel_message(
+        &self,
+        alias: &str,
+        msg_id: impl Into<String>,
+        sender: impl Into<String>,
+        content: impl Into<String>,
+        thread_ts: Option<String>,
+        explicitly_addressed: bool,
+    ) -> ChannelMessage {
+        ChannelMessage {
+            channel_alias: Some(alias.to_string()),
+            thread_ts,
+            interruption_scope_id: self.interruption_scope_id.clone(),
+            explicitly_addressed,
+            conversation_scope: self.conversation_scope,
+            ..ChannelMessage::new(
+                msg_id,
+                sender,
+                self.reply_target.clone(),
+                content,
+                "wecom_ws",
+                bytes_timestamp_now(),
+            )
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -431,12 +461,12 @@ impl WeComWsChannel {
         evaluate_access_decision(&allowed_users, &self.cfg.allowed_groups, inbound)
     }
 
-    fn compose_content_for_framework_with_bot_hint(
-        &self,
-        inbound: &ParsedInbound,
-        normalized: &str,
-    ) -> String {
-        compose_content_for_framework(inbound, normalized, self.cfg.bot_name.as_deref())
+    fn compose_content_for_framework(&self, inbound: &ParsedInbound, normalized: &str) -> String {
+        compose_content_for_framework(inbound, normalized)
+    }
+
+    fn message_explicitly_addresses_bot(&self, inbound: &ParsedInbound, normalized: &str) -> bool {
+        message_explicitly_addresses_bot(inbound, normalized, self.cfg.bot_name.as_deref())
     }
 
     async fn respond_access_denied(
@@ -630,7 +660,7 @@ impl WeComWsChannel {
         wecom_log_info!(
             "[wecom_ws] from {} in {}: {} (msg_type={}, msg_id={}, aibot_id={})",
             parsed.sender_userid,
-            scopes.conversation_scope,
+            scopes.reply_target,
             preview,
             parsed.msg_type,
             msg_id_str,
@@ -673,22 +703,18 @@ impl WeComWsChannel {
         if is_clear_session_command(&stop_text) {
             wecom_log_info!(
                 "WeCom session cleared: scope={} msg_id={}",
-                scopes.conversation_scope,
+                scopes.reply_target,
                 parsed.msg_id
             );
             let _ = tx
-                .send(ChannelMessage {
-                    channel_alias: Some(self.alias.clone()),
-                    thread_ts: Some(req_id),
-                    ..ChannelMessage::new(
-                        parsed.msg_id.clone(),
-                        parsed.sender_userid.clone(),
-                        scopes.conversation_scope.clone(),
-                        "/new",
-                        "wecom_ws",
-                        bytes_timestamp_now(),
-                    )
-                })
+                .send(scopes.channel_message(
+                    &self.alias,
+                    parsed.msg_id.clone(),
+                    parsed.sender_userid.clone(),
+                    "/new",
+                    Some(req_id),
+                    false,
+                ))
                 .await;
             return;
         }
@@ -701,17 +727,14 @@ impl WeComWsChannel {
                 .ws_queue_respond_msg(&req_id, &stream_id, &msg, true)
                 .await;
             let _ = tx
-                .send(ChannelMessage {
-                    channel_alias: Some(self.alias.clone()),
-                    ..ChannelMessage::new(
-                        parsed.msg_id.clone(),
-                        parsed.sender_userid.clone(),
-                        scopes.conversation_scope.clone(),
-                        "/stop",
-                        "wecom_ws",
-                        bytes_timestamp_now(),
-                    )
-                })
+                .send(scopes.channel_message(
+                    &self.alias,
+                    parsed.msg_id.clone(),
+                    parsed.sender_userid.clone(),
+                    "/stop",
+                    None,
+                    false,
+                ))
                 .await;
             return;
         }
@@ -719,23 +742,19 @@ impl WeComWsChannel {
         if let Some(runtime_command) = extract_runtime_model_switch_command(&stop_text) {
             wecom_log_info!(
                 "WeCom runtime command forwarded: scope={} msg_id={} command={}",
-                scopes.conversation_scope,
+                scopes.reply_target,
                 parsed.msg_id,
                 runtime_command
             );
             let _ = tx
-                .send(ChannelMessage {
-                    channel_alias: Some(self.alias.clone()),
-                    thread_ts: Some(req_id),
-                    ..ChannelMessage::new(
-                        parsed.msg_id.clone(),
-                        parsed.sender_userid.clone(),
-                        scopes.conversation_scope.clone(),
-                        runtime_command,
-                        "wecom_ws",
-                        bytes_timestamp_now(),
-                    )
-                })
+                .send(scopes.channel_message(
+                    &self.alias,
+                    parsed.msg_id.clone(),
+                    parsed.sender_userid.clone(),
+                    runtime_command,
+                    Some(req_id),
+                    false,
+                ))
                 .await;
             return;
         }
@@ -797,29 +816,26 @@ impl WeComWsChannel {
                 NormalizedMessage::Ready(content) => content,
             };
 
-            let composed =
-                channel_self.compose_content_for_framework_with_bot_hint(&inbound, &content);
+            let explicitly_addressed =
+                channel_self.message_explicitly_addresses_bot(&inbound, &content);
+            let composed = channel_self.compose_content_for_framework(&inbound, &content);
 
             wecom_log_info!(
                 "WeCom: forwarding to framework: msg_id={} req_id={} scope={}",
                 inbound.msg_id,
                 req_id,
-                scopes.conversation_scope
+                scopes.reply_target
             );
 
             let _ = tx
-                .send(ChannelMessage {
-                    channel_alias: Some(channel_self.alias.clone()),
-                    thread_ts: Some(req_id),
-                    ..ChannelMessage::new(
-                        inbound.msg_id.clone(),
-                        inbound.sender_userid.clone(),
-                        scopes.conversation_scope.clone(),
-                        composed,
-                        "wecom_ws",
-                        bytes_timestamp_now(),
-                    )
-                })
+                .send(scopes.channel_message(
+                    &channel_self.alias,
+                    inbound.msg_id.clone(),
+                    inbound.sender_userid.clone(),
+                    composed,
+                    Some(req_id),
+                    explicitly_addressed,
+                ))
                 .await;
         });
     }
@@ -1463,6 +1479,10 @@ impl Channel for WeComWsChannel {
         "wecom_ws"
     }
 
+    fn is_direct_message(&self, msg: &ChannelMessage) -> bool {
+        msg.reply_target.starts_with("user--")
+    }
+
     async fn send(&self, message: &SendMessage) -> Result<()> {
         if let Some(req_id) = message
             .thread_ts
@@ -1877,13 +1897,17 @@ fn compute_scopes(inbound: &ParsedInbound) -> ScopeDecision {
             .unwrap_or_else(|| "unknown".to_string());
         let scope = format!("group--{chat_id}");
         return ScopeDecision {
-            conversation_scope: scope,
+            reply_target: scope.clone(),
+            conversation_scope: ChannelConversationScope::ReplyTarget,
+            interruption_scope_id: Some(scope),
         };
     }
 
     let scope = format!("user--{}", inbound.sender_userid);
     ScopeDecision {
-        conversation_scope: scope,
+        reply_target: scope,
+        conversation_scope: ChannelConversationScope::ReplyTarget,
+        interruption_scope_id: None,
     }
 }
 
@@ -2004,41 +2028,28 @@ fn build_access_denied_message(
 
 /// Compose content for framework: quote context (if any) + normalized user text.
 /// Sender prefix and static context are handled by the framework (mod.rs).
-fn compose_content_for_framework(
-    inbound: &ParsedInbound,
-    normalized: &str,
-    bot_name: Option<&str>,
-) -> String {
+fn compose_content_for_framework(inbound: &ParsedInbound, normalized: &str) -> String {
     let quote_context = extract_quote_context(&inbound.raw_payload);
-    let mention_hint = build_group_bot_mention_hint(inbound, normalized, bot_name);
-    let body = match mention_hint {
-        Some(hint) => format!("{hint}\n{normalized}"),
-        None => normalized.to_string(),
-    };
 
     match quote_context {
-        Some(quote) => format!("{quote}\n\n{body}"),
-        None => body,
+        Some(quote) => format!("{quote}\n\n{normalized}"),
+        None => normalized.to_string(),
     }
 }
 
-fn build_group_bot_mention_hint(
+fn message_explicitly_addresses_bot(
     inbound: &ParsedInbound,
     normalized: &str,
     bot_name: Option<&str>,
-) -> Option<String> {
+) -> bool {
     if !inbound.chat_type.eq_ignore_ascii_case("group") {
-        return None;
+        return false;
     }
 
-    let bot_name = bot_name.map(str::trim).filter(|name| !name.is_empty())?;
-    if !text_mentions_bot_name(normalized, bot_name) {
-        return None;
-    }
-
-    Some(format!(
-        "[WeCom group message addressed to this bot via @{bot_name}]"
-    ))
+    bot_name
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .is_some_and(|bot_name| text_mentions_bot_name(normalized, bot_name))
 }
 
 fn text_mentions_bot_name(text: &str, bot_name: &str) -> bool {
@@ -2052,7 +2063,7 @@ fn text_mentions_bot_name(text: &str, bot_name: &str) -> bool {
         text[after..]
             .chars()
             .next()
-            .is_none_or(|ch| ch.is_whitespace() || ch.is_ascii_punctuation())
+            .is_none_or(|ch| ch.is_whitespace() || !(ch == '_' || ch.is_alphanumeric()))
     })
 }
 
@@ -2643,7 +2654,61 @@ mod tests {
         };
 
         let scopes = compute_scopes(&inbound);
-        assert_eq!(scopes.conversation_scope, "group--g1");
+        assert_eq!(scopes.reply_target, "group--g1");
+        assert_eq!(
+            scopes.conversation_scope,
+            ChannelConversationScope::ReplyTarget
+        );
+        assert_eq!(scopes.interruption_scope_id.as_deref(), Some("group--g1"));
+    }
+
+    #[test]
+    fn scope_uses_reply_target_for_single_chat_without_thread_fragmentation() {
+        let inbound = test_inbound("single", None, "user-1");
+        let scopes = compute_scopes(&inbound);
+
+        assert_eq!(scopes.reply_target, "user--user-1");
+        assert_eq!(
+            scopes.conversation_scope,
+            ChannelConversationScope::ReplyTarget
+        );
+        assert!(scopes.interruption_scope_id.is_none());
+
+        let first = scopes.channel_message(
+            "work",
+            "msg-1",
+            "user-1",
+            "hello",
+            Some("req-1".to_string()),
+            false,
+        );
+        let second = scopes.channel_message(
+            "work",
+            "msg-2",
+            "user-1",
+            "follow up",
+            Some("req-2".to_string()),
+            false,
+        );
+        let clear = scopes.channel_message(
+            "work",
+            "msg-3",
+            "user-1",
+            "/new",
+            Some("req-clear".to_string()),
+            false,
+        );
+
+        let first_key = crate::orchestrator::conversation_history_key(&first);
+        assert_eq!(
+            first_key,
+            crate::orchestrator::conversation_history_key(&second)
+        );
+        assert_eq!(
+            first_key,
+            crate::orchestrator::conversation_history_key(&clear)
+        );
+        assert!(!first_key.contains("req-"));
     }
 
     #[test]
@@ -2702,37 +2767,54 @@ mod tests {
     }
 
     #[test]
-    fn group_bot_mention_hint_marks_addressed_wecom_message() {
+    fn group_bot_mention_sets_structured_addressing_without_content_marker() {
         let inbound = test_inbound("group", Some("group-1"), "user-1");
-        let composed = compose_content_for_framework(&inbound, "@danya say hi", Some("danya"));
+        let composed = compose_content_for_framework(&inbound, "@danya say hi");
 
-        assert!(composed.starts_with("[WeCom group message addressed to this bot via @danya]"));
-        assert!(composed.ends_with("@danya say hi"));
+        assert_eq!(composed, "@danya say hi");
+        assert!(message_explicitly_addresses_bot(
+            &inbound,
+            "@danya say hi",
+            Some("danya")
+        ));
     }
 
     #[test]
-    fn group_bot_mention_hint_omits_non_matching_messages() {
+    fn group_bot_addressing_omits_non_matching_messages() {
         let inbound = test_inbound("group", Some("group-1"), "user-1");
         assert_eq!(
-            compose_content_for_framework(&inbound, "@otherbot say hi", Some("danya")),
+            compose_content_for_framework(&inbound, "@otherbot say hi"),
             "@otherbot say hi"
         );
-        assert_eq!(
-            compose_content_for_framework(&inbound, "@danya say hi", None),
-            "@danya say hi"
-        );
+        assert!(!message_explicitly_addresses_bot(
+            &inbound,
+            "@otherbot say hi",
+            Some("danya")
+        ));
+        assert!(!message_explicitly_addresses_bot(
+            &inbound,
+            "@danya say hi",
+            None
+        ));
 
         let dm = test_inbound("single", None, "user-1");
         assert_eq!(
-            compose_content_for_framework(&dm, "@danya say hi", Some("danya")),
+            compose_content_for_framework(&dm, "@danya say hi"),
             "@danya say hi"
         );
+        assert!(!message_explicitly_addresses_bot(
+            &dm,
+            "@danya say hi",
+            Some("danya")
+        ));
     }
 
     #[test]
     fn text_mentions_bot_name_uses_simple_boundary_check() {
         assert!(text_mentions_bot_name("@danya say hi", "danya"));
         assert!(text_mentions_bot_name("hey @danya, say hi", "danya"));
+        assert!(text_mentions_bot_name("@danya，帮我看一下", "danya"));
+        assert!(text_mentions_bot_name("@danya：帮我看一下", "danya"));
         assert!(!text_mentions_bot_name("@danyabot say hi", "danya"));
     }
 
@@ -3062,6 +3144,16 @@ mod tests {
 
         let partial = WeComWsChannel::new(&test_wecom_ws_config(), Path::new("/tmp")).unwrap();
         assert!(partial.supports_draft_updates());
+    }
+
+    #[test]
+    fn single_chat_reply_target_is_direct_message() {
+        let channel = WeComWsChannel::new(&test_wecom_ws_config(), Path::new("/tmp")).unwrap();
+        let single = ChannelMessage::new("msg-1", "user-1", "user--user-1", "hi", "wecom_ws", 1);
+        let group = ChannelMessage::new("msg-2", "user-1", "group--group-1", "hi", "wecom_ws", 1);
+
+        assert!(channel.is_direct_message(&single));
+        assert!(!channel.is_direct_message(&group));
     }
 
     #[test]

--- a/crates/zeroclaw-channels/src/wecom_ws.rs
+++ b/crates/zeroclaw-channels/src/wecom_ws.rs
@@ -220,7 +220,7 @@ struct WeComRuntimeConfig {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct WeComWsRuntimePolicy {
-    allowed_users: Vec<String>,
+    direct_userids: Vec<String>,
     allowed_groups: Vec<String>,
     bot_name: Option<String>,
 }
@@ -239,7 +239,7 @@ impl WeComWsRuntimePolicy {
         }
 
         Self {
-            allowed_users,
+            direct_userids: allowed_users,
             allowed_groups: normalize_wecom_allowlist(config.allowed_groups.clone()),
             bot_name: normalize_optional_wecom_identity(config.bot_name.as_deref()),
         }
@@ -490,7 +490,7 @@ impl WeComWsChannel {
 
     fn access_decision(&self, inbound: &ParsedInbound) -> AccessDecision {
         let policy = (self.policy_resolver)();
-        evaluate_access_decision(&policy.allowed_users, &policy.allowed_groups, inbound)
+        evaluate_access_decision(&policy.direct_userids, &policy.allowed_groups, inbound)
     }
 
     fn compose_content_for_framework(&self, inbound: &ParsedInbound, normalized: &str) -> String {
@@ -3135,7 +3135,7 @@ mod tests {
         );
 
         assert_eq!(
-            policy.allowed_users,
+            policy.direct_userids,
             vec!["user-1".to_string(), "external-1".to_string()]
         );
         assert_eq!(policy.allowed_groups, vec!["group-1".to_string()]);

--- a/crates/zeroclaw-channels/src/whatsapp_web.rs
+++ b/crates/zeroclaw-channels/src/whatsapp_web.rs
@@ -909,6 +909,7 @@ impl WhatsAppWebChannel {
                 attachments,
                 subject: None,
                 passive_context,
+                explicitly_addressed: false,
                 conversation_scope,
             })
             .await


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Adds `ChannelMessage::explicitly_addressed` so channel adapters can pass platform-level addressing as structured metadata instead of injecting WeCom marker text into user content.
  - Removes the remaining `wecom_ws` special cases from orchestrator conversation-history and interruption-scope helpers by representing WeCom scopes through the existing channel message fields.
  - Updates WeCom WS inbound routing so group chats share a group reply target/interruption scope, single chats keep one user reply target across request IDs, and one-to-one messages bypass the reply-intent precheck as direct messages.
  - Resolves WeCom WS message-time policy from live channel config for direct users, external peers, allowed groups, and bot-name addressing.
  - Extends WeCom group mention matching so full-width punctuation after an `@bot` mention is accepted while longer names such as `@danyabot` still do not match.
- **Scope boundary:** This PR does not change WeCom WS subscribe/auth/media behavior, does not add generic WebSocket infrastructure, and does not add the per-agent precheck controls from #8319. WeCom WS connection/resource settings such as stream mode, proxy, client, bot ID, and secret remain construction-time snapshots. If #8319 lands first, this PR may need a small refresh in the shared reply-intent precheck block. The WhatsApp Web change only initializes the new `ChannelMessage` field to `false`.
- **Blast radius:** `zeroclaw-api::channel::ChannelMessage`, orchestrator conversation/interruption scope keys, reply-intent precheck bypass logic, WeCom WS inbound routing, and WeCom WS message-time policy resolution. Other channel adapters keep the default `explicitly_addressed = false` behavior unless they opt in later.
- **Linked issue(s):** Related #6680. Related #8319.
- **Labels:** `bug`, `channel`, `channel:wecom`, `channel:whatsapp`, `risk:medium`, `size:L`.

## Validation Evidence (required)

- **Commands run and tail output:**

```text
cargo fmt --all -- --check
- PASS: no output.

git diff --check
- PASS: no output.

cargo test -p zeroclaw-api channel_message_new_zeros_optional_fields
- PASS: 1 passed; 0 failed; 94 filtered out.

cargo test -p zeroclaw-channels reply_target_conversation_history_key_uses_room_scope
- PASS: 1 passed; 0 failed; 1160 filtered out.

cargo test -p zeroclaw-channels reply_intent_precheck_uses_structured_addressing_signal
- PASS: 1 passed; 0 failed; 1160 filtered out.

cargo test -p zeroclaw-channels --features channel-wecom-ws scope_uses_reply_target_for_single_chat_without_thread_fragmentation
- PASS: 1 passed; 0 failed; 1213 filtered out.

cargo test -p zeroclaw-channels --features channel-wecom-ws single_chat_reply_target_is_direct_message
- PASS: 1 passed; 0 failed; 1213 filtered out.

cargo test -p zeroclaw-channels --features channel-wecom-ws text_mentions_bot_name_uses_simple_boundary_check
- PASS: 1 passed; 0 failed; 1213 filtered out.

cargo test -p zeroclaw-channels --features channel-wecom-ws scope_uses_group_shared_mode_by_default_for_group_chat
- PASS: 1 passed; 0 failed; 1213 filtered out.

cargo test -p zeroclaw-channels --features channel-wecom-ws group_bot_mention_sets_structured_addressing_without_content_marker
- PASS: 1 passed; 0 failed; 1213 filtered out.

cargo test -p zeroclaw-channels --features channel-wecom-ws group_bot_addressing_omits_non_matching_messages
- PASS: 1 passed; 0 failed; 1213 filtered out.

cargo test -p zeroclaw-channels --features channel-wecom-ws wecom_ws -- --nocapture
- PASS: 57 passed; 0 failed; 1160 filtered out.
```

- **Beyond CI — what did you manually verify?** Reviewed the surviving diff against the merged WeCom WS PR shape. The patch removes marker-text control flow from user-visible content, keeps WeCom group and single-chat routing on structured `ChannelMessage` fields, resolves WeCom WS access and bot-name policy from live config at message time, keeps WhatsApp Web behavior unchanged apart from the new default field, and leaves #8319's per-agent precheck controls out of scope. No live WeCom smoke test was run for this follow-up.
- **If any command was intentionally skipped, why:** Workspace-shaped clippy and CI-shaped full tests have not been run yet. This PR should get those before reviewer sign-off unless another maintainer decides the focused API/channel evidence plus GitHub CI is enough for this follow-up.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: N/A.

## Compatibility (required)

- Backward compatible? `No`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: Existing configs and runtime behavior do not need migration. Downstream Rust code that constructs `ChannelMessage` with raw struct literals must either set `explicitly_addressed: false` or use `ChannelMessage::new` / `..Default::default()` so new optional fields get defaults.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert this commit.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** WeCom WS one-to-one conversations lose continuity across request IDs; WeCom group messages share or interrupt the wrong scope; group `@bot` messages fail to bypass the reply-intent classifier; runtime allowlist or bot-name changes are ignored until restart; or user-visible WeCom content includes internal addressing markers again.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A.
- Scope materially carried forward: N/A.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`.
- If `No`, why (inspiration-only, no direct code/design carry-over): This is a maintainer follow-up to merged PR #6680, not a superseding PR.
