### PR TITLE
feat(memory): persist embedding identity and auto-migrate vectors on change

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -10096,12 +10096,15 @@ pub struct MemoryConfig {
     /// Source of embedding vectors for semantic search. `none` = keyword-only retrieval (no API calls, no vector cost); `openai` = OpenAI's embedding API; `custom:URL` = any OpenAI-compatible embedding endpoint (LiteLLM, local gateway, etc.).
     #[serde(default = "default_embedding_provider")]
     pub embedding_provider: String,
-    /// Embedding model identifier — must match a model your chosen embedding model_provider serves (e.g. `text-embedding-3-small` for OpenAI). Changing this invalidates existing embeddings; you'll need to re-index.
+    /// Embedding model identifier — must match a model your chosen embedding model_provider serves (e.g. `text-embedding-3-small` for OpenAI). Changing this invalidates existing embeddings: the change is detected at startup and stale vectors are cleared automatically; run `zeroclaw memory reindex` to re-embed (or set `auto_reindex_on_identity_change`).
     #[serde(default = "default_embedding_model")]
     pub embedding_model: String,
     /// Vector width produced by the embedding model — must match the model's native dimension or vectors won't store correctly. Look up the number on the model_provider's model page.
     #[serde(default = "default_embedding_dims")]
     pub embedding_dimensions: usize,
+    /// Automatically re-embed all memories in the background when a change of embedding provider/model/dimensions is detected at startup (after the stale vectors have been cleared). Costs one embedding API call per memory, so it's off by default — leave it off for large stores and run `zeroclaw memory reindex` explicitly instead.
+    #[serde(default)]
+    pub auto_reindex_on_identity_change: bool,
     /// Optional API key for the embedding endpoint. When set, embedding calls use this key instead of inheriting one from the seed model provider — decoupling embeddings from the chat model. Use it when the chat model runs on a provider that carries no usable embedding credential (e.g. an OAuth-only provider) while embeddings keep hitting an `openai`/`custom:` endpoint with their own key. Leave unset to inherit the seed provider's key (backward-compatible default).
     #[secret]
     #[credential_class = "encrypted_secret"]
@@ -10306,6 +10309,7 @@ impl Default for MemoryConfig {
             embedding_provider: default_embedding_provider(),
             embedding_model: default_embedding_model(),
             embedding_dimensions: default_embedding_dims(),
+            auto_reindex_on_identity_change: false,
             embedding_api_key: None,
             vector_weight: default_vector_weight(),
             keyword_weight: default_keyword_weight(),

--- a/crates/zeroclaw-memory/src/embeddings.rs
+++ b/crates/zeroclaw-memory/src/embeddings.rs
@@ -1,5 +1,30 @@
 use async_trait::async_trait;
 
+/// The identity of the embedder that produced a store's vectors: resolved
+/// provider, model, and dimensions. Two identities are compatible only when
+/// all three match — a change in any of them means existing vectors live in
+/// a different (or differently-sized) vector space and must be re-embedded.
+///
+/// `provider` is the *resolved* provider string (`openai`, `openrouter`, or
+/// `custom:<base_url>`), not a dotted `[[embedding_routes]]` reference, so the
+/// identity reflects the endpoint that actually served the embeddings.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmbeddingIdentity {
+    pub provider: String,
+    pub model: String,
+    pub dimensions: usize,
+}
+
+impl std::fmt::Display for EmbeddingIdentity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}/{} ({} dims)",
+            self.provider, self.model, self.dimensions
+        )
+    }
+}
+
 /// Trait for embedding model_providers — convert text to vectors
 #[async_trait]
 pub trait EmbeddingProvider: Send + Sync {

--- a/crates/zeroclaw-memory/src/lib.rs
+++ b/crates/zeroclaw-memory/src/lib.rs
@@ -59,6 +59,8 @@ pub use backend::{
     MemoryBackendKind, MemoryBackendProfile, classify_memory_backend, default_memory_backend_key,
     memory_backend_profile, selectable_memory_backends,
 };
+#[allow(unused_imports)]
+pub use embeddings::EmbeddingIdentity;
 pub use lucid::LucidMemory;
 pub use markdown::MarkdownMemory;
 pub use none::NoneMemory;
@@ -559,6 +561,7 @@ pub fn create_memory_with_storage_and_routes(
                 &resolved_embedding.model,
                 resolved_embedding.dimensions,
             ));
+        let has_embedder = embedder.dimensions() > 0;
 
         #[allow(clippy::cast_possible_truncation)]
         let mem = SqliteMemory::with_embedder(
@@ -571,6 +574,23 @@ pub fn create_memory_with_storage_and_routes(
             sqlite_open_timeout_secs,
             config.search_mode.clone(),
         )?;
+
+        // Identity reconciliation is lifecycle policy, kept out of the
+        // backend per the #6850 storage/policy boundary. Skipped without a
+        // real embedder so keyword-only setups stay byte-identical: a
+        // temporarily unresolved provider (NoopEmbedding) must not be
+        // mistaken for an identity change and wipe valid vectors.
+        if has_embedder {
+            reconcile_embedding_identity(
+                &mem,
+                &embeddings::EmbeddingIdentity {
+                    provider: resolved_embedding.model_provider.clone(),
+                    model: resolved_embedding.model.clone(),
+                    dimensions: resolved_embedding.dimensions,
+                },
+                config.auto_reindex_on_identity_change,
+            );
+        }
         Ok(mem)
     }
 
@@ -644,6 +664,152 @@ pub fn create_memory_with_storage_and_routes(
         },
         "",
     )
+}
+
+/// Outcome of a startup embedding-identity reconciliation.
+#[derive(Debug, PartialEq, Eq)]
+enum EmbeddingIdentityOutcome {
+    /// No identity was recorded (fresh store, or one predating identity
+    /// tracking): the current identity was adopted without touching vectors.
+    Adopted,
+    /// Stored identity matches the current config — nothing to do.
+    Match,
+    /// Stored identity differed: vectors were invalidated (set to NULL),
+    /// the embedding cache cleared, and the new identity stamped.
+    Invalidated(usize),
+    /// Reconciliation failed; the store is untouched and the error was
+    /// logged. Startup proceeds — recall degrades no further than it
+    /// already would, and the next boot retries.
+    Failed,
+}
+
+/// Compare the embedding identity recorded in the store against the one the
+/// current config resolves to, and auto-migrate on mismatch (issue #7948).
+///
+/// Policy (this fn) is deliberately separate from the storage primitives on
+/// [`SqliteMemory`], following the #6850 storage/lifecycle boundary:
+///
+/// - no identity recorded → adopt the current one silently (a pre-existing
+///   store's vectors were produced by an unknown embedder; wiping them on
+///   upgrade would surprise operators, and recall behavior is unchanged);
+/// - identical → no-op;
+/// - mismatch → invalidate vectors + clear the embedding cache (lossless,
+///   zero API calls — `content` is retained on every row) and warn. The
+///   expensive re-embed is gated: run `zeroclaw memory reindex`, or set
+///   `[memory] auto_reindex_on_identity_change = true` to have it kicked
+///   off in the background here.
+///
+/// Errors are logged, not propagated: a reconcile failure must not take
+/// memory (or the daemon) down with it.
+fn reconcile_embedding_identity(
+    mem: &SqliteMemory,
+    current: &embeddings::EmbeddingIdentity,
+    auto_reindex: bool,
+) -> EmbeddingIdentityOutcome {
+    let stored = match mem.stored_embedding_identity() {
+        Ok(stored) => stored,
+        Err(e) => {
+            ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                    .with_attrs(::serde_json::json!({"error": format!("{e}")})),
+                "memory: failed to read stored embedding identity; skipping reconciliation"
+            );
+            return EmbeddingIdentityOutcome::Failed;
+        }
+    };
+
+    match stored {
+        None => match mem.record_embedding_identity(current) {
+            Ok(()) => EmbeddingIdentityOutcome::Adopted,
+            Err(e) => {
+                ::zeroclaw_log::record!(
+                    WARN,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                        .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                        .with_attrs(::serde_json::json!({"error": format!("{e}")})),
+                    "memory: failed to record embedding identity; will retry next startup"
+                );
+                EmbeddingIdentityOutcome::Failed
+            }
+        },
+        Some(stored) if stored == *current => EmbeddingIdentityOutcome::Match,
+        Some(stored) => match mem.invalidate_embeddings_for_identity_change(current) {
+            Ok(invalidated) => {
+                ::zeroclaw_log::record!(
+                    WARN,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                        .with_attrs(::serde_json::json!({
+                            "stored_identity": stored.to_string(),
+                            "current_identity": current.to_string(),
+                            "vectors_invalidated": invalidated,
+                        })),
+                    "memory: embedding identity changed; stored vectors invalidated and \
+                     embedding cache cleared (content retained). Semantic recall is \
+                     keyword-only until re-embedded — run `zeroclaw memory reindex`"
+                );
+                if auto_reindex && invalidated > 0 {
+                    spawn_auto_reindex(mem);
+                }
+                EmbeddingIdentityOutcome::Invalidated(invalidated)
+            }
+            Err(e) => {
+                ::zeroclaw_log::record!(
+                    WARN,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                        .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                        .with_attrs(::serde_json::json!({
+                            "stored_identity": stored.to_string(),
+                            "current_identity": current.to_string(),
+                            "error": format!("{e}"),
+                        })),
+                    "memory: embedding identity changed but invalidation failed; \
+                     store untouched, will retry next startup"
+                );
+                EmbeddingIdentityOutcome::Failed
+            }
+        },
+    }
+}
+
+/// Kick off the gated re-embed in the background after an identity
+/// migration, when `[memory] auto_reindex_on_identity_change` opts in.
+/// Outside an async runtime (no tokio context) the spawn is skipped and the
+/// operator is pointed at `zeroclaw memory reindex` instead.
+fn spawn_auto_reindex(mem: &SqliteMemory) {
+    let Ok(handle) = tokio::runtime::Handle::try_current() else {
+        ::zeroclaw_log::record!(
+            WARN,
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note),
+            "memory: auto_reindex_on_identity_change is set but no async runtime is \
+             available here; run `zeroclaw memory reindex` to re-embed"
+        );
+        return;
+    };
+    let mem = mem.clone();
+    handle.spawn(async move {
+        match mem.reindex().await {
+            Ok(count) => {
+                ::zeroclaw_log::record!(
+                    INFO,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                        .with_attrs(::serde_json::json!({"reembedded": count})),
+                    "memory: background re-embed after embedding identity change complete"
+                );
+            }
+            Err(e) => {
+                ::zeroclaw_log::record!(
+                    WARN,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                        .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                        .with_attrs(::serde_json::json!({"error": format!("{e}")})),
+                    "memory: background re-embed after embedding identity change failed; \
+                     run `zeroclaw memory reindex` to retry"
+                );
+            }
+        }
+    });
 }
 
 pub fn create_memory_for_migration(
@@ -796,6 +962,202 @@ mod tests {
         };
         let mem = create_memory(&cfg, tmp.path(), None).unwrap();
         assert_eq!(mem.name(), "sqlite");
+    }
+
+    // ── Embedding identity reconciliation policy (issue #7948) ────
+
+    /// Embedder returning fixed vectors so store() persists real embeddings.
+    struct StaticEmbedding(usize);
+
+    #[async_trait::async_trait]
+    impl embeddings::EmbeddingProvider for StaticEmbedding {
+        fn name(&self) -> &str {
+            "static"
+        }
+        fn dimensions(&self) -> usize {
+            self.0
+        }
+        async fn embed(&self, texts: &[&str]) -> anyhow::Result<Vec<Vec<f32>>> {
+            Ok(texts.iter().map(|_| vec![0.25f32; self.0]).collect())
+        }
+    }
+
+    fn static_sqlite(dir: &Path, dims: usize) -> SqliteMemory {
+        SqliteMemory::with_embedder(
+            "test",
+            dir,
+            Arc::new(StaticEmbedding(dims)),
+            0.7,
+            0.3,
+            1000,
+            None,
+            zeroclaw_config::schema::SearchMode::default(),
+        )
+        .unwrap()
+    }
+
+    fn ident(provider: &str, model: &str, dimensions: usize) -> embeddings::EmbeddingIdentity {
+        embeddings::EmbeddingIdentity {
+            provider: provider.into(),
+            model: model.into(),
+            dimensions,
+        }
+    }
+
+    fn embedded_rows(mem: &SqliteMemory) -> i64 {
+        let conn = mem.connection().lock();
+        conn.query_row(
+            "SELECT COUNT(*) FROM memories WHERE embedding IS NOT NULL",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn identity_adopted_on_fresh_store_then_matches() {
+        let tmp = TempDir::new().unwrap();
+        let mem = static_sqlite(tmp.path(), 4);
+        let id = ident("openai", "text-embedding-3-small", 4);
+
+        assert_eq!(
+            reconcile_embedding_identity(&mem, &id, false),
+            EmbeddingIdentityOutcome::Adopted
+        );
+        assert_eq!(
+            reconcile_embedding_identity(&mem, &id, false),
+            EmbeddingIdentityOutcome::Match
+        );
+        assert_eq!(mem.stored_embedding_identity().unwrap(), Some(id));
+    }
+
+    #[tokio::test]
+    async fn identity_adoption_on_legacy_store_keeps_vectors() {
+        let tmp = TempDir::new().unwrap();
+        let mem = static_sqlite(tmp.path(), 4);
+        // Rows written before identity tracking existed: vectors present,
+        // no recorded identity. Adoption must not invalidate them.
+        mem.store("legacy", "pre-existing row", MemoryCategory::Core, None)
+            .await
+            .unwrap();
+        assert_eq!(embedded_rows(&mem), 1);
+
+        assert_eq!(
+            reconcile_embedding_identity(&mem, &ident("openai", "model-a", 4), false),
+            EmbeddingIdentityOutcome::Adopted
+        );
+        assert_eq!(embedded_rows(&mem), 1);
+    }
+
+    #[tokio::test]
+    async fn identity_mismatch_invalidates_vectors() {
+        let tmp = TempDir::new().unwrap();
+        let mem = static_sqlite(tmp.path(), 4);
+        reconcile_embedding_identity(&mem, &ident("openai", "model-a", 4), false);
+        mem.store("k1", "first row", MemoryCategory::Core, None)
+            .await
+            .unwrap();
+        mem.store("k2", "second row", MemoryCategory::Core, None)
+            .await
+            .unwrap();
+        assert_eq!(embedded_rows(&mem), 2);
+
+        let new_id = ident("openai", "model-b", 4);
+        assert_eq!(
+            reconcile_embedding_identity(&mem, &new_id, false),
+            EmbeddingIdentityOutcome::Invalidated(2)
+        );
+        assert_eq!(embedded_rows(&mem), 0);
+        assert_eq!(mem.stored_embedding_identity().unwrap(), Some(new_id));
+
+        // Content was retained: rows are still recallable by keyword.
+        let hits = mem.recall("second", 10, None, None, None).await.unwrap();
+        assert_eq!(hits.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn identity_dimension_change_alone_triggers_invalidation() {
+        let tmp = TempDir::new().unwrap();
+        let mem = static_sqlite(tmp.path(), 4);
+        reconcile_embedding_identity(&mem, &ident("openai", "model-a", 4), false);
+
+        assert_eq!(
+            reconcile_embedding_identity(&mem, &ident("openai", "model-a", 8), false),
+            EmbeddingIdentityOutcome::Invalidated(0)
+        );
+    }
+
+    #[tokio::test]
+    async fn identity_mismatch_with_auto_reindex_reembeds_in_background() {
+        let tmp = TempDir::new().unwrap();
+        let mem = static_sqlite(tmp.path(), 4);
+        reconcile_embedding_identity(&mem, &ident("openai", "model-a", 4), false);
+        mem.store("k1", "auto reindex row", MemoryCategory::Core, None)
+            .await
+            .unwrap();
+        assert_eq!(embedded_rows(&mem), 1);
+
+        assert_eq!(
+            reconcile_embedding_identity(&mem, &ident("openai", "model-b", 4), true),
+            EmbeddingIdentityOutcome::Invalidated(1)
+        );
+
+        // The re-embed runs on the runtime in the background; poll briefly.
+        let mut restored = false;
+        for _ in 0..100 {
+            if embedded_rows(&mem) == 1 {
+                restored = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        assert!(restored, "background auto-reindex did not re-embed the row");
+    }
+
+    #[test]
+    fn keyword_only_factory_records_no_identity() {
+        let tmp = TempDir::new().unwrap();
+        // Default config: embedding_provider = "none" → NoopEmbedding.
+        let cfg = MemoryConfig {
+            backend: "sqlite".into(),
+            ..MemoryConfig::default()
+        };
+        drop(create_memory(&cfg, tmp.path(), None).unwrap());
+
+        let mem = SqliteMemory::new("test", tmp.path()).unwrap();
+        assert_eq!(mem.stored_embedding_identity().unwrap(), None);
+    }
+
+    #[test]
+    fn factory_with_embedder_stamps_and_migrates_identity() {
+        let tmp = TempDir::new().unwrap();
+        let mut cfg = MemoryConfig {
+            backend: "sqlite".into(),
+            embedding_provider: "openai".into(),
+            embedding_model: "model-a".into(),
+            embedding_dimensions: 4,
+            ..MemoryConfig::default()
+        };
+        drop(create_memory(&cfg, tmp.path(), Some("test-key")).unwrap());
+        {
+            let mem = SqliteMemory::new("test", tmp.path()).unwrap();
+            assert_eq!(
+                mem.stored_embedding_identity().unwrap(),
+                Some(ident("openai", "model-a", 4))
+            );
+        }
+
+        // Same config again → identity unchanged (Match path, no churn).
+        drop(create_memory(&cfg, tmp.path(), Some("test-key")).unwrap());
+
+        // Model change → factory reconciles to the new identity.
+        cfg.embedding_model = "model-b".into();
+        drop(create_memory(&cfg, tmp.path(), Some("test-key")).unwrap());
+        let mem = SqliteMemory::new("test", tmp.path()).unwrap();
+        assert_eq!(
+            mem.stored_embedding_identity().unwrap(),
+            Some(ident("openai", "model-b", 4))
+        );
     }
 
     #[test]

--- a/crates/zeroclaw-memory/src/sqlite.rs
+++ b/crates/zeroclaw-memory/src/sqlite.rs
@@ -36,6 +36,11 @@ fn acquire_sqlite_startup_lock() -> MutexGuard<'static, ()> {
 /// - **Hybrid Merge**: weighted fusion of vector + keyword results
 /// - **Embedding Cache**: LRU-evicted cache to avoid redundant API calls
 /// - **Safe Reindex**: temp DB → seed → sync → atomic swap → rollback
+///
+/// Cloning is cheap and yields a handle to the SAME database connection and
+/// embedder (all shared state is behind `Arc`) — used to hand a background
+/// task (e.g. an auto-triggered reindex) its own handle.
+#[derive(Clone)]
 pub struct SqliteMemory {
     alias: String,
     conn: Arc<Mutex<Connection>>,
@@ -296,7 +301,15 @@ impl SqliteMemory {
                 created_at   TEXT NOT NULL,
                 accessed_at  TEXT NOT NULL
             );
-            CREATE INDEX IF NOT EXISTS idx_cache_accessed ON embedding_cache(accessed_at);",
+            CREATE INDEX IF NOT EXISTS idx_cache_accessed ON embedding_cache(accessed_at);
+
+            -- Store-level metadata (e.g. the embedding identity that produced
+            -- the stored vectors). Sits beside schema_version, which is keyed
+            -- by component with an INTEGER version and can't carry strings.
+            CREATE TABLE IF NOT EXISTS memory_meta (
+                key   TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            );",
         )
         .with_context(|| "SQLite init_schema failed: CREATE base schema")?;
 
@@ -416,6 +429,99 @@ impl SqliteMemory {
     /// Provide access to the connection for advanced queries (e.g. retrieval pipeline).
     pub fn connection(&self) -> &Arc<Mutex<Connection>> {
         &self.conn
+    }
+
+    /// Read the embedding identity recorded in `memory_meta`, if any.
+    ///
+    /// Returns `None` when the store predates identity tracking (or any of
+    /// the three keys is missing/unparseable) — callers treat that as "adopt
+    /// the current identity" rather than a mismatch.
+    pub fn stored_embedding_identity(
+        &self,
+    ) -> anyhow::Result<Option<super::embeddings::EmbeddingIdentity>> {
+        let conn = self.conn.lock();
+        let mut stmt = conn.prepare(
+            "SELECT key, value FROM memory_meta WHERE key IN \
+             ('embedding_provider', 'embedding_model', 'embedding_dimensions')",
+        )?;
+        let mut provider = None;
+        let mut model = None;
+        let mut dimensions = None;
+        let mut rows = stmt.query([])?;
+        while let Some(row) = rows.next()? {
+            let key: String = row.get(0)?;
+            let value: String = row.get(1)?;
+            match key.as_str() {
+                "embedding_provider" => provider = Some(value),
+                "embedding_model" => model = Some(value),
+                "embedding_dimensions" => dimensions = value.parse::<usize>().ok(),
+                _ => {}
+            }
+        }
+        Ok(match (provider, model, dimensions) {
+            (Some(provider), Some(model), Some(dimensions)) => {
+                Some(super::embeddings::EmbeddingIdentity {
+                    provider,
+                    model,
+                    dimensions,
+                })
+            }
+            _ => None,
+        })
+    }
+
+    /// Record `identity` in `memory_meta` without touching any vectors.
+    ///
+    /// Used to adopt the current identity on stores that predate identity
+    /// tracking, and after a match check confirms nothing changed.
+    pub fn record_embedding_identity(
+        &self,
+        identity: &super::embeddings::EmbeddingIdentity,
+    ) -> anyhow::Result<()> {
+        let conn = self.conn.lock();
+        let tx = conn.unchecked_transaction()?;
+        Self::write_identity_rows(&tx, identity)?;
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Migrate the store to a new embedding identity: NULL every stored
+    /// vector, clear the (identity-agnostic, content-hash-keyed)
+    /// `embedding_cache`, and stamp the new identity — atomically.
+    ///
+    /// This is the cheap, lossless half of an identity migration: `content`
+    /// is retained on every row, so `reindex()` can re-embed from it later.
+    /// No embedding API calls are made here. Returns the number of rows
+    /// whose vector was invalidated.
+    pub fn invalidate_embeddings_for_identity_change(
+        &self,
+        new_identity: &super::embeddings::EmbeddingIdentity,
+    ) -> anyhow::Result<usize> {
+        let conn = self.conn.lock();
+        let tx = conn.unchecked_transaction()?;
+        let invalidated = tx.execute(
+            "UPDATE memories SET embedding = NULL WHERE embedding IS NOT NULL",
+            [],
+        )?;
+        tx.execute("DELETE FROM embedding_cache", [])?;
+        Self::write_identity_rows(&tx, new_identity)?;
+        tx.commit()?;
+        Ok(invalidated)
+    }
+
+    fn write_identity_rows(
+        conn: &Connection,
+        identity: &super::embeddings::EmbeddingIdentity,
+    ) -> anyhow::Result<()> {
+        let mut stmt =
+            conn.prepare("INSERT OR REPLACE INTO memory_meta (key, value) VALUES (?1, ?2)")?;
+        stmt.execute(params!["embedding_provider", identity.provider])?;
+        stmt.execute(params!["embedding_model", identity.model])?;
+        stmt.execute(params![
+            "embedding_dimensions",
+            identity.dimensions.to_string()
+        ])?;
+        Ok(())
     }
 
     /// Get embedding from cache, or compute + cache it
@@ -2509,6 +2615,133 @@ mod tests {
         // FTS should still work after rebuild
         let results = mem.recall("reindex", 10, None, None, None).await.unwrap();
         assert_eq!(results.len(), 2);
+    }
+
+    // ── Embedding identity primitives (issue #7948) ──────────────
+
+    /// Embedder that returns a fixed vector, so store() persists real
+    /// (non-NULL) embeddings and populates the embedding cache.
+    struct FixedEmbedding(usize);
+
+    #[async_trait::async_trait]
+    impl super::super::embeddings::EmbeddingProvider for FixedEmbedding {
+        fn name(&self) -> &str {
+            "fixed"
+        }
+        fn dimensions(&self) -> usize {
+            self.0
+        }
+        async fn embed(&self, texts: &[&str]) -> anyhow::Result<Vec<Vec<f32>>> {
+            Ok(texts.iter().map(|_| vec![0.5f32; self.0]).collect())
+        }
+    }
+
+    fn identity(
+        provider: &str,
+        model: &str,
+        dimensions: usize,
+    ) -> super::super::embeddings::EmbeddingIdentity {
+        super::super::embeddings::EmbeddingIdentity {
+            provider: provider.into(),
+            model: model.into(),
+            dimensions,
+        }
+    }
+
+    fn count_scalar(mem: &SqliteMemory, sql: &str) -> i64 {
+        let conn = mem.connection().lock();
+        conn.query_row(sql, [], |row| row.get(0)).unwrap()
+    }
+
+    #[test]
+    fn embedding_identity_roundtrip() {
+        let (_tmp, mem) = temp_sqlite();
+        // A fresh store (and any store predating identity tracking) has none.
+        assert_eq!(mem.stored_embedding_identity().unwrap(), None);
+
+        let id = identity("openai", "text-embedding-3-small", 1536);
+        mem.record_embedding_identity(&id).unwrap();
+        assert_eq!(mem.stored_embedding_identity().unwrap(), Some(id));
+    }
+
+    #[test]
+    fn embedding_identity_partial_rows_read_as_absent() {
+        let (_tmp, mem) = temp_sqlite();
+        {
+            let conn = mem.connection().lock();
+            conn.execute(
+                "INSERT INTO memory_meta (key, value) VALUES ('embedding_model', 'orphan')",
+                [],
+            )
+            .unwrap();
+        }
+        assert_eq!(mem.stored_embedding_identity().unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn invalidate_nulls_vectors_clears_cache_and_stamps_identity() {
+        let tmp = TempDir::new().unwrap();
+        let mem = SqliteMemory::with_embedder(
+            "test",
+            tmp.path(),
+            Arc::new(FixedEmbedding(4)),
+            0.7,
+            0.3,
+            1000,
+            None,
+            SearchMode::default(),
+        )
+        .unwrap();
+        mem.record_embedding_identity(&identity("openai", "old-model", 4))
+            .unwrap();
+
+        mem.store("a", "alpha content", MemoryCategory::Core, None)
+            .await
+            .unwrap();
+        mem.store("b", "beta content", MemoryCategory::Core, None)
+            .await
+            .unwrap();
+        assert_eq!(
+            count_scalar(
+                &mem,
+                "SELECT COUNT(*) FROM memories WHERE embedding IS NOT NULL"
+            ),
+            2
+        );
+        assert_eq!(
+            count_scalar(&mem, "SELECT COUNT(*) FROM embedding_cache"),
+            2
+        );
+
+        let new_id = identity("openai", "new-model", 4);
+        let invalidated = mem
+            .invalidate_embeddings_for_identity_change(&new_id)
+            .unwrap();
+
+        assert_eq!(invalidated, 2);
+        assert_eq!(
+            count_scalar(
+                &mem,
+                "SELECT COUNT(*) FROM memories WHERE embedding IS NOT NULL"
+            ),
+            0
+        );
+        assert_eq!(
+            count_scalar(&mem, "SELECT COUNT(*) FROM embedding_cache"),
+            0
+        );
+        assert_eq!(mem.stored_embedding_identity().unwrap(), Some(new_id));
+
+        // Content is retained, so the existing reindex path re-embeds losslessly.
+        let reembedded = mem.reindex().await.unwrap();
+        assert_eq!(reembedded, 2);
+        assert_eq!(
+            count_scalar(
+                &mem,
+                "SELECT COUNT(*) FROM memories WHERE embedding IS NOT NULL"
+            ),
+            2
+        );
     }
 
     // ── Recall limit test ────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `brain.db` never recorded which embedder produced its stored vectors, so changing `[memory].embedding_provider` / `embedding_model` / `embedding_dimensions` silently made every stored vector incompatible — recall quietly degraded with no warning and no migration path (#7948).
  - A new `memory_meta` key/value table (beside `schema_version`, whose `INTEGER` value column can't carry the identity strings) persists the resolved embedding identity: provider, model, dimensions.
  - On startup the memory factory reconciles config against the stored identity: a store with no recorded identity adopts the current one silently (vectors untouched — we can't know what produced them, and wiping on upgrade would surprise operators); a match is a no-op; a mismatch sets `embedding = NULL` on all rows, clears the content-hash-keyed `embedding_cache` (it would otherwise serve stale vectors across the model change), stamps the new identity atomically, and logs a WARN. This half of the migration is lossless and costs zero API calls — `content` is retained on every row.
  - The expensive half (N embedding calls) stays gated: `zeroclaw memory reindex` backfills NULL vectors exactly as before, or the new opt-in `[memory].auto_reindex_on_identity_change = true` kicks off the re-embed in the background right after the invalidation.
  - Storage/policy split follows the #6850 boundary: `SqliteMemory` gains storage primitives only (read/record identity, transactional invalidate); the reconcile *decision* lives in the memory factory next to the existing hygiene/hydration policy. No `Memory` or `MemoryStrategy` trait changes, no collision with #7234.
- **Scope boundary:** sqlite backend only — postgres/qdrant identity tracking is a follow-up. Does not change the default embedder, dotted-ref resolution (#8152), or keyword-only (`none`) setups, which stay byte-identical: reconciliation is skipped entirely without a real embedder, so a temporarily unresolved provider can't masquerade as an identity change and wipe valid vectors.
- **Blast radius:** memory construction path (gateway, daemon, CLI) now runs the reconcile; `[memory]` gains one optional bool. Existing DBs adopt the current identity on first startup after upgrade, without invalidation. The stored identity includes the *resolved* provider string, so relocating a `custom:<url>` endpoint (same model) triggers a false-positive invalidation — safe (lossless) but costs one re-embed; called out in the field docs.
- **Linked issue(s):** Closes #7948. Related #7942 (store survives embed failures; NULL-backfill path this reuses), #6850 (storage/lifecycle boundary).
- **Labels:** (set by maintainers; suggest `memory`, `config`, `enhancement`, `risk:medium`)

## Validation Evidence (required)

- **Commands run and tail output:**

```text
$ cargo fmt --all -- --check
(no output — clean)

$ cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
(no output — zero warnings, exit 0; run with -j4, ci-all features, zeroclaw-desktop excluded)
```

- **Beyond CI — what did you manually verify?** Test coverage added for: identity roundtrip + partial-row handling (primitives), legacy-store adoption keeps vectors, mismatch invalidates + clears cache + stamps identity, dimension-only change triggers, reindex backfills after invalidation, background auto-reindex re-embeds, keyword-only factory records no identity, and end-to-end factory stamp/migrate across reconstructions. Not verified: postgres/qdrant backends (out of scope), a live provider endpoint (mock embedders only).
- **If any command was intentionally skipped, why:** `cargo test` is not runnable on this dev machine (14 GB RAM, workspace test build OOMs) — relying on CI for the test run; the full test build compiles locally (`cargo check --tests`).

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No — the optional background re-embed calls the already-configured embedding endpoint via the existing `reindex()` path.
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? Yes — new optional `[memory].auto_reindex_on_identity_change` (default `false`; no action needed). No CLI changes; `zeroclaw memory reindex` behaves as before.
- Upgrade steps: none. First startup after upgrade records the current identity; existing vectors are untouched until an actual identity change.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <sha>` — the `memory_meta` table is additive and ignored by older binaries.
- **Feature flags or config toggles:** `auto_reindex_on_identity_change` (default off) gates the only behavior with API cost.
- **Observable failure symptoms:** WARN `embedding identity changed; stored vectors invalidated` (attrs: `stored_identity`, `current_identity`, `vectors_invalidated`) on an unexpected startup; `SELECT COUNT(*) FROM memories WHERE embedding IS NULL` spiking; `memory_meta` rows `embedding_provider/model/dimensions` show what the store believes.
