### PR TITLE
test(config): cover LinkedIn Schema V4 removal scope

### DIFF
--- a/crates/zeroclaw-config/tests/schema_v4_external_saas.rs
+++ b/crates/zeroclaw-config/tests/schema_v4_external_saas.rs
@@ -1,0 +1,48 @@
+use std::collections::BTreeSet;
+
+use zeroclaw_config::schema::Config;
+
+#[test]
+fn linkedin_schema_v4_removal_scope_matches_schema_leaf_paths() {
+    let actual: BTreeSet<String> = Config::default()
+        .prop_fields()
+        .into_iter()
+        .filter_map(|field| {
+            field
+                .name
+                .strip_prefix("linkedin.")
+                .map(|suffix| format!("linkedin.{suffix}"))
+        })
+        .collect();
+
+    let expected = BTreeSet::from([
+        "linkedin.api_version".to_string(),
+        "linkedin.content.github_repos".to_string(),
+        "linkedin.content.github_users".to_string(),
+        "linkedin.content.instructions".to_string(),
+        "linkedin.content.persona".to_string(),
+        "linkedin.content.rss_feeds".to_string(),
+        "linkedin.content.topics".to_string(),
+        "linkedin.enabled".to_string(),
+        "linkedin.image.card_accent_color".to_string(),
+        "linkedin.image.dalle.api_key_env".to_string(),
+        "linkedin.image.dalle.model".to_string(),
+        "linkedin.image.dalle.size".to_string(),
+        "linkedin.image.enabled".to_string(),
+        "linkedin.image.fallback_card".to_string(),
+        "linkedin.image.flux.api_key_env".to_string(),
+        "linkedin.image.flux.model".to_string(),
+        "linkedin.image.imagen.api_key_env".to_string(),
+        "linkedin.image.imagen.project_id_env".to_string(),
+        "linkedin.image.imagen.region".to_string(),
+        "linkedin.image.providers".to_string(),
+        "linkedin.image.stability.api_key_env".to_string(),
+        "linkedin.image.stability.model".to_string(),
+        "linkedin.image.temp_dir".to_string(),
+    ]);
+
+    assert_eq!(
+        actual, expected,
+        "Schema V4's LinkedIn removal scope must track every schema-derived linkedin.* leaf path"
+    );
+}


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Adds a focused config regression test for the LinkedIn Schema V4 removal scope.
  - Derives the current `linkedin.*` leaf paths from `Config::prop_fields()` so the schema remains the source of truth.
  - Locks the expected LinkedIn leaf set for the #8310 external SaaS removal cut, including nested `[linkedin.image.*]` provider fields.
- **Scope boundary:** Does not remove LinkedIn config, change runtime registration, bump `CURRENT_SCHEMA_VERSION`, or change any user-facing behavior.
- **Blast radius:** Test-only change in `zeroclaw-config`; no production code path changes.
- **Linked issue(s):** Related #8310. Related #6165.
- **Labels:** `config`, `risk:low`, `size:XS`, `tests`

## Validation Evidence (required)

- **Commands run and tail output:**
  - `cargo test -p zeroclaw-config linkedin_schema_v4_removal_scope_matches_schema_leaf_paths`

```text
running 1 test
test linkedin_schema_v4_removal_scope_matches_schema_leaf_paths ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
```

  - `cargo fmt --all -- --check`

```text
clean
```

  - `git diff --check`

```text
clean
```

- **Beyond CI — what did you manually verify?** Confirmed the test derives `linkedin.*` paths from `Config::prop_fields()` rather than a production-side hand-maintained map.
- **If any command was intentionally skipped, why:** Full workspace clippy/test were not run; this is a test-only, single-crate guard with focused `zeroclaw-config` validation.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- If `No` or `Yes` to either: N/A

## Rollback (required for medium/high-risk PRs)

Low-risk PR. Rollback is `git revert <merge-commit>`.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A
