### PR TITLE
feat(zerocode): add ctrl-w word delete

### DIFF
--- a/apps/zerocode/src/input_bar.rs
+++ b/apps/zerocode/src/input_bar.rs
@@ -391,6 +391,35 @@ fn wrapped_line_count(text: &str, width: u16) -> u16 {
         .unwrap_or(u16::MAX)
 }
 
+fn is_word_character(character: char) -> bool {
+    character == '_' || character.is_alphanumeric()
+}
+
+fn previous_word_boundary(text: &str, cursor: usize) -> Option<usize> {
+    let mut chars = text[..cursor].char_indices().rev();
+
+    let mut target_is_word = None;
+    for (_, character) in chars.by_ref() {
+        if character.is_whitespace() {
+            continue;
+        }
+        target_is_word = Some(is_word_character(character));
+        break;
+    }
+
+    let Some(target_is_word) = target_is_word else {
+        return (cursor > 0).then_some(0);
+    };
+
+    for (index, character) in chars {
+        if character.is_whitespace() || is_word_character(character) != target_is_word {
+            return Some(index + character.len_utf8());
+        }
+    }
+
+    Some(0)
+}
+
 /// Decide which overflow arrows to show for `(up, down)` given the total
 /// content rows, the visible window, and the current scroll offset. Arrows
 /// only appear when content exceeds the window.
@@ -778,6 +807,20 @@ impl InputBarState {
         }
     }
 
+    pub fn delete_previous_word(&mut self) {
+        if self.selection.is_some() {
+            self.delete_selection();
+            self.update_autocomplete();
+            return;
+        }
+        let Some(delete_from) = previous_word_boundary(&self.input, self.cursor) else {
+            return;
+        };
+        self.input.replace_range(delete_from..self.cursor, "");
+        self.cursor = delete_from;
+        self.update_autocomplete();
+    }
+
     pub fn move_cursor_left(&mut self) {
         self.clear_selection();
         if self.cursor > 0 {
@@ -1063,6 +1106,10 @@ impl InputBarState {
             }
             Some(IbWidgetAction::Backspace) => {
                 self.pop_input_char();
+                return InputBarAction::Consumed;
+            }
+            Some(IbWidgetAction::DeletePreviousWord) => {
+                self.delete_previous_word();
                 return InputBarAction::Consumed;
             }
             Some(IbWidgetAction::ClearInput) => {
@@ -1716,6 +1763,81 @@ mod tests {
         let act = bar.handle_key(KeyEvent::new(KeyCode::Char('u'), KeyModifiers::CONTROL));
         assert!(matches!(act, InputBarAction::Consumed));
         assert_eq!(bar.input(), "");
+    }
+
+    #[test]
+    fn ctrl_w_deletes_previous_word() {
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        let mut bar = InputBarState::new();
+        bar.insert_text("hello world");
+        let action = bar.handle_key(KeyEvent::new(KeyCode::Char('w'), KeyModifiers::CONTROL));
+        assert!(matches!(action, InputBarAction::Consumed));
+        assert_eq!(bar.input(), "hello ");
+        assert_eq!(bar.cursor(), 6);
+    }
+
+    #[test]
+    fn ctrl_w_deletes_trailing_space_and_word() {
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        let mut bar = InputBarState::new();
+        bar.insert_text("hello world   ");
+        bar.handle_key(KeyEvent::new(KeyCode::Char('w'), KeyModifiers::CONTROL));
+        assert_eq!(bar.input(), "hello ");
+        assert_eq!(bar.cursor(), 6);
+    }
+
+    #[test]
+    fn ctrl_w_deletes_word_before_cursor() {
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        let mut bar = InputBarState::new();
+        bar.insert_text("hello brave world");
+        for _ in 0..5 {
+            bar.move_cursor_left();
+        }
+        bar.handle_key(KeyEvent::new(KeyCode::Char('w'), KeyModifiers::CONTROL));
+        assert_eq!(bar.input(), "hello world");
+        assert_eq!(bar.cursor(), 6);
+    }
+
+    #[test]
+    fn ctrl_w_deletes_selection() {
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        let mut bar = InputBarState::new();
+        bar.insert_text("hello world");
+        bar.selection = Some((6, 11));
+        bar.handle_key(KeyEvent::new(KeyCode::Char('w'), KeyModifiers::CONTROL));
+        assert_eq!(bar.input(), "hello ");
+        assert_eq!(bar.cursor(), 6);
+    }
+
+    #[test]
+    fn ctrl_w_deletes_punctuation_run_like_vim() {
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        let mut bar = InputBarState::new();
+        bar.insert_text("hello world...");
+        bar.handle_key(KeyEvent::new(KeyCode::Char('w'), KeyModifiers::CONTROL));
+        assert_eq!(bar.input(), "hello world");
+        assert_eq!(bar.cursor(), 11);
+    }
+
+    #[test]
+    fn ctrl_w_deletes_word_after_punctuation_like_vim() {
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        let mut bar = InputBarState::new();
+        bar.insert_text("hello-world");
+        bar.handle_key(KeyEvent::new(KeyCode::Char('w'), KeyModifiers::CONTROL));
+        assert_eq!(bar.input(), "hello-");
+        assert_eq!(bar.cursor(), 6);
+    }
+
+    #[test]
+    fn ctrl_w_deletes_only_whitespace_before_cursor() {
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        let mut bar = InputBarState::new();
+        bar.insert_text("   ");
+        bar.handle_key(KeyEvent::new(KeyCode::Char('w'), KeyModifiers::CONTROL));
+        assert_eq!(bar.input(), "");
+        assert_eq!(bar.cursor(), 0);
     }
 
     #[test]

--- a/apps/zerocode/src/keymap/actions.rs
+++ b/apps/zerocode/src/keymap/actions.rs
@@ -289,6 +289,7 @@ keyactions! {
         CursorEnd          [Chord::key(KeyCode::End), Chord::ctrl('e')] => "line end",
         OpenFileBrowser    [Chord::ctrl('a')] => "browse files",
         Backspace          [Chord::key(KeyCode::Backspace)] => "backspace",
+        DeletePreviousWord [Chord::ctrl('w')] => "delete previous word",
         ClearInput         [Chord::ctrl('u')] => "clear input",
         SelectAll          [] => "select all",
         Paste              [Chord::ctrl('v')] => "paste",


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Adds a zerocode input-bar action for deleting the previous word with `Ctrl+W`, matching common Vim/shell editing behavior.
  - Wires the binding through the existing keymap registry as `DeletePreviousWord`, so help/keybinding discovery stays registry-derived instead of using a hardcoded input-handler shortcut.
  - Handles selections, trailing whitespace, punctuation runs, cursor-in-middle edits, and whitespace-only input.
- **Scope boundary:**
  - This PR does not change `Ctrl+C` behavior.
  - This PR does not add config settings or feature flags.
  - This PR does not change slash-command handling or skill invocation.
  - This PR does not change model/provider/channel registries.
- **Blast radius:**
  - `apps/zerocode/src/input_bar.rs`: input editing behavior and tests.
  - `apps/zerocode/src/keymap/actions.rs`: input-bar keymap registry.
- **Linked issue(s):**
  - No issue is closed by this PR.
- **Labels:**
  - Suggested: `zerocode`, `size:XS`, `risk:low`

## Validation Evidence (required)

```bash
cargo fmt --manifest-path zeroclaw/Cargo.toml --all -- --check
cargo test --manifest-path zeroclaw/Cargo.toml -p zerocode input_bar::tests::ctrl_w -- --nocapture
cargo test --manifest-path zeroclaw/Cargo.toml -p zerocode keymap::tests:: -- --nocapture
cargo clippy --manifest-path zeroclaw/Cargo.toml -p zerocode --all-targets -- -D warnings
```

- **Commands run and tail output:**
  - `cargo fmt --manifest-path zeroclaw/Cargo.toml --all -- --check`
    - Exit 0, no output.
  - `cargo test --manifest-path zeroclaw/Cargo.toml -p zerocode input_bar::tests::ctrl_w -- --nocapture`
    - `7 passed; 0 failed`
    - The lib test binary reported `0 passed; 0 failed; 126 filtered out`; the bin test binary ran the matching tests.
  - `cargo test --manifest-path zeroclaw/Cargo.toml -p zerocode keymap::tests:: -- --nocapture`
    - `8 passed; 0 failed`
    - `8 passed; 0 failed`
  - `cargo clippy --manifest-path zeroclaw/Cargo.toml -p zerocode --all-targets -- -D warnings`
    - Exit 0, no output.

- **Beyond CI — what did you manually verify?**
  - Reviewed the diff to confirm `Ctrl+W` is registered through the keymap enum and handled through `IbWidgetAction::DeletePreviousWord`, not by matching raw key literals in the input handler.
  - Reviewed behavior for normal words, trailing whitespace, cursor-in-middle deletion, selected text, punctuation runs, word-after-punctuation deletion, and whitespace-only input.

- **If any command was intentionally skipped, why:**
  - Full workspace `cargo test` and full workspace `cargo clippy --all-targets -- -D warnings` were not run locally; this is a small zerocode-only input/keymap change, so targeted zerocode tests and clippy were run.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation:
  - N/A

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: exact upgrade steps for existing users:
  - N/A

## Rollback (required for medium/high-risk PRs)

Low-risk rollback:

```bash
git revert <sha>
```

- **Fast rollback command/path:** `git revert <sha>`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:**
  - Pressing `Ctrl+W` in zerocode input deletes the wrong text range.
  - Keymap conflict checks fail for `input_bar` actions.
  - Input autocomplete does not refresh after word deletion.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Scope materially carried forward: N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`No`)
- If `No`, why (inspiration-only, no direct code/design carry-over): N/A