### PR TITLE
docs(labels): document provider router and security labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -322,6 +322,11 @@
       - any-glob-to-any-file:
           - "crates/zeroclaw-runtime/src/security/docker.rs"
 
+"security:leak-detector":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/zeroclaw-runtime/src/security/leak_detector.rs"
+
 "security:pairing":
   - changed-files:
       - any-glob-to-any-file:
@@ -341,6 +346,11 @@
       - any-glob-to-any-file:
           - "crates/zeroclaw-runtime/src/security/secrets.rs"
           - "crates/zeroclaw-config/src/secrets.rs"
+
+"security:traits":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/zeroclaw-runtime/src/security/traits.rs"
 
 "runtime":
   - changed-files:
@@ -449,6 +459,11 @@
   - changed-files:
       - any-glob-to-any-file:
           - "crates/zeroclaw-providers/src/reliable.rs"
+
+"provider:router":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/zeroclaw-providers/src/router.rs"
 
 "provider:telnyx":
   - changed-files:

--- a/docs/book/src/maintainers/labels.md
+++ b/docs/book/src/maintainers/labels.md
@@ -128,9 +128,11 @@ Scoped path labels do not guarantee a same-prefix base label. Because `pr-path-l
 | `runtime:wasm` | runtime WASM platform and first-party WASM plugin host files |
 | `security:bubblewrap` | `bubblewrap.rs` |
 | `security:docker` | `docker.rs` |
+| `security:leak-detector` | LeakDetector redaction and sensitive-output scanning |
 | `security:pairing` | pairing security, gateway pairing API, and web pairing page |
 | `security:policy` | runtime security policy, IAM policy, and config policy files |
 | `security:secrets` | runtime and config secrets handling |
+| `security:traits` | shared security trait and interface definitions |
 | `memory:backend` | memory backend selection and storage implementation files |
 
 ### Manual component labels
@@ -142,6 +144,8 @@ Some scoped component labels are manual routing labels rather than synchronized 
 `agent:loop` is retired. For agent-loop routing, use base `agent` plus any matching `runtime`, provider, channel, tool, or risk labels.
 
 Do not apply legacy `observability: runtime_trace` to new issues or PRs. Use `observability:otel` when the work is about OpenTelemetry tracing, add base `observability` only when the issue or PR also matches that base surface, and decide any future runtime-trace-specific canonical label in a separate create/migrate packet.
+
+Do not apply legacy `security: leak_detector` to new issues or PRs. Use `security:leak-detector` for LeakDetector redaction and sensitive-output scanning work.
 
 Gateway subarea labels such as `gateway: api`, `gateway: sse`, `gateway:local_bridge`, and `gateway:webhook_ingress` remain live migration holdbacks. New routing should use base `gateway` until a separate packet either creates canonical no-space/hyphenated sublabels and migrates refs, or collapses those labels into base `gateway`.
 
@@ -186,7 +190,9 @@ Each channel gets a `channel:<name>` label in addition to the base `channel` lab
 
 ### Per-provider labels
 
-Provider-specific labels match dedicated provider source files. Shared registry
+Provider-specific labels match dedicated provider source files. The provider
+router has its own scoped label because routing and model-dispatch work is a
+shared provider subarea, not one concrete provider integration. Shared registry
 or factory files should receive the base `provider` label only; maintainers can
 add a provider-specific label manually when a shared-file change is truly scoped
 to one provider.
@@ -206,6 +212,7 @@ to one provider.
 | `provider:openai` | `openai.rs`, `openai_codex.rs` |
 | `provider:openrouter` | `openrouter.rs` |
 | `provider:reliable` | `reliable.rs` |
+| `provider:router` | `router.rs` |
 | `provider:telnyx` | `telnyx.rs` |
 
 Some provider labels describe provider families that currently share the OpenAI-compatible provider implementation instead of a dedicated source file. Maintainers may apply these manually when an issue or PR is truly about that family: `provider:groq`, `provider:kimi`, `provider:minimax`, `provider:moonshot`, and `provider:qwen`. Do not add shared factory or compatible-provider files to these labeler rules; that would over-label unrelated shared changes.


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:** Adds path-labeler ownership for `provider:router`, `security:leak-detector`, and `security:traits` so the remaining #6808 provider/security labels are checked into the maintainer label contract. Documents `provider:router` as shared provider routing/model-dispatch work, documents LeakDetector and security-traits scoped labels, and records `security: leak_detector` as a legacy spelling that should not be used for new issues or PRs.
- **Scope boundary:** This PR does not migrate #4832, delete `security: leak_detector`, update live descriptions for `provider:router` or `security:traits`, or change stale automation, issue state, milestones, Project fields, or runtime behavior.
- **Blast radius:** PR path-labeler and maintainer label guide only. Future PRs that touch `router.rs`, `leak_detector.rs`, or `traits.rs` may receive these scoped labels.
- **Linked issue(s):** Related #6808. References #4832, #7142, and #7951.
- **Labels:** `type:docs`, `risk:low`, `size:XS`, `docs`, `ci`

## Validation Evidence (required)

- **Commands run and tail output:**

```bash
ruby -e 'require "yaml"; YAML.load_file(".github/labeler.yml"); puts "labeler YAML OK"'
labeler YAML OK

git diff --check
# no output

npx --yes markdownlint-cli2@0.20.0 docs/book/src/maintainers/labels.md
markdownlint-cli2 v0.20.0 (markdownlint v0.40.0)
Summary: 0 error(s)

DOCS_FILES=docs/book/src/maintainers/labels.md bash scripts/ci/docs_quality_gate.sh
No prose em-dashes in changed docs files.
Linting docs files: docs/book/src/maintainers/labels.md
Summary: 0 error(s)

DOCS_FILES=docs/book/src/maintainers/labels.md bash scripts/ci/docs_links_gate.sh
Collected 0 added link(s) from 1 docs file(s).
No added links detected in changed docs lines.
```

- **Beyond CI — what did you manually verify?** Verified live labels exist for `provider:router`, `security:traits`, and `security:leak-detector` before adding labeler rules that reference them.
- **If any command was intentionally skipped, why:** Rust validation skipped because this changes only `.github/labeler.yml` and maintainer Markdown documentation.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: None.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No user upgrade steps. Maintainers should migrate the old `security: leak_detector` label to `security:leak-detector` in a later exact packet.

## Rollback (required for medium/high-risk PRs)

Low-risk PR: `git revert <sha>` restores the prior labeler/docs wording.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): None.
- Scope materially carried forward: None.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why (inspiration-only, no direct code/design carry-over): No superseded PR content is carried forward.
