### PR TITLE
fix(runtime): hot-reload log persistence config

### DIFF
--- a/crates/zeroclaw-log/src/writer.rs
+++ b/crates/zeroclaw-log/src/writer.rs
@@ -609,6 +609,63 @@ mod tests {
         );
     }
 
+    #[test]
+    fn reinit_applies_changed_rotation_policy() {
+        let _guard = WRITER_TEST_LOCK.lock();
+        let tmp = tempfile::tempdir().unwrap();
+        install_rotating(tmp.path(), 0, false, 0, 0);
+
+        emit("before-reload");
+
+        let path = runtime_trace_path().unwrap();
+        assert!(
+            list_archives(&path).unwrap().is_empty(),
+            "size rotation should be disabled before re-init"
+        );
+        assert_eq!(total_events(&path), 1);
+
+        install_rotating(tmp.path(), 1, false, 1, 0);
+        emit("after-reload");
+
+        let archives = list_archives(&path).unwrap();
+        assert_eq!(
+            archives.len(),
+            1,
+            "re-init should apply the new byte budget and rotate on the next append"
+        );
+        assert_eq!(
+            total_events(&path),
+            2,
+            "re-init must preserve already-written events while applying the new policy"
+        );
+    }
+
+    #[test]
+    fn reinit_can_disable_persistence_without_restart() {
+        let _guard = WRITER_TEST_LOCK.lock();
+        let tmp = tempfile::tempdir().unwrap();
+        install_writer(tmp.path(), 10);
+
+        emit("persisted-before-disable");
+
+        let path = runtime_trace_path().unwrap();
+        assert_eq!(count_lines(&path), 1);
+
+        let cfg = LogConfig {
+            log_persistence: "none".into(),
+            ..LogConfig::default()
+        };
+        init_from_config(&cfg, tmp.path());
+
+        emit("not-persisted-after-disable");
+
+        assert_eq!(
+            count_lines(&path),
+            1,
+            "disabled persistence after re-init should stop appending without deleting existing logs"
+        );
+    }
+
     // ── Rotation (StoragePolicy::Rotating) ───────────────────────
 
     fn install_rotating(

--- a/crates/zeroclaw-runtime/src/observability/runtime_trace.rs
+++ b/crates/zeroclaw-runtime/src/observability/runtime_trace.rs
@@ -16,13 +16,10 @@ pub use zeroclaw_log::{LogEvent as RuntimeTraceEvent, LogFilter, LogPage};
 /// [`zeroclaw_log::LogConfig`] (the boundary that breaks the `zeroclaw-config`
 /// dependency cycle; see `docs/book/src/architecture/logging.md`).
 ///
-/// This copies values once, at startup / explicit re-init. The `zeroclaw-log`
-/// writer then holds that snapshot for the life of the process, so a live config
-/// reload does not propagate to it: changes to any `log_persistence*` field,
-/// including the `rotating`-mode knobs (`log_persistence_max_bytes`,
-/// `log_persistence_rotate_daily`, `log_persistence_retention_max_files`,
-/// `log_persistence_retention_max_age_days`), take effect only after a daemon
-/// restart. Hot-reload is tracked as a follow-up in issue #8314.
+/// This copies values at startup and every daemon config reload. The
+/// `zeroclaw-log` writer holds the resulting policy snapshot until the next
+/// explicit re-init, so reload handling must call [`init_from_config`] after a
+/// fresh `Config::load_or_init()` for `log_persistence*` changes to take effect.
 fn to_log_config(config: &zeroclaw_config::schema::ObservabilityConfig) -> zeroclaw_log::LogConfig {
     zeroclaw_log::LogConfig {
         log_persistence: config.log_persistence.as_wire().to_string(),

--- a/docs/book/src/architecture/logging.md
+++ b/docs/book/src/architecture/logging.md
@@ -221,7 +221,7 @@ The on-disk JSON shape (`LogEvent` in `event.rs`):
 
 ## `LogConfig` vs `ObservabilityConfig`
 
-`zeroclaw-log` defines its own minimal `LogConfig` (in `crates/zeroclaw-log/src/config.rs`): `log_persistence`, `log_persistence_path`, `log_persistence_max_entries`, `log_persistence_max_bytes`, `log_persistence_rotate_daily`, `log_persistence_retention_max_files`, `log_persistence_retention_max_age_days`, `log_tool_io`, `log_tool_io_truncate_bytes`, `log_tool_io_denylist`. This breaks what would otherwise be a dep cycle: `zeroclaw-config::ObservabilityConfig` carries the full schema (with TOML deserialization and validation), and the runtime converts to `LogConfig` at startup via `crates/zeroclaw-runtime/src/observability/runtime_trace.rs::to_log_config`. The result: `zeroclaw-config` can `record!` without inverting the dep tree.
+`zeroclaw-log` defines its own minimal `LogConfig` (in `crates/zeroclaw-log/src/config.rs`): `log_persistence`, `log_persistence_path`, `log_persistence_max_entries`, `log_persistence_max_bytes`, `log_persistence_rotate_daily`, `log_persistence_retention_max_files`, `log_persistence_retention_max_age_days`, `log_tool_io`, `log_tool_io_truncate_bytes`, `log_tool_io_denylist`. This breaks what would otherwise be a dep cycle: `zeroclaw-config::ObservabilityConfig` carries the full schema (with TOML deserialization and validation), and the runtime converts to `LogConfig` at startup and after daemon config reload via `crates/zeroclaw-runtime/src/observability/runtime_trace.rs::to_log_config`. The result: `zeroclaw-config` can `record!` without inverting the dep tree, while log persistence and rotation policy changes still take effect on the next daemon reload.
 
 ## Subscriber installation
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4309,6 +4309,11 @@ async fn main() -> Result<()> {
                             "🔄 Daemon reload — re-reading config from disk"
                         );
                         current_config = Box::pin(Config::load_or_init()).await?;
+                        #[cfg(feature = "agent-runtime")]
+                        observability::runtime_trace::init_from_config(
+                            &current_config.observability,
+                            &current_config.data_dir,
+                        );
                         // Stop the stale nag and re-gate against the fresh
                         // config: a repaired posture silences the warning, a
                         // newly-degraded one (still allowed) restarts it. A


### PR DESCRIPTION
## Summary

Fixes #8314.

- Re-applies `observability::runtime_trace::init_from_config(...)` immediately after daemon reload reads a fresh `Config`, so `log_persistence`, rotation, retention, path, and related log policy edits take effect without a daemon restart.
- Keeps `Config.observability` as the single source of truth and keeps `zeroclaw-log` decoupled from `zeroclaw-config` by reusing the existing runtime adapter boundary.
- Adds `zeroclaw-log` regression coverage for changed rotation policy and disabling persistence across explicit re-init.
- Updates the logging architecture doc to state that `LogConfig` is derived both at startup and after daemon config reload.

Risk: medium. The behavior change touches daemon reload observability policy, but it is narrowly scoped to re-running the existing adapter after a fresh config load.

## Validation Evidence (required)

- `cargo fmt --all -- --check`
- `cargo clippy -p zeroclaw-log --all-targets -- -D warnings`
- `cargo clippy -p zeroclaw-runtime --all-targets -- -D warnings`
- `cargo clippy -p zeroclawlabs --features agent-runtime --bin zeroclaw -- -D warnings`
- `cargo clippy --all-targets -- -D warnings`
- `cargo check -p zeroclawlabs --features agent-runtime`
- `cargo test -p zeroclaw-log reinit_`
- `cargo test -p zeroclaw-log -- --test-threads=1`
- `cargo test -p zeroclaw-runtime agent::turn::parse_response::cost_usd_regression_tests::cost_usd_flows_to_usage_event_and_llm_response --lib`
- `cargo test -p zeroclaw-runtime --lib -- --test-threads=1`
- `cargo test`
- `BASE_SHA=invalid DOCS_FILES='docs/book/src/architecture/logging.md' bash scripts/ci/docs_quality_gate.sh`
- `DOCS_FILES='docs/book/src/architecture/logging.md' bash scripts/ci/docs_links_gate.sh`

Notes from validation:

- One parallel `cargo test -p zeroclaw-log` run hit global writer-state contention; the full package passed when serialized with `-- --test-threads=1`.
- One parallel `cargo test -p zeroclaw-runtime --lib` run hit log-capture contention in the existing cost regression test; the exact test and the serialized full runtime lib suite both passed.
- An initial docs quality run against stale `origin/master` reported an unrelated pre-existing release-runbook issue outside this diff. Targeting the changed docs file passed.

## Security & Privacy Impact (required)

- No new config keys, schema fields, secrets, credentials, network paths, or personal data.
- No access-control behavior changes.
- The canonical source of truth remains `Config.observability`; the daemon reload path only re-derives the existing `zeroclaw_log::LogConfig` adapter snapshot.

## Compatibility (required)

- Backward compatible config and log format.
- Restart remains valid, but is no longer required for log persistence/rotation policy edits after daemon reload.
- Disabling persistence after reload stops future appends and does not delete existing log files.

## Rollback (required for medium/high-risk PRs)

Revert this commit. The daemon will return to the previous behavior where log persistence/rotation changes require a full process restart after editing config.

## Supersede Attribution (required only when Supersedes # is used)

N/A.
