### PR TITLE
feat(runtime): sample process RAM/CPU on macOS, Windows, FreeBSD via sysinfo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6160,6 +6160,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6448,6 +6457,16 @@ dependencies = [
  "block2",
  "libc",
  "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
  "objc2-core-foundation",
 ]
 
@@ -9472,6 +9491,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252800745060e7b9ffb7b2badbd8b31cfa4aa2e61af879d0a3bf2a317c20217d"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -13531,6 +13564,7 @@ dependencies = [
  "sha2 0.10.9",
  "shellexpand",
  "sys-locale",
+ "sysinfo",
  "tar",
  "tempfile",
  "thiserror 2.0.18",

--- a/crates/zeroclaw-runtime/Cargo.toml
+++ b/crates/zeroclaw-runtime/Cargo.toml
@@ -55,6 +55,11 @@ serde_json = { version = "1.0", default-features = false, features = ["std"] }
 sha2 = "0.10"
 shellexpand = "3.1"
 sys-locale.workspace = true
+# Pinned to 0.36 because 0.37+ requires rustc 1.88; workspace MSRV is 1.87.
+# Used only by `process_stats.rs` to sample this process's RSS/CPU% across
+# Linux, macOS, Windows, and FreeBSD. `default-features = false` drops the
+# multi-threaded refresh path (we sample a single pid).
+sysinfo = { version = "0.36", default-features = false, features = ["system"] }
 tar = "0.4"
 tempfile = "3.26"
 thiserror = "2.0"

--- a/crates/zeroclaw-runtime/src/process_stats.rs
+++ b/crates/zeroclaw-runtime/src/process_stats.rs
@@ -1,37 +1,37 @@
 //! Self-process resource sampling — RSS (resident memory) and CPU%.
 //!
-//! Linux-only via `/proc/self/{status,stat}` so no extra deps. macOS /
-//! Windows return `ProcessStats::unsupported()` (rss=0, cpu=None); the
-//! dashboard renders the rss tile blank-with-note on those platforms.
+//! Backed by the `sysinfo` crate so Linux, macOS, Windows, and FreeBSD are
+//! all supported uniformly. Unsupported hosts (whatever `sysinfo` doesn't
+//! recognise) fall back to `ProcessStats::unsupported()` (rss=0, cpu=None);
+//! the dashboard renders the tiles blank-with-note on those platforms.
 //!
-//! CPU% is computed across calls by stashing the previous (wall_instant,
-//! process_ticks) sample in a process-global `OnceLock<Mutex<...>>` and
-//! taking the delta. First call returns `cpu_percent = None` since
-//! there's no baseline yet; the first refresh after gateway boot fills
-//! it in.
+//! CPU% is computed across calls: we hold a process-global `System` inside
+//! a `OnceLock<Mutex<...>>` and refresh the same pid on each `sample()` so
+//! sysinfo can diff against the previous sample. The first call returns
+//! `cpu_percent = None` (no baseline yet); the first refresh after gateway
+//! boot fills it in. Value semantics match the historical Linux
+//! implementation: 0..100*ncpu (100% = one core saturated). The dashboard
+//! divides by `num_cpus` for its normalized display.
 
-#[cfg(target_os = "linux")]
 use parking_lot::Mutex;
 use serde::Serialize;
-#[cfg(target_os = "linux")]
 use std::sync::OnceLock;
-#[cfg(target_os = "linux")]
 use std::time::Instant;
+use sysinfo::{MemoryRefreshKind, Pid, ProcessRefreshKind, ProcessesToUpdate, RefreshKind, System};
 
 #[derive(Debug, Clone, Serialize)]
 pub struct ProcessStats {
     /// Resident set size in bytes. `0` when unsupported.
     pub rss_bytes: u64,
-    /// Total system RAM in bytes, from `/proc/meminfo`'s `MemTotal`.
-    /// `0` when unsupported. The dashboard renders `rss / system_ram_total`
-    /// as a percentage so the RAM tile is meaningful at a glance regardless
-    /// of host size.
+    /// Total system RAM in bytes. `0` when unsupported. The dashboard
+    /// renders `rss / system_ram_total` as a percentage so the RAM tile is
+    /// meaningful at a glance regardless of host size.
     pub system_ram_total_bytes: u64,
-    /// CPU usage as a percentage averaged across logical cores (0..100*ncpu).
+    /// CPU usage as a percentage summed across logical cores (0..100*ncpu).
     /// `None` on the first sample (no baseline) or unsupported platforms.
     pub cpu_percent: Option<f32>,
-    /// Number of logical CPUs the OS reports. Useful for clamping the
-    /// CPU% bar on the dashboard. `0` when unknown.
+    /// Number of logical CPUs the OS reports. Useful for clamping the CPU%
+    /// bar on the dashboard. `0` when unknown.
     pub num_cpus: u32,
 }
 
@@ -46,129 +46,118 @@ impl ProcessStats {
     }
 }
 
-#[cfg(target_os = "linux")]
-struct LastSample {
-    wall: Instant,
-    process_ticks: u64,
+struct State {
+    system: System,
+    /// True once we've refreshed at least once — only then does
+    /// `Process::cpu_usage()` have a delta to report. We return `None` on
+    /// the first sample to preserve the pre-sysinfo contract (dashboard
+    /// already handles this).
+    have_baseline: bool,
+    /// Wall-clock of the last CPU refresh, used to rate-limit CPU refreshes
+    /// to at least `MINIMUM_CPU_UPDATE_INTERVAL` — refreshing sooner makes
+    /// sysinfo return `0` (most platforms) or `100 * ncpu` (Linux),
+    /// which shows up as a hard floor/ceiling artifact on high-frequency
+    /// callers like `/rpc/health`.
+    last_cpu_refresh: Option<Instant>,
+    /// Last CPU% we returned; served on rapid re-samples so callers still
+    /// see a plausible value instead of a sysinfo-internal artifact.
+    last_cpu_percent: Option<f32>,
+    pid: Pid,
 }
 
-#[cfg(target_os = "linux")]
-static LAST: OnceLock<Mutex<Option<LastSample>>> = OnceLock::new();
+static STATE: OnceLock<Mutex<Option<State>>> = OnceLock::new();
 
-#[cfg(target_os = "linux")]
-fn last() -> &'static Mutex<Option<LastSample>> {
-    LAST.get_or_init(|| Mutex::new(None))
+fn state() -> &'static Mutex<Option<State>> {
+    STATE.get_or_init(|| Mutex::new(None))
 }
 
-/// Sample current RSS + CPU%. Cheap to call (single /proc read on Linux).
-/// Safe to call from any thread.
+/// Sample current RSS + CPU%. Cheap to call — refreshes only this process
+/// and only the CPU/memory fields. Safe to call from any thread.
 pub fn sample() -> ProcessStats {
-    #[cfg(target_os = "linux")]
-    {
-        sample_linux().unwrap_or_else(ProcessStats::unsupported)
+    if !sysinfo::IS_SUPPORTED_SYSTEM {
+        return ProcessStats::unsupported();
     }
-    #[cfg(not(target_os = "linux"))]
-    {
-        ProcessStats::unsupported()
-    }
-}
+    let Ok(pid) = sysinfo::get_current_pid() else {
+        return ProcessStats::unsupported();
+    };
 
-#[cfg(target_os = "linux")]
-fn sample_linux() -> Option<ProcessStats> {
-    let rss_bytes = read_rss_bytes()?;
-    let ticks = read_process_ticks()?;
+    let mut guard = state().lock();
+    let st = guard.get_or_insert_with(|| {
+        // Populate `cpus()` and initial memory once. `RefreshKind::nothing()`
+        // keeps the constructor cheap; per-sample refreshes fill in the
+        // fields we actually read below.
+        let system = System::new_with_specifics(
+            RefreshKind::nothing()
+                .with_cpu(sysinfo::CpuRefreshKind::nothing())
+                .with_memory(MemoryRefreshKind::nothing().with_ram()),
+        );
+        State {
+            system,
+            have_baseline: false,
+            last_cpu_refresh: None,
+            last_cpu_percent: None,
+            pid,
+        }
+    });
+
+    // Skip the CPU-refresh half when the caller is hammering us faster than
+    // sysinfo's internal tick window; otherwise `cpu_usage()` returns a
+    // meaningless floor/ceiling value. Memory refresh is always cheap and
+    // has no minimum-interval constraint, so we always update RSS.
     let now = Instant::now();
-    let num_cpus = read_num_cpus();
-    let clock_ticks = clock_ticks_per_sec();
-    let system_ram_total_bytes = read_system_ram_total().unwrap_or(0);
+    let cpu_stale = st
+        .last_cpu_refresh
+        .is_none_or(|prev| now.duration_since(prev) >= sysinfo::MINIMUM_CPU_UPDATE_INTERVAL);
+    let refresh_kind = if cpu_stale {
+        ProcessRefreshKind::nothing().with_cpu().with_memory()
+    } else {
+        ProcessRefreshKind::nothing().with_memory()
+    };
+    st.system
+        .refresh_processes_specifics(ProcessesToUpdate::Some(&[st.pid]), true, refresh_kind);
+    // Total system RAM can change at runtime (memory hot-add on enterprise
+    // servers, hypervisor ballooning on VMs), so refresh it every sample.
+    // Cost is a single sysctl / /proc/meminfo read / GlobalMemoryStatusEx —
+    // cheap enough that we don't rate-limit it.
+    st.system
+        .refresh_memory_specifics(MemoryRefreshKind::nothing().with_ram());
+    // Refresh the CPU list too — logical CPU count can shift (Linux CPU
+    // hot-plug via /sys/devices/system/cpu/cpuN/online, cloud VM vCPU
+    // resize). Only piggy-backs when we're already doing a CPU refresh, so
+    // rapid re-samples remain cheap.
+    if cpu_stale {
+        st.system
+            .refresh_cpu_specifics(sysinfo::CpuRefreshKind::nothing());
+    }
 
-    let mut guard = last().lock();
-    let cpu_percent = if let Some(prev) = guard.as_ref() {
-        let elapsed = now.duration_since(prev.wall).as_secs_f64();
-        if elapsed > 0.0 && clock_ticks > 0 {
-            let dticks = ticks.saturating_sub(prev.process_ticks) as f64;
-            let cpu_seconds = dticks / clock_ticks as f64;
-            Some(((cpu_seconds / elapsed) * 100.0) as f32)
+    let Some(proc) = st.system.process(st.pid) else {
+        return ProcessStats::unsupported();
+    };
+    let rss_bytes = proc.memory();
+    let cpu_percent = if cpu_stale {
+        st.last_cpu_refresh = Some(now);
+        if st.have_baseline {
+            let v = proc.cpu_usage();
+            st.last_cpu_percent = Some(v);
+            Some(v)
         } else {
+            st.have_baseline = true;
             None
         }
     } else {
-        None
+        // Sub-interval refresh: reuse the previous reading rather than
+        // returning a sysinfo artifact.
+        st.last_cpu_percent
     };
-    *guard = Some(LastSample {
-        wall: now,
-        process_ticks: ticks,
-    });
+    let system_ram_total_bytes = st.system.total_memory();
+    let num_cpus = st.system.cpus().len() as u32;
 
-    Some(ProcessStats {
+    ProcessStats {
         rss_bytes,
         system_ram_total_bytes,
         cpu_percent,
         num_cpus,
-    })
-}
-
-#[cfg(target_os = "linux")]
-fn read_system_ram_total() -> Option<u64> {
-    let meminfo = std::fs::read_to_string("/proc/meminfo").ok()?;
-    for line in meminfo.lines() {
-        if let Some(rest) = line.strip_prefix("MemTotal:") {
-            let kb: u64 = rest
-                .split_whitespace()
-                .next()
-                .and_then(|s| s.parse().ok())?;
-            return Some(kb.saturating_mul(1024));
-        }
     }
-    None
-}
-
-#[cfg(target_os = "linux")]
-fn read_rss_bytes() -> Option<u64> {
-    let status = std::fs::read_to_string("/proc/self/status").ok()?;
-    for line in status.lines() {
-        if let Some(rest) = line.strip_prefix("VmRSS:") {
-            // Format: `VmRSS:    12345 kB`
-            let kb: u64 = rest
-                .split_whitespace()
-                .next()
-                .and_then(|s| s.parse().ok())?;
-            return Some(kb.saturating_mul(1024));
-        }
-    }
-    None
-}
-
-#[cfg(target_os = "linux")]
-fn read_process_ticks() -> Option<u64> {
-    // /proc/self/stat fields are space-delimited but `comm` (field 2) is
-    // parenthesized and may contain spaces, so anchor on the closing `)`
-    // and count from there. Fields after comm: state(3) ppid(4) ...
-    // utime(14) stime(15).
-    let stat = std::fs::read_to_string("/proc/self/stat").ok()?;
-    let close = stat.rfind(')')?;
-    let after: &str = stat[close + 1..].trim_start();
-    let fields: Vec<&str> = after.split_whitespace().collect();
-    // After `comm)`, field indices are 0-based here but correspond to
-    // /proc indices 3..; utime is /proc field 14 → here index 11,
-    // stime is /proc field 15 → here index 12.
-    let utime: u64 = fields.get(11)?.parse().ok()?;
-    let stime: u64 = fields.get(12)?.parse().ok()?;
-    Some(utime + stime)
-}
-
-#[cfg(target_os = "linux")]
-fn clock_ticks_per_sec() -> u64 {
-    // SAFETY: sysconf(_SC_CLK_TCK) is a const POSIX query, no side effects.
-    let v = unsafe { libc::sysconf(libc::_SC_CLK_TCK) };
-    if v > 0 { v as u64 } else { 100 }
-}
-
-#[cfg(target_os = "linux")]
-fn read_num_cpus() -> u32 {
-    // SAFETY: sysconf(_SC_NPROCESSORS_ONLN) is a const POSIX query.
-    let v = unsafe { libc::sysconf(libc::_SC_NPROCESSORS_ONLN) };
-    if v > 0 { v as u32 } else { 0 }
 }
 
 #[cfg(test)]
@@ -176,19 +165,23 @@ mod tests {
     use super::*;
 
     #[test]
-    #[cfg(target_os = "linux")]
-    fn sample_returns_rss_on_linux() {
+    fn sample_returns_rss_on_supported_hosts() {
+        if !sysinfo::IS_SUPPORTED_SYSTEM {
+            return;
+        }
         let s = sample();
-        assert!(s.rss_bytes > 0, "rss should be non-zero on Linux");
+        assert!(s.rss_bytes > 0, "rss should be non-zero on supported hosts");
     }
 
     #[test]
-    #[cfg(target_os = "linux")]
     fn sample_returns_system_ram_total_and_rss_is_a_subset() {
+        if !sysinfo::IS_SUPPORTED_SYSTEM {
+            return;
+        }
         let s = sample();
         assert!(
             s.system_ram_total_bytes > 0,
-            "MemTotal should be non-zero on Linux"
+            "total memory should be non-zero on supported hosts"
         );
         assert!(
             s.rss_bytes <= s.system_ram_total_bytes,
@@ -199,10 +192,16 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_os = "linux")]
     fn cpu_percent_filled_on_second_sample() {
+        if !sysinfo::IS_SUPPORTED_SYSTEM {
+            return;
+        }
         let _ = sample();
-        std::thread::sleep(std::time::Duration::from_millis(20));
+        // sysinfo requires at least MINIMUM_CPU_UPDATE_INTERVAL between
+        // refreshes for the CPU% delta to be meaningful. Sleep just past it.
+        std::thread::sleep(
+            sysinfo::MINIMUM_CPU_UPDATE_INTERVAL + std::time::Duration::from_millis(10),
+        );
         for _ in 0..10_000 {
             std::hint::black_box(0u64);
         }
@@ -214,10 +213,45 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(target_os = "linux"))]
-    fn sample_is_unsupported_off_linux() {
+    fn sample_reports_num_cpus_on_supported_hosts() {
+        if !sysinfo::IS_SUPPORTED_SYSTEM {
+            return;
+        }
         let s = sample();
-        assert_eq!(s.rss_bytes, 0);
-        assert!(s.cpu_percent.is_none());
+        assert!(
+            s.num_cpus > 0,
+            "num_cpus should be non-zero on supported hosts"
+        );
+    }
+
+    #[test]
+    fn rapid_resample_reuses_last_cpu_percent_instead_of_sysinfo_artifact() {
+        if !sysinfo::IS_SUPPORTED_SYSTEM {
+            return;
+        }
+        // Prime a real reading so `last_cpu_percent` is populated.
+        let _ = sample();
+        std::thread::sleep(
+            sysinfo::MINIMUM_CPU_UPDATE_INTERVAL + std::time::Duration::from_millis(10),
+        );
+        let primed = sample();
+        assert!(primed.cpu_percent.is_some(), "primed sample has cpu%");
+
+        // Two back-to-back calls well under MINIMUM_CPU_UPDATE_INTERVAL —
+        // without rate limiting sysinfo would return 0 (or 100*ncpu on
+        // Linux). We should instead see the cached value from `primed`.
+        let a = sample();
+        let b = sample();
+        assert_eq!(
+            a.cpu_percent, primed.cpu_percent,
+            "rapid resample must reuse the last real reading, not a sysinfo artifact"
+        );
+        assert_eq!(
+            b.cpu_percent, primed.cpu_percent,
+            "second rapid resample also reuses cached value"
+        );
+        // RSS is fine to update at any cadence — just check it stays plausible.
+        assert!(a.rss_bytes > 0);
+        assert!(b.rss_bytes > 0);
     }
 }

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -16,16 +16,16 @@ export interface StatusResponse {
   paired: boolean;
   channels: Record<string, boolean>;
   health: HealthSnapshot;
-  /** Self-process resource snapshot. Present on Linux; on unsupported
-   * platforms `rss_bytes = 0` and `cpu_percent = null`. */
+  /** Self-process resource snapshot. Populated on Linux, macOS, Windows,
+   * and FreeBSD via the `sysinfo` crate; on unsupported hosts
+   * `rss_bytes = 0` and `cpu_percent = null`. */
   process?: ProcessStats;
 }
 
 export interface ProcessStats {
   rss_bytes: number;
-  /** Total system RAM in bytes (`/proc/meminfo`'s `MemTotal`). `0` on
-   * unsupported platforms; render the RAM tile as `rss / total * 100%`
-   * when this is non-zero. */
+  /** Total system RAM in bytes. `0` on unsupported platforms; render the
+   * RAM tile as `rss / total * 100%` when this is non-zero. */
   system_ram_total_bytes: number;
   /** Average CPU% across logical cores (0..100 * num_cpus). `null` on the
    * first sample after boot (no baseline) or on unsupported platforms. */


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Replace the Linux-only `/proc/self/{status,stat}` + `libc::sysconf` path in `crates/zeroclaw-runtime/src/process_stats.rs` with a uniform sysinfo-backed sampler. The `ProcessStats` JSON contract, field semantics (`cpu_percent` in 0..100*ncpu, first-sample `None` baseline), and both consumption sites (web dashboard tiles + zerocode TUI status line) stay identical — only the under-the-hood sampling changes. Motivation: Windows and macOS users were seeing blank RAM/CPU tiles because the fallback path returned `ProcessStats::unsupported()` on any non-Linux target.
- **Scope boundary:** No changes to the JSON schema, RPC endpoint (`handle_health`), gateway `/api/status` response shape, front-end tile rendering, or the TUI status line. `cpu_percent` is still 0..100*ncpu (front-end divides by `num_cpus` for its normalized display); the front-end `unsupported` branch still triggers on `rss_bytes === 0` / `cpu_percent === null`.
- **Blast radius:** `crates/zeroclaw-runtime/src/process_stats.rs` (rewrite), one new dep in `crates/zeroclaw-runtime/Cargo.toml`, doc-comment refresh in `web/src/types/api.ts`. No other crate or subsystem needs to know.
- **Linked issue(s):** None.
- **Labels:** `enhancement`, `runtime`, `dependencies`, `risk:high`, `size:M`.

### Cross-platform coverage now populated

| Platform | Before | After |
|---|---|---|
| Linux | ✅ hand-rolled `/proc` reader | ✅ sysinfo (equivalent semantics) |
| macOS | ❌ blank tiles | ✅ sysinfo (Mach `task_info` + `hw.memsize` + `hw.logicalcpu`) |
| Windows | ❌ blank tiles | ✅ sysinfo (`GetProcessTimes` + `GetProcessMemoryInfo` + `GlobalMemoryStatusEx`) |
| FreeBSD | ❌ blank tiles | ✅ sysinfo |

### Design notes

- **sysinfo 0.36** pinned because 0.37+ raises its MSRV to 1.88; the workspace MSRV is 1.87 (see `Cargo.toml`). Uses `default-features = false, features = ["system"]` so we don't drag in the multi-threaded process-tree refresh path — we only sample a single pid.
- **CPU% rate limit.** `handle_health` is a public RPC and any external caller can poll it at arbitrary frequency. sysinfo documents that a refresh interval below `MINIMUM_CPU_UPDATE_INTERVAL` (≈200 ms) yields a floor/ceiling artifact — `0` on most platforms and `100 * ncpu` on Linux — which the old hand-rolled implementation would have avoided by returning a noisy-but-plausible value. We gate the CPU-half of the refresh on `MINIMUM_CPU_UPDATE_INTERVAL` and reuse the last real reading for sub-interval callers. Dashboard (5 s poll) and TUI (5 s poll) are well above the interval and unaffected; scripted callers no longer see the artifact.
- **Refresh cadence.** Total system RAM and logical CPU count are refreshed on every sample (RAM) / every CPU-refresh cycle (num_cpus). Memory hot-add on enterprise servers, hypervisor ballooning on VMs, and Linux CPU hot-plug / cloud vCPU resize are all reflected — matching the pre-PR behavior where each `sample()` re-read `/proc/meminfo` and re-called `sysconf(_SC_NPROCESSORS_ONLN)`.
- **`have_baseline` contract preserved.** First `sample()` after boot still returns `cpu_percent = None`; second and subsequent samples return `Some(..)`. The dashboard already renders the tile as `—` for `None` — no front-end change needed.

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- **Commands run and tail output:**

**`cargo fmt --all -- --check`** — clean, no output.

**`cargo clippy --all-targets -- -D warnings`** — clean, no warnings:
```
    Checking zeroclaw-eval v0.8.2 (…/crates/zeroclaw-eval)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 15m 04s
```

**`cargo test`** — all unit + integration + system tests pass. Doc-tests fail with `Option 'default-theme' given more than once`, which is **pre-existing on master** and unrelated to this PR: `.cargo/config.toml` sets `rustdocflags = ["--default-theme=ayu"]` and rustc 1.96's rustdoc now also injects the flag itself, producing the duplicate. Independently reproducible with `git checkout origin/master && cargo test --doc`. Non-doc test summary (new tests **bolded**):

```
   Compiling zeroclaw-runtime v0.8.2 (…/crates/zeroclaw-runtime)

# process_stats unit tests
test process_stats::tests::cpu_percent_filled_on_second_sample ... ok
test process_stats::tests::rapid_resample_reuses_last_cpu_percent_instead_of_sysinfo_artifact ... ok  # NEW
test process_stats::tests::sample_reports_num_cpus_on_supported_hosts ... ok                          # NEW
test process_stats::tests::sample_returns_rss_on_supported_hosts ... ok
test process_stats::tests::sample_returns_system_ram_total_and_rss_is_a_subset ... ok

# workspace summary tail
test result: ok. 158 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 0 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out  # live/* – no credentials in CI
test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

   Doc-tests zeroclaw
error: Option 'default-theme' given more than once   # PRE-EXISTING on master – unrelated
```

- **Beyond CI — what did you manually verify?**
  - Sampled locally on Linux (native): `rss_bytes`, `system_ram_total_bytes`, and `cpu_percent` all populate and match `ps -o rss=` / `/proc/meminfo` / `top` within rounding.
  - Two rapid back-to-back `sample()` calls under `MINIMUM_CPU_UPDATE_INTERVAL` return the same cached `cpu_percent` rather than a `0` / `100*ncpu` artifact (guarded by the new `rapid_resample_reuses_last_cpu_percent_instead_of_sysinfo_artifact` test).
  - Front-end contract: `web/src/types/api.ts` still matches the Rust JSON output (field names, types, nullability). `Dashboard.tsx` `ProcessRamCard` / `ProcessCpuCard` `supported` predicates unchanged.
- **Not verified locally:** live sampling on macOS and Windows (no hardware/VM here). sysinfo has broad CI coverage for those platforms upstream; a follow-up manual check by a maintainer with the hardware would be welcome.
- **If any command was intentionally skipped, why:** none skipped. Doc-tests fail on the workspace level for reasons documented above (pre-existing).

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No` — sysinfo reads the same `/proc/self/*` files on Linux that the old hand-rolled code did; on macOS/Windows/FreeBSD it uses standard user-mode syscalls (`task_info`, `GetProcessTimes`, `sysctl`) with no elevated privileges.
- New external network calls? `No`.
- Secrets / tokens / credentials handling changed? `No`.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`.

## Compatibility (required)

- Backward compatible? `Yes` — `ProcessStats` JSON schema, field names, field types, and semantic ranges (0..100*ncpu for `cpu_percent`, byte units for RAM, `None`/null on first sample) are all preserved. Existing web dashboard and TUI consumers keep working without changes.
- Config / env / CLI surface changed? `No`.

## Rollback (required for medium/high-risk PRs)

Low-risk PR — `git revert <sha>` restores the pre-sysinfo Linux-only sampler; unaffected platforms simply return to `unsupported()` tiles as they were before.
