### PR TITLE
fix(sop): fall through to next step when when is false

### DIFF
--- a/crates/zeroclaw-runtime/src/sop/route/mod.rs
+++ b/crates/zeroclaw-runtime/src/sop/route/mod.rs
@@ -37,11 +37,11 @@ pub fn resolve_next(ctx: &RouteCtx<'_>) -> NextStep {
         return NextStep::Complete;
     };
 
-    if let Some(when) = current.routing.when.as_deref()
-        && !evaluate_condition(when, Some(&ctx.run_data.to_payload().to_string()))
-    {
-        return NextStep::Complete;
-    }
+    let payload = ctx.run_data.to_payload().to_string();
+    let when_allows_jump = match current.routing.when.as_deref() {
+        None => true,
+        Some(when) => evaluate_condition(when, Some(&payload)),
+    };
 
     // ── Switch: evaluate ports top to bottom; first passing rule routes. A
     // rule with no `when` is the catch-all. No rule matches → Complete.
@@ -74,12 +74,19 @@ pub fn resolve_next(ctx: &RouteCtx<'_>) -> NextStep {
     }
 
     let explicit_next = current.routing.next;
-    if explicit_next.is_none() && current.routing.terminal {
+    // A failed `when` disables the explicit jump: the step routes as if
+    // `next` were absent, so `terminal` still completes the run.
+    let effective_next = if when_allows_jump {
+        explicit_next
+    } else {
+        None
+    };
+    if effective_next.is_none() && current.routing.terminal {
         return NextStep::Complete;
     }
-    let next_step = explicit_next.unwrap_or_else(|| ctx.run.current_step.saturating_add(1));
+    let next_step = effective_next.unwrap_or_else(|| ctx.run.current_step.saturating_add(1));
     let Some(step) = ctx.sop.steps.iter().find(|step| step.number == next_step) else {
-        return if explicit_next.is_none() && next_step > ctx.run.total_steps {
+        return if effective_next.is_none() && next_step > ctx.run.total_steps {
             NextStep::Complete
         } else {
             NextStep::Fail(format!("step {next_step} does not exist"))
@@ -119,7 +126,7 @@ mod tests {
         }
     }
 
-    fn sop() -> Sop {
+    fn sop_with_steps(steps: Vec<SopStep>) -> Sop {
         Sop {
             name: "test".into(),
             description: "test".into(),
@@ -127,12 +134,46 @@ mod tests {
             priority: SopPriority::Normal,
             execution_mode: SopExecutionMode::Auto,
             triggers: Vec::new(),
-            steps: vec![step(1), step(2)],
+            steps,
             cooldown_secs: 0,
             max_concurrent: 1,
             location: None,
             deterministic: false,
             agent: None,
+        }
+    }
+
+    fn sop() -> Sop {
+        sop_with_steps(vec![step(1), step(2)])
+    }
+
+    fn run_at(current_step: u32, total_steps: u32) -> SopRun {
+        let mut run = run();
+        run.current_step = current_step;
+        run.total_steps = total_steps;
+        run
+    }
+
+    fn loop_step(number: u32) -> SopStep {
+        let mut loop_step = step(number);
+        loop_step.routing.when = Some(format!("$.steps.{number}.remaining > 0"));
+        loop_step.routing.next = Some(number);
+        loop_step
+    }
+
+    fn run_data_with_remaining(step_number: u32, remaining: u32) -> RunData {
+        let mut run_data = RunData::default();
+        run_data.insert_output_str(step_number, &format!(r#"{{"remaining":{remaining}}}"#));
+        run_data
+    }
+
+    fn route_ctx<'a>(sop: &'a Sop, run: &'a SopRun, run_data: &'a RunData) -> RouteCtx<'a> {
+        RouteCtx {
+            sop,
+            run,
+            run_data,
+            last_status: SopStepStatus::Completed,
+            max_step_visits: 256,
         }
     }
 
@@ -190,5 +231,35 @@ mod tests {
         };
 
         assert_eq!(resolve_next(&ctx), NextStep::Wait(2));
+    }
+
+    #[test]
+    fn when_true_self_loop_routes_back() {
+        let sop = sop_with_steps(vec![step(1), loop_step(2), step(3)]);
+        let run = run_at(2, 3);
+        let run_data = run_data_with_remaining(2, 1);
+        let ctx = route_ctx(&sop, &run, &run_data);
+
+        assert_eq!(resolve_next(&ctx), NextStep::Step(2));
+    }
+
+    #[test]
+    fn when_false_advances_to_following_step() {
+        let sop = sop_with_steps(vec![step(1), loop_step(2), step(3)]);
+        let run = run_at(2, 3);
+        let run_data = run_data_with_remaining(2, 0);
+        let ctx = route_ctx(&sop, &run, &run_data);
+
+        assert_eq!(resolve_next(&ctx), NextStep::Step(3));
+    }
+
+    #[test]
+    fn when_false_tail_loop_completes() {
+        let sop = sop_with_steps(vec![step(1), loop_step(2)]);
+        let run = run_at(2, 2);
+        let run_data = run_data_with_remaining(2, 0);
+        let ctx = route_ctx(&sop, &run, &run_data);
+
+        assert_eq!(resolve_next(&ctx), NextStep::Complete);
     }
 }

--- a/docs/book/src/sop/syntax.md
+++ b/docs/book/src/sop/syntax.md
@@ -43,6 +43,8 @@ Parser behavior:
 - `- input:` and `- output:` attach JSON Schema-like step boundary contracts.
 - `- next:` and `- depends_on:` route non-linear runs. Ineligible routed steps
   are marked `skipped` and leave the run `pending` instead of dispatching.
+- `- when:` guards an explicit `- next:` jump; when the condition is false, the
+  run advances to the next linear step (`current_step + 1`) instead of completing.
 - `- on_failure:` accepts `fail`, `retry:<count>`, or `goto:<step>` and is
   enforced for reported step failures and output schema failures.
 - `- mode:` overrides the SOP execution mode for that step.


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - When a SOP step's `when` condition is false, routing now falls through to the linear next step instead of completing the run.
  - Enables multi-phase SOPs: a self-looping step followed by a finalize/review step (issue #8719).
  - Documents `- when:` semantics in the SOP syntax reference.
- **Scope boundary:** No changes to `sop_advance` schema, `depends_on`, `on_failure`, or `Wait` behavior.
- **Blast radius:** SOP engine routing only (`route::resolve_next`). Tail-loop SOPs (loop on last step) behave unchanged.
- **Linked issue(s):** Closes #8719
- **Labels:** docs, runtime, tool:sop, risk:high, size:S

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy --locked -p zeroclaw-runtime --all-targets -- -D warnings
cargo test -p zeroclaw-runtime --lib sop:: -- --test-threads=2
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check`: exit 0
  - `cargo clippy --locked -p zeroclaw-runtime --all-targets -- -D warnings`: `Finished dev profile [unoptimized + debuginfo] target(s)` — clean, no warnings
  - `cargo test -p zeroclaw-runtime --lib sop::`: `test result: ok. 269 passed; 0 failed; 0 ignored; 0 measured; 2519 filtered out` — includes the 3 new routing tests (`when_true_self_loop_routes_back`, `when_false_advances_to_following_step`, `when_false_tail_loop_completes`) plus the 2 pre-existing `route::tests` and all other `sop::` unit tests (store, types, capability, engine helpers)
- **Beyond CI:** Unit tests cover loop-back, fall-through to following step, and tail-loop complete. Full engine integration not manually exercised. Branch rebased onto current `master` to pick up the `SopStep::capability`/`capability_input` fields added upstream after this branch was cut.
- **If any command was intentionally skipped, why:** Scoped to `-p zeroclaw-runtime --lib sop::` rather than the full workspace suite — this covers the entire changed module and its direct dependents (store, types, engine glue), the actual blast radius of a one-function change. CI runs the full workspace suite on this PR.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility (required)

- Backward compatible? **Yes** — tail-loop SOPs still complete when the condition clears; only SOPs with a step after a guarded loop change behavior (intended).
- Config / env / CLI surface changed? **No**

## Rollback (required for medium/high-risk PRs)

`git revert b55fa00213`
