### PR TITLE
fix(web): add missing zh chat-toolbar i18n keys

### DIFF
--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -73,6 +73,13 @@ const translations: Record<Locale, Record<string, string>> = {
     'agent.message_error': '消息错误',
     'agent.failed_switch_model': '切换模型失败',
     'agent.model_switch_timeout': '模型切换超时，请检查网络后重试',
+    'agent.clear_all': '全部清除',
+    'agent.delete_message': '删除消息',
+    'agent.compact_mode': '紧凑',
+    'agent.tool_activity_show': '显示工具活动',
+    'agent.tool_activity_hide': '隐藏工具活动',
+    'agent.running': '运行中…',
+    'agent.stop': '停止',
 
     // Supervised-mode tool approval (#6522)
     'agent.approval_title': '需要授权工具调用',


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** The chat toolbar calls `t('agent.clear_all')`, `t('agent.delete_message')`, `t('agent.compact_mode')`, `t('agent.tool_activity_show')`, `t('agent.tool_activity_hide')`, `t('agent.running')`, and `t('agent.stop')`, but the `zh` locale defined none of them. Chinese users saw the raw English fallback (`translations.en[key]` at `i18n.ts:12643`) for every one of these toolbar controls. This adds proper `zh` translations for all seven keys.
- **Scope boundary:** Only the seven missing `zh` toolbar keys. No new keys, no `en` changes, no component logic, no other locales. The other 11 locales already rely on the `en` fallback for these strings, matching the established two-locale (en + zh) maintenance pattern used across the rest of `agent.*` (e.g. `agent.approval_title` from #6522 also exists only in en + zh).
- **Blast radius:** Chat toolbar rendering under `zh` locale only. No runtime, API, or config surface touched.
- **Linked issue(s):** Closes #7139
- **Labels:** `bug`, `web`

## Validation Evidence (required)

Web/TypeScript change; the Rust battery does not apply. Frontend typecheck:

```bash
cd web && npx tsc -b
```

- **Commands run and tail output:** `npx tsc -b` exits 0 (clean, no diagnostics).
- **Beyond CI — what did you manually verify?** Confirmed all seven keys are referenced by toolbar components via grep, and that each now resolves in `zh` instead of falling through to `en`. Verified no other locale regressed. Did not run a full visual pass of the running UI.
- **If any command was intentionally skipped, why:** `cargo fmt/clippy/test` skipped — no Rust changed.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`

## Rollback (required for medium/high-risk PRs)

Low-risk: `git revert <sha>`.