### PR TITLE
fix(zerocode): use daemon final text when no streaming text was accumulated

### DIFF
--- a/apps/zerocode/locales/en/zerocode.ftl
+++ b/apps/zerocode/locales/en/zerocode.ftl
@@ -104,6 +104,7 @@ zc-input-clipboard-error = Clipboard error: { $error }
 
 zc-queue-empty = Nothing to send.
 zc-cancel-timed-out = Cancel timed out; turn settled locally.
+zc-turn-no-output = Turn completed with no output.
 zc-queue-full = Queue is full ({ $cap } max). Wait for messages to send.
 zc-queue-title = Queue ({ $count })
 zc-queue-empty-list = No queued messages.

--- a/apps/zerocode/locales/es/zerocode.ftl
+++ b/apps/zerocode/locales/es/zerocode.ftl
@@ -92,6 +92,7 @@ zc-input-pending-attachments-header = Adjuntos pendientes:
 zc-input-clipboard-error = Error del portapapeles: { $error }
 zc-queue-empty = Nada que enviar.
 zc-cancel-timed-out = La cancelación expiró; el turno se resolvió localmente.
+zc-turn-no-output = Turno completado sin salida.
 zc-queue-full = La cola está llena ({ $cap } máx.). Espera a que se envíen los mensajes.
 zc-queue-title = Cola ({ $count })
 zc-queue-empty-list = No hay mensajes en cola.

--- a/apps/zerocode/locales/fr/zerocode.ftl
+++ b/apps/zerocode/locales/fr/zerocode.ftl
@@ -92,6 +92,7 @@ zc-input-pending-attachments-header = Pièces jointes en attente :
 zc-input-clipboard-error = Erreur de presse-papiers : { $error }
 zc-queue-empty = Rien à envoyer.
 zc-cancel-timed-out = Délai d'annulation dépassé ; le tour a été réglé localement.
+zc-turn-no-output = Tour terminé sans production.
 zc-queue-full = La file d'attente est pleine ({ $cap } max). Attendez que les messages soient envoyés.
 zc-queue-title = File d'attente ({ $count })
 zc-queue-empty-list = Aucun message en file d'attente.

--- a/apps/zerocode/locales/ja/zerocode.ftl
+++ b/apps/zerocode/locales/ja/zerocode.ftl
@@ -92,6 +92,7 @@ zc-input-pending-attachments-header = 保留中の添付ファイル:
 zc-input-clipboard-error = クリップボードエラー: { $error }
 zc-queue-empty = 送信するものがありません。
 zc-cancel-timed-out = キャンセルがタイムアウトしました。ターンはローカルで確定されました。
+zc-turn-no-output = ターンが出力なしで完了しました。
 zc-queue-full = キューが満杯です（最大 { $cap } 件）。メッセージが送信されるまでお待ちください。
 zc-queue-title = キュー（{ $count }）
 zc-queue-empty-list = キュー済みメッセージはありません。

--- a/apps/zerocode/locales/zh-CN/zerocode.ftl
+++ b/apps/zerocode/locales/zh-CN/zerocode.ftl
@@ -92,6 +92,7 @@ zc-input-pending-attachments-header = 待处理附件：
 zc-input-clipboard-error = 剪贴板错误：{ $error }
 zc-queue-empty = 没有可发送的内容。
 zc-cancel-timed-out = 取消操作超时；回合已在本地结束。
+zc-turn-no-output = 回合已完成，无输出。
 zc-queue-full = 队列已满（最多 { $cap } 条）。请等待消息发送。
 zc-queue-title = 队列（{ $count }）
 zc-queue-empty-list = 没有排队消息。

--- a/apps/zerocode/src/chat.rs
+++ b/apps/zerocode/src/chat.rs
@@ -4686,6 +4686,15 @@ pub struct ChatState {
     pending_approval: Option<PendingApproval>,
     pending_elicitation: Option<PendingElicitation>,
     pub turn_in_flight: bool,
+    /// Set when any streaming text was flushed during the current turn.
+    /// Used by `commit_turn` to decide whether `full_text` is a fallback
+    /// (no streaming happened) or a duplicate (streaming already committed).
+    turn_had_streaming_text: bool,
+    /// Set when any `ToolCall` event arrived during the current turn.
+    /// Used by `commit_turn` to distinguish "empty completion with tool
+    /// calls" (normal — tool output is the visible record) from "empty
+    /// completion with nothing at all" (needs a diagnostic row).
+    turn_had_tool_calls: bool,
     /// Fine-grained label for the input-bar title while a turn is active.
     /// Lockstep with `turn_in_flight` (`Idle` ↔ `false`) but adds the
     /// thinking / responding / tool-call breakdown for the UI.
@@ -4809,6 +4818,8 @@ impl ChatState {
             pending_approval: None,
             pending_elicitation: None,
             turn_in_flight: false,
+            turn_had_streaming_text: false,
+            turn_had_tool_calls: false,
             turn_status: TurnStatus::Idle,
             turn_started_at: Instant::now(),
             show_thoughts: true,
@@ -5417,12 +5428,16 @@ impl ChatState {
     /// Commit any accumulated streaming text as an `AgentMessage` entry.
     /// Called when a tool call interrupts the text stream so that pre-tool
     /// text is committed in conversation order before the `Tool` entry.
-    fn flush_streaming_text(&mut self) {
+    /// Returns `true` if any text was flushed.
+    fn flush_streaming_text(&mut self) -> bool {
         let text = std::mem::take(&mut self.streaming_text);
         if !text.is_empty() {
             self.entries
                 .push(ChatEntry::AgentMessage(Arc::<str>::from(text)));
             self.mark_dirty_append();
+            true
+        } else {
+            false
         }
     }
 
@@ -5473,8 +5488,11 @@ impl ChatState {
                 // Flush any accumulated text and thought before the tool call
                 // so that pre-tool agent text and thinking both appear in
                 // conversation order before the Tool entry.
-                self.flush_streaming_text();
+                if self.flush_streaming_text() {
+                    self.turn_had_streaming_text = true;
+                }
                 self.flush_streaming_thought();
+                self.turn_had_tool_calls = true;
                 if self.turn_in_flight {
                     self.turn_status = TurnStatus::CallingTool(name.clone());
                 }
@@ -5571,9 +5589,30 @@ impl ChatState {
     }
 
     pub fn commit_turn(&mut self, full_text: String, clean: bool) {
-        self.flush_streaming_text();
+        if self.flush_streaming_text() {
+            self.turn_had_streaming_text = true;
+        }
         self.flush_streaming_thought();
-        let _ = full_text;
+        // If no streaming text was accumulated during this turn, use the
+        // daemon-provided final text as a fallback so the turn is never
+        // invisible to the user.
+        if !self.turn_had_streaming_text && !full_text.is_empty() {
+            self.entries
+                .push(ChatEntry::AgentMessage(Arc::<str>::from(full_text)));
+            self.mark_dirty_append();
+        } else if !self.turn_had_streaming_text && !self.turn_had_tool_calls && full_text.is_empty()
+        {
+            // Turn completed with no streamed text, no tool calls, and no
+            // final content — render a diagnostic so the user knows the
+            // turn finished rather than silently vanishing (#8644).
+            self.entries
+                .push(ChatEntry::SystemMessage(Arc::<str>::from(crate::i18n::t(
+                    "zc-turn-no-output",
+                ))));
+            self.mark_dirty_append();
+        }
+        self.turn_had_streaming_text = false;
+        self.turn_had_tool_calls = false;
         self.mark_dirty_append();
         self.turn_in_flight = false;
         self.turn_status = TurnStatus::Idle;
@@ -5610,6 +5649,8 @@ impl ChatState {
         });
         self.mark_dirty_append();
         self.turn_in_flight = true;
+        self.turn_had_streaming_text = false;
+        self.turn_had_tool_calls = false;
         // Start a fresh status + animation anchor. We're `Working` until the
         // first chunk (thought / message / tool-call) tells us otherwise.
         self.turn_status = TurnStatus::Working;
@@ -7837,6 +7878,62 @@ mod tests {
             matches!(&s.entries()[0], ChatEntry::AgentMessage(t) if t.as_ref() == "Before tool.")
         );
         assert!(matches!(&s.entries()[1], ChatEntry::Tool { .. }));
+    }
+
+    /// When no streaming text was accumulated, commit_turn must use the
+    /// daemon-provided final text as a fallback — rendered exactly once.
+    #[test]
+    fn commit_turn_renders_nonempty_fallback_when_no_streaming() {
+        let mut s = state();
+        s.turn_in_flight = true;
+
+        // No streaming chunks; commit_turn receives non-empty final text.
+        s.commit_turn("Hello from daemon.".to_string(), true);
+
+        assert_eq!(s.entries().len(), 1);
+        assert!(
+            matches!(&s.entries()[0], ChatEntry::AgentMessage(t) if t.as_ref() == "Hello from daemon.")
+        );
+    }
+
+    /// When a turn completes with no streamed text, no tool calls, and no
+    /// final content, commit_turn must render a diagnostic system message
+    /// so the user knows the turn finished (#8644).
+    #[test]
+    fn commit_turn_shows_diagnostic_when_no_output_at_all() {
+        let mut s = state();
+        s.turn_in_flight = true;
+
+        // Empty everything: no streaming, no tools, empty final text.
+        s.commit_turn(String::new(), true);
+
+        assert_eq!(s.entries().len(), 1);
+        assert!(
+            matches!(&s.entries()[0], ChatEntry::SystemMessage(t) if t.as_ref() == "Turn completed with no output."),
+            "expected diagnostic SystemMessage for empty completion, got {:?}",
+            s.entries()[0]
+        );
+    }
+
+    /// When tool calls were made during a turn but no text was streamed and
+    /// final text is empty, commit_turn must NOT add a diagnostic — the tool
+    /// entries are the visible record of work.
+    #[test]
+    fn commit_turn_no_diagnostic_when_tool_calls_present() {
+        let mut s = state();
+        s.turn_in_flight = true;
+
+        s.apply_update(SessionUpdate::ToolCall {
+            session_id: "sess-1".to_string(),
+            tool_call_id: "tc1".to_string(),
+            name: "shell".to_string(),
+            raw_input: serde_json::json!({"command": "ls"}),
+        });
+        s.commit_turn(String::new(), true);
+
+        // Only the Tool entry — no diagnostic needed.
+        assert_eq!(s.entries().len(), 1);
+        assert!(matches!(&s.entries()[0], ChatEntry::Tool { .. }));
     }
 
     #[test]

--- a/apps/zerocode/src/chat.rs
+++ b/apps/zerocode/src/chat.rs
@@ -5600,10 +5600,13 @@ impl ChatState {
             self.entries
                 .push(ChatEntry::AgentMessage(Arc::<str>::from(full_text)));
             self.mark_dirty_append();
-        } else if !self.turn_had_streaming_text && !self.turn_had_tool_calls && full_text.is_empty()
+        } else if clean
+            && !self.turn_had_streaming_text
+            && !self.turn_had_tool_calls
+            && full_text.is_empty()
         {
-            // Turn completed with no streamed text, no tool calls, and no
-            // final content — render a diagnostic so the user knows the
+            // Clean completion with no streamed text, no tool calls, and
+            // no final content — render a diagnostic so the user knows the
             // turn finished rather than silently vanishing (#8644).
             self.entries
                 .push(ChatEntry::SystemMessage(Arc::<str>::from(crate::i18n::t(
@@ -7912,6 +7915,24 @@ mod tests {
             matches!(&s.entries()[0], ChatEntry::SystemMessage(t) if t.as_ref() == "Turn completed with no output."),
             "expected diagnostic SystemMessage for empty completion, got {:?}",
             s.entries()[0]
+        );
+    }
+
+    /// When a cancelled or failed turn has no output, commit_turn must NOT
+    /// append the "Turn completed with no output" diagnostic — cancelled/
+    /// failed turns are not clean completions and should not claim otherwise.
+    #[test]
+    fn commit_turn_no_diagnostic_when_not_clean() {
+        let mut s = state();
+        s.turn_in_flight = true;
+
+        // Clean=false (cancelled/failed), empty everything.
+        s.commit_turn(String::new(), false);
+
+        assert!(
+            s.entries().is_empty(),
+            "cancelled turn should not emit completion diagnostic, got {:?}",
+            s.entries()
         );
     }
 

--- a/apps/zerocode/src/chat.rs
+++ b/apps/zerocode/src/chat.rs
@@ -5607,7 +5607,7 @@ impl ChatState {
         {
             // Clean completion with no streamed text, no tool calls, and
             // no final content — render a diagnostic so the user knows the
-            // turn finished rather than silently vanishing (#8644).
+            // turn finished rather than silently vanishing.
             self.entries
                 .push(ChatEntry::SystemMessage(Arc::<str>::from(crate::i18n::t(
                     "zc-turn-no-output",
@@ -7901,7 +7901,7 @@ mod tests {
 
     /// When a turn completes with no streamed text, no tool calls, and no
     /// final content, commit_turn must render a diagnostic system message
-    /// so the user knows the turn finished (#8644).
+    /// so the user knows the turn finished.
     #[test]
     fn commit_turn_shows_diagnostic_when_no_output_at_all() {
         let mut s = state();


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:** `commit_turn` now uses the daemon-provided `TurnComplete.content` as a fallback when no `AgentMessageChunk` streaming text was accumulated during the turn, and renders an explicit diagnostic system message when a completed turn has no assistant text, no tool calls, and no final content. Previously, empty completions were silently discarded, leaving the transcript blank after a successful turn.
- **Scope boundary:** Does not change streaming behavior, tool-call handling, or cancel/failure paths. Only affects the case where a turn completes with no streamed text.
- **Blast radius:** ZeroCode TUI transcript rendering on turn completion. No runtime, provider, gateway, or channel impact.
- **Linked issue(s):** Fixes #8644
- **Labels:** `bug`, `zerocode`, `risk:medium`, `size:S`

## Validation Evidence (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — behavior is covered by unit tests; no manual setup needed.
- **Interface(s) exercised:** `tui` — ZeroCode transcript rendering on turn completion
- **Setup / preconditions:** None
- **Steps to run:** N/A
- **Expected on this branch (after):** Empty completions render a diagnostic; non-empty final text renders as fallback; cancelled turns do not show completion diagnostic.
- **Prior behavior on `master` (before):** Empty completions silently vanish from transcript.

### How I tested

```bash
cargo fmt --all -- --check   # clean
cargo clippy -p zerocode --all-targets -- -D warnings   # clean
cargo test -p zerocode   # 443 passed, 0 failed
```

- **CI checks relied on and why they cover this change:** `cargo fmt`, `cargo clippy`, `cargo test -p zerocode` cover the changed chat.rs and locale files
- **Known CI coverage gap, if any:** None
- **Commands run and tail output:** `test result: ok. 443 passed; 0 failed`
- **Beyond CI — what did you manually verified?**
  - `commit_turn_renders_nonempty_fallback_when_no_streaming` — non-empty final text renders once when no streaming text was accumulated
  - `commit_turn_does_not_duplicate_already_flushed_text` — existing test still passes (no duplicate when streaming text was already flushed)
  - `commit_turn_shows_diagnostic_when_no_output_at_all` — empty completion with no streaming, no tools, and no final text renders the diagnostic system message
  - `commit_turn_no_diagnostic_when_not_clean` — cancelled/failed turn (clean=false) with no output does NOT append the completion diagnostic
  - `commit_turn_no_diagnostic_when_tool_calls_present` — empty completion with tool calls present does NOT add diagnostic (tool entries are the visible record)
- **If any command was intentionally skipped, why:** None

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No

## Rollback (required for medium/high-risk PRs)

- **Fast rollback:** `git revert <sha>` on the merge commit reverts the chat.rs and locale changes; no data migration needed.
- **Feature flags / toggles:** None — behavior is always-on.
- **Observable failure symptoms if rollback needed:** Users see blank transcripts after turns that produce no streaming text (the pre-existing behavior this PR fixes). Rollback restores that behavior without side effects.