### PR TITLE
refactor(runtime): split-history loop contract for Agent entry points (PR-1 of #7846 rework)

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -119,11 +119,11 @@ use zeroclaw_providers::reliable::{scope_provider_fallback, take_last_provider_f
 use zeroclaw_providers::{self, ChatMessage, ModelProvider, ProviderDispatch};
 use zeroclaw_runtime::agent::loop_::{
     LoopKnobs, ResolvedAgentExecution, ResolvedIo, ResolvedModelAccess, ResolvedRuntimeKnobs,
-    ToolLoop, apply_policy_tool_filter, apply_text_tool_prompt_policy,
+    ToolLoopWithCurrentTurn, apply_policy_tool_filter, apply_text_tool_prompt_policy,
     build_tool_instructions_for_names, clear_model_switch_request, eager_mcp_tool_allowed,
     get_model_switch_state, is_model_switch_requested, mcp_tool_access_policy,
-    register_eager_mcp_tool_if_allowed, run_tool_call_loop, scope_session_key, scope_thread_id,
-    scrub_credentials,
+    register_eager_mcp_tool_if_allowed, run_tool_call_loop_with_current_turn, scope_session_key,
+    scope_thread_id, scrub_credentials,
 };
 use zeroclaw_runtime::approval::ApprovalManager;
 use zeroclaw_runtime::observability::traits::{ObserverEvent, ObserverMetric};
@@ -5328,6 +5328,15 @@ async fn process_channel_message_body(
         Some(ctx.agent_alias.to_string()),
         Some(turn_id.clone()),
     );
+    // Split history at the last user message to separate the durable
+    // past-turn prefix from the mutable current-turn working set. This
+    // boundary stays stable across model-switch retries without needing
+    // to re-discover it by content inspection.
+    let split = history
+        .iter()
+        .rposition(|m| m.role == "user")
+        .unwrap_or(history.len());
+    let mut current_turn = history.split_off(split);
     let (llm_result, fallback_info) = scope_provider_fallback(async {
         let llm_result = loop {
             let thread_scope_id = msg
@@ -5341,7 +5350,7 @@ async fn process_channel_message_body(
                 } else {
                     ctx.non_cli_excluded_tools.as_ref()
                 };
-            let tool_loop = run_tool_call_loop(ToolLoop {
+            let tool_loop = run_tool_call_loop_with_current_turn(ToolLoopWithCurrentTurn {
                 exec: ResolvedAgentExecution::resolve(
                     ResolvedModelAccess {
                         model_provider: active_model_provider.as_ref(),
@@ -5373,6 +5382,7 @@ async fn process_channel_message_body(
                     },
                 ),
                 history: &mut history,
+                current_turn: &mut current_turn,
                 channel_name: msg.channel.as_str(),
                 channel_reply_target: Some(msg.reply_target.as_str()),
                 cancellation_token: Some(cancellation_token.clone()),
@@ -5388,7 +5398,7 @@ async fn process_channel_message_body(
                     .map(|_| tool_receipts_collector.as_ref()),
                 event_tx: None,
                 steering: None,
-                new_messages_out: None,
+
                 image_cache: None,
                 // Channel-orchestrator dispatch; source/transport/trust stay
                 // placeholders, not yet stamped at the edge.
@@ -5526,6 +5536,9 @@ async fn process_channel_message_body(
         (llm_result, fb)
     })
     .await;
+
+    // Merge the completed current turn back into the durable history.
+    history.extend(current_turn);
 
     // Attribute the closing event to the final route and attach aggregate
     // usage. Explicit completion records the normal duration; the guard's

--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -988,11 +988,9 @@ impl Agent {
         ))
     }
 
-    async fn append_streamed_user_message_to_history(
-        &mut self,
-        user_message: &str,
-        new_msgs: &mut Vec<ConversationMessage>,
-    ) {
+    /// Build the enriched user message for this turn (memory context + timestamp
+    /// + raw text) and return it as a `ChatMessage`.
+    async fn build_enriched_user_message(&mut self, user_message: &str) -> ChatMessage {
         // Memory context is injected once in the engine, keyed on the
         // ingress origin (agent::memory_inject).
         if self.auto_save {
@@ -1017,9 +1015,7 @@ impl Agent {
         let now = self.current_turn_datetime().format("%Y-%m-%d %H:%M:%S %Z");
         let enriched = format!("[{now}] {user_message}");
 
-        let user_msg = ConversationMessage::Chat(ChatMessage::user(enriched));
-        new_msgs.push(user_msg.clone());
-        self.history.push(user_msg);
+        ChatMessage::user(enriched)
     }
 
     pub fn set_memory_session_id(&mut self, session_id: Option<String>) {
@@ -2093,8 +2089,18 @@ impl Agent {
             });
         }
 
+        // Split the provider-visible transcript at the last user message: the
+        // prefix becomes the loop's read-only `history`, the suffix (starting
+        // at this turn's enriched user message) becomes the mutable
+        // `current_turn` working set the loop appends assistant/tool messages
+        // to. `provider_messages` already ends with the user message, so the
+        // split keeps it as `loop_current_turn[0]`.
+        let split = provider_messages
+            .iter()
+            .rposition(|m| m.role == "user")
+            .unwrap_or(provider_messages.len());
         let mut loop_history = provider_messages;
-        let mut loop_new_messages: Vec<ChatMessage> = Vec::new();
+        let mut loop_current_turn: Vec<ChatMessage> = loop_history.split_off(split);
 
         let knobs = crate::agent::loop_::LoopKnobs {
             dedup_enabled: false,
@@ -2122,69 +2128,77 @@ impl Agent {
                 Some(cost_context.clone()),
                 crate::agent::tool_receipts::scope_receipts(
                     receipt_scope.clone(),
-                    crate::agent::loop_::run_tool_call_loop(crate::agent::loop_::ToolLoop {
-                        exec: crate::agent::loop_::ResolvedAgentExecution::resolve(
-                            crate::agent::loop_::ResolvedModelAccess {
-                                model_provider: self.model_provider.as_ref(),
-                                provider_name: &self.model_provider_name,
-                                model: &effective_model,
-                                temperature: self.temperature,
-                            },
-                            crate::agent::loop_::ResolvedIo {
-                                tools_registry: &self.tools,
-                                observer: self.observer.as_ref(),
-                                silent: false,
-                                approval: self.approval_manager.as_deref(),
-                                multimodal_config: &self.multimodal_config,
-                                hooks: self.hook_runner.as_deref(),
-                                activated_tools: self.activated_tools.as_ref(),
-                                model_switch_callback: None,
-                                receipt_generator: receipt_scope
-                                    .as_ref()
-                                    .map(crate::agent::tool_receipts::ReceiptScope::generator),
-                            },
-                            crate::agent::loop_::ResolvedRuntimeKnobs {
-                                max_tool_iterations: self.config.resolved.max_tool_iterations,
-                                excluded_tools: &[],
-                                dedup_exempt_tools: &self.config.resolved.tool_call_dedup_exempt,
-                                pacing: &pacing,
-                                strict_tool_parsing: self.config.resolved.strict_tool_parsing,
-                                parallel_tools: self.config.resolved.parallel_tools,
-                                max_tool_result_chars: self.config.resolved.max_tool_result_chars,
-                                context_token_budget: self
-                                    .config
-                                    .resolved
-                                    .effective_context_budget(),
-                                knobs: &knobs,
-                            },
-                        ),
-                        history: &mut loop_history,
-                        channel_name: &self.channel_name,
-                        channel_reply_target: None,
-                        cancellation_token: None,
-                        on_delta: None,
-                        shared_budget: None,
-                        channel: None,
-                        collected_receipts: receipt_scope
-                            .as_ref()
-                            .map(crate::agent::tool_receipts::ReceiptScope::collector),
-                        event_tx: None,
-                        steering: None,
-                        new_messages_out: Some(&mut loop_new_messages),
-                        image_cache: Some(&mut self.image_cache),
-                        // Direct embedded Agent::turn call; source/transport/
-                        // trust stay placeholders, not yet stamped at the edge.
-                        memory: Some(crate::agent::memory_inject::TurnMemory {
-                            handle: self.memory.as_ref(),
-                            query: user_message.to_string(),
-                            sessions: vec![self.memory_session_id.clone()],
-                            suppress: false,
-                            cfg: self.memory_inject_cfg,
-                        }),
-                        ingress: zeroclaw_api::ingress::IngressContext::agent_direct(),
-                        agent_alias: agent_alias_for_loop.as_deref(),
-                        turn_id: &turn_id,
-                    }),
+                    crate::agent::loop_::run_tool_call_loop_with_current_turn(
+                        crate::agent::loop_::ToolLoopWithCurrentTurn {
+                            exec: crate::agent::loop_::ResolvedAgentExecution::resolve(
+                                crate::agent::loop_::ResolvedModelAccess {
+                                    model_provider: self.model_provider.as_ref(),
+                                    provider_name: &self.model_provider_name,
+                                    model: &effective_model,
+                                    temperature: self.temperature,
+                                },
+                                crate::agent::loop_::ResolvedIo {
+                                    tools_registry: &self.tools,
+                                    observer: self.observer.as_ref(),
+                                    silent: false,
+                                    approval: self.approval_manager.as_deref(),
+                                    multimodal_config: &self.multimodal_config,
+                                    hooks: self.hook_runner.as_deref(),
+                                    activated_tools: self.activated_tools.as_ref(),
+                                    model_switch_callback: None,
+                                    receipt_generator: receipt_scope
+                                        .as_ref()
+                                        .map(crate::agent::tool_receipts::ReceiptScope::generator),
+                                },
+                                crate::agent::loop_::ResolvedRuntimeKnobs {
+                                    max_tool_iterations: self.config.resolved.max_tool_iterations,
+                                    excluded_tools: &[],
+                                    dedup_exempt_tools: &self
+                                        .config
+                                        .resolved
+                                        .tool_call_dedup_exempt,
+                                    pacing: &pacing,
+                                    strict_tool_parsing: self.config.resolved.strict_tool_parsing,
+                                    parallel_tools: self.config.resolved.parallel_tools,
+                                    max_tool_result_chars: self
+                                        .config
+                                        .resolved
+                                        .max_tool_result_chars,
+                                    context_token_budget: self
+                                        .config
+                                        .resolved
+                                        .effective_context_budget(),
+                                    knobs: &knobs,
+                                },
+                            ),
+                            history: &mut loop_history,
+                            current_turn: &mut loop_current_turn,
+                            channel_name: &self.channel_name,
+                            channel_reply_target: None,
+                            cancellation_token: None,
+                            on_delta: None,
+                            shared_budget: None,
+                            channel: None,
+                            collected_receipts: receipt_scope
+                                .as_ref()
+                                .map(crate::agent::tool_receipts::ReceiptScope::collector),
+                            event_tx: None,
+                            steering: None,
+                            image_cache: Some(&mut self.image_cache),
+                            // Direct embedded Agent::turn call; source/transport/
+                            // trust stay placeholders, not yet stamped at the edge.
+                            memory: Some(crate::agent::memory_inject::TurnMemory {
+                                handle: self.memory.as_ref(),
+                                query: user_message.to_string(),
+                                sessions: vec![self.memory_session_id.clone()],
+                                suppress: false,
+                                cfg: self.memory_inject_cfg,
+                            }),
+                            ingress: zeroclaw_api::ingress::IngressContext::agent_direct(),
+                            agent_alias: agent_alias_for_loop.as_deref(),
+                            turn_id: &turn_id,
+                        },
+                    ),
                 ),
             )
             .await;
@@ -2202,7 +2216,16 @@ impl Agent {
                 None,
             );
         }
-        for replayed in Self::replay_loop_messages(&loop_new_messages) {
+
+        // Replay the loop's current turn into the conversation history BEFORE
+        // propagating any loop error: rounds that already executed carry side
+        // effects (tools ran), and the split-history engine keeps them in
+        // `loop_current_turn` on error exits too; `replay_loop_messages` reverses
+        // the loop's provider encodings back into structured `ConversationMessage`s.
+        // Pop the placeholder user message committed above so the
+        // potentially hook-modified version from `loop_current_turn[0]` wins.
+        self.history.pop();
+        for replayed in Self::replay_loop_messages(&loop_current_turn) {
             self.history.push(replayed);
         }
         let response = loop_result?;
@@ -2210,11 +2233,12 @@ impl Agent {
         let response = self.append_receipts_block(response, receipt_scope.as_ref());
 
         // Store in the response cache only when the turn was a single
-        // tool-free exchange (exactly one assistant message), mirroring the
-        // old "no tool calls" put condition.
+        // tool-free exchange (user message + exactly one assistant message),
+        // mirroring the old "no tool calls" put condition.
         if let (Some(cache), Some(key)) = (&self.response_cache, &cache_key)
-            && loop_new_messages.len() == 1
-            && loop_new_messages[0].role == "assistant"
+            && loop_current_turn.len() == 2
+            && loop_current_turn[0].role == "user"
+            && loop_current_turn[1].role == "assistant"
         {
             #[allow(clippy::cast_possible_truncation)]
             let _ = cache.put(key, &effective_model, &response, usage.output_tokens as u32);
@@ -2303,9 +2327,9 @@ impl Agent {
                 )));
         }
 
-        let mut new_msgs: Vec<ConversationMessage> = Vec::new();
-        self.append_streamed_user_message_to_history(user_message, &mut new_msgs)
-            .await;
+        let user_msg = self.build_enriched_user_message(user_message).await;
+        self.history
+            .push(ConversationMessage::Chat(user_msg.clone()));
 
         // `effective_model` is `mut` so a `model_switch` requested mid-turn
         // (handled in the round loop's `ModelSwitchRequested` arm via
@@ -2335,7 +2359,7 @@ impl Agent {
                 .map_err(|error| StreamedTurnError {
                     error,
                     committed_response: String::new(),
-                    new_messages: new_msgs.clone(),
+                    new_messages: vec![ConversationMessage::Chat(user_msg.clone())],
                 })?;
             let active_provider: &dyn ModelProvider = vision_provider_box
                 .as_deref()
@@ -2347,7 +2371,7 @@ impl Agent {
             .map_err(|error| StreamedTurnError {
                 error,
                 committed_response: String::new(),
-                new_messages: new_msgs.clone(),
+                new_messages: vec![ConversationMessage::Chat(user_msg.clone())],
             })?;
 
         let provider_messages = active_dispatcher.to_provider_messages(&self.history);
@@ -2359,15 +2383,19 @@ impl Agent {
                     cache_type: "response".into(),
                     tokens_saved: 0,
                 });
-                let cached_msg = ConversationMessage::Chat(ChatMessage::assistant(cached.clone()));
-                new_msgs.push(cached_msg.clone());
-                self.history.push(cached_msg);
+                self.history
+                    .push(ConversationMessage::Chat(ChatMessage::assistant(
+                        cached.clone(),
+                    )));
                 self.trim_history();
                 self.observer.record_event(&ObserverEvent::TurnComplete);
                 committed_response.push_str(&cached);
                 return Ok(StreamedTurnSuccess {
                     response: committed_response,
-                    new_messages: new_msgs,
+                    new_messages: vec![
+                        ConversationMessage::Chat(user_msg.clone()),
+                        ConversationMessage::Chat(ChatMessage::assistant(cached.clone())),
+                    ],
                 });
             }
             self.observer.record_event(&ObserverEvent::CacheMiss {
@@ -2375,7 +2403,18 @@ impl Agent {
             });
         }
 
+        // Split the provider-visible transcript at the last user message: the
+        // prefix becomes the loop's read-only `history`, the suffix (starting
+        // at this turn's enriched user message) becomes the mutable
+        // `current_turn` working set the loop appends assistant/tool messages
+        // to. `provider_messages` already ends with the user message, so the
+        // split keeps it as `loop_current_turn[0]`.
+        let split = provider_messages
+            .iter()
+            .rposition(|m| m.role == "user")
+            .unwrap_or(provider_messages.len());
         let mut loop_history = provider_messages;
+        let mut loop_current_turn: Vec<ChatMessage> = loop_history.split_off(split);
 
         let approval_bridge: Option<Box<dyn zeroclaw_api::channel::Channel>> =
             self.channel_handles.ask_user.as_ref().map(|handles| {
@@ -2409,6 +2448,15 @@ impl Agent {
         );
 
         // ── Round loop: one tool-call-loop run per steering round ──────────
+        // Pop the placeholder user message committed above so the
+        // potentially hook-modified version from `loop_current_turn[0]` wins.
+        self.history.pop();
+
+        // `replay_start` tracks how much of `loop_current_turn` has already
+        // been committed into `self.history`. It begins at 0; the pop
+        // above removed the placeholder, and the first round replays the full
+        // current turn (including the seed user message at index 0).
+        let mut replay_start: usize = 0;
         for round in 0..self.config.resolved.max_tool_iterations {
             // Early exit if the caller cancelled this turn (e.g. user abort)
             if cancel_token
@@ -2416,109 +2464,112 @@ impl Agent {
                 .is_some_and(tokio_util::sync::CancellationToken::is_cancelled)
             {
                 let marker = crate::i18n::get_required_cli_string("turn-interrupted-by-user");
-                let interruption =
-                    ConversationMessage::Chat(ChatMessage::assistant(marker.clone()));
-                new_msgs.push(interruption.clone());
-                self.history.push(interruption);
+                loop_current_turn.push(ChatMessage::assistant(marker.clone()));
+                self.history.extend(Self::replay_loop_messages(
+                    &loop_current_turn[replay_start..],
+                ));
                 committed_response.push_str(&marker);
                 return Err(StreamedTurnError {
                     error: crate::agent::loop_::ToolLoopCancelled.into(),
                     committed_response,
-                    new_messages: new_msgs,
+                    new_messages: Self::replay_loop_messages(&loop_current_turn),
                 });
             }
 
             // Steering drain: each accepted mid-turn message becomes its own
-            // enriched user turn in both transcripts before the next round.
+            // enriched user turn in the loop's mutable `loop_current_turn` so
+            // the next provider call sees the full current-turn transcript.
             for steering_message in crate::agent::loop_::drain_steering_messages(&mut steering_rx) {
-                self.append_streamed_user_message_to_history(&steering_message, &mut new_msgs)
-                    .await;
-                if let Some(ConversationMessage::Chat(user_msg)) = new_msgs.last() {
-                    loop_history.push(user_msg.clone());
-                }
+                let steering_msg = self.build_enriched_user_message(&steering_message).await;
+                loop_current_turn.push(steering_msg);
             }
 
-            // Per-round append-log: the loop mirrors every message it adds to
-            // `loop_history` into this capture at push time, on success AND
-            // error exits — never derived from history indices, which the
-            // loop's own preflight pruning can invalidate.
-            let mut round_added: Vec<ChatMessage> = Vec::new();
+            // Per-round append-log: the loop appends assistant/tool messages
+            // directly into `loop_current_turn`.
             let loop_result = crate::agent::loop_::TOOL_LOOP_COST_TRACKING_CONTEXT
                 .scope(
                     Some(cost_context.clone()),
                     crate::agent::tool_receipts::scope_receipts(
                         receipt_scope.clone(),
-                        crate::agent::loop_::run_tool_call_loop(crate::agent::loop_::ToolLoop {
-                            exec: crate::agent::loop_::ResolvedAgentExecution::resolve(
-                                crate::agent::loop_::ResolvedModelAccess {
-                                    model_provider: self.model_provider.as_ref(),
-                                    provider_name: &self.model_provider_name,
-                                    model: &effective_model,
-                                    temperature: self.temperature,
-                                },
-                                crate::agent::loop_::ResolvedIo {
-                                    tools_registry: &self.tools,
-                                    observer: self.observer.as_ref(),
-                                    silent: true,
-                                    approval: self.approval_manager.as_deref(),
-                                    multimodal_config: &self.multimodal_config,
-                                    hooks: self.hook_runner.as_deref(),
-                                    activated_tools: self.activated_tools.as_ref(),
-                                    model_switch_callback: Some(
-                                        crate::agent::loop_::get_model_switch_state(),
-                                    ),
-                                    receipt_generator: receipt_scope
-                                        .as_ref()
-                                        .map(crate::agent::tool_receipts::ReceiptScope::generator),
-                                },
-                                crate::agent::loop_::ResolvedRuntimeKnobs {
-                                    max_tool_iterations: self.config.resolved.max_tool_iterations,
-                                    excluded_tools: &[],
-                                    dedup_exempt_tools: &self
-                                        .config
-                                        .resolved
-                                        .tool_call_dedup_exempt,
-                                    pacing: &pacing,
-                                    strict_tool_parsing: self.config.resolved.strict_tool_parsing,
-                                    parallel_tools: self.config.resolved.parallel_tools,
-                                    max_tool_result_chars: self
-                                        .config
-                                        .resolved
-                                        .max_tool_result_chars,
-                                    context_token_budget: self
-                                        .config
-                                        .resolved
-                                        .effective_context_budget(),
-                                    knobs: &knobs,
-                                },
-                            ),
-                            history: &mut loop_history,
-                            channel_name: &self.channel_name,
-                            channel_reply_target: None,
-                            cancellation_token: cancel_token.clone(),
-                            on_delta: None,
-                            shared_budget: None,
-                            channel: approval_bridge.as_deref(),
-                            collected_receipts: receipt_scope
-                                .as_ref()
-                                .map(crate::agent::tool_receipts::ReceiptScope::collector),
-                            event_tx: Some(event_tx.clone()),
-                            steering: None,
-                            new_messages_out: Some(&mut round_added),
-                            image_cache: Some(&mut self.image_cache),
-                            // Direct embedded Agent::turn call; source/transport/
-                            // trust stay placeholders, not yet stamped at the edge.
-                            memory: Some(crate::agent::memory_inject::TurnMemory {
-                                handle: self.memory.as_ref(),
-                                query: user_message.to_string(),
-                                sessions: vec![self.memory_session_id.clone()],
-                                suppress: false,
-                                cfg: self.memory_inject_cfg,
-                            }),
-                            ingress: zeroclaw_api::ingress::IngressContext::agent_direct(),
-                            agent_alias: agent_alias_for_loop.as_deref(),
-                            turn_id: &turn_id,
-                        }),
+                        crate::agent::loop_::run_tool_call_loop_with_current_turn(
+                            crate::agent::loop_::ToolLoopWithCurrentTurn {
+                                exec: crate::agent::loop_::ResolvedAgentExecution::resolve(
+                                    crate::agent::loop_::ResolvedModelAccess {
+                                        model_provider: self.model_provider.as_ref(),
+                                        provider_name: &self.model_provider_name,
+                                        model: &effective_model,
+                                        temperature: self.temperature,
+                                    },
+                                    crate::agent::loop_::ResolvedIo {
+                                        tools_registry: &self.tools,
+                                        observer: self.observer.as_ref(),
+                                        silent: true,
+                                        approval: self.approval_manager.as_deref(),
+                                        multimodal_config: &self.multimodal_config,
+                                        hooks: self.hook_runner.as_deref(),
+                                        activated_tools: self.activated_tools.as_ref(),
+                                        model_switch_callback: Some(
+                                            crate::agent::loop_::get_model_switch_state(),
+                                        ),
+                                        receipt_generator: receipt_scope.as_ref().map(
+                                            crate::agent::tool_receipts::ReceiptScope::generator,
+                                        ),
+                                    },
+                                    crate::agent::loop_::ResolvedRuntimeKnobs {
+                                        max_tool_iterations: self
+                                            .config
+                                            .resolved
+                                            .max_tool_iterations,
+                                        excluded_tools: &[],
+                                        dedup_exempt_tools: &self
+                                            .config
+                                            .resolved
+                                            .tool_call_dedup_exempt,
+                                        pacing: &pacing,
+                                        strict_tool_parsing: self
+                                            .config
+                                            .resolved
+                                            .strict_tool_parsing,
+                                        parallel_tools: self.config.resolved.parallel_tools,
+                                        max_tool_result_chars: self
+                                            .config
+                                            .resolved
+                                            .max_tool_result_chars,
+                                        context_token_budget: self
+                                            .config
+                                            .resolved
+                                            .effective_context_budget(),
+                                        knobs: &knobs,
+                                    },
+                                ),
+                                history: &mut loop_history,
+                                current_turn: &mut loop_current_turn,
+                                channel_name: &self.channel_name,
+                                channel_reply_target: None,
+                                cancellation_token: cancel_token.clone(),
+                                on_delta: None,
+                                shared_budget: None,
+                                channel: approval_bridge.as_deref(),
+                                collected_receipts: receipt_scope
+                                    .as_ref()
+                                    .map(crate::agent::tool_receipts::ReceiptScope::collector),
+                                event_tx: Some(event_tx.clone()),
+                                steering: None,
+                                image_cache: Some(&mut self.image_cache),
+                                // Direct embedded Agent::turn call; source/transport/
+                                // trust stay placeholders, not yet stamped at the edge.
+                                memory: Some(crate::agent::memory_inject::TurnMemory {
+                                    handle: self.memory.as_ref(),
+                                    query: user_message.to_string(),
+                                    sessions: vec![self.memory_session_id.clone()],
+                                    suppress: false,
+                                    cfg: self.memory_inject_cfg,
+                                }),
+                                ingress: zeroclaw_api::ingress::IngressContext::agent_direct(),
+                                agent_alias: agent_alias_for_loop.as_deref(),
+                                turn_id: &turn_id,
+                            },
+                        ),
                     ),
                 )
                 .await;
@@ -2537,20 +2588,25 @@ impl Agent {
                 );
             }
 
-            // Replay everything the loop appended this round into the
-            // conversation history and the persistence capture.
-            let single_text_exchange =
-                round == 0 && round_added.len() == 1 && round_added[0].role == "assistant";
-            for replayed in Self::replay_loop_messages(&round_added) {
-                new_msgs.push(replayed.clone());
-                self.history.push(replayed);
-            }
+            let single_text_exchange = round == 0
+                && loop_current_turn.len() == 2
+                && loop_current_turn[0].role == "user"
+                && loop_current_turn[1].role == "assistant";
+
+            // Replay only the slice appended since the last commit into the
+            // conversation history. Earlier rounds (and any steering user
+            // messages consumed before them) are already durable; replaying the
+            // full `loop_current_turn` here would duplicate them.
+            self.history.extend(Self::replay_loop_messages(
+                &loop_current_turn[replay_start..],
+            ));
+            replay_start = loop_current_turn.len();
 
             match loop_result {
                 Ok(response) => {
                     // Commit-before-drain: this round's assistant output is in
-                    // history/new_msgs (replay above) and committed_response
-                    // before any steering continuation is folded in.
+                    // history (replay above) and committed_response before any
+                    // steering continuation is folded in.
                     committed_response.push_str(&response);
                     self.trim_history();
 
@@ -2575,7 +2631,7 @@ impl Agent {
                         self.append_receipts_block(committed_response, receipt_scope.as_ref());
                     return Ok(StreamedTurnSuccess {
                         response: committed_response,
-                        new_messages: new_msgs,
+                        new_messages: Self::replay_loop_messages(&loop_current_turn),
                     });
                 }
                 Err(error) => {
@@ -2591,7 +2647,7 @@ impl Agent {
                     // assistant output (e.g. a persisted stream partial) when
                     // no prior round committed anything.
                     if committed_response.is_empty() {
-                        for replayed in Self::replay_loop_messages(&round_added) {
+                        for replayed in Self::replay_loop_messages(&loop_current_turn) {
                             if let ConversationMessage::Chat(message) = &replayed
                                 && message.role == "assistant"
                             {
@@ -2619,14 +2675,16 @@ impl Agent {
                                 let interruption = ConversationMessage::Chat(
                                     ChatMessage::assistant(marker.clone()),
                                 );
-                                new_msgs.push(interruption.clone());
+                                loop_current_turn.push(ChatMessage::assistant(marker.clone()));
+                                // The marker is appended after the round's
+                                // normal replay slice, so commit it directly.
                                 self.history.push(interruption);
                             }
                         }
                         return Err(StreamedTurnError {
                             error: crate::agent::loop_::ToolLoopCancelled.into(),
                             committed_response,
-                            new_messages: new_msgs,
+                            new_messages: Self::replay_loop_messages(&loop_current_turn),
                         });
                     }
                     // Mark the interruption only when nothing was committed —
@@ -2639,7 +2697,7 @@ impl Agent {
                     return Err(StreamedTurnError {
                         error,
                         committed_response,
-                        new_messages: new_msgs,
+                        new_messages: Self::replay_loop_messages(&loop_current_turn),
                     });
                 }
             }
@@ -2651,7 +2709,7 @@ impl Agent {
                 self.config.resolved.max_tool_iterations
             )),
             committed_response,
-            new_messages: new_msgs,
+            new_messages: Self::replay_loop_messages(&loop_current_turn),
         })
     }
 
@@ -6415,6 +6473,198 @@ mod tests {
                 .filter(|msg| msg.role == "user")
                 .any(|msg| msg.content.contains("second")),
             "second provider call must include the accepted steering user message"
+        );
+    }
+
+    #[tokio::test]
+    async fn turn_streamed_with_steering_does_not_duplicate_history() {
+        // Regression for the split-history streaming engine: each accepted
+        // steering round appends to `loop_current_turn`, but only the newly
+        // added slice must be replayed into the durable `self.history`. If the
+        // full `loop_current_turn` is replayed every round, seed user/assistant
+        // messages appear multiple times.
+        let memory_cfg = zeroclaw_config::schema::MemoryConfig {
+            backend: "none".into(),
+            ..zeroclaw_config::schema::MemoryConfig::default()
+        };
+        let mem: Arc<dyn Memory> = Arc::from(
+            zeroclaw_memory::create_memory(&memory_cfg, std::path::Path::new("/tmp"), None)
+                .expect("memory creation should succeed with valid config"),
+        );
+
+        let model_provider = Box::new(StreamingSteeringModelProvider {
+            seen_messages: Arc::new(Mutex::new(Vec::new())),
+            call_count: AtomicUsize::new(0),
+            fail_on_call: None,
+            fail_chat_on_call: None,
+            fail_after_delta_on_call: None,
+            delay_chat_on_call: None,
+        });
+        let observer: Arc<dyn Observer> = Arc::from(crate::observability::NoopObserver {});
+        let mut agent = Agent::builder()
+            .model_provider(model_provider)
+            .tools(vec![Box::new(MockTool)])
+            .memory(mem)
+            .observer(observer)
+            .tool_dispatcher(Box::new(NativeToolDispatcher))
+            .workspace_dir(std::path::PathBuf::from("/tmp"))
+            .build()
+            .expect("agent builder should succeed with valid config");
+
+        let _history_before = agent.history.len();
+
+        let (event_tx, mut event_rx) = tokio::sync::mpsc::channel::<TurnEvent>(64);
+        let (steering_tx, mut steering_rx) = tokio::sync::mpsc::channel::<String>(4);
+        let handle = zeroclaw_spawn::spawn!(async move {
+            let result = agent
+                .turn_streamed_with_steering_state("first", event_tx, None, Some(&mut steering_rx))
+                .await;
+            (agent, result)
+        });
+
+        loop {
+            match event_rx.recv().await.expect("turn event should arrive") {
+                TurnEvent::Chunk { delta } if delta == "draft" => {
+                    steering_tx
+                        .send("second".into())
+                        .await
+                        .expect("steering message should enqueue");
+                    break;
+                }
+                _ => {}
+            }
+        }
+
+        let (agent, outcome) = handle.await.expect("turn task should finish");
+        let outcome = outcome.expect("steered turn should succeed");
+
+        let _history_after = agent.history.len();
+
+        // Extract the committed chat messages. This is the durable transcript
+        // that matters for the no-duplicates regression.
+        let committed: Vec<_> = agent
+            .history
+            .iter()
+            .filter_map(|msg| match msg {
+                ConversationMessage::Chat(message) => {
+                    Some((message.role.as_str(), message.content.as_str()))
+                }
+                _ => None,
+            })
+            .collect();
+
+        // Build a frequency map keyed by a coarse content tag. User messages
+        // are enriched with a timestamp prefix, so match by substring.
+        let first_user_count = committed
+            .iter()
+            .filter(|(role, content)| *role == "user" && content.contains("first"))
+            .count();
+        let second_user_count = committed
+            .iter()
+            .filter(|(role, content)| *role == "user" && content.contains("second"))
+            .count();
+        let draft_assistant_count = committed
+            .iter()
+            .filter(|(role, content)| *role == "assistant" && *content == "draft")
+            .count();
+        let final_assistant_count = committed
+            .iter()
+            .filter(|(role, content)| *role == "assistant" && *content == "final")
+            .count();
+
+        assert_eq!(
+            first_user_count, 1,
+            "seed user message must appear exactly once in history"
+        );
+        assert_eq!(
+            second_user_count, 1,
+            "steering user message must appear exactly once in history"
+        );
+        assert_eq!(
+            draft_assistant_count, 1,
+            "first assistant response must appear exactly once in history"
+        );
+        assert_eq!(
+            final_assistant_count, 1,
+            "second assistant response must appear exactly once in history"
+        );
+
+        // Also assert the turn's reported new_messages are the full turn.
+        let new_chat_messages: Vec<_> = outcome
+            .new_messages
+            .iter()
+            .filter_map(|msg| match msg {
+                ConversationMessage::Chat(message) => {
+                    Some((message.role.as_str(), message.content.as_str()))
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            new_chat_messages.len(),
+            4,
+            "new_messages must contain four chat messages"
+        );
+        assert!(
+            new_chat_messages[0].0 == "user" && new_chat_messages[0].1.contains("first"),
+            "new_messages[0] must be the seed user message"
+        );
+        assert!(
+            new_chat_messages[1] == ("assistant", "draft"),
+            "new_messages[1] must be the first assistant response"
+        );
+        assert!(
+            new_chat_messages[2].0 == "user" && new_chat_messages[2].1.contains("second"),
+            "new_messages[2] must be the accepted steering user message"
+        );
+        assert!(
+            new_chat_messages[3] == ("assistant", "final"),
+            "new_messages[3] must be the second assistant response"
+        );
+
+        // The durable history tail must equal new_messages (modulo timestamp
+        // enrichment of user messages).
+        let tail = &committed[committed.len().saturating_sub(new_chat_messages.len())..];
+        assert_eq!(
+            tail.len(),
+            new_chat_messages.len(),
+            "durable history tail and new_messages must have same length"
+        );
+        for (actual, expected) in tail.iter().zip(new_chat_messages.iter()) {
+            assert_eq!(
+                actual.0, expected.0,
+                "durable history tail role must match new_messages"
+            );
+            if actual.0 == "user" {
+                assert!(
+                    actual.1.contains(expected.1),
+                    "durable history tail user content must contain new_messages user content"
+                );
+            } else {
+                assert_eq!(
+                    actual.1, expected.1,
+                    "durable history tail assistant content must equal new_messages"
+                );
+            }
+        }
+
+        // The regression: each turn-related message appears exactly once in the
+        // durable history. No message is duplicated across steering rounds.
+        assert_eq!(
+            first_user_count, 1,
+            "seed user message must appear exactly once in history"
+        );
+        assert_eq!(
+            second_user_count, 1,
+            "steering user message must appear exactly once in history"
+        );
+        assert_eq!(
+            draft_assistant_count, 1,
+            "first assistant response must appear exactly once in history"
+        );
+        assert_eq!(
+            final_assistant_count, 1,
+            "second assistant response must appear exactly once in history"
         );
     }
 

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -845,7 +845,6 @@ pub async fn agent_turn(
         collected_receipts: None,
         event_tx: None,
         steering: None,
-        new_messages_out: None,
         image_cache: None,
         // Origin and the per-turn memory half are threaded from the entry
         // point; source/transport/trust stay phase-1 placeholders until
@@ -899,6 +898,7 @@ pub use super::turn::{
     ResolvedRuntimeKnobs, StreamDelta, ToolLoop, ToolLoopCancelled, drain_steering_messages,
     is_model_switch_requested, is_tool_loop_cancelled, run_tool_call_loop, scrub_credentials,
 };
+pub use super::turn::{ToolLoopWithCurrentTurn, run_tool_call_loop_with_current_turn};
 
 /// Build the tool instruction block for the system prompt so the LLM knows
 /// how to invoke tools.
@@ -1798,7 +1798,7 @@ pub async fn run(
                                 collected_receipts: None,
                                 event_tx: None,
                                 steering: None,
-                                new_messages_out: None,
+
                                 image_cache: None,
                                 // Origin is threaded from the entry point;
                                 // source/transport/trust stay phase-1
@@ -2341,7 +2341,7 @@ pub async fn run(
                                     collected_receipts: None,
                                     event_tx: None,
                                     steering: None,
-                                    new_messages_out: None,
+
                                     image_cache: None,
                                     // Origin is threaded from the entry point;
                                     // source/transport/trust stay phase-1
@@ -4908,7 +4908,7 @@ mod tests {
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -4982,7 +4982,7 @@ mod tests {
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -5063,7 +5063,7 @@ mod tests {
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -5149,7 +5149,7 @@ mod tests {
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -5220,7 +5220,7 @@ mod tests {
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -5294,7 +5294,7 @@ mod tests {
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -5369,7 +5369,7 @@ mod tests {
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -5431,7 +5431,7 @@ mod tests {
                 collected_receipts: None,
                 event_tx: None,
                 steering: None,
-                new_messages_out: None,
+
                 image_cache: None,
                 memory: None,
                 ingress: ctx,
@@ -5570,8 +5570,12 @@ mod tests {
         async fn run_case(
             mem: &dyn zeroclaw_memory::Memory,
             origin: zeroclaw_api::ingress::TurnOrigin,
-        ) -> (String, Vec<(Option<String>, bool)>) {
-            let model_provider = ScriptedModelProvider::from_text_responses(vec!["done"]);
+        ) -> (String, String, Vec<(Option<String>, bool)>) {
+            let requests = Arc::new(Mutex::new(Vec::new()));
+            let model_provider = RecordingModelProvider {
+                requests: Arc::clone(&requests),
+                capabilities: ProviderCapabilities::default(),
+            };
             let mut history = vec![ChatMessage::user("what server?".to_string())];
             let tools_registry: Vec<Box<dyn Tool>> = Vec::new();
             let observer = RecallCountingObserver::default();
@@ -5614,7 +5618,6 @@ mod tests {
                 collected_receipts: None,
                 event_tx: None,
                 steering: None,
-                new_messages_out: None,
                 image_cache: None,
                 memory: Some(crate::agent::memory_inject::TurnMemory {
                     handle: mem,
@@ -5630,9 +5633,16 @@ mod tests {
             .await
             .expect("turn should complete");
 
-            let user_msg = history
+            let durable_user_msg = history
                 .iter()
                 .find(|m| m.role == "user")
+                .map(|m| m.content.clone())
+                .unwrap_or_default();
+            let provider_user_msg = requests
+                .lock()
+                .expect("requests lock should be valid")
+                .last()
+                .and_then(|req| req.iter().find(|m| m.role == "user"))
                 .map(|m| m.content.clone())
                 .unwrap_or_default();
             let recalls = observer
@@ -5641,37 +5651,46 @@ mod tests {
                 .iter()
                 .map(|r| (r.query_summary.clone(), r.success))
                 .collect();
-            (user_msg, recalls)
+            (durable_user_msg, provider_user_msg, recalls)
         }
 
-        // User-facing origin: preamble injected, one successful recall event.
-        let (msg, recalls) = run_case(
+        // User-facing origin: provider sees the preamble, durable history stays
+        // clean, and exactly one successful recall event is emitted.
+        let (durable, provider, recalls) = run_case(
             &StaticRecallMemory,
             zeroclaw_api::ingress::TurnOrigin::Interactive,
         )
         .await;
-        assert!(msg.starts_with(zeroclaw_memory::MEMORY_CONTEXT_OPEN));
-        assert!(msg.contains("- remembered: the server is prod-3"));
-        assert!(msg.ends_with("what server?"));
+        assert!(
+            !durable.contains(zeroclaw_memory::MEMORY_CONTEXT_OPEN),
+            "durable history must stay clean, got: {durable}"
+        );
+        assert_eq!(durable, "what server?");
+        assert!(provider.starts_with(zeroclaw_memory::MEMORY_CONTEXT_OPEN));
+        assert!(provider.contains("- remembered: the server is prod-3"));
+        assert!(provider.ends_with("what server?"));
         assert_eq!(recalls.len(), 1);
         assert!(recalls[0].1, "recall event must report success");
 
         // SubTurn origin: no injection, no recall, no event.
-        let (msg, recalls) = run_case(
+        let (durable, provider, recalls) = run_case(
             &StaticRecallMemory,
             zeroclaw_api::ingress::TurnOrigin::SubTurn,
         )
         .await;
-        assert_eq!(msg, "what server?");
+        assert_eq!(durable, "what server?");
+        assert_eq!(provider, "what server?");
         assert!(recalls.is_empty(), "sub-turns must not recall memory");
 
-        // Failing backend: turn proceeds bare, one failure event.
-        let (msg, recalls) = run_case(
+        // Failing backend: turn proceeds bare, durable history stays clean, one
+        // failure event.
+        let (durable, provider, recalls) = run_case(
             &FailingRecallMemory,
             zeroclaw_api::ingress::TurnOrigin::Interactive,
         )
         .await;
-        assert_eq!(msg, "what server?");
+        assert_eq!(durable, "what server?");
+        assert_eq!(provider, "what server?");
         assert_eq!(recalls.len(), 1);
         assert!(!recalls[0].1, "recall event must report failure");
     }
@@ -5736,7 +5755,7 @@ mod tests {
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -5810,7 +5829,7 @@ mod tests {
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -5883,7 +5902,7 @@ mod tests {
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -6042,7 +6061,7 @@ mod tests {
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -6178,7 +6197,7 @@ mod tests {
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             memory: None,
             ingress: IngressContext::sub_turn(),
@@ -6334,7 +6353,7 @@ mod tests {
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             memory: None,
             ingress: IngressContext::sub_turn(),
@@ -6449,7 +6468,7 @@ mod tests {
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -6619,7 +6638,7 @@ mod tests {
             collected_receipts: None,
             event_tx: Some(event_tx),
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -6725,7 +6744,7 @@ mod tests {
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -6815,7 +6834,7 @@ mod tests {
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -6897,7 +6916,7 @@ mod tests {
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -6987,7 +7006,7 @@ mod tests {
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -7080,7 +7099,7 @@ mod tests {
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -7178,7 +7197,7 @@ mod tests {
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -7273,7 +7292,7 @@ mod tests {
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             memory: None,
             ingress: IngressContext::sub_turn(),
@@ -7368,7 +7387,7 @@ mod tests {
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             memory: None,
             ingress: IngressContext::sub_turn(),
@@ -7468,7 +7487,7 @@ mod tests {
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             memory: None,
             ingress: IngressContext::sub_turn(),
@@ -7558,7 +7577,7 @@ mod tests {
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -7652,7 +7671,7 @@ mod tests {
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -7748,7 +7767,7 @@ mod tests {
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -7830,7 +7849,7 @@ mod tests {
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -7916,7 +7935,7 @@ mod tests {
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -7997,7 +8016,7 @@ mod tests {
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -8076,7 +8095,7 @@ mod tests {
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -8158,7 +8177,7 @@ mod tests {
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -8237,7 +8256,7 @@ mod tests {
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -8315,7 +8334,7 @@ mod tests {
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -8385,7 +8404,7 @@ mod tests {
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -8456,7 +8475,7 @@ mod tests {
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -8527,7 +8546,7 @@ mod tests {
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -8600,7 +8619,7 @@ This is an example, not an invocation."#;
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -8678,7 +8697,7 @@ This is an example, not an invocation."#;
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -8768,7 +8787,7 @@ This is an example, not an invocation."#;
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -8841,7 +8860,7 @@ Done."#;
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -8917,7 +8936,7 @@ Done."#;
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -8991,7 +9010,7 @@ Done."#;
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -9066,7 +9085,7 @@ This is an example, not an invocation."#;
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -9198,7 +9217,7 @@ This is an example, not an invocation."#;
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -9281,7 +9300,7 @@ This is an example, not an invocation."#;
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -9368,7 +9387,7 @@ This is an example, not an invocation."#;
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -9478,7 +9497,7 @@ This is an example, not an invocation."#;
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -9593,7 +9612,7 @@ This is an example, not an invocation."#;
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -9682,7 +9701,7 @@ This is an example, not an invocation."#;
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -9782,7 +9801,7 @@ This is an example, not an invocation."#;
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             memory: None,
             ingress: zeroclaw_api::ingress::IngressContext::sub_turn(),
@@ -10662,7 +10681,7 @@ This is an example, not an invocation."#;
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -10764,7 +10783,7 @@ This is an example, not an invocation."#;
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             memory: None,
             ingress: IngressContext::sub_turn(),
@@ -10865,7 +10884,7 @@ This is an example, not an invocation."#;
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             memory: None,
             ingress: IngressContext::sub_turn(),
@@ -10966,7 +10985,7 @@ This is an example, not an invocation."#;
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             memory: None,
             ingress: IngressContext::sub_turn(),
@@ -11122,7 +11141,7 @@ This is an example, not an invocation."#;
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -13438,7 +13457,7 @@ Let me check the result."#;
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -13613,7 +13632,7 @@ Let me check the result."#;
                     collected_receipts: None,
                     event_tx: None,
                     steering: None,
-                    new_messages_out: None,
+
                     image_cache: None,
                     // Phase 1: stamp Internal/Trusted. Per-transport
                     // stamping lands in a later phase.
@@ -13687,7 +13706,7 @@ Let me check the result."#;
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -13800,7 +13819,7 @@ Let me check the result."#;
                     collected_receipts: None,
                     event_tx: None,
                     steering: None,
-                    new_messages_out: None,
+
                     image_cache: None,
                     // Phase 1: stamp Internal/Trusted. Per-transport
                     // stamping lands in a later phase.
@@ -13879,7 +13898,7 @@ Let me check the result."#;
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             // Phase 1: stamp Internal/Trusted until per-transport
             // stamping lands.
@@ -13965,7 +13984,7 @@ Let me check the result."#;
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             memory: None,
             ingress: IngressContext::sub_turn(),
@@ -15106,7 +15125,7 @@ Let me check the result."#;
             collected_receipts: None,
             event_tx: None,
             steering: None,
-            new_messages_out: None,
+
             image_cache: None,
             memory: None,
             ingress: IngressContext::sub_turn(),

--- a/crates/zeroclaw-runtime/src/agent/parity.rs
+++ b/crates/zeroclaw-runtime/src/agent/parity.rs
@@ -164,7 +164,6 @@ async fn parity_l1_engine_honors_excluded_tools() {
         collected_receipts: None,
         event_tx: None,
         steering: None,
-        new_messages_out: None,
         image_cache: None,
         ingress: IngressContext::sub_turn(),
         memory: None,

--- a/crates/zeroclaw-runtime/src/agent/safety_net.rs
+++ b/crates/zeroclaw-runtime/src/agent/safety_net.rs
@@ -462,7 +462,7 @@ async fn safety_net_thinking_never_leaks_into_draft_or_chunks() {
         collected_receipts: None,
         event_tx: None,
         steering: None,
-        new_messages_out: None,
+
         image_cache: None,
         // Phase 1: stamp Internal/Trusted. Per-transport
         // stamping lands in a later phase.
@@ -844,7 +844,7 @@ async fn safety_net_task_locals_probe_per_entry_path() {
                 collected_receipts: None,
                 event_tx: None,
                 steering: None,
-                new_messages_out: None,
+
                 image_cache: None,
                 // Phase 1: stamp Internal/Trusted. Per-transport
                 // stamping lands in a later phase.
@@ -1097,7 +1097,7 @@ async fn safety_net_turn_survives_in_loop_history_pruning() {
         ..zeroclaw_config::schema::ResolvedRuntime::default()
     };
 
-    // Agent::turn (new_messages_out path)
+    // Agent::turn (current_turn replay path)
     let calls = Arc::new(AtomicUsize::new(0));
     let mut agent = build_agent_with_runtime(
         Box::new(ScriptedProvider::new(vec![

--- a/crates/zeroclaw-runtime/src/agent/turn/max_iter.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/max_iter.rs
@@ -13,7 +13,8 @@ use zeroclaw_providers::{ChatMessage, ModelProvider};
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn finish_after_max_iterations(
     model_provider: &dyn ModelProvider,
-    history: &mut Vec<ChatMessage>,
+    history: &[ChatMessage],
+    current_turn: &mut Vec<ChatMessage>,
     provider_name: &str,
     model: &str,
     temperature: Option<f64>,
@@ -23,7 +24,6 @@ pub(crate) async fn finish_after_max_iterations(
     mut accumulated_display_text: String,
     turn_id: &str,
     knobs: &LoopKnobs,
-    mut new_messages_out: Option<&mut Vec<ChatMessage>>,
 ) -> Result<String> {
     ::zeroclaw_log::record!(
         WARN,
@@ -54,9 +54,9 @@ pub(crate) async fn finish_after_max_iterations(
         "Max iterations reached, requesting final summary"
     );
     let tool_calls_stripped =
-        crate::agent::history_pruner::strip_orphaned_tool_calls_from_assistants(history);
+        crate::agent::history_pruner::strip_orphaned_tool_calls_from_assistants(current_turn);
     let tool_messages_removed =
-        crate::agent::history_pruner::remove_orphaned_tool_messages(history).removed;
+        crate::agent::history_pruner::remove_orphaned_tool_messages(current_turn).removed;
     if tool_calls_stripped > 0 || tool_messages_removed > 0 {
         ::zeroclaw_log::record!(
             WARN,
@@ -76,8 +76,7 @@ pub(crate) async fn finish_after_max_iterations(
          Summarize what you accomplished and what remains to be done."
             .to_string(),
     );
-    let summary_prompt_mirror = summary_prompt.clone();
-    history.push(summary_prompt);
+    current_turn.push(summary_prompt);
 
     enum SummaryCall {
         Cancelled,
@@ -85,8 +84,12 @@ pub(crate) async fn finish_after_max_iterations(
         Done(Result<zeroclaw_providers::ChatResponse>),
     }
     let summary_call = {
+        let mut summary_messages: Vec<ChatMessage> =
+            Vec::with_capacity(history.len() + current_turn.len());
+        summary_messages.extend(history.iter().cloned());
+        summary_messages.extend(current_turn.iter().cloned());
         let summary_request = zeroclaw_providers::ChatRequest {
-            messages: history,
+            messages: &summary_messages,
             tools: None, // No tools — force a text response
             thinking: zeroclaw_api::NATIVE_THINKING_OVERRIDE
                 .try_with(Clone::clone)
@@ -138,11 +141,11 @@ pub(crate) async fn finish_after_max_iterations(
 
     let resp = match summary_call {
         SummaryCall::Cancelled => {
-            history.pop();
+            current_turn.pop();
             return Err(ToolLoopCancelled.into());
         }
         SummaryCall::TimedOut(step_secs) => {
-            history.pop();
+            current_turn.pop();
             anyhow::bail!("Final summary LLM call timed out after {step_secs}s (step_timeout_secs)")
         }
         SummaryCall::Done(Err(e)) => {
@@ -160,7 +163,7 @@ pub(crate) async fn finish_after_max_iterations(
                     })),
                 "final summary LLM call failed after iteration exhaustion; bailing"
             );
-            history.pop();
+            current_turn.pop();
             anyhow::bail!("Agent exceeded maximum tool iterations ({max_iterations})")
         }
         SummaryCall::Done(Ok(resp)) => resp,
@@ -168,15 +171,11 @@ pub(crate) async fn finish_after_max_iterations(
 
     let text = resp.text.unwrap_or_default();
     if text.is_empty() {
-        history.pop();
+        current_turn.pop();
         anyhow::bail!("Agent exceeded maximum tool iterations ({max_iterations})")
     }
     let summary_msg = ChatMessage::assistant(text.clone());
-    if let Some(out) = &mut new_messages_out {
-        out.push(summary_prompt_mirror);
-        out.push(summary_msg.clone());
-    }
-    history.push(summary_msg);
+    current_turn.push(summary_msg);
     accumulated_display_text.push_str(&text);
     // Graceful shutdown with a visible reason so the user knows why the
     // agent stopped making progress.
@@ -250,12 +249,14 @@ mod graceful_summary_metering_tests {
     }
 
     async fn run_summary(provider: &CountingUsageProvider) -> anyhow::Result<String> {
-        let mut history = vec![ChatMessage::user("do the work")];
+        let history: Vec<ChatMessage> = Vec::new();
+        let mut current_turn = vec![ChatMessage::user("do the work")];
         let pacing = PacingConfig::default();
         let knobs = LoopKnobs::default(); // GracefulSummary
         finish_after_max_iterations(
             provider,
-            &mut history,
+            &history,
+            &mut current_turn,
             "custom",
             "test-model",
             None,
@@ -265,7 +266,6 @@ mod graceful_summary_metering_tests {
             String::new(),
             "trace-req-test",
             &knobs,
-            None,
         )
         .await
     }

--- a/crates/zeroclaw-runtime/src/agent/turn/mod.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/mod.rs
@@ -86,12 +86,50 @@ pub(crate) const MAX_MALFORMED_TOOL_PROTOCOL_RETRIES: usize = 2;
 /// Used as a safe fallback when `max_tool_iterations` is unset or configured as zero.
 pub(crate) const DEFAULT_MAX_TOOL_ITERATIONS: usize = 10;
 
+pub struct ToolLoopWithCurrentTurn<'a> {
+    /// The resolved per-agent execution context: model binding, gated tool
+    /// registry, approval, observability, and resolved runtime knobs. Stable
+    /// for every turn to this agent; built once and reused. See
+    /// [`ResolvedAgentExecution`]. Everything below is per-message turn state.
+    pub exec: ResolvedAgentExecution<'a>,
+    pub history: &'a mut Vec<ChatMessage>,
+    pub current_turn: &'a mut Vec<ChatMessage>,
+    pub channel_name: &'a str,
+    pub channel_reply_target: Option<&'a str>,
+    pub cancellation_token: Option<CancellationToken>,
+    pub on_delta: Option<tokio::sync::mpsc::Sender<DraftEvent>>,
+    pub shared_budget: Option<Arc<std::sync::atomic::AtomicUsize>>,
+    pub channel: Option<&'a dyn Channel>,
+    pub collected_receipts: Option<&'a std::sync::Mutex<Vec<String>>>,
+    pub event_tx: Option<tokio::sync::mpsc::Sender<TurnEvent>>,
+    pub steering: Option<&'a mut tokio::sync::mpsc::Receiver<String>>,
+    pub image_cache: Option<&'a mut zeroclaw_providers::multimodal::LocalImageCache>,
+    pub ingress: IngressContext,
+    /// The per-turn memory half for unified memory-context injection: the
+    /// handle, raw recall query, session scopes, and spawn-site suppression.
+    /// `None` for nested sub-turn sites and paths without a memory backend;
+    /// the injection decision itself is keyed on `ingress.origin`.
+    pub memory: Option<crate::agent::memory_inject::TurnMemory<'a>>,
+    /// Observer metadata: agent alias and turn id, stamped onto every
+    /// turn-level observer event so OTel spans correlate across the loop.
+    pub agent_alias: Option<&'a str>,
+    pub turn_id: &'a str,
+}
+
 pub struct ToolLoop<'a> {
     /// The resolved per-agent execution context: model binding, gated tool
     /// registry, approval, observability, and resolved runtime knobs. Stable
     /// for every turn to this agent; built once and reused. See
     /// [`ResolvedAgentExecution`]. Everything below is per-message turn state.
     pub exec: ResolvedAgentExecution<'a>,
+    /// Full conversation transcript for this turn.
+    ///
+    /// **Contract**: the last `user`-role message in this history MUST be the
+    /// real user message for the current turn. The compatibility wrapper uses
+    /// this as the boundary between the durable past-turn prefix and the
+    /// mutable current-turn working set. Callers that retry (e.g. on
+    /// model-switch) should use [`run_tool_call_loop_with_current_turn`]
+    /// directly so the split boundary stays stable without re-discovery.
     pub history: &'a mut Vec<ChatMessage>,
     pub channel_name: &'a str,
     pub channel_reply_target: Option<&'a str>,
@@ -102,7 +140,6 @@ pub struct ToolLoop<'a> {
     pub collected_receipts: Option<&'a std::sync::Mutex<Vec<String>>>,
     pub event_tx: Option<tokio::sync::mpsc::Sender<TurnEvent>>,
     pub steering: Option<&'a mut tokio::sync::mpsc::Receiver<String>>,
-    pub new_messages_out: Option<&'a mut Vec<ChatMessage>>,
     pub image_cache: Option<&'a mut zeroclaw_providers::multimodal::LocalImageCache>,
     pub ingress: IngressContext,
     /// The per-turn memory half for unified memory-context injection: the
@@ -160,10 +197,13 @@ async fn enforce_reported_budget(
     }
 }
 
-pub async fn run_tool_call_loop(p: ToolLoop<'_>) -> Result<String> {
-    let ToolLoop {
+pub async fn run_tool_call_loop_with_current_turn(
+    p: ToolLoopWithCurrentTurn<'_>,
+) -> Result<String> {
+    let ToolLoopWithCurrentTurn {
         exec,
         history,
+        current_turn,
         channel_name,
         channel_reply_target,
         cancellation_token,
@@ -173,7 +213,6 @@ pub async fn run_tool_call_loop(p: ToolLoop<'_>) -> Result<String> {
         collected_receipts,
         event_tx,
         mut steering,
-        mut new_messages_out,
         mut image_cache,
         ingress,
         memory,
@@ -209,10 +248,10 @@ pub async fn run_tool_call_loop(p: ToolLoop<'_>) -> Result<String> {
     } = exec;
 
     let ingress_policy_cfg = IngressPolicy::default();
-    let p1_text = history
+    let p1_text = current_turn
         .iter()
-        .rev()
         .find(|m| m.role == "user")
+        .or_else(|| history.iter().rev().find(|m| m.role == "user"))
         .map_or("", |m| m.content.as_str());
     match ingress_policy(p1_text, &ingress, &ingress_policy_cfg) {
         // DEFAULT — the only arm reachable under the default policy. Proceed
@@ -235,38 +274,32 @@ pub async fn run_tool_call_loop(p: ToolLoop<'_>) -> Result<String> {
         }
     }
 
-    if let Some(turn_memory) = &memory {
-        let has_session = turn_memory.sessions.iter().any(Option::is_some);
-        if let crate::agent::memory_inject::InjectPolicy::Inject {
+    let precomputed_memory_context: Option<String> = if let Some(turn_memory) = &memory
+        && let crate::agent::memory_inject::InjectPolicy::Inject {
             exclude_conversation,
         } = crate::agent::memory_inject::resolve_inject_policy(
             ingress.origin,
-            has_session,
+            turn_memory.sessions.iter().any(Option::is_some),
             turn_memory.suppress,
-        ) && let Some(last_user_idx) = history.iter().rposition(|m| m.role == "user")
-            // Idempotence: a model-switch retry re-enters the engine with the
-            // same history; the preamble must not stack.
-            && !history[last_user_idx]
-                .content
-                .starts_with(zeroclaw_memory::MEMORY_CONTEXT_OPEN)
-        {
-            let scopes: Vec<Option<&str>> =
-                turn_memory.sessions.iter().map(|s| s.as_deref()).collect();
-            let context = crate::agent::memory_inject::render_memory_context(
-                turn_memory.handle,
-                observer,
-                &turn_memory.query,
-                &scopes,
-                &turn_memory.cfg,
-                exclude_conversation,
-            )
-            .await;
-            if !context.is_empty() {
-                let existing = &history[last_user_idx].content;
-                history[last_user_idx].content = format!("{context}{existing}");
-            }
+        ) {
+        let scopes: Vec<Option<&str>> = turn_memory.sessions.iter().map(|s| s.as_deref()).collect();
+        let context = crate::agent::memory_inject::render_memory_context(
+            turn_memory.handle,
+            observer,
+            &turn_memory.query,
+            &scopes,
+            &turn_memory.cfg,
+            exclude_conversation,
+        )
+        .await;
+        if context.is_empty() {
+            None
+        } else {
+            Some(context)
         }
-    }
+    } else {
+        None
+    };
 
     let max_iterations = if max_tool_iterations == 0 {
         DEFAULT_MAX_TOOL_ITERATIONS
@@ -322,26 +355,23 @@ pub async fn run_tool_call_loop(p: ToolLoop<'_>) -> Result<String> {
     for iteration in 0..max_iterations {
         for steering_message in drain_steering_messages(&mut steering) {
             match ingress_policy(&steering_message, &ingress, &ingress_policy_cfg) {
-                // DEFAULT — append the injection to history exactly as today.
+                // DEFAULT — append the injection to the current turn exactly as today.
                 IngressDecision::Loop => {}
                 // Phase 3: frame as untrusted data; proceed as Loop until
                 // framing exists (behavior-identical).
                 IngressDecision::Annotate { .. } => {}
                 // Phase 2: divert this injection into the SOP run rather than
-                // history. Not reachable under the default policy.
+                // the current turn. Not reachable under the default policy.
                 IngressDecision::Gate { .. } => {
                     // TODO(PR C): route this steering message into the gated
-                    // SOP run instead of appending it to history.
+                    // SOP run instead of appending it to the current turn.
                 }
                 // Not reachable under the default policy; drop the injection
                 // (do not append it) when it is.
                 IngressDecision::Drop { .. } => continue,
             }
             let msg = ChatMessage::user(steering_message);
-            if let Some(out) = new_messages_out.as_deref_mut() {
-                out.push(msg.clone());
-            }
-            history.push(msg);
+            current_turn.push(msg);
         }
 
         let mut seen_tool_signatures: HashSet<(String, String)> = HashSet::new();
@@ -398,9 +428,14 @@ pub async fn run_tool_call_loop(p: ToolLoop<'_>) -> Result<String> {
                     )
                 );
             }
+            // Reserve budget for `current_turn` before trimming `history`:
+            // the provider sees `history + current_turn`, so trimming must
+            // leave enough headroom for the active turn's tokens.
+            let current_turn_estimate =
+                crate::agent::history::estimate_history_tokens(current_turn);
+            let history_budget = context_token_budget.saturating_sub(current_turn_estimate);
             let taken = std::mem::take(history);
-            let result =
-                crate::agent::history_trim::trim_to_recent_turns(taken, context_token_budget);
+            let result = crate::agent::history_trim::trim_to_recent_turns(taken, history_budget);
             if result.trimmed {
                 let mut trimmed = result.history;
                 crate::agent::history_trim::insert_breadcrumb_deduped(&mut trimmed);
@@ -493,8 +528,33 @@ pub async fn run_tool_call_loop(p: ToolLoop<'_>) -> Result<String> {
             activated_tools,
         )?;
 
+        // Prepend the once-per-invocation memory context to the current turn's
+        // seed user message before merging into the provider-visible transcript.
+        // The context is rendered once before the loop (above); here we only
+        // splice it into a fresh clone so the durable `current_turn` stays clean.
+        // Anchoring to the first user message avoids mis-injecting into steering
+        // messages appended later in the same round.
+        let mut current_turn_with_memory: Vec<ChatMessage> = current_turn.clone();
+        if let Some(ref context) = precomputed_memory_context
+            && let Some(seed_user_idx) = current_turn_with_memory
+                .iter()
+                .position(|m| m.role == "user")
+        {
+            let existing = &current_turn_with_memory[seed_user_idx].content;
+            current_turn_with_memory[seed_user_idx].content = format!("{context}{existing}");
+        }
+
+        // Build the provider-visible merged transcript. A temporary owned Vec is
+        // required because downstream consumers need a contiguous slice and
+        // `current_turn` must remain mutable for assistant/tool-result appends
+        // after the provider call returns.
+        let mut merged: Vec<ChatMessage> =
+            Vec::with_capacity(history.len() + current_turn_with_memory.len());
+        merged.extend(history.iter().cloned());
+        merged.extend(current_turn_with_memory);
+
         let (vision_model_provider_box, degrade_strip_images) =
-            resolve_vision_provider(model_provider, history, multimodal_config, provider_name)?;
+            resolve_vision_provider(model_provider, &merged, multimodal_config, provider_name)?;
 
         let (active_model_provider, active_model_provider_name, active_model): (
             &dyn ModelProvider,
@@ -518,9 +578,12 @@ pub async fn run_tool_call_loop(p: ToolLoop<'_>) -> Result<String> {
         } = iteration_tool_specs;
 
         refresh_prompt_anchor(history, use_native_tools);
+        if let Some(refreshed) = history.first() {
+            merged[0] = refreshed.clone();
+        }
 
         let prepared_messages = prepare_messages_for_iteration(
-            history,
+            &merged,
             multimodal_config,
             degrade_strip_images,
             image_cache.as_deref_mut(),
@@ -529,7 +592,7 @@ pub async fn run_tool_call_loop(p: ToolLoop<'_>) -> Result<String> {
 
         let llm_started_at = announce_llm_request(
             &ctx,
-            history,
+            &merged,
             active_model_provider,
             active_model_provider_name,
             active_model,
@@ -652,10 +715,7 @@ pub async fn run_tool_call_loop(p: ToolLoop<'_>) -> Result<String> {
                         interrupted.partial_text,
                         crate::i18n::get_required_cli_string("turn-stream-interrupted")
                     ));
-                    if let Some(out) = new_messages_out.as_deref_mut() {
-                        out.push(msg.clone());
-                    }
-                    history.push(msg);
+                    current_turn.push(msg);
                 }
                 // Same for a user cancel after visible streamed output —
                 // the pre-consolidation streaming engine committed the
@@ -668,10 +728,7 @@ pub async fn run_tool_call_loop(p: ToolLoop<'_>) -> Result<String> {
                         cancelled.partial_text,
                         crate::i18n::get_required_cli_string("turn-interrupted-by-user")
                     ));
-                    if let Some(out) = new_messages_out.as_deref_mut() {
-                        out.push(msg.clone());
-                    }
-                    history.push(msg);
+                    current_turn.push(msg);
                 }
                 return Err(e);
             }
@@ -728,10 +785,7 @@ pub async fn run_tool_call_loop(p: ToolLoop<'_>) -> Result<String> {
                      tool-call schema, or answer in natural language if no tool is needed."
                         .to_string(),
                 );
-                if let Some(out) = new_messages_out.as_deref_mut() {
-                    out.push(msg.clone());
-                }
-                history.push(msg);
+                current_turn.push(msg);
                 continue;
             }
 
@@ -742,10 +796,7 @@ pub async fn run_tool_call_loop(p: ToolLoop<'_>) -> Result<String> {
                 let _ = tx.send(StreamDelta::Text(fallback.to_string())).await;
             }
             let msg = ChatMessage::assistant(fallback.to_string());
-            if let Some(out) = new_messages_out.as_deref_mut() {
-                out.push(msg.clone());
-            }
-            history.push(msg);
+            current_turn.push(msg);
             return Ok(accumulated_display_text);
         }
 
@@ -796,14 +847,15 @@ pub async fn run_tool_call_loop(p: ToolLoop<'_>) -> Result<String> {
             }
 
             let msg = ChatMessage::assistant(response_text.clone());
-            if let Some(out) = new_messages_out.as_deref_mut() {
-                out.push(msg.clone());
-            }
-            history.push(msg);
+            current_turn.push(msg);
             if let Some(reported) = reported_input_tokens {
+                // `reported` covers history + current_turn, but the trimmer
+                // only sees history. Subtract current_turn's estimated token
+                // contribution so the scaled budget is not underestimated.
+                let ct_est = crate::agent::history::estimate_history_tokens(current_turn);
                 enforce_reported_budget(
                     history,
-                    reported as usize,
+                    (reported as usize).saturating_sub(ct_est),
                     context_token_budget,
                     event_tx.as_ref(),
                     observer,
@@ -1006,18 +1058,14 @@ pub async fn run_tool_call_loop(p: ToolLoop<'_>) -> Result<String> {
             )?;
         }
 
-        let appended_from = history.len();
         append_tool_round_to_history(
-            history,
+            current_turn,
             assistant_history_content,
             &native_tool_calls,
             &individual_results,
             &tool_results,
             use_native_tools,
         );
-        if let Some(out) = new_messages_out.as_deref_mut() {
-            out.extend_from_slice(&history[appended_from..]);
-        }
 
         if cancelled_mid_batch {
             return Err(ToolLoopCancelled.into());
@@ -1028,6 +1076,7 @@ pub async fn run_tool_call_loop(p: ToolLoop<'_>) -> Result<String> {
             drive_live_sop_actions(
                 queued_sop_actions,
                 history,
+                current_turn,
                 model_provider,
                 provider_name,
                 model,
@@ -1058,7 +1107,6 @@ pub async fn run_tool_call_loop(p: ToolLoop<'_>) -> Result<String> {
                 channel,
                 collected_receipts,
                 event_tx.clone(),
-                new_messages_out.as_deref_mut(),
                 image_cache.as_deref_mut(),
                 agent_alias,
             )
@@ -1066,9 +1114,13 @@ pub async fn run_tool_call_loop(p: ToolLoop<'_>) -> Result<String> {
         }
 
         if let Some(reported) = reported_input_tokens {
+            // `reported` covers history + current_turn, but the trimmer
+            // only sees history. Subtract current_turn's estimated token
+            // contribution so the scaled budget is not underestimated.
+            let ct_est = crate::agent::history::estimate_history_tokens(current_turn);
             enforce_reported_budget(
                 history,
-                reported as usize,
+                (reported as usize).saturating_sub(ct_est),
                 context_token_budget,
                 event_tx.as_ref(),
                 observer,
@@ -1080,6 +1132,7 @@ pub async fn run_tool_call_loop(p: ToolLoop<'_>) -> Result<String> {
     finish_after_max_iterations(
         model_provider,
         history,
+        current_turn,
         provider_name,
         model,
         temperature,
@@ -1089,9 +1142,72 @@ pub async fn run_tool_call_loop(p: ToolLoop<'_>) -> Result<String> {
         accumulated_display_text,
         turn_id,
         knobs,
-        new_messages_out,
     )
     .await
+}
+
+pub async fn run_tool_call_loop(p: ToolLoop<'_>) -> Result<String> {
+    let ToolLoop {
+        exec,
+        history,
+        channel_name,
+        channel_reply_target,
+        cancellation_token,
+        on_delta,
+        shared_budget,
+        channel,
+        collected_receipts,
+        event_tx,
+        steering,
+        image_cache,
+        memory,
+        ingress,
+        agent_alias,
+        turn_id,
+    } = p;
+
+    // Contract: callers guarantee the last user-role message in `history` is
+    // the real user message for the current turn. This boundary splits the
+    // durable past-turn prefix from the mutable current-turn working set.
+    //
+    // Callers that retry on errors (e.g. model-switch) should use the
+    // split-aware entry point (`run_tool_call_loop_with_current_turn`)
+    // directly so the split boundary is stable across retries without
+    // content inspection.
+    let split = history
+        .iter()
+        .rposition(|m| m.role == "user")
+        .unwrap_or(history.len());
+    let mut current_turn = history.split_off(split);
+
+    // Box the inner future so the compatibility wrapper's own async state
+    // machine stays small; the core loop's state machine can be large because
+    // of all the scope-wrapped call sites in channels/orchestrator.
+    let result = Box::pin(run_tool_call_loop_with_current_turn(
+        ToolLoopWithCurrentTurn {
+            exec,
+            history,
+            current_turn: &mut current_turn,
+            channel_name,
+            channel_reply_target,
+            cancellation_token,
+            on_delta,
+            shared_budget,
+            channel,
+            collected_receipts,
+            event_tx,
+            steering,
+            image_cache,
+            memory,
+            ingress,
+            agent_alias,
+            turn_id,
+        },
+    ))
+    .await;
+
+    history.extend(current_turn);
+    result
 }
 
 fn collect_callable_tool_names(
@@ -1183,6 +1299,7 @@ fn sop_step_excluded_tools(
 async fn drive_live_sop_actions(
     queued_actions: Vec<crate::sop::executor::QueuedSopAction>,
     history: &mut Vec<ChatMessage>,
+    current_turn: &mut Vec<ChatMessage>,
     model_provider: &dyn ModelProvider,
     provider_name: &str,
     model: &str,
@@ -1213,7 +1330,6 @@ async fn drive_live_sop_actions(
     channel: Option<&dyn Channel>,
     collected_receipts: Option<&std::sync::Mutex<Vec<String>>>,
     event_tx: Option<tokio::sync::mpsc::Sender<TurnEvent>>,
-    mut new_messages_out: Option<&mut Vec<ChatMessage>>,
     mut image_cache: Option<&mut zeroclaw_providers::multimodal::LocalImageCache>,
     agent_alias: Option<&str>,
 ) -> Result<()> {
@@ -1229,10 +1345,11 @@ async fn drive_live_sop_actions(
                 } => {
                     let started_at = crate::sop::engine::now_iso8601();
                     let user_message = ChatMessage::user(context.clone());
-                    history.push(user_message.clone());
-                    if let Some(out) = new_messages_out.as_deref_mut() {
-                        out.push(user_message);
-                    }
+                    // SOP steps are part of the outer current turn under the
+                    // split-history contract. They are visible to the provider
+                    // alongside the turn that triggered them and are replayed
+                    // into persistent history with the rest of this turn.
+                    current_turn.push(user_message.clone());
 
                     let sop_excluded_tools = sop_step_excluded_tools(
                         &queued,
@@ -1247,54 +1364,56 @@ async fn drive_live_sop_actions(
                     let step_call_sink = crate::sop::executor::new_step_call_sink();
                     let step_output = crate::sop::executor::scope_step_call_sink(
                         step_call_sink.clone(),
-                        Box::pin(run_tool_call_loop(ToolLoop {
-                            exec: ResolvedAgentExecution::resolve(
-                                ResolvedModelAccess {
-                                    model_provider,
-                                    provider_name,
-                                    model,
-                                    temperature,
-                                },
-                                ResolvedIo {
-                                    tools_registry,
-                                    observer,
-                                    silent,
-                                    approval,
-                                    multimodal_config,
-                                    hooks,
-                                    activated_tools,
-                                    model_switch_callback: model_switch_callback.clone(),
-                                    receipt_generator,
-                                },
-                                ResolvedRuntimeKnobs {
-                                    max_tool_iterations,
-                                    excluded_tools: &sop_excluded_tools,
-                                    dedup_exempt_tools,
-                                    pacing,
-                                    strict_tool_parsing,
-                                    parallel_tools,
-                                    max_tool_result_chars,
-                                    context_token_budget,
-                                    knobs,
-                                },
-                            ),
-                            history,
-                            channel_name,
-                            channel_reply_target,
-                            cancellation_token: cancellation_token.clone(),
-                            on_delta: on_delta.clone(),
-                            shared_budget: shared_budget.clone(),
-                            channel,
-                            collected_receipts,
-                            event_tx: event_tx.clone(),
-                            steering: None,
-                            new_messages_out: new_messages_out.as_deref_mut(),
-                            image_cache: image_cache.as_deref_mut(),
-                            memory: None,
-                            ingress: IngressContext::sub_turn(),
-                            agent_alias,
-                            turn_id: &nested_turn_id,
-                        })),
+                        Box::pin(run_tool_call_loop_with_current_turn(
+                            ToolLoopWithCurrentTurn {
+                                exec: ResolvedAgentExecution::resolve(
+                                    ResolvedModelAccess {
+                                        model_provider,
+                                        provider_name,
+                                        model,
+                                        temperature,
+                                    },
+                                    ResolvedIo {
+                                        tools_registry,
+                                        observer,
+                                        silent,
+                                        approval,
+                                        multimodal_config,
+                                        hooks,
+                                        activated_tools,
+                                        model_switch_callback: model_switch_callback.clone(),
+                                        receipt_generator,
+                                    },
+                                    ResolvedRuntimeKnobs {
+                                        max_tool_iterations,
+                                        excluded_tools: &sop_excluded_tools,
+                                        dedup_exempt_tools,
+                                        pacing,
+                                        strict_tool_parsing,
+                                        parallel_tools,
+                                        max_tool_result_chars,
+                                        context_token_budget,
+                                        knobs,
+                                    },
+                                ),
+                                history,
+                                current_turn,
+                                channel_name,
+                                channel_reply_target,
+                                cancellation_token: cancellation_token.clone(),
+                                on_delta: on_delta.clone(),
+                                shared_budget: shared_budget.clone(),
+                                channel,
+                                collected_receipts,
+                                event_tx: event_tx.clone(),
+                                steering: None,
+                                image_cache: image_cache.as_deref_mut(),
+                                memory: None,
+                                ingress: IngressContext::sub_turn(),
+                                agent_alias,
+                                turn_id: &nested_turn_id,
+                            },
+                        )),
                     )
                     .await;
 

--- a/crates/zeroclaw-runtime/src/lib.rs
+++ b/crates/zeroclaw-runtime/src/lib.rs
@@ -3,6 +3,7 @@
     clippy::useless_format,
     clippy::manual_inspect
 )]
+#![recursion_limit = "256"]
 //! Agent runtime — orchestration, security, observability, cron, SOP, skills, hardware, and more.
 
 pub mod cli_input;

--- a/crates/zeroclaw-runtime/src/skills/review.rs
+++ b/crates/zeroclaw-runtime/src/skills/review.rs
@@ -120,7 +120,7 @@ pub async fn maybe_run_skill_review(
                 collected_receipts: Some(&receipts),
                 event_tx: None,
                 steering: None,
-                new_messages_out: None,
+
                 image_cache: None,
                 // Phase 1: stamp Internal/Trusted. Per-transport
                 // stamping lands in a later phase.

--- a/crates/zeroclaw-runtime/src/tools/delegate.rs
+++ b/crates/zeroclaw-runtime/src/tools/delegate.rs
@@ -2661,7 +2661,7 @@ impl DelegateTool {
                 collected_receipts,
                 event_tx: None,
                 steering: None,
-                new_messages_out: None,
+
                 image_cache: None,
                 // Phase 1: stamp Internal/Trusted. Per-transport
                 // stamping lands in a later phase.


### PR DESCRIPTION
### Summary

- **Base branch:** `master`
- **Context:** PR #7846 attempted to wire the `before_llm_call` hook by passing the loop's mutable `history` to the hook. Reviewers identified that this breaks the append-log contract: hook rewrites of historical messages reach the provider but are not replayed into `Agent::history`, causing the stored transcript to diverge from the provider-visible transcript. The agreed fix in #7846 is to split the loop input into:
  - `history` — immutable past turns (read-only to hooks);
  - `current_turn` — mutable current-turn working set that hooks may rewrite.

  After the loop, the entire `current_turn` is replayed into persistent history, so provider-visible and stored transcripts stay identical by construction.

- **What this PR does (PR-1):** Implements the split-history loop input contract **without** changing the `before_llm_call` hook signature or adding any hook call site. It lays the foundation for PR-2.
  - Adds `run_tool_call_loop_with_current_turn` / `ToolLoopWithCurrentTurn` as the core split-history entry point.
  - Keeps `run_tool_call_loop` / `ToolLoop` as a behavior-equivalent compatibility wrapper that auto-splits `history` at the last `role=user` message, runs the core loop, and re-attaches the mutated suffix.
  - Refactors `Agent::turn` and `turn_streamed_with_steering_state` to use the explicit split: the enriched user message lives only in `loop_current_turn` and is replayed into `self.history` together with assistant/tool messages after the loop.
  - Removes the `new_messages_out` append-log path; persistence replays `current_turn`.
  - Fixes `drive_live_sop_actions` so that SOP `ExecuteStep` user messages and nested-loop results are written into the outer `current_turn` instead of `history`. This preserves the pre-split behavior where SOP steps see the current turn's full context, and ensures SOP messages are replayed into persistent history as part of the current turn.
  - Preserves response cache logic exactly as today; cache key is still computed from the full provider-visible transcript.

- **What this PR does NOT do:**
  - Does NOT change the `before_llm_call` signature (deferred to PR-2).
  - Does NOT add a `before_llm_call` call site (deferred to PR-2).
  - Does NOT remove or change the response cache behavior. We note that, because the enriched user message carries a timestamp precise to the second, cache hits are effectively impossible in practice; the cache discussion in #7846 regarding hook-modified user messages therefore does not apply. Future work may remove the cache entirely.

### Follow-up plan

- **PR-2:** Change `before_llm_call` signature to `history: &[ChatMessage], current_turn: &mut Vec<ChatMessage>, model: &mut String`, wire it inside `run_tool_call_loop_with_current_turn` after preflight maintenance and before vision routing, and add regression tests proving hook rewrites reach both the provider and durable history.
- **PR-3 (optional):** Evaluate removing the response cache, since the per-second timestamp makes cache hits practically unreachable.

### Validation Evidence

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
LC_ALL=en_US.UTF-8 cargo test -p zeroclaw-runtime --lib
```

Result:
```
test result: ok. 2837 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out
```

### Security & Privacy Impact

- No new permissions, capabilities, network calls, secrets handling, or PII.

### Compatibility

- Backward compatible: existing callers continue using `run_tool_call_loop`; the wrapper preserves the old single-history behavior.
- No config/env/CLI changes.

### Rollback

- Revert this PR to restore the previous single-history `run_tool_call_loop` contract.
