### PR TITLE
feat(tools): gate the gateway tool registries through the ScopedToolRegistry assemble seam

### DIFF
--- a/crates/zeroclaw-gateway/src/lib.rs
+++ b/crates/zeroclaw-gateway/src/lib.rs
@@ -146,9 +146,6 @@ use zeroclaw_config::schema::Config;
 use zeroclaw_infra::session_backend::SessionBackend;
 use zeroclaw_memory::{self, Memory, MemoryCategory};
 use zeroclaw_providers::{self, ModelProvider};
-use zeroclaw_runtime::agent::loop_::{
-    eager_mcp_tool_allowed, mcp_tool_access_policy, register_eager_mcp_tool_if_allowed,
-};
 use zeroclaw_runtime::agent::memory_strategy::DefaultMemoryStrategy;
 use zeroclaw_runtime::cost::CostTracker;
 use zeroclaw_runtime::i18n;
@@ -156,6 +153,7 @@ use zeroclaw_runtime::platform;
 use zeroclaw_runtime::security::pairing::{PairingGuard, constant_time_eq, is_public_bind};
 use zeroclaw_runtime::tools;
 use zeroclaw_runtime::tools::CanvasStore;
+use zeroclaw_runtime::tools::scoped;
 
 /// Maximum request body size (64KB) — prevents memory exhaustion
 pub const MAX_BODY_SIZE: usize = 65_536;
@@ -463,135 +461,6 @@ fn default_agent_alias(config: &Config) -> Option<String> {
         .filter(|(_, a)| a.enabled)
         .map(|(alias, _)| alias.clone())
         .min()
-}
-
-/// Connect the MCP servers granted to `agent_alias` by its `mcp_bundles` and
-/// append the resulting tools to `gw_tools`, gated by the agent's tool-access
-/// policy. Shared by the dashboard-agent seed and the per-agent
-/// `/api/tools` registry builder so both surfaces scope MCP identically
-/// (omission is not a grant; deny wins). A no-op when MCP is disabled or the
-/// agent's bundles grant no servers, and non-fatal on connect failure so the
-/// gateway still boots.
-async fn append_scoped_mcp_tools(
-    config: &Config,
-    agent_alias: &str,
-    security: &Arc<SecurityPolicy>,
-    gw_tools: &mut Vec<Box<dyn tools::Tool>>,
-    gw_delegate: Option<&tools::DelegateParentToolsHandle>,
-) {
-    let agent_mcp_servers = if config.mcp.enabled {
-        config.mcp_servers_for_agent(agent_alias)
-    } else {
-        Vec::new()
-    };
-    if agent_mcp_servers.is_empty() {
-        return;
-    }
-    use ::zeroclaw_log::Instrument;
-    let mcp_policy = mcp_tool_access_policy(security, None);
-    let mcp_model_provider = config
-        .agents
-        .get(agent_alias)
-        .map(|a| a.model_provider.as_str().to_string())
-        .unwrap_or_default();
-    let mcp_model = config
-        .model_provider_for_agent(agent_alias)
-        .and_then(|p| p.model.clone())
-        .unwrap_or_default();
-    let attribution_span =
-        ::zeroclaw_log::attribution_span!(&zeroclaw_runtime::agent::AgentAttribution(agent_alias));
-    ::zeroclaw_log::scope!(
-        model_provider: mcp_model_provider,
-        model: mcp_model,
-        =>
-        async {
-            match tools::McpRegistry::connect_all(&agent_mcp_servers).await {
-                Ok(registry) => {
-                    let registry = std::sync::Arc::new(registry);
-                    if config.mcp.deferred_loading {
-                        let deferred_set = tools::DeferredMcpToolSet::from_registry(
-                            std::sync::Arc::clone(&registry),
-                        )
-                        .await;
-                        ::zeroclaw_log::record!(
-                            INFO,
-                            ::zeroclaw_log::Event::new(
-                                module_path!(),
-                                ::zeroclaw_log::Action::Note
-                            ),
-                            &format!(
-                                "Gateway MCP deferred_loading: {} tool stub(s) from {} server(s)",
-                                deferred_set.len(),
-                                registry.server_count()
-                            )
-                        );
-                        let activated = std::sync::Arc::new(std::sync::Mutex::new(
-                            tools::ActivatedToolSet::new(),
-                        ));
-                        let mut tool_search =
-                            tools::ToolSearchTool::new(deferred_set, activated);
-                        if let Some(policy) = mcp_policy {
-                            tool_search = tool_search.with_access_policy(policy);
-                        }
-                        gw_tools.push(Box::new(tool_search));
-                    } else {
-                        let names = registry.tool_names();
-                        let mut registered = 0usize;
-                        let mut skipped = 0usize;
-                        for name in names {
-                            if !eager_mcp_tool_allowed(&name, mcp_policy.as_ref()) {
-                                skipped += 1;
-                                continue;
-                            }
-                            if let Some(def) = registry.get_tool_def(&name).await {
-                                let wrapper: std::sync::Arc<dyn tools::Tool> =
-                                    std::sync::Arc::new(tools::McpToolWrapper::new(
-                                        name,
-                                        def,
-                                        std::sync::Arc::clone(&registry),
-                                    ));
-                                if register_eager_mcp_tool_if_allowed(
-                                    wrapper,
-                                    gw_tools,
-                                    gw_delegate,
-                                    mcp_policy.as_ref(),
-                                ) {
-                                    registered += 1;
-                                }
-                            }
-                        }
-                        ::zeroclaw_log::record!(
-                            INFO,
-                            ::zeroclaw_log::Event::new(
-                                module_path!(),
-                                ::zeroclaw_log::Action::Note
-                            )
-                            .with_attrs(::serde_json::json!({"skipped": skipped})),
-                            &format!(
-                                "Gateway MCP: {} tool(s) registered from {} server(s)",
-                                registered,
-                                registry.server_count()
-                            )
-                        );
-                    }
-                }
-                Err(e) => {
-                    ::zeroclaw_log::record!(
-                        ERROR,
-                        ::zeroclaw_log::Event::new(
-                            module_path!(),
-                            ::zeroclaw_log::Action::Fail
-                        )
-                        .with_outcome(::zeroclaw_log::EventOutcome::Failure)
-                        .with_attrs(::serde_json::json!({"error": format!("{}", e)})),
-                        "Gateway MCP registry failed to initialize"
-                    );
-                }
-            }
-        }
-    )
-    .instrument(attribution_span)
-    .await;
 }
 
 /// Shared state for all axum handlers
@@ -1013,19 +882,43 @@ pub async fn run_gateway(
                 sop_audit.clone(),
                 None,
             );
+            // Mint the registry through the gated seam: the built-in
+            // allow/deny filter and MCP scope+gate (omission is not a grant)
+            // run inside `assemble`, shared with every other path routed
+            // through it. The gateway previously applied only the MCP step,
+            // so its /api/tools listings showed unfiltered built-ins the
+            // agent's policy denies.
+            let assembled = scoped::ScopedToolRegistry::assemble(scoped::ScopedAssembly {
+                config: &config,
+                agent_alias,
+                security: &security,
+                built: all_tools_result,
+                // The gateway registers no skills today; unifying the two
+                // skill loaders through this seam is the Epic F follow-up.
+                skills: &[],
+                runtime: Arc::clone(&runtime),
+                caller_allowed: None,
+                connect_mcp: true,
+                // Listing-only registry: loading peripherals physically opens
+                // hardware (exclusive serial holds) that the live turn paths
+                // need. Never connect them for a registry no turn runs against.
+                connect_peripherals: false,
+                exclude_memory: false,
+            })
+            .await;
             // Wire channel-driven tool handles so the dashboard agent can
             // deliver messages to configured channels (same pattern as
             // orchestrator::start_channels).
-            // reaction_handle_gw is PerToolChannelHandle (not Option);
+            // reaction_handle is PerToolChannelHandle (not Option);
             // register_channels_for_tools expects &Option for all handles.
-            let reaction_handle_gw_opt = Some(all_tools_result.reaction_handle.clone());
+            let reaction_handle_gw_opt = Some(assembled.reaction_handle.clone());
             let channel_names = zeroclaw_channels::orchestrator::register_channels_for_tools(
                 &config,
-                &all_tools_result.ask_user_handle,
-                &all_tools_result.channel_room_handle,
+                &assembled.ask_user_handle,
+                &assembled.channel_room_handle,
                 &reaction_handle_gw_opt,
-                &all_tools_result.poll_handle,
-                &all_tools_result.escalate_handle,
+                &assembled.poll_handle,
+                &assembled.escalate_handle,
             );
             if !channel_names.is_empty() {
                 ::zeroclaw_log::record!(
@@ -1038,22 +931,11 @@ pub async fn run_gateway(
                     ),
                 );
             }
-            let mut gw_tools = all_tools_result.tools;
-            let gw_delegate = all_tools_result.delegate_handle;
-            // MCP tools, scoped to this agent's `mcp_bundles` and gated by its
-            // tool policy (parity with the orchestrator + runtime paths;
-            // omission is not a grant). Factored into `append_scoped_mcp_tools`
-            // so the per-agent registry below scopes MCP identically; a gateway
-            // with no resolved agent gets no MCP servers.
-            append_scoped_mcp_tools(
-                &config,
-                agent_alias,
-                &security,
-                &mut gw_tools,
-                gw_delegate.as_ref(),
-            )
-            .await;
-            (gw_tools, gw_delegate)
+            // Listing-only registry: no turn runs against it, so the
+            // deferred-MCP prompt section and activation handle returned by
+            // `assemble` have no consumer here (live gateway chat resolves
+            // its tools inside process_message).
+            (assembled.registry.into_inner(), assembled.delegate_handle)
         }
         (Some(_), None) => {
             // Agent existed but its config failed to resolve. Warned
@@ -1148,17 +1030,29 @@ pub async fn run_gateway(
             sop_audit.clone(),
             None,
         );
-        let mut agent_tools = agent_tools_result.tools;
-        let agent_delegate = agent_tools_result.delegate_handle;
-        append_scoped_mcp_tools(
-            &config,
-            &alias,
-            &security,
-            &mut agent_tools,
-            agent_delegate.as_ref(),
-        )
+        // Same gated seam as the dashboard seed above, so this listing shows
+        // the agent's policy-filtered set (filter + MCP). The tools are only
+        // enumerated for their specs, never invoked, so the returned channel
+        // handles, deferred section, and activation handle are unused.
+        let assembled = scoped::ScopedToolRegistry::assemble(scoped::ScopedAssembly {
+            config: &config,
+            agent_alias: &alias,
+            security: &security,
+            built: agent_tools_result,
+            // Same divergence note as the dashboard seed: no skills on the
+            // gateway until Epic F unifies the loaders.
+            skills: &[],
+            runtime: Arc::clone(&runtime),
+            caller_allowed: None,
+            connect_mcp: true,
+            // Same as the seed: never open hardware for a listing (and
+            // `config.peripherals` is global - N per-agent opens of the same
+            // boards would fail against the first holder anyway).
+            connect_peripherals: false,
+            exclude_memory: false,
+        })
         .await;
-        let specs: Vec<ToolSpec> = agent_tools.iter().map(|t| t.spec()).collect();
+        let specs: Vec<ToolSpec> = assembled.registry.iter().map(|t| t.spec()).collect();
         tools_registry_by_agent.insert(alias, Arc::new(specs));
     }
     let tools_registry_by_agent: Arc<HashMap<String, Arc<Vec<ToolSpec>>>> =
@@ -4422,6 +4316,9 @@ mod tests {
     use zeroclaw_api::channel::ChannelMessage;
     use zeroclaw_memory::{Memory, MemoryCategory, MemoryEntry};
     use zeroclaw_providers::ModelProvider;
+    use zeroclaw_runtime::agent::loop_::{
+        mcp_tool_access_policy, register_eager_mcp_tool_if_allowed,
+    };
 
     #[test]
     fn default_agent_alias_picks_smallest_enabled_and_is_deterministic() {
@@ -4482,82 +4379,6 @@ mod tests {
                 error: None,
             })
         }
-    }
-
-    /// Regression test for #7733 at the gateway MCP wiring site.
-    /// `append_scoped_mcp_tools` must early-return without mutating
-    /// `gw_tools` when the agent has no `mcp_bundles` grant, even if
-    /// `[[mcp.servers]]` is non-empty.
-    ///
-    /// Note: this is a behavior-pinning test, not a mutation-discriminating
-    /// one. The configured stdio server (`/usr/bin/mcp-fs`) is unlikely
-    /// to exist on the test host, so a hypothetical regression that
-    /// reverted to `&config.mcp.servers` would also produce zero
-    /// registered tools (the stdio connect fails non-fatally). The
-    /// stronger guard against that regression is
-    /// `crates/zeroclaw-channels/tests/orchestrator_mcp_scope.rs` plus
-    /// the resolver-level pins in `zeroclaw-config`. This test still
-    /// adds value by exercising the `append_scoped_mcp_tools` call
-    /// surface and ensuring it does not hang or panic for an unscoped
-    /// agent.
-    #[tokio::test]
-    async fn append_scoped_mcp_tools_is_a_noop_for_agent_without_bundles() {
-        use std::sync::Arc;
-        use zeroclaw_config::schema::{
-            AliasedAgentConfig, McpServerConfig, McpTransport, RiskProfileConfig,
-        };
-
-        let mut config = Config::default();
-        config.mcp.enabled = true;
-        config.mcp.servers = vec![McpServerConfig {
-            name: "fs".into(),
-            transport: McpTransport::Stdio,
-            command: "/usr/bin/mcp-fs".into(),
-            ..Default::default()
-        }];
-        // Critically: NO mcp_bundles configured and NO agent grants.
-        config
-            .risk_profiles
-            .insert("test-profile".into(), RiskProfileConfig::default());
-        config.agents.insert(
-            "unscoped".into(),
-            AliasedAgentConfig {
-                enabled: true,
-                model_provider: "openai.test-provider".into(),
-                risk_profile: "test-profile".into(),
-                mcp_bundles: Vec::new(),
-                ..Default::default()
-            },
-        );
-
-        let security: Arc<SecurityPolicy> = Arc::new(SecurityPolicy {
-            workspace_dir: std::env::temp_dir(),
-            ..SecurityPolicy::default()
-        });
-
-        let mut gw_tools: Vec<Box<dyn tools::Tool>> = Vec::new();
-        let initial_len = gw_tools.len();
-
-        // Bound the call with a short timeout: if the no-bundle branch
-        // ever stops being an early-return and tries to spawn an stdio
-        // MCP child, we'd rather see a timeout failure here than a
-        // hanging CI job.
-        tokio::time::timeout(
-            std::time::Duration::from_secs(5),
-            super::append_scoped_mcp_tools(&config, "unscoped", &security, &mut gw_tools, None),
-        )
-        .await
-        .expect("append_scoped_mcp_tools must not hang for an unscoped agent");
-
-        assert_eq!(
-            gw_tools.len(),
-            initial_len,
-            "append_scoped_mcp_tools must not push any tool when the \
-             agent has no mcp_bundles grant; gw_tools went from {} \
-             to {}",
-            initial_len,
-            gw_tools.len()
-        );
     }
 
     /// Gateway parity with the channel path: the gateway now scopes MCP servers

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -28,6 +28,7 @@ pub mod file_read;
 pub mod model_switch;
 pub mod read_skill;
 pub mod schedule;
+pub mod scoped;
 pub mod security_ops;
 pub mod send_message_to_peer;
 pub mod shell;

--- a/crates/zeroclaw-runtime/src/tools/scoped.rs
+++ b/crates/zeroclaw-runtime/src/tools/scoped.rs
@@ -1,0 +1,367 @@
+//! `ScopedToolRegistry` - the one gated seam that mints the per-agent tool set.
+//!
+//! Epic A of the agent-policy enforcement-unification program. The per-agent tool
+//! registry was assembled by hand at five construction sites (channels orchestrator,
+//! runtime `run` / `process_message`, `Agent::from_config`, the gateway), and each
+//! site re-applied the policy itself. That is why the built-in allow/deny filter and
+//! the MCP scoping had to be patched repeatedly (#7064, #6960, #8120) and why the
+//! gateway still leaked: a path that forgets a step silently widens the agent's
+//! authority. `ScopedToolRegistry` makes that unrepresentable - its field is private
+//! and the only constructor that mints one is [`ScopedToolRegistry::assemble`], which
+//! always applies, in order: built-in `allowed_tools`/`excluded_tools` filtering,
+//! per-agent MCP server scoping (`mcp_bundles`, omission is not a grant), MCP tool
+//! gating, and skill registration under the same `SecurityPolicy`.
+//!
+//! Per-site variation is expressed as DATA, never as "skip a security step": the only
+//! knobs are three documented divergences - a per-run caller allowlist that only
+//! narrows, the ACP fast-boot that does not connect MCP, and the ACP memory-tool strip.
+//! Peripherals, the policy filter, and skills run on every path (the gateway and
+//! `from_config` omissions were latent bugs, now fixed by construction).
+
+use std::sync::Arc;
+
+use zeroclaw_api::runtime_traits::RuntimeAdapter;
+use zeroclaw_config::policy::SecurityPolicy;
+use zeroclaw_config::schema::Config;
+
+use crate::agent::loop_::{
+    apply_policy_tool_filter, eager_mcp_tool_allowed, load_peripheral_tools, mcp_allowed_tool_count,
+    mcp_tool_access_policy, register_eager_mcp_tool_if_allowed,
+};
+use crate::skills::Skill;
+use crate::tools::{
+    self, ActivatedToolSet, AllToolsResult, DelegateParentToolsHandle, PerToolChannelHandle, Tool,
+    register_skill_tools_with_context_and_runtime,
+};
+
+/// A per-agent tool registry that has been scoped and gated. The inner field is
+/// private; the engine accepts only a `ScopedToolRegistry`, so a construction path
+/// physically cannot hand it an unfiltered registry - that is a compile error, not a
+/// review checklist item.
+pub struct ScopedToolRegistry(Vec<Box<dyn Tool>>);
+
+impl std::ops::Deref for ScopedToolRegistry {
+    type Target = [Box<dyn Tool>];
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl ScopedToolRegistry {
+    /// Consume the assembled registry into the owned `Vec` (for the few callers that
+    /// still pass `&[Box<dyn Tool>]` into the engine during the P1 cut-over).
+    pub fn into_inner(self) -> Vec<Box<dyn Tool>> {
+        self.0
+    }
+
+    /// Test-only escape hatch. Production code has no other way to build one.
+    #[cfg(test)]
+    pub fn from_raw_for_test(tools: Vec<Box<dyn Tool>>) -> Self {
+        Self(tools)
+    }
+}
+
+/// Inputs to [`ScopedToolRegistry::assemble`]. The eager built-ins arrive already
+/// built (`built`); `assemble` does the policy-bearing steps the sites used to repeat.
+pub struct ScopedAssembly<'a> {
+    pub config: &'a Config,
+    pub agent_alias: &'a str,
+    pub security: &'a Arc<SecurityPolicy>,
+    /// Eager built-in tools + the channel/delegate handle bundle, consumed here.
+    pub built: AllToolsResult,
+    /// Skills loaded by the caller's (single) loader; registered under the same gate.
+    pub skills: &'a [Skill],
+    pub runtime: Arc<dyn RuntimeAdapter>,
+    /// Documented divergence: a per-run caller allowlist. It only NARROWS, and is
+    /// threaded into BOTH the built-in filter and the MCP tool-access policy. `None`
+    /// on every path except `run`.
+    pub caller_allowed: Option<&'a [String]>,
+    /// Documented divergence: ACP `session/new` must return promptly, so it skips
+    /// connecting MCP servers (scoping is still computed; nothing is granted).
+    pub connect_mcp: bool,
+    /// Documented divergence: ACP excludes persistent memory tools.
+    pub exclude_memory: bool,
+}
+
+/// Output of [`ScopedToolRegistry::assemble`]: the scoped registry plus the
+/// side-channel handles + the deferred-MCP prompt section the callers thread on.
+pub struct ScopedAssembled {
+    pub registry: ScopedToolRegistry,
+    pub delegate_handle: Option<DelegateParentToolsHandle>,
+    pub ask_user_handle: Option<PerToolChannelHandle>,
+    pub reaction_handle: PerToolChannelHandle,
+    pub poll_handle: Option<PerToolChannelHandle>,
+    pub escalate_handle: Option<PerToolChannelHandle>,
+    pub channel_room_handle: Option<PerToolChannelHandle>,
+    /// The deferred-MCP tool-search prompt section (empty when deferred loading is off
+    /// or no MCP tools are granted). The caller injects this into its system prompt.
+    pub deferred_section: String,
+    /// Live handle to the activated deferred-MCP set (present only when a deferred
+    /// `tool_search` tool was registered).
+    pub activated_handle: Option<Arc<std::sync::Mutex<ActivatedToolSet>>>,
+}
+
+impl ScopedToolRegistry {
+    /// Mint a scoped, gated registry from already-built eager tools. The single seam
+    /// every construction path goes through.
+    pub async fn assemble(spec: ScopedAssembly<'_>) -> ScopedAssembled {
+        let ScopedAssembly {
+            config,
+            agent_alias,
+            security,
+            built,
+            skills,
+            runtime,
+            caller_allowed,
+            connect_mcp,
+            exclude_memory,
+        } = spec;
+
+        let AllToolsResult {
+            tools: mut tools_registry,
+            delegate_handle,
+            ask_user_handle,
+            reaction_handle,
+            poll_handle,
+            escalate_handle,
+            channel_room_handle,
+            unfiltered_tool_arcs,
+        } = built;
+
+        // 1. Peripherals (uniform: every path wires the agent's `config.peripherals`;
+        //    the gateway + from_config used to skip this).
+        let peripheral_tools = load_peripheral_tools(config.peripherals.clone()).await;
+        tools_registry.extend(peripheral_tools);
+
+        // 2. Built-in allow/deny filter (uniform: the gateway used to skip it entirely).
+        //    `caller_allowed` narrows on top of the policy, for the `run` path only.
+        apply_policy_tool_filter(&mut tools_registry, Some(security.as_ref()), caller_allowed);
+
+        // 3. Documented divergence: ACP strips persistent memory tools.
+        if exclude_memory {
+            tools_registry.retain(|t| !zeroclaw_tools::MEMORY_TOOL_NAMES.contains(&t.name()));
+        }
+
+        // 4. MCP: scope servers per `mcp_bundles` (omission is not a grant), then gate
+        //    each tool. Skipped only when this path does not connect MCP (ACP) or MCP
+        //    is disabled - in both cases nothing is granted.
+        let mut deferred_section = String::new();
+        let mut activated_handle: Option<Arc<std::sync::Mutex<ActivatedToolSet>>> = None;
+        let mut mcp_elevation_arcs: Vec<Arc<dyn Tool>> = Vec::new();
+
+        let agent_mcp_servers = if connect_mcp && config.mcp.enabled {
+            config.mcp_servers_for_agent(agent_alias)
+        } else {
+            Vec::new()
+        };
+        if !agent_mcp_servers.is_empty() {
+            match tools::McpRegistry::connect_all(&agent_mcp_servers).await {
+                Ok(registry) => {
+                    let registry = Arc::new(registry);
+                    mcp_elevation_arcs = tools::collect_mcp_elevation_arcs(&registry).await;
+                    let mcp_policy = mcp_tool_access_policy(security.as_ref(), caller_allowed);
+                    if config.mcp.deferred_loading {
+                        let deferred_set =
+                            tools::DeferredMcpToolSet::from_registry(Arc::clone(&registry)).await;
+                        let allowed_stub_count = mcp_allowed_tool_count(
+                            deferred_set.stubs.iter().map(|stub| stub.prefixed_name.as_str()),
+                            mcp_policy.as_ref(),
+                        );
+                        deferred_section = tools::build_deferred_tools_section_filtered(
+                            &deferred_set,
+                            mcp_policy.as_ref(),
+                        );
+                        if allowed_stub_count > 0 {
+                            let activated =
+                                Arc::new(std::sync::Mutex::new(ActivatedToolSet::new()));
+                            activated_handle = Some(Arc::clone(&activated));
+                            let mut tool_search =
+                                tools::ToolSearchTool::new(deferred_set, activated);
+                            if let Some(policy) = mcp_policy {
+                                tool_search = tool_search.with_access_policy(policy);
+                            }
+                            // Newly-activated deferred tools are also exposed to the
+                            // delegate parent set, matching the run/process_message paths.
+                            if let Some(ref handle) = delegate_handle {
+                                let delegate_tools = Arc::clone(handle);
+                                tool_search =
+                                    tool_search.with_activation_hook(Arc::new(move |tool| {
+                                        let mut tools = delegate_tools.write();
+                                        let already = tools
+                                            .iter()
+                                            .any(|existing| existing.name() == tool.name());
+                                        if !already {
+                                            tools.push(tool);
+                                        }
+                                    }));
+                            }
+                            tools_registry.push(Box::new(tool_search));
+                        }
+                    } else {
+                        let names = registry.tool_names();
+                        for name in names {
+                            if !eager_mcp_tool_allowed(&name, mcp_policy.as_ref()) {
+                                continue;
+                            }
+                            if let Some(def) = registry.get_tool_def(&name).await {
+                                let wrapper: Arc<dyn Tool> = Arc::new(tools::McpToolWrapper::new(
+                                    name,
+                                    def,
+                                    Arc::clone(&registry),
+                                ));
+                                register_eager_mcp_tool_if_allowed(
+                                    wrapper,
+                                    &mut tools_registry,
+                                    delegate_handle.as_ref(),
+                                    mcp_policy.as_ref(),
+                                );
+                            }
+                        }
+                    }
+                }
+                Err(err) => {
+                    ::zeroclaw_log::record!(
+                        WARN,
+                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Load)
+                            .with_category(::zeroclaw_log::EventCategory::Tool),
+                        &format!("MCP connect failed (non-fatal): {err}")
+                    );
+                }
+            }
+        }
+
+        // 5. Skills (uniform: the gateway used to skip them). Registered under the same
+        //    `SecurityPolicy`, resolving builtin/MCP elevation against the pre-filter arcs.
+        let resolution_registry: Vec<Arc<dyn Tool>> = unfiltered_tool_arcs
+            .iter()
+            .cloned()
+            .chain(mcp_elevation_arcs.iter().cloned())
+            .collect();
+        register_skill_tools_with_context_and_runtime(
+            &mut tools_registry,
+            skills,
+            Arc::clone(security),
+            &resolution_registry,
+            runtime,
+        );
+
+        ScopedAssembled {
+            registry: ScopedToolRegistry(tools_registry),
+            delegate_handle,
+            ask_user_handle,
+            reaction_handle,
+            poll_handle,
+            escalate_handle,
+            channel_room_handle,
+            deferred_section,
+            activated_handle,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tools::ToolResult;
+    use async_trait::async_trait;
+
+    struct MockTool(&'static str);
+
+    impl zeroclaw_api::attribution::Attributable for MockTool {
+        fn role(&self) -> zeroclaw_api::attribution::Role {
+            zeroclaw_api::attribution::Role::Tool(zeroclaw_api::attribution::ToolKind::Plugin)
+        }
+        fn alias(&self) -> &str {
+            self.0
+        }
+    }
+
+    #[async_trait]
+    impl Tool for MockTool {
+        fn name(&self) -> &str {
+            self.0
+        }
+        fn description(&self) -> &str {
+            ""
+        }
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({})
+        }
+        async fn execute(&self, _args: serde_json::Value) -> anyhow::Result<ToolResult> {
+            Ok(ToolResult {
+                success: true,
+                output: String::new(),
+                error: None,
+            })
+        }
+    }
+
+    fn built_with(tools: Vec<Box<dyn Tool>>) -> AllToolsResult {
+        AllToolsResult {
+            tools,
+            delegate_handle: None,
+            ask_user_handle: None,
+            reaction_handle: Arc::new(parking_lot::RwLock::new(std::collections::HashMap::new())),
+            poll_handle: None,
+            escalate_handle: None,
+            unfiltered_tool_arcs: Vec::new(),
+        }
+    }
+
+    async fn assemble_names(
+        security: Arc<SecurityPolicy>,
+        tools: Vec<Box<dyn Tool>>,
+        caller_allowed: Option<&[String]>,
+    ) -> Vec<String> {
+        let config = Config::default();
+        let out = ScopedToolRegistry::assemble(ScopedAssembly {
+            config: &config,
+            agent_alias: "default",
+            security: &security,
+            built: built_with(tools),
+            skills: &[],
+            runtime: Arc::new(crate::platform::NativeRuntime::new()),
+            caller_allowed,
+            connect_mcp: false, // exercise the filter path without MCP fixtures
+            exclude_memory: false,
+        })
+        .await;
+        out.registry.iter().map(|t| t.name().to_string()).collect()
+    }
+
+    #[tokio::test]
+    async fn assemble_applies_the_builtin_filter_uniformly() {
+        // The gateway path historically SKIPPED the built-in allow/deny filter, leaking
+        // excluded tools. Through the one seam the filter ALWAYS runs - the leak is fixed
+        // by construction, not by remembering to call it.
+        let security = Arc::new(SecurityPolicy {
+            excluded_tools: Some(vec!["spawn_subagent".into()]),
+            ..SecurityPolicy::default()
+        });
+        let names = assemble_names(
+            security,
+            vec![Box::new(MockTool("shell")), Box::new(MockTool("spawn_subagent"))],
+            None,
+        )
+        .await;
+        assert!(names.iter().any(|n| n == "shell"), "unlisted tool kept: {names:?}");
+        assert!(
+            !names.iter().any(|n| n == "spawn_subagent"),
+            "excluded tool dropped: {names:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn assemble_threads_caller_allowed_narrowing() {
+        // The documented per-run caller allowlist (run() path) narrows further, and is
+        // honored through the seam like every other path that narrows.
+        let allow = vec!["shell".to_string()];
+        let names = assemble_names(
+            Arc::new(SecurityPolicy::default()),
+            vec![Box::new(MockTool("shell")), Box::new(MockTool("file_read"))],
+            Some(&allow),
+        )
+        .await;
+        assert_eq!(names, vec!["shell".to_string()], "caller_allowed narrows: {names:?}");
+    }
+}

--- a/crates/zeroclaw-runtime/src/tools/scoped.rs
+++ b/crates/zeroclaw-runtime/src/tools/scoped.rs
@@ -1,22 +1,37 @@
 //! `ScopedToolRegistry` - the one gated seam that mints the per-agent tool set.
 //!
-//! Epic A of the agent-policy enforcement-unification program. The per-agent tool
-//! registry was assembled by hand at five construction sites (channels orchestrator,
-//! runtime `run` / `process_message`, `Agent::from_config`, the gateway), and each
-//! site re-applied the policy itself. That is why the built-in allow/deny filter and
-//! the MCP scoping had to be patched repeatedly (#7064, #6960, #8120) and why the
-//! gateway still leaked: a path that forgets a step silently widens the agent's
-//! authority. `ScopedToolRegistry` makes that unrepresentable - its field is private
-//! and the only constructor that mints one is [`ScopedToolRegistry::assemble`], which
-//! always applies, in order: built-in `allowed_tools`/`excluded_tools` filtering,
-//! per-agent MCP server scoping (`mcp_bundles`, omission is not a grant), MCP tool
-//! gating, and skill registration under the same `SecurityPolicy`.
+//! Epic A of the agent-policy enforcement-unification program (see the contributing
+//! page `agent-policy-parity-harness.md`). The per-agent tool registry has
+//! historically been assembled by hand at six construction sites (channels
+//! orchestrator, runtime `run` / `process_message`, `Agent::from_config`, the
+//! gateway, and the delegate independent-target builder), each re-applying the
+//! policy itself. That is why the built-in filter and the MCP scoping had to be
+//! patched per-site (#7064, #6960, #8120) and why the gateway's `/api/tools`
+//! listings misreported the tool set a real turn receives (its live chat resolves
+//! through `process_message`, which filters; its listing registries never did).
 //!
-//! Per-site variation is expressed as DATA, never as "skip a security step": the only
-//! knobs are three documented divergences - a per-run caller allowlist that only
-//! narrows, the ACP fast-boot that does not connect MCP, and the ACP memory-tool strip.
-//! Peripherals, the policy filter, and skills run on every path (the gateway and
-//! `from_config` omissions were latent bugs, now fixed by construction).
+//! [`ScopedToolRegistry::assemble`] is the seam that ends the copying: it applies,
+//! in order, peripherals, the built-in `allowed_tools`/`excluded_tools` filter, the
+//! ACP memory strip, per-agent MCP server scoping (`mcp_bundles`, omission is not a
+//! grant) with per-tool gating plus the MCP capability tools and pinned-resources
+//! section, and skill registration under the same `SecurityPolicy`.
+//!
+//! Cut-over status: the gateway's two registry builders are the first consumers;
+//! the remaining sites migrate one PR at a time, after which the engine's tools
+//! field seals to this newtype and handing it an unfiltered registry becomes a
+//! compile error instead of a review-checklist item. Until that seal lands, the
+//! guarantee is that every path routed through `assemble` shares one
+//! implementation; paths not yet routed remain hand-rolled by convention.
+//!
+//! Per-site variation is expressed as DATA, never as "skip a security step": the
+//! knobs are documented divergences - a per-run caller allowlist that only narrows,
+//! `connect_mcp` (ACP fast-boot), `connect_peripherals` (listing-only surfaces must
+//! not open hardware), and the ACP memory-tool strip. One known cross-path
+//! divergence remains OUTSIDE the seam: `process_message` filters built-ins via
+//! `filter_channel_builtin_tools`, which admits the canonical read-only defaults
+//! past `allowed_tools` at non-Full autonomy; `assemble` applies the plain policy
+//! filter (as `run` and the orchestrator do). Unifying that semantic into the seam
+//! is a tracked follow-up of the parity program.
 
 use std::sync::Arc;
 
@@ -25,8 +40,8 @@ use zeroclaw_config::policy::SecurityPolicy;
 use zeroclaw_config::schema::Config;
 
 use crate::agent::loop_::{
-    apply_policy_tool_filter, eager_mcp_tool_allowed, load_peripheral_tools, mcp_allowed_tool_count,
-    mcp_tool_access_policy, register_eager_mcp_tool_if_allowed,
+    apply_policy_tool_filter, eager_mcp_tool_allowed, load_peripheral_tools,
+    mcp_allowed_tool_count, mcp_tool_access_policy, register_eager_mcp_tool_if_allowed,
 };
 use crate::skills::Skill;
 use crate::tools::{
@@ -35,9 +50,12 @@ use crate::tools::{
 };
 
 /// A per-agent tool registry that has been scoped and gated. The inner field is
-/// private; the engine accepts only a `ScopedToolRegistry`, so a construction path
-/// physically cannot hand it an unfiltered registry - that is a compile error, not a
-/// review checklist item.
+/// private and production code can only mint one through
+/// [`ScopedToolRegistry::assemble`]. Today (the unsealed P1 phase) the engine still
+/// takes `&[Box<dyn Tool>]`, so callers dissolve the type via [`Deref`] or
+/// [`Self::into_inner`] at the boundary; once every construction site is cut over,
+/// the engine's tools field seals to this type and handing it an unfiltered
+/// registry becomes a compile error instead of a review-checklist item.
 pub struct ScopedToolRegistry(Vec<Box<dyn Tool>>);
 
 impl std::ops::Deref for ScopedToolRegistry {
@@ -76,9 +94,15 @@ pub struct ScopedAssembly<'a> {
     /// threaded into BOTH the built-in filter and the MCP tool-access policy. `None`
     /// on every path except `run`.
     pub caller_allowed: Option<&'a [String]>,
-    /// Documented divergence: ACP `session/new` must return promptly, so it skips
-    /// connecting MCP servers (scoping is still computed; nothing is granted).
+    /// Documented divergence: ACP `session/new` must return promptly, so it does not
+    /// connect MCP servers - they are neither resolved nor connected; nothing is
+    /// granted.
     pub connect_mcp: bool,
+    /// Documented divergence: loading peripherals physically connects hardware (the
+    /// daemon's loader opens serial ports, exclusively for real devices). Listing-only
+    /// surfaces (the gateway's `/api/tools` registries) MUST pass `false` so they never
+    /// hold devices the live turn paths need; execution surfaces pass `true`.
+    pub connect_peripherals: bool,
     /// Documented divergence: ACP excludes persistent memory tools.
     pub exclude_memory: bool,
 }
@@ -114,6 +138,7 @@ impl ScopedToolRegistry {
             runtime,
             caller_allowed,
             connect_mcp,
+            connect_peripherals,
             exclude_memory,
         } = spec;
 
@@ -128,10 +153,14 @@ impl ScopedToolRegistry {
             unfiltered_tool_arcs,
         } = built;
 
-        // 1. Peripherals (uniform: every path wires the agent's `config.peripherals`;
-        //    the gateway + from_config used to skip this).
-        let peripheral_tools = load_peripheral_tools(config.peripherals.clone()).await;
-        tools_registry.extend(peripheral_tools);
+        // 1. Peripherals. Loading CONNECTS hardware (serial opens are exclusive for
+        //    real devices), so this is gated: execution surfaces pass
+        //    `connect_peripherals: true`; listing-only surfaces pass `false` and
+        //    enumerate without holding devices.
+        if connect_peripherals {
+            let peripheral_tools = load_peripheral_tools(config.peripherals.clone()).await;
+            tools_registry.extend(peripheral_tools);
+        }
 
         // 2. Built-in allow/deny filter (uniform: the gateway used to skip it entirely).
         //    `caller_allowed` narrows on top of the policy, for the `run` path only.
@@ -158,13 +187,37 @@ impl ScopedToolRegistry {
             match tools::McpRegistry::connect_all(&agent_mcp_servers).await {
                 Ok(registry) => {
                     let registry = Arc::new(registry);
-                    mcp_elevation_arcs = tools::collect_mcp_elevation_arcs(&registry).await;
+                    // Elevation arcs exist only to resolve skill-declared MCP
+                    // elevation in step 5; skip the collection when no skills are
+                    // registered through this assembly.
+                    if !skills.is_empty() {
+                        mcp_elevation_arcs = tools::collect_mcp_elevation_arcs(&registry).await;
+                    }
                     let mcp_policy = mcp_tool_access_policy(security.as_ref(), caller_allowed);
+                    // Generic MCP resource/prompt capability tools (policy-gated in
+                    // deferred-loading and eager modes) - parity with run/process_message.
+                    for tool in tools::build_mcp_capability_tools(&registry, mcp_policy.as_ref()) {
+                        register_eager_mcp_tool_if_allowed(
+                            tool,
+                            &mut tools_registry,
+                            delegate_handle.as_ref(),
+                            mcp_policy.as_ref(),
+                        );
+                    }
+                    let pinned_section = tools::mcp_context::build_pinned_resources_section(
+                        &registry,
+                        &agent_mcp_servers,
+                        mcp_policy.as_ref(),
+                    )
+                    .await;
                     if config.mcp.deferred_loading {
                         let deferred_set =
                             tools::DeferredMcpToolSet::from_registry(Arc::clone(&registry)).await;
                         let allowed_stub_count = mcp_allowed_tool_count(
-                            deferred_set.stubs.iter().map(|stub| stub.prefixed_name.as_str()),
+                            deferred_set
+                                .stubs
+                                .iter()
+                                .map(|stub| stub.prefixed_name.as_str()),
                             mcp_policy.as_ref(),
                         );
                         deferred_section = tools::build_deferred_tools_section_filtered(
@@ -218,13 +271,27 @@ impl ScopedToolRegistry {
                             }
                         }
                     }
+                    // Pinned MCP resources ride the same prompt section in both
+                    // modes - parity with run/process_message.
+                    crate::agent::loop_::append_pinned_mcp_section(
+                        &mut deferred_section,
+                        &pinned_section,
+                    );
                 }
                 Err(err) => {
+                    // Non-fatal (the assembly proceeds without MCP), but an ERROR
+                    // with structured attrs - parity with the run/process_message
+                    // connect-failure logging.
                     ::zeroclaw_log::record!(
-                        WARN,
-                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Load)
-                            .with_category(::zeroclaw_log::EventCategory::Tool),
-                        &format!("MCP connect failed (non-fatal): {err}")
+                        ERROR,
+                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+                            .with_category(::zeroclaw_log::EventCategory::Tool)
+                            .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                            .with_attrs(::serde_json::json!({
+                                "agent_alias": agent_alias,
+                                "error": format!("{err}"),
+                            })),
+                        "MCP registry failed to initialize (assembly proceeds without MCP)"
                     );
                 }
             }
@@ -304,6 +371,7 @@ mod tests {
             reaction_handle: Arc::new(parking_lot::RwLock::new(std::collections::HashMap::new())),
             poll_handle: None,
             escalate_handle: None,
+            channel_room_handle: None,
             unfiltered_tool_arcs: Vec::new(),
         }
     }
@@ -323,6 +391,7 @@ mod tests {
             runtime: Arc::new(crate::platform::NativeRuntime::new()),
             caller_allowed,
             connect_mcp: false, // exercise the filter path without MCP fixtures
+            connect_peripherals: false,
             exclude_memory: false,
         })
         .await;
@@ -340,14 +409,97 @@ mod tests {
         });
         let names = assemble_names(
             security,
-            vec![Box::new(MockTool("shell")), Box::new(MockTool("spawn_subagent"))],
+            vec![
+                Box::new(MockTool("shell")),
+                Box::new(MockTool("spawn_subagent")),
+            ],
             None,
         )
         .await;
-        assert!(names.iter().any(|n| n == "shell"), "unlisted tool kept: {names:?}");
+        assert!(
+            names.iter().any(|n| n == "shell"),
+            "unlisted tool kept: {names:?}"
+        );
         assert!(
             !names.iter().any(|n| n == "spawn_subagent"),
             "excluded tool dropped: {names:?}"
+        );
+    }
+
+    /// Regression pin for #7733 at the seam (ported from the gateway's
+    /// `append_scoped_mcp_tools_is_a_noop_for_agent_without_bundles` when the
+    /// gateway cut over to `assemble`): an agent with NO `mcp_bundles` grant
+    /// must get no MCP tools even when `[[mcp.servers]]` is non-empty and MCP
+    /// is enabled - omission is not a grant. Bounded by a timeout so a
+    /// regression that tries to spawn the phantom stdio server fails fast
+    /// instead of hanging CI.
+    ///
+    /// Note (carried from the original): this is a behavior-pinning test, not a
+    /// mutation-discriminating one - the phantom stdio server would also yield
+    /// zero tools if the scoping regressed to `&config.mcp.servers` (the connect
+    /// fails non-fatally). The stronger guards are
+    /// `crates/zeroclaw-channels/tests/orchestrator_mcp_scope.rs` and the
+    /// resolver-level pins in `zeroclaw-config`.
+    #[tokio::test]
+    async fn assemble_grants_no_mcp_to_agent_without_bundles() {
+        use zeroclaw_config::schema::{
+            AliasedAgentConfig, McpServerConfig, McpTransport, RiskProfileConfig,
+        };
+
+        let mut config = Config::default();
+        config.mcp.enabled = true;
+        config.mcp.servers = vec![McpServerConfig {
+            name: "fs".into(),
+            transport: McpTransport::Stdio,
+            command: "/usr/bin/mcp-fs".into(),
+            ..Default::default()
+        }];
+        // Critically: NO mcp_bundles configured and NO agent grants.
+        config
+            .risk_profiles
+            .insert("test-profile".into(), RiskProfileConfig::default());
+        config.agents.insert(
+            "unscoped".into(),
+            AliasedAgentConfig {
+                enabled: true,
+                model_provider: "openai.test-provider".into(),
+                risk_profile: "test-profile".into(),
+                mcp_bundles: Vec::new(),
+                ..Default::default()
+            },
+        );
+        let security = Arc::new(SecurityPolicy {
+            workspace_dir: std::env::temp_dir(),
+            ..SecurityPolicy::default()
+        });
+
+        let out = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            ScopedToolRegistry::assemble(ScopedAssembly {
+                config: &config,
+                agent_alias: "unscoped",
+                security: &security,
+                built: built_with(Vec::new()),
+                skills: &[],
+                runtime: Arc::new(crate::platform::NativeRuntime::new()),
+                caller_allowed: None,
+                connect_mcp: true,
+                connect_peripherals: false,
+                exclude_memory: false,
+            }),
+        )
+        .await
+        .expect("assemble must not hang for an unscoped agent");
+
+        assert!(
+            out.registry.is_empty(),
+            "assemble must not mint any MCP tool when the agent has no \
+             mcp_bundles grant; got {:?}",
+            out.registry.iter().map(|t| t.name()).collect::<Vec<_>>()
+        );
+        assert!(
+            out.activated_handle.is_none() && out.deferred_section.is_empty(),
+            "no deferred-MCP artifacts may exist for an unscoped agent"
         );
     }
 
@@ -362,6 +514,10 @@ mod tests {
             Some(&allow),
         )
         .await;
-        assert_eq!(names, vec!["shell".to_string()], "caller_allowed narrows: {names:?}");
+        assert_eq!(
+            names,
+            vec!["shell".to_string()],
+            "caller_allowed narrows: {names:?}"
+        );
     }
 }

--- a/docs/book/src/contributing/agent-policy-parity-harness.md
+++ b/docs/book/src/contributing/agent-policy-parity-harness.md
@@ -63,9 +63,63 @@ into it and seal the inputs. With that resolution and sealing in place:
 The end state is that the divergence is uncompilable rather than merely tested
 against. Current/future boundary: `ResolvedAgentExecution`, its `resolve()`
 constructor, and the `ResolvedIo` / `ResolvedRuntimeKnobs` input layers all exist on
-`master` and every production path constructs through them; absorbing each surface's
-per-field resolution into `resolve()`, and sealing the bundle's fields behind it, are
-the work later surface PRs do.
+`master` and every production path constructs through them; the TOOL surface now has
+its gated constructor too (`ScopedToolRegistry::assemble`, below, with the gateway as
+its first consumer); absorbing the remaining surfaces' per-field resolution into
+`resolve()`, and sealing the bundle's fields behind it, are the work later surface
+PRs do.
+
+## The tool-assembly seam (Epic A, the first surface)
+
+The per-agent tool registry is the first surface with a single gated constructor:
+`ScopedToolRegistry::assemble` (`crates/zeroclaw-runtime/src/tools/scoped.rs`). The
+registry has historically been assembled by hand at six construction sites - the
+reason the built-in filter and MCP scoping had to be patched per-site (#7064,
+#6960, #8120). `assemble` applies, in order: the agent's `config.peripherals`
+(when connected - see the knob below), the built-in `allowed_tools`/
+`excluded_tools` filter, the ACP memory strip, MCP server scoping per `mcp_bundles`
+plus per-tool gating (eager or deferred; omission is not a grant) with the MCP
+capability tools and pinned-resources prompt section, and skill registration under
+the same `SecurityPolicy` (a site with no skills passes an empty slice - the
+gateway does, until the Epic F loader unification).
+
+Per-site variation is expressed as data, never as a skipped security step. The
+`ScopedAssembly` knobs only narrow or withhold - none can widen what the policy
+grants:
+
+- `caller_allowed` - a per-run allowlist (the `run()` path); intersects with, never
+  overrides, the policy filter and the MCP tool-access policy.
+- `connect_mcp` - `false` on the ACP fast-boot path: MCP servers are neither
+  resolved nor connected, so nothing is granted.
+- `connect_peripherals` - `false` on listing-only surfaces: loading peripherals
+  physically connects hardware (exclusive serial holds), which a registry no turn
+  runs against must never do.
+- `exclude_memory` - the ACP memory-tool strip.
+
+Cut-over status (the strangle, one site per PR): the **gateway** constructs through
+`assemble` today - both its registry builders, the dashboard-agent seed and the
+per-agent `/api/tools` listings. That closed the gateway's filter gap by
+construction: its listings previously showed unfiltered built-ins the agent's
+policy denies (live gateway chat resolves through `process_message`, which already
+filtered), plus a `tool_search` stub even when policy denied every deferred MCP
+tool. Two scoping notes keep the listings claim honest: peripherals are excluded
+from listings by design (`connect_peripherals: false` - enumerating them without
+connecting hardware is a future refinement), and `process_message` filters
+built-ins through a variant that admits the canonical read-only defaults at
+non-Full autonomy - a cross-path filter divergence that predates the seam, tracked
+as its own parity row and unified when that surface strangles in.
+
+The remaining hand-rolled sites - the channels orchestrator (`start_channels`),
+`loop_` `run` / `process_message`, `Agent::from_config`, and the delegate
+independent-target builder (`independent_agentic_tools_for_target`, added by #8239
+while this program was in flight - the recurrence the seal exists to end) - migrate
+in follow-up PRs. Once all sites mint through `assemble`, the engine's tools field
+seals to `ScopedToolRegistry` (a private-field newtype only `assemble` constructs),
+and handing the engine an unscoped registry - or quietly re-inlining a construction
+site, as a cross-merge did to the channel path once already - becomes a compile
+error instead of a review catch. Until that seal, cross-site parity for the
+not-yet-migrated sites remains by convention; what the seam guarantees today is
+that every path routed through it shares one implementation.
 
 ## The harness
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Adds `crates/zeroclaw-runtime/src/tools/scoped.rs`: **`ScopedToolRegistry`**, a
    private-field newtype whose only production constructor is
    **`ScopedToolRegistry::assemble`**. `assemble` applies, in order: the agent's
    `config.peripherals` (when connected - knob below), the built-in
    `allowed_tools`/`excluded_tools` filter, the ACP memory strip, MCP server scoping
    per `mcp_bundles` + per-tool gating (eager or deferred; omission is not a grant)
    with the MCP capability tools (`mcp_resources`/`mcp_prompts`) and pinned-resources
    prompt section, and skill registration under the same `SecurityPolicy`. Per-site
    variation is data and only narrows/withholds: `caller_allowed`, `connect_mcp`,
    `connect_peripherals`, `exclude_memory`. This is Epic A of the agent-policy
    enforcement-unification program - the tool-surface seam the contributing page
    (`docs/book/src/contributing/agent-policy-parity-harness.md`) describes.
  - Cuts the **gateway** over as the seam's first consumer: both registry builders
    (the dashboard-agent seed and the per-agent `/api/tools` listings) mint through
    `assemble()` instead of the hand-rolled `all_tools` + `append_scoped_mcp_tools`
    pair. The dead `append_scoped_mcp_tools` is deleted; its #7733 regression pin is
    ported to the seam (`assemble_grants_no_mcp_to_agent_without_bundles`,
    timeout-bounded, caveat carried) and the #8120 gateway pin test is kept.
  - Documents the seam in the program page: the ordered steps, the narrowing-only
    knobs, cut-over status, the residual divergences (named below), and the seal
    end-state.
  - Remaining construction sites (orchestrator `start_channels`, `loop_`
    run/process_message, `Agent::from_config`, and the delegate independent-target
    builder added by #8239 while this program was in flight) cut over in follow-up
    PRs; the final PR seals the engine's tools field to the newtype so an unscoped
    registry becomes a compile error. The #8011 regression fixed by #8629 (a
    behavior-neutral un-routing invisible to CI) and the #8239 sixth site are the
    live motivation for that seal. Until the seal, the guarantee is shared
    implementation for routed paths; unrouted paths remain by-convention.
- **Behavior changes (the honest, complete list).** The gateway's own registries feed
  its tool-spec listings (`/api/tools`, `/api/tools?agent=`) and the tool count in
  `POST /api/hardware/reload`; no turn executes against them (live gateway chat
  resolves through `process_message`). Deltas:
  1. Listings stop showing built-ins the agent's policy excludes (the filter now
     runs), and stop showing a `tool_search` stub when policy denies every deferred
     MCP tool (registered only when at least one stub is allowed).
  2. Listings gain the policy-gated MCP capability tools
     (`mcp_resources`/`mcp_prompts`) for MCP-granted agents - real turns already
     receive these; the old gateway builders omitted them.
  3. Peripherals are deliberately EXCLUDED from listings (`connect_peripherals:
     false`): loading peripherals physically connects hardware (exclusive serial
     holds for real devices), which a listings-only registry must never do - it
     would hold devices the live turn paths and the channel orchestrator need.
     Enumerating peripheral specs without connecting is a named future refinement.
  4. MCP connect-failure logging on the gateway path goes from the deleted helper's
     WARN to ERROR with structured attrs (parity with run/process_message); the
     helper's registered/skipped INFO counts are not reproduced (uniform seam
     observability is a follow-up).
- **Known residual divergence (named, tracked):** `process_message` filters built-ins
  via `filter_channel_builtin_tools`, which admits the canonical read-only defaults
  past `allowed_tools` at non-Full autonomy; `assemble` (like `run` and the
  orchestrator) applies the plain policy filter. So `/api/tools` can under-report
  those safe-default tools relative to a `process_message` turn at non-Full autonomy.
  This cross-path filter divergence predates the seam (it exists between
  `process_message` and the orchestrator on master today); it gets its own parity
  row and is unified into the seam when that surface strangles in, rather than
  silently picking a winner here.
- **Blast radius:** `zeroclaw-runtime/src/tools/` (new module) +
  `zeroclaw-gateway/src/lib.rs` + the program docs page. No engine, channel, or
  config change.
- **Linked issue(s):** Related #8179 (the resolve() seam + program doc), #8629 (the
  CH re-route + seal motivation), #7733 / #8120 (regression pins moved to / kept
  against the seam), #8054 (the listings-vs-actual mismatch class), #8496
  (complementary deferred-MCP policy centralization; coordinated), #8239 (the sixth
  site).
- **Labels:** suggested `docs`, `tool`, `gateway`, `runtime`, `risk:medium`, `size:M`.

## Validation Evidence (required)

Toolchain pinned to 1.93.0 (matches CI). Literal output in the review artifact;
re-run on the final tree:

- `cargo clippy -p zeroclaw-gateway -p zeroclaw-runtime -p zeroclaw-channels
  --all-targets -- -D warnings`: clean.
- `cargo test -p zeroclaw-gateway`: all passing (332 baseline).
- `cargo test -p zeroclaw-runtime --lib tools::scoped`: 3 passing - built-in-filter
  uniformity (the historic gateway gap, pinned at the seam), `caller_allowed`
  only-narrows, and the ported #7733 no-MCP-without-bundles pin.
- `cargo fmt --all -- --check`: clean. Docs gate: clean on changed lines.
- **Beyond CI - manually verified:** traced every consumer of the gateway registries
  on master (spec listings + the hardware/reload count; `run_gateway_chat_with_tools`
  at its 5 call sites delegates to `process_message`). Diffed `assemble()`'s MCP step
  against the deleted `append_scoped_mcp_tools` and against `run`/`process_message`'s
  MCP blocks line-by-line; the deltas are exactly the enumerated behavior changes
  above. An additional multi-lens adversarial review pass ran over this diff before
  submission; its confirmed findings (hardware side effect, capability-tool gap,
  doc overclaims, filter divergence) are fixed or disclosed in this body.
- **Intentionally skipped:** web / shell batteries (no such files changed).

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No.**
- New external network calls? **No.**
- Secrets / tokens / credentials handling changed? **No.**
- PII or personal data in diff/tests/docs? **No.**
- Listings narrow for built-ins and deferred stubs (filter now applied; deny wins;
  omission is not a grant) and gain only the policy-gated MCP capability tools that
  real turns already receive. The gateway never opens peripheral hardware
  (`connect_peripherals: false`), removing the possibility of a listings-only
  surface holding devices execution paths need. No trust boundary moves.

## Compatibility (required)

- Backward compatible? **Yes**, with the intended listings corrections enumerated
  above. AppState shapes (`Arc<Vec<ToolSpec>>`) are unchanged.
- Config / env / CLI surface changed? **No.**
- Upgrade steps: none.

## Rollback (required for medium/high-risk PRs)

`git revert` of the squash commit restores the hand-rolled gateway builders and the
helper; no data or config migration. The seam module is additive and has no other
consumer yet.
