### PR TITLE
fix(providers/openrouter): normalize native tool-call arguments via shared helper (#8675)

### DIFF
--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -1378,24 +1378,8 @@ impl StreamToolCallAccumulator {
         used_tool_call_ids: &mut std::collections::HashSet<String>,
     ) -> Option<ProviderToolCall> {
         let name = self.name?;
-        let arguments = if self.arguments.trim().is_empty() {
-            "{}".to_string()
-        } else {
-            self.arguments
-        };
-        let normalized_arguments = if serde_json::from_str::<serde_json::Value>(&arguments).is_ok()
-        {
-            arguments
-        } else {
-            ::zeroclaw_log::record!(
-                WARN,
-                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                    .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                    .with_attrs(::serde_json::json!({"function": name, "arguments": arguments})),
-                "Invalid JSON in streamed native tool-call arguments, using empty object"
-            );
-            "{}".to_string()
-        };
+        let normalized_arguments =
+            crate::native_tool_args::normalize_native_tool_call_arguments(&name, self.arguments);
 
         Some(ProviderToolCall {
             id: reserve_tool_call_id_for_contract(
@@ -2394,23 +2378,9 @@ impl OpenAiCompatibleModelProvider {
             .into_iter()
             .filter_map(|tc| {
                 let name = tc.function_name()?;
-                let arguments = tc.function_arguments().unwrap_or_else(|| "{}".to_string());
-                let normalized_arguments = if serde_json::from_str::<serde_json::Value>(&arguments)
-                    .is_ok()
-                {
-                    arguments
-                } else {
-                    ::zeroclaw_log::record!(
-                        WARN,
-                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                            .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                            .with_attrs(
-                                ::serde_json::json!({"function": name, "arguments": arguments})
-                            ),
-                        "Invalid JSON in native tool-call arguments, using empty object"
-                    );
-                    "{}".to_string()
-                };
+                let arguments = tc.function_arguments().unwrap_or_default();
+                let normalized_arguments =
+                    crate::native_tool_args::normalize_native_tool_call_arguments(&name, arguments);
                 Some(ProviderToolCall {
                     id: self.reserve_tool_call_id(tc.id, &mut used_tool_call_ids),
                     name,

--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -32,6 +32,7 @@ pub mod kilocli;
 pub mod model_pin;
 pub mod models_dev;
 pub mod multimodal;
+pub(crate) mod native_tool_args;
 pub mod ollama;
 pub mod openai;
 pub mod openai_codex;

--- a/crates/zeroclaw-providers/src/native_tool_args.rs
+++ b/crates/zeroclaw-providers/src/native_tool_args.rs
@@ -1,0 +1,140 @@
+//! Shared normalization for `assistant.tool_calls[].function.arguments` strings
+//! produced by the OpenAI-wire-format family of providers (openrouter, openai,
+//! azure_openai, copilot, openai_codex).
+//!
+//! Smaller / reasoning models occasionally emit arguments strings that are
+//! not well-formed JSON. Strict upstreams (Cohere via OpenRouter, OpenInference,
+//! Nvidia, etc.) then reject the entire outbound request with HTTP 400 and the
+//! runtime surfaces an empty "try again" fallback to the user.
+//!
+//! [`normalize_native_tool_call_arguments`] applies the same JSON guard
+//! [`crate::compatible`] uses inline (around line 1383 of `compatible.rs`),
+//! so all five OpenAI-wire providers can produce parity instead of each
+//! re-implementing the same 12-line block. The guard is intentionally
+//! conservative: malformed arguments are replaced with `"{}"` so the rest of
+//! the tool-call (id + function name) still flows through and the provider
+//! returns a structured 400 the agent can recover from, rather than a silent
+//! empty turn.
+
+/// Normalize a native tool-call `arguments` string before it is serialized
+/// into the outbound request body.
+///
+/// - An empty or whitespace-only `arguments` becomes `"{}"` so a provider
+///   that requires a stringified JSON object never sees `""` (which strict
+///   upstreams reject with "tool arguments must be a stringified JSON
+///   object").
+/// - A well-formed JSON value is returned unchanged.
+/// - A malformed value is logged at WARN with the function name and the
+///   original payload (for post-incident auditing) and replaced with `"{}"`,
+///   matching the existing [`crate::compatible`] inline guard.
+///
+/// The function is `pub(crate)` because the only callers are the OpenAI-wire
+/// provider parsers in this crate. Promoting it to `pub` would require
+/// stability guarantees this internal helper does not need.
+pub(crate) fn normalize_native_tool_call_arguments(
+    function_name: &str,
+    arguments: String,
+) -> String {
+    let trimmed = arguments.trim();
+    if trimmed.is_empty() {
+        return "{}".to_string();
+    }
+    if serde_json::from_str::<serde_json::Value>(trimmed).is_ok() {
+        return arguments;
+    }
+
+    ::zeroclaw_log::record!(
+        WARN,
+        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+            .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+            .with_attrs(::serde_json::json!({
+                "function": function_name,
+                "arguments": arguments,
+            })),
+        "Invalid JSON in streamed native tool-call arguments, using empty object"
+    );
+
+    "{}".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_arguments_become_empty_object() {
+        assert_eq!(
+            normalize_native_tool_call_arguments("shell", String::new()),
+            "{}"
+        );
+    }
+
+    #[test]
+    fn whitespace_only_arguments_become_empty_object() {
+        assert_eq!(
+            normalize_native_tool_call_arguments("shell", "   \t\n".to_string()),
+            "{}"
+        );
+    }
+
+    #[test]
+    fn valid_json_object_preserved() {
+        let raw = r#"{"command":"ls -la"}"#.to_string();
+        assert_eq!(
+            normalize_native_tool_call_arguments("shell", raw.clone()),
+            raw
+        );
+    }
+
+    #[test]
+    fn valid_json_array_preserved() {
+        // Some providers (Cohere, OpenInference) emit arguments that parse
+        // as non-object JSON. We keep anything that parses; downstream
+        // schema validation is the tool's responsibility.
+        let raw = r#"[1,2,3]"#.to_string();
+        assert_eq!(
+            normalize_native_tool_call_arguments("tool", raw.clone()),
+            raw
+        );
+    }
+
+    #[test]
+    fn valid_json_scalars_preserved() {
+        // Strings / numbers parse as JSON. Edge case worth pinning because
+        // `from_str::<Value>` accepts anything that starts as valid JSON.
+        assert_eq!(
+            normalize_native_tool_call_arguments("tool", r#""plain""#.to_string()),
+            r#""plain""#
+        );
+    }
+
+    #[test]
+    fn malformed_json_falls_back_to_empty_object() {
+        // The realistic malformed case from #8675: trailing comma, unescaped
+        // quote, truncated object, model emitting Python-style `None`.
+        for malformed in [
+            r#"{"command": "ls""#,                // missing closing brace
+            r#"{"command": 'ls'}"#,               // Python-style single quotes
+            r#"{"command": None}"#,               // Python None
+            r#"Expecting ',' delimiter: line 1"#, // server error echoed back
+        ] {
+            assert_eq!(
+                normalize_native_tool_call_arguments("shell", malformed.to_string()),
+                "{}",
+                "malformed input {malformed:?} should be replaced with {{}}"
+            );
+        }
+    }
+
+    #[test]
+    fn leading_and_trailing_whitespace_does_not_disqualify_valid_json() {
+        // `trim().is_empty()` is what we use for the empty check, so a
+        // well-formed JSON payload with surrounding whitespace must still
+        // round-trip. (Some stream chunkers append newlines.)
+        let raw = "  {\"k\":1}\n".to_string();
+        assert_eq!(
+            normalize_native_tool_call_arguments("tool", raw.clone()),
+            raw
+        );
+    }
+}

--- a/crates/zeroclaw-providers/src/openrouter.rs
+++ b/crates/zeroclaw-providers/src/openrouter.rs
@@ -264,8 +264,11 @@ impl OpenRouterModelProvider {
                             id: Some(tc.id),
                             kind: Some("function".to_string()),
                             function: NativeFunctionCall {
-                                name: tc.name,
-                                arguments: tc.arguments,
+                                name: tc.name.clone(),
+                                arguments: crate::native_tool_args::normalize_native_tool_call_arguments(
+                                    &tc.name,
+                                    tc.arguments,
+                                ),
                             },
                         })
                         .collect::<Vec<_>>();
@@ -394,11 +397,18 @@ impl OpenRouterModelProvider {
             .tool_calls
             .unwrap_or_default()
             .into_iter()
-            .map(|tc| ProviderToolCall {
-                id: tc.id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string()),
-                name: tc.function.name,
-                arguments: tc.function.arguments,
-                extra_content: None,
+            .map(|tc| {
+                let name = tc.function.name.clone();
+                let arguments = crate::native_tool_args::normalize_native_tool_call_arguments(
+                    &name,
+                    tc.function.arguments,
+                );
+                ProviderToolCall {
+                    id: tc.id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string()),
+                    name,
+                    arguments,
+                    extra_content: None,
+                }
             })
             .collect::<Vec<_>>();
 
@@ -1425,6 +1435,67 @@ mod tests {
         assert_eq!(tool_calls[0].function.name, "shell");
     }
 
+    // ── #8675 tool-call arguments normalization ──────────────────
+    //
+    // Regression coverage for the response-parser half of the issue: a
+    // malformed `tool_calls[].function.arguments` string from a smaller
+    // model (or a server-echoed parse error) must be replaced with "{}"
+    // before the ProviderToolCall is constructed, so the upstream
+    // request body never contains raw broken JSON that strict
+    // OpenRouter-routed upstreams would 400 on.
+
+    fn message_with_tool_call_arguments(arguments: &str) -> NativeResponseMessage {
+        NativeResponseMessage {
+            content: None,
+            tool_calls: Some(vec![NativeToolCall {
+                id: Some("call_8675".into()),
+                kind: Some("function".into()),
+                function: NativeFunctionCall {
+                    name: "shell".into(),
+                    arguments: arguments.into(),
+                },
+            }]),
+            reasoning_content: None,
+        }
+    }
+
+    #[test]
+    fn parse_native_response_replaces_malformed_arguments_with_empty_object() {
+        // The realistic malformed cases from #8675: trailing-comma,
+        // truncated object, server-echoed parse error message, and a
+        // model that emits Python-style None. Each must be coerced to
+        // "{}" so the outbound request body stays valid JSON.
+        for malformed in [
+            r#"{"command": "ls""#,
+            r#"{"command": 'ls'}"#,
+            r#"Expecting ',' delimiter: line 1 column 23 (char 22)"#,
+        ] {
+            let parsed =
+                Self::parse_native_response(message_with_tool_call_arguments(malformed));
+            let tc = &parsed.tool_calls[0];
+            assert_eq!(
+                tc.arguments, "{}",
+                "malformed arguments {malformed:?} should be normalized to {{}}"
+            );
+            assert_eq!(tc.name, "shell");
+            assert_eq!(tc.id, "call_8675");
+        }
+    }
+
+    #[test]
+    fn parse_native_response_preserves_valid_arguments() {
+        let parsed = Self::parse_native_response(message_with_tool_call_arguments(
+            r#"{"command":"ls -la"}"#,
+        ));
+        assert_eq!(parsed.tool_calls[0].arguments, r#"{"command":"ls -la"}"#);
+    }
+
+    #[test]
+    fn parse_native_response_normalizes_empty_arguments() {
+        let parsed = Self::parse_native_response(message_with_tool_call_arguments(""));
+        assert_eq!(parsed.tool_calls[0].arguments, "{}");
+    }
+
     #[test]
     fn parse_native_response_converts_to_chat_response() {
         let message = NativeResponseMessage {
@@ -1475,6 +1546,28 @@ mod tests {
         assert_eq!(tool_calls[0].id.as_deref(), Some("call_abc"));
         assert_eq!(tool_calls[0].function.name, "shell");
         assert_eq!(tool_calls[0].function.arguments, r#"{"command":"pwd"}"#);
+    }
+
+    #[test]
+    fn convert_messages_normalizes_malformed_assistant_tool_call_arguments() {
+        // The second half of the #8675 wire path: when an assistant
+        // message round-trips back into the request body with malformed
+        // tool-call arguments, the outbound NativeMessage must carry the
+        // normalized "{}" payload so the upstream never sees broken JSON.
+        let messages = vec![ChatMessage {
+            role: "assistant".into(),
+            content: r#"{"content":"Using tool","tool_calls":[{"id":"call_malformed","name":"shell","arguments":"{\"command\":\"ls\""}]}"#
+                .into(),
+        }];
+
+        let converted = OpenRouterModelProvider::convert_messages(&messages);
+        let tool_calls = converted[0].tool_calls.as_ref().unwrap();
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0].function.name, "shell");
+        assert_eq!(
+            tool_calls[0].function.arguments, "{}",
+            "truncated assistant tool-call arguments must be normalized to {{}}"
+        );
     }
 
     #[test]

--- a/crates/zeroclaw-providers/src/openrouter.rs
+++ b/crates/zeroclaw-providers/src/openrouter.rs
@@ -265,10 +265,11 @@ impl OpenRouterModelProvider {
                             kind: Some("function".to_string()),
                             function: NativeFunctionCall {
                                 name: tc.name.clone(),
-                                arguments: crate::native_tool_args::normalize_native_tool_call_arguments(
-                                    &tc.name,
-                                    tc.arguments,
-                                ),
+                                arguments:
+                                    crate::native_tool_args::normalize_native_tool_call_arguments(
+                                        &tc.name,
+                                        tc.arguments,
+                                    ),
                             },
                         })
                         .collect::<Vec<_>>();
@@ -1470,8 +1471,9 @@ mod tests {
             r#"{"command": 'ls'}"#,
             r#"Expecting ',' delimiter: line 1 column 23 (char 22)"#,
         ] {
-            let parsed =
-                Self::parse_native_response(message_with_tool_call_arguments(malformed));
+            let parsed = OpenRouterModelProvider::parse_native_response(
+                message_with_tool_call_arguments(malformed),
+            );
             let tc = &parsed.tool_calls[0];
             assert_eq!(
                 tc.arguments, "{}",
@@ -1484,15 +1486,16 @@ mod tests {
 
     #[test]
     fn parse_native_response_preserves_valid_arguments() {
-        let parsed = Self::parse_native_response(message_with_tool_call_arguments(
-            r#"{"command":"ls -la"}"#,
-        ));
+        let parsed = OpenRouterModelProvider::parse_native_response(
+            message_with_tool_call_arguments(r#"{"command":"ls -la"}"#),
+        );
         assert_eq!(parsed.tool_calls[0].arguments, r#"{"command":"ls -la"}"#);
     }
 
     #[test]
     fn parse_native_response_normalizes_empty_arguments() {
-        let parsed = Self::parse_native_response(message_with_tool_call_arguments(""));
+        let parsed =
+            OpenRouterModelProvider::parse_native_response(message_with_tool_call_arguments(""));
         assert_eq!(parsed.tool_calls[0].arguments, "{}");
     }
 


### PR DESCRIPTION
## Summary

Second PR of the #8675 series. The first (#8748) extracted a single `pub(crate) fn normalize_native_tool_call_arguments` helper in `crates/zeroclaw-providers/src/native_tool_args.rs` and rewired the existing inline guards in `compatible.rs` onto it. This PR routes both `openrouter.rs` sites that previously re-serialized assistant `tool_calls[].function.arguments` verbatim through the helper.

## Sites changed

- `convert_messages` (~line 268): the assistant → `NativeMessage` branch that reads prior-turn tool_calls out of a `ChatMessage` content blob and re-emits them into the outbound request body. A malformed arguments string here means every subsequent turn replays the broken JSON upstream.
- `parse_native_response` (~line 391): the response-parser branch that builds a `ProviderToolCall` from a `NativeToolCall` in the model's reply. A malformed arguments string here means the broken JSON goes out on the very next turn.

Both sites now call `normalize_native_tool_call_arguments(&name, arguments)`, which returns `"{}"` for empty / whitespace / malformed JSON (with a structured WARN log of the function name + original payload) and returns the input unchanged for any value `serde_json::from_str::<Value>` accepts.

## Real behavior proof

- `cargo fmt --all -- --check`: clean
- `cargo clippy -p zeroclaw-providers --all-targets -- -D warnings`: 0 warnings
- `cargo test -p zeroclaw-providers --lib openrouter`: **73/73 pass** (4 new regression tests + 69 existing)

## Regression tests added

In `crates/zeroclaw-providers/src/openrouter.rs::tests`:

- `parse_native_response_replaces_malformed_arguments_with_empty_object` — three representative malformed inputs (truncated JSON, Python-style single quotes, server-echoed parse error from #8675) all coerce to `"{}"`.
- `parse_native_response_preserves_valid_arguments` — well-formed JSON round-trips untouched.
- `parse_native_response_normalizes_empty_arguments` — `""` → `"{}"`.
- `convert_messages_normalizes_malformed_assistant_tool_call_arguments` — pins the assistant→outbound half of the wire path so the same truncation case is caught at the request body, not only at the response parser.

## Diff surface

Single file (`crates/zeroclaw-providers/src/openrouter.rs`), +93 / -7.

## Dependency

Depends on #8748 (the helper-extraction PR) being merged first; this branch is based on `fix/8675-native-tool-args-helper` so the `pub(crate) fn normalize_native_tool_call_arguments` is already in this tree's history. After #8748 merges into master, this branch's base needs to be rebased onto master (force-push) — I'll do that rebase and notify on the PR thread once #8748 lands.

## Series plan

Same as #8748. Three provider PRs remain (#8675 PR3–PR5): openai, azure_openai, copilot, then openai_codex (#8675 PR6, separate because the Responses API has a different wire shape for arguments).