### PR TITLE
fix(windows): silence config shell clippy warnings

### DIFF
--- a/crates/zeroclaw-config/src/platform/mod.rs
+++ b/crates/zeroclaw-config/src/platform/mod.rs
@@ -165,6 +165,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(target_os = "windows"))]
     fn factory_native_default_shell_is_sh() {
         let cfg = RuntimeConfig {
             kind: RuntimeKind::Native,
@@ -176,7 +177,6 @@ mod tests {
             .build_shell_command("echo hi", &std::env::temp_dir())
             .unwrap();
         let debug = format!("{cmd:?}");
-        #[cfg(not(target_os = "windows"))]
         assert!(
             debug.contains("\"sh\""),
             "default shell should be 'sh', got: {debug}"

--- a/crates/zeroclaw-config/src/platform/native.rs
+++ b/crates/zeroclaw-config/src/platform/native.rs
@@ -45,6 +45,7 @@ pub fn windows_std_cmd_shell_command(command: &str) -> std::process::Command {
 /// Native runtime — full access, runs on Mac/Linux/Windows/Docker/Raspberry Pi
 pub struct NativeRuntime {
     /// Shell binary to invoke for command execution (e.g. `"sh"`, `"bash"`).
+    #[cfg(not(target_os = "windows"))]
     shell: String,
 }
 
@@ -57,7 +58,7 @@ impl Default for NativeRuntime {
 impl NativeRuntime {
     /// Create a native runtime that uses the system default shell (`sh`).
     pub fn new() -> Self {
-        Self { shell: "sh".into() }
+        Self::with_shell("sh".into())
     }
 
     /// Create a native runtime that uses a specific shell binary.
@@ -65,7 +66,16 @@ impl NativeRuntime {
     /// `shell` should be a path or name resolvable via `PATH`,
     /// e.g. `"bash"`, `"/bin/zsh"`, `"/usr/bin/fish"`.
     pub fn with_shell(shell: String) -> Self {
-        Self { shell }
+        #[cfg(not(target_os = "windows"))]
+        {
+            Self { shell }
+        }
+
+        #[cfg(target_os = "windows")]
+        {
+            drop(shell);
+            Self {}
+        }
     }
 }
 
@@ -350,11 +360,11 @@ mod tests {
     // ── Configurable shell tests ─────────────────────────────
 
     #[test]
+    #[cfg(not(target_os = "windows"))]
     fn native_with_shell_defaults_to_sh() {
         let runtime = NativeRuntime::new();
         let cwd = std::env::temp_dir();
         let cmd = runtime.build_shell_command("echo hi", &cwd).unwrap();
-        #[cfg(not(target_os = "windows"))]
         assert!(
             format!("{cmd:?}").contains("\"sh\""),
             "default shell should be 'sh', got: {cmd:?}"
@@ -362,11 +372,11 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(target_os = "windows"))]
     fn native_with_shell_bash() {
         let runtime = NativeRuntime::with_shell("bash".into());
         let cwd = std::env::temp_dir();
         let cmd = runtime.build_shell_command("echo hi", &cwd).unwrap();
-        #[cfg(not(target_os = "windows"))]
         assert!(
             format!("{cmd:?}").contains("\"bash\""),
             "configured shell should appear in command debug, got: {cmd:?}"
@@ -374,11 +384,11 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(target_os = "windows"))]
     fn native_with_shell_absolute_path() {
         let runtime = NativeRuntime::with_shell("/usr/bin/zsh".into());
         let cwd = std::env::temp_dir();
         let cmd = runtime.build_shell_command("echo hi", &cwd).unwrap();
-        #[cfg(not(target_os = "windows"))]
         assert!(
             format!("{cmd:?}").contains("/usr/bin/zsh"),
             "absolute path should appear verbatim, got: {cmd:?}"
@@ -386,25 +396,23 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(target_os = "windows"))]
     fn native_default_and_with_shell_are_different() {
         let default = NativeRuntime::new();
         let configured = NativeRuntime::with_shell("bash".into());
         let cwd = std::env::temp_dir();
-        #[cfg(not(target_os = "windows"))]
-        {
-            let default_debug = format!(
-                "{:?}",
-                default.build_shell_command("echo hi", &cwd).unwrap()
-            );
-            let configured_debug = format!(
-                "{:?}",
-                configured.build_shell_command("echo hi", &cwd).unwrap()
-            );
-            assert_ne!(
-                default_debug, configured_debug,
-                "default shell and configured shell should produce different commands"
-            );
-        }
+        let default_debug = format!(
+            "{:?}",
+            default.build_shell_command("echo hi", &cwd).unwrap()
+        );
+        let configured_debug = format!(
+            "{:?}",
+            configured.build_shell_command("echo hi", &cwd).unwrap()
+        );
+        assert_ne!(
+            default_debug, configured_debug,
+            "default shell and configured shell should produce different commands"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Makes `NativeRuntime.shell` Unix-only so Windows builds do not retain a dead shell field.
  - Keeps Unix configurable-shell behavior through the existing native runtime path.
  - Moves Unix-only shell-debug assertions behind function-level cfg gates so Windows clippy does not compile unused locals.
  - Leaves Windows command construction on the existing `cmd.exe /C` helper path.
- **Scope boundary:** This only addresses the `zeroclaw-config` Windows clippy bucket from #7462. It does not address the remaining locale-sensitive assertions, cron/shell `sh` assumptions, path/media marker failures, gateway pairing/archive failures, model catalog assertions, or security-status failures.
- **Blast radius:** `zeroclaw-config` native runtime construction and adjacent platform tests.
- **Linked issue(s):** Related #7462
- **Labels:** `bug`, `config`, `risk:medium`, `size:XS`

## Validation Evidence (required)

- **Commands run and tail output:**
  - `git diff --check` — passed.
  - `cargo fmt -p zeroclaw-config -- --check` — passed.
  - `cargo test -p zeroclaw-config native_with_shell` — passed: `4 passed; 0 failed; 1054 filtered out`.
  - `cargo clippy -p zeroclaw-config --tests -- -D warnings` — passed.
  - `cargo clippy -p zeroclaw-config --target x86_64-pc-windows-msvc --tests -- -D warnings` — attempted, but the local macOS cross-target environment stopped in `ring` before reaching ZeroClaw code because Windows/MSVC C headers were unavailable.
- **Beyond CI — what did you manually verify?** Checked the diff preserves Unix `self.shell` command construction, keeps Windows on the existing `cmd.exe /C` helper path, and removes the Windows-compiled unused locals/dead field reported in #7462.
- **If any command was intentionally skipped, why:** Full workspace validation was not run for this XS `zeroclaw-config` slice. The Windows-native claim still needs an unskipped Windows clippy run, a native Windows validation run, or a reporter/maintainer Windows rerun before reviewer sign-off.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: `N/A`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: `N/A`

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert this commit.
- **Feature flags or config toggles:** `None`
- **Observable failure symptoms:** Windows clippy continues to report unused locals or a dead `NativeRuntime.shell` field in `zeroclaw-config`, or native runtime shell tests fail.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors: `N/A`
- Scope materially carried forward: `N/A`
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why: `No superseded PR or carried-forward contributor patch.`

