### PR TITLE
docs(labels): document agent prompt label

### DIFF
--- a/docs/book/src/maintainers/labels.md
+++ b/docs/book/src/maintainers/labels.md
@@ -133,6 +133,14 @@ Scoped path labels do not guarantee a same-prefix base label. Because `pr-path-l
 | `security:secrets` | runtime and config secrets handling |
 | `memory:backend` | memory backend selection and storage implementation files |
 
+### Manual component labels
+
+Some scoped component labels are manual routing labels rather than synchronized path labels.
+
+`agent:prompt` is for provider-visible prompt, context, and response-guidance policy. Use it when the work is about system-prompt content, tool-call formatting guidance, prompt-cache-sensitive context, channel response guidance, or other model-visible instruction surfaces that cross the base `agent`, `channel`, `memory`, `provider`, or `runtime` labels. Apply it in addition to applicable base or scope labels; it does not replace them. Do not apply it to every `crates/zeroclaw-runtime/src/agent/**` change; use the base `agent` label for ordinary agent runtime changes.
+
+`agent:loop` is retired. For agent-loop routing, use base `agent` plus any matching `runtime`, provider, channel, tool, or risk labels.
+
 Do not apply legacy `observability: runtime_trace` to new issues or PRs. Use `observability:otel` when the work is about OpenTelemetry tracing, add base `observability` only when the issue or PR also matches that base surface, and decide any future runtime-trace-specific canonical label in a separate create/migrate packet.
 
 Gateway subarea labels such as `gateway: api`, `gateway: sse`, `gateway:local_bridge`, and `gateway:webhook_ingress` remain live migration holdbacks. New routing should use base `gateway` until a separate packet either creates canonical no-space/hyphenated sublabels and migrates refs, or collapses those labels into base `gateway`.


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Documents `agent:prompt` in a manual component-label subsection.
  - Clarifies that `agent:prompt` is for model-visible instruction surfaces that cross base labels such as `agent`, `channel`, `memory`, `provider`, and `runtime`.
  - Records that `agent:loop` is no longer a live label and ordinary agent-loop routing should use base labels instead.
- **Scope boundary:** This PR does not add `.github/labeler.yml` ownership for `agent:prompt`, create or delete live labels, or change automation behavior.
- **Blast radius:** Maintainer documentation only. No runtime, CI, labeler, or user-facing behavior changes.
- **Linked issue(s):** Related #6808.
- **Labels:** `type:docs`, `risk:low`, `size:XS`, `docs`

## Validation Evidence (required)

- **Commands run and tail output:**

```bash
$ DOCS_FILES='docs/book/src/maintainers/labels.md' scripts/ci/docs_quality_gate.sh
No prose em-dashes in changed docs files.
Linting docs files: docs/book/src/maintainers/labels.md
markdownlint-cli2 v0.20.0 (markdownlint v0.40.0)
Finding: docs/book/src/maintainers/labels.md !target/** !docs/book/src/SUMMARY.md
Linting: 1 file(s)
Summary: 0 error(s)

$ git diff --check
# no output

$ scripts/check-pr-title.sh "docs(labels): document agent prompt label"
# no output
```

- **Beyond CI — what did you manually verify?** Verified the diff only changes `docs/book/src/maintainers/labels.md` and does not add path-labeler ownership for `agent:prompt`.
- **If any command was intentionally skipped, why:** Rust build/test commands were skipped because this is a maintainer-docs-only label guidance change.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: N/A

## Rollback (required for medium/high-risk PRs)

Low-risk PR: `git revert <sha>` is the rollback plan.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A
