### PR TITLE
fix(security): remove stale advisory ignores for crates no longer in dependency tree

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -3,29 +3,25 @@
 
 [advisories]
 ignore = [
-    # ── Synced from deny.toml — baseline triage ─────────────────────────────
+    # ── Live in both audit.toml and deny.toml ──────────────────────────────
     # Tracking: new ignores need a tracking issue URL reference.
     # Each entry below mirrors the `reason` field in deny.toml.
     # When a fix lands, remove from BOTH files.
-    "RUSTSEC-2025-0141",  # bincode unmaintained (informational, no CVE); transitive via probe-rs `builtin-targets`; behind optional `probe` feature; awaiting probe-rs upstream serialization migration
     "RUSTSEC-2025-0134",  # rustls-pemfile unmaintained; transitive dep awaiting upstream migration to rustls-pki-types
-    "RUSTSEC-2026-0097",  # rand re-entrancy unsoundness; 0.8.6 copy is patched; 0.7.x copy predates rand::rng() and is not affected
-    "RUSTSEC-2026-0104",  # rustls-webpki CRL parsing panic; 0.102.x copy via rumqttc v0.25.1 has no fix in 0.102.x series; 0.103.x copy patched at v0.103.13; awaiting rumqttc upgrade
-    "RUSTSEC-2024-0429",  # glib VariantStrIter unsoundness; transitive via zeroclaw-desktop/tauri/webkit2gtk; no compatible fix in glib 0.18.x series
-    "RUSTSEC-2026-0049",  # rustls-webpki CRL matching bug; 0.102.x copy via rumqttc v0.25.1; 0.103.x copy is patched; awaiting rumqttc upgrade
-    "RUSTSEC-2026-0098",  # rustls-webpki URI name constraints; 0.102.x copy via rumqttc v0.25.1; 0.103.x copy is patched; awaiting rumqttc upgrade
-    "RUSTSEC-2026-0099",  # rustls-webpki wildcard name constraints; 0.102.x copy via rumqttc v0.25.1; 0.103.x copy is patched; awaiting rumqttc upgrade
+    "RUSTSEC-2026-0173",  # proc-macro-error2 unmaintained; in cargo-deny's resolved graph via matrix-sdk dev-deps; tracking #8519
 
-    # ── Informational only (no tracking issue required) ────────────────────
-    "RUSTSEC-2024-0384",  # instant unmaintained; informational advisory; transitive dep
+    # ── cargo-audit reads the full Cargo.lock, so it flags advisories for
+    # crates that cargo-deny (graph-aware) does not pull into the resolved
+    # dependency graph. These entries are needed only in audit.toml. ──
+    "RUSTSEC-2026-0049",  # rustls-webpki CRL matching bug; 0.102.x in Cargo.lock but not in resolved graph; awaiting rumqttc upgrade
+    "RUSTSEC-2026-0098",  # rustls-webpki URI name constraints; same as above
+    "RUSTSEC-2026-0099",  # rustls-webpki wildcard name constraints; same as above
+    "RUSTSEC-2026-0104",  # rustls-webpki CRL parsing panic; same as above
 
-    # ── audit.toml/deny.toml drift reconcile + wasmtime CVEs; tracking #8519 ──
-    # cargo-audit reads the whole Cargo.lock, so it flags advisories cargo-deny
-    # (graph-aware) tolerates. Reconcile and remediate per #8519.
-    # RUSTSEC-2026-0149, -0182, -0188 cleared by wasmtime/wasmtime-wasi 43 -> 45.0.3
-    # bump in crates/zeroclaw-plugins. Resolved by #8542.
-    # RUSTSEC-2026-0222 cleared by wasmtime stack 45.0.3 -> 47.0.3 bump.
-    # GTK3 stack unmaintained via zeroclaw-desktop (tauri -> webkit2gtk); tracking #8519
+    # ── Still present in Cargo.lock though no longer in cargo-deny's resolved
+    # graph (removed from deny.toml in this same PR); audit-only, tracked in
+    # #8519. ──
+    "RUSTSEC-2024-0429",  # glib VariantStrIter unsoundness; GTK3 stack in Cargo.lock but not resolved graph
     "RUSTSEC-2024-0411",  # gdkwayland-sys unmaintained gtk-rs GTK3 bindings; tracking #8519
     "RUSTSEC-2024-0412",  # gdk unmaintained gtk-rs GTK3 bindings; tracking #8519
     "RUSTSEC-2024-0413",  # atk unmaintained gtk-rs GTK3 bindings; tracking #8519
@@ -36,15 +32,12 @@ ignore = [
     "RUSTSEC-2024-0418",  # gdk-sys unmaintained gtk-rs GTK3 bindings; tracking #8519
     "RUSTSEC-2024-0419",  # gtk3-macros unmaintained gtk-rs GTK3 bindings; tracking #8519
     "RUSTSEC-2024-0420",  # gtk-sys unmaintained gtk-rs GTK3 bindings; tracking #8519
-    # unic-* unmaintained unicode tables (transitive); tracking #8519
-    "RUSTSEC-2025-0075",  # unic-char-range unmaintained; tracking #8519
-    "RUSTSEC-2025-0080",  # unic-common unmaintained; tracking #8519
-    "RUSTSEC-2025-0081",  # unic-char-property unmaintained; tracking #8519
-    "RUSTSEC-2025-0098",  # unic-ucd-version unmaintained; tracking #8519
-    "RUSTSEC-2025-0100",  # unic-ucd-ident unmaintained; tracking #8519
-    # macro/font helpers unmaintained (transitive); tracking #8519.
-    # RUSTSEC-2024-0370 (proc-macro-error) was dropped when zeroclaw-desktop
-    # (Tauri) was removed in PR #8544.
-    "RUSTSEC-2026-0173",  # proc-macro-error2 unmaintained; transitive macro helper; tracking #8519
-    "RUSTSEC-2024-0388",  # derivative unmaintained; transitive derive helper; tracking #8519
+    "RUSTSEC-2025-0075",  # unic-char-range unmaintained; in Cargo.lock but not resolved graph; tracking #8519
+    "RUSTSEC-2025-0080",  # unic-common unmaintained; in Cargo.lock but not resolved graph; tracking #8519
+    "RUSTSEC-2025-0081",  # unic-char-property unmaintained; in Cargo.lock but not resolved graph; tracking #8519
+    "RUSTSEC-2025-0098",  # unic-ucd-version unmaintained; in Cargo.lock but not resolved graph; tracking #8519
+    "RUSTSEC-2025-0100",  # unic-ucd-ident unmaintained; in Cargo.lock but not resolved graph; tracking #8519
+    "RUSTSEC-2024-0388",  # derivative unmaintained; in Cargo.lock but not resolved graph; tracking #8519
+    "RUSTSEC-2025-0141",  # bincode unmaintained (informational, no CVE); in Cargo.lock but not resolved graph; tracking #8519
+    "RUSTSEC-2024-0384",  # instant unmaintained (informational); in Cargo.lock but not resolved graph; tracking #8519
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -9,60 +9,12 @@ unmaintained = "all"
 yanked = "deny"
 # Ignore known unmaintained transitive deps we cannot easily replace
 ignore = [
-    # bincode -- unmaintained advisory (informational only, no CVE); team ceased
-    # development after a doxxing/harassment incident; advisory affects all
-    # versions including 2.x. In our tree, bincode is pulled in only via
-    # probe-rs 0.31's `builtin-targets` feature (precompiled chip definitions)
-    # behind the optional `probe` cargo feature on zeroclaw-tools and
-    # zeroclaw-hardware. probe-rs is the de facto Rust embedded debug toolchain
-    # with no alternative; replacing builtin-targets requires runtime Registry
-    # construction (separate work). Not in any default build path.
-    { id = "RUSTSEC-2025-0141", reason = "bincode unmaintained (informational, no CVE); transitive via probe-rs `builtin-targets`; behind optional `probe` feature; awaiting probe-rs upstream serialization migration" },
-    # rand -- re-entrancy unsoundness via custom global logger; fixed in rand 0.8.6
-    # for the 0.8.x copy in our tree; the 0.7.x copy predates rand::rng() entirely
-    # and is not affected; the 0.9.x copy is outside the advisory's affected range
-    { id = "RUSTSEC-2026-0097", reason = "rand re-entrancy unsoundness; 0.8.6 copy is patched; 0.7.x copy predates rand::rng() and is not affected" },
     # rustls-pemfile -- unmaintained, functionality moved to rustls-pki-types;
     # transitive dep, upstream migration tracked
     { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile unmaintained; transitive dep awaiting upstream migration to rustls-pki-types" },
-    # rustls-webpki -- two versions in tree; direct dep bumped in #5786 but a
-    # second transitive copy via rumqttc v0.25.1 remains; all advisories below
-    # affect only the 0.102.x copy; the 0.103.x copy is patched.
-    # Revisit when rumqttc upgrades past rustls-webpki 0.102.x; tracking #5869 / #8519.
-    { id = "RUSTSEC-2026-0049", reason = "rustls-webpki CRL matching bug; 0.102.x copy via rumqttc v0.25.1; 0.103.x copy is patched; awaiting rumqttc upgrade; tracking #8519" },
-    { id = "RUSTSEC-2026-0098", reason = "rustls-webpki URI name constraints; 0.102.x copy via rumqttc v0.25.1; 0.103.x copy is patched; awaiting rumqttc upgrade; tracking #8519" },
-    { id = "RUSTSEC-2026-0099", reason = "rustls-webpki wildcard name constraints; 0.102.x copy via rumqttc v0.25.1; 0.103.x copy is patched; awaiting rumqttc upgrade; tracking #8519" },
-    { id = "RUSTSEC-2026-0104", reason = "rustls-webpki CRL parsing panic; 0.102.x copy via rumqttc v0.25.1 has no fix in 0.102.x series; 0.103.x copy patched at v0.103.13; awaiting rumqttc upgrade; tracking #8519" },
-    # glib -- unsoundness in VariantStrIter Iterator/DoubleEndedIterator impls;
-    # transitive via zeroclaw-desktop (tauri -> webkit2gtk); glib 0.18.5 is the
-    # latest compatible version with the GTK3 stack; fix requires gtk-rs series bump
-    { id = "RUSTSEC-2024-0429", reason = "glib VariantStrIter unsoundness; transitive via zeroclaw-desktop/tauri/webkit2gtk; no compatible fix in glib 0.18.x series" },
-    # audit.toml/deny.toml drift reconcile + wasmtime CVEs; tracking #8519.
-    # RUSTSEC-2026-0149, -0182, -0188 cleared by wasmtime/wasmtime-wasi 43 -> 45.0.3
-    # bump in crates/zeroclaw-plugins. Resolved by #8542.
-    # RUSTSEC-2026-0222 cleared by wasmtime stack 45.0.3 -> 47.0.3 bump.
-    # GTK3 stack unmaintained via zeroclaw-desktop (tauri -> webkit2gtk); tracking #8519.
-    { id = "RUSTSEC-2024-0411", reason = "gdkwayland-sys unmaintained gtk-rs GTK3 bindings; tracking #8519" },
-    { id = "RUSTSEC-2024-0412", reason = "gdk unmaintained gtk-rs GTK3 bindings; tracking #8519" },
-    { id = "RUSTSEC-2024-0413", reason = "atk unmaintained gtk-rs GTK3 bindings; tracking #8519" },
-    { id = "RUSTSEC-2024-0414", reason = "gdkx11-sys unmaintained gtk-rs GTK3 bindings; tracking #8519" },
-    { id = "RUSTSEC-2024-0415", reason = "gtk unmaintained gtk-rs GTK3 bindings; tracking #8519" },
-    { id = "RUSTSEC-2024-0416", reason = "atk-sys unmaintained gtk-rs GTK3 bindings; tracking #8519" },
-    { id = "RUSTSEC-2024-0417", reason = "gdkx11 unmaintained gtk-rs GTK3 bindings; tracking #8519" },
-    { id = "RUSTSEC-2024-0418", reason = "gdk-sys unmaintained gtk-rs GTK3 bindings; tracking #8519" },
-    { id = "RUSTSEC-2024-0419", reason = "gtk3-macros unmaintained gtk-rs GTK3 bindings; tracking #8519" },
-    { id = "RUSTSEC-2024-0420", reason = "gtk-sys unmaintained gtk-rs GTK3 bindings; tracking #8519" },
-    # unic-* unmaintained unicode tables (transitive); tracking #8519.
-    { id = "RUSTSEC-2025-0075", reason = "unic-char-range unmaintained; tracking #8519" },
-    { id = "RUSTSEC-2025-0080", reason = "unic-common unmaintained; tracking #8519" },
-    { id = "RUSTSEC-2025-0081", reason = "unic-char-property unmaintained; tracking #8519" },
-    { id = "RUSTSEC-2025-0098", reason = "unic-ucd-version unmaintained; tracking #8519" },
-    { id = "RUSTSEC-2025-0100", reason = "unic-ucd-ident unmaintained; tracking #8519" },
-    # macro/font helpers unmaintained (transitive); tracking #8519.
-    # RUSTSEC-2024-0370 (proc-macro-error) was dropped when zeroclaw-desktop
-    # (Tauri) was removed in PR #8544.
-    { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 unmaintained; transitive macro helper; tracking #8519" },
-    { id = "RUSTSEC-2024-0388", reason = "derivative unmaintained; transitive derive helper; tracking #8519" },
+    # proc-macro-error2 -- unmaintained derive/attribute macro helper; still in
+    # the resolved graph via matrix-sdk dev-deps (aquamarine) in zeroclaw-channels
+    { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 unmaintained; transitive macro helper via matrix-sdk dev-deps; tracking #8519" },
 ]
 
 [licenses]

--- a/docs/maintainers/audit-policy.md
+++ b/docs/maintainers/audit-policy.md
@@ -23,22 +23,39 @@ no-longer-needed ignore.
   resolved dep graph and only reports advisories for crates actually
   pulled in by the workspace.
 
-The result is that `cargo audit` can fail with advisories
+The result is that `cargo audit` can report advisories
 `cargo deny` considers non-applicable, even when both files are
 configured against the same `Cargo.lock`. The drift between the two
 tools is tracked in **#8519**.
 
-When the two tools disagree, the Security job in
-`.github/workflows/ci.yml` runs **both** `cargo audit` and
-`cargo deny check advisories` as hard gates. A non-zero exit from
-either tool blocks the PR.
+The Security job in `.github/workflows/ci.yml` runs **both** `cargo
+audit` and `cargo deny check advisories`. A non-zero exit from either
+tool blocks the PR. What actually fails each tool differs by category:
 
-The difference between the tools is **scope**, not enforcement:
+- **`cargo audit`** (bare, no `--deny warnings`): vulnerability
+  advisories are errors (exit 1); informational and unmaintained
+  advisories are reported as allowed warnings and exit 0.
+- **`cargo deny check advisories`**: vulnerability *and* unmaintained
+  advisories for crates in the resolved graph are errors (exit 1) —
+  that is exactly why the two live unmaintained denies
+  (`rustls-pemfile`, `proc-macro-error2`) must stay in `deny.toml`.
+  A stale graph-ignore instead emits `advisory-not-detected`, which is
+  a warning (exit 0); it is never triggered by removing an entry from
+  `.cargo/audit.toml`.
+
+An audit-only ignore covers a crate `cargo deny`'s resolved graph does
+not pull in, so it affects only `cargo audit`: removing it while the
+crate stays locked re-reports the advisory as an allowed warning (exit
+0), not a CI failure. Keeping it is therefore accepted full-lock noise
+control, not a hard-gate bypass — but dropping it does not break the
+gate.
+
+The difference between the tools is **scope**, not severity:
 `cargo audit` reports every advisory touching the lockfile, while
 `cargo deny` only reports advisories for crates in the resolved
 workspace graph. Use the narrower `cargo deny` result to confirm an
-advisory is not actually pulled in, but treat both CI failures as
-blocking.
+advisory is not actually pulled in; keep the audit-only entry while
+the crate remains locked.
 
 ---
 
@@ -49,20 +66,21 @@ There are two kinds of ignored advisory:
 ### 1. Real CVE / vulnerability (must be remediated)
 
 These ignores mark advisories with an exploitable bug. They are
-**temporary** and must be removed when a fix lands. The remaining live
-example is the wasmtime-wasi CVE bundle in **#8519**:
-`RUSTSEC-2026-0149`, `-0182`, `-0188`, which is cleared by the
-wasmtime `43` → `45.0.3` bump in `crates/zeroclaw-plugins/Cargo.toml`
-(see PR #8542, awaiting maintainer re-approval after the latest
-`upstream/master` merge).
+**temporary** and must be removed when a fix lands. There is currently
+no live entry in this category: the wasmtime-wasi CVE bundle tracked in
+**#8519** (`RUSTSEC-2026-0149`, `-0182`, `-0188`, then `-0222`) was
+cleared by the `45.0.3` bump in PR #8542 and the subsequent `47.0.3`
+bump in PR #9589, which also removed the temporary waivers from both
+files.
 
 **Process for this category:**
 
 - Add the entry with a single-line `reason` ending in the tracking
   issue URL or PR number.
 - When a fix lands, remove the entry from **both** `.cargo/audit.toml`
-  *and* `deny.toml` in the same PR. A drift here re-introduces the
-  original CI failure.
+  *and* `deny.toml` in the same PR. Leaving a stale ignore behind makes
+  `cargo deny` emit `advisory-not-detected` (a warning, not a gate
+  failure) for the entry, so keep the two files in sync.
 - Each file has a one-line `── tracking #... ──` header above its
   block. Preserve the header when adding entries to the same category;
   introduce a new header for a new category.
@@ -75,52 +93,95 @@ successor on the dependency lines we use. They are
 is replaced (e.g. GTK3 → GTK4, rumqttc upgrade that pulls
 `rustls-webpki 0.103.x`).
 
-Live groups:
+Live, deny+audit (both files):
 
+- **`rustls-pemfile` (`RUSTSEC-2025-0134`)**: unmaintained;
+  transitive dep awaiting upstream migration to `rustls-pki-types`.
+  Present in both `deny.toml` and `audit.toml`.
+- **`proc-macro-error2` (`RUSTSEC-2026-0173`)**: unmaintained
+  derive/attribute macro helper. Still in `cargo deny`'s resolved graph
+  via `matrix-sdk` dev-deps (`aquamarine`) in `zeroclaw-channels`, so it
+  needs the ignore in both files.
+
+Live, audit-only (`cargo deny`'s resolved graph no longer pulls these
+in, but they remain in `Cargo.lock` and `cargo audit` reads the whole
+lockfile — remove from `audit.toml` only once the crate is either
+dropped from `Cargo.lock` entirely, e.g. via `cargo update` or a
+dependency bump, or every locked version of it is patched/unaffected
+per the advisory):
+
+- **`rustls-webpki` (4 entries, `RUSTSEC-2026-0049`, `-0098`, `-0099`,
+  `-0104`)**: 0.102.x copy is in `Cargo.lock` but not in the resolved
+  dependency graph. `cargo deny` does not flag it; `cargo audit` does.
+- **GTK3 stack (11 entries, `RUSTSEC-2024-0411..-0420`, `-0429`)**:
+  `gdk`/`gtk`/`atk`-family gtk-rs bindings and `glib`. Present in
+  `Cargo.lock` — `zeroclaw-desktop` (Tauri) was removed in PR #8544
+  and reintroduced in PR #8565 — but not needed by `cargo deny`'s
+  current default-target resolved graph (`cargo deny check bans` and
+  `check advisories` both pass clean without these ignores). Do not
+  assume this means the crates are gone from the tree; re-check with
+  `grep '^name = "<crate>"$' Cargo.lock` before removing from
+  `audit.toml`. Tracking #8519.
 - **`unic-*` (5 entries, `RUSTSEC-2025-0075`, `-0080`, `-0081`,
-  `-0098`, `-0100`)**: Unicode data tables. Transitive via
-  `pulldown-cmark` and `mime_guess`. Both crates still depend on
-  `unicase` in their latest releases; replacing either requires
-  rewriting downstream code (`apps/zerocode/src/chat.rs` for
-  `pulldown-cmark`, multiple MIME-type call sites for `mime_guess`) or
-  waiting for upstream releases that drop the dependency. Tracking
+  `-0098`, `-0100`)**: Unicode data tables, previously transitive via
+  `pulldown-cmark` and `mime_guess`. Same drift as above; tracking
   #8519.
-- **macro / font helpers (3 entries, `RUSTSEC-2026-0173`,
-  `-2024-0388`, `-2026-0192`)**: `proc-macro-error2`, `derivative`,
-  `ttf-parser`. Transitive derive / macro helpers; replacing each
-  requires coordinated upstream migration.
-  - `proc-macro-error` (`RUSTSEC-2024-0370`) was cleared when
-    `zeroclaw-desktop` (Tauri) was removed in PR #8544.
-  - `ttf-parser` is handled by PR #8547, which removes the `rag-pdf`
-    feature and the `pdf-extract -> lopdf -> ttf-parser` chain.
-  Tracking #8519.
+- **macro / font helpers (1 entry, `RUSTSEC-2024-0388`)**:
+  `derivative`. Same drift; tracking #8519.
+- **`bincode` (`RUSTSEC-2025-0141`)**: previously transitive via
+  `probe-rs builtin-targets`. Same drift; tracking #8519.
+- **`instant` (`RUSTSEC-2024-0384`)**: informational-only unmaintained
+  advisory. Same drift; tracking #8519.
 
-Resolved groups:
+Resolved (safe to drop from both files — either the crate is gone
+from `Cargo.lock` entirely, or every locked version is patched /
+unaffected by the advisory):
 
-- **GTK3 stack (10 entries, `RUSTSEC-2024-0411..-0420`)**: pulled in
-  transitively by the now-removed `zeroclaw-desktop` (Tauri →
-  webkit2gtk → gtk-rs bindings). These ignore entries were dropped in
-  PR #8544 along with the desktop app. No GTK3 code remains in the
-  workspace.
+- **`rand` (`RUSTSEC-2026-0097`)**: re-entrancy unsoundness in a
+  custom global logger. `Cargo.lock` still resolves `rand` 0.8.6,
+  0.9.4, and 0.10.1 — the crate is not absent — but the
+  [advisory](https://rustsec.org/advisories/RUSTSEC-2026-0097.html)
+  marks all three of those versions as patched, so no locked copy is
+  affected and the ignore is no longer needed.
 
 **Process for this category:**
 
 - Use a short reason naming the crate role, e.g.
-  `gtk-rs GTK3 bindings; transitive via zeroclaw-desktop/tauri/webkit2gtk`.
+  `gtk-rs GTK3 bindings; transitive via zeroclaw-desktop/tauri`.
 - Do not add `; tracking #...` for entries that are stable
   unmaintained warnings and unlikely to be resolved in the next
   release cycle.
-- When a replacement lands upstream and the dep gets bumped, remove
-  the entry from both files.
+- An entry drops out of `deny.toml` as soon as `cargo deny`'s resolved
+  graph no longer needs it — that is a graph fact, not a lockfile fact,
+  and it can change on the next dependency bump or feature change
+  without the crate leaving `Cargo.lock`. It only drops out of
+  `audit.toml` once the crate is either gone from `Cargo.lock`
+  entirely or every locked version of it is patched/unaffected per the
+  advisory. Removing an audit-only entry while a still-affected
+  version remains resolvable makes `cargo audit` report the advisory
+  again as an allowed warning (it does not fail CI — `cargo audit`
+  exits 0 on warnings under the configured invocation) — but it drops
+  the accepted full-lock noise control this document records. Always
+  check `Cargo.lock` and the advisory's patched-version range directly,
+  not just `cargo deny`'s last result.
 
 ---
 
 ## Tracking issues
 
 - **#8519**: *Reconcile cargo-audit ignores and remediate wasmtime-wasi
-  CVEs.* Master issue for the audit/deny drift and the unmaintained
-  GTK3 / unic-* / macro entries. Updates belong in the comments of
-  the affected entries, not in this file.
+  CVEs.* Master issue for the audit/deny drift. The wasmtime-wasi CVE
+  bundle is fully remediated (PR #8542, then PR #9589) and no longer
+  needs an ignore in either file. The GTK3 stack, unic-*, macro/font
+  helpers, `bincode`, and `instant` are no longer needed in
+  `deny.toml` (removed from the resolved dependency graph) but remain
+  audit-only ignores in `.cargo/audit.toml` until they're gone from
+  `Cargo.lock`. `rand` is removed from both files because every
+  locked version (0.8.6, 0.9.4, 0.10.1) is patched per the advisory,
+  not because the crate left `Cargo.lock`. Remaining deny+audit live
+  ignores: `rustls-pemfile`, `proc-macro-error2`. Remaining
+  audit-only ignores: `rustls-webpki` (4) plus the 19 lockfile-stale
+  entries above.
 - **#8059**: *Policy cleanup: deny.toml ignored-advisory tracking,
   multiple-versions, wildcards.* piiiico's RFC on adding per-entry
   rationale to `deny.toml` ignore blocks. This doc is the
@@ -152,6 +213,73 @@ two tools have drifted again. Open or update the tracking issue.
 
 ## Change log
 
+- 2026-08-04: Rebased onto `upstream/master`, which merged PR #9589
+  (wasmtime `45.0.3` → `47.0.3`, clearing `RUSTSEC-2026-0222` and
+  removing the waiver from both files). Removed the now-stale
+  wasmtime references from the "Real CVE" category, the "Live,
+  audit-only" list, and the #8519 tracking summary above — there is
+  currently no live entry in the real-CVE category.
+- 2026-08-03: Corrected the in-file block classification in
+  `.cargo/audit.toml` to match the actual file contents: `wasmtime`
+  (`RUSTSEC-2026-0222`) is back in the audit-only block (it was
+  removed from `deny.toml`, so "Live in both" was wrong), and
+  `proc-macro-error2` (`RUSTSEC-2026-0173`) moved to the "Live in
+  both" block (it is present in `deny.toml`). Also corrected the
+  enforcement claims per tool: under the configured invocations,
+  informational/unmaintained advisories are allowed warnings in
+  `cargo audit` (exit 0) but unmaintained advisories for crates in
+  `cargo deny`'s resolved graph are errors (exit 1) — hence the two
+  live unmaintained denies — while `advisory-not-detected` is `cargo
+  deny`'s stale graph-ignore warning (exit 0). `rand`
+  (`RUSTSEC-2026-0097`) was the only entry removed from
+  `.cargo/audit.toml` in this PR; everything else that left `deny.toml`
+  remains an audit-only ignore here.
+- 2026-07-31: Corrected the 07-19 pass for `proc-macro-error2`
+  (`RUSTSEC-2026-0173`): it is still in `cargo deny`'s resolved graph
+  via `matrix-sdk` dev-deps (`aquamarine`) in `zeroclaw-channels`, so it
+  is a live deny+audit ignore, not audit-only drift — removed from
+  `deny.toml` in the 07-06/07-19 passes, it re-fails `cargo deny check`.
+  Restored it in `deny.toml`. Also moved `wasmtime` (`RUSTSEC-2026-0222`)
+  to audit-only: it sits behind the optional `plugins-wasmtime` feature,
+  so `cargo deny` no longer matches it (`advisory-not-detected`), while
+  `cargo audit` still reads the `45.0.3` copy from `Cargo.lock`.
+- 2026-07-22: Tightened the "Live, audit-only" intro to state the
+  complete removal criterion (crate absent from `Cargo.lock`, *or*
+  every locked version patched/unaffected) instead of only the
+  crate-absent half. Removed an inaccurate `.cargo/audit.toml` header
+  claim that the 20 lockfile-stale entries each have a replacement
+  "already landed or in flight" — they are simply audit-only and
+  tracked in #8519.
+- 2026-07-21: Corrected the `rand` rationale: `Cargo.lock` still
+  resolves `rand` 0.8.6, 0.9.4, and 0.10.1, so the crate was never
+  absent from the lockfile. The ignore is removed from both files
+  because `RUSTSEC-2026-0097` marks all three locked versions as
+  patched, not because `rand` disappeared. Reworded the "Resolved"
+  category and its process bullet to state the actual removal
+  criterion: crate absent from `Cargo.lock`, *or* every locked version
+  patched/unaffected per the advisory.
+- 2026-07-19: Corrected the 07-06 pass, which removed 20 entries from
+  `.cargo/audit.toml` (`unic-*`, `proc-macro-error2`, `derivative`,
+  `instant`, `bincode`, `glib`, all 10 GTK3 stack entries) that were
+  still present in `Cargo.lock` and still reported by `cargo audit`.
+  Restored those 20 as audit-only ignores; they remain removed from
+  `deny.toml`, where `cargo deny`'s resolved graph still doesn't need
+  them even after the `zeroclaw-desktop` (Tauri) reintroduction in PR
+  #8565 (`cargo deny check advisories`/`bans` verified clean). `rand`
+  (`RUSTSEC-2026-0097`) stays removed from both files: it is still
+  resolved in `Cargo.lock` (0.8.6, 0.9.4, 0.10.1), but the advisory
+  marks all three of those versions as patched, so no ignore is
+  needed.
+- 2026-07-06: Removed advisory ignores from `deny.toml` for crates no
+  longer in `cargo deny`'s resolved dependency graph: `unic-*`
+  (5 entries), `proc-macro-error2`, `derivative`, `instant`, `bincode`,
+  `glib`, all GTK3 stack entries, `rand` (all locked versions patched
+  per the advisory), and the `rustls-webpki` entries (0.102.x no longer in resolved
+  graph). Remaining deny+audit ignore: `rustls-pemfile` (1). Remaining
+  audit-only ignores: `rustls-webpki` (4 entries; in `Cargo.lock` but
+  not in resolved dep graph). Cleared the stale `advisory-not-detected`
+  warnings `cargo deny` emitted for entries whose crates left its
+  resolved graph (a warning class, not a gate failure).
 - 2026-07-01: Updated after `upstream/master` merge. Documented that
   the GTK3 stack was resolved by PR #8544 (Tauri desktop removal),
   `proc-macro-error` ignore was dropped, `ttf-parser` is being handled


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:** Removes 24 of 26 advisory-ignore entries from `deny.toml`. `cargo deny` checks the resolved dependency graph, and none of these crates are in it anymore: GTK3 stack (`gdk*`/`gtk*`/`atk*`, 10 entries), `unic-*` (5), `rustls-webpki` 0.102.x (4), `glib`, `bincode`, `derivative`, and `rand`. (`wasmtime` was also in this drift set originally, but PR #9589 landed on `master` since this branch was opened and fully remediated it in both files via a dependency bump, so it's no longer part of this PR's diff after the rebase.) The remaining two `deny.toml` ignores are the graph-live ones: `rustls-pemfile` (`RUSTSEC-2025-0134`) and `proc-macro-error2` (`RUSTSEC-2026-0173`, via `matrix-sdk` dev-deps).
  `.cargo/audit.toml` reads the full `Cargo.lock`, so it keeps audit-only ignore entries for the crates that are still in the lockfile but outside the resolved graph (23 audit-only + 2 shared = 25 total). `rand` is the one entry removed from `audit.toml`: it is still resolved (0.8.6, 0.9.4, 0.10.1) but `RUSTSEC-2026-0097` marks all three as patched, so the ignore is no longer needed. `docs/maintainers/audit-policy.md` is updated to document the deny-vs-audit distinction and to correct a stale claim that `zeroclaw-desktop` (the GTK3 stack's transitive source) had been permanently removed — it was reintroduced in PR #8565. It also corrects the enforcement claims per tool: under the configured invocations, informational/unmaintained advisories are allowed warnings in `cargo audit` (exit 0), but unmaintained advisories for crates in `cargo deny`'s resolved graph are errors (exit 1) — hence the two live unmaintained denies — while `advisory-not-detected` is cargo-deny's stale graph-ignore warning (exit 0), not a gate triggered by removing an `audit.toml` entry.
- **Scope boundary:** Does not change any runtime, provider, gateway, or channel behavior. Only touches `deny.toml`, `.cargo/audit.toml`, and `docs/maintainers/audit-policy.md`.
- **Blast radius:** Security CI gate only. All other CI gates unaffected.
- **Linked issue(s):** Refs #8519 — the wasmtime-wasi CVE bundle and the full audit/deny reconciliation tracked there are not fully resolved by this PR; this PR narrows the drift for the `unic-*`/GTK3/macro-helper/`bincode`/`glib`/`rand` group only. #8519 stays open.
- **Labels:** `bug`, `docs`, `dependencies`, `principal contributor`, `domain:security`, `risk:medium`, `size:S`, `type:dependencies`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — docs/config-only change; the Security CI job runs both `cargo audit` and `cargo deny check advisories bans` at the pinned toolchain, matching the commands below.
- **Interface(s) exercised:** `cli` — `cargo deny check advisories bans`, `cargo audit`

### How I tested

- **CI checks relied on and why they cover this change:** The Security job runs `cargo audit` and `cargo deny check advisories bans` at the pinned `1.96.1` toolchain, covering the exact advisory/ban surface this PR changes. Format, Lint, and all other required checks are also green.
- **Known CI coverage gap, if any:** None; the Security job covers the changed surface.
- **Commands run and tail output:**
```bash
cargo audit                     # exit 0 — "4 allowed warnings found" (proc-macro-error, event-listener, async-utility, spin: pre-existing, unrelated to this PR's scope)
cargo deny check advisories bans   # "advisories ok, bans ok"
cargo fmt --all -- --check      # clean (docs/config only, no Rust changes)
```
- **Beyond CI, what did you manually verify?**
  - Local toolchain: `rustc 1.96.0`. CI pins a fixed `1.96.1` toolchain (`dtolnay/rust-toolchain@... toolchain: 1.96.1`) across every workflow, including the Security job — not a floating `stable`, correcting an earlier revision of this PR body that claimed otherwise.
  - `deny.toml` contains exactly two advisory ignores: `rustls-pemfile` (`RUSTSEC-2025-0134`) and `proc-macro-error2` (`RUSTSEC-2026-0173`), both graph-live (verified via `cargo tree`).
  - `.cargo/audit.toml` contains 25 ignore entries: 2 shared with `deny.toml` (`rustls-pemfile`, `proc-macro-error2`) + 23 audit-only (`rustls-webpki` ×4, GTK3 stack ×11, `unic-*` ×5, `derivative`, `bincode`, `instant`). `wasmtime` was removed from this list entirely by PR #9589 landing on `master` during the rebase. Each remaining audit-only entry's crate is still present in `Cargo.lock` (verified via `grep '^name = "<crate>"$' Cargo.lock`).
  - Confirmed `rand` is still resolved in `Cargo.lock` at 0.8.6, 0.9.4, and 0.10.1; the ignore is removed because `RUSTSEC-2026-0097` marks all three as patched, not because the crate is absent.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No

## Rollback (required for medium/high-risk PRs)

Revert the eventual squash-merge commit on `master` (not `git revert <sha>` against a placeholder sha, since squash-merge produces a single new commit whose sha isn't known until merge). Reverting restores the pre-PR ignore lists in both files and the prior (stale) `audit-policy.md` wording.


