### PR TITLE
refactor(providers): extract normalize_native_tool_call_arguments helper (#8675 prep)

### DIFF
--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -1375,24 +1375,8 @@ impl StreamToolCallAccumulator {
         used_tool_call_ids: &mut std::collections::HashSet<String>,
     ) -> Option<ProviderToolCall> {
         let name = self.name?;
-        let arguments = if self.arguments.trim().is_empty() {
-            "{}".to_string()
-        } else {
-            self.arguments
-        };
-        let normalized_arguments = if serde_json::from_str::<serde_json::Value>(&arguments).is_ok()
-        {
-            arguments
-        } else {
-            ::zeroclaw_log::record!(
-                WARN,
-                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                    .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                    .with_attrs(::serde_json::json!({"function": name, "arguments": arguments})),
-                "Invalid JSON in streamed native tool-call arguments, using empty object"
-            );
-            "{}".to_string()
-        };
+        let normalized_arguments =
+            crate::native_tool_args::normalize_native_tool_call_arguments(&name, self.arguments);
 
         Some(ProviderToolCall {
             id: reserve_tool_call_id_for_contract(
@@ -2391,23 +2375,9 @@ impl OpenAiCompatibleModelProvider {
             .into_iter()
             .filter_map(|tc| {
                 let name = tc.function_name()?;
-                let arguments = tc.function_arguments().unwrap_or_else(|| "{}".to_string());
-                let normalized_arguments = if serde_json::from_str::<serde_json::Value>(&arguments)
-                    .is_ok()
-                {
-                    arguments
-                } else {
-                    ::zeroclaw_log::record!(
-                        WARN,
-                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                            .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                            .with_attrs(
-                                ::serde_json::json!({"function": name, "arguments": arguments})
-                            ),
-                        "Invalid JSON in native tool-call arguments, using empty object"
-                    );
-                    "{}".to_string()
-                };
+                let arguments = tc.function_arguments().unwrap_or_default();
+                let normalized_arguments =
+                    crate::native_tool_args::normalize_native_tool_call_arguments(&name, arguments);
                 Some(ProviderToolCall {
                     id: self.reserve_tool_call_id(tc.id, &mut used_tool_call_ids),
                     name,

--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -32,6 +32,7 @@ pub mod kilocli;
 pub mod model_pin;
 pub mod models_dev;
 pub mod multimodal;
+pub(crate) mod native_tool_args;
 pub mod ollama;
 pub mod openai;
 pub mod openai_codex;

--- a/crates/zeroclaw-providers/src/native_tool_args.rs
+++ b/crates/zeroclaw-providers/src/native_tool_args.rs
@@ -1,0 +1,140 @@
+//! Shared normalization for `assistant.tool_calls[].function.arguments` strings
+//! produced by the OpenAI-wire-format family of providers (openrouter, openai,
+//! azure_openai, copilot, openai_codex).
+//!
+//! Smaller / reasoning models occasionally emit arguments strings that are
+//! not well-formed JSON. Strict upstreams (Cohere via OpenRouter, OpenInference,
+//! Nvidia, etc.) then reject the entire outbound request with HTTP 400 and the
+//! runtime surfaces an empty "try again" fallback to the user.
+//!
+//! [`normalize_native_tool_call_arguments`] applies the same JSON guard
+//! [`crate::compatible`] uses inline (around line 1383 of `compatible.rs`),
+//! so all five OpenAI-wire providers can produce parity instead of each
+//! re-implementing the same 12-line block. The guard is intentionally
+//! conservative: malformed arguments are replaced with `"{}"` so the rest of
+//! the tool-call (id + function name) still flows through and the provider
+//! returns a structured 400 the agent can recover from, rather than a silent
+//! empty turn.
+
+/// Normalize a native tool-call `arguments` string before it is serialized
+/// into the outbound request body.
+///
+/// - An empty or whitespace-only `arguments` becomes `"{}"` so a provider
+///   that requires a stringified JSON object never sees `""` (which strict
+///   upstreams reject with "tool arguments must be a stringified JSON
+///   object").
+/// - A well-formed JSON value is returned unchanged.
+/// - A malformed value is logged at WARN with the function name and the
+///   original payload (for post-incident auditing) and replaced with `"{}"`,
+///   matching the existing [`crate::compatible`] inline guard.
+///
+/// The function is `pub(crate)` because the only callers are the OpenAI-wire
+/// provider parsers in this crate. Promoting it to `pub` would require
+/// stability guarantees this internal helper does not need.
+pub(crate) fn normalize_native_tool_call_arguments(
+    function_name: &str,
+    arguments: String,
+) -> String {
+    let trimmed = arguments.trim();
+    if trimmed.is_empty() {
+        return "{}".to_string();
+    }
+    if serde_json::from_str::<serde_json::Value>(trimmed).is_ok() {
+        return arguments;
+    }
+
+    ::zeroclaw_log::record!(
+        WARN,
+        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+            .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+            .with_attrs(::serde_json::json!({
+                "function": function_name,
+                "arguments": arguments,
+            })),
+        "Invalid JSON in streamed native tool-call arguments, using empty object"
+    );
+
+    "{}".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_arguments_become_empty_object() {
+        assert_eq!(
+            normalize_native_tool_call_arguments("shell", String::new()),
+            "{}"
+        );
+    }
+
+    #[test]
+    fn whitespace_only_arguments_become_empty_object() {
+        assert_eq!(
+            normalize_native_tool_call_arguments("shell", "   \t\n".to_string()),
+            "{}"
+        );
+    }
+
+    #[test]
+    fn valid_json_object_preserved() {
+        let raw = r#"{"command":"ls -la"}"#.to_string();
+        assert_eq!(
+            normalize_native_tool_call_arguments("shell", raw.clone()),
+            raw
+        );
+    }
+
+    #[test]
+    fn valid_json_array_preserved() {
+        // Some providers (Cohere, OpenInference) emit arguments that parse
+        // as non-object JSON. We keep anything that parses; downstream
+        // schema validation is the tool's responsibility.
+        let raw = r#"[1,2,3]"#.to_string();
+        assert_eq!(
+            normalize_native_tool_call_arguments("tool", raw.clone()),
+            raw
+        );
+    }
+
+    #[test]
+    fn valid_json_scalars_preserved() {
+        // Strings / numbers parse as JSON. Edge case worth pinning because
+        // `from_str::<Value>` accepts anything that starts as valid JSON.
+        assert_eq!(
+            normalize_native_tool_call_arguments("tool", r#""plain""#.to_string()),
+            r#""plain""#
+        );
+    }
+
+    #[test]
+    fn malformed_json_falls_back_to_empty_object() {
+        // The realistic malformed case from #8675: trailing comma, unescaped
+        // quote, truncated object, model emitting Python-style `None`.
+        for malformed in [
+            r#"{"command": "ls""#,                // missing closing brace
+            r#"{"command": 'ls'}"#,               // Python-style single quotes
+            r#"{"command": None}"#,               // Python None
+            r#"Expecting ',' delimiter: line 1"#, // server error echoed back
+        ] {
+            assert_eq!(
+                normalize_native_tool_call_arguments("shell", malformed.to_string()),
+                "{}",
+                "malformed input {malformed:?} should be replaced with {{}}"
+            );
+        }
+    }
+
+    #[test]
+    fn leading_and_trailing_whitespace_does_not_disqualify_valid_json() {
+        // `trim().is_empty()` is what we use for the empty check, so a
+        // well-formed JSON payload with surrounding whitespace must still
+        // round-trip. (Some stream chunkers append newlines.)
+        let raw = "  {\"k\":1}\n".to_string();
+        assert_eq!(
+            normalize_native_tool_call_arguments("tool", raw.clone()),
+            raw
+        );
+    }
+}


### PR DESCRIPTION
## Summary

First of a six-PR series for #8675. Several OpenAI-wire providers (openrouter, openai, azure_openai, copilot, openai_codex) re-serialize assistant `tool_calls[].function.arguments` verbatim into the outbound request without validating that the string is well-formed JSON. When a smaller model emits a malformed arguments string, strict upstreams (Cohere via OpenRouter, OpenInference, Nvidia, ...) reject the entire request with HTTP 400 and the runtime surfaces an empty "try again" fallback with no recovery within the turn.

`compatible.rs` already has an inline guard for this (around line 1383 in `into_provider_tool_call` and line 2395 in `parse_native_response`) but each of the five OpenAI-wire providers has a parallel un-guarded path. To keep blast radius per provider small and avoid N copies of the same 12-line WARN block, this PR extracts a single `pub(crate)` helper in a new `native_tool_args` module and rewires both `compatible.rs` call sites onto it. Subsequent PRs in the series will replace the un-guarded `arguments` passthrough in the five provider parsers with a call to this helper.

## Helper contract

`pub(crate) fn normalize_native_tool_call_arguments(function_name: &str, arguments: String) -> String`

- Empty or whitespace-only `arguments` → `"{}"` (a strict upstream that requires a stringified JSON object never sees `""`).
- `serde_json::from_str::<Value>` accepts → input returned unchanged (object, array, scalar, whitespace-padded JSON all round-trip).
- Malformed JSON → structured WARN log with the function name and original payload, then `"{}"` — byte-for-byte identical to the existing `compatible.rs` inline behaviour so no provider contract changes.

## Real behavior proof

- `cargo fmt --all -- --check`: clean
- `cargo clippy -p zeroclaw-providers --all-targets -- -D warnings`: 0 warnings
- `cargo test -p zeroclaw-providers --lib native_tool_args`: **7/7 pass** (`empty_arguments_become_empty_object`, `whitespace_only_arguments_become_empty_object`, `valid_json_object_preserved`, `valid_json_array_preserved`, `valid_json_scalars_preserved`, `malformed_json_falls_back_to_empty_object`, `leading_and_trailing_whitespace_does_not_disqualify_valid_json`)
- `cargo test -p zeroclaw-providers --lib compatible`: **203/203 pass** (no regression from the `compatible.rs` call-site rewiring)

## Diff surface

3 files, +146 / -35:

- `crates/zeroclaw-providers/src/native_tool_args.rs` (new, +140): the helper plus seven unit tests covering empty / whitespace / valid object / valid array / valid scalar / malformed (4 representative patterns from the issue) / whitespace-padded valid JSON.
- `crates/zeroclaw-providers/src/compatible.rs` (-29 net): two inline guard blocks (12 + 14 lines) replaced with a one-line call each. Behaviour preserved exactly.
- `crates/zeroclaw-providers/src/lib.rs` (+1): register the new `pub(crate) mod native_tool_args` next to the other private modules.

## Why `pub(crate)`

The helper is only consumed by the five OpenAI-wire provider parsers in this crate. Promoting it to `pub` would require stability guarantees an internal helper does not need. `pub(crate)` keeps the door open for a future `pub` bump if a downstream consumer ever needs it, but does not lock us in.

## Series plan

This PR is dependency-free. The remaining five (#8675 PR2–PR6) each replace one provider's `arguments: tc.arguments` / `arguments: tc.function.arguments` / `arguments: call.arguments` / `arguments: item.get("arguments")` passthrough with `crate::native_tool_args::normalize_native_tool_call_arguments(&name, arguments)`, plus a per-provider regression test. Each provider PR can land independently once this helper is in master.