### PR TITLE
docs(sop): add no-toml syntax examples

### DIFF
--- a/docs/book/src/sop/syntax.md
+++ b/docs/book/src/sop/syntax.md
@@ -13,7 +13,16 @@ SOP definitions are loaded from subdirectories under `sops_dir`. When `sops_dir`
 
 Each SOP must have `SOP.toml`. `SOP.md` is optional, but runs with no parsed steps will fail validation.
 
-## 2. `SOP.toml`
+## 2. Authoring Boundary
+
+The file-backed representation still contains a manifest file plus `SOP.md`.
+This page intentionally does not enumerate manifest fields or provide
+hand-authored manifest examples.
+
+Use this page for the syntax that remains visible when reviewing, validating, or
+debugging SOPs: `SOP.md` step bullets, trigger field summaries generated from
+the runtime schema, and `condition` expressions. Before running a generated or
+checked-in SOP, validate it with `zeroclaw sop validate <name>`.
 
 ## 3. `SOP.md` Step Format
 
@@ -33,14 +42,49 @@ Steps are parsed from the `## Steps` section.
    - next: 3
 ```
 
+Routing and approval bullets can be combined in the same `SOP.md` steps:
+
+```md
+## Steps
+
+1. **Classify event** — Inspect the incoming payload.
+   - output: {"type":"object","required":["severity"],"properties":{"severity":{"type":"string"}}}
+   - when: $.steps.1.severity == "critical"
+   - next: 2
+
+2. **Prepare summary** — Build the operator-facing remediation plan.
+   - depends_on: 1
+   - on_failure: retry:2
+   - next: 3
+
+3. **Approval gate** — Require explicit approval before changing state.
+   - kind: checkpoint
+   - requires_confirmation: true
+   - next: 4
+
+4. **Apply remediation** — Execute the approved action.
+   - tools: shell
+   - allow-tools: shell
+   - on_failure: goto:5
+
+5. **Notify operator** — Send a failure notice for follow-up.
+   - tools: http_request
+```
+
 Parser behavior:
 
 - Numbered items (`1.`, `2.`, ...) define step order.
 - Leading bold text (`**Title**`) becomes step title.
 - `- tools:` maps to `suggested_tools`.
 - `- requires_confirmation: true` enforces approval for that step.
+- `- kind:` accepts `execute` (default) or `checkpoint`. A checkpoint step
+  pauses deterministic execution at that step. Use `requires_confirmation: true`
+  when a step must require approval in any execution mode.
 - `- allow-tools:` and `- deny-tools:` define an explicit per-step tool scope.
 - `- input:` and `- output:` attach JSON Schema-like step boundary contracts.
+- `- when:` is a routing guard evaluated against accumulated completed-step
+  outputs after the current step finishes. When it does not match, the run
+  completes instead of dispatching another step.
 - `- next:` and `- depends_on:` route non-linear runs. Ineligible routed steps
   are marked `skipped` and leave the run `pending` instead of dispatching.
 - `- on_failure:` accepts `fail`, `retry:<count>`, or `goto:<step>` and is
@@ -94,11 +138,78 @@ For the live-versus-unwired status of each source and the transport details, see
 
 ## 5. Condition Syntax
 
-`condition` is evaluated fail-closed (invalid condition/payload => no match).
+Trigger `condition` fields and step `when:` guards use the same expression
+grammar. Trigger conditions evaluate against the event payload. Step `when:`
+guards evaluate against accumulated completed-step outputs in this shape:
 
-- JSON path comparisons: `$.value > 85`, `$.status == "critical"`
-- Direct numeric comparisons: `> 0` (useful for simple payloads)
-- Operators: `>=`, `<=`, `!=`, `>`, `<`, `==`
+```json
+{
+  "steps": {
+    "1": {
+      "severity": "critical"
+    }
+  }
+}
+```
+
+Evaluation is fail-closed for invalid conditions, missing payloads, unresolved
+JSON paths, and direct numeric comparisons whose payload or comparand is not a
+number. An empty condition matches unconditionally.
+
+### JSON Path Form
+
+A condition beginning with `$` compares a value inside a JSON payload:
+`$.path.to.field <op> <value>`.
+
+| Expression | Payload | Matches |
+|---|---|---|
+| `$.value > 85` | `{"value":90}` | yes |
+| `$.value >= 85` | `{"value":85}` | yes |
+| `$.temp < 25` | `{"temp":20}` | yes |
+| `$.temp <= 25` | `{"temp":25}` | yes |
+| `$.status == "critical"` | `{"status":"critical"}` | yes |
+| `$.status != "error"` | `{"status":"ok"}` | yes |
+| `$.count == 42` | `{"count":42}` | yes |
+| `$.data.sensor.value > 85` | `{"data":{"sensor":{"value":87.3}}}` | yes |
+| `$.readings.1 == 20` | `{"readings":[10,20,30]}` | yes |
+| `$.active == "true"` | `{"active":true}` | yes |
+| `$.nonexistent > 0` | `{"value":90}` | no |
+
+Path rules:
+
+- Use dot-separated segments. Array elements use a numeric segment such as
+  `$.readings.1`; bracket syntax is not supported.
+- Missing keys, out-of-range array indexes, invalid JSON, and empty payloads
+  fail closed.
+- There are no wildcards, filters, recursive descent, or built-in variables.
+
+### Direct Numeric Form
+
+A condition with no leading `$` compares the whole payload as a number. This is
+useful for scalar event payloads.
+
+| Expression | Payload | Matches |
+|---|---|---|
+| `> 0` | `1` | yes |
+| `> 0` | `0` | no |
+| `>= 5` | `6` | yes |
+| `< 100` | `50` | yes |
+| `== 42` | `42` | yes |
+| `!= 0` | `1` | yes |
+| `> 3.14` | `3.15` | yes |
+| `> 0` | `not a number` | no |
+
+### Operators
+
+A comparison uses one operator, matched longest-first: `>=`, `<=`, `!=`, `==`,
+`>`, `<`. JSON-path comparisons try numeric comparison first. If both sides
+parse as numbers, they compare numerically; otherwise values compare as strings.
+Surrounding double quotes on the comparand are stripped, so quote string
+literals: `$.status == "critical"`. Direct numeric conditions are numeric-only:
+if either side does not parse as a number, there is no match.
+
+A condition is a single comparison. Logical combinators such as `AND`, `OR`,
+and `NOT` are not supported.
 
 ## 6. Validation
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Replaces the empty `SOP.toml` section on the SOP syntax page with an authoring boundary that keeps this reference from enumerating manifest fields or hand-authored manifest examples.
  - Adds a copyable `SOP.md` routing and approval example covering `kind: checkpoint`, `requires_confirmation`, `when:`, `depends_on`, `next`, and `on_failure`.
  - Expands condition syntax with runtime-backed JSON-path and direct numeric examples, plus fail-closed behavior and operator limits.
- **Scope boundary:** Docs-only. This does not change the SOP runtime, parser, trigger schema, or authoring surfaces, and it does not document hand-authored SOP manifest TOML.
- **Blast radius:** `docs/book/src/sop/syntax.md` only.
- **Linked issue(s):** Related #8587. Related #8590. Follow-up context: #8679 review requested avoiding TOML authoring docs.
- **Labels:** `type:docs`, `risk:low`, `size:S`, `docs`, `tool:sop`

## Validation Evidence (required)

- **Commands run and tail output:**

  ```bash
  git diff --check
  ```

  No output; exit 0.

  ```bash
  env BASE_SHA=origin/master DOCS_FILES=docs/book/src/sop/syntax.md bash scripts/ci/docs_links_gate.sh
  ```

  Output:

  ```text
  Collected 0 added link(s) from 1 docs file(s).
  No added links detected in changed docs lines.
  ```

  ```bash
  bash scripts/check-pr-title.sh 'docs(sop): add no-toml syntax examples'
  ```

  No output; exit 0.

  Manual markdown sanity check for trailing whitespace, tabs, and balanced fenced code blocks:

  ```text
  manual markdown sanity: ok
  ```

- **Beyond CI — what did you manually verify?** Checked the edited examples against the current parser and condition evaluator: `kind: checkpoint`, `requires_confirmation`, `when:`, `depends_on`, `next`, and `on_failure` are parsed from `SOP.md`; the text now qualifies checkpoint pause behavior for deterministic execution and points approval requirements at `requires_confirmation`; `when:` uses the same condition evaluator over completed-step outputs shaped as `{"steps":{"<n>": ...}}`; the JSON-path/direct numeric examples match the runtime condition tests.
- **If any command was intentionally skipped, why:** Full `scripts/ci/docs_quality_gate.sh` did not complete locally. Its em-dash subcheck passed, but the markdownlint phase did not complete in the local environment. The PR's GitHub `Docs Style` check is the markdownlint source of truth before ready-for-review.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: N/A

## Rollback (required for medium/high-risk PRs)

Low-risk docs-only PR: `git revert <sha>` is the rollback plan.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A. No `Supersedes #` used.
