### PR TITLE
fix(zerocode): expose channel root settings

### DIFF
--- a/apps/zerocode/src/config_manager.rs
+++ b/apps/zerocode/src/config_manager.rs
@@ -32,6 +32,25 @@ fn keyboard_enhancement_flags() -> KeyboardEnhancementFlags {
         | KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
 }
 
+fn type_template_label(template: &ConfigTemplateEntry) -> String {
+    template
+        .path
+        .rsplit('.')
+        .next()
+        .unwrap_or(&template.path)
+        .to_string()
+}
+
+fn is_direct_child_path(path: &str, prefix: &str) -> bool {
+    path.strip_prefix(prefix)
+        .and_then(|suffix| suffix.strip_prefix('.'))
+        .is_some_and(|relative| !relative.is_empty() && !relative.contains('.'))
+}
+
+fn retain_direct_children(fields: &mut Vec<ConfigFieldEntry>, prefix: &str) {
+    fields.retain(|field| is_direct_child_path(&field.path, prefix));
+}
+
 pub(crate) fn init_terminal() -> Result<Term> {
     enable_raw_mode()?;
     let mut stdout = io::stdout();
@@ -967,12 +986,8 @@ impl App {
                 let labels: Vec<String> = self.sections.iter().map(|s| s.label.clone()).collect();
                 self.filtered_indices(&labels).len()
             }
-            Screen::TypeList { .. } => {
-                let names: Vec<String> = self
-                    .types
-                    .iter()
-                    .map(|t| t.path.rsplit('.').next().unwrap_or(&t.path).to_string())
-                    .collect();
+            Screen::TypeList { section_idx } => {
+                let names = self.type_list_labels(*section_idx);
                 self.filtered_indices(&names).len()
             }
             Screen::AliasList { .. } => {
@@ -1073,15 +1088,11 @@ impl App {
                         .unwrap_or(0)
                 }
             }
-            Screen::TypeList { .. } => {
+            Screen::TypeList { section_idx } => {
                 if self.filter.is_some() {
                     self.filter_cursor
                 } else {
-                    let names: Vec<String> = self
-                        .types
-                        .iter()
-                        .map(|t| t.path.rsplit('.').next().unwrap_or(&t.path).to_string())
-                        .collect();
+                    let names = self.type_list_labels(*section_idx);
                     self.filtered_indices(&names)
                         .iter()
                         .position(|&i| i == self.type_cursor)
@@ -1146,12 +1157,8 @@ impl App {
                     self.section_cursor = orig;
                 }
             }
-            Screen::TypeList { .. } => {
-                let names: Vec<String> = self
-                    .types
-                    .iter()
-                    .map(|t| t.path.rsplit('.').next().unwrap_or(&t.path).to_string())
-                    .collect();
+            Screen::TypeList { section_idx } => {
+                let names = self.type_list_labels(*section_idx);
                 let visible = self.filtered_indices(&names);
                 if self.filter.is_some() {
                     self.filter_cursor = pos.min(visible.len().saturating_sub(1));
@@ -1218,6 +1225,20 @@ impl App {
         }
     }
 
+    fn selected_type_row(&self) -> Option<usize> {
+        let Screen::TypeList { section_idx } = &self.screen else {
+            return None;
+        };
+        let names = self.type_list_labels(*section_idx);
+        let visible = self.filtered_indices(&names);
+        let cursor = if self.filter.is_some() {
+            self.filter_cursor
+        } else {
+            visible.iter().position(|&i| i == self.type_cursor)?
+        };
+        visible.get(cursor).copied()
+    }
+
     /// Activate the currently selected item (double-click equivalent of Enter).
     async fn activate_mouse(&mut self, term: &mut Term) -> Result<()> {
         match &self.screen {
@@ -1226,8 +1247,9 @@ impl App {
                 self.enter_section(idx).await?;
             }
             Screen::TypeList { .. } => {
-                let idx = self.type_cursor;
-                self.enter_type(idx).await?;
+                if let Some(idx) = self.selected_type_row() {
+                    self.enter_type(idx).await?;
+                }
             }
             Screen::AliasList { .. } => {
                 if self.alias_list_has_tabs() && self.alias_tab == 1 {
@@ -1277,6 +1299,43 @@ impl App {
             .filter(|t| t.path.starts_with(&prefix))
             .cloned()
             .collect()
+    }
+
+    fn section_has_root_settings_row(&self, section_idx: usize) -> bool {
+        self.sections.get(section_idx).is_some_and(|section| {
+            section.shape == Some(SectionShape::TypedFamilyMap) && section.key == "channels"
+        })
+    }
+
+    fn type_list_labels(&self, section_idx: usize) -> Vec<String> {
+        let has_root_row = self.section_has_root_settings_row(section_idx);
+        let root_count = usize::from(has_root_row);
+        let mut labels = Vec::with_capacity(self.types.len() + root_count);
+        if has_root_row {
+            labels.push(format!("[{}]", self.sections[section_idx].key));
+        }
+        labels.extend(self.types.iter().map(type_template_label));
+        labels
+    }
+
+    fn type_list_len(&self, section_idx: usize) -> usize {
+        self.types.len() + usize::from(self.section_has_root_settings_row(section_idx))
+    }
+
+    fn template_idx_for_type_row(&self, section_idx: usize, row_idx: usize) -> Option<usize> {
+        if self.section_has_root_settings_row(section_idx) {
+            row_idx.checked_sub(1).filter(|&idx| idx < self.types.len())
+        } else if row_idx < self.types.len() {
+            Some(row_idx)
+        } else {
+            None
+        }
+    }
+
+    fn is_typed_family_root_field_list(&self, section_idx: usize, prefix: &str) -> bool {
+        self.sections.get(section_idx).is_some_and(|section| {
+            section.shape == Some(SectionShape::TypedFamilyMap) && section.key == prefix
+        })
     }
 
     async fn load_type_alias_counts(&mut self) -> Result<()> {
@@ -1437,6 +1496,9 @@ impl App {
 
     async fn load_fields(&mut self, prefix: &str) -> Result<()> {
         self.fields = self.rpc.config_list(Some(prefix)).await?;
+        if prefix == "channels" {
+            retain_direct_children(&mut self.fields, prefix);
+        }
         self.field_cursor = 0;
         // Compute distinct tab names in field-declaration order.
         let mut tabs = Vec::new();
@@ -1508,6 +1570,9 @@ impl App {
         // fields so tab_field_indices() keeps finding them.
         let has_settings_tab = self.tab_names.contains(&ConfigTab::Settings);
         let mut new_fields = new_fields;
+        if prefix == "channels" {
+            retain_direct_children(&mut new_fields, prefix);
+        }
         if has_settings_tab {
             for f in &mut new_fields {
                 if f.tab == ConfigTab::None {
@@ -1673,8 +1738,8 @@ impl App {
     /// clamped to the loaded list length.
     fn restore_top_cursor(&mut self, pos: usize) {
         match &self.screen {
-            Screen::TypeList { .. } => {
-                self.type_cursor = pos.min(self.types.len().saturating_sub(1));
+            Screen::TypeList { section_idx } => {
+                self.type_cursor = pos.min(self.type_list_len(*section_idx).saturating_sub(1));
             }
             Screen::AliasList { breadcrumb, .. } if breadcrumb.len() <= 1 => {
                 self.alias_cursor = pos.min(self.aliases.len().saturating_sub(1));
@@ -1778,11 +1843,11 @@ impl App {
     // ── Type list (TypedFamilyMap) ───────────────────────────────
 
     async fn handle_type_list(&mut self, key: KeyEvent) -> Result<()> {
-        let type_names: Vec<String> = self
-            .types
-            .iter()
-            .map(|t| t.path.rsplit('.').next().unwrap_or(&t.path).to_string())
-            .collect();
+        let section_idx = match &self.screen {
+            Screen::TypeList { section_idx } => *section_idx,
+            _ => return Ok(()),
+        };
+        let type_names = self.type_list_labels(section_idx);
         let visible = self.filtered_indices(&type_names);
 
         match self.handle_filter_key(key, visible.len()) {
@@ -1807,7 +1872,9 @@ impl App {
             Some(ConfigTabAction::Up) => {
                 self.type_cursor = self.type_cursor.saturating_sub(1);
             }
-            Some(ConfigTabAction::Down) if self.type_cursor + 1 < self.types.len() => {
+            Some(ConfigTabAction::Down)
+                if self.type_cursor + 1 < self.type_list_len(section_idx) =>
+            {
                 self.type_cursor += 1;
             }
             Some(ConfigTabAction::Enter | ConfigTabAction::TabRight) => {
@@ -1819,13 +1886,28 @@ impl App {
     }
 
     async fn enter_type(&mut self, orig_idx: usize) -> Result<()> {
-        if let (Some(tmpl), Screen::TypeList { section_idx }) =
-            (self.types.get(orig_idx), &self.screen)
-        {
+        if let Screen::TypeList { section_idx } = &self.screen {
             let section_idx = *section_idx;
-            let map_path = tmpl.path.clone();
-            let type_name = map_path.rsplit('.').next().unwrap_or(&map_path).to_string();
             let section_key = self.sections[section_idx].key.clone();
+            if self.section_has_root_settings_row(section_idx) && orig_idx == 0 {
+                self.load_fields(&section_key).await?;
+                self.screen = Screen::FieldList {
+                    section_idx,
+                    prefix: section_key.clone(),
+                    breadcrumb: vec![section_key.clone(), format!("[{section_key}]")],
+                };
+                self.status_msg = None;
+                return Ok(());
+            }
+
+            let Some(template_idx) = self.template_idx_for_type_row(section_idx, orig_idx) else {
+                return Ok(());
+            };
+            let Some(tmpl) = self.types.get(template_idx) else {
+                return Ok(());
+            };
+            let map_path = tmpl.path.clone();
+            let type_name = type_template_label(tmpl);
             self.load_aliases(&map_path).await?;
             self.screen = Screen::AliasList {
                 section_idx,
@@ -2319,13 +2401,17 @@ impl App {
                 let screen = std::mem::replace(&mut self.screen, Screen::SectionList);
                 if let Screen::FieldList {
                     section_idx,
+                    prefix,
                     breadcrumb,
                     ..
                 } = screen
-                    && breadcrumb.len() >= 2
                 {
-                    self.restore_alias_list_from_field_back(section_idx, breadcrumb)
-                        .await?;
+                    if self.is_typed_family_root_field_list(section_idx, &prefix) {
+                        self.screen = Screen::TypeList { section_idx };
+                    } else if breadcrumb.len() >= 2 {
+                        self.restore_alias_list_from_field_back(section_idx, breadcrumb)
+                            .await?;
+                    }
                 }
                 self.status_msg = None;
             }
@@ -3511,18 +3597,17 @@ impl App {
             );
         }
 
-        let type_names: Vec<String> = self
-            .types
-            .iter()
-            .map(|t| t.path.rsplit('.').next().unwrap_or(&t.path).to_string())
-            .collect();
+        let type_names = self.type_list_labels(section_idx);
         let visible = self.filtered_indices(&type_names);
 
         let items: Vec<ListItem> = visible
             .iter()
             .map(|&i| {
                 let name = &type_names[i];
-                let count = self.type_alias_counts.get(i).copied().unwrap_or(0);
+                let count = self
+                    .template_idx_for_type_row(section_idx, i)
+                    .and_then(|template_idx| self.type_alias_counts.get(template_idx).copied())
+                    .unwrap_or(0);
                 let mut spans = vec![Span::styled(name.to_string(), theme::body_style())];
                 if count > 0 {
                     spans.push(Span::styled(format!("  ({count})"), theme::accent_style()));
@@ -4798,6 +4883,112 @@ mod tests {
             shape: None,
             cost_category: cost_category.to_string(),
         }
+    }
+
+    fn typed_section(key: &str) -> ConfigSectionEntry {
+        ConfigSectionEntry {
+            key: key.to_string(),
+            label: key.to_string(),
+            help: String::new(),
+            completed: false,
+            group: String::new(),
+            shape: Some(SectionShape::TypedFamilyMap),
+            cost_category: String::new(),
+        }
+    }
+
+    fn field(path: &str) -> ConfigFieldEntry {
+        ConfigFieldEntry {
+            path: path.to_string(),
+            category: String::new(),
+            kind: PropKind::String,
+            type_hint: String::new(),
+            value: None,
+            populated: false,
+            is_secret: false,
+            is_env_overridden: false,
+            enum_variants: Vec::new(),
+            description: String::new(),
+            section: None,
+            tab: ConfigTab::None,
+            alias_source: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn channels_type_list_reserves_a_global_settings_row() {
+        let mut mgr = test_manager();
+        mgr.sections = vec![typed_section("channels")];
+        mgr.screen = Screen::TypeList { section_idx: 0 };
+        mgr.types = vec![
+            ConfigTemplateEntry {
+                path: "channels.telegram".to_string(),
+            },
+            ConfigTemplateEntry {
+                path: "channels.whatsapp".to_string(),
+            },
+        ];
+
+        assert_eq!(mgr.visible_count(), 3);
+        assert_eq!(
+            mgr.type_list_labels(0),
+            vec!["[channels]", "telegram", "whatsapp"]
+        );
+        assert_eq!(mgr.template_idx_for_type_row(0, 0), None);
+        assert_eq!(mgr.template_idx_for_type_row(0, 1), Some(0));
+        assert_eq!(mgr.template_idx_for_type_row(0, 2), Some(1));
+    }
+
+    #[tokio::test]
+    async fn non_channel_type_list_does_not_reserve_global_settings_row() {
+        let mut mgr = test_manager();
+        mgr.sections = vec![typed_section("providers.models")];
+        mgr.screen = Screen::TypeList { section_idx: 0 };
+        mgr.types = vec![ConfigTemplateEntry {
+            path: "providers.models.anthropic".to_string(),
+        }];
+
+        assert_eq!(mgr.type_list_labels(0), vec!["anthropic"]);
+        assert_eq!(mgr.template_idx_for_type_row(0, 0), Some(0));
+    }
+
+    #[test]
+    fn channels_root_settings_keep_only_direct_children() {
+        let mut fields = vec![
+            field("channels.show_tool_calls"),
+            field("channels.ack_reactions"),
+            field("channels.matrix.default.enabled"),
+            field("channels.whatsapp.personal.session_path"),
+            field("agents.default.model"),
+        ];
+
+        retain_direct_children(&mut fields, "channels");
+
+        let paths: Vec<&str> = fields.iter().map(|field| field.path.as_str()).collect();
+        assert_eq!(
+            paths,
+            vec!["channels.show_tool_calls", "channels.ack_reactions"]
+        );
+    }
+
+    #[tokio::test]
+    async fn filtered_type_list_selected_row_tracks_filter_cursor() {
+        let mut mgr = test_manager();
+        mgr.sections = vec![typed_section("channels")];
+        mgr.screen = Screen::TypeList { section_idx: 0 };
+        mgr.types = vec![
+            ConfigTemplateEntry {
+                path: "channels.telegram".to_string(),
+            },
+            ConfigTemplateEntry {
+                path: "channels.whatsapp".to_string(),
+            },
+        ];
+        mgr.type_cursor = 2;
+        mgr.filter = Some("chan".to_string());
+        mgr.filter_cursor = 0;
+
+        assert_eq!(mgr.selected_type_row(), Some(0));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Adds a root `[channels]` row to ZeroCode's `Config -> Channels` type list so direct channel settings such as `show_tool_calls` are discoverable from the TUI.
  - Keeps per-platform channel entries such as `whatsapp` and `discord` in the existing type list instead of changing the config schema or RPC shape.
  - Filters the `[channels]` field editor to direct root fields only, so nested alias fields like `channels.whatsapp.<alias>.*` do not appear in the global settings view.
  - Fixes filtered type-list mouse activation so clicks open the filtered row the user clicked instead of the stale unfiltered cursor.
- **Scope boundary:** This PR does not change the canonical config schema, channel runtime behavior, CLI config commands, or per-channel alias settings. It only changes how the existing ZeroCode config editor exposes the existing `[channels]` root surface.
- **Blast radius:** ZeroCode config navigation for typed-family sections. The new global row is limited to the `channels` section; other typed-family sections keep their existing type-list behavior.
- **Linked issue(s):** Closes #8757.
- **Labels:** `bug`, `zerocode`, `config`, `channel`, `priority:p2`, `risk:medium`, `size:M`

## Validation Evidence (required)

- **Commands run and tail output:**

```text
zc-cargo test -p zerocode config_manager::tests
running 8 tests
test config_manager::tests::keyboard_enhancement_flags_disambiguate_modified_enter ... ok
test config_manager::tests::config_scalar_validation_rejects_invalid_float ... ok
test config_manager::tests::config_scalar_validation_rejects_invalid_integer ... ok
test config_manager::tests::channels_root_settings_keep_only_direct_children ... ok
test config_manager::tests::left_on_leftmost_alias_tab_walks_back_to_type_list ... ok
test config_manager::tests::channels_type_list_reserves_a_global_settings_row ... ok
test config_manager::tests::filtered_type_list_selected_row_tracks_filter_cursor ... ok
test config_manager::tests::non_channel_type_list_does_not_reserve_global_settings_row ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 426 filtered out; finished in 0.05s

zc-cargo fmt --all -- --check
Result: passed with no rustfmt changes.

git diff --check origin/master...HEAD
exit status: 0

scripts/check-pr-title.sh "fix(zerocode): expose channel root settings"
exit status: 0
```

- **Beyond CI — what did you manually verify?** Dan dogfooded the change in ZeroCode and confirmed that `Config -> Channels -> [channels]` exposes direct root fields such as `show_tool_calls` without mixing in per-alias channel fields.
- **If any command was intentionally skipped, why:** No broad local workspace clippy or full local test suite was run before opening the PR. The PR has focused local ZeroCode coverage, manual TUI smoke evidence, and green GitHub CI on the submitted head.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: Not applicable.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: No upgrade steps required. This only exposes existing config fields in ZeroCode.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert a44b61c42f7452dc97e36260e9fef82281aeece5`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** In ZeroCode, `Config -> Channels` may fail to show the `[channels]` root row, may show nested per-alias fields in that root view, or may open the wrong channel type after filtering and clicking the type list.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): Not applicable.
- Scope materially carried forward: Not applicable.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why (inspiration-only, no direct code/design carry-over): No superseded PR or incorporated contributor code.
