### PR TITLE
ci(release): ship self-contained desktop installers on all three platforms

### DIFF
--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -381,7 +381,9 @@ jobs:
     name: Build Desktop App (macOS Universal)
     needs: [validate]
     runs-on: macos-14
-    timeout-minutes: 40
+    # Two kernel release builds (arm64 + x86_64) feed the universal sidecar,
+    # then the universal app build on top.
+    timeout-minutes: 180
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -413,9 +415,45 @@ jobs:
           fi
           echo "Tauri version set to: $VERSION"
 
-      - name: Build Tauri app (universal binary)
+      - name: Stage bundled kernel sidecar (universal)
+        run: scripts/desktop/prepare-kernel.sh --target universal-apple-darwin
+
+      # Code-signing + notarization are optional: when the APPLE_* secrets are
+      # configured the Tauri bundler picks them up from the environment and
+      # signs/notarizes the app; when absent the build stays unsigned (ad-hoc),
+      # exactly as before. Secrets never gate the build itself.
+      - name: Enable macOS signing (when secrets are configured)
+        shell: bash
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          if [ -n "$APPLE_CERTIFICATE" ]; then
+            {
+              echo "APPLE_CERTIFICATE=$APPLE_CERTIFICATE"
+              echo "APPLE_CERTIFICATE_PASSWORD=$APPLE_CERTIFICATE_PASSWORD"
+              echo "APPLE_SIGNING_IDENTITY=$APPLE_SIGNING_IDENTITY"
+            } >> "$GITHUB_ENV"
+            echo "macOS code signing enabled."
+          else
+            echo "APPLE_CERTIFICATE secret not set — building unsigned."
+          fi
+          if [ -n "$APPLE_ID" ]; then
+            {
+              echo "APPLE_ID=$APPLE_ID"
+              echo "APPLE_PASSWORD=$APPLE_PASSWORD"
+              echo "APPLE_TEAM_ID=$APPLE_TEAM_ID"
+            } >> "$GITHUB_ENV"
+            echo "macOS notarization enabled."
+          fi
+
+      - name: Build Tauri app (universal binary, bundled kernel)
         working-directory: apps/tauri
-        run: cargo tauri build --target universal-apple-darwin
+        run: cargo tauri build --target universal-apple-darwin --config tauri.bundled.conf.json
 
       - name: Prepare desktop release assets
         run: |
@@ -432,9 +470,125 @@ jobs:
           path: desktop-assets/*
           retention-days: 14
 
+  # New desktop platforms. continue-on-error keeps them non-blocking for the
+  # release while they bed in — the macOS dmg remains the only required
+  # desktop asset. Promote by removing continue-on-error and adding their
+  # assets to the required list in `publish`.
+  build-desktop-linux:
+    name: Build Desktop App (Linux x86_64)
+    needs: [validate]
+    runs-on: ubuntu-22.04
+    timeout-minutes: 120
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install Linux desktop toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libsoup-3.0-dev \
+            libgtk-3-dev \
+            librsvg2-dev \
+            libayatana-appindicator3-dev
+
+      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
+        with:
+          toolchain: 1.93.0
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          prefix-key: linux-tauri
+
+      - name: Install Tauri CLI
+        run: cargo install tauri-cli --locked
+
+      - name: Sync Tauri version with Cargo.toml
+        shell: bash
+        run: |
+          VERSION=$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -1)
+          cd apps/tauri
+          jq --arg v "$VERSION" '.version = $v' tauri.conf.json > tmp.json && mv tmp.json tauri.conf.json
+          echo "Tauri version set to: $VERSION"
+
+      - name: Stage bundled kernel sidecar
+        run: scripts/desktop/prepare-kernel.sh --target x86_64-unknown-linux-gnu
+
+      - name: Build Tauri app (bundled kernel)
+        working-directory: apps/tauri
+        run: cargo tauri build --config tauri.bundled.conf.json
+
+      - name: Prepare desktop release assets
+        run: |
+          mkdir -p desktop-assets
+          find target -name '*.deb' -exec cp {} desktop-assets/ZeroClaw-linux-amd64.deb \; 2>/dev/null || true
+          find target -name '*.AppImage' -exec cp {} desktop-assets/ZeroClaw-linux-x86_64.AppImage \; 2>/dev/null || true
+          echo "--- Desktop assets ---"
+          ls -lh desktop-assets/
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: desktop-linux
+          path: desktop-assets/*
+          retention-days: 14
+
+  build-desktop-windows:
+    name: Build Desktop App (Windows x86_64)
+    needs: [validate]
+    runs-on: windows-latest
+    timeout-minutes: 150
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
+        with:
+          toolchain: 1.93.0
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          prefix-key: windows-tauri
+
+      - name: Install Tauri CLI
+        run: cargo install tauri-cli --locked
+
+      - name: Sync Tauri version with Cargo.toml
+        shell: bash
+        run: |
+          VERSION=$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -1)
+          cd apps/tauri
+          jq --arg v "$VERSION" '.version = $v' tauri.conf.json > tmp.json && mv tmp.json tauri.conf.json
+          echo "Tauri version set to: $VERSION"
+
+      - name: Stage bundled kernel sidecar
+        shell: bash
+        run: scripts/desktop/prepare-kernel.sh --target x86_64-pc-windows-msvc
+
+      - name: Build Tauri app (bundled kernel)
+        working-directory: apps/tauri
+        run: cargo tauri build --config tauri.bundled.conf.json
+
+      - name: Prepare desktop release assets
+        shell: bash
+        run: |
+          mkdir -p desktop-assets
+          find target -name '*.msi' -exec cp {} desktop-assets/ZeroClaw-windows-x64.msi \; 2>/dev/null || true
+          find target -name '*-setup.exe' -exec cp {} desktop-assets/ZeroClaw-windows-x64-setup.exe \; 2>/dev/null || true
+          echo "--- Desktop assets ---"
+          ls -lh desktop-assets/
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: desktop-windows
+          path: desktop-assets/*
+          retention-days: 14
+
   publish:
     name: Publish Stable Release
-    needs: [validate, release-notes, build, build-desktop]
+    # The Linux/Windows desktop jobs are continue-on-error: listing them in
+    # needs only sequences the download; their failure cannot block publish.
+    needs: [validate, release-notes, build, build-desktop, build-desktop-linux, build-desktop-windows]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -457,6 +611,20 @@ jobs:
         with:
           name: desktop-macos
           path: artifacts/desktop-macos
+
+      # Optional platforms — the artifact may not exist when the
+      # continue-on-error bundle job failed; never block publish on it.
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        continue-on-error: true
+        with:
+          name: desktop-linux
+          path: artifacts/desktop-linux
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        continue-on-error: true
+        with:
+          name: desktop-windows
+          path: artifacts/desktop-windows
 
       - name: Verify required release assets
         shell: bash
@@ -490,13 +658,13 @@ jobs:
       - name: Generate checksums
         run: |
           cd artifacts
-          find . -type f \( -name '*.tar.gz' -o -name '*.zip' -o -name '*.dmg' \) -exec sha256sum {} + | sed 's|  \./[^/]*/|  |' > SHA256SUMS
+          find . -type f \( -name '*.tar.gz' -o -name '*.zip' -o -name '*.dmg' -o -name '*.deb' -o -name '*.AppImage' -o -name '*.msi' -o -name '*-setup.exe' \) -exec sha256sum {} + | sed 's|  \./[^/]*/|  |' > SHA256SUMS
           cat SHA256SUMS
 
       - name: Collect release assets
         run: |
           mkdir -p release-assets
-          find artifacts -type f \( -name '*.tar.gz' -o -name '*.zip' -o -name '*.dmg' -o -name 'SHA256SUMS' \) -exec cp {} release-assets/ \;
+          find artifacts -type f \( -name '*.tar.gz' -o -name '*.zip' -o -name '*.dmg' -o -name '*.deb' -o -name '*.AppImage' -o -name '*.msi' -o -name '*-setup.exe' -o -name 'SHA256SUMS' \) -exec cp {} release-assets/ \;
           cp install.sh release-assets/
           echo "--- Assets ---"
           ls -lh release-assets/
@@ -526,7 +694,7 @@ jobs:
 
           artifact_count=0
           bundle_count=0
-          for artifact in *.tar.gz *.zip *.dmg SHA256SUMS install.sh; do
+          for artifact in *.tar.gz *.zip *.dmg *.deb *.AppImage *.msi *-setup.exe SHA256SUMS install.sh; do
             [ -f "$artifact" ] || continue
             artifact_count=$((artifact_count + 1))
             digest=$(sha256sum "$artifact" | awk '{print $1}')
@@ -754,7 +922,7 @@ jobs:
   # ── Post-publish: signing, SBOM, and SLSA provenance ─────────────────
   hash-artifacts:
     name: Hash Release Artifacts
-    needs: [validate, build, build-desktop]
+    needs: [validate, build, build-desktop, build-desktop-linux, build-desktop-windows]
     runs-on: ubuntu-latest
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}
@@ -769,13 +937,26 @@ jobs:
           name: desktop-macos
           path: artifacts/desktop
 
+      # Optional platforms — may be absent when their bundle job failed.
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        continue-on-error: true
+        with:
+          name: desktop-linux
+          path: artifacts/desktop-linux
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        continue-on-error: true
+        with:
+          name: desktop-windows
+          path: artifacts/desktop-windows
+
       - name: Compute SHA256 hashes (base64, SLSA input format)
         id: hash
         run: |
           set -euo pipefail
           cd artifacts
           # Collect all release archives and desktop artifacts; strip leading directory
-          hashes=$(find . -type f \( -name '*.tar.gz' -o -name '*.zip' -o -name '*.dmg' \) \
+          hashes=$(find . -type f \( -name '*.tar.gz' -o -name '*.zip' -o -name '*.dmg' -o -name '*.deb' -o -name '*.AppImage' -o -name '*.msi' -o -name '*-setup.exe' \) \
             -exec sha256sum {} + \
             | sed 's|  \./[^/]*/|  |' \
             | base64 -w0)
@@ -835,7 +1016,7 @@ jobs:
         # verify with: cosign verify-blob --bundle <file>.bundle <file>
         # The Rekor log URL is printed to stdout for each signature.
         run: |
-          for f in release-assets/*.tar.gz release-assets/*.zip release-assets/*.dmg; do
+          for f in release-assets/*.tar.gz release-assets/*.zip release-assets/*.dmg release-assets/*.deb release-assets/*.AppImage release-assets/*.msi release-assets/*-setup.exe; do
             [ -f "$f" ] || continue
             cosign sign-blob --yes --bundle "${f}.bundle" "$f"
             echo "Signed: $(basename "$f")"


### PR DESCRIPTION
> **Stack 4/4 of the desktop reintroduction series** (#8565 → #8706 → #8708 → this). Contains its predecessors' commits until they land; the single-layer diff is the last commit (also viewable at JordanTheJet/zeroclaw#16).

## Summary

- **Base branch:** `master`
- **What changed and why:** wires the self-contained desktop installer into `release-stable-manual.yml` so releases actually ship the zero-install artifact:
  - **macOS `build-desktop`**: stages a universal (arm64+x86_64, lipo-fused, stripped) kernel sidecar via `scripts/desktop/prepare-kernel.sh`, bundles with `--config tauri.bundled.conf.json`. The released `ZeroClaw.dmg` is now self-contained. Timeout raised 40→180 min for the two kernel release builds.
  - **Signing/notarization gates**: when `APPLE_CERTIFICATE` / `APPLE_ID` (+ companions) secrets are configured, they're exported to the environment and the Tauri bundler signs/notarizes; absent secrets keep today's unsigned behavior. Secrets never gate the build.
  - **New `build-desktop-linux`** (deb + AppImage) and **`build-desktop-windows`** (msi + NSIS setup.exe) jobs, both bundling the kernel for their host triple. Marked `continue-on-error` while they bed in — the macOS dmg remains the only *required* desktop asset. Promote by removing the flag and adding their assets to the required list.
  - `publish` / `hash-artifacts`: download the new artifacts (tolerant of absence), extend checksum/cosign/SLSA/attestation globs with `.deb`/`.AppImage`/`.msi`/`-setup.exe`.
- **Scope boundary:** release workflow only; no shipped-code changes; Windows code-signing intentionally not added (needs a cert-infrastructure decision).
- **Blast radius:** the manual stable-release workflow. Failure mode is contained: new jobs are non-blocking; the required-asset list is unchanged.
- **Linked issue(s):** Related #8565; implements the release side of fnd-001 D5 and the fnd-004 "Tauri build jobs for macOS, Windows, and Linux" milestone.
- **Labels:** `ci`, `risk:high`, `size:M`

## Validation Evidence (required)

- **Commands run and tail output** (one battery on the full stacked tree — arm64 macOS, `rustc 1.93` host `aarch64-apple-darwin`; covers every layer of the series):

  `cargo fmt --all -- --check` → clean, no diffs.

  `cargo clippy --all-targets -- -D warnings`:
  ```text
      Checking zeroclaw-runtime v0.8.2
      Checking zeroclaw-hardware v0.8.2
      Checking zeroclaw-channels v0.8.2
      Checking zeroclaw-eval v0.8.2
      Finished `dev` profile [unoptimized + debuginfo] target(s) in 3m 44s
  ```

  `cargo test` (tail):
  ```text
  running 9 tests
  test system::multi_agent_e2e::peer_group_routes_messages_only_within_resolved_peer_set ... ok
  test system::multi_agent_e2e::peer_group_dotted_channel_refs_remain_alias_scoped_for_dispatch ... ok
  test system::multi_agent_e2e::legacy_install_upgrades_cleanly_with_backup ... ok
  test system::multi_agent_e2e::two_sqlite_agents_on_one_install_have_isolated_memory ... ok
  test system::full_stack::system_parallel_tool_execution ... ok
  test system::full_stack::system_simple_text_response ... ok
  test system::full_stack::system_tool_execution_flow ... ok
  test system::full_stack::system_multi_turn_conversation ... ok
  test system::full_stack::system_tool_arguments_passed_correctly ... ok

  test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.15s
  ```
  Battery exit code 0.

- **Beyond CI — what did you manually verify?** YAML parses; `actionlint` findings on this workflow are **pre-existing and unchanged** (17 on base, 17 after — none introduced). The exact bundled-build command the macOS job runs (`prepare-kernel.sh` + `cargo tauri build --config tauri.bundled.conf.json`) was executed locally end-to-end on arm64 macOS (see stack-3 PR evidence). **Not verified:** an actual `workflow_dispatch` release run (requires cutting a release); the Linux/Windows jobs are compile-pattern mirrors of the macOS job and are deliberately non-blocking for their first release cycle.
- **If any command was intentionally skipped, why:** the release workflow itself can only be exercised by dispatching a release; validated by YAML parse + actionlint parity + local execution of the commands the jobs run.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No** (workflow jobs use existing permission sets).
- New external network calls? **No** beyond standard Actions setup on the new runners.
- Secrets / tokens / credentials handling changed? **Yes** — the macOS job now *reads* optional `APPLE_*` secrets and exports them to the Tauri bundler for signing/notarization. They are written to `GITHUB_ENV` only when non-empty, never logged, and absent secrets are a no-op.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**.

## Compatibility (required)

- Backward compatible? **Yes** — with no secrets configured and the new jobs failing, the release output is byte-for-byte what it is today plus a bundled kernel inside the dmg.
- Config / env / CLI surface changed? **No** (repo secrets are new *optional* inputs).

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <sha>` — restores the previous release workflow; already-published releases are unaffected.
- **Feature flags or config toggles:** the `APPLE_*` secrets (unset = unsigned builds); `continue-on-error` on the new platform jobs.
- **Observable failure symptoms:** `build-desktop` job timeout/failed `prepare-kernel` step; missing `ZeroClaw.dmg` in the required-asset verification; grep the run log for `prepare-kernel:`.

