### PR TITLE
chore(deps): bump crossbeam-epoch 0.9.18 -> 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1871,9 +1871,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** `cargo update -p crossbeam-epoch` bumps the locked version 0.9.18 → 0.9.20 (Cargo.lock only, 2 lines). Clears RUSTSEC-2026-0204: invalid pointer dereference in the `fmt::Pointer` impl for `Atomic`/`Shared`; fixed in >=0.9.20.
- **Scope boundary:** No Cargo.toml, source, or config changes. No other dependencies move (`cargo update -p` locked exactly one package).
- **Blast radius:** Minimal — crossbeam-epoch is only reachable as a dev-dependency: `criterion → rayon → rayon-core → crossbeam-deque → crossbeam-epoch` (benchmarks only). No production code path uses it.
- **Linked issue(s):** None
- **Labels:** suggested `dependencies`, `type:dependencies`, `domain:security`, `risk:low`, `size:XS` (per #8542 precedent; maintainers own risk/size)

## Validation Evidence (required)

Toolchain: rustc 1.95.0, cargo-audit 0.22.2.

- **Commands run and tail output:**

`cargo audit` — clean, exit 0, no vulnerabilities reported:

```text
    Loaded 1159 security advisories (from /Users/<user>/.cargo/advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (1048 crate dependencies)
```

`cargo fmt --all -- --check` — exit 0, no output.

`cargo clippy --all-targets -- -D warnings` — exit 0:

```text
    Checking zeroclaw-eval v0.8.2 (.../crates/zeroclaw-eval)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 4m 06s
```

`cargo test` — all test targets pass:

```text
test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.05s

   Doc-tests zeroclaw
running 0 tests
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

- **Beyond CI — what did you manually verify?** `cargo tree -i crossbeam-epoch` confirms the only reverse path is `criterion → rayon → rayon-core → crossbeam-deque` under `[dev-dependencies]` — no runtime consumer. Verified the lockfile diff touches exactly one package (version + checksum). Did NOT run benchmarks (`criterion`), the only consumer of this crate.
- **If any command was intentionally skipped, why:** None skipped. Note: the doctest step initially errored in my nested-worktree checkout (`Option 'default-theme' given more than once` — the repo's `.cargo/config.toml` is loaded twice when the worktree lives inside the repo directory, duplicating `rustdocflags`). Re-ran `cargo test --doc` with `RUSTDOCFLAGS="--default-theme=ayu"` overriding config merge: passes. Environment artifact, unrelated to this change.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No

(This PR removes a known vulnerability — RUSTSEC-2026-0204 — rather than adding surface.)

## Compatibility (required)

- Backward compatible? Yes — semver-compatible patch bump of a transitive dev-dependency, lockfile only.
- Config / env / CLI surface changed? No

## Rollback (required for medium/high-risk PRs)

Low-risk: `git revert <sha>` (restores the 0.9.18 lock entry; note this re-introduces the advisory finding in `cargo audit`).