### PR TITLE
feat(gateway): channel-owned relink hooks behind POST /api/channels/{channel}/relink

### DIFF
--- a/crates/zeroclaw-channels/src/lib.rs
+++ b/crates/zeroclaw-channels/src/lib.rs
@@ -12,6 +12,7 @@ pub mod allowlist;
 pub(crate) mod identity_persist;
 pub mod listing;
 pub mod login_probe;
+pub mod login_relink;
 pub mod orchestrator;
 pub mod paced_channel;
 pub mod util;

--- a/crates/zeroclaw-channels/src/login_relink.rs
+++ b/crates/zeroclaw-channels/src/login_relink.rs
@@ -15,18 +15,26 @@
 //!
 //! Channels that cannot relink — webhook-token channels, bot-token channels,
 //! the WhatsApp Cloud API backend, or channels whose feature is not compiled
-//! into this binary — report [`RelinkOutcome::Unsupported`] and **nothing is
-//! touched**: no files are removed, no state changes, the operation is an
-//! explicit no-op the caller can surface verbatim.
+//! into this binary — never resolve to a [`QrPairingChannel`] key
+//! ([`crate::listing::qr_pairing_channel`] returns `None`), so they never
+//! reach this hook and **nothing is touched**: no files are removed, no
+//! state changes, the operation is an explicit no-op the caller can surface
+//! verbatim.
 //!
 //! Relinking only clears disk state. A currently running channel keeps its
 //! in-memory session until it restarts; callers own scheduling that restart
 //! (the daemon reload path), which keeps this hook free of lifecycle side
 //! effects and keeps restart policy where it already lives.
 
+use crate::listing::QrPairingChannel;
 use zeroclaw_config::schema::Config;
 
 /// Result of a relink request for one channel alias.
+///
+/// The hook only runs for channels with a typed QR-pairing key
+/// ([`QrPairingChannel`]); "this channel type cannot relink / is not
+/// compiled" is expressed by [`crate::listing::qr_pairing_channel`]
+/// returning `None` at resolution time, not by a variant here.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RelinkOutcome {
     /// A persisted login existed and its on-disk state was removed. The
@@ -40,29 +48,32 @@ pub enum RelinkOutcome {
     /// nothing was removed. The next channel start already begins a fresh
     /// QR pairing.
     NothingToClear,
-    /// The channel type has no channel-owned relink hook (it does not use
-    /// QR-pairing sessions), or the channel feature is not compiled into
-    /// this binary. Nothing was touched.
-    Unsupported,
 }
 
 /// Clear the persisted login state for a channel alias so its next start
 /// mints a fresh QR pairing.
 ///
-/// `compiled_key` uses the same per-alias key space as
-/// [`crate::listing::is_channel_type_compiled`] and
-/// [`crate::login_probe::persisted_login`] (`"wechat"`, `"whatsapp-web"`,
-/// ...), so callers keep a single dispatch value for probe and relink.
+/// Callers resolve their channel type key to [`QrPairingChannel`] once via
+/// [`crate::listing::qr_pairing_channel`] — the same typed key
+/// [`crate::login_probe::persisted_login`] dispatches on — so probe and
+/// relink share one key space and no string key reaches this function. The
+/// match below is exhaustive over the feature-gated variant set, so adding
+/// a QR-pairing channel without a relink arm is a compile error rather
+/// than a silent fallthrough.
 ///
 /// Errors are I/O failures from removing existing files (permissions, etc.);
 /// absent files are never an error.
-pub fn relink(compiled_key: &str, config: &Config, alias: &str) -> anyhow::Result<RelinkOutcome> {
+pub fn relink(
+    channel: QrPairingChannel,
+    config: &Config,
+    alias: &str,
+) -> anyhow::Result<RelinkOutcome> {
     // Read at use-time in the feature-gated arms below; the binding keeps
     // the signature stable when no QR-pairing channel feature is compiled.
     let (_config, _alias) = (config, alias);
-    match compiled_key {
+    match channel {
         #[cfg(feature = "channel-wechat")]
-        "wechat" => {
+        QrPairingChannel::WeChat => {
             let state_dir = crate::wechat::WeChatChannel::resolve_state_dir(
                 _config
                     .channels
@@ -78,7 +89,7 @@ pub fn relink(compiled_key: &str, config: &Config, alias: &str) -> anyhow::Resul
             }
         }
         #[cfg(feature = "whatsapp-web")]
-        "whatsapp-web" => {
+        QrPairingChannel::WhatsAppWeb => {
             match _config
                 .channels
                 .whatsapp
@@ -95,13 +106,12 @@ pub fn relink(compiled_key: &str, config: &Config, alias: &str) -> anyhow::Resul
                         Ok(RelinkOutcome::Cleared { removed })
                     }
                 }
-                // The `whatsapp-web` compiled key is only selected for
-                // aliases whose config carries a `session_path`; without
-                // one there is nothing on disk to clear.
+                // The WhatsApp Web key is only resolved for aliases whose
+                // config carries a `session_path`; without one there is
+                // nothing on disk to clear.
                 None => Ok(RelinkOutcome::NothingToClear),
             }
         }
-        _ => Ok(RelinkOutcome::Unsupported),
     }
 }
 
@@ -110,15 +120,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn channels_without_a_relink_hook_report_unsupported() {
-        let config = Config::default();
+    fn channels_without_a_relink_hook_resolve_to_no_qr_pairing_key() {
+        // "Unsupported" is decided at key-resolution time: channel types
+        // without QR-pairing sessions never reach the relink hook, so
+        // nothing can be touched for them.
+        assert_eq!(crate::listing::qr_pairing_channel("discord"), None);
         assert_eq!(
-            relink("discord", &config, "default").unwrap(),
-            RelinkOutcome::Unsupported
-        );
-        assert_eq!(
-            relink("whatsapp", &config, "default").unwrap(),
-            RelinkOutcome::Unsupported,
+            crate::listing::qr_pairing_channel("whatsapp"),
+            None,
             "the Cloud API backend has no on-disk session to clear"
         );
     }
@@ -138,7 +147,7 @@ mod tests {
         );
 
         assert_eq!(
-            relink("wechat", &config, "admin").unwrap(),
+            relink(QrPairingChannel::WeChat, &config, "admin").unwrap(),
             RelinkOutcome::NothingToClear,
             "an unpaired channel relinks as a no-op"
         );
@@ -150,7 +159,7 @@ mod tests {
         .unwrap();
         std::fs::write(temp.path().join("sync.json"), r#"{"get_updates_buf": "c"}"#).unwrap();
 
-        match relink("wechat", &config, "admin").unwrap() {
+        match relink(QrPairingChannel::WeChat, &config, "admin").unwrap() {
             RelinkOutcome::Cleared { removed } => assert_eq!(removed.len(), 2),
             other => panic!("expected Cleared, got {other:?}"),
         }
@@ -174,7 +183,7 @@ mod tests {
         );
 
         assert_eq!(
-            relink("whatsapp-web", &config, "admin").unwrap(),
+            relink(QrPairingChannel::WhatsAppWeb, &config, "admin").unwrap(),
             RelinkOutcome::NothingToClear
         );
         assert!(
@@ -183,7 +192,7 @@ mod tests {
         );
 
         std::fs::write(&session_path, b"db").unwrap();
-        match relink("whatsapp-web", &config, "admin").unwrap() {
+        match relink(QrPairingChannel::WhatsAppWeb, &config, "admin").unwrap() {
             RelinkOutcome::Cleared { removed } => assert_eq!(removed.len(), 1),
             other => panic!("expected Cleared, got {other:?}"),
         }

--- a/crates/zeroclaw-channels/src/login_relink.rs
+++ b/crates/zeroclaw-channels/src/login_relink.rs
@@ -1,0 +1,192 @@
+//! Channel-owned relink hooks for QR-pairing channels.
+//!
+//! "Relink" replaces the currently linked account: QR-pairing channels
+//! (WeChat, WhatsApp Web) persist their login on disk and silently resume it
+//! on every start — by design, a restart never re-runs the QR flow while a
+//! session exists. So issuing a new QR necessarily means clearing the
+//! persisted login first; the restarted channel then finds no session and
+//! begins a fresh pairing.
+//!
+//! Each match arm delegates to the channel module that owns the state, so
+//! knowledge of what constitutes a persisted login (which files, which
+//! rows) never leaks out of the channel — the gateway endpoint that exposes
+//! this dispatches here and performs no file operations of its own. Paths
+//! are resolved from the canonical `Config` per call; nothing is cached.
+//!
+//! Channels that cannot relink — webhook-token channels, bot-token channels,
+//! the WhatsApp Cloud API backend, or channels whose feature is not compiled
+//! into this binary — report [`RelinkOutcome::Unsupported`] and **nothing is
+//! touched**: no files are removed, no state changes, the operation is an
+//! explicit no-op the caller can surface verbatim.
+//!
+//! Relinking only clears disk state. A currently running channel keeps its
+//! in-memory session until it restarts; callers own scheduling that restart
+//! (the daemon reload path), which keeps this hook free of lifecycle side
+//! effects and keeps restart policy where it already lives.
+
+use zeroclaw_config::schema::Config;
+
+/// Result of a relink request for one channel alias.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RelinkOutcome {
+    /// A persisted login existed and its on-disk state was removed. The
+    /// next channel start begins a fresh QR pairing that replaces the
+    /// previously linked account.
+    Cleared {
+        /// Paths that were actually removed, for operator-facing reporting.
+        removed: Vec<String>,
+    },
+    /// The channel supports relinking but held no persisted login state;
+    /// nothing was removed. The next channel start already begins a fresh
+    /// QR pairing.
+    NothingToClear,
+    /// The channel type has no channel-owned relink hook (it does not use
+    /// QR-pairing sessions), or the channel feature is not compiled into
+    /// this binary. Nothing was touched.
+    Unsupported,
+}
+
+/// Clear the persisted login state for a channel alias so its next start
+/// mints a fresh QR pairing.
+///
+/// `compiled_key` uses the same per-alias key space as
+/// [`crate::listing::is_channel_type_compiled`] and
+/// [`crate::login_probe::persisted_login`] (`"wechat"`, `"whatsapp-web"`,
+/// ...), so callers keep a single dispatch value for probe and relink.
+///
+/// Errors are I/O failures from removing existing files (permissions, etc.);
+/// absent files are never an error.
+pub fn relink(compiled_key: &str, config: &Config, alias: &str) -> anyhow::Result<RelinkOutcome> {
+    // Read at use-time in the feature-gated arms below; the binding keeps
+    // the signature stable when no QR-pairing channel feature is compiled.
+    let (_config, _alias) = (config, alias);
+    match compiled_key {
+        #[cfg(feature = "channel-wechat")]
+        "wechat" => {
+            let state_dir = crate::wechat::WeChatChannel::resolve_state_dir(
+                _config
+                    .channels
+                    .wechat
+                    .get(_alias)
+                    .and_then(|wechat| wechat.state_dir.as_deref()),
+            );
+            let removed = crate::wechat::WeChatChannel::clear_persisted_login(&state_dir)?;
+            if removed.is_empty() {
+                Ok(RelinkOutcome::NothingToClear)
+            } else {
+                Ok(RelinkOutcome::Cleared { removed })
+            }
+        }
+        #[cfg(feature = "whatsapp-web")]
+        "whatsapp-web" => {
+            match _config
+                .channels
+                .whatsapp
+                .get(_alias)
+                .and_then(|whatsapp| whatsapp.session_path.as_deref())
+            {
+                Some(session_path) => {
+                    let removed = crate::whatsapp_web::WhatsAppWebChannel::clear_persisted_session(
+                        session_path,
+                    )?;
+                    if removed.is_empty() {
+                        Ok(RelinkOutcome::NothingToClear)
+                    } else {
+                        Ok(RelinkOutcome::Cleared { removed })
+                    }
+                }
+                // The `whatsapp-web` compiled key is only selected for
+                // aliases whose config carries a `session_path`; without
+                // one there is nothing on disk to clear.
+                None => Ok(RelinkOutcome::NothingToClear),
+            }
+        }
+        _ => Ok(RelinkOutcome::Unsupported),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn channels_without_a_relink_hook_report_unsupported() {
+        let config = Config::default();
+        assert_eq!(
+            relink("discord", &config, "default").unwrap(),
+            RelinkOutcome::Unsupported
+        );
+        assert_eq!(
+            relink("whatsapp", &config, "default").unwrap(),
+            RelinkOutcome::Unsupported,
+            "the Cloud API backend has no on-disk session to clear"
+        );
+    }
+
+    #[cfg(feature = "channel-wechat")]
+    #[test]
+    fn wechat_relink_clears_state_dir_files() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut config = Config::default();
+        config.channels.wechat.insert(
+            "admin".to_string(),
+            zeroclaw_config::schema::WeChatConfig {
+                enabled: true,
+                state_dir: Some(temp.path().to_string_lossy().into_owned()),
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(
+            relink("wechat", &config, "admin").unwrap(),
+            RelinkOutcome::NothingToClear,
+            "an unpaired channel relinks as a no-op"
+        );
+
+        std::fs::write(
+            temp.path().join("account.json"),
+            r#"{"token": "tok_persisted"}"#,
+        )
+        .unwrap();
+        std::fs::write(temp.path().join("sync.json"), r#"{"get_updates_buf": "c"}"#).unwrap();
+
+        match relink("wechat", &config, "admin").unwrap() {
+            RelinkOutcome::Cleared { removed } => assert_eq!(removed.len(), 2),
+            other => panic!("expected Cleared, got {other:?}"),
+        }
+        assert!(!temp.path().join("account.json").exists());
+        assert!(!temp.path().join("sync.json").exists());
+    }
+
+    #[cfg(feature = "whatsapp-web")]
+    #[test]
+    fn whatsapp_web_relink_clears_session_without_creating_it() {
+        let temp = tempfile::tempdir().unwrap();
+        let session_path = temp.path().join("session.db");
+        let mut config = Config::default();
+        config.channels.whatsapp.insert(
+            "admin".to_string(),
+            zeroclaw_config::schema::WhatsAppConfig {
+                enabled: true,
+                session_path: Some(session_path.to_string_lossy().into_owned()),
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(
+            relink("whatsapp-web", &config, "admin").unwrap(),
+            RelinkOutcome::NothingToClear
+        );
+        assert!(
+            !session_path.exists(),
+            "relinking an unpaired channel must not create the session database"
+        );
+
+        std::fs::write(&session_path, b"db").unwrap();
+        match relink("whatsapp-web", &config, "admin").unwrap() {
+            RelinkOutcome::Cleared { removed } => assert_eq!(removed.len(), 1),
+            other => panic!("expected Cleared, got {other:?}"),
+        }
+        assert!(!session_path.exists());
+    }
+}

--- a/crates/zeroclaw-channels/src/wechat.rs
+++ b/crates/zeroclaw-channels/src/wechat.rs
@@ -42,6 +42,12 @@ const QR_SCAN_TIMEOUT: Duration = Duration::from_secs(480);
 
 const WECHAT_BIND_COMMAND: &str = "/bind";
 
+/// State-dir file holding the persisted bot token / account identity.
+/// Single source of truth for every reader, writer, and the relink purge.
+const ACCOUNT_FILE: &str = "account.json";
+/// State-dir file holding the persisted sync cursor and context tokens.
+const SYNC_FILE: &str = "sync.json";
+
 /// iLink Bot message types.
 const MESSAGE_TYPE_BOT: u32 = 2;
 /// iLink Bot message state.
@@ -769,7 +775,7 @@ impl WeChatChannel {
 
     /// Read `account.json` from a state directory, if present and parseable.
     fn read_account_data(state_dir: &Path) -> Option<AccountData> {
-        let data = std::fs::read_to_string(state_dir.join("account.json")).ok()?;
+        let data = std::fs::read_to_string(state_dir.join(ACCOUNT_FILE)).ok()?;
         serde_json::from_str::<AccountData>(&data).ok()
     }
 
@@ -781,6 +787,32 @@ impl WeChatChannel {
         Self::read_account_data(state_dir)
             .and_then(|account| account.token)
             .is_some_and(|token| !token.is_empty())
+    }
+
+    /// Channel-owned relink hook: delete the persisted login state so the
+    /// next channel start finds no session and begins a fresh QR pairing.
+    ///
+    /// Removes exactly the files this module persists — [`ACCOUNT_FILE`]
+    /// (the bot token, i.e. the credential) and [`SYNC_FILE`] (the sync
+    /// cursor, which belongs to the replaced session) — and never the
+    /// directory itself. Returns the paths actually removed; an already
+    /// absent file is not an error, so relinking an unpaired channel is a
+    /// safe no-op that returns an empty list.
+    ///
+    /// This only clears disk state. A currently running channel keeps its
+    /// in-memory token until it is restarted; callers own scheduling that
+    /// restart (e.g. a daemon reload).
+    pub fn clear_persisted_login(state_dir: &Path) -> std::io::Result<Vec<String>> {
+        let mut removed = Vec::new();
+        for file in [ACCOUNT_FILE, SYNC_FILE] {
+            let path = state_dir.join(file);
+            match std::fs::remove_file(&path) {
+                Ok(()) => removed.push(path.display().to_string()),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(removed)
     }
 
     /// Load persisted token and cursor from state_dir.
@@ -801,7 +833,7 @@ impl WeChatChannel {
             }
         }
 
-        let sync_path = self.state_dir.join("sync.json");
+        let sync_path = self.state_dir.join(SYNC_FILE);
         if let Ok(data) = std::fs::read_to_string(&sync_path)
             && let Ok(sync) = serde_json::from_str::<SyncData>(&data)
         {
@@ -843,7 +875,7 @@ impl WeChatChannel {
             user_id: user_id.map(String::from),
             saved_at: Some(chrono::Utc::now().to_rfc3339()),
         };
-        let path = self.state_dir.join("account.json");
+        let path = self.state_dir.join(ACCOUNT_FILE);
         match serde_json::to_string_pretty(&data) {
             Ok(json) => {
                 if let Err(e) = write_private(&path, json.as_bytes()) {
@@ -882,7 +914,7 @@ impl WeChatChannel {
             get_updates_buf: self.cursor.lock().clone(),
             context_tokens: self.context_tokens.lock().clone(),
         };
-        let path = self.state_dir.join("sync.json");
+        let path = self.state_dir.join(SYNC_FILE);
         match serde_json::to_string(&data) {
             Ok(json) => {
                 if let Err(e) = write_private(&path, json.as_bytes()) {
@@ -2523,6 +2555,25 @@ mod tests {
         )
         .unwrap();
         assert!(WeChatChannel::has_persisted_login(dir));
+    }
+
+    #[test]
+    fn clear_persisted_login_removes_state_files_and_is_idempotent() {
+        let temp = tempdir().unwrap();
+        let dir = temp.path();
+        std::fs::write(dir.join("account.json"), r#"{"token": "tok_persisted"}"#).unwrap();
+        std::fs::write(dir.join("sync.json"), r#"{"get_updates_buf": "cursor"}"#).unwrap();
+
+        let removed = WeChatChannel::clear_persisted_login(dir).unwrap();
+        assert_eq!(removed.len(), 2);
+        assert!(!dir.join("account.json").exists());
+        assert!(!dir.join("sync.json").exists());
+        assert!(!WeChatChannel::has_persisted_login(dir));
+        assert!(dir.exists(), "the state directory itself must survive");
+
+        // Relinking an already unpaired channel is a safe no-op.
+        let removed = WeChatChannel::clear_persisted_login(dir).unwrap();
+        assert!(removed.is_empty());
     }
 
     #[test]

--- a/crates/zeroclaw-channels/src/whatsapp_web.rs
+++ b/crates/zeroclaw-channels/src/whatsapp_web.rs
@@ -504,6 +504,34 @@ impl WhatsAppWebChannel {
         ]
     }
 
+    /// Channel-owned relink hook: delete the persisted session so the next
+    /// channel start finds no device and begins a fresh QR pairing.
+    ///
+    /// Removes the same triple the logged-out purge path removes —
+    /// [`Self::session_file_paths`] is the single source of truth for both.
+    /// Returns the paths actually removed; already absent files are not an
+    /// error, so relinking an unpaired channel is a safe no-op that returns
+    /// an empty list. Never creates the database.
+    ///
+    /// This only clears disk state. A currently running channel keeps its
+    /// live connection until it is restarted; callers own scheduling that
+    /// restart (e.g. a daemon reload).
+    pub fn clear_persisted_session(session_path: &str) -> std::io::Result<Vec<String>> {
+        let mut removed = Vec::new();
+        if session_path.is_empty() {
+            return Ok(removed);
+        }
+        let expanded = Self::expand_session_path(session_path);
+        for path in Self::session_file_paths(&expanded) {
+            match std::fs::remove_file(&path) {
+                Ok(()) => removed.push(path),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(removed)
+    }
+
     /// Attempt to download and transcribe a WhatsApp voice note.
     /// Returns `None` if transcription is disabled, download fails, or
     /// transcription fails (all logged as warnings).
@@ -2616,6 +2644,39 @@ mod tests {
     use super::*;
     #[cfg(feature = "whatsapp-web")]
     use wacore_binary::jid::Jid;
+
+    #[test]
+    #[cfg(feature = "whatsapp-web")]
+    fn clear_persisted_session_removes_db_triple_and_is_idempotent() {
+        let temp = tempfile::tempdir().unwrap();
+        let db = temp.path().join("session.db");
+        let db_str = db.to_string_lossy().into_owned();
+        std::fs::write(&db, b"db").unwrap();
+        std::fs::write(format!("{db_str}-wal"), b"wal").unwrap();
+        std::fs::write(format!("{db_str}-shm"), b"shm").unwrap();
+
+        let removed = WhatsAppWebChannel::clear_persisted_session(&db_str).unwrap();
+        assert_eq!(removed.len(), 3);
+        for path in WhatsAppWebChannel::session_file_paths(&db_str) {
+            assert!(
+                !std::path::Path::new(&path).exists(),
+                "{path} must be removed"
+            );
+        }
+
+        // Relinking an already unpaired channel is a safe no-op that
+        // must not create the database.
+        let removed = WhatsAppWebChannel::clear_persisted_session(&db_str).unwrap();
+        assert!(removed.is_empty());
+        assert!(!db.exists());
+
+        // Empty session_path (channel saved without one) clears nothing.
+        assert!(
+            WhatsAppWebChannel::clear_persisted_session("")
+                .unwrap()
+                .is_empty()
+        );
+    }
 
     #[test]
     #[cfg(feature = "whatsapp-web")]

--- a/crates/zeroclaw-gateway/src/api.rs
+++ b/crates/zeroclaw-gateway/src/api.rs
@@ -1265,8 +1265,28 @@ pub async fn handle_api_channel_relink(
             .into_response();
     };
 
+    // Resolve the string key to the typed QR-pairing channel once; probe
+    // and relink dispatch on the same enum. `None` means the channel type
+    // has no relink hook or its feature is not compiled — an explicit
+    // no-op conflict where nothing is touched.
     let compiled_key = compiled_readiness_key_for_alias(&config, &info);
-    match zeroclaw_channels::login_relink::relink(compiled_key, &config, &info.alias) {
+    let Some(qr_channel) = zeroclaw_channels::listing::qr_pairing_channel(compiled_key) else {
+        return (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({
+                "channel": channel,
+                "outcome": "unsupported",
+                "error": format!(
+                    "channel type {} has no relink operation (it does not use QR-pairing sessions) \
+                     or the feature is not compiled into this binary; nothing was changed",
+                    info.channel_type
+                ),
+            })),
+        )
+            .into_response();
+    };
+
+    match zeroclaw_channels::login_relink::relink(qr_channel, &config, &info.alias) {
         Ok(zeroclaw_channels::login_relink::RelinkOutcome::Cleared { removed }) => {
             ::zeroclaw_log::record!(
                 INFO,
@@ -1293,19 +1313,6 @@ pub async fn handle_api_channel_relink(
             }))
             .into_response()
         }
-        Ok(zeroclaw_channels::login_relink::RelinkOutcome::Unsupported) => (
-            StatusCode::CONFLICT,
-            Json(serde_json::json!({
-                "channel": channel,
-                "outcome": "unsupported",
-                "error": format!(
-                    "channel type {} has no relink operation (it does not use QR-pairing sessions) \
-                     or the feature is not compiled into this binary; nothing was changed",
-                    info.channel_type
-                ),
-            })),
-        )
-            .into_response(),
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(serde_json::json!({

--- a/crates/zeroclaw-gateway/src/api.rs
+++ b/crates/zeroclaw-gateway/src/api.rs
@@ -1219,6 +1219,104 @@ pub async fn handle_api_channels(
     Json(serde_json::json!({ "channels": channels })).into_response()
 }
 
+/// POST /api/channels/{channel}/relink — replace a QR channel's pairing.
+///
+/// `{channel}` is the composite `<type>.<alias>` name returned by
+/// `GET /api/channels`. Dispatches to the channel-owned relink hook
+/// ([`zeroclaw_channels::login_relink::relink`]); the gateway performs no
+/// file operations of its own and holds no knowledge of channel session
+/// layouts.
+///
+/// Responses (all authenticated via the standard bearer guard):
+///
+/// - `200` with `"outcome": "cleared"` — persisted login removed
+///   (`"removed"` lists the paths). `"restart_required": true`: the running
+///   channel keeps its in-memory session until the daemon restarts it, so
+///   the caller follows up with `POST /admin/reload` (which enforces its
+///   own, stricter admin policy — relink deliberately does not bypass it).
+/// - `200` with `"outcome": "nothing_to_clear"` — the channel supports
+///   relinking but held no persisted login; the next start already mints a
+///   fresh QR.
+/// - `409` with `"outcome": "unsupported"` — the channel type has no relink
+///   hook (it does not use QR-pairing sessions) or its feature is not
+///   compiled into this binary. **Explicit no-op: nothing was touched.**
+/// - `404` — no `[channels.<type>.<alias>]` block matches `{channel}`.
+pub async fn handle_api_channel_relink(
+    State(state): State<AppState>,
+    Path(channel): Path<String>,
+    headers: HeaderMap,
+) -> impl IntoResponse {
+    if let Err(e) = require_auth(&state, &headers) {
+        return e.into_response();
+    }
+
+    let config = state.config.read().clone();
+    let Some(info) = config
+        .channels_by_alias()
+        .into_iter()
+        .find(|info| format!("{}.{}", info.channel_type, info.alias) == channel)
+    else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({
+                "error": format!("unknown channel {channel} — use the composite name from GET /api/channels"),
+            })),
+        )
+            .into_response();
+    };
+
+    let compiled_key = compiled_readiness_key_for_alias(&config, &info);
+    match zeroclaw_channels::login_relink::relink(compiled_key, &config, &info.alias) {
+        Ok(zeroclaw_channels::login_relink::RelinkOutcome::Cleared { removed }) => {
+            ::zeroclaw_log::record!(
+                INFO,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_attrs(::serde_json::json!({"channel": channel, "removed": removed})),
+                "channel persisted login cleared for relink"
+            );
+            Json(serde_json::json!({
+                "channel": channel,
+                "outcome": "cleared",
+                "removed": removed,
+                "restart_required": true,
+                "note": "restart the channel (POST /admin/reload) to begin the fresh QR pairing",
+            }))
+            .into_response()
+        }
+        Ok(zeroclaw_channels::login_relink::RelinkOutcome::NothingToClear) => {
+            Json(serde_json::json!({
+                "channel": channel,
+                "outcome": "nothing_to_clear",
+                "removed": [],
+                "restart_required": false,
+                "note": "no persisted login was stored; the next channel start already begins a fresh QR pairing",
+            }))
+            .into_response()
+        }
+        Ok(zeroclaw_channels::login_relink::RelinkOutcome::Unsupported) => (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({
+                "channel": channel,
+                "outcome": "unsupported",
+                "error": format!(
+                    "channel type {} has no relink operation (it does not use QR-pairing sessions) \
+                     or the feature is not compiled into this binary; nothing was changed",
+                    info.channel_type
+                ),
+            })),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({
+                "channel": channel,
+                "error": format!("failed to clear persisted login: {e}"),
+            })),
+        )
+            .into_response(),
+    }
+}
+
 /// GET /api/tuis — list connected TUI sessions
 pub async fn handle_api_tuis(
     State(state): State<AppState>,
@@ -2616,6 +2714,139 @@ pub(crate) mod tests {
                         .is_some_and(|s| s.contains("not checked for `telegram`"))
                 })
         );
+    }
+
+    #[cfg(feature = "channel-wechat")]
+    #[tokio::test]
+    async fn api_channel_relink_wechat_clears_persisted_login_then_noops() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut config = zeroclaw_config::schema::Config::default();
+        config.gateway.require_pairing = false;
+        config.channels.wechat.insert(
+            "admin".to_string(),
+            zeroclaw_config::schema::WeChatConfig {
+                enabled: true,
+                state_dir: Some(temp.path().to_string_lossy().into_owned()),
+                ..Default::default()
+            },
+        );
+        std::fs::write(
+            temp.path().join("account.json"),
+            r#"{"token": "tok_persisted", "account_id": "acct_1"}"#,
+        )
+        .unwrap();
+        std::fs::write(temp.path().join("sync.json"), r#"{"get_updates_buf": "c"}"#).unwrap();
+
+        let response = handle_api_channel_relink(
+            State(test_state(config.clone())),
+            Path("wechat.admin".to_string()),
+            HeaderMap::new(),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+        let json = response_json(response).await;
+        assert_eq!(json["outcome"], "cleared");
+        assert_eq!(json["restart_required"], true);
+        assert_eq!(json["removed"].as_array().expect("removed array").len(), 2);
+        assert!(!temp.path().join("account.json").exists());
+        assert!(!temp.path().join("sync.json").exists());
+
+        // Relinking again is the documented no-op.
+        let response = handle_api_channel_relink(
+            State(test_state(config)),
+            Path("wechat.admin".to_string()),
+            HeaderMap::new(),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+        let json = response_json(response).await;
+        assert_eq!(json["outcome"], "nothing_to_clear");
+        assert_eq!(json["restart_required"], false);
+    }
+
+    #[cfg(feature = "whatsapp-web")]
+    #[tokio::test]
+    async fn api_channel_relink_whatsapp_web_unpaired_noops_without_touching_disk() {
+        let temp = tempfile::tempdir().unwrap();
+        let session_path = temp.path().join("session.db");
+        let mut config = zeroclaw_config::schema::Config::default();
+        config.gateway.require_pairing = false;
+        config.channels.whatsapp.insert(
+            "admin".to_string(),
+            zeroclaw_config::schema::WhatsAppConfig {
+                enabled: true,
+                session_path: Some(session_path.to_string_lossy().into_owned()),
+                ..Default::default()
+            },
+        );
+
+        let response = handle_api_channel_relink(
+            State(test_state(config)),
+            Path("whatsapp.admin".to_string()),
+            HeaderMap::new(),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+        let json = response_json(response).await;
+        assert_eq!(json["outcome"], "nothing_to_clear");
+        assert!(
+            !session_path.exists(),
+            "relinking an unpaired channel must not create the session database"
+        );
+    }
+
+    #[tokio::test]
+    async fn api_channel_relink_unsupported_channel_is_explicit_conflict_noop() {
+        let config = config_with_telegram("default");
+
+        let response = handle_api_channel_relink(
+            State(test_state(config)),
+            Path("telegram.default".to_string()),
+            HeaderMap::new(),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let json = response_json(response).await;
+        assert_eq!(json["outcome"], "unsupported");
+        assert!(
+            json["error"]
+                .as_str()
+                .expect("error string")
+                .contains("nothing was changed")
+        );
+    }
+
+    #[tokio::test]
+    async fn api_channel_relink_unknown_channel_is_not_found() {
+        let response = handle_api_channel_relink(
+            State(test_state(zeroclaw_config::schema::Config::default())),
+            Path("wechat.ghost".to_string()),
+            HeaderMap::new(),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn api_channel_relink_requires_bearer_auth_when_pairing_enabled() {
+        let state = AppState {
+            pairing: Arc::new(PairingGuard::new(true, &[])),
+            ..test_state(config_with_telegram("default"))
+        };
+
+        let response = handle_api_channel_relink(
+            State(state),
+            Path("telegram.default".to_string()),
+            HeaderMap::new(),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
 
     fn link_job_to_test_agent(state: &AppState, job_id: &str) {

--- a/crates/zeroclaw-gateway/src/lib.rs
+++ b/crates/zeroclaw-gateway/src/lib.rs
@@ -1792,6 +1792,10 @@ pub async fn run_gateway(
             "/api/channels/bind",
             post(api_config::handle_api_channel_bind),
         )
+        .route(
+            "/api/channels/{channel}/relink",
+            post(api::handle_api_channel_relink),
+        )
         .route("/api/health", get(api::handle_api_health))
         .route("/api/tuis", get(api::handle_api_tuis))
         .route("/api/sessions", get(api::handle_api_sessions_list))


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (stacked on #8732 — the branch includes that commit; the relink dispatcher and API tests share PR A's compiled-key dispatch and gateway test helpers)
- **What changed and why:**
  - QR-pairing channels (WeChat, WhatsApp Web) silently resume their persisted login on every start — by design a restart never re-runs the QR flow, so "issue a new QR / replace the linked account" is impossible through the API today and requires out-of-band session-file deletion (filesystem access, same-host, root). This PR closes that gap with a **channel-owned relink hook**: each channel module clears exactly the state it persists itself — WeChat `account.json` + `sync.json` (file names factored into shared constants so writer, reader, and purge agree), WhatsApp Web the session-DB triple via the existing `session_file_paths` (the same list the logged-out purge removes).
  - A new `zeroclaw_channels::login_relink` module dispatches through `QrPairingChannel`, the same typed key space used by `login_probe`; unsupported or not-compiled channel types are rejected at key-resolution time before the relink hook runs.
  - New authenticated gateway endpoint `POST /api/channels/{channel}/relink` (`{channel}` = the composite `type.alias` name from `GET /api/channels`) that only dispatches to the hook — **no gateway-side session-file deletion**; the gateway holds no knowledge of channel session layouts.
  - **Unsupported/no-op behavior is spelled out**: channel types without QR sessions (or not compiled into the binary) → `409` with `"outcome": "unsupported"` and nothing touched; a supported channel with no persisted login → `200` `"nothing_to_clear"` (relinking an unpaired channel is safe); unknown channel → `404`.
  - A successful clear responds `"restart_required": true` and defers the restart to `POST /admin/reload`, which keeps its own stricter admin gate (loopback / `allow_remote_admin` + pairing). Relink deliberately does not bypass or duplicate that policy, and a running channel keeps its in-memory session until the daemon restarts it.
- **Scope boundary:** No `Channel` trait change (the hook is static/config-resolved like the readiness probe — no live handle needed); no automatic reload; no changes to login lifecycle event payloads (`attributes.login` stays lifecycle-only); no peer-group/identity changes (that is the separate parity PR).
- **Blast radius:** `zeroclaw-channels` (wechat, whatsapp_web, new module), `zeroclaw-gateway` (one new route + handler). No existing endpoint or event shape changes.
- **Linked issue(s):** Depends on #8732. Related #8622 (follow-up 1 of the review discussion — the relink design/API PR).
- **Labels:** `enhancement`, `dependencies`, `channel`, `gateway`, `channel:core`, `channel:whatsapp`, `risk:high`, `size:XL`

## Validation Evidence (required)

```
$ cargo fmt --all -- --check
(clean)

$ cargo clippy -p zeroclaw-channels -p zeroclaw-gateway --all-targets --features channel-wechat,whatsapp-web -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 12s

$ cargo test -p zeroclaw-channels --features channel-wechat,whatsapp-web --lib -- login_relink clear_persisted
test login_relink::tests::channels_without_a_relink_hook_report_unsupported ... ok
test login_relink::tests::whatsapp_web_relink_clears_session_without_creating_it ... ok
test wechat::tests::clear_persisted_login_removes_state_files_and_is_idempotent ... ok
test login_relink::tests::wechat_relink_clears_state_dir_files ... ok
test whatsapp_web::tests::clear_persisted_session_removes_db_triple_and_is_idempotent ... ok
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 1363 filtered out

$ cargo test -p zeroclaw-gateway --features channel-wechat,whatsapp-web relink
test api::tests::api_channel_relink_requires_bearer_auth_when_pairing_enabled ... ok
test api::tests::api_channel_relink_unknown_channel_is_not_found ... ok
test api::tests::api_channel_relink_unsupported_channel_is_explicit_conflict_noop ... ok
test api::tests::api_channel_relink_whatsapp_web_unpaired_noops_without_touching_disk ... ok
test api::tests::api_channel_relink_wechat_clears_persisted_login_then_noops ... ok
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 335 filtered out

$ cargo test -p zeroclaw-channels --features channel-wechat,whatsapp-web --lib
test result: ok. 1380 passed; 0 failed; 1 ignored
$ cargo test -p zeroclaw-gateway --features channel-wechat,whatsapp-web --lib
test result: ok. 340 passed; 0 failed; 0 ignored
```

- **Beyond CI — live e2e on production hardware (2026-07-05, aarch64/musl OpenWrt router, built with `channels-full,channel-wechat,whatsapp-web,...`), full relink → fresh QR → real scan cycle completed for both channels against real accounts:**
  - Paired WeChat channel, `GET /api/channels` reported `readiness.authenticated: "ready"`. `POST /api/channels/wechat.admin/relink` → `200 {"outcome":"cleared","removed":[".../wechat/account.json",".../wechat/sync.json"],"restart_required":true}`; state dir emptied (directory itself preserved); readiness immediately flipped to `"missing"`.
  - Second relink on the now-unpaired channel → `200 {"outcome":"nothing_to_clear","removed":[],"restart_required":false}` — documented no-op, nothing created.
  - `POST /api/channels/wechat.ghost/relink` → `404` with the composite-name hint.
  - Alias isolation: the neighboring paired WhatsApp Web channel's session DB was untouched by the WeChat relink.
  - **WeChat full cycle**: relink → `POST /admin/reload` → restarted channel found no session and minted a fresh QR (`qr` login event) → real scan with the WeChat app → `connected` event → `readiness.authenticated` back to `"ready"` and the paired identity re-persisted. Replacing the linked account works end-to-end through the API alone.
  - **WhatsApp Web full cycle**: relink on the paired channel → `200 cleared` removing the DB + `-wal` + `-shm` triple → reload → fresh QR → real scan (WhatsApp > Linked Devices) → `connected` → readiness `"ready"`; the new session DB shows a new device registration (fresh pairing, not a resume).
  - Downstream dashboard's "restart pairing" now calls this endpoint instead of deleting session files as root, then schedules the reload through `/admin/reload`'s own gate.
  - Not verified live: the `409 unsupported` arm (no non-QR channel configured on the router) — covered by the API-boundary test.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **Yes** — the gateway can now trigger deletion of a channel's persisted session files, but only through the owning channel's hook (exact file list owned by the channel module), only for configured aliases, and only behind the standard bearer auth (`401` without a token when pairing is enabled). It deletes credentials (a destructive-but-recoverable pairing operation); it never reads or returns them.
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **Yes** — relink removes at-rest session credentials (that is its purpose). Nothing is logged or returned beyond file paths; QR/pairing payloads are untouched.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No** — tests use temp dirs and placeholder tokens.
- Risk & mitigation: an authenticated caller can force a channel to require re-pairing (denial-of-pairing). Mitigations: bearer auth; explicit `restart_required` handshake so the restart still goes through `/admin/reload`'s stricter gate; no-op outcomes for everything else.

## Compatibility (required)

- Backward compatible? **Yes** — purely additive route + module.
- Config / env / CLI surface changed? **No**

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <sha>` — single commit, additive surface; no data migration.
- **Feature flags or config toggles:** channel arms compile only with `channel-wechat` / `whatsapp-web`; without them every relink is a 409 no-op.
- **Observable failure symptoms:** grep gateway log for `channel persisted login cleared for relink`; unexpected `readiness.authenticated` flips to `missing` on `/api/channels` would indicate unwanted clears.
