### PR TITLE
ci(actions): summarize benchmark compile diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -446,7 +446,39 @@ jobs:
       - name: Ensure web/dist placeholder exists
         run: mkdir -p web/dist && touch web/dist/.gitkeep
       - name: Verify benchmarks compile
-        run: cargo bench --no-run --locked
+        shell: bash
+        run: |
+          set +e
+          cargo_log="${RUNNER_TEMP}/cargo-bench.log"
+          SECONDS=0
+          cargo bench --no-run --locked 2>&1 | tee "$cargo_log"
+          cargo_status=${PIPESTATUS[0]}
+          duration_seconds=$SECONDS
+          set -e
+
+          workspace_path_compiles="$(grep -E -c 'Compiling.*\([^)]*zeroclaw' "$cargo_log" || true)"
+          total_compiles="$(grep -c 'Compiling' "$cargo_log" || true)"
+          downloaded_crates="$(grep -c 'Downloaded' "$cargo_log" || true)"
+          cache_hit="${RUST_CACHE_HIT:-unknown}"
+          summary_file="${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+          {
+            echo "### Benchmarks Compile diagnostics"
+            echo ""
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Runner OS | \`${{ runner.os }}\` |"
+            echo "| Rust cache exact hit | \`${cache_hit}\` |"
+            echo "| Cargo duration | \`${duration_seconds}s\` |"
+            echo "| Cargo status | \`${cargo_status}\` |"
+            echo "| Workspace path compile lines | \`${workspace_path_compiles}\` |"
+            echo "| Total compile lines | \`${total_compiles}\` |"
+            echo "| Downloaded crate lines | \`${downloaded_crates}\` |"
+          } >> "$summary_file"
+
+          exit "$cargo_status"
+        env:
+          RUST_CACHE_HIT: ${{ steps.rust-cache.outputs.cache-hit }}
 
   # ── Post-format tests ─────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Adds the same step-summary diagnostics to `Benchmarks Compile` that the `Lint` and `Build` jobs already emit.
  - Records Rust cache exact-hit output, cargo duration, cargo status, workspace compile-line count, total compile-line count, and downloaded-crate line count for `cargo bench --no-run --locked`.
  - Keeps the existing benchmark compile command as the required signal while making the current #7108 long-pole investigation visible without raw-log spelunking.
- **Scope boundary:** Does not change required CI coverage, workflow triggers, cache keys, cache save policy, runner selection, Rust build flags, or the benchmark command.
- **Blast radius:** High-risk CI workflow surface, limited to the `Benchmarks Compile` job in `.github/workflows/ci.yml`.
- **Linked issue(s):** Related #7108.
- **Labels:** `ci`, `type:ci`, `risk:high`, `size:XS`.

## Validation Evidence (required)

- **Commands run and tail output:**
  - `ruby -e 'require "yaml"; YAML.safe_load(File.read(".github/workflows/ci.yml"), aliases: true); puts "yaml ok"'` -> `yaml ok`
  - `actionlint .github/workflows/ci.yml` -> passed with no output
  - `git diff --check` -> passed with no output
  - Fake `cargo` success smoke for the benchmark wrapper -> exited `0` and wrote the expected summary rows
  - Fake `cargo` failure smoke for the benchmark wrapper -> exited `42` and still wrote the diagnostic summary rows
- **Beyond CI — what did you manually verify?** Reviewed the diff against the existing lint/build diagnostic wrappers. The benchmark wrapper captures `PIPESTATUS[0]` after `tee`, writes only observational rows to `$GITHUB_STEP_SUMMARY`, and exits with the original cargo status.
- **If any command was intentionally skipped, why:** Rust cargo validation was skipped because this is a workflow-only shell/YAML change with no Rust source changes. The benchmark command itself is unchanged and will run in CI.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: None.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No upgrade steps.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert this PR to restore the previous single-line benchmark compile step.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** `Benchmarks Compile` fails before or during the wrapped cargo command, the GitHub step summary is malformed or missing, or a failing `cargo bench --no-run --locked` does not fail the job.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): None.
- Scope materially carried forward: None.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why (inspiration-only, no direct code/design carry-over): No superseded contributor work is incorporated.
