### PR TITLE
fix(ci): include --workspace in rust quality gate and dev/ci test (#8753)

### DIFF
--- a/dev/ci.sh
+++ b/dev/ci.sh
@@ -87,7 +87,11 @@ case "$1" in
     ;;
 
   test)
-    run_in_ci "cargo test --locked --verbose"
+    # `--workspace` matches CI's `cargo nextest run --locked --workspace
+    # --exclude zeroclaw-desktop` (#8753): without it, the local gate
+    # compiles and tests only the root package and silently skips
+    # member-crate test targets.
+    run_in_ci "cargo test --locked --workspace --verbose"
     ;;
 
   test-component)
@@ -134,7 +138,7 @@ case "$1" in
 
   all)
     run_in_ci "./scripts/ci/rust_quality_gate.sh"
-    run_in_ci "cargo test --locked --verbose"
+    run_in_ci "cargo test --locked --workspace --verbose"
     run_in_ci "bash tests/manual/test_dockerignore.sh"
     run_in_ci "cargo build --release --locked --verbose"
     run_in_ci "cargo deny check licenses sources"

--- a/scripts/ci/rust_quality_gate.sh
+++ b/scripts/ci/rust_quality_gate.sh
@@ -11,11 +11,16 @@ echo "==> rust quality: cargo fmt --all -- --check"
 cargo fmt --all -- --check
 
 if [ "$MODE" = "strict" ]; then
-    echo "==> rust quality: cargo clippy --locked --all-targets -- -D warnings"
-    cargo clippy --locked --all-targets -- -D warnings
+    echo "==> rust quality: cargo clippy --locked --workspace --all-targets -- -D warnings"
+    # `--workspace` is required: with only the root package listed in the
+    # workspace `members` array, plain `cargo clippy --all-targets` from the
+    # repo root compiles only the root package's targets and silently skips
+    # member-crate lib-test targets. That blind spot has repeatedly let
+    # broken member-crate code land on master (see #8753, #6009, #8702).
+    cargo clippy --locked --workspace --all-targets -- -D warnings
 else
-    echo "==> rust quality: cargo clippy --locked --all-targets -- -D clippy::correctness"
-    cargo clippy --locked --all-targets -- -D clippy::correctness
+    echo "==> rust quality: cargo clippy --locked --workspace --all-targets -- -D clippy::correctness"
+    cargo clippy --locked --workspace --all-targets -- -D clippy::correctness
 fi
 
 echo "==> rust quality: provider dispatch gate (no direct ModelProvider method calls outside ProviderDispatch)"


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - `scripts/ci/rust_quality_gate.sh` ran `cargo clippy --locked --all-targets` from the workspace root. Because the root package is itself a workspace member (listed in `Cargo.toml`'s `members` array as `"."`), that command only compiled the root package's targets and silently skipped member-crate lib-test targets. The same blind spot existed in `dev/ci.sh`'s `test` and `all` commands, which ran plain `cargo test --locked`.
  - This class of breakage has already landed on master twice: a missing struct field in `zeroclaw-gateway` lib tests behind #6009 (2026-05-20), and two `ChannelMessage` test fixtures missing the `explicitly_addressed` field between 2026-07-04 and 2026-07-06 (recovered by #8702). In both cases the local `rust_quality_gate.sh` stayed green because it never compiled the affected member crate's test target.
  - This change adds `--workspace` to the two `cargo clippy` invocations in `scripts/ci/rust_quality_gate.sh` and to the two `cargo test` invocations in `dev/ci.sh` so the local gate compiles the same target set as CI's `cargo nextest run --locked --workspace`.
- **Scope boundary:** This PR does NOT change the `--test component|integration|system|live` invocations in `dev/ci.sh` — those target a single named integration test target and are intentionally scoped to that target. It also does NOT add `--exclude zeroclaw-desktop` or `--features ci-all`; matching CI's exact flags is a separate concern.
- **Blast radius:** Local pre-push CI gate only. The CI workflow files (`.github/workflows/ci.yml`) and the actual `cargo nextest` command on PR runs are unchanged. No code paths, configs, or runtime behavior are affected.
- **Linked issue(s):** Closes #8753
- **Labels:** `risk:low`, `size:XS`, `ci`

## Validation Evidence (required)

Local validation is the signal CI cannot replace. Run the full battery and paste literal output (tails, failures, warnings — not "all passed").

- **Commands run and tail output:**
  - `bash -n scripts/ci/rust_quality_gate.sh` — OK (syntax check).
  - `bash -n dev/ci.sh` — OK (syntax check).
  - `git diff --stat scripts/ci/rust_quality_gate.sh dev/ci.sh` — 2 files changed, 15 insertions(+), 6 deletions(-). The two `--workspace` flags are appended in the documented positions; no other command-line changes.
  - `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` were NOT run locally: this sandbox does not have a Rust toolchain available (`cargo` is not on `$PATH`). I confirmed by code reading and the issue's reproduction history that the bug is real; CI will run the full workspace compile on the PR.
- **Beyond CI — what did you manually verify?** (scenarios, edge cases, what you did NOT verify)
  - Verified by reading the script that both affected commands previously lacked `--workspace` and that the workspace `members` array starts with `"."` (so cargo's default package-set from the root is the root package only).
  - Verified the suggested fix matches what CI runs (`cargo clippy --workspace ...` and `cargo nextest run --locked --workspace` per `.github/workflows/ci.yml` and `.github/workflows/master-branch-flow.md`).
  - Did NOT run the gate end-to-end (no local toolchain); CI will exercise the `--workspace` flag and prove the gate now catches the failure mode that the issue describes.
- **If any command was intentionally skipped, why:** `cargo fmt` / `cargo clippy` / `cargo test` were not run because the shell environment has no Rust toolchain installed. CI will validate the full workspace on the PR.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No (the change is to local CI scripts only; flags added to existing invocations, no new entry points)
- If `No` or `Yes` to either: exact upgrade steps for existing users: N/A

## Rollback (required for medium/high-risk PRs)

Low-risk PRs: `git revert <sha>` is the plan unless otherwise noted.

- **Fast rollback command/path:** `git revert <sha>`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** None expected. If the broader workspace compile surfaces a latent issue that the previous gate had been hiding, the gate will fail; revert this commit and the issue will resurface exactly as described in #8753.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Scope materially carried forward: N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? No
- If `No`, why (inspiration-only, no direct code/design carry-over): N/A
