### PR TITLE
fix(providers): omit Responses tool_choice for empty tools

### DIFF
--- a/crates/zeroclaw-providers/src/openai.rs
+++ b/crates/zeroclaw-providers/src/openai.rs
@@ -706,6 +706,10 @@ struct ResponsesApiReasoning {
     effort: String,
 }
 
+fn has_responses_tools(tools: Option<&[ResponsesToolSpec]>) -> bool {
+    tools.is_some_and(|tools| !tools.is_empty())
+}
+
 /// Non-streaming response body from `/v1/responses`.
 #[derive(Debug, Deserialize)]
 struct ResponsesApiBody {
@@ -931,7 +935,7 @@ impl OpenAiResponsesModelProvider {
         temperature: Option<f64>,
         stream: bool,
     ) -> ResponsesApiRequest {
-        let has_tools = tools.is_some();
+        let has_tools = has_responses_tools(tools.as_deref());
         let reasoning = self
             .reasoning_effort
             .as_deref()
@@ -1122,7 +1126,7 @@ impl ModelProvider for OpenAiResponsesModelProvider {
             };
             let tools = convert_tools(tools_owned.as_deref());
             let tools_count = tools.as_ref().map_or(0, Vec::len);
-            let has_tools = tools.is_some();
+            let has_tools = has_responses_tools(tools.as_deref());
             let reasoning = reasoning_effort
                 .as_deref()
                 .map(|effort| ResponsesApiReasoning {
@@ -1999,6 +2003,44 @@ mod tests {
                     .and_then(serde_json::Value::as_null)
                     .is_some(),
             "no tools → parallel_tool_calls must be omitted (skipped via skip_serializing_if)"
+        );
+    }
+
+    #[test]
+    fn responses_request_omits_tool_choice_and_parallel_when_tools_empty() {
+        let provider = OpenAiResponsesModelProvider::new("openai", None, None);
+        let req = provider.build_request(
+            None,
+            vec![serde_json::json!({"role": "user", "content": "hi"})],
+            Some(Vec::new()),
+            "gpt-5",
+            None,
+            false,
+        );
+        let json = serde_json::to_value(&req).expect("ResponsesApiRequest must serialize");
+        assert!(
+            json.get("tool_choice").is_none()
+                || json
+                    .get("tool_choice")
+                    .and_then(serde_json::Value::as_null)
+                    .is_some(),
+            "empty tools list → tool_choice must be omitted (vLLM rejects tool_choice without non-empty tools)"
+        );
+        assert!(
+            json.get("parallel_tool_calls").is_none()
+                || json
+                    .get("parallel_tool_calls")
+                    .and_then(serde_json::Value::as_null)
+                    .is_some(),
+            "empty tools list → parallel_tool_calls must be omitted with tool_choice"
+        );
+        let wire_tools = json
+            .get("tools")
+            .and_then(serde_json::Value::as_array)
+            .expect("tools must be a JSON array on the wire body");
+        assert!(
+            wire_tools.is_empty(),
+            "empty tools should remain an empty tools array; only tool_choice and parallel_tool_calls are suppressed"
         );
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** `OpenAiResponsesModelProvider` still treated `Some(vec![])` as "tools are present" on the Responses API path, so it emitted `tool_choice: "auto"` and `parallel_tool_calls: true` even when the wire `tools` array was empty. vLLM and other strict OpenAI-compatible validators reject that shape.
- **What changed and why:** Added a shared Responses-path predicate that requires the converted tools list to be non-empty before emitting `tool_choice` / `parallel_tool_calls`, and used it in both non-streaming and streaming Responses requests.
- **What changed and why:** Added a focused regression for `Some(Vec::new())` beside the existing absent-tools and present-tools request-shape tests.
- **Scope boundary:** Does not touch chat-completions provider paths, OpenAI Codex, compatible/Azure/Copilot/OpenRouter providers, tool conversion, model selection, credentials, streaming event parsing, or provider factory wiring. Merged #7864 and #8476 cover the other known #7862 provider surfaces; this PR is the remaining current-master Responses provider residual.
- **Blast radius:** Limited to OpenAI Responses request serialization in `crates/zeroclaw-providers/src/openai.rs`. Requests with one or more tools still emit `tool_choice: "auto"` and `parallel_tool_calls: true`; requests with no tools or an empty tools array omit those fields.
- **Linked issue(s):** Closes #7862
- **Labels:** `bug`, `provider`, `provider:openai`, `priority:p1`, `risk:medium`, `size:XS`

## Validation Evidence (required)

**Commands run and tail output:**

```text
cargo fmt --all -- --check
(exit 0, no formatting changes)

cargo test -p zeroclaw-providers responses_request_omits_tool_choice_and_parallel_when_tools_empty
running 1 test
test openai::tests::responses_request_omits_tool_choice_and_parallel_when_tools_empty ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1061 filtered out

cargo test -p zeroclaw-providers responses_request_
running 8 tests
test openai::tests::responses_request_omits_tool_choice_and_parallel_when_tools_absent ... ok
test openai::tests::responses_request_omits_tool_choice_and_parallel_when_tools_empty ... ok
test openai::tests::responses_request_propagates_tool_choice_and_parallel_when_tools_present ... ok
test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 1054 filtered out

cargo clippy -p zeroclaw-providers --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s)
```

- **Beyond CI - what did you manually verify?** Read current `master` and live #7862/#7864/#8476 state before patching. Confirmed #7864 merged the shared provider/chat-completions surfaces and #8476 merged the OpenAI Codex Responses path, while current `OpenAiResponsesModelProvider` still gated `tool_choice` / `parallel_tool_calls` on `tools.is_some()` in both non-streaming and streaming Responses request construction. The new helper is used by both call sites.
- **If any command was intentionally skipped, why:** Workspace-wide clippy and full CI-shaped tests were not run locally for this one-file request-shape slice. The provider-scoped clippy and focused request-shape tests above are the current local evidence; GitHub CI is expected to provide the broader PR matrix.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- If any `Yes`, describe the risk and mitigation: Not applicable. This only suppresses invalid Responses API request fields when the converted tool list is empty.

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- If `No` or `Yes` to either: No upgrade steps. Requests with actual tools keep the existing `tool_choice: "auto"` behavior; empty tool lists now match absent tool lists and avoid a strict-validator HTTP 400.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <sha>`; this is a one-file request-serialization change with no migration.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** OpenAI Responses-compatible backends may again reject empty-tool requests with errors like `When using tool_choice, tools must be set` when the converted tool list is empty.

## Supersede Attribution (required only when `Supersedes #` is used)

Not applicable.
