### PR TITLE
fix(skills): restore always: true frontmatter flag for compact prompt mode

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -6109,6 +6109,7 @@ mod tests {
                 .collect(),
             prompts: vec![],
             location: None,
+            always: false,
         }
     }
 
@@ -6197,6 +6198,7 @@ mod tests {
             }],
             prompts: vec![],
             location: None,
+            always: false,
         };
         tools::register_skill_tools_with_context(
             &mut tools,

--- a/crates/zeroclaw-runtime/src/agent/prompt.rs
+++ b/crates/zeroclaw-runtime/src/agent/prompt.rs
@@ -486,6 +486,7 @@ mod tests {
             }],
             prompts: vec!["Run smoke tests before deploy.".into()],
             location: None,
+            always: false,
         }];
 
         let ctx = PromptContext {
@@ -533,6 +534,7 @@ mod tests {
             }],
             prompts: vec!["Run smoke tests before deploy.".into()],
             location: Some(Path::new("/tmp/workspace/skills/deploy/SKILL.md").to_path_buf()),
+            always: false,
         }];
 
         let ctx = PromptContext {
@@ -613,6 +615,7 @@ mod tests {
             }],
             prompts: vec!["Use <tool_call> and & keep output \"safe\"".into()],
             location: None,
+            always: false,
         }];
         let ctx = PromptContext {
             workspace_dir: Path::new("/tmp/workspace"),

--- a/crates/zeroclaw-runtime/src/skills/cache.rs
+++ b/crates/zeroclaw-runtime/src/skills/cache.rs
@@ -251,6 +251,7 @@ mod tests {
                 tools: vec![],
                 prompts: vec![],
                 location: None,
+                always: false,
             }]
         };
 

--- a/crates/zeroclaw-runtime/src/skills/document.rs
+++ b/crates/zeroclaw-runtime/src/skills/document.rs
@@ -286,6 +286,7 @@ mod tests {
                 version: Some("0.2.0".into()),
                 category: Some("coding".into()),
                 tags: vec!["slash".into(), "ops".into()],
+                always: false,
             },
             body: "# Code Review\n\nReviews diffs.\n".into(),
         };

--- a/crates/zeroclaw-runtime/src/skills/frontmatter.rs
+++ b/crates/zeroclaw-runtime/src/skills/frontmatter.rs
@@ -35,6 +35,11 @@ pub struct SkillFrontmatter {
     /// longer silently strips its tags.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tags: Vec<String>,
+    /// When `true`, this skill's instructions should always be injected into the
+    /// system prompt, even in compact prompt mode. Use sparingly for critical
+    /// skills that must be followed at all times.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub always: bool,
 }
 
 impl SkillFrontmatter {
@@ -92,6 +97,12 @@ impl SkillFrontmatter {
                 tab: zeroclaw_config::config::ConfigTab::None,
                 alias_source: None,
             },
+            field(
+                "always",
+                "bool",
+                false,
+                "When true, always inject this skill's instructions even in compact prompt mode.",
+            ),
         ]
     }
 }
@@ -133,7 +144,7 @@ mod tests {
         let fields = SkillFrontmatter::prop_fields();
         assert_eq!(
             fields.len(),
-            7,
+            8,
             "SkillFrontmatter::prop_fields drifted from struct definition; \
              update both when adding/removing fields"
         );

--- a/crates/zeroclaw-runtime/src/skills/mod.rs
+++ b/crates/zeroclaw-runtime/src/skills/mod.rs
@@ -67,6 +67,8 @@ pub struct Skill {
     pub tools: Vec<SkillTool>,
     #[serde(default)]
     pub prompts: Vec<String>,
+    #[serde(default)]
+    pub always: bool,
     #[serde(skip)]
     pub location: Option<PathBuf>,
 }
@@ -1313,11 +1315,14 @@ pub fn skills_to_prompt_with_mode(
         // In Full mode, inline both instructions and tools.
         // In Compact mode, skip instructions (loaded on demand) but keep tools
         // so the LLM knows which skill tools are available.
-        if matches!(
+        // Exception: skills with `always: true` have their instructions injected
+        // even in compact mode.
+        let should_inline_instructions = matches!(
             mode,
             zeroclaw_config::schema::SkillsPromptInjectionMode::Full
-        ) && !skill.prompts.is_empty()
-        {
+        ) || (skill.always && !skill.prompts.is_empty());
+
+        if should_inline_instructions && !skill.prompts.is_empty() {
             let _ = writeln!(prompt, "    <instructions>");
             for instruction in &skill.prompts {
                 write_xml_text_element(&mut prompt, 6, "instruction", instruction);
@@ -2889,6 +2894,79 @@ mod prompt_callable_name_tests {
             !prompt.contains("pr-review-toolkit:code-reviewer__run.lint"),
             "prompt advertised the raw, unsanitized composed name:\n{prompt}",
         );
+    }
+
+    /// Regression test for #7904: verify that skills with `always: true`
+    /// have their instructions injected even in compact prompt mode.
+    #[test]
+    fn test_always_skill_injected_in_compact_mode() {
+        let always_skill = Skill {
+            name: "critical-skill".to_string(),
+            description: "A skill that must always be followed.".to_string(),
+            version: "1.0.0".to_string(),
+            author: None,
+            tags: Vec::new(),
+            tools: Vec::new(),
+            prompts: vec!["Always do X when Y happens.".to_string()],
+            always: true,
+            location: None,
+        };
+
+        let normal_skill = Skill {
+            name: "normal-skill".to_string(),
+            description: "A normal skill.".to_string(),
+            version: "1.0.0".to_string(),
+            author: None,
+            tags: Vec::new(),
+            tools: Vec::new(),
+            prompts: vec!["Do Z when W happens.".to_string()],
+            always: false,
+            location: None,
+        };
+
+        let prompt = skills_to_prompt_with_mode(
+            &[always_skill, normal_skill],
+            Path::new("/tmp"),
+            zeroclaw_config::schema::SkillsPromptInjectionMode::Compact,
+        );
+
+        // The always skill's instructions should be present
+        assert!(
+            prompt.contains("Always do X when Y happens."),
+            "compact mode should include always skill instructions:\n{prompt}"
+        );
+
+        // The normal skill's instructions should NOT be present in compact mode
+        assert!(
+            !prompt.contains("Do Z when W happens."),
+            "compact mode should omit normal skill instructions:\n{prompt}"
+        );
+    }
+
+    #[test]
+    fn test_always_skill_without_prompts_does_not_crash() {
+        let always_skill = Skill {
+            name: "always-no-prompts".to_string(),
+            description: "Always skill but no instructions.".to_string(),
+            version: "1.0.0".to_string(),
+            author: None,
+            tags: Vec::new(),
+            tools: Vec::new(),
+            prompts: Vec::new(),
+            always: true,
+            location: None,
+        };
+
+        // Should not panic even with always=true but no prompts
+        let prompt = skills_to_prompt_with_mode(
+            &[always_skill],
+            Path::new("/tmp"),
+            zeroclaw_config::schema::SkillsPromptInjectionMode::Compact,
+        );
+
+        // Should contain skill summary but no instructions section
+        assert!(prompt.contains("<name>always-no-prompts</name>"));
+        assert!(!prompt.contains("<instructions>"));
     }
 }
 

--- a/crates/zeroclaw-runtime/src/skills/mod.rs
+++ b/crates/zeroclaw-runtime/src/skills/mod.rs
@@ -1022,6 +1022,7 @@ fn load_skill_toml(path: &Path) -> Result<Skill> {
         tools: manifest.tools,
         prompts,
         location: Some(path.to_path_buf()),
+        always: manifest.skill.always,
     })
 }
 
@@ -1048,6 +1049,7 @@ fn load_skill_md(path: &Path, dir: &Path) -> Result<Skill> {
         tools: Vec::new(),
         prompts: vec![parsed.body],
         location: Some(path.to_path_buf()),
+        always: parsed.meta.always,
     })
 }
 
@@ -1087,6 +1089,7 @@ fn load_open_skill_md(path: &Path) -> Result<Skill> {
         tools: Vec::new(),
         prompts: vec![parsed.body],
         location: Some(path.to_path_buf()),
+        always: parsed.meta.always.unwrap_or(false),
     }))
 }
 
@@ -2875,6 +2878,7 @@ mod prompt_callable_name_tests {
             tools: vec![tool("run.lint", "shell")],
             prompts: Vec::new(),
             location: None,
+            always: false,
         };
 
         let prompt = skills_to_prompt_with_mode(

--- a/crates/zeroclaw-runtime/src/skills/suggestions.rs
+++ b/crates/zeroclaw-runtime/src/skills/suggestions.rs
@@ -310,6 +310,7 @@ mod tests {
             tools: vec![],
             prompts: vec![],
             location: None,
+            always: false,
         }
     }
 

--- a/crates/zeroclaw-runtime/src/tools/skill_tool.rs
+++ b/crates/zeroclaw-runtime/src/tools/skill_tool.rs
@@ -1076,6 +1076,7 @@ mod tests {
             }],
             prompts: vec![],
             location: None,
+            always: false,
         };
         crate::tools::register_skill_tools_with_context(
             &mut registry,

--- a/docs/book/src/tools/skills.md
+++ b/docs/book/src/tools/skills.md
@@ -49,7 +49,22 @@ tags: [release, docs]
 Review the release notes, changelog, version tags, and migration notes before confirming that a release is ready.
 ```
 
-Supported frontmatter fields are `name`, `description`, `version`, `author`, and `tags`.
+Supported frontmatter fields are `name`, `description`, `version`, `author`, `tags`, and `always`.
+
+The `always: true` flag controls whether the skill's instructions are injected into the prompt when using compact prompt mode. By default, compact mode only includes skill tool definitions but omits their instructions. Setting `always: true` ensures the skill's instructions are always included, even in compact mode. This is useful for critical skills that must be followed in all contexts.
+
+Example:
+```markdown
+---
+name: security-review
+description: Security review checklist
+always: true
+---
+
+# Security Review
+
+Always check for SQL injection, XSS vulnerabilities, and proper authentication before deploying.
+```
 
 ## Create a TOML skill
 


### PR DESCRIPTION
Fixes #7904.

## Summary
Restore the `always: true` frontmatter flag for skills, ensuring critical skill instructions are injected even in compact prompt mode.

## Changes
- Add `always: bool` field to `SkillFrontmatter` and `Skill` structs
- Update `skills_to_prompt_with_mode` to check `skill.always` when in compact mode
- Add `always` field parsing from SKILL.md frontmatter and SKILL.toml manifests
- Fix all missing `always` field construction sites across the workspace
- Add documentation for the `always` flag in skills.md

## Testing
- Added regression test `test_always_skill_injected_in_compact_mode` verifying:
  - always skill instructions ARE present in compact mode output
  - normal skill instructions are NOT present in compact mode output
- Added test `test_always_skill_without_prompts_does_not_crash` for edge case

## Documentation
- Updated docs/book/src/tools/skills.md with `always` field explanation and example
