### PR TITLE
docs(channels): expand Telegram setup guide in chat-others.md (#8810)

### DIFF
--- a/docs/book/src/channels/chat-others.md
+++ b/docs/book/src/channels/chat-others.md
@@ -16,10 +16,48 @@ Use case: paired-identity channels where sub-second replies are an AI-tell. Wire
 
 ## Telegram
 
+### Setup
+
+1. **Create a bot** with [@BotFather](https://t.me/botfather) on Telegram. Send `/newbot`, pick a name, and copy the token BotFather returns.
+2. **Add the bot to your config** with the token you just copied. The token is
+   a secret, so set it through a surface that encrypts it rather than typing it
+   into `config.toml`:
+
+   {{#config-where channels telegram}}
+
+   {{#secret-config channels.telegram.<alias>.bot_token}}
+
+3. **Start the bot**: send `/start` to it in a Telegram chat so it can begin
+   receiving messages.
+
+### Who can talk to the agent
+
 {{#peer-group telegram}}
 
-- Long polling is the default; no public URL required.
-- Streaming draft edits are supported but capped by Telegram's rate limit. Tune `draft_update_interval_ms` if you see "Too Many Requests".
+Inbound senders are gated through **peer groups**, not a per-channel
+`allowed_users` field. After the channel is configured, authorized senders
+are listed in `[peer_groups.<name>].external_peers`. See
+[Peer Groups](./peer-groups.md) for the full decision logic.
+
+If you want to let anyone message the bot without pairing, add `"*"` to the
+peer group's `external_peers`:
+
+```toml
+[peer_groups.telegram_default]
+channel = "telegram"
+external_peers = ["*"]
+```
+
+### Binding a Telegram identity
+
+Once the channel is configured, use `zeroclaw channel bind-telegram` to
+authorize a specific Telegram user. The identity can be:
+
+- A **numeric user ID** (e.g., `zeroclaw channel bind-telegram 111111111`)
+- An **@username** (e.g., `zeroclaw channel bind-telegram @alice`)
+
+To find your Telegram user ID, send a message to [@userinfobot](https://t.me/userinfobot)
+or use a bot that echoes back your chat ID.
 
 ## iMessage (macOS only)
 

--- a/docs/book/src/channels/chat-others.md
+++ b/docs/book/src/channels/chat-others.md
@@ -27,8 +27,15 @@ Use case: paired-identity channels where sub-second replies are an AI-tell. Wire
 
    {{#secret-config channels.telegram.<alias>.bot_token}}
 
-3. **Start the bot**: send `/start` to it in a Telegram chat so it can begin
-   receiving messages.
+3. **Enable the channel and start the service**: set `enabled = true` on the
+   alias you configured. Telegram aliases default to disabled, and the
+   orchestrator skips any alias that is not active, so this is required before
+   inbound messages are accepted. If you run with explicit agent-channel
+   bindings, also attach `telegram.<alias>` to an enabled agent; with no
+   explicit binding the channel routes to the default agent. Then start or
+   restart the ZeroClaw daemon/service. Telegram uses long polling by default
+   and does not need a public URL. Once the service is running, send `/start`
+   to your bot in a Telegram chat so it can begin receiving messages.
 
 ### Who can talk to the agent
 
@@ -48,16 +55,34 @@ channel = "telegram"
 external_peers = ["*"]
 ```
 
+`channel = "telegram"` is a type-wide reference: paired with `["*"]` it opens
+**every** Telegram alias to anyone. To open just one configured bot, scope the
+group to a single alias with `channel = "telegram.<alias>"` instead. See
+[Peer Groups](./peer-groups.md) for the decision logic.
+
+> Streaming draft edits are supported but capped by Telegram's rate limit.
+> Tune `draft_update_interval_ms` if you see "Too Many Requests".
+
 ### Binding a Telegram identity
 
-Once the channel is configured, use `zeroclaw channel bind-telegram` to
-authorize a specific Telegram user. The identity can be:
+Use `zeroclaw channel bind-telegram <identity>` to authorize a specific
+Telegram user. Without `--alias` the identity is bound to the `default`
+alias (`channels.telegram.default`); pass `--alias <alias>` to target
+`channels.telegram.<alias>`:
 
-- A **numeric user ID** (e.g., `zeroclaw channel bind-telegram 111111111`)
-- An **@username** (e.g., `zeroclaw channel bind-telegram @alice`)
+```sh
+zeroclaw channel bind-telegram 111111111                       # default alias
+zeroclaw channel bind-telegram @zeroclaw_user --alias alerts   # channels.telegram.alerts
+```
 
-To find your Telegram user ID, send a message to [@userinfobot](https://t.me/userinfobot)
-or use a bot that echoes back your chat ID.
+The identity can be a **numeric user ID** or an **@username**. When you bind a
+non-default alias, the agent that runs on that alias requires a matching
+identity, otherwise an authorized sender keeps being asked for approval.
+
+To find your Telegram user ID, send any message to the bot — ZeroClaw
+replies to unauthorized senders with the exact `zeroclaw channel
+bind-telegram <identity>` command to run. You can also look up your
+ID through [@userinfobot](https://t.me/userinfobot).
 
 ## iMessage (macOS only)
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - The Telegram section in `docs/book/src/channels/chat-others.md` was a two-line bullet list with no step-by-step setup, no peer-group examples, and no mention of `bind-telegram`. Users arriving at the docs for Telegram setup had no guidance on how to configure the channel, how access control works, or how to authorize a Telegram identity.
  - Added a step-by-step **Setup** section (create bot with BotFather, add config through the secret-aware surface, enable the channel and start the service, then send `/start`).
  - Expanded the **Who can talk to the agent** section with an explicit peer-group configuration example (`external_peers = ["*"]` for open access) and a note that access control is in `[peer_groups]`, not a per-channel `allowed_users` field. States that `channel = "telegram"` is type-wide (opens every Telegram alias when paired with `["*"]`) and that `channel = "telegram.<alias>"` scopes to one bot. Restored the `draft_update_interval_ms` rate-limit tuning note.
  - Added a **Binding a Telegram identity** section documenting both forms of `zeroclaw channel bind-telegram` (default alias, and `--alias <alias>` for non-default aliases now that alias-aware binding has landed), with examples for numeric user IDs and @usernames using the project-scoped `@zeroclaw_user` placeholder, and first-party identity discovery through the bot itself.
- **Scope boundary:** only the Telegram subsection of `chat-others.md`. No other channel sections, no code, no config schema changes.
- **Blast radius:** docs only. The rendered page is part of the mdBook output; the `{{#peer-group telegram}}` template directive is unchanged and continues to render the auto-generated peer-group snippet.
- **Linked issue(s):** Related #8810

## Validation Evidence (required)

- **CI checks relied on and why they cover this change:** `Docs Style` lints the changed Markdown. No `Docs Links` check runs on this head, so links were verified manually instead (see below).
- **Commands run and tail output:**
  - `git diff --stat` -> `1 file changed, 33 insertions(+), 8 deletions(-)`
- **Beyond CI - what did you manually verify?**
  - Verified the inline TOML config examples are syntactically valid.
  - Verified the `zeroclaw channel bind-telegram` syntax and `--alias` flag match the CLI definition in `src/lib.rs` (`BindTelegram { identity, alias }`, `alias` defaults to `default`) and the help-text examples there.
  - Verified the `@BotFather` and `@userinfobot` links resolve to correct Telegram URLs.
  - Verified the `{{#peer-group telegram}}` template directive remains in place and is registered in `docs/book/peer-groups.toml`.
- **If any command was intentionally skipped, why:** markdown lint runs in CI (`scripts/ci/docs_quality_gate.sh`).

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No** - no runtime credential handling changed; the documentation routes `bot_token` through secret-aware surfaces.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No** (example token `123456789:ABCdef...` is synthetic, example user IDs are generic, identity placeholder is project-scoped)

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- If `No` or `Yes` to either: exact upgrade steps for existing users: N/A

## Rollback (required for medium/high-risk PRs)

Low-risk (docs-only). `git revert <sha>` is the plan.
