### PR TITLE
fix(channels): refine Lark/Feishu tool-use prompt

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -911,10 +911,13 @@ fn channel_delivery_instructions(channel_name: &str) -> Option<&'static str> {
         "lark" | "feishu" => Some(
             "When responding on Lark/Feishu:\n\
              - Be concise and direct\n\
+             - Use Markdown formatting for readable answers\n\
+             - If a tool can answer the task, use your tools instead of stopping at a plain chat reply\n\
+             - Use tool results silently: answer with the outcome and do not narrate internal tool execution bookkeeping\n\
              - For media attachments use markers: [IMAGE:<path>], [DOCUMENT:<path>], [VIDEO:<path>], [AUDIO:<path>], or [VOICE:<path>]\n\
              - Marker paths must refer to local files inside the configured workspace directory. Absolute paths and workspace-relative paths are accepted when they stay inside that workspace.\n\
              - Do not use http://, https://, data:, file:, or any other URL scheme in Lark/Feishu media markers.\n\
-             - Keep normal text outside markers and never wrap markers in code fences.\n",
+             - Keep normal text outside markers and never wrap markers, tool output, or protocol markup in code fences.\n",
         ),
         "telegram" => Some(
             "When responding on Telegram:\n\
@@ -20404,6 +20407,40 @@ BTC is currently around $65,000 based on latest tool output."#
             Some(block),
             "the compatibility alias should use the same WhatsApp Web guidance"
         );
+    }
+
+    #[test]
+    fn channel_delivery_instructions_for_lark_and_feishu_encourage_tool_use() {
+        for channel_name in ["lark", "feishu"] {
+            let block = channel_delivery_instructions(channel_name)
+                .expect("lark and feishu must have a delivery-instructions block");
+            assert!(
+                block.contains("When responding on Lark/Feishu:"),
+                "{channel_name} block must identify itself"
+            );
+            assert!(
+                block.contains("use your tools"),
+                "{channel_name} block must steer the model toward the agent tool path"
+            );
+            assert!(
+                block.contains("Use tool results silently"),
+                "{channel_name} block must keep internal tool bookkeeping out of replies"
+            );
+
+            let prompt = build_channel_system_prompt("base prompt", channel_name, None);
+            assert!(
+                prompt.contains("base prompt"),
+                "{channel_name} system prompt must retain the base prompt"
+            );
+            assert!(
+                prompt.contains("When responding on Lark/Feishu:"),
+                "{channel_name} system prompt must include channel instructions"
+            );
+            assert!(
+                prompt.contains("Use tool results silently"),
+                "{channel_name} system prompt must include the tool-use guidance"
+            );
+        }
     }
 
     // Regression guard for #6646: web_search_tool / web_fetch never fired via


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Refined the Lark/Feishu delivery instructions so the channel prompt now explicitly tells the model to use tools when they can answer the task.
  - Kept the existing media-marker rules intact and clarified that tool results should be returned directly, without narrating internal tool bookkeeping.
  - Added a regression test that covers both `lark` and `feishu` and verifies the channel instructions are injected into the channel system prompt.
- **Scope boundary:** This PR only changes the Lark/Feishu prompt guidance and its regression test. It does not change channel routing, tool execution, config, or message transport.
- **Blast radius:** `crates/zeroclaw-channels` system-prompt generation for `lark` and `feishu` sessions.
- **Linked issue(s):** Related #4873
- **Labels:** bug, channel, channel:lark, priority:p2, risk:medium, size:XS, status:accepted

## Validation Evidence (required)

- **Commands run and tail output:**

```bash
cargo fmt --all -- --check
# exit 0
```

```bash
git diff --check
# exit 0
```

```bash
cargo test -p zeroclaw-channels channel_delivery_instructions_for_lark_and_feishu_encourage_tool_use
```

```text
running 1 test
test orchestrator::tests::channel_delivery_instructions_for_lark_and_feishu_encourage_tool_use ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1166 filtered out; finished in 0.00s
```

```bash
cargo clippy -p zeroclaw-channels --all-targets -- -D warnings
```

```text
Checking zeroclaw-channels v0.8.2 (...)
Finished `dev` profile [unoptimized + debuginfo] target(s) in 11m 25s
```

- **Beyond CI — what did you manually verify?** Confirmed the Lark/Feishu prompt block still preserves the media-marker contract and now includes the tool-use guidance that addresses the issue report.
- **If any command was intentionally skipped, why:** None.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: No upgrade steps required. The change only adjusts prompt guidance for the existing Lark/Feishu channel flow.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert 5ad7505`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Lark/Feishu sessions stop being nudged toward tool use and regress to plain chat replies for tool-eligible tasks.
