### PR TITLE
chore(msrv): bump workspace MSRV to 1.96.1 and align CI, Docker, docs

### DIFF
--- a/.github/workflows/ci-sbom.yml
+++ b/.github/workflows/ci-sbom.yml
@@ -27,7 +27,7 @@ jobs:
       # ── Rust SBOM (cargo-cyclonedx) ──────────────────────────────────
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          toolchain: 1.93.0
+          toolchain: 1.96.1
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           cache-on-failure: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          toolchain: 1.93.0
+          toolchain: 1.96.1
           components: rustfmt
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -92,7 +92,7 @@ jobs:
           fetch-depth: 0
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          toolchain: 1.93.0
+          toolchain: 1.96.1
           components: clippy
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         id: rust-cache
@@ -196,7 +196,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
-          toolchain: 1.93.0
+          toolchain: 1.96.1
           components: clippy
           targets: x86_64-pc-windows-msvc
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -276,7 +276,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          toolchain: 1.93.0
+          toolchain: 1.96.1
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         id: rust-cache
@@ -350,7 +350,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          toolchain: 1.93.0
+          toolchain: 1.96.1
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         id: rust-cache
         with:
@@ -396,7 +396,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         if: steps.changed.outputs.run == 'true'
         with:
-          toolchain: 1.93.0
+          toolchain: 1.96.1
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         if: steps.changed.outputs.run == 'true'
         with:
@@ -415,7 +415,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          toolchain: 1.93.0
+          toolchain: 1.96.1
           targets: i686-unknown-linux-gnu
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         id: rust-cache
@@ -438,7 +438,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          toolchain: 1.93.0
+          toolchain: 1.96.1
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         id: rust-cache
         with:
@@ -460,7 +460,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          toolchain: 1.93.0
+          toolchain: 1.96.1
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         id: rust-cache
         with:
@@ -493,7 +493,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          toolchain: 1.93.0
+          toolchain: 1.96.1
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         id: rust-cache
         with:
@@ -632,7 +632,7 @@ jobs:
         run: bash scripts/ci/install_target_triple_test.sh
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          toolchain: 1.93.0
+          toolchain: 1.96.1
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         id: rust-cache
         with:

--- a/.github/workflows/cross-platform-build-manual.yml
+++ b/.github/workflows/cross-platform-build-manual.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
-          toolchain: 1.93.0
+          toolchain: 1.96.1
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -85,7 +85,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
-          toolchain: 1.93.0
+          toolchain: 1.96.1
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         if: runner.os != 'Windows'

--- a/.github/workflows/cross-platform-clippy.yml
+++ b/.github/workflows/cross-platform-clippy.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
-          toolchain: 1.93.0
+          toolchain: 1.96.1
           components: clippy
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1

--- a/.github/workflows/daily-audit.yml
+++ b/.github/workflows/daily-audit.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
-          toolchain: 1.93.0
+          toolchain: 1.96.1
 
       - name: Install cargo-deny
         run: cargo install cargo-deny --locked

--- a/.github/workflows/desktop-check.yml
+++ b/.github/workflows/desktop-check.yml
@@ -55,7 +55,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
-          toolchain: 1.93.0
+          toolchain: 1.96.1
           components: clippy
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1

--- a/.github/workflows/monthly-outdated.yml
+++ b/.github/workflows/monthly-outdated.yml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
-          toolchain: 1.93.0
+          toolchain: 1.96.1
 
       - name: Install cargo-outdated
         run: cargo install cargo-outdated@0.16.0 --locked

--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -88,7 +88,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
         with:
-          toolchain: 1.93.0
+          toolchain: 1.96.1
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -269,7 +269,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
         with:
-          toolchain: 1.93.0
+          toolchain: 1.96.1
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         if: runner.os != 'Windows'
@@ -389,7 +389,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
         with:
-          toolchain: 1.93.0
+          toolchain: 1.96.1
           targets: aarch64-apple-darwin,x86_64-apple-darwin
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -495,7 +495,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
         with:
-          toolchain: 1.93.0
+          toolchain: 1.96.1
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
@@ -544,7 +544,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
         with:
-          toolchain: 1.93.0
+          toolchain: 1.96.1
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.8.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/zeroclaw-labs/zeroclaw"
-rust-version = "1.87"
+rust-version = "1.96.1"
 
 [workspace.dependencies]
 zeroclaw-api = { path = "crates/zeroclaw-api", version = "0.8.2" }

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 ARG ZEROCLAW_BASE_NODE=node:24-bookworm-slim@sha256:b31e7a42fdf8b8aa5f5ed477c72d694301273f1069c5a2f71d53c6482e99a2fc
 # >>> end generated:base-arg-node <<<
 # >>> generated:base-arg-rust-slim from dev/ci/container-base-images.toml by `cargo generate installers` - do not edit <<<
-ARG ZEROCLAW_BASE_RUST_SLIM=rust:1.94-slim@sha256:cf09adf8c3ebaba10779e5c23ff7fe4df4cccdab8a91f199b0c142c53fef3e1a
+ARG ZEROCLAW_BASE_RUST_SLIM=rust:1.96-slim@sha256:31ee7fc65186be7e0e0ccb3f2ca305f14e4739e7642a1ae65753aa5d7b874523
 # >>> end generated:base-arg-rust-slim <<<
 # >>> generated:base-arg-debian from dev/ci/container-base-images.toml by `cargo generate installers` - do not edit <<<
 ARG ZEROCLAW_BASE_DEBIAN=debian:trixie-slim@sha256:28de0877c2189802884ccd20f15ee41c203573bd87bb6b883f5f46362d24c5c2

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -4,7 +4,7 @@
 ARG ZEROCLAW_BASE_NODE=node:24-bookworm-slim@sha256:b31e7a42fdf8b8aa5f5ed477c72d694301273f1069c5a2f71d53c6482e99a2fc
 # >>> end generated:base-arg-node <<<
 # >>> generated:base-arg-rust-bookworm from dev/ci/container-base-images.toml by `cargo generate installers` - do not edit <<<
-ARG ZEROCLAW_BASE_RUST_BOOKWORM=rust:1.94-bookworm@sha256:6ae102bdbf528294bc79ad6e1fae682f6f7c2a6e6621506ba959f9685b308a55
+ARG ZEROCLAW_BASE_RUST_BOOKWORM=rust:1.96-bookworm@sha256:a339861ae23e9abb272cea45dfafde21760d2ce6577a70f8a926153677902663
 # >>> end generated:base-arg-rust-bookworm <<<
 
 # ── Stage 0: Frontend build ─────────────────────────────────────

--- a/crates/zeroclaw-channels/Cargo.toml
+++ b/crates/zeroclaw-channels/Cargo.toml
@@ -137,7 +137,8 @@ tokio-socks = "0.5"
 #
 # Commit history:
 # - 9734fb2: MSRV fix for `if let` guard (wacore/src/history_sync.rs:93)
-#            stable only on Rust 1.94+; ZeroClaw CI pins 1.93.0.
+#            stable only on Rust 1.94+; ZeroClaw MSRV is 1.96.1 so this is
+#            well within the supported baseline.
 #            Fixes the post-2026-04-24 WhatsApp Web protocol break (#6246).
 # - cbcdd2a: PR #636 fix for LID namespace conversion. Fixes ACK 400
 #            "server requires all participants to share the same JID

--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -9,9 +9,8 @@
 # to both. Simulator runs by default on :8080; use run-zeroclaw.sh for the agent.
 
 # ─── Stage 1: build ────────────────────────────────────────────────────────
-# Rust 1.91 (matches the workspace's actual feature usage — let-chains, etc.;
-# the workspace's rust-version=1.87 in Cargo.toml is an outdated pin).
-FROM rust:1.91-slim-bookworm AS builder
+# Matches the workspace `rust-version = "1.96.1"` MSRV declared in Cargo.toml.
+FROM rust:1.96-slim-bookworm AS builder
 
 WORKDIR /build
 

--- a/dev/README.md
+++ b/dev/README.md
@@ -159,4 +159,4 @@ Note: local `deny` focuses on license/source policy; advisory scanning is handle
 - The root `Dockerfile` also caches Rust `target/` (`id=zeroclaw-target`) to speed repeat local image builds.
 - Local CI reuses named Docker volumes for Cargo registry/git and target outputs.
 - `./dev/ci.sh docker-smoke` and `./dev/ci.sh all` now use `docker buildx` local cache at `.cache/buildx-smoke` when available.
-- The CI image keeps Rust toolchain defaults from `rust:1.92-slim` and installs pinned toolchain `1.92.0` (no custom `CARGO_HOME`/`RUSTUP_HOME` overrides), preventing repeated toolchain bootstrapping on each run.
+- The CI image keeps Rust toolchain defaults from `rust:1.96-slim` and installs pinned toolchain `1.96.1` (no custom `CARGO_HOME`/`RUSTUP_HOME` overrides), preventing repeated toolchain bootstrapping on each run.

--- a/dev/ci/Dockerfile
+++ b/dev/ci/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-FROM rust:1.92-slim@sha256:bf3368a992915f128293ac76917ab6e561e4dda883273c8f5c9f6f8ea37a378e
+FROM rust:1.96-slim@sha256:31ee7fc65186be7e0e0ccb3f2ca305f14e4739e7642a1ae65753aa5d7b874523
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-RUN rustup toolchain install 1.92.0 --profile minimal --component rustfmt --component clippy
+RUN rustup toolchain install 1.96.1 --profile minimal --component rustfmt --component clippy
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \

--- a/dev/ci/container-base-images.toml
+++ b/dev/ci/container-base-images.toml
@@ -22,8 +22,8 @@ arg = "ZEROCLAW_BASE_RUST_SLIM"
 registry = "dockerhub"
 repo = "library/rust"
 image_ref = "rust"
-tag = "1.94-slim"
-digest = "sha256:cf09adf8c3ebaba10779e5c23ff7fe4df4cccdab8a91f199b0c142c53fef3e1a"
+tag = "1.96-slim"
+digest = "sha256:31ee7fc65186be7e0e0ccb3f2ca305f14e4739e7642a1ae65753aa5d7b874523"
 
 [[image]]
 zone = "base-arg-rust-bookworm"
@@ -31,8 +31,8 @@ arg = "ZEROCLAW_BASE_RUST_BOOKWORM"
 registry = "dockerhub"
 repo = "library/rust"
 image_ref = "rust"
-tag = "1.94-bookworm"
-digest = "sha256:6ae102bdbf528294bc79ad6e1fae682f6f7c2a6e6621506ba959f9685b308a55"
+tag = "1.96-bookworm"
+digest = "sha256:a339861ae23e9abb272cea45dfafde21760d2ce6577a70f8a926153677902663"
 
 [[image]]
 zone = "base-arg-debian"

--- a/docs/book/src/setup/freebsd.md
+++ b/docs/book/src/setup/freebsd.md
@@ -27,7 +27,7 @@ doas pkg install -y rust git
 
 | Package | Why |
 |---|---|
-| `rust` | Provides `cargo` and `rustc` to build the binary. ZeroClaw's workspace MSRV is Rust 1.87; the FreeBSD `rust` port tracks a newer stable, so `pkg install rust` satisfies it. |
+| `rust` | Provides `cargo` and `rustc` to build the binary. ZeroClaw's workspace MSRV is Rust 1.96.1; the FreeBSD `rust` port tracks a newer stable, so `pkg install rust` satisfies it. |
 | `git` | Cloning the repo, and required at runtime if you use any git-backed tools. |
 
 > **`doas`, not `sudo`.** FreeBSD ships `doas` as the base privilege-escalation tool; `sudo` is an optional port. The examples here use `doas`. A minimal `/usr/local/etc/doas.conf` granting the `wheel` group passwordless escalation is:

--- a/src/alias_cli/mod.rs
+++ b/src/alias_cli/mod.rs
@@ -517,18 +517,18 @@ async fn agent_delete_owned_state(
     // Archive the workspace dir alongside the owned-state exports. `workspace`
     // was resolved by the caller before the config entry was removed, so a
     // custom `workspace.path` is preserved (post-removal it would default).
-    if workspace.exists() {
-        if let Err(e) = tokio::fs::rename(&workspace, archive_dir.join("workspace")).await {
-            let es = e.to_string();
-            eprintln!(
-                "{}",
-                mta(
-                    "cli-alias-warn-workspace-archive",
-                    &[("error", es.as_str())],
-                    "warning: workspace archive failed: {$error}"
-                )
-            );
-        }
+    if workspace.exists()
+        && let Err(e) = tokio::fs::rename(&workspace, archive_dir.join("workspace")).await
+    {
+        let es = e.to_string();
+        eprintln!(
+            "{}",
+            mta(
+                "cli-alias-warn-workspace-archive",
+                &[("error", es.as_str())],
+                "warning: workspace archive failed: {$error}"
+            )
+        );
     }
     let report = crate::gateway::agent_owned_state::cascade_owned_state(
         config,

--- a/src/commands/self_test.rs
+++ b/src/commands/self_test.rs
@@ -480,10 +480,10 @@ async fn check_websocket_handshake(config: &crate::config::Config) -> CheckResul
 
     let request = match probe_url.as_str().into_client_request() {
         Ok(mut req) => {
-            if let Some(token) = token {
-                if let Ok(value) = header::HeaderValue::from_str(&format!("Bearer {token}")) {
-                    req.headers_mut().insert(header::AUTHORIZATION, value);
-                }
+            if let Some(token) = token
+                && let Ok(value) = header::HeaderValue::from_str(&format!("Bearer {token}"))
+            {
+                req.headers_mut().insert(header::AUTHORIZATION, value);
             }
             req
         }
@@ -524,13 +524,11 @@ fn build_websocket_probe_url(
         Some(alias) => format!("ws://{probe_host}:{port}/ws/chat?agent={alias}"),
         None => format!("ws://{probe_host}:{port}/ws/chat"),
     };
-    if require_pairing {
-        if let Some(token) = token {
-            let sep = if url.contains('?') { '&' } else { '?' };
-            url.push(sep);
-            url.push_str("token=");
-            url.push_str(token);
-        }
+    if require_pairing && let Some(token) = token {
+        let sep = if url.contains('?') { '&' } else { '?' };
+        url.push(sep);
+        url.push_str("token=");
+        url.push_str(token);
     }
     url
 }

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -402,7 +402,7 @@ fn should_install(is_newer: bool, force: bool) -> bool {
 async fn download_binary(url: &str, sha256sums_url: Option<&str>, dest: &Path) -> Result<()> {
     let client = reqwest::Client::builder()
         .user_agent(format!("zeroclaw/{}", env!("CARGO_PKG_VERSION")))
-        .timeout(std::time::Duration::from_secs(300))
+        .timeout(std::time::Duration::from_mins(5))
         .build()?;
 
     let resp = client
@@ -648,13 +648,13 @@ async fn check_binary_arch(path: &Path) -> Result<()> {
     let binary_arch = detect_arch_from_header(&header);
     let host_arch = host_architecture();
 
-    if let (Some(bin), Some(host)) = (binary_arch, host_arch) {
-        if bin != host {
-            bail!(
-                "architecture mismatch: downloaded binary is {bin} but this host is {host} — \
-                 the release asset may be mispackaged"
-            );
-        }
+    if let (Some(bin), Some(host)) = (binary_arch, host_arch)
+        && bin != host
+    {
+        bail!(
+            "architecture mismatch: downloaded binary is {bin} but this host is {host} — \
+             the release asset may be mispackaged"
+        );
     }
 
     Ok(())
@@ -699,17 +699,16 @@ fn detect_arch_from_header(header: &[u8]) -> Option<&'static str> {
         if let Some(coff) = pe_off
             .checked_add(6)
             .and_then(|end| header.get(pe_off..end))
+            && &coff[0..4] == b"PE\0\0"
         {
-            if &coff[0..4] == b"PE\0\0" {
-                let machine = u16::from_le_bytes([coff[4], coff[5]]);
-                return match machine {
-                    0x8664 => Some("x86_64"),
-                    0xAA64 => Some("aarch64"),
-                    0x014C => Some("x86"),
-                    0x01C0 => Some("arm"),
-                    _ => None,
-                };
-            }
+            let machine = u16::from_le_bytes([coff[4], coff[5]]);
+            return match machine {
+                0x8664 => Some("x86_64"),
+                0xAA64 => Some("aarch64"),
+                0x014C => Some("x86"),
+                0x01C0 => Some("arm"),
+                _ => None,
+            };
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3922,11 +3922,11 @@ async fn main() -> Result<()> {
                                 t("cli-pairing-enabled", "🔐 Gateway pairing is enabled.")
                             );
                             println!();
-                            if let Some(message) = message.as_deref() {
-                                if rotating {
-                                    println!("  ✅ {message}");
-                                    println!();
-                                }
+                            if let Some(message) = message.as_deref()
+                                && rotating
+                            {
+                                println!("  ✅ {message}");
+                                println!();
                             }
                             println!("  ┌──────────────┐");
                             println!("  │  {code}  │");
@@ -5064,12 +5064,12 @@ async fn main() -> Result<()> {
                 }
 
                 // 2. Same directory as the current executable
-                if found.is_none() {
-                    if let Ok(exe) = std::env::current_exe() {
-                        let sibling = exe.with_file_name("zeroclaw-desktop");
-                        if sibling.is_file() {
-                            found = Some(sibling);
-                        }
+                if found.is_none()
+                    && let Ok(exe) = std::env::current_exe()
+                {
+                    let sibling = exe.with_file_name("zeroclaw-desktop");
+                    if sibling.is_file() {
+                        found = Some(sibling);
                     }
                 }
 
@@ -5077,38 +5077,37 @@ async fn main() -> Result<()> {
                 //    Uses directories::UserDirs so HOME (Unix) and USERPROFILE (Windows)
                 //    are both resolved correctly. On Windows the binary is .exe — try
                 //    both names since which::which (step 4) only catches PATH entries.
-                if found.is_none() {
-                    if let Some(home) =
+                if found.is_none()
+                    && let Some(home) =
                         directories::UserDirs::new().map(|u| u.home_dir().to_path_buf())
-                    {
-                        let bin_names: &[&str] = if cfg!(windows) {
-                            &["zeroclaw-desktop.exe", "zeroclaw-desktop"]
-                        } else {
-                            &["zeroclaw-desktop"]
-                        };
-                        // .cargo/bin works the same on Windows; .local/bin is XDG (Unix only).
-                        let dirs: &[&str] = if cfg!(windows) {
-                            &[".cargo/bin"]
-                        } else {
-                            &[".cargo/bin", ".local/bin"]
-                        };
-                        'outer: for dir in dirs {
-                            for name in bin_names {
-                                let candidate = home.join(dir).join(name);
-                                if candidate.is_file() {
-                                    found = Some(candidate);
-                                    break 'outer;
-                                }
+                {
+                    let bin_names: &[&str] = if cfg!(windows) {
+                        &["zeroclaw-desktop.exe", "zeroclaw-desktop"]
+                    } else {
+                        &["zeroclaw-desktop"]
+                    };
+                    // .cargo/bin works the same on Windows; .local/bin is XDG (Unix only).
+                    let dirs: &[&str] = if cfg!(windows) {
+                        &[".cargo/bin"]
+                    } else {
+                        &[".cargo/bin", ".local/bin"]
+                    };
+                    'outer: for dir in dirs {
+                        for name in bin_names {
+                            let candidate = home.join(dir).join(name);
+                            if candidate.is_file() {
+                                found = Some(candidate);
+                                break 'outer;
                             }
                         }
                     }
                 }
 
                 // 4. Fallback to PATH lookup
-                if found.is_none() {
-                    if let Ok(path) = which::which("zeroclaw-desktop") {
-                        found = Some(path);
-                    }
+                if found.is_none()
+                    && let Ok(path) = which::which("zeroclaw-desktop")
+                {
+                    found = Some(path);
                 }
 
                 found
@@ -5289,10 +5288,10 @@ async fn main() -> Result<()> {
                     if secrets && !entry.is_secret {
                         continue;
                     }
-                    if let Some(ref f) = filter {
-                        if !entry.name.starts_with(f.as_str()) {
-                            continue;
-                        }
+                    if let Some(ref f) = filter
+                        && !entry.name.starts_with(f.as_str())
+                    {
+                        continue;
                     }
                     if entry.category != current_category {
                         if !current_category.is_empty() {

--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -284,10 +284,10 @@ pub async fn handle_command(
             let canonical_skills = skills_dir(workspace_dir)
                 .canonicalize()
                 .unwrap_or_else(|_| skills_dir(workspace_dir));
-            if let Ok(canonical_skill) = skill_path.canonicalize() {
-                if !canonical_skill.starts_with(&canonical_skills) {
-                    anyhow::bail!("Skill path escapes skills directory: {name}");
-                }
+            if let Ok(canonical_skill) = skill_path.canonicalize()
+                && !canonical_skill.starts_with(&canonical_skills)
+            {
+                anyhow::bail!("Skill path escapes skills directory: {name}");
             }
 
             if !skill_path.exists() {

--- a/tests/integration/email_attachments.rs
+++ b/tests/integration/email_attachments.rs
@@ -164,10 +164,10 @@ fn extract_attachments_with_limit(
             ct.map(|c| format!("{}/{}", c.ctype(), c.subtype().unwrap_or("octet-stream")));
 
         // Skip text parts — already handled by extract_text()
-        if let Some(ref m) = mime_str {
-            if m.starts_with("text/") {
-                continue;
-            }
+        if let Some(ref m) = mime_str
+            && m.starts_with("text/")
+        {
+            continue;
         }
 
         let data = part.contents().to_vec();


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Bumps `[workspace.package] rust-version` from `1.87` to `1.96.1`. The 1.87 pin dated from early 2025; the workspace has since taken hard dependencies on features stabilized well after 1.87 (let-chains from 1.88, `str::floor_char_boundary` from 1.91), CI already tracked `1.93.0` toolchains, and the Docker base images ran on `1.91`–`1.94`. `install.sh`'s version guard reads `rust-version` as the compatibility promise to downstream, so the stale pin was misleading.
  - Aligns all 19 GitHub Actions `toolchain: 1.93.0` pins to `1.96.1` so CI actually validates the declared MSRV.
  - Regenerates `Dockerfile` and `Dockerfile.debian` via `cargo generate installers` after updating `dev/ci/container-base-images.toml` to `rust:1.96-slim`/`rust:1.96-bookworm` (fresh sha256 digests resolved from dockerhub's registry manifest API — same protocol xtask uses).
  - Updates `dev/ci/Dockerfile` (`rust:1.92-slim` + `rustup toolchain install 1.92.0`) and `demo/Dockerfile` (`rust:1.91-slim-bookworm`) to the 1.96 base images. These two are not covered by `cargo generate installers`.
  - Adopts the two new Rust 1.96 lints across the tree so `cargo clippy -D warnings` stays green on the new baseline:
    - `clippy::collapsible_if` learned to see nested `if let` — 12 sites collapsed to let-chains (`if let ... && cond { ... }`), possible thanks to let-chains being stable since Rust 1.88.
    - `clippy::duration_suboptimal_units` prefers larger units — one `Duration::from_secs(300)` in `src/commands/update.rs` becomes `Duration::from_mins(5)` (stable since Rust 1.91).
  - Cleans up stale MSRV comments in `crates/zeroclaw-channels/Cargo.toml` (which claimed "CI pins 1.93.0"), `demo/Dockerfile` (which called `rust-version=1.87` an outdated pin), and updates `docs/book/src/setup/freebsd.md`.
- **Scope boundary:** does NOT retire the `MSRV-compatible replacement for str::floor_char_boundary` shim at `crates/zeroclaw-runtime/src/agent/history.rs:31` — that's a follow-up now that the shim is unnecessary. Does NOT touch `.cargo/config.toml`'s `rustdocflags = ["--default-theme=ayu"]` — that's the root cause of a pre-existing `cargo test --doc` failure (see Validation Evidence) which reproduces on master and is orthogonal to MSRV correctness.
- **Blast radius:** any downstream that reads `rust-version` for toolchain selection now requires ≥ 1.96.1. The 13 mechanical lint rewrites and one `from_secs(300)` → `from_mins(5)` are behaviorally identical. Docker image consumers pick up whatever the `rust:1.96-{slim,bookworm}` published images ship — most notably Cargo security fixes CVE-2026-5223 (medium, tarball/symlink extraction) and CVE-2026-5222 (low, normalized-URL auth) that landed in Rust 1.96.
- **Linked issue(s):** None.
- **Labels:** `ci`, `docs`, `dependencies`, `core`, `skills`, `tests`, `dev`, `risk:high`, `size:S`, `type:ci`.

## What actually changed in Rust 1.88 → 1.96.1 (rationale)

Nine stable releases between 1.87 and 1.96.1. Highlights maintainers should care about:

| Release | Date | Highlights we benefit from |
|---|---|---|
| **1.88.0** | 2025-06-26 | **Let chains** (`if let ... && ...`) — used to flatten the 12 nested `if let` sites in this PR. `#[unsafe(naked)]` for full-assembly control. Boolean `cfg(true)`/`cfg(false)`. `Cell::update`, `HashMap::extract_if`, slice `as_chunks`. Cargo GC of unused registry downloads. |
| **1.89.0** | 2025-08-07 | Inferred const generics (`[false; _]`). `File::lock` / `File::try_lock` / `File::unlock`. `Result::flatten`. `NonZero<char>`. `mismatched_lifetime_syntaxes` lint. `x86_64-apple-darwin` demoted to Tier 2 (Apple Silicon is now the default). |
| **1.90.0** | 2025-09-18 | LLD default linker on `x86_64-unknown-linux-gnu` (faster CI link times). `cargo publish --workspace` (native dependency-ordered workspace publishing). `checked_sub_signed` / `wrapping_sub_signed` for unsigned integers. Const float rounding (`floor`, `ceil`, `round`, `round_ties_even`). |
| **1.91.0** | 2025-10-30 | `aarch64-pc-windows-msvc` promoted to Tier 1. **`Duration::from_mins` / `from_hours`** (used by this PR). **`str::floor_char_boundary` / `ceil_char_boundary`** (obsoletes the runtime shim at `crates/zeroclaw-runtime/src/agent/history.rs:31`). `dangling_pointers_from_locals` warn-by-default lint. `BTreeMap/BTreeSet::extract_if`. Strict integer arithmetic (`strict_add`, `strict_sub`, …) that panic on overflow in all build modes. `Ipv4Addr::from_octets` / `Ipv6Addr::from_octets`. |
| **1.92.0** | 2025-12-11 | Never-type fallback lints (`never_type_fallback_flowing_into_unsafe`) become deny-by-default. Unwind tables emitted with `-Cpanic=abort` on Linux (restores backtraces broken since 1.23). `RwLockWriteGuard::downgrade`. `Box::new_zeroed` / `Rc::new_zeroed` / `Arc::new_zeroed`. |
| **1.93.0** | 2026-01-22 | `cfg` on individual `asm!` lines (no more duplicating whole blocks for conditional inline asm). `Vec::into_raw_parts` / `String::into_raw_parts`. `VecDeque::pop_front_if` / `pop_back_if`. musl 1.2.5 (better DNS resolution for static Linux builds). |
| **1.94.0** | 2026-03-05 | `<[T]>::array_windows` (compile-time-const window size). `LazyCell::get` / `LazyLock::get`. `Peekable::next_if_map`. Cargo `include` key in `.cargo/config.toml` for composable configs. TOML 1.1 support. |
| **1.95.0** | 2026-04-16 | `cfg_select!` macro (built-in `cfg-if` replacement). `if let` guards in match arms. Integer atomics gain `.update()` / `.try_update()`. `core::hint::cold_path`. |
| **1.96.0** | 2026-05-28 | New `core::range::{Range, RangeInclusive}` (`Copy`, `IntoIterator`). `assert_matches!` / `debug_assert_matches!`. **Enhanced `collapsible_if`** (fires on the 12 sites this PR fixes). **`duration_suboptimal_units` lint** (fires on the one site). Cargo security fixes **CVE-2026-5223** (medium, tarball/symlink extraction) + **CVE-2026-5222** (low, normalized-URL auth). WASM `--allow-undefined` no longer implicit. |
| **1.96.1** | 2026-06-30 | Point release; picking `1.96.1` rather than `1.96.0` so downstream toolchains carry the point-release fixes bundled by rustup. |

## Validation Evidence (required)

Local toolchain: `rustc 1.96.1 (31fca3adb 2026-06-26)`, `cargo 1.96.1 (356927216 2026-06-26)`.

```
$ cargo fmt --all -- --check
(no output — clean)

$ cargo clippy --all-targets -- -D warnings
    Checking zeroclaw-eval v0.8.2
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 6m 35s

$ cargo test --lib --bins --tests
test result: ok. 158 passed; 0 failed [unit + integration]
test result: ok. 9 passed; 0 failed [system e2e]
(all per-crate suites pass)

$ cargo run --release -p xtask --bin generate -- installers
wrote /.../Dockerfile
wrote /.../Dockerfile.debian
(everything else unchanged — install.sh, setup.bat, Containerfile, PKGBUILD, scoop, flake.nix, docker-tags.toml all match)
```

- **Commands run and tail output:** see above. `fmt --check` clean, `clippy -D warnings` clean, all 158 unit + 9 system integration tests pass on the new toolchain.
- **Beyond CI — what did you manually verify?**
  1. Resolved fresh sha256 digests for `rust:1.96-slim` (`sha256:31ee7fc65186be7e0e0ccb3f2ca305f14e4739e7642a1ae65753aa5d7b874523`) and `rust:1.96-bookworm` (`sha256:a339861ae23e9abb272cea45dfafde21760d2ce6577a70f8a926153677902663`) from `https://registry-1.docker.io/v2/library/rust/manifests/<tag>` — the same registry manifest API `xtask/src/generate/container_base.rs` uses. Cross-checked by running `cargo generate installers` and confirming it produced identical splice output.
  2. All 13 clippy lint auto-suggestions reviewed by hand (no `--fix`); each collapsed nested `if let ... { if cond { ... } }` → `if let ... && cond { ... }` verified for semantic equivalence (no `else` branches, no side effects between outer bind and inner cond).
  3. Confirmed `install.sh`'s MSRV guard reads `[workspace.package] rust-version` dynamically via `awk` — no hardcoded version to update.
  4. Verified `Duration::from_mins` was stabilized in Rust 1.91 (well below the new 1.96.1 MSRV).
- **If any command was intentionally skipped, why:** `cargo test --doc` fails on Rust 1.96 with `error: Option 'default-theme' given more than once`. **This failure reproduces identically on master** (verified with `git stash && cargo test --doc` before opening this PR), so it is not caused by this change. Root cause: `.cargo/config.toml`'s `rustdocflags = ["--default-theme=ayu"]` reaches rustdoc twice under Rust 1.96's stricter arg parser — orthogonal to MSRV correctness. Will be handled in a separate follow-up PR.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- If any `Yes`, describe the risk and mitigation: N/A.

Positive security impact: downstream consumers moving to the new MSRV automatically pick up Rust 1.96's Cargo advisories **CVE-2026-5223** (medium, tarball/symlink extraction during dependency unpacking) and **CVE-2026-5222** (low, normalized-URL authentication). Users of crates.io were noted as unaffected by upstream.

## Compatibility (required)

- Backward compatible? **No** (raises the required Rust toolchain from 1.87 to 1.96.1)
- Config / env / CLI surface changed? **No**
- If `No` or `Yes` to either: exact upgrade steps for existing users:
  - Rustup users: `rustup update stable` on a system with rustup ≥ 1.28.
  - Distro packages: install Rust stable ≥ 1.96.1 via the distro package manager.
  - `install.sh` already reads the MSRV from `[workspace.package] rust-version` and refuses older toolchains with a clear error (`Rust <X> is too old. ZeroClaw requires 1.96.1+ (edition 2024). Run: rustup update stable`) — no silent build failures.
  - Docker consumers: no action needed; the generated Dockerfiles pull the new base images by tag+digest automatically.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <sha>` on the single squashed commit — MSRV bump, CI toolchain pins, Docker image rotations, and the 13 lint rewrites were prepared as one behavioral unit so revert is atomic. Historical dockerhub digests (the previous `sha256:cf09…` and `sha256:6ae1…`) are still available if a rollback is needed.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Builds on Rust < 1.96.1 fail at Cargo's manifest-parse step with `package requires rustc 1.96.1` — surfaces before compilation, not a runtime symptom. Users on rustup can `rustup update stable` and re-run. CI runs use the pinned `1.96.1` in `.github/workflows/*.yml`, so no ambiguity there.
