### PR TITLE
fix(zerocode): apply theme background to queue and session overlays

### DIFF
--- a/apps/zerocode/src/chat.rs
+++ b/apps/zerocode/src/chat.rs
@@ -2864,7 +2864,8 @@ fn render_queue_sidebar(f: &mut Frame, state: &mut ChatState, area: Rect) {
     );
     let block = Block::default()
         .borders(Borders::ALL)
-        .title(Span::styled(format!(" {title} "), theme::title_style()));
+        .title(Span::styled(format!(" {title} "), theme::title_style()))
+        .style(theme::fill_style());
     let inner = block.inner(area);
     f.render_widget(Clear, area);
     f.render_widget(block, area);
@@ -3640,7 +3641,7 @@ fn render_session_list_overlay(
             " Sessions (Enter=switch, Esc=close) ",
             theme::overlay_border_style(),
         ))
-        .style(theme::overlay_border_style());
+        .style(theme::fill_style());
 
     let inner = block.inner(overlay_area);
     f.render_widget(block, overlay_area);


### PR DESCRIPTION
This fixes an issue where the ZeroCode queue sidebar and session picker overlays could render with a terminal-derived background instead of the active ZeroCode theme background.

## Problem
The queue sidebar and session picker can render with a white interior and light-blue themed text over the dark Chat pane, making the UI unreadable when the terminal default background is light.

## Root Cause
Both overlays called `Clear` to erase their drawing area, but then rendered blocks without applying `theme::fill_style()` to repaint the cleared interior with the active theme background.

## Solution
- `render_queue_sidebar`: added `.style(theme::fill_style())` to the queue sidebar block
- `render_session_list_overlay`: changed from `overlay_border_style()` to `fill_style()` for the session list overlay block

Now both overlays correctly use the active ZeroCode theme background, making them independent of the terminal's default background color.

Fixes: #8765