### PR TITLE
fix(deps): bump crossbeam-epoch to 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2102,9 +2102,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:** Bumps `crossbeam-epoch` `0.9.18` -> `0.9.20` in `Cargo.lock` to clear **RUSTSEC-2026-0204** (invalid pointer dereference in the `fmt::Pointer` impl for `Atomic` and `Shared` when the underlying pointer is invalid). Both `cargo audit` and `cargo deny check advisories` error on the 0.9.18 copy, which was blocking merges.
- **Scope boundary:** Lockfile-only. No manifest (`Cargo.toml`) edits, no source changes, no `deny.toml`/`.cargo/audit.toml` ignore entries. The advisory is a real vulnerability, not an unmaintained notice, so it is fixed by bumping rather than ignored.
- **Blast radius:** `crossbeam-epoch` enters the tree transitively as a dev-dependency via `criterion -> rayon -> rayon-core -> crossbeam-deque`. It is not in any shipped binary path; only benchmark/test builds consume it. `cargo audit`/`cargo deny` scan the whole `Cargo.lock`, which is why it gated merges.
- **Linked issue(s):** Closes #8782
- **Labels:** `dependencies`, `type:dependencies`, `risk:low`, `size:XS`

## Validation Evidence (required)

```bash
cargo audit
cargo deny check advisories
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- **Commands run and tail output:**
  - `cargo audit` (after bump):
    ```
    warning: 1 allowed warning found
    ```
    0 vulnerabilities. The single remaining allowed warning is `proc-macro-error` unmaintained (informational, pre-existing baseline). Before the bump this reported `error: 1 vulnerability found!` for RUSTSEC-2026-0204.
  - `cargo deny check advisories`:
    ```
    advisories ok
    ```
  - `cargo fmt --all -- --check`: exit 0, no diff.
  - `cargo clippy --all-targets -- -D warnings`:
    ```
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 34s
    ```
    No warnings or errors.
  - `cargo test`: all completed suites passed (e.g. `245 passed; 0 failed`, `300 passed; 0 failed`, `189 passed; 0 failed`, `158 passed; 0 failed`); 0 failures across the run.
- **Beyond CI — what did you manually verify?** Confirmed via `cargo tree -i crossbeam-epoch` that the crate is a dev-only transitive dep (criterion -> rayon -> crossbeam-deque), so no shipped binary path changes. Confirmed the advisory solution range (`>=0.9.20`) is satisfied. Confirmed no open or queued Dependabot PR covers it (grouped `rust-all`, manifest-driven; it cannot surface a pure transitive lockfile bump).
- **If any command was intentionally skipped, why:** None skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: N/A. This is a security-positive change: it removes a known advisory from the dependency tree.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: exact upgrade steps for existing users: None. Semver-compatible patch bump within `0.9.x`; no API or behavior change reaches this project.

## Rollback (required for medium/high-risk PRs)

Low-risk. `git revert <sha>` restores the prior `Cargo.lock` entry, which reintroduces the advisory.
