### PR TITLE
refactor(runtime): route the independent-delegate tool registry through the scoped seam

### DIFF
--- a/crates/zeroclaw-runtime/src/tools/delegate.rs
+++ b/crates/zeroclaw-runtime/src/tools/delegate.rs
@@ -729,18 +729,17 @@ impl DelegateTool {
             None,
         );
 
-        // Route the independent-target registry through the one gated seam - the same
-        // `assemble` seam run(), process_message, and the gateway use (from_config's
-        // migration is #8711, in review). Tool-set-neutral on this
-        // path: assemble step 2 filters with the TARGET's SecurityPolicy (the #8239
-        // invariant - target tools, not the caller's), caller_allowed is None (no per-run
-        // allowlist here), and MCP / peripherals / skill-tools / memory-strip are all off,
-        // exactly what this builder did by hand. `emit_assembly_logs: true` because this
-        // is an execution surface (the target then runs a turn), so operators get the same
-        // "which tools were admitted / did policy drop tools" audit breadcrumbs the other
-        // execution paths emit. The `delegate` tool is stripped afterward because
-        // `all_tools_with_runtime` unconditionally injects it and an independent delegate
-        // must not be able to recurse into further delegation.
+        // Route the independent-target registry through the one gated `assemble`
+        // seam. Tool-set-neutral on this path: assemble's built-in filter runs
+        // against the TARGET's SecurityPolicy (target tools, not the caller's),
+        // caller_allowed is None (no per-run allowlist here), and MCP / peripherals
+        // / skill-tools / memory-strip are all off, exactly what this builder did by
+        // hand. `emit_assembly_logs: true` because this is an execution surface (the
+        // target then runs a turn), so operators get the same "which tools were
+        // admitted / did policy drop tools" audit breadcrumbs the other execution
+        // paths emit. The `delegate` tool is stripped afterward because
+        // `all_tools_with_runtime` unconditionally injects it and an independent
+        // delegate must not be able to recurse into further delegation.
         let assembled = crate::tools::scoped::ScopedToolRegistry::assemble(
             crate::tools::scoped::ScopedAssembly {
                 config,

--- a/crates/zeroclaw-runtime/src/tools/delegate.rs
+++ b/crates/zeroclaw-runtime/src/tools/delegate.rs
@@ -705,12 +705,12 @@ impl DelegateTool {
             .resolved_model_provider_for_agent(agent_name)
             .and_then(|(_, _, provider)| provider.api_key.as_deref());
 
-        let mut tools = crate::tools::all_tools_with_runtime(
+        let all_tools_result = crate::tools::all_tools_with_runtime(
             Arc::clone(config),
             &target_policy,
             &risk_profile,
             agent_name,
-            runtime,
+            runtime.clone(),
             memory,
             composio_key,
             composio_entity_id,
@@ -727,14 +727,38 @@ impl DelegateTool {
             None,
             None,
             None,
-        )
-        .tools;
-
-        crate::agent::loop_::apply_policy_tool_filter(
-            &mut tools,
-            Some(target_policy.as_ref()),
-            None,
         );
+
+        // Route the independent-target registry through the one gated seam - the same
+        // `assemble` seam run(), process_message, and the gateway use (from_config's
+        // migration is #8711, in review). Tool-set-neutral on this
+        // path: assemble step 2 filters with the TARGET's SecurityPolicy (the #8239
+        // invariant - target tools, not the caller's), caller_allowed is None (no per-run
+        // allowlist here), and MCP / peripherals / skill-tools / memory-strip are all off,
+        // exactly what this builder did by hand. `emit_assembly_logs: true` because this
+        // is an execution surface (the target then runs a turn), so operators get the same
+        // "which tools were admitted / did policy drop tools" audit breadcrumbs the other
+        // execution paths emit. The `delegate` tool is stripped afterward because
+        // `all_tools_with_runtime` unconditionally injects it and an independent delegate
+        // must not be able to recurse into further delegation.
+        let assembled = crate::tools::scoped::ScopedToolRegistry::assemble(
+            crate::tools::scoped::ScopedAssembly {
+                config,
+                agent_alias: agent_name,
+                security: &target_policy,
+                built: all_tools_result,
+                skills: &[],
+                runtime,
+                caller_allowed: None,
+                connect_mcp: false,
+                connect_peripherals: false,
+                exclude_memory: false,
+                emit_assembly_logs: true,
+            },
+        )
+        .await;
+        let mut tools = assembled.registry.into_inner();
+
         tools.retain(|tool| tool.name() != Self::NAME);
         Ok(tools)
     }


### PR DESCRIPTION
## Summary

Routes the independent-delegate tool registry (`independent_agentic_tools_for_target`
in `crates/zeroclaw-runtime/src/tools/delegate.rs`) through the one gated tool-assembly
seam, `ScopedToolRegistry::assemble` -- the same seam `run`, `process_message`, the
gateway, and `Agent::from_config` use. This is the delegate site of Epic A of the
agent-policy enforcement-unification program; it removes the last hand-rolled
`all_tools_with_runtime` + `apply_policy_tool_filter` pair on the independent-delegation
path.

This is a **tool-set-neutral** cut-over: the assembled tool set is byte-for-byte what the
inline path produced. It additionally emits the seam's per-step assembly audit logs
(`emit_assembly_logs: true`), because the independent delegate is an execution surface
(the target then runs a turn) -- see the knobs below.

## Why it's neutral

The independent-delegate builder constructs a fresh tool registry for a *target* agent
(issue #8239: the target's risk profile, workspace, memory, and provider creds -- never
the caller's). Today it calls `all_tools_with_runtime(...)` then
`apply_policy_tool_filter(&mut tools, Some(target_policy.as_ref()), None)`. Routed
through the seam with these knobs, `assemble` reduces to exactly that:

- `security: &target_policy` -- assemble's built-in filter runs against the **target's**
  `SecurityPolicy`, preserving the #8239 invariant (target tools, not the caller's).
- `caller_allowed: None` -- matches the third argument the inline filter passed; no
  per-run allowlist on this path.
- `connect_mcp: false`, `connect_peripherals: false`, `exclude_memory: false`,
  `skills: &[]` -- the inline path wired no MCP, no peripherals, no skill *tools*, and
  kept the target's memory tools; every one of these knobs makes the corresponding
  `assemble` step a no-op, so the tool set is identical.
- `emit_assembly_logs: true` -- the independent delegate is an execution surface (the
  target runs a turn against this registry), so it now emits the same assembly audit
  breadcrumbs (which tools were admitted, whether policy dropped any) that `run` /
  `process_message` / `from_config` emit. Observability-only; no effect on the tool set.

The independent delegate returns a bare `Vec<Box<dyn Tool>>` (no handles, no system
prompt, no deferred-MCP section), so it is fully decoupled from the in-flight
`ScopedAssembled` prompt-section work in #8711.

The one delegate-specific step stays where it was: after `registry.into_inner()`, the
`delegate` tool is stripped (`tools.retain(|t| t.name() != Self::NAME)`) -- because
`all_tools_with_runtime` unconditionally injects a `DelegateTool`, and an independent
delegate must not be able to recurse into further delegation.

## Changes

- `crates/zeroclaw-runtime/src/tools/delegate.rs` -- `independent_agentic_tools_for_target`
  now calls `ScopedToolRegistry::assemble` (with the neutral knob set above) instead of
  the inline `all_tools_with_runtime().tools` + `apply_policy_tool_filter`. The
  `delegate`-tool strip and the `Vec<Box<dyn Tool>>` return are unchanged. (+29 / -8.)

## Known divergence, preserved (tracked as a separate follow-up)

This path passes `connect_mcp: false` and `skills: &[]`, so an independent delegate to a
target agent does **not** receive that target's MCP-bundle tools or callable skill tools
-- only the built-in registry, filtered by the target's policy. That is a **pre-existing**
divergence: the inline code this replaces wired neither MCP nor skills, so this cut-over
is faithfully tool-set-neutral (and the #8239 pin holds).

It is, however, a real gap against the documented contract that independent delegation is
"like opening a fresh chat with the target" (`docs/book/src/agents/delegation.md`), which
*would* include the target's MCP and skills. Closing it means turning on
`connect_mcp`/skills and threading the deferred-MCP `deferred_section`/`activated_handle`
into the delegate loop -- a behavior **widening** that deserves its own PR and review, not
a rider on a neutral cut-over. It is tracked as an Epic-A follow-up and is exactly the
kind of per-path divergence the parity harness (#8659) is built to catch. Keeping this PR
neutral follows the "one behavior change per PR" rule.

## Validation

- `cargo test -p zeroclaw-runtime --lib independent_agentic_tools_use_target_registry_not_parent_registry`
  -- passes. This is the load-bearing pin: it asserts the target's `shell` is present,
  the `delegate` tool is absent (the strip), and the caller-only `echo_tool` is absent
  (fresh-target build, not parent inheritance) -- so the #8239 invariant survives the
  cut-over.
- `cargo fmt --all -- --check` -- clean.
- `cargo clippy -p zeroclaw-runtime --all-targets -- -D warnings` -- clean.
- `cargo test -p zeroclaw-runtime` -- `2776 passed; 0 failed; 2 ignored`.
- `cargo build --workspace --all-targets` (excluding the GTK-only `zeroclaw-desktop`
  crate, which needs system GTK libs not on the build host) -- clean.

## Related

- Epic A cut-over sites already merged: gateway (#8640), `run` (#8700),
  `process_message` (#8701); `Agent::from_config` in review (#8711). The channel
  orchestrator is the remaining site.
- Epic A design: the `agent-policy-parity-harness` contributing page (#8179).
