### PR TITLE
fix(tests): make media marker assertions portable on Windows

### DIFF
--- a/crates/zeroclaw-runtime/src/rpc/attachments.rs
+++ b/crates/zeroclaw-runtime/src/rpc/attachments.rs
@@ -228,6 +228,14 @@ fn attachment_kind(mime: &str) -> &'static str {
 mod tests {
     use super::*;
     use serde_json::json;
+    use std::ffi::OsStr;
+    use std::path::{Component, Path};
+
+    fn path_contains_uploads_component(path: &str) -> bool {
+        Path::new(path)
+            .components()
+            .any(|component| matches!(component, Component::Normal(name) if name == OsStr::new("uploads")))
+    }
 
     #[test]
     fn mime_from_filename_common_types() {
@@ -458,13 +466,14 @@ mod tests {
             r.marker
         );
         assert!(
-            r.marker.contains("/uploads/"),
+            path_contains_uploads_component(&r.workspace_path),
             "clipboard image marker should reference workspace uploads path: {}",
             r.marker
         );
+        assert!(r.marker.contains(&r.workspace_path));
         assert!(!r.deduplicated);
         assert_eq!(r.size_bytes, png_bytes.len() as u64);
-        assert!(std::path::Path::new(&r.workspace_path).exists());
+        assert!(Path::new(&r.workspace_path).exists());
     }
 
     #[tokio::test]
@@ -494,10 +503,11 @@ mod tests {
             r.marker
         );
         assert!(
-            r.marker.contains("/uploads/"),
+            path_contains_uploads_component(&r.workspace_path),
             "marker should include workspace uploads path: {}",
             r.marker
         );
+        assert!(r.marker.contains(&r.workspace_path));
         assert!(!r.deduplicated);
     }
 
@@ -631,11 +641,12 @@ mod tests {
             r.marker
         );
         assert!(
-            r.marker.contains("/uploads/"),
+            path_contains_uploads_component(&r.workspace_path),
             "marker should include workspace path: {}",
             r.marker
         );
+        assert!(r.marker.contains(&r.workspace_path));
         assert!(!r.deduplicated);
-        assert!(std::path::Path::new(&r.workspace_path).exists());
+        assert!(Path::new(&r.workspace_path).exists());
     }
 }

--- a/crates/zeroclaw-tools/src/image_info.rs
+++ b/crates/zeroclaw-tools/src/image_info.rs
@@ -298,6 +298,12 @@ mod tests {
         relative
     }
 
+    async fn expected_marker_path(path: &Path) -> String {
+        let canonical = tokio::fs::canonicalize(path).await.unwrap();
+        let display = canonical.display().to_string();
+        ImageInfoTool::strip_windows_verbatim_prefix(&display).into_owned()
+    }
+
     /// Wraps `ImageInfoTool` with the production `PathGuardedTool` +
     /// `RateLimitedTool` stack, mirroring the registration in
     /// `zeroclaw-runtime::tools::mod`.  Use this in tests that exercise
@@ -552,11 +558,9 @@ mod tests {
         assert!(!result.output.contains("data:"));
         // The output carries an absolute-path [IMAGE:] marker so the
         // multimodal pipeline can inline the image for vision models.
-        let canonical = tokio::fs::canonicalize(&png_path).await.unwrap();
+        let marker_path = expected_marker_path(&png_path).await;
         assert!(
-            result
-                .output
-                .contains(&format!("[IMAGE:{}]", canonical.display())),
+            result.output.contains(&format!("[IMAGE:{marker_path}]")),
             "expected absolute-path image marker, got: {}",
             result.output
         );
@@ -644,16 +648,14 @@ mod tests {
         // emitted as an absolute-path [IMAGE:] marker. Before the fix the tool
         // echoed the relative input, which the marker promoter (anchored on a
         // leading `/`) silently dropped, so the image never reached the model.
-        let canonical = tokio::fs::canonicalize(&png_path).await.unwrap();
+        let marker_path = expected_marker_path(&png_path).await;
         assert!(
-            result
-                .output
-                .contains(&format!("[IMAGE:{}]", canonical.display())),
+            result.output.contains(&format!("[IMAGE:{marker_path}]")),
             "expected absolute-path image marker, got: {}",
             result.output
         );
         assert!(
-            canonical.is_absolute(),
+            Path::new(&marker_path).is_absolute(),
             "marker path must be absolute so the multimodal pipeline can load it"
         );
     }
@@ -759,11 +761,9 @@ mod tests {
             .unwrap();
 
         assert!(result.success);
-        let canonical = tokio::fs::canonicalize(&png_path).await.unwrap();
+        let marker_path = expected_marker_path(&png_path).await;
         assert!(
-            result
-                .output
-                .contains(&format!("[IMAGE:{}]", canonical.display())),
+            result.output.contains(&format!("[IMAGE:{marker_path}]")),
             "expected absolute-path image marker, got: {}",
             result.output
         );


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Update RPC attachment tests to identify the `uploads` path component instead of matching the Unix-only `"/uploads/"` substring.
  - Keep attachment marker assertions tied to the exact workspace path produced by each fixture.
  - Compare `image_info` markers against the same Windows verbatim-prefix-normalized path that production emits.
- **Scope boundary:** This is a tests-only Windows portability slice. It does not change marker formatting, attachment handling, image promotion, the #7461 CI matrix, or other Windows failures tracked in #7462.
- **Blast radius:** `zeroclaw-runtime` RPC attachment tests and `zeroclaw-tools` `image_info` tests only. Runtime and tool behavior are unchanged.
- **Linked issue(s):** Related #7462. Related #7461.
- **Labels:** `bug`, `runtime`, `tool`, `type:test`, `risk:low`, `size:XS`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes. Native Windows execution of the affected test groups is the platform boundary this patch addresses.
- **Interface(s) exercised:** N/A; test harness only, with no user-facing surface.
- **Setup / preconditions:** Windows with the Rust toolchain, this branch checked out, and dependencies available for a locked build.
- **Steps to run:**
  1. Run `cargo test --locked -p zeroclaw-runtime rpc::attachments -- --nocapture`.
  2. Run `cargo test --locked -p zeroclaw-tools image_info -- --nocapture`.
- **Expected on this branch (after):** The runtime group passes 16/16 and the `image_info` group passes 29/29 on the reporter's Windows environment.
- **Prior behavior on `master` (before):** The affected assertions fail on Windows because they assume Unix separators or compare against canonical paths before production removes the Windows verbatim prefix, as reported in #7462.

### How I tested

- **CI checks relied on and why they cover this change:** Fresh current-head CI passed Format, Lint, Test, `Check x86_64-pc-windows-msvc`, targeted Windows Clippy, and CI Required Gate. Format, Lint, and Test cover formatting, repository linting, and Linux execution. Windows CI compiles the Windows production targets, while targeted Windows Clippy compiles the `zeroclaw-tools` test targets; it does not execute the affected tests or compile the changed `zeroclaw-runtime` test module.
- **Known CI coverage gap, if any:** Required CI does not execute these focused tests on Windows. Native Windows execution passed on pre-refresh head `67308b896e826701ea8b1f98a37ad6e94b21b3c3`; `git range-diff` confirms the patch is unchanged on current head `b146ce1163b7bdfbd26d710dc1397d2c38069945`, but the rebased SHA was not rerun natively on Windows.
- **Commands run and tail output:**

```text
# Reporter-supplied native Windows run from #7462: Windows 11,
# x86_64-pc-windows-msvc, Rust 1.96.0, code page 936
cargo test --locked -p zeroclaw-runtime rpc::attachments -- --nocapture
test result: ok. 16 passed; 0 failed; 0 ignored; 0 measured; 2739 filtered out

cargo test --locked -p zeroclaw-tools image_info -- --nocapture
test result: ok. 29 passed; 0 failed; 0 ignored; 0 measured; 1438 filtered out

# Branch refresh checks
git range-diff 67308b896e^..67308b896e origin/master..b146ce1163
1:  67308b896e = 1:  b146ce1163 fix(tests): make media marker assertions portable on Windows

bash scripts/ci/comment_hygiene_gate.sh
Comment hygiene gate passed.

git diff --check origin/master...HEAD
# passed
```

Native Windows output and the wider remaining-failure snapshot are attached in the [#7462 reporter comment](https://github.com/zeroclaw-labs/zeroclaw/issues/7462#issuecomment-5018433634).

- **Beyond CI, what did you manually verify?** I verified that the refreshed diff remains limited to test assertions and helpers in `crates/zeroclaw-runtime/src/rpc/attachments.rs` and `crates/zeroclaw-tools/src/image_info.rs`, and that range-diff reports the rebased patch as unchanged.
- **If any command was intentionally skipped, why:** Workspace-wide local Clippy and nextest were not duplicated because fresh required CI passed on the rebased head. Native Windows execution on the rebased SHA remains the disclosed gap; the affected patch itself is unchanged from the reporter-tested head.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: `N/A`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: `N/A`

## Rollback (required for medium/high-risk PRs)

Low-risk PRs: run `git revert <merge-sha>`.
