### PR TITLE
docs(skills): align squash-merge gh version floor

### DIFF
--- a/.claude/skills/squash-merge/SKILL.md
+++ b/.claude/skills/squash-merge/SKILL.md
@@ -32,7 +32,7 @@ GitHub's default squash merge omits the PR number from the commit subject and fo
 
 ## Prerequisites
 
-Requires `gh` CLI ≥ 2.17.0 (for `--subject` and `--body` flags on `gh pr merge`). Verify with:
+Requires `gh` CLI ≥ 2.50.0 (for `--json name,state,bucket` on `gh pr checks`). Verify with:
 
 ```bash
 gh --version
@@ -56,7 +56,7 @@ Then fetch PR metadata:
 
 ```bash
 gh pr view "$NUMBER" --repo zeroclaw-labs/zeroclaw \
-  --json number,title,headRefName,baseRefName,headRefOid,state,author,mergeable,mergeStateStatus,reviewDecision,updatedAt
+  --json number,title,headRefName,baseRefName,headRefOid,state,author,mergeable,mergeStateStatus,reviewDecision
 ```
 
 Save `headRefOid` as `$HEAD_SHA` for the confirmation and merge command.
@@ -99,11 +99,12 @@ gh pr checks "$NUMBER" --repo zeroclaw-labs/zeroclaw \
   --json name,state,bucket
 ```
 
-| State | Action |
+| Bucket value | Action |
 |---|---|
-| All required checks, including `CI Required Gate`, are in a passing bucket | Proceed to Step 1c |
-| Any required check is failing, cancelled, timed out, or action-required | Stop — report failing check names; do not merge |
-| Any required check is pending, queued, or in progress | Stop — tell user to wait for CI; offer to retry later |
+| `pass` for every required check, including the repo's required aggregate gate (currently `CI Required Gate`) | Proceed to Step 1c |
+| `fail` or `cancel` for any required check | Stop — report failing or cancelled check names; do not merge |
+| `pending` for any required check | Stop — tell user to wait for CI; offer to retry later |
+| `skipping` for any required check | Stop — report the skipped required check names and ask whether the skip is expected before proceeding |
 | No required checks are configured or returned | Warn and ask user whether to proceed |
 
 Do not merge on red CI unless the user explicitly overrides after seeing the failure list.
@@ -129,7 +130,8 @@ Use one of these freshness bases:
 3. **Exact merge-result smoke** — you locally construct or inspect the exact
    merge result that will be created, then run an appropriate compile/test smoke
    for the touched surface. Use this only after the user approves the validation
-   scope.
+   scope, and see the `BEHIND`/`UNSTABLE` constraint below before choosing it
+   over official CI.
 4. **Explicit stale-risk acceptance** — if checks or merge-result validation are
    stale or unavailable, tell the user exactly what is stale or unverified and
    get explicit approval to accept that risk for this PR.


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Bumps the squash-merge skill's documented `gh` minimum from 2.17.0 to 2.50.0 because Step 1b now uses `gh pr checks --json name,state,bucket`.
  - Keys the required-check action table directly on `bucket` values, including an explicit `skipping` path.
  - Softens the hardcoded aggregate-gate wording and cross-references the merge-result smoke constraint before choosing local smoke over official CI.
  - Drops the unused `updatedAt` metadata field from the preflight query.
- **Scope boundary:** This does not change runtime code, GitHub Actions, helper scripts, or merge behavior.
- **Blast radius:** Maintainer/agent squash-merge workflow documentation only.
- **Linked issue(s):** Related #8613.
- **Labels:** `type:docs`, `risk:low`, `size:XS`, `docs`.

## Validation Evidence (required)

- **Commands run and tail output:**

```text
$ scripts/check-pr-title.sh "docs(skills): align squash-merge gh version floor"
Passed with no output.

$ git diff --check
Passed with no output.

$ scripts/ci/docs_quality_gate.sh
No docs files detected; skipping docs quality gate.

$ gh --version
gh version 2.92.0 (2026-04-28)
https://github.com/cli/cli/releases/tag/v2.92.0

$ gh pr checks --help | rg -n -- "--required|--json|bucket"
6:When the `--json` flag is used, it includes a `bucket` field, which categorizes
21:      --json fields       Output JSON with the specified fields
22:      --required          Only show checks that are required
32:  bucket, completedAt, description, event, link, name, startedAt, state, workflow

$ gh pr merge --help | rg -n "match-head-commit|subject|body"
19:  -b, --body text               Body text for the merge commit
20:  -F, --body-file file          Read body text from file
23:      --match-head-commit SHA   Commit SHA that the pull request head must match to allow merge
27:  -t, --subject text            Subject text for the merge commit
```

- **Beyond CI — what did you manually verify?** Verified the installed `gh` supports the documented `pr checks --required`, `pr checks --json ... bucket`, and `pr merge --match-head-commit` flags.
- **If any command was intentionally skipped, why:** Rust validation was not run because this is a `.claude/skills` Markdown-only workflow documentation change with no Rust/runtime surface.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: `N/A`

## Compatibility (required)

- Backward compatible? `Yes` for ZeroClaw runtime and users; this only corrects the maintainer workflow's documented `gh` version floor.
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: `N/A` for product users. Maintainers or agents using the squash-merge skill with `gh` older than 2.50.0 should upgrade before relying on Step 1b.

## Rollback (required for medium/high-risk PRs)

Low-risk PR: `git revert <sha>` is the rollback plan.
