### PR TITLE
fix(provider): guard SSE parsers against EOF-as-success truncation

### DIFF
--- a/crates/zeroclaw-providers/src/anthropic.rs
+++ b/crates/zeroclaw-providers/src/anthropic.rs
@@ -893,9 +893,33 @@ impl AnthropicModelProvider {
         let mut cached_input_tokens: Option<u64> = None;
         let mut cache_creation_input_tokens: Option<u64> = None;
 
-        while let Ok(Some(line)) =
-            match tokio::time::timeout(SSE_IDLE_TIMEOUT, lines.next_line()).await {
-                Ok(read) => read,
+        // EOF is only a clean end when the model already reported how it
+        // stopped (message_delta stop_reason; message_stop returns directly).
+        // A socket that closes before then is a truncated response and must
+        // surface an error so the runtime can retry, not a Final that the
+        // agent loop mistakes for an empty completed turn.
+        let mut saw_stop_reason = false;
+
+        loop {
+            let line = match tokio::time::timeout(SSE_IDLE_TIMEOUT, lines.next_line()).await {
+                Ok(Ok(Some(line))) => line,
+                Ok(Ok(None)) => break,
+                Ok(Err(err)) => {
+                    ::zeroclaw_log::record!(
+                        WARN,
+                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+                            .with_category(::zeroclaw_log::EventCategory::Provider)
+                            .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                            .with_attrs(::serde_json::json!({
+                                "error": format!("{err}"),
+                            })),
+                        "stream: SSE read error — aborting stream"
+                    );
+                    let _ = tx
+                        .send(Err(StreamError::Http(format!("SSE read error: {err}"))))
+                        .await;
+                    return;
+                }
                 Err(_) => {
                     ::zeroclaw_log::record!(
                         WARN,
@@ -914,8 +938,7 @@ impl AnthropicModelProvider {
                         .await;
                     return;
                 }
-            }
-        {
+            };
             let line = line.trim().to_string();
             if !line.starts_with("data: ") {
                 continue;
@@ -1045,6 +1068,9 @@ impl AnthropicModelProvider {
                         .and_then(|d| d.get("stop_reason"))
                         .and_then(|s| s.as_str())
                         .unwrap_or("none");
+                    if stop_reason != "none" {
+                        saw_stop_reason = true;
+                    }
                     // Anthropic's running-total: each `message_delta`
                     // supersedes the previous one, so we always overwrite.
                     let observed_output = event
@@ -1119,6 +1145,26 @@ impl AnthropicModelProvider {
                 }
                 _ => {}
             }
+        }
+
+        if !saw_stop_reason {
+            ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+                    .with_category(::zeroclaw_log::EventCategory::Provider)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                    .with_attrs(::serde_json::json!({
+                        "input_tokens": input_tokens,
+                        "output_tokens": output_tokens,
+                    })),
+                "stream: SSE connection closed before message_stop — truncated response, surfacing error"
+            );
+            let _ = tx
+                .send(Err(StreamError::Http(
+                    "SSE stream closed before message_stop: response truncated".to_string(),
+                )))
+                .await;
+            return;
         }
 
         ::zeroclaw_log::record!(
@@ -1917,6 +1963,44 @@ data: {\"type\":\"message_start\",\"message\":{\"id\":\"m\",\"type\":\"message\"
         assert!(
             probe.is_finished(),
             "guard drop must abort the parser task immediately, not wait out the idle timeout"
+        );
+    }
+
+    #[tokio::test]
+    async fn eof_before_message_stop_surfaces_error_not_final() {
+        // Live repro (trace aaf558a6): the SSE socket closed mid-response
+        // after tool-result submission; the parser fell through to Final and
+        // the turn ended as an empty "final response" with no explanation.
+        // EOF without message_stop (or a stop_reason) is a truncated
+        // response and must surface a retryable error.
+        use std::io::Cursor;
+
+        let bytes = b"event: message_start\n\
+data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"model\":\"claude\",\"usage\":{\"input_tokens\":10}}}\n\n\
+event: content_block_start\n\
+data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n\
+event: content_block_delta\n\
+data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"partial\"}}\n\n";
+        let reader = tokio::io::BufReader::new(Cursor::new(bytes.as_slice()));
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<StreamResult<StreamEvent>>(64);
+        AnthropicModelProvider::parse_anthropic_sse_from_reader(reader, &tx).await;
+
+        let mut saw_final = false;
+        let mut last_err = None;
+        while let Ok(Some(ev)) =
+            tokio::time::timeout(std::time::Duration::from_millis(50), rx.recv()).await
+        {
+            match ev {
+                Ok(StreamEvent::Final) => saw_final = true,
+                Err(e) => last_err = Some(e),
+                Ok(_) => {}
+            }
+        }
+        assert!(!saw_final, "truncated stream must not emit Final");
+        let err = last_err.expect("truncated stream must emit a StreamError");
+        assert!(
+            matches!(err, StreamError::Http(ref m) if m.contains("truncated")),
+            "expected truncation error, got: {err:?}"
         );
     }
 

--- a/crates/zeroclaw-providers/src/anthropic.rs
+++ b/crates/zeroclaw-providers/src/anthropic.rs
@@ -893,11 +893,6 @@ impl AnthropicModelProvider {
         let mut cached_input_tokens: Option<u64> = None;
         let mut cache_creation_input_tokens: Option<u64> = None;
 
-        // EOF is only a clean end when the model already reported how it
-        // stopped (message_delta stop_reason; message_stop returns directly).
-        // A socket that closes before then is a truncated response and must
-        // surface an error so the runtime can retry, not a Final that the
-        // agent loop mistakes for an empty completed turn.
         let mut saw_stop_reason = false;
 
         loop {
@@ -1147,38 +1142,7 @@ impl AnthropicModelProvider {
             }
         }
 
-        if !saw_stop_reason {
-            ::zeroclaw_log::record!(
-                WARN,
-                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
-                    .with_category(::zeroclaw_log::EventCategory::Provider)
-                    .with_outcome(::zeroclaw_log::EventOutcome::Failure)
-                    .with_attrs(::serde_json::json!({
-                        "input_tokens": input_tokens,
-                        "output_tokens": output_tokens,
-                    })),
-                "stream: SSE connection closed before message_stop — truncated response, surfacing error"
-            );
-            let _ = tx
-                .send(Err(StreamError::Http(
-                    "SSE stream closed before message_stop: response truncated".to_string(),
-                )))
-                .await;
-            return;
-        }
-
-        ::zeroclaw_log::record!(
-            DEBUG,
-            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Complete)
-                .with_category(::zeroclaw_log::EventCategory::Provider)
-                .with_outcome(::zeroclaw_log::EventOutcome::Success)
-                .with_attrs(::serde_json::json!({
-                    "input_tokens": input_tokens,
-                    "output_tokens": output_tokens,
-                })),
-            "stream: SSE parser reached end of stream, emitting Final"
-        );
-        let _ = tx.send(Ok(StreamEvent::Final)).await;
+        crate::stream_guard::finish_sse_stream(tx, saw_stop_reason, "message_stop").await;
     }
 }
 

--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -1697,6 +1697,7 @@ fn sse_bytes_to_events_for_contract(
         let mut tool_calls: Vec<StreamToolCallAccumulator> = Vec::new();
         let mut used_tool_call_ids = std::collections::HashSet::new();
         let mut emitted_tool_calls = false;
+        let mut saw_completion = false;
 
         match response.error_for_status_ref() {
             Ok(_) => {}
@@ -1753,7 +1754,14 @@ fn sse_bytes_to_events_for_contract(
 
                         let chunk = match parse_sse_chunk(&line) {
                             Ok(Some(chunk)) => chunk,
-                            Ok(None) => continue,
+                            Ok(None) => {
+                                if line.trim().strip_prefix("data:").map(str::trim)
+                                    == Some("[DONE]")
+                                {
+                                    saw_completion = true;
+                                }
+                                continue;
+                            }
                             Err(e) => {
                                 let _ = tx.send(Err(e)).await;
                                 return;
@@ -1762,6 +1770,9 @@ fn sse_bytes_to_events_for_contract(
 
                         let mut should_emit_tool_calls = false;
                         for choice in &chunk.choices {
+                            if choice.finish_reason.is_some() {
+                                saw_completion = true;
+                            }
                             if let Some(reasoning_delta) = extract_sse_reasoning_delta(choice) {
                                 let reasoning_chunk = StreamChunk::reasoning(reasoning_delta);
                                 if tx
@@ -1847,7 +1858,8 @@ fn sse_bytes_to_events_for_contract(
             }
         }
 
-        let _ = tx.send(Ok(StreamEvent::Final)).await;
+        crate::stream_guard::finish_sse_stream(&tx, saw_completion, "[DONE] or finish_reason")
+            .await;
     });
 
     let guard = AbortOnDrop::new(handle.abort_handle());
@@ -3630,6 +3642,68 @@ mod tests {
         assert!(
             !err_msg.contains("API key not set"),
             "should not get credential error, got: {err_msg}"
+        );
+    }
+
+    fn sse_response(body: &'static str) -> reqwest::Response {
+        reqwest::Response::from(
+            axum::http::Response::builder()
+                .status(reqwest::StatusCode::OK)
+                .body(reqwest::Body::from(body))
+                .expect("test response should build"),
+        )
+    }
+
+    async fn collect_stream_events(body: &'static str) -> Vec<StreamResult<StreamEvent>> {
+        let mut stream = sse_bytes_to_events(sse_response(body), false);
+        let mut events = Vec::new();
+        while let Ok(Some(ev)) =
+            tokio::time::timeout(std::time::Duration::from_secs(2), stream.next()).await
+        {
+            events.push(ev);
+        }
+        events
+    }
+
+    #[tokio::test]
+    async fn eof_after_done_sentinel_emits_final() {
+        let events = collect_stream_events(
+            "data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\ndata: [DONE]\n\n",
+        )
+        .await;
+        assert!(
+            matches!(events.last(), Some(Ok(StreamEvent::Final))),
+            "got: {events:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn eof_after_finish_reason_without_done_emits_final() {
+        let events = collect_stream_events(
+            "data: {\"choices\":[{\"delta\":{\"content\":\"hi\"},\"finish_reason\":\"stop\"}]}\n\n",
+        )
+        .await;
+        assert!(
+            matches!(events.last(), Some(Ok(StreamEvent::Final))),
+            "got: {events:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn eof_before_completion_signal_surfaces_error_not_final() {
+        let events =
+            collect_stream_events("data: {\"choices\":[{\"delta\":{\"content\":\"par\"}}]}\n\n")
+                .await;
+        assert!(
+            !events.iter().any(|e| matches!(e, Ok(StreamEvent::Final))),
+            "truncated stream must not emit Final, got: {events:?}"
+        );
+        assert!(
+            matches!(
+                events.last(),
+                Some(Err(StreamError::Http(msg))) if msg.contains("truncated")
+            ),
+            "expected truncation error, got: {events:?}"
         );
     }
 

--- a/crates/zeroclaw-providers/src/openai.rs
+++ b/crates/zeroclaw-providers/src/openai.rs
@@ -880,7 +880,12 @@ pub(crate) async fn run_responses_sse(
         let _ = tx.send(Ok(StreamEvent::TextDelta(chunk))).await;
     }
 
-    let _ = tx.send(Ok(StreamEvent::Final)).await;
+    crate::stream_guard::finish_sse_stream(
+        tx,
+        state.saw_completion,
+        "response.completed or [DONE]",
+    )
+    .await;
 }
 
 pub struct OpenAiResponsesModelProvider {

--- a/crates/zeroclaw-providers/src/openai_codex.rs
+++ b/crates/zeroclaw-providers/src/openai_codex.rs
@@ -89,6 +89,7 @@ struct ResponsesResponse {
 #[derive(Debug, Default)]
 pub(crate) struct ResponsesStreamState {
     pub(crate) saw_text_delta: bool,
+    pub(crate) saw_completion: bool,
     pub(crate) text_accumulator: String,
     pub(crate) fallback_text: Option<String>,
     pub(crate) tool_calls: HashMap<String, PendingToolCall>,
@@ -829,6 +830,7 @@ pub(crate) fn process_responses_stream_event(
             }
         }
         Some("response.completed" | "response.done") => {
+            state.saw_completion = true;
             if let Some(response) = event
                 .get("response")
                 .and_then(|value| serde_json::from_value::<ResponsesResponse>(value.clone()).ok())
@@ -866,6 +868,9 @@ pub(crate) fn process_sse_chunk(
     let joined = data_lines.join("\n");
     let trimmed = joined.trim();
     if trimmed.is_empty() || trimmed == "[DONE]" {
+        if trimmed == "[DONE]" {
+            state.saw_completion = true;
+        }
         return Ok(Vec::new());
     }
 
@@ -877,6 +882,9 @@ pub(crate) fn process_sse_chunk(
     for line in data_lines {
         let line = line.trim();
         if line.is_empty() || line == "[DONE]" {
+            if line == "[DONE]" {
+                state.saw_completion = true;
+            }
             continue;
         }
         let event = serde_json::from_str::<Value>(line).map_err(|err| {
@@ -2082,6 +2090,35 @@ data: [DONE]
             parse_sse_turn(payload).unwrap().text.as_deref(),
             Some("Hello world")
         );
+    }
+
+    #[test]
+    fn process_sse_chunk_marks_completion_on_response_completed() {
+        let mut state = ResponsesStreamState::default();
+        let _ = process_sse_chunk(
+            "data: {\"type\":\"response.completed\",\"response\":{\"output_text\":\"hi\"}}",
+            &mut state,
+        )
+        .unwrap();
+        assert!(state.saw_completion);
+    }
+
+    #[test]
+    fn process_sse_chunk_marks_completion_on_done_sentinel() {
+        let mut state = ResponsesStreamState::default();
+        let _ = process_sse_chunk("data: [DONE]", &mut state).unwrap();
+        assert!(state.saw_completion);
+    }
+
+    #[test]
+    fn process_sse_chunk_leaves_completion_unset_on_text_delta() {
+        let mut state = ResponsesStreamState::default();
+        let _ = process_sse_chunk(
+            "data: {\"type\":\"response.output_text.delta\",\"delta\":\"partial\"}",
+            &mut state,
+        )
+        .unwrap();
+        assert!(!state.saw_completion);
     }
 
     #[test]

--- a/crates/zeroclaw-providers/src/stream_guard.rs
+++ b/crates/zeroclaw-providers/src/stream_guard.rs
@@ -29,3 +29,73 @@ impl Drop for AbortOnDrop {
         );
     }
 }
+
+/// Close out an SSE parser at EOF: `Final` only when the provider's own
+/// completion signal was observed, otherwise a truncation `StreamError`.
+///
+/// Socket EOF alone proves nothing — a connection dropped mid-response reads
+/// exactly like a finished one. Treating bare EOF as success made the agent
+/// loop end turns as empty "final responses" with no explanation (live repro:
+/// trace aaf558a6). The truncation error is retryable downstream:
+/// `call_provider` falls back to non-streaming chat on stream errors.
+pub(crate) async fn finish_sse_stream(
+    tx: &tokio::sync::mpsc::Sender<
+        ::zeroclaw_api::model_provider::StreamResult<::zeroclaw_api::model_provider::StreamEvent>,
+    >,
+    saw_completion: bool,
+    completion_signal: &str,
+) {
+    if saw_completion {
+        ::zeroclaw_log::record!(
+            DEBUG,
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Complete)
+                .with_category(::zeroclaw_log::EventCategory::Provider)
+                .with_outcome(::zeroclaw_log::EventOutcome::Success),
+            "stream: SSE parser reached end of stream, emitting Final"
+        );
+        let _ = tx
+            .send(Ok(::zeroclaw_api::model_provider::StreamEvent::Final))
+            .await;
+        return;
+    }
+    ::zeroclaw_log::record!(
+        WARN,
+        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+            .with_category(::zeroclaw_log::EventCategory::Provider)
+            .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+            .with_attrs(::serde_json::json!({
+                "completion_signal": completion_signal,
+            })),
+        "stream: SSE connection closed before completion signal — truncated response, surfacing error"
+    );
+    let _ = tx
+        .send(Err(::zeroclaw_api::model_provider::StreamError::Http(
+            format!("SSE stream closed before {completion_signal}: response truncated"),
+        )))
+        .await;
+}
+
+#[cfg(test)]
+mod tests {
+    use ::zeroclaw_api::model_provider::{StreamError, StreamEvent, StreamResult};
+
+    #[tokio::test]
+    async fn finish_emits_final_when_completion_seen() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<StreamResult<StreamEvent>>(4);
+        super::finish_sse_stream(&tx, true, "message_stop").await;
+        assert!(matches!(rx.recv().await, Some(Ok(StreamEvent::Final))));
+    }
+
+    #[tokio::test]
+    async fn finish_emits_truncation_error_without_completion() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<StreamResult<StreamEvent>>(4);
+        super::finish_sse_stream(&tx, false, "message_stop").await;
+        match rx.recv().await {
+            Some(Err(StreamError::Http(msg))) => {
+                assert!(msg.contains("truncated"), "got: {msg}");
+                assert!(msg.contains("message_stop"), "got: {msg}");
+            }
+            other => panic!("expected truncation StreamError, got {other:?}"),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Every streaming SSE parser treated socket EOF as a clean end of stream and emitted `StreamEvent::Final` with success. A connection dropped mid-response read exactly like a finished one.
  - Live repro (trace `aaf558a6`, Anthropic): the connection dropped right after tool-result submission, before any `content_block_delta` arrived. The runtime received a "successfully completed" stream with zero text and zero tool calls, and the agent loop ended the turn as a legitimate empty final response. The session stops silently with `outcome: success` and no explanation. Null `input_tokens`/`output_tokens` in the `llm_response` record confirm no completion frame ever arrived.
  - New shared helper `stream_guard::finish_sse_stream`: `Final` is emitted only when the protocol's own completion signal was observed; otherwise a truncation `StreamError` surfaces. The existing `llm_stream_fallback` path in `call_provider` catches it and retries non-streaming, so the turn recovers.
  - Completion signals per protocol: Anthropic `stop_reason`; OpenAI-compatible chat completions `[DONE]` or any `finish_reason` (some compatible servers close without sending `[DONE]`); Responses API `response.completed`/`response.done` or `[DONE]`.
  - Anthropic parser additionally surfaces `next_line()` read errors, previously swallowed by the `while let Ok(...)` pattern.
- **Scope boundary:** SSE parsers in `zeroclaw-providers` only (`anthropic.rs`, `compatible.rs`, `openai.rs`, `openai_codex.rs`, shared helper in `stream_guard.rs`). No changes to the runtime turn loop or non-streaming chat paths. `openrouter.rs` is covered via `compatible::sse_bytes_to_events`; `openai_codex` via the shared `run_responses_sse`.
- **Blast radius:** All streaming consumers of these providers. Streams that end at EOF without a protocol completion signal (previously silently accepted as complete) now produce a retryable error and trigger the non-streaming fallback.
- **Linked issue(s):** None
- **Labels:** (to be applied)

## Validation Evidence (required)

- **Commands run and tail output:**

`cargo fmt --all -- --check`
```
(clean, no output)
```

`cargo clippy -p zeroclaw-providers --all-targets -- -D warnings`
```
(clean, no errors or warnings)
```

`cargo test -p zeroclaw-providers`
```
test result: ok. 1070 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.07s
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

`cargo test -p zeroclaw-runtime --lib`
```
test result: ok. 2737 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 6.32s
```

- **Beyond CI — what did you manually verify?** Root-caused against a live production trace (runtime-trace.jsonl + ACP session DB): `llm_response` with `raw_response: ""`, `native_tool_calls: 0`, null token counts, preceded by 2x "stream: consumer dropped" records, followed by an empty `turn_final_response`. Regression tests reproduce that shape per parser: `eof_before_message_stop_surfaces_error_not_final` (anthropic), `eof_before_completion_signal_surfaces_error_not_final` / `eof_after_done_sentinel_emits_final` / `eof_after_finish_reason_without_done_emits_final` (compatible), `process_sse_chunk_marks_completion_*` (responses state), plus unit tests on the shared helper. Existing stall-timeout, usage-ordering, and no-usage tests still pass, confirming clean streams are unaffected.
- **If any command was intentionally skipped, why:** Full-workspace `cargo test` skipped for turnaround time; the diff is confined to `zeroclaw-providers`, which passed its full package battery, and the primary streaming consumer (`zeroclaw-runtime`) passed its full lib suite.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- If `No` or `Yes` to either: N/A

## Rollback (required for medium/high-risk PRs)

Low-risk: `git revert <sha>`. Observable failure symptom if this change misbehaves: grep logs for `SSE stream closed before` firing on streams that should have been treated as complete, paired with `llm_stream_fallback` records. Most likely culprit would be an OpenAI-compatible server that sends neither `[DONE]` nor a `finish_reason`; such servers were already out of spec and now fall back to non-streaming instead of silently truncating.