### PR TITLE
feat(desktop): self-contained installer — bundle the kernel as a Tauri sidecar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 
 # Desktop installer build artifacts
 *.dmg
+# Kernel sidecar staging for the self-contained desktop build
+/apps/tauri/binaries/
 /docs/book/book/
 /docs/book/po/messages.pot
 /docs/book/po/*.failures.log

--- a/apps/tauri/TESTING.md
+++ b/apps/tauri/TESTING.md
@@ -18,9 +18,12 @@ On launch:
    `web/src/App.tsx`) sends first-time users — no agents yet, Quickstart never
    completed — to `/quickstart`. Returning users land on the dashboard.
 
-> The app assumes a gateway is reachable on `127.0.0.1:42617`. It does **not**
-> start the gateway itself yet — bundling the gateway as a Tauri sidecar is the
-> planned "full experience" distribution (architecture RFC fnd-001, D5).
+> The app looks for a gateway on `127.0.0.1:42617`: it reuses a running
+> daemon, or spawns `zeroclaw daemon` itself (preferring a kernel bundled
+> next to the app executable, then `PATH` and the common install dirs — see
+> `src/daemon.rs::find_zeroclaw_binary`). The self-contained installer below
+> bundles the kernel as a Tauri sidecar — the "full experience" distribution
+> from architecture RFC fnd-001, D5.
 >
 > **Run `zeroclaw daemon`, not `zeroclaw gateway start`.** Both serve the
 > dashboard on 42617, but only the daemon attaches the supervisor that powers
@@ -28,6 +31,43 @@ On launch:
 > a standalone `gateway start` has no supervisor and returns
 > `503 "no daemon supervisor — running as standalone gateway"`, so the new agent
 > won't go live until the process is restarted. The daemon hot-reloads instead.
+
+## Self-contained build (bundled kernel)
+
+The plain `cargo tauri build` produces an app that *finds* an installed
+`zeroclaw`. To produce the zero-install artifact — double-click on a machine
+with nothing pre-installed and get a running agent — bundle the kernel as a
+sidecar:
+
+```sh
+# 1. Build (or reuse) the kernel and stage it for the bundler.
+scripts/desktop/prepare-kernel.sh                          # host triple
+scripts/desktop/prepare-kernel.sh --target universal-apple-darwin  # mac universal
+# Reuse an existing kernel instead of rebuilding (single-target only):
+ZEROCLAW_KERNEL_PATH=~/.cargo/bin/zeroclaw scripts/desktop/prepare-kernel.sh
+
+# 2. Bundle with the sidecar overlay (adds bundle.externalBin).
+cd apps/tauri && cargo tauri build --config tauri.bundled.conf.json
+```
+
+The overlay keeps the default config untouched, so `cargo tauri build`
+without the staged kernel keeps working. Tauri places the sidecar next to the
+app executable as `zeroclaw`, which is the first place
+`find_zeroclaw_binary()` looks — so the bundled app starts its own daemon
+from its own kernel.
+
+To verify self-containment, launch on a machine (or shell) where `zeroclaw`
+is not on `PATH` and not in `~/.cargo/bin`, then check the daemon's process
+path points inside the app bundle:
+
+```sh
+pgrep -fl 'zeroclaw daemon'   # expect .../ZeroClaw.app/Contents/MacOS/zeroclaw
+```
+
+> Size note: the kernel dominates the artifact. A stripped release kernel is
+> ~146 MB per arch (~55–65 MB compressed dmg); a universal (two-slice) kernel
+> roughly doubles that. The unstripped dev kernel is ~228 MB — always let
+> `prepare-kernel.sh` strip it.
 
 ## macOS (current target)
 

--- a/apps/tauri/tauri.bundled.conf.json
+++ b/apps/tauri/tauri.bundled.conf.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/config.schema.json",
+  "bundle": {
+    "externalBin": ["binaries/zeroclaw"]
+  }
+}

--- a/scripts/desktop/prepare-kernel.sh
+++ b/scripts/desktop/prepare-kernel.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# prepare-kernel.sh: build (or reuse) the `zeroclaw` kernel binary and place it
+# where the Tauri bundler expects a sidecar, so the desktop installer is
+# self-contained — double-click, and the app starts its own daemon from the
+# bundled kernel with nothing pre-installed.
+#
+# The desktop app already prefers a sibling `zeroclaw` binary at runtime
+# (apps/tauri/src/daemon.rs::find_zeroclaw_binary), which is exactly where
+# Tauri places externalBin sidecars. This script only produces the build-time
+# input: apps/tauri/binaries/zeroclaw-<target-triple>[.exe].
+#
+# Usage:
+#   scripts/desktop/prepare-kernel.sh                          # host triple
+#   scripts/desktop/prepare-kernel.sh --target aarch64-apple-darwin
+#   scripts/desktop/prepare-kernel.sh --target universal-apple-darwin
+#       # builds both mac arches and fuses them with lipo
+#
+# Environment:
+#   ZEROCLAW_KERNEL_PATH   Reuse an existing kernel binary instead of building
+#                          (single-target only; ignored for universal).
+#   CARGO_PROFILE          Cargo profile to build (default: release).
+#
+# Then bundle with the sidecar overlay:
+#   cd apps/tauri && cargo tauri build --config tauri.bundled.conf.json
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+OUT_DIR="$REPO_ROOT/apps/tauri/binaries"
+PROFILE="${CARGO_PROFILE:-release}"
+
+TARGET=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target) TARGET="$2"; shift 2 ;;
+    -h|--help) sed -n '3,25p' "$0"; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+host_triple() {
+  rustc -vV | sed -n 's/^host: //p'
+}
+
+# Fail fast when a prebuilt kernel's architecture doesn't match the triple it
+# would be staged as — a mismatched sidecar produces an installer that can't
+# start its own daemon.
+check_arch() {
+  local path="$1" triple="$2" want=""
+  command -v file >/dev/null || return 0
+  case "$triple" in
+    aarch64-apple-darwin) want="arm64" ;;
+    aarch64-*) want="aarch64" ;;
+    x86_64-*) want="x86_64" ;;
+    *) return 0 ;;
+  esac
+  if ! file "$path" | grep -q "$want"; then
+    echo "prepare-kernel: ERROR: $path is not a $triple binary:" >&2
+    file "$path" >&2
+    exit 1
+  fi
+}
+
+# Build the kernel for one triple and echo the path to the built binary.
+build_kernel() {
+  local triple="$1"
+  local exe=""
+  [[ "$triple" == *windows* ]] && exe=".exe"
+  if [[ -n "${ZEROCLAW_KERNEL_PATH:-}" ]]; then
+    echo "prepare-kernel: using prebuilt kernel: $ZEROCLAW_KERNEL_PATH" >&2
+    check_arch "$ZEROCLAW_KERNEL_PATH" "$triple"
+    echo "$ZEROCLAW_KERNEL_PATH"
+    return
+  fi
+  echo "prepare-kernel: cargo build --profile $PROFILE --bin zeroclaw --target $triple" >&2
+  (cd "$REPO_ROOT" && cargo build --profile "$PROFILE" --bin zeroclaw --target "$triple")
+  local dir="release"
+  [[ "$PROFILE" != "release" ]] && dir="$PROFILE"
+  echo "$REPO_ROOT/target/$triple/$dir/zeroclaw$exe"
+}
+
+# Strip a copy of the kernel into place; re-sign on macOS (stripping
+# invalidates the ad-hoc signature arm64 requires to exec).
+place_stripped() {
+  local src="$1" dest="$2"
+  cp "$src" "$dest"
+  case "$(uname -s)" in
+    Darwin)
+      strip -x "$dest" 2>/dev/null || true
+      command -v codesign >/dev/null && codesign --force --sign - "$dest" 2>/dev/null || true
+      ;;
+    *)
+      strip "$dest" 2>/dev/null || true
+      ;;
+  esac
+}
+
+mkdir -p "$OUT_DIR"
+
+if [[ "$TARGET" == "universal-apple-darwin" ]]; then
+  # Tauri's universal build expects binaries/zeroclaw-universal-apple-darwin.
+  # A single prebuilt kernel can't serve both slices — always build per-arch.
+  ZEROCLAW_KERNEL_PATH=""
+  ARM_SRC="$(build_kernel aarch64-apple-darwin)"
+  X86_SRC="$(build_kernel x86_64-apple-darwin)"
+  place_stripped "$ARM_SRC" "$OUT_DIR/zeroclaw-aarch64-apple-darwin"
+  place_stripped "$X86_SRC" "$OUT_DIR/zeroclaw-x86_64-apple-darwin"
+  lipo -create \
+    "$OUT_DIR/zeroclaw-aarch64-apple-darwin" \
+    "$OUT_DIR/zeroclaw-x86_64-apple-darwin" \
+    -output "$OUT_DIR/zeroclaw-universal-apple-darwin"
+  DEST="$OUT_DIR/zeroclaw-universal-apple-darwin"
+else
+  TARGET="${TARGET:-$(host_triple)}"
+  EXE=""
+  [[ "$TARGET" == *windows* ]] && EXE=".exe"
+  SRC="$(build_kernel "$TARGET")"
+  DEST="$OUT_DIR/zeroclaw-$TARGET$EXE"
+  place_stripped "$SRC" "$DEST"
+fi
+
+echo "prepare-kernel: sidecar ready at ${DEST#"$REPO_ROOT"/}"
+ls -lh "$DEST" | awk '{print "prepare-kernel: size " $5}'


### PR DESCRIPTION
> **Stack 3/4 of the desktop reintroduction series** (#8565 → #8706 → this → #8709). Contains its predecessors' commits until they land; the single-layer diff is the last commit (also viewable at JordanTheJet/zeroclaw#15).

## Summary

- **Base branch:** `master`
- **What changed and why:**
  - The desktop app's core value is **zero-install onboarding**, but the plain build only *finds* an installed `zeroclaw` — on a clean machine it dead-ends at "couldn't find the zeroclaw binary". This makes the self-contained artifact buildable.
  - `scripts/desktop/prepare-kernel.sh`: builds (or reuses via `ZEROCLAW_KERNEL_PATH`, with an architecture sanity check) the kernel, **strips** it, re-signs on macOS (stripping invalidates the ad-hoc signature arm64 requires), and stages it as `apps/tauri/binaries/zeroclaw-<triple>`. `--target universal-apple-darwin` builds both mac arches and fuses them with `lipo`.
  - `apps/tauri/tauri.bundled.conf.json`: a config **overlay** adding `bundle.externalBin`, used via `cargo tauri build --config tauri.bundled.conf.json`. The default `tauri.conf.json` is untouched, so ordinary dev builds don't require a staged kernel.
  - Tauri places the sidecar next to the app executable — the **first** location `find_zeroclaw_binary()` checks — so the bundled app starts its own daemon from its own kernel, beating any PATH-installed copy.
  - Kernel size reality: the default-feature release kernel strips to ~19 MB (arm64); the full-feature (`channels-full`) build is much larger. The bundled kernel is the **default-feature** build.
- **Scope boundary:** Build tooling + docs only — no shipped-code changes; no release-workflow changes (stack 4 wires this into CI).
- **Blast radius:** none at runtime for existing flows; `apps/tauri/binaries/` is gitignored staging.
- **Linked issue(s):** Related #8565. Implements the "desktop app bundles the kernel" distribution from `docs/book/src/foundations/fnd-001-intentional-architecture.md` (D5).
- **Labels:** suggest `type:build`, `risk:low`, `size:M`.

## Validation Evidence (required)

- **Commands run and tail output** (one battery on the full stacked tree — arm64 macOS, `rustc 1.93` host `aarch64-apple-darwin`; covers every layer of the series):

  `cargo fmt --all -- --check` → clean, no diffs.

  `cargo clippy --all-targets -- -D warnings`:
  ```text
      Checking zeroclaw-runtime v0.8.2
      Checking zeroclaw-hardware v0.8.2
      Checking zeroclaw-channels v0.8.2
      Checking zeroclaw-eval v0.8.2
      Finished `dev` profile [unoptimized + debuginfo] target(s) in 3m 44s
  ```

  `cargo test` (tail):
  ```text
  running 9 tests
  test system::multi_agent_e2e::peer_group_routes_messages_only_within_resolved_peer_set ... ok
  test system::multi_agent_e2e::peer_group_dotted_channel_refs_remain_alias_scoped_for_dispatch ... ok
  test system::multi_agent_e2e::legacy_install_upgrades_cleanly_with_backup ... ok
  test system::multi_agent_e2e::two_sqlite_agents_on_one_install_have_isolated_memory ... ok
  test system::full_stack::system_parallel_tool_execution ... ok
  test system::full_stack::system_simple_text_response ... ok
  test system::full_stack::system_tool_execution_flow ... ok
  test system::full_stack::system_multi_turn_conversation ... ok
  test system::full_stack::system_tool_arguments_passed_correctly ... ok

  test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.15s
  ```
  Battery exit code 0.

- **Beyond CI — what did you manually verify?** End-to-end on arm64 macOS: `scripts/desktop/prepare-kernel.sh` built, stripped, re-signed, and staged the kernel sidecar (19 MB arm64); `cargo tauri build --config tauri.bundled.conf.json` produced `ZeroClaw_0.8.2_aarch64.dmg` — **19 MB total, fully self-contained** (`ZeroClaw.app/Contents/MacOS/` contains the 19 MB kernel + 4.3 MB release desktop binary). Launched the bundled app against a fresh temp config dir: it spawned its daemon **from the bundle's own sidecar** (process path `…/ZeroClaw.app/Contents/MacOS/zeroclaw daemon -p 42617`), the gateway came up, the dashboard opened at the gateway root, and the web Quickstart auto-loaded. Negative test: the script's architecture check hard-fails when a prebuilt kernel's arch doesn't match the staged triple (caught a real x86_64-as-aarch64 mislabel during development). For scale: OpenClaw's macOS dmg is 37 MB and requires a system Node 24 + runtime package fetching; this artifact is 19 MB with zero external dependencies.

- **If any command was intentionally skipped, why:** none skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No** new runtime surface — the app already spawns a discovered kernel (#8565); this changes *which* kernel is found first (the bundled, signed-with-the-app copy — a hardening, since it beats PATH-planted binaries).
- New external network calls? **No**.
- Secrets / tokens / credentials handling changed? **No**.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**.

## Compatibility (required)

- Backward compatible? **Yes** — plain `cargo tauri build` behavior is unchanged; the overlay is opt-in.
- Config / env / CLI surface changed? **No** (new optional build script + `ZEROCLAW_KERNEL_PATH`/`CARGO_PROFILE` env for the script only).

## Rollback (required for medium/high-risk PRs)

Low-risk: `git revert <sha>` (removes the script + overlay; no runtime code changes).
