### PR TITLE
docs(skills): route issue filing by current templates

### DIFF
--- a/.claude/skills/github-issue/SKILL.md
+++ b/.claude/skills/github-issue/SKILL.md
@@ -1,35 +1,42 @@
 # Skill: github-issue
 
-File a structured GitHub issue (bug report or feature request) for ZeroClaw interactively from Claude Code.
+File a structured GitHub issue for ZeroClaw interactively from Claude Code.
 
 ## When to Use
 
-Trigger when the user wants to file a GitHub issue, report a bug, or request a feature for ZeroClaw. Keywords: "file issue", "report bug", "feature request", "open issue", "create issue", "github issue".
+Trigger when the user wants to create or route a ZeroClaw GitHub issue through the repository's current issue forms. Keywords: "file issue", "report bug", "feature request", "RFC", "tracker", "docs issue", "support issue", "contributor task", "open issue", "create issue", "github issue".
 
 ## Instructions
 
 You are filing a GitHub issue against the ZeroClaw repository using structured issue forms. Follow this workflow exactly.
 
-### Step 1: Detect Issue Type and Read the Template
+### Step 1: Route the Request and Read the Template
 
-Determine from the user's message whether this is a **bug report** or **feature request**.
-- If unclear, use AskUserQuestion to ask: "Is this a bug report or a feature request?"
+Read `.github/ISSUE_TEMPLATE/config.yml` first. It is contact-link metadata, not an issue form. Use it to route requests before drafting a public issue:
 
-Then read the corresponding issue template to understand the required fields:
+- Security vulnerabilities: use the private security reporting route. Do not draft or file a public issue.
+- Non-security content containing secrets, tokens, private URLs, personal data, or sensitive logs: stop, redact or sanitize the content, then continue only with safe public text.
+- Quick non-durable setup or usage help: use the configured Discord/support contact link unless durable tracking is needed.
+- Community Q&A, show-and-tell, polls, or early design exploration: use the configured Discussions contact link unless durable tracking is needed.
+- Contribution mechanics, RFC process, or PR workflow questions: use the relevant docs or contact link unless durable tracking is needed.
+- Durable tracked bugs, features, RFCs, docs gaps, support/configuration records, and contributor tasks: continue to the issue forms.
 
-- Bug report: `.github/ISSUE_TEMPLATE/bug_report.yml`
-- Feature request: `.github/ISSUE_TEMPLATE/feature_request.yml`
+Discover the issue forms from the current repository. Enumerate `.github/ISSUE_TEMPLATE/*.yml` excluding `config.yml`, then parse each form's `name`, `description`, `title`, `labels`, and `body`.
+
+Choose the best form from the parsed inventory. If the type is unclear, use AskUserQuestion with the parsed form names and descriptions. Do not collapse unclear issues to bug or feature by default.
+
+Then read the selected issue template to understand the required fields:
 
 Parse the YAML to extract:
-- The `title` prefix (e.g. `[Bug]: `, `[Feature]: `)
-- The `labels` array
-- Each field in the `body` array: its `type` (dropdown, textarea, input, checkboxes, markdown), `id`, `attributes.label`, `attributes.options` (for dropdowns), `attributes.description`, `attributes.placeholder`, and `validations.required`
+- The `title` prefix, for example `[Bug]:`, `[Feature]:`, `RFC:`, or `[Tracker]:`
+- The `labels` array, if present
+- Each field in the `body` array: its `type` (dropdown, textarea, input, checkboxes, markdown), `id`, `attributes.label`, `attributes.options` (for dropdowns and checkboxes), `attributes.description`, `attributes.placeholder`, `attributes.render` (for rendered text areas), and `validations.required`
 
-This is the source of truth for what fields exist, what they're called, what options are available, and which are required. Do not assume or hardcode any field names or options — always derive them from the template file.
+This is the source of truth for what forms exist, what fields exist, what they're called, what options are available, and which fields are required. Do not assume or hardcode any form names, field names, labels, or options; always derive them from the current template files.
 
 ### Step 2: Auto-Gather Context
 
-Before asking the user anything, silently gather environment and repo context:
+After selecting a form, silently gather only the environment and repo context that maps to the selected template fields. Use these helpers when the selected fields ask for version, operating system, Rust toolchain, current behavior, reproduction, or recent local changes:
 
 ```bash
 # Git context
@@ -37,7 +44,7 @@ git log --oneline -5
 git status --short
 git diff --stat HEAD~1 2>/dev/null
 
-# For bug reports — environment detection
+# For bug reports and support/configuration issues: environment detection
 uname -s -r -m                          # OS info
 sw_vers 2>/dev/null                     # macOS version
 rustc --version 2>/dev/null             # Rust version
@@ -45,23 +52,23 @@ cargo metadata --format-version=1 --no-deps 2>/dev/null | jq -r '.packages[] | s
 git rev-parse --short HEAD              # commit SHA fallback
 ```
 
-Also read recently changed files to infer the affected component and architecture impact.
+Also read recently changed files when they help infer the affected component, docs location, contributor scope, or architecture impact. For RFC/design, roadmap/tracker, docs, support/configuration, and contributor-task issues, search named paths/components and one or two exact title or keyword queries for related issues, PRs, RFCs, docs, or code paths before drafting. If no obvious related work appears, say so instead of widening the search indefinitely.
 
 ### Step 3: Pre-Fill and Present the Form
 
 Using the parsed template fields and gathered context, draft values for ALL fields from the template:
 
 - **dropdown** fields: select the most likely option from `attributes.options` based on context. For dropdowns where you're uncertain, note your best guess and flag it for the user.
-- **textarea** fields: draft content based on the user's description, git context, and the field's `attributes.description`/`attributes.placeholder` for guidance on what's expected.
+- **textarea** fields: draft content based on the user's description, git context, and the field's `attributes.description`/`attributes.placeholder` for guidance on what's expected. If the field has `attributes.render`, preserve exact output and plan to wrap the value in a fenced code block using that render language in Step 5.
 - **input** fields: fill with auto-detected values (versions, OS) or draft from user context.
-- **checkboxes** fields: auto-check all items (the skill itself ensures compliance with the stated checks).
-- **markdown** fields: skip these — they're informational headers, not form inputs.
-- **optional fields** (where `validations.required` is false): fill if there's enough context, otherwise note "(optional — not enough context to fill)".
+- **checkboxes** fields: auto-check only items you actually enforced or verified. For external attestations such as latest `master` reproduction, user confirmation, or upstream CI state, either gather real evidence, ask the user, or leave the item unchecked with a note that confirmation is needed.
+- **markdown** fields: skip these; they're informational headers, not form inputs.
+- **optional fields** (where `validations.required` is false): fill if there's enough context, otherwise note "(optional, not enough context to fill)".
 
 Present the complete draft to the user in a clean readable format:
 
 ```
-## Issue Draft: [Bug]: <title> / [Feature]: <title>
+## Issue Draft: <template title prefix><title>
 **Labels**: <from template>
 
 ### <Field Label>
@@ -82,6 +89,9 @@ If the user requests changes, update the draft and re-present. Iterate until the
 Before final submission, analyze the collected content for scope creep:
 - Does the bug report describe multiple independent defects?
 - Does the feature request bundle unrelated changes?
+- Is an RFC/design proposal being filed as an ordinary feature request?
+- Is an active coordination surface being filed as one ordinary bug or feature instead of a roadmap/tracker?
+- Is a docs-only gap being mixed with a behavior change that should have its own bug or feature issue?
 
 If multi-concept issues are detected:
 1. Inform the user: "This issue appears to cover multiple distinct topics. Focused, single-concept issues are strongly preferred and more likely to be accepted."
@@ -103,6 +113,16 @@ For each non-markdown field from the template, in order:
 
 For optional fields with no content, use `_No response_` as the value (this matches GitHub's native rendering for empty optional fields).
 
+For textarea fields with `attributes.render`, wrap the value in a fenced code block using that render language:
+
+````markdown
+### <attributes.label>
+
+```<attributes.render>
+<exact value>
+```
+````
+
 For checkbox fields, render each option as:
 ```markdown
 - [X] <option label text>
@@ -110,7 +130,7 @@ For checkbox fields, render each option as:
 
 ### Step 6: Final Preview and Submit
 
-Show the final constructed issue (title + labels + full body) for one last confirmation.
+Show the final constructed issue (title + labels + full body) for one last confirmation. If the selected template has no labels, show `Labels: none` and omit `--label` from the create command.
 
 Then submit using a HEREDOC for the body to preserve formatting:
 
@@ -121,14 +141,24 @@ ISSUE_EOF
 )"
 ```
 
+When the selected template has no labels:
+
+```bash
+gh issue create --title "<title prefix><user title>" --body "$(cat <<'ISSUE_EOF'
+<body content>
+ISSUE_EOF
+)"
+```
+
 Return the resulting issue URL to the user.
 
 ### Important Rules
 
-- **Always read the template file** — never assume field names, options, or structure. The templates are the source of truth and may change over time.
-- **Never include personal/sensitive data** in the issue. Redact secrets, tokens, emails, real names.
+- **Always discover and read the current template files**: enumerate issue forms from `.github/ISSUE_TEMPLATE/*.yml` excluding `config.yml`, then parse the selected template. Never assume field names, options, labels, render modes, or structure.
+- **Use `config.yml` as a routing gate**: route private security reports, quick support, Discussions, and docs/process contacts before drafting a durable public issue.
+- **Never include personal/sensitive data** in the issue. Redact secrets, tokens, emails, real names, private URLs, and sensitive logs before public drafting. Security vulnerabilities must use the private route instead.
 - **Use neutral project-scoped placeholders** per ZeroClaw's privacy contract.
-- **One concept per issue** — enforce the scope guard.
-- **Auto-detect, don't guess** — use real command output for environment fields.
-- **Quote observed output verbatim** — error messages, stack traces, warnings, and command output must be copy-pasted into the relevant fields (`Steps to reproduce`, `Observed behavior`, `Logs`) exactly as they appeared. Do not paraphrase. Do not summarize. The maintainer searching for this bug later will grep for the exact string; paraphrase breaks that search. If the output is long, include the head and tail with a `...` marker in the middle rather than rewriting it.
-- **Match GitHub's rendering** — use `### Field Label` sections so issues look consistent whether filed via web UI or this skill.
+- **One concept per issue**: enforce the scope guard.
+- **Auto-detect, don't guess**: use real command output for environment fields.
+- **Quote observed output verbatim**: error messages, stack traces, warnings, and command output must be copy-pasted into the relevant fields (`Steps to reproduce`, `Observed behavior`, `Logs`) exactly as they appeared. Do not paraphrase. Do not summarize. The maintainer searching for this bug later will grep for the exact string; paraphrase breaks that search. If the output is long, include the head and tail with a `...` marker in the middle rather than rewriting it.
+- **Match GitHub's rendering**: use `### Field Label` sections so issues look consistent whether filed via web UI or this skill.


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Expand the issue-filing skill trigger and routing guidance beyond bug reports and feature requests.
  - Tell the skill to read `config.yml` first as contact-link metadata and route private security reports, quick support, Discussions, and docs/process contacts before public issue drafting.
  - Route issue drafts from the live `.github/ISSUE_TEMPLATE/*.yml` inventory by enumerating issue forms, excluding `config.yml`, and parsing the current form metadata.
  - Preserve current form details that affect generated issue bodies, including `attributes.render`, optional labels, and checkbox attestations that require real evidence.
  - Update the scope guard so agents catch RFCs, trackers, and docs gaps that should not be collapsed into ordinary bug or feature issues.
- **Scope boundary:** This PR does not change issue templates, labels, GitHub Actions, or application runtime behavior; it only changes `.claude/skills/github-issue/SKILL.md` issue-filing guidance, including the no-label issue-create path.
- **Blast radius:** Coding assistants using `.claude/skills/github-issue/SKILL.md`; public issue-filing guidance only.
- **Linked issue(s):** None.
- **Labels:** `docs`, `risk:low`, `size:XS`, `type:docs`

## Validation Evidence (required)

- **Commands run and tail output:**

```text
$ scripts/check-pr-title.sh "docs(skills): route issue filing by current templates"
# no output; exit 0

$ git diff --check
# no output; exit 0

$ npm_config_cache=<isolated npm cache> DOCS_FILES='.claude/skills/github-issue/SKILL.md' bash scripts/ci/docs_quality_gate.sh
No prose em-dashes in changed docs files.
Linting docs files: .claude/skills/github-issue/SKILL.md
markdownlint-cli2 v0.20.0 (markdownlint v0.40.0)
Finding: .claude/skills/github-issue/SKILL.md !target/** !docs/book/src/SUMMARY.md
Linting: 1 file(s)
Summary: 0 error(s)
```

- **Beyond CI — what did you manually verify?**
  - Confirmed the skill now treats `config.yml` as contact-link metadata, not an issue form.
  - Confirmed the skill now discovers issue forms by enumerating `.github/ISSUE_TEMPLATE/*.yml` while excluding `config.yml`, instead of relying on a static template list.
  - Confirmed the old bug/feature-only routing question and static issue-form inventory are gone.
  - Confirmed the skill now preserves `attributes.render`, omits `--label` when a selected template has no labels, and checks only checkbox attestations that were actually verified or enforced.
  - Did not file a test issue.
- **If any command was intentionally skipped, why:** Rust build/test commands were skipped because this is a docs/skill-only change.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: Not applicable.

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: No upgrade steps required.

## Rollback (required for medium/high-risk PRs)

Low-risk PRs: `git revert <sha>` is the plan unless otherwise noted.

## Supersede Attribution (required only when `Supersedes #` is used)

Not used.
