### PR TITLE
Fix 8757 channels clean

### DIFF
--- a/apps/zerocode/src/config_manager.rs
+++ b/apps/zerocode/src/config_manager.rs
@@ -1271,12 +1271,29 @@ impl App {
     // ── Data loading ─────────────────────────────────────────────
 
     fn types_for_section(&self, section_key: &str) -> Vec<ConfigTemplateEntry> {
+        let mut types: Vec<ConfigTemplateEntry> = Vec::new();
+
+        // Special case: channels section gets a "Global settings" entry first
+        if section_key == "channels" {
+            // Create a synthetic entry for global channels settings
+            let global_entry = ConfigTemplateEntry {
+                path: "channels.global_settings".to_string(),
+                description: Some("Global channel settings (show_tool_calls, ack_reactions, etc.)".to_string()),
+                ..Default::default()
+            };
+            types.push(global_entry);
+        }
+
+        // Then add the regular type entries
         let prefix = format!("{}.", section_key);
-        self.templates
+        let mut regular_types: Vec<ConfigTemplateEntry> = self.templates
             .iter()
             .filter(|t| t.path.starts_with(&prefix))
             .cloned()
-            .collect()
+            .collect();
+
+        types.append(&mut regular_types);
+        types
     }
 
     async fn load_type_alias_counts(&mut self) -> Result<()> {
@@ -1824,8 +1841,20 @@ impl App {
         {
             let section_idx = *section_idx;
             let map_path = tmpl.path.clone();
-            let type_name = map_path.rsplit('.').next().unwrap_or(&map_path).to_string();
             let section_key = self.sections[section_idx].key.clone();
+
+            // Special case: "Global settings" for channels should show root fields directly
+            if map_path == "channels.global_settings" {
+                self.load_fields("channels").await?;
+                self.screen = Screen::FieldList {
+                    section_idx,
+                    prefix: "channels".to_string(),
+                    breadcrumb: vec![section_key, "Global settings".to_string()],
+                };
+                return Ok(());
+            }
+
+            let type_name = map_path.rsplit('.').next().unwrap_or(&map_path).to_string();
             self.load_aliases(&map_path).await?;
             self.screen = Screen::AliasList {
                 section_idx,

--- a/apps/zerocode/src/config_manager.rs
+++ b/apps/zerocode/src/config_manager.rs
@@ -1278,7 +1278,9 @@ impl App {
             // Create a synthetic entry for global channels settings
             let global_entry = ConfigTemplateEntry {
                 path: "channels.global_settings".to_string(),
-                description: Some("Global channel settings (show_tool_calls, ack_reactions, etc.)".to_string()),
+                description: Some(
+                    "Global channel settings (show_tool_calls, ack_reactions, etc.)".to_string(),
+                ),
                 ..Default::default()
             };
             types.push(global_entry);
@@ -1286,7 +1288,8 @@ impl App {
 
         // Then add the regular type entries
         let prefix = format!("{}.", section_key);
-        let mut regular_types: Vec<ConfigTemplateEntry> = self.templates
+        let mut regular_types: Vec<ConfigTemplateEntry> = self
+            .templates
             .iter()
             .filter(|t| t.path.starts_with(&prefix))
             .cloned()


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:** (2–5 bullets — the diff shows *what*, you explain *why*)
- **Scope boundary:** (what this PR explicitly does NOT change)
- **Blast radius:** (what other subsystems or consumers could be affected)
- **Linked issue(s):** Use plain text outside backticks. Use `Closes #`,
  `Fixes #`, or `Resolves #` only for issues this PR fully resolves. Use
  `Related #`, `Depends on #`, or `Supersedes #` for non-closing relationships.
- **Labels:** Snapshot the current GitHub labels after labels are applied, for
  example `type:docs`, `risk:low`, `size:S`, `docs`. During label-spelling
  migration, copy the exact live label spelling from the GitHub UI.

## Validation Evidence (required)

Local validation is the signal CI cannot replace. Run the full battery and paste literal output (tails, failures, warnings — not "all passed").

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

Docs-only changes: replace with markdown lint + link-integrity (`scripts/ci/docs_quality_gate.sh`). Bootstrap scripts: add `bash -n install.sh`.

- **Commands run and tail output:**
- **Beyond CI — what did you manually verify?** (scenarios, edge cases, what you did NOT verify)
- **If any command was intentionally skipped, why:**

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? (`Yes/No`)
- New external network calls? (`Yes/No`)
- Secrets / tokens / credentials handling changed? (`Yes/No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`Yes/No`)
- If any `Yes`, describe the risk and mitigation:

## Compatibility (required)

- Backward compatible? (`Yes/No`)
- Config / env / CLI surface changed? (`Yes/No`)
- If `No` or `Yes` to either: exact upgrade steps for existing users:

## Rollback (required for medium/high-risk PRs)

Low-risk PRs: `git revert <sha>` is the plan unless otherwise noted.

Medium/high-risk PRs must fill:

- **Fast rollback command/path:**
- **Feature flags or config toggles:** (or `None`)
- **Observable failure symptoms:** (what to grep logs for, which metric moves, which alert fires)

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line):
- Scope materially carried forward:
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`Yes/No`)
- If `No`, why (inspiration-only, no direct code/design carry-over):

---

**Labels** live in the GitHub label UI, not in the body. Maintainers and reviewers with label permissions set `risk:*`, `size:*`, and any missing manual labels via the sidebar. The PR path labeler only owns path/scope labels from `.github/labeler.yml`. Contributors without label permission can note obvious label mismatches in a comment. Canonical colon-scoped labels use no-space spelling; during migration, copy exact live label spelling from the GitHub UI.

**Do not add bot/AI attribution footers** such as `Co-authored-by: Claude ...`
or `Created with Claude Code` to the PR body or commit-message tail. Human
co-author trailers are appropriate only for incorporated contributor work under
the supersede-attribution section and privacy contract.

**Privacy contract** (`docs/book/src/contributing/privacy.md`) is a merge gate. Never commit real identities, secrets, personal emails, or PII in diff, tests, fixtures, or docs.
