### PR TITLE
fix(tools): allow http_request secrets to resolve from env

### DIFF
--- a/crates/zeroclaw-tools/src/http_request.rs
+++ b/crates/zeroclaw-tools/src/http_request.rs
@@ -275,11 +275,7 @@ impl HttpRequestTool {
             .filter(|secret| !secret.is_empty())
             .ok_or_else(|| anyhow::Error::msg(format!("auth_secret '{secret_name}' not found")))?;
 
-        if let Some(secret) = resolve_env_backed_auth_secret(secret_name, raw_secret)? {
-            return Ok(secret);
-        }
-
-        if zeroclaw_config::secrets::SecretStore::is_encrypted(raw_secret) {
+        let secret = if zeroclaw_config::secrets::SecretStore::is_encrypted(raw_secret) {
             let zeroclaw_dir = config_path.parent().unwrap_or_else(|| Path::new("."));
             let store =
                 zeroclaw_config::secrets::SecretStore::new(zeroclaw_dir, self.secrets_encrypt);
@@ -287,9 +283,15 @@ impl HttpRequestTool {
             if plaintext.is_empty() {
                 anyhow::bail!("auth_secret '{secret_name}' is empty after decryption");
             }
-            Ok(plaintext)
+            plaintext
         } else {
-            Ok(raw_secret.clone())
+            raw_secret.clone()
+        };
+
+        if let Some(env_secret) = resolve_env_backed_auth_secret(secret_name, &secret)? {
+            Ok(env_secret)
+        } else {
+            Ok(secret)
         }
     }
 
@@ -946,6 +948,44 @@ api_token = "{encrypted}"
         assert_eq!(
             headers.get(AUTHORIZATION).unwrap(),
             "Bearer encrypted-secret"
+        );
+    }
+
+    #[test]
+    fn auth_secret_resolves_encrypted_env_backed_config_value() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        let store = zeroclaw_config::secrets::SecretStore::new(tmp.path(), true);
+        let encrypted = store
+            .encrypt("${ZEROCLAW_TEST_HTTP_REQUEST_ENCRYPTED_SECRET}")
+            .unwrap();
+        std::fs::write(
+            &config_path,
+            format!(
+                r#"
+[http_request.secrets]
+api_token = "{encrypted}"
+"#
+            ),
+        )
+        .unwrap();
+        unsafe {
+            std::env::set_var(
+                "ZEROCLAW_TEST_HTTP_REQUEST_ENCRYPTED_SECRET",
+                "Bearer encrypted-env",
+            );
+        }
+        scopeguard::defer! {
+            unsafe {
+                std::env::remove_var("ZEROCLAW_TEST_HTTP_REQUEST_ENCRYPTED_SECRET");
+            }
+        }
+
+        let tool = test_tool_with_auth_config(config_path, true);
+
+        assert_eq!(
+            tool.resolve_auth_secret("api_token").unwrap(),
+            "Bearer encrypted-env"
         );
     }
 

--- a/crates/zeroclaw-tools/src/http_request.rs
+++ b/crates/zeroclaw-tools/src/http_request.rs
@@ -275,6 +275,10 @@ impl HttpRequestTool {
             .filter(|secret| !secret.is_empty())
             .ok_or_else(|| anyhow::Error::msg(format!("auth_secret '{secret_name}' not found")))?;
 
+        if let Some(secret) = resolve_env_backed_auth_secret(secret_name, raw_secret)? {
+            return Ok(secret);
+        }
+
         if zeroclaw_config::secrets::SecretStore::is_encrypted(raw_secret) {
             let zeroclaw_dir = config_path.parent().unwrap_or_else(|| Path::new("."));
             let store =
@@ -385,6 +389,48 @@ impl HttpRequestTool {
     }
 }
 
+fn resolve_env_backed_auth_secret(
+    secret_name: &str,
+    raw_secret: &str,
+) -> anyhow::Result<Option<String>> {
+    let Some(env_name) = env_secret_reference(raw_secret)? else {
+        return Ok(None);
+    };
+
+    let value = std::env::var(env_name).map_err(|e| {
+        anyhow::Error::msg(format!(
+            "auth_secret '{secret_name}' references environment variable '{env_name}', but it could not be read: {e}"
+        ))
+    })?;
+    if value.is_empty() {
+        anyhow::bail!(
+            "auth_secret '{secret_name}' references environment variable '{env_name}', but it is empty"
+        );
+    }
+    Ok(Some(value))
+}
+
+fn env_secret_reference(raw_secret: &str) -> anyhow::Result<Option<&str>> {
+    let Some(inner) = raw_secret
+        .strip_prefix("${")
+        .and_then(|value| value.strip_suffix('}'))
+    else {
+        return Ok(None);
+    };
+
+    if inner.is_empty() {
+        anyhow::bail!(
+            "environment-backed auth_secret references an empty environment variable name"
+        );
+    }
+    if !inner.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+        anyhow::bail!(
+            "environment-backed auth_secret '{inner}' must contain only ASCII letters, numbers, or underscores"
+        );
+    }
+    Ok(Some(inner))
+}
+
 #[async_trait]
 impl Tool for HttpRequestTool {
     fn name(&self) -> &str {
@@ -416,7 +462,7 @@ impl Tool for HttpRequestTool {
                 },
                 "auth_secret": {
                     "type": "string",
-                    "description": "Name of a secret in [http_request.secrets] to send as the Authorization header. Overrides any literal Authorization header."
+                    "description": "Name of a secret in [http_request.secrets] to send as the Authorization header. Secret entries may be literal, encrypted, or environment-backed as ${ENV_VAR}. Overrides any literal Authorization header."
                 },
                 "body": {
                     "type": "string",
@@ -788,6 +834,73 @@ api_token = "Bearer from-disk"
         assert_eq!(
             tool.resolve_auth_secret("api_token").unwrap(),
             "Bearer from-disk"
+        );
+    }
+
+    #[test]
+    fn auth_secret_resolves_env_backed_config_value() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            r#"
+[http_request.secrets]
+api_token = "${ZEROCLAW_TEST_HTTP_REQUEST_SECRET}"
+"#,
+        )
+        .unwrap();
+        unsafe {
+            std::env::set_var("ZEROCLAW_TEST_HTTP_REQUEST_SECRET", "Bearer from-env");
+        }
+        scopeguard::defer! {
+            unsafe {
+                std::env::remove_var("ZEROCLAW_TEST_HTTP_REQUEST_SECRET");
+            }
+        }
+
+        let tool = test_tool_with_auth_config(config_path, false);
+
+        assert_eq!(
+            tool.resolve_auth_secret("api_token").unwrap(),
+            "Bearer from-env"
+        );
+    }
+
+    #[test]
+    fn auth_secret_reports_missing_env_backed_config_value() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            r#"
+[http_request.secrets]
+api_token = "${ZEROCLAW_TEST_HTTP_REQUEST_MISSING_SECRET}"
+"#,
+        )
+        .unwrap();
+        unsafe {
+            std::env::remove_var("ZEROCLAW_TEST_HTTP_REQUEST_MISSING_SECRET");
+        }
+
+        let tool = test_tool_with_auth_config(config_path, false);
+        let err = tool
+            .resolve_auth_secret("api_token")
+            .unwrap_err()
+            .to_string();
+
+        assert!(
+            err.contains("ZEROCLAW_TEST_HTTP_REQUEST_MISSING_SECRET"),
+            "missing env-backed secret should name the missing variable: {err}"
+        );
+    }
+
+    #[test]
+    fn auth_secret_rejects_invalid_env_reference_name() {
+        let err = env_secret_reference("${BAD-NAME}").unwrap_err().to_string();
+
+        assert!(
+            err.contains("ASCII letters, numbers, or underscores"),
+            "invalid env-backed secret name should fail clearly: {err}"
         );
     }
 


### PR DESCRIPTION
﻿## Summary

- **Base branch:** `master`.
- **What changed and why:**
  - Allows explicitly configured `[http_request.secrets]` values of the form `${ENV_VAR}` to resolve from the ZeroClaw process environment.
  - Keeps `http_request.secrets` as the allowlist boundary, matching the maintainer triage direction in #8553 and avoiding automatic exposure of the full process environment.
- **Scope boundary:** This does not add automatic environment-variable discovery, per-agent environment injection, or changes to non-`http_request` secret handling.
- **Blast radius:** Limited to `http_request` `auth_secret` resolution and the tool schema description.
- **Linked issue(s):** Fixes #8553.
- **Labels:** bug, tool, domain:security, tool:web, risk:high, size:S.

## Validation Evidence (required)

- **Commands run and tail output:**

```bash
git diff --check
# no output
```

Attempted local Rust validation with a temporary workspace-local toolchain, but the toolchain install/repair left rustup without a usable manifest:

```text
cargo fmt --check
error: Missing manifest in toolchain 'stable-x86_64-pc-windows-msvc'

rustc --version
error: Missing manifest in toolchain 'stable-x86_64-pc-windows-msvc'

cargo test -p zeroclaw-tools auth_secret --no-run
error: process didn't exit successfully: `rustc -vV` (exit code: 1)
--- stderr
error: Missing manifest in toolchain 'stable-x86_64-pc-windows-msvc'
```

- **Beyond CI - what did you manually verify?**
  - Confirmed #8553 is open, unassigned, has no linked closing PR, and has maintainer/collaborator triage accepting the explicit allowlist + env-backed secret direction.
  - Reviewed the existing `http_request` secret reload path and added tests next to existing auth_secret coverage for env-backed success, missing env, and invalid env-reference names.
- **If any command was intentionally skipped, why:** `cargo fmt`, `cargo clippy`, and `cargo test` could not complete locally because the temporary Rust toolchain failed with the manifest error above; CI should run the full Rust gate.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `Yes`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: `http_request` can now resolve a configured secret from an environment variable, but only when the operator explicitly allowlists that secret name in `[http_request.secrets]` with a `${ENV_VAR}` value. The implementation does not expose arbitrary environment variables to tool calls.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `Yes`
- If `No` or `Yes` to either: Existing literal and encrypted secret values continue to work. Operators may opt into env-backed secrets with entries such as `SLACK_BOT_TOKEN = "${SLACK_BOT_TOKEN}"`.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert 25b3a92087e76d914606072b84c4543dbdecfc55`
- **Feature flags or config toggles:** None. Env-backed resolution only activates for explicit `${ENV_VAR}` secret values.
- **Observable failure symptoms:** `http_request` returns `auth_secret '<name>' references environment variable '<ENV>', but it could not be read` or `... but it is empty` for misconfigured env-backed secrets.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors: N/A
- Scope materially carried forward: N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? N/A
- If `No`, why: N/A


