### PR TITLE
fix(sop): reject sop_advance on runs parked at a gate (#8678)

### DIFF
--- a/crates/zeroclaw-runtime/src/sop/engine.rs
+++ b/crates/zeroclaw-runtime/src/sop/engine.rs
@@ -490,6 +490,16 @@ impl SopEngine {
 
     /// Report the result of the current step and advance the run.
     /// Returns the next action to take.
+    ///
+    /// Refuses to advance a run whose status is `WaitingApproval` or
+    /// `PausedCheckpoint`: those states mean an external gate is pending
+    /// (an approval, or a deterministic checkpoint resume) and a driver
+    /// supplying a fabricated `SopStepResult` must not be allowed to skip
+    /// the gate. The legitimate path for clearing a `WaitingApproval` gate
+    /// is `resolve_gate` / `clear_waiting_gate`; the legitimate path for
+    /// resuming a `PausedCheckpoint` is `approve_step`. Mirrors the
+    /// status check `approve_step` already performs for the checkpoint
+    /// case.
     pub fn advance_step(&mut self, run_id: &str, result: SopStepResult) -> Result<SopRunAction> {
         let (sop_name, current_step_number) = {
             let run = self.active_runs.get(run_id).ok_or_else(|| {
@@ -502,6 +512,28 @@ impl SopEngine {
                 );
                 anyhow::Error::msg(format!("Active run not found: {run_id}"))
             })?;
+            if matches!(
+                run.status,
+                SopRunStatus::WaitingApproval | SopRunStatus::PausedCheckpoint
+            ) {
+                ::zeroclaw_log::record!(
+                    WARN,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Reject)
+                        .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                        .with_attrs(::serde_json::json!({
+                            "run_id": run_id,
+                            "status": run.status.to_string(),
+                            "step": run.current_step,
+                        })),
+                    "SOP engine: advance_step rejected — run is paused at a gate"
+                );
+                bail!(
+                    "Run {run_id} is paused at a {} gate; resolve the gate through \
+                     `resolve_gate` (WaitingApproval) or `approve_step` (PausedCheckpoint) \
+                     before advancing with sop_advance",
+                    run.status
+                );
+            }
             (run.sop_name.clone(), run.current_step)
         };
 
@@ -3916,6 +3948,126 @@ mod tests {
         let action = engine.start_run("s1", manual_event()).unwrap();
         let run_id = extract_run_id(&action).to_string();
         assert!(engine.approve_step(&run_id).is_err());
+    }
+
+    // ── Advance step gate guard (#8678) ─────────────────
+    //
+    // A driver calling `sop_advance` while a run is parked at an external
+    // gate (WaitingApproval or PausedCheckpoint) used to be allowed to
+    // fabricate a Completed step result, record it, and dispatch the next
+    // step — silently bypassing the approval flow or the deterministic
+    // checkpoint resume. `advance_step` now refuses those calls.
+
+    #[test]
+    fn advance_step_rejects_waiting_approval_run() {
+        // requires_confirmation forces the run to WaitApproval on step 1.
+        let mut sop = test_sop("s1", SopExecutionMode::Auto, SopPriority::Critical);
+        sop.steps[0].requires_confirmation = true;
+        let mut engine = engine_with_sops(vec![sop]);
+        let action = engine.start_run("s1", manual_event()).unwrap();
+        let run_id = extract_run_id(&action).to_string();
+
+        // Sanity: run is parked at the gate.
+        let run = engine.active_runs().get(&run_id).unwrap();
+        assert_eq!(run.status, SopRunStatus::WaitingApproval);
+        let step_results_before = run.step_results.len();
+
+        // Driver tries to fabricate success for the gated step.
+        let err = engine
+            .advance_step(
+                &run_id,
+                SopStepResult {
+                    step_number: 1,
+                    status: SopStepStatus::Completed,
+                    output: "fabricated".into(),
+                    started_at: now_iso8601(),
+                    completed_at: Some(now_iso8601()),
+                },
+            )
+            .unwrap_err();
+
+        // Error must point at the gate, not the run id.
+        assert!(
+            err.to_string().contains("WaitingApproval"),
+            "rejection should mention the gate status, got: {err}"
+        );
+
+        // The run state must be unchanged: still WaitingApproval, no
+        // phantom step result recorded, no next step dispatched.
+        let run = engine.active_runs().get(&run_id).unwrap();
+        assert_eq!(run.status, SopRunStatus::WaitingApproval);
+        assert_eq!(run.step_results.len(), step_results_before);
+    }
+
+    #[test]
+    fn advance_step_rejects_paused_checkpoint_run() {
+        // A deterministic SOP with a Checkpoint step pauses the run in
+        // PausedCheckpoint after step 1 completes. Driving `sop_advance`
+        // directly must be rejected — the only legitimate resume path is
+        // `approve_step`.
+        let mut engine = engine_with_sops(vec![deterministic_sop("det-cp")]);
+        let action = engine.start_run("det-cp", manual_event()).unwrap();
+        let run_id = extract_run_id(&action).to_string();
+
+        // Advance through step 1 (Execute) to reach the checkpoint.
+        engine
+            .advance_deterministic_step(&run_id, serde_json::json!({"ok": true}), None)
+            .unwrap();
+        let run = engine.get_run(&run_id).unwrap();
+        assert_eq!(run.status, SopRunStatus::PausedCheckpoint);
+
+        // Driver tries to fabricate completion of the checkpoint step.
+        let err = engine
+            .advance_step(
+                &run_id,
+                SopStepResult {
+                    step_number: 2,
+                    status: SopStepStatus::Completed,
+                    output: "fabricated".into(),
+                    started_at: now_iso8601(),
+                    completed_at: Some(now_iso8601()),
+                },
+            )
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("PausedCheckpoint"),
+            "rejection should mention the gate status, got: {err}"
+        );
+
+        // The run must still be parked at the checkpoint, not advanced
+        // past it.
+        let run = engine.get_run(&run_id).unwrap();
+        assert_eq!(run.status, SopRunStatus::PausedCheckpoint);
+    }
+
+    #[test]
+    fn advance_step_still_works_for_running_run() {
+        // Control case: a non-paused run must still be drivable through
+        // sop_advance. Without this case, the new guard could be hiding
+        // a regression on the happy path.
+        let mut engine = engine_with_sops(vec![test_sop(
+            "s1",
+            SopExecutionMode::Auto,
+            SopPriority::Normal,
+        )]);
+        let action = engine.start_run("s1", manual_event()).unwrap();
+        let run_id = extract_run_id(&action).to_string();
+
+        let action = engine
+            .advance_step(
+                &run_id,
+                SopStepResult {
+                    step_number: 1,
+                    status: SopStepStatus::Completed,
+                    output: "done".into(),
+                    started_at: now_iso8601(),
+                    completed_at: Some(now_iso8601()),
+                },
+            )
+            .unwrap();
+
+        assert!(matches!(action, SopRunAction::ExecuteStep { .. }));
     }
 
     // ── Context formatting ──────────────────────────────


### PR DESCRIPTION
Closes #8678

## Summary

`SopEngine::advance_step` resolved the run and the current step but never checked `run.status`. A driver with the run_id could call `sop_advance` while the run was parked in `WaitingApproval` or `PausedCheckpoint`, fabricate a `SopStepResult` with `status="completed"`, and walk past the gated step into the next dispatch. The approval flow was never resolved through `resolve_gate` / `clear_waiting_gate`, the deterministic checkpoint resume was never run through `approve_step`, and no `gate_resolved` ledger entry was written. The bypass was silent.

This patch mirrors the run.status guard `approve_step` already performs for the checkpoint case: `advance_step` now refuses to act on a run whose status is `WaitingApproval` or `PausedCheckpoint` and surfaces a structured error naming the gate and the legitimate resolution path.

## Real behavior proof

- `cargo fmt --check`: clean
- `cargo clippy -p zeroclaw-runtime --all-targets -- -D warnings`: 0 warnings
- `cargo test -p zeroclaw-runtime --lib sop::`: **262 passed, 0 failed** (4 in `engine::tests::advance_step*`, 8 in `tools::sop_advance`, 6 in `tools::sop_approve`)
- `cargo test --locked -p zeroclaw-runtime --lib sop::`: 262 passed
- 7 pre-existing failures in `agent::agent::safety_net` / `agent::agent::tests::turn_streamed_*` reproduce on upstream/master at HEAD and are unrelated to this patch (verified by `git stash` + run on the unmodified tree).

## Diff surface

Single file (`crates/zeroclaw-runtime/src/sop/engine.rs`), +152 LoC:

1. `advance_step` — add a `run.status` check after the active-run lookup, log a structured Reject event with the run_id / status / step attributes, and bail with a message that names the gate (`WaitingApproval` / `PausedCheckpoint`) and points the caller at `resolve_gate` / `approve_step` as the legitimate resume paths.
2. Three regression tests in `mod tests`:
   - `advance_step_rejects_waiting_approval_run` — `requires_confirmation` parks the run in `WaitingApproval`; a fabricated `Completed` result is rejected, run status and `step_results` length are unchanged.
   - `advance_step_rejects_paused_checkpoint_run` — a deterministic SOP pauses at the `Checkpoint` step; `sop_advance` on the parked run is rejected, run status stays at `PausedCheckpoint`.
   - `advance_step_still_works_for_running_run` — control case pinning the happy path so the new guard cannot silently regress `advance_step` for a normal `Running` run.

## Why a single rejection at the engine boundary

Two layers considered:
- (a) Reject in `SopAdvanceTool::execute` (the tool boundary). Drawback: anyone calling `engine.advance_step` directly (the determinism runner, integration tests, future internal callers) gets the same hole for free.
- (b) Reject in `SopEngine::advance_step` (the engine boundary, chosen). Matches the `approve_step` precedent; closes every entrypoint in one place; the tool surface is just a wrapper.

The audit trail (structured Reject event with run_id / status / step) lives at the engine boundary too, so the bypass-attempt signal is consistent with the existing `active run not found` and `step no longer exists` rejections.

## Out of scope (per issue author note)

The issue also flags a related checkpoint vs. `out_of_band_required` question — `sop_approve` for a deterministic `kind: checkpoint` falls through to `approve_step` without consulting `approval_mode`, so the driving agent can resume its own checkpoint under `out_of_band_required`. That's a separate design question (doc note vs. behavior change) and intentionally not addressed here.