### PR TITLE
feat(runtime): add goal task storage foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13226,6 +13226,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeroclaw-commands"
+version = "0.8.2"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "zeroclaw-config"
 version = "0.8.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "crates/zeroclaw-api", "crates/zeroclaw-infra", "crates/zeroclaw-config", "crates/zeroclaw-log", "crates/zeroclaw-spawn", "crates/zeroclaw-providers", "crates/zeroclaw-memory", "crates/zeroclaw-channels", "crates/zeroclaw-tools", "crates/zeroclaw-runtime", "crates/zeroclaw-eval", "apps/zerocode", "crates/zeroclaw-plugins", "crates/zeroclaw-gateway", "crates/zeroclaw-hardware", "crates/zeroclaw-tool-call-parser", "crates/robot-kit", "crates/aardvark-sys", "crates/zeroclaw-macros", "apps/tauri", "tools/fill-translations", "xtask"]
+members = [".", "crates/zeroclaw-api", "crates/zeroclaw-infra", "crates/zeroclaw-config", "crates/zeroclaw-log", "crates/zeroclaw-spawn", "crates/zeroclaw-commands", "crates/zeroclaw-providers", "crates/zeroclaw-memory", "crates/zeroclaw-channels", "crates/zeroclaw-tools", "crates/zeroclaw-runtime", "crates/zeroclaw-eval", "apps/zerocode", "crates/zeroclaw-plugins", "crates/zeroclaw-gateway", "crates/zeroclaw-hardware", "crates/zeroclaw-tool-call-parser", "crates/robot-kit", "crates/aardvark-sys", "crates/zeroclaw-macros", "apps/tauri", "tools/fill-translations", "xtask"]
 resolver = "2"
 
 [workspace.package]
@@ -15,6 +15,7 @@ zeroclaw-infra = { path = "crates/zeroclaw-infra", version = "0.8.2" }
 zeroclaw-config = { path = "crates/zeroclaw-config", version = "0.8.2", default-features = false }
 zeroclaw-log = { path = "crates/zeroclaw-log", version = "0.8.2" }
 zeroclaw-spawn = { path = "crates/zeroclaw-spawn", version = "0.8.2" }
+zeroclaw-commands = { path = "crates/zeroclaw-commands", version = "0.8.2" }
 zeroclaw-providers = { path = "crates/zeroclaw-providers", version = "0.8.2" }
 zeroclaw-memory = { path = "crates/zeroclaw-memory", version = "0.8.2" }
 zeroclaw-channels = { path = "crates/zeroclaw-channels", version = "0.8.2", default-features = false }

--- a/crates/zeroclaw-commands/Cargo.toml
+++ b/crates/zeroclaw-commands/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "zeroclaw-commands"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Shared built-in slash command catalogue for ZeroClaw surfaces."
+publish = false
+
+[dependencies]
+serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/crates/zeroclaw-commands/src/lib.rs
+++ b/crates/zeroclaw-commands/src/lib.rs
@@ -1,0 +1,286 @@
+//! Shared built-in channel slash command catalogue.
+//!
+//! This crate is the source of truth for built-in command metadata that is
+//! accepted or advertised by channel runtimes. Web and TUI command discovery are
+//! intentionally not represented here until those clients consume a generated or
+//! RPC-backed catalogue; keeping local client command lists out of this crate
+//! avoids pretending duplicated metadata is shared state.
+
+use serde::Serialize;
+
+/// User-facing surface where a command can be advertised or accepted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CommandSurface {
+    /// Command is available from the local CLI.
+    Cli,
+    /// Command is available from the Web UI/API surface.
+    Web,
+    /// Command is available from the terminal UI.
+    Tui,
+    /// Command is available from message-channel ingress.
+    Channel,
+}
+
+/// Stable built-in command identity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BuiltinCommandId {
+    /// Show runtime command help.
+    Help,
+    /// Clear local conversation history.
+    Clear,
+    /// Start a fresh conversation/session.
+    New,
+    /// Stop current work where the owning surface supports it.
+    Stop,
+    /// Show or change the selected model.
+    Model,
+    /// List configured/known models.
+    Models,
+    /// Show runtime config visible to the surface.
+    Config,
+    /// Show or change model thinking/reasoning effort.
+    Thinking,
+    /// Manage durable goal-mode work.
+    Goal,
+}
+
+/// Where command execution is owned today.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CommandExecution {
+    /// The client surface handles the command without runtime admission.
+    ClientLocal,
+    /// The channel/runtime command handler owns the command.
+    RuntimeCommand,
+    /// The durable goal controller/admission path owns the command.
+    GoalAdmission,
+}
+
+/// Built-in command metadata.
+///
+/// This is descriptive catalogue state, not an execution dispatcher. Command
+/// handlers still parse their own arguments so the catalogue does not become a
+/// second copy of runtime policy or command semantics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct CommandSpec {
+    /// Stable id for code that should not branch on display text.
+    pub id: BuiltinCommandId,
+    /// Canonical slash command name without the leading slash.
+    pub name: &'static str,
+    /// Additional names accepted by the same handler.
+    pub aliases: &'static [&'static str],
+    /// Human-readable usage shape shown in help.
+    pub usage: &'static str,
+    /// Fluent key for the localized command description.
+    pub description_key: &'static str,
+    /// Surfaces where this command may be advertised or accepted.
+    pub surfaces: &'static [CommandSurface],
+    /// Current owner of command execution.
+    pub execution: CommandExecution,
+}
+
+impl CommandSpec {
+    pub fn supports(self, surface: CommandSurface) -> bool {
+        self.surfaces.contains(&surface)
+    }
+
+    pub fn token_matches(self, token: &str) -> bool {
+        self.name == token || self.aliases.contains(&token)
+    }
+}
+
+impl CommandSurface {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Cli => "cli",
+            Self::Web => "web",
+            Self::Tui => "tui",
+            Self::Channel => "channel",
+        }
+    }
+}
+
+/// Parsed command token before surface-specific argument handling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ParsedCommandToken {
+    /// Catalogue entry matched by the leading slash token.
+    pub command: CommandSpec,
+}
+
+const CHANNEL_ONLY: &[CommandSurface] = &[CommandSurface::Channel];
+
+static BUILTIN_COMMANDS: &[CommandSpec] = &[
+    CommandSpec {
+        id: BuiltinCommandId::Help,
+        name: "help",
+        aliases: &[],
+        usage: "/help",
+        description_key: "command-help-description",
+        surfaces: CHANNEL_ONLY,
+        execution: CommandExecution::ClientLocal,
+    },
+    CommandSpec {
+        id: BuiltinCommandId::Clear,
+        name: "clear",
+        aliases: &[],
+        usage: "/clear",
+        description_key: "command-clear-description",
+        surfaces: CHANNEL_ONLY,
+        execution: CommandExecution::RuntimeCommand,
+    },
+    CommandSpec {
+        id: BuiltinCommandId::New,
+        name: "new",
+        aliases: &["new-session"],
+        usage: "/new",
+        description_key: "command-new-description",
+        surfaces: CHANNEL_ONLY,
+        execution: CommandExecution::RuntimeCommand,
+    },
+    CommandSpec {
+        id: BuiltinCommandId::Stop,
+        name: "stop",
+        aliases: &[],
+        usage: "/stop",
+        description_key: "command-stop-description",
+        surfaces: CHANNEL_ONLY,
+        execution: CommandExecution::RuntimeCommand,
+    },
+    CommandSpec {
+        id: BuiltinCommandId::Model,
+        name: "model",
+        aliases: &[],
+        usage: "/model [--user|--agent] [model]",
+        description_key: "command-model-description",
+        surfaces: CHANNEL_ONLY,
+        execution: CommandExecution::RuntimeCommand,
+    },
+    CommandSpec {
+        id: BuiltinCommandId::Models,
+        name: "models",
+        aliases: &[],
+        usage: "/models [provider]",
+        description_key: "command-models-description",
+        surfaces: CHANNEL_ONLY,
+        execution: CommandExecution::RuntimeCommand,
+    },
+    CommandSpec {
+        id: BuiltinCommandId::Config,
+        name: "config",
+        aliases: &[],
+        usage: "/config",
+        description_key: "command-config-description",
+        surfaces: CHANNEL_ONLY,
+        execution: CommandExecution::RuntimeCommand,
+    },
+    CommandSpec {
+        id: BuiltinCommandId::Thinking,
+        name: "thinking",
+        aliases: &["think"],
+        usage: "/thinking [off|low|medium|high|max|reset]",
+        description_key: "command-thinking-description",
+        surfaces: CHANNEL_ONLY,
+        execution: CommandExecution::RuntimeCommand,
+    },
+    CommandSpec {
+        id: BuiltinCommandId::Goal,
+        name: "goal",
+        aliases: &[],
+        usage: "/goal <start <objective>|objective <objective>|status|budget|pause|resume [reason]|cancel|help> ...",
+        description_key: "command-goal-description",
+        surfaces: CHANNEL_ONLY,
+        execution: CommandExecution::GoalAdmission,
+    },
+];
+
+pub fn builtin_commands() -> &'static [CommandSpec] {
+    BUILTIN_COMMANDS
+}
+
+pub fn commands_for_surface(
+    surface: CommandSurface,
+) -> impl Iterator<Item = CommandSpec> + 'static {
+    BUILTIN_COMMANDS
+        .iter()
+        .copied()
+        .filter(move |spec| spec.supports(surface))
+}
+
+pub fn command_by_name(name: &str) -> Option<CommandSpec> {
+    let normalized = normalize_command_name(name)?;
+    BUILTIN_COMMANDS
+        .iter()
+        .copied()
+        .find(|spec| spec.token_matches(&normalized))
+}
+
+pub fn parse_command_token(token: &str, surface: CommandSurface) -> Option<ParsedCommandToken> {
+    let command = command_by_name(token)?;
+    command
+        .supports(surface)
+        .then_some(ParsedCommandToken { command })
+}
+
+pub fn normalize_command_name(token: &str) -> Option<String> {
+    let trimmed = token.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let without_slash = trimmed.strip_prefix('/').unwrap_or(trimmed);
+    let without_bot_suffix = without_slash.split('@').next().unwrap_or(without_slash);
+    let normalized = without_bot_suffix.trim().to_ascii_lowercase();
+    (!normalized.is_empty()).then_some(normalized)
+}
+
+pub fn usage_for_surface(surface: CommandSurface) -> Vec<&'static str> {
+    commands_for_surface(surface)
+        .map(|spec| spec.usage)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn command_lookup_accepts_slash_alias_and_bot_suffix() {
+        assert_eq!(
+            command_by_name("/new@zeroclaw_bot").map(|spec| spec.id),
+            Some(BuiltinCommandId::New)
+        );
+        assert_eq!(
+            command_by_name("new-session").map(|spec| spec.id),
+            Some(BuiltinCommandId::New)
+        );
+        assert_eq!(
+            command_by_name("/think").map(|spec| spec.id),
+            Some(BuiltinCommandId::Thinking)
+        );
+    }
+
+    #[test]
+    fn surface_filter_rejects_unavailable_commands() {
+        assert!(parse_command_token("/config", CommandSurface::Channel).is_some());
+        assert!(parse_command_token("/config", CommandSurface::Web).is_none());
+        assert!(parse_command_token("/attach", CommandSurface::Tui).is_none());
+        assert!(parse_command_token("/attach", CommandSurface::Channel).is_none());
+    }
+
+    #[test]
+    fn goal_is_advertised_only_where_admission_is_implemented() {
+        assert!(parse_command_token("/goal", CommandSurface::Web).is_none());
+        assert!(parse_command_token("/goal", CommandSurface::Tui).is_none());
+        assert!(parse_command_token("/goal", CommandSurface::Channel).is_some());
+        let goal = command_by_name("/goal").expect("goal command should be registered");
+        assert!(
+            goal.usage.contains("start <objective>"),
+            "goal command usage must advertise the required start objective"
+        );
+        assert!(
+            goal.usage.contains("objective <objective>"),
+            "goal command usage must advertise objective amendment syntax"
+        );
+    }
+}

--- a/crates/zeroclaw-runtime/src/control_plane/goal_task.rs
+++ b/crates/zeroclaw-runtime/src/control_plane/goal_task.rs
@@ -1,0 +1,461 @@
+//! Goal-specific task extensions for the durable control plane.
+//!
+//! Goal mode is represented as [`TaskKind::Goal`](super::TaskKind::Goal) in
+//! the canonical task table. This module owns only the goal extension record,
+//! continuation context, and goal-oriented repository operations layered on top
+//! of that generic task record.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use super::task_registry::{TaskRecord, TaskStatus};
+
+/// Goal-specific extension record keyed by the canonical task id.
+///
+/// Lifecycle, ownership, route, principal, timestamps, and terminal state stay on
+/// [`TaskRecord`]. This record owns only goal-specific state that has no meaning
+/// for delegates/subagents. In source-of-truth terms: this is the authoritative
+/// row for the objective, effective limits, and goal pause details; it is not a
+/// copy of the generic task row.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct GoalTaskRecord {
+    /// Foreign key to the canonical [`TaskRecord`].
+    pub task_id: String,
+    /// Operator/model-supplied objective text. Treated as prompt input, not as
+    /// trusted policy data.
+    pub objective: String,
+    /// Effective token limit for this goal after config defaults and command
+    /// overrides have been resolved.
+    ///
+    /// This is persisted because later config edits must not rewrite a goal's
+    /// already-admitted policy. Consumed and remaining tokens stay derived from
+    /// the cost ledger.
+    #[serde(default)]
+    pub effective_token_limit: Option<u64>,
+    /// Effective USD limit for this goal after config defaults and command
+    /// overrides have been resolved.
+    ///
+    /// This is the admitted limit, not a usage counter. Actual spend is derived
+    /// from canonical cost records.
+    #[serde(default)]
+    pub effective_cost_limit_usd: Option<f64>,
+    /// Controller-readable reason the goal is paused.
+    ///
+    /// This explains a canonical [`TaskStatus::Paused`] state, but does not
+    /// replace it. Terminal lifecycle state remains on the canonical task row.
+    #[serde(default)]
+    pub pause_reason: Option<GoalPauseReason>,
+    /// Human-facing pause summary. Policy must branch on `pause_reason` and
+    /// `blockers`, not by parsing this text.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pause_description: Option<String>,
+    /// Structured blockers that explain what must change before continuation.
+    ///
+    /// The blocker list is the durable machine-readable resume surface for
+    /// goal-specific pauses.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub blockers: Vec<GoalBlocker>,
+}
+
+/// Per-call view of a canonical task plus its goal extension.
+///
+/// This is deliberately not stored or cached. Lifecycle, routing, ownership,
+/// timestamps, and terminal state remain canonical on [`TaskRecord`];
+/// goal-only state remains canonical on [`GoalTaskRecord`]. The view exists so
+/// controller code can pass one coherent domain object instead of repeatedly
+/// pairing unrelated-looking values.
+#[derive(Debug, Clone)]
+pub struct TaskGoal {
+    /// Canonical task row: lifecycle, ownership, route, principal, timestamps.
+    task: TaskRecord,
+    /// Goal extension row: objective, effective limits, pause/blocker detail.
+    goal: GoalTaskRecord,
+}
+
+impl TaskGoal {
+    /// Build an on-demand goal view from its canonical task row and goal
+    /// extension row.
+    pub fn new(task: TaskRecord, goal: GoalTaskRecord) -> Self {
+        Self { task, goal }
+    }
+
+    /// Borrow the canonical task row.
+    pub fn task(&self) -> &TaskRecord {
+        &self.task
+    }
+
+    /// Borrow the goal extension row.
+    pub fn goal(&self) -> &GoalTaskRecord {
+        &self.goal
+    }
+
+    /// Canonical task id for this goal.
+    pub fn task_id(&self) -> &str {
+        &self.task.id
+    }
+
+    /// Agent alias that owns this goal.
+    pub fn agent(&self) -> &str {
+        &self.task.agent
+    }
+
+    /// Canonical lifecycle state for this goal task.
+    pub fn status(&self) -> TaskStatus {
+        self.task.status
+    }
+
+    /// True when the canonical task status is `Running`.
+    pub fn is_running(&self) -> bool {
+        self.status() == TaskStatus::Running
+    }
+
+    /// True when the canonical task status is terminal.
+    pub fn is_terminal(&self) -> bool {
+        self.status().is_terminal()
+    }
+
+    /// Untrusted objective text from the goal extension.
+    pub fn objective(&self) -> &str {
+        &self.goal.objective
+    }
+
+    /// Return a per-call view with updated effective budget limits.
+    ///
+    /// This does not persist anything. The caller must first commit the limit
+    /// update through [`GoalTaskRegistry::update_goal_limits`], then use this
+    /// helper to keep the controller's in-memory task/goal pair coherent for
+    /// the rest of the admission decision.
+    pub fn with_effective_limits(
+        mut self,
+        token_limit: Option<u64>,
+        cost_limit_usd: Option<f64>,
+    ) -> Self {
+        self.goal.effective_token_limit = token_limit;
+        self.goal.effective_cost_limit_usd = cost_limit_usd;
+        self
+    }
+
+    /// Consume the view and return only the canonical task row.
+    ///
+    /// Use this after goal-extension facts have already been folded into the
+    /// controller decision. Mutations that move both lifecycle and pause state
+    /// must still go through [`GoalTaskRegistry`] transaction methods.
+    pub fn into_task(self) -> TaskRecord {
+        self.task
+    }
+
+    /// Consume the view and return both canonical rows.
+    pub fn into_parts(self) -> (TaskRecord, GoalTaskRecord) {
+        (self.task, self.goal)
+    }
+}
+
+/// Typed policy input for why a goal is paused.
+///
+/// A pause reason is goal-specific explanation layered on top of
+/// [`TaskStatus::Paused`]. It must not be used as a second lifecycle enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GoalPauseReason {
+    /// An operator explicitly paused the goal through the control plane.
+    OperatorPaused,
+    /// The agent needs an operator answer before it can continue.
+    NeedsUserInput,
+    /// The agent escalated work to a human.
+    HumanEscalation,
+    /// A non-human dependency outside ZeroClaw is blocking progress.
+    ExternalDependency,
+    /// The selected provider or provider configuration is unavailable.
+    ProviderUnavailable,
+    /// The verifier could not produce a usable decision.
+    VerifierBlocked,
+    /// Goal-attributed usage reached an effective limit.
+    BudgetExhausted,
+    /// An effective limit exists but canonical usage records are unavailable.
+    BudgetUnavailable,
+    /// The daemon stopped before the goal could finish and restart recovery
+    /// chose not to auto-continue it.
+    #[serde(rename = "daemon_restarted", alias = "daemon_restart")]
+    DaemonRestart,
+}
+
+/// Structured blocker packet attached to a paused goal.
+///
+/// Free-form text is only explanatory. Policy branches on `kind` and payload.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GoalBlocker {
+    /// Machine-readable blocker class used for policy and resume routing.
+    pub kind: GoalBlockerKind,
+    /// Human-readable explanation of the blocker.
+    pub message: String,
+    /// Optional structured detail supplied by the tool/controller that created
+    /// the blocker.
+    ///
+    /// This is durable goal-control metadata, not a generic event log. Consumers
+    /// must treat embedded user/model text as untrusted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub payload: Option<Value>,
+}
+
+/// Coarse class of a blocker attached to a paused goal.
+///
+/// This is intentionally separate from [`GoalPauseReason`]: a pause has one
+/// primary reason, while the blocker list can contain several actionable items.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GoalBlockerKind {
+    /// Waiting for an operator to resume an explicitly paused goal.
+    OperatorPause,
+    /// Waiting for an operator answer.
+    NeedsUserInput,
+    /// Waiting for human escalation handling.
+    HumanEscalation,
+    /// Waiting on an external system or dependency.
+    ExternalDependency,
+    /// Provider configuration or availability problem.
+    Provider,
+    /// Verifier outage or refusal to decide.
+    Verifier,
+    /// Effective budget limit or usage-ledger availability problem.
+    Budget,
+    /// Restart recovery state that needs continuation or operator action.
+    RestartRecovery,
+}
+
+/// Complete pause extension to persist on a goal task.
+///
+/// The canonical task row says only that the task is paused. This structure
+/// carries the goal-specific reason and actionable blockers needed for status,
+/// resume, and recovery behavior.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GoalPauseState {
+    /// Primary pause reason for controller policy.
+    pub reason: GoalPauseReason,
+    /// Optional human-visible summary.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Actionable blockers associated with the pause.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub blockers: Vec<GoalBlocker>,
+}
+
+/// Persisted channel scope needed to synthesize trusted goal continuation turns.
+///
+/// This is intentionally narrower than `ChannelMessage`: it owns only delivery
+/// and history-routing facts that cannot be reconstructed from
+/// [`TaskRecord::originator_route`]. User text, attachments, and other
+/// transient message data stay out of the durable control plane. The same
+/// scope is reused for `/goal resume`, budget-triggered continuation, and
+/// daemon-restart recovery so those paths do not invent separate delivery
+/// state.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TaskContinuationContext {
+    /// Channel family that should receive the continuation turn.
+    pub channel: String,
+    /// Configured channel alias when multiple bots share the same channel
+    /// family.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub channel_alias: Option<String>,
+    /// Channel-native target used for replies or room/channel sends.
+    pub reply_target: String,
+    /// Original sender identity for history scope and user-visible routing.
+    pub sender: String,
+    /// Channel-native thread/topic id when the transport supports one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thread_ts: Option<String>,
+    /// Optional debouncer/interruption scope id to keep continuation ordering
+    /// consistent with live channel turns.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub interruption_scope_id: Option<String>,
+    /// Conversation history scope to hydrate before injecting the continuation
+    /// prompt.
+    pub conversation_scope: TaskContinuationConversationScope,
+}
+
+/// Durable representation of the channel history scope for a continuation
+/// prompt. Kept local to the control plane so the store does not depend on
+/// channel transport structs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskContinuationConversationScope {
+    /// Continue in the same sender-scoped history used by direct chats.
+    Sender,
+    /// Continue in the same reply-target scoped history used by shared rooms or
+    /// channels.
+    ReplyTarget,
+}
+
+/// Repository operations for the goal extension table.
+///
+/// Implementations should store goal-specific rows beside, not inside, the
+/// canonical [`TaskRecord`]. `create_goal` exists only to preserve the atomic
+/// transaction boundary between the generic task row and its goal extension.
+#[async_trait::async_trait]
+pub trait GoalTaskRegistry: Send + Sync {
+    /// Atomically insert the canonical task row and its goal extension row.
+    ///
+    /// The caller supplies both records because they are different sources of
+    /// truth: [`TaskRecord`] owns lifecycle/routing/ownership, while
+    /// [`GoalTaskRecord`] owns objective/limits/pause details. Implementations
+    /// must reject mismatched ids or non-goal task kinds rather than repairing
+    /// them silently.
+    async fn create_goal(
+        &self,
+        task: TaskRecord,
+        goal: GoalTaskRecord,
+        continuation_context: Option<TaskContinuationContext>,
+    ) -> anyhow::Result<()>;
+
+    /// Resolve the latest non-terminal goal task for `agent` directly from the
+    /// canonical task table. This is a read-only resolver, not cached state.
+    async fn latest_active_goal_for_agent(&self, agent: &str)
+    -> anyhow::Result<Option<TaskRecord>>;
+
+    /// Resolve the latest non-terminal goal for the trusted runtime context.
+    ///
+    /// Route and principal filters are matched against canonical `TaskRecord`
+    /// fields when present. Callers that have no route/principal context pass
+    /// `None` and intentionally fall back to agent-scoped resolution.
+    async fn latest_active_goal_for_context(
+        &self,
+        agent: &str,
+        originator_route: Option<&str>,
+        principal_id: Option<&str>,
+    ) -> anyhow::Result<Option<TaskRecord>>;
+
+    /// Resolve only the id of the latest non-terminal goal for the trusted
+    /// runtime context. This is a read-only projection from `tasks.id`, used
+    /// by hot attribution paths that do not need the full task record.
+    async fn latest_active_goal_id_for_context(
+        &self,
+        agent: &str,
+        originator_route: Option<&str>,
+        principal_id: Option<&str>,
+    ) -> anyhow::Result<Option<String>>;
+
+    /// Load the goal extension row for a canonical task id.
+    ///
+    /// Absence means either the task is not a goal or the extension row is
+    /// missing. Callers that require lifecycle state must pair this with a
+    /// fresh canonical [`TaskRecord`] read; the extension row alone is not a
+    /// complete lifecycle view.
+    async fn get_goal_task(&self, task_id: &str) -> anyhow::Result<Option<GoalTaskRecord>>;
+
+    /// Replace the canonical objective text for a goal.
+    ///
+    /// Objective text is goal-specific untrusted prompt input, so it belongs on
+    /// the goal extension row rather than the generic task row. Callers must
+    /// resolve lifecycle and visibility from the canonical [`TaskRecord`]
+    /// before invoking this mutation; the store only owns the extension write.
+    async fn update_goal_objective(&self, task_id: &str, objective: &str) -> anyhow::Result<()>;
+
+    /// Replace the persisted effective budget limits for a goal.
+    ///
+    /// These are creation/update-time policy limits only. Consumed and
+    /// remaining usage stay derived from canonical usage ledger rows.
+    async fn update_goal_limits(
+        &self,
+        task_id: &str,
+        token_limit: Option<u64>,
+        cost_limit_usd: Option<f64>,
+    ) -> anyhow::Result<()>;
+
+    /// Replace only the goal-extension pause payload.
+    ///
+    /// This is for extension-only repairs or tests that already control the
+    /// canonical lifecycle row. Runtime pause/resume paths must use
+    /// [`GoalTaskRegistry::pause_goal_task`] or
+    /// [`GoalTaskRegistry::resume_goal_task`] so `tasks.status` and
+    /// `goal_tasks` cannot diverge.
+    async fn update_goal_pause(
+        &self,
+        task_id: &str,
+        pause: Option<GoalPauseState>,
+    ) -> anyhow::Result<()>;
+
+    /// Atomically persist a goal pause and the canonical paused lifecycle state.
+    ///
+    /// This is goal-specific because the transaction spans the generic `tasks`
+    /// row and the goal extension row. `TaskRegistry` stays generic; callers use
+    /// this when the goal controller needs both source-of-truth rows to move
+    /// together.
+    async fn pause_goal_task(&self, task_id: &str, pause: GoalPauseState) -> anyhow::Result<()>;
+
+    /// Atomically clear goal pause state, claim ownership, and mark the task running.
+    ///
+    /// `continuation_context` is written only when supplied by trusted ingress.
+    /// This keeps manual resume, budget-triggered resume, and future recovery
+    /// paths from splitting lifecycle and goal-extension updates across
+    /// independent writes.
+    async fn resume_goal_task(
+        &self,
+        task_id: &str,
+        owner_pid: u32,
+        owner_boot_id: &str,
+        continuation_context: Option<TaskContinuationContext>,
+    ) -> anyhow::Result<()>;
+
+    /// Replace or clear the continuation delivery context for a task.
+    ///
+    /// The context is control-plane-owned delivery state, not lifecycle state.
+    /// It is consumed when resume, budget, or restart-recovery paths need to
+    /// enqueue a trusted continuation prompt through the channel runtime.
+    async fn set_continuation_context(
+        &self,
+        task_id: &str,
+        context: Option<TaskContinuationContext>,
+    ) -> anyhow::Result<()>;
+
+    /// Load the durable channel continuation context for a task, when present.
+    ///
+    /// The returned context is delivery metadata only. It does not authorize a
+    /// resume by itself; callers still need trusted admission/recovery context
+    /// before injecting a synthetic continuation into a channel loop.
+    async fn get_continuation_context(
+        &self,
+        task_id: &str,
+    ) -> anyhow::Result<Option<TaskContinuationContext>>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn daemon_restart_pause_reason_uses_rfc_name_with_legacy_alias() {
+        // Restart recovery is an RFC-visible persisted reason; old local rows
+        // that used the draft spelling must continue to deserialize.
+        let serialized = serde_json::to_string(&GoalPauseReason::DaemonRestart).unwrap();
+        assert_eq!(serialized, "\"daemon_restarted\"");
+
+        let legacy: GoalPauseReason = serde_json::from_str("\"daemon_restart\"").unwrap();
+        assert_eq!(legacy, GoalPauseReason::DaemonRestart);
+    }
+
+    #[test]
+    fn operator_pause_reason_roundtrips_with_control_plane_name() {
+        // `/goal pause` is a controller request, not a human escalation. Its
+        // persisted reason must stay distinguishable for status and resume
+        // policy.
+        let serialized = serde_json::to_string(&GoalPauseReason::OperatorPaused).unwrap();
+        assert_eq!(serialized, "\"operator_paused\"");
+
+        let parsed: GoalPauseReason = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(parsed, GoalPauseReason::OperatorPaused);
+    }
+
+    #[test]
+    fn goal_task_loads_without_effective_limits() {
+        let legacy = r#"{
+            "task_id": "goal-1",
+            "objective": "ship goal mode"
+        }"#;
+        let rec: GoalTaskRecord = serde_json::from_str(legacy).unwrap();
+        assert_eq!(rec.task_id, "goal-1");
+        assert!(rec.effective_token_limit.is_none());
+        assert!(rec.effective_cost_limit_usd.is_none());
+        assert!(rec.pause_reason.is_none());
+        assert!(rec.pause_description.is_none());
+        assert!(rec.blockers.is_empty());
+    }
+}

--- a/crates/zeroclaw-runtime/src/control_plane/mod.rs
+++ b/crates/zeroclaw-runtime/src/control_plane/mod.rs
@@ -5,6 +5,7 @@
 //! the megafiles (`tools/delegate.rs`, `tools/spawn_subagent.rs`, `daemon/mod.rs`)
 //! change only as thin wiring at named seams:
 //!   * [`task_registry`] — the `TaskRegistry` trait + `TaskRecord`/`TaskKind`/`TaskStatus`.
+//!   * [`goal_task`] — goal-mode extension records and repository operations.
 //!   * [`task_store_sqlite`] — the single SQLite impl, modelled on
 //!     `zeroclaw_infra::acp_session_store`.
 //!   * [`authority`] — `is_authoritative`: the runtime-authority reclaim guard.
@@ -19,6 +20,7 @@
 pub mod authority;
 pub mod boot;
 pub mod global;
+pub mod goal_task;
 pub mod reaper;
 pub mod task_registry;
 pub mod task_store_sqlite;
@@ -26,5 +28,9 @@ pub mod task_store_sqlite;
 pub use authority::is_authoritative;
 pub use boot::ControlPlaneHandle;
 pub use global::{control_plane, init_control_plane};
+pub use goal_task::{
+    GoalBlocker, GoalBlockerKind, GoalPauseReason, GoalPauseState, GoalTaskRecord,
+    GoalTaskRegistry, TaskContinuationContext, TaskContinuationConversationScope, TaskGoal,
+};
 pub use task_registry::{TaskKind, TaskRecord, TaskRegistry, TaskStatus};
 pub use task_store_sqlite::SqliteTaskStore;

--- a/crates/zeroclaw-runtime/src/control_plane/task_registry.rs
+++ b/crates/zeroclaw-runtime/src/control_plane/task_registry.rs
@@ -12,28 +12,44 @@
 
 use serde::{Deserialize, Serialize};
 
-/// Discriminates which producer registered a unit of work. EXTEND, don't fork:
-/// EPIC E adds `RemoteTurn`; EPIC B treats a paused task as a supervised *status*,
-/// not a new kind.
+/// Discriminates which producer registered a unit of work.
+///
+/// This is the task's durable domain type, not a status bucket. Goal mode, for
+/// example, is a task kind because it owns a goal extension row, while `Paused`
+/// is still just a lifecycle status on [`TaskRecord`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum TaskKind {
+    /// Background delegation task.
     Delegate,
+    /// Subagent task spawned under the runtime.
     Subagent,
+    /// Goal-mode task. Goal-specific state lives in the goal extension table;
+    /// lifecycle and route ownership still live on [`TaskRecord`].
+    Goal,
+    /// Peer inbox task.
     PeerInbox,
     // EPIC E: RemoteTurn
 }
 
-/// The task state machine. Supersedes `BackgroundTaskStatus` (delegate.rs) by
-/// ADDING the terminal-loss states a fire-and-forget task cannot write for itself.
-/// `snake_case` repr keeps on-disk JSON stable: the legacy
+/// Canonical lifecycle state for every supervised task.
+///
+/// Feature-specific extension tables may explain why a task is paused or what
+/// work it represents, but they must not duplicate terminal/lifecycle state.
+/// The `snake_case` repr keeps on-disk JSON stable: legacy
 /// `running|completed|failed|cancelled` values still parse unchanged.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum TaskStatus {
+    /// Task is currently eligible to execute or already executing.
     Running,
+    /// Task is intentionally stopped but resumable.
+    Paused,
+    /// Task finished successfully.
     Completed,
+    /// Task ended with an error.
     Failed,
+    /// Task was intentionally cancelled.
     Cancelled,
     /// Written by the reaper/recovery sweep from OUTSIDE the task body — the state
     /// today's enum literally cannot represent (task-lifecycle-supervision gap).
@@ -57,14 +73,22 @@ impl TaskStatus {
     }
 }
 
-/// The durable record. New fields are `#[serde(default)]` so pre-existing on-disk
-/// payloads load unchanged; downstream epics ADD fields here.
+/// Canonical durable task record.
+///
+/// This row is the source of truth for lifecycle, ownership, routing,
+/// principal, and parentage across all task kinds. Feature-specific modules may
+/// add extension rows keyed by `id`, but must not copy these facts into those
+/// rows. New fields are `#[serde(default)]` so pre-existing on-disk payloads
+/// load unchanged.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TaskRecord {
-    /// UUID — validated at the producer boundary (reuse `validate_task_id`).
+    /// Stable task id. Producers validate it at registration boundaries.
     pub id: String,
+    /// Durable task domain type.
     pub kind: TaskKind,
+    /// Agent alias that owns and executes this task.
     pub agent: String,
+    /// Canonical lifecycle state for the task.
     pub status: TaskStatus,
     /// OS pid of the daemon that created the task; paired with `owner_boot_id` so a
     /// recycled pid on a later boot is not mistaken for the live owner.
@@ -74,20 +98,28 @@ pub struct TaskRecord {
     /// a live same-boot task.
     #[serde(default)]
     pub owner_boot_id: String,
+    /// Optional owner heartbeat timestamp in RFC3339 form.
+    ///
+    /// Only tasks that actively heartbeat may be timed out by heartbeat age; an
+    /// absent heartbeat is not a derived runtime duration.
     #[serde(default)]
     pub heartbeat_at: Option<String>,
-    /// GOVERNOR: monotonic, persisted recursion depth.
+    /// Monotonic persisted recursion depth for delegation/subagent governors.
     #[serde(default)]
     pub depth: u32,
+    /// Parent task id for synchronous child work, when one exists.
     #[serde(default)]
     pub parent_id: Option<String>,
-    /// EPIC B threads the originator's HITL reply-target across the spawn boundary.
+    /// Trusted route/reply target that originated the task.
+    ///
+    /// Goal admission and visibility checks use this canonical route instead of
+    /// trusting model-supplied task selectors.
     #[serde(default)]
     pub originator_route: Option<String>,
-    /// EPIC C delivery evidence.
+    /// Whether user-visible completion delivery has been confirmed.
     #[serde(default)]
     pub delivered: bool,
-    /// EPIC C idempotency key.
+    /// Optional idempotency key for completion/delivery operations.
     #[serde(default)]
     pub idem_key: Option<String>,
     /// EPIC D attribution (Principal co-design `COORD-principal-contract.md` §7/R3): the
@@ -98,7 +130,9 @@ pub struct TaskRecord {
     /// It resolves to the carried `Principal.id` (never a bare principal-`None`).
     #[serde(default)]
     pub principal_id: Option<String>,
+    /// Task registration/start timestamp in RFC3339 form.
     pub started_at: String,
+    /// Terminal transition timestamp in RFC3339 form.
     #[serde(default)]
     pub finished_at: Option<String>,
 }
@@ -119,6 +153,17 @@ pub trait TaskRegistry: Send + Sync {
         output: Option<String>,
         error: Option<String>,
     ) -> anyhow::Result<()>;
+    /// Claim a resumable task for the current daemon owner.
+    ///
+    /// This updates the canonical ownership fields on [`TaskRecord`]. It does
+    /// not create a secondary ownership cache; callers use it when a durable
+    /// paused task becomes eligible to run under a new daemon boot.
+    async fn claim_owner(
+        &self,
+        id: &str,
+        owner_pid: u32,
+        owner_boot_id: &str,
+    ) -> anyhow::Result<()>;
     async fn get(&self, id: &str) -> anyhow::Result<Option<TaskRecord>>;
     async fn list_running(&self) -> anyhow::Result<Vec<TaskRecord>>;
     async fn list_by_agent(&self, agent: &str) -> anyhow::Result<Vec<TaskRecord>>;
@@ -137,6 +182,7 @@ mod tests {
         // Backward-compat: pre-EPIC-A on-disk values must deserialize unchanged.
         for (json, want) in [
             ("\"running\"", TaskStatus::Running),
+            ("\"paused\"", TaskStatus::Paused),
             ("\"completed\"", TaskStatus::Completed),
             ("\"failed\"", TaskStatus::Failed),
             ("\"cancelled\"", TaskStatus::Cancelled),
@@ -144,6 +190,14 @@ mod tests {
             let got: TaskStatus = serde_json::from_str(json).unwrap();
             assert_eq!(got, want, "legacy status {json} must parse");
         }
+    }
+
+    #[test]
+    fn goal_kind_roundtrips_snake_case() {
+        let s = serde_json::to_string(&TaskKind::Goal).unwrap();
+        assert_eq!(s, "\"goal\"");
+        let back: TaskKind = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, TaskKind::Goal);
     }
 
     #[test]
@@ -155,6 +209,11 @@ mod tests {
             assert_eq!(back, st);
             assert!(st.is_terminal());
         }
+    }
+
+    #[test]
+    fn paused_status_is_non_terminal() {
+        assert!(!TaskStatus::Paused.is_terminal());
     }
 
     #[test]

--- a/crates/zeroclaw-runtime/src/control_plane/task_store_sqlite.rs
+++ b/crates/zeroclaw-runtime/src/control_plane/task_store_sqlite.rs
@@ -18,8 +18,22 @@ use rusqlite::{Connection, OptionalExtension, params};
 use super::authority::is_authoritative;
 use super::task_registry::{TaskKind, TaskRecord, TaskRegistry, TaskStatus};
 
-/// The durable task registry. `tasks.db` lives beside the other workspace DBs.
+mod goal;
+
+const CONTROL_PLANE_SCHEMA_VERSION: i64 = 6;
+
+/// SQLite-backed durable task registry.
+///
+/// The `tasks` table in `control_plane.db` is the source of truth for generic
+/// task lifecycle, route, principal, ownership, and parentage. Goal-specific
+/// rows live in extension tables owned by `task_store_sqlite::goal`, sharing
+/// this connection so task and extension writes can be committed atomically.
 pub struct SqliteTaskStore {
+    /// Single SQLite connection protected by a synchronous mutex.
+    ///
+    /// This connection owns both the generic `tasks` table and goal extension
+    /// tables so cross-table registration can be atomic. It is not an in-memory
+    /// task cache; every query resolves from SQLite.
     conn: Mutex<Connection>,
 }
 
@@ -45,7 +59,8 @@ impl SqliteTaskStore {
             "PRAGMA journal_mode = WAL;
              PRAGMA synchronous = NORMAL;
              PRAGMA busy_timeout = 5000;
-             PRAGMA temp_store = MEMORY;",
+             PRAGMA temp_store = MEMORY;
+             PRAGMA foreign_keys = ON;",
         )
         .context("set control-plane PRAGMAs")?;
         conn.execute_batch(
@@ -69,9 +84,12 @@ impl SqliteTaskStore {
                  error           TEXT
              );
              CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status);
-             CREATE INDEX IF NOT EXISTS idx_tasks_agent  ON tasks(agent);",
+             CREATE INDEX IF NOT EXISTS idx_tasks_agent  ON tasks(agent);
+             CREATE INDEX IF NOT EXISTS idx_tasks_agent_kind_started
+                ON tasks(agent, kind, started_at DESC);",
         )
-        .context("create control-plane schema")?;
+        .context("create control-plane base schema")?;
+        migrate_schema(&conn).context("migrate control-plane schema")?;
         Ok(Self {
             conn: Mutex::new(conn),
         })
@@ -99,6 +117,46 @@ impl SqliteTaskStore {
             .context("delete tasks by agent")?;
         Ok(n as u64)
     }
+}
+
+fn migrate_schema(conn: &Connection) -> Result<()> {
+    let version: i64 = conn
+        .query_row("PRAGMA user_version", [], |row| row.get(0))
+        .context("read control-plane schema version")?;
+    goal::migrate_schema(conn, version)?;
+    if version > CONTROL_PLANE_SCHEMA_VERSION {
+        ::zeroclaw_log::record!(
+            WARN,
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(
+                ::serde_json::json!({
+                    "db_version": version,
+                    "known_version": CONTROL_PLANE_SCHEMA_VERSION,
+                })
+            ),
+            "control-plane DB was created by a newer schema version"
+        );
+    }
+    Ok(())
+}
+
+fn add_column_if_missing(
+    conn: &Connection,
+    table: &str,
+    column: &str,
+    alter_sql: &str,
+) -> Result<()> {
+    let mut stmt = conn
+        .prepare(&format!("PRAGMA table_info({table})"))
+        .with_context(|| format!("inspect {table} columns"))?;
+    let mut rows = stmt
+        .query_map([], |row| row.get::<_, String>(1))
+        .with_context(|| format!("query {table} columns"))?;
+    let exists = rows.any(|name| matches!(name, Ok(name) if name == column));
+    if !exists {
+        conn.execute_batch(alter_sql)
+            .with_context(|| format!("add {table}.{column}"))?;
+    }
+    Ok(())
 }
 
 // ── serde<->TEXT helpers (reuse the snake_case derive, no hand-kept string tables) ──
@@ -170,51 +228,106 @@ where
     for r in rows {
         match r {
             Ok(rec) => out.push(rec),
-            Err(e) => ::zeroclaw_log::record!(
-                WARN,
-                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                    .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                    .with_attrs(::serde_json::json!({ "error": format!("{e}") })),
-                "control-plane: skipping unreadable task row"
-            ),
+            Err(e) => log_unreadable_task_row(e),
         }
     }
     out
+}
+
+fn log_unreadable_task_row(error: rusqlite::Error) {
+    ::zeroclaw_log::record!(
+        WARN,
+        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+            .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+            .with_attrs(::serde_json::json!({ "error": format!("{error}") })),
+        "control-plane: skipping unreadable task row"
+    );
+}
+
+fn insert_task_record(conn: &Connection, rec: TaskRecord) -> Result<()> {
+    // ON CONFLICT DO NOTHING, NOT INSERT OR REPLACE: re-registering an existing id
+    // must be a true no-op, never clobber an already-recorded output/error/terminal
+    // status back to NULL/running (review finding #11 — the documented idempotency).
+    conn.execute(
+        "INSERT INTO tasks
+            (id, kind, agent, status, owner_pid, owner_boot_id, heartbeat_at, depth,
+             parent_id, originator_route, delivered, idem_key, principal_id,
+             started_at, finished_at)
+         VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15)
+         ON CONFLICT(id) DO NOTHING",
+        params![
+            rec.id,
+            kind_to_db(rec.kind),
+            rec.agent,
+            status_to_db(rec.status),
+            rec.owner_pid as i64,
+            rec.owner_boot_id,
+            rec.heartbeat_at,
+            rec.depth as i64,
+            rec.parent_id,
+            rec.originator_route,
+            rec.delivered as i64,
+            rec.idem_key,
+            rec.principal_id,
+            rec.started_at,
+            rec.finished_at,
+        ],
+    )
+    .context("insert task record")?;
+    Ok(())
+}
+
+fn update_task_status_record(
+    conn: &Connection,
+    id: &str,
+    status: TaskStatus,
+    output: Option<String>,
+    error: Option<String>,
+) -> Result<usize> {
+    let finished_at = status
+        .is_terminal()
+        .then(|| chrono::Utc::now().to_rfc3339());
+    // Terminal-state guard: once a task has reached ANY terminal state this is a
+    // no-op. Closes the reaper-sweep TOCTOU where a task that legitimately Completed
+    // between the reaper's snapshot and its update could be clobbered back to
+    // TimedOut (and its real finished_at lost). Mirrors reconcile_lost's
+    // `AND status='running'` discipline (review finding #2).
+    conn.execute(
+        "UPDATE tasks
+            SET status = ?1,
+                output = COALESCE(?2, output),
+                error  = COALESCE(?3, error),
+                finished_at = COALESCE(?4, finished_at)
+          WHERE id = ?5
+            AND status NOT IN ('completed','failed','cancelled','lost','timed_out')",
+        params![status_to_db(status), output, error, finished_at, id],
+    )
+    .context("update task status")
+}
+
+fn claim_task_owner_record(
+    conn: &Connection,
+    id: &str,
+    owner_pid: u32,
+    owner_boot_id: &str,
+) -> Result<usize> {
+    conn.execute(
+        "UPDATE tasks
+            SET owner_pid = ?1,
+                owner_boot_id = ?2,
+                heartbeat_at = NULL
+          WHERE id = ?3
+            AND status NOT IN ('completed','failed','cancelled','lost','timed_out')",
+        params![owner_pid as i64, owner_boot_id, id],
+    )
+    .context("claim task owner")
 }
 
 #[async_trait::async_trait]
 impl TaskRegistry for SqliteTaskStore {
     async fn create(&self, rec: TaskRecord) -> Result<()> {
         let conn = self.conn.lock();
-        // ON CONFLICT DO NOTHING, NOT INSERT OR REPLACE: re-registering an existing id
-        // must be a true no-op, never clobber an already-recorded output/error/terminal
-        // status back to NULL/running (review finding #11 — the documented idempotency).
-        conn.execute(
-            "INSERT INTO tasks
-                (id, kind, agent, status, owner_pid, owner_boot_id, heartbeat_at, depth,
-                 parent_id, originator_route, delivered, idem_key, principal_id,
-                 started_at, finished_at)
-             VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15)
-             ON CONFLICT(id) DO NOTHING",
-            params![
-                rec.id,
-                kind_to_db(rec.kind),
-                rec.agent,
-                status_to_db(rec.status),
-                rec.owner_pid as i64,
-                rec.owner_boot_id,
-                rec.heartbeat_at,
-                rec.depth as i64,
-                rec.parent_id,
-                rec.originator_route,
-                rec.delivered as i64,
-                rec.idem_key,
-                rec.principal_id,
-                rec.started_at,
-                rec.finished_at,
-            ],
-        )
-        .context("insert task record")?;
+        insert_task_record(&conn, rec)?;
         Ok(())
     }
 
@@ -239,26 +352,14 @@ impl TaskRegistry for SqliteTaskStore {
         output: Option<String>,
         error: Option<String>,
     ) -> Result<()> {
-        let finished_at = status
-            .is_terminal()
-            .then(|| chrono::Utc::now().to_rfc3339());
         let conn = self.conn.lock();
-        // Terminal-state guard: once a task has reached ANY terminal state this is a
-        // no-op. Closes the reaper-sweep TOCTOU where a task that legitimately Completed
-        // between the reaper's snapshot and its update could be clobbered back to
-        // TimedOut (and its real finished_at lost). Mirrors reconcile_lost's
-        // `AND status='running'` discipline (review finding #2).
-        conn.execute(
-            "UPDATE tasks
-                SET status = ?1,
-                    output = COALESCE(?2, output),
-                    error  = COALESCE(?3, error),
-                    finished_at = COALESCE(?4, finished_at)
-              WHERE id = ?5
-                AND status NOT IN ('completed','failed','cancelled','lost','timed_out')",
-            params![status_to_db(status), output, error, finished_at, id],
-        )
-        .context("update task status")?;
+        update_task_status_record(&conn, id, status, output, error)?;
+        Ok(())
+    }
+
+    async fn claim_owner(&self, id: &str, owner_pid: u32, owner_boot_id: &str) -> Result<()> {
+        let conn = self.conn.lock();
+        claim_task_owner_record(&conn, id, owner_pid, owner_boot_id)?;
         Ok(())
     }
 
@@ -422,5 +523,18 @@ mod tests {
         assert!(s.get("a").await.unwrap().unwrap().heartbeat_at.is_none());
         s.heartbeat("a", "boot-1").await.unwrap(); // owner: stamps
         assert!(s.get("a").await.unwrap().unwrap().heartbeat_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn claim_owner_updates_canonical_owner_fields_for_resumed_task() {
+        let s = SqliteTaskStore::new_in_memory().unwrap();
+        s.create(rec("a", "main", 1, "boot-old")).await.unwrap();
+
+        s.claim_owner("a", 42, "boot-new").await.unwrap();
+
+        let got = s.get("a").await.unwrap().unwrap();
+        assert_eq!(got.owner_pid, 42);
+        assert_eq!(got.owner_boot_id, "boot-new");
+        assert!(got.heartbeat_at.is_none());
     }
 }

--- a/crates/zeroclaw-runtime/src/control_plane/task_store_sqlite.rs
+++ b/crates/zeroclaw-runtime/src/control_plane/task_store_sqlite.rs
@@ -20,7 +20,7 @@ use super::task_registry::{TaskKind, TaskRecord, TaskRegistry, TaskStatus};
 
 mod goal;
 
-const CONTROL_PLANE_SCHEMA_VERSION: i64 = 6;
+const CONTROL_PLANE_SCHEMA_VERSION: i64 = 7;
 
 /// SQLite-backed durable task registry.
 ///

--- a/crates/zeroclaw-runtime/src/control_plane/task_store_sqlite/goal.rs
+++ b/crates/zeroclaw-runtime/src/control_plane/task_store_sqlite/goal.rs
@@ -1,0 +1,1080 @@
+//! SQLite-backed [`GoalTaskRegistry`] implementation.
+//!
+//! The concrete store remains [`SqliteTaskStore`](super::SqliteTaskStore) so
+//! goal creation can share one transaction with the canonical task row. This
+//! module only separates the goal-specific repository surface from the generic
+//! task registry implementation.
+
+use anyhow::{Context, Result};
+use rusqlite::{Connection, OptionalExtension, params};
+
+use crate::control_plane::goal_task::{
+    GoalBlocker, GoalPauseReason, GoalPauseState, GoalTaskRecord, GoalTaskRegistry,
+    TaskContinuationContext,
+};
+use crate::control_plane::task_registry::{TaskKind, TaskRecord, TaskStatus};
+
+use super::{
+    SqliteTaskStore, add_column_if_missing, claim_task_owner_record, insert_task_record,
+    log_unreadable_task_row, row_to_record, update_task_status_record,
+};
+
+/// Apply goal-extension schema migrations.
+///
+/// The root SQLite store owns the connection and generic `tasks` table. Goal
+/// extension tables, indexes, and continuation payload storage stay here with
+/// the `GoalTaskRegistry` implementation so the generic task store does not
+/// need to understand goal row serialization.
+///
+/// The database has one shared `PRAGMA user_version`, so this function still
+/// advances the control-plane schema version for goal-owned migrations. If a
+/// future generic-task migration lands, keep the version sequence coordinated
+/// from `task_store_sqlite::migrate_schema`; do not introduce a second version
+/// counter for goal tables.
+pub(super) fn migrate_schema(conn: &Connection, version: i64) -> Result<()> {
+    if version < 1 {
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS goal_tasks (
+                 task_id        TEXT PRIMARY KEY
+                                REFERENCES tasks(id) ON DELETE CASCADE,
+                 objective      TEXT NOT NULL
+             );
+             PRAGMA user_version = 1;",
+        )
+        .context("apply control-plane schema v1")?;
+    }
+    if version < 2 {
+        add_column_if_missing(
+            conn,
+            "goal_tasks",
+            "effective_token_limit",
+            "ALTER TABLE goal_tasks ADD COLUMN effective_token_limit INTEGER",
+        )?;
+        add_column_if_missing(
+            conn,
+            "goal_tasks",
+            "effective_cost_limit_usd",
+            "ALTER TABLE goal_tasks ADD COLUMN effective_cost_limit_usd REAL",
+        )?;
+        conn.execute_batch("PRAGMA user_version = 2;")
+            .context("mark control-plane schema v2")?;
+    }
+    if version < 3 {
+        add_column_if_missing(
+            conn,
+            "goal_tasks",
+            "pause_reason",
+            "ALTER TABLE goal_tasks ADD COLUMN pause_reason TEXT",
+        )?;
+        add_column_if_missing(
+            conn,
+            "goal_tasks",
+            "pause_description",
+            "ALTER TABLE goal_tasks ADD COLUMN pause_description TEXT",
+        )?;
+        add_column_if_missing(
+            conn,
+            "goal_tasks",
+            "blockers_json",
+            "ALTER TABLE goal_tasks ADD COLUMN blockers_json TEXT NOT NULL DEFAULT '[]'",
+        )?;
+        conn.execute_batch("PRAGMA user_version = 3;")
+            .context("mark control-plane schema v3")?;
+    }
+    if version < 4 {
+        conn.execute_batch(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_tasks_active_goal_context
+                ON tasks(
+                    agent,
+                    COALESCE(originator_route, ''),
+                    COALESCE(principal_id, '')
+                )
+                WHERE kind = 'goal'
+                  AND status NOT IN ('completed','failed','cancelled','lost','timed_out');
+             PRAGMA user_version = 4;",
+        )
+        .context("apply control-plane schema v4")?;
+    }
+    if version < 5 {
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS task_continuation_contexts (
+                 task_id      TEXT PRIMARY KEY
+                              REFERENCES tasks(id) ON DELETE CASCADE,
+                 context_json TEXT NOT NULL
+             );
+             PRAGMA user_version = 5;",
+        )
+        .context("apply control-plane schema v5")?;
+    }
+    if version < 6 {
+        conn.execute_batch(
+            "CREATE TRIGGER IF NOT EXISTS trg_goal_tasks_require_goal_kind
+                BEFORE INSERT ON goal_tasks
+                FOR EACH ROW
+                WHEN COALESCE((SELECT kind FROM tasks WHERE id = NEW.task_id), '') != 'goal'
+                BEGIN
+                    SELECT RAISE(ABORT, 'goal_tasks.task_id must reference TaskKind::Goal');
+                END;
+             PRAGMA user_version = 6;",
+        )
+        .context("apply control-plane schema v6")?;
+    }
+    Ok(())
+}
+
+fn ensure_goal_task_identity(task: &TaskRecord, goal: &GoalTaskRecord) -> Result<()> {
+    if task.kind != TaskKind::Goal {
+        anyhow::bail!("goal task {} must use TaskKind::Goal", task.id);
+    }
+    if task.id != goal.task_id {
+        anyhow::bail!(
+            "goal task id mismatch: TaskRecord id {} does not match GoalTaskRecord task_id {}",
+            task.id,
+            goal.task_id
+        );
+    }
+    Ok(())
+}
+
+fn pause_reason_to_db(reason: GoalPauseReason) -> Result<String> {
+    let value = serde_json::to_value(reason).context("serialize goal pause reason")?;
+    value
+        .as_str()
+        .map(str::to_owned)
+        .context("serialized goal pause reason is not a string")
+}
+
+fn pause_reason_from_db(value: Option<String>) -> Result<Option<GoalPauseReason>> {
+    value
+        .map(|value| {
+            serde_json::from_value(serde_json::Value::String(value.clone()))
+                .with_context(|| format!("unknown goal pause reason {value:?}"))
+        })
+        .transpose()
+}
+
+fn blockers_to_db(blockers: &[GoalBlocker]) -> Result<String> {
+    serde_json::to_string(blockers).context("serialize goal blockers")
+}
+
+fn blockers_from_db(value: String) -> rusqlite::Result<Vec<GoalBlocker>> {
+    serde_json::from_str(&value).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, e.into())
+    })
+}
+
+fn continuation_context_to_db(context: &TaskContinuationContext) -> Result<String> {
+    serde_json::to_string(context).context("serialize task continuation context")
+}
+
+fn continuation_context_from_db(value: String) -> rusqlite::Result<TaskContinuationContext> {
+    serde_json::from_str(&value).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, e.into())
+    })
+}
+
+fn row_to_goal_task(row: &rusqlite::Row<'_>) -> rusqlite::Result<GoalTaskRecord> {
+    let pause_reason = pause_reason_from_db(row.get("pause_reason")?).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, e.into())
+    })?;
+    Ok(GoalTaskRecord {
+        task_id: row.get("task_id")?,
+        objective: row.get("objective")?,
+        effective_token_limit: row
+            .get::<_, Option<i64>>("effective_token_limit")?
+            .map(|value| value as u64),
+        effective_cost_limit_usd: row.get("effective_cost_limit_usd")?,
+        pause_reason,
+        pause_description: row.get("pause_description")?,
+        blockers: blockers_from_db(row.get("blockers_json")?)?,
+    })
+}
+
+fn insert_goal_task_record(conn: &Connection, rec: GoalTaskRecord) -> Result<()> {
+    let pause_reason = rec.pause_reason.map(pause_reason_to_db).transpose()?;
+    let blockers_json = blockers_to_db(&rec.blockers)?;
+    conn.execute(
+        "INSERT INTO goal_tasks
+            (task_id, objective, effective_token_limit, effective_cost_limit_usd,
+             pause_reason, pause_description, blockers_json)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+         ON CONFLICT(task_id) DO NOTHING",
+        params![
+            rec.task_id,
+            rec.objective,
+            rec.effective_token_limit.map(|value| value as i64),
+            rec.effective_cost_limit_usd,
+            pause_reason,
+            rec.pause_description,
+            blockers_json,
+        ],
+    )
+    .context("insert goal task record")?;
+    Ok(())
+}
+
+fn update_goal_pause_record(
+    conn: &Connection,
+    task_id: &str,
+    pause: Option<GoalPauseState>,
+) -> Result<usize> {
+    let (reason, description, blockers_json) = match pause {
+        Some(pause) => (
+            Some(pause_reason_to_db(pause.reason)?),
+            pause.description,
+            blockers_to_db(&pause.blockers)?,
+        ),
+        None => (None, None, blockers_to_db(&[])?),
+    };
+    conn.execute(
+        "UPDATE goal_tasks
+            SET pause_reason = ?1,
+                pause_description = ?2,
+                blockers_json = ?3
+          WHERE task_id = ?4",
+        params![reason, description, blockers_json, task_id],
+    )
+    .context("update goal pause state")
+}
+
+fn ensure_goal_task_row(conn: &Connection, task_id: &str) -> Result<()> {
+    let exists = conn
+        .query_row(
+            "SELECT EXISTS(
+                 SELECT 1
+                   FROM tasks
+                   JOIN goal_tasks ON goal_tasks.task_id = tasks.id
+                  WHERE tasks.id = ?1
+                    AND tasks.kind = 'goal'
+             )",
+            params![task_id],
+            |row| row.get::<_, i64>(0),
+        )
+        .context("verify goal task row")?
+        != 0;
+    if !exists {
+        anyhow::bail!("goal task {task_id} has no canonical TaskKind::Goal row and goal extension");
+    }
+    Ok(())
+}
+
+fn upsert_continuation_context(
+    conn: &Connection,
+    task_id: &str,
+    context: &TaskContinuationContext,
+) -> Result<()> {
+    conn.execute(
+        "INSERT INTO task_continuation_contexts (task_id, context_json)
+         VALUES (?1, ?2)
+         ON CONFLICT(task_id) DO UPDATE
+             SET context_json = excluded.context_json",
+        params![task_id, continuation_context_to_db(context)?],
+    )
+    .context("upsert task continuation context")?;
+    Ok(())
+}
+
+#[async_trait::async_trait]
+impl GoalTaskRegistry for SqliteTaskStore {
+    async fn create_goal(
+        &self,
+        task: TaskRecord,
+        goal: GoalTaskRecord,
+        continuation_context: Option<TaskContinuationContext>,
+    ) -> Result<()> {
+        ensure_goal_task_identity(&task, &goal)?;
+        let mut conn = self.conn.lock();
+        let tx = conn
+            .transaction()
+            .context("start create goal transaction")?;
+        let task_id = goal.task_id.clone();
+        insert_task_record(&tx, task)?;
+        insert_goal_task_record(&tx, goal)?;
+        if let Some(context) = continuation_context {
+            upsert_continuation_context(&tx, &task_id, &context)?;
+        }
+        tx.commit().context("commit create goal transaction")?;
+        Ok(())
+    }
+
+    async fn latest_active_goal_for_agent(&self, agent: &str) -> Result<Option<TaskRecord>> {
+        let conn = self.conn.lock();
+        let mut stmt = conn
+            .prepare_cached(
+                "SELECT * FROM tasks
+              WHERE agent = ?1
+                AND kind = 'goal'
+                AND status IN ('running','paused')
+              ORDER BY started_at DESC, rowid DESC
+              LIMIT 1",
+            )
+            .context("prepare latest active goal by agent")?;
+        let rows = stmt
+            .query_map(params![agent], row_to_record)
+            .context("query latest active goal by agent")?;
+        for row in rows {
+            match row {
+                Ok(task) => return Ok(Some(task)),
+                Err(error) => log_unreadable_task_row(error),
+            }
+        }
+        Ok(None)
+    }
+
+    async fn latest_active_goal_for_context(
+        &self,
+        agent: &str,
+        originator_route: Option<&str>,
+        principal_id: Option<&str>,
+    ) -> Result<Option<TaskRecord>> {
+        let conn = self.conn.lock();
+        let mut stmt = conn
+            .prepare_cached(
+                "SELECT * FROM tasks
+              WHERE agent = ?1
+                AND kind = 'goal'
+                AND status IN ('running','paused')
+                AND (?2 IS NULL OR originator_route = ?2)
+                AND (?3 IS NULL OR principal_id = ?3)
+              ORDER BY started_at DESC, rowid DESC
+              LIMIT 1",
+            )
+            .context("prepare latest active goal by context")?;
+        let rows = stmt
+            .query_map(
+                params![agent, originator_route, principal_id],
+                row_to_record,
+            )
+            .context("query latest active goal by context")?;
+        for row in rows {
+            match row {
+                Ok(task) => return Ok(Some(task)),
+                Err(error) => log_unreadable_task_row(error),
+            }
+        }
+        Ok(None)
+    }
+
+    async fn latest_active_goal_id_for_context(
+        &self,
+        agent: &str,
+        originator_route: Option<&str>,
+        principal_id: Option<&str>,
+    ) -> Result<Option<String>> {
+        let conn = self.conn.lock();
+        let mut stmt = conn
+            .prepare_cached(
+                "SELECT id FROM tasks
+                 WHERE agent = ?1
+                   AND kind = 'goal'
+                   AND status IN ('running','paused')
+                   AND (?2 IS NULL OR originator_route = ?2)
+                   AND (?3 IS NULL OR principal_id = ?3)
+                 ORDER BY started_at DESC, rowid DESC
+                 LIMIT 1",
+            )
+            .context("prepare latest active goal id by context")?;
+        stmt.query_row(params![agent, originator_route, principal_id], |row| {
+            row.get::<_, String>(0)
+        })
+        .optional()
+        .context("query latest active goal id by context")
+    }
+
+    async fn get_goal_task(&self, task_id: &str) -> Result<Option<GoalTaskRecord>> {
+        let conn = self.conn.lock();
+        conn.query_row(
+            "SELECT task_id, objective, effective_token_limit, effective_cost_limit_usd,
+                    pause_reason, pause_description, blockers_json
+             FROM goal_tasks WHERE task_id = ?1",
+            params![task_id],
+            row_to_goal_task,
+        )
+        .optional()
+        .context("get goal task")
+    }
+
+    async fn update_goal_objective(&self, task_id: &str, objective: &str) -> Result<()> {
+        let conn = self.conn.lock();
+        let updated = conn
+            .execute(
+                "UPDATE goal_tasks
+                    SET objective = ?1
+                  WHERE task_id = ?2",
+                params![objective, task_id],
+            )
+            .context("update goal objective")?;
+        if updated == 0 {
+            anyhow::bail!("goal task {task_id} has no goal extension row");
+        }
+        Ok(())
+    }
+
+    async fn update_goal_limits(
+        &self,
+        task_id: &str,
+        token_limit: Option<u64>,
+        cost_limit_usd: Option<f64>,
+    ) -> Result<()> {
+        let conn = self.conn.lock();
+        conn.execute(
+            "UPDATE goal_tasks
+                SET effective_token_limit = ?1,
+                    effective_cost_limit_usd = ?2
+              WHERE task_id = ?3",
+            params![
+                token_limit.map(|value| value as i64),
+                cost_limit_usd,
+                task_id
+            ],
+        )
+        .context("update goal effective limits")?;
+        Ok(())
+    }
+
+    async fn update_goal_pause(&self, task_id: &str, pause: Option<GoalPauseState>) -> Result<()> {
+        let conn = self.conn.lock();
+        update_goal_pause_record(&conn, task_id, pause)?;
+        Ok(())
+    }
+
+    async fn pause_goal_task(&self, task_id: &str, pause: GoalPauseState) -> Result<()> {
+        let mut conn = self.conn.lock();
+        let tx = conn
+            .transaction()
+            .context("start pause goal task transaction")?;
+        ensure_goal_task_row(&tx, task_id)?;
+        let updated = update_task_status_record(&tx, task_id, TaskStatus::Paused, None, None)?;
+        if updated == 0 {
+            anyhow::bail!("goal task {task_id} is terminal or missing");
+        }
+        let updated = update_goal_pause_record(&tx, task_id, Some(pause))?;
+        if updated == 0 {
+            anyhow::bail!("goal task {task_id} has no goal extension row");
+        }
+        tx.commit().context("commit pause goal task transaction")?;
+        Ok(())
+    }
+
+    async fn resume_goal_task(
+        &self,
+        task_id: &str,
+        owner_pid: u32,
+        owner_boot_id: &str,
+        continuation_context: Option<TaskContinuationContext>,
+    ) -> Result<()> {
+        let mut conn = self.conn.lock();
+        let tx = conn
+            .transaction()
+            .context("start resume goal task transaction")?;
+        ensure_goal_task_row(&tx, task_id)?;
+        if let Some(context) = continuation_context {
+            upsert_continuation_context(&tx, task_id, &context)?;
+        }
+        let claimed = claim_task_owner_record(&tx, task_id, owner_pid, owner_boot_id)?;
+        if claimed == 0 {
+            anyhow::bail!("goal task {task_id} is terminal or missing");
+        }
+        let updated = update_task_status_record(&tx, task_id, TaskStatus::Running, None, None)?;
+        if updated == 0 {
+            anyhow::bail!("goal task {task_id} is terminal or missing");
+        }
+        let updated = update_goal_pause_record(&tx, task_id, None)?;
+        if updated == 0 {
+            anyhow::bail!("goal task {task_id} has no goal extension row");
+        }
+        tx.commit().context("commit resume goal task transaction")?;
+        Ok(())
+    }
+
+    async fn set_continuation_context(
+        &self,
+        task_id: &str,
+        context: Option<TaskContinuationContext>,
+    ) -> Result<()> {
+        let conn = self.conn.lock();
+        match context {
+            Some(context) => upsert_continuation_context(&conn, task_id, &context)?,
+            None => {
+                conn.execute(
+                    "DELETE FROM task_continuation_contexts WHERE task_id = ?1",
+                    params![task_id],
+                )
+                .context("delete task continuation context")?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn get_continuation_context(
+        &self,
+        task_id: &str,
+    ) -> Result<Option<TaskContinuationContext>> {
+        let conn = self.conn.lock();
+        conn.query_row(
+            "SELECT context_json
+             FROM task_continuation_contexts WHERE task_id = ?1",
+            params![task_id],
+            |row| continuation_context_from_db(row.get("context_json")?),
+        )
+        .optional()
+        .context("get task continuation context")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::control_plane::goal_task::{GoalBlockerKind, GoalTaskRegistry};
+    use crate::control_plane::task_registry::{TaskKind, TaskRegistry, TaskStatus};
+    use rusqlite::params;
+
+    fn rec(id: &str, agent: &str, owner_pid: u32, boot: &str) -> TaskRecord {
+        TaskRecord {
+            id: id.into(),
+            kind: TaskKind::Delegate,
+            agent: agent.into(),
+            status: TaskStatus::Running,
+            owner_pid,
+            owner_boot_id: boot.into(),
+            heartbeat_at: None,
+            depth: 0,
+            parent_id: None,
+            originator_route: None,
+            delivered: false,
+            idem_key: None,
+            principal_id: None,
+            started_at: "2026-06-18T00:00:00Z".into(),
+            finished_at: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn latest_active_goal_for_agent_resolves_in_sql() {
+        let s = SqliteTaskStore::new_in_memory().unwrap();
+
+        let mut old_goal = rec("old-goal", "main", 1, "boot-1");
+        old_goal.kind = TaskKind::Goal;
+        old_goal.originator_route = Some("route-old".into());
+        old_goal.started_at = "2026-06-18T00:00:00Z".into();
+        s.create(old_goal).await.unwrap();
+
+        let mut newer_terminal_goal = rec("done-goal", "main", 1, "boot-1");
+        newer_terminal_goal.kind = TaskKind::Goal;
+        newer_terminal_goal.started_at = "2026-06-20T00:00:00Z".into();
+        s.create(newer_terminal_goal).await.unwrap();
+        s.update_status("done-goal", TaskStatus::Completed, None, None)
+            .await
+            .unwrap();
+
+        let mut newest_delegate = rec("newest-delegate", "main", 1, "boot-1");
+        newest_delegate.started_at = "2026-06-21T00:00:00Z".into();
+        s.create(newest_delegate).await.unwrap();
+
+        let mut latest_active_goal = rec("latest-goal", "main", 1, "boot-1");
+        latest_active_goal.kind = TaskKind::Goal;
+        latest_active_goal.started_at = "2026-06-19T00:00:00Z".into();
+        s.create(latest_active_goal).await.unwrap();
+
+        let got = s
+            .latest_active_goal_for_agent("main")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(got.id, "latest-goal");
+        assert!(
+            s.latest_active_goal_for_agent("other")
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn latest_active_goal_for_context_filters_route_and_principal() {
+        let s = SqliteTaskStore::new_in_memory().unwrap();
+
+        let mut other_route_goal = rec("other-route", "main", 1, "boot-1");
+        other_route_goal.kind = TaskKind::Goal;
+        other_route_goal.originator_route = Some("route-b".into());
+        other_route_goal.principal_id = Some("principal-a".into());
+        other_route_goal.started_at = "2026-06-20T00:00:00Z".into();
+        s.create(other_route_goal).await.unwrap();
+
+        let mut other_principal_goal = rec("other-principal", "main", 1, "boot-1");
+        other_principal_goal.kind = TaskKind::Goal;
+        other_principal_goal.originator_route = Some("route-a".into());
+        other_principal_goal.principal_id = Some("principal-b".into());
+        other_principal_goal.started_at = "2026-06-19T00:00:00Z".into();
+        s.create(other_principal_goal).await.unwrap();
+
+        let mut wanted_goal = rec("wanted", "main", 1, "boot-1");
+        wanted_goal.kind = TaskKind::Goal;
+        wanted_goal.originator_route = Some("route-a".into());
+        wanted_goal.principal_id = Some("principal-a".into());
+        wanted_goal.started_at = "2026-06-18T00:00:00Z".into();
+        s.create(wanted_goal).await.unwrap();
+
+        let got = s
+            .latest_active_goal_for_context("main", Some("route-a"), Some("principal-a"))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(got.id, "wanted");
+        let got_id = s
+            .latest_active_goal_id_for_context("main", Some("route-a"), Some("principal-a"))
+            .await
+            .unwrap();
+        assert_eq!(got_id.as_deref(), Some("wanted"));
+    }
+
+    #[tokio::test]
+    async fn latest_active_goal_breaks_started_at_ties_by_insert_order() {
+        let s = SqliteTaskStore::new_in_memory().unwrap();
+
+        let mut first_goal = rec("first-goal", "main", 1, "boot-1");
+        first_goal.kind = TaskKind::Goal;
+        first_goal.originator_route = Some("route-a".into());
+        first_goal.principal_id = Some("principal-a".into());
+        first_goal.started_at = "2026-06-19T00:00:00Z".into();
+        s.create(first_goal).await.unwrap();
+
+        let mut second_goal = rec("second-goal", "main", 1, "boot-1");
+        second_goal.kind = TaskKind::Goal;
+        second_goal.originator_route = Some("route-b".into());
+        second_goal.principal_id = Some("principal-b".into());
+        second_goal.started_at = "2026-06-19T00:00:00Z".into();
+        s.create(second_goal).await.unwrap();
+
+        let got = s
+            .latest_active_goal_for_agent("main")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(got.id, "second-goal");
+
+        let got = s
+            .latest_active_goal_for_context("main", None, None)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(got.id, "second-goal");
+
+        let got_id = s
+            .latest_active_goal_id_for_context("main", None, None)
+            .await
+            .unwrap();
+        assert_eq!(got_id.as_deref(), Some("second-goal"));
+    }
+
+    #[tokio::test]
+    async fn latest_active_goal_for_context_ignores_unknown_status_candidate() {
+        let s = SqliteTaskStore::new_in_memory().unwrap();
+
+        let mut older_valid_goal = rec("older-valid-goal", "main", 1, "boot-1");
+        older_valid_goal.kind = TaskKind::Goal;
+        older_valid_goal.originator_route = Some("route-a".into());
+        older_valid_goal.principal_id = Some("principal-a".into());
+        older_valid_goal.started_at = "2026-06-19T00:00:00Z".into();
+        s.create(older_valid_goal).await.unwrap();
+
+        {
+            let conn = s.conn.lock();
+            conn.execute("DROP INDEX idx_tasks_active_goal_context", [])
+                .unwrap();
+        }
+
+        let mut unreadable_newer_goal = rec("unreadable-newer-goal", "main", 1, "boot-1");
+        unreadable_newer_goal.kind = TaskKind::Goal;
+        unreadable_newer_goal.originator_route = Some("route-a".into());
+        unreadable_newer_goal.principal_id = Some("principal-a".into());
+        unreadable_newer_goal.started_at = "2026-06-20T00:00:00Z".into();
+        s.create(unreadable_newer_goal).await.unwrap();
+        {
+            let conn = s.conn.lock();
+            conn.execute(
+                "UPDATE tasks SET status = 'future_paused' WHERE id = ?1",
+                params!["unreadable-newer-goal"],
+            )
+            .unwrap();
+        }
+
+        let got = s
+            .latest_active_goal_for_context("main", Some("route-a"), Some("principal-a"))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(got.id, "older-valid-goal");
+        let got_id = s
+            .latest_active_goal_id_for_context("main", Some("route-a"), Some("principal-a"))
+            .await
+            .unwrap();
+        assert_eq!(got_id.as_deref(), Some("older-valid-goal"));
+    }
+
+    #[tokio::test]
+    async fn latest_active_goal_for_agent_ignores_unknown_status_candidate() {
+        let s = SqliteTaskStore::new_in_memory().unwrap();
+
+        let mut older_valid_goal = rec("older-valid-goal", "main", 1, "boot-1");
+        older_valid_goal.kind = TaskKind::Goal;
+        older_valid_goal.originator_route = Some("route-valid".into());
+        older_valid_goal.started_at = "2026-06-19T00:00:00Z".into();
+        s.create(older_valid_goal).await.unwrap();
+
+        let mut unreadable_newer_goal = rec("unreadable-newer-goal", "main", 1, "boot-1");
+        unreadable_newer_goal.kind = TaskKind::Goal;
+        unreadable_newer_goal.started_at = "2026-06-20T00:00:00Z".into();
+        s.create(unreadable_newer_goal).await.unwrap();
+        {
+            let conn = s.conn.lock();
+            conn.execute(
+                "UPDATE tasks SET status = 'future_paused' WHERE id = ?1",
+                params!["unreadable-newer-goal"],
+            )
+            .unwrap();
+        }
+
+        let got = s
+            .latest_active_goal_for_agent("main")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(got.id, "older-valid-goal");
+    }
+
+    #[tokio::test]
+    async fn goal_task_extension_roundtrips_without_duplicating_lifecycle() {
+        let s = SqliteTaskStore::new_in_memory().unwrap();
+        let mut task = rec("goal-1", "main", 1, "boot-1");
+        task.kind = TaskKind::Goal;
+        task.status = TaskStatus::Paused;
+        s.create_goal(
+            task,
+            GoalTaskRecord {
+                task_id: "goal-1".into(),
+                objective: "ship goal mode".into(),
+                effective_token_limit: Some(10_000),
+                effective_cost_limit_usd: Some(1.25),
+                pause_reason: Some(GoalPauseReason::NeedsUserInput),
+                pause_description: Some("waiting for operator".into()),
+                blockers: vec![GoalBlocker {
+                    kind: GoalBlockerKind::NeedsUserInput,
+                    message: "Need operator answer".into(),
+                    payload: Some(serde_json::json!({"question": "continue?"})),
+                }],
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+        let task = s.get("goal-1").await.unwrap().unwrap();
+        let goal = s.get_goal_task("goal-1").await.unwrap().unwrap();
+
+        assert_eq!(task.kind, TaskKind::Goal);
+        assert_eq!(task.status, TaskStatus::Paused);
+        assert_eq!(goal.task_id, task.id);
+        assert_eq!(goal.objective, "ship goal mode");
+        assert_eq!(goal.effective_token_limit, Some(10_000));
+        assert_eq!(goal.effective_cost_limit_usd, Some(1.25));
+        assert_eq!(goal.pause_reason, Some(GoalPauseReason::NeedsUserInput));
+        assert_eq!(
+            goal.pause_description.as_deref(),
+            Some("waiting for operator")
+        );
+        assert_eq!(goal.blockers.len(), 1);
+
+        s.update_goal_limits("goal-1", Some(20_000), None)
+            .await
+            .unwrap();
+        let limited = s.get_goal_task("goal-1").await.unwrap().unwrap();
+        assert_eq!(limited.effective_token_limit, Some(20_000));
+        assert_eq!(limited.effective_cost_limit_usd, None);
+        assert_eq!(
+            limited.objective, "ship goal mode",
+            "budget updates must not duplicate or rewrite objective state"
+        );
+
+        s.update_goal_objective("goal-1", "ship amended goal mode")
+            .await
+            .unwrap();
+        let amended = s.get_goal_task("goal-1").await.unwrap().unwrap();
+        assert_eq!(amended.objective, "ship amended goal mode");
+
+        s.update_goal_pause("goal-1", None).await.unwrap();
+        let resumed = s.get_goal_task("goal-1").await.unwrap().unwrap();
+        assert!(resumed.pause_reason.is_none());
+        assert!(resumed.pause_description.is_none());
+        assert!(resumed.blockers.is_empty());
+    }
+
+    #[tokio::test]
+    async fn goal_task_requires_canonical_goal_task_record() {
+        let s = SqliteTaskStore::new_in_memory().unwrap();
+        let err = {
+            let conn = s.conn.lock();
+            insert_goal_task_record(
+                &conn,
+                GoalTaskRecord {
+                    task_id: "missing".into(),
+                    objective: "orphan objective".into(),
+                    effective_token_limit: None,
+                    effective_cost_limit_usd: None,
+                    pause_reason: None,
+                    pause_description: None,
+                    blockers: Vec::new(),
+                },
+            )
+        }
+        .unwrap_err();
+
+        assert!(format!("{err:#}").contains("TaskKind::Goal"));
+    }
+
+    #[tokio::test]
+    async fn goal_task_extension_rejects_non_goal_task_record() {
+        let s = SqliteTaskStore::new_in_memory().unwrap();
+        s.create(rec("delegate-1", "main", 1, "boot-1"))
+            .await
+            .unwrap();
+
+        let err = {
+            let conn = s.conn.lock();
+            insert_goal_task_record(
+                &conn,
+                GoalTaskRecord {
+                    task_id: "delegate-1".into(),
+                    objective: "must not attach to a delegate".into(),
+                    effective_token_limit: None,
+                    effective_cost_limit_usd: None,
+                    pause_reason: None,
+                    pause_description: None,
+                    blockers: Vec::new(),
+                },
+            )
+        }
+        .unwrap_err();
+
+        assert!(format!("{err:#}").contains("TaskKind::Goal"));
+    }
+
+    #[tokio::test]
+    async fn create_goal_rejects_non_goal_task_record() {
+        let s = SqliteTaskStore::new_in_memory().unwrap();
+        let task = rec("delegate-goal", "main", 1, "boot-1");
+
+        let err = s
+            .create_goal(
+                task,
+                GoalTaskRecord {
+                    task_id: "delegate-goal".into(),
+                    objective: "should fail before insert".into(),
+                    effective_token_limit: None,
+                    effective_cost_limit_usd: None,
+                    pause_reason: None,
+                    pause_description: None,
+                    blockers: Vec::new(),
+                },
+                None,
+            )
+            .await
+            .expect_err("non-goal task records must not create goal extensions");
+
+        assert!(format!("{err:#}").contains("TaskKind::Goal"));
+        assert!(
+            s.get("delegate-goal").await.unwrap().is_none(),
+            "pre-validation failure must not create a generic task row"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_goal_rejects_mismatched_task_and_goal_ids() {
+        let s = SqliteTaskStore::new_in_memory().unwrap();
+        let mut task = rec("goal-task", "main", 1, "boot-1");
+        task.kind = TaskKind::Goal;
+
+        let err = s
+            .create_goal(
+                task,
+                GoalTaskRecord {
+                    task_id: "missing-extension-parent".into(),
+                    objective: "should roll back".into(),
+                    effective_token_limit: None,
+                    effective_cost_limit_usd: None,
+                    pause_reason: None,
+                    pause_description: None,
+                    blockers: Vec::new(),
+                },
+                None,
+            )
+            .await
+            .expect_err("goal task id mismatch must be rejected before insert");
+
+        assert!(format!("{err:#}").contains("id mismatch"));
+        assert!(
+            s.get("goal-task").await.unwrap().is_none(),
+            "pre-validation failure must not create a generic task row"
+        );
+    }
+
+    #[tokio::test]
+    async fn pause_goal_task_updates_status_and_pause_atomically() {
+        let s = SqliteTaskStore::new_in_memory().unwrap();
+        let mut task = rec("goal-paused", "main", 1, "boot-1");
+        task.kind = TaskKind::Goal;
+        s.create_goal(
+            task,
+            GoalTaskRecord {
+                task_id: "goal-paused".into(),
+                objective: "pause me".into(),
+                effective_token_limit: None,
+                effective_cost_limit_usd: None,
+                pause_reason: None,
+                pause_description: None,
+                blockers: Vec::new(),
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+        s.pause_goal_task(
+            "goal-paused",
+            GoalPauseState {
+                reason: GoalPauseReason::NeedsUserInput,
+                description: Some("waiting".into()),
+                blockers: vec![GoalBlocker {
+                    kind: GoalBlockerKind::NeedsUserInput,
+                    message: "Need operator answer".into(),
+                    payload: None,
+                }],
+            },
+        )
+        .await
+        .unwrap();
+
+        let task = s.get("goal-paused").await.unwrap().unwrap();
+        let goal = s.get_goal_task("goal-paused").await.unwrap().unwrap();
+        assert_eq!(task.status, TaskStatus::Paused);
+        assert_eq!(goal.pause_reason, Some(GoalPauseReason::NeedsUserInput));
+        assert_eq!(goal.pause_description.as_deref(), Some("waiting"));
+        assert_eq!(goal.blockers.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn pause_goal_task_roundtrips_operator_pause() {
+        let s = SqliteTaskStore::new_in_memory().unwrap();
+        let mut task = rec("goal-operator-paused", "main", 1, "boot-1");
+        task.kind = TaskKind::Goal;
+        s.create_goal(
+            task,
+            GoalTaskRecord {
+                task_id: "goal-operator-paused".into(),
+                objective: "pause from operator command".into(),
+                effective_token_limit: None,
+                effective_cost_limit_usd: None,
+                pause_reason: None,
+                pause_description: None,
+                blockers: Vec::new(),
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+        s.pause_goal_task(
+            "goal-operator-paused",
+            GoalPauseState {
+                reason: GoalPauseReason::OperatorPaused,
+                description: Some("maintenance window".into()),
+                blockers: vec![GoalBlocker {
+                    kind: GoalBlockerKind::OperatorPause,
+                    message: "maintenance window".into(),
+                    payload: None,
+                }],
+            },
+        )
+        .await
+        .unwrap();
+
+        let task = s.get("goal-operator-paused").await.unwrap().unwrap();
+        let goal = s
+            .get_goal_task("goal-operator-paused")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(task.status, TaskStatus::Paused);
+        assert_eq!(goal.pause_reason, Some(GoalPauseReason::OperatorPaused));
+        assert_eq!(
+            goal.pause_description.as_deref(),
+            Some("maintenance window")
+        );
+        assert_eq!(goal.blockers[0].kind, GoalBlockerKind::OperatorPause);
+        assert_eq!(goal.blockers[0].message, "maintenance window");
+    }
+
+    #[tokio::test]
+    async fn pause_goal_task_rejects_goal_without_extension_before_status_change() {
+        let s = SqliteTaskStore::new_in_memory().unwrap();
+        let mut task = rec("goal-missing-extension", "main", 1, "boot-1");
+        task.kind = TaskKind::Goal;
+        s.create(task).await.unwrap();
+
+        let err = s
+            .pause_goal_task(
+                "goal-missing-extension",
+                GoalPauseState {
+                    reason: GoalPauseReason::NeedsUserInput,
+                    description: None,
+                    blockers: Vec::new(),
+                },
+            )
+            .await
+            .expect_err("goal pause must require the goal extension row");
+
+        assert!(format!("{err:#}").contains("goal extension"));
+        let task = s.get("goal-missing-extension").await.unwrap().unwrap();
+        assert_eq!(task.status, TaskStatus::Running);
+    }
+
+    #[tokio::test]
+    async fn resume_goal_task_clears_pause_claims_owner_and_sets_running() {
+        let s = SqliteTaskStore::new_in_memory().unwrap();
+        let mut task = rec("goal-resume", "main", 1, "boot-1");
+        task.kind = TaskKind::Goal;
+        task.status = TaskStatus::Paused;
+        s.create_goal(
+            task,
+            GoalTaskRecord {
+                task_id: "goal-resume".into(),
+                objective: "resume me".into(),
+                effective_token_limit: None,
+                effective_cost_limit_usd: None,
+                pause_reason: Some(GoalPauseReason::NeedsUserInput),
+                pause_description: Some("waiting".into()),
+                blockers: vec![GoalBlocker {
+                    kind: GoalBlockerKind::NeedsUserInput,
+                    message: "Need operator answer".into(),
+                    payload: None,
+                }],
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+        s.resume_goal_task("goal-resume", 42, "boot-2", None)
+            .await
+            .unwrap();
+
+        let task = s.get("goal-resume").await.unwrap().unwrap();
+        let goal = s.get_goal_task("goal-resume").await.unwrap().unwrap();
+        assert_eq!(task.status, TaskStatus::Running);
+        assert_eq!(task.owner_pid, 42);
+        assert_eq!(task.owner_boot_id, "boot-2");
+        assert!(goal.pause_reason.is_none());
+        assert!(goal.pause_description.is_none());
+        assert!(goal.blockers.is_empty());
+    }
+}

--- a/crates/zeroclaw-runtime/src/control_plane/task_store_sqlite/goal.rs
+++ b/crates/zeroclaw-runtime/src/control_plane/task_store_sqlite/goal.rs
@@ -119,6 +119,58 @@ pub(super) fn migrate_schema(conn: &Connection, version: i64) -> Result<()> {
         )
         .context("apply control-plane schema v6")?;
     }
+    if version < 7 {
+        conn.execute_batch(
+            "CREATE TRIGGER IF NOT EXISTS trg_goal_tasks_effective_limits_insert
+                BEFORE INSERT ON goal_tasks
+                FOR EACH ROW
+                WHEN (NEW.effective_token_limit IS NOT NULL AND NEW.effective_token_limit < 0)
+                  OR (NEW.effective_cost_limit_usd IS NOT NULL
+                      AND NOT (NEW.effective_cost_limit_usd >= 0.0
+                               AND NEW.effective_cost_limit_usd <= 1.7976931348623157e308))
+                BEGIN
+                    SELECT RAISE(ABORT, 'goal effective limits must be non-negative finite values');
+                END;
+             CREATE TRIGGER IF NOT EXISTS trg_goal_tasks_effective_limits_update
+                BEFORE UPDATE OF effective_token_limit, effective_cost_limit_usd ON goal_tasks
+                FOR EACH ROW
+                WHEN (NEW.effective_token_limit IS NOT NULL AND NEW.effective_token_limit < 0)
+                  OR (NEW.effective_cost_limit_usd IS NOT NULL
+                      AND NOT (NEW.effective_cost_limit_usd >= 0.0
+                               AND NEW.effective_cost_limit_usd <= 1.7976931348623157e308))
+                BEGIN
+                    SELECT RAISE(ABORT, 'goal effective limits must be non-negative finite values');
+                END;
+             CREATE TRIGGER IF NOT EXISTS trg_task_continuation_contexts_require_goal_insert
+                BEFORE INSERT ON task_continuation_contexts
+                FOR EACH ROW
+                WHEN NOT EXISTS (
+                    SELECT 1
+                      FROM tasks
+                      JOIN goal_tasks ON goal_tasks.task_id = tasks.id
+                     WHERE tasks.id = NEW.task_id
+                       AND tasks.kind = 'goal'
+                )
+                BEGIN
+                    SELECT RAISE(ABORT, 'task_continuation_contexts.task_id must reference a goal task');
+                END;
+             CREATE TRIGGER IF NOT EXISTS trg_task_continuation_contexts_require_goal_update
+                BEFORE UPDATE OF task_id ON task_continuation_contexts
+                FOR EACH ROW
+                WHEN NOT EXISTS (
+                    SELECT 1
+                      FROM tasks
+                      JOIN goal_tasks ON goal_tasks.task_id = tasks.id
+                     WHERE tasks.id = NEW.task_id
+                       AND tasks.kind = 'goal'
+                )
+                BEGIN
+                    SELECT RAISE(ABORT, 'task_continuation_contexts.task_id must reference a goal task');
+                END;
+             PRAGMA user_version = 7;",
+        )
+        .context("apply control-plane schema v7")?;
+    }
     Ok(())
 }
 
@@ -173,6 +225,55 @@ fn continuation_context_from_db(value: String) -> rusqlite::Result<TaskContinuat
     })
 }
 
+fn token_limit_to_db(value: u64) -> Result<i64> {
+    i64::try_from(value)
+        .with_context(|| format!("effective token limit {value} exceeds SQLite INTEGER domain"))
+}
+
+fn token_limit_from_db(value: Option<i64>) -> rusqlite::Result<Option<u64>> {
+    value
+        .map(|value| {
+            u64::try_from(value).map_err(|e| {
+                rusqlite::Error::FromSqlConversionFailure(
+                    0,
+                    rusqlite::types::Type::Integer,
+                    e.into(),
+                )
+            })
+        })
+        .transpose()
+}
+
+fn cost_limit_to_db(value: f64) -> Result<f64> {
+    if !value.is_finite() || value < 0.0 {
+        anyhow::bail!("effective cost limit must be a non-negative finite value");
+    }
+    Ok(value)
+}
+
+fn cost_limit_from_db(value: Option<f64>) -> rusqlite::Result<Option<f64>> {
+    match value {
+        Some(value) if !value.is_finite() || value < 0.0 => {
+            Err(rusqlite::Error::FromSqlConversionFailure(
+                0,
+                rusqlite::types::Type::Real,
+                format!("invalid effective cost limit {value}").into(),
+            ))
+        }
+        other => Ok(other),
+    }
+}
+
+fn goal_limits_to_db(
+    token_limit: Option<u64>,
+    cost_limit_usd: Option<f64>,
+) -> Result<(Option<i64>, Option<f64>)> {
+    Ok((
+        token_limit.map(token_limit_to_db).transpose()?,
+        cost_limit_usd.map(cost_limit_to_db).transpose()?,
+    ))
+}
+
 fn row_to_goal_task(row: &rusqlite::Row<'_>) -> rusqlite::Result<GoalTaskRecord> {
     let pause_reason = pause_reason_from_db(row.get("pause_reason")?).map_err(|e| {
         rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, e.into())
@@ -180,10 +281,8 @@ fn row_to_goal_task(row: &rusqlite::Row<'_>) -> rusqlite::Result<GoalTaskRecord>
     Ok(GoalTaskRecord {
         task_id: row.get("task_id")?,
         objective: row.get("objective")?,
-        effective_token_limit: row
-            .get::<_, Option<i64>>("effective_token_limit")?
-            .map(|value| value as u64),
-        effective_cost_limit_usd: row.get("effective_cost_limit_usd")?,
+        effective_token_limit: token_limit_from_db(row.get("effective_token_limit")?)?,
+        effective_cost_limit_usd: cost_limit_from_db(row.get("effective_cost_limit_usd")?)?,
         pause_reason,
         pause_description: row.get("pause_description")?,
         blockers: blockers_from_db(row.get("blockers_json")?)?,
@@ -193,6 +292,8 @@ fn row_to_goal_task(row: &rusqlite::Row<'_>) -> rusqlite::Result<GoalTaskRecord>
 fn insert_goal_task_record(conn: &Connection, rec: GoalTaskRecord) -> Result<()> {
     let pause_reason = rec.pause_reason.map(pause_reason_to_db).transpose()?;
     let blockers_json = blockers_to_db(&rec.blockers)?;
+    let (effective_token_limit, effective_cost_limit_usd) =
+        goal_limits_to_db(rec.effective_token_limit, rec.effective_cost_limit_usd)?;
     conn.execute(
         "INSERT INTO goal_tasks
             (task_id, objective, effective_token_limit, effective_cost_limit_usd,
@@ -202,8 +303,8 @@ fn insert_goal_task_record(conn: &Connection, rec: GoalTaskRecord) -> Result<()>
         params![
             rec.task_id,
             rec.objective,
-            rec.effective_token_limit.map(|value| value as i64),
-            rec.effective_cost_limit_usd,
+            effective_token_limit,
+            effective_cost_limit_usd,
             pause_reason,
             rec.pause_description,
             blockers_json,
@@ -416,25 +517,30 @@ impl GoalTaskRegistry for SqliteTaskStore {
         token_limit: Option<u64>,
         cost_limit_usd: Option<f64>,
     ) -> Result<()> {
+        let (effective_token_limit, effective_cost_limit_usd) =
+            goal_limits_to_db(token_limit, cost_limit_usd)?;
         let conn = self.conn.lock();
-        conn.execute(
-            "UPDATE goal_tasks
+        let updated = conn
+            .execute(
+                "UPDATE goal_tasks
                 SET effective_token_limit = ?1,
                     effective_cost_limit_usd = ?2
               WHERE task_id = ?3",
-            params![
-                token_limit.map(|value| value as i64),
-                cost_limit_usd,
-                task_id
-            ],
-        )
-        .context("update goal effective limits")?;
+                params![effective_token_limit, effective_cost_limit_usd, task_id],
+            )
+            .context("update goal effective limits")?;
+        if updated == 0 {
+            anyhow::bail!("goal task {task_id} has no goal extension row");
+        }
         Ok(())
     }
 
     async fn update_goal_pause(&self, task_id: &str, pause: Option<GoalPauseState>) -> Result<()> {
         let conn = self.conn.lock();
-        update_goal_pause_record(&conn, task_id, pause)?;
+        let updated = update_goal_pause_record(&conn, task_id, pause)?;
+        if updated == 0 {
+            anyhow::bail!("goal task {task_id} has no goal extension row");
+        }
         Ok(())
     }
 
@@ -493,6 +599,7 @@ impl GoalTaskRegistry for SqliteTaskStore {
         context: Option<TaskContinuationContext>,
     ) -> Result<()> {
         let conn = self.conn.lock();
+        ensure_goal_task_row(&conn, task_id)?;
         match context {
             Some(context) => upsert_continuation_context(&conn, task_id, &context)?,
             None => {
@@ -511,6 +618,7 @@ impl GoalTaskRegistry for SqliteTaskStore {
         task_id: &str,
     ) -> Result<Option<TaskContinuationContext>> {
         let conn = self.conn.lock();
+        ensure_goal_task_row(&conn, task_id)?;
         conn.query_row(
             "SELECT context_json
              FROM task_continuation_contexts WHERE task_id = ?1",
@@ -546,6 +654,31 @@ mod tests {
             principal_id: None,
             started_at: "2026-06-18T00:00:00Z".into(),
             finished_at: None,
+        }
+    }
+
+    fn goal_record(task_id: &str, objective: &str) -> GoalTaskRecord {
+        GoalTaskRecord {
+            task_id: task_id.into(),
+            objective: objective.into(),
+            effective_token_limit: None,
+            effective_cost_limit_usd: None,
+            pause_reason: None,
+            pause_description: None,
+            blockers: Vec::new(),
+        }
+    }
+
+    fn continuation_context() -> TaskContinuationContext {
+        TaskContinuationContext {
+            channel: "telegram".into(),
+            channel_alias: Some("main".into()),
+            reply_target: "chat-1".into(),
+            sender: "alice".into(),
+            thread_ts: None,
+            interruption_scope_id: Some("scope-1".into()),
+            conversation_scope:
+                crate::control_plane::goal_task::TaskContinuationConversationScope::Sender,
         }
     }
 
@@ -916,6 +1049,172 @@ mod tests {
             s.get("goal-task").await.unwrap().is_none(),
             "pre-validation failure must not create a generic task row"
         );
+    }
+
+    #[tokio::test]
+    async fn update_goal_limits_rejects_invalid_effective_limits() {
+        let s = SqliteTaskStore::new_in_memory().unwrap();
+        let mut task = rec("goal-limit-validation", "main", 1, "boot-1");
+        task.kind = TaskKind::Goal;
+        s.create_goal(
+            task,
+            goal_record("goal-limit-validation", "validate limits"),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let err = s
+            .update_goal_limits("goal-limit-validation", Some(i64::MAX as u64 + 1), None)
+            .await
+            .expect_err("token limit outside SQLite INTEGER domain must fail");
+        assert!(format!("{err:#}").contains("SQLite INTEGER domain"));
+
+        for invalid in [-1.0, f64::INFINITY, f64::NAN] {
+            let err = s
+                .update_goal_limits("goal-limit-validation", None, Some(invalid))
+                .await
+                .expect_err("invalid cost limit must fail before SQLite bind");
+            assert!(format!("{err:#}").contains("non-negative finite"));
+        }
+    }
+
+    #[tokio::test]
+    async fn sqlite_rejects_invalid_effective_limit_rows() {
+        let s = SqliteTaskStore::new_in_memory().unwrap();
+        let mut task = rec("goal-sqlite-limit-validation", "main", 1, "boot-1");
+        task.kind = TaskKind::Goal;
+        s.create_goal(
+            task,
+            goal_record("goal-sqlite-limit-validation", "validate SQLite limits"),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let conn = s.conn.lock();
+        let err = conn
+            .execute(
+                "UPDATE goal_tasks
+                    SET effective_token_limit = -1
+                  WHERE task_id = ?1",
+                params!["goal-sqlite-limit-validation"],
+            )
+            .expect_err("SQLite must reject negative token limits");
+        assert!(format!("{err:#}").contains("non-negative finite"));
+
+        let err = conn
+            .execute(
+                "UPDATE goal_tasks
+                    SET effective_cost_limit_usd = -0.01
+                  WHERE task_id = ?1",
+                params!["goal-sqlite-limit-validation"],
+            )
+            .expect_err("SQLite must reject negative cost limits");
+        assert!(format!("{err:#}").contains("non-negative finite"));
+
+        let err = conn
+            .execute(
+                "UPDATE goal_tasks
+                    SET effective_cost_limit_usd = 1e999
+                  WHERE task_id = ?1",
+                params!["goal-sqlite-limit-validation"],
+            )
+            .expect_err("SQLite must reject non-finite cost limits");
+        assert!(format!("{err:#}").contains("non-negative finite"));
+    }
+
+    #[tokio::test]
+    async fn get_goal_task_rejects_legacy_negative_token_limit() {
+        let s = SqliteTaskStore::new_in_memory().unwrap();
+        let mut task = rec("goal-corrupt-limit", "main", 1, "boot-1");
+        task.kind = TaskKind::Goal;
+        s.create_goal(
+            task,
+            goal_record("goal-corrupt-limit", "reject legacy corrupt limit"),
+            None,
+        )
+        .await
+        .unwrap();
+
+        {
+            let conn = s.conn.lock();
+            conn.execute("DROP TRIGGER trg_goal_tasks_effective_limits_update", [])
+                .unwrap();
+            conn.execute(
+                "UPDATE goal_tasks
+                    SET effective_token_limit = -1
+                  WHERE task_id = ?1",
+                params!["goal-corrupt-limit"],
+            )
+            .unwrap();
+        }
+
+        let err = s
+            .get_goal_task("goal-corrupt-limit")
+            .await
+            .expect_err("legacy negative token limits must not inflate to u64");
+        assert!(format!("{err:#}").contains("get goal task"));
+    }
+
+    #[tokio::test]
+    async fn goal_extension_updates_reject_missing_goal_rows() {
+        let s = SqliteTaskStore::new_in_memory().unwrap();
+        let mut task = rec("goal-without-extension", "main", 1, "boot-1");
+        task.kind = TaskKind::Goal;
+        s.create(task).await.unwrap();
+
+        let err = s
+            .update_goal_limits("goal-without-extension", Some(100), None)
+            .await
+            .expect_err("limit updates must reject missing goal extension rows");
+        assert!(format!("{err:#}").contains("goal extension"));
+
+        let err = s
+            .update_goal_pause(
+                "goal-without-extension",
+                Some(GoalPauseState {
+                    reason: GoalPauseReason::NeedsUserInput,
+                    description: None,
+                    blockers: Vec::new(),
+                }),
+            )
+            .await
+            .expect_err("pause updates must reject missing goal extension rows");
+        assert!(format!("{err:#}").contains("goal extension"));
+    }
+
+    #[tokio::test]
+    async fn continuation_context_requires_goal_extension_row() {
+        let s = SqliteTaskStore::new_in_memory().unwrap();
+        s.create(rec("delegate-context", "main", 1, "boot-1"))
+            .await
+            .unwrap();
+
+        let err = s
+            .set_continuation_context("delegate-context", Some(continuation_context()))
+            .await
+            .expect_err("continuation context must reject non-goal tasks");
+        assert!(format!("{err:#}").contains("goal extension"));
+
+        let err = s
+            .get_continuation_context("delegate-context")
+            .await
+            .expect_err("continuation context reads must reject non-goal tasks");
+        assert!(format!("{err:#}").contains("goal extension"));
+
+        let conn = s.conn.lock();
+        let err = conn
+            .execute(
+                "INSERT INTO task_continuation_contexts (task_id, context_json)
+                    VALUES (?1, ?2)",
+                params![
+                    "delegate-context",
+                    continuation_context_to_db(&continuation_context()).unwrap()
+                ],
+            )
+            .expect_err("SQLite must reject continuation contexts for non-goal tasks");
+        assert!(format!("{err:#}").contains("goal task"));
     }
 
     #[tokio::test]

--- a/docs/architecture/decisions/ADR-008-goal-mode-control-plane-and-usage-accounting.md
+++ b/docs/architecture/decisions/ADR-008-goal-mode-control-plane-and-usage-accounting.md
@@ -1,0 +1,106 @@
+---
+id: ADR-008
+title: Anchor goal mode in the durable task control plane
+date: 2026-06-25
+status: accepted
+relates-to:
+  - https://github.com/zeroclaw-labs/zeroclaw/issues/8303
+  - https://github.com/zeroclaw-labs/zeroclaw/issues/7929
+  - https://github.com/zeroclaw-labs/zeroclaw/pull/8217
+  - crates/zeroclaw-runtime
+  - crates/zeroclaw-config
+  - crates/zeroclaw-tools
+---
+
+# ADR-008: Anchor goal mode in the durable task control plane
+
+## Context
+
+Goal mode changes an agent interaction from a single response into autonomous
+work against a user objective. A goal can outlive the inbound message that
+started it, pause while waiting for input or an external dependency, recover
+after daemon restart, and spend model usage across multiple worker, verifier,
+or delegated calls.
+
+That kind of work needs one durable authority for its lifecycle. The system must
+be able to answer which work is alive, which work is eligible to run another
+turn, which work is paused, which work is terminal, and which actor or route is
+allowed to resume or cancel it. A prompt convention or side registry would make
+those answers dependent on duplicated state.
+
+Budget accounting adds another source-of-truth constraint. Tokens and cost are
+facts produced by model-provider calls. Remaining budget is derived from a
+limit and consumed usage; storing it as its own mutable counter would create a
+second accounting system.
+
+Goal mode also crosses a trust boundary. A slash command and a model-generated
+request can both express that a goal should start, but neither should be able to
+self-authorize trusted runtime facts such as caller identity, route, channel, or
+agent eligibility.
+
+The main options considered were ordinary multi-turn chat with prompt guidance,
+a separate goal subsystem, or anchoring goal mode in the existing durable task
+control plane with goal-specific extension state.
+
+## Decision
+
+We will anchor goal mode in the durable task control plane instead of building a
+parallel goal task system.
+
+The task control plane is the source of truth for goal lifecycle, ownership,
+route, principal, parent relation, and recovery eligibility. Goal-specific state
+may extend task records, but it must not duplicate lifecycle, identity, route,
+timestamp, delivery, or terminal-state facts owned by the task record.
+
+Consumed model usage remains owned by the canonical usage ledger. Goal budgets
+are limits interpreted against usage records; remaining budget is always
+derived, never stored as a second mutable total.
+
+Pause, resume, cancellation, restart recovery, and completion are control-plane
+policy decisions. Prompt text can explain or request those transitions, but it
+does not authorize them.
+
+All goal entry paths use one trusted Rust-side admission gate. Runtime context
+supplies trusted facts such as surface, channel, principal, route, and agent
+eligibility; model-supplied arguments cannot declare those facts.
+
+Goal completion requires an explicit completion decision by the goal controller.
+Silence, lack of further tool calls, or a final-looking assistant message is not
+enough to mark durable autonomous work complete.
+
+## Consequences
+
+Goal mode inherits the existing supervised task lifecycle instead of adding a
+second task registry. This keeps restart recovery, cancellation, and future
+supervision improvements attached to one control-plane contract.
+
+The control plane becomes responsible for distinguishing paused but resumable
+goal work from terminal, lost, or still-running work. That increases the
+importance of precise task status transitions and restart recovery policy.
+
+Budget enforcement becomes auditable because consumed usage is derived from
+canonical usage records. It also means goal mode cannot be correct until every
+model call that can spend against a goal reports usage with goal attribution.
+
+Delegation and background work must respect the same lifecycle and usage
+boundaries. Work that cannot report completion and usage back to the owning goal
+cannot safely participate in goal mode.
+
+A single trusted admission gate prevents command and model-initiated entry paths
+from becoming separate authorization systems. The cost is that every supported
+surface must route goal entry through the shared command/admission machinery.
+
+Detailed implementation choices, including command syntax, pause reason
+inventory, payload shapes, verifier configuration, and rollout staging, are left
+to implementation plans and follow-up PRs. They must remain consistent with this
+ADR's source-of-truth boundaries.
+
+## References
+
+- RFC #8303: <https://github.com/zeroclaw-labs/zeroclaw/issues/8303>
+- Shared command-catalogue RFC #7929: <https://github.com/zeroclaw-labs/zeroclaw/issues/7929>
+- Durable task control plane PR #8217: <https://github.com/zeroclaw-labs/zeroclaw/pull/8217>
+- Control-plane commit: <https://github.com/zeroclaw-labs/zeroclaw/commit/607d69ef44dca07e2605e822db13fb437b462f4a>
+- Gateway ask-user/free-form gap #7776: <https://github.com/zeroclaw-labs/zeroclaw/issues/7776>
+- Cached token and cost accounting #7248: <https://github.com/zeroclaw-labs/zeroclaw/issues/7248>
+- Command localization gap #6548: <https://github.com/zeroclaw-labs/zeroclaw/issues/6548>


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Adds the durable goal task storage foundation: `TaskKind::Goal`, `TaskStatus::Paused`, `GoalTaskRecord`, `TaskGoal`, pause/blocker types, and continuation context storage.
  - Adds SQLite-backed `GoalTaskRegistry` operations for atomic task-plus-goal creation, active-goal lookup, objective/limit/pause updates, resume owner claiming, and continuation context persistence.
  - Hardens storage invariants after review: effective limits are validated before SQLite bind, direct SQLite writes are guarded by migration triggers, missing goal-extension updates fail instead of silently no-oping, and continuation context rows must belong to canonical goal tasks.
  - Adds real SQLite coverage for goal extension round-trips, active-goal queries, pause/resume atomicity, invalid effective limits, missing extension rows, non-goal rejection, and canonical lifecycle separation.
  - Keeps consumed usage accounting, controller/verifier policy, trusted tools, and channel `/goal` admission out of this PR.
- **Scope boundary:**
  - This PR persists admitted budget limits as goal policy state, but does not account consumed usage or derive remaining budget.
  - Does not add `[goal]` config, model-callable tools, `/goal` commands, verifier behavior, channel ingress, localization, or user/operator docs.
  - Does not close or supersede PR #8393 by itself; this is the third split-stack PR tracked by #8681.
- **Blast radius:** `zeroclaw-runtime` durable control-plane task storage and SQLite schema migrations.
- **Linked issue(s):**
  - Depends on PR #8683: https://github.com/zeroclaw-labs/zeroclaw/pull/8683
  - Depends on PR #8682: https://github.com/zeroclaw-labs/zeroclaw/pull/8682
  - Related #8303: https://github.com/zeroclaw-labs/zeroclaw/issues/8303
  - Tracks #8681: https://github.com/zeroclaw-labs/zeroclaw/issues/8681
  - Split from PR #8393: https://github.com/zeroclaw-labs/zeroclaw/pull/8393
- **Labels:** `docs`, `dependencies`, `enhancement`, `runtime`, `rust`, `risk:high`, `size:XL`.

## Validation Evidence (required)

- **Commands run and tail output:**

```text
$ cargo fmt --all -- --check
```

No output; command exited successfully.

```text
$ cargo test -p zeroclaw-runtime control_plane::task_store_sqlite::goal::tests --lib
running 19 tests
test control_plane::task_store_sqlite::goal::tests::update_goal_limits_rejects_invalid_effective_limits ... ok
test control_plane::task_store_sqlite::goal::tests::sqlite_rejects_invalid_effective_limit_rows ... ok
test control_plane::task_store_sqlite::goal::tests::goal_extension_updates_reject_missing_goal_rows ... ok
test control_plane::task_store_sqlite::goal::tests::get_goal_task_rejects_legacy_negative_token_limit ... ok
test control_plane::task_store_sqlite::goal::tests::continuation_context_requires_goal_extension_row ... ok
test control_plane::task_store_sqlite::goal::tests::goal_task_extension_roundtrips_without_duplicating_lifecycle ... ok
test control_plane::task_store_sqlite::goal::tests::pause_goal_task_updates_status_and_pause_atomically ... ok
test control_plane::task_store_sqlite::goal::tests::resume_goal_task_clears_pause_claims_owner_and_sets_running ... ok

test result: ok. 19 passed; 0 failed; 0 ignored; 0 measured; 2866 filtered out; finished in 0.05s
```

```text
$ cargo check -p zeroclaw-channels --all-features
    Checking zeroclaw-runtime v0.8.2
    Checking zeroclaw-channels v0.8.2
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 25.39s
```

- **Beyond CI — what did you manually verify?**
  - Confirmed this branch is based on `upstream/master` at `665308d617fc1e332d68fe424db7bfee0222523c`.
  - Confirmed the storage slice remains limited to the control-plane task store and goal task primitives.
  - Confirmed SQLite tests exercise real in-memory SQLite stores rather than mocks.
  - Confirmed the top-of-stack channel branch still compiles with all channel features after rebasing downstream PRs over this storage hardening commit.
- **If any command was intentionally skipped, why:**
  - Full workspace tests were skipped because this is a split-stack storage PR with focused runtime control-plane coverage; full-stack validation is reserved for the final stack pass.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: `N/A`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: Existing control-plane task rows continue to deserialize; the SQLite schema migration adds goal-extension tables, indexes, and invariant triggers for goal effective limits and continuation context ownership.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <merge-commit>` before later goal-mode PRs depend on the schema.
- **Feature flags or config toggles:** None in this PR.
- **Observable failure symptoms:** Control-plane DB migration errors, runtime startup errors around `control_plane.db`, or failing goal task storage tests.
