### PR TITLE
refactor(channels): route the orchestrator turn back through ResolvedAgentExecution::resolve

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -126,11 +126,12 @@ use zeroclaw_memory::{self, MEMORY_CONTEXT_CLOSE, MEMORY_CONTEXT_OPEN, Memory};
 use zeroclaw_providers::reliable::{scope_provider_fallback, take_last_provider_fallback};
 use zeroclaw_providers::{self, ChatMessage, ModelProvider, ProviderDispatch};
 use zeroclaw_runtime::agent::loop_::{
-    LoopKnobs, ResolvedAgentExecution, ResolvedModelAccess, ToolLoop, apply_policy_tool_filter,
-    apply_text_tool_prompt_policy, build_tool_instructions_for_names, clear_model_switch_request,
-    eager_mcp_tool_allowed, get_model_switch_state, is_model_switch_requested,
-    mcp_tool_access_policy, register_eager_mcp_tool_if_allowed, run_tool_call_loop,
-    scope_session_key, scope_thread_id, scrub_credentials,
+    LoopKnobs, ResolvedAgentExecution, ResolvedIo, ResolvedModelAccess, ResolvedRuntimeKnobs,
+    ToolLoop, apply_policy_tool_filter, apply_text_tool_prompt_policy,
+    build_tool_instructions_for_names, clear_model_switch_request, eager_mcp_tool_allowed,
+    get_model_switch_state, is_model_switch_requested, mcp_tool_access_policy,
+    register_eager_mcp_tool_if_allowed, run_tool_call_loop, scope_session_key, scope_thread_id,
+    scrub_credentials,
 };
 use zeroclaw_runtime::approval::ApprovalManager;
 use zeroclaw_runtime::observability::traits::{ObserverEvent, ObserverMetric};
@@ -5134,38 +5135,42 @@ async fn process_channel_message_body(
                     ctx.non_cli_excluded_tools.as_ref()
                 };
             let tool_loop = run_tool_call_loop(ToolLoop {
-                exec: ResolvedAgentExecution {
-                    model_access: ResolvedModelAccess {
+                exec: ResolvedAgentExecution::resolve(
+                    ResolvedModelAccess {
                         model_provider: active_model_provider.as_ref(),
                         provider_name: route.model_provider.as_str(),
                         model: route.model.as_str(),
                         temperature: thinking.effective_temperature,
                     },
-                    tools_registry: ctx.tools_registry.as_ref(),
-                    observer: notify_observer.as_ref() as &dyn Observer,
-                    silent: true,
-                    approval: Some(&*ctx.approval_manager),
-                    multimodal_config: &ctx.multimodal,
-                    max_tool_iterations: ctx.max_tool_iterations,
-                    hooks: ctx.hooks.as_deref(),
-                    excluded_tools,
-                    dedup_exempt_tools: ctx.tool_call_dedup_exempt.as_ref(),
-                    activated_tools: ctx.activated_tools.as_ref(),
-                    model_switch_callback: Some(model_switch_callback.clone()),
-                    pacing: &ctx.pacing,
-                    strict_tool_parsing: ctx
-                        .prompt_config
-                        .agent(ctx.agent_alias.as_str())
-                        .is_some_and(|agent| agent.resolved.strict_tool_parsing),
-                    parallel_tools: ctx
-                        .prompt_config
-                        .agent(ctx.agent_alias.as_str())
-                        .is_some_and(|agent| agent.resolved.parallel_tools),
-                    max_tool_result_chars: ctx.max_tool_result_chars,
-                    context_token_budget: ctx.context_token_budget,
-                    receipt_generator: ctx.receipt_generator.as_ref(),
-                    knobs: &loop_knobs,
-                },
+                    ResolvedIo {
+                        tools_registry: ctx.tools_registry.as_ref(),
+                        observer: notify_observer.as_ref() as &dyn Observer,
+                        silent: true,
+                        approval: Some(&*ctx.approval_manager),
+                        multimodal_config: &ctx.multimodal,
+                        hooks: ctx.hooks.as_deref(),
+                        activated_tools: ctx.activated_tools.as_ref(),
+                        model_switch_callback: Some(model_switch_callback.clone()),
+                        receipt_generator: ctx.receipt_generator.as_ref(),
+                    },
+                    ResolvedRuntimeKnobs {
+                        max_tool_iterations: ctx.max_tool_iterations,
+                        excluded_tools,
+                        dedup_exempt_tools: ctx.tool_call_dedup_exempt.as_ref(),
+                        pacing: &ctx.pacing,
+                        strict_tool_parsing: ctx
+                            .prompt_config
+                            .agent(ctx.agent_alias.as_str())
+                            .is_some_and(|agent| agent.resolved.strict_tool_parsing),
+                        parallel_tools: ctx
+                            .prompt_config
+                            .agent(ctx.agent_alias.as_str())
+                            .is_some_and(|agent| agent.resolved.parallel_tools),
+                        max_tool_result_chars: ctx.max_tool_result_chars,
+                        context_token_budget: ctx.context_token_budget,
+                        knobs: &loop_knobs,
+                    },
+                ),
                 history: &mut history,
                 channel_name: msg.channel.as_str(),
                 channel_reply_target: Some(msg.reply_target.as_str()),


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** #8179 routed the channel orchestrator's turn construction
  through the `ResolvedAgentExecution::resolve` seam. #8011 (per-sender `/thinking`
  overrides), which branched before #8179 landed, rewrote the same block in
  `process_channel_message_body` and re-inlined the flat `ResolvedAgentExecution { .. }`
  literal - unintentionally reverting the routing. CI stayed green because `resolve()` is
  a pure field spread, so an un-routing is invisible to tests; only the structure
  regressed. This PR restores the routing: the turn constructs through
  `resolve(ResolvedModelAccess, ResolvedIo, ResolvedRuntimeKnobs)` with the exact field
  values the inline literal used - including `thinking.effective_temperature`, so #8011's
  per-sender thinking behavior is untouched. With this, every production turn path again
  constructs through the one seam, as the contributing page
  (`docs/book/src/contributing/agent-policy-parity-harness.md`) states.
- **Scope boundary:** one construction site regrouped + two type imports restored. No
  behavior change, no API change, no doc change.
- **Blast radius:** `crates/zeroclaw-channels/src/orchestrator/mod.rs` only.
- **Linked issue(s):** Restores the #8179 invariant; regression introduced by #8011
  (its feature is preserved). The incident also motivates the planned follow-up that
  makes this class of silent un-routing a compile error (sealing the bundle so only the
  resolver constructs it) - tracked in the agent-policy parity-harness program.
- **Labels:** suggested `channel`, `risk: low`, `size: XS`.

## Validation Evidence (required)

Toolchain pinned to 1.93.0 (matches CI). Literal output:

- `cargo check -p zeroclaw-channels`: clean.
- `cargo clippy -p zeroclaw-channels -p zeroclaw-runtime --all-targets -- -D warnings`:
  "Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 27s", exit 0
  (compiles all test targets in both crates).
- `cargo fmt --all -- --check`: clean.
- **Beyond CI - manually verified:** field-by-field diff of the removed inline literal vs
  the `resolve()` inputs: identical values and expressions for all 19 fields (including
  the two `ctx.prompt_config.agent(...)` closures and the hoisted `excluded_tools`
  binding). `resolve()` itself is unchanged on master (pure field spread), so the engine
  receives byte-identical inputs.
- **Intentionally skipped:** web / shell / docs batteries (no such files changed);
  `cargo test` full suite deferred to CI (clippy `--all-targets` already type-checks all
  test code; the diff cannot change runtime behavior).

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No.**
- New external network calls? **No.**
- Secrets / tokens / credentials handling changed? **No.**
- PII or personal data in diff/tests/docs? **No.**
- Behavior-neutral regrouping: approval manager, excluded tools, pacing, and every other
  policy field reach the engine with the same values as before.

## Compatibility (required)

- Backward compatible? **Yes** (internal construction-site regrouping only).
- Config / env / CLI surface changed? **No.**
- Upgrade steps: none.

## Rollback (required for medium/high-risk PRs)

Low risk: `git revert <squash-sha>` - one self-contained commit, one file.
