### PR TITLE
fix(zerocode): improve quickstart agent setup flow

### DIFF
--- a/apps/zerocode/src/app.rs
+++ b/apps/zerocode/src/app.rs
@@ -45,6 +45,12 @@ pub struct CrossReconnectState {
 
 pub type SharedReconnectState = Arc<Mutex<CrossReconnectState>>;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum QuickstartChatDrain {
+    Immediate,
+    AfterReconnect,
+}
+
 /// How often the UI redraws when no input arrives (for live panes).
 const TICK: Duration = Duration::from_millis(200);
 
@@ -117,27 +123,41 @@ async fn switch_mode(
     *mode = next;
 }
 
-async fn consume_immediate_start_chat(
+fn take_pending_quickstart_chat(
+    reconnect_state: &SharedReconnectState,
+    drain: QuickstartChatDrain,
+) -> Option<String> {
+    let Ok(mut guard) = reconnect_state.lock() else {
+        return None;
+    };
+    let pending = guard.pending_quickstart_chat.take()?;
+    match (drain, pending) {
+        (QuickstartChatDrain::Immediate, PendingQuickstartChat::Immediate(alias))
+        | (QuickstartChatDrain::AfterReconnect, PendingQuickstartChat::AfterReconnect(alias)) => {
+            Some(alias)
+        }
+        (_, other) => {
+            guard.pending_quickstart_chat = Some(other);
+            None
+        }
+    }
+}
+
+async fn consume_pending_quickstart_chat(
+    conn_state: &ConnectionState,
     reconnect_state: &SharedReconnectState,
     mode: &mut Mode,
     chat_pane: &mut chat::Chat,
 ) {
-    let alias = {
-        let Ok(mut guard) = reconnect_state.lock() else {
-            return;
-        };
-        match guard.pending_quickstart_chat.take() {
-            Some(PendingQuickstartChat::Immediate(alias)) => Some(alias),
-            other => {
-                guard.pending_quickstart_chat = other;
-                None
-            }
-        }
-    };
-    if let Some(alias) = alias {
-        chat_pane.focus_agent(&alias).await;
-        *mode = Mode::Chat;
+    if matches!(conn_state, ConnectionState::Disconnected { .. }) {
+        return;
     }
+    let Some(alias) = take_pending_quickstart_chat(reconnect_state, QuickstartChatDrain::Immediate)
+    else {
+        return;
+    };
+    chat_pane.focus_agent(&alias).await;
+    *mode = Mode::Chat;
 }
 
 // ── Top-level entry point ────────────────────────────────────────
@@ -215,16 +235,10 @@ pub async fn run(
                 chat_pane.set_resume_session_id($resume_chat.0);
                 chat_pane.set_resume_agent_alias($resume_chat.1);
                 chat_pane.init().await?;
-                let pending_start_chat = {
-                    let mut guard = reconnect_state.lock().expect("reconnect state poisoned");
-                    match guard.pending_quickstart_chat.take() {
-                        Some(PendingQuickstartChat::AfterReconnect(alias)) => Some(alias),
-                        other => {
-                            guard.pending_quickstart_chat = other;
-                            None
-                        }
-                    }
-                };
+                let pending_start_chat = take_pending_quickstart_chat(
+                    &reconnect_state,
+                    QuickstartChatDrain::AfterReconnect,
+                );
                 let mut logs_pane = logs::Logs::new(rpc.clone());
                 logs_pane.init().await?;
                 let mut quickstart =
@@ -268,7 +282,6 @@ pub async fn run(
         if mode == Mode::Doctor && !matches!(conn_state, ConnectionState::Disconnected { .. }) {
             doctor_pane.refresh_if_inactive();
         }
-
         // Per-agent theme override: while the Code or Chat pane is focused on
         // an agent with a configured override, swap that palette in for the
         // whole frame (backdrop, pane, bars) so the pane reads cohesively, then
@@ -531,6 +544,13 @@ pub async fn run(
             if mode == Mode::Quickstart {
                 quickstart.tick().await;
             }
+            consume_pending_quickstart_chat(
+                &conn_state,
+                &reconnect_state,
+                &mut mode,
+                &mut chat_pane,
+            )
+            .await;
             continue;
         }
 
@@ -679,7 +699,13 @@ pub async fn run(
                     )
                     .await;
                 }
-                consume_immediate_start_chat(&reconnect_state, &mut mode, &mut chat_pane).await;
+                consume_pending_quickstart_chat(
+                    &conn_state,
+                    &reconnect_state,
+                    &mut mode,
+                    &mut chat_pane,
+                )
+                .await;
             }
             Event::Mouse(mouse) => {
                 // Dismiss help on any click
@@ -762,7 +788,13 @@ pub async fn run(
                             quickstart.handle_mouse(mouse, content_area).await;
                         }
                     }
-                    consume_immediate_start_chat(&reconnect_state, &mut mode, &mut chat_pane).await;
+                    consume_pending_quickstart_chat(
+                        &conn_state,
+                        &reconnect_state,
+                        &mut mode,
+                        &mut chat_pane,
+                    )
+                    .await;
                 }
             }
             Event::Paste(text) if !matches!(conn_state, ConnectionState::Disconnected { .. }) => {
@@ -775,6 +807,13 @@ pub async fn run(
                     Mode::Dashboard => dashboard_pane.handle_paste(&text),
                     Mode::Logs => logs_pane.handle_paste(&text),
                 }
+                consume_pending_quickstart_chat(
+                    &conn_state,
+                    &reconnect_state,
+                    &mut mode,
+                    &mut chat_pane,
+                )
+                .await;
             }
             _ => {} // Resize, etc. — just redraw on next iteration
         }
@@ -1252,4 +1291,58 @@ fn draw_reload_status_toast(frame: &mut ratatui::Frame, area: Rect, msg: &str) {
         Paragraph::new(Span::styled(text, theme::body_style())).style(theme::fill_style()),
         inner,
     );
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quickstart_chat_handoff_consumes_immediate_target() {
+        let state = SharedReconnectState::default();
+        {
+            let mut guard = state.lock().unwrap();
+            guard.pending_quickstart_chat = Some(PendingQuickstartChat::Immediate("scout".into()));
+        }
+
+        assert_eq!(
+            take_pending_quickstart_chat(&state, QuickstartChatDrain::Immediate),
+            Some("scout".into())
+        );
+        assert!(state.lock().unwrap().pending_quickstart_chat.is_none());
+    }
+
+    #[test]
+    fn quickstart_chat_handoff_immediate_drain_preserves_after_reconnect_target() {
+        let state = SharedReconnectState::default();
+        {
+            let mut guard = state.lock().unwrap();
+            guard.pending_quickstart_chat =
+                Some(PendingQuickstartChat::AfterReconnect("scout".into()));
+        }
+
+        assert_eq!(
+            take_pending_quickstart_chat(&state, QuickstartChatDrain::Immediate),
+            None
+        );
+        assert_eq!(
+            state.lock().unwrap().pending_quickstart_chat,
+            Some(PendingQuickstartChat::AfterReconnect("scout".into()))
+        );
+    }
+
+    #[test]
+    fn quickstart_chat_handoff_consumes_after_reconnect_target() {
+        let state = SharedReconnectState::default();
+        {
+            let mut guard = state.lock().unwrap();
+            guard.pending_quickstart_chat =
+                Some(PendingQuickstartChat::AfterReconnect("scout".into()));
+        }
+
+        assert_eq!(
+            take_pending_quickstart_chat(&state, QuickstartChatDrain::AfterReconnect),
+            Some("scout".into())
+        );
+        assert!(state.lock().unwrap().pending_quickstart_chat.is_none());
+    }
 }

--- a/apps/zerocode/src/quickstart_pane.rs
+++ b/apps/zerocode/src/quickstart_pane.rs
@@ -723,6 +723,21 @@ struct FileEditorState {
     cursor_col: usize,
 }
 
+fn personality_file_needs_template(agent: &AgentModal, filename: &str) -> bool {
+    agent
+        .files
+        .get(filename)
+        .map(|content| content.trim().is_empty())
+        .unwrap_or(true)
+}
+
+fn advance_agent_modal_after_file(agent: &mut AgentModal) {
+    let row_count = agent.filenames.len() + 2;
+    if agent.cursor + 1 < row_count {
+        agent.cursor += 1;
+    }
+}
+
 impl FileEditorState {
     fn new(filename: String, content: String) -> Self {
         let mut lines: Vec<String> = content.split('\n').map(str::to_string).collect();
@@ -1677,6 +1692,29 @@ impl QuickstartPane {
                         self.active_modal = None;
                         self.revalidate().await;
                         self.advance_after_completed(Selector::Agent);
+                    }
+                    Some(QuickstartModalAction::Confirm) if on_file => {
+                        let filename = a.filenames[a.cursor - 1].clone();
+                        if !personality_file_needs_template(a, &filename) {
+                            advance_agent_modal_after_file(a);
+                            return;
+                        }
+                        let agent_name = a.name.trim().to_string();
+                        let templated = self
+                            .fetch_personality_template(&filename, Some(agent_name.as_str()))
+                            .await;
+                        match templated {
+                            Some(content) => {
+                                if let Some(Modal::Agent(a)) = self.active_modal.as_mut() {
+                                    a.files.insert(filename, content);
+                                    advance_agent_modal_after_file(a);
+                                }
+                                self.last_errors.clear();
+                            }
+                            None => {
+                                self.last_errors = vec![missing_template_error(&filename)];
+                            }
+                        }
                     }
                     Some(QuickstartModalAction::NextField) | Some(QuickstartModalAction::Down)
                         if a.cursor + 1 < row_count =>
@@ -3329,6 +3367,43 @@ mod tests {
         assert_eq!(err.step, QuickstartStep::Agent);
         assert_eq!(err.field, "MEMORY.md");
         assert!(err.message.contains("MEMORY.md"));
+    }
+
+    fn test_agent_modal() -> AgentModal {
+        AgentModal {
+            cursor: 1,
+            name: "scout".into(),
+            files: std::collections::BTreeMap::new(),
+            filenames: vec!["MEMORY.md".into(), "SKILL.md".into()],
+            editor: None,
+        }
+    }
+
+    #[test]
+    fn agent_file_enter_loads_template_when_unset() {
+        let agent = test_agent_modal();
+
+        assert!(personality_file_needs_template(&agent, "MEMORY.md"));
+    }
+
+    #[test]
+    fn agent_file_enter_advances_when_content_already_set() {
+        let mut agent = test_agent_modal();
+        agent.files.insert("MEMORY.md".into(), "custom".into());
+
+        assert!(!personality_file_needs_template(&agent, "MEMORY.md"));
+        advance_agent_modal_after_file(&mut agent);
+        assert_eq!(agent.cursor, 2);
+    }
+
+    #[test]
+    fn last_agent_file_enter_advances_to_save_row() {
+        let mut agent = test_agent_modal();
+        agent.cursor = 2;
+        agent.files.insert("SKILL.md".into(), "custom".into());
+
+        advance_agent_modal_after_file(&mut agent);
+        assert_eq!(agent.cursor, 3);
     }
 
     fn err(step: QuickstartStep) -> QuickstartError {


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Let Enter on an agent personality file row use the default template when that file is unset, then advance to the next file row.
  - Let Enter on an already-filled personality file row advance without overwriting custom content.
  - Drain pending Quickstart-created-agent Chat handoffs after reconnect and on normal idle/event paths, so Chat focuses the newly created agent once the client is connected.
- **Scope boundary:** This PR does not change the broader Quickstart provider picker work in #8522, Logs detail payload handling, model switching, Dashboard agent rename behavior, or active-session agent switching.
- **Blast radius:** ZeroCode Quickstart agent setup and the post-create Chat handoff path. It does not change daemon config schema, provider/channel registries, model-provider selection, or gateway behavior.
- **Linked issue(s):** Related #8522
- **Labels:** `bug`, `quickstart`, `zerocode`, `risk:medium`, `size:S`

## Validation Evidence (required)

- **Commands run and tail output:**

```text
zc-cargo fmt --package zerocode
Result: passed

zc-cargo test -p zerocode agent_file -- --nocapture
Result: passed
running 3 tests
test quickstart_pane::tests::agent_file_enter_advances_when_content_already_set ... ok
test quickstart_pane::tests::last_agent_file_enter_advances_to_save_row ... ok
test quickstart_pane::tests::agent_file_enter_loads_template_when_unset ... ok
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured

zc-cargo test -p zerocode quickstart_chat_handoff -- --nocapture
Result: passed
running 3 tests
test app::tests::quickstart_chat_handoff_consumes_immediate_target ... ok
test app::tests::quickstart_chat_handoff_immediate_drain_preserves_after_reconnect_target ... ok
test app::tests::quickstart_chat_handoff_consumes_after_reconnect_target ... ok
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured

git diff --cached --check
Result: passed
```

- **Beyond CI — what did you manually verify?** Manual dogfood covered the Quickstart agent setup flow: personality-file Enter behavior works, and the post-create Chat handoff works after the follow-up handoff patch.
- **If any command was intentionally skipped, why:** Broad local workspace validation was not run; this is a focused ZeroCode Quickstart UI/flow fix with focused unit coverage, manual dogfood coverage, and green GitHub CI on the PR.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: `N/A`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: `N/A`

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <merge-sha>`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Enter on Quickstart personality-file rows does not advance as expected, unset file rows do not pick up templates, or creating an agent leaves the user in Quickstart instead of opening Chat focused on the new agent after reconnect.
