### PR TITLE
fix(skill_http): reject URL userinfo to close parser-level SSRF gap

### DIFF
--- a/crates/zeroclaw-runtime/src/tools/skill_http.rs
+++ b/crates/zeroclaw-runtime/src/tools/skill_http.rs
@@ -90,8 +90,30 @@ impl Tool for SkillHttpTool {
     async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
         let url = self.substitute_args(&args);
 
-        // Validate URL scheme
-        if !url.starts_with("http://") && !url.starts_with("https://") {
+        // Parse with `reqwest::Url` instead of hand-rolled scheme check. The
+        // pre-fix check only verified the URL prefix, so a template like
+        // `http://{{user}}@{{host}}/...` with attacker-controlled `{{user}}`
+        // could land `http://attacker@127.0.0.1/...` (userinfo bypass).
+        // Reject userinfo outright (parser-level SSRF defense; no skill-author
+        // opt-out). Mirrors the `text_browser` fix in PR #8635.
+        let parsed = match reqwest::Url::parse(&url) {
+            Ok(p) => p,
+            Err(e) => {
+                return Ok(ToolResult {
+                    success: false,
+                    output: String::new(),
+                    error: Some(format!("Invalid URL: {e}")),
+                });
+            }
+        };
+        if !parsed.username().is_empty() || parsed.password().is_some() {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some("URL userinfo is not allowed".to_string()),
+            });
+        }
+        if !matches!(parsed.scheme(), "http" | "https") {
             return Ok(ToolResult {
                 success: false,
                 output: String::new(),
@@ -165,6 +187,7 @@ impl Tool for SkillHttpTool {
 mod tests {
     use super::*;
     use crate::skills::SkillTool;
+    use serde_json::json;
 
     fn sample_http_tool() -> SkillTool {
         let mut args = HashMap::new();
@@ -302,5 +325,87 @@ mod tests {
         let tool = SkillHttpTool::new("s", &st);
         let schema = tool.parameters_schema();
         assert!(schema["properties"].as_object().unwrap().is_empty());
+    }
+
+    // ── SSRF guards (audit-zeroclaw-2026-07-03.md follow-up finding) ──
+    //
+    // The URL template is operator-trust (skill author), but `{{arg_name}}`
+    // is LLM-supplied at runtime. A template like `http://{{user}}@{{host}}`
+    // with attacker-controlled `{{user}}` would yield a userinfo bypass
+    // (`http://attacker@127.0.0.1/...`). Reject userinfo at the parser layer
+    // so the LLM cannot smuggle a private host through credential syntax.
+
+    fn http_tool_with_command(command: &str) -> SkillHttpTool {
+        let st = SkillTool {
+            name: "fetch".to_string(),
+            description: "test".to_string(),
+            kind: "http".to_string(),
+            command: command.to_string(),
+            args: HashMap::new(),
+            target: None,
+            locked_args: HashMap::new(),
+            timeout_secs: None,
+        };
+        SkillHttpTool::new("test_skill", &st)
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn rejects_userinfo_targeting_private_host() {
+        // `{{user}}` substitution yields a userinfo prefix. Parser-level
+        // reject, no opt-out (the skill author cannot allow userinfo even
+        // for legitimate credentials in URL).
+        let tool = http_tool_with_command("https://{{user}}@api.example.com/path");
+        let result = tool
+            .execute(json!({"user": "attacker@127.0.0.1"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("userinfo"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn rejects_userinfo_with_password() {
+        let tool = http_tool_with_command("https://{{u}}:{{p}}@api.example.com/path");
+        let result = tool
+            .execute(json!({"u": "alice", "p": "secret@10.0.0.1"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("userinfo"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn rejects_userinfo_even_when_host_is_public() {
+        // The userinfo reject is parser-level, not policy-level. A
+        // legitimate-looking public host with userinfo is still rejected
+        // so the gate cannot be bypassed by mixing public/private strings.
+        let tool = http_tool_with_command("https://{{u}}@example.com/path");
+        let result = tool.execute(json!({"u": "anyone"})).await.unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("userinfo"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn rejects_non_http_scheme() {
+        // `file://`, `gopher://`, etc. must still be rejected.
+        let tool = http_tool_with_command("file://etc/passwd");
+        let result = tool.execute(json!({})).await.unwrap();
+        assert!(!result.success);
+        let err = result.error.unwrap();
+        assert!(
+            err.contains("http") || err.contains("Invalid URL"),
+            "got: {err}"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn rejects_malformed_url() {
+        // The skill author supplied a template with no scheme, only a host.
+        // `reqwest::Url::parse` rejects it as RelativeUrlWithoutBase.
+        let tool = http_tool_with_command("example.com/ping");
+        let result = tool.execute(json!({})).await.unwrap();
+        assert!(!result.success);
+        let err = result.error.unwrap();
+        assert!(err.contains("Invalid URL"), "got: {err}");
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** `skill_http` substitutes `{{arg_name}}` placeholders in the URL template with LLM-supplied values at runtime. The pre-fix `validate_url` only checked that the substituted string started with `http://` or `https://`, so a template like `http://{{user}}@{{host}}/...` with attacker-controlled `{{user}}` could yield a URL whose effective host is whatever the LLM put after the `@` (userinfo bypass). This PR replaces the `starts_with` check with `reqwest::Url::parse` and rejects any URL with a username or password — parser-level defense with no skill-author opt-out.
- **Why now:** Proactive finding from `audit/zeroclaw-2026-07-03.md` (the follow-up scan after PR #8635). Same parser-mismatch class as the gap PR #8635 closed for `text_browser`, and the same `reqwest::Url::parse` defense.
- **Scope boundary:** Only closes the parser-mismatch surface. Does **not** add a per-skill `allowed_private_hosts` (the skill author owns the URL template's host, which is operator-trust). Does **not** add a per-skill `allowed_domains` (the URL template's host is fixed by the skill manifest, not the LLM). Operators who need to call a private host should embed it in the template literal; skill authors who need LLM-controlled host selection should redesign the skill.
- **Blast radius:** Single file, single function. No config surface, no schema changes, no migration. Deny-by-default: zero behavior change for templates without `{{arg}}` substitution and zero behavior change for templates that do not put userinfo in a substituted position.
- **Linked issue(s):** None — proactively found by the audit.

## Validation Evidence

```bash
$ cargo fmt --all -- --check
(exit 0)

$ cargo clippy -p zeroclaw-runtime --locked --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 33s
(zero warnings)

$ cargo test -p zeroclaw-runtime --locked --lib tools::skill_http
test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 2720 filtered out
(8 existing + 5 new SSRF regression tests)
```

## Security Impact

- **Permissions / capabilities added:** None — closes a gap, doesn't open one.
- **New external network calls:** No.
- **Threat model:** Closes an LLM-reachable SSRF via `skill_http`. Concrete exploit: a skill with template `https://{{user}}@{{host}}/api` (deliberate host exposure) where the LLM supplies `user = "attacker"` could previously bypass intent of the host allowlist (none in this tool today) by hiding the actual destination in userinfo syntax. The new `reqwest::Url::parse` + `username().is_empty() && password().is_none()` reject closes that path.
- **Backward compat:** Templates that do not put userinfo in a substituted position are unaffected. Templates that legitimately need credential-in-URL (e.g. `https://user:pass@api.example.com/`) must be written as template literals (the `user:pass` portion is operator-trust), not via `{{arg}}` substitution. This is a deliberate choice: the LLM should never be the source of credentials.

## Risks and Mitigations

- **Risk:** A skill author wrote a template like `https://{{u}}:{{p}}@api.example.com/...` where `u` and `p` are intended to come from the operator's secret store, not the LLM. The new gate would block this.
  **Mitigation:** Two paths. (a) Use `locked_args` (the existing `SkillTool` mechanism for operator-fixed args) so the substitution happens at skill load time, not at every tool call — though even that still substitutes before URL parse, so a separate fix is needed. (b) Embed the credentials in the template literal directly, since they are operator-trust. We will document (a)/(b) in a follow-up if a real skill needs this; the audit found no in-tree skill that does.

## Rollback Plan

- **Fast rollback:** `git revert 890c07714`.
- **Feature flag/config toggle:** None — the change is unconditional.
- **Observable failure symptoms:** Any skill that previously got `userinfo is not allowed` errors only because the LLM-supplied arg contained `@` will now also get the error; the only fix path is the template-author redirecting through `locked_args` or hardcoding.
