### PR TITLE
fix(zerocode): stop intermittent ask_user failures under ACP elicitation

### DIFF
--- a/CHANGELOG-next.md
+++ b/CHANGELOG-next.md
@@ -170,6 +170,7 @@ ZeroClaw treats every inbound payload as untrusted and tightens the seams an att
 | web_fetch | `allowed_private_hosts = ["*"]` covers DNS-resolved private hosts (#7412) |
 | skills | Correct the "ClawhHub" typo in skill installer messages (#8262) |
 | docker | Keep Node base policy in container TOML (#8112); correct Node 24 digest pins (#7932); drop stale aardvark-sys build.rs COPY (#8092) |
+| zerocode/elicitation | Fix intermittent `ask_user`/`poll` failures under ACP elicitation: defer (rather than immediately cancel) an inbound `elicitation/create` whose session is mid resume/reset/switch, and surface — instead of silently dropping — a lagged inbound-request broadcast so a prompt can no longer hang the daemon's tool call until the session timeout |
 
 ## Docs
 

--- a/apps/zerocode/locales/en/zerocode.ftl
+++ b/apps/zerocode/locales/en/zerocode.ftl
@@ -334,6 +334,7 @@ zc-chat-pane-acp = ACP
 zc-chat-no-agents = No enabled agents yet. Open Quickstart to create one, or use Config to add and enable an agent.
 zc-chat-error-fetch-agents = Failed to fetch agents: { $error }
 zc-chat-error-create-session = Failed to create session: { $error }
+zc-chat-elicitation-dropped = A prompt from the agent was dropped before it could be shown (the client fell behind). The agent's question may be waiting; try again.
 zc-chat-session-restarted = New session started.
 zc-chat-session-restart-error = Failed to start a new session: { $error }
 

--- a/apps/zerocode/locales/es/zerocode.ftl
+++ b/apps/zerocode/locales/es/zerocode.ftl
@@ -279,6 +279,7 @@ zc-chat-pane-acp = ACP
 zc-chat-no-agents = No hay agentes habilitados. Configura un agente en la pestaña Config.
 zc-chat-error-fetch-agents = No se pudieron obtener los agentes: { $error }
 zc-chat-error-create-session = No se pudo crear la sesión: { $error }
+zc-chat-elicitation-dropped = Se descartó una pregunta del agente antes de poder mostrarla (el cliente se retrasó). Es posible que la pregunta del agente siga esperando; inténtalo de nuevo.
 zc-chat-session-restarted = Nueva sesión iniciada.
 zc-chat-session-restart-error = No se pudo iniciar una nueva sesión: { $error }
 zc-chat-thinking-visible = Salida de razonamiento: visible

--- a/apps/zerocode/locales/fr/zerocode.ftl
+++ b/apps/zerocode/locales/fr/zerocode.ftl
@@ -279,6 +279,7 @@ zc-chat-pane-acp = ACP
 zc-chat-no-agents = Aucun agent activé. Configurez un agent dans l'onglet Config.
 zc-chat-error-fetch-agents = Échec de la récupération des agents : { $error }
 zc-chat-error-create-session = Échec de la création de la session : { $error }
+zc-chat-elicitation-dropped = Une question de l'agent a été abandonnée avant de pouvoir être affichée (le client a pris du retard). La question de l'agent est peut-être toujours en attente ; réessayez.
 zc-chat-session-restarted = Nouvelle session démarrée.
 zc-chat-session-restart-error = Échec du démarrage d'une nouvelle session : { $error }
 zc-chat-thinking-visible = Sortie de réflexion : visible

--- a/apps/zerocode/locales/ja/zerocode.ftl
+++ b/apps/zerocode/locales/ja/zerocode.ftl
@@ -279,6 +279,7 @@ zc-chat-pane-acp = ACP
 zc-chat-no-agents = 有効なエージェントがありません。Configタブでエージェントを設定してください。
 zc-chat-error-fetch-agents = エージェントの取得に失敗しました: { $error }
 zc-chat-error-create-session = セッションの作成に失敗しました: { $error }
+zc-chat-elicitation-dropped = エージェントからの質問が表示される前に破棄されました（クライアントの処理が追いつきませんでした）。エージェントの質問がまだ待機している可能性があります。もう一度お試しください。
 zc-chat-session-restarted = 新しいセッションを開始しました。
 zc-chat-session-restart-error = 新しいセッションを開始できませんでした: { $error }
 zc-chat-thinking-visible = 思考出力: 表示

--- a/apps/zerocode/locales/zh-CN/zerocode.ftl
+++ b/apps/zerocode/locales/zh-CN/zerocode.ftl
@@ -279,6 +279,7 @@ zc-chat-pane-acp = ACP
 zc-chat-no-agents = 没有已启用的代理。请在配置选项卡中配置代理。
 zc-chat-error-fetch-agents = 获取代理失败：{ $error }
 zc-chat-error-create-session = 创建会话失败：{ $error }
+zc-chat-elicitation-dropped = 代理的一个提问在显示前被丢弃（客户端处理不及时）。代理的问题可能仍在等待；请重试。
 zc-chat-session-restarted = 已启动新会话。
 zc-chat-session-restart-error = 无法启动新会话：{ $error }
 zc-chat-thinking-visible = 思考输出：可见

--- a/apps/zerocode/src/chat.rs
+++ b/apps/zerocode/src/chat.rs
@@ -124,6 +124,41 @@ pub(crate) struct Chat {
     /// Double-click tracker for the agent picker: a second click on the same row
     /// confirms (enters the session), matching the keyboard Enter.
     pick_agent_double_click: crate::mouse::DoubleClickTracker,
+    /// Inbound `elicitation/create` requests that arrived while the pane was
+    /// not yet `Active` on their target session (e.g. mid resume/reset/switch).
+    /// Rather than auto-cancel a legitimately-owned prompt during that
+    /// transient window — which silently drops the agent's `ask_user` — we
+    /// hold it here and retry installation on subsequent drains until it
+    /// either matches (modal installed) or its grace deadline expires (then
+    /// answered `cancel`, unblocking the daemon's tool call). See
+    /// `drain_inbound_requests` / `try_install_elicitation`.
+    deferred_elicitations: Vec<DeferredInboundRequest>,
+}
+
+/// How long an unroutable inbound `elicitation/create` is retried before it is
+/// answered `cancel`. Covers the transient window where the pane is switching
+/// or resuming a session and `phase` is briefly not `Active` on the target
+/// session. Short enough that a genuinely-unroutable request still unblocks the
+/// daemon's tool call promptly.
+const ELICITATION_ROUTE_GRACE: Duration = Duration::from_secs(2);
+
+/// An inbound server-initiated request buffered for a retry pass because it
+/// could not be installed on arrival. Carries the arrival instant so the drain
+/// loop can enforce [`ELICITATION_ROUTE_GRACE`].
+struct DeferredInboundRequest {
+    req: crate::client::RpcInboundRequest,
+    first_seen: Instant,
+}
+
+/// Outcome of attempting to route one inbound `elicitation/create` to the
+/// active session. See `Chat::try_install_elicitation`.
+enum ElicitationRouting {
+    /// Modal installed on the active session; it owns the request id.
+    Installed,
+    /// Schema/params could not be decoded; caller must answer `cancel`.
+    Unparseable(serde_json::Value),
+    /// Parsed but does not target the active session yet; retry briefly.
+    Defer(crate::client::RpcInboundRequest),
 }
 
 /// Result of one background `session/git_branch` poll, routed back to the UI
@@ -178,6 +213,7 @@ impl Chat {
             resume_agent_alias: None,
             pick_agent_list_area: Rect::default(),
             pick_agent_double_click: crate::mouse::DoubleClickTracker::new(),
+            deferred_elicitations: Vec::new(),
         }
     }
 
@@ -514,15 +550,17 @@ impl Chat {
     /// `elicitation/create`) and dispatch them so the daemon's tool call
     /// doesn't stall.
     ///
-    /// An `elicitation/create` targeting the active session with a schema
-    /// we understand is installed as an interactive picker modal
-    /// (`handle_inbound_elicitation`); the user's selection is sent back as
-    /// the JSON-RPC response. A request we can't match to the active
-    /// session, or whose schema won't parse, is auto-answered with
-    /// `{"action": "cancel"}`, which the daemon's
-    /// `RpcApprovalChannel::request_choice` collapses to `Ok(None)` so the
-    /// calling tool can fall back to its non-channel path. See the ACP
-    /// elicitation RFD
+    /// An `elicitation/create` targeting the active session with a schema we
+    /// understand is installed as an interactive picker modal (via
+    /// `route_inbound_elicitation` → `try_install_elicitation`); the user's
+    /// selection is sent back as the JSON-RPC response. A request whose schema
+    /// won't parse is answered `{"action": "cancel"}` immediately. A request
+    /// that parses but does not target the active session — the pane may be
+    /// mid resume/reset/switch — is *deferred* and retried for a short grace
+    /// window before it is cancelled, so a legitimately-owned prompt is never
+    /// dropped during a transition. `cancel` collapses to `Ok(None)` in the
+    /// daemon's `RpcApprovalChannel::request_choice`, letting the calling tool
+    /// fall back to its non-channel path. See the ACP elicitation RFD
     /// (https://agentclientprotocol.com/rfds/elicitation).
     ///
     /// Unknown server methods get a `METHOD_NOT_FOUND` response so a
@@ -531,11 +569,30 @@ impl Chat {
         loop {
             let req = match self.inbound_rx.try_recv() {
                 Ok(req) => req,
-                Err(broadcast::error::TryRecvError::Lagged(_)) => continue,
+                // A `Lagged` receiver has irrecoverably lost frames from the
+                // broadcast buffer. For response-bearing requests (today:
+                // `elicitation/create`) a lost frame means the daemon parks
+                // its tool call until `session_timeout_secs` (default 3600s) —
+                // the user sees `ask_user` hang. We cannot recover the dropped
+                // ids here, but we MUST NOT swallow it silently: surface a
+                // system message so the hang is diagnosable, then keep draining
+                // the frames still buffered. The capacity bump on the sender
+                // side (`INBOUND_REQUEST_CHANNEL_CAPACITY`) makes this rare.
+                Err(broadcast::error::TryRecvError::Lagged(_)) => {
+                    if let ChatPhase::Active(ref mut state) = self.phase {
+                        state
+                            .entries
+                            .push(ChatEntry::SystemMessage(Arc::<str>::from(crate::i18n::t(
+                                "zc-chat-elicitation-dropped",
+                            ))));
+                        state.mark_dirty_append();
+                    }
+                    continue;
+                }
                 Err(_) => break,
             };
             match req.method.as_str() {
-                "elicitation/create" => self.handle_inbound_elicitation(req),
+                "elicitation/create" => self.route_inbound_elicitation(req),
                 other => {
                     let method = other.to_string();
                     let id = req.id.clone();
@@ -555,50 +612,110 @@ impl Chat {
                 }
             }
         }
+
+        // Retry any elicitations that arrived before their session was
+        // installable, and cancel the ones whose grace window has elapsed.
+        self.drain_deferred_elicitations();
     }
 
-    /// Decode an inbound elicitation and install an interactive modal on
-    /// the matching session so the user can pick an answer.
+    /// Route one inbound `elicitation/create`: install it if its session is
+    /// active, defer it if the pane is mid-transition (so a legitimately-owned
+    /// prompt is not dropped during a session switch/resume), or cancel it
+    /// outright if its schema is unparseable.
+    fn route_inbound_elicitation(&mut self, req: crate::client::RpcInboundRequest) {
+        match self.try_install_elicitation(req) {
+            ElicitationRouting::Installed => {}
+            ElicitationRouting::Unparseable(id) => Self::answer_cancel(&self.rpc, id),
+            ElicitationRouting::Defer(req) => {
+                self.deferred_elicitations.push(DeferredInboundRequest {
+                    req,
+                    first_seen: Instant::now(),
+                });
+            }
+        }
+    }
+
+    /// Retry deferred elicitations. Each is re-attempted once per drain; when
+    /// its session becomes active the modal installs, and when its grace
+    /// deadline lapses it is answered `cancel` so the daemon's tool call never
+    /// stalls indefinitely on a session that never materialised in this pane.
+    fn drain_deferred_elicitations(&mut self) {
+        if self.deferred_elicitations.is_empty() {
+            return;
+        }
+        let pending = std::mem::take(&mut self.deferred_elicitations);
+        for entry in pending {
+            let expired = entry.first_seen.elapsed() >= ELICITATION_ROUTE_GRACE;
+            match self.try_install_elicitation(entry.req) {
+                ElicitationRouting::Installed => {}
+                ElicitationRouting::Unparseable(id) => Self::answer_cancel(&self.rpc, id),
+                ElicitationRouting::Defer(req) => {
+                    if expired {
+                        Self::answer_cancel(&self.rpc, req.id);
+                    } else {
+                        self.deferred_elicitations.push(DeferredInboundRequest {
+                            req,
+                            first_seen: entry.first_seen,
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    /// Answer an inbound request with `{"action":"cancel"}`, which the daemon's
+    /// `RpcApprovalChannel::request_choice` collapses to `Ok(None)` so the
+    /// calling tool takes its non-channel fallback path.
+    fn answer_cancel(rpc: &Arc<RpcClient>, id: serde_json::Value) {
+        let rpc = rpc.clone();
+        tokio::spawn(async move {
+            let _ = rpc
+                .respond_to_inbound_request(id, Ok(serde_json::json!({ "action": "cancel" })))
+                .await;
+        });
+    }
+
+    /// Try to install an inbound elicitation as a modal on the active session.
     ///
-    /// The modal owns the JSON-RPC request id; the response is sent later
-    /// from the key handler (`confirm_elicitation` / `cancel_elicitation`)
-    /// once the user acts. If the request can't be matched to the active
-    /// session, or its schema is unparseable, we answer `cancel`
-    /// immediately so the daemon's tool call doesn't stall.
+    /// Returns [`ElicitationRouting`]:
+    /// - `Installed` — the request targets the active session and parsed; a
+    ///   modal was installed and owns the request id.
+    /// - `Unparseable(id)` — the schema could not be decoded; the caller must
+    ///   answer `cancel` (retrying would never succeed).
+    /// - `Defer(req)` — the request parsed but does not (yet) target the
+    ///   active session; the caller should retry it briefly rather than
+    ///   cancelling a possibly-owned prompt during a session transition.
     ///
     /// Wire shape per the ACP elicitation RFD
     /// (https://agentclientprotocol.com/rfds/elicitation).
-    fn handle_inbound_elicitation(&mut self, req: crate::client::RpcInboundRequest) {
+    fn try_install_elicitation(
+        &mut self,
+        req: crate::client::RpcInboundRequest,
+    ) -> ElicitationRouting {
         let params: Option<crate::wire::ElicitationRequestParams> =
             serde_json::from_value(req.params.clone()).ok();
         let shape = params
             .as_ref()
             .and_then(|p| crate::wire::ElicitationShape::from_schema(&p.requested_schema));
 
-        // The request must target the active session AND carry a schema
-        // we understand. Anything else gets an immediate `cancel`.
-        let installable = match (&params, &shape) {
-            (Some(p), Some(_)) => matches!(
-                &self.phase,
-                ChatPhase::Active(state) if state.session_id == p.session_id
-            ),
-            _ => false,
+        // A request we can't decode (missing params or an unknown schema)
+        // can never install — cancel it immediately, no retry.
+        let (params, shape) = match (params, shape) {
+            (Some(p), Some(s)) => (p, s),
+            _ => return ElicitationRouting::Unparseable(req.id),
         };
 
-        if !installable {
-            let id = req.id;
-            let rpc = self.rpc.clone();
-            tokio::spawn(async move {
-                let _ = rpc
-                    .respond_to_inbound_request(id, Ok(serde_json::json!({ "action": "cancel" })))
-                    .await;
-            });
-            return;
+        // Must target THIS pane's active session. If not, it may simply be
+        // that the pane is mid resume/reset/switch — defer and retry rather
+        // than cancel a prompt this pane will shortly own.
+        let matches_active = matches!(
+            &self.phase,
+            ChatPhase::Active(state) if state.session_id == params.session_id
+        );
+        if !matches_active {
+            return ElicitationRouting::Defer(req);
         }
 
-        // Unwraps are safe: `installable` proved both are `Some`.
-        let params = params.unwrap();
-        let shape = shape.unwrap();
         let pending = match shape {
             crate::wire::ElicitationShape::Single { choices, .. } => PendingElicitation {
                 request_id: req.id,
@@ -635,6 +752,7 @@ impl Chat {
         if let ChatPhase::Active(ref mut state) = self.phase {
             state.set_pending_elicitation(pending);
         }
+        ElicitationRouting::Installed
     }
 
     fn settle_stuck_cancel(&mut self) {
@@ -4203,7 +4321,7 @@ pub struct PendingElicitation {
     /// Session this elicitation belongs to. Captured at install time so a
     /// future mouse handler (or a cross-session correctness assert) can
     /// confirm the modal still targets the active session. Read indirectly
-    /// today via the install-time match in `handle_inbound_elicitation`.
+    /// today via the install-time match in `try_install_elicitation`.
     #[allow(dead_code)]
     pub session_id: String,
     /// Prompt text shown above the choice list.
@@ -7812,5 +7930,164 @@ mod tests {
             s.pending_elicitation().is_none(),
             "a session switch must drop any stale elicitation modal"
         );
+    }
+
+    // ── Inbound elicitation routing (ask_user intermittent-failure fix) ──
+
+    /// Build an inbound `elicitation/create` request for `session_id` with a
+    /// canonical single-select schema (the shape the daemon emits).
+    fn inbound_single_elicitation(id: &str, session_id: &str) -> crate::client::RpcInboundRequest {
+        crate::client::RpcInboundRequest {
+            id: serde_json::json!(id),
+            method: "elicitation/create".to_string(),
+            params: serde_json::json!({
+                "sessionId": session_id,
+                "mode": "form",
+                "message": "Pick one",
+                "requestedSchema": {
+                    "type": "object",
+                    "properties": {
+                        "choice": {
+                            "type": "string",
+                            "oneOf": [
+                                { "const": "choice-0", "title": "Yes" },
+                                { "const": "choice-1", "title": "No" }
+                            ]
+                        }
+                    }
+                }
+            }),
+        }
+    }
+
+    fn test_chat() -> (Chat, mpsc::Receiver<String>) {
+        let (tx, rx) = mpsc::channel::<String>(16);
+        let rpc = Arc::new(RpcOutbound::new(tx));
+        let client = Arc::new(RpcClient::with_rpc(rpc));
+        (Chat::new(client, PaneKind::Chat), rx)
+    }
+
+    /// An elicitation whose session matches the active pane installs a modal
+    /// immediately and sends no response (the user answers it later).
+    #[tokio::test]
+    async fn elicitation_matching_active_session_installs_modal() {
+        let (mut chat, mut rx) = test_chat();
+        chat.phase = ChatPhase::Active(Box::new(state())); // session_id = "sess-1"
+
+        chat.route_inbound_elicitation(inbound_single_elicitation("e1", "sess-1"));
+
+        // Modal installed.
+        match &chat.phase {
+            ChatPhase::Active(s) => assert!(
+                s.pending_elicitation().is_some(),
+                "matching-session elicitation must install a modal"
+            ),
+            _ => panic!("expected Active phase"),
+        }
+        // Nothing deferred, and no auto-response was written.
+        assert!(chat.deferred_elicitations.is_empty());
+        assert!(
+            rx.try_recv().is_err(),
+            "an installed elicitation must not be auto-answered"
+        );
+    }
+
+    /// An elicitation for a *different* session must NOT be auto-cancelled on
+    /// arrival — the pane may be mid-transition. It is deferred for retry.
+    #[tokio::test]
+    async fn elicitation_for_other_session_is_deferred_not_cancelled() {
+        let (mut chat, mut rx) = test_chat();
+        chat.phase = ChatPhase::Active(Box::new(state())); // active = "sess-1"
+
+        chat.route_inbound_elicitation(inbound_single_elicitation("e1", "sess-OTHER"));
+
+        assert_eq!(
+            chat.deferred_elicitations.len(),
+            1,
+            "a non-matching elicitation must be deferred, not cancelled outright"
+        );
+        // Give the (non-)spawned responder a chance — nothing must be sent yet.
+        tokio::task::yield_now().await;
+        assert!(
+            rx.try_recv().is_err(),
+            "a deferred elicitation must not be answered during its grace window"
+        );
+    }
+
+    /// A deferred elicitation installs as soon as its session becomes active.
+    #[tokio::test]
+    async fn deferred_elicitation_installs_once_session_becomes_active() {
+        let (mut chat, _rx) = test_chat();
+        // No active session yet (still picking an agent) → defer.
+        chat.route_inbound_elicitation(inbound_single_elicitation("e1", "sess-1"));
+        assert_eq!(chat.deferred_elicitations.len(), 1);
+
+        // Session comes up.
+        chat.phase = ChatPhase::Active(Box::new(state())); // "sess-1"
+        chat.drain_deferred_elicitations();
+
+        assert!(
+            chat.deferred_elicitations.is_empty(),
+            "the deferred elicitation must be consumed once installable"
+        );
+        match &chat.phase {
+            ChatPhase::Active(s) => assert!(s.pending_elicitation().is_some()),
+            _ => panic!("expected Active"),
+        }
+    }
+
+    /// A deferred elicitation whose grace window elapses without becoming
+    /// installable is answered `cancel` so the daemon's tool call unblocks.
+    #[tokio::test]
+    async fn expired_deferred_elicitation_is_cancelled() {
+        let (mut chat, mut rx) = test_chat();
+        chat.phase = ChatPhase::Active(Box::new(state())); // active = "sess-1"
+
+        // Defer an elicitation for a session this pane will never own, with an
+        // already-expired arrival time.
+        chat.deferred_elicitations.push(DeferredInboundRequest {
+            req: inbound_single_elicitation("e1", "sess-GONE"),
+            first_seen: Instant::now() - (ELICITATION_ROUTE_GRACE + Duration::from_millis(1)),
+        });
+
+        chat.drain_deferred_elicitations();
+
+        assert!(
+            chat.deferred_elicitations.is_empty(),
+            "an expired deferral must be dropped from the retry buffer"
+        );
+        // A `{"action":"cancel"}` response must have been written.
+        let line = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("expired deferral must emit a cancel response")
+            .expect("writer channel open");
+        let frame: serde_json::Value = serde_json::from_str(&line).unwrap();
+        assert_eq!(frame["id"], serde_json::json!("e1"));
+        assert_eq!(frame["result"]["action"], "cancel");
+    }
+
+    /// An unparseable elicitation (unknown schema) is cancelled immediately —
+    /// deferring it would never succeed.
+    #[tokio::test]
+    async fn unparseable_elicitation_is_cancelled_immediately() {
+        let (mut chat, mut rx) = test_chat();
+        chat.phase = ChatPhase::Active(Box::new(state()));
+
+        let mut req = inbound_single_elicitation("e1", "sess-1");
+        // Corrupt the schema so `ElicitationShape::from_schema` returns None.
+        req.params["requestedSchema"] = serde_json::json!({ "type": "object" });
+
+        chat.route_inbound_elicitation(req);
+
+        assert!(
+            chat.deferred_elicitations.is_empty(),
+            "an unparseable elicitation must not be deferred"
+        );
+        let line = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("unparseable elicitation must emit a cancel response")
+            .expect("writer channel open");
+        let frame: serde_json::Value = serde_json::from_str(&line).unwrap();
+        assert_eq!(frame["result"]["action"], "cancel");
     }
 }

--- a/apps/zerocode/src/client.rs
+++ b/apps/zerocode/src/client.rs
@@ -191,6 +191,15 @@ pub struct RpcInboundRequest {
     pub params: Value,
 }
 
+/// Buffer capacity for the server-initiated inbound-request broadcast.
+///
+/// These frames are response-bearing (today: `elicitation/create`): a dropped
+/// one parks the daemon's tool call until the session timeout. The buffer is
+/// sized generously so a busy TUI draw loop does not lag the receiver and lose
+/// an elicitation. The Chat pane additionally surfaces a `Lagged` overflow so
+/// the rare drop is diagnosable rather than a silent hang.
+pub const INBOUND_REQUEST_CHANNEL_CAPACITY: usize = 1024;
+
 // ── Typed session updates ────────────────────────────────────────
 
 #[derive(Debug, Clone)]
@@ -522,7 +531,8 @@ impl RpcClient {
         let rpc = Arc::new(RpcOutbound::new(writer_tx));
         let (notif_tx, _) = broadcast::channel::<RpcNotification>(256);
         let notif_tx_for_reader = notif_tx.clone();
-        let (inbound_tx, _) = broadcast::channel::<RpcInboundRequest>(64);
+        let (inbound_tx, _) =
+            broadcast::channel::<RpcInboundRequest>(INBOUND_REQUEST_CHANNEL_CAPACITY);
         let inbound_tx_for_reader = inbound_tx.clone();
 
         let conn_state = Arc::new(Mutex::new(ConnectionState::Connected));
@@ -667,7 +677,8 @@ impl RpcClient {
         let rpc = Arc::new(jsonrpc::RpcOutbound::new(writer_tx));
         let (notif_tx, _) = broadcast::channel::<RpcNotification>(256);
         let notif_tx_for_reader = notif_tx.clone();
-        let (inbound_tx, _) = broadcast::channel::<RpcInboundRequest>(64);
+        let (inbound_tx, _) =
+            broadcast::channel::<RpcInboundRequest>(INBOUND_REQUEST_CHANNEL_CAPACITY);
         let inbound_tx_for_reader = inbound_tx.clone();
 
         let conn_state = Arc::new(Mutex::new(ConnectionState::Connected));


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Fixes intermittent `ask_user`/`poll` failures under ACP elicitation. An inbound `elicitation/create` whose target session didn't match the Code tab's *currently*-active session was answered `{"action":"cancel"}` immediately. During the transient window where the pane is resuming/resetting/switching sessions, this auto-cancelled a legitimately-owned prompt; the daemon collapses `cancel` to `Ok(None)`, so the tool resolved without an answer and the turn ended "cancelled". (Widened by the post-squash `ee97859e4b` "let active sessions switch agents".)
  - Inbound elicitations now route through `try_install_elicitation`, returning install / cancel-if-unparseable / **defer**. A request that parses but doesn't yet target the active session is buffered and retried for a short grace window (`ELICITATION_ROUTE_GRACE`, 2s) before being cancelled — so a prompt the pane is about to own is never dropped mid-transition.
  - A `Lagged` inbound-request broadcast was silently dropped via `continue`, parking the daemon's tool call until `session_timeout_secs` (default 3600s). It now surfaces a user-visible system message (`zc-chat-elicitation-dropped`, added to all 5 locales), and the inbound-request broadcast capacity is raised to `INBOUND_REQUEST_CHANNEL_CAPACITY` (1024) so the overflow is rare.
- **Scope boundary:** No changes to the daemon-side elicitation emitter (`AcpChannel`, `RpcApprovalChannel`), the wire format, or the `ask_user`/`poll` tools. Client-side (Zerocode TUI) routing only.
- **Blast radius:** `apps/zerocode` Code/Chat tab inbound-request handling. No daemon-side elicitation emitter, wire-format, `ask_user`/`poll` tool, external ACP channel, or non-Zerocode channel behavior changes.
- **Linked issue(s):** None.
- **Labels:** `bug`, `docs`, `risk:medium`, `size:M`, `zerocode` (see sidebar)

## Validation Evidence (required)

- **Commands run and tail output:**

`cargo fmt --all -- --check` -> clean (exit 0) after formatting.

`cargo clippy -p zerocode --all-targets -- -D warnings`:
```
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 7.12s
```
(exit 0)

`cargo test -p zerocode`:
```
test result: ok. 126 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 434 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

- **Beyond CI — what did you manually verify?** Added 5 targeted tests for the routing outcomes (install-on-match, defer-on-mismatch, install-once-active, expired-deferral-cancels, unparseable-cancels). Confirmed both target bugs still exist on current `master` before fixing. Note: `chat` is declared only in `main.rs`, so its tests run under the **bin** target (`cargo test -p zerocode --bin zerocode`), not `--lib`.
- **If any command was intentionally skipped, why:** `cargo test -p zerocode --doc` fails with `Option 'default-theme' given more than once` — a **pre-existing** local rustdoc quirk from `.cargo/config.toml`'s `rustdocflags = ["--default-theme=ayu"]` being passed twice; reproduces identically on clean `master` with my changes stashed, unrelated to this diff.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Upgrade steps: none — internal TUI behavior only.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert b89f6aba54`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** `ask_user`/`poll` prompts resolving without an answer; turns ending with "turn cancelled via client_rpc in RPC_SESSION"; the new `zc-chat-elicitation-dropped` system message appearing in the Code tab.
