### PR TITLE
docs(architecture): record goal-mode control-plane decision

### DIFF
--- a/docs/architecture/decisions/ADR-008-goal-mode-control-plane-and-usage-accounting.md
+++ b/docs/architecture/decisions/ADR-008-goal-mode-control-plane-and-usage-accounting.md
@@ -1,0 +1,106 @@
+---
+id: ADR-008
+title: Anchor goal mode in the durable task control plane
+date: 2026-06-25
+status: accepted
+relates-to:
+  - https://github.com/zeroclaw-labs/zeroclaw/issues/8303
+  - https://github.com/zeroclaw-labs/zeroclaw/issues/7929
+  - https://github.com/zeroclaw-labs/zeroclaw/pull/8217
+  - crates/zeroclaw-runtime
+  - crates/zeroclaw-config
+  - crates/zeroclaw-tools
+---
+
+# ADR-008: Anchor goal mode in the durable task control plane
+
+## Context
+
+Goal mode changes an agent interaction from a single response into autonomous
+work against a user objective. A goal can outlive the inbound message that
+started it, pause while waiting for input or an external dependency, recover
+after daemon restart, and spend model usage across multiple worker, verifier,
+or delegated calls.
+
+That kind of work needs one durable authority for its lifecycle. The system must
+be able to answer which work is alive, which work is eligible to run another
+turn, which work is paused, which work is terminal, and which actor or route is
+allowed to resume or cancel it. A prompt convention or side registry would make
+those answers dependent on duplicated state.
+
+Budget accounting adds another source-of-truth constraint. Tokens and cost are
+facts produced by model-provider calls. Remaining budget is derived from a
+limit and consumed usage; storing it as its own mutable counter would create a
+second accounting system.
+
+Goal mode also crosses a trust boundary. A slash command and a model-generated
+request can both express that a goal should start, but neither should be able to
+self-authorize trusted runtime facts such as caller identity, route, channel, or
+agent eligibility.
+
+The main options considered were ordinary multi-turn chat with prompt guidance,
+a separate goal subsystem, or anchoring goal mode in the existing durable task
+control plane with goal-specific extension state.
+
+## Decision
+
+We will anchor goal mode in the durable task control plane instead of building a
+parallel goal task system.
+
+The task control plane is the source of truth for goal lifecycle, ownership,
+route, principal, parent relation, and recovery eligibility. Goal-specific state
+may extend task records, but it must not duplicate lifecycle, identity, route,
+timestamp, delivery, or terminal-state facts owned by the task record.
+
+Consumed model usage remains owned by the canonical usage ledger. Goal budgets
+are limits interpreted against usage records; remaining budget is always
+derived, never stored as a second mutable total.
+
+Pause, resume, cancellation, restart recovery, and completion are control-plane
+policy decisions. Prompt text can explain or request those transitions, but it
+does not authorize them.
+
+All goal entry paths use one trusted Rust-side admission gate. Runtime context
+supplies trusted facts such as surface, channel, principal, route, and agent
+eligibility; model-supplied arguments cannot declare those facts.
+
+Goal completion requires an explicit completion decision by the goal controller.
+Silence, lack of further tool calls, or a final-looking assistant message is not
+enough to mark durable autonomous work complete.
+
+## Consequences
+
+Goal mode inherits the existing supervised task lifecycle instead of adding a
+second task registry. This keeps restart recovery, cancellation, and future
+supervision improvements attached to one control-plane contract.
+
+The control plane becomes responsible for distinguishing paused but resumable
+goal work from terminal, lost, or still-running work. That increases the
+importance of precise task status transitions and restart recovery policy.
+
+Budget enforcement becomes auditable because consumed usage is derived from
+canonical usage records. It also means goal mode cannot be correct until every
+model call that can spend against a goal reports usage with goal attribution.
+
+Delegation and background work must respect the same lifecycle and usage
+boundaries. Work that cannot report completion and usage back to the owning goal
+cannot safely participate in goal mode.
+
+A single trusted admission gate prevents command and model-initiated entry paths
+from becoming separate authorization systems. The cost is that every supported
+surface must route goal entry through the shared command/admission machinery.
+
+Detailed implementation choices, including command syntax, pause reason
+inventory, payload shapes, verifier configuration, and rollout staging, are left
+to implementation plans and follow-up PRs. They must remain consistent with this
+ADR's source-of-truth boundaries.
+
+## References
+
+- RFC #8303: <https://github.com/zeroclaw-labs/zeroclaw/issues/8303>
+- Shared command-catalogue RFC #7929: <https://github.com/zeroclaw-labs/zeroclaw/issues/7929>
+- Durable task control plane PR #8217: <https://github.com/zeroclaw-labs/zeroclaw/pull/8217>
+- Control-plane commit: <https://github.com/zeroclaw-labs/zeroclaw/commit/607d69ef44dca07e2605e822db13fb437b462f4a>
+- Gateway ask-user/free-form gap #7776: <https://github.com/zeroclaw-labs/zeroclaw/issues/7776>
+- Cached token and cost accounting #7248: <https://github.com/zeroclaw-labs/zeroclaw/issues/7248>
+- Command localization gap #6548: <https://github.com/zeroclaw-labs/zeroclaw/issues/6548>


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Adds ADR-008 for the goal-mode control-plane decision.
  - Records the implemented conceptual boundaries: task-control-plane ownership, goal-only extension state, ledger-owned consumed usage, derived remaining budget, trusted Rust admission, and explicit controller completion.
  - Preserves the ADR text exactly from the local `feat/goal-mode` split baseline at `75b95a1f8`; the extracted file hash matches the baseline blob.
- **Scope boundary:**
  - Does not add or change runtime code, configuration, command surfaces, storage, model-callable tools, or channel behavior.
  - Does not add goal-mode user/operator docs or book navigation; those move with the later behavior/documentation slices.
  - Does not close or supersede PR #8393 by itself; this is the first PR in the split stack tracked by #8681.
- **Blast radius:** Documentation-only architecture record under `docs/architecture/decisions`.
- **Linked issue(s):**
  - Related #8303: https://github.com/zeroclaw-labs/zeroclaw/issues/8303
  - Tracks #8681: https://github.com/zeroclaw-labs/zeroclaw/issues/8681
  - Split from PR #8393: https://github.com/zeroclaw-labs/zeroclaw/pull/8393
- **Labels:** `docs`, `type:docs`, `risk:low`, `size:XS`.

## Validation Evidence (required)

- **Commands run and tail output:**

```text
$ scripts/ci/docs_quality_gate.sh
No prose em-dashes in changed docs files.
Linting docs files: docs/book/src/SUMMARY.md docs/book/src/_snippets/sop-unwired.md docs/book/src/agents/delegation.md docs/book/src/agents/filesystem.md docs/book/src/agents/history-management.md docs/book/src/architecture/config-lifecycle.md docs/book/src/architecture/crates.md docs/book/src/architecture/memory-payload-lifecycle.md docs/book/src/architecture/request-lifecycle.md docs/book/src/architecture/runtime-state-and-persistence.md docs/book/src/channels/amqp.md docs/book/src/channels/filesystem.md docs/book/src/channels/mqtt.md docs/book/src/channels/overview.md docs/book/src/channels/whatsapp.md docs/book/src/contributing/agent-policy-parity-harness.md docs/book/src/contributing/architecture-map.md docs/book/src/contributing/how-to.md docs/book/src/contributing/testing.md docs/book/src/developing/plugin-protocol.md docs/book/src/developing/tool-inventory.md docs/book/src/foundations/fnd-001-intentional-architecture.md docs/book/src/foundations/fnd-004-engineering-infrastructure.md docs/book/src/getting-started/multi-model-setup.md docs/book/src/getting-started/yolo.md docs/book/src/maintainers/ci-and-actions.md docs/book/src/maintainers/docs-and-translations.md docs/book/src/maintainers/labels.md docs/book/src/maintainers/release-runbook.md docs/book/src/maintainers/release-verification.md docs/book/src/maintainers/reviewer-playbook.md docs/book/src/ops/cost-tracking.md docs/book/src/ops/observability.md docs/book/src/ops/overview.md docs/book/src/providers/catalog.md docs/book/src/security/autonomy.md docs/book/src/security/model.md docs/book/src/security/overview.md docs/book/src/security/sandboxing.md docs/book/src/security/tool-receipts.md docs/book/src/sop/example.md docs/book/src/sop/fan-in/amqp.md docs/book/src/sop/fan-in/calendar.md docs/book/src/sop/fan-in/cron.md docs/book/src/sop/fan-in/filesystem.md docs/book/src/sop/fan-in/manual.md docs/book/src/sop/fan-in/mqtt.md docs/book/src/sop/fan-in/overview.md docs/book/src/sop/fan-in/peripheral.md docs/book/src/sop/fan-in/webhook.md docs/book/src/sop/how-it-works.md docs/book/src/sop/index.md docs/book/src/sop/syntax.md docs/book/src/tools/mcp.md docs/book/src/tools/relationship-memory-skill-template.md docs/book/src/tools/relationship-memory.md docs/book/src/tools/skills.md
Existing markdown issues outside changed lines (non-blocking):
  - docs/book/src/contributing/agent-policy-parity-harness.md:78:1 MD018/no-missing-space-atx No space after hash on atx style heading [Context: "#6960, #8120). `assemble` appl..."]
  - docs/book/src/maintainers/release-runbook.md:376 MD028/no-blanks-blockquote Blank line inside blockquote
  - docs/book/src/maintainers/release-runbook.md:448 MD012/no-multiple-blanks Multiple consecutive blank lines [Expected: 1; Actual: 2]
No blocking markdown issues on changed lines.
```

```text
$ git hash-object docs/architecture/decisions/ADR-008-goal-mode-control-plane-and-usage-accounting.md
589bb72c85faa04fd85e522bf54a90000dc5bf02

$ git rev-parse 75b95a1f8:docs/architecture/decisions/ADR-008-goal-mode-control-plane-and-usage-accounting.md
589bb72c85faa04fd85e522bf54a90000dc5bf02
```

- **Beyond CI — what did you manually verify?**
  - Confirmed the ADR-only patch applied cleanly from `1dddc3bc..75b95a1f8` onto current upstream `master`.
  - Confirmed the book `SUMMARY.md` goal-mode entry from the baseline was intentionally not included here because the corresponding `agents/goal-mode.md` user/operator docs belong to a later split slice.
- **If any command was intentionally skipped, why:**
  - Rust format, clippy, and tests were skipped because this PR is docs-only and the repository PR template directs docs-only changes to `scripts/ci/docs_quality_gate.sh`.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: `N/A`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No upgrade steps; documentation-only ADR.

## Rollback (required for medium/high-risk PRs)

Low-risk PR; `git revert <merge-commit>` is sufficient.

