### PR TITLE
docs(sop): correct cron trigger dispatch status (wired via maintenance tick)

### DIFF
--- a/crates/zeroclaw-runtime/src/sop/types.rs
+++ b/crates/zeroclaw-runtime/src/sop/types.rs
@@ -156,7 +156,7 @@ pub enum SopTrigger {
         /// Request path matched exactly against the event path.
         path: String,
     },
-    /// Time-based firing. Defined and matched, but no scheduler feeds it.
+    /// Time-based firing. Live: dispatched by the SOP maintenance tick (daemon / channel-start paths).
     #[trigger(display = "expression")]
     Cron {
         /// Cron expression evaluated over the run window.

--- a/docs/book/src/sop/fan-in/cron.md
+++ b/docs/book/src/sop/fan-in/cron.md
@@ -1,6 +1,6 @@
 # SOP Fan-In: Cron
 
-{{#include ../../_snippets/sop-unwired.md}}
+> **Wired.** Cron triggers are dispatched by the periodic SOP maintenance tick, so this is a poller rather than a per-schedule timer. Firing needs that tick, which a `zeroclaw daemon` or the `zeroclaw channel start` supervisor spawns (built with the `agent-runtime` feature, `sop.sops_dir` set, and `sop.maintenance_interval_secs` non-zero, default `60`). Standalone `zeroclaw gateway start` does **not** spawn the maintenance tick, so it does not fire cron triggers; a gateway hosted inside the daemon does, because the daemon spawns the tick. Schedules are parsed once at startup, so a SOP added while the daemon is running needs a reload before its cron trigger takes effect.
 
 A cron trigger fires on a time window described by a cron expression. Invalid expressions fail closed during parsing and cache build.
 

--- a/docs/book/src/sop/fan-in/overview.md
+++ b/docs/book/src/sop/fan-in/overview.md
@@ -17,7 +17,7 @@ Every SOP trigger type, its fields, and its dispatch status, projected directly 
 
 {{#sop-trigger-index}}
 
-Each source has a dedicated guide in the sidebar. Live sources (delivered by a running listener) start runs as events arrive; agent-initiated runs start from inside an agent turn via [`sop_execute`](./manual.md); defined-but-unwired sources validate and match but have no live event source routing into the dispatcher yet.
+Each source has a dedicated guide in the sidebar. Live sources (delivered by a running listener) start runs as events arrive; cron triggers are dispatched by the daemon's periodic SOP maintenance tick; agent-initiated runs start from inside an agent turn via [`sop_execute`](./manual.md); the remaining defined-but-unwired sources (webhook, peripheral, calendar) validate and match but have no live event source routing into the dispatcher yet.
 
 ## Security defaults
 
@@ -37,7 +37,8 @@ Each source has a dedicated guide in the sidebar. Live sources (delivered by a r
 |---|---|---|
 | SOP never starts from a live source | trigger pattern mismatch or a failing `condition` | Verify the trigger pattern matches the delivered event; check the `condition` against the payload |
 | SOP started but a step did not execute | headless trigger without an active agent loop | Run an agent loop for `ExecuteStep`, or design the run to pause on approvals |
-| Webhook, cron, peripheral, or calendar trigger never fires | event source not wired into the dispatcher | Use a live source ([MQTT](./mqtt.md), [Filesystem](./filesystem.md), [AMQP](./amqp.md)) or start the run with [`sop_execute`](./manual.md) |
+| Webhook, peripheral, or calendar trigger never fires | event source not wired into the dispatcher | Use a live source ([MQTT](./mqtt.md), [Filesystem](./filesystem.md), [AMQP](./amqp.md)) or start the run with [`sop_execute`](./manual.md) |
+| Cron trigger never fires | maintenance tick not running (no `zeroclaw daemon` or `zeroclaw channel start`; standalone `gateway start` does not run it), `sops_dir` unset, or `maintenance_interval_secs = 0` | Run `zeroclaw daemon` (or `zeroclaw channel start`) with `sop.sops_dir` set and `sop.maintenance_interval_secs` non-zero (default `60`) |
 
 ## See also
 

--- a/docs/book/src/sop/how-it-works.md
+++ b/docs/book/src/sop/how-it-works.md
@@ -4,7 +4,7 @@
 
 - SOP definitions are loaded from `<workspace>/sops/<sop_name>/SOP.toml` plus optional `SOP.md`.
 - CLI `zeroclaw sop` currently manages definitions only: `list`, `validate`, `show`.
-- SOP runs are started by a live event fan-in (MQTT, filesystem, or AMQP) or by the in-agent tool `sop_execute`. Other trigger types are defined and matched but not yet wired to a live event source (see [SOP Fan-In](./fan-in/overview.md)).
+- SOP runs are started by a live event fan-in (MQTT, filesystem, or AMQP), by the daemon's periodic SOP maintenance tick for `cron` triggers, or by the in-agent tool `sop_execute`. The remaining trigger types (webhook, peripheral, calendar) are defined and matched but not yet wired to a live event source (see [SOP Fan-In](./fan-in/overview.md)).
 - Run progression uses tools: `sop_status`, `sop_approve`, `sop_advance`.
 - SOP audit records are persisted in the configured Memory backend under category `sop`.
 
@@ -15,7 +15,7 @@ graph LR
     MQTT[MQTT listener] -->|topic match| Dispatch
     TOOL[sop_execute tool] -->|manual| Dispatch
     WH[Webhook trigger] -.->|defined, unwired| Dispatch
-    CRON[Cron trigger] -.->|defined, unwired| Dispatch
+    CRON[Cron trigger] -->|daemon maintenance tick| Dispatch
     GPIO[Peripheral trigger] -.->|defined, unwired| Dispatch
 
     Dispatch --> Engine[SOP Engine]

--- a/docs/book/src/sop/index.md
+++ b/docs/book/src/sop/index.md
@@ -5,6 +5,6 @@ SOPs are deterministic procedures executed by the `SopEngine`. They provide expl
 - [How SOPs run](./how-it-works.md): the runtime contract, event flow, and a getting-started walkthrough.
 - [Syntax](./syntax.md): required file layout and trigger/step syntax.
 - [Cookbook](./cookbook.md): reusable SOP patterns.
-- [SOP Fan-In](./fan-in/overview.md): event fan-in to the SOP engine. MQTT, filesystem, and AMQP are wired live sources; webhook, cron, peripheral, and calendar triggers are defined and matched but not yet routed to a live event source.
+- [SOP Fan-In](./fan-in/overview.md): event fan-in to the SOP engine. MQTT, filesystem, and AMQP are wired live sources, and the daemon's periodic maintenance tick dispatches cron triggers; webhook, peripheral, and calendar triggers are defined and matched but not yet routed to a live event source.
 - [Observability](./observability.md): where run state and audit entries are stored.
 - [Worked Example](./example.md): the stagehand StageX auto-update bot, from build to draft PR, driven by a deterministic SOP over an AMQP feed.


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - The SOP docs describe the `cron` trigger as "defined, unwired," but cron is actually dispatched on master by the daemon's periodic SOP maintenance tick (`spawn_sop_maintenance` -> `run_sop_maintenance_tick` -> `check_sop_cron_triggers` in `src/main.rs`, spawned from the full daemon and the `channel start` supervisor). The docs are stale relative to that wiring.
  - The wired/unwired label shown in the fan-in tables is generated from the `SopTrigger::Cron` variant doc-comment (via the `{{#sop-trigger-index}}` / `{{#sop-trigger}}` mdbook widgets in `xtask/src/cmd/mdbook/peer_groups.rs`, which read the schemars `description`). So this updates that doc-comment plus the four hand-written pages that assert cron is unwired.
  - The corrected pages note what cron firing actually depends on: the `agent-runtime` feature, `sop.sops_dir` set, `sop.maintenance_interval_secs` non-zero (default `60`), and a running daemon or the `channel start` supervisor. Standalone `zeroclaw gateway start` does not run the maintenance tick and so does not fire cron; a gateway hosted inside the daemon does, because the daemon spawns the tick. Cron is a poller bounded by the maintenance interval, not a per-schedule timer, and its schedule cache is built at startup.
- **Scope boundary:** Only the cron trigger's dispatch-status wording. No logic change. Webhook, peripheral, and calendar stay defined-but-unwired, and the shared `docs/book/src/_snippets/sop-unwired.md` snippet is left untouched (still correct for those three). `syntax.md` needs no manual edit because its table is generated from the same doc-comment.
- **Blast radius:** Documentation only. The one non-markdown file, `crates/zeroclaw-runtime/src/sop/types.rs`, is a doc-comment change on the `SopTrigger::Cron` variant with no logic or codegen impact; it is included because the mdbook widgets render that doc-comment into the fan-in tables, so leaving it stale would contradict the prose. Flagging it so a reviewer expecting a pure `docs/` diff is not surprised.
- **Linked issue(s):** None. Standalone documentation correction.
- **Labels:** `docs`, `runtime`, `risk:low`, `size:XS`, `type:docs` (live snapshot; path/scope labels auto-applied by the labeler). I do not have label permission on the repo.

## Testing (required)

### How you can test

- **Reviewer testing requested?** `N/A`. Docs-only wording correction with no user-visible behavior change; the source trace below and the docs CI gates cover it.

### How I tested

Documentation change, so the docs gates plus a formatting check on the single touched `.rs` file.

```bash
$ rustfmt --edition 2024 --check crates/zeroclaw-runtime/src/sop/types.rs
# (no diff; clean)

$ BASE_SHA=<merge-base> bash scripts/ci/docs_quality_gate.sh
No prose em-dashes in changed docs files.
Linting docs files: docs/book/src/sop/fan-in/cron.md docs/book/src/sop/fan-in/overview.md docs/book/src/sop/how-it-works.md docs/book/src/sop/index.md
markdownlint-cli2 v0.20.0 (markdownlint v0.40.0)
Linting: 4 file(s)
Summary: 0 error(s)

$ BASE_SHA=<merge-base> bash scripts/ci/docs_links_gate.sh
Collected 5 added link(s) from 4 docs file(s).
Checked 5 local docs link target(s).
No added HTTP(S) links detected in changed docs lines.
```

- **CI checks relied on and why they cover this change:** `Docs Style` lints the four changed Markdown pages; `Format` covers the `rustfmt` check on the one touched `.rs` doc-comment; `Test` and `CI Required Gate` confirm the doc-comment change does not break the build or codegen. All green on head `6115dbc0e`.
- **Known CI coverage gap, if any:** None after the docs quality and links gates.
- **Commands run and tail output:** the three tails above (`rustfmt --check`, `docs_quality_gate.sh`, `docs_links_gate.sh`).
- **Beyond CI, what I manually verified:** traced the widget source of truth (`xtask/src/cmd/mdbook/peer_groups.rs` reads the schemars `description` = the variant doc-comment), so the generated `overview.md`/`syntax.md` tables now render the corrected status consistently with the hand-written prose; confirmed the cron dispatch path is production (not test-only) and reached from the daemon and `channel start` supervisor paths; confirmed standalone `zeroclaw gateway start` calls `run_gateway(..., None, None)` with no maintenance worker and does not fire cron; confirmed the shared unwired snippet remains accurate for webhook/peripheral/calendar. Did not exercise a live cron run end to end.
- **If any command was intentionally skipped, why:** full `cargo clippy --all-targets` / `cargo test` beyond required CI. The only Rust change is a doc-comment (no logic, no codegen, no doc-test), so `rustfmt --check` on the file plus the CI `Test` gate cover it. Happy to run the full battery if a maintainer prefers.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No` (documentation wording only)
- Rust/MSRV/toolchain floor changed? `No`

## Rollback

Low-risk: `git revert <sha>` is the plan.
