### PR TITLE
docs(config): clarify credential env bridge contract

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -4732,7 +4732,9 @@ pub struct TranscriptionConfig {
     pub enabled: bool,
     /// API key used for transcription requests (Groq transcription provider).
     ///
-    /// If unset, runtime falls back to `GROQ_API_KEY` for backward compatibility.
+    /// Use the schema-mirror env grammar (`ZEROCLAW_transcription__api_key=...`)
+    /// for runtime env injection. Legacy `GROQ_API_KEY` constructor fallback was
+    /// removed in v0.8.0.
     #[serde(default)]
     #[secret]
     #[credential_class = "encrypted_secret"]
@@ -10252,21 +10254,22 @@ impl Default for PostgresStorageConfig {
 
 /// Qdrant vector database backend (`[storage.qdrant.<alias>]`).
 ///
-/// URL, collection, and API key all fall back to environment variables
-/// (`QDRANT_URL`, `QDRANT_COLLECTION`, `QDRANT_API_KEY`) when unset.
+/// URL, collection, and API key are typed config values. Use schema-mirror env
+/// overrides such as `ZEROCLAW_storage__qdrant__<alias>__url=...` for runtime
+/// env injection.
 #[derive(Debug, Clone, Serialize, Deserialize, Configurable)]
 #[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
 #[prefix = "storage_qdrant"]
 #[serde(default)]
 pub struct QdrantStorageConfig {
     /// Qdrant server URL (e.g. `"http://localhost:6333"`).
-    /// Falls back to `QDRANT_URL` env var if unset.
+    /// Use `ZEROCLAW_storage__qdrant__<alias>__url=...` for env injection.
     pub url: Option<String>,
     /// Collection name for storing memories.
-    /// Falls back to `QDRANT_COLLECTION` env var, or `"zeroclaw_memories"`.
+    /// Use `ZEROCLAW_storage__qdrant__<alias>__collection=...` for env injection.
     pub collection: String,
     /// API key for Qdrant Cloud or secured instances.
-    /// Falls back to `QDRANT_API_KEY` env var if unset.
+    /// Use `ZEROCLAW_storage__qdrant__<alias>__api_key=...` for env injection.
     #[secret]
     #[credential_class = "encrypted_secret"]
     #[cfg_attr(feature = "schema-export", schemars(extend("x-secret" = true)))]

--- a/docs/book/src/architecture/config-lifecycle.md
+++ b/docs/book/src/architecture/config-lifecycle.md
@@ -67,6 +67,14 @@ Review config changes with this invariant in mind:
 - Save paths must preserve encrypted secrets and external secret references
   unless the same path was intentionally edited.
 
+## Credential inputs stay typed
+
+Credential-like runtime values are still config values. API keys, OAuth tokens, endpoint URLs, and other provider/channel credentials should flow through the typed config schema, config secret handling, or schema-mirror `ZEROCLAW_*` overrides before a runtime constructor sees them.
+
+Do not add ad-hoc `std::env::var("PROVIDER_API_KEY")` reads inside provider, channel, tool, transcription, TTS, memory, or gateway constructors. That creates a second credential source outside `Config`, bypasses env-override visibility, and can make CLI, gateway, RPC/TUI, quickstart, and reload behavior disagree.
+
+If ZeroClaw intentionally supports a native environment bridge for an integration family, document that bridge at the integration boundary and map it into the same typed config value before construction. Otherwise, ecosystem-default shell names such as `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY`, or `QDRANT_URL` should be bridged by operators into the corresponding `ZEROCLAW_*` schema-mirror variable; see [Environment variables](../reference/env-vars.md#bridging-ecosystem-default-env-vars).
+
 ## Dirty paths and incremental writes
 
 Most editing surfaces use `Config::mark_dirty()` plus `save_dirty()`, not a
@@ -160,6 +168,7 @@ For config-schema, env-var, default, or reload changes, ask:
   prose?
 - Are env overrides load-time only and masked during saves?
 - Do CLI, gateway, RPC/TUI, and quickstart surfaces agree on the dotted path?
+- Are credentials resolved through typed config or documented schema-mirror bridges rather than ad-hoc provider-native env reads?
 - Does a save survive process reload, not just immediate in-memory rendering?
 - Does the PR say whether users need reload, restart, migration, or manual
   rollback?

--- a/docs/book/src/getting-started/multi-model-setup.md
+++ b/docs/book/src/getting-started/multi-model-setup.md
@@ -146,8 +146,7 @@ Each provider entry resolves credentials in this order:
 
 1. **Inline `api_key`** on the provider entry.
 2. **Secrets store** at `~/.zeroclaw/secrets`.
-3. **Generic env override**: `ZEROCLAW_providers__models__<type>__<alias>__api_key=...` at startup. See [Environment variables](../reference/env-vars.md) for the full grammar.
-4. **Per-vendor env var** when the family supports it (e.g. `ANTHROPIC_API_KEY` / `ANTHROPIC_OAUTH_TOKEN` for Anthropic; `OPENROUTER_API_KEY` for OpenRouter).
+3. **Generic env override**: `ZEROCLAW_providers__models__<type>__<alias>__api_key=...` at startup. If your shell already exports `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY`, or a similar vendor-default name, bridge it into this schema-mirror variable before startup unless the provider family explicitly documents a native runtime env bridge. See [Environment variables](../reference/env-vars.md) for the full grammar and bridge examples.
 
 Credentials are not shared between providers, set them per provider entry.
 

--- a/docs/book/src/reference/env-vars.md
+++ b/docs/book/src/reference/env-vars.md
@@ -92,6 +92,8 @@ The schema-mirror grammar is the canonical way to inject values, but `ANTHROPIC_
 
 Substitute the alias name in place of `home` to match your config. For multiple aliases on the same family, repeat the line with each alias.
 
+These lines are shell bridges into typed config, not a general rule that constructors read provider-native env vars. Runtime code should receive the resolved value from `Config` unless the integration family explicitly documents a native env bridge.
+
 ## OAuth and CLI-path fields
 
 A handful of fields live as schema fields, reachable via the standard mapping:


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Add a config-lifecycle rule that credential-like runtime values flow through typed config, config secret handling, or schema-mirror `ZEROCLAW_*` overrides before constructors consume them.
  - Clarify that ecosystem names such as `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY`, and `QDRANT_URL` are shell bridge inputs unless an integration family explicitly documents a native runtime bridge.
  - Correct stale Groq transcription and Qdrant schema comments, and align the multi-model setup guide with the typed credential path.
- **Scope boundary:** Documentation and source comments only. This PR does not change runtime credential resolution, environment overrides, schema fields, generated references, provider error strings, or CLI behavior. Issue #9154 owns the remaining Anthropic/OpenRouter error guidance that still advertises unsupported native environment variables.
- **Blast radius:** Config/environment credential documentation and reviewer guidance. Runtime behavior is unchanged.
- **Linked issue(s):** Related #7899 and #9154. PR #8576 is the implementation context that exposed the contract gap.
- **Labels:** `docs`, `config`, `type:docs`, `risk:low`, `size:XS`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A. This is a documentation and source-comment correction with no runtime or user-interface behavior change.

### How I tested

- **CI checks relied on and why they cover this change:** Exact-head GitHub checks passed on `e9a6fbfb4f18d17eb9b23e9adf8bc36107f72d00`, including `Docs Style`, `Format`, `Test`, and `CI Required Gate`. Together with the focused local docs quality, link integrity, comment hygiene, and whitespace checks, they cover the changed documentation and source-comment surfaces.
- **Known CI coverage gap, if any:** No runtime smoke or additional broad Cargo validation was run because this PR changes no executable behavior. Issue #9154 separately owns the stale Anthropic/OpenRouter runtime error guidance outside this PR's scope.
- **Commands run and tail output:**
  - `DOCS_FILES='docs/book/src/architecture/config-lifecycle.md docs/book/src/getting-started/multi-model-setup.md docs/book/src/reference/env-vars.md' BASE_SHA=origin/master bash scripts/ci/docs_links_gate.sh`: `Collected 0 added link(s)` and `No added links detected in changed docs lines.`
  - The same full-file selection with `bash scripts/ci/docs_quality_gate.sh`: `Summary: 0 error(s)`.
  - `bash scripts/ci/comment_hygiene_gate.sh`: `Comment hygiene gate passed.`
  - `git diff --check`: passed.
  - `cargo fmt --all -- --check`: passed through the local Cargo target wrapper.
- **Beyond CI, what did you manually verify?** Checked current `master` for the affected config comments, the provider constructors, and every `ANTHROPIC_API_KEY` / `OPENROUTER_API_KEY` error path. The constructors consume typed config, while two Anthropic and five OpenRouter errors retain stale native-env guidance; #9154 tracks that separate runtime-message cleanup.
- **If any command was intentionally skipped, why:** No broad Cargo checks or runtime smoke were run because this PR changes no executable behavior.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`; this PR clarifies the existing credential-source contract without changing resolution behavior.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

Low-risk documentation/source-comment rollback: `git revert <merge-commit>`.
