### PR TITLE
docs(review): require template truthfulness checks

### DIFF
--- a/.claude/skills/github-pr-review-session/SKILL.md
+++ b/.claude/skills/github-pr-review-session/SKILL.md
@@ -23,7 +23,8 @@ Read these files at the start of every session. They are authoritative.
 
 - `AGENTS.md` — risk tiers, high-risk paths, anti-patterns, commands
 - `docs/book/src/contributing/pr-review-protocol.md` — **the full review protocol**;
-  follow it exactly for every PR, including the review-body Markdown format
+  follow it exactly for every PR, including template completeness,
+  public-artifact truthfulness, and the review-body Markdown format
 - `.github/pull_request_template.md` — required PR body sections; used to
   check template completeness
 - `docs/book/src/foundations/fnd-003-governance.md` — label taxonomy, tracking
@@ -96,6 +97,8 @@ The protocol specifies:
 - **Label hygiene** — fix obvious label mismatches yourself when the active
   reviewer has label permissions, after approval for the public-state mutation;
   do not ask authors to update labels they may not be allowed to edit
+- **Template and public-artifact checks** — run the checks defined in the
+  protocol before approving
 - **The verdict decision tree** — which flag to use based on review state
 - **The feedback taxonomy** (🔴 / 🟡 / ✅ / 🔵 / 🟢), including the required
   H3 review-body heading format that starts each formal finding with the

--- a/docs/book/src/contributing/pr-review-protocol.md
+++ b/docs/book/src/contributing/pr-review-protocol.md
@@ -99,6 +99,8 @@ Before you write a single line of review, name out loud:
 - What's settled (resolved by author, dismissed by reviewer, addressed in a later commit).
 - What's still live (open blockers, unresolved questions, things the author committed to but didn't ship).
 - Who holds active blocks, and whether the diff addresses them.
+- Whether any obvious PR-template, public metadata, or body-claim gaps affect
+  the verdict. Run the full template/truthfulness check before approving.
 
 The take-stock pass is what stops you from re-raising settled points and what surfaces who's actually waiting on what.
 
@@ -108,11 +110,45 @@ Labels are maintainer metadata, not a contributor blocker. If the right label is
 
 Ask the author about labels only when the right label choice is ambiguous or nobody with label permissions is available. Do not request changes or hold merge solely because an author cannot edit labels.
 
+## Template and public artifact checks
+
+Before approving, compare the live PR body against the current
+`.github/pull_request_template.md`. The template is the source of truth: check
+every required and applicable prompt, including conditional sections. Custom
+narrative is fine only when it still satisfies that template contract.
+
+Missing required substance is a review finding. If the content is present but
+the heading or placement needs mechanical cleanup, and a maintainer can safely
+repair it, fix or propose the exact cleanup instead of making the author do
+metadata work. When acting through an assistant, show the exact PR-body or
+metadata diff and get human reviewer approval before mutating GitHub. If the
+missing section is substantive, unsupported, or changes reviewer confidence, do
+not approve until it is filled.
+
+Also run a truthfulness scrub on the public artifacts before choosing a
+verdict:
+
+- Live labels match the PR body's label snapshot and the diff's real risk,
+  size, and type.
+- Linked issue verbs are accurate: use `Closes` / `Fixes` / `Resolves` only
+  when the PR fully resolves the issue; otherwise use `Related`, `Depends on`,
+  or `Supersedes`.
+- Validation evidence names commands that actually ran, includes relevant
+  output or an honest skip reason, and does not treat pending CI as local
+  validation.
+- Security/privacy, compatibility, rollback, and scope-boundary claims match
+  the diff and current behavior.
+- Public text does not include bot/AI attribution footers, local workflow
+  mechanics, private paths, unredacted sensitive logs, excessive raw logs,
+  irrelevant dumps, or stale lifecycle wording. Concise, relevant command
+  output tails in Validation Evidence are expected when the template asks for
+  them.
+
 ## Verdict decision tree
 
 | Situation | Verdict flag |
 |---|---|
-| Your review is approving and no other reviewer holds an active block | `--approve` |
+| Your review is approving, the template/truthfulness checks are satisfied, and no other reviewer holds an active block | `--approve` |
 | Your review is rejecting on substantive grounds you'd block on personally | `--request-changes` |
 | You have nothing new to block on but other reviewers hold active blocks | `--comment` |
 | You have specific findings but they're all 🔵 suggestions or non-blocking clarification questions | `--comment` |


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Add PR-template completeness and public-artifact truthfulness checks to the `github-pr-review-session` skill summary.
  - Extend the PR review protocol's take-stock pass so reviewers notice PR-body and metadata gaps that affect the verdict.
  - Add an explicit template/truthfulness check before approval, while keeping `.github/pull_request_template.md` as the source of truth.
  - Clarify that maintainers can fix mechanical body/metadata cleanup, but assistant-applied public cleanup still needs exact human approval.
- **Scope boundary:** Review workflow documentation only. This does not change runtime code, CI behavior, label automation, PR templates, or GitHub permissions.
- **Blast radius:** Reviewers and review-assistant sessions that follow the public review protocol will be stricter about PR-body template compliance and public-claim accuracy before approval.
- **Linked issue(s):** None. Related #8488.
- **Labels:** `docs`, `risk:low`, `size:XS`, `type:docs`

## Validation Evidence (required)

- **Commands run and tail output:**

```bash
git diff --check
# passed

scripts/check-pr-title.sh "docs(review): require template truthfulness checks"
# passed

DOCS_FILES='docs/book/src/contributing/pr-review-protocol.md' bash scripts/ci/docs_quality_gate.sh
# markdownlint-cli2 v0.20.0 (markdownlint v0.40.0)
# Summary: 0 error(s)
```

- **Beyond CI — what did you manually verify?** Confirmed the new guidance keeps the PR template as the source of truth, preserves required validation output tails, keeps mechanical maintainer-editable cleanup separate from substantive blockers, and does not reference local/private review-gate mechanics.
- **If any command was intentionally skipped, why:** Rust formatting, clippy, and tests were skipped because this is a docs/workflow-only change.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: N/A

## Rollback (required for medium/high-risk PRs)

Low-risk PR: revert the merge commit if the guidance proves noisy or counterproductive.

## Supersede Attribution (required only when `Supersedes #` is used)

Not used.
