### PR TITLE
feat(commands): add built-in command catalogue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,7 @@ Every workspace crate carries a stability tier per the Microkernel Architecture 
 | `zeroclaw-providers` | Beta | — |
 | `zeroclaw-memory` | Beta | — |
 | `zeroclaw-infra` | Beta | — |
+| `zeroclaw-commands` | Experimental | Built-in command catalogue and metadata |
 | `zeroclaw-tool-call-parser` | Beta | Stable at v0.8.0 |
 | `zeroclaw-channels` | Experimental | Plugin migration at v1.0.0 |
 | `zeroclaw-tools` | Experimental | Plugin migration at v1.0.0 |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13226,6 +13226,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeroclaw-commands"
+version = "0.8.2"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "zeroclaw-config"
 version = "0.8.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "crates/zeroclaw-api", "crates/zeroclaw-infra", "crates/zeroclaw-config", "crates/zeroclaw-log", "crates/zeroclaw-spawn", "crates/zeroclaw-providers", "crates/zeroclaw-memory", "crates/zeroclaw-channels", "crates/zeroclaw-tools", "crates/zeroclaw-runtime", "crates/zeroclaw-eval", "apps/zerocode", "crates/zeroclaw-plugins", "crates/zeroclaw-gateway", "crates/zeroclaw-hardware", "crates/zeroclaw-tool-call-parser", "crates/robot-kit", "crates/aardvark-sys", "crates/zeroclaw-macros", "apps/tauri", "tools/fill-translations", "xtask"]
+members = [".", "crates/zeroclaw-api", "crates/zeroclaw-infra", "crates/zeroclaw-config", "crates/zeroclaw-log", "crates/zeroclaw-spawn", "crates/zeroclaw-commands", "crates/zeroclaw-providers", "crates/zeroclaw-memory", "crates/zeroclaw-channels", "crates/zeroclaw-tools", "crates/zeroclaw-runtime", "crates/zeroclaw-eval", "apps/zerocode", "crates/zeroclaw-plugins", "crates/zeroclaw-gateway", "crates/zeroclaw-hardware", "crates/zeroclaw-tool-call-parser", "crates/robot-kit", "crates/aardvark-sys", "crates/zeroclaw-macros", "apps/tauri", "tools/fill-translations", "xtask"]
 resolver = "2"
 
 [workspace.package]
@@ -15,6 +15,7 @@ zeroclaw-infra = { path = "crates/zeroclaw-infra", version = "0.8.2" }
 zeroclaw-config = { path = "crates/zeroclaw-config", version = "0.8.2", default-features = false }
 zeroclaw-log = { path = "crates/zeroclaw-log", version = "0.8.2" }
 zeroclaw-spawn = { path = "crates/zeroclaw-spawn", version = "0.8.2" }
+zeroclaw-commands = { path = "crates/zeroclaw-commands", version = "0.8.2" }
 zeroclaw-providers = { path = "crates/zeroclaw-providers", version = "0.8.2" }
 zeroclaw-memory = { path = "crates/zeroclaw-memory", version = "0.8.2" }
 zeroclaw-channels = { path = "crates/zeroclaw-channels", version = "0.8.2", default-features = false }

--- a/crates/zeroclaw-commands/Cargo.toml
+++ b/crates/zeroclaw-commands/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "zeroclaw-commands"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Shared built-in slash command catalogue for ZeroClaw surfaces."
+publish = false
+
+[dependencies]
+serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/crates/zeroclaw-commands/src/lib.rs
+++ b/crates/zeroclaw-commands/src/lib.rs
@@ -1,0 +1,286 @@
+//! Shared built-in channel slash command catalogue.
+//!
+//! This crate is the source of truth for built-in command metadata that is
+//! accepted or advertised by channel runtimes. Web and TUI command discovery are
+//! intentionally not represented here until those clients consume a generated or
+//! RPC-backed catalogue; keeping local client command lists out of this crate
+//! avoids pretending duplicated metadata is shared state.
+
+use serde::Serialize;
+
+/// User-facing surface where a command can be advertised or accepted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CommandSurface {
+    /// Command is available from the local CLI.
+    Cli,
+    /// Command is available from the Web UI/API surface.
+    Web,
+    /// Command is available from the terminal UI.
+    Tui,
+    /// Command is available from message-channel ingress.
+    Channel,
+}
+
+/// Stable built-in command identity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BuiltinCommandId {
+    /// Show runtime command help.
+    Help,
+    /// Clear local conversation history.
+    Clear,
+    /// Start a fresh conversation/session.
+    New,
+    /// Stop current work where the owning surface supports it.
+    Stop,
+    /// Show or change the selected model.
+    Model,
+    /// List configured/known models.
+    Models,
+    /// Show runtime config visible to the surface.
+    Config,
+    /// Show or change model thinking/reasoning effort.
+    Thinking,
+    /// Manage durable goal-mode work.
+    Goal,
+}
+
+/// Where command execution is owned today.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CommandExecution {
+    /// The client surface handles the command without runtime admission.
+    ClientLocal,
+    /// The channel/runtime command handler owns the command.
+    RuntimeCommand,
+    /// The durable goal controller/admission path owns the command.
+    GoalAdmission,
+}
+
+/// Built-in command metadata.
+///
+/// This is descriptive catalogue state, not an execution dispatcher. Command
+/// handlers still parse their own arguments so the catalogue does not become a
+/// second copy of runtime policy or command semantics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct CommandSpec {
+    /// Stable id for code that should not branch on display text.
+    pub id: BuiltinCommandId,
+    /// Canonical slash command name without the leading slash.
+    pub name: &'static str,
+    /// Additional names accepted by the same handler.
+    pub aliases: &'static [&'static str],
+    /// Human-readable usage shape shown in help.
+    pub usage: &'static str,
+    /// Fluent key for the localized command description.
+    pub description_key: &'static str,
+    /// Surfaces where this command may be advertised or accepted.
+    pub surfaces: &'static [CommandSurface],
+    /// Current owner of command execution.
+    pub execution: CommandExecution,
+}
+
+impl CommandSpec {
+    pub fn supports(self, surface: CommandSurface) -> bool {
+        self.surfaces.contains(&surface)
+    }
+
+    pub fn token_matches(self, token: &str) -> bool {
+        self.name == token || self.aliases.contains(&token)
+    }
+}
+
+impl CommandSurface {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Cli => "cli",
+            Self::Web => "web",
+            Self::Tui => "tui",
+            Self::Channel => "channel",
+        }
+    }
+}
+
+/// Parsed command token before surface-specific argument handling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ParsedCommandToken {
+    /// Catalogue entry matched by the leading slash token.
+    pub command: CommandSpec,
+}
+
+const CHANNEL_ONLY: &[CommandSurface] = &[CommandSurface::Channel];
+
+static BUILTIN_COMMANDS: &[CommandSpec] = &[
+    CommandSpec {
+        id: BuiltinCommandId::Help,
+        name: "help",
+        aliases: &[],
+        usage: "/help",
+        description_key: "command-help-description",
+        surfaces: CHANNEL_ONLY,
+        execution: CommandExecution::ClientLocal,
+    },
+    CommandSpec {
+        id: BuiltinCommandId::Clear,
+        name: "clear",
+        aliases: &[],
+        usage: "/clear",
+        description_key: "command-clear-description",
+        surfaces: CHANNEL_ONLY,
+        execution: CommandExecution::RuntimeCommand,
+    },
+    CommandSpec {
+        id: BuiltinCommandId::New,
+        name: "new",
+        aliases: &["new-session"],
+        usage: "/new",
+        description_key: "command-new-description",
+        surfaces: CHANNEL_ONLY,
+        execution: CommandExecution::RuntimeCommand,
+    },
+    CommandSpec {
+        id: BuiltinCommandId::Stop,
+        name: "stop",
+        aliases: &[],
+        usage: "/stop",
+        description_key: "command-stop-description",
+        surfaces: CHANNEL_ONLY,
+        execution: CommandExecution::RuntimeCommand,
+    },
+    CommandSpec {
+        id: BuiltinCommandId::Model,
+        name: "model",
+        aliases: &[],
+        usage: "/model [--user|--agent] [model]",
+        description_key: "command-model-description",
+        surfaces: CHANNEL_ONLY,
+        execution: CommandExecution::RuntimeCommand,
+    },
+    CommandSpec {
+        id: BuiltinCommandId::Models,
+        name: "models",
+        aliases: &[],
+        usage: "/models [provider]",
+        description_key: "command-models-description",
+        surfaces: CHANNEL_ONLY,
+        execution: CommandExecution::RuntimeCommand,
+    },
+    CommandSpec {
+        id: BuiltinCommandId::Config,
+        name: "config",
+        aliases: &[],
+        usage: "/config",
+        description_key: "command-config-description",
+        surfaces: CHANNEL_ONLY,
+        execution: CommandExecution::RuntimeCommand,
+    },
+    CommandSpec {
+        id: BuiltinCommandId::Thinking,
+        name: "thinking",
+        aliases: &["think"],
+        usage: "/thinking [off|low|medium|high|max|reset]",
+        description_key: "command-thinking-description",
+        surfaces: CHANNEL_ONLY,
+        execution: CommandExecution::RuntimeCommand,
+    },
+    CommandSpec {
+        id: BuiltinCommandId::Goal,
+        name: "goal",
+        aliases: &[],
+        usage: "/goal <start <objective>|objective <objective>|status|budget|pause|resume [reason]|cancel|help> ...",
+        description_key: "command-goal-description",
+        surfaces: CHANNEL_ONLY,
+        execution: CommandExecution::GoalAdmission,
+    },
+];
+
+pub fn builtin_commands() -> &'static [CommandSpec] {
+    BUILTIN_COMMANDS
+}
+
+pub fn commands_for_surface(
+    surface: CommandSurface,
+) -> impl Iterator<Item = CommandSpec> + 'static {
+    BUILTIN_COMMANDS
+        .iter()
+        .copied()
+        .filter(move |spec| spec.supports(surface))
+}
+
+pub fn command_by_name(name: &str) -> Option<CommandSpec> {
+    let normalized = normalize_command_name(name)?;
+    BUILTIN_COMMANDS
+        .iter()
+        .copied()
+        .find(|spec| spec.token_matches(&normalized))
+}
+
+pub fn parse_command_token(token: &str, surface: CommandSurface) -> Option<ParsedCommandToken> {
+    let command = command_by_name(token)?;
+    command
+        .supports(surface)
+        .then_some(ParsedCommandToken { command })
+}
+
+pub fn normalize_command_name(token: &str) -> Option<String> {
+    let trimmed = token.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let without_slash = trimmed.strip_prefix('/').unwrap_or(trimmed);
+    let without_bot_suffix = without_slash.split('@').next().unwrap_or(without_slash);
+    let normalized = without_bot_suffix.trim().to_ascii_lowercase();
+    (!normalized.is_empty()).then_some(normalized)
+}
+
+pub fn usage_for_surface(surface: CommandSurface) -> Vec<&'static str> {
+    commands_for_surface(surface)
+        .map(|spec| spec.usage)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn command_lookup_accepts_slash_alias_and_bot_suffix() {
+        assert_eq!(
+            command_by_name("/new@zeroclaw_bot").map(|spec| spec.id),
+            Some(BuiltinCommandId::New)
+        );
+        assert_eq!(
+            command_by_name("new-session").map(|spec| spec.id),
+            Some(BuiltinCommandId::New)
+        );
+        assert_eq!(
+            command_by_name("/think").map(|spec| spec.id),
+            Some(BuiltinCommandId::Thinking)
+        );
+    }
+
+    #[test]
+    fn surface_filter_rejects_unavailable_commands() {
+        assert!(parse_command_token("/config", CommandSurface::Channel).is_some());
+        assert!(parse_command_token("/config", CommandSurface::Web).is_none());
+        assert!(parse_command_token("/attach", CommandSurface::Tui).is_none());
+        assert!(parse_command_token("/attach", CommandSurface::Channel).is_none());
+    }
+
+    #[test]
+    fn goal_is_advertised_only_where_admission_is_implemented() {
+        assert!(parse_command_token("/goal", CommandSurface::Web).is_none());
+        assert!(parse_command_token("/goal", CommandSurface::Tui).is_none());
+        assert!(parse_command_token("/goal", CommandSurface::Channel).is_some());
+        let goal = command_by_name("/goal").expect("goal command should be registered");
+        assert!(
+            goal.usage.contains("start <objective>"),
+            "goal command usage must advertise the required start objective"
+        );
+        assert!(
+            goal.usage.contains("objective <objective>"),
+            "goal command usage must advertise objective amendment syntax"
+        );
+    }
+}

--- a/docs/architecture/decisions/ADR-008-goal-mode-control-plane-and-usage-accounting.md
+++ b/docs/architecture/decisions/ADR-008-goal-mode-control-plane-and-usage-accounting.md
@@ -1,0 +1,106 @@
+---
+id: ADR-008
+title: Anchor goal mode in the durable task control plane
+date: 2026-06-25
+status: accepted
+relates-to:
+  - https://github.com/zeroclaw-labs/zeroclaw/issues/8303
+  - https://github.com/zeroclaw-labs/zeroclaw/issues/7929
+  - https://github.com/zeroclaw-labs/zeroclaw/pull/8217
+  - crates/zeroclaw-runtime
+  - crates/zeroclaw-config
+  - crates/zeroclaw-tools
+---
+
+# ADR-008: Anchor goal mode in the durable task control plane
+
+## Context
+
+Goal mode changes an agent interaction from a single response into autonomous
+work against a user objective. A goal can outlive the inbound message that
+started it, pause while waiting for input or an external dependency, recover
+after daemon restart, and spend model usage across multiple worker, verifier,
+or delegated calls.
+
+That kind of work needs one durable authority for its lifecycle. The system must
+be able to answer which work is alive, which work is eligible to run another
+turn, which work is paused, which work is terminal, and which actor or route is
+allowed to resume or cancel it. A prompt convention or side registry would make
+those answers dependent on duplicated state.
+
+Budget accounting adds another source-of-truth constraint. Tokens and cost are
+facts produced by model-provider calls. Remaining budget is derived from a
+limit and consumed usage; storing it as its own mutable counter would create a
+second accounting system.
+
+Goal mode also crosses a trust boundary. A slash command and a model-generated
+request can both express that a goal should start, but neither should be able to
+self-authorize trusted runtime facts such as caller identity, route, channel, or
+agent eligibility.
+
+The main options considered were ordinary multi-turn chat with prompt guidance,
+a separate goal subsystem, or anchoring goal mode in the existing durable task
+control plane with goal-specific extension state.
+
+## Decision
+
+We will anchor goal mode in the durable task control plane instead of building a
+parallel goal task system.
+
+The task control plane is the source of truth for goal lifecycle, ownership,
+route, principal, parent relation, and recovery eligibility. Goal-specific state
+may extend task records, but it must not duplicate lifecycle, identity, route,
+timestamp, delivery, or terminal-state facts owned by the task record.
+
+Consumed model usage remains owned by the canonical usage ledger. Goal budgets
+are limits interpreted against usage records; remaining budget is always
+derived, never stored as a second mutable total.
+
+Pause, resume, cancellation, restart recovery, and completion are control-plane
+policy decisions. Prompt text can explain or request those transitions, but it
+does not authorize them.
+
+All goal entry paths use one trusted Rust-side admission gate. Runtime context
+supplies trusted facts such as surface, channel, principal, route, and agent
+eligibility; model-supplied arguments cannot declare those facts.
+
+Goal completion requires an explicit completion decision by the goal controller.
+Silence, lack of further tool calls, or a final-looking assistant message is not
+enough to mark durable autonomous work complete.
+
+## Consequences
+
+Goal mode inherits the existing supervised task lifecycle instead of adding a
+second task registry. This keeps restart recovery, cancellation, and future
+supervision improvements attached to one control-plane contract.
+
+The control plane becomes responsible for distinguishing paused but resumable
+goal work from terminal, lost, or still-running work. That increases the
+importance of precise task status transitions and restart recovery policy.
+
+Budget enforcement becomes auditable because consumed usage is derived from
+canonical usage records. It also means goal mode cannot be correct until every
+model call that can spend against a goal reports usage with goal attribution.
+
+Delegation and background work must respect the same lifecycle and usage
+boundaries. Work that cannot report completion and usage back to the owning goal
+cannot safely participate in goal mode.
+
+A single trusted admission gate prevents command and model-initiated entry paths
+from becoming separate authorization systems. The cost is that every supported
+surface must route goal entry through the shared command/admission machinery.
+
+Detailed implementation choices, including command syntax, pause reason
+inventory, payload shapes, verifier configuration, and rollout staging, are left
+to implementation plans and follow-up PRs. They must remain consistent with this
+ADR's source-of-truth boundaries.
+
+## References
+
+- RFC #8303: <https://github.com/zeroclaw-labs/zeroclaw/issues/8303>
+- Shared command-catalogue RFC #7929: <https://github.com/zeroclaw-labs/zeroclaw/issues/7929>
+- Durable task control plane PR #8217: <https://github.com/zeroclaw-labs/zeroclaw/pull/8217>
+- Control-plane commit: <https://github.com/zeroclaw-labs/zeroclaw/commit/607d69ef44dca07e2605e822db13fb437b462f4a>
+- Gateway ask-user/free-form gap #7776: <https://github.com/zeroclaw-labs/zeroclaw/issues/7776>
+- Cached token and cost accounting #7248: <https://github.com/zeroclaw-labs/zeroclaw/issues/7248>
+- Command localization gap #6548: <https://github.com/zeroclaw-labs/zeroclaw/issues/6548>


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Adds `zeroclaw-commands`, a shared metadata crate for built-in command identity, surfaces, usage strings, aliases, and execution ownership.
  - Registers the new crate as a workspace member and workspace dependency.
  - Keeps this slice metadata-only: it does not wire command execution, Telegram command registration, addressed-command stripping, or `/goal` channel admission.
  - Defers the addressed-command helper to the later channel admission PR because publishing it unwired emits `dead_code` warnings, while wiring it now would change channel ingress before trusted `/goal` admission exists.
- **Scope boundary:**
  - Does not add storage, budgets, controller behavior, model-callable tools, config, localization, Telegram command advertising, Matrix mention stripping, or channel `/goal` handling.
  - Does not close or supersede PR #8393 by itself; this is the second split-stack PR tracked by #8681.
- **Blast radius:** New Rust metadata crate plus workspace manifest/lockfile wiring. No runtime behavior consumes the crate in this PR.
- **Linked issue(s):**
  - Depends on PR #8682: https://github.com/zeroclaw-labs/zeroclaw/pull/8682
  - Related #7929: https://github.com/zeroclaw-labs/zeroclaw/issues/7929
  - Related #8303: https://github.com/zeroclaw-labs/zeroclaw/issues/8303
  - Tracks #8681: https://github.com/zeroclaw-labs/zeroclaw/issues/8681
  - Split from PR #8393: https://github.com/zeroclaw-labs/zeroclaw/pull/8393
- **Labels:** `docs`, `dependencies`, `enhancement`, `rust`, `risk:medium`, `size:M`.

## Validation Evidence (required)

- **Commands run and tail output:**

```text
$ cargo test -p zeroclaw-commands
running 3 tests
test tests::command_lookup_accepts_slash_alias_and_bot_suffix ... ok
test tests::surface_filter_rejects_unavailable_commands ... ok
test tests::goal_is_advertised_only_where_admission_is_implemented ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

Doc-tests zeroclaw_commands

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

```text
$ cargo fmt --all -- --check
```

No output; command exited successfully.

```text
$ cargo clippy -p zeroclaw-commands --all-targets -- -D warnings
    Checking zeroclaw-commands v0.8.2
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.19s
```

```text
$ git hash-object crates/zeroclaw-commands/src/lib.rs crates/zeroclaw-commands/Cargo.toml
f51bd497a7272c8ded964d352a2ea00e27746384
5da12faa9053eaeefc03da87d7296203ec1e054a

$ git rev-parse 75b95a1f8:crates/zeroclaw-commands/src/lib.rs 75b95a1f8:crates/zeroclaw-commands/Cargo.toml
f51bd497a7272c8ded964d352a2ea00e27746384
5da12faa9053eaeefc03da87d7296203ec1e054a
```

- **Beyond CI — what did you manually verify?**
  - Confirmed the command crate files match the local `feat/goal-mode` baseline blobs exactly.
  - Confirmed the initial addressed-command helper extraction passed its focused tests but produced four `dead_code` warnings when left unwired, so it was intentionally moved to the later channel admission slice.
- **If any command was intentionally skipped, why:**
  - Full workspace tests were skipped because this slice adds an isolated metadata crate and the split-stack plan calls for focused validation per code PR plus final full-stack validation.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: `N/A`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No upgrade steps. This PR adds metadata only and no runtime consumer.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <merge-commit>`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Build failure involving the `zeroclaw-commands` workspace member or dependency resolution.
