### PR TITLE
fix(runtime): enforce leading user-turn invariant before provider dispatch

### DIFF
--- a/crates/zeroclaw-api/src/model_provider.rs
+++ b/crates/zeroclaw-api/src/model_provider.rs
@@ -948,6 +948,12 @@ mod turn_order_tests {
         assert_eq!(msgs[1].role, "user");
     }
 
+    /// The sanitizer is a pure leading-turn repair: with no `user` anywhere it
+    /// drains every non-system turn, leaving system-only. That system-only
+    /// shape is NOT a valid provider payload; the prep boundary
+    /// (`prepare_messages_for_iteration`) fails closed on a no-user history
+    /// before dispatch. See the runtime `prepare_fails_closed_when_no_user_turn_survives`
+    /// regression.
     #[test]
     fn no_user_turn_drops_all_non_system() {
         let mut msgs = vec![

--- a/crates/zeroclaw-api/src/model_provider.rs
+++ b/crates/zeroclaw-api/src/model_provider.rs
@@ -98,6 +98,35 @@ impl ChatMessage {
                 .and_then(|previous| messages.get(previous))
                 .is_some_and(Self::is_pruned_tool_exchange_summary)
     }
+
+    pub fn is_system(&self) -> bool {
+        self.role == "system"
+    }
+
+    pub fn is_user(&self) -> bool {
+        self.role == "user"
+    }
+
+    /// Drop leading turns that violate the universal turn-order invariant that
+    /// strict providers enforce: the first non-system turn must be a `user`
+    /// turn. Context trims, session restores, and synthetic priming can
+    /// decapitate the anchoring `user` message and leave an `assistant`
+    /// tool-call or a `tool` result as the first non-system turn, which strict
+    /// providers reject. Tolerant providers silently accept the malformed
+    /// shape, so the defect only surfaces on strict routes.
+    pub fn sanitize_leading_turn_order(messages: &mut Vec<Self>) {
+        let first_non_system = messages
+            .iter()
+            .position(|m| !m.is_system())
+            .unwrap_or(messages.len());
+        let mut drop_to = first_non_system;
+        while drop_to < messages.len() && !messages[drop_to].is_user() {
+            drop_to += 1;
+        }
+        if drop_to > first_non_system {
+            messages.drain(first_non_system..drop_to);
+        }
+    }
 }
 
 /// A tool call requested by the LLM.
@@ -876,4 +905,65 @@ pub fn build_tool_instructions_text(tools: &[ToolSpec]) -> String {
     }
 
     instructions
+}
+
+#[cfg(test)]
+mod turn_order_tests {
+    use super::ChatMessage;
+
+    #[test]
+    fn drops_leading_assistant_tool_call_before_first_user() {
+        let mut msgs = vec![
+            ChatMessage::system("sys"),
+            ChatMessage::assistant("[tool_call] fire"),
+            ChatMessage::tool("result"),
+            ChatMessage::user("actual user"),
+        ];
+        ChatMessage::sanitize_leading_turn_order(&mut msgs);
+        assert_eq!(msgs[0].role, "system");
+        assert_eq!(msgs[1].role, "user");
+        assert_eq!(msgs[1].content, "actual user");
+    }
+
+    #[test]
+    fn drops_leading_orphan_tool_turn() {
+        let mut msgs = vec![ChatMessage::tool("orphan result"), ChatMessage::user("hi")];
+        ChatMessage::sanitize_leading_turn_order(&mut msgs);
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].role, "user");
+    }
+
+    #[test]
+    fn preserves_already_valid_history() {
+        let mut msgs = vec![
+            ChatMessage::system("sys"),
+            ChatMessage::user("q"),
+            ChatMessage::assistant("[tool_call] x"),
+            ChatMessage::tool("r"),
+            ChatMessage::assistant("done"),
+        ];
+        let before = msgs.clone();
+        ChatMessage::sanitize_leading_turn_order(&mut msgs);
+        assert_eq!(msgs.len(), before.len());
+        assert_eq!(msgs[1].role, "user");
+    }
+
+    #[test]
+    fn no_user_turn_drops_all_non_system() {
+        let mut msgs = vec![
+            ChatMessage::system("sys"),
+            ChatMessage::assistant("[tool_call] x"),
+            ChatMessage::tool("r"),
+        ];
+        ChatMessage::sanitize_leading_turn_order(&mut msgs);
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].role, "system");
+    }
+
+    #[test]
+    fn empty_history_is_noop() {
+        let mut msgs: Vec<ChatMessage> = vec![];
+        ChatMessage::sanitize_leading_turn_order(&mut msgs);
+        assert!(msgs.is_empty());
+    }
 }

--- a/crates/zeroclaw-api/src/model_provider.rs
+++ b/crates/zeroclaw-api/src/model_provider.rs
@@ -107,13 +107,6 @@ impl ChatMessage {
         self.role == "user"
     }
 
-    /// Drop leading turns that violate the universal turn-order invariant that
-    /// strict providers enforce: the first non-system turn must be a `user`
-    /// turn. Context trims, session restores, and synthetic priming can
-    /// decapitate the anchoring `user` message and leave an `assistant`
-    /// tool-call or a `tool` result as the first non-system turn, which strict
-    /// providers reject. Tolerant providers silently accept the malformed
-    /// shape, so the defect only surfaces on strict routes.
     pub fn sanitize_leading_turn_order(messages: &mut Vec<Self>) {
         let first_non_system = messages
             .iter()
@@ -948,12 +941,6 @@ mod turn_order_tests {
         assert_eq!(msgs[1].role, "user");
     }
 
-    /// The sanitizer is a pure leading-turn repair: with no `user` anywhere it
-    /// drains every non-system turn, leaving system-only. That system-only
-    /// shape is NOT a valid provider payload; the prep boundary
-    /// (`prepare_messages_for_iteration`) fails closed on a no-user history
-    /// before dispatch. See the runtime `prepare_fails_closed_when_no_user_turn_survives`
-    /// regression.
     #[test]
     fn no_user_turn_drops_all_non_system() {
         let mut msgs = vec![

--- a/crates/zeroclaw-runtime/src/agent/turn/vision_route.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/vision_route.rs
@@ -131,6 +131,12 @@ pub(crate) async fn prepare_messages_for_iteration(
     degrade_strip_images: bool,
     image_cache: Option<&mut multimodal::LocalImageCache>,
 ) -> Result<multimodal::PreparedMessages> {
+    // Enforce the universal leading-turn-order invariant before any provider
+    // sees the history: strict providers reject a first non-system turn that is
+    // not `user`, which context trims and session restores can produce.
+    let mut sanitized = history.to_vec();
+    ChatMessage::sanitize_leading_turn_order(&mut sanitized);
+    let history = sanitized.as_slice();
     if degrade_strip_images {
         // Text-only fallback: replace every media marker with a
         // `[media attachment]` placeholder so no filesystem path or data
@@ -205,5 +211,32 @@ mod tests {
             .await
             .unwrap();
         assert!(uncached.contains_images);
+    }
+
+    /// Regression: a history whose first non-system turn is an assistant
+    /// tool-call (context trim / restore decapitated the anchoring user turn)
+    /// must be sanitized before any provider sees it, so strict providers no
+    /// longer reject the leading tool-call turn.
+    #[tokio::test]
+    async fn prepare_strips_leading_assistant_tool_call() {
+        let history = vec![
+            ChatMessage::system("sys"),
+            ChatMessage::assistant("[tool_call] fire"),
+            ChatMessage::tool("result"),
+            ChatMessage::user("actual user"),
+        ];
+        let cfg = MultimodalConfig::default();
+        let prepared = prepare_messages_for_iteration(&history, &cfg, false, None)
+            .await
+            .unwrap();
+        let first_non_system = prepared
+            .messages
+            .iter()
+            .find(|m| m.role != "system")
+            .expect("a non-system turn survives");
+        assert_eq!(
+            first_non_system.role, "user",
+            "leading non-user turns must be dropped before dispatch"
+        );
     }
 }

--- a/crates/zeroclaw-runtime/src/agent/turn/vision_route.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/vision_route.rs
@@ -136,6 +136,18 @@ pub(crate) async fn prepare_messages_for_iteration(
     // not `user`, which context trims and session restores can produce.
     let mut sanitized = history.to_vec();
     ChatMessage::sanitize_leading_turn_order(&mut sanitized);
+    // Fail closed before any provider sees the history. A no-user history
+    // (session-only, or a leading assistant/tool block with no anchoring user
+    // turn) sanitizes down to system-only, which every strict provider rejects
+    // and which silently discards the only surviving non-system context.
+    // Refuse to build a provider payload with zero user turns rather than
+    // trade one strict-provider failure shape for another.
+    if !sanitized.iter().any(ChatMessage::is_user) {
+        anyhow::bail!(
+            "refusing to dispatch to provider: prepared history has no user turn \
+             (system-only after leading-turn-order sanitize)"
+        );
+    }
     let history = sanitized.as_slice();
     if degrade_strip_images {
         // Text-only fallback: replace every media marker with a
@@ -237,6 +249,41 @@ mod tests {
         assert_eq!(
             first_non_system.role, "user",
             "leading non-user turns must be dropped before dispatch"
+        );
+    }
+
+    /// Fail-closed regression (#6302, "NO USER TURN AT ALL"): a history that
+    /// sanitizes down to system-only must NOT produce a provider payload. The
+    /// prep boundary returns an error before dispatch instead of sending a
+    /// user-less request (or silently discarding the surviving context).
+    #[tokio::test]
+    async fn prepare_fails_closed_when_no_user_turn_survives() {
+        let cfg = MultimodalConfig::default();
+
+        // Pure system history.
+        let system_only = vec![ChatMessage::system("sys")];
+        let err = prepare_messages_for_iteration(&system_only, &cfg, false, None)
+            .await
+            .expect_err("system-only history must not reach the provider");
+        assert!(
+            err.to_string().contains("no user turn"),
+            "expected a no-user-turn fail-closed error, got: {err}"
+        );
+
+        // Leading assistant/tool block with no anchoring user turn: sanitize
+        // drains every non-system turn, leaving system-only, which must fail
+        // closed rather than dispatch.
+        let no_user = vec![
+            ChatMessage::system("sys"),
+            ChatMessage::assistant("[tool_call] fire"),
+            ChatMessage::tool("result"),
+        ];
+        let err = prepare_messages_for_iteration(&no_user, &cfg, false, None)
+            .await
+            .expect_err("no-user history must not reach the provider");
+        assert!(
+            err.to_string().contains("no user turn"),
+            "expected a no-user-turn fail-closed error, got: {err}"
         );
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Strict providers reject a conversation whose first non-system turn is not a `user` turn (function-call turn must come immediately after a user or function-response turn). Context trims, session restores, and synthetic priming can decapitate the anchoring user turn and leave an `assistant` tool-call or a `tool` result at index 0, so the request 400s on strict routes while tolerant providers silently accept the malformed shape.
  - Add `ChatMessage::sanitize_leading_turn_order`, a pure pass that drops leading non-`user` turns (after any leading system turns) down to the first `user` turn.
  - Run the pass once in `prepare_messages_for_iteration`, the single per-iteration chokepoint every dispatch path flows through, so CLI, gateway, and channel turns are all covered by one provider-agnostic sanitization.
- **Scope boundary:** Only the leading-turn-order invariant is enforced here. Mid-history tool_call/tool pairing and empty-role repair are out of scope and left for follow-up; this narrow fix targets the reported leading-orphan 400 without touching the trimmer or provider adapters.
- **Blast radius:** All provider calls route through `prepare_messages_for_iteration`. The pass is a no-op for already-valid histories (leading system turns then a user turn), so tolerant providers see identical payloads; only histories with a leading non-user turn change, and those were previously malformed.
- **Linked issue(s):** Closes #6302

- **Labels:** `bug`, `agent`, `runtime`, `priority:p1`, `risk:high`, `size:S`

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy -p zeroclaw-api -p zeroclaw-runtime --all-targets -- -D warnings
cargo test -p zeroclaw-api turn_order
cargo test -p zeroclaw-runtime vision_route
```

- **Commands run and tail output:**

`cargo fmt --all -- --check` → clean (no diff).

`cargo clippy -p zeroclaw-api -p zeroclaw-runtime --all-targets -- -D warnings`:
```
    Checking zeroclaw-runtime v0.8.2 (/home/shane/git/zeroclaw-temp/crates/zeroclaw-runtime)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 32s
```

`cargo test -p zeroclaw-api turn_order`:
```
running 5 tests
test model_provider::turn_order_tests::drops_leading_assistant_tool_call_before_first_user ... ok
test model_provider::turn_order_tests::drops_leading_orphan_tool_turn ... ok
test model_provider::turn_order_tests::empty_history_is_noop ... ok
test model_provider::turn_order_tests::no_user_turn_drops_all_non_system ... ok
test model_provider::turn_order_tests::preserves_already_valid_history ... ok
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 97 filtered out
```

`cargo test -p zeroclaw-runtime vision_route`:
```
running 4 tests
test agent::turn::vision_route::tests::prepare_strips_leading_assistant_tool_call ... ok
test agent::turn::vision_route::tests::prepare_messages_for_iteration_populates_and_reuses_image_cache ... ok
test agent::agent::tests::surface2_tests::turn_streamed_rebuilds_prompt_for_vision_routed_native_provider ... ok
test agent::agent::tests::surface2_tests::turn_rebuilds_prompt_for_vision_routed_xml_provider ... ok
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 2756 filtered out
```

- **Beyond CI — what did you manually verify?** Confirmed `prepare_messages_for_iteration` is the single per-iteration path `call_provider` dispatches from for both streaming and non-streaming, so the pass covers CLI, gateway, and channels without per-adapter changes. Did NOT run a live Gemini/LiteLLM request; the reproducer is asserted via the sanitizer unit tests and the prepared-message regression test.
- **If any command was intentionally skipped, why:** Full-workspace `cargo test` not pasted here; ran targeted crate tests for the changed crates.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- The pass is a no-op for valid histories; only previously-malformed leading turns change. No upgrade steps.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <sha>`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** A strict-provider 400 referencing "function call turn comes immediately after a user turn or after a function response turn" would reappear; grep provider error logs for that message.
